### PR TITLE
fix(signals): guard scout scan windows against timezone-shifted literals

### DIFF
--- a/products/signals/skills/authoring-scouts/SKILL.md
+++ b/products/signals/skills/authoring-scouts/SKILL.md
@@ -100,6 +100,12 @@ When the project's metrics catalog is enabled, it may hold a governed definition
 Where a governed metric exists, reference it by name in any `references/queries.md` you ship, and label every hand-written derivation there a noncanonical fallback — an unlabeled "validated query" outranks the harness's catalog-first rule at run time, which is exactly how a scout ends up re-deriving a number the team already governs.
 Freshness, availability, and schema checks are exempt: they stay schema-first, with no catalog detour.
 
+A third rule binds any scout that **scans on a time window** — which is most of them.
+Two clocks are in play: HogQL resolves a naive datetime literal in the _project's_ timezone, while everything the harness hands a run (`started_at`, run rows, scratchpad timestamps) is UTC.
+Mixing them shifts a scan window by the project's UTC offset, and when that offset exceeds the scan interval the window lands entirely in the future — the query returns zero rows on a live surface and the run closes out "quiet" with nothing having errored.
+Prefer `now() - INTERVAL N` arithmetic, make the zone explicit on any literal you do write, and give the scout a way to tell a broken window from a quiet surface.
+[`references/scout-anatomy.md`](references/scout-anatomy.md) has the rules and the control-count pattern that catches it.
+
 ## Run posture (config)
 
 A scout's schedule and emit behavior live on its `SignalScoutConfig`, separate from the skill body.

--- a/products/signals/skills/authoring-scouts/references/scout-anatomy.md
+++ b/products/signals/skills/authoring-scouts/references/scout-anatomy.md
@@ -8,6 +8,7 @@ Keep the body lean and push depth into references — every line of the body is 
 - Naming
 - Frontmatter
 - Body structure (the ten canonical sections)
+- Time bounds and incremental scans
 - References
 - Skeleton — specialist scout
 - Skeleton — broad / cross-product scout
@@ -109,6 +110,43 @@ The fleet's specialists all share this shape:
 
 Not every scout needs all ten sections, but every scout needs 1 (discriminator), 2 (quick close-out), 3 (orient), 7 (decide), 8 (disqualifiers), and 10 (close out).
 Sections 4–6 and 9 are where a specialist earns its keep.
+
+## Time bounds and incremental scans
+
+Two clocks are in play on every run, and mixing them silently corrupts a scan.
+HogQL resolves a **naive** datetime literal in the **project's** timezone, so `toDateTime('2026-01-02 10:00:00')` is project-local, not UTC.
+Everything the harness hands a scout — `started_at`, run rows, scratchpad timestamps — is UTC.
+A scout that keeps a UTC cursor and interpolates it into a naive literal therefore reads a window shifted by the project's UTC offset.
+
+The failure mode is silent and total rather than partial.
+When the offset exceeds the scan interval, the whole window lands in the future, the query returns zero rows on a busy surface, and the run closes out "quiet" with a confident summary.
+Nothing errors, so the scout advances its cursor and overwrites its baselines with zeros — and does it again on every subsequent run.
+A window shorter than the offset is the dangerous case; a longer one still returns rows, just the wrong ones, which is harder to notice.
+
+**Rules for any scout that scans on a time window:**
+
+1. **Prefer relative arithmetic.** `now() - INTERVAL N DAY` needs no literal and cannot be misread. Reach for a literal only when you genuinely need a fixed boundary.
+2. **When you do write a literal, make the zone explicit** — `toDateTime('<ts>', 'UTC')`, or an ISO-8601 string with a `Z` suffix. Never a bare `toDateTime('YYYY-MM-DD HH:MM:SS')`.
+3. **Read timestamps back in the zone you store them in** — `toTimeZone(timestamp, 'UTC') AS ts_utc` — so the cursor you write matches the cursor you read.
+4. **Store instants in UTC, not project-local time.** Across a DST transition a local wall-clock cursor is ambiguous for one hour and nonexistent for another, so it can double-scan or skip an hour.
+5. **Bucket in project time deliberately.** `toDate()` and `toStartOfDay()` already resolve in the project's timezone — usually what you want for day-grain analysis, but it means a UTC cursor and a `toDate()` bucket are two different clocks in one query. Know which you're using and why.
+
+### Prove a zero before you trust it
+
+Prevention leaks, so a scout that scans incrementally shouldn't be able to report "nothing new" without evidence.
+Pair the incremental window with a broad control over the same source:
+
+```sql
+SELECT
+  countIf(timestamp >= toDateTime('<cursor>', 'UTC')) AS window_rows,
+  countIf(timestamp >= now() - INTERVAL 7 DAY)        AS control_rows
+FROM events
+WHERE event = '<the watched event>'
+```
+
+`window_rows` at zero alongside a healthy `control_rows` means the **window** is broken, not that the surface is quiet.
+Treat it as a scan fault: don't advance the cursor, don't overwrite a good baseline with zeros, and don't close out quiet.
+State both counts in the close-out so the next run — and a human reading the summary — can tell a genuinely idle surface from a blind one.
 
 ## References
 

