### PR TITLE
fix(aio): self-driving tab follow-ups — shortcut routing and docs link

### DIFF
--- a/products/ai_observability/frontend/AIObservabilityScene.tsx
+++ b/products/ai_observability/frontend/AIObservabilityScene.tsx
@@ -513,12 +513,12 @@ function AIObservabilitySceneContent(): JSX.Element {
     useShortcut({
         name: 'AIObservabilityTab4',
         keybind: [keyBinds.tab4],
-        intent: selfDrivingEnabled ? 'Go to Generations' : 'Go to Sessions',
+        intent: selfDrivingEnabled ? 'Go to Generations' : 'Go to Users',
         interaction: 'function',
         callback: () =>
             push(
                 combineUrl(
-                    selfDrivingEnabled ? urls.aiObservabilityGenerations() : urls.aiObservabilitySessions(),
+                    selfDrivingEnabled ? urls.aiObservabilityGenerations() : urls.aiObservabilityUsers(),
                     searchParams
                 ).url
             ),
@@ -527,12 +527,12 @@ function AIObservabilitySceneContent(): JSX.Element {
     useShortcut({
         name: 'AIObservabilityTab5',
         keybind: [keyBinds.tab5],
-        intent: selfDrivingEnabled ? 'Go to Sessions' : 'Go to Users',
+        intent: selfDrivingEnabled ? 'Go to Sessions' : 'Go to Errors',
         interaction: 'function',
         callback: () =>
             push(
                 combineUrl(
-                    selfDrivingEnabled ? urls.aiObservabilitySessions() : urls.aiObservabilityUsers(),
+                    selfDrivingEnabled ? urls.aiObservabilitySessions() : urls.aiObservabilityErrors(),
                     searchParams
                 ).url
             ),

--- a/products/ai_observability/frontend/selfDriving/AIObservabilitySelfDriving.tsx
+++ b/products/ai_observability/frontend/selfDriving/AIObservabilitySelfDriving.tsx
@@ -13,7 +13,7 @@ import {
     isAIObservabilityScout,
 } from './aiObservabilityScoutTemplates'
 
-const SCOUTS_DOCS_URL = 'https://posthog.com/docs/self-driving/scouts'
+const SCOUTS_DOCS_URL = 'https://posthog.com/docs/ai-observability/self-driving'
 
 const TEMPLATE_ICONS: Record<AIObservabilityScoutTemplate['key'], JSX.Element> = {
     'daily-digest': <IconCalendar />,


### PR DESCRIPTION
## Problem

Two follow-ups to #79881 that landed after it was merged:

1. [Graphite's finding](https://github.com/PostHog/posthog/pull/79745#discussion_r3737793753) on #79745: with the self-driving flag **off**, the tab4/tab5 keyboard shortcuts routed to Sessions and Users instead of master's Users and Errors.
2. The templates tooltip linked to the general scouts docs; the AIO self-driving docs page ships together with this tab, so it should link there.

## Changes

- Tab4/tab5 shortcuts restore master's routing (Users, Errors) when the flag is off; the flag-on mapping is unchanged.
- The tooltip's `docLink` now points to `posthog.com/docs/ai-observability/self-driving`.

## How did you test this code?

- Verified the flag-off mapping against master's shortcut definitions (`git show origin/master`): tab4 → Users, tab5 → Errors.
- `oxfmt` and `oxlint` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)