### PR TITLE
fix(grafana): stop reporting exhausted 429/503 retries as error-tracking noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/grafana/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/grafana/source.py
@@ -150,6 +150,12 @@ Self-hosted Grafana OSS can alternatively authenticate with a username and passw
             HOST_NOT_ALLOWED_ERROR: "The Grafana host is not allowed. Please use your instance's public URL.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # `_make_fetch` already retries a 429/5xx in-line with backoff (see grafana.py); if that
+        # budget is still exhausted, the failure is a transient Grafana-side blip rather than a
+        # bug here, and Temporal's activity retry will pick the sync back up.
+        return {"(retryable)"}
+
     def _build_auth(self, config: GrafanaSourceConfig) -> GrafanaAuth:
         return GrafanaAuth(
             method=config.auth_method.selection,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/grafana/tests/test_grafana_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/grafana/tests/test_grafana_source.py
@@ -14,6 +14,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.grafana.gr
     TOKEN_AUTH,
     GrafanaAuth,
     GrafanaResumeConfig,
+    GrafanaRetryableError,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.grafana.settings import ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.grafana.source import GrafanaSource
@@ -81,6 +82,16 @@ class TestGrafanaSource:
     )
     def test_non_retryable_errors(self, expected_key):
         assert expected_key in self.source.get_non_retryable_errors()
+
+    @pytest.mark.parametrize("status_code", [429, 503])
+    def test_retryable_status_error_matches_retryable_pattern(self, status_code):
+        # `fetch()` in grafana.py raises this after its own tenacity retries are exhausted; it
+        # must stay classified as retryable rather than paging on every remaining Temporal attempt.
+        patterns = self.source.get_retryable_errors()
+        error = GrafanaRetryableError(
+            f"Grafana API error (retryable): status={status_code}, url=https://yourstack.grafana.net/api/annotations"
+        )
+        assert any(pattern in str(error) for pattern in patterns)
 
     def test_get_schemas_returns_all_endpoints(self):
         schemas = self.source.get_schemas(self.config, self.team_id)


### PR DESCRIPTION
## Problem

A Grafana annotations sync that hits a transient rate limit or server error still shows up in error tracking on every retry, even though the sync recovers on its own.

- [The reported issue](https://us.posthog.com/project/2/error_tracking/019fdf33-3493-7323-9589-c475a0990166): a 503 from `/api/annotations` raised as `GrafanaRetryableError`.
- `fetch()` in `grafana.py` already retries a 429/5xx in-line with exponential backoff before raising.
- If that budget is exhausted, Temporal retries the whole sync activity (up to 15 attempts), and each attempt reported the same self-recovering error again.

## Changes

- Add `GrafanaSource.get_retryable_errors()` matching the `(retryable)` tag already in `GrafanaRetryableError`'s message.
- This routes an exhausted 429/503 to a warning log and a non-reported retry instead of an exception capture, mirroring the existing Stripe and Google Analytics sources.

## How did you test this code?

- Added `test_retryable_status_error_matches_retryable_pattern`, parametrized over 429 and 503, asserting the error message matches a pattern in `get_retryable_errors()`.
- Ran the full `test_grafana_source.py` suite locally: 24 passed.
- Not run: an end-to-end sync against a live Grafana instance.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None – no user-facing behavior or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking MCP tools (issue details, stack trace, and event sample) and code exploration, then compared with the equivalent `get_retryable_errors()` pattern already used in the Stripe and Google Analytics sources. No skills were invoked beyond `/writing-pr-descriptions` for this body.