### PR TITLE
fix(customer-analytics): restore calendar person matching

### DIFF
--- a/products/customer_analytics/backend/logic/calendar_sync.py
+++ b/products/customer_analytics/backend/logic/calendar_sync.py
@@ -38,7 +38,7 @@ ORDER BY is_identified DESC, created_at ASC, id ASC
 GROUP_KEY_BY_DISTINCT_ID_QUERY = """
 SELECT distinct_id, argMaxIf({group_col}, timestamp, {group_col} != '') AS group_key
 FROM events
-WHERE distinct_id IN {distinct_ids} AND timestamp > now() - INTERVAL 90 DAY
+WHERE distinct_id IN {{distinct_ids}} AND timestamp > now() - INTERVAL 90 DAY
 GROUP BY distinct_id
 """
 

--- a/products/customer_analytics/backend/test/test_calendar_sync.py
+++ b/products/customer_analytics/backend/test/test_calendar_sync.py
@@ -150,6 +150,26 @@ class TestCalendarSync(BaseTest):
         self._sync([_pages_response([event])])
         assert Meeting.objects.for_team(self.team.id).get().account_id == account.id
 
+    def test_matches_account_via_person_group(self) -> None:
+        self.team.customer_analytics_config.account_group_type_index = 0
+        self.team.customer_analytics_config.save()
+        account = Account.objects.for_team(self.team.id).create(team=self.team, name="Acme", external_id="acme")
+        person_uuid = "0198b6f3-0000-0000-0000-000000000001"
+        person = MagicMock(uuid=person_uuid, distinct_ids=["person-distinct-id"])
+        group_query_response = MagicMock(results=[["person-distinct-id", "acme"]])
+
+        with (
+            patch.object(calendar_sync, "get_persons_by_uuids", return_value=[person]),
+            patch("posthog.hogql.query.execute_hogql_query", return_value=group_query_response),
+        ):
+            counts = self._sync(
+                [_pages_response([_event()])],
+                person_uuids={"jane@acme.com": person_uuid},
+            )
+
+        assert Meeting.objects.for_team(self.team.id).get().account_id == account.id
+        assert counts.matched == 1
+
     def test_removed_attendee_is_deleted_on_resync(self):
         self._sync([_pages_response([_event()])])
         assert MeetingParticipant.objects.for_team(self.team.id).count() == 2


### PR DESCRIPTION
## Problem

Calendar syncs fail when meeting attendees match accounts through person group membership.

The group query formatter treats the HogQL attendee placeholder as a Python format field and raises `KeyError` before executing the query.

Part of #76088.

## Changes

- Preserve the attendee placeholder while substituting the configured account group column.
- Cover attendee-to-person-to-account matching with a regression test.

## How did you test this code?

- The new test reproduced the formatting `KeyError` before the fix.
- Local: `hogli test products/customer_analytics/backend/test/test_calendar_sync.py`.
- Local: `hogli ci:preflight --fix`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No user-facing workflow changed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi authored the fix with the `/writing-tests`, `/running-ci-preflight`, `/writing-pr-descriptions`, `/establishing-code-ownership`, and `/merging-prs` skills.

The regression fixture is invented and contains no session-derived operational data.
