### PR TITLE
fix(personhog): install rustls provider in the test harness

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8663,6 +8663,7 @@ dependencies = [
  "personhog-proto",
  "rand 0.8.5",
  "rdkafka",
+ "rustls 0.23.37",
  "serde_json",
  "sqlx",
  "tokio",

--- a/rust/personhog-test-harness/Cargo.toml
+++ b/rust/personhog-test-harness/Cargo.toml
@@ -23,6 +23,7 @@ k8s-openapi = { version = "0.24", features = ["latest"] }
 kube = { version = "0.98", features = ["client"] }
 rand = { workspace = true }
 rdkafka = { workspace = true }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 serde_json = { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true }

--- a/rust/personhog-test-harness/src/main.rs
+++ b/rust/personhog-test-harness/src/main.rs
@@ -17,6 +17,15 @@ use cli::{Cli, Command};
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Install a process-wide rustls CryptoProvider before any TLS use.
+    // kube's client resolves it lazily, so without this the first chaos
+    // scenario's Kubernetes API call panics its worker while plaintext
+    // traffic carries on — chaos dies silently. Mirrors the leader and
+    // router mains.
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("failed to install rustls ring CryptoProvider");
+
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::try_from_default_env()


### PR DESCRIPTION
## Problem

kube's client resolves the process-level CryptoProvider lazily, so the first chaos scenario's Kubernetes API call panicked its worker while plaintext traffic carried on and chaos died silently. Install ring at main start, as the leader and router already do.

## Changes

- install the crypto provider at start