### PR TITLE
feat(clickhouse): sweep orphaned distinct ids and hand persons to Postgres

### DIFF
--- a/posthog/dags/clickhouse_cleanup.py
+++ b/posthog/dags/clickhouse_cleanup.py
@@ -1,42 +1,89 @@
-"""Weekly ClickHouse cleanup sweeps: deleted cohort memberships, then deleted persons.
+"""Weekly ClickHouse cleanup sweeps: deleted cohort memberships, then deleted persons and the
+distinct ids that belonged to them.
 
-ClickHouse cannot cheaply delete individual rows, so deletions are marked and swept later.
-Both sweeps issue cluster-wide mutations, and running those at the same time overloads the
-cluster, so the ops below are chained on each other's output to force them into sequence.
+ClickHouse cannot cheaply delete individual rows, so deletions are marked and swept later. Every
+sweep issues cluster-wide mutations, and running those at the same time overloads the cluster, so
+the ops below are chained on each other's output to force them into sequence.
+
+The person sweep destroys the tombstones its own worklist is derived from, so the run freezes that
+worklist into a persisted snapshot table first, scoped by run id. Everything downstream, including
+the Postgres handoff, reads the snapshot rather than recomputing it.
 """
 
 import time
-from dataclasses import dataclass
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime, timedelta
 from functools import partial
+from math import ceil
 
 from django.conf import settings
 
 import dagster
 import pydantic
+import psycopg2.extensions
 from clickhouse_driver.client import Client
+from prometheus_client import Counter
+from psycopg2.extras import execute_values
 
-from posthog.clickhouse.cleanup_snapshots import CLEANUP_DELETED_PERSONS_TABLE
-from posthog.clickhouse.client.connection import ClickHouseUser, get_clickhouse_creds
-from posthog.clickhouse.cluster import (
-    ClickhouseCluster,
-    LightweightDeleteMutationRunner,
-    MutationNotFound,
-    NodeRole,
-    RetryPolicy,
+from posthog.clickhouse.cleanup_snapshots import (
+    CLEANUP_DELETED_PERSONS_TABLE,
+    CLEANUP_ORPHANED_DISTINCT_IDS_TABLE,
+    CLEANUP_REVIVED_DISTINCT_IDS_TABLE,
+    CLEANUP_REVIVED_PERSONS_TABLE,
+    CLEANUP_SNAPSHOT_TABLES,
 )
+from posthog.clickhouse.client.connection import ClickHouseUser, get_clickhouse_creds
+from posthog.clickhouse.cluster import ClickhouseCluster, LightweightDeleteMutationRunner, MutationWaiter, NodeRole
+from posthog.clickhouse.custom_metrics import MetricsClient
 from posthog.dags.common import JobOwners
+from posthog.dags.common.common import settings_with_log_comment
 from posthog.models.async_deletion.delete_cohorts import sweep_cohort_deletions
-from posthog.models.person.sql import PERSONS_TABLE
+from posthog.models.person.sql import PERSON_DISTINCT_ID2_TABLE, PERSONS_TABLE
+
+logger = dagster.get_dagster_logger(__name__)
+
+REVIVED_PERSON_COUNTER = Counter(
+    "posthog_clickhouse_cleanup_revived_persons_total",
+    "Persons that came back to life between the snapshot and the sweep, and were excluded",
+)
+
+REVIVED_DISTINCT_ID_COUNTER = Counter(
+    "posthog_clickhouse_cleanup_revived_distinct_ids_total",
+    "Distinct id mappings that came back between the snapshot and the sweep, and were excluded",
+)
+
+PG_CLEANUP_QUEUE_TABLE = "person_pg_cleanup_queue"
+
+# How many queued persons travel per ClickHouse read and per Postgres upsert transaction. Bounds
+# the op's memory to one page however large the snapshot is.
+PERSIST_PAGE_SIZE = 50_000
+
+# Each delete runs as one pair of ordered mutations per contiguous team-id range. Ranges do not
+# reduce what a mutation reads or rewrites: merged parts span nearly the whole team-id space, so
+# every batch touches most parts and each extra batch re-rewrites their delete masks. What
+# batching buys is granularity, since each batch is a separate mutation with stable command text
+# that a retry re-attaches to instead of restarting a table-sized mutation. Keep this small.
+DEFAULT_TEAM_BATCHES = 4
 
 
 class CleanupConfig(dagster.Config):
+    """Read once, by the first op, and carried to every later op on CleanupRun.
+
+    Setting any of these on another op's config has no effect.
+    """
+
     dry_run: bool = pydantic.Field(
         default=True,
         description="Build the snapshot and report what would be removed, without deleting anything.",
     )
     cleanup: bool = pydantic.Field(
         default=True,
-        description="Drop the dictionary and clear this run's snapshot rows when the run finishes.",
+        description="Drop the dictionaries and clear this run's snapshot rows when the run finishes.",
+    )
+    team_batches: int = pydantic.Field(
+        default=DEFAULT_TEAM_BATCHES,
+        description="How many contiguous team ranges to split each delete into.",
     )
     shards: int = pydantic.Field(default=16, description="Dictionary SHARDS, which parallelize loading.")
     max_execution_time: int = pydantic.Field(default=0, description="Dictionary load timeout, 0 for no limit.")
@@ -45,48 +92,95 @@ class CleanupConfig(dagster.Config):
         default=600,
         description="How long to wait for a dictionary to finish loading on a host before failing the run.",
     )
-
-
-@dataclass(frozen=True, kw_only=True)
-class CleanupRun:
-    """Every per-run asset, threaded through the ops so they execute in sequence.
-
-    Settings that outlive the first op travel here rather than being read from config by each op,
-    so they are set in one place. Declaring dry_run on every op would let a launch set it on one
-    and miss another, and half a sweep is worse than none.
-    """
-
-    persons: "DeletedPersonsTable"
-    dry_run: bool
-    dictionary_load_timeout: int
-
-    @property
-    def persons_dictionary(self) -> "DeletedPersonsDictionary":
-        return DeletedPersonsDictionary(source=self.persons)
+    mutation_stall_timeout: int = pydantic.Field(
+        default=1800,
+        description="Fail a delete batch when attempts keep failing and no part completes for this many seconds.",
+    )
 
 
 @dataclass(frozen=True)
-class DeletedPersonsTable:
-    """One run's slice of the persons whose latest ClickHouse version is deleted.
+class SnapshotTable:
+    """One run's rows in a persisted worklist holding one stage of the sweep.
 
-    The sweep removes those rows, which destroys the tombstones the set was derived from, so
-    the set is captured here first and every later step reads it from here rather than
-    recomputing it.
-
-    Every run writes into the same persisted table and reads back its own rows by run id.
-    Creating and dropping a replicated table per run instead would churn DDL across every node
-    once a week, and a run's rows expire on their own through the table's TTL.
+    Every run writes into the same table and reads back its own rows by run id. Creating and
+    dropping a replicated table per run instead would churn DDL across every node once a week.
+    `run_id` leads the sort key, so a run reads only its own rows through the primary index, and
+    a successful run clears them when it finishes.
     """
 
     run_id: str
 
     @property
     def table_name(self) -> str:
-        return CLEANUP_DELETED_PERSONS_TABLE
+        raise NotImplementedError
+
+    @property
+    def keys(self) -> str:
+        """The columns that identify a row within a run."""
+        raise NotImplementedError
+
+    @property
+    def dictionary_types(self) -> str:
+        """The column list a dictionary over this table declares."""
+        raise NotImplementedError
 
     @property
     def qualified_name(self) -> str:
         return f"{settings.CLICKHOUSE_DATABASE}.{self.table_name}"
+
+    @property
+    def run_keys_query(self) -> str:
+        """This run's keys, for embedding in an IN or NOT IN clause.
+
+        The run id is interpolated rather than passed as a parameter because these fragments end
+        up inside dictionary source queries and mutation commands, neither of which carries
+        parameters. It is a Dagster run id with the dashes replaced, so there is nothing to quote.
+        """
+        return f"SELECT {self.keys} FROM {self.qualified_name} WHERE run_id = '{self.run_id}'"
+
+    def count(self, client: Client) -> int:
+        [[count]] = client.execute(
+            f"SELECT count() FROM {self.qualified_name} WHERE run_id = %(run_id)s",
+            {"run_id": self.run_id},
+        )
+        return count
+
+    def team_ids(self, client: Client) -> list[int]:
+        rows = client.execute(
+            f"SELECT DISTINCT team_id FROM {self.qualified_name} WHERE run_id = %(run_id)s ORDER BY team_id",
+            {"run_id": self.run_id},
+        )
+        return [row[0] for row in rows]
+
+    def distinct_key_count(self, client: Client) -> int:
+        # Deduplicated, so the number is stable whether or not a merge has collapsed the
+        # duplicate rows a retried populate leaves behind.
+        [[count]] = client.execute(
+            f"SELECT count() FROM (SELECT {self.keys} FROM {self.qualified_name}"
+            f" WHERE run_id = %(run_id)s GROUP BY {self.keys})",
+            {"run_id": self.run_id},
+        )
+        return count
+
+    def sync_replica(self, client: Client) -> None:
+        client.execute(f"SYSTEM SYNC REPLICA {self.qualified_name} STRICT")
+
+    def drop_run_partition(self, client: Client) -> None:
+        # The table is partitioned by run_id, so clearing a run is a metadata-only partition drop
+        # rather than a mutation that rewrites every part. A missing partition is a no-op.
+        client.execute(
+            f"ALTER TABLE {self.qualified_name} DROP PARTITION %(run_id)s",
+            {"run_id": self.run_id},
+        )
+
+
+@dataclass(frozen=True)
+class DeletedPersonsTable(SnapshotTable):
+    """Persons whose latest ClickHouse version is deleted."""
+
+    table_name = CLEANUP_DELETED_PERSONS_TABLE
+    keys = "team_id, person_id"
+    dictionary_types = "team_id Int64, person_id UUID, max_version UInt64"
 
     def populate(self, client: Client) -> None:
         # A person can be soft-deleted and later revived by a higher version, so membership is
@@ -104,29 +198,138 @@ class DeletedPersonsTable:
             {"run_id": self.run_id},
         )
 
