### PR TITLE
fix(desktop/sidebar): stop marking a finished session as pending

### DIFF
--- a/products/desktop/packages/core/src/sidebar/buildSidebarData.test.ts
+++ b/products/desktop/packages/core/src/sidebar/buildSidebarData.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { limitTasksPerGroup, sliceVisibleTasks } from "./buildSidebarData";
+import {
+  limitTasksPerGroup,
+  readRunMode,
+  sliceVisibleTasks,
+} from "./buildSidebarData";
 import type { TaskData, TaskGroup } from "./sidebarData.types";
 
 function makeTask(id: string): TaskData {
@@ -72,5 +76,21 @@ describe("limitTasksPerGroup", () => {
     const { groups: limited, hasMore } = limitTasksPerGroup(groups, 25);
     expect(limited[0]).toBe(groups[0]);
     expect(hasMore).toBe(false);
+  });
+});
+
+// The mode decides whether a run's `in_progress` is a claim that work is
+// happening. Defaulting the wrong way marks every finished interactive session
+// as pending, which is what this replaced.
+describe("readRunMode", () => {
+  it.each([
+    ["an interactive run", { mode: "interactive" }, "interactive"],
+    ["a background run", { mode: "background" }, "background"],
+    // The backend's own default for a run whose state never carried a mode.
+    ["a run with no mode", {}, "background"],
+    ["a run with no state at all", undefined, "background"],
+    ["a mode that is not a mode", { mode: 7 }, "background"],
+  ])("reads %s", (_case, state, expected) => {
+    expect(readRunMode(state)).toBe(expected);
   });
 });

--- a/products/desktop/packages/core/src/sidebar/buildSidebarData.ts
+++ b/products/desktop/packages/core/src/sidebar/buildSidebarData.ts
@@ -33,7 +33,30 @@ export interface SidebarTask {
     status?: TaskRunStatus | null;
     environment?: "local" | "cloud" | null;
     output?: { pr_url?: unknown } | null;
+    /** "interactive" or "background"; see `readRunMode`. */
+    mode?: RunMode | null;
   } | null;
+}
+
+/**
+ * Whether anyone is expected to follow the run. The backend keeps an
+ * interactive run `in_progress` after it succeeds, on purpose — the session
+ * stays open for a follow-up, so that status is not a claim that work is
+ * happening. Only a background run is one-shot, and only its `in_progress`
+ * means the agent is still on it.
+ */
+export type RunMode = "interactive" | "background";
+
+/**
+ * The run's mode, off the untyped `state` bag the backend stores it in. It
+ * defaults to background there, so an absent value defaults the same way here.
+ */
+export function readRunMode(state: unknown): RunMode {
+  const mode =
+    state && typeof state === "object"
+      ? (state as { mode?: unknown }).mode
+      : undefined;
+  return mode === "interactive" ? "interactive" : "background";
 }
 
 // Accepts both the local `FullTask` shape and the canonical `Task` from
@@ -52,6 +75,7 @@ export function narrowFullTask(task: FullTask | Task): SidebarTask {
           status: task.latest_run.status,
           environment: task.latest_run.environment ?? null,
           output: task.latest_run.output ?? null,
+          mode: readRunMode(task.latest_run.state),
         }
       : null,
     origin_product: task.origin_product,
