### PR TITLE
feat(clickhouse): add Dagster job for the weekly cleanup sweeps

### DIFF
--- a/posthog/clickhouse/cleanup_snapshots.py
+++ b/posthog/clickhouse/cleanup_snapshots.py
@@ -1,0 +1,145 @@
+"""Persisted worklists for the weekly ClickHouse cleanup sweep.
+
+The sweep destroys the tombstones its own worklists are derived from, so each stage has to be
+frozen before the first mutation. Runs share these tables and scope their rows by `run_id`
+instead of each creating and dropping their own, which would churn table DDL across every node
+every week. `run_id` leads every sort key so a run reads only its own rows through the primary
+index.
+"""
+
+from posthog.clickhouse.table_engines import ReplacingMergeTree
+
+CLEANUP_DELETED_PERSONS_TABLE = "clickhouse_cleanup_deleted_persons"
+CLEANUP_REVIVED_PERSONS_TABLE = "clickhouse_cleanup_revived_persons"
+CLEANUP_ORPHANED_DISTINCT_IDS_TABLE = "clickhouse_cleanup_orphaned_distinct_ids"
+CLEANUP_REVIVED_DISTINCT_IDS_TABLE = "clickhouse_cleanup_revived_distinct_ids"
+
+# A run's rows stay readable for a fortnight so a failed weekly sweep can still be inspected on the
+# next working day. A successful run clears its own rows, so this only ever covers failures.
+CLEANUP_SNAPSHOT_TTL_DAYS = 14
+
+
+def _cleanup_snapshot_table_sql(table_name: str, columns: str, sort_key: str) -> str:
+    # Partitioning by run id makes clearing a finished run a metadata-only DROP PARTITION instead
+    # of a mutation that rewrites every part. created_at is the ReplacingMergeTree version, and
+    # its sub-second resolution is what makes a retried populate deterministic: two inserts of the
+    # same key in the same second would otherwise tie and let merge order pick the survivor.
+    # ttl_only_drop_parts stops TTL merges from rewriting a part that holds any expired row; the
+    # TTL is a backstop for failed runs, so reclaiming whole parts late beats weekly rewrites.
+    return """
+CREATE TABLE IF NOT EXISTS {table_name}
+(
+    run_id String,
+    {columns},
+    created_at DateTime64(6, 'UTC') DEFAULT now64()
+) ENGINE = {engine}
+PARTITION BY run_id
+ORDER BY (run_id, {sort_key})
+TTL created_at + INTERVAL {ttl_days} DAY
+SETTINGS ttl_only_drop_parts = 1
+""".format(
+        table_name=table_name,
+        columns=columns,
+        engine=ReplacingMergeTree(table_name, ver="created_at"),
+        sort_key=sort_key,
+        ttl_days=CLEANUP_SNAPSHOT_TTL_DAYS,
+    )
+
+
+def _drop_cleanup_snapshot_table_sql(table_name: str) -> str:
+    return f"""
+DROP TABLE IF EXISTS {table_name}
+"""
+
+
+def CLEANUP_DELETED_PERSONS_TABLE_SQL():
+    """Persons the run will delete, one row each, with the version the run observed as latest.
+
+    `max_version` bounds the delete so a version written after the snapshot survives a run that
+    never saw it. It matches `person.version` (UInt64) so the dictionary attribute the delete
+    predicate reads compares against the source column without promotion.
+    """
+    return _cleanup_snapshot_table_sql(
+        CLEANUP_DELETED_PERSONS_TABLE,
+        "team_id Int64, person_id UUID, max_version UInt64",
+        "team_id, person_id",
+    )
+
+
+def CLEANUP_REVIVED_PERSONS_TABLE_SQL():
+    """Snapshotted persons that came back to life mid-run, and so must not be deleted.
+
+    Every dictionary over the worklists anti-joins this table, which is how a checkpoint drops a
+    key without mutating the worklist it came from.
+    """
+    return _cleanup_snapshot_table_sql(
+        CLEANUP_REVIVED_PERSONS_TABLE,
+        "team_id Int64, person_id UUID",
+        "team_id, person_id",
+    )
+
+
+def CLEANUP_ORPHANED_DISTINCT_IDS_TABLE_SQL():
+    """Distinct id mappings the run will delete, with the reason each one qualified.
+
+    `own_tombstone` distinguishes a mapping deleted in its own right from one deleted because its
+    owning person is going away. `max_version` matches `person_distinct_id2.version` (Int64).
+    """
+    return _cleanup_snapshot_table_sql(
+        CLEANUP_ORPHANED_DISTINCT_IDS_TABLE,
+        "team_id Int64, distinct_id String, person_id UUID, own_tombstone UInt8, max_version Int64",
+        "team_id, distinct_id",
+    )
+
+
+def CLEANUP_REVIVED_DISTINCT_IDS_TABLE_SQL():
+    """Snapshotted distinct id mappings that stopped qualifying mid-run."""
+    return _cleanup_snapshot_table_sql(
+        CLEANUP_REVIVED_DISTINCT_IDS_TABLE,
+        "team_id Int64, distinct_id String",
+        "team_id, distinct_id",
+    )
+
+
+def DROP_CLEANUP_DELETED_PERSONS_TABLE_SQL():
+    return _drop_cleanup_snapshot_table_sql(CLEANUP_DELETED_PERSONS_TABLE)
+
+
+def DROP_CLEANUP_REVIVED_PERSONS_TABLE_SQL():
+    return _drop_cleanup_snapshot_table_sql(CLEANUP_REVIVED_PERSONS_TABLE)
+
+
+def DROP_CLEANUP_ORPHANED_DISTINCT_IDS_TABLE_SQL():
+    return _drop_cleanup_snapshot_table_sql(CLEANUP_ORPHANED_DISTINCT_IDS_TABLE)
+
+
+def DROP_CLEANUP_REVIVED_DISTINCT_IDS_TABLE_SQL():
+    return _drop_cleanup_snapshot_table_sql(CLEANUP_REVIVED_DISTINCT_IDS_TABLE)
+
+
+CLEANUP_SNAPSHOT_TABLES = (
+    CLEANUP_DELETED_PERSONS_TABLE,
+    CLEANUP_REVIVED_PERSONS_TABLE,
+    CLEANUP_ORPHANED_DISTINCT_IDS_TABLE,
+    CLEANUP_REVIVED_DISTINCT_IDS_TABLE,
+)
+
+CLEANUP_SNAPSHOT_TABLE_SQL = (
+    CLEANUP_DELETED_PERSONS_TABLE_SQL,
+    CLEANUP_REVIVED_PERSONS_TABLE_SQL,
+    CLEANUP_ORPHANED_DISTINCT_IDS_TABLE_SQL,
+    CLEANUP_REVIVED_DISTINCT_IDS_TABLE_SQL,
+)
+
+DROP_CLEANUP_SNAPSHOT_TABLE_SQL = (
+    DROP_CLEANUP_DELETED_PERSONS_TABLE_SQL,
+    DROP_CLEANUP_REVIVED_PERSONS_TABLE_SQL,
+    DROP_CLEANUP_ORPHANED_DISTINCT_IDS_TABLE_SQL,
+    DROP_CLEANUP_REVIVED_DISTINCT_IDS_TABLE_SQL,
+)
+
+
+def TRUNCATE_CLEANUP_SNAPSHOT_TABLES_SQL():
+    # Unqualified so the test harness can match these against the tables ClickHouse reports as
+    # empty and skip the keeper round-trip.
+    return [f"TRUNCATE TABLE IF EXISTS {table_name}" for table_name in CLEANUP_SNAPSHOT_TABLES]

--- a/posthog/clickhouse/hcl/golden/local-multi/data.hcl
+++ b/posthog/clickhouse/hcl/golden/local-multi/data.hcl
@@ -389,6 +389,130 @@ database "posthog" {
     }
   }
 
