### PR TITLE
feat(replay-vision): create a scanner from replay filters

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5964,6 +5964,10 @@ snapshots:
         hash: v1.k794b7964.9621e94ace22f6b0c839d8f7890e3cdf4aa9951c7bfee8f2a089e46a5f7f977a.dZbjaDtE-CMiMTkhTxV1u5NVSvEugAeaZ5oBS64HcH4
     replay-tabs-home-filters-banner--product-analytics-under-limit--light:
         hash: v1.k794b7964.621980b6676868038ef6fda307d5b134d3879bc0638acf8936832351dc325f9e.q32al8_1uMGCjpaxXcoxMHz611C3uiHkep-dhcwXkjM
+    replay-tabs-home-filters-banner--scanner-cross-sell--dark:
+        hash: v1.k794b7964.4b7a86e24d7b4aecd1b2051c74066379234055102679d2cd9e3377cabfec1c85.lU1XSNZg9HsA_jvvHz2_-MCOut14PyOkhmtd0y58ryA
+    replay-tabs-home-filters-banner--scanner-cross-sell--light:
+        hash: v1.k794b7964.2ebece8a17cef6899018a8385b263e143b45c4d45dd1654c24e541f1ce9407e2.hqvO1qD8EnGP7XACzYjS7NbTi0zlhZw7rTCgJPrSTas
     replay-tabs-home-success--filters-expanded--dark:
         hash: v1.k794b7964.e85cac90eb14f279e3367d8d2ab0db3011d7bb6c5d85fee2fb5cd2d0095ea956.9KZY5n5cdZIaHcp8HzrLMg-rgB2x7i_uH93bqNN_MzU
     replay-tabs-home-success--filters-expanded--light:
@@ -6785,9 +6789,9 @@ snapshots:
     scenes-app-engineering-analytics-repo-overview--repo-overview--light:
         hash: v1.k794b7964.f709ff67c44f86f69d951fc6fbb18b17b6090f6c5793bf6bc16fc803e0a0498c.SmWuVYGMNsp3hU9ipmoQyalTt57uRsG0DrLJlw7LzPU
     scenes-app-engineering-analytics-repo-overview--repo-overview-with-trunk-queue-data--dark:
-        hash: v1.k794b7964.1a470083e7a94ff46652f4368277eae5d35c927d65b58685e43ce34881e1e728.JjIWr0Wfj8Nzl407D1c7pkfeDecNV2UVZEKUSyLdGrE
+        hash: v1.k794b7964.99bcc4aa618c0c6ceb0f5589213426fb51865d6353f30beaed25b64578f5ffc0.F-ci8KA9aLO2BdWqAoyqoJe0vw3cdwL870yzUWI1ilI
     scenes-app-engineering-analytics-repo-overview--repo-overview-with-trunk-queue-data--light:
-        hash: v1.k794b7964.f709ff67c44f86f69d951fc6fbb18b17b6090f6c5793bf6bc16fc803e0a0498c.CCyr3jIgq9vy0b1RORwsIhSMVbL0qyRKSNgdK6Y_oZg
+        hash: v1.k794b7964.fb0d3e9e51c16c40878d5b96d93d31aad8842801049a97f647ad0635b4a224c4.a9xQ7QWBiUGQMZHwjUBzX1e93fYB2mxdleiXIswFwnM
     scenes-app-engineering-analytics-run-activity-chart--default--dark:
         hash: v1.k794b7964.7f17c5ac7c6862493f7c4d59e6e3c3146c42e3d7b08908ee1716d387c129ba64.lPsE9KrOSZee9wJq8zjqYnvk09numvEFWOn4mdCOgJE
     scenes-app-engineering-analytics-run-activity-chart--default--light:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5965,9 +5965,9 @@ snapshots:
     replay-tabs-home-filters-banner--product-analytics-under-limit--light:
         hash: v1.k794b7964.621980b6676868038ef6fda307d5b134d3879bc0638acf8936832351dc325f9e.q32al8_1uMGCjpaxXcoxMHz611C3uiHkep-dhcwXkjM
     replay-tabs-home-filters-banner--scanner-cross-sell--dark:
-        hash: v1.k794b7964.4b7a86e24d7b4aecd1b2051c74066379234055102679d2cd9e3377cabfec1c85.lU1XSNZg9HsA_jvvHz2_-MCOut14PyOkhmtd0y58ryA
+        hash: v1.k794b7964.c27886267fbfa39c64398e447e3cf63d5929fc3c9ede6fc8bf9c30bfaeea87a7.YxiOImD793nydIZ3ort6IyBzGmOcsZQb9RmqCuyx0tk
     replay-tabs-home-filters-banner--scanner-cross-sell--light:
-        hash: v1.k794b7964.2ebece8a17cef6899018a8385b263e143b45c4d45dd1654c24e541f1ce9407e2.hqvO1qD8EnGP7XACzYjS7NbTi0zlhZw7rTCgJPrSTas
+        hash: v1.k794b7964.6cf63eeaf5abe507d73ec12a3ec9f404ce02e3c07e0aab059a3a1ea97ccfeb8d.O72XHqs276ly-AWZdwJvr_leOyBMigsKLK1SWFQ3XBo
     replay-tabs-home-success--filters-expanded--dark:
         hash: v1.k794b7964.e85cac90eb14f279e3367d8d2ab0db3011d7bb6c5d85fee2fb5cd2d0095ea956.9KZY5n5cdZIaHcp8HzrLMg-rgB2x7i_uH93bqNN_MzU
     replay-tabs-home-success--filters-expanded--light:

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -529,6 +529,7 @@ export const FEATURE_FLAGS = {
     UX_HIDE_PROJECT_NOTICE: 'ux-hide-project-notice', // owner: #team-platform-ux, hides the project notice banner across all scenes
     UX_REMOVE_SIDEPANEL: 'ux-remove-sidepanel', // owner: #team-surveys
     VISION_ENTRYPOINT_EXPERIMENTS: 'vision-entrypoint-experiments', // owner: #team-replay, cross-sell entry points from experiments
+    VISION_ENTRYPOINT_REPLAY_FILTERS: 'vision-entrypoint-replay-filters', // owner: #team-replay, cross-sell entry point from the replay filters panel
     VISION_GOAL_BASED_CREATION_FLOW: 'vision-goal-based-creation-flow', // owner: #team-replay multivariate=control,test — gate on === 'test'; a truthy check turns on for control too
     VISUAL_REVIEW: 'visual-review', // owner: #team-devex
     WAREHOUSE_MULTI_DESTINATION: 'warehouse-multi-destination', // owner: #team-warehouse-sources

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -40080,6 +40080,7 @@
                 "feature flag created",
                 "session_replay_set_filters",
                 "session_replay_experiment_link_clicked",
+                "session_replay_save_filters_as_scanner",
                 "error_tracking_exception_autocapture_enabled",
                 "error_tracking_issue_sorting",
                 "error_tracking_docs_viewed",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -10172,6 +10172,7 @@ export enum ProductIntentContext {
     // Session Replay
     SESSION_REPLAY_SET_FILTERS = 'session_replay_set_filters',
     SESSION_REPLAY_EXPERIMENT_LINK_CLICKED = 'session_replay_experiment_link_clicked',
+    SESSION_REPLAY_SAVE_FILTERS_AS_SCANNER = 'session_replay_save_filters_as_scanner',
 
     // Error Tracking
     ERROR_TRACKING_EXCEPTION_AUTOCAPTURE_ENABLED = 'error_tracking_exception_autocapture_enabled',

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.stories.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react'
 import { combineUrl } from 'kea-router'
 
+import { FEATURE_FLAGS } from 'lib/constants'
 import { App } from 'scenes/App'
 import recordingEventsJson from 'scenes/session-recordings/__mocks__/recording_events_query'
 import { recordingPlaylists } from 'scenes/session-recordings/__mocks__/recording_playlists'
@@ -64,4 +65,15 @@ export const ProductAnalyticsUnderLimit: Story = {
             },
         }),
     ],