--- a/products/signals/skills/signals-scout-product-analytics/SKILL.md
+++ b/products/signals/skills/signals-scout-product-analytics/SKILL.md
@@ -82,6 +82,10 @@ For each watchlist flow whose cadence is due (default: re-score daily flows ~dai
 
 Spend a slice of each run widening coverage: pull any newly-saved funnel/retention/lifecycle insights (by `created_at` / `last_modified_at` recency in `system.insights`) and add the strong ones; refresh the inferred flow if the activation milestones changed. Importance decays — every few days reconcile the watchlist against what's actually saved and viewed; retire flows whose insights were deleted.
 
+**Timezone footgun:** HogQL parses a naive timestamp literal in the _project_ timezone, not UTC, so a UTC cursor interpolated into a bare `toDateTime('…')` shifts the window by the project's offset — and when that offset exceeds your run interval the whole window lands in the future, so the scan returns nothing on a project that is editing flows all day. Use `now() - INTERVAL N DAY` for recency windows; when you need a fixed boundary, write `toDateTime('<ts>', 'UTC')`.
+
+**Prove a zero before you trust it.** If the incremental scan finds no modified insights, re-count over a broad window (e.g. 7d) before concluding nothing changed. A zero next to a healthy broad count means your window is wrong, not that the team stopped editing flows — don't advance the cursor on a scan you couldn't verify, and say both counts in the close-out.
+
 ### Save memory as you go
 
 Maintain the watchlist and baselines as you work, encoding the category in the key prefix so a future run finds it with one `text=` search:


### PR DESCRIPTION
## Problem

A scout that scans on a stored cursor can go silently blind: it reports "nothing new" on every run while the surface it watches is busy, and nothing errors.

- HogQL resolves a naive datetime literal in the *project's* timezone. Everything the harness hands a run (`started_at`, run rows, scratchpad timestamps) is UTC.
- A scout that keeps a UTC cursor and interpolates it into a bare `toDateTime('…')` reads a window shifted by the project's UTC offset.
- When the offset exceeds the scan interval, the whole window lands in the future and the query returns zero rows.
- The run then closes out quiet, advances its cursor, and overwrites its baselines with zeros. It repeats every run after that.
- `authoring-scouts` never mentioned this. Seven scout bodies had each written their own warning independently, which is the signal that it belonged in the shared guidance.

## Changes

- `authoring-scouts/SKILL.md` gains a third design rule, next to the discriminator and metric-catalog rules, for any scout that scans on a time window.
- `scout-anatomy.md` gains a "Time bounds and incremental scans" section with five rules: prefer `now() - INTERVAL N` arithmetic, make the zone explicit on any literal, read timestamps back in the zone you store them in, store instants in UTC, and bucket in project time deliberately.
- The same section adds a control-count check. A scout pairs its incremental window with a broad count over the same source, and treats a zero beside a healthy control as a broken window rather than a quiet surface.
- `signals-scout-product-analytics` gains both warnings inline. It scans `system.insights` on a cursor and carried no timezone guidance.

Rule 5 is the non-obvious one. `toDate()` and `toStartOfDay()` already resolve in project time, so a UTC cursor and a day bucket in the same query are two different clocks. That is a live footgun even for a scout whose literals are correct.

I rejected the simpler fix of standardising scouts on project-local time. It removes the naive-literal problem, but a local wall-clock cursor is ambiguous for one hour and nonexistent for another across a DST transition, so it trades a silent window shift for a silent double-scan or skip twice a year. Storing instants in UTC and bucketing in project time keeps both properties.

Prevention alone would not have caught this, which is why the control-count check is in scope. The guidance can only reach a scout author; the check reaches the run.

## How did you test this code?

- Ran the skills linter (`products/posthog_ai/scripts/build_skills.py --lint`): 142 skills pass. It flags 3 advisory stale-reference warnings, all pre-existing and in other products.
- No automated test covers scout prose, and this PR changes no Python. I did not run the backend suites.
- I have not observed a scout run against the edited `signals-scout-product-analytics` body. Canonical bodies reach teams through `lazy_seed` on the next coordinator tick, so that is only observable after merge.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The changed files are the scout authoring guidance and one scout body.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via the PostHog Slack app) wrote this. It started from a report that a scout was not surfacing anything, which turned out to be this bug rather than a quiet surface. Two read-only subagents then swept the fleet and the harness to find how far it reached.

Two findings changed the shape of the PR. There is no naive `toDateTime` in any canonical scout body, so patching skill bodies was the wrong layer: the bad SQL is improvised at run time by a model reconstituting a timestamp out of a free-text scratchpad cursor. And the project timezone is already injected into every scout run through the MCP environment block, so restating it in the Signals prompt would not have helped. That is why this PR changes guidance and adds a detection check, rather than adding a warning to all 28 scouts.

The structural fix is not here. The harness tells every scout to hand-roll its own cursor as prose (`scout_harness/prompt.py`, `_SCRATCHPAD_KEYS`) and `SignalScratchpad.content` is a plain `TextField`, so there is nowhere typed to keep an instant. Having the harness own the scan window, and having the inactivity sweep tell a blind scout apart from a quiet one, is a follow-up that touches the model, runner, and prompt. It deserves its own review.

Skills invoked: `/writing-pr-descriptions`. Repo skill guidance consulted: `products/signals/skills/CLAUDE.md`, `authoring-scouts`, `exploring-scouts`.

Please assign the requesting engineer as the DRI. I did not set an assignee because I could not verify their GitHub handle from this session, and I will not guess one.