+  table "clickhouse_cleanup_deleted_persons" {
+    order_by     = ["run_id", "team_id", "person_id"]
+    partition_by = "run_id"
+    ttl          = "created_at + toIntervalDay(14)"
+    settings = {
+      index_granularity   = "8192"
+      ttl_only_drop_parts = "1"
+    }
+    column "run_id" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "person_id" {
+      type = "UUID"
+    }
+    column "max_version" {
+      type = "UInt64"
+    }
+    column "created_at" {
+      type    = "DateTime64(6, 'UTC')"
+      default = "now64()"
+    }
+    engine "replicated_replacing_merge_tree" {
+      zoo_path       = "/clickhouse/tables/noshard/posthog.clickhouse_cleanup_deleted_persons"
+      replica_name   = "{replica}-{shard}"
+      version_column = "created_at"
+    }
+  }
+
+  table "clickhouse_cleanup_orphaned_distinct_ids" {
+    order_by     = ["run_id", "team_id", "distinct_id"]
+    partition_by = "run_id"
+    ttl          = "created_at + toIntervalDay(14)"
+    settings = {
+      index_granularity   = "8192"
+      ttl_only_drop_parts = "1"
+    }
+    column "run_id" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "distinct_id" {
+      type = "String"
+    }
+    column "person_id" {
+      type = "UUID"
+    }
+    column "own_tombstone" {
+      type = "UInt8"
+    }
+    column "max_version" {
+      type = "Int64"
+    }
+    column "created_at" {
+      type    = "DateTime64(6, 'UTC')"
+      default = "now64()"
+    }
+    engine "replicated_replacing_merge_tree" {
+      zoo_path       = "/clickhouse/tables/noshard/posthog.clickhouse_cleanup_orphaned_distinct_ids"
+      replica_name   = "{replica}-{shard}"
+      version_column = "created_at"
+    }
+  }
+
+  table "clickhouse_cleanup_revived_distinct_ids" {
+    order_by     = ["run_id", "team_id", "distinct_id"]
+    partition_by = "run_id"
+    ttl          = "created_at + toIntervalDay(14)"
+    settings = {
+      index_granularity   = "8192"
+      ttl_only_drop_parts = "1"
+    }
+    column "run_id" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "distinct_id" {
+      type = "String"
+    }
+    column "created_at" {
+      type    = "DateTime64(6, 'UTC')"
+      default = "now64()"
+    }
+    engine "replicated_replacing_merge_tree" {
+      zoo_path       = "/clickhouse/tables/noshard/posthog.clickhouse_cleanup_revived_distinct_ids"
+      replica_name   = "{replica}-{shard}"
+      version_column = "created_at"
+    }
+  }
+
+  table "clickhouse_cleanup_revived_persons" {
+    order_by     = ["run_id", "team_id", "person_id"]
+    partition_by = "run_id"
+    ttl          = "created_at + toIntervalDay(14)"
+    settings = {
+      index_granularity   = "8192"
+      ttl_only_drop_parts = "1"
+    }
+    column "run_id" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "person_id" {
+      type = "UUID"
+    }
+    column "created_at" {
+      type    = "DateTime64(6, 'UTC')"
+      default = "now64()"
+    }
+    engine "replicated_replacing_merge_tree" {
+      zoo_path       = "/clickhouse/tables/noshard/posthog.clickhouse_cleanup_revived_persons"
+      replica_name   = "{replica}-{shard}"
+      version_column = "created_at"
+    }
+  }
+
   table "cohort_membership" {
     order_by = ["team_id", "cohort_id", "person_id"]
     settings = {

--- a/posthog/clickhouse/hcl/golden/local-single/all.hcl
+++ b/posthog/clickhouse/hcl/golden/local-single/all.hcl
@@ -416,6 +416,130 @@ database "posthog" {
     }
   }
 
+  table "clickhouse_cleanup_deleted_persons" {
+    order_by     = ["run_id", "team_id", "person_id"]
+    partition_by = "run_id"
+    ttl          = "created_at + toIntervalDay(14)"
+    settings = {
+      index_granularity   = "8192"
+      ttl_only_drop_parts = "1"
+    }
+    column "run_id" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "person_id" {
+      type = "UUID"
+    }
+    column "max_version" {
+      type = "UInt64"
+    }
+    column "created_at" {
+      type    = "DateTime64(6, 'UTC')"
+      default = "now64()"
+    }
+    engine "replicated_replacing_merge_tree" {
+      zoo_path       = "/clickhouse/tables/noshard/posthog.clickhouse_cleanup_deleted_persons"
+      replica_name   = "{replica}-{shard}"
+      version_column = "created_at"
+    }
+  }
+
+  table "clickhouse_cleanup_orphaned_distinct_ids" {
+    order_by     = ["run_id", "team_id", "distinct_id"]
+    partition_by = "run_id"
+    ttl          = "created_at + toIntervalDay(14)"
+    settings = {
+      index_granularity   = "8192"
+      ttl_only_drop_parts = "1"
+    }
+    column "run_id" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "distinct_id" {
+      type = "String"
+    }
+    column "person_id" {
+      type = "UUID"
+    }
+    column "own_tombstone" {
+      type = "UInt8"
+    }
+    column "max_version" {
+      type = "Int64"
+    }
+    column "created_at" {
+      type    = "DateTime64(6, 'UTC')"
+      default = "now64()"
+    }
+    engine "replicated_replacing_merge_tree" {
+      zoo_path       = "/clickhouse/tables/noshard/posthog.clickhouse_cleanup_orphaned_distinct_ids"
+      replica_name   = "{replica}-{shard}"
+      version_column = "created_at"
+    }
+  }
+
+  table "clickhouse_cleanup_revived_distinct_ids" {
+    order_by     = ["run_id", "team_id", "distinct_id"]
+    partition_by = "run_id"
+    ttl          = "created_at + toIntervalDay(14)"
+    settings = {
+      index_granularity   = "8192"
+      ttl_only_drop_parts = "1"
+    }
+    column "run_id" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "distinct_id" {
+      type = "String"
+    }
+    column "created_at" {
+      type    = "DateTime64(6, 'UTC')"
+      default = "now64()"
+    }
+    engine "replicated_replacing_merge_tree" {
+      zoo_path       = "/clickhouse/tables/noshard/posthog.clickhouse_cleanup_revived_distinct_ids"
+      replica_name   = "{replica}-{shard}"
+      version_column = "created_at"
+    }
+  }
+
+  table "clickhouse_cleanup_revived_persons" {
+    order_by     = ["run_id", "team_id", "person_id"]
+    partition_by = "run_id"
+    ttl          = "created_at + toIntervalDay(14)"
+    settings = {
+      index_granularity   = "8192"
+      ttl_only_drop_parts = "1"
+    }
+    column "run_id" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "person_id" {
+      type = "UUID"
+    }
+    column "created_at" {
+      type    = "DateTime64(6, 'UTC')"
+      default = "now64()"
+    }
+    engine "replicated_replacing_merge_tree" {
+      zoo_path       = "/clickhouse/tables/noshard/posthog.clickhouse_cleanup_revived_persons"
+      replica_name   = "{replica}-{shard}"
+      version_column = "created_at"
+    }
+  }
+
   table "cohort_membership" {
     order_by = ["team_id", "cohort_id", "person_id"]
     settings = {

--- a/posthog/clickhouse/hcl/roles/data/local/tables.hcl
+++ b/posthog/clickhouse/hcl/roles/data/local/tables.hcl
@@ -245,6 +245,126 @@ database "posthog" {
       replica_name = "{replica}-{shard}"
     }
   }
+  table "clickhouse_cleanup_deleted_persons" {
+    partition_by = "run_id"
+    order_by = ["run_id", "team_id", "person_id"]
+    ttl      = "created_at + toIntervalDay(14)"
+    settings = {
+      index_granularity = "8192"
+      ttl_only_drop_parts = "1"
+    }
+    column "run_id" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "person_id" {
+      type = "UUID"
+    }
+    column "max_version" {
+      type = "UInt64"
+    }
+    column "created_at" {
+      type    = "DateTime64(6, 'UTC')"
+      default = "now64()"
+    }
+    engine "replicated_replacing_merge_tree" {
+      zoo_path       = "/clickhouse/tables/noshard/posthog.clickhouse_cleanup_deleted_persons"
+      replica_name   = "{replica}-{shard}"
+      version_column = "created_at"
+    }
+  }
+  table "clickhouse_cleanup_orphaned_distinct_ids" {
+    partition_by = "run_id"
+    order_by = ["run_id", "team_id", "distinct_id"]
+    ttl      = "created_at + toIntervalDay(14)"
+    settings = {
+      index_granularity = "8192"
+      ttl_only_drop_parts = "1"
+    }
+    column "run_id" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "distinct_id" {
+      type = "String"
+    }
+    column "person_id" {
+      type = "UUID"
+    }
+    column "own_tombstone" {
+      type = "UInt8"
+    }
+    column "max_version" {
+      type = "Int64"
+    }
+    column "created_at" {
+      type    = "DateTime64(6, 'UTC')"
+      default = "now64()"
+    }
+    engine "replicated_replacing_merge_tree" {
+      zoo_path       = "/clickhouse/tables/noshard/posthog.clickhouse_cleanup_orphaned_distinct_ids"
+      replica_name   = "{replica}-{shard}"
+      version_column = "created_at"
+    }
+  }
+  table "clickhouse_cleanup_revived_distinct_ids" {
+    partition_by = "run_id"
+    order_by = ["run_id", "team_id", "distinct_id"]
+    ttl      = "created_at + toIntervalDay(14)"
+    settings = {
+      index_granularity = "8192"
+      ttl_only_drop_parts = "1"
+    }
+    column "run_id" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "distinct_id" {
+      type = "String"
+    }
+    column "created_at" {
+      type    = "DateTime64(6, 'UTC')"
+      default = "now64()"
+    }
+    engine "replicated_replacing_merge_tree" {
+      zoo_path       = "/clickhouse/tables/noshard/posthog.clickhouse_cleanup_revived_distinct_ids"
+      replica_name   = "{replica}-{shard}"
+      version_column = "created_at"
+    }
+  }
+  table "clickhouse_cleanup_revived_persons" {
+    partition_by = "run_id"
+    order_by = ["run_id", "team_id", "person_id"]
+    ttl      = "created_at + toIntervalDay(14)"
+    settings = {
+      index_granularity = "8192"
+      ttl_only_drop_parts = "1"
+    }
+    column "run_id" {
+      type = "String"
+    }
+    column "team_id" {
+      type = "Int64"
+    }
+    column "person_id" {
+      type = "UUID"
+    }
+    column "created_at" {
+      type    = "DateTime64(6, 'UTC')"
+      default = "now64()"
+    }
+    engine "replicated_replacing_merge_tree" {
+      zoo_path       = "/clickhouse/tables/noshard/posthog.clickhouse_cleanup_revived_persons"
+      replica_name   = "{replica}-{shard}"
+      version_column = "created_at"
+    }
+  }
   table "cohort_membership" {
     order_by = ["team_id", "cohort_id", "person_id"]
     settings = {

--- a/posthog/clickhouse/hcl/sql/local-multi/data.sql
+++ b/posthog/clickhouse/hcl/sql/local-multi/data.sql
@@ -77,6 +77,34 @@ CREATE TABLE posthog.channel_definition (
   type_if_paid Nullable(String),
   type_if_organic Nullable(String)
 ) ENGINE = ReplicatedMergeTree('/clickhouse/tables/noshard/posthog.channel_definition', '{replica}-{shard}') ORDER BY (domain, kind) SETTINGS index_granularity = 8192;
+CREATE TABLE posthog.clickhouse_cleanup_deleted_persons (
+  run_id String,
+  team_id Int64,
+  person_id UUID,
+  max_version UInt64,
+  created_at DateTime64(6, 'UTC') DEFAULT now64()
+) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog.clickhouse_cleanup_deleted_persons', '{replica}-{shard}', created_at) ORDER BY (run_id, team_id, person_id) PARTITION BY run_id TTL created_at + toIntervalDay(14) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+CREATE TABLE posthog.clickhouse_cleanup_orphaned_distinct_ids (
+  run_id String,
+  team_id Int64,
+  distinct_id String,
+  person_id UUID,
+  own_tombstone UInt8,
+  max_version Int64,
+  created_at DateTime64(6, 'UTC') DEFAULT now64()
+) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog.clickhouse_cleanup_orphaned_distinct_ids', '{replica}-{shard}', created_at) ORDER BY (run_id, team_id, distinct_id) PARTITION BY run_id TTL created_at + toIntervalDay(14) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+CREATE TABLE posthog.clickhouse_cleanup_revived_distinct_ids (
+  run_id String,
+  team_id Int64,
+  distinct_id String,
+  created_at DateTime64(6, 'UTC') DEFAULT now64()
+) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog.clickhouse_cleanup_revived_distinct_ids', '{replica}-{shard}', created_at) ORDER BY (run_id, team_id, distinct_id) PARTITION BY run_id TTL created_at + toIntervalDay(14) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+CREATE TABLE posthog.clickhouse_cleanup_revived_persons (
+  run_id String,
+  team_id Int64,
+  person_id UUID,
+  created_at DateTime64(6, 'UTC') DEFAULT now64()
+) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog.clickhouse_cleanup_revived_persons', '{replica}-{shard}', created_at) ORDER BY (run_id, team_id, person_id) PARTITION BY run_id TTL created_at + toIntervalDay(14) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 CREATE TABLE posthog.cohort_membership (
   team_id Int64,
   cohort_id Int64,

--- a/posthog/clickhouse/hcl/sql/local-single/all.sql
+++ b/posthog/clickhouse/hcl/sql/local-single/all.sql
@@ -15,6 +15,34 @@ CREATE TABLE posthog.channel_definition (
   type_if_paid Nullable(String),
   type_if_organic Nullable(String)
 ) ENGINE = ReplicatedMergeTree('/clickhouse/tables/noshard/posthog.channel_definition', '{replica}-{shard}') ORDER BY (domain, kind) SETTINGS index_granularity = 8192;
+CREATE TABLE posthog.clickhouse_cleanup_deleted_persons (
+  run_id String,
+  team_id Int64,
+  person_id UUID,
+  max_version UInt64,
+  created_at DateTime64(6, 'UTC') DEFAULT now64()
+) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog.clickhouse_cleanup_deleted_persons', '{replica}-{shard}', created_at) ORDER BY (run_id, team_id, person_id) PARTITION BY run_id TTL created_at + toIntervalDay(14) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+CREATE TABLE posthog.clickhouse_cleanup_orphaned_distinct_ids (
+  run_id String,
+  team_id Int64,
+  distinct_id String,
+  person_id UUID,
+  own_tombstone UInt8,
+  max_version Int64,
+  created_at DateTime64(6, 'UTC') DEFAULT now64()
+) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog.clickhouse_cleanup_orphaned_distinct_ids', '{replica}-{shard}', created_at) ORDER BY (run_id, team_id, distinct_id) PARTITION BY run_id TTL created_at + toIntervalDay(14) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+CREATE TABLE posthog.clickhouse_cleanup_revived_distinct_ids (
+  run_id String,
+  team_id Int64,
+  distinct_id String,
+  created_at DateTime64(6, 'UTC') DEFAULT now64()
+) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog.clickhouse_cleanup_revived_distinct_ids', '{replica}-{shard}', created_at) ORDER BY (run_id, team_id, distinct_id) PARTITION BY run_id TTL created_at + toIntervalDay(14) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+CREATE TABLE posthog.clickhouse_cleanup_revived_persons (
+  run_id String,
+  team_id Int64,
+  person_id UUID,
+  created_at DateTime64(6, 'UTC') DEFAULT now64()
+) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog.clickhouse_cleanup_revived_persons', '{replica}-{shard}', created_at) ORDER BY (run_id, team_id, person_id) PARTITION BY run_id TTL created_at + toIntervalDay(14) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 CREATE TABLE posthog.cohort_membership (
   team_id Int64,
   cohort_id Int64,

