### PR TITLE
fix(storage): retry transient object storage 5xx on reads

### DIFF
--- a/posthog/storage/object_storage.py
+++ b/posthog/storage/object_storage.py
@@ -424,17 +424,33 @@ def is_usable_endpoint(endpoint: str | None) -> bool:
     return bool(parsed.scheme and parsed.netloc)
 
 
+def _s3_config(**overrides: Any) -> Config:
+    """
+    Shared client config for every reader and writer that routes through this module.
+
+    Object storage answers with 5xx under transient load, and boto3's default `legacy` retry mode
+    applies no jitter, so a fleet of pods retries a degraded backend in lockstep and amplifies the
+    outage. `standard` mode retries 500/502/503/504 with jittered exponential backoff instead.
+    Three total attempts costs at most a couple of seconds of backoff, which is the ceiling worth
+    paying on the read paths that serve HTTP requests directly. `total_max_attempts` counts
+    attempts as written, whereas boto3 reads `max_attempts` as the number of retries on top of the
+    first attempt.
+    """
+    return Config(
+        signature_version="s3v4",
+        connect_timeout=1,
+        retries={"mode": "standard", "total_max_attempts": 3},
+        **overrides,
+    )
+
+
 def object_storage_client() -> ObjectStorageClient:
     global _client
 
     if not settings.OBJECT_STORAGE_ENABLED:
         _client = UnavailableStorage()
     elif isinstance(_client, UnavailableStorage):
