### PR TITLE
fix(data-imports): stop reporting expected row-tracking drift as an exception

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
@@ -188,9 +188,12 @@ async def update_external_data_job_model(inputs: UpdateExternalDataJobStatusInpu
 
     rows_tracked = await get_rows(inputs.team_id, inputs.schema_id)
     if rows_tracked > 0 and inputs.status == ExternalDataJob.Status.COMPLETED:
-        msg = f"Rows tracked is greater than 0 on a COMPLETED job. rows_tracked={rows_tracked}"
-        logger.debug(msg)
-        capture_exception(Exception(msg))
+        # `rows_tracked` is decremented by rows actually written, but incremented by
+        # `resource.rows_to_sync`, a pre-extraction COUNT(*) probe (see e.g. `_get_rows_to_sync`)
+        # that can race with concurrent changes on a live source table. A small positive leftover
+        # here is an expected consequence of that estimate rather than a pipeline bug, so log it
+        # instead of capture_exception; finish_row_tracking below clears the key regardless.
+        logger.warning(f"Rows tracked is greater than 0 on a COMPLETED job. rows_tracked={rows_tracked}")
 
     await finish_row_tracking(inputs.team_id, inputs.schema_id)
 

--- a/products/warehouse_sources/backend/temporal/data_imports/tests/test_external_data_job_activities.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/test_external_data_job_activities.py
@@ -1,6 +1,7 @@
 from posthog.test.base import BaseTest
 from unittest import mock
 
+from asgiref.sync import async_to_sync
 from parameterized import parameterized
 from temporalio.testing import ActivityEnvironment
 
@@ -10,7 +11,9 @@ from products.warehouse_sources.backend.models.external_data_job import External
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 from products.warehouse_sources.backend.temporal.data_imports.external_data_job import (
+    UpdateExternalDataJobStatusInputs,
     trigger_schedule_buffer_one_activity,
+    update_external_data_job_model,
 )
 
 
@@ -56,3 +59,41 @@ class TestTriggerScheduleBufferOneActivity(BaseTest):
         assert isinstance(inputs, ExternalDataWorkflowInputs)
         assert inputs.billable is False
         assert inputs.external_data_schema_id == schema.id
+
+
+class TestUpdateExternalDataJobModelActivity(BaseTest):
+    def test_leftover_tracked_rows_on_completed_job_are_not_captured_as_an_exception(self) -> None:
+        # rows_to_sync is a pre-extraction COUNT(*) estimate that can race with concurrent
+        # changes on the source table, so a small leftover on a completed job is expected and
+        # must not be reported to error tracking as a bug.
+        env = ActivityEnvironment()
+        inputs = UpdateExternalDataJobStatusInputs(
+            team_id=self.team.id,
+            job_id="019fde98-0727-0000-3f05-9991b4c84155",
+            schema_id="019fde98-0727-0000-3f05-9991b4c84156",
+            source_id="019fde98-0727-0000-3f05-9991b4c84157",
+            status=ExternalDataJob.Status.COMPLETED,
+            internal_error=None,
+            latest_error=None,
+        )
+
+        with (
+            mock.patch(
+                "products.warehouse_sources.backend.temporal.data_imports.external_data_job.get_rows",
+                return_value=1,
+            ),
+            mock.patch(
+                "products.warehouse_sources.backend.temporal.data_imports.external_data_job.finish_row_tracking"
+            ) as mock_finish_row_tracking,
+            mock.patch(
+                "products.warehouse_sources.backend.temporal.data_imports.external_data_job.capture_exception"
+            ) as mock_capture_exception,
+            mock.patch(
+                "products.warehouse_sources.backend.temporal.data_imports.external_data_job.update_external_job_status"
+            ) as mock_update_job_status,
+        ):
+            async_to_sync(env.run)(update_external_data_job_model, inputs)
+
+        mock_capture_exception.assert_not_called()
+        mock_finish_row_tracking.assert_called_once_with(self.team.id, inputs.schema_id)
+        mock_update_job_status.assert_called_once()

--- a/products/warehouse_sources/backend/temporal/data_imports/tests/test_external_data_job_activities.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/test_external_data_job_activities.py
@@ -1,7 +1,8 @@
+import asyncio
+
 from posthog.test.base import BaseTest
 from unittest import mock
 
-from asgiref.sync import async_to_sync
 from parameterized import parameterized
 from temporalio.testing import ActivityEnvironment
 
@@ -92,7 +93,7 @@ class TestUpdateExternalDataJobModelActivity(BaseTest):
                 "products.warehouse_sources.backend.temporal.data_imports.external_data_job.update_external_job_status"
             ) as mock_update_job_status,
         ):
-            async_to_sync(env.run)(update_external_data_job_model, inputs)
+            asyncio.run(env.run(update_external_data_job_model, inputs))
 
         mock_capture_exception.assert_not_called()
         mock_finish_row_tracking.assert_called_once_with(self.team.id, inputs.schema_id)


### PR DESCRIPTION
## Problem

A data warehouse sync that finishes successfully can raise `Exception('Rows tracked is greater than 0 on a COMPLETED job. rows_tracked=1')` to error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019fde7b-d23f-7c11-840d-ad0b5ba1b7bb)), even though nothing actually broke.

`rows_tracked` is a Redis counter incremented from `resource.rows_to_sync`, a pre-extraction `COUNT(*)` probe, and decremented by rows actually written during the sync. The probe deliberately shares its `FROM`/`WHERE` with the real extraction query, but the two still run as separate queries against a live source table, so a row added or removed between them is expected to leave a small leftover. `finish_row_tracking` clears the Redis key unconditionally right after this check, so the leftover never persists or affects billing.

## Changes

- `update_external_data_job_model` now logs this leftover with `logger.warning` instead of calling `capture_exception`, so it stays visible in logs without paging on-call for an expected mismatch.
- This mirrors the existing precedent for the same estimate-vs-actual mismatch in `_get_rows_to_sync` (Postgres source), which already logs at debug instead of capturing, for the same reason.

## How did you test this code?

- Added `TestUpdateExternalDataJobModelActivity` in `test_external_data_job_activities.py`: runs the activity with `get_rows` mocked to return a leftover count on a `COMPLETED` job, and asserts `capture_exception` is not called while `finish_row_tracking` still runs. Confirmed it fails against the pre-fix code and passes after the fix.
- Not run: a live warehouse sync against a real source, since the mismatch depends on timing against a live table that isn't reproducible locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude Code) investigated a real error surfaced by PostHog error tracking, traced the exception to its source, and determined it was a false-positive check comparing an estimate to an actual count rather than a real pipeline bug. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