--- a/posthog/clickhouse/migrations/0309_add_cleanup_snapshot_tables.py
+++ b/posthog/clickhouse/migrations/0309_add_cleanup_snapshot_tables.py
@@ -1,0 +1,6 @@
+from posthog.clickhouse.cleanup_snapshots import CLEANUP_SNAPSHOT_TABLE_SQL
+from posthog.clickhouse.client.migration_tools import NodeRole, run_sql_with_exceptions
+
+operations = [
+    run_sql_with_exceptions(table_sql(), node_roles=[NodeRole.DATA]) for table_sql in CLEANUP_SNAPSHOT_TABLE_SQL
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0308_drop_warpstream_calculated_events_kafka_engines
+0309_add_cleanup_snapshot_tables

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -89,6 +89,7 @@ def create_clickhouse_tables():
 def reset_clickhouse_tables():
     # Truncate clickhouse tables to default before running test
     # Mostly so that test runs locally work correctly
+    from posthog.clickhouse.cleanup_snapshots import TRUNCATE_CLEANUP_SNAPSHOT_TABLES_SQL
     from posthog.clickhouse.dead_letter_queue import TRUNCATE_DEAD_LETTER_QUEUE_TABLE_SQL
     from posthog.clickhouse.plugin_log_entries import TRUNCATE_PLUGIN_LOG_ENTRIES_TABLE_SQL
     from posthog.heatmaps.sql import TRUNCATE_HEATMAPS_TABLE_SQL
@@ -149,6 +150,7 @@ def reset_clickhouse_tables():
         TRUNCATE_HEATMAPS_TABLE_SQL(),
         TRUNCATE_PG_EMBEDDINGS_TABLE_SQL(),
         TRUNCATE_AI_EVENTS_TABLE_SQL(),
+        *TRUNCATE_CLEANUP_SNAPSHOT_TABLES_SQL(),
     ]
 
     # Drop created Kafka tables because some tests don't expect it.