-        s3_config = Config(
-            signature_version="s3v4",
-            connect_timeout=1,
-            retries={"max_attempts": 1},
-        )
+        s3_config = _s3_config()
         aws_client = client(
             "s3",
             endpoint_url=settings.OBJECT_STORAGE_ENDPOINT,
@@ -584,12 +600,7 @@ def _get_accelerated_presigned_client() -> Optional[Any]:
     if _accelerated_presigned_client is None and settings.OBJECT_STORAGE_TRANSFER_ACCELERATION:
         with _accelerated_client_lock:
             if _accelerated_presigned_client is None:
-                s3_config = Config(
-                    signature_version="s3v4",
-                    connect_timeout=1,
-                    retries={"max_attempts": 1},
-                    s3={"use_accelerate_endpoint": True},
-                )
+                s3_config = _s3_config(s3={"use_accelerate_endpoint": True})
                 _accelerated_presigned_client = client(
                     "s3",
                     aws_access_key_id=settings.OBJECT_STORAGE_ACCESS_KEY_ID,

--- a/posthog/storage/test/test_object_storage.py
+++ b/posthog/storage/test/test_object_storage.py
@@ -256,6 +256,21 @@ class TestObjectStorageClientFactory(SimpleTestCase):
     def test_is_usable_endpoint(self, _name: str, endpoint: str | None, expected: bool) -> None:
         assert is_usable_endpoint(endpoint) is expected
 
+    def test_client_retries_transient_storage_failures(self) -> None:
+        with self.settings(
+            OBJECT_STORAGE_ENABLED=True,
+            OBJECT_STORAGE_ENDPOINT="http://objectstorage:19000",
+            OBJECT_STORAGE_PUBLIC_ENDPOINT="http://objectstorage:19000",
+        ):
+            storage = object_storage_client()
+
+        assert isinstance(storage, ObjectStorage)
+        # Asserted on the client boto3 actually built, because boto3 normalizes the retry dict it is
+        # handed: a `max_attempts` of N silently becomes N + 1 total attempts.
+        retries = storage.aws_client.meta.config.retries
+        assert retries["mode"] == "standard"
+        assert retries["total_max_attempts"] == 3
+
     @patch("posthog.storage.object_storage.capture_exception")
     @patch("posthog.storage.object_storage.client")
     def test_bad_public_endpoint_does_not_crash_read_path(self, patched_client, patched_capture) -> None:


### PR DESCRIPTION
## Problem

- Anyone downloading an export, opening a dashboard image, or loading a canvas artifact gets a failed request whenever object storage returns a transient 503.
- The shared S3 client runs with `retries={"max_attempts": 1}`. boto3 reads that as one retry on top of the first attempt, so the request gets two attempts about half a second apart.
- No retry `mode` is set, so the client uses boto3's `legacy` mode, which applies no jitter. Every pod retries a degraded backend in lockstep.
- A 503 that outlasts that one retry becomes `ObjectStorageError`, and the download endpoints turn it into a 500.
- This factory is the single client behind every object storage reader and writer in the Django app, so the thin retry budget is one shared point of fragility.

Reported in [this error tracking issue](https://us.posthog.com/error_tracking/019a0252-f43d-7d10-985b-546317ced425): `ClientError: An error occurred (503) when calling the GetObject operation (reached max retries: 1)`.

## Changes

- The client now uses `standard` retry mode with three total attempts, so it retries 500, 502, 503 and 504 with jittered exponential backoff.
- A failing read costs at most a couple of extra seconds of backoff before it gives up. That ceiling is why the count is three and not higher, since several of these readers serve HTTP requests directly.
- The config declares `total_max_attempts` rather than `max_attempts`, because boto3 uses the first as written and reads the second as retries on top of the first attempt. That off-by-one is what made the old value read as more generous than it was.
- `_s3_config` replaces the two copies of the config in this file, one for the main client and one for the accelerated presigned client.
- `connect_timeout=1` is unchanged. With retries enabled it now fails fast and retries, instead of failing fast and returning a 500.

Left alone deliberately:

- `read_timeout` stays at boto3's 60 second default. Tightening it risks the large object readers, such as export bundles and replay video.
- The 28 call sites are unchanged. The user-facing download endpoints still return a 500 when storage is genuinely down, which is a separate problem from this transient one.

## How did you test this code?

I (actually Claude) verified the behavior change against a local stub rather than inferring it from the boto3 docs, because the retry happens inside the client and cannot be observed by mocking `get_object`. The stub returned 503 twice and then 200, driven with both the old and new config on the pinned botocore 1.40.49.

<details>
<summary>Stub output</summary>

```
old (max_attempts=1): resolved retries = {'total_max_attempts': 2, 'mode': 'legacy'}
old (max_attempts=1): FAILED after 2 attempts: An error occurred (ServiceUnavailable) when calling the GetObject operation (reached max retries: 1): Service Unavailable

new (standard/total=3): resolved retries = {'mode': 'standard', 'total_max_attempts': 3}
new (standard/total=3): SUCCEEDED after 3 attempts, body=b'the object body'
```

The old config reproduces the reported error text, including the `reached max retries: 1` wording.

</details>

The one new test asserts the retry config on the client boto3 actually built, not on the `Config` object passed in. It catches a revert to a no-retry budget, and it catches the `max_attempts` off-by-one, which no existing test covers. The existing read-failure tests build `ObjectStorage(MagicMock())` directly, so they never construct a real client and needed no change.

I ran the storage suite locally against Postgres, ClickHouse and SeaweedFS. Three presigned-URL tests fail, and they fail identically on unmodified `master` in this sandbox because they expect a `localhost:19000` endpoint while my containers use `objectstorage:19000`. Not checked: whether a real 503 from production SeaweedFS clears within three attempts. The stub proves the client retries; it cannot prove the backend recovers that fast.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I am Claude Code, working from a stack trace pasted into the session. The in-app frame pointed at a line number that had since moved, so I traced it to the current `read_object` and confirmed `read` and `read_bytes` both delegate through it.

The framing changed once during the session. The 503 first looked like a backend problem to route elsewhere. Reading the vendored botocore showed the `max_attempts` normalization at `botocore/args.py:588-593`, which meant the config only ever allowed two attempts, and that turned it into a fixable client-side bug.

I also mapped the other boto3 clients in the repo. Retry config there is inconsistent, with two other sites copying this no-retry pattern and the batch export write path left unconfigured. Out of scope here, and worth a separate look. The Temporal deletion client copies the same config, but Temporal retries those activities at the workflow level.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

I did not run `hogli ci:preflight`, since this sandbox has no `node_modules`.