@@ -176,6 +200,7 @@ export function deriveTaskData(
     folderId: workspace?.folderId || undefined,
     taskRunStatus: session?.cloudStatus ?? task.latest_run?.status ?? undefined,
     taskRunEnvironment: task.latest_run?.environment ?? undefined,
+    runMode: task.latest_run?.mode ?? undefined,
     // The `latest_run` fallback only matters in the `showAllUsers` view: the
     // default view's `filterVisibleTasks` already restricts to tasks with a
     // local `workspace`, so a pure-cloud task without one only shows up there.

--- a/products/desktop/packages/core/src/sidebar/sidebarData.types.ts
+++ b/products/desktop/packages/core/src/sidebar/sidebarData.types.ts
@@ -1,5 +1,6 @@
 import type { WorkspaceMode } from "@posthog/shared";
 import type { TaskRunStatus } from "@posthog/shared/domain-types";
+import type { RunMode } from "./buildSidebarData";
 import type {
   TaskGroup as GenericTaskGroup,
   TaskRepositoryInfo,
@@ -19,6 +20,7 @@ export interface TaskData {
   folderId?: string;
   taskRunStatus?: TaskRunStatus;
   taskRunEnvironment?: "local" | "cloud";
+  runMode?: RunMode;
   workspaceMode?: WorkspaceMode;
   originProduct?: string;
   slackThreadUrl?: string;

--- a/products/desktop/packages/ui/src/features/browser-tabs/TaskTabIcon.tsx
+++ b/products/desktop/packages/ui/src/features/browser-tabs/TaskTabIcon.tsx
@@ -41,6 +41,7 @@ export function TaskTabIcon({
       isSuspended={taskData.isSuspended}
       needsPermission={taskData.needsPermission}
       taskRunStatus={taskData.taskRunStatus}
+      runMode={taskData.runMode}
       originProduct={taskData.originProduct}
       slackThreadUrl={taskData.slackThreadUrl}
       prState={prState}

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
@@ -78,12 +78,24 @@ describe("ChannelItemRow", () => {
     ],
     ["a streaming agent", { isGenerating: true }, "Working"],
     [
-      // The run says in_progress, but nothing is streaming: a local run never
-      // gets a terminal status written, and the cloud one holds in_progress past
-      // the agent. Live, but not moving — the still dot, not the spinner.
-      "a run claiming progress with nothing in flight",
-      { taskRunStatus: "in_progress" as const },
+      // A background run is one-shot and unattended, so its in_progress really
+      // is a claim that the agent is still on it. Live, but nothing streaming —
+      // the still dot, not the spinner.
+      "a background run claiming progress with nothing in flight",
+      { taskRunStatus: "in_progress" as const, runMode: "background" as const },
       "Pending — no work in flight",
+    ],
+    [
+      // The backend leaves an interactive run in_progress after it succeeds, so
+      // the session stays open for a follow-up. Reading that as a claim marked
+      // every finished session pending, forever, on a row opening it could not
+      // clear.
+      "an interactive run left in_progress after it finished",
+      {
+        taskRunStatus: "in_progress" as const,
+        runMode: "interactive" as const,
+      },
+      "All caught up",
     ],
     [
       // Launching: a sandbox is being claimed and the backend leaves this state
@@ -93,10 +105,10 @@ describe("ChannelItemRow", () => {
       "Starting",
     ],
     [
-      // A local run's status is never advanced, so queued here means "was
-      // launched at some point", not "is starting". Seen parked for hours.
-      "a local run parked at queued",
-      { taskRunStatus: "queued" as const },
+      // A background run's status is never advanced once it parks, so queued
+      // here means "was launched at some point", not "is starting".
+      "a local background run parked at queued",
+      { taskRunStatus: "queued" as const, runMode: "background" as const },
       "Pending — no work in flight",
     ],
     [
@@ -123,13 +135,18 @@ describe("ChannelItemRow", () => {
       // opening the PR; under a merge queue that wait can outlast the agent by
       // hours, so the PR's existence has to win over the run's claim.
       "a run still babysitting CI behind an open PR",
-      { taskRunStatus: "in_progress" as const, prState: "open" as const },
+      {
+        taskRunStatus: "in_progress" as const,
+        runMode: "background" as const,
+        prState: "open" as const,
+      },
       "All caught up",
     ],
     [
       "a run whose PR url is known but state isn't",
       {
         taskRunStatus: "in_progress" as const,
+        runMode: "background" as const,
         prUrl: "https://github.com/PostHog/code/pull/1",
       },
       "All caught up",

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTaskStatus.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTaskStatus.ts
@@ -49,6 +49,7 @@ export function useChannelTaskStatus(
     isSuspended: taskData.isSuspended,
     needsPermission: taskData.needsPermission,
     taskRunStatus: taskData.taskRunStatus,
+    runMode: taskData.runMode,
     originProduct: taskData.originProduct,
     slackThreadUrl: taskData.slackThreadUrl,
     prState,

--- a/products/desktop/packages/ui/src/features/sidebar/components/TaskListView.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/TaskListView.tsx
@@ -117,6 +117,7 @@ function TaskRow({
       isPinned={task.isPinned}
       needsPermission={task.needsPermission}
       taskRunStatus={task.taskRunStatus}
+      runMode={task.runMode}
       originProduct={task.originProduct}
       slackThreadUrl={task.slackThreadUrl}
       prState={prState}

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
@@ -17,6 +17,7 @@ import {
   SlackLogo,
   WarningCircle,
 } from "@phosphor-icons/react";
+import type { RunMode } from "@posthog/core/sidebar/buildSidebarData";
 import type { WorkspaceMode } from "@posthog/shared";
 import {
   isTerminalStatus,
@@ -274,6 +275,8 @@ export interface TaskIconProps {
   isSuspended?: boolean;
   needsPermission?: boolean;
   taskRunStatus?: TaskRunStatus;
+  /** Whether anyone follows this run. Only a background run's status claims work. */
+  runMode?: RunMode;
   originProduct?: string;
   /** Pre-built URL to the originating Slack thread (read from
    * `task.latest_run.state.slack_thread_url`). When set, the Slack icon

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
@@ -1,4 +1,5 @@
 import { Archive, GitPullRequest, PushPin } from "@phosphor-icons/react";
+import type { RunMode } from "@posthog/core/sidebar/buildSidebarData";
 import { parseGithubUrl } from "@posthog/git/utils";
 import type { WorkspaceMode } from "@posthog/shared";
 import { formatRelativeTimeShort } from "@posthog/shared";
@@ -45,6 +46,7 @@ interface TaskItemProps {
   isSuspended?: boolean;
   needsPermission?: boolean;
   taskRunStatus?: TaskRunStatus;
+  runMode?: RunMode;
   originProduct?: string;
   slackThreadUrl?: string;
   prState?: SidebarPrState;
@@ -117,6 +119,7 @@ export function TaskItem({
   isPinned = false,
   needsPermission = false,
   taskRunStatus,
+  runMode,
   originProduct,
   slackThreadUrl,
   prState,
@@ -143,6 +146,7 @@ export function TaskItem({
       isSuspended={isSuspended}
       needsPermission={needsPermission}
       taskRunStatus={taskRunStatus}
+      runMode={runMode}
       originProduct={originProduct}
       slackThreadUrl={slackThreadUrl}
       prState={prState}

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.ts
@@ -148,12 +148,14 @@ export function taskDot(props: TaskStatusInput): TaskDot {
       label: props.isGenerating ? "Working" : "Starting",
     };
   }
-  // The statuses that lie. Nothing writes a terminal status when a local agent
-  // goes idle, and the cloud workflow holds in_progress while it babysits CI, so
-  // the claim outlives the work, sometimes for the row's whole life. Live, but
-  // nothing moving: the still dot.
+  // Only a background run's status is a claim about work. An interactive run is
+  // left `in_progress` after it succeeds, deliberately — the session stays open
+  // for a follow-up, so the status says "followable", not "working". Reading it
+  // as a claim marked every finished session as pending, on a row nobody could
+  // clear: opening the session writes a viewed timestamp, not a status.
   const runClaimsWork =
-    props.taskRunStatus === "in_progress" || props.taskRunStatus === "queued";
+    props.runMode === "background" &&
+    (props.taskRunStatus === "in_progress" || props.taskRunStatus === "queued");
   if (runClaimsWork && !hasPullRequest(props)) {
     return {
       tone: "yellow",


### PR DESCRIPTION
## Problem

A session you finished keeps a filled dot in the sidebar for the rest of its life, and opening it does not clear it.

- The dot reads the run's `in_progress` as a claim that work is happening, and labels it "Pending — no work in flight".
- For an interactive run that status is not a claim. `_maybe_record_terminal_status` leaves it `in_progress` after a success on purpose, so the session stays followable, and a parameterized test locks that in as `("interactive", "completed", None)`.
- So the status never leaves `in_progress`, and nothing a reader does moves it. Opening the session writes a viewed timestamp, which feeds `isUnread`, not the run's status.
- Only a background run is one-shot and unattended. The workflow marks those terminal when it reclaims the sandbox, so only their `in_progress` means the agent is still on it.

## Changes

- `taskDot` treats `in_progress` and `queued` as a claim of work only for a background run. An interactive one falls through to the quiet dot.
- `readRunMode` reads the mode off `latest_run.state`, the untyped bag the backend stores it in, and defaults to background exactly as the backend's own `TaskRun.mode` does.
- `SidebarTask`, `TaskData` and `TaskIconProps` carry `runMode`, so the sidebar rows, the space tree, the command palette and the browser tab icon all read one value.
- A run whose mode never arrives reads as background. That direction is the safe one: the dot can under-report a stalled background run, and cannot mark a finished session pending again.

Gating the display, rather than writing a terminal status from the agent, is what makes this correct. My first attempt did the latter, and it contradicted the backend decision above — an interactive run has to stay `in_progress` to stay followable, so marking it completed would have traded a wrong dot for a broken session.

## How did you test this code?

I (actually Claude) wrote and ran the automated tests below. I did not test this manually.

- `readRunMode` gets 5 cases: both modes, a run with no mode, no state at all, and a mode that is not a string. The default is the whole point, and getting it backwards restores the bug for every run.
- The dot vocabulary table gains the case this fixes: an interactive run left `in_progress` reads "All caught up".
- The existing "run claiming progress with nothing in flight" case is now explicitly a background run, which is the only run that still claims work.
- Two PR-override cases now set `runMode: "background"`. They exist to prove a PR beats a work claim, so they need a run that makes one.

**Not checked:** the running app. The fix depends on `latest_run.state.mode` arriving on the task DTO, which I read from the backend model and the workflow rather than from a live response.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No doc describes what a run's status means to the client.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I am Claude Opus 5, working in Claude Code. [Session](https://claude.ai/code/session_01XSPQAQGhxP3jGyXDLkmLWE).

Skills invoked: `/posthog-desktop` for the tree's toolchain and scope, `/writing-tests` before touching the tests, `/test-electron-app` to read the running app's accessibility tree, and `/writing-pr-descriptions` for this body.

Adam found this from the symptom: clicking into a session with a coloured dot did not clear it. The dot turned out not to be the unread dot, so the fix he remembered for unread activity (#78708) correctly did not apply.

This branch first carried an agent-side change that wrote `completed` when an interactive turn ended. I replaced it after finding the backend keeps those runs `in_progress` deliberately. The earlier approach is not in the diff.

**Public artifact:** nothing here draws on a customer conversation, ticket, or log.