--- a/posthog/dags/clickhouse_cleanup.py
+++ b/posthog/dags/clickhouse_cleanup.py
@@ -1,0 +1,380 @@
+"""Weekly ClickHouse cleanup sweeps: deleted cohort memberships, then deleted persons.
+
+ClickHouse cannot cheaply delete individual rows, so deletions are marked and swept later.
+Both sweeps issue cluster-wide mutations, and running those at the same time overloads the
+cluster, so the ops below are chained on each other's output to force them into sequence.
+"""
+
+import time
+from dataclasses import dataclass
+from functools import partial
+
+from django.conf import settings
+
+import dagster
+import pydantic
+from clickhouse_driver.client import Client
+
+from posthog.clickhouse.cleanup_snapshots import CLEANUP_DELETED_PERSONS_TABLE
+from posthog.clickhouse.client.connection import ClickHouseUser, get_clickhouse_creds
+from posthog.clickhouse.cluster import (
+    ClickhouseCluster,
+    LightweightDeleteMutationRunner,
+    MutationNotFound,
+    NodeRole,
+    RetryPolicy,
+)
+from posthog.dags.common import JobOwners
+from posthog.models.async_deletion.delete_cohorts import sweep_cohort_deletions
+from posthog.models.person.sql import PERSONS_TABLE
+
+
+class CleanupConfig(dagster.Config):
+    dry_run: bool = pydantic.Field(
+        default=True,
+        description="Build the snapshot and report what would be removed, without deleting anything.",
+    )
+    cleanup: bool = pydantic.Field(
+        default=True,
+        description="Drop the dictionary and clear this run's snapshot rows when the run finishes.",
+    )
+    shards: int = pydantic.Field(default=16, description="Dictionary SHARDS, which parallelize loading.")
+    max_execution_time: int = pydantic.Field(default=0, description="Dictionary load timeout, 0 for no limit.")
+    max_memory_usage: int = pydantic.Field(default=0, description="Dictionary load memory cap, 0 for no limit.")
+    dictionary_load_timeout: int = pydantic.Field(
+        default=600,
+        description="How long to wait for a dictionary to finish loading on a host before failing the run.",
+    )
+
+
+@dataclass(frozen=True, kw_only=True)
+class CleanupRun:
+    """Every per-run asset, threaded through the ops so they execute in sequence.
+
+    Settings that outlive the first op travel here rather than being read from config by each op,
+    so they are set in one place. Declaring dry_run on every op would let a launch set it on one
+    and miss another, and half a sweep is worse than none.
+    """
+
+    persons: "DeletedPersonsTable"
+    dry_run: bool
+    dictionary_load_timeout: int
+
+    @property
+    def persons_dictionary(self) -> "DeletedPersonsDictionary":
+        return DeletedPersonsDictionary(source=self.persons)
+
+
+@dataclass(frozen=True)
+class DeletedPersonsTable:
+    """One run's slice of the persons whose latest ClickHouse version is deleted.
+
+    The sweep removes those rows, which destroys the tombstones the set was derived from, so
+    the set is captured here first and every later step reads it from here rather than
+    recomputing it.
+
+    Every run writes into the same persisted table and reads back its own rows by run id.
+    Creating and dropping a replicated table per run instead would churn DDL across every node
+    once a week, and a run's rows expire on their own through the table's TTL.
+    """
+
+    run_id: str
+
+    @property
+    def table_name(self) -> str:
+        return CLEANUP_DELETED_PERSONS_TABLE
+
+    @property
+    def qualified_name(self) -> str:
+        return f"{settings.CLICKHOUSE_DATABASE}.{self.table_name}"
+
+    def populate(self, client: Client) -> None:
+        # A person can be soft-deleted and later revived by a higher version, so membership is
+        # decided by the latest version rather than by any version having is_deleted set. The
+        # inner IN narrows the aggregation to persons with at least one deleted version.
+        client.execute(
+            f"""
+            INSERT INTO {self.qualified_name} (run_id, team_id, person_id, max_version)
+            SELECT %(run_id)s, team_id, id, max(version)
+            FROM {PERSONS_TABLE}
+            WHERE (team_id, id) IN (SELECT team_id, id FROM {PERSONS_TABLE} WHERE is_deleted > 0)
+            GROUP BY team_id, id
+            HAVING argMax(is_deleted, version) > 0
+            """,
+            {"run_id": self.run_id},
+        )
+
+    def count(self, client: Client) -> int:
+        [[count]] = client.execute(
+            f"SELECT count() FROM {self.qualified_name} WHERE run_id = %(run_id)s",
+            {"run_id": self.run_id},
+        )
+        return count
+
+    def drop_run_partition(self, client: Client) -> None:
+        # The table is partitioned by run_id, so clearing a run is a metadata-only partition drop
+        # rather than a mutation that rewrites every part. A missing partition is a no-op.
+        client.execute(
+            f"ALTER TABLE {self.qualified_name} DROP PARTITION %(run_id)s",
+            {"run_id": self.run_id},
+        )
+
+
+@dataclass(frozen=True)
+class DeletedPersonsDictionary:
+    source: DeletedPersonsTable
+
+    @property
+    def name(self) -> str:
+        # Runs share the table, so the run id has to live on the dictionary instead for two runs
+        # not to fight over one name.
+        return f"{self.source.table_name}_{self.source.run_id}_dictionary"
+
+    @property
+    def qualified_name(self) -> str:
+        return f"{settings.CLICKHOUSE_DATABASE}.{self.name}"
+
+    @property
+    def query(self) -> str:
+        return (
+            f"SELECT team_id, person_id, max_version FROM {self.source.qualified_name}"
+            f" WHERE run_id = '{self.source.run_id}'"
+        )
+
+    def create(self, client: Client, shards: int, max_execution_time: int, max_memory_usage: int) -> None:
+        # The source reads as the low-privilege dict_reader user, which falls back to the default
+        # user's credentials where dict_reader is not provisioned. Credentials are query parameters
+        # so they stay out of the traced statement.
+        creds = get_clickhouse_creds(ClickHouseUser.DICT_READER)
+        client.execute(
+            f"""
+            CREATE DICTIONARY IF NOT EXISTS {self.qualified_name} (
+                team_id Int64,
+                person_id UUID,
+                max_version UInt64
+            )
+            PRIMARY KEY team_id, person_id
+            SOURCE(CLICKHOUSE(DB %(database)s USER %(user)s PASSWORD %(password)s QUERY %(query)s))
+            LAYOUT(COMPLEX_KEY_HASHED(SHARDS {shards}))
+            LIFETIME(0)
+            SETTINGS(max_execution_time={max_execution_time}, max_memory_usage={max_memory_usage})
+            """,
+            {
+                "database": settings.CLICKHOUSE_DATABASE,
+                "user": creds.user,
+                "password": creds.password,
+                "query": self.query,
+            },
+        )
+
+    def drop(self, client: Client) -> None:
+        client.execute(f"DROP DICTIONARY IF EXISTS {self.qualified_name} SYNC")
+
+    def is_loaded(self, client: Client) -> bool:
+        results = client.execute(
+            "SELECT status, last_exception FROM system.dictionaries WHERE database = %(database)s AND name = %(name)s",
+            {"database": settings.CLICKHOUSE_DATABASE, "name": self.name},
+        )
+        if not results:
+            raise Exception(f"{self.qualified_name} does not exist")
+        [[status, last_exception]] = results
+        if status == "LOADED":
+            return True
+        if status in {"LOADING", "FAILED_AND_RELOADING", "LOADED_AND_RELOADING"}:
+            return False
+        if status == "FAILED":
+            raise Exception(f"{self.qualified_name} failed to load: {last_exception}")
+        raise Exception(f"{self.qualified_name} in unexpected status: {status}")
+
+    def load(self, client: Client, timeout_seconds: int) -> int:
+        client.execute(f"SYSTEM RELOAD DICTIONARY {self.qualified_name}")
+
+        # The reload is asynchronous, so the mutation would read a half-populated dictionary
+        # without this wait. A dictionary wedged in LOADING would otherwise hold the run open
+        # forever, and a weekly job nobody is watching is exactly where that goes unnoticed.
+        deadline = time.monotonic() + timeout_seconds
+        while not self.is_loaded(client):
+            if time.monotonic() > deadline:
+                raise Exception(f"{self.qualified_name} still not loaded after {timeout_seconds}s")
+            time.sleep(5.0)
+
+        return self.checksum(client)
+
+    def checksum(self, client: Client) -> int:
+        # XOR is order independent, so hosts that hold the same keys agree regardless of read order.
+        [[checksum]] = client.execute(f"SELECT groupBitXor(cityHash64(team_id, person_id)) FROM {self.qualified_name}")
+        return checksum
+
+
+@dagster.op
+def clear_removed_cohort_data(
+    context: dagster.OpExecutionContext,
+    config: CleanupConfig,
+) -> CleanupRun:
+    """Remove cohort membership rows for cohorts that were deleted or recalculated.
+
+    Runs ahead of the person sweep rather than after it. The two cannot overlap, and the person
+    mutation can run for hours, so putting it first would leave cohort rows unswept whenever it
+    ran long or failed. Going first also keeps the person snapshot as close to its own delete as
+    possible, which is what bounds how many persons can revive mid-run.
+    """
+    run = CleanupRun(
+        persons=DeletedPersonsTable(run_id=context.run_id.replace("-", "_")),
+        dry_run=config.dry_run,
+        dictionary_load_timeout=config.dictionary_load_timeout,
+    )
+    context.add_output_metadata({"dry_run": dagster.MetadataValue.bool(run.dry_run)})
+
+    if run.dry_run:
+        context.log.info("dry run: skipping the cohort sweep")
+        return run
+
+    failed = sweep_cohort_deletions()
+    context.add_output_metadata({"failed_passes": dagster.MetadataValue.text(", ".join(failed) or "none")})
+    return run
+
+
+@dagster.op
+def snapshot_deleted_persons(
+    context: dagster.OpExecutionContext,
+    cluster: dagster.ResourceParam[ClickhouseCluster],
+    run: CleanupRun,
+) -> CleanupRun:
+    """Capture the persons whose latest version is deleted, tagged with this run's id."""
+    table = run.persons
+
+    cluster.any_host_by_role(table.populate, NodeRole.DATA).result()
+
+    # The insert lands on one host, but every host reads this table when the dictionary loads.
+    def sync_replica(client: Client) -> None:
+        client.execute(f"SYSTEM SYNC REPLICA {table.qualified_name} STRICT")
+
+    cluster.map_all_hosts(sync_replica).result()
+
+    count = cluster.any_host_by_role(table.count, NodeRole.DATA).result()
+    context.add_output_metadata(
+        {
+            "deleted_persons": dagster.MetadataValue.int(count),
+            "table_name": dagster.MetadataValue.text(table.table_name),
+        }
+    )
+    return run
+
+
+@dagster.op
+def build_deleted_persons_dictionary(
+    config: CleanupConfig,
+    cluster: dagster.ResourceParam[ClickhouseCluster],
+    run: CleanupRun,
+) -> CleanupRun:
+    """Create the dictionary the delete predicate probes, on every host."""
+    cluster.map_all_hosts(
+        partial(
+            run.persons_dictionary.create,
+            shards=config.shards,
+            max_execution_time=config.max_execution_time,
+            max_memory_usage=config.max_memory_usage,
+        )
+    ).result()
+    return run
+
+
+@dagster.op
+def load_and_verify_deleted_persons_dictionary(
+    cluster: dagster.ResourceParam[ClickhouseCluster],
+    run: CleanupRun,
+) -> CleanupRun:
+    """Load the dictionary on all hosts and confirm they hold identical keys."""
+    checksums = cluster.map_all_hosts(
+        partial(run.persons_dictionary.load, timeout_seconds=run.dictionary_load_timeout),
+        concurrency=1,
+    ).result()
+    assert len(set(checksums.values())) == 1
+    return run
+
+
+@dagster.op
+def delete_persons(
+    context: dagster.OpExecutionContext,
+    cluster: dagster.ResourceParam[ClickhouseCluster],
+    run: CleanupRun,
+) -> CleanupRun:
+    """Remove the snapshotted persons from the ClickHouse person table.
+
+    Bounded by the version the snapshot observed, so a person recreated after the snapshot keeps
+    the rows this run never saw. Without the bound, a client recapturing a deleted distinct id
+    mid-run would have that new person state swept away.
+    """
+    if run.dry_run:
+        context.log.info("dry run: skipping the delete from %s", PERSONS_TABLE)
+        return run
+
+    dictionary = run.persons_dictionary.qualified_name
+    runner = LightweightDeleteMutationRunner(
+        table=PERSONS_TABLE,
+        predicate=(
+            f"isNotNull(dictGetOrNull({dictionary!r}, 'max_version', (team_id, id)) as snapshot_max)"
+            " AND version <= snapshot_max"
+        ),
+    )
+
+    # person is replicated and not sharded, so a mutation started on one host reaches all of them.
+    mutation = cluster.any_host(runner).result()
+    # The mutation entry replicates through Keeper, so a lagged replica can briefly not know it
+    # and raise MutationNotFound; retry the wait like MutationRunner.run_on_shards does.
+    retry_lagged_replicas = RetryPolicy(max_attempts=3, delay=10.0, exceptions=(MutationNotFound,))
+    cluster.map_all_hosts(retry_lagged_replicas(mutation.wait)).result()
+
+    return run
+
+
+@dagster.op
+def drop_snapshot_assets(
+    context: dagster.OpExecutionContext,
+    config: CleanupConfig,
+    cluster: dagster.ResourceParam[ClickhouseCluster],
+    run: CleanupRun,
+) -> None:
+    """Drop this run's dictionary and clear the rows it read."""
+    dictionary = run.persons_dictionary
+
+    if not config.cleanup:
+        context.log.info("cleanup disabled, leaving %s in place", dictionary.qualified_name)
+        return
+
+    # The dictionary reads from the table, so it has to go first.
+    cluster.map_all_hosts(dictionary.drop).result()
+    # The TTL would reap these anyway. Clearing them now keeps the shared table small enough that
+    # a run's own rows stay cheap to read.
+    cluster.any_host_by_role(run.persons.drop_run_partition, NodeRole.DATA).result()
+
+
+@dagster.failure_hook(required_resource_keys={"cluster"})
+def drop_assets_on_failure(context: dagster.HookContext) -> None:
+    """Drop this run's dictionary when an op fails.
+
+    Dagster skips downstream ops after a failure, so drop_snapshot_assets never runs and the
+    dictionary would survive on the cluster and accumulate across failures. The name comes from
+    the run id alone, so this needs nothing from the failed op.
+
+    This ignores the cleanup flag on purpose. A stranded dictionary holds its whole key set in
+    memory on every host, which costs more than the ability to inspect it after a failure.
+
+    The failed run's rows are left behind deliberately. They cost far less than a dictionary and
+    the table's TTL reaps them, so a failed sweep stays inspectable in the meantime.
+    """
+    run_id = context.run_id.replace("-", "_")
+    name = f"{settings.CLICKHOUSE_DATABASE}.{CLEANUP_DELETED_PERSONS_TABLE}_{run_id}_dictionary"
+    cluster = context.resources.cluster
+
+    cluster.map_all_hosts(lambda client: client.execute(f"DROP DICTIONARY IF EXISTS {name} SYNC")).result()
+
+
+@dagster.job(hooks={drop_assets_on_failure}, tags={"owner": JobOwners.TEAM_CLICKHOUSE.value})
+def clickhouse_deletion_sweep_job():
+    """Sweep deleted cohort memberships out of ClickHouse, then deleted persons."""
+    # Each op takes the previous op's output, which is what keeps the two sweeps in sequence.
+    run = snapshot_deleted_persons(clear_removed_cohort_data())
+    drop_snapshot_assets(
+        delete_persons(load_and_verify_deleted_persons_dictionary(build_deleted_persons_dictionary(run)))
+    )