+}
+
+// The footer action row with the Replay vision cross-sell shown, so the divider that splits it
+// from the filter-management buttons stays covered by visual review. The non-default date range
+// puts the filter count above zero, which is what makes the button actionable.
+export const ScannerCrossSell: Story = {
+    parameters: {
+        featureFlags: [FEATURE_FLAGS.VISION_ENTRYPOINT_REPLAY_FILTERS],
+        pageUrl: combineUrl(urls.replay(), { showFilters: true, filters: { date_from: '-7d' } }).url,
+        testOptions: { waitForSelector: '[data-attr="replay-save-filters-as-scanner"]' },
+    },
 }

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.stories.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.stories.tsx
@@ -68,12 +68,21 @@ export const ProductAnalyticsUnderLimit: Story = {
 }
 
 // The footer action row with the Replay vision cross-sell shown, so the divider that splits it
-// from the filter-management buttons stays covered by visual review. The non-default date range
-// puts the filter count above zero, which is what makes the button actionable.
+// from the filter-management buttons stays covered by visual review. The event filter is what makes
+// the button actionable: a scanner keeps neither the date range nor pinned sessions, so filtering by
+// those alone leaves it disabled.
 export const ScannerCrossSell: Story = {
     parameters: {
         featureFlags: [FEATURE_FLAGS.VISION_ENTRYPOINT_REPLAY_FILTERS],
-        pageUrl: combineUrl(urls.replay(), { showFilters: true, filters: { date_from: '-7d' } }).url,
+        pageUrl: combineUrl(urls.replay(), {
+            showFilters: true,
+            filters: {
+                filter_group: {
+                    type: 'AND',
+                    values: [{ type: 'AND', values: [{ id: '$pageview', name: '$pageview', type: 'events' }] }],
+                },
+            },
+        }).url,
         testOptions: { waitForSelector: '[data-attr="replay-save-filters-as-scanner"]' },
     },
 }

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx'
 import { deepEqual as equal } from 'fast-equals'
 import { BindLogic, useActions, useMountedLogic, useValues } from 'kea'
