### PR TITLE
feat(persons): add person_pg_cleanup_queue table

### DIFF
--- a/rust/persons_migrations/20260807000001_add_person_pg_cleanup_queue.sql
+++ b/rust/persons_migrations/20260807000001_add_person_pg_cleanup_queue.sql
@@ -1,0 +1,29 @@
+-- Handoff queue from the ClickHouse cleanup sweep to the Postgres one.
+--
+-- The ClickHouse sweep hard-deletes a deleted person's rows, and once it does,
+-- the tombstones it derived that set from are gone. So it records each person
+-- here first, and a later job drains this queue to clear posthog_person and
+-- posthog_persondistinctid.
+--
+-- team_id is carried because posthog_person is 64-way HASH (team_id): the
+-- drain resolves uuid -> id through the unique (team_id, uuid) index, which
+-- prunes to one partition. Without team_id it fans out across all 64.
+--
+-- Only the person UUID is stored. ClickHouse has no integer person id, so the
+-- BIGINT posthog_person.id is resolved by the drain rather than carried here.
+--
+-- SAFE: creates a new empty table and index only; takes no locks on existing
+-- tables. Idempotent and safe to re-run.
+
+CREATE TABLE IF NOT EXISTS person_pg_cleanup_queue (
+    team_id     INTEGER NOT NULL,
+    person_uuid UUID NOT NULL,
+    deleted_at  TIMESTAMP WITH TIME ZONE NOT NULL,  -- when the ClickHouse sweep finished
+    cleaned_at  TIMESTAMP WITH TIME ZONE,
+    PRIMARY KEY (team_id, person_uuid)              -- lets the sweep re-run without duplicating rows
+);
+
+-- Drain scan: least-recently-queued rows still awaiting Postgres cleanup.
+CREATE INDEX IF NOT EXISTS person_pg_cleanup_queue_drain
+    ON person_pg_cleanup_queue (deleted_at)
+    WHERE cleaned_at IS NULL;


### PR DESCRIPTION
## Problem

Nothing records which persons the ClickHouse cleanup sweep deletes, so no follow-on job can clear their rows from `posthog_person` and `posthog_persondistinctid`.

The sweep hard-deletes the tombstones it derives that list from, so the list is unrecoverable once it runs. It has to be written down before the delete, not reconstructed after.

## Changes

- Adds `person_pg_cleanup_queue` to the persons database. Schema only; nothing reads or writes it yet.
- Stores `team_id` because `posthog_person` is 64-way hash partitioned on it. The drain resolves uuid to id through the unique `(team_id, uuid)` index, which prunes to one partition.
- Stores only the person UUID. ClickHouse has no integer person id, so the drain resolves `posthog_person.id` itself.
- Indexes `deleted_at` partially on `cleaned_at IS NULL`, so the drain pages oldest-first and skips rows it already finished.
- Creates the index without `CONCURRENTLY`. The runner wraps each file in one transaction, which rules that out, and the table is empty inside that transaction anyway.

This is the first of four PRs. The rest move the two weekly ClickHouse cleanup sweeps off Celery into a Dagster job, then add `person_distinct_id2` cleanup that writes here.

## How did you test this code?

I (actually Claude) ran the checks below. No manual product testing happened.

- Applied the file to a scratch Postgres database, then applied it a second time. Both runs succeeded, so the `IF NOT EXISTS` guards make it re-runnable.
- Seeded 200k rows, 20k of them with `cleaned_at IS NULL`, and ran `EXPLAIN ANALYZE` on the drain query. The planner picks the partial index and returns 1000 rows with no sort step.
- Not run: the repo test suites and the local dev persons database. No code path references the table in this PR.

No tests added. The file has no behavior to exercise, and the PR that writes to this table will assert the schema through its own tests.

<details>
<summary>EXPLAIN ANALYZE on the drain query</summary>

```
Limit (actual time=0.008..0.173 rows=1000 loops=1)
  Buffers: shared hit=89
  ->  Index Scan using person_pg_cleanup_queue_drain on person_pg_cleanup_queue (actual time=0.007..0.143 rows=1000 loops=1)
        Buffers: shared hit=89
Planning Time: 0.108 ms
Execution Time: 0.206 ms
```

</details>

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Nothing user-facing changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude Opus 5, via Claude Code) wrote this under Eli's direction, after researching the existing cleanup paths and confirming the deployment facts against the charts repository.

Skills invoked: `/writing-pr-descriptions`, `/django-migrations`. The migrations skill covers Django only, and this is a sqlx file for the persons database, which has no Django connection. Its index and locking guidance is what transferred, and it is why the index is plain rather than concurrent.

Two decisions worth a reviewer's attention. `cleaned_at` is in the initial schema rather than a later migration, because deleting rows as they drain would lose the audit trail, and a partial index on a queue that empties stays cheaper than a total one. The table lives in the persons database rather than the main one so the drain can commit its person deletes and its queue advance in a single transaction.

Public artifact: everything in this diff and description comes from this repository and the charts repository. No customer or session material is present.