--- a/posthog/dags/locations/clickhouse.py
+++ b/posthog/dags/locations/clickhouse.py
@@ -5,6 +5,7 @@ from posthog.dags import (
     backfill_materialized_column,
     backups,
     ch_examples,
+    clickhouse_cleanup,
     create_materialized_column,
     data_deletion_requests,
     deletes,
@@ -33,6 +34,7 @@ defs = dagster.Definitions(
     ],
     jobs=[
         add_index_to_materialized_column.add_index_to_materialized_column,
+        clickhouse_cleanup.clickhouse_deletion_sweep_job,
         create_materialized_column.create_materialized_column,
         drop_materialized_column.drop_materialized_column,
         deletes.deletes_job,

--- a/posthog/dags/tests/test_clickhouse_cleanup.py
+++ b/posthog/dags/tests/test_clickhouse_cleanup.py
@@ -1,0 +1,254 @@
+from uuid import UUID
+
+import pytest
+from unittest.mock import patch
+
+from clickhouse_driver import Client
+
+from posthog.clickhouse.cleanup_snapshots import CLEANUP_DELETED_PERSONS_TABLE
+from posthog.clickhouse.cluster import ClickhouseCluster
+from posthog.dags.clickhouse_cleanup import DeletedPersonsDictionary, clickhouse_deletion_sweep_job
+from posthog.models.async_deletion import AsyncDeletion, DeletionType
+from posthog.models.person.util import create_person
+
+TEAM_ID = 4242
+COHORT_ID = 77
+
+# dry_run is declared on the first op alone, which is what stops a launch from setting it on one
+# op and missing another.
+RUN_FOR_REAL = {"ops": {"clear_removed_cohort_data": {"config": {"dry_run": False}}}}
+
+
+def visible_persons(client: Client) -> int:
+    # SELECT hides lightweight-deleted rows, so this counts what survived the sweep.
+    [[count]] = client.execute("SELECT count() FROM person WHERE team_id = %(team_id)s", {"team_id": TEAM_ID})
+    return count
+
+
+def current_persons(client: Client) -> int:
+    [[count]] = client.execute("SELECT count() FROM person FINAL WHERE team_id = %(team_id)s", {"team_id": TEAM_ID})
+    return count
+
+
+def rows_for(person_uuid: str):
+    # Raw row count, so it sees every surviving version rather than the collapsed one.
+    def query(client: Client) -> int:
+        [[count]] = client.execute(
+            "SELECT count() FROM person WHERE team_id = %(team_id)s AND id = %(id)s",
+            {"team_id": TEAM_ID, "id": person_uuid},
+        )
+        return count
+
+    return query
+
+
+def cohort_rows(client: Client) -> int:
+    [[count]] = client.execute("SELECT count() FROM cohortpeople WHERE team_id = %(team_id)s", {"team_id": TEAM_ID})
+    return count
+
+
+def snapshot_rows(client: Client) -> int:
+    # The snapshot table is created by migration and outlives every run, so what a run has to clean
+    # up is its rows rather than the table. Anchored to the constant, not to a literal that can
+    # drift out of step with a rename.
+    [[rows]] = client.execute(f"SELECT count() FROM {CLEANUP_DELETED_PERSONS_TABLE}")
+    return rows
+
+
+def leftover_dictionaries(client: Client) -> int:
+    [[dictionaries]] = client.execute(
+        "SELECT count() FROM system.dictionaries WHERE name LIKE %(pattern)s",
+        {"pattern": f"{CLEANUP_DELETED_PERSONS_TABLE}\\_%"},
+    )
+    return dictionaries
+
+
+def seed_cohort_rows(cluster: ClickhouseCluster, count: int) -> None:
+    rows = [(TEAM_ID, UUID(int=i), COHORT_ID, 1) for i in range(count)]
+    cluster.any_host(
+        lambda client: client.execute("INSERT INTO cohortpeople (team_id, person_id, cohort_id, sign) VALUES", rows)
+    ).result()
+
+
+def versions_for(person_uuid: str):
+    def query(client: Client) -> list[int]:
+        rows = client.execute(
+            "SELECT version FROM person WHERE team_id = %(team_id)s AND id = %(id)s ORDER BY version",
+            {"team_id": TEAM_ID, "id": person_uuid},
+        )
+        return [row[0] for row in rows]
+
+    return query
+
+
+@pytest.mark.django_db
+def test_a_person_version_written_after_the_snapshot_survives(cluster: ClickhouseCluster):
+    # The delete is bounded by the version the snapshot observed. A client can recapture a deleted
+    # distinct id mid-run, which writes a live person version the run never saw; dropping the bound
+    # sweeps that new state away with the old.
+    doomed = create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+
+    original = DeletedPersonsDictionary.load
+
+    def revive_after_snapshot(self, client, timeout_seconds):
+        result = original(self, client, timeout_seconds)
+        create_person(uuid=doomed, team_id=TEAM_ID, version=500, is_deleted=False)
+        return result
+
+    with patch.object(DeletedPersonsDictionary, "load", revive_after_snapshot):
+        clickhouse_deletion_sweep_job.execute_in_process(run_config=RUN_FOR_REAL, resources={"cluster": cluster})
+
+    assert cluster.any_host(versions_for(doomed)).result() == [500]
+
+
+@pytest.mark.django_db
+def test_deletes_soft_deleted_persons_and_preserves_the_rest(cluster: ClickhouseCluster):
+    # Deleted at a later version: every version has to go, which is why the delete keys on the
+    # person rather than on is_deleted.
+    deleted_later = create_person(team_id=TEAM_ID, version=0, is_deleted=False)
+    create_person(uuid=deleted_later, team_id=TEAM_ID, version=1, is_deleted=True)
+    # Deleted at its only version.
+    deleted_once = create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+    # Never deleted.
+    live = create_person(team_id=TEAM_ID, version=0)
+    # Deleted, then revived by a higher version: currently live, so it has to survive. Dropping the
+    # argMax gate for a plain is_deleted check would delete this person.
+    revived = create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+    create_person(uuid=revived, team_id=TEAM_ID, version=1, is_deleted=False)
+
+    clickhouse_deletion_sweep_job.execute_in_process(run_config=RUN_FOR_REAL, resources={"cluster": cluster})
+
+    # The live version of deleted_later would survive a delete keyed on is_deleted rather than on
+    # the person, so this asserts on the raw count rather than the collapsed one.
+    assert cluster.any_host(rows_for(deleted_later)).result() == 0
+    assert cluster.any_host(rows_for(deleted_once)).result() == 0
+    assert cluster.any_host(rows_for(live)).result() == 1
+    assert cluster.any_host(rows_for(revived)).result() > 0
+    # Survivor counts go through FINAL: a background merge may collapse the revived person's two
+    # versions at any point, so its raw count is not stable.
+    assert cluster.any_host(current_persons).result() == 2
+
+
+@pytest.mark.django_db
+def test_no_op_when_nothing_is_soft_deleted(cluster: ClickhouseCluster):
+    # The snapshot is empty, so the dictionary source returns nothing and dictHas never matches.
+    create_person(team_id=TEAM_ID, version=0)
+
+    clickhouse_deletion_sweep_job.execute_in_process(run_config=RUN_FOR_REAL, resources={"cluster": cluster})
+
+    assert cluster.any_host(visible_persons).result() == 1
+
+
+@pytest.mark.django_db
+def test_is_idempotent(cluster: ClickhouseCluster):
+    create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+    create_person(team_id=TEAM_ID, version=0)
+
+    clickhouse_deletion_sweep_job.execute_in_process(run_config=RUN_FOR_REAL, resources={"cluster": cluster})
+    # The first run tombstones the deleted rows, so the second snapshot no longer sees them.
+    clickhouse_deletion_sweep_job.execute_in_process(run_config=RUN_FOR_REAL, resources={"cluster": cluster})
+
+    assert cluster.any_host(visible_persons).result() == 1
+
+
+@pytest.mark.django_db
+def test_dry_run_deletes_nothing(cluster: ClickhouseCluster):
+    create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+    seed_cohort_rows(cluster, count=5)
+    AsyncDeletion.objects.create(deletion_type=DeletionType.Cohort_full, team_id=TEAM_ID, key=f"{COHORT_ID}_0")
+
+    clickhouse_deletion_sweep_job.execute_in_process(resources={"cluster": cluster})
+
+    assert cluster.any_host(visible_persons).result() == 1
+    assert cluster.any_host(cohort_rows).result() == 5
+    assert AsyncDeletion.objects.get(team_id=TEAM_ID).delete_verified_at is None
+
+
+@pytest.mark.django_db
+def test_drops_the_dictionary_and_clears_the_run_rows(cluster: ClickhouseCluster):
+    create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+
+    clickhouse_deletion_sweep_job.execute_in_process(run_config=RUN_FOR_REAL, resources={"cluster": cluster})
+
+    # A leaked dictionary holds the key set in memory on every host. The rows are cheaper, but the
+    # table is shared now, so a run that never clears its own rows makes every later run read them.
+    assert cluster.any_host(leftover_dictionaries).result() == 0
+    assert cluster.any_host(snapshot_rows).result() == 0
+
+
+@pytest.mark.django_db
+def test_clears_cohort_rows_and_marks_the_deletion_verified_on_the_next_run(cluster: ClickhouseCluster):
+    seed_cohort_rows(cluster, count=10)
+    AsyncDeletion.objects.create(deletion_type=DeletionType.Cohort_full, team_id=TEAM_ID, key=f"{COHORT_ID}_0")
+
+    clickhouse_deletion_sweep_job.execute_in_process(run_config=RUN_FOR_REAL, resources={"cluster": cluster})
+
+    # The mark pass runs before the delete pass, so it sees rows that are still present and
+    # verification lands a run later. A reordering that drops the mark pass would leave
+    # AsyncDeletion rows unverified forever, and they would be re-swept every week.
+    assert cluster.any_host(cohort_rows).result() == 0
+    assert AsyncDeletion.objects.get(team_id=TEAM_ID).delete_verified_at is None
+
+    clickhouse_deletion_sweep_job.execute_in_process(run_config=RUN_FOR_REAL, resources={"cluster": cluster})
+
+    assert AsyncDeletion.objects.get(team_id=TEAM_ID).delete_verified_at is not None
+
+
+@pytest.mark.django_db
+def test_cohort_delete_pass_runs_when_the_mark_pass_fails(cluster: ClickhouseCluster):
+    seed_cohort_rows(cluster, count=10)
+    AsyncDeletion.objects.create(deletion_type=DeletionType.Cohort_full, team_id=TEAM_ID, key=f"{COHORT_ID}_0")
+
+    with patch(
+        "posthog.models.async_deletion.delete_cohorts.AsyncCohortDeletion.mark_deletions_done",
+        side_effect=Exception("boom"),
+    ):
+        result = clickhouse_deletion_sweep_job.execute_in_process(
+            run_config=RUN_FOR_REAL, resources={"cluster": cluster}
+        )
+
+    # Collapsing the two guards into one try would skip the pass that actually removes rows.
+    assert result.success
+    assert cluster.any_host(cohort_rows).result() == 0
+
+
+@pytest.mark.django_db
+def test_cohort_sweep_runs_even_when_the_person_delete_fails(cluster: ClickhouseCluster):
+    create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+    seed_cohort_rows(cluster, count=10)
+    AsyncDeletion.objects.create(deletion_type=DeletionType.Cohort_full, team_id=TEAM_ID, key=f"{COHORT_ID}_0")
+
+    with patch(
+        "posthog.dags.clickhouse_cleanup.LightweightDeleteMutationRunner",
+        side_effect=Exception("boom"),
+    ):
+        result = clickhouse_deletion_sweep_job.execute_in_process(
+            run_config=RUN_FOR_REAL, resources={"cluster": cluster}, raise_on_error=False
+        )
+
+    # Moving the cohort sweep back downstream of the person delete would strand cohort rows every
+    # week the person mutation ran long or failed, which is why it goes first.
+    assert not result.success
+    assert cluster.any_host(cohort_rows).result() == 0
+
+
+@pytest.mark.django_db
+def test_a_failed_run_drops_its_dictionary_and_keeps_its_rows(cluster: ClickhouseCluster):
+    create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+
+    # Fails once the dictionary is built, so there is something to strand.
+    with patch(
+        "posthog.dags.clickhouse_cleanup.LightweightDeleteMutationRunner",
+        side_effect=Exception("boom"),
+    ):
+        result = clickhouse_deletion_sweep_job.execute_in_process(
+            run_config=RUN_FOR_REAL, resources={"cluster": cluster}, raise_on_error=False
+        )
+
+    assert not result.success
+    # Dagster skips drop_snapshot_assets after a failure, so without the hook the dictionary
+    # would survive on every host and accumulate across failed runs.
+    assert cluster.any_host(leftover_dictionaries).result() == 0
+    # The rows survive on purpose: they cost far less than a dictionary, the table's TTL reaps
+    # them, and they are what makes a failed sweep inspectable in the meantime.
+    assert cluster.any_host(snapshot_rows).result() > 0

--- a/posthog/management/commands/start_delete_mutation.py
+++ b/posthog/management/commands/start_delete_mutation.py
@@ -4,7 +4,7 @@ from django.core.management.base import BaseCommand
 
 import structlog
 
-from posthog.tasks.tasks import clickhouse_clear_removed_data
+from posthog.models.async_deletion.delete_cohorts import sweep_cohort_deletions
 
 logger = structlog.get_logger(__name__)
 logger.setLevel(logging.INFO)
@@ -22,5 +22,5 @@ class Command(BaseCommand):
 
 def run():
     logger.info("Starting deletion of data for teams")
-    clickhouse_clear_removed_data()
-    logger.info("Finished deletion of data for teams")
+    failed = sweep_cohort_deletions()
+    logger.info("Finished deletion of data for teams", failed_passes=failed)

--- a/posthog/models/async_deletion/delete_cohorts.py
+++ b/posthog/models/async_deletion/delete_cohorts.py
@@ -1,8 +1,20 @@
 from typing import Any
 
+from prometheus_client import Counter
+
 from posthog.clickhouse.client import sync_execute
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
 from posthog.models.async_deletion.delete import AsyncDeletionProcess, logger
+
+COHORT_DELETION_MARK_FAILURE_COUNTER = Counter(
+    "posthog_cohort_deletion_mark_failure_total",
+    "Times cohort deletion mark failed",
+)
+
+COHORT_DELETION_RUN_FAILURE_COUNTER = Counter(
+    "posthog_cohort_deletion_run_failure_total",
+    "Times cohort deletion run failed",
+)
 
 
 class AsyncCohortDeletion(AsyncDeletionProcess):
@@ -86,3 +98,29 @@ class AsyncCohortDeletion(AsyncDeletionProcess):
                     key_param: key,
                 },
             )
