### PR TITLE
fix(data-imports): keep initial_sync_complete across full-refresh syncs

### DIFF
--- a/products/warehouse_sources/backend/models/external_data_schema.py
+++ b/products/warehouse_sources/backend/models/external_data_schema.py
@@ -664,7 +664,7 @@ class ExternalDataSchema(ModelActivityMixin, CreatedMetaFields, UpdatedMetaField
                 return str(value)
         return str(value)
 
-    def update_sync_type_config_for_reset_pipeline(self) -> None:
+    def update_sync_type_config_for_reset_pipeline(self, *, clear_initial_sync_complete: bool = True) -> None:
         self.sync_type_config.pop("reset_pipeline", None)
         self.sync_type_config.pop("incremental_field_last_value", None)
         self.sync_type_config.pop("incremental_field_earliest_value", None)
@@ -685,7 +685,13 @@ class ExternalDataSchema(ModelActivityMixin, CreatedMetaFields, UpdatedMetaField
         # repartition / change-partition-mode actions precisely so they survive this reset and win
         # the resync it triggers. They're consumed in set_partitioning_enabled.
 
-        self.initial_sync_complete = False
+        # Routine full-refresh syncs pass False: the flag is a "first sync ever completed" latch
+        # consumed by webhook gating and schema-state displays, and clearing it on every run left
+        # it false between runs whenever a sync wrote zero rows (no Delta table means post-load
+        # never re-set it). Explicit resets (reset_pipeline, corruption rebuild, sync-method
+        # change, delete_table) keep clearing so CDC's False->True streaming flip still fires.
+        if clear_initial_sync_complete:
+            self.initial_sync_complete = False
 
         self.save(skip_activity_log=True)
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
@@ -383,7 +383,11 @@ async def handle_reset_or_full_refresh(
         # Avoid schema mismatches from existing data about to be overwritten
         await logger.adebug("Deleting existing table due to sync being full refresh")
         await delta_table_ref.reset_table()
-        await database_sync_to_async_pool(schema.update_sync_type_config_for_reset_pipeline)()
+        # Keep the initial_sync_complete latch: this branch runs on every scheduled full-refresh
+        # sync, and a run that extracts zero rows never reaches post-load to re-set it.
+        await database_sync_to_async_pool(schema.update_sync_type_config_for_reset_pipeline)(
+            clear_initial_sync_complete=False
+        )
 
 
 def _capture_delta_revived(

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
@@ -446,6 +446,36 @@ class TestHandleResetOrFullRefresh:
         helper.reset_table.assert_awaited_once()
         schema.refresh_from_db()
         assert "reset_pipeline" not in schema.sync_type_config
+        # An explicit reset redoes the initial sync, so the latch must drop (CDC's snapshot->
+        # streaming flip fires on the False->True transition).
+        assert schema.initial_sync_complete is False
+
+    def test_full_refresh_sync_keeps_initial_sync_complete(self, team):
+        # The prod regression: routine full-refresh runs cleared the latch at extraction start,
+        # and a zero-row run never reaches post-load to re-set it, so the flag read false
+        # between runs on ~1k schemas despite daily completed syncs.
+        source = ExternalDataSource.objects.create(
+            source_id=str(uuid.uuid4()), connection_id=str(uuid.uuid4()), team=team, source_type="Clickhouse"
+        )
+        schema = ExternalDataSchema.objects.create(
+            name="events",
+            team=team,
+            source=source,
+            sync_type=ExternalDataSchema.SyncType.FULL_REFRESH,
+            sync_type_config={"incremental_field_last_value": "2026-01-01T00:00:00"},
+            initial_sync_complete=True,
+        )
+        helper = MagicMock(reset_table=AsyncMock())
+
+        async_to_sync(handle_reset_or_full_refresh)(
+            False, False, schema, helper, MagicMock(adebug=AsyncMock()), webhook_only=False
+        )
+
+        helper.reset_table.assert_awaited_once()
+        assert schema.initial_sync_complete is True
+        schema.refresh_from_db()
+        assert schema.initial_sync_complete is True
+        assert "incremental_field_last_value" not in schema.sync_type_config
 
 
 class TestValidateIncrementalSync:


### PR DESCRIPTION
## Problem

- Full-refresh schemas read as "initial sync never completed" despite weeks of completed syncs, misleading schema-state displays and anyone investigating sync health.
- Webhook consumption also gates on this flag, so a healthy table can be treated as not yet synced.
- Every scheduled full-refresh run clears the flag at extraction start, in `update_sync_type_config_for_reset_pipeline`.
- A run that extracts zero rows never creates a Delta table, so post-load exits early and never re-sets the flag.
- Schemas whose source often returns zero rows therefore sit at false almost permanently. Production job snapshots show the flag flipping exactly with `rows_synced > 0`.

## Changes

- The routine full-refresh reset keeps `initial_sync_complete` (new `clear_initial_sync_complete=False`), turning the flag into a latch: set by the first sync that lands data, kept across re-syncs.
- Explicit resets (`reset_pipeline`, corruption rebuild, `delete_table`, sync-method changes) still clear it, so CDC's snapshot-to-streaming flip on the False→True transition is unchanged.
- Covers v2 and v3, which share `handle_reset_or_full_refresh`.
- Already-stuck schemas self-heal on their next sync that writes rows. Schemas that only ever run zero-row syncs stay false until a backfill, which is not part of this PR.

## How did you test this code?

- New `test_full_refresh_sync_keeps_initial_sync_complete` catches the regression: without the fix it fails on the flag being cleared by a routine full-refresh run.
- `test_poll_backfillable_reset_still_wipes` now also pins that an explicit reset still clears the flag, guarding the CDC transition.
- Not run: the e2e suite. Its `_run` helper already asserts the first-sync latch and is unaffected.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal pipeline bookkeeping, not documented behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session. Root-caused from production job snapshot data: `schema_snapshot.initial_sync_complete` at each run's creation correlates exactly with whether the previous run synced rows. Tenant identifiers and counts from that investigation were kept out of this PR.
- The suggested first-sync e2e reproduction passes today; the failing shape is a non-first, zero-row run, which the new unit test covers at the reset helper instead.
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