-    def count(self, client: Client) -> int:
-        [[count]] = client.execute(
-            f"SELECT count() FROM {self.qualified_name} WHERE run_id = %(run_id)s",
+
+@dataclass(frozen=True)
+class RevivedPersonsTable(SnapshotTable):
+    """Snapshotted persons that came back to life while the run was in flight.
+
+    Every dictionary below reads its source through an anti-join against this table, so recording
+    a revival here is what excludes it. That keeps the checkpoints free of mutations on the
+    snapshot tables, which would be far slower than an insert.
+    """
+
+    table_name = CLEANUP_REVIVED_PERSONS_TABLE
+    keys = "team_id, person_id"
+    dictionary_types = "team_id Int64, person_id UUID"
+
+    def populate(self, client: Client, persons: DeletedPersonsTable) -> int:
+        # Later checkpoints re-run this, so already-recorded revivals are excluded rather than
+        # inserted again. Counting this run's rows is what reports how many are newly revived.
+        client.execute(
+            f"""
+            INSERT INTO {self.qualified_name} (run_id, team_id, person_id)
+            SELECT %(run_id)s, team_id, id
+            FROM {PERSONS_TABLE}
+            WHERE (team_id, id) IN ({persons.run_keys_query})
+              AND (team_id, id) NOT IN ({self.run_keys_query})
+            GROUP BY team_id, id
+            HAVING argMax(is_deleted, version) = 0
+            """,
             {"run_id": self.run_id},
         )
-        return count
+        return self.count(client)
 
-    def drop_run_partition(self, client: Client) -> None:
-        # The table is partitioned by run_id, so clearing a run is a metadata-only partition drop
-        # rather than a mutation that rewrites every part. A missing partition is a no-op.
+
+@dataclass(frozen=True)
+class OrphanedDistinctIdsTable(SnapshotTable):
+    """Distinct ids to remove, with the reason each one qualified.
+
+    own_tombstone records why a key is here. The exclusion at each checkpoint is re-derived from
+    live data in RevivedDistinctIdsTable rather than from this column, because both the tombstone
+    and the owner can change while the run is in flight.
+    """
+
+    table_name = CLEANUP_ORPHANED_DISTINCT_IDS_TABLE
+    keys = "team_id, distinct_id"
+    dictionary_types = "team_id Int64, distinct_id String, max_version Int64"
+
+    def populate(self, client: Client, persons_dictionary: "SnapshotDictionary") -> None:
+        # person_distinct_id2 is keyed on (team_id, distinct_id) with person_id as a value, so a
+        # distinct id can be repointed over time. Deleting rows that merely match a deleted
+        # person_id can strip the newest row and resurrect an older mapping underneath it, so the
+        # current owner is resolved with argMax and every version of a qualifying key is removed.
         client.execute(
-            f"ALTER TABLE {self.qualified_name} DROP PARTITION %(run_id)s",
+            f"""
+            INSERT INTO {self.qualified_name} (run_id, team_id, distinct_id, person_id, own_tombstone, max_version)
+            SELECT
+                %(run_id)s,
+                team_id,
+                distinct_id,
+                argMax(person_id, version) AS person_id,
+                argMax(is_deleted, version) > 0 AS own_tombstone,
+                max(version) AS max_version
+            FROM {PERSON_DISTINCT_ID2_TABLE}
+            WHERE (team_id, distinct_id) IN (
+                SELECT team_id, distinct_id
+                FROM {PERSON_DISTINCT_ID2_TABLE}
+                WHERE is_deleted > 0 OR dictHas('{persons_dictionary.qualified_name}', (team_id, person_id))
+            )
+            GROUP BY team_id, distinct_id
+            HAVING own_tombstone OR dictHas('{persons_dictionary.qualified_name}', (team_id, person_id))
+            """,
             {"run_id": self.run_id},
         )
 
 
 @dataclass(frozen=True)
-class DeletedPersonsDictionary:
-    source: DeletedPersonsTable
+class RevivedDistinctIdsTable(SnapshotTable):
+    """Snapshotted distinct ids that no longer qualify for deletion.
+
+    A mapping can come back the same way a person can: ingestion re-captures a tombstoned
+    distinct id, or reset_deleted_person_distinct_ids republishes it at a higher version. The
+    snapshot froze the reason each key qualified, so without this the delete would strip every
+    version of a key that is live again, including the new row.
+    """
+
+    table_name = CLEANUP_REVIVED_DISTINCT_IDS_TABLE
+    keys = "team_id, distinct_id"
+    dictionary_types = "team_id Int64, distinct_id String"
+
+    def populate(
+        self,
+        client: Client,
+        orphaned: OrphanedDistinctIdsTable,
+        persons: DeletedPersonsTable,
+        revived: RevivedPersonsTable,
+    ) -> int:
+        # A key stops qualifying once its latest version is live AND its current owner is not a
+        # person this run is still deleting. Both arms of the original predicate have to fail.
+        client.execute(
+            f"""
+            INSERT INTO {self.qualified_name} (run_id, team_id, distinct_id)
+            SELECT %(run_id)s, team_id, distinct_id
+            FROM {PERSON_DISTINCT_ID2_TABLE}
+            WHERE (team_id, distinct_id) IN ({orphaned.run_keys_query})
+              AND (team_id, distinct_id) NOT IN ({self.run_keys_query})
+            GROUP BY team_id, distinct_id
+            HAVING argMax(is_deleted, version) = 0
+               AND (team_id, argMax(person_id, version)) NOT IN (
+                   SELECT team_id, person_id FROM {persons.qualified_name}
+                   WHERE run_id = '{persons.run_id}'
+                     AND (team_id, person_id) NOT IN ({revived.run_keys_query})
+               )
+            """,
+            {"run_id": self.run_id},
+        )
+        return self.count(client)
+
+
+@dataclass(frozen=True, kw_only=True)
+class SnapshotDictionary:
+    """A cluster-wide dictionary over one run's rows in a worklist, minus anything since revived."""
+
+    source: SnapshotTable
+    # Keys recorded here are anti-joined out of the dictionary, which is how a checkpoint
+    # excludes something without mutating the worklist it came from.
+    excluded: SnapshotTable
+
+    @property
+    def key_columns(self) -> str:
+        return self.source.keys
 
     @property
     def name(self) -> str:
-        # Runs share the table, so the run id has to live on the dictionary instead for two runs
+        # Runs share the tables, so the run id has to live on the dictionary instead for two runs
         # not to fight over one name.
         return f"{self.source.table_name}_{self.source.run_id}_dictionary"
 
@@ -136,10 +339,16 @@ class DeletedPersonsDictionary:
 
     @property
     def query(self) -> str:
-        return (
-            f"SELECT team_id, person_id, max_version FROM {self.source.qualified_name}"
-            f" WHERE run_id = '{self.source.run_id}'"
-        )
+        # Aggregated because a retried populate leaves duplicate key rows until a merge collapses
+        # them, and an unaggregated read would hand the dictionary an arbitrary one. max() picks
+        # the newest bound, matching the row the sub-second version column keeps at merge time.
+        return f"""
+            SELECT {self.key_columns}, max(max_version) AS max_version
+            FROM {self.source.qualified_name}
+            WHERE run_id = '{self.source.run_id}'
+              AND ({self.key_columns}) NOT IN ({self.excluded.run_keys_query})
+            GROUP BY {self.key_columns}
+        """
 
     def create(self, client: Client, shards: int, max_execution_time: int, max_memory_usage: int) -> None:
         # The source reads as the low-privilege dict_reader user, which falls back to the default
@@ -148,12 +357,8 @@ class DeletedPersonsDictionary:
         creds = get_clickhouse_creds(ClickHouseUser.DICT_READER)
         client.execute(
             f"""
-            CREATE DICTIONARY IF NOT EXISTS {self.qualified_name} (
-                team_id Int64,
-                person_id UUID,
-                max_version UInt64
-            )
-            PRIMARY KEY team_id, person_id
+            CREATE DICTIONARY IF NOT EXISTS {self.qualified_name} ({self.source.dictionary_types})
+            PRIMARY KEY {self.key_columns}
             SOURCE(CLICKHOUSE(DB %(database)s USER %(user)s PASSWORD %(password)s QUERY %(query)s))
             LAYOUT(COMPLEX_KEY_HASHED(SHARDS {shards}))
             LIFETIME(0)
@@ -201,28 +406,116 @@ class DeletedPersonsDictionary:
         return self.checksum(client)
 
     def checksum(self, client: Client) -> int:
-        # XOR is order independent, so hosts that hold the same keys agree regardless of read order.
-        [[checksum]] = client.execute(f"SELECT groupBitXor(cityHash64(team_id, person_id)) FROM {self.qualified_name}")
+        # XOR is order independent, so hosts that hold the same entries agree regardless of read
+        # order. max_version is hashed along with the keys because the delete mutation reads it
+        # from each host's local dictionary: hosts agreeing on keys but not on the version bound
+        # would delete different version sets per replica and diverge the table.
+        [[checksum]] = client.execute(
+            f"SELECT groupBitXor(cityHash64({self.key_columns}, max_version)) FROM {self.qualified_name}"
+        )
         return checksum
+
+
+@dataclass(frozen=True, kw_only=True)
+class CleanupRun:
+    """Every per-run asset and setting, threaded through the ops so they execute in sequence.
+
+    Settings travel here rather than being read from config by each op, so a launch sets them in
+    one place: the first op's config. Declaring them per op would let a launch set one on some
+    ops and miss others, and a sweep whose halves disagree on dry_run or batching is worse than
+    none.
+    """
+
+    persons: DeletedPersonsTable
+    revived: RevivedPersonsTable
+    orphaned: OrphanedDistinctIdsTable
+    revived_distinct_ids: RevivedDistinctIdsTable
+    dry_run: bool
+    cleanup: bool
+    team_batches: int
+    shards: int
+    max_execution_time: int
+    max_memory_usage: int
+    dictionary_load_timeout: int
+    mutation_stall_timeout: int
+    distinct_ids_deleted_at: datetime | None = None
+    # Distinct key counts recorded when each snapshot was taken. The deletes assert against them,
+    # so a snapshot the 14-day TTL reaped mid-run fails the run instead of under-deleting silently.
+    persons_count: int = 0
+    orphaned_count: int = 0
+
+    @classmethod
+    def for_run(cls, run_id: str, config: CleanupConfig) -> "CleanupRun":
+        # Dictionary names embed the run id, and a dash is not valid in an identifier.
+        scoped = run_id.replace("-", "_")
+        return cls(
+            persons=DeletedPersonsTable(run_id=scoped),
+            revived=RevivedPersonsTable(run_id=scoped),
+            orphaned=OrphanedDistinctIdsTable(run_id=scoped),
+            revived_distinct_ids=RevivedDistinctIdsTable(run_id=scoped),
+            dry_run=config.dry_run,
+            cleanup=config.cleanup,
+            team_batches=config.team_batches,
+            shards=config.shards,
+            max_execution_time=config.max_execution_time,
+            max_memory_usage=config.max_memory_usage,
+            dictionary_load_timeout=config.dictionary_load_timeout,
+            mutation_stall_timeout=config.mutation_stall_timeout,
+        )
+
+    @property
+    def all_tables(self) -> tuple[SnapshotTable, ...]:
+        return (self.persons, self.revived, self.orphaned, self.revived_distinct_ids)
+
+    @property
+    def persons_dictionary(self) -> SnapshotDictionary:
+        return SnapshotDictionary(source=self.persons, excluded=self.revived)
+
+    @property
+    def orphaned_dictionary(self) -> SnapshotDictionary:
+        return SnapshotDictionary(source=self.orphaned, excluded=self.revived_distinct_ids)
+
+
+def _load_and_verify(cluster: ClickhouseCluster, dictionary: SnapshotDictionary, timeout_seconds: int) -> None:
+    """Load on every host and require them to agree.
+
+    The delete predicate probes whichever host runs the mutation, so hosts holding different key
+    sets would delete different rows. Every load goes through here, including the reloads a
+    checkpoint issues after recording a revival.
+    """
+    checksums = cluster.map_all_hosts(partial(dictionary.load, timeout_seconds=timeout_seconds), concurrency=1).result()
+    assert len(set(checksums.values())) == 1, f"{dictionary.name} differs across hosts: {checksums}"
+
+
+def _create_dictionary(
+    cluster: ClickhouseCluster, dictionary: SnapshotDictionary, run: CleanupRun
+) -> SnapshotDictionary:
+    cluster.map_all_hosts(
+        partial(
+            dictionary.create,
+            shards=run.shards,
+            max_execution_time=run.max_execution_time,
+            max_memory_usage=run.max_memory_usage,
+        )
+    ).result()
+    _load_and_verify(cluster, dictionary, run.dictionary_load_timeout)
+    return dictionary
 
 
 @dagster.op
 def clear_removed_cohort_data(
     context: dagster.OpExecutionContext,
     config: CleanupConfig,
+    cluster: dagster.ResourceParam[ClickhouseCluster],
 ) -> CleanupRun:
     """Remove cohort membership rows for cohorts that were deleted or recalculated.
 
-    Runs ahead of the person sweep rather than after it. The two cannot overlap, and the person
-    mutation can run for hours, so putting it first would leave cohort rows unswept whenever it
-    ran long or failed. Going first also keeps the person snapshot as close to its own delete as
+    Runs ahead of the person sweep rather than after it. The sweeps cannot overlap, and the person
+    path runs for hours, so putting it last would leave cohort rows unswept whenever that path ran
+    long or failed. Going first also keeps the person snapshot as close to its own delete as
     possible, which is what bounds how many persons can revive mid-run.
     """
-    run = CleanupRun(
-        persons=DeletedPersonsTable(run_id=context.run_id.replace("-", "_")),
-        dry_run=config.dry_run,
-        dictionary_load_timeout=config.dictionary_load_timeout,
-    )
+    run = CleanupRun.for_run(context.run_id, config)
     context.add_output_metadata({"dry_run": dagster.MetadataValue.bool(run.dry_run)})
 
     if run.dry_run:
@@ -231,6 +524,10 @@ def clear_removed_cohort_data(
 
     failed = sweep_cohort_deletions()
     context.add_output_metadata({"failed_passes": dagster.MetadataValue.text(", ".join(failed) or "none")})
+    # The prometheus counters sweep_cohort_deletions increments die with this run's pod, so the
+    # scrapeable record of a failed pass is the ClickHouse-backed counter.
+    for name in failed:
+        _emit(MetricsClient(cluster), "clickhouse_cleanup_cohort_sweep_failed_passes", {"pass": name})
     return run
 
 
@@ -241,55 +538,475 @@ def snapshot_deleted_persons(
     run: CleanupRun,
 ) -> CleanupRun:
     """Capture the persons whose latest version is deleted, tagged with this run's id."""
-    table = run.persons
-
-    cluster.any_host_by_role(table.populate, NodeRole.DATA).result()
-
+    cluster.any_host_by_role(run.persons.populate, NodeRole.DATA).result()
     # The insert lands on one host, but every host reads this table when the dictionary loads.
-    def sync_replica(client: Client) -> None:
-        client.execute(f"SYSTEM SYNC REPLICA {table.qualified_name} STRICT")
+    cluster.map_all_hosts(run.persons.sync_replica).result()
 
-    cluster.map_all_hosts(sync_replica).result()
-
-    count = cluster.any_host_by_role(table.count, NodeRole.DATA).result()
-    context.add_output_metadata(
-        {
-            "deleted_persons": dagster.MetadataValue.int(count),
-            "table_name": dagster.MetadataValue.text(table.table_name),
-        }
-    )
-    return run
+    count = cluster.any_host_by_role(run.persons.distinct_key_count, NodeRole.DATA).result()
+    context.add_output_metadata({"deleted_persons": dagster.MetadataValue.int(count)})
+    return replace(run, persons_count=count)
 
 
 @dagster.op
-def build_deleted_persons_dictionary(
-    config: CleanupConfig,
+def snapshot_orphaned_distinct_ids(
+    context: dagster.OpExecutionContext,
     cluster: dagster.ResourceParam[ClickhouseCluster],
     run: CleanupRun,
 ) -> CleanupRun:
-    """Create the dictionary the delete predicate probes, on every host."""
-    cluster.map_all_hosts(
-        partial(
-            run.persons_dictionary.create,
-            shards=config.shards,
-            max_execution_time=config.max_execution_time,
-            max_memory_usage=config.max_memory_usage,
+    """Resolve which distinct ids belong to the snapshotted persons, or tombstoned themselves."""
+    _create_dictionary(cluster, run.persons_dictionary, run)
+
+    cluster.any_host_by_role(
+        partial(run.orphaned.populate, persons_dictionary=run.persons_dictionary), NodeRole.DATA
+    ).result()
+    cluster.map_all_hosts(run.orphaned.sync_replica).result()
+    _create_dictionary(cluster, run.orphaned_dictionary, run)
+
+    count = cluster.any_host_by_role(run.orphaned.distinct_key_count, NodeRole.DATA).result()
+    context.add_output_metadata({"orphaned_distinct_ids": dagster.MetadataValue.int(count)})
+    return replace(run, orphaned_count=count)
+
+
+def recheck_revived_persons(name: str) -> dagster.OpDefinition:
+    """Build a checkpoint op that excludes any person revived since the snapshot.
+
+    The checkpoints sit at phase boundaries rather than inside the mutation, because a mutation
+    over an unpartitioned table runs long and re-checking mid-flight cannot retract work already
+    applied. A person revived inside that window has already lost its distinct id rows;
+    reset_deleted_person_distinct_ids and the sync_person_distinct_ids workflow republish them
+    from Postgres.
+    """
+
+    @dagster.op(name=name)
+    def checkpoint(
+        context: dagster.OpExecutionContext,
+        cluster: dagster.ResourceParam[ClickhouseCluster],
+        run: CleanupRun,
+    ) -> CleanupRun:
+        persons_before = cluster.any_host_by_role(run.revived.count, NodeRole.DATA).result()
+        persons_total = cluster.any_host_by_role(
+            partial(run.revived.populate, persons=run.persons), NodeRole.DATA
+        ).result()
+        cluster.map_all_hosts(run.revived.sync_replica).result()
+
+        # Runs second: which distinct ids still qualify depends on which persons are still deleted.
+        ids_before = cluster.any_host_by_role(run.revived_distinct_ids.count, NodeRole.DATA).result()
+        ids_total = cluster.any_host_by_role(
+            partial(
+                run.revived_distinct_ids.populate,
+                orphaned=run.orphaned,
+                persons=run.persons,
+                revived=run.revived,
+            ),
+            NodeRole.DATA,
+        ).result()
+        cluster.map_all_hosts(run.revived_distinct_ids.sync_replica).result()
+
+        revived_persons = persons_total - persons_before
+        revived_ids = ids_total - ids_before
+        context.add_output_metadata(
+            {
+                "revived_persons": dagster.MetadataValue.int(revived_persons),
+                "revived_distinct_ids": dagster.MetadataValue.int(revived_ids),
+            }
         )
-    ).result()
-    return run
+        if not revived_persons and not revived_ids:
+            return run
+
+        # Reloading is what applies the exclusion, so it only happens when something came back.
+        # Counted twice on purpose: the prometheus counters only surface if this pod is ever
+        # scraped, while the ClickHouse-backed counters survive the run.
+        REVIVED_PERSON_COUNTER.inc(revived_persons)
+        REVIVED_DISTINCT_ID_COUNTER.inc(revived_ids)
+        metrics = MetricsClient(cluster)
+        if revived_persons:
+            _emit(metrics, "clickhouse_cleanup_revived", {"kind": "persons"}, value=revived_persons)
+        if revived_ids:
+            _emit(metrics, "clickhouse_cleanup_revived", {"kind": "distinct_ids"}, value=revived_ids)
+        context.log.warning(
+            "%s persons and %s distinct ids came back during the run and are excluded from it",
+            revived_persons,
+            revived_ids,
+        )
+        for dictionary in (run.persons_dictionary, run.orphaned_dictionary):
+            _load_and_verify(cluster, dictionary, run.dictionary_load_timeout)
+        return run
+
+    return checkpoint
+
+
+def _emit(metrics: MetricsClient, name: str, labels: Mapping[str, str], value: float = 1.0) -> None:
+    """Record a counter, never letting telemetry fail the sweep."""
+    try:
+        metrics.increment(name, labels=dict(labels), value=value).result()
+    except Exception:
+        logger.warning("failed to record %s", name, exc_info=True)
+
+
+MUTATION_POLL_SECONDS = 15.0
+MUTATION_VISIBILITY_TIMEOUT_SECONDS = 300.0
+
+
+class MutationStalled(Exception):
+    pass
+
+
+@dataclass(frozen=True, kw_only=True)
+class MutationStatus:
+    """One host's view of a delete batch's mutations, read from its system.mutations."""
+
+    done: bool
+    visible: bool
+    parts_to_do: int
+    latest_fail_time: datetime | None
+    latest_fail_reason: str
+    server_now: datetime
+
+
+class MutationProgress:
+    """Decides when a polled mutation is stuck rather than merely slow or still retrying.
+
+    ClickHouse retries a failed part mutation on its own, and system.mutations keeps the
+    latest_fail_* columns populated from the newest failed attempt even after later attempts
+    succeed, so a failure reason alone is not evidence the mutation is dying. A batch is declared
+    stuck only when attempts are still failing while no part has completed for stall_timeout
+    seconds. A batch that is slow without failing is left to run: that is a big part or a busy
+    cluster, not a fault.
+
+    A failure recorded before polling began is treated as history rather than evidence, because
+    MutationRunner can re-attach to an existing mutation whose old attempts failed; only failures
+    within one stall window of the first poll, or newer than the newest one already seen, count.
+    """
+
+    def __init__(self, stall_timeout: float, visibility_timeout: float = MUTATION_VISIBILITY_TIMEOUT_SECONDS) -> None:
+        self.stall_timeout = stall_timeout
+        self.visibility_timeout = visibility_timeout
+        self._started_at: float | None = None
+        self._last_progress_at: float = 0.0
+        self._min_parts_to_do: int | None = None
+        self._last_fail_time: datetime | None = None
+        self._failed_since_progress = False
+
+    def observe(self, statuses: Sequence[MutationStatus], now: float) -> None:
+        """Digest one poll of every host, raising MutationStalled when the batch is stuck."""
+        first = self._started_at is None
+        if first:
+            self._started_at = now
+            self._last_progress_at = now
+        assert self._started_at is not None
+
+        if not all(status.visible for status in statuses):
+            # The mutation entry replicates through Keeper, so a lagged replica can briefly not
+            # know it yet; that only becomes a fault when it persists.
+            if now - self._started_at > self.visibility_timeout:
+                raise MutationStalled(f"not visible on every host after {self.visibility_timeout:.0f}s")
+            return
+
+        parts_to_do = sum(status.parts_to_do for status in statuses)
+        if self._min_parts_to_do is None or parts_to_do < self._min_parts_to_do:
+            self._min_parts_to_do = parts_to_do
+            self._last_progress_at = now
+            self._failed_since_progress = False
+
+        newest_fail = max((s.latest_fail_time for s in statuses if s.latest_fail_time is not None), default=None)
+        if first:
+            self._last_fail_time = newest_fail
+            if newest_fail is not None:
+                freshness_horizon = max(s.server_now for s in statuses) - timedelta(seconds=self.stall_timeout)
+                self._failed_since_progress = newest_fail > freshness_horizon
+        elif newest_fail is not None and (self._last_fail_time is None or newest_fail > self._last_fail_time):
+            self._last_fail_time = newest_fail
+            self._failed_since_progress = True
+
+        stalled_for = now - self._last_progress_at
+        if self._failed_since_progress and stalled_for > self.stall_timeout:
+            raise MutationStalled(f"attempts keep failing and no part completed in {stalled_for:.0f}s")
+
+
+def _wait_for_mutation(
+    context: dagster.OpExecutionContext,
+    cluster: ClickhouseCluster,
+    table: str,
+    mutation: MutationWaiter,
+    label: str,
+    stall_timeout: float,
+) -> None:
+    """Block until the mutation finishes on every host, failing only when it is stuck.
+
+    MutationWaiter.wait polls is_done forever and never reads latest_fail_reason, so a mutation
+    failing on every attempt is indistinguishable from a slow one. MutationProgress arbitrates
+    between the two, and the raised Failure names the batch and mutation ids for diagnosis.
+
+    Every host is polled, not one: a mutation can fail on a single replica, and asking only one
+    host would poll a stuck mutation forever.
+    """
+    ids = tuple(mutation.mutation_ids)
+
+    def status(client: Client) -> MutationStatus:
+        [[done, visible, parts_to_do, fail_time, fail_reason, server_now]] = client.execute(
+            """
+            SELECT
+                countIf(is_done) = count() AND count() = %(expected)s,
+                count() = %(expected)s,
+                sum(parts_to_do),
+                max(latest_fail_time),
+                argMax(latest_fail_reason, latest_fail_time),
+                now()
+            FROM system.mutations
+            WHERE database = %(database)s AND table = %(table)s AND mutation_id IN %(ids)s
+            """,
+            {"database": settings.CLICKHOUSE_DATABASE, "table": table, "ids": ids, "expected": len(ids)},
+        )
+        return MutationStatus(
+            done=bool(done),
+            visible=bool(visible),
+            parts_to_do=int(parts_to_do or 0),
+            # latest_fail_time is the epoch when no attempt ever failed, so the reason is the
+            # authoritative "has failed" signal and the time is only meaningful alongside it.
+            latest_fail_time=fail_time if fail_reason else None,
+            latest_fail_reason=fail_reason or "",
+            server_now=server_now,
+        )
+
+    progress = MutationProgress(stall_timeout=stall_timeout)
+    while True:
+        statuses = list(cluster.map_all_hosts(status).result().values())
+        if statuses and all(s.done for s in statuses):
+            return
+
+        parts_to_do = sum(s.parts_to_do for s in statuses)
+        fail_reason = next((s.latest_fail_reason for s in statuses if s.latest_fail_reason), "")
+        try:
+            progress.observe(statuses, time.monotonic())
+        except MutationStalled as stalled:
+            raise dagster.Failure(
+                description=f"mutation on {table} looks stuck: {fail_reason or stalled}",
+                metadata={
+                    "batch": dagster.MetadataValue.text(label),
+                    "mutation_ids": dagster.MetadataValue.text(", ".join(ids)),
+                    "parts_to_do": dagster.MetadataValue.int(parts_to_do),
+                    "latest_fail_reason": dagster.MetadataValue.text(fail_reason),
+                    "stall": dagster.MetadataValue.text(str(stalled)),
+                },
+            ) from stalled
+
+        if fail_reason:
+            context.log.warning(
+                "%s: %s parts remaining, ClickHouse retrying after: %s", label, parts_to_do, fail_reason
+            )
+        else:
+            context.log.info("%s: %s parts remaining", label, parts_to_do)
+        time.sleep(MUTATION_POLL_SECONDS)
+
+
+@dataclass(frozen=True, kw_only=True)
+class TeamRange:
+    """One inclusive [low, high] slice of the candidate team ids."""
+
+    low: int
+    high: int
+
+
+def _team_ranges(team_ids: list[int], batches: int) -> list[TeamRange]:
+    """Cut sorted team ids into contiguous, inclusive [low, high] ranges that cover all of them.
+
+    Bounds are real team ids rather than an even split of the id space, so batches hold roughly
+    equal numbers of teams however sparsely the ids are distributed. They are also literal
+    integers, which keeps each batch's mutation command text short and identical across reruns —
+    that is what lets MutationRunner re-attach to a batch instead of reissuing it.
+    """
+    if not team_ids:
+        return []
+    ordered = sorted(team_ids)
+    size = max(1, ceil(len(ordered) / max(1, batches)))
+    return [
+        TeamRange(low=chunk[0], high=chunk[-1])
+        for chunk in (ordered[i : i + size] for i in range(0, len(ordered), size))
+    ]
+
+
+def _run_ordered_delete(
+    context: dagster.OpExecutionContext,
+    cluster: ClickhouseCluster,
+    table: str,
+    dictionary: SnapshotDictionary,
+    key_tuple: str,
+    team_ranges: list[TeamRange],
+    metrics: MetricsClient,
+    stall_timeout: float,
+) -> int:
+    """Delete every snapshotted row from `table`, oldest version first.
+
+    Two passes per team range, in this order and never merged:
+
+      A. every version below the key's snapshot max
+      B. the max itself
+
+    Pass A can never remove the tombstone, so while it runs the surviving max for each key is
+    still the tombstone and readers keep resolving the key as deleted. Only once A has finished
+    for a range does B remove the last row, and by then there is no older version left to fall
+    back to. Doing this in one pass instead would let an interrupted mutation strip the tombstone
+    from a part while an older live row survived in another, handing the key back to a person
+    this run is about to delete.
+
+    Both passes are bounded by the snapshot's max_version, so rows written after the snapshot are
+    never touched by a run that did not observe them.
+    """
+    lookup = f"dictGetOrNull({dictionary.qualified_name!r}, 'max_version', {key_tuple}) as snapshot_max"
+    passes = (
+        ("below_max", f"isNotNull({lookup}) AND version < snapshot_max"),
+        ("max", f"isNotNull({lookup}) AND version <= snapshot_max"),
+    )
+
+    batches = 0
+    for team_range in team_ranges:
+        for pass_name, key_predicate in passes:
+            predicate = f"team_id >= {team_range.low} AND team_id <= {team_range.high} AND {key_predicate}"
+            runner = LightweightDeleteMutationRunner(
+                table=table,
+                predicate=predicate,
+                settings=settings_with_log_comment(context),
+            )
+            # Both tables are replicated and not sharded, so a mutation started on one host
+            # reaches all of them.
+            mutation = cluster.any_host(runner).result()
+            _wait_for_mutation(
+                context,
+                cluster,
+                table,
+                mutation,
+                f"{table}:{team_range.low}-{team_range.high}:{pass_name}",
+                stall_timeout,
+            )
+            _emit(metrics, "clickhouse_cleanup_delete_pass_total", {"table": table, "pass": pass_name})
+            batches += 1
+
+    context.log.info("%s: completed %s ordered delete mutations", table, batches)
+    return batches
+
+
+def _require_snapshot_intact(cluster: ClickhouseCluster, table: SnapshotTable, recorded: int) -> None:
+    """Fail the run if the snapshot lost rows since it was recorded.
+
+    The 14-day TTL drops a run's partition unconditionally, so a run stalled past it would
+    otherwise sweep from a silently shrunken worklist, and nothing would distinguish
+    "under-deleted" from "had fewer rows".
+    """
+    current = cluster.any_host_by_role(table.distinct_key_count, NodeRole.DATA).result()
+    if current != recorded:
+        raise dagster.Failure(
+            f"{table.table_name} holds {current} keys for this run but {recorded} were snapshotted;"
+            " the snapshot TTL has likely expired mid-run, so re-run from a fresh snapshot"
+        )
 
 
 @dagster.op
-def load_and_verify_deleted_persons_dictionary(
+def delete_orphaned_distinct_ids(
+    context: dagster.OpExecutionContext,
     cluster: dagster.ResourceParam[ClickhouseCluster],
     run: CleanupRun,
 ) -> CleanupRun:
-    """Load the dictionary on all hosts and confirm they hold identical keys."""
-    checksums = cluster.map_all_hosts(
-        partial(run.persons_dictionary.load, timeout_seconds=run.dictionary_load_timeout),
-        concurrency=1,
-    ).result()
-    assert len(set(checksums.values())) == 1
+    """Remove every version of the qualifying distinct id mappings, oldest version first."""
+    if run.dry_run:
+        context.log.info("dry run: skipping the delete from %s", PERSON_DISTINCT_ID2_TABLE)
+        return run
+
+    _require_snapshot_intact(cluster, run.orphaned, run.orphaned_count)
+    ranges = _team_ranges(cluster.any_host_by_role(run.orphaned.team_ids, NodeRole.DATA).result(), run.team_batches)
+    context.add_output_metadata({"team_ranges": dagster.MetadataValue.int(len(ranges))})
+
+    _run_ordered_delete(
+        context,
+        cluster,
+        PERSON_DISTINCT_ID2_TABLE,
+        run.orphaned_dictionary,
+        "(team_id, distinct_id)",
+        ranges,
+        MetricsClient(cluster),
+        run.mutation_stall_timeout,
+    )
+
+    return replace(run, distinct_ids_deleted_at=datetime.now(UTC))
+
+
+@dagster.op
+def persist_deleted_persons(
+    context: dagster.OpExecutionContext,
+    cluster: dagster.ResourceParam[ClickhouseCluster],
+    persons_database: dagster.ResourceParam[psycopg2.extensions.connection],
+    run: CleanupRun,
+) -> CleanupRun:
+    """Hand the swept persons to Postgres, before the step that makes them unrecoverable.
+
+    The queue is advisory, never authoritative. Rows sit here until the drain runs, so a person
+    can be revived after being queued no matter how carefully this op checks. ClickHouse also
+    trails Postgres, so a person revived in Postgres can still read as deleted here. The drain
+    has to re-verify each person against Postgres before deleting it.
+    """
+    if run.dry_run:
+        context.log.info("dry run: skipping the write to %s", PG_CLEANUP_QUEUE_TABLE)
+        return run
+
+    def read_page(client: Client, after: tuple[int, str] | None) -> list[tuple[int, str]]:
+        # Reads the snapshot directly rather than the dictionary's query, so adding attributes to
+        # the dictionary cannot silently change the shape of what gets queued. Keyset pagination
+        # over (team_id, person_id) follows the table's sort key, and DISTINCT collapses the
+        # duplicate versions a retried snapshot insert can leave in the ReplacingMergeTree.
+        page_filter = "AND (team_id, person_id) > (%(after_team)s, toUUID(%(after_person)s))" if after else ""
+        return client.execute(
+            f"""
+            SELECT DISTINCT team_id, person_id FROM {run.persons.qualified_name}
+            WHERE run_id = %(run_id)s
+              AND (team_id, person_id) NOT IN ({run.revived.run_keys_query})
+              {page_filter}
+            ORDER BY team_id, person_id
+            LIMIT %(limit)s
+            """,
+            {
+                "run_id": run.persons.run_id,
+                "limit": PERSIST_PAGE_SIZE,
+                "after_team": after[0] if after else 0,
+                "after_person": after[1] if after else "",
+            },
+        )
+
+    deleted_at = run.distinct_ids_deleted_at
+    written = 0
+    after: tuple[int, str] | None = None
+    with persons_database.cursor() as cursor:
+        cursor.execute("SET application_name = 'clickhouse_cleanup'")
+        while True:
+            page = cluster.any_host_by_role(partial(read_page, after=after), NodeRole.DATA).result()
+            if not page:
+                break
+            # A person can be deleted, drained, re-created and deleted again under the same uuid,
+            # and the drain only looks at rows where cleaned_at is null. Leaving an already-cleaned
+            # row untouched would drop that second deletion on the floor and leak its Postgres rows
+            # for good, so the conflict re-arms the row instead of ignoring it. This is also what
+            # makes a rerun idempotent for persons the drain has not reached yet.
+            execute_values(
+                cursor,
+                f"""
+                INSERT INTO {PG_CLEANUP_QUEUE_TABLE} (team_id, person_uuid, deleted_at)
+                VALUES %s
+                ON CONFLICT (team_id, person_uuid) DO UPDATE
+                SET deleted_at = EXCLUDED.deleted_at, cleaned_at = NULL
+                """,
+                [(team_id, str(person_id), deleted_at) for team_id, person_id in page],
+                # One statement per page, so rowcount is the whole page rather than the last
+                # sub-batch of psycopg2's default 100-row paging.
+                page_size=len(page),
+            )
+            written += cursor.rowcount
+            # Commit per page: the upsert makes replays idempotent, and one transaction across
+            # millions of rows would hold WAL and xmin on the persons writer for the whole op.
+            persons_database.commit()
+            if len(page) < PERSIST_PAGE_SIZE:
+                break
+            last_team, last_person = page[-1]
+            after = (last_team, str(last_person))
+
+    context.add_output_metadata({"queued_for_postgres": dagster.MetadataValue.int(written)})
     return run
 
 
@@ -299,31 +1016,29 @@ def delete_persons(
     cluster: dagster.ResourceParam[ClickhouseCluster],
     run: CleanupRun,
 ) -> CleanupRun:
-    """Remove the snapshotted persons from the ClickHouse person table.
+    """Remove the snapshotted persons from the ClickHouse person table, oldest version first.
 
-    Bounded by the version the snapshot observed, so a person recreated after the snapshot keeps
-    the rows this run never saw. Without the bound, a client recapturing a deleted distinct id
-    mid-run would have that new person state swept away.
+    `person` carries the same tombstone-on-top-of-live-versions shape as person_distinct_id2, so
+    it has the same resurrection hazard and gets the same two ordered passes.
     """
     if run.dry_run:
         context.log.info("dry run: skipping the delete from %s", PERSONS_TABLE)
         return run
 
-    dictionary = run.persons_dictionary.qualified_name
-    runner = LightweightDeleteMutationRunner(
-        table=PERSONS_TABLE,
-        predicate=(
-            f"isNotNull(dictGetOrNull({dictionary!r}, 'max_version', (team_id, id)) as snapshot_max)"
-            " AND version <= snapshot_max"
-        ),
-    )
+    _require_snapshot_intact(cluster, run.persons, run.persons_count)
+    ranges = _team_ranges(cluster.any_host_by_role(run.persons.team_ids, NodeRole.DATA).result(), run.team_batches)
+    context.add_output_metadata({"team_ranges": dagster.MetadataValue.int(len(ranges))})
 
-    # person is replicated and not sharded, so a mutation started on one host reaches all of them.
-    mutation = cluster.any_host(runner).result()
-    # The mutation entry replicates through Keeper, so a lagged replica can briefly not know it
-    # and raise MutationNotFound; retry the wait like MutationRunner.run_on_shards does.
-    retry_lagged_replicas = RetryPolicy(max_attempts=3, delay=10.0, exceptions=(MutationNotFound,))
-    cluster.map_all_hosts(retry_lagged_replicas(mutation.wait)).result()
+    _run_ordered_delete(
+        context,
+        cluster,
+        PERSONS_TABLE,
+        run.persons_dictionary,
+        "(team_id, id)",
+        ranges,
+        MetricsClient(cluster),
+        run.mutation_stall_timeout,
+    )
 
     return run
 
@@ -331,50 +1046,76 @@ def delete_persons(
 @dagster.op
 def drop_snapshot_assets(
     context: dagster.OpExecutionContext,
-    config: CleanupConfig,
     cluster: dagster.ResourceParam[ClickhouseCluster],
     run: CleanupRun,
 ) -> None:
-    """Drop this run's dictionary and clear the rows it read."""
-    dictionary = run.persons_dictionary
-
-    if not config.cleanup:
-        context.log.info("cleanup disabled, leaving %s in place", dictionary.qualified_name)
+    """Drop this run's dictionaries and clear the rows they read."""
+    if not run.cleanup:
+        context.log.info("cleanup disabled, leaving the assets for run %s in place", run.persons.run_id)
         return
 
-    # The dictionary reads from the table, so it has to go first.
-    cluster.map_all_hosts(dictionary.drop).result()
-    # The TTL would reap these anyway. Clearing them now keeps the shared table small enough that
+    # The dictionaries read from the tables, so they have to go first.
+    for dictionary in (run.orphaned_dictionary, run.persons_dictionary):
+        cluster.map_all_hosts(dictionary.drop).result()
+    # The TTL would reap these anyway. Clearing them now keeps the shared tables small enough that
     # a run's own rows stay cheap to read.
-    cluster.any_host_by_role(run.persons.drop_run_partition, NodeRole.DATA).result()
+    for table in run.all_tables:
+        cluster.any_host_by_role(table.drop_run_partition, NodeRole.DATA).result()
 
 
 @dagster.failure_hook(required_resource_keys={"cluster"})
 def drop_assets_on_failure(context: dagster.HookContext) -> None:
-    """Drop this run's dictionary when an op fails.
+    """Drop this run's dictionaries when an op fails.
 
     Dagster skips downstream ops after a failure, so drop_snapshot_assets never runs and the
-    dictionary would survive on the cluster and accumulate across failures. The name comes from
-    the run id alone, so this needs nothing from the failed op.
+    dictionaries would survive on the cluster and accumulate across failures. Their names come
+    from the run id alone, so this needs nothing from the failed op.
 
     This ignores the cleanup flag on purpose. A stranded dictionary holds its whole key set in
     memory on every host, which costs more than the ability to inspect it after a failure.
 
     The failed run's rows are left behind deliberately. They cost far less than a dictionary and
-    the table's TTL reaps them, so a failed sweep stays inspectable in the meantime.
+    the tables' TTL reaps them, so a failed sweep stays inspectable in the meantime.
     """
     run_id = context.run_id.replace("-", "_")
-    name = f"{settings.CLICKHOUSE_DATABASE}.{CLEANUP_DELETED_PERSONS_TABLE}_{run_id}_dictionary"
     cluster = context.resources.cluster
 
-    cluster.map_all_hosts(lambda client: client.execute(f"DROP DICTIONARY IF EXISTS {name} SYNC")).result()
+    # A mutation still reading one of these dictionaries would fail the moment it is dropped, so
+    # kill this run's mutations first. Killing a half-applied ordered delete is safe: every
+    # intermediate state leaves each key's tombstone as the surviving max version, so nothing
+    # resurrects. Only mutations naming this run's dictionaries are touched.
+    def kill_run_mutations(client: Client) -> None:
+        for table in (PERSON_DISTINCT_ID2_TABLE, PERSONS_TABLE):
+            client.execute(
+                f"KILL MUTATION WHERE database = %(database)s AND table = %(table)s"
+                f" AND NOT is_done AND command LIKE %(pattern)s SYNC",
+                {
+                    "database": settings.CLICKHOUSE_DATABASE,
+                    "table": table,
+                    "pattern": f"%_{run_id}_dictionary%",
+                },
+            )
+
+    cluster.map_all_hosts(kill_run_mutations).result()
+
+    for table_name in CLEANUP_SNAPSHOT_TABLES:
+        name = f"{settings.CLICKHOUSE_DATABASE}.{table_name}_{run_id}_dictionary"
+        cluster.map_all_hosts(lambda client, n=name: client.execute(f"DROP DICTIONARY IF EXISTS {n} SYNC")).result()
 
 
 @dagster.job(hooks={drop_assets_on_failure}, tags={"owner": JobOwners.TEAM_CLICKHOUSE.value})
 def clickhouse_deletion_sweep_job():
-    """Sweep deleted cohort memberships out of ClickHouse, then deleted persons."""
-    # Each op takes the previous op's output, which is what keeps the two sweeps in sequence.
-    run = snapshot_deleted_persons(clear_removed_cohort_data())
-    drop_snapshot_assets(
-        delete_persons(load_and_verify_deleted_persons_dictionary(build_deleted_persons_dictionary(run)))
-    )
+    """Sweep deleted cohort memberships, then deleted persons and their distinct ids."""
+    run = snapshot_orphaned_distinct_ids(snapshot_deleted_persons(clear_removed_cohort_data()))
+
+    run = recheck_revived_persons("recheck_before_distinct_id_delete")(run)
+    run = delete_orphaned_distinct_ids(run)
+
+    # One checkpoint covers both the handoff and the person delete, so they agree on who is
+    # deleted. Checking again between them would let a revival spare a person in ClickHouse
+    # while its row stayed queued, and the Postgres drain would then clear a live person.
+    run = recheck_revived_persons("recheck_before_person_delete")(run)
+    run = persist_deleted_persons(run)
+
+    # Each op takes the previous op's output, which is what keeps the sweeps in sequence.
+    drop_snapshot_assets(delete_persons(run))

--- a/posthog/dags/tests/test_clickhouse_cleanup.py
+++ b/posthog/dags/tests/test_clickhouse_cleanup.py
@@ -1,22 +1,64 @@
+import itertools
+from collections.abc import Iterator
+from dataclasses import replace
+from datetime import datetime, timedelta
+from functools import partial
 from uuid import UUID
 
 import pytest
 from unittest.mock import patch
 
+import dagster
+import psycopg2
 from clickhouse_driver import Client
 
-from posthog.clickhouse.cleanup_snapshots import CLEANUP_DELETED_PERSONS_TABLE
+from posthog.clickhouse.cleanup_snapshots import (
+    CLEANUP_DELETED_PERSONS_TABLE,
+    CLEANUP_ORPHANED_DISTINCT_IDS_TABLE,
+    CLEANUP_REVIVED_DISTINCT_IDS_TABLE,
+    CLEANUP_REVIVED_PERSONS_TABLE,
+    CLEANUP_SNAPSHOT_TABLES,
+)
 from posthog.clickhouse.cluster import ClickhouseCluster
-from posthog.dags.clickhouse_cleanup import DeletedPersonsDictionary, clickhouse_deletion_sweep_job
+from posthog.dags import clickhouse_cleanup
+from posthog.dags.clickhouse_cleanup import (
+    PG_CLEANUP_QUEUE_TABLE,
+    MutationProgress,
+    MutationStalled,
+    MutationStatus,
+    OrphanedDistinctIdsTable,
+    clickhouse_deletion_sweep_job,
+)
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
-from posthog.models.person.util import create_person
+from posthog.models.person.util import create_person, create_person_distinct_id
+from posthog.persons_db import persons_db_url
 
 TEAM_ID = 4242
 COHORT_ID = 77
 
-# dry_run is declared on the first op alone, which is what stops a launch from setting it on one
-# op and missing another.
+# dry_run defaults to true, so a real sweep opts in. Declared on the first op alone, which is
+# what stops a launch from setting it on one op and missing another.
 RUN_FOR_REAL = {"ops": {"clear_removed_cohort_data": {"config": {"dry_run": False}}}}
+
+
+@pytest.fixture
+def persons_database() -> Iterator[psycopg2.extensions.connection]:
+    conn = psycopg2.connect(persons_db_url(writer=True))
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute(f"TRUNCATE {PG_CLEANUP_QUEUE_TABLE}")
+        conn.commit()
+        yield conn
+    finally:
+        conn.close()
+
+
+def run_job(cluster: ClickhouseCluster, persons_database, run_config=RUN_FOR_REAL, raise_on_error=True):
+    return clickhouse_deletion_sweep_job.execute_in_process(
+        run_config=run_config,
+        resources={"cluster": cluster, "persons_database": persons_database},
+        raise_on_error=raise_on_error,
+    )
 
 
 def visible_persons(client: Client) -> int:
@@ -42,25 +84,111 @@ def rows_for(person_uuid: str):
     return query
 
 
+def surviving_distinct_ids(client: Client) -> set[str]:
+    rows = client.execute(
+        "SELECT DISTINCT distinct_id FROM person_distinct_id2 WHERE team_id = %(team_id)s", {"team_id": TEAM_ID}
+    )
+    return {row[0] for row in rows}
+
+
+def current_owner(distinct_id: str):
+    def query(client: Client) -> UUID | None:
+        rows = client.execute(
+            """
+            SELECT argMax(person_id, version)
+            FROM person_distinct_id2
+            WHERE team_id = %(team_id)s AND distinct_id = %(distinct_id)s
+            GROUP BY distinct_id
+            """,
+            {"team_id": TEAM_ID, "distinct_id": distinct_id},
+        )
+        return rows[0][0] if rows else None
+
+    return query
+
+
 def cohort_rows(client: Client) -> int:
     [[count]] = client.execute("SELECT count() FROM cohortpeople WHERE team_id = %(team_id)s", {"team_id": TEAM_ID})
     return count
 
 
-def snapshot_rows(client: Client) -> int:
-    # The snapshot table is created by migration and outlives every run, so what a run has to clean
-    # up is its rows rather than the table. Anchored to the constant, not to a literal that can
-    # drift out of step with a rename.
-    [[rows]] = client.execute(f"SELECT count() FROM {CLEANUP_DELETED_PERSONS_TABLE}")
-    return rows
+def dictionaries_for_run(run_id: str):
+    """Count only this run's dictionaries.
+
+    Scoped to the run rather than the table prefixes, so the assertion cannot be thrown off by
+    leftovers another test or an earlier session left in the shared dev database.
+    """
+    suffix = f"%{run_id.replace('-', '_')}%"
+
+    def query(client: Client) -> int:
+        [[dictionaries]] = client.execute(
+            "SELECT count() FROM system.dictionaries WHERE name LIKE %(suffix)s", {"suffix": suffix}
+        )
+        return dictionaries
+
+    return query
 
 
-def leftover_dictionaries(client: Client) -> int:
-    [[dictionaries]] = client.execute(
-        "SELECT count() FROM system.dictionaries WHERE name LIKE %(pattern)s",
-        {"pattern": f"{CLEANUP_DELETED_PERSONS_TABLE}\\_%"},
-    )
-    return dictionaries
+def snapshot_rows_for_run(run_id: str):
+    """Count this run's rows across every snapshot table.
+
+    The tables are created by migration and outlive every run, so what a run has to clean up is
+    its rows rather than the tables. Anchored to the constants, not to literals that can drift out
+    of step with a rename.
+    """
+    scoped = run_id.replace("-", "_")
+
+    def query(client: Client) -> int:
+        return sum(
+            client.execute(
+                f"SELECT count() FROM {table} WHERE run_id = %(run_id)s",
+                {"run_id": scoped},
+            )[0][0]
+            for table in CLEANUP_SNAPSHOT_TABLES
+        )
+
+    return query
+
+
+DECOY_RUN_ID = "decoy_run"
+
+
+def seed_decoy_run(cluster: ClickhouseCluster, spared_person: str, spared_distinct_id: str, doomed_person: str) -> None:
+    """Fill every snapshot table with a second run's rows, chosen to break this run if it reads them.
+
+    The worklists name a live person and a live mapping, so an unscoped read would delete them. The
+    exclusion tables name the person this run is deleting, so an unscoped read would spare it.
+    """
+
+    def seed(client: Client) -> None:
+        client.execute(
+            f"INSERT INTO {CLEANUP_DELETED_PERSONS_TABLE} (run_id, team_id, person_id, max_version) VALUES",
+            [(DECOY_RUN_ID, TEAM_ID, spared_person, 0)],
+        )
+        client.execute(
+            f"INSERT INTO {CLEANUP_ORPHANED_DISTINCT_IDS_TABLE}"
+            " (run_id, team_id, distinct_id, person_id, own_tombstone, max_version) VALUES",
+            [(DECOY_RUN_ID, TEAM_ID, spared_distinct_id, spared_person, 1, 0)],
+        )
+        client.execute(
+            f"INSERT INTO {CLEANUP_REVIVED_PERSONS_TABLE} (run_id, team_id, person_id) VALUES",
+            [(DECOY_RUN_ID, TEAM_ID, doomed_person)],
+        )
+        client.execute(
+            f"INSERT INTO {CLEANUP_REVIVED_DISTINCT_IDS_TABLE} (run_id, team_id, distinct_id) VALUES",
+            [(DECOY_RUN_ID, TEAM_ID, "gone")],
+        )
+
+    cluster.any_host(seed).result()
+    cluster.map_all_hosts(
+        lambda client: [client.execute(f"SYSTEM SYNC REPLICA {table} STRICT") for table in CLEANUP_SNAPSHOT_TABLES]
+    ).result()
+
+
+def queued_rows(conn) -> list[tuple]:
+    with conn.cursor() as cursor:
+        cursor.execute(f"SELECT team_id, person_uuid, deleted_at, cleaned_at FROM {PG_CLEANUP_QUEUE_TABLE} ORDER BY 2")
+        return cursor.fetchall()
 
 
 def seed_cohort_rows(cluster: ClickhouseCluster, count: int) -> None:
@@ -70,39 +198,8 @@ def seed_cohort_rows(cluster: ClickhouseCluster, count: int) -> None:
     ).result()
 
 
-def versions_for(person_uuid: str):
-    def query(client: Client) -> list[int]:
-        rows = client.execute(
-            "SELECT version FROM person WHERE team_id = %(team_id)s AND id = %(id)s ORDER BY version",
-            {"team_id": TEAM_ID, "id": person_uuid},
-        )
-        return [row[0] for row in rows]
-
-    return query
-
-
 @pytest.mark.django_db
-def test_a_person_version_written_after_the_snapshot_survives(cluster: ClickhouseCluster):
-    # The delete is bounded by the version the snapshot observed. A client can recapture a deleted
-    # distinct id mid-run, which writes a live person version the run never saw; dropping the bound
-    # sweeps that new state away with the old.
-    doomed = create_person(team_id=TEAM_ID, version=0, is_deleted=True)
-
-    original = DeletedPersonsDictionary.load
-
-    def revive_after_snapshot(self, client, timeout_seconds):
-        result = original(self, client, timeout_seconds)
-        create_person(uuid=doomed, team_id=TEAM_ID, version=500, is_deleted=False)
-        return result
-
-    with patch.object(DeletedPersonsDictionary, "load", revive_after_snapshot):
-        clickhouse_deletion_sweep_job.execute_in_process(run_config=RUN_FOR_REAL, resources={"cluster": cluster})
-
-    assert cluster.any_host(versions_for(doomed)).result() == [500]
-
-
-@pytest.mark.django_db
-def test_deletes_soft_deleted_persons_and_preserves_the_rest(cluster: ClickhouseCluster):
+def test_deletes_soft_deleted_persons_and_preserves_the_rest(cluster: ClickhouseCluster, persons_database):
     # Deleted at a later version: every version has to go, which is why the delete keys on the
     # person rather than on is_deleted.
     deleted_later = create_person(team_id=TEAM_ID, version=0, is_deleted=False)
@@ -116,7 +213,7 @@ def test_deletes_soft_deleted_persons_and_preserves_the_rest(cluster: Clickhouse
     revived = create_person(team_id=TEAM_ID, version=0, is_deleted=True)
     create_person(uuid=revived, team_id=TEAM_ID, version=1, is_deleted=False)
 
-    clickhouse_deletion_sweep_job.execute_in_process(run_config=RUN_FOR_REAL, resources={"cluster": cluster})
+    run_job(cluster, persons_database)
 
     # The live version of deleted_later would survive a delete keyed on is_deleted rather than on
     # the person, so this asserts on the raw count rather than the collapsed one.
@@ -130,58 +227,207 @@ def test_deletes_soft_deleted_persons_and_preserves_the_rest(cluster: Clickhouse
 
 
 @pytest.mark.django_db
-def test_no_op_when_nothing_is_soft_deleted(cluster: ClickhouseCluster):
+def test_removes_distinct_ids_of_deleted_persons_and_keeps_live_ones(cluster: ClickhouseCluster, persons_database):
+    deleted = create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+    live = create_person(team_id=TEAM_ID, version=0)
+    create_person_distinct_id(team_id=TEAM_ID, distinct_id="gone", person_id=deleted, version=0)
+    create_person_distinct_id(team_id=TEAM_ID, distinct_id="kept", person_id=live, version=0)
+
+    run_job(cluster, persons_database)
+
+    assert cluster.any_host(surviving_distinct_ids).result() == {"kept"}
+
+
+@pytest.mark.django_db
+def test_removes_a_distinct_id_that_tombstoned_itself(cluster: ClickhouseCluster, persons_database):
+    # The mapping is tombstoned while its person stays live, which is the leak the person-driven
+    # arm alone would miss.
+    live = create_person(team_id=TEAM_ID, version=0)
+    create_person_distinct_id(team_id=TEAM_ID, distinct_id="detached", person_id=live, version=0)
+    create_person_distinct_id(team_id=TEAM_ID, distinct_id="detached", person_id=live, version=100, is_deleted=True)
+    create_person_distinct_id(team_id=TEAM_ID, distinct_id="kept", person_id=live, version=0)
+
+    run_job(cluster, persons_database)
+
+    assert cluster.any_host(surviving_distinct_ids).result() == {"kept"}
+
+
+@pytest.mark.django_db
+def test_keeps_a_distinct_id_repointed_to_a_live_person(cluster: ClickhouseCluster, persons_database):
+    # Newest version points at a live person, so the mapping is in use and has to stay whole.
+    deleted = create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+    live = create_person(team_id=TEAM_ID, version=0)
+    create_person_distinct_id(team_id=TEAM_ID, distinct_id="moved", person_id=deleted, version=0)
+    create_person_distinct_id(team_id=TEAM_ID, distinct_id="moved", person_id=live, version=1)
+
+    run_job(cluster, persons_database)
+
+    assert cluster.any_host(surviving_distinct_ids).result() == {"moved"}
+    assert cluster.any_host(current_owner("moved")).result() == UUID(live)
+
+
+@pytest.mark.django_db
+def test_removes_every_version_of_a_distinct_id_repointed_to_a_deleted_person(
+    cluster: ClickhouseCluster, persons_database
+):
+    # Newest version points at a deleted person. Deleting only the rows whose person_id matches
+    # would strip that row and hand the mapping back to the live person underneath it.
+    live = create_person(team_id=TEAM_ID, version=0)
+    deleted = create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+    create_person_distinct_id(team_id=TEAM_ID, distinct_id="moved", person_id=live, version=0)
+    create_person_distinct_id(team_id=TEAM_ID, distinct_id="moved", person_id=deleted, version=1)
+
+    run_job(cluster, persons_database)
+
+    assert cluster.any_host(surviving_distinct_ids).result() == set()
+    assert cluster.any_host(current_owner("moved")).result() is None
+
+
+@pytest.mark.django_db
+def test_queues_the_deleted_persons_for_postgres(cluster: ClickhouseCluster, persons_database):
+    deleted = create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+    create_person(team_id=TEAM_ID, version=0)
+
+    run_job(cluster, persons_database)
+
+    rows = queued_rows(persons_database)
+    assert len(rows) == 1
+    team_id, person_uuid, deleted_at, cleaned_at = rows[0]
+    assert (team_id, str(person_uuid)) == (TEAM_ID, deleted)
+    assert deleted_at is not None
+    assert cleaned_at is None
+
+    # A second run must not raise on the primary key: it re-queues persons the drain has not
+    # reached yet.
+    run_job(cluster, persons_database)
+    assert len(queued_rows(persons_database)) == 1
+
+
+@pytest.mark.django_db
+def test_queues_every_person_across_page_boundaries(cluster: ClickhouseCluster, persons_database, monkeypatch):
+    # The handoff pages its ClickHouse read by keyset and commits per page; an off-by-one at a
+    # page edge, or stopping after a full page that happened to be the last, silently drops
+    # persons from the queue and leaks their Postgres rows forever.
+    monkeypatch.setattr(clickhouse_cleanup, "PERSIST_PAGE_SIZE", 2)
+    expected = sorted(create_person(team_id=TEAM_ID, version=0, is_deleted=True) for _ in range(5))
+
+    run_job(cluster, persons_database)
+
+    assert sorted(str(row[1]) for row in queued_rows(persons_database)) == expected
+
+
+@pytest.mark.django_db
+def test_requeues_a_person_the_drain_already_cleaned(cluster: ClickhouseCluster, persons_database):
+    # A person can be deleted, drained, then re-created and deleted again under the same uuid. The
+    # drain only reads rows where cleaned_at is null, so leaving the cleaned row untouched would
+    # drop the second deletion and leak that person's Postgres rows for good.
+    deleted = create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+    run_job(cluster, persons_database)
+
+    # Stand in for the drain having processed it.
+    with persons_database.cursor() as cursor:
+        cursor.execute(f"UPDATE {PG_CLEANUP_QUEUE_TABLE} SET cleaned_at = now()")
+    persons_database.commit()
+    assert queued_rows(persons_database)[0][3] is not None
+
+    # The same person is deleted again at a higher version, so a later run snapshots it afresh.
+    create_person(uuid=deleted, team_id=TEAM_ID, version=10, is_deleted=True)
+    run_job(cluster, persons_database)
+
+    rows = queued_rows(persons_database)
+    assert len(rows) == 1, "the row is keyed on (team_id, person_uuid), so this stays a single row"
+    assert rows[0][3] is None, "cleaned_at must be cleared so the drain picks the person up again"
+
+
+@pytest.mark.django_db
+def test_excludes_a_person_revived_while_the_run_is_in_flight(cluster: ClickhouseCluster, persons_database):
+    revived = create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+    create_person_distinct_id(team_id=TEAM_ID, distinct_id="spared", person_id=revived, version=0)
+    doomed = create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+    create_person_distinct_id(team_id=TEAM_ID, distinct_id="gone", person_id=doomed, version=0)
+
+    original = OrphanedDistinctIdsTable.populate
+
+    def revive_then_populate(self, client, persons_dictionary):
+        # Fires after the snapshot is taken and the dictionary is loaded, so the checkpoint is
+        # the only thing standing between the revived person and the delete.
+        create_person(uuid=revived, team_id=TEAM_ID, version=10, is_deleted=False)
+        return original(self, client, persons_dictionary)
+
+    with patch.object(OrphanedDistinctIdsTable, "populate", revive_then_populate):
+        run_job(cluster, persons_database)
+
+    assert cluster.any_host(surviving_distinct_ids).result() == {"spared"}
+    assert cluster.any_host(rows_for(doomed)).result() == 0
+    assert cluster.any_host(rows_for(revived)).result() > 0
+    # The queued set has to match the set deleted in ClickHouse. If they diverge, the Postgres
+    # drain clears a person that is still live here.
+    assert [str(row[1]) for row in queued_rows(persons_database)] == [doomed]
+
+
+@pytest.mark.django_db
+def test_no_op_when_nothing_is_soft_deleted(cluster: ClickhouseCluster, persons_database):
     # The snapshot is empty, so the dictionary source returns nothing and dictHas never matches.
-    create_person(team_id=TEAM_ID, version=0)
+    live = create_person(team_id=TEAM_ID, version=0)
+    create_person_distinct_id(team_id=TEAM_ID, distinct_id="kept", person_id=live, version=0)
 
-    clickhouse_deletion_sweep_job.execute_in_process(run_config=RUN_FOR_REAL, resources={"cluster": cluster})
+    run_job(cluster, persons_database)
 
     assert cluster.any_host(visible_persons).result() == 1
+    assert cluster.any_host(surviving_distinct_ids).result() == {"kept"}
+    assert queued_rows(persons_database) == []
 
 
 @pytest.mark.django_db
-def test_is_idempotent(cluster: ClickhouseCluster):
-    create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+def test_is_idempotent(cluster: ClickhouseCluster, persons_database):
+    deleted = create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+    create_person_distinct_id(team_id=TEAM_ID, distinct_id="gone", person_id=deleted, version=0)
     create_person(team_id=TEAM_ID, version=0)
 
-    clickhouse_deletion_sweep_job.execute_in_process(run_config=RUN_FOR_REAL, resources={"cluster": cluster})
+    run_job(cluster, persons_database)
     # The first run tombstones the deleted rows, so the second snapshot no longer sees them.
-    clickhouse_deletion_sweep_job.execute_in_process(run_config=RUN_FOR_REAL, resources={"cluster": cluster})
+    run_job(cluster, persons_database)
 
     assert cluster.any_host(visible_persons).result() == 1
+    assert cluster.any_host(surviving_distinct_ids).result() == set()
 
 
 @pytest.mark.django_db
-def test_dry_run_deletes_nothing(cluster: ClickhouseCluster):
-    create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+def test_dry_run_deletes_nothing(cluster: ClickhouseCluster, persons_database):
+    deleted = create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+    create_person_distinct_id(team_id=TEAM_ID, distinct_id="gone", person_id=deleted, version=0)
     seed_cohort_rows(cluster, count=5)
     AsyncDeletion.objects.create(deletion_type=DeletionType.Cohort_full, team_id=TEAM_ID, key=f"{COHORT_ID}_0")
 
-    clickhouse_deletion_sweep_job.execute_in_process(resources={"cluster": cluster})
+    run_job(cluster, persons_database, run_config=None)
 
     assert cluster.any_host(visible_persons).result() == 1
+    assert cluster.any_host(surviving_distinct_ids).result() == {"gone"}
     assert cluster.any_host(cohort_rows).result() == 5
+    assert queued_rows(persons_database) == []
     assert AsyncDeletion.objects.get(team_id=TEAM_ID).delete_verified_at is None
 
 
 @pytest.mark.django_db
-def test_drops_the_dictionary_and_clears_the_run_rows(cluster: ClickhouseCluster):
+def test_drops_the_dictionaries_and_clears_the_run_rows(cluster: ClickhouseCluster, persons_database):
     create_person(team_id=TEAM_ID, version=0, is_deleted=True)
 
-    clickhouse_deletion_sweep_job.execute_in_process(run_config=RUN_FOR_REAL, resources={"cluster": cluster})
+    result = run_job(cluster, persons_database)
 
-    # A leaked dictionary holds the key set in memory on every host. The rows are cheaper, but the
-    # table is shared now, so a run that never clears its own rows makes every later run read them.
-    assert cluster.any_host(leftover_dictionaries).result() == 0
-    assert cluster.any_host(snapshot_rows).result() == 0
+    # A leaked dictionary holds its key set in memory on every host. The rows are cheaper, but the
+    # tables are shared, so a run that never clears its own rows makes every later run read them.
+    assert cluster.any_host(dictionaries_for_run(result.run_id)).result() == 0
+    assert cluster.any_host(snapshot_rows_for_run(result.run_id)).result() == 0
 
 
 @pytest.mark.django_db
-def test_clears_cohort_rows_and_marks_the_deletion_verified_on_the_next_run(cluster: ClickhouseCluster):
+def test_clears_cohort_rows_and_marks_the_deletion_verified_on_the_next_run(
+    cluster: ClickhouseCluster, persons_database
+):
     seed_cohort_rows(cluster, count=10)
     AsyncDeletion.objects.create(deletion_type=DeletionType.Cohort_full, team_id=TEAM_ID, key=f"{COHORT_ID}_0")
 
-    clickhouse_deletion_sweep_job.execute_in_process(run_config=RUN_FOR_REAL, resources={"cluster": cluster})
+    run_job(cluster, persons_database)
 
     # The mark pass runs before the delete pass, so it sees rows that are still present and
     # verification lands a run later. A reordering that drops the mark pass would leave
@@ -189,13 +435,13 @@ def test_clears_cohort_rows_and_marks_the_deletion_verified_on_the_next_run(clus
     assert cluster.any_host(cohort_rows).result() == 0
     assert AsyncDeletion.objects.get(team_id=TEAM_ID).delete_verified_at is None
 
-    clickhouse_deletion_sweep_job.execute_in_process(run_config=RUN_FOR_REAL, resources={"cluster": cluster})
+    run_job(cluster, persons_database)
 
     assert AsyncDeletion.objects.get(team_id=TEAM_ID).delete_verified_at is not None
 
 
 @pytest.mark.django_db
-def test_cohort_delete_pass_runs_when_the_mark_pass_fails(cluster: ClickhouseCluster):
+def test_cohort_delete_pass_runs_when_the_mark_pass_fails(cluster: ClickhouseCluster, persons_database):
     seed_cohort_rows(cluster, count=10)
     AsyncDeletion.objects.create(deletion_type=DeletionType.Cohort_full, team_id=TEAM_ID, key=f"{COHORT_ID}_0")
 
@@ -203,9 +449,7 @@ def test_cohort_delete_pass_runs_when_the_mark_pass_fails(cluster: ClickhouseClu
         "posthog.models.async_deletion.delete_cohorts.AsyncCohortDeletion.mark_deletions_done",
         side_effect=Exception("boom"),
     ):
-        result = clickhouse_deletion_sweep_job.execute_in_process(
-            run_config=RUN_FOR_REAL, resources={"cluster": cluster}
-        )
+        result = run_job(cluster, persons_database)
 
     # Collapsing the two guards into one try would skip the pass that actually removes rows.
     assert result.success
@@ -213,7 +457,7 @@ def test_cohort_delete_pass_runs_when_the_mark_pass_fails(cluster: ClickhouseClu
 
 
 @pytest.mark.django_db
-def test_cohort_sweep_runs_even_when_the_person_delete_fails(cluster: ClickhouseCluster):
+def test_cohort_sweep_runs_even_when_the_person_delete_fails(cluster: ClickhouseCluster, persons_database):
     create_person(team_id=TEAM_ID, version=0, is_deleted=True)
     seed_cohort_rows(cluster, count=10)
     AsyncDeletion.objects.create(deletion_type=DeletionType.Cohort_full, team_id=TEAM_ID, key=f"{COHORT_ID}_0")
@@ -222,33 +466,339 @@ def test_cohort_sweep_runs_even_when_the_person_delete_fails(cluster: Clickhouse
         "posthog.dags.clickhouse_cleanup.LightweightDeleteMutationRunner",
         side_effect=Exception("boom"),
     ):
-        result = clickhouse_deletion_sweep_job.execute_in_process(
-            run_config=RUN_FOR_REAL, resources={"cluster": cluster}, raise_on_error=False
-        )
+        result = run_job(cluster, persons_database, raise_on_error=False)
 
-    # Moving the cohort sweep back downstream of the person delete would strand cohort rows every
-    # week the person mutation ran long or failed, which is why it goes first.
+    # Moving the cohort sweep back downstream of the person path would strand cohort rows every
+    # week that path ran long or failed, which is why it goes first.
     assert not result.success
     assert cluster.any_host(cohort_rows).result() == 0
 
 
 @pytest.mark.django_db
-def test_a_failed_run_drops_its_dictionary_and_keeps_its_rows(cluster: ClickhouseCluster):
+def test_a_run_ignores_another_runs_snapshot_rows(cluster: ClickhouseCluster, persons_database):
+    # Runs share the snapshot tables, so every read of them has to be scoped by run id. Drop any
+    # one of those WHERE clauses and this fails: the decoy's worklist rows delete a live person and
+    # a live mapping, and its exclusion rows spare the person this run is deleting.
+    live = create_person(team_id=TEAM_ID, version=0)
+    create_person_distinct_id(team_id=TEAM_ID, distinct_id="kept", person_id=live, version=0)
+    doomed = create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+    create_person_distinct_id(team_id=TEAM_ID, distinct_id="gone", person_id=doomed, version=0)
+
+    seed_decoy_run(cluster, spared_person=live, spared_distinct_id="kept", doomed_person=doomed)
+
+    run_job(cluster, persons_database)
+
+    assert cluster.any_host(rows_for(live)).result() == 1
+    assert cluster.any_host(surviving_distinct_ids).result() == {"kept"}
+    assert cluster.any_host(rows_for(doomed)).result() == 0
+    assert [str(row[1]) for row in queued_rows(persons_database)] == [doomed]
+    # Clearing rows at the end of a run has to be scoped too, or one run wipes another's worklist.
+    assert cluster.any_host(snapshot_rows_for_run(DECOY_RUN_ID)).result() > 0
+
+
+@pytest.mark.django_db
+def test_a_failed_run_drops_its_dictionaries_and_keeps_its_rows(cluster: ClickhouseCluster, persons_database):
     create_person(team_id=TEAM_ID, version=0, is_deleted=True)
 
-    # Fails once the dictionary is built, so there is something to strand.
+    # Fails once the dictionaries are built, so there is something to strand.
     with patch(
         "posthog.dags.clickhouse_cleanup.LightweightDeleteMutationRunner",
         side_effect=Exception("boom"),
     ):
-        result = clickhouse_deletion_sweep_job.execute_in_process(
-            run_config=RUN_FOR_REAL, resources={"cluster": cluster}, raise_on_error=False
-        )
+        result = run_job(cluster, persons_database, raise_on_error=False)
 
     assert not result.success
-    # Dagster skips drop_snapshot_assets after a failure, so without the hook the dictionary
+    # Dagster skips drop_snapshot_assets after a failure, so without the hook the dictionaries
     # would survive on every host and accumulate across failed runs.
-    assert cluster.any_host(leftover_dictionaries).result() == 0
-    # The rows survive on purpose: they cost far less than a dictionary, the table's TTL reaps
+    assert cluster.any_host(dictionaries_for_run(result.run_id)).result() == 0
+    # The rows survive on purpose: they cost far less than a dictionary, the tables' TTL reaps
     # them, and they are what makes a failed sweep inspectable in the meantime.
-    assert cluster.any_host(snapshot_rows).result() > 0
+    assert cluster.any_host(snapshot_rows_for_run(result.run_id)).result() > 0
+
+
+@pytest.mark.django_db
+def test_keeps_a_distinct_id_recaptured_while_the_run_is_in_flight(cluster: ClickhouseCluster, persons_database):
+    live = create_person(team_id=TEAM_ID, version=0)
+    for distinct_id in ("recaptured", "gone"):
+        create_person_distinct_id(team_id=TEAM_ID, distinct_id=distinct_id, person_id=live, version=0)
+        create_person_distinct_id(
+            team_id=TEAM_ID, distinct_id=distinct_id, person_id=live, version=100, is_deleted=True
+        )
+
+    original = OrphanedDistinctIdsTable.populate
+
+    def recapture_then_populate(self, client, persons_dictionary):
+        result = original(self, client, persons_dictionary)
+        # A client captures the id again after the snapshot froze the reason it qualified. Trusting
+        # that snapshot would delete every version of the mapping, including this live one.
+        create_person_distinct_id(team_id=TEAM_ID, distinct_id="recaptured", person_id=live, version=200)
+        return result
+
+    with patch.object(OrphanedDistinctIdsTable, "populate", recapture_then_populate):
+        run_job(cluster, persons_database)
+
+    assert cluster.any_host(surviving_distinct_ids).result() == {"recaptured"}
+    assert cluster.any_host(current_owner("recaptured")).result() == UUID(live)
+
+
+def versions_for(distinct_id: str):
+    def query(client: Client) -> list[int]:
+        rows = client.execute(
+            "SELECT version FROM person_distinct_id2 WHERE team_id = %(team_id)s AND distinct_id = %(d)s ORDER BY version",
+            {"team_id": TEAM_ID, "d": distinct_id},
+        )
+        return [row[0] for row in rows]
+
+    return query
+
+
+def current_deleted(distinct_id: str):
+    def query(client: Client) -> int | None:
+        rows = client.execute(
+            """
+            SELECT argMax(is_deleted, version) FROM person_distinct_id2
+            WHERE team_id = %(team_id)s AND distinct_id = %(d)s GROUP BY distinct_id
+            """,
+            {"team_id": TEAM_ID, "d": distinct_id},
+        )
+        return rows[0][0] if rows else None
+
+    return query
+
+
+@pytest.mark.django_db
+def test_an_interrupted_sweep_leaves_the_tombstone_as_the_surviving_version(
+    cluster: ClickhouseCluster, persons_database
+):
+    # The reason the delete is ordered at all. The first pass runs for real; the second is cut off
+    # the way a killed or failed mutation would cut it off. The key must still resolve as deleted.
+    # Reverse the two passes and this fails: the tombstone goes first and the older live row is
+    # handed back to a person the run is about to delete.
+    deleted = create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+    create_person_distinct_id(team_id=TEAM_ID, distinct_id="doomed", person_id=deleted, version=0)
+    create_person_distinct_id(team_id=TEAM_ID, distinct_id="doomed", person_id=deleted, version=100, is_deleted=True)
+
+    real_runner = clickhouse_cleanup.LightweightDeleteMutationRunner
+    calls = itertools.count()
+
+    def fail_on_the_second_pass(*args, **kwargs):
+        if next(calls) >= 1:
+            raise RuntimeError("interrupted between passes")
+        return real_runner(*args, **kwargs)
+
+    with patch.object(clickhouse_cleanup, "LightweightDeleteMutationRunner", fail_on_the_second_pass):
+        result = run_job(cluster, persons_database, raise_on_error=False)
+
+    assert not result.success
+    surviving = cluster.any_host(versions_for("doomed")).result()
+    assert surviving == [100], f"expected only the tombstone to survive, got {surviving}"
+    assert cluster.any_host(current_deleted("doomed")).result() == 1
+
+
+@pytest.mark.django_db
+def test_removes_every_version_below_the_max_in_one_pass(cluster: ClickhouseCluster, persons_database):
+    # Depth must not drive the number of passes: three versions collapse in the same two passes
+    # as two do.
+    deleted = create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+    for version in (0, 5):
+        create_person_distinct_id(team_id=TEAM_ID, distinct_id="deep", person_id=deleted, version=version)
+    create_person_distinct_id(team_id=TEAM_ID, distinct_id="deep", person_id=deleted, version=100, is_deleted=True)
+
+    run_job(cluster, persons_database)
+
+    assert cluster.any_host(versions_for("deep")).result() == []
+
+
+@pytest.mark.django_db
+def test_rows_written_after_the_snapshot_survive(cluster: ClickhouseCluster, persons_database):
+    # Both passes are bounded by the snapshot's max_version, so a run never removes a row it did
+    # not observe.
+    deleted = create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+    create_person_distinct_id(team_id=TEAM_ID, distinct_id="racing", person_id=deleted, version=0)
+    create_person_distinct_id(team_id=TEAM_ID, distinct_id="racing", person_id=deleted, version=100, is_deleted=True)
+
+    original = OrphanedDistinctIdsTable.populate
+
+    def write_after_snapshot(self, client, persons_dictionary):
+        result = original(self, client, persons_dictionary)
+        create_person_distinct_id(team_id=TEAM_ID, distinct_id="racing", person_id=deleted, version=500)
+        return result
+
+    with patch.object(OrphanedDistinctIdsTable, "populate", write_after_snapshot):
+        run_job(cluster, persons_database)
+
+    assert cluster.any_host(versions_for("racing")).result() == [500]
+
+
+@pytest.mark.django_db
+def test_team_ranges_cover_every_candidate_team_exactly_once():
+    teams = [3, 1, 9, 4, 7, 2]
+    ranges = clickhouse_cleanup._team_ranges(teams, batches=3)
+
+    assert clickhouse_cleanup._team_ranges([], batches=4) == []
+    # Contiguous and non-overlapping, so no key falls between two batches.
+    assert [r.low for r in ranges] == sorted(r.low for r in ranges)
+    for earlier, later in zip(ranges, ranges[1:]):
+        assert earlier.high < later.low
+    for team in teams:
+        assert sum(1 for r in ranges if r.low <= team <= r.high) == 1
+
+
+@pytest.mark.django_db
+def test_more_batches_than_teams_does_not_produce_empty_ranges():
+    ranges = clickhouse_cleanup._team_ranges([5, 6], batches=10)
+    assert ranges == [clickhouse_cleanup.TeamRange(low=5, high=5), clickhouse_cleanup.TeamRange(low=6, high=6)]
+
+
+@pytest.mark.django_db
+def test_a_retried_snapshot_populate_cannot_skew_the_dictionary(cluster: ClickhouseCluster):
+    # An op retry re-runs populate, leaving duplicate key rows until a merge collapses them. The
+    # dictionary must read the newest max_version bound, not whichever duplicate it happens upon.
+    person = create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+    table = clickhouse_cleanup.DeletedPersonsTable(run_id="retry_run")
+    cluster.any_host(table.populate).result()
+    # The person gains a higher deleted version between the attempt and its retry.
+    create_person(uuid=person, team_id=TEAM_ID, version=3, is_deleted=True)
+    cluster.any_host(table.populate).result()
+    cluster.map_all_hosts(table.sync_replica).result()
+
+    dictionary = clickhouse_cleanup.SnapshotDictionary(
+        source=table, excluded=clickhouse_cleanup.RevivedPersonsTable(run_id="retry_run")
+    )
+    try:
+        cluster.map_all_hosts(partial(dictionary.create, shards=1, max_execution_time=0, max_memory_usage=0)).result()
+        cluster.map_all_hosts(partial(dictionary.load, timeout_seconds=60), concurrency=1).result()
+        rows = cluster.any_host(
+            lambda client: client.execute(f"SELECT person_id, max_version FROM {dictionary.qualified_name}")
+        ).result()
+        assert rows == [(UUID(person), 3)]
+    finally:
+        cluster.map_all_hosts(dictionary.drop).result()
+        cluster.any_host(table.drop_run_partition).result()
+
+
+@pytest.mark.django_db
+def test_a_reaped_snapshot_fails_the_delete_instead_of_under_deleting(cluster: ClickhouseCluster):
+    # The 14-day TTL drops a stalled run's partition; the delete must then fail loudly rather
+    # than sweep from a silently shrunken worklist.
+    run = clickhouse_cleanup.CleanupRun.for_run("reaped-run", clickhouse_cleanup.CleanupConfig(dry_run=False))
+    run = replace(run, persons_count=5)
+
+    with pytest.raises(dagster.Failure, match="snapshot TTL"):
+        clickhouse_cleanup.delete_persons(dagster.build_op_context(resources={"cluster": cluster}), run=run)
+
+
+T0 = datetime(2026, 1, 1, 12, 0, 0)
+
+
+def failing_status(fail_at: datetime, parts: int = 10, now: datetime | None = None) -> MutationStatus:
+    return MutationStatus(
+        done=False,
+        visible=True,
+        parts_to_do=parts,
+        latest_fail_time=fail_at,
+        latest_fail_reason="boom",
+        server_now=now or fail_at,
+    )
+
+
+def quiet_status(parts: int = 10, visible: bool = True) -> MutationStatus:
+    return MutationStatus(
+        done=False,
+        visible=visible,
+        parts_to_do=parts,
+        latest_fail_time=None,
+        latest_fail_reason="",
+        server_now=T0,
+    )
+
+
+def test_mutation_progress_tolerates_failures_while_parts_still_complete():
+    # ClickHouse retries failed part mutations itself; as long as parts keep completing the run
+    # must keep waiting. Reverting to fail-on-any-reason kills a batch that would have finished.
+    progress = MutationProgress(stall_timeout=100)
+    progress.observe([quiet_status(parts=20)], now=0)
+    for tick in range(1, 15):
+        progress.observe([failing_status(T0 + timedelta(seconds=tick * 60), parts=20 - tick)], now=tick * 60)
+
+
+def test_mutation_progress_declares_a_stall_when_failures_recur_without_progress():
+    progress = MutationProgress(stall_timeout=100)
+    progress.observe([quiet_status(parts=3), quiet_status(parts=10)], now=0)
+    progress.observe([quiet_status(parts=3), failing_status(T0 + timedelta(seconds=15))], now=15)
+    with pytest.raises(MutationStalled):
+        progress.observe([quiet_status(parts=3), failing_status(T0 + timedelta(seconds=120))], now=120)
+
+
+def test_mutation_progress_ignores_a_failure_that_predates_polling():
+    # MutationRunner can re-attach to an existing mutation whose old attempts failed; that history
+    # must not condemn a batch that has not failed since.
+    stale = T0 - timedelta(hours=6)
+    progress = MutationProgress(stall_timeout=100)
+    progress.observe([failing_status(stale, now=T0)], now=0)
+    progress.observe([failing_status(stale, now=T0 + timedelta(seconds=200))], now=200)
+    with pytest.raises(MutationStalled):
+        progress.observe([failing_status(T0 + timedelta(seconds=300))], now=300)
+
+
+def test_mutation_progress_counts_a_failure_just_before_the_first_poll():
+    # A freshly enqueued mutation can fail before the first poll lands; unlike a re-attached
+    # mutation's stale history, that failure is evidence.
+    progress = MutationProgress(stall_timeout=100)
+    progress.observe([failing_status(T0 - timedelta(seconds=5), now=T0)], now=0)
+    with pytest.raises(MutationStalled):
+        progress.observe([failing_status(T0 - timedelta(seconds=5), now=T0 + timedelta(seconds=150))], now=150)
+
+
+def test_mutation_progress_waits_on_a_slow_mutation_that_is_not_failing():
+    # No failures means a big part or a busy cluster; declaring that stuck would kill every
+    # long-running healthy batch.
+    progress = MutationProgress(stall_timeout=100)
+    for tick in range(100):
+        progress.observe([quiet_status(parts=10)], now=tick * 60)
+
+
+def test_mutation_progress_tolerates_brief_invisibility_and_fails_when_it_persists():
+    # The mutation entry replicates through Keeper, so a lagged replica briefly not knowing it is
+    # normal; a replica that never learns of it is not.
+    progress = MutationProgress(stall_timeout=100, visibility_timeout=300)
+    progress.observe([quiet_status(visible=False)], now=0)
+    progress.observe([quiet_status(visible=False)], now=299)
+    with pytest.raises(MutationStalled):
+        progress.observe([quiet_status(visible=False)], now=301)
+
+
+@pytest.mark.django_db
+def test_a_mutation_that_fails_every_attempt_fails_the_run_and_gets_killed(
+    cluster: ClickhouseCluster, persons_database, monkeypatch
+):
+    deleted = create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+    create_person_distinct_id(team_id=TEAM_ID, distinct_id="doomed", person_id=deleted, version=0)
+
+    monkeypatch.setattr(clickhouse_cleanup, "MUTATION_POLL_SECONDS", 0.1)
+    real_runner = clickhouse_cleanup.LightweightDeleteMutationRunner
+
+    def poisoned_runner(*args, **kwargs):
+        # Fails at part-mutation time on every attempt, not at submission: the predicate reads a
+        # column, so ClickHouse cannot constant-fold the throw during validation.
+        kwargs["predicate"] = f"throwIf(version >= 0, 'poisoned sweep') OR ({kwargs['predicate']})"
+        return real_runner(*args, **kwargs)
+
+    stalling = {"ops": {"clear_removed_cohort_data": {"config": {"dry_run": False, "mutation_stall_timeout": 1}}}}
+    with patch.object(clickhouse_cleanup, "LightweightDeleteMutationRunner", poisoned_runner):
+        result = run_job(cluster, persons_database, run_config=stalling, raise_on_error=False)
+
+    assert not result.success
+    # The poisoned mutation never applied, so the data is intact.
+    assert cluster.any_host(surviving_distinct_ids).result() == {"doomed"}
+
+    # The failure hook must kill the stuck mutation, or it retries in the background forever and
+    # blocks every later mutation on the table.
+    def unfinished_mutations(client: Client) -> int:
+        [[count]] = client.execute(
+            "SELECT count() FROM system.mutations WHERE NOT is_done AND NOT is_killed AND table = %(table)s",
+            {"table": "person_distinct_id2"},
+        )
+        return count
+
+    assert cluster.any_host(unfinished_mutations).result() == 0


### PR DESCRIPTION
## Problem

`person_distinct_id2` rows for deleted persons are never physically removed, so they accumulate without bound.

Deleting a person writes a Kafka tombstone for each of its distinct ids, and readers filter tombstoned mappings out with `argMax(is_deleted, version) = 0`. Nothing ever deletes the rows. The only physical removal is [the team-scoped sweep in `deletes_job`](https://github.com/PostHog/posthog/blob/master/posthog/dags/deletes.py#L675-L686); for a single person, `deletes_job` deletes events and nothing else.

Postgres has the mirror problem: `posthog_person` and `posthog_persondistinctid` rows for swept persons need clearing too, and nothing records which persons were swept.

## Changes

- Removes every version of a distinct id whose current owner is a swept person, or whose own latest version is tombstoned.
- Records each swept person in `person_pg_cleanup_queue` before the person delete, so a later job can clear the Postgres side.
- Re-checks for revived persons at two checkpoints and excludes them from the rest of the run.
- Deletes both tables oldest-version-first, in two passes per team range, bounded by the version the snapshot observed.
- Replaces the single bounded pass #80009 uses for `person` with that shared ordered delete, so the person-level bound test from #80009 goes away here rather than duplicating `test_rows_written_after_the_snapshot_survive` on the same code path.

**The delete keys on `(team_id, distinct_id)`, not on `person_id`.** `person_distinct_id2` is a `ReplacingMergeTree` ordered on `(team_id, distinct_id)` with `person_id` as a value, so a distinct id can be repointed over time. Deleting the rows whose `person_id` matches a swept person can strip the newest row and hand the mapping back to whoever owned it before. The run resolves the current owner with `argMax` and then removes every version of a qualifying key.

**The two delete passes are never merged.** Pass A removes every version below the key's snapshot max, so while it runs the surviving max is still the tombstone and readers keep resolving the key as deleted. Only then does pass B remove the last row. One pass instead would let an interrupted mutation strip the tombstone from one part while an older live row survived in another, handing the key back to a person the run is about to delete.

**Postgres is written before the person delete.** That delete tombstones the `person` rows, and a tombstoned row is invisible to `SELECT`, so the set cannot be recomputed afterwards. The handoff pages its ClickHouse read by keyset and commits per page, so its memory stays bounded and no multi-million-row transaction sits on the persons writer.

**Revivals are recorded, not mutated away.** Each checkpoint inserts newly-revived persons into a snapshot table, and every dictionary reads its source through an anti-join against it. Excluding a person is an insert plus a dictionary reload rather than a mutation on the snapshot, and the reload only happens when something was actually revived.

**Every read of a snapshot table is scoped by `run_id`.** The tables from #80943 are shared across runs, so an unscoped read is a data-loss bug rather than a bookkeeping one: another run's worklist row would delete a live person. `run_keys_query` is the single place that builds the scoped subquery every cross-table `IN` and `NOT IN` embeds.

**A delete batch fails only when it is actually stuck.** ClickHouse retries a failed part mutation on its own and keeps `latest_fail_reason` populated while it does, so a failure reason alone is not evidence the mutation is dying. `MutationProgress` fails the batch only when attempts keep failing while no part completes for a stall window (default 30 minutes), tolerates a lagged replica briefly not knowing the mutation, and ignores failure history on a re-attached mutation.

**Settings are read once.** Every op reads its settings from `CleanupRun`, built from the first op's config, so a launch cannot set `team_batches` or `cleanup` on one op and miss another. Team batching defaults to 4: merged parts span nearly the whole team-id space, so ranges never prune reads, and each extra batch re-rewrites the same delete masks. Batching only buys retry granularity.

**Telemetry survives the run pod.** Dagster run pods are not scraped, so revived counts and failed cohort passes also land in the ClickHouse-backed custom metrics. The dictionary checksum hashes `max_version` alongside the keys, because replicas agreeing on keys but not on the version bound would delete different version sets.

> [!NOTE]
> The checkpoints sit at phase boundaries, not inside the mutation. A mutation over an unpartitioned table runs long and re-checking mid-flight cannot retract work already applied, so a person revived inside that window has already lost its distinct id rows. `reset_deleted_person_distinct_ids` and the `sync_person_distinct_ids` workflow republish those from Postgres, and the run logs and counts every exclusion.

The `person_pg_cleanup_queue` table this writes to landed in #80002. The weekly trigger lives in #82729 and Celery retirement in #80015, both above this layer, so the whole delete path can be smoke-tested manually before anything fires automatically.

**Stack order (rebuilt 2026-08-27):** #80943 → #80009 → #80017 → #83981 land first and are inert (no schedule, `dry_run` defaults true) so the sweep can be smoke-tested by hand; #82729 then enables the trigger; #80015 retires Celery last, after the smoke run.

Fourth of five PRs.

## How did you test this code?

I (actually Claude) ran the tests below against the dev ClickHouse and the dev persons Postgres. No manual product testing happened, and I have not launched this in a real Dagster deployment.

The suite in `posthog/dags/tests/test_clickhouse_cleanup.py`. The two that matter most are the repointing pair, because they are the bug the `argMax` keying exists to prevent:

- Newest version points at a live person: the mapping survives whole, and its owner is unchanged. Keying the delete on `person_id` would delete the older row here.
- Newest version points at a swept person: every version goes, and the older mapping does not come back. Keying on `person_id` would leave the live person owning the id again.

The ordered delete:

- An interrupted sweep leaves the tombstone as the surviving version. The first pass runs for real and the second is cut off the way a killed mutation would cut it off. Reverse the two passes and this fails.
- A row written after the snapshot survives, because both passes are bounded by the snapshot's `max_version`.
- Three versions collapse in the same two passes as two do, so depth does not drive the pass count.

The stall detector:

- Six unit cases over `MutationProgress`: failures with progress keep waiting, recurring failures without progress stall, pre-polling failure history is ignored, a failure just before the first poll counts, a slow non-failing mutation waits forever, and brief invisibility is tolerated while persistent invisibility fails.
- One integration case: a mutation poisoned to fail every attempt fails the run, and the failure hook kills it so nothing retries in the background and blocks the table's mutation queue.

Run isolation, which is the failure mode the shared tables introduce:

- A decoy run's rows sit in all four snapshot tables. Its worklist names a live person and a live mapping; its exclusion rows name the person this run is deleting. The live pair survives, the doomed person still goes, and the decoy's rows survive this run's cleanup.
- I checked this test has teeth rather than assuming it: removing the `WHERE run_id` from the dictionary source query alone makes it fail on the live person's row count, `assert 0 == 1`. The scope was restored and it passes again.

The rest:

- A distinct id that tombstoned itself is removed even though its person is live. That is the leak the person-driven arm alone misses.
- Swept persons land in `person_pg_cleanup_queue` with the right team, uuid and `deleted_at`, and a second run does not raise on the primary key.
- Every person is queued across page boundaries: with the page size forced to 2 and five swept persons, an off-by-one at a page edge or a dropped final page fails the test.
- A person revived after the snapshot keeps its distinct ids, keeps its rows, and is left out of the Postgres queue. The test revives it mid-run, between the dictionary load and the delete.
- A distinct id recaptured mid-run survives whole.
- The cohort sweep still clears its rows when the person delete raises.
- Both dictionaries are dropped and the run's rows are cleared; a failed run drops its dictionaries and keeps its rows for the TTL.

Not run: the wider backend suite, and nothing at cluster scale.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Nothing user-facing changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via Claude Code) wrote this under Eli's direction. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/stacking-prs`, `/clickhouse-migrations`.

This PR was restructured after review on #80009. It originally built four `ReplicatedReplacingMergeTree` tables per run and dropped them at the end, which is the per-run DDL churn the review objected to. It now uses the persisted tables from #80943 and scopes rows by run id. A later review pass over the whole stack added the stall-detecting mutation wait, the paged Postgres handoff, the checksum and telemetry hardening, the config consolidation, and moved the weekly schedule out to its own final PR.

Public artifact: everything in this diff and description comes from this repository and the charts repository. No customer or session material is present.