+
+
+def sweep_cohort_deletions() -> list[str]:
+    """Run both cohort deletion passes and return the names of any that failed.
+
+    Each pass is guarded on its own: failing to tick off cohorts whose rows are already gone
+    must not stop the pass that actually removes rows.
+    """
+    runner = AsyncCohortDeletion()
+    failed = []
+
+    try:
+        runner.mark_deletions_done()
+    except Exception as e:
+        logger.error("Failed to mark cohort deletions done", error=e, exc_info=True)
+        COHORT_DELETION_MARK_FAILURE_COUNTER.inc()
+        failed.append("mark")
+
+    try:
+        runner.run()
+    except Exception as e:
+        logger.error("Failed to run cohort deletions", error=e, exc_info=True)
+        COHORT_DELETION_RUN_FAILURE_COUNTER.inc()
+        failed.append("run")
+
+    return failed

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -53,16 +53,6 @@ FEATURE_FLAG_LAST_CALLED_AT_SYNC_CHUNK_FAILURE_COUNTER = Counter(
 )
 
 
-COHORT_DELETION_MARK_FAILURE_COUNTER = Counter(
-    "posthog_cohort_deletion_mark_failure_total",
-    "Times cohort deletion mark failed",
-)
-
-COHORT_DELETION_RUN_FAILURE_COUNTER = Counter(
-    "posthog_cohort_deletion_run_failure_total",
-    "Times cohort deletion run failed",
-)
-
 STALE_QUEUED_TASK_RUN_SWEPT_COUNTER = Counter(
     "posthog_task_run_stale_queued_swept_total",
     "TaskRuns marked FAILED by the stale-queued cleanup sweep",
@@ -760,21 +750,9 @@ def clickhouse_mutation_count() -> None:
 
 @shared_task(ignore_result=True)
 def clickhouse_clear_removed_data() -> None:
-    from posthog.models.async_deletion.delete_cohorts import AsyncCohortDeletion
+    from posthog.models.async_deletion.delete_cohorts import sweep_cohort_deletions
 
-    cohort_runner = AsyncCohortDeletion()
-
-    try:
-        cohort_runner.mark_deletions_done()
-    except Exception as e:
-        logger.error("Failed to mark cohort deletions done", error=e, exc_info=True)
-        COHORT_DELETION_MARK_FAILURE_COUNTER.inc()
-
-    try:
-        cohort_runner.run()
-    except Exception as e:
-        logger.error("Failed to run cohort deletions", error=e, exc_info=True)
-        COHORT_DELETION_RUN_FAILURE_COUNTER.inc()
+    sweep_cohort_deletions()
 
 
 @shared_task(ignore_result=True)

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -52,6 +52,7 @@ from posthog.clickhouse.adhoc_events_deletion import (
     ADHOC_EVENTS_DELETION_TABLE_SQL,
     DROP_ADHOC_EVENTS_DELETION_TABLE_SQL,
 )
+from posthog.clickhouse.cleanup_snapshots import CLEANUP_SNAPSHOT_TABLE_SQL, DROP_CLEANUP_SNAPSHOT_TABLE_SQL
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import get_client_from_pool
 from posthog.clickhouse.cluster import ON_CLUSTER_CLAUSE
@@ -2030,6 +2031,7 @@ def reset_clickhouse_database() -> None:
             DROP_EXCHANGE_RATE_DICTIONARY_SQL(),
             DROP_WEB_PRE_AGGREGATED_TEAM_SELECTION_DICTIONARY_SQL(),
             DROP_ADHOC_EVENTS_DELETION_TABLE_SQL(),
+            *[drop_sql() for drop_sql in DROP_CLEANUP_SNAPSHOT_TABLE_SQL],
         ]
     )
     run_clickhouse_statement_in_parallel(
@@ -2152,6 +2154,7 @@ def reset_clickhouse_database() -> None:
             SESSIONS_TABLE_MV_SQL(),
             SESSIONS_VIEW_SQL(),
             ADHOC_EVENTS_DELETION_TABLE_SQL(),
+            *[table_sql() for table_sql in CLEANUP_SNAPSHOT_TABLE_SQL],
             CUSTOM_METRICS_VIEW(include_counters=True),
             WEB_PRE_AGGREGATED_TEAM_SELECTION_DATA_SQL(),
             COHORT_MEMBERSHIP_MV_SQL(),


### PR DESCRIPTION
## Problem

Two weekly ClickHouse cleanup sweeps fire at the same minute, Sunday 05:00 UTC, and each issues cluster-wide mutations.

ClickHouse cannot cheaply delete individual rows, so deletions are marked and swept later. One sweep removes persons whose latest version is deleted; the other removes membership rows for deleted or recalculated cohorts. Cohort cleanup was already disabled inside `deletes_job` because [its mutations overload the cluster](https://github.com/PostHog/posthog/blob/master/posthog/dags/deletes.py#L813), which leaves the Celery path as the only cohort cleanup, competing with the person sweep every week.

## Changes

- Adds `clickhouse_deletion_sweep_job`, which runs the cohort sweep and then the person sweep. Each op takes the previous op's output, so the two never mutate at once.
- Registers the job **without a schedule**. The Celery tasks still own the weekly run, so merging changes nothing in production. The job is there to be launched by hand.
- Snapshots the deleted persons into the persisted table from #80943, scoped by run id, before deleting them. The sweep destroys the tombstones the set is derived from, so a later step cannot recompute it. This is what lets #80017 add `person_distinct_id2` cleanup as an insertion rather than a rewrite.
- Authenticates the dictionary source as `dict_reader`, matching the Celery `delete_person.py` that #80015 deletes.
- Extracts the two guarded cohort passes into `sweep_cohort_deletions()` in `delete_cohorts.py`. The Dagster op, the Celery task and `start_delete_mutation` all call it, so there is one implementation while both paths exist.
- Retries the wait on a mutation when a lagged replica does not know it yet. The mutation entry replicates through Keeper, `MutationWaiter.is_done` raises `MutationNotFound` in that window, and `run_on_shards` already guards the same case.
- Caps the wait for a dictionary to load at 600s. The Celery job had that cap; the polling loop this replaces had none, so a dictionary wedged in `LOADING` would hold a weekly run open indefinitely.
- Moves the two cohort failure counters next to `AsyncCohortDeletion`. Defining them in the job as well would register the same metric name twice in one process.
- `dry_run` defaults to true and is declared on the first op alone, then travels to the rest on that op's output. Declaring it on every op would let a launch set it on one and miss another.

**The cohort sweep goes first, not last.** Both sweeps issue cluster-wide mutations and cannot overlap, so one has to be first. The person mutation can run for hours, so putting it first would leave cohort rows unswept every week it ran long or failed. Going cohorts-first also keeps the person snapshot as close to its own delete as possible, which is what bounds how many persons can revive mid-run.

**The delete is bounded by the version the snapshot observed.** [The Celery job deletes every version of a matched person](https://github.com/PostHog/posthog/blob/master/posthog/models/async_deletion/delete_person.py#L70-L74), so a client that recaptures a deleted distinct id mid-run has that new person state swept away with the old. The predicate reads `max_version` off the dictionary and stops there. This is one pass, not the two ordered passes #80017 adds; those address a different hazard, an interrupted mutation leaving an older live row as the surviving version.

This is the second PR of the stack. The next one adds `person_distinct_id2` cleanup and the Postgres handoff, then the shared dictionary lifecycle, then the trigger; Celery is retired last.

**Stack order (rebuilt 2026-08-27):** #80943 → #80009 → #80017 → #83981 land first and are inert (no schedule, `dry_run` defaults true) so the sweep can be smoke-tested by hand; #82729 then enables the trigger; #80015 retires Celery last, after the smoke run.

## How did you test this code?

I (actually Claude) ran the tests below against the dev ClickHouse. No manual product testing happened, and I have not launched this in a real Dagster deployment.

Ten cases in `posthog/dags/tests/test_clickhouse_cleanup.py`. Six carry over the regressions that [`test_delete_person.py`](https://github.com/PostHog/posthog/blob/master/posthog/models/async_deletion/test_delete_person.py) already guards, because the sweep logic moved and those have to keep holding:

- A person deleted at a later version loses every version. A delete keyed on `is_deleted` instead of on the person would strand the earlier live row.
- A person deleted then revived at a higher version survives. Dropping the `argMax` gate for a plain `is_deleted` check deletes a live person.
- An empty snapshot is a no-op, and a second run changes nothing.
- The dictionary is dropped and the run's rows are cleared. Leaking the dictionary holds the key set in memory on every host; leaving the rows makes every later run read them, now that the table is shared.

The rest are new to this PR:

- `dry_run` deletes no persons, no cohort rows, and marks no `AsyncDeletion` rows.
- The cohort sweep clears rows on the first run and marks the deletion verified on the next. The mark pass runs before the delete pass, so verification lags by one run; a reordering that drops the mark pass would leave rows unverified forever.
- The cohort delete pass still runs when the mark pass raises. Collapsing the two guards into one `try` would skip the pass that removes rows.

One catches the ordering above: the cohort sweep still clears its rows when the person delete raises. Move the cohort op back downstream and it fails.

One catches the version bound: a person version written after the snapshot survives the sweep. I checked it has teeth rather than assuming — swapping the predicate back to the Celery job's unbounded `dictHas` makes it fail, with the recreated person's row gone. That is the data-loss case, not a bookkeeping difference.

One existing assertion was wrong and had never executed. It required a failed run to have cleared its snapshot rows, which the failure hook deliberately does not do — the rows are what makes a failed sweep inspectable until the TTL reaps them. It now asserts the dictionary invariant and the row invariant separately.

Not run: the wider backend suite. I did run repo-wide mypy.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Nothing user-facing changes, and the job is not scheduled yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude Opus 5, via Claude Code) wrote this under Eli's direction. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

Three things changed after review. The dictionary originally authenticated as the default user with a comment defending it; since the Celery code this replaces used `dict_reader`, keeping the default user would have made the cutover a privilege regression, so it now resolves `dict_reader` and falls back to default credentials where that user is not provisioned. The cohort sweep moved from last to first, which is what the `CleanupRun` carrier threaded through the ops is for. The version bound came from a review comment on this PR pointing out that the port inherited the Celery job's unbounded delete; the 600s dictionary cap turned up while checking what else the Celery job did that the port dropped.

Public artifact: everything in this diff and description comes from this repository.

