### PR TITLE
feat(flags): pre-create hypercache verification task metric series

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -23,6 +23,8 @@ from django_structlog.celery.steps import DjangoStructLogInitStep
 from opentelemetry import trace
 from prometheus_client import Counter, Histogram, start_http_server
 
+from posthog.celery_task_names import LIVENESS_ALERTED_TASK_NAMES
+
 # When PROMETHEUS_MULTIPROC_DIR is set (by bin/docker-worker-celery),
 # prometheus_client uses file-backed storage so all prefork children's
 # metrics are aggregated into a single /metrics endpoint.  Without it,
@@ -54,7 +56,7 @@ CELERY_TASK_SUCCESS_COUNTER = Counter(
 
 CELERY_TASK_FAILURE_COUNTER = Counter(
     "posthog_celery_task_failure",
-    "task failure signal is dispatched when a task succeeds.",
+    "task failure signal is dispatched when a task fails.",
     labelnames=["task_name"],
 )
 
@@ -98,7 +100,30 @@ task_timings: dict[str, float] = {}
 
 
 def _initialize_worker_metrics() -> None:
-    """Initialize metrics that need to survive pod restarts."""
+    """Initialize metrics that need to survive pod restarts.
+
+    Each initializer runs unconditionally and carries its own worker-type gate, so
+    adding one here cannot be silently skipped by another's early return.
+    """
+    _initialize_liveness_alerted_task_series()
+    _initialize_cohort_backlog_metric()
+
+
+def _initialize_liveness_alerted_task_series() -> None:
+    # Counter series are created lazily on a task's first prerun/success/failure event,
+    # so a task that stops running vanishes from the metrics once its pods are replaced
+    # (vmalert reads an empty result as resolved) instead of freezing at zero, where the
+    # `increase(...) == 0` liveness alerts pinning these names can see it.
+    signal_counters = (CELERY_TASK_PRE_RUN_COUNTER, CELERY_TASK_SUCCESS_COUNTER, CELERY_TASK_FAILURE_COUNTER)
+    try:
+        for task_name in LIVENESS_ALERTED_TASK_NAMES:
+            for counter in signal_counters:
+                counter.labels(task_name=task_name)
+    except Exception:
+        logger.warning("failed_to_initialize_task_metric_series", exc_info=True)
+
+
+def _initialize_cohort_backlog_metric() -> None:
     # Only initialize cohort metrics on long-running workers that handle cohort calculations
     if not _is_longrunning_worker():
         return

--- a/posthog/celery_task_names.py
+++ b/posthog/celery_task_names.py
@@ -1,0 +1,24 @@
+# Task names pinned by vmalert liveness alerts in PostHog/charts (currently
+# FlagsCacheVerificationNotRunning), which fire on
+# `increase(posthog_celery_task_success_total{task_name="..."}[window]) == 0`.
+#
+# Each name here must be passed as `name=` to its @shared_task decorator, so the
+# task_name label the alert matches on stays stable across module moves and renames,
+# and is pre-created at worker start (posthog/celery.py, _initialize_worker_metrics)
+# so a task that stops running freezes at zero instead of vanishing from the metrics.
+#
+# This module must stay import-light (like posthog/celery_queues.py): the metric seed
+# reads it without importing task code, because an import error killing the seed is
+# exactly the failure mode the alerts exist to catch.
+
+VERIFY_FLAGS_CACHE_TASK_NAME = "posthog.tasks.hypercache_verification.verify_and_fix_flags_cache_task"
+VERIFY_TEAM_METADATA_CACHE_TASK_NAME = "posthog.tasks.hypercache_verification.verify_and_fix_team_metadata_cache_task"
+VERIFY_FLAG_DEFINITIONS_CACHE_TASK_NAME = (
+    "posthog.tasks.hypercache_verification.verify_and_fix_flag_definitions_cache_task"
+)
+
+LIVENESS_ALERTED_TASK_NAMES = (
+    VERIFY_FLAGS_CACHE_TASK_NAME,
+    VERIFY_TEAM_METADATA_CACHE_TASK_NAME,
+    VERIFY_FLAG_DEFINITIONS_CACHE_TASK_NAME,
+)

--- a/posthog/tasks/hypercache_verification.py
+++ b/posthog/tasks/hypercache_verification.py
@@ -20,6 +20,11 @@ from celery import shared_task
 from celery.exceptions import SoftTimeLimitExceeded
 from prometheus_client import Counter
 
+from posthog.celery_task_names import (
+    VERIFY_FLAG_DEFINITIONS_CACHE_TASK_NAME,
+    VERIFY_FLAGS_CACHE_TASK_NAME,
+    VERIFY_TEAM_METADATA_CACHE_TASK_NAME,
+)
 from posthog.exceptions_capture import capture_exception
 from posthog.storage.hypercache_manager import HyperCacheManagementConfig
 from posthog.storage.hypercache_verifier import TeamBatchFetchError, VerifyTeamFn, _run_verification_for_cache
@@ -199,6 +204,7 @@ def _run_cache_verification(cache_type: CacheType, chunk_size: int) -> None:
     bind=True,
     base=PushGatewayTask,
     ignore_result=True,
+    name=VERIFY_FLAGS_CACHE_TASK_NAME,
     queue=CeleryQueue.FEATURE_FLAGS_LONG_RUNNING.value,
     soft_time_limit=20 * 60,  # 20 min soft limit
     time_limit=25 * 60,  # 25 min hard limit (matches LOCK_TIMEOUT_SECONDS)
@@ -223,6 +229,7 @@ def verify_and_fix_flags_cache_task(self: PushGatewayTask) -> None:
     bind=True,
     base=PushGatewayTask,
     ignore_result=True,
+    name=VERIFY_TEAM_METADATA_CACHE_TASK_NAME,
     queue=CeleryQueue.DEFAULT.value,
     soft_time_limit=20 * 60,  # 20 min soft limit
     time_limit=25 * 60,  # 25 min hard limit (matches LOCK_TIMEOUT_SECONDS)
@@ -247,6 +254,7 @@ def verify_and_fix_team_metadata_cache_task(self: PushGatewayTask) -> None:
     bind=True,
     base=PushGatewayTask,
     ignore_result=True,
+    name=VERIFY_FLAG_DEFINITIONS_CACHE_TASK_NAME,
     queue=CeleryQueue.FEATURE_FLAGS_LONG_RUNNING.value,
     soft_time_limit=25 * 60,  # 25 min soft limit
     time_limit=30 * 60,  # 30 min hard limit (matches FLAG_DEFINITIONS_LOCK_TIMEOUT_SECONDS)

--- a/posthog/test/test_celery.py
+++ b/posthog/test/test_celery.py
@@ -1,3 +1,4 @@
+import os
 import threading
 
 from unittest import TestCase
@@ -5,9 +6,15 @@ from unittest.mock import MagicMock, patch
 
 import posthoganalytics
 from parameterized import parameterized
+from prometheus_client import REGISTRY
 
 import posthog.celery
-from posthog.celery import on_worker_process_shutdown
+from posthog.celery import _initialize_worker_metrics, on_worker_process_shutdown
+from posthog.celery_task_names import (
+    VERIFY_FLAG_DEFINITIONS_CACHE_TASK_NAME,
+    VERIFY_FLAGS_CACHE_TASK_NAME,
+    VERIFY_TEAM_METADATA_CACHE_TASK_NAME,
+)
 from posthog.tasks.tasks import clickhouse_errors_count
 
 
@@ -63,6 +70,31 @@ class TestAnalyticsMetricsConfig(TestCase):
         config = getattr(posthoganalytics, "metrics", None)
         assert isinstance(config, dict)
         assert config["service_name"]
+
+
+class TestWorkerMetricsInitialization(TestCase):
+    # "celery" excludes long_running, so this also proves the seed does not depend on
+    # the queue set (and keeps the DB-touching cohort branch off).
+    @patch.dict(os.environ, {"CELERY_WORKER_QUEUES": "celery"})
+    def test_seeds_hypercache_verification_task_series(self) -> None:
+        _initialize_worker_metrics()
+
+        for task_name in (
+            VERIFY_FLAGS_CACHE_TASK_NAME,
+            VERIFY_TEAM_METADATA_CACHE_TASK_NAME,
+            VERIFY_FLAG_DEFINITIONS_CACHE_TASK_NAME,
+        ):
+            for sample_name in (
+                "posthog_celery_task_pre_run_total",
+                "posthog_celery_task_success_total",
+                "posthog_celery_task_failure_total",
+            ):
+                # Existence, not == 0: another test running one of these tasks in the
+                # same process increments the counter, and the alert only needs the
+                # series to exist.
+                assert REGISTRY.get_sample_value(sample_name, {"task_name": task_name}) is not None, (
+                    f"{sample_name} has no series for {task_name}"
+                )
 
 
 class TestCeleryMetrics(TestCase):


### PR DESCRIPTION
## Problem

- Whoever is on call for feature flags can't rely on the `FlagsCacheVerificationNotRunning` alert ([PostHog/charts#14042](https://github.com/PostHog/charts/pull/14042)) to catch a verification task that has permanently stopped running.
- `posthog_celery_task_success_total` only creates a task's series on its first success.
- A dead task's series disappears once its pods are replaced, instead of freezing at zero.
- vmalert reads an empty result as resolved rather than firing, so the alert goes quiet exactly when the task is gone for good.

## Changes

- Every Celery worker now pre-creates the three verification tasks' `pre_run`, `success`, and `failure` counter series at start.
- The three task names live as shared constants in `posthog/celery_task_names.py`, so the decorator and the seed read the same string and can't drift apart.
- The constants module stays free of task imports, so an import error can't kill the seed the same way it would kill the task.
- Seeding runs on every worker, not just the tasks' own queues, since an extra zero series only adds a harmless zero to the alert's sum.
- `_initialize_worker_metrics()` now calls two independently gated initializers instead of one, so a future addition can't land silently behind the existing long-running-worker check.

## How did you test this code?

- Added `test_seeds_hypercache_verification_task_series` in `posthog/test/test_celery.py`. It patches `CELERY_WORKER_QUEUES` to a queue that excludes `long_running`, then checks that all three tasks' `pre_run`/`success`/`failure` series exist.
- That catches a task falling out of the seed list, or the seed landing behind the wrong worker-type gate again.
- Ran that file, `posthog/tasks/test/test_hypercache_verification.py`, `ruff check`, and `ruff format --check` locally on the changed files.
- Not checked: prod metrics after deploy. `posthog_celery_task_success_total` should show continuous series for these three task names in prod-us and prod-eu once this ships.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This changes worker-internal metrics, not documented behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tools: Claude Code (PostHog Code), this session.
- Skills invoked: `/simplify` (reuse, simplification, efficiency, and altitude passes), `/writing-tests`, `/writing-code-comments`, `/squash`, `/writing-pr-descriptions`.
- I first proposed gating the metric seed by which Celery queue serves each task. That plan's core risk claim was wrong: seeding a task's series on a worker that never runs it can't falsely trigger the alert, since the alert sums across every pod in the environment. The seed became unconditional on every worker instead, dropping the queue-to-task lookup entirely.
- The altitude pass of `/simplify` flagged the task-name constants as living inside `posthog/celery.py`, scoped to one client (hypercache) rather than the general mechanism (any liveness-alerted task). They moved to a new `posthog/celery_task_names.py`, and `_initialize_worker_metrics()` split into two independently gated initializers.
- The new test lists the three task names explicitly rather than importing the shared tuple the seed iterates. That was a deliberate call: importing the tuple would let the test pass even if a name were dropped from it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*