### PR TITLE
fix(data-warehouse): autofocus the new-source catalog search

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/SourceCatalog.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/SourceCatalog.tsx
@@ -164,7 +164,13 @@ export function SourceCatalog({ allowedSources }: SourceCatalogProps): JSX.Eleme
 
             <div className="flex flex-col gap-4 flex-1">
                 <WarehouseWizardHint />
-                <LemonInput type="search" placeholder="Search sources..." value={search} onChange={setSearch} />
+                <LemonInput
+                    type="search"
+                    placeholder="Search sources..."
+                    value={search}
+                    onChange={setSearch}
+                    autoFocus
+                />
 
                 {filteredItems.length === 0 &&
                     (hasCrossCategoryMatches ? (


### PR DESCRIPTION
## Problem

Someone adding a data warehouse source lands on the "New source" catalog, which lists hundreds of connectors in a scrollable grid. Session replays of this flow show users scrolling the whole grid to find their connector instead of using the search box, and some give up before finding it. The search input starts unfocused, so it reads as optional rather than the fastest way through the catalog.

## Changes

- Autofocus the catalog search input on the "New source" scene, so the cursor is in the search box on load and the first keystroke filters the list.

The change is one prop on the existing `LemonInput`; search behavior is unchanged.

## How did you test this code?

- Ran `oxlint` and `oxfmt --check` over the touched file; both pass.
- I did not run the app or add automated tests — this is a one-prop UI change with no logic to assert.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Found while reviewing anonymized session-replay summaries of the data-warehouse new-source onboarding flow for friction themes. Across several sessions users scrolled the large connector catalog rather than searching; autofocusing the search box is the smallest safe nudge toward the faster path. No customer-specific data from those sessions is used in the code, commit, or this description.

Tools: Claude Code. Skills invoked: /writing-pr-descriptions, /writing-user-facing-copy (no visible copy changed).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