+import { combineUrl, router } from 'kea-router'
 import { useEffect, useId, useRef, useState } from 'react'
 
 import {
@@ -51,15 +52,17 @@ import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { getProjectEventExistence } from 'lib/utils/getAppContext'
+import { addProductIntentForCrossSell } from 'lib/utils/product-intents'
 import { TestAccountFilter } from 'scenes/insights/filters/TestAccountFilter'
 import { MaxTool } from 'scenes/max/MaxTool'
 import { TimestampFormatToLabel } from 'scenes/session-recordings/utils'
+import { urls } from 'scenes/urls'
 
 import { actionsModel } from '~/models/actionsModel'
 import { cohortsModel } from '~/models/cohortsModel'
 import { groupsModel } from '~/models/groupsModel'
 import { AndOrFilterSelect } from '~/queries/nodes/InsightViz/PropertyGroupFilters/AndOrFilterSelect'
-import { NodeKind, RecordingsQuery } from '~/queries/schema/schema-general'
+import { NodeKind, ProductIntentContext, ProductKey, RecordingsQuery } from '~/queries/schema/schema-general'
 import {
     PropertyFilterType,
     PropertyOperator,
@@ -86,6 +89,7 @@ import { ProductAnalyticsOverLimitBanner } from './ProductAnalyticsOverLimitBann
 import {
     DEFAULT_RECORDING_FILTERS_ORDER_BY,
     DURATION_KEYS,
+    convertUniversalFiltersToRecordingsQuery,
     deriveOperand,
     isValidRecordingOrder,
     recordingsQueryToUniversalFilters,
@@ -1030,6 +1034,27 @@ export const ReplayFiltersTab = ({
                         )}
                         <div className="flex gap-2 ml-auto">
                             {resetButton}
+                            <LemonButton
+                                type="secondary"
+                                size="small"
+                                data-attr="replay-save-filters-as-scanner"
+                                tooltip="Create a Replay Vision scanner that keeps watching sessions matching these filters"
+                                onClick={() => {
+                                    const query = convertUniversalFiltersToRecordingsQuery(filters)
+                                    void addProductIntentForCrossSell({
+                                        from: ProductKey.SESSION_REPLAY,
+                                        to: ProductKey.REPLAY_VISION,
+                                        intent_context: ProductIntentContext.SESSION_REPLAY_SAVE_FILTERS_AS_SCANNER,
+                                    })
+                                    router.actions.push(
+                                        combineUrl(urls.replayVisionScannerConfigure('new'), {
+                                            filters: JSON.stringify(query),
+                                        }).url
+                                    )
+                                }}
+                            >
+                                Create scanner from filters
+                            </LemonButton>
                             <LemonButton type="primary" size="small" onClick={() => setIsSaveFiltersModalOpen(true)}>
                                 Save as new filter
                             </LemonButton>

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -744,6 +744,7 @@ export const ReplayFiltersTab = ({
         featureFlags[FEATURE_FLAGS.TAXONOMIC_FILTER_CATEGORY_DROPDOWN]
     )
     const showFeedbackButton = useFeatureFlag('SHOW_REPLAY_FILTERS_FEEDBACK_BUTTON')
+    const scannerCrossSellEnabled = useFeatureFlag('VISION_ENTRYPOINT_REPLAY_FILTERS')
 
     useMountedLogic(cohortsModel)
     useMountedLogic(actionsModel)
@@ -1034,27 +1035,37 @@ export const ReplayFiltersTab = ({
                         )}
                         <div className="flex gap-2 ml-auto">
                             {resetButton}
-                            <LemonButton
-                                type="secondary"
-                                size="small"
-                                data-attr="replay-save-filters-as-scanner"
-                                tooltip="Create a Replay Vision scanner that keeps watching sessions matching these filters"
-                                onClick={() => {
-                                    const query = convertUniversalFiltersToRecordingsQuery(filters)
-                                    void addProductIntentForCrossSell({
-                                        from: ProductKey.SESSION_REPLAY,
-                                        to: ProductKey.REPLAY_VISION,
-                                        intent_context: ProductIntentContext.SESSION_REPLAY_SAVE_FILTERS_AS_SCANNER,
-                                    })
-                                    router.actions.push(
-                                        combineUrl(urls.replayVisionScannerConfigure('new'), {
-                                            filters: JSON.stringify(query),
-                                        }).url
-                                    )
-                                }}
-                            >
-                                Create scanner from filters
-                            </LemonButton>
+                            {scannerCrossSellEnabled && (
+                                <LemonButton
+                                    type="secondary"
+                                    size="small"
+                                    data-attr="replay-save-filters-as-scanner"
+                                    tooltip="Create a Replay Vision scanner that keeps watching sessions matching these filters. The date range doesn't carry over, so the scanner watches sessions from now on."
+                                    disabledReason={
+                                        (totalFiltersCount ?? 0) === 0
+                                            ? 'Add a filter first. A scanner with no filters watches every session.'
+                                            : undefined
+                                    }
+                                    onClick={() => {
+                                        // Session IDs pin the query to recordings that already exist, and nothing
+                                        // downstream removes them, so a scanner built from them would match nothing
+                                        // ever while looking healthy in the list.
+                                        const query = convertUniversalFiltersToRecordingsQuery(stripSessionIds(filters))
+                                        void addProductIntentForCrossSell({
+                                            from: ProductKey.SESSION_REPLAY,
+                                            to: ProductKey.REPLAY_VISION,
+                                            intent_context: ProductIntentContext.SESSION_REPLAY_SAVE_FILTERS_AS_SCANNER,
+                                        })
+                                        router.actions.push(
+                                            combineUrl(urls.replayVisionScannerConfigure('new'), {
+                                                filters: JSON.stringify(query),
+                                            }).url
+                                        )
+                                    }}
+                                >
+                                    Create scanner from filters
+                                </LemonButton>
+                            )}
                             <LemonButton type="primary" size="small" onClick={() => setIsSaveFiltersModalOpen(true)}>
                                 Save as new filter
                             </LemonButton>

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -16,6 +16,7 @@ import {
     IconRefresh,
     IconRevert,
     IconSearch,
+    IconSparkles,
     IconTrash,
     IconX,
 } from '@posthog/icons'
@@ -1034,38 +1035,47 @@ export const ReplayFiltersTab = ({
                             </LemonButton>
                         )}
                         <div className="flex gap-2 ml-auto">
-                            {resetButton}
                             {scannerCrossSellEnabled && (
-                                <LemonButton
-                                    type="secondary"
-                                    size="small"
-                                    data-attr="replay-save-filters-as-scanner"
-                                    tooltip="Create a Replay Vision scanner that keeps watching sessions matching these filters. The date range doesn't carry over, so the scanner watches sessions from now on."
-                                    disabledReason={
-                                        (totalFiltersCount ?? 0) === 0
-                                            ? 'Add a filter first. A scanner with no filters watches every session.'
-                                            : undefined
-                                    }
-                                    onClick={() => {
-                                        // Session IDs pin the query to recordings that already exist, and nothing
-                                        // downstream removes them, so a scanner built from them would match nothing
-                                        // ever while looking healthy in the list.
-                                        const query = convertUniversalFiltersToRecordingsQuery(stripSessionIds(filters))
-                                        void addProductIntentForCrossSell({
-                                            from: ProductKey.SESSION_REPLAY,
-                                            to: ProductKey.REPLAY_VISION,
-                                            intent_context: ProductIntentContext.SESSION_REPLAY_SAVE_FILTERS_AS_SCANNER,
-                                        })
-                                        router.actions.push(
-                                            combineUrl(urls.replayVisionScannerConfigure('new'), {
-                                                filters: JSON.stringify(query),
-                                            }).url
-                                        )
-                                    }}
-                                >
-                                    Create scanner from filters
-                                </LemonButton>
+                                <>
+                                    <LemonButton
+                                        type="secondary"
+                                        size="small"
+                                        icon={<IconSparkles className="text-ai" />}
+                                        data-attr="replay-save-filters-as-scanner"
+                                        tooltip="Create a Replay vision scanner that keeps watching sessions matching these filters. The date range does not carry over, so the scanner watches sessions from now on."
+                                        disabledReason={
+                                            (totalFiltersCount ?? 0) === 0
+                                                ? 'Add a filter first. A scanner with no filters watches every session.'
+                                                : undefined
+                                        }
+                                        onClick={() => {
+                                            // Session IDs pin the query to recordings that already exist, and nothing
+                                            // downstream removes them, so a scanner built from them would match
+                                            // nothing ever while looking healthy in the list.
+                                            const query = convertUniversalFiltersToRecordingsQuery(
+                                                stripSessionIds(filters)
+                                            )
+                                            void addProductIntentForCrossSell({
+                                                from: ProductKey.SESSION_REPLAY,
+                                                to: ProductKey.REPLAY_VISION,
+                                                intent_context:
+                                                    ProductIntentContext.SESSION_REPLAY_SAVE_FILTERS_AS_SCANNER,
+                                            })
+                                            router.actions.push(
+                                                combineUrl(urls.replayVisionScannerConfigure('new'), {
+                                                    filters: JSON.stringify(query),
+                                                }).url
+                                            )
+                                        }}
+                                    >
+                                        Create scanner
+                                    </LemonButton>
+                                    {/* Grouped away from the buttons that act on the filters themselves:
+                                        this one leaves for another product. */}
+                                    <LemonDivider vertical className="mx-1 self-stretch" />
+                                </>
                             )}
+                            {resetButton}
                             <LemonButton type="primary" size="small" onClick={() => setIsSaveFiltersModalOpen(true)}>
                                 Save as new filter
                             </LemonButton>

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx'
 import { deepEqual as equal } from 'fast-equals'
 import { BindLogic, useActions, useMountedLogic, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
-import { useEffect, useId, useRef, useState } from 'react'
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
 
 import {
     IconAsterisk,
@@ -74,6 +74,7 @@ import {
 
 import { useAttachedContext, useMcpToolApplyBack } from 'products/posthog_ai/frontend/api/logics'
 import type { AttachedContextItem } from 'products/posthog_ai/frontend/api/types'
+import { scannerHandoffFromFilters } from 'products/replay_vision/frontend/replay_scanners/scannerHandoffFromFilters'
 
 import { sessionRecordingSavedFiltersLogic } from '../filters/sessionRecordingSavedFiltersLogic'
 import { TimestampFormat, playerSettingsLogic } from '../player/playerSettingsLogic'
@@ -90,7 +91,6 @@ import { ProductAnalyticsOverLimitBanner } from './ProductAnalyticsOverLimitBann
 import {
     DEFAULT_RECORDING_FILTERS_ORDER_BY,
     DURATION_KEYS,
-    convertUniversalFiltersToRecordingsQuery,
     deriveOperand,
     isValidRecordingOrder,
     recordingsQueryToUniversalFilters,
@@ -746,6 +746,9 @@ export const ReplayFiltersTab = ({
     )
     const showFeedbackButton = useFeatureFlag('SHOW_REPLAY_FILTERS_FEEDBACK_BUTTON')
     const scannerCrossSellEnabled = useFeatureFlag('VISION_ENTRYPOINT_REPLAY_FILTERS')
+    // A scanner keeps less of the filter set than this panel does, so what it would actually watch
+    // decides both the destination and whether the button is worth offering.
+    const scannerHandoff = useMemo(() => scannerHandoffFromFilters(filters), [filters])
 
     useMountedLogic(cohortsModel)
     useMountedLogic(actionsModel)
@@ -1044,17 +1047,11 @@ export const ReplayFiltersTab = ({
                                         data-attr="replay-save-filters-as-scanner"
                                         tooltip="Create a Replay vision scanner that keeps watching sessions matching these filters. The date range does not carry over, so the scanner watches sessions from now on."
                                         disabledReason={
-                                            (totalFiltersCount ?? 0) === 0
-                                                ? 'Add a filter first. A scanner with no filters watches every session.'
-                                                : undefined
+                                            scannerHandoff.narrowsSessions
+                                                ? undefined
+                                                : 'Add an event or property filter. A date range and pinned sessions do not carry over to a scanner.'
                                         }
                                         onClick={() => {
-                                            // Session IDs pin the query to recordings that already exist, and nothing
-                                            // downstream removes them, so a scanner built from them would match
-                                            // nothing ever while looking healthy in the list.
-                                            const query = convertUniversalFiltersToRecordingsQuery(
-                                                stripSessionIds(filters)
-                                            )
                                             void addProductIntentForCrossSell({
                                                 from: ProductKey.SESSION_REPLAY,
                                                 to: ProductKey.REPLAY_VISION,
@@ -1062,9 +1059,10 @@ export const ReplayFiltersTab = ({
                                                     ProductIntentContext.SESSION_REPLAY_SAVE_FILTERS_AS_SCANNER,
                                             })
                                             router.actions.push(
-                                                combineUrl(urls.replayVisionScannerConfigure('new'), {
-                                                    filters: JSON.stringify(query),
-                                                }).url
+                                                combineUrl(
+                                                    urls.replayVisionScannerConfigure('new'),
+                                                    scannerHandoff.searchParams
+                                                ).url
                                             )
                                         }}
                                     >

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -3586,6 +3586,7 @@ class ProductIntentContext(StrEnum):
     FEATURE_FLAG_CREATED = "feature flag created"
     SESSION_REPLAY_SET_FILTERS = "session_replay_set_filters"
     SESSION_REPLAY_EXPERIMENT_LINK_CLICKED = "session_replay_experiment_link_clicked"
+    SESSION_REPLAY_SAVE_FILTERS_AS_SCANNER = "session_replay_save_filters_as_scanner"
     ERROR_TRACKING_EXCEPTION_AUTOCAPTURE_ENABLED = "error_tracking_exception_autocapture_enabled"
     ERROR_TRACKING_ISSUE_SORTING = "error_tracking_issue_sorting"
     ERROR_TRACKING_DOCS_VIEWED = "error_tracking_docs_viewed"

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
@@ -24,7 +24,7 @@ import {
 import { readScannerDraft, writeScannerDraft } from './scannerDraft'
 import { scannerEditorSceneLogic } from './scannerEditorSceneLogic'
 import { observationsDrilldownSearchParams } from './scannerOverviewLogic'
-import { defaultScannerTemplates } from './scannerTemplates'
+import { defaultScannerTemplates, newScanner } from './scannerTemplates'
 import { ClassifierScanner, ReplayScanner, ScorerScanner } from './types'
 
 jest.mock('lib/forms/scrollToFormError', () => ({
@@ -102,6 +102,36 @@ describe('replayScannerLogic', () => {
                     scanner_type: template.scanner_type,
                     scanner_config: template.scanner_config,
                 }),
+            })
+        })
+
+        it('new scanner seeds its query from a ?filters= deep link', async () => {
+            const query = {
+                kind: 'RecordingsQuery',
+                events: [{ id: '$pageview', name: '$pageview', type: 'events' }],
+            }
+            router.actions.push('/replay-vision/new', { filters: JSON.stringify(query) })
+            await expectLogic(logic, () => logic.actions.loadScanner()).toMatchValues({
+                scanner: expect.objectContaining({ query: expect.objectContaining({ events: query.events }) }),
+            })
+        })
+
+        it('a ?filters= deep link outranks a saved draft', async () => {
+            const query = { kind: 'RecordingsQuery', events: [{ id: '$autocapture', type: 'events' }] }
+            writeScannerDraft(teamLogic.values.currentTeamId!, { ...newScanner(null), name: 'stale draft' })
+            router.actions.push('/replay-vision/new', { filters: JSON.stringify(query) })
+            await expectLogic(logic, () => logic.actions.loadScanner()).toMatchValues({
+                scanner: expect.objectContaining({
+                    name: '',
+                    query: expect.objectContaining({ events: query.events }),
+                }),
+            })
+        })
+
+        it('a malformed ?filters= param falls back to the blank wizard', async () => {
+            router.actions.push('/replay-vision/new', { filters: 'not-json{' })
+            await expectLogic(logic, () => logic.actions.loadScanner()).toMatchValues({
+                scanner: expect.objectContaining({ name: '', scanner_type: 'monitor' }),
             })
         })
     })

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
@@ -128,8 +128,14 @@ describe('replayScannerLogic', () => {
             })
         })
 
-        it('a malformed ?filters= param falls back to the blank wizard', async () => {
-            router.actions.push(urls.replayVisionScannerConfigure('new'), { filters: 'not-json{' })
+        // A crafted or truncated param must not reach the filter UI, which spreads what it gets:
+        // a list field holding a string renders one filter per character.
+        it.each([
+            ['unparseable JSON', 'not-json{'],
+            ['a JSON array', '[]'],
+            ['a list field that is not a list', '{"kind":"RecordingsQuery","events":"x"}'],
+        ])('a ?filters= param carrying %s falls back to the blank wizard', async (_label, filters) => {
+            router.actions.push(urls.replayVisionScannerConfigure('new'), { filters })
             await expectLogic(logic, () => logic.actions.loadScanner()).toMatchValues({
                 scanner: expect.objectContaining({
                     scanner_type: 'monitor',

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
@@ -150,6 +150,25 @@ describe('replayScannerLogic', () => {
             await expectLogic(logic, () => logic.actions.loadScanner()).toFinishAllListeners()
             expect(router.values.searchParams.filters).toBeUndefined()
         })
+
+        // The replay filters entry point sends both when the filters scope to an experiment, since
+        // exposure can't ride inside the query. Keeping only the targeting would silently widen the
+        // scanner to every session; keeping only the filters would drop the experiment entirely.
+        it('combines an experiment deep link with a ?filters= query rather than dropping either', async () => {
+            useMocks({
+                get: { '/api/projects/:team/experiments/:id/': () => [200, { id: 7, name: 'Checkout redesign' }] },
+            })
+            const query = { kind: 'RecordingsQuery', events: [{ id: '$pageview', type: 'events' }] }
+            router.actions.push(urls.replayVisionScannerConfigure('new'), {
+                experiment: '7',
+                filters: JSON.stringify(query),
+            })
+
+            await expectLogic(logic, () => logic.actions.loadScanner()).toFinishAllListeners()
+
+            expect(logic.values.scanner?.experiment_targeting).toMatchObject({ experiment_id: 7 })
+            expect(logic.values.scanner?.query).toMatchObject({ events: query.events })
+        })
     })
 
     describe('draftScannerFromGoal', () => {

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
@@ -110,7 +110,7 @@ describe('replayScannerLogic', () => {
                 kind: 'RecordingsQuery',
                 events: [{ id: '$pageview', name: '$pageview', type: 'events' }],
             }
-            router.actions.push('/replay-vision/new', { filters: JSON.stringify(query) })
+            router.actions.push(urls.replayVisionScannerConfigure('new'), { filters: JSON.stringify(query) })
             await expectLogic(logic, () => logic.actions.loadScanner()).toMatchValues({
                 scanner: expect.objectContaining({ query: expect.objectContaining({ events: query.events }) }),
             })
@@ -119,25 +119,28 @@ describe('replayScannerLogic', () => {
         it('a ?filters= deep link outranks a saved draft', async () => {
             const query = { kind: 'RecordingsQuery', events: [{ id: '$autocapture', type: 'events' }] }
             writeScannerDraft(teamLogic.values.currentTeamId!, { ...newScanner(null), name: 'stale draft' })
-            router.actions.push('/replay-vision/new', { filters: JSON.stringify(query) })
+            router.actions.push(urls.replayVisionScannerConfigure('new'), { filters: JSON.stringify(query) })
             await expectLogic(logic, () => logic.actions.loadScanner()).toMatchValues({
                 scanner: expect.objectContaining({
-                    name: '',
+                    name: newScanner(null, teamLogic.values.currentTeam?.name).name,
                     query: expect.objectContaining({ events: query.events }),
                 }),
             })
         })
 
         it('a malformed ?filters= param falls back to the blank wizard', async () => {
-            router.actions.push('/replay-vision/new', { filters: 'not-json{' })
+            router.actions.push(urls.replayVisionScannerConfigure('new'), { filters: 'not-json{' })
             await expectLogic(logic, () => logic.actions.loadScanner()).toMatchValues({
-                scanner: expect.objectContaining({ name: '', scanner_type: 'monitor' }),
+                scanner: expect.objectContaining({
+                    scanner_type: 'monitor',
+                    query: { kind: 'RecordingsQuery' },
+                }),
             })
         })
 
         it('strips the consumed ?filters= param, so a reload does not re-seed over the user edits', async () => {
             const query = { kind: 'RecordingsQuery', events: [{ id: '$pageview', type: 'events' }] }
-            router.actions.push('/replay-vision/new', { filters: JSON.stringify(query) })
+            router.actions.push(urls.replayVisionScannerConfigure('new'), { filters: JSON.stringify(query) })
             await expectLogic(logic, () => logic.actions.loadScanner()).toFinishAllListeners()
             expect(router.values.searchParams.filters).toBeUndefined()
         })

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
@@ -134,6 +134,13 @@ describe('replayScannerLogic', () => {
                 scanner: expect.objectContaining({ name: '', scanner_type: 'monitor' }),
             })
         })
+
+        it('strips the consumed ?filters= param, so a reload does not re-seed over the user edits', async () => {
+            const query = { kind: 'RecordingsQuery', events: [{ id: '$pageview', type: 'events' }] }
+            router.actions.push('/replay-vision/new', { filters: JSON.stringify(query) })
+            await expectLogic(logic, () => logic.actions.loadScanner()).toFinishAllListeners()
+            expect(router.values.searchParams.filters).toBeUndefined()
+        })
     })
 
     describe('draftScannerFromGoal', () => {
@@ -618,6 +625,23 @@ describe('replayScannerLogic', () => {
             logic.unmount()
 
             router.actions.push(urls.replayVisionScannerConfigure('new'), { experiment: '7' })
+            logic = replayScannerLogic({ id: 'new' })
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(readScannerDraft(teamId)?.scanner.name).toBe('Drafted')
+        })
+
+        it('preserves an existing draft when the wizard is entered from a ?filters= deep link', async () => {
+            // The prefill outranks the draft for this entry but must not delete it; without the
+            // restoringDraft guard, persistDraft sees scanner === originalScanner and clears it.
+            const teamId = teamLogic.values.currentTeamId!
+            logic.actions.setScannerValues({ name: 'Drafted' })
+            expect(readScannerDraft(teamId)?.scanner.name).toBe('Drafted')
+            logic.unmount()
+
+            const query = { kind: 'RecordingsQuery', events: [{ id: '$pageview', type: 'events' }] }
+            router.actions.push(urls.replayVisionScannerConfigure('new'), { filters: JSON.stringify(query) })
             logic = replayScannerLogic({ id: 'new' })
             logic.mount()
             await expectLogic(logic).toFinishAllListeners()

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -1671,6 +1671,12 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                         router.actions.replace(router.values.location.pathname, nextParams, router.values.hashParams)
                     }
                     if (experimentParams) {
+                        // The two deep links combine rather than compete: the replay filters entry
+                        // point sends targeting and filters together, because exposure can't ride
+                        // inside `query` and dropping either one silently rescopes the scanner.
+                        const experimentBase = prefillQuery
+                            ? { ...newScanner(templateKey, teamName), query: prefillQuery }
+                            : newScanner(templateKey, teamName)
                         // An experiment deep link expresses fresh intent, so it outranks a saved
                         // draft; restoringDraft guards persistDraft so the prefill can't clobber the
                         // draft this user may already have for the next plain entry.
@@ -1681,7 +1687,7 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                                 experiment,
                                 variantKey: reconcileVariantKey(experiment, experimentParams.variantKey),
                             }
-                            const prefilled = prefillScannerForExperiment(newScanner(templateKey, teamName), context)
+                            const prefilled = prefillScannerForExperiment(experimentBase, context)
                             // Set the context only after the prefill is built, so a throw inside it
                             // doesn't leave a dangling context that the next startFromTemplate re-applies.
                             actions.setExperimentContext(context)
@@ -1690,7 +1696,9 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                             // Clear any context a partial run left set before surfacing the failure.
                             actions.setExperimentContext(null)
                             lemonToast.error("Couldn't load the experiment. Set recording filters manually instead.")
-                            actions.loadScannerSuccess(newScanner(templateKey, teamName))
+                            // Keep the filters that came with the link: they're the part of the
+                            // hand-off that survived, and re-entering them by hand is the fallback.
+                            actions.loadScannerSuccess(experimentBase)
                         } finally {
                             cache.restoringDraft = false
                         }

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -1625,10 +1625,12 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                     // free-text goal. A URL carrying both ?filters= and ?goal= deterministically
                     // takes the filters and drops the goal.
                     const hasFiltersPrefill = 'filters' in router.values.searchParams
+                    const prefillQuery = prefillQueryFromUrl()
                     // Strip the params the wizard has now consumed so a reload doesn't re-run the prefill
                     // over the user's edits: an unknown template that fell back to from-scratch (a valid
-                    // template stays), the experiment deep-link params, and the goal param. One replace
-                    // covers all of them and preserves the URL hash, which a second back-to-back replace
+                    // template stays), the experiment deep-link params, the goal param, and the
+                    // `?filters=` prefill. One replace covers all of them and preserves the URL hash,
+                    // which a second back-to-back replace
                     // would drop.
                     const nextParams = { ...router.values.searchParams }
                     if (urlTemplateKey && !templateKey) {
@@ -1640,6 +1642,9 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                     }
                     if (nextParams.goal !== undefined) {
                         delete nextParams.goal
+                    }
+                    if ('filters' in nextParams) {
+                        delete nextParams.filters
                     }
                     if (Object.keys(nextParams).length !== Object.keys(router.values.searchParams).length) {
                         router.actions.replace(router.values.location.pathname, nextParams, router.values.hashParams)
@@ -1671,10 +1676,15 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                         return
                     }
                     // A `?filters=` deep link expresses fresh intent (e.g. "save these playlist
-                    // filters as a scanner"), so it seeds the query and outranks a saved draft.
-                    const prefillQuery = prefillQueryFromUrl()
+                    // filters as a scanner"), so it seeds the query and outranks a saved draft;
+                    // restoringDraft guards persistDraft so the prefill can't delete that draft.
                     if (prefillQuery) {
-                        actions.loadScannerSuccess({ ...newScanner(templateKey), query: prefillQuery })
+                        cache.restoringDraft = true
+                        try {
+                            actions.loadScannerSuccess({ ...newScanner(templateKey, teamName), query: prefillQuery })
+                        } finally {
+                            cache.restoringDraft = false
+                        }
                         return
                     }
                     cache.restoringDraft = true

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -124,6 +124,25 @@ function currentTemplateKey(): string | null {
     return typeof value === 'string' ? value : null
 }
 
+/**
+ * A `RecordingsQuery` handed to the new-scanner wizard via `?filters=<url-encoded JSON>`, used by
+ * cross-sell entry points (e.g. "save these filters as a scanner" in the replay playlist) to seed
+ * the scanner's query. Returns null on a missing or unparseable param so a malformed link just
+ * opens the blank wizard rather than throwing.
+ */
+function prefillQueryFromUrl(): RecordingsQuery | null {
+    const value = router.values.searchParams.filters
+    if (typeof value !== 'string' || !value) {
+        return null
+    }
+    try {
+        const parsed = JSON.parse(value)
+        return parsed && typeof parsed === 'object' ? (parsed as RecordingsQuery) : null
+    } catch {
+        return null
+    }
+}
+
 function defaultConfigForType(scannerType: ScannerType): ScannerConfig {
     if (scannerType === 'summarizer') {
         return { prompt: '', length: 'medium' }
@@ -1649,6 +1668,13 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                         } finally {
                             cache.restoringDraft = false
                         }
+                        return
+                    }
+                    // A `?filters=` deep link expresses fresh intent (e.g. "save these playlist
+                    // filters as a scanner"), so it seeds the query and outranks a saved draft.
+                    const prefillQuery = prefillQueryFromUrl()
+                    if (prefillQuery) {
+                        actions.loadScannerSuccess({ ...newScanner(templateKey), query: prefillQuery })
                         return
                     }
                     cache.restoringDraft = true

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -30,7 +30,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
-import type { RecordingsQuery } from '~/queries/schema/schema-general'
+import { NodeKind, type RecordingsQuery } from '~/queries/schema/schema-general'
 
 import {
     visionScannersAffectedCohortCreate,
@@ -124,11 +124,32 @@ function currentTemplateKey(): string | null {
     return typeof value === 'string' ? value : null
 }
 
+// The filter UI spreads each of these straight into its list of filter values, so a string here
+// renders one filter per character instead of failing.
+const PREFILL_QUERY_LIST_FIELDS = [
+    'events',
+    'actions',
+    'properties',
+    'console_log_filters',
+    'having_predicates',
+] as const
+
+function isValidPrefillQuery(parsed: unknown): parsed is RecordingsQuery {
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return false
+    }
+    const query = parsed as Record<string, unknown>
+    if ('kind' in query && query.kind !== NodeKind.RecordingsQuery) {
+        return false
+    }
+    return PREFILL_QUERY_LIST_FIELDS.every((field) => !(field in query) || Array.isArray(query[field]))
+}
+
 /**
  * A `RecordingsQuery` handed to the new-scanner wizard via `?filters=<url-encoded JSON>`, used by
  * cross-sell entry points (e.g. "save these filters as a scanner" in the replay playlist) to seed
- * the scanner's query. Returns null on a missing or unparseable param so a malformed link just
- * opens the blank wizard rather than throwing.
+ * the scanner's query. Returns null on a missing, unparseable, or wrong-shaped param so a malformed
+ * link just opens the blank wizard rather than throwing or rendering nonsense filters.
  */
 function prefillQueryFromUrl(): RecordingsQuery | null {
     const value = router.values.searchParams.filters
@@ -137,7 +158,7 @@ function prefillQueryFromUrl(): RecordingsQuery | null {
     }
     try {
         const parsed = JSON.parse(value)
-        return parsed && typeof parsed === 'object' ? (parsed as RecordingsQuery) : null
+        return isValidPrefillQuery(parsed) ? parsed : null
     } catch {
         return null
     }

--- a/products/replay_vision/frontend/replay_scanners/scannerHandoffFromFilters.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerHandoffFromFilters.test.ts
@@ -1,0 +1,96 @@
+import { defaultRecordingDurationFilter } from 'scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic'
+
+import {
+    FilterLogicalOperator,
+    PropertyFilterType,
+    PropertyOperator,
+    RecordingDurationFilter,
+    RecordingUniversalFilters,
+    UniversalFiltersGroupValue,
+} from '~/types'
+
+import { scannerHandoffFromFilters } from './scannerHandoffFromFilters'
+
+/** A default replay filter set, with `values` filling the inner filter group the converter reads. */
+function filters(
+    partial: Partial<RecordingUniversalFilters> & { values?: UniversalFiltersGroupValue[] } = {}
+): RecordingUniversalFilters {
+    const { values = [], ...rest } = partial
+    return {
+        filter_test_accounts: false,
+        date_from: '-3d',
+        date_to: null,
+        duration: [defaultRecordingDurationFilter],
+        order: 'start_time',
+        order_direction: 'DESC',
+        filter_group: {
+            type: FilterLogicalOperator.And,
+            values: [{ type: FilterLogicalOperator.And, values }],
+        },
+        ...rest,
+    } as RecordingUniversalFilters
+}
+
+const PAGEVIEW = { id: '$pageview', type: 'events' } as unknown as UniversalFiltersGroupValue
+const LONG_SESSIONS: RecordingDurationFilter = {
+    type: PropertyFilterType.Recording,
+    key: 'active_seconds',
+    value: 600,
+    operator: PropertyOperator.GreaterThan,
+}
+
+function handoffQuery(f: RecordingUniversalFilters): Record<string, any> {
+    return JSON.parse(scannerHandoffFromFilters(f).searchParams.filters)
+}
+
+describe('scannerHandoffFromFilters', () => {
+    // A scanner carrying session IDs is pinned to recordings that already exist, so it matches
+    // nothing ever while still looking healthy in the scanner list.
+    it('drops pinned session IDs from the query', () => {
+        const query = handoffQuery(filters({ values: [PAGEVIEW], session_ids: ['abc-123'] }))
+
+        expect(query.session_ids).toBeUndefined()
+        expect(query.events).toHaveLength(1)
+    })
+
+    // The API rejects exposure inside `query`, so leaving it there opens a wizard that can't be
+    // saved. It has to travel as the experiment deep link the wizard access-checks instead.
+    it('sends experiment exposure as targeting params, never inside the query', () => {
+        const { searchParams } = scannerHandoffFromFilters(
+            filters({ values: [PAGEVIEW], experiment_exposure: { experiment_id: 42, variant: 'test' } })
+        )
+
+        expect(searchParams).toMatchObject({ experiment: '42', variant: 'test' })
+        expect(JSON.parse(searchParams.filters)).not.toHaveProperty('experiment_exposure')
+    })
+
+    it('omits the variant param when the filters cover every variant', () => {
+        const { searchParams } = scannerHandoffFromFilters(
+            filters({ values: [PAGEVIEW], experiment_exposure: { experiment_id: 42 } })
+        )
+
+        expect(searchParams.experiment).toEqual('42')
+        expect(searchParams).not.toHaveProperty('variant')
+    })
+
+    describe('narrowsSessions', () => {
+        // Guards the one-click path to a scanner pointed at every session: the replay list counts
+        // these as filters, but a scanner keeps none of them.
+        it.each([
+            ['an untouched filter set', filters()],
+            ['only a date range', filters({ date_from: '-7d' })],
+            ['only pinned session IDs', filters({ session_ids: ['abc-123'] })],
+            ['only the default duration floor', filters({ duration: [defaultRecordingDurationFilter] })],
+        ])('is false for %s', (_label, f) => {
+            expect(scannerHandoffFromFilters(f).narrowsSessions).toBe(false)
+        })
+
+        it.each([
+            ['an event filter', filters({ values: [PAGEVIEW] })],
+            ['a duration the user moved off the default', filters({ duration: [LONG_SESSIONS] })],
+            ['experiment exposure', filters({ experiment_exposure: { experiment_id: 42 } })],
+        ])('is true for %s', (_label, f) => {
+            expect(scannerHandoffFromFilters(f).narrowsSessions).toBe(true)
+        })
+    })
+})

--- a/products/replay_vision/frontend/replay_scanners/scannerHandoffFromFilters.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerHandoffFromFilters.ts
@@ -1,0 +1,64 @@
+import { objectsEqual } from 'lib/utils/objects'
+import { convertUniversalFiltersToRecordingsQuery } from 'scenes/session-recordings/filters/recordingsQueryConversions'
+import { stripSessionIds } from 'scenes/session-recordings/playlist/playlistUtils'
+import { defaultRecordingDurationFilter } from 'scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic'
+import { filtersFromUniversalFilterGroups } from 'scenes/session-recordings/utils'
+
+import type { RecordingUniversalFilters } from '~/types'
+
+import { experimentScannerParams } from './experimentTargeting'
+
+/** The wizard hand-off for "create a scanner from these replay filters". */
+export interface ScannerHandoffFromFilters {
+    /** Params for the new-scanner wizard URL: the encoded query, plus experiment targeting when the filters carry it. */
+    searchParams: Record<string, string>
+    /**
+     * Whether the resulting scanner would watch a subset of sessions rather than all of them.
+     *
+     * Deliberately not the replay list's filter count, which also counts the date range and pinned
+     * session IDs. A scanner keeps neither, so counting them offers a one-click path to a scanner
+     * aimed at every session.
+     */
+    narrowsSessions: boolean
+}
+
+/**
+ * Converts the replay list's filters into the scanner the wizard should open with.
+ *
+ * A scanner keeps less of a filter set than this panel does, and each difference fails silently:
+ * the dropped pieces save into a scanner that matches nothing, or one that matches everything, and
+ * both look healthy in the scanner list. So the lossy fields are resolved here rather than at the
+ * call site.
+ *
+ * - Session IDs pin the query to recordings that already exist. Nothing downstream removes them and
+ *   the sweep only moves forward, so a scanner carrying them never matches again.
+ * - Experiment exposure is rejected inside `query` by the API, which resolves it from
+ *   `experiment_targeting` at scan time so the experiment stays behind that field's access check.
+ *   Left in, the wizard can't be saved; dropped, the scanner silently widens past the experiment.
+ *   It becomes the wizard's experiment deep link instead, which carries the same targeting the
+ *   experiment's own entry point uses.
+ * - The date range is dropped by the backend on save, because a scanner's schedule owns time.
+ */
+export function scannerHandoffFromFilters(filters: RecordingUniversalFilters): ScannerHandoffFromFilters {
+    const { experiment_exposure: exposure, ...query } = convertUniversalFiltersToRecordingsQuery(
+        stripSessionIds(filters)
+    )
+
+    return {
+        searchParams: {
+            filters: JSON.stringify(query),
+            ...(exposure
+                ? experimentScannerParams({
+                      experimentId: exposure.experiment_id,
+                      variantKey: exposure.variant ?? null,
+                  })
+                : {}),
+        },
+        narrowsSessions:
+            filtersFromUniversalFilterGroups(filters).length > 0 ||
+            // Every filter set carries a duration floor, so only one the user moved off the default
+            // counts as narrowing.
+            (filters.duration ?? []).some((predicate) => !objectsEqual(predicate, defaultRecordingDurationFilter)) ||
+            !!exposure,
+    }
+}


### PR DESCRIPTION
## Problem

Replay users who dial in a useful set of recording filters have no way to keep watching for sessions that match them. Turning those filters into a Replay vision scanner today means rebuilding the query by hand in the scanner wizard.

## Changes

- Adds a "Create scanner" button to the replay filters panel footer, behind `vision-entrypoint-replay-filters`.
- The button converts the current filters to a recordings query and opens the scanner wizard with it encoded in a `?filters=` URL param. Session IDs are stripped first: they pin the query to recordings that already exist, so a scanner built from them would match nothing ever while still looking healthy in the list.
- The wizard seeds a new scanner's query from that param, and the param outranks a locally saved draft. A malformed or wrong-shaped param falls back to the blank wizard.
- Clicking fires a `session_replay` -> `replay_vision` product intent (`SESSION_REPLAY_SAVE_FILTERS_AS_SCANNER`).

The button carries the sparkle icon in the shared AI colour and sits on its own side of a divider, because it is the one control in the row that leaves for another product instead of acting on the filters. It is disabled until at least one filter is set, and its tooltip says the date range does not carry over.

**Flag on**

<img width="1030" alt="Filters panel footer with the Create scanner button" src="https://raw.githubusercontent.com/PostHog/pr-assets/c6160cc73a64ca5dfef1f997a61a510b45190818/2026/09/cd8d7553-ba81-4ec3-9e9b-2f6d3d9ab3e8.png" />

**Flag off**

<img width="1030" alt="The same footer with the flag off: no button and no leftover divider" src="https://raw.githubusercontent.com/PostHog/pr-assets/c6160cc73a64ca5dfef1f997a61a510b45190818/2026/09/f9b769c2-b56e-4ce4-a34c-215b767740c3.png" />

## How did you test this code?

- `replayScannerLogic.test.ts` passes locally (143 tests), covering the `?filters=` prefill, its precedence over a saved draft, that the consumed param is stripped, and three malformed-param shapes.
- Rendered both states in Storybook at 1600px and 1000px (screenshots above). The sparkle resolves to the shared `--color-ai` token rather than a one-off purple, and with the flag off neither the button nor an orphan divider renders.
- Frontend typecheck and lint report nothing on the touched files.
- Not checked: click-through in a running app against real data.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code. Skills invoked: /writing-user-facing-copy, /writing-ui-components, /writing-tests.
- The action started in the playlist bulk-actions menu behind a `vision-entrypoint-replay-playlist` flag, then moved to the filters panel.
- Rebased onto master after the `?goal=` prefill landed. The two share the wizard entry point, with an explicit precedence: experiment deep link, then `?filters=`, then a saved draft, then the free-text goal.
- `vision-entrypoint-replay-filters` exists in production, created disabled with an internal-only release condition staged for the first rollout step. Nothing renders until someone activates it.
- The storybook baseline commit from the original branch was dropped during the rebase; the baselines need regenerating against current master.
