### PR TITLE
feat(desktop): support Agent Plugin skills

### DIFF
--- a/products/desktop/apps/code/src/main/di/bindings.ts
+++ b/products/desktop/apps/code/src/main/di/bindings.ts
@@ -143,6 +143,8 @@ import type {
   AGENT_SERVICE,
   AGENT_SLEEP_COORDINATOR,
 } from "@posthog/workspace-server/services/agent/identifiers";
+import type { AgentPluginsService } from "@posthog/workspace-server/services/agent-plugins/agent-plugins";
+import type { AGENT_PLUGINS_SERVICE } from "@posthog/workspace-server/services/agent-plugins/identifiers";
 import type {
   ARCHIVE_FILE_WATCHER,
   ARCHIVE_SESSION_CANCELLER,
@@ -515,6 +517,7 @@ export interface MainBindings {
   [FS_SERVICE]: FsCapability;
 
   // Typed container.get-only tokens (bound via loaded modules)
+  [AGENT_PLUGINS_SERVICE]: AgentPluginsService;
   [AGENT_SERVICE]: AgentService;
   [OAUTH_SERVICE]: OAuthService;
   [GITHUB_INTEGRATION_SERVICE]: GitHubIntegrationService;

--- a/products/desktop/apps/code/src/main/di/container.ts
+++ b/products/desktop/apps/code/src/main/di/container.ts
@@ -148,6 +148,7 @@ import {
   AGENT_SLEEP_COORDINATOR,
 } from "@posthog/workspace-server/services/agent/identifiers";
 import { AgentServiceEvent } from "@posthog/workspace-server/services/agent/schemas";
+import { agentPluginsModule } from "@posthog/workspace-server/services/agent-plugins/agent-plugins.module";
 import { archiveModule } from "@posthog/workspace-server/services/archive/archive.module";
 import {
   ARCHIVE_FILE_WATCHER,
@@ -381,6 +382,7 @@ container.bind(MAIN_SUSPENSION_REPOSITORY).toService(SUSPENSION_REPOSITORY);
 container
   .bind(MAIN_DEFAULT_ADDITIONAL_DIRECTORY_REPOSITORY)
   .toService(DEFAULT_ADDITIONAL_DIRECTORY_REPOSITORY);
+container.load(agentPluginsModule);
 container.load(agentModule);
 container.bind(PI_RUNTIME_FACTORY).to(DesktopPiRuntimeFactory);
 container.load(piSessionModule);

--- a/products/desktop/apps/code/src/main/trpc/router.ts
+++ b/products/desktop/apps/code/src/main/trpc/router.ts
@@ -1,6 +1,7 @@
 import type { HostRouter } from "@posthog/host-router/router";
 import { additionalDirectoriesRouter } from "@posthog/host-router/routers/additional-directories.router";
 import { agentRouter } from "@posthog/host-router/routers/agent.router";
+import { agentPluginsRouter } from "@posthog/host-router/routers/agent-plugins.router";
 import { analyticsRouter } from "@posthog/host-router/routers/analytics.router";
 import { archiveRouter } from "@posthog/host-router/routers/archive.router";
 import { authRouter } from "@posthog/host-router/routers/auth.router";
@@ -60,6 +61,7 @@ import { router } from "./trpc";
 
 export const trpcRouter = router({
   additionalDirectories: additionalDirectoriesRouter,
+  agentPlugins: agentPluginsRouter,
   agent: agentRouter,
   analytics: analyticsRouter,
   archive: archiveRouter,

--- a/products/desktop/apps/code/src/renderer/di/bindings.ts
+++ b/products/desktop/apps/code/src/renderer/di/bindings.ts
@@ -1,5 +1,9 @@
 import type { TrpcRouter } from "@main/trpc/router";
 import {
+  AGENT_PLUGINS_CLIENT,
+  type AgentPluginsClient,
+} from "@posthog/core/agent-plugins/agentPluginsClient";
+import {
   ARCHIVE_CLIENT,
   type ArchiveClient,
 } from "@posthog/core/archive/identifiers";
@@ -291,6 +295,7 @@ export interface RendererBindings {
   [HOST_LOGGER]: HostLogger;
   [TRPC_CLIENT]: TRPCClient<TrpcRouter>;
   [HOST_TRPC_CLIENT]: HostTrpcClient;
+  [AGENT_PLUGINS_CLIENT]: AgentPluginsClient;
   [UPDATES_CLIENT]: UpdatesClient;
   [DEV_MODE_CLIENT]: DevModeClient;
   [CONNECTIVITY_CLIENT]: ConnectivityClient;

--- a/products/desktop/apps/code/src/renderer/di/container.ts
+++ b/products/desktop/apps/code/src/renderer/di/container.ts
@@ -2,6 +2,10 @@ import "reflect-metadata";
 import { useDevFlagsStore } from "@features/dev-toolbar/devFlagsStore";
 import { TypedContainer } from "@inversifyjs/strongly-typed";
 import type { TrpcRouter } from "@main/trpc/router";
+import {
+  AGENT_PLUGINS_CLIENT,
+  type AgentPluginsClient,
+} from "@posthog/core/agent-plugins/agentPluginsClient";
 import { canvasApplicationModule } from "@posthog/core/canvas/canvas.module";
 import {
   CLOUD_TASK_CLIENT,
@@ -184,6 +188,18 @@ container.bind(HOST_LOGGER).toConstantValue(hostLog);
 container.bind<TRPCClient<TrpcRouter>>(TRPC_CLIENT).toConstantValue(trpcClient);
 
 container.bind(HOST_TRPC_CLIENT).toConstantValue(hostTrpcClient);
+
+container.bind(AGENT_PLUGINS_CLIENT).toConstantValue({
+  list: () => hostTrpcClient.agentPlugins.list.query(),
+  select: () => hostTrpcClient.agentPlugins.select.mutate(),
+  register: (selectionToken: string) =>
+    hostTrpcClient.agentPlugins.register.mutate({ selectionToken }),
+  setEnabled: (id: string, enabled: boolean) =>
+    hostTrpcClient.agentPlugins.setEnabled.mutate({ id, enabled }),
+  unregister: async (id: string) => {
+    await hostTrpcClient.agentPlugins.unregister.mutate({ id });
+  },
+} satisfies AgentPluginsClient);
 
 container.bind(UPDATES_CLIENT).toConstantValue(updatesClient);
 

--- a/products/desktop/apps/web/src/web-container.ts
+++ b/products/desktop/apps/web/src/web-container.ts
@@ -5,6 +5,10 @@ import {
   getGatewayUsageUrl,
   getLlmGatewayUrl,
 } from "@posthog/agent/posthog-api";
+import {
+  AGENT_PLUGINS_CLIENT,
+  type AgentPluginsClient,
+} from "@posthog/core/agent-plugins/agentPluginsClient";
 import { archiveModule } from "@posthog/core/archive/archive.module";
 import {
   ARCHIVE_CLIENT,
@@ -380,6 +384,7 @@ interface WebBindings {
   [GIT_CACHE_KEY_PROVIDER]: GitCacheKeyProvider;
   [TEAM_SKILLS_SERVICE]: TeamSkillsService;
   [SKILLS_WORKSPACE_CLIENT]: SkillsWorkspaceClient;
+  [AGENT_PLUGINS_CLIENT]: AgentPluginsClient;
   [CLOUD_ARTIFACT_SERVICE]: CloudArtifactService;
   [CLOUD_ARTIFACT_READ_FILE_AS_BASE64]: ReadFileAsBase64;
   [CLOUD_ARTIFACT_BUNDLE_LOCAL_SKILL]: BundleLocalSkill;
@@ -703,6 +708,19 @@ container.bind(GIT_CACHE_KEY_PROVIDER).toConstantValue(webGitCacheKeyProvider);
 // local skill / materialize a team skill to disk) — neither exists on web, so
 // those two methods reject.
 container.load(skillsCoreModule);
+container.bind(AGENT_PLUGINS_CLIENT).toConstantValue({
+  list: async () => [],
+  select: async () => null,
+  register: async () => {
+    throw new Error("Agent Plugins are not available on the web");
+  },
+  setEnabled: async () => {
+    throw new Error("Agent Plugins are not available on the web");
+  },
+  unregister: async () => {
+    throw new Error("Agent Plugins are not available on the web");
+  },
+} satisfies AgentPluginsClient);
 container.bind(SKILLS_WORKSPACE_CLIENT).toConstantValue({
   exportSkill: () =>
     Promise.reject(

--- a/products/desktop/docs/AGENT-PLUGINS.md
+++ b/products/desktop/docs/AGENT-PLUGINS.md
@@ -37,6 +37,8 @@ The manifest must include the canonical schema and a valid plugin name:
 
 Each skill must follow the [Agent Skills specification](https://agentskills.io/specification). Invalid skills are skipped without disabling valid skills from the same plugin. Skill directories must contain only regular files and directories. Symbolic links are not loaded.
 
+Session snapshots are limited to 256 files and 8 MiB per skill, with a 1 MiB limit for each file. A plugin can contribute up to 1,024 files and 32 MiB across its skill snapshots. Skills that exceed these limits are skipped.
+
 ## Current limitations
 
 - Only local directory installation is available.

--- a/products/desktop/docs/AGENT-PLUGINS.md
+++ b/products/desktop/docs/AGENT-PLUGINS.md
@@ -1,0 +1,46 @@
+# Agent Plugins
+
+PostHog Desktop supports skills from local [Agent Plugins 1.0.0](https://agent-plugins.org/).
+
+## Add a local plugin
+
+1. Open **Skills**.
+2. Select the **Plugins** tab.
+3. Select **Add local plugin**.
+4. Choose the directory that contains `plugin.json`.
+5. Review the plugin metadata, valid skills, and diagnostics, then select **Add plugin**.
+
+PostHog Desktop keeps a reference to the selected directory. It does not copy the plugin into the app. Changes on disk are validated again when an agent session starts.
+
+You can disable a plugin without removing it. Removing a plugin only removes its registration from PostHog Desktop and does not delete the source directory.
+
+## Supported format
+
+A plugin must target Agent Plugins 1.0.0 and can provide Agent Skills in the standard location:
+
+```text
+my-plugin/
+├── plugin.json
+└── skills/
+    └── summarize/
+        └── SKILL.md
+```
+
+The manifest must include the canonical schema and a valid plugin name:
+
+```json
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "my-plugin"
+}
+```
+
+Each skill must follow the [Agent Skills specification](https://agentskills.io/specification). Invalid skills are skipped without disabling valid skills from the same plugin.
+
+## Current limitations
+
+- Only local directory installation is available.
+- Agent Skills are supported in Claude and Codex sessions.
+- `mcp.json` is not loaded yet.
+- Agent Plugins does not define portable commands, hooks, or agents. PostHog Desktop does not load those components from a portable plugin.
+- Plugin updates and registries are not supported. Edit or update the source directory directly.

--- a/products/desktop/docs/AGENT-PLUGINS.md
+++ b/products/desktop/docs/AGENT-PLUGINS.md
@@ -10,7 +10,7 @@ PostHog Desktop supports skills from local [Agent Plugins 1.0.0](https://agent-p
 4. Choose the directory that contains `plugin.json`.
 5. Review the plugin metadata, valid skills, and diagnostics, then select **Add plugin**.
 
-PostHog Desktop keeps a reference to the selected directory. It does not copy the plugin into the app. Changes on disk are validated again when an agent session starts.
+PostHog Desktop keeps a reference to the selected directory. When an agent session starts, it validates the plugin again and copies valid skill files into temporary app storage for that session. The temporary copy is removed when the session ends.
 
 You can disable a plugin without removing it. Removing a plugin only removes its registration from PostHog Desktop and does not delete the source directory.
 
@@ -35,7 +35,7 @@ The manifest must include the canonical schema and a valid plugin name:
 }
 ```
 
-Each skill must follow the [Agent Skills specification](https://agentskills.io/specification). Invalid skills are skipped without disabling valid skills from the same plugin.
+Each skill must follow the [Agent Skills specification](https://agentskills.io/specification). Invalid skills are skipped without disabling valid skills from the same plugin. Skill directories must contain only regular files and directories. Symbolic links are not loaded.
 
 ## Current limitations
 

--- a/products/desktop/packages/core/src/agent-plugins/agentPluginsClient.ts
+++ b/products/desktop/packages/core/src/agent-plugins/agentPluginsClient.ts
@@ -1,0 +1,54 @@
+export const AGENT_PLUGINS_CLIENT = Symbol.for(
+  "posthog.core.agentPlugins.client",
+);
+
+export interface AgentPluginDiagnostic {
+  severity: "warning" | "error";
+  code: string;
+  message: string;
+  path?: string;
+}
+
+export interface AgentPluginManifest {
+  $schema: string;
+  name: string;
+  version?: string;
+  description?: string;
+  author?: { name?: string; email?: string; url?: string };
+  homepage?: string;
+  repository?: string;
+  license?: string;
+  keywords?: string[];
+}
+
+export interface AgentPluginSkill {
+  name: string;
+  description: string;
+  path: string;
+}
+
+export interface AgentPluginPreview {
+  valid: boolean;
+  sourcePath: string;
+  manifest: AgentPluginManifest | null;
+  skills: AgentPluginSkill[];
+  diagnostics: AgentPluginDiagnostic[];
+  selectionToken?: string;
+}
+
+export interface AgentPluginInstallation {
+  id: string;
+  sourcePath: string;
+  enabled: boolean;
+  manifest: AgentPluginManifest;
+  skills: AgentPluginSkill[];
+  diagnostics: AgentPluginDiagnostic[];
+}
+
+export interface AgentPluginsClient {
+  list(): Promise<AgentPluginInstallation[]>;
+  select(): Promise<AgentPluginPreview | null>;
+  register(selectionToken: string): Promise<AgentPluginInstallation>;
+  setEnabled(id: string, enabled: boolean): Promise<AgentPluginInstallation>;
+  unregister(id: string): Promise<void>;
+}

--- a/products/desktop/packages/host-router/src/router.ts
+++ b/products/desktop/packages/host-router/src/router.ts
@@ -1,6 +1,7 @@
 import { router } from "@posthog/host-trpc/trpc";
 import { additionalDirectoriesRouter } from "./routers/additional-directories.router";
 import { agentRouter } from "./routers/agent.router";
+import { agentPluginsRouter } from "./routers/agent-plugins.router";
 import { analyticsRouter } from "./routers/analytics.router";
 import { archiveRouter } from "./routers/archive.router";
 import { authRouter } from "./routers/auth.router";
@@ -54,6 +55,7 @@ import { workspaceRouter } from "./routers/workspace.router";
 
 export const hostRouter = router({
   additionalDirectories: additionalDirectoriesRouter,
+  agentPlugins: agentPluginsRouter,
   agent: agentRouter,
   analytics: analyticsRouter,
   archive: archiveRouter,

--- a/products/desktop/packages/host-router/src/routers/agent-plugins.router.ts
+++ b/products/desktop/packages/host-router/src/routers/agent-plugins.router.ts
@@ -1,0 +1,58 @@
+import { publicProcedure, router } from "@posthog/host-trpc/trpc";
+import type { AgentPluginsService } from "@posthog/workspace-server/services/agent-plugins/agent-plugins";
+import { AGENT_PLUGINS_SERVICE } from "@posthog/workspace-server/services/agent-plugins/identifiers";
+import {
+  agentPluginIdInput,
+  agentPluginInstallation,
+  listAgentPluginsOutput,
+  previewAgentPluginInput,
+  registerAgentPluginInput,
+  selectAgentPluginOutput,
+  setAgentPluginEnabledInput,
+} from "@posthog/workspace-server/services/agent-plugins/schemas";
+
+export const agentPluginsRouter = router({
+  list: publicProcedure
+    .output(listAgentPluginsOutput)
+    .query(({ ctx }) =>
+      ctx.container.get<AgentPluginsService>(AGENT_PLUGINS_SERVICE).list(),
+    ),
+  preview: publicProcedure
+    .input(previewAgentPluginInput)
+    .output(selectAgentPluginOutput.unwrap())
+    .query(({ ctx, input }) =>
+      ctx.container
+        .get<AgentPluginsService>(AGENT_PLUGINS_SERVICE)
+        .preview(input.sourcePath),
+    ),
+  select: publicProcedure
+    .output(selectAgentPluginOutput)
+    .mutation(({ ctx }) =>
+      ctx.container
+        .get<AgentPluginsService>(AGENT_PLUGINS_SERVICE)
+        .selectDirectory(),
+    ),
+  register: publicProcedure
+    .input(registerAgentPluginInput)
+    .output(agentPluginInstallation)
+    .mutation(({ ctx, input }) =>
+      ctx.container
+        .get<AgentPluginsService>(AGENT_PLUGINS_SERVICE)
+        .register(input.sourcePath),
+    ),
+  setEnabled: publicProcedure
+    .input(setAgentPluginEnabledInput)
+    .output(agentPluginInstallation)
+    .mutation(({ ctx, input }) =>
+      ctx.container
+        .get<AgentPluginsService>(AGENT_PLUGINS_SERVICE)
+        .setEnabled(input.id, input.enabled),
+    ),
+  unregister: publicProcedure
+    .input(agentPluginIdInput)
+    .mutation(({ ctx, input }) =>
+      ctx.container
+        .get<AgentPluginsService>(AGENT_PLUGINS_SERVICE)
+        .unregister(input.id),
+    ),
+});

--- a/products/desktop/packages/host-router/src/routers/agent-plugins.router.ts
+++ b/products/desktop/packages/host-router/src/routers/agent-plugins.router.ts
@@ -5,7 +5,6 @@ import {
   agentPluginIdInput,
   agentPluginInstallation,
   listAgentPluginsOutput,
-  previewAgentPluginInput,
   registerAgentPluginInput,
   selectAgentPluginOutput,
   setAgentPluginEnabledInput,
@@ -16,14 +15,6 @@ export const agentPluginsRouter = router({
     .output(listAgentPluginsOutput)
     .query(({ ctx }) =>
       ctx.container.get<AgentPluginsService>(AGENT_PLUGINS_SERVICE).list(),
-    ),
-  preview: publicProcedure
-    .input(previewAgentPluginInput)
-    .output(selectAgentPluginOutput.unwrap())
-    .query(({ ctx, input }) =>
-      ctx.container
-        .get<AgentPluginsService>(AGENT_PLUGINS_SERVICE)
-        .preview(input.sourcePath),
     ),
   select: publicProcedure
     .output(selectAgentPluginOutput)
@@ -38,7 +29,7 @@ export const agentPluginsRouter = router({
     .mutation(({ ctx, input }) =>
       ctx.container
         .get<AgentPluginsService>(AGENT_PLUGINS_SERVICE)
-        .register(input.sourcePath),
+        .register(input.selectionToken),
     ),
   setEnabled: publicProcedure
     .input(setAgentPluginEnabledInput)

--- a/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.test.tsx
+++ b/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentPluginsView } from "./AgentPluginsView";
+
+const mocks = vi.hoisted(() => ({
+  list: vi.fn(),
+  refetch: vi.fn(),
+  select: vi.fn(),
+  register: vi.fn(),
+  setEnabled: vi.fn(),
+  unregister: vi.fn(),
+}));
+
+vi.mock("./useAgentPlugins", () => ({
+  useAgentPlugins: () => mocks.list(),
+  useSelectAgentPlugin: () => ({
+    data: undefined,
+    error: null,
+    isPending: false,
+    mutate: mocks.select,
+    reset: vi.fn(),
+  }),
+  useRegisterAgentPlugin: () => ({
+    error: null,
+    isPending: false,
+    mutate: mocks.register,
+  }),
+  useSetAgentPluginEnabled: () => ({
+    error: null,
+    isPending: false,
+    mutate: mocks.setEnabled,
+  }),
+  useUnregisterAgentPlugin: () => ({
+    error: null,
+    isPending: false,
+    variables: undefined,
+    mutate: mocks.unregister,
+  }),
+}));
+
+describe("AgentPluginsView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows a retry action when the installed plugin list fails", async () => {
+    mocks.refetch.mockResolvedValue(undefined);
+    mocks.list.mockReturnValue({
+      data: undefined,
+      error: new Error("Agent Plugin installation data is invalid."),
+      isError: true,
+      isFetching: false,
+      isLoading: false,
+      refetch: mocks.refetch,
+    });
+
+    render(<AgentPluginsView />);
+
+    expect(
+      screen.getByText("Could not load Agent Plugins"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("No Agent Plugins added"),
+    ).not.toBeInTheDocument();
+    await userEvent.click(screen.getByText("Try again"));
+    expect(mocks.refetch).toHaveBeenCalledOnce();
+  });
+
+  it("shows diagnostic paths and messages for installed plugins", () => {
+    mocks.list.mockReturnValue({
+      data: [
+        {
+          id: "0123456789abcdef",
+          sourcePath: "/plugins/example",
+          enabled: true,
+          manifest: {
+            $schema:
+              "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+            name: "example-plugin",
+          },
+          skills: [],
+          diagnostics: [
+            {
+              severity: "error",
+              code: "invalid_skill",
+              path: "skills/broken/SKILL.md",
+              message: "SKILL.md is not valid YAML.",
+            },
+          ],
+        },
+      ],
+      error: null,
+      isError: false,
+      isFetching: false,
+      isLoading: false,
+      refetch: mocks.refetch,
+    });
+
+    render(<AgentPluginsView />);
+
+    expect(
+      screen.getByText("skills/broken/SKILL.md: SKILL.md is not valid YAML."),
+    ).toBeInTheDocument();
+  });
+});

--- a/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.tsx
+++ b/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.tsx
@@ -1,0 +1,216 @@
+import { FolderOpen, Package, Trash, Warning } from "@phosphor-icons/react";
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+  Spinner,
+  Switch,
+  Text,
+} from "@posthog/quill";
+import {
+  useAgentPlugins,
+  useRegisterAgentPlugin,
+  useSelectAgentPlugin,
+  useSetAgentPluginEnabled,
+  useUnregisterAgentPlugin,
+} from "./useAgentPlugins";
+
+function errorMessage(error: unknown): string | null {
+  return error instanceof Error ? error.message : null;
+}
+
+export function AgentPluginsView() {
+  const plugins = useAgentPlugins();
+  const selectPlugin = useSelectAgentPlugin();
+  const registerPlugin = useRegisterAgentPlugin();
+  const setEnabled = useSetAgentPluginEnabled();
+  const unregister = useUnregisterAgentPlugin();
+  const preview = selectPlugin.data;
+
+  const handleRegister = (): void => {
+    if (!preview) return;
+    registerPlugin.mutate(
+      { sourcePath: preview.sourcePath },
+      { onSuccess: () => selectPlugin.reset() },
+    );
+  };
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex flex-col gap-1">
+          <Text weight="semibold">Agent Plugins</Text>
+          <Text size="sm" variant="muted">
+            Add local Agent Plugins that provide portable skills. MCP servers
+            are not supported yet.
+          </Text>
+        </div>
+        <Button
+          variant="primary"
+          loading={selectPlugin.isPending}
+          onClick={() => selectPlugin.mutate()}
+        >
+          <FolderOpen />
+          Add local plugin
+        </Button>
+      </div>
+
+      {preview && (
+        <Card>
+          <CardHeader>
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex flex-col gap-1">
+                <CardTitle>
+                  {preview.manifest?.name ?? "Invalid Agent Plugin"}
+                </CardTitle>
+                <CardDescription className="break-all">
+                  {preview.sourcePath}
+                </CardDescription>
+              </div>
+              <Badge variant={preview.valid ? "success" : "destructive"}>
+                {preview.valid ? "Ready to add" : "Invalid"}
+              </Badge>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-col gap-4">
+              {preview.manifest?.description && (
+                <Text size="sm">{preview.manifest.description}</Text>
+              )}
+              <div className="flex flex-wrap gap-2">
+                {preview.skills.map((skill) => (
+                  <Badge key={skill.path}>{skill.name}</Badge>
+                ))}
+                {preview.skills.length === 0 && (
+                  <Text size="sm" variant="muted">
+                    No valid skills found
+                  </Text>
+                )}
+              </div>
+              {preview.diagnostics.length > 0 && (
+                <div className="flex flex-col gap-2 rounded-md border border-border p-3">
+                  {preview.diagnostics.map((item, index) => (
+                    <div
+                      key={`${item.code}-${item.path ?? "root"}-${index}`}
+                      className="flex items-start gap-2"
+                    >
+                      <Warning className="mt-0.5 shrink-0" />
+                      <Text
+                        size="xs"
+                        variant={
+                          item.severity === "error" ? "destructive" : "muted"
+                        }
+                      >
+                        {item.message}
+                      </Text>
+                    </div>
+                  ))}
+                </div>
+              )}
+              <div className="flex justify-end gap-2">
+                <Button variant="outline" onClick={() => selectPlugin.reset()}>
+                  Cancel
+                </Button>
+                <Button
+                  variant="primary"
+                  loading={registerPlugin.isPending}
+                  disabled={!preview.valid}
+                  onClick={handleRegister}
+                >
+                  Add plugin
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {(errorMessage(selectPlugin.error) ||
+        errorMessage(registerPlugin.error) ||
+        errorMessage(setEnabled.error) ||
+        errorMessage(unregister.error)) && (
+        <Text variant="destructive" size="sm">
+          {errorMessage(selectPlugin.error) ??
+            errorMessage(registerPlugin.error) ??
+            errorMessage(setEnabled.error) ??
+            errorMessage(unregister.error)}
+        </Text>
+      )}
+
+      {plugins.isLoading ? (
+        <div className="flex justify-center p-8">
+          <Spinner />
+        </div>
+      ) : plugins.data?.length ? (
+        <div className="flex flex-col gap-2">
+          {plugins.data.map((plugin) => (
+            <Card key={plugin.id} size="sm">
+              <CardContent>
+                <div className="flex items-center gap-3">
+                  <Package className="shrink-0" />
+                  <div className="min-w-0 flex-1">
+                    <Text weight="medium">{plugin.manifest.name}</Text>
+                    <Text size="xs" variant="muted" className="block truncate">
+                      {plugin.skills.length} valid skill
+                      {plugin.skills.length === 1 ? "" : "s"} from{" "}
+                      {plugin.sourcePath}
+                    </Text>
+                  </div>
+                  {plugin.diagnostics.length > 0 && (
+                    <Badge variant="warning">
+                      {plugin.diagnostics.length} diagnostic
+                      {plugin.diagnostics.length === 1 ? "" : "s"}
+                    </Badge>
+                  )}
+                  <Switch
+                    checked={plugin.enabled}
+                    disabled={setEnabled.isPending}
+                    aria-label={`Enable ${plugin.manifest.name}`}
+                    onCheckedChange={(enabled) =>
+                      setEnabled.mutate({ id: plugin.id, enabled })
+                    }
+                  />
+                  <Button
+                    variant="destructive"
+                    size="icon-sm"
+                    loading={
+                      unregister.isPending &&
+                      unregister.variables?.id === plugin.id
+                    }
+                    disabled={unregister.isPending}
+                    aria-label={`Remove ${plugin.manifest.name}`}
+                    onClick={() => unregister.mutate({ id: plugin.id })}
+                  >
+                    <Trash />
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      ) : (
+        <Empty>
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <Package />
+            </EmptyMedia>
+            <EmptyTitle>No Agent Plugins added</EmptyTitle>
+            <EmptyDescription>
+              Choose a local plugin directory to make its valid skills available
+              to agents.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      )}
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.tsx
+++ b/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.tsx
@@ -8,6 +8,7 @@ import {
   CardHeader,
   CardTitle,
   Empty,
+  EmptyContent,
   EmptyDescription,
   EmptyHeader,
   EmptyMedia,
@@ -16,6 +17,7 @@ import {
   Switch,
   Text,
 } from "@posthog/quill";
+import type { ReactElement } from "react";
 import {
   useAgentPlugins,
   useRegisterAgentPlugin,
@@ -28,7 +30,11 @@ function errorMessage(error: unknown): string | null {
   return error instanceof Error ? error.message : null;
 }
 
-export function AgentPluginsView() {
+function diagnosticText(item: { message: string; path?: string }): string {
+  return item.path ? `${item.path}: ${item.message}` : item.message;
+}
+
+export function AgentPluginsView(): ReactElement {
   const plugins = useAgentPlugins();
   const selectPlugin = useSelectAgentPlugin();
   const registerPlugin = useRegisterAgentPlugin();
@@ -37,180 +43,232 @@ export function AgentPluginsView() {
   const preview = selectPlugin.data;
 
   const handleRegister = (): void => {
-    if (!preview) return;
+    if (!preview?.selectionToken) return;
     registerPlugin.mutate(
-      { sourcePath: preview.sourcePath },
+      { selectionToken: preview.selectionToken },
       { onSuccess: () => selectPlugin.reset() },
     );
   };
 
   return (
-    <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 p-4">
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex flex-col gap-1">
-          <Text weight="semibold">Agent Plugins</Text>
-          <Text size="sm" variant="muted">
-            Add local Agent Plugins that provide portable skills. MCP servers
-            are not supported yet.
-          </Text>
+    <div className="h-full min-h-0 overflow-y-auto">
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 p-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex flex-col gap-1">
+            <Text weight="semibold">Agent Plugins</Text>
+            <Text size="sm" variant="muted">
+              Add local Agent Plugins that provide portable skills. MCP servers
+              are not supported yet.
+            </Text>
+          </div>
+          <Button
+            variant="primary"
+            loading={selectPlugin.isPending}
+            onClick={() => selectPlugin.mutate()}
+          >
+            <FolderOpen />
+            Add local plugin
+          </Button>
         </div>
-        <Button
-          variant="primary"
-          loading={selectPlugin.isPending}
-          onClick={() => selectPlugin.mutate()}
-        >
-          <FolderOpen />
-          Add local plugin
-        </Button>
-      </div>
 
-      {preview && (
-        <Card>
-          <CardHeader>
-            <div className="flex items-start justify-between gap-4">
-              <div className="flex flex-col gap-1">
-                <CardTitle>
-                  {preview.manifest?.name ?? "Invalid Agent Plugin"}
-                </CardTitle>
-                <CardDescription className="break-all">
-                  {preview.sourcePath}
-                </CardDescription>
-              </div>
-              <Badge variant={preview.valid ? "success" : "destructive"}>
-                {preview.valid ? "Ready to add" : "Invalid"}
-              </Badge>
-            </div>
-          </CardHeader>
-          <CardContent>
-            <div className="flex flex-col gap-4">
-              {preview.manifest?.description && (
-                <Text size="sm">{preview.manifest.description}</Text>
-              )}
-              <div className="flex flex-wrap gap-2">
-                {preview.skills.map((skill) => (
-                  <Badge key={skill.path}>{skill.name}</Badge>
-                ))}
-                {preview.skills.length === 0 && (
-                  <Text size="sm" variant="muted">
-                    No valid skills found
-                  </Text>
-                )}
-              </div>
-              {preview.diagnostics.length > 0 && (
-                <div className="flex flex-col gap-2 rounded-md border border-border p-3">
-                  {preview.diagnostics.map((item, index) => (
-                    <div
-                      key={`${item.code}-${item.path ?? "root"}-${index}`}
-                      className="flex items-start gap-2"
-                    >
-                      <Warning className="mt-0.5 shrink-0" />
-                      <Text
-                        size="xs"
-                        variant={
-                          item.severity === "error" ? "destructive" : "muted"
-                        }
-                      >
-                        {item.message}
-                      </Text>
-                    </div>
-                  ))}
+        {preview && (
+          <Card>
+            <CardHeader>
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex flex-col gap-1">
+                  <CardTitle>
+                    {preview.manifest?.name ?? "Invalid Agent Plugin"}
+                  </CardTitle>
+                  <CardDescription className="break-all">
+                    {preview.sourcePath}
+                  </CardDescription>
                 </div>
-              )}
-              <div className="flex justify-end gap-2">
-                <Button variant="outline" onClick={() => selectPlugin.reset()}>
-                  Cancel
-                </Button>
-                <Button
-                  variant="primary"
-                  loading={registerPlugin.isPending}
-                  disabled={!preview.valid}
-                  onClick={handleRegister}
-                >
-                  Add plugin
-                </Button>
+                <Badge variant={preview.valid ? "success" : "destructive"}>
+                  {preview.valid ? "Ready to add" : "Invalid"}
+                </Badge>
               </div>
-            </div>
-          </CardContent>
-        </Card>
-      )}
-
-      {(errorMessage(selectPlugin.error) ||
-        errorMessage(registerPlugin.error) ||
-        errorMessage(setEnabled.error) ||
-        errorMessage(unregister.error)) && (
-        <Text variant="destructive" size="sm">
-          {errorMessage(selectPlugin.error) ??
-            errorMessage(registerPlugin.error) ??
-            errorMessage(setEnabled.error) ??
-            errorMessage(unregister.error)}
-        </Text>
-      )}
-
-      {plugins.isLoading ? (
-        <div className="flex justify-center p-8">
-          <Spinner />
-        </div>
-      ) : plugins.data?.length ? (
-        <div className="flex flex-col gap-2">
-          {plugins.data.map((plugin) => (
-            <Card key={plugin.id} size="sm">
-              <CardContent>
-                <div className="flex items-center gap-3">
-                  <Package className="shrink-0" />
-                  <div className="min-w-0 flex-1">
-                    <Text weight="medium">{plugin.manifest.name}</Text>
-                    <Text size="xs" variant="muted" className="block truncate">
-                      {plugin.skills.length} valid skill
-                      {plugin.skills.length === 1 ? "" : "s"} from{" "}
-                      {plugin.sourcePath}
+            </CardHeader>
+            <CardContent>
+              <div className="flex flex-col gap-4">
+                {preview.manifest?.description && (
+                  <Text size="sm">{preview.manifest.description}</Text>
+                )}
+                <div className="flex flex-wrap gap-2">
+                  {preview.skills.map((skill) => (
+                    <Badge key={skill.path}>{skill.name}</Badge>
+                  ))}
+                  {preview.skills.length === 0 && (
+                    <Text size="sm" variant="muted">
+                      No valid skills found
                     </Text>
-                  </div>
-                  {plugin.diagnostics.length > 0 && (
-                    <Badge variant="warning">
-                      {plugin.diagnostics.length} diagnostic
-                      {plugin.diagnostics.length === 1 ? "" : "s"}
-                    </Badge>
                   )}
-                  <Switch
-                    checked={plugin.enabled}
-                    disabled={setEnabled.isPending}
-                    aria-label={`Enable ${plugin.manifest.name}`}
-                    onCheckedChange={(enabled) =>
-                      setEnabled.mutate({ id: plugin.id, enabled })
-                    }
-                  />
+                </div>
+                {preview.diagnostics.length > 0 && (
+                  <div className="flex flex-col gap-2 rounded-md border border-border p-3">
+                    {preview.diagnostics.map((item, index) => (
+                      <div
+                        key={`${item.code}-${item.path ?? "root"}-${index}`}
+                        className="flex items-start gap-2"
+                      >
+                        <Warning className="mt-0.5 shrink-0" />
+                        <Text
+                          size="xs"
+                          variant={
+                            item.severity === "error" ? "destructive" : "muted"
+                          }
+                          className="break-all"
+                        >
+                          {diagnosticText(item)}
+                        </Text>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                <div className="flex justify-end gap-2">
                   <Button
-                    variant="destructive"
-                    size="icon-sm"
-                    loading={
-                      unregister.isPending &&
-                      unregister.variables?.id === plugin.id
-                    }
-                    disabled={unregister.isPending}
-                    aria-label={`Remove ${plugin.manifest.name}`}
-                    onClick={() => unregister.mutate({ id: plugin.id })}
+                    variant="outline"
+                    onClick={() => selectPlugin.reset()}
                   >
-                    <Trash />
+                    Cancel
+                  </Button>
+                  <Button
+                    variant="primary"
+                    loading={registerPlugin.isPending}
+                    disabled={!preview.valid || !preview.selectionToken}
+                    onClick={handleRegister}
+                  >
+                    Add plugin
                   </Button>
                 </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      ) : (
-        <Empty>
-          <EmptyHeader>
-            <EmptyMedia variant="icon">
-              <Package />
-            </EmptyMedia>
-            <EmptyTitle>No Agent Plugins added</EmptyTitle>
-            <EmptyDescription>
-              Choose a local plugin directory to make its valid skills available
-              to agents.
-            </EmptyDescription>
-          </EmptyHeader>
-        </Empty>
-      )}
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {(errorMessage(selectPlugin.error) ||
+          errorMessage(registerPlugin.error) ||
+          errorMessage(setEnabled.error) ||
+          errorMessage(unregister.error)) && (
+          <Text variant="destructive" size="sm">
+            {errorMessage(selectPlugin.error) ??
+              errorMessage(registerPlugin.error) ??
+              errorMessage(setEnabled.error) ??
+              errorMessage(unregister.error)}
+          </Text>
+        )}
+
+        {plugins.isLoading ? (
+          <div className="flex justify-center p-8">
+            <Spinner />
+          </div>
+        ) : plugins.isError ? (
+          <Empty>
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <Warning />
+              </EmptyMedia>
+              <EmptyTitle>Could not load Agent Plugins</EmptyTitle>
+              <EmptyDescription>
+                {plugins.error.message} Try again. If it keeps happening,
+                contact support.
+              </EmptyDescription>
+            </EmptyHeader>
+            <EmptyContent>
+              <Button
+                variant="outline"
+                loading={plugins.isFetching}
+                onClick={() => void plugins.refetch()}
+              >
+                Try again
+              </Button>
+            </EmptyContent>
+          </Empty>
+        ) : plugins.data?.length ? (
+          <div className="flex flex-col gap-2">
+            {plugins.data.map((plugin) => (
+              <Card key={plugin.id} size="sm">
+                <CardContent>
+                  <div className="flex flex-col gap-2">
+                    <div className="flex items-center gap-3">
+                      <Package className="shrink-0" />
+                      <div className="min-w-0 flex-1">
+                        <Text weight="medium">{plugin.manifest.name}</Text>
+                        <Text
+                          size="xs"
+                          variant="muted"
+                          className="block break-all"
+                        >
+                          {plugin.skills.length} valid skill
+                          {plugin.skills.length === 1 ? "" : "s"} from{" "}
+                          {plugin.sourcePath}
+                        </Text>
+                      </div>
+                      {plugin.diagnostics.length > 0 && (
+                        <Badge variant="warning">
+                          {plugin.diagnostics.length} diagnostic
+                          {plugin.diagnostics.length === 1 ? "" : "s"}
+                        </Badge>
+                      )}
+                      <Switch
+                        checked={plugin.enabled}
+                        disabled={setEnabled.isPending}
+                        aria-label={`Enable ${plugin.manifest.name}`}
+                        onCheckedChange={(enabled) =>
+                          setEnabled.mutate({ id: plugin.id, enabled })
+                        }
+                      />
+                      <Button
+                        variant="destructive"
+                        size="icon-sm"
+                        loading={
+                          unregister.isPending &&
+                          unregister.variables?.id === plugin.id
+                        }
+                        disabled={unregister.isPending}
+                        aria-label={`Remove ${plugin.manifest.name}`}
+                        onClick={() => unregister.mutate({ id: plugin.id })}
+                      >
+                        <Trash />
+                      </Button>
+                    </div>
+                    {plugin.diagnostics.length > 0 && (
+                      <div className="flex flex-col gap-1 rounded-md border border-border p-3">
+                        {plugin.diagnostics.map((item, index) => (
+                          <Text
+                            key={`${item.code}-${item.path ?? "root"}-${index}`}
+                            size="xs"
+                            variant={
+                              item.severity === "error"
+                                ? "destructive"
+                                : "muted"
+                            }
+                            className="break-all"
+                          >
+                            {diagnosticText(item)}
+                          </Text>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        ) : (
+          <Empty>
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <Package />
+              </EmptyMedia>
+              <EmptyTitle>No Agent Plugins added</EmptyTitle>
+              <EmptyDescription>
+                Choose a local plugin directory to make its valid skills
+                available to agents.
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        )}
+      </div>
     </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/agent-plugins/useAgentPlugins.test.tsx
+++ b/products/desktop/packages/ui/src/features/agent-plugins/useAgentPlugins.test.tsx
@@ -1,0 +1,74 @@
+import type { AgentPluginsClient } from "@posthog/core/agent-plugins/agentPluginsClient";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const mockClient = vi.hoisted<AgentPluginsClient>(() => ({
+  list: vi.fn(),
+  select: vi.fn(),
+  register: vi.fn(),
+  setEnabled: vi.fn(),
+  unregister: vi.fn(),
+}));
+
+vi.mock("@posthog/di/react", () => ({
+  useService: () => mockClient,
+}));
+
+import { useSetAgentPluginEnabled } from "./useAgentPlugins";
+
+function deferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+} {
+  let resolve = (): void => {};
+  const promise = new Promise<void>((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
+}
+
+describe("useAgentPlugins", () => {
+  it("keeps a mutation pending until the installed list is refreshed", async () => {
+    const refresh = deferred();
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    vi.spyOn(queryClient, "invalidateQueries").mockReturnValue(refresh.promise);
+    vi.mocked(mockClient.setEnabled).mockResolvedValue({
+      id: "0123456789abcdef",
+      sourcePath: "/plugins/example",
+      enabled: false,
+      manifest: { $schema: "schema", name: "example" },
+      skills: [],
+      diagnostics: [],
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(() => useSetAgentPluginEnabled(), {
+      wrapper,
+    });
+
+    let mutation!: Promise<unknown>;
+    await act(async () => {
+      mutation = result.current.mutateAsync({
+        id: "0123456789abcdef",
+        enabled: false,
+      });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(result.current.isPending).toBe(true));
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["agent-plugins"],
+    });
+
+    refresh.resolve();
+    await act(async () => {
+      await mutation;
+    });
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+  });
+});

--- a/products/desktop/packages/ui/src/features/agent-plugins/useAgentPlugins.ts
+++ b/products/desktop/packages/ui/src/features/agent-plugins/useAgentPlugins.ts
@@ -26,11 +26,10 @@ export function useAgentPlugins(): UseQueryResult<
   });
 }
 
-function useInvalidateAgentPlugins(): () => void {
+function useInvalidateAgentPlugins(): () => Promise<void> {
   const queryClient = useQueryClient();
-  return () => {
-    void queryClient.invalidateQueries({ queryKey: agentPluginsQueryKey });
-  };
+  return () =>
+    queryClient.invalidateQueries({ queryKey: agentPluginsQueryKey });
 }
 
 export function useSelectAgentPlugin(): UseMutationResult<
@@ -51,7 +50,7 @@ export function useRegisterAgentPlugin(): UseMutationResult<
   const invalidate = useInvalidateAgentPlugins();
   return useMutation({
     mutationFn: ({ selectionToken }) => client.register(selectionToken),
-    onSuccess: invalidate,
+    onSettled: invalidate,
   });
 }
 
@@ -64,7 +63,7 @@ export function useSetAgentPluginEnabled(): UseMutationResult<
   const invalidate = useInvalidateAgentPlugins();
   return useMutation({
     mutationFn: ({ id, enabled }) => client.setEnabled(id, enabled),
-    onSuccess: invalidate,
+    onSettled: invalidate,
   });
 }
 
@@ -77,6 +76,6 @@ export function useUnregisterAgentPlugin(): UseMutationResult<
   const invalidate = useInvalidateAgentPlugins();
   return useMutation({
     mutationFn: ({ id }) => client.unregister(id),
-    onSuccess: invalidate,
+    onSettled: invalidate,
   });
 }

--- a/products/desktop/packages/ui/src/features/agent-plugins/useAgentPlugins.ts
+++ b/products/desktop/packages/ui/src/features/agent-plugins/useAgentPlugins.ts
@@ -1,0 +1,45 @@
+import { useHostTRPC } from "@posthog/host-router/react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+
+export function useAgentPlugins() {
+  const trpc = useHostTRPC();
+  return useQuery(trpc.agentPlugins.list.queryOptions());
+}
+
+function useInvalidateAgentPlugins(): () => void {
+  const trpc = useHostTRPC();
+  const queryClient = useQueryClient();
+  return useCallback(() => {
+    void queryClient.invalidateQueries(trpc.agentPlugins.pathFilter());
+  }, [queryClient, trpc]);
+}
+
+export function useSelectAgentPlugin() {
+  const trpc = useHostTRPC();
+  return useMutation(trpc.agentPlugins.select.mutationOptions());
+}
+
+export function useRegisterAgentPlugin() {
+  const trpc = useHostTRPC();
+  const invalidate = useInvalidateAgentPlugins();
+  return useMutation(
+    trpc.agentPlugins.register.mutationOptions({ onSuccess: invalidate }),
+  );
+}
+
+export function useSetAgentPluginEnabled() {
+  const trpc = useHostTRPC();
+  const invalidate = useInvalidateAgentPlugins();
+  return useMutation(
+    trpc.agentPlugins.setEnabled.mutationOptions({ onSuccess: invalidate }),
+  );
+}
+
+export function useUnregisterAgentPlugin() {
+  const trpc = useHostTRPC();
+  const invalidate = useInvalidateAgentPlugins();
+  return useMutation(
+    trpc.agentPlugins.unregister.mutationOptions({ onSuccess: invalidate }),
+  );
+}

--- a/products/desktop/packages/ui/src/features/agent-plugins/useAgentPlugins.ts
+++ b/products/desktop/packages/ui/src/features/agent-plugins/useAgentPlugins.ts
@@ -1,45 +1,82 @@
-import { useHostTRPC } from "@posthog/host-router/react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback } from "react";
+import {
+  AGENT_PLUGINS_CLIENT,
+  type AgentPluginInstallation,
+  type AgentPluginPreview,
+  type AgentPluginsClient,
+} from "@posthog/core/agent-plugins/agentPluginsClient";
+import { useService } from "@posthog/di/react";
+import {
+  type UseMutationResult,
+  type UseQueryResult,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 
-export function useAgentPlugins() {
-  const trpc = useHostTRPC();
-  return useQuery(trpc.agentPlugins.list.queryOptions());
+const agentPluginsQueryKey = ["agent-plugins"] as const;
+
+export function useAgentPlugins(): UseQueryResult<
+  AgentPluginInstallation[],
+  Error
+> {
+  const client = useService<AgentPluginsClient>(AGENT_PLUGINS_CLIENT);
+  return useQuery({
+    queryKey: agentPluginsQueryKey,
+    queryFn: () => client.list(),
+  });
 }
 
 function useInvalidateAgentPlugins(): () => void {
-  const trpc = useHostTRPC();
   const queryClient = useQueryClient();
-  return useCallback(() => {
-    void queryClient.invalidateQueries(trpc.agentPlugins.pathFilter());
-  }, [queryClient, trpc]);
+  return () => {
+    void queryClient.invalidateQueries({ queryKey: agentPluginsQueryKey });
+  };
 }
 
-export function useSelectAgentPlugin() {
-  const trpc = useHostTRPC();
-  return useMutation(trpc.agentPlugins.select.mutationOptions());
+export function useSelectAgentPlugin(): UseMutationResult<
+  AgentPluginPreview | null,
+  Error,
+  void
+> {
+  const client = useService<AgentPluginsClient>(AGENT_PLUGINS_CLIENT);
+  return useMutation({ mutationFn: () => client.select() });
 }
 
-export function useRegisterAgentPlugin() {
-  const trpc = useHostTRPC();
+export function useRegisterAgentPlugin(): UseMutationResult<
+  AgentPluginInstallation,
+  Error,
+  { selectionToken: string }
+> {
+  const client = useService<AgentPluginsClient>(AGENT_PLUGINS_CLIENT);
   const invalidate = useInvalidateAgentPlugins();
-  return useMutation(
-    trpc.agentPlugins.register.mutationOptions({ onSuccess: invalidate }),
-  );
+  return useMutation({
+    mutationFn: ({ selectionToken }) => client.register(selectionToken),
+    onSuccess: invalidate,
+  });
 }
 
-export function useSetAgentPluginEnabled() {
-  const trpc = useHostTRPC();
+export function useSetAgentPluginEnabled(): UseMutationResult<
+  AgentPluginInstallation,
+  Error,
+  { id: string; enabled: boolean }
+> {
+  const client = useService<AgentPluginsClient>(AGENT_PLUGINS_CLIENT);
   const invalidate = useInvalidateAgentPlugins();
-  return useMutation(
-    trpc.agentPlugins.setEnabled.mutationOptions({ onSuccess: invalidate }),
-  );
+  return useMutation({
+    mutationFn: ({ id, enabled }) => client.setEnabled(id, enabled),
+    onSuccess: invalidate,
+  });
 }
 
-export function useUnregisterAgentPlugin() {
-  const trpc = useHostTRPC();
+export function useUnregisterAgentPlugin(): UseMutationResult<
+  void,
+  Error,
+  { id: string }
+> {
+  const client = useService<AgentPluginsClient>(AGENT_PLUGINS_CLIENT);
   const invalidate = useInvalidateAgentPlugins();
-  return useMutation(
-    trpc.agentPlugins.unregister.mutationOptions({ onSuccess: invalidate }),
-  );
+  return useMutation({
+    mutationFn: ({ id }) => client.unregister(id),
+    onSuccess: invalidate,
+  });
 }

--- a/products/desktop/packages/ui/src/features/skills/SkillsView.tsx
+++ b/products/desktop/packages/ui/src/features/skills/SkillsView.tsx
@@ -12,6 +12,8 @@ import {
 } from "@radix-ui/themes";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ResizableSidebar } from "../../primitives/ResizableSidebar";
+import { useHostCapabilities } from "../../shell/useHostCapabilities";
+import { AgentPluginsView } from "../agent-plugins/AgentPluginsView";
 import { MarketplaceBrowse } from "./MarketplaceBrowse";
 import { NewSkillDialog } from "./NewSkillDialog";
 import { SkillSection, SOURCE_CONFIG } from "./SkillCard";
@@ -36,10 +38,11 @@ const SOURCE_ORDER: SkillSource[] = [
 
 // Installed = on disk, usable by agents right now. Team and Marketplace are
 // remote catalogs; installing materializes a skill into Installed.
-type SkillsTab = "installed" | "team" | "marketplace";
+type SkillsTab = "installed" | "team" | "marketplace" | "plugins";
 
 export function SkillsView() {
   const { data: skills = [], isLoading } = useSkills();
+  const { localWorkspaces } = useHostCapabilities();
   useSkillsWatcher();
 
   const [tab, setTab] = useState<SkillsTab>("installed");
@@ -52,7 +55,10 @@ export function SkillsView() {
   const teamAvailable = teamListing?.available ?? false;
   // Team access revoked mid-session: fall back to Installed.
   const activeTab: SkillsTab =
-    tab === "team" && !teamAvailable ? "installed" : tab;
+    (tab === "team" && !teamAvailable) ||
+    (tab === "plugins" && !localWorkspaces)
+      ? "installed"
+      : tab;
 
   const {
     width: sidebarWidth,
@@ -133,6 +139,11 @@ export function SkillsView() {
             <TabsTrigger value="marketplace" className="gap-1.5 px-2.5 py-2">
               <span className="font-medium text-[13px]">Marketplace</span>
             </TabsTrigger>
+            {localWorkspaces && (
+              <TabsTrigger value="plugins" className="gap-1.5 px-2.5 py-2">
+                <span className="font-medium text-[13px]">Plugins</span>
+              </TabsTrigger>
+            )}
           </TabsList>
         </Tabs>
       </Box>
@@ -141,6 +152,8 @@ export function SkillsView() {
         <MarketplaceBrowse />
       ) : activeTab === "team" ? (
         <TeamSkillsTab skills={teamListing?.skills ?? []} />
+      ) : activeTab === "plugins" ? (
+        <AgentPluginsView />
       ) : (
         <Flex className="min-h-0 flex-1">
           <Box flexGrow="1" className="min-w-0">

--- a/products/desktop/packages/workspace-server/package.json
+++ b/products/desktop/packages/workspace-server/package.json
@@ -43,6 +43,7 @@
     "reflect-metadata": "catalog:",
     "smol-toml": "^1.6.0",
     "superjson": "catalog:",
+    "yaml": "^2.9.0",
     "zod": "^4.1.12"
   },
   "devDependencies": {

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.module.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.module.ts
@@ -1,0 +1,7 @@
+import { ContainerModule } from "inversify";
+import { AgentPluginsService } from "./agent-plugins";
+import { AGENT_PLUGINS_SERVICE } from "./identifiers";
+
+export const agentPluginsModule = new ContainerModule(({ bind }) => {
+  bind(AGENT_PLUGINS_SERVICE).to(AgentPluginsService).inSingletonScope();
+});

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
@@ -2,7 +2,10 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { AgentPluginsService } from "./agent-plugins";
+import {
+  AgentPluginsService,
+  assertAgentPluginSnapshotFileLimits,
+} from "./agent-plugins";
 import { loadAgentPlugin } from "./loader";
 import { AGENT_PLUGINS_MANIFEST_SCHEMA } from "./schemas";
 
@@ -605,19 +608,6 @@ describe("Agent Plugins skills support", () => {
       },
     ],
     [
-      "file count",
-      async (skillDirectory: string) => {
-        await Promise.all(
-          Array.from({ length: 256 }, (_, index) =>
-            fs.promises.writeFile(
-              path.join(skillDirectory, `file-${index}.txt`),
-              "x",
-            ),
-          ),
-        );
-      },
-    ],
-    [
       "skill bytes",
       async (skillDirectory: string) => {
         await Promise.all(
@@ -654,37 +644,25 @@ describe("Agent Plugins skills support", () => {
   );
 
   it.each([
-    [
-      "files",
-      async (skillDirectories: string[]) => {
-        for (const skillDirectory of skillDirectories) {
-          await Promise.all(
-            Array.from({ length: 255 }, (_, index) =>
-              fs.promises.writeFile(
-                path.join(skillDirectory, `file-${index}.txt`),
-                "x",
-              ),
-            ),
-          );
-        }
-      },
-    ],
-    [
-      "bytes",
-      async (skillDirectories: string[]) => {
-        await Promise.all(
-          skillDirectories.flatMap((skillDirectory) =>
-            Array.from({ length: 7 }, (_, index) =>
-              writeSparseFile(
-                path.join(skillDirectory, `chunk-${index}.bin`),
-                1024 * 1024,
-              ),
-            ),
-          ),
-        );
-      },
-    ],
-  ])("bounds the total %s copied for one plugin", async (label, addPayload) => {
+    ["skill boundary", 256, 256, false],
+    ["plugin boundary", 256, 1024, false],
+    ["skill overflow", 257, 257, true],
+    ["plugin overflow", 256, 1025, true],
+  ])(
+    "enforces the snapshot file limit at the %s",
+    (_label, skillFiles, pluginFiles, exceedsLimit) => {
+      const assertLimits = (): void =>
+        assertAgentPluginSnapshotFileLimits(skillFiles, pluginFiles);
+
+      if (exceedsLimit) {
+        expect(assertLimits).toThrow("too many snapshot files");
+      } else {
+        expect(assertLimits).not.toThrow();
+      }
+    },
+  );
+
+  it("bounds the total bytes copied for one plugin", async () => {
     const appDataPath = path.join(root, "app-data");
     const pluginDirectory = path.join(root, "plugin");
     await writePlugin(pluginDirectory);
@@ -695,11 +673,20 @@ describe("Agent Plugins skills support", () => {
     );
     const service = createService(appDataPath, [pluginDirectory]);
     await registerSelectedPlugin(service);
-    await addPayload(skillDirectories);
+    await Promise.all(
+      skillDirectories.flatMap((skillDirectory) =>
+        Array.from({ length: 7 }, (_, index) =>
+          writeSparseFile(
+            path.join(skillDirectory, `chunk-${index}.bin`),
+            1024 * 1024,
+          ),
+        ),
+      ),
+    );
     const skipped: string[] = [];
 
     const runtime = await service.prepareRuntimePlugins(
-      `run-plugin-${label}`,
+      "run-plugin-bytes",
       new Set(),
       (_pluginName, skillName) => skipped.push(skillName),
     );

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
@@ -139,6 +139,49 @@ describe("Agent Plugins skills support", () => {
     );
   });
 
+  it.each([
+    [
+      "plugin.json",
+      async (pluginDirectory: string, _skillDirectory: string) => {
+        await writeSparseFile(
+          path.join(pluginDirectory, "plugin.json"),
+          1024 * 1024 + 1,
+        );
+      },
+      false,
+    ],
+    [
+      "SKILL.md",
+      async (_pluginDirectory: string, skillDirectory: string) => {
+        await writeSparseFile(
+          path.join(skillDirectory, "SKILL.md"),
+          1024 * 1024 + 1,
+        );
+      },
+      true,
+    ],
+  ])(
+    "rejects an oversized %s before parsing it",
+    async (_label, addPayload, manifestRemainsValid) => {
+      const pluginDirectory = path.join(root, "plugin");
+      await writePlugin(pluginDirectory);
+      const skillDirectory = await writeSkill(pluginDirectory, "summarize");
+      await addPayload(pluginDirectory, skillDirectory);
+
+      const preview = await loadAgentPlugin(pluginDirectory);
+
+      expect(preview.valid).toBe(manifestRemainsValid);
+      expect(preview.skills).toEqual([]);
+      expect(preview.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: manifestRemainsValid ? "invalid_skill" : "invalid_manifest",
+          }),
+        ]),
+      );
+    },
+  );
+
   it("isolates invalid skills and does not search nested descendants", async () => {
     const pluginDirectory = path.join(root, "plugin");
     await writePlugin(pluginDirectory);
@@ -188,6 +231,52 @@ describe("Agent Plugins skills support", () => {
       ]),
     );
   });
+
+  it.each([
+    [
+      "entry count",
+      async (skillDirectory: string) => {
+        await Promise.all(
+          Array.from({ length: 512 }, (_, index) =>
+            fs.promises.mkdir(path.join(skillDirectory, `directory-${index}`)),
+          ),
+        );
+      },
+      "too many files or directories",
+    ],
+    [
+      "directory depth",
+      async (skillDirectory: string) => {
+        let nestedDirectory = skillDirectory;
+        for (let depth = 0; depth < 33; depth += 1) {
+          nestedDirectory = path.join(nestedDirectory, "d");
+          await fs.promises.mkdir(nestedDirectory);
+        }
+      },
+      "nested too deeply",
+    ],
+  ])(
+    "rejects a skill that exceeds the tree %s limit",
+    async (_label, addPayload, expectedMessage) => {
+      const pluginDirectory = path.join(root, "plugin");
+      await writePlugin(pluginDirectory);
+      const skillDirectory = await writeSkill(pluginDirectory, "summarize");
+      await addPayload(skillDirectory);
+
+      const preview = await loadAgentPlugin(pluginDirectory);
+
+      expect(preview.valid).toBe(true);
+      expect(preview.skills).toEqual([]);
+      expect(preview.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "skill_escape",
+            message: expect.stringContaining(expectedMessage),
+          }),
+        ]),
+      );
+    },
+  );
 
   it("persists stable installation identity and enablement", async () => {
     const pluginDirectory = path.join(root, "plugin");

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
@@ -1,0 +1,210 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AgentPluginsService } from "./agent-plugins";
+import { loadAgentPlugin } from "./loader";
+import { AGENT_PLUGINS_MANIFEST_SCHEMA } from "./schemas";
+
+let root: string;
+
+async function writePlugin(
+  directory: string,
+  manifest: Record<string, unknown> = {
+    $schema: AGENT_PLUGINS_MANIFEST_SCHEMA,
+    name: "example-plugin",
+  },
+): Promise<void> {
+  await fs.promises.mkdir(directory, { recursive: true });
+  await fs.promises.writeFile(
+    path.join(directory, "plugin.json"),
+    JSON.stringify(manifest),
+  );
+}
+
+async function writeSkill(
+  pluginDirectory: string,
+  name: string,
+  description = "Use this skill for tests.",
+): Promise<string> {
+  const skillDirectory = path.join(pluginDirectory, "skills", name);
+  await fs.promises.mkdir(skillDirectory, { recursive: true });
+  await fs.promises.writeFile(
+    path.join(skillDirectory, "SKILL.md"),
+    `---\nname: ${name}\ndescription: ${description}\n---\n\nInstructions.\n`,
+  );
+  return skillDirectory;
+}
+
+function createService(appDataPath: string): AgentPluginsService {
+  return new AgentPluginsService(
+    {
+      appDataPath,
+      logsPath: path.join(appDataPath, "logs"),
+      logFolderPath: "",
+    },
+    { confirm: async () => 0, pickFile: async () => [] },
+  );
+}
+
+describe("Agent Plugins skills support", () => {
+  beforeEach(async () => {
+    root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "agent-plugins-"));
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(root, { recursive: true, force: true });
+  });
+
+  it("reports and ignores the two non-fatal manifest exceptions", async () => {
+    const pluginDirectory = path.join(root, "plugin");
+    await writePlugin(pluginDirectory, {
+      $schema: AGENT_PLUGINS_MANIFEST_SCHEMA,
+      name: "example-plugin",
+      extensions: "invalid but non-fatal",
+      futureField: true,
+    });
+    await writeSkill(pluginDirectory, "summarize");
+
+    const preview = await loadAgentPlugin(pluginDirectory);
+
+    expect(preview.valid).toBe(true);
+    expect(preview.skills.map((skill) => skill.name)).toEqual(["summarize"]);
+    expect(preview.diagnostics.map((item) => item.code)).toEqual([
+      "unknown_manifest_field",
+      "invalid_extensions",
+    ]);
+  });
+
+  it.each([
+    [
+      "unsupported schema",
+      { $schema: "https://example.com/schema", name: "ok" },
+    ],
+    [
+      "invalid name",
+      { $schema: AGENT_PLUGINS_MANIFEST_SCHEMA, name: "Bad Name" },
+    ],
+    [
+      "invalid metadata type",
+      { $schema: AGENT_PLUGINS_MANIFEST_SCHEMA, name: "ok", version: 1 },
+    ],
+    [
+      "invalid author field",
+      {
+        $schema: AGENT_PLUGINS_MANIFEST_SCHEMA,
+        name: "ok",
+        author: { company: "Example" },
+      },
+    ],
+  ])("rejects a manifest with %s", async (_label, manifest) => {
+    const pluginDirectory = path.join(root, "plugin");
+    await writePlugin(pluginDirectory, manifest);
+
+    const preview = await loadAgentPlugin(pluginDirectory);
+
+    expect(preview.valid).toBe(false);
+    expect(preview.manifest).toBeNull();
+    expect(preview.diagnostics.some((item) => item.severity === "error")).toBe(
+      true,
+    );
+  });
+
+  it("isolates invalid skills and does not search nested descendants", async () => {
+    const pluginDirectory = path.join(root, "plugin");
+    await writePlugin(pluginDirectory);
+    await writeSkill(pluginDirectory, "valid-skill");
+    await writeSkill(pluginDirectory, "wrong-directory");
+    await fs.promises.writeFile(
+      path.join(pluginDirectory, "skills", "wrong-directory", "SKILL.md"),
+      "---\nname: different-name\ndescription: Invalid.\n---\n",
+    );
+    await writeSkill(
+      path.join(pluginDirectory, "skills", "container"),
+      "nested-skill",
+    );
+
+    const preview = await loadAgentPlugin(pluginDirectory);
+
+    expect(preview.skills.map((skill) => skill.name)).toEqual(["valid-skill"]);
+    expect(preview.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "invalid_skill" }),
+      ]),
+    );
+  });
+
+  it("rejects a skill whose package files escape through a symlink", async () => {
+    const pluginDirectory = path.join(root, "plugin");
+    const outsideDirectory = path.join(root, "outside");
+    await writePlugin(pluginDirectory);
+    const skillDirectory = await writeSkill(pluginDirectory, "unsafe-skill");
+    await fs.promises.mkdir(outsideDirectory);
+    await fs.promises.writeFile(
+      path.join(outsideDirectory, "secret.txt"),
+      "secret",
+    );
+    await fs.promises.symlink(
+      path.join(outsideDirectory, "secret.txt"),
+      path.join(skillDirectory, "reference.txt"),
+    );
+
+    const preview = await loadAgentPlugin(pluginDirectory);
+
+    expect(preview.valid).toBe(true);
+    expect(preview.skills).toEqual([]);
+    expect(preview.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "skill_escape" }),
+      ]),
+    );
+  });
+
+  it("persists stable installation identity and enablement", async () => {
+    const pluginDirectory = path.join(root, "plugin");
+    const appDataPath = path.join(root, "app-data");
+    await writePlugin(pluginDirectory);
+    await writeSkill(pluginDirectory, "summarize");
+    const service = createService(appDataPath);
+
+    const installed = await service.register(pluginDirectory);
+    await service.setEnabled(installed.id, false);
+    const restartedService = createService(appDataPath);
+    const [persisted] = await restartedService.list();
+
+    expect(persisted).toMatchObject({ id: installed.id, enabled: false });
+    expect(persisted.skills.map((skill) => skill.name)).toEqual(["summarize"]);
+  });
+
+  it("prepares deterministic shims and preserves reserved skill names", async () => {
+    const appDataPath = path.join(root, "app-data");
+    const alpha = path.join(root, "alpha");
+    const beta = path.join(root, "beta");
+    await writePlugin(alpha, {
+      $schema: AGENT_PLUGINS_MANIFEST_SCHEMA,
+      name: "alpha-plugin",
+    });
+    await writePlugin(beta, {
+      $schema: AGENT_PLUGINS_MANIFEST_SCHEMA,
+      name: "beta-plugin",
+    });
+    await writeSkill(alpha, "shared");
+    await writeSkill(alpha, "alpha-only");
+    await writeSkill(beta, "shared");
+    await writeSkill(beta, "reserved");
+    const service = createService(appDataPath);
+    await service.register(beta);
+    await service.register(alpha);
+
+    const runtime = await service.prepareRuntimePlugins(
+      "run-1",
+      new Set(["reserved"]),
+    );
+
+    expect(runtime).toHaveLength(1);
+    expect(await fs.promises.readdir(runtime[0].skillsPath)).toEqual([
+      "alpha-only",
+      "shared",
+    ]);
+  });
+});

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
@@ -564,6 +564,36 @@ describe("Agent Plugins skills support", () => {
     expect(skipped).toEqual(["summarize"]);
   });
 
+  it("removes partial runtime snapshots when preparation fails", async () => {
+    const appDataPath = path.join(root, "app-data");
+    const pluginDirectory = path.join(root, "plugin");
+    await writePlugin(pluginDirectory);
+    await writeSkill(pluginDirectory, "summarize");
+    const service = createService(appDataPath, [pluginDirectory]);
+    await registerSelectedPlugin(service);
+    const originalWriteFile = fs.promises.writeFile.bind(fs.promises);
+    vi.spyOn(fs.promises, "writeFile").mockImplementation(
+      async (target, data, options) => {
+        if (
+          String(target).includes(path.join("runtime", "run-cleanup")) &&
+          String(target).endsWith("plugin.json")
+        ) {
+          throw new Error("Simulated runtime metadata failure");
+        }
+        return originalWriteFile(target, data, options);
+      },
+    );
+
+    await expect(
+      service.prepareRuntimePlugins("run-cleanup", new Set()),
+    ).rejects.toThrow("Simulated runtime metadata failure");
+    await expect(
+      fs.promises.lstat(
+        path.join(appDataPath, "agent-plugins", "runtime", "run-cleanup"),
+      ),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it.each([
     [
       "file bytes",

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
@@ -36,15 +36,34 @@ async function writeSkill(
   return skillDirectory;
 }
 
-function createService(appDataPath: string): AgentPluginsService {
+function createService(
+  appDataPath: string,
+  selectedPaths: string[] = [],
+): AgentPluginsService {
   return new AgentPluginsService(
     {
       appDataPath,
       logsPath: path.join(appDataPath, "logs"),
       logFolderPath: "",
     },
-    { confirm: async () => 0, pickFile: async () => [] },
+    {
+      confirm: async () => 0,
+      pickFile: async () => {
+        const selectedPath = selectedPaths.shift();
+        return selectedPath ? [selectedPath] : [];
+      },
+    },
   );
+}
+
+async function registerSelectedPlugin(
+  service: AgentPluginsService,
+): Promise<Awaited<ReturnType<AgentPluginsService["register"]>>> {
+  const preview = await service.selectDirectory();
+  if (!preview?.selectionToken) {
+    throw new Error("Expected a valid selected plugin");
+  }
+  return service.register(preview.selectionToken);
 }
 
 describe("Agent Plugins skills support", () => {
@@ -165,9 +184,9 @@ describe("Agent Plugins skills support", () => {
     const appDataPath = path.join(root, "app-data");
     await writePlugin(pluginDirectory);
     await writeSkill(pluginDirectory, "summarize");
-    const service = createService(appDataPath);
+    const service = createService(appDataPath, [pluginDirectory]);
 
-    const installed = await service.register(pluginDirectory);
+    const installed = await registerSelectedPlugin(service);
     await service.setEnabled(installed.id, false);
     const restartedService = createService(appDataPath);
     const [persisted] = await restartedService.list();
@@ -192,19 +211,150 @@ describe("Agent Plugins skills support", () => {
     await writeSkill(alpha, "alpha-only");
     await writeSkill(beta, "shared");
     await writeSkill(beta, "reserved");
-    const service = createService(appDataPath);
-    await service.register(beta);
-    await service.register(alpha);
+    const service = createService(appDataPath, [beta, alpha]);
+    await registerSelectedPlugin(service);
+    await registerSelectedPlugin(service);
 
+    const skipped: string[] = [];
     const runtime = await service.prepareRuntimePlugins(
       "run-1",
       new Set(["reserved"]),
+      (pluginName, skillName) => skipped.push(`${pluginName}:${skillName}`),
     );
 
     expect(runtime).toHaveLength(1);
+    expect(skipped).toEqual(["beta-plugin:reserved", "beta-plugin:shared"]);
     expect(await fs.promises.readdir(runtime[0].skillsPath)).toEqual([
       "alpha-only",
       "shared",
     ]);
+  });
+
+  it("snapshots regular skill files instead of linking mutable sources", async () => {
+    const appDataPath = path.join(root, "app-data");
+    const pluginDirectory = path.join(root, "plugin");
+    await writePlugin(pluginDirectory);
+    const sourceSkill = await writeSkill(pluginDirectory, "summarize");
+    const service = createService(appDataPath, [pluginDirectory]);
+    await registerSelectedPlugin(service);
+
+    const [runtime] = await service.prepareRuntimePlugins("run-1", new Set());
+    const snapshotSkill = path.join(runtime.skillsPath, "summarize");
+    const original = await fs.promises.readFile(
+      path.join(snapshotSkill, "SKILL.md"),
+      "utf8",
+    );
+    expect((await fs.promises.lstat(snapshotSkill)).isDirectory()).toBe(true);
+    expect((await fs.promises.lstat(snapshotSkill)).isSymbolicLink()).toBe(
+      false,
+    );
+
+    await fs.promises.writeFile(
+      path.join(sourceSkill, "SKILL.md"),
+      "changed after validation",
+    );
+    await fs.promises.symlink(
+      path.join(root, "outside.txt"),
+      path.join(sourceSkill, "outside.txt"),
+    );
+
+    expect(
+      await fs.promises.readFile(path.join(snapshotSkill, "SKILL.md"), "utf8"),
+    ).toBe(original);
+    await expect(
+      fs.promises.lstat(path.join(snapshotSkill, "outside.txt")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("serializes removal and enablement without resurrecting an installation", async () => {
+    const appDataPath = path.join(root, "app-data");
+    const pluginDirectory = path.join(root, "plugin");
+    await writePlugin(pluginDirectory);
+    await writeSkill(pluginDirectory, "summarize");
+    const service = createService(appDataPath, [pluginDirectory]);
+    const installed = await registerSelectedPlugin(service);
+
+    const outcomes = await Promise.allSettled([
+      service.unregister(installed.id),
+      service.setEnabled(installed.id, false),
+    ]);
+
+    expect(outcomes.map((outcome) => outcome.status)).toEqual([
+      "fulfilled",
+      "rejected",
+    ]);
+    expect(await service.list()).toEqual([]);
+  });
+
+  it("rejects tampered persisted identities before managed path operations", async () => {
+    const appDataPath = path.join(root, "app-data");
+    const pluginDirectory = path.join(root, "plugin");
+    await writePlugin(pluginDirectory);
+    await writeSkill(pluginDirectory, "summarize");
+    const service = createService(appDataPath, [pluginDirectory]);
+    await registerSelectedPlugin(service);
+    const statePath = path.join(
+      appDataPath,
+      "agent-plugins",
+      "installations.json",
+    );
+    const originalState = JSON.parse(
+      await fs.promises.readFile(statePath, "utf8"),
+    ) as { installations: Array<Record<string, unknown>> };
+    const invalidStates = [
+      {
+        ...originalState,
+        installations: [
+          { ...originalState.installations[0], id: "../outside" },
+        ],
+      },
+      {
+        ...originalState,
+        installations: [
+          { ...originalState.installations[0], id: "0000000000000000" },
+        ],
+      },
+      {
+        ...originalState,
+        installations: [
+          originalState.installations[0],
+          originalState.installations[0],
+        ],
+      },
+    ];
+    const outsideMarker = path.join(root, "outside-marker");
+    await fs.promises.writeFile(outsideMarker, "keep");
+
+    for (const invalidState of invalidStates) {
+      await fs.promises.writeFile(statePath, JSON.stringify(invalidState));
+      await expect(service.list()).rejects.toThrow(
+        "Agent Plugin installation data is invalid",
+      );
+      await expect(
+        service.prepareRuntimePlugins("run-1", new Set()),
+      ).rejects.toThrow("Agent Plugin installation data is invalid");
+      expect(await fs.promises.readFile(outsideMarker, "utf8")).toBe("keep");
+    }
+  });
+
+  it("requires a one-time native directory selection before registration", async () => {
+    const appDataPath = path.join(root, "app-data");
+    const pluginDirectory = path.join(root, "plugin");
+    await writePlugin(pluginDirectory);
+    await writeSkill(pluginDirectory, "summarize");
+    const service = createService(appDataPath, [pluginDirectory]);
+
+    await expect(service.register(pluginDirectory)).rejects.toThrow(
+      "Choose the Agent Plugin directory again",
+    );
+    const preview = await service.selectDirectory();
+    expect(preview?.selectionToken).toBeTypeOf("string");
+    const installed = await service.register(preview?.selectionToken ?? "");
+    expect(installed.sourcePath).toBe(
+      await fs.promises.realpath(pluginDirectory),
+    );
+    await expect(
+      service.register(preview?.selectionToken ?? ""),
+    ).rejects.toThrow("Choose the Agent Plugin directory again");
   });
 });

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentPluginsService } from "./agent-plugins";
 import { loadAgentPlugin } from "./loader";
 import { AGENT_PLUGINS_MANIFEST_SCHEMA } from "./schemas";
@@ -20,6 +20,15 @@ async function writePlugin(
     path.join(directory, "plugin.json"),
     JSON.stringify(manifest),
   );
+}
+
+async function writeSparseFile(filePath: string, size: number): Promise<void> {
+  const handle = await fs.promises.open(filePath, "w");
+  try {
+    await handle.truncate(size);
+  } finally {
+    await handle.close();
+  }
 }
 
 async function writeSkill(
@@ -72,6 +81,7 @@ describe("Agent Plugins skills support", () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await fs.promises.rm(root, { recursive: true, force: true });
   });
 
@@ -335,6 +345,271 @@ describe("Agent Plugins skills support", () => {
       ).rejects.toThrow("Agent Plugin installation data is invalid");
       expect(await fs.promises.readFile(outsideMarker, "utf8")).toBe("keep");
     }
+  });
+
+  it("skips all skills when the skills directory disappears after discovery", async () => {
+    const pluginDirectory = path.join(root, "plugin");
+    const skillsDirectory = path.join(pluginDirectory, "skills");
+    await writePlugin(pluginDirectory);
+    await writeSkill(pluginDirectory, "summarize");
+    const originalStat = fs.promises.stat.bind(fs.promises);
+    vi.spyOn(fs.promises, "stat").mockImplementation(
+      async (target, options) => {
+        if (String(target).endsWith(path.join("plugin", "skills"))) {
+          await fs.promises.rm(skillsDirectory, { recursive: true });
+        }
+        return originalStat(target, options);
+      },
+    );
+
+    const preview = await loadAgentPlugin(pluginDirectory);
+
+    expect(preview.valid).toBe(true);
+    expect(preview.skills).toEqual([]);
+    expect(preview.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "invalid_skills" }),
+      ]),
+    );
+  });
+
+  it("skips all skills when the skills directory cannot be listed", async () => {
+    const pluginDirectory = path.join(root, "plugin");
+    const _skillsDirectory = path.join(pluginDirectory, "skills");
+    await writePlugin(pluginDirectory);
+    await writeSkill(pluginDirectory, "summarize");
+    const originalReaddir = fs.promises.readdir.bind(fs.promises);
+    vi.spyOn(fs.promises, "readdir").mockImplementation(
+      async (target, options) => {
+        if (String(target).endsWith(path.join("plugin", "skills"))) {
+          throw Object.assign(new Error("denied"), { code: "EACCES" });
+        }
+        return originalReaddir(target, options);
+      },
+    );
+
+    const preview = await loadAgentPlugin(pluginDirectory);
+
+    expect(preview.valid).toBe(true);
+    expect(preview.skills).toEqual([]);
+    expect(preview.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "invalid_skills" }),
+      ]),
+    );
+  });
+
+  it("skips a skill when its file identity changes before opening", async () => {
+    const appDataPath = path.join(root, "app-data");
+    const pluginDirectory = path.join(root, "plugin");
+    const skillDirectory = await writeSkill(pluginDirectory, "summarize");
+    await writePlugin(pluginDirectory);
+    const referencePath = path.join(skillDirectory, "reference.txt");
+    await fs.promises.writeFile(referencePath, "original");
+    const service = createService(appDataPath, [pluginDirectory]);
+    await registerSelectedPlugin(service);
+    const originalOpen = fs.promises.open.bind(fs.promises);
+    let replaced = false;
+    vi.spyOn(fs.promises, "open").mockImplementation(
+      async (target, flags, mode) => {
+        if (
+          String(target).endsWith(
+            path.join("skills", "summarize", "reference.txt"),
+          ) &&
+          !replaced
+        ) {
+          replaced = true;
+          await fs.promises.rename(referencePath, `${referencePath}.old`);
+          await fs.promises.writeFile(referencePath, "replacement");
+        }
+        return originalOpen(target, flags, mode);
+      },
+    );
+    const skipped: string[] = [];
+
+    const runtime = await service.prepareRuntimePlugins(
+      "run-identity",
+      new Set(),
+      (_pluginName, skillName) => skipped.push(skillName),
+    );
+
+    expect(runtime).toEqual([]);
+    expect(skipped).toEqual(["summarize"]);
+  });
+
+  it("validates the completed snapshot when a source changes before file copying", async () => {
+    const appDataPath = path.join(root, "app-data");
+    const pluginDirectory = path.join(root, "plugin");
+    await writePlugin(pluginDirectory);
+    const skillDirectory = await writeSkill(pluginDirectory, "summarize");
+    const service = createService(appDataPath, [pluginDirectory]);
+    await registerSelectedPlugin(service);
+    const originalMkdir = fs.promises.mkdir.bind(fs.promises);
+    let changed = false;
+    vi.spyOn(fs.promises, "mkdir").mockImplementation(
+      async (target, options) => {
+        const result = await originalMkdir(target, options);
+        if (
+          String(target).includes(path.join("runtime", "run-postvalidate")) &&
+          String(target).endsWith(path.join("skills", "summarize")) &&
+          !changed
+        ) {
+          changed = true;
+          await fs.promises.writeFile(
+            path.join(skillDirectory, "SKILL.md"),
+            "content without frontmatter",
+          );
+        }
+        return result;
+      },
+    );
+    const skipped: string[] = [];
+
+    const runtime = await service.prepareRuntimePlugins(
+      "run-postvalidate",
+      new Set(),
+      (_pluginName, skillName) => skipped.push(skillName),
+    );
+
+    expect(runtime).toEqual([]);
+    expect(skipped).toEqual(["summarize"]);
+  });
+
+  it.each([
+    [
+      "file bytes",
+      async (skillDirectory: string) => {
+        await writeSparseFile(
+          path.join(skillDirectory, "large.bin"),
+          1024 * 1024 + 1,
+        );
+      },
+    ],
+    [
+      "file count",
+      async (skillDirectory: string) => {
+        await Promise.all(
+          Array.from({ length: 256 }, (_, index) =>
+            fs.promises.writeFile(
+              path.join(skillDirectory, `file-${index}.txt`),
+              "x",
+            ),
+          ),
+        );
+      },
+    ],
+    [
+      "skill bytes",
+      async (skillDirectory: string) => {
+        await Promise.all(
+          Array.from({ length: 8 }, (_, index) =>
+            writeSparseFile(
+              path.join(skillDirectory, `chunk-${index}.bin`),
+              1024 * 1024,
+            ),
+          ),
+        );
+      },
+    ],
+  ])(
+    "skips a skill that exceeds the snapshot %s limit",
+    async (_label, addPayload) => {
+      const appDataPath = path.join(root, "app-data");
+      const pluginDirectory = path.join(root, "plugin");
+      await writePlugin(pluginDirectory);
+      const skillDirectory = await writeSkill(pluginDirectory, "summarize");
+      const service = createService(appDataPath, [pluginDirectory]);
+      await registerSelectedPlugin(service);
+      await addPayload(skillDirectory);
+      const skipped: string[] = [];
+
+      const runtime = await service.prepareRuntimePlugins(
+        `run-${_label.replace(" ", "-")}`,
+        new Set(),
+        (_pluginName, skillName) => skipped.push(skillName),
+      );
+
+      expect(runtime).toEqual([]);
+      expect(skipped).toEqual(["summarize"]);
+    },
+  );
+
+  it.each([
+    [
+      "files",
+      async (skillDirectories: string[]) => {
+        for (const skillDirectory of skillDirectories) {
+          await Promise.all(
+            Array.from({ length: 255 }, (_, index) =>
+              fs.promises.writeFile(
+                path.join(skillDirectory, `file-${index}.txt`),
+                "x",
+              ),
+            ),
+          );
+        }
+      },
+    ],
+    [
+      "bytes",
+      async (skillDirectories: string[]) => {
+        await Promise.all(
+          skillDirectories.flatMap((skillDirectory) =>
+            Array.from({ length: 7 }, (_, index) =>
+              writeSparseFile(
+                path.join(skillDirectory, `chunk-${index}.bin`),
+                1024 * 1024,
+              ),
+            ),
+          ),
+        );
+      },
+    ],
+  ])("bounds the total %s copied for one plugin", async (label, addPayload) => {
+    const appDataPath = path.join(root, "app-data");
+    const pluginDirectory = path.join(root, "plugin");
+    await writePlugin(pluginDirectory);
+    const skillDirectories = await Promise.all(
+      Array.from({ length: 5 }, (_, index) =>
+        writeSkill(pluginDirectory, `skill-${index}`),
+      ),
+    );
+    const service = createService(appDataPath, [pluginDirectory]);
+    await registerSelectedPlugin(service);
+    await addPayload(skillDirectories);
+    const skipped: string[] = [];
+
+    const runtime = await service.prepareRuntimePlugins(
+      `run-plugin-${label}`,
+      new Set(),
+      (_pluginName, skillName) => skipped.push(skillName),
+    );
+
+    expect(runtime).toHaveLength(1);
+    expect(await fs.promises.readdir(runtime[0].skillsPath)).toHaveLength(4);
+    expect(skipped).toEqual(["skill-4"]);
+  });
+
+  it.each(["../outside", "000000000000000g", "short"])(
+    "rejects malformed installation ID %s",
+    async (invalidId) => {
+      const service = createService(path.join(root, "app-data"));
+
+      await expect(service.setEnabled(invalidId, false)).rejects.toThrow(
+        "Invalid Agent Plugin installation ID",
+      );
+      await expect(service.unregister(invalidId)).rejects.toThrow(
+        "Invalid Agent Plugin installation ID",
+      );
+    },
+  );
+
+  it("rejects removal of a missing installation", async () => {
+    const service = createService(path.join(root, "app-data"));
+
+    await expect(service.unregister("0000000000000000")).rejects.toThrow(
+      "Agent Plugin installation not found",
+    );
   });
 
   it("requires a one-time native directory selection before registration", async () => {

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
@@ -11,6 +11,8 @@ import { isSafePathSegment } from "../skills/skill-discovery";
 import {
   isPathContained,
   loadAgentPlugin,
+  MAX_SKILL_TREE_DEPTH,
+  MAX_SKILL_TREE_ENTRIES,
   validateAgentPluginSkillSnapshot,
 } from "./loader";
 import {
@@ -38,6 +40,7 @@ interface PendingSelection {
 interface SnapshotUsage {
   files: number;
   bytes: number;
+  entries: number;
 }
 
 const SELECTION_TTL_MS = 10 * 60 * 1000;
@@ -46,6 +49,7 @@ const MAX_SKILL_SNAPSHOT_FILE_BYTES = 1024 * 1024;
 const MAX_SKILL_SNAPSHOT_BYTES = 8 * 1024 * 1024;
 const MAX_PLUGIN_SNAPSHOT_FILES = 1024;
 const MAX_PLUGIN_SNAPSHOT_BYTES = 32 * 1024 * 1024;
+const MAX_PLUGIN_SNAPSHOT_ENTRIES = 2048;
 const SNAPSHOT_READ_CHUNK_BYTES = 64 * 1024;
 
 @injectable()
@@ -234,7 +238,7 @@ export class AgentPluginsService {
       const skillsPath = path.join(pluginPath, "skills");
       await this.makeManagedDirectory(skillsPath);
       const copiedSkillNames: string[] = [];
-      const pluginUsage: SnapshotUsage = { files: 0, bytes: 0 };
+      const pluginUsage: SnapshotUsage = { files: 0, bytes: 0, entries: 0 };
       for (const skill of availableSkills) {
         const destination = path.join(skillsPath, skill.name);
         try {
@@ -252,6 +256,7 @@ export class AgentPluginsService {
           if (snapshotError) throw new Error(snapshotError);
           pluginUsage.files += skillUsage.files;
           pluginUsage.bytes += skillUsage.bytes;
+          pluginUsage.entries += skillUsage.entries;
           copiedSkillNames.push(skill.name);
         } catch {
           await this.removeManagedPath(destination);
@@ -395,10 +400,11 @@ export class AgentPluginsService {
       throw new Error("Skill path escaped the plugin directory.");
     }
 
-    const skillUsage: SnapshotUsage = { files: 0, bytes: 0 };
+    const skillUsage: SnapshotUsage = { files: 0, bytes: 0, entries: 0 };
     const copyEntry = async (
       source: string,
       destination: string,
+      depth: number,
     ): Promise<void> => {
       const sourceStat = await fs.promises.lstat(source);
       if (sourceStat.isSymbolicLink()) {
@@ -407,6 +413,20 @@ export class AgentPluginsService {
       const resolvedSource = await fs.promises.realpath(source);
       if (!isPathContained(resolvedPluginRoot, resolvedSource)) {
         throw new Error("Skill path escaped the plugin directory.");
+      }
+      if (depth > MAX_SKILL_TREE_DEPTH) {
+        throw new Error("Skill snapshot directories are nested too deeply.");
+      }
+      if (depth > 0) {
+        const nextSkillEntries = skillUsage.entries + 1;
+        const nextPluginEntries = pluginUsage.entries + nextSkillEntries;
+        if (
+          nextSkillEntries > MAX_SKILL_TREE_ENTRIES ||
+          nextPluginEntries > MAX_PLUGIN_SNAPSHOT_ENTRIES
+        ) {
+          throw new Error("A skill contains too many snapshot entries.");
+        }
+        skillUsage.entries = nextSkillEntries;
       }
 
       if (sourceStat.isDirectory()) {
@@ -420,6 +440,7 @@ export class AgentPluginsService {
           await copyEntry(
             path.join(source, entry),
             path.join(destination, entry),
+            depth + 1,
           );
         }
         const finalStat = await fs.promises.lstat(source);
@@ -493,7 +514,7 @@ export class AgentPluginsService {
       }
     };
 
-    await copyEntry(resolvedSourceRoot, destinationRoot);
+    await copyEntry(resolvedSourceRoot, destinationRoot, 0);
     const finalPluginRootStat = await fs.promises.lstat(resolvedPluginRoot);
     if (!this.hasSameSnapshotMetadata(pluginRootStat, finalPluginRootStat)) {
       throw new Error("Agent Plugin directory changed while it was copied.");

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
@@ -1,0 +1,244 @@
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { DIALOG_SERVICE, type IDialog } from "@posthog/platform/dialog";
+import {
+  type IStoragePaths,
+  STORAGE_PATHS_SERVICE,
+} from "@posthog/platform/storage-paths";
+import { inject, injectable } from "inversify";
+import { isSafePathSegment } from "../skills/skill-discovery";
+import { loadAgentPlugin } from "./loader";
+import {
+  type AgentPluginInstallation,
+  type AgentPluginPreview,
+  agentPluginState,
+} from "./schemas";
+
+interface RuntimeAgentPlugin {
+  pluginPath: string;
+  skillsPath: string;
+}
+
+interface PersistedState {
+  version: 1;
+  installations: AgentPluginInstallation[];
+}
+
+@injectable()
+export class AgentPluginsService {
+  private writeQueue: Promise<void> = Promise.resolve();
+
+  constructor(
+    @inject(STORAGE_PATHS_SERVICE)
+    private readonly storagePaths: IStoragePaths,
+    @inject(DIALOG_SERVICE)
+    private readonly dialog: IDialog,
+  ) {}
+
+  async list(): Promise<AgentPluginInstallation[]> {
+    const state = await this.readState();
+    const installations = await Promise.all(
+      state.installations.map(async (installation) => {
+        const preview = await loadAgentPlugin(installation.sourcePath);
+        return {
+          ...installation,
+          sourcePath: preview.sourcePath,
+          manifest: preview.manifest ?? installation.manifest,
+          skills: preview.valid ? preview.skills : [],
+          diagnostics: preview.diagnostics,
+        } satisfies AgentPluginInstallation;
+      }),
+    );
+    await this.writeState({ version: 1, installations });
+    return installations;
+  }
+
+  preview(sourcePath: string): Promise<AgentPluginPreview> {
+    return loadAgentPlugin(sourcePath);
+  }
+
+  async selectDirectory(): Promise<AgentPluginPreview | null> {
+    const [sourcePath] = await this.dialog.pickFile({
+      title: "Choose an Agent Plugin directory",
+      directories: true,
+    });
+    return sourcePath ? this.preview(sourcePath) : null;
+  }
+
+  async register(sourcePath: string): Promise<AgentPluginInstallation> {
+    const preview = await loadAgentPlugin(sourcePath);
+    if (!preview.valid || !preview.manifest) {
+      throw new Error(
+        preview.diagnostics.find((item) => item.severity === "error")
+          ?.message ?? "The selected directory is not a valid Agent Plugin.",
+      );
+    }
+
+    const state = await this.readState();
+    const id = this.installationId(preview.sourcePath);
+    const existing = state.installations.find(
+      (installation) => installation.id === id,
+    );
+    const installation: AgentPluginInstallation = {
+      id,
+      sourcePath: preview.sourcePath,
+      enabled: existing?.enabled ?? true,
+      manifest: preview.manifest,
+      skills: preview.skills,
+      diagnostics: preview.diagnostics,
+    };
+    const installations = state.installations.filter(
+      (item) => item.id !== installation.id,
+    );
+    installations.push(installation);
+    await this.writeState({ version: 1, installations });
+    return installation;
+  }
+
+  async setEnabled(
+    id: string,
+    enabled: boolean,
+  ): Promise<AgentPluginInstallation> {
+    const state = await this.readState();
+    const installation = state.installations.find((item) => item.id === id);
+    if (!installation) throw new Error("Agent Plugin installation not found.");
+    const updated = { ...installation, enabled };
+    await this.writeState({
+      version: 1,
+      installations: state.installations.map((item) =>
+        item.id === id ? updated : item,
+      ),
+    });
+    return updated;
+  }
+
+  async unregister(id: string): Promise<void> {
+    const state = await this.readState();
+    await this.writeState({
+      version: 1,
+      installations: state.installations.filter((item) => item.id !== id),
+    });
+  }
+
+  async prepareRuntimePlugins(
+    taskRunId: string,
+    reservedSkillNames: ReadonlySet<string>,
+  ): Promise<RuntimeAgentPlugin[]> {
+    if (!isSafePathSegment(taskRunId)) {
+      throw new Error(`Unsafe taskRunId: ${JSON.stringify(taskRunId)}`);
+    }
+
+    const runtimeRoot = this.runtimeRoot(taskRunId);
+    await fs.promises.rm(runtimeRoot, { recursive: true, force: true });
+    await fs.promises.mkdir(runtimeRoot, { recursive: true });
+
+    const claimedSkillNames = new Set(reservedSkillNames);
+    const state = await this.readState();
+    const installations = state.installations
+      .filter((installation) => installation.enabled)
+      .sort(
+        (left, right) =>
+          left.manifest.name.localeCompare(right.manifest.name) ||
+          left.id.localeCompare(right.id),
+      );
+
+    const plugins: RuntimeAgentPlugin[] = [];
+    for (const installation of installations) {
+      const preview = await loadAgentPlugin(installation.sourcePath);
+      if (!preview.valid || !preview.manifest) continue;
+      const skills = preview.skills.filter((skill) => {
+        if (claimedSkillNames.has(skill.name)) return false;
+        claimedSkillNames.add(skill.name);
+        return true;
+      });
+      if (skills.length === 0) continue;
+
+      const pluginPath = path.join(runtimeRoot, installation.id);
+      const skillsPath = path.join(pluginPath, "skills");
+      await fs.promises.mkdir(skillsPath, { recursive: true });
+      await fs.promises.writeFile(
+        path.join(pluginPath, "plugin.json"),
+        `${JSON.stringify({
+          name: preview.manifest.name,
+          ...(preview.manifest.version
+            ? { version: preview.manifest.version }
+            : {}),
+          ...(preview.manifest.description
+            ? { description: preview.manifest.description }
+            : {}),
+        })}\n`,
+        "utf8",
+      );
+      for (const skill of skills) {
+        await fs.promises.symlink(
+          skill.path,
+          path.join(skillsPath, skill.name),
+        );
+      }
+      plugins.push({ pluginPath, skillsPath });
+    }
+    return plugins;
+  }
+
+  async cleanupRuntimePlugins(taskRunId: string): Promise<void> {
+    if (!isSafePathSegment(taskRunId)) return;
+    await fs.promises.rm(this.runtimeRoot(taskRunId), {
+      recursive: true,
+      force: true,
+    });
+  }
+
+  private statePath(): string {
+    return path.join(
+      this.storagePaths.appDataPath,
+      "agent-plugins",
+      "installations.json",
+    );
+  }
+
+  private runtimeRoot(taskRunId: string): string {
+    return path.join(
+      this.storagePaths.appDataPath,
+      "agent-plugins",
+      "runtime",
+      taskRunId,
+    );
+  }
+
+  private installationId(sourcePath: string): string {
+    return crypto
+      .createHash("sha256")
+      .update(sourcePath)
+      .digest("hex")
+      .slice(0, 16);
+  }
+
+  private async readState(): Promise<PersistedState> {
+    try {
+      const value: unknown = JSON.parse(
+        await fs.promises.readFile(this.statePath(), "utf8"),
+      );
+      const parsed = agentPluginState.safeParse(value);
+      return parsed.success ? parsed.data : { version: 1, installations: [] };
+    } catch {
+      return { version: 1, installations: [] };
+    }
+  }
+
+  private async writeState(state: PersistedState): Promise<void> {
+    const write = async (): Promise<void> => {
+      const statePath = this.statePath();
+      const temporaryPath = `${statePath}.tmp`;
+      await fs.promises.mkdir(path.dirname(statePath), { recursive: true });
+      await fs.promises.writeFile(
+        temporaryPath,
+        `${JSON.stringify(state, null, 2)}\n`,
+        "utf8",
+      );
+      await fs.promises.rename(temporaryPath, statePath);
+    };
+    this.writeQueue = this.writeQueue.then(write, write);
+    await this.writeQueue;
+  }
+}

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
@@ -52,6 +52,18 @@ const MAX_PLUGIN_SNAPSHOT_BYTES = 32 * 1024 * 1024;
 const MAX_PLUGIN_SNAPSHOT_ENTRIES = 2048;
 const SNAPSHOT_READ_CHUNK_BYTES = 64 * 1024;
 
+export function assertAgentPluginSnapshotFileLimits(
+  skillFiles: number,
+  pluginFiles: number,
+): void {
+  if (
+    skillFiles > MAX_SKILL_SNAPSHOT_FILES ||
+    pluginFiles > MAX_PLUGIN_SNAPSHOT_FILES
+  ) {
+    throw new Error("A skill contains too many snapshot files.");
+  }
+}
+
 @injectable()
 export class AgentPluginsService {
   private stateQueue: Promise<void> = Promise.resolve();
@@ -480,12 +492,7 @@ export class AgentPluginsService {
 
         const nextSkillFiles = skillUsage.files + 1;
         const nextPluginFiles = pluginUsage.files + nextSkillFiles;
-        if (
-          nextSkillFiles > MAX_SKILL_SNAPSHOT_FILES ||
-          nextPluginFiles > MAX_PLUGIN_SNAPSHOT_FILES
-        ) {
-          throw new Error("A skill contains too many snapshot files.");
-        }
+        assertAgentPluginSnapshotFileLimits(nextSkillFiles, nextPluginFiles);
 
         const content = await this.readSnapshotFile(handle);
         const nextSkillBytes = skillUsage.bytes + content.byteLength;

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
@@ -8,7 +8,7 @@ import {
 } from "@posthog/platform/storage-paths";
 import { inject, injectable } from "inversify";
 import { isSafePathSegment } from "../skills/skill-discovery";
-import { loadAgentPlugin } from "./loader";
+import { isPathContained, loadAgentPlugin } from "./loader";
 import {
   type AgentPluginInstallation,
   type AgentPluginPreview,
@@ -25,9 +25,17 @@ interface PersistedState {
   installations: AgentPluginInstallation[];
 }
 
+interface PendingSelection {
+  sourcePath: string;
+  expiresAt: number;
+}
+
+const SELECTION_TTL_MS = 10 * 60 * 1000;
+
 @injectable()
 export class AgentPluginsService {
-  private writeQueue: Promise<void> = Promise.resolve();
+  private stateQueue: Promise<void> = Promise.resolve();
+  private readonly pendingSelections = new Map<string, PendingSelection>();
 
   constructor(
     @inject(STORAGE_PATHS_SERVICE)
@@ -36,26 +44,38 @@ export class AgentPluginsService {
     private readonly dialog: IDialog,
   ) {}
 
-  async list(): Promise<AgentPluginInstallation[]> {
-    const state = await this.readState();
-    const installations = await Promise.all(
-      state.installations.map(async (installation) => {
-        const preview = await loadAgentPlugin(installation.sourcePath);
-        return {
-          ...installation,
-          sourcePath: preview.sourcePath,
-          manifest: preview.manifest ?? installation.manifest,
-          skills: preview.valid ? preview.skills : [],
-          diagnostics: preview.diagnostics,
-        } satisfies AgentPluginInstallation;
-      }),
-    );
-    await this.writeState({ version: 1, installations });
-    return installations;
-  }
-
-  preview(sourcePath: string): Promise<AgentPluginPreview> {
-    return loadAgentPlugin(sourcePath);
+  list(): Promise<AgentPluginInstallation[]> {
+    return this.withStateTransaction(async () => {
+      const state = await this.readState();
+      const installations = await Promise.all(
+        state.installations.map(async (installation) => {
+          const preview = await loadAgentPlugin(installation.sourcePath);
+          const sourceUnchanged =
+            preview.sourcePath === installation.sourcePath;
+          return {
+            ...installation,
+            manifest:
+              sourceUnchanged && preview.manifest
+                ? preview.manifest
+                : installation.manifest,
+            skills: sourceUnchanged && preview.valid ? preview.skills : [],
+            diagnostics: sourceUnchanged
+              ? preview.diagnostics
+              : [
+                  ...preview.diagnostics,
+                  {
+                    severity: "error",
+                    code: "source_changed",
+                    message:
+                      "The Agent Plugin directory changed. Remove it and add it again.",
+                  },
+                ],
+          } satisfies AgentPluginInstallation;
+        }),
+      );
+      await this.writeState({ version: 1, installations });
+      return installations;
+    });
   }
 
   async selectDirectory(): Promise<AgentPluginPreview | null> {
@@ -63,78 +83,102 @@ export class AgentPluginsService {
       title: "Choose an Agent Plugin directory",
       directories: true,
     });
-    return sourcePath ? this.preview(sourcePath) : null;
+    if (!sourcePath) return null;
+
+    const preview = await loadAgentPlugin(sourcePath);
+    if (!preview.valid) return preview;
+
+    const selectionToken = crypto.randomUUID();
+    this.pendingSelections.set(selectionToken, {
+      sourcePath: preview.sourcePath,
+      expiresAt: Date.now() + SELECTION_TTL_MS,
+    });
+    return { ...preview, selectionToken };
   }
 
-  async register(sourcePath: string): Promise<AgentPluginInstallation> {
-    const preview = await loadAgentPlugin(sourcePath);
-    if (!preview.valid || !preview.manifest) {
+  async register(selectionToken: string): Promise<AgentPluginInstallation> {
+    const selection = this.takeSelection(selectionToken);
+    const preview = await loadAgentPlugin(selection.sourcePath);
+    if (
+      !preview.valid ||
+      !preview.manifest ||
+      preview.sourcePath !== selection.sourcePath
+    ) {
       throw new Error(
-        preview.diagnostics.find((item) => item.severity === "error")
-          ?.message ?? "The selected directory is not a valid Agent Plugin.",
+        preview.sourcePath !== selection.sourcePath
+          ? "The selected Agent Plugin directory changed. Choose it again."
+          : (preview.diagnostics.find((item) => item.severity === "error")
+              ?.message ??
+              "The selected directory is not a valid Agent Plugin."),
       );
     }
 
-    const state = await this.readState();
-    const id = this.installationId(preview.sourcePath);
-    const existing = state.installations.find(
-      (installation) => installation.id === id,
-    );
-    const installation: AgentPluginInstallation = {
-      id,
-      sourcePath: preview.sourcePath,
-      enabled: existing?.enabled ?? true,
-      manifest: preview.manifest,
-      skills: preview.skills,
-      diagnostics: preview.diagnostics,
-    };
-    const installations = state.installations.filter(
-      (item) => item.id !== installation.id,
-    );
-    installations.push(installation);
-    await this.writeState({ version: 1, installations });
-    return installation;
-  }
-
-  async setEnabled(
-    id: string,
-    enabled: boolean,
-  ): Promise<AgentPluginInstallation> {
-    const state = await this.readState();
-    const installation = state.installations.find((item) => item.id === id);
-    if (!installation) throw new Error("Agent Plugin installation not found.");
-    const updated = { ...installation, enabled };
-    await this.writeState({
-      version: 1,
-      installations: state.installations.map((item) =>
-        item.id === id ? updated : item,
-      ),
+    const manifest = preview.manifest;
+    return this.withStateTransaction(async () => {
+      const state = await this.readState();
+      const id = this.installationId(preview.sourcePath);
+      const existing = state.installations.find(
+        (installation) => installation.id === id,
+      );
+      const installation: AgentPluginInstallation = {
+        id,
+        sourcePath: preview.sourcePath,
+        enabled: existing?.enabled ?? true,
+        manifest,
+        skills: preview.skills,
+        diagnostics: preview.diagnostics,
+      };
+      const installations = state.installations.filter(
+        (item) => item.id !== installation.id,
+      );
+      installations.push(installation);
+      await this.writeState({ version: 1, installations });
+      return installation;
     });
-    return updated;
   }
 
-  async unregister(id: string): Promise<void> {
-    const state = await this.readState();
-    await this.writeState({
-      version: 1,
-      installations: state.installations.filter((item) => item.id !== id),
+  setEnabled(id: string, enabled: boolean): Promise<AgentPluginInstallation> {
+    return this.withStateTransaction(async () => {
+      const state = await this.readState();
+      const installation = state.installations.find((item) => item.id === id);
+      if (!installation)
+        throw new Error("Agent Plugin installation not found.");
+      const updated = { ...installation, enabled };
+      await this.writeState({
+        version: 1,
+        installations: state.installations.map((item) =>
+          item.id === id ? updated : item,
+        ),
+      });
+      return updated;
+    });
+  }
+
+  unregister(id: string): Promise<void> {
+    return this.withStateTransaction(async () => {
+      const state = await this.readState();
+      await this.writeState({
+        version: 1,
+        installations: state.installations.filter((item) => item.id !== id),
+      });
     });
   }
 
   async prepareRuntimePlugins(
     taskRunId: string,
     reservedSkillNames: ReadonlySet<string>,
+    onSkillSkipped: (pluginName: string, skillName: string) => void = () => {},
   ): Promise<RuntimeAgentPlugin[]> {
     if (!isSafePathSegment(taskRunId)) {
       throw new Error(`Unsafe taskRunId: ${JSON.stringify(taskRunId)}`);
     }
 
     const runtimeRoot = this.runtimeRoot(taskRunId);
-    await fs.promises.rm(runtimeRoot, { recursive: true, force: true });
-    await fs.promises.mkdir(runtimeRoot, { recursive: true });
+    await this.removeManagedPath(runtimeRoot);
+    await this.makeManagedDirectory(runtimeRoot);
 
     const claimedSkillNames = new Set(reservedSkillNames);
-    const state = await this.readState();
+    const state = await this.withStateTransaction(() => this.readState());
     const installations = state.installations
       .filter((installation) => installation.enabled)
       .sort(
@@ -146,18 +190,49 @@ export class AgentPluginsService {
     const plugins: RuntimeAgentPlugin[] = [];
     for (const installation of installations) {
       const preview = await loadAgentPlugin(installation.sourcePath);
-      if (!preview.valid || !preview.manifest) continue;
-      const skills = preview.skills.filter((skill) => {
-        if (claimedSkillNames.has(skill.name)) return false;
+      if (
+        !preview.valid ||
+        !preview.manifest ||
+        preview.sourcePath !== installation.sourcePath
+      )
+        continue;
+      const availableSkills = preview.skills.filter((skill) => {
+        if (claimedSkillNames.has(skill.name)) {
+          onSkillSkipped(
+            preview.manifest?.name ?? installation.manifest.name,
+            skill.name,
+          );
+          return false;
+        }
         claimedSkillNames.add(skill.name);
         return true;
       });
-      if (skills.length === 0) continue;
+      if (availableSkills.length === 0) continue;
 
       const pluginPath = path.join(runtimeRoot, installation.id);
       const skillsPath = path.join(pluginPath, "skills");
-      await fs.promises.mkdir(skillsPath, { recursive: true });
-      await fs.promises.writeFile(
+      await this.makeManagedDirectory(skillsPath);
+      const copiedSkillNames: string[] = [];
+      for (const skill of availableSkills) {
+        const destination = path.join(skillsPath, skill.name);
+        try {
+          await this.copySkillSnapshot(
+            installation.sourcePath,
+            skill.path,
+            destination,
+          );
+          copiedSkillNames.push(skill.name);
+        } catch {
+          await this.removeManagedPath(destination);
+          onSkillSkipped(preview.manifest.name, skill.name);
+        }
+      }
+      if (copiedSkillNames.length === 0) {
+        await this.removeManagedPath(pluginPath);
+        continue;
+      }
+
+      await this.writeManagedFile(
         path.join(pluginPath, "plugin.json"),
         `${JSON.stringify({
           name: preview.manifest.name,
@@ -168,14 +243,7 @@ export class AgentPluginsService {
             ? { description: preview.manifest.description }
             : {}),
         })}\n`,
-        "utf8",
       );
-      for (const skill of skills) {
-        await fs.promises.symlink(
-          skill.path,
-          path.join(skillsPath, skill.name),
-        );
-      }
       plugins.push({ pluginPath, skillsPath });
     }
     return plugins;
@@ -183,27 +251,37 @@ export class AgentPluginsService {
 
   async cleanupRuntimePlugins(taskRunId: string): Promise<void> {
     if (!isSafePathSegment(taskRunId)) return;
-    await fs.promises.rm(this.runtimeRoot(taskRunId), {
-      recursive: true,
-      force: true,
-    });
+    await this.removeManagedPath(this.runtimeRoot(taskRunId));
+  }
+
+  private takeSelection(selectionToken: string): PendingSelection {
+    const selection = this.pendingSelections.get(selectionToken);
+    this.pendingSelections.delete(selectionToken);
+    if (!selection || selection.expiresAt < Date.now()) {
+      throw new Error("Choose the Agent Plugin directory again.");
+    }
+    return selection;
+  }
+
+  private withStateTransaction<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.stateQueue.then(operation, operation);
+    this.stateQueue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+
+  private managedRoot(): string {
+    return path.resolve(this.storagePaths.appDataPath, "agent-plugins");
   }
 
   private statePath(): string {
-    return path.join(
-      this.storagePaths.appDataPath,
-      "agent-plugins",
-      "installations.json",
-    );
+    return path.join(this.managedRoot(), "installations.json");
   }
 
   private runtimeRoot(taskRunId: string): string {
-    return path.join(
-      this.storagePaths.appDataPath,
-      "agent-plugins",
-      "runtime",
-      taskRunId,
-    );
+    return path.join(this.managedRoot(), "runtime", taskRunId);
   }
 
   private installationId(sourcePath: string): string {
@@ -215,30 +293,186 @@ export class AgentPluginsService {
   }
 
   private async readState(): Promise<PersistedState> {
+    let raw: string;
     try {
-      const value: unknown = JSON.parse(
-        await fs.promises.readFile(this.statePath(), "utf8"),
-      );
-      const parsed = agentPluginState.safeParse(value);
-      return parsed.success ? parsed.data : { version: 1, installations: [] };
-    } catch {
-      return { version: 1, installations: [] };
+      raw = await fs.promises.readFile(this.statePath(), "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return { version: 1, installations: [] };
+      }
+      throw error;
     }
+
+    let value: unknown;
+    try {
+      value = JSON.parse(raw);
+    } catch {
+      throw new Error("Agent Plugin installation data is invalid.");
+    }
+    const parsed = agentPluginState.safeParse(value);
+    if (!parsed.success) {
+      throw new Error("Agent Plugin installation data is invalid.");
+    }
+
+    const ids = new Set<string>();
+    for (const installation of parsed.data.installations) {
+      if (
+        !path.isAbsolute(installation.sourcePath) ||
+        path.normalize(installation.sourcePath) !== installation.sourcePath ||
+        this.installationId(installation.sourcePath) !== installation.id ||
+        ids.has(installation.id)
+      ) {
+        throw new Error("Agent Plugin installation data is invalid.");
+      }
+      ids.add(installation.id);
+    }
+    return parsed.data;
   }
 
   private async writeState(state: PersistedState): Promise<void> {
-    const write = async (): Promise<void> => {
-      const statePath = this.statePath();
-      const temporaryPath = `${statePath}.tmp`;
-      await fs.promises.mkdir(path.dirname(statePath), { recursive: true });
-      await fs.promises.writeFile(
-        temporaryPath,
-        `${JSON.stringify(state, null, 2)}\n`,
-        "utf8",
+    const statePath = await this.assertManagedPath(this.statePath());
+    const temporaryPath = await this.assertManagedPath(`${statePath}.tmp`);
+    await this.makeManagedDirectory(path.dirname(statePath));
+    await this.writeManagedFile(
+      temporaryPath,
+      `${JSON.stringify(state, null, 2)}\n`,
+    );
+    await this.assertManagedPath(statePath);
+    await this.assertManagedPath(temporaryPath);
+    await fs.promises.rename(temporaryPath, statePath);
+  }
+
+  private async copySkillSnapshot(
+    pluginRoot: string,
+    sourceRoot: string,
+    destinationRoot: string,
+  ): Promise<void> {
+    const resolvedPluginRoot = await fs.promises.realpath(pluginRoot);
+    const resolvedSourceRoot = await fs.promises.realpath(sourceRoot);
+    if (!isPathContained(resolvedPluginRoot, resolvedSourceRoot)) {
+      throw new Error("Skill path escaped the plugin directory.");
+    }
+
+    const copyEntry = async (
+      source: string,
+      destination: string,
+    ): Promise<void> => {
+      const sourceStat = await fs.promises.lstat(source);
+      if (sourceStat.isSymbolicLink()) {
+        throw new Error("Skill snapshots do not follow symbolic links.");
+      }
+      const resolvedSource = await fs.promises.realpath(source);
+      if (!isPathContained(resolvedPluginRoot, resolvedSource)) {
+        throw new Error("Skill path escaped the plugin directory.");
+      }
+
+      if (sourceStat.isDirectory()) {
+        await this.makeManagedDirectory(destination);
+        const entries = await fs.promises.readdir(source);
+        for (const entry of entries.sort()) {
+          await copyEntry(
+            path.join(source, entry),
+            path.join(destination, entry),
+          );
+        }
+        return;
+      }
+      if (!sourceStat.isFile()) {
+        throw new Error("Skill snapshots contain only regular files.");
+      }
+
+      const noFollow = fs.constants.O_NOFOLLOW ?? 0;
+      const handle = await fs.promises.open(
+        source,
+        fs.constants.O_RDONLY | noFollow,
       );
-      await fs.promises.rename(temporaryPath, statePath);
+      try {
+        const openedStat = await handle.stat();
+        if (!openedStat.isFile()) {
+          throw new Error("Skill snapshots contain only regular files.");
+        }
+        const content = await handle.readFile();
+        await this.writeManagedFile(
+          destination,
+          content,
+          openedStat.mode & 0o777,
+        );
+      } finally {
+        await handle.close();
+      }
     };
-    this.writeQueue = this.writeQueue.then(write, write);
-    await this.writeQueue;
+
+    await copyEntry(resolvedSourceRoot, destinationRoot);
+  }
+
+  private async ensureManagedRoot(): Promise<string> {
+    const root = this.managedRoot();
+    try {
+      const existing = await fs.promises.lstat(root);
+      if (existing.isSymbolicLink() || !existing.isDirectory()) {
+        throw new Error("Agent Plugin storage root is unsafe.");
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      await fs.promises.mkdir(root, { recursive: true });
+      const created = await fs.promises.lstat(root);
+      if (created.isSymbolicLink() || !created.isDirectory()) {
+        throw new Error("Agent Plugin storage root is unsafe.");
+      }
+    }
+    return fs.promises.realpath(root);
+  }
+
+  private async assertManagedPath(candidate: string): Promise<string> {
+    const root = this.managedRoot();
+    const absoluteCandidate = path.resolve(candidate);
+    if (!isPathContained(root, absoluteCandidate)) {
+      throw new Error("Agent Plugin storage path is unsafe.");
+    }
+
+    const resolvedRoot = await this.ensureManagedRoot();
+    const relative = path.relative(root, absoluteCandidate);
+    let current = root;
+    for (const segment of relative.split(path.sep).filter(Boolean)) {
+      current = path.join(current, segment);
+      try {
+        const stat = await fs.promises.lstat(current);
+        if (stat.isSymbolicLink()) {
+          throw new Error("Agent Plugin storage path is unsafe.");
+        }
+        const resolvedCurrent = await fs.promises.realpath(current);
+        if (!isPathContained(resolvedRoot, resolvedCurrent)) {
+          throw new Error("Agent Plugin storage path is unsafe.");
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") break;
+        throw error;
+      }
+    }
+    return absoluteCandidate;
+  }
+
+  private async makeManagedDirectory(directory: string): Promise<void> {
+    const safeDirectory = await this.assertManagedPath(directory);
+    await fs.promises.mkdir(safeDirectory, { recursive: true });
+    await this.assertManagedPath(safeDirectory);
+  }
+
+  private async writeManagedFile(
+    filePath: string,
+    content: string | Uint8Array,
+    mode?: number,
+  ): Promise<void> {
+    const safePath = await this.assertManagedPath(filePath);
+    await this.makeManagedDirectory(path.dirname(safePath));
+    await this.assertManagedPath(safePath);
+    await fs.promises.writeFile(safePath, content, {
+      ...(mode === undefined ? {} : { mode }),
+    });
+  }
+
+  private async removeManagedPath(target: string): Promise<void> {
+    const safeTarget = await this.assertManagedPath(target);
+    await fs.promises.rm(safeTarget, { recursive: true, force: true });
   }
 }

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
@@ -8,8 +8,13 @@ import {
 } from "@posthog/platform/storage-paths";
 import { inject, injectable } from "inversify";
 import { isSafePathSegment } from "../skills/skill-discovery";
-import { isPathContained, loadAgentPlugin } from "./loader";
 import {
+  isPathContained,
+  loadAgentPlugin,
+  validateAgentPluginSkillSnapshot,
+} from "./loader";
+import {
+  AGENT_PLUGIN_INSTALLATION_ID_PATTERN,
   type AgentPluginInstallation,
   type AgentPluginPreview,
   agentPluginState,
@@ -30,7 +35,18 @@ interface PendingSelection {
   expiresAt: number;
 }
 
+interface SnapshotUsage {
+  files: number;
+  bytes: number;
+}
+
 const SELECTION_TTL_MS = 10 * 60 * 1000;
+const MAX_SKILL_SNAPSHOT_FILES = 256;
+const MAX_SKILL_SNAPSHOT_FILE_BYTES = 1024 * 1024;
+const MAX_SKILL_SNAPSHOT_BYTES = 8 * 1024 * 1024;
+const MAX_PLUGIN_SNAPSHOT_FILES = 1024;
+const MAX_PLUGIN_SNAPSHOT_BYTES = 32 * 1024 * 1024;
+const SNAPSHOT_READ_CHUNK_BYTES = 64 * 1024;
 
 @injectable()
 export class AgentPluginsService {
@@ -139,6 +155,7 @@ export class AgentPluginsService {
 
   setEnabled(id: string, enabled: boolean): Promise<AgentPluginInstallation> {
     return this.withStateTransaction(async () => {
+      this.assertInstallationId(id);
       const state = await this.readState();
       const installation = state.installations.find((item) => item.id === id);
       if (!installation)
@@ -156,7 +173,11 @@ export class AgentPluginsService {
 
   unregister(id: string): Promise<void> {
     return this.withStateTransaction(async () => {
+      this.assertInstallationId(id);
       const state = await this.readState();
+      if (!state.installations.some((item) => item.id === id)) {
+        throw new Error("Agent Plugin installation not found.");
+      }
       await this.writeState({
         version: 1,
         installations: state.installations.filter((item) => item.id !== id),
@@ -213,14 +234,24 @@ export class AgentPluginsService {
       const skillsPath = path.join(pluginPath, "skills");
       await this.makeManagedDirectory(skillsPath);
       const copiedSkillNames: string[] = [];
+      const pluginUsage: SnapshotUsage = { files: 0, bytes: 0 };
       for (const skill of availableSkills) {
         const destination = path.join(skillsPath, skill.name);
         try {
-          await this.copySkillSnapshot(
+          const skillUsage = await this.copySkillSnapshot(
             installation.sourcePath,
             skill.path,
             destination,
+            pluginUsage,
           );
+          const snapshotError = await validateAgentPluginSkillSnapshot(
+            pluginPath,
+            destination,
+            skill.name,
+          );
+          if (snapshotError) throw new Error(snapshotError);
+          pluginUsage.files += skillUsage.files;
+          pluginUsage.bytes += skillUsage.bytes;
           copiedSkillNames.push(skill.name);
         } catch {
           await this.removeManagedPath(destination);
@@ -282,6 +313,12 @@ export class AgentPluginsService {
 
   private runtimeRoot(taskRunId: string): string {
     return path.join(this.managedRoot(), "runtime", taskRunId);
+  }
+
+  private assertInstallationId(id: string): void {
+    if (!AGENT_PLUGIN_INSTALLATION_ID_PATTERN.test(id)) {
+      throw new Error("Invalid Agent Plugin installation ID.");
+    }
   }
 
   private installationId(sourcePath: string): string {
@@ -346,13 +383,19 @@ export class AgentPluginsService {
     pluginRoot: string,
     sourceRoot: string,
     destinationRoot: string,
-  ): Promise<void> {
+    pluginUsage: SnapshotUsage,
+  ): Promise<SnapshotUsage> {
     const resolvedPluginRoot = await fs.promises.realpath(pluginRoot);
+    const pluginRootStat = await fs.promises.lstat(resolvedPluginRoot);
     const resolvedSourceRoot = await fs.promises.realpath(sourceRoot);
-    if (!isPathContained(resolvedPluginRoot, resolvedSourceRoot)) {
+    if (
+      !pluginRootStat.isDirectory() ||
+      !isPathContained(resolvedPluginRoot, resolvedSourceRoot)
+    ) {
       throw new Error("Skill path escaped the plugin directory.");
     }
 
+    const skillUsage: SnapshotUsage = { files: 0, bytes: 0 };
     const copyEntry = async (
       source: string,
       destination: string,
@@ -369,16 +412,27 @@ export class AgentPluginsService {
       if (sourceStat.isDirectory()) {
         await this.makeManagedDirectory(destination);
         const entries = await fs.promises.readdir(source);
+        const currentStat = await fs.promises.lstat(source);
+        if (!this.hasSameSnapshotMetadata(sourceStat, currentStat)) {
+          throw new Error("Skill directory changed while it was copied.");
+        }
         for (const entry of entries.sort()) {
           await copyEntry(
             path.join(source, entry),
             path.join(destination, entry),
           );
         }
+        const finalStat = await fs.promises.lstat(source);
+        if (!this.hasSameSnapshotMetadata(sourceStat, finalStat)) {
+          throw new Error("Skill directory changed while it was copied.");
+        }
         return;
       }
       if (!sourceStat.isFile()) {
         throw new Error("Skill snapshots contain only regular files.");
+      }
+      if (sourceStat.size > MAX_SKILL_SNAPSHOT_FILE_BYTES) {
+        throw new Error("A skill file exceeds the snapshot size limit.");
       }
 
       const noFollow = fs.constants.O_NOFOLLOW ?? 0;
@@ -388,21 +442,100 @@ export class AgentPluginsService {
       );
       try {
         const openedStat = await handle.stat();
-        if (!openedStat.isFile()) {
-          throw new Error("Skill snapshots contain only regular files.");
+        if (
+          !openedStat.isFile() ||
+          !this.hasSameFileIdentity(sourceStat, openedStat)
+        ) {
+          throw new Error("Skill file changed before it was copied.");
         }
-        const content = await handle.readFile();
+        if (openedStat.size > MAX_SKILL_SNAPSHOT_FILE_BYTES) {
+          throw new Error("A skill file exceeds the snapshot size limit.");
+        }
+
+        const nextSkillFiles = skillUsage.files + 1;
+        const nextPluginFiles = pluginUsage.files + nextSkillFiles;
+        if (
+          nextSkillFiles > MAX_SKILL_SNAPSHOT_FILES ||
+          nextPluginFiles > MAX_PLUGIN_SNAPSHOT_FILES
+        ) {
+          throw new Error("A skill contains too many snapshot files.");
+        }
+
+        const content = await this.readSnapshotFile(handle);
+        const nextSkillBytes = skillUsage.bytes + content.byteLength;
+        const nextPluginBytes = pluginUsage.bytes + nextSkillBytes;
+        if (
+          nextSkillBytes > MAX_SKILL_SNAPSHOT_BYTES ||
+          nextPluginBytes > MAX_PLUGIN_SNAPSHOT_BYTES
+        ) {
+          throw new Error("A skill exceeds the snapshot size limit.");
+        }
+
+        const finalStat = await handle.stat();
+        if (
+          !this.hasSameFileIdentity(sourceStat, finalStat) ||
+          finalStat.size !== sourceStat.size ||
+          finalStat.mtimeMs !== sourceStat.mtimeMs ||
+          content.byteLength !== finalStat.size
+        ) {
+          throw new Error("Skill file changed while it was copied.");
+        }
+
         await this.writeManagedFile(
           destination,
           content,
           openedStat.mode & 0o777,
         );
+        skillUsage.files = nextSkillFiles;
+        skillUsage.bytes = nextSkillBytes;
       } finally {
         await handle.close();
       }
     };
 
     await copyEntry(resolvedSourceRoot, destinationRoot);
+    const finalPluginRootStat = await fs.promises.lstat(resolvedPluginRoot);
+    if (!this.hasSameSnapshotMetadata(pluginRootStat, finalPluginRootStat)) {
+      throw new Error("Agent Plugin directory changed while it was copied.");
+    }
+    return skillUsage;
+  }
+
+  private hasSameFileIdentity(left: fs.Stats, right: fs.Stats): boolean {
+    return (
+      left.dev === right.dev &&
+      left.ino === right.ino &&
+      left.mode === right.mode
+    );
+  }
+
+  private hasSameSnapshotMetadata(left: fs.Stats, right: fs.Stats): boolean {
+    return (
+      this.hasSameFileIdentity(left, right) &&
+      left.size === right.size &&
+      left.mtimeMs === right.mtimeMs
+    );
+  }
+
+  private async readSnapshotFile(
+    handle: fs.promises.FileHandle,
+  ): Promise<Buffer> {
+    const chunks: Buffer[] = [];
+    let bytesRead = 0;
+    while (bytesRead <= MAX_SKILL_SNAPSHOT_FILE_BYTES) {
+      const remaining = MAX_SKILL_SNAPSHOT_FILE_BYTES + 1 - bytesRead;
+      const chunk = Buffer.allocUnsafe(
+        Math.min(SNAPSHOT_READ_CHUNK_BYTES, remaining),
+      );
+      const result = await handle.read(chunk, 0, chunk.byteLength, null);
+      if (result.bytesRead === 0) break;
+      bytesRead += result.bytesRead;
+      if (bytesRead > MAX_SKILL_SNAPSHOT_FILE_BYTES) {
+        throw new Error("A skill file exceeds the snapshot size limit.");
+      }
+      chunks.push(chunk.subarray(0, result.bytesRead));
+    }
+    return Buffer.concat(chunks, bytesRead);
   }
 
   private async ensureManagedRoot(): Promise<string> {
@@ -473,6 +606,9 @@ export class AgentPluginsService {
 
   private async removeManagedPath(target: string): Promise<void> {
     const safeTarget = await this.assertManagedPath(target);
+    if (safeTarget === this.managedRoot()) {
+      throw new Error("Agent Plugin storage root cannot be removed.");
+    }
     await fs.promises.rm(safeTarget, { recursive: true, force: true });
   }
 }

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
@@ -202,87 +202,92 @@ export class AgentPluginsService {
     await this.removeManagedPath(runtimeRoot);
     await this.makeManagedDirectory(runtimeRoot);
 
-    const claimedSkillNames = new Set(reservedSkillNames);
-    const state = await this.withStateTransaction(() => this.readState());
-    const installations = state.installations
-      .filter((installation) => installation.enabled)
-      .sort(
-        (left, right) =>
-          left.manifest.name.localeCompare(right.manifest.name) ||
-          left.id.localeCompare(right.id),
-      );
+    try {
+      const claimedSkillNames = new Set(reservedSkillNames);
+      const state = await this.withStateTransaction(() => this.readState());
+      const installations = state.installations
+        .filter((installation) => installation.enabled)
+        .sort(
+          (left, right) =>
+            left.manifest.name.localeCompare(right.manifest.name) ||
+            left.id.localeCompare(right.id),
+        );
 
-    const plugins: RuntimeAgentPlugin[] = [];
-    for (const installation of installations) {
-      const preview = await loadAgentPlugin(installation.sourcePath);
-      if (
-        !preview.valid ||
-        !preview.manifest ||
-        preview.sourcePath !== installation.sourcePath
-      )
-        continue;
-      const availableSkills = preview.skills.filter((skill) => {
-        if (claimedSkillNames.has(skill.name)) {
-          onSkillSkipped(
-            preview.manifest?.name ?? installation.manifest.name,
-            skill.name,
-          );
-          return false;
+      const plugins: RuntimeAgentPlugin[] = [];
+      for (const installation of installations) {
+        const preview = await loadAgentPlugin(installation.sourcePath);
+        if (
+          !preview.valid ||
+          !preview.manifest ||
+          preview.sourcePath !== installation.sourcePath
+        )
+          continue;
+        const availableSkills = preview.skills.filter((skill) => {
+          if (claimedSkillNames.has(skill.name)) {
+            onSkillSkipped(
+              preview.manifest?.name ?? installation.manifest.name,
+              skill.name,
+            );
+            return false;
+          }
+          claimedSkillNames.add(skill.name);
+          return true;
+        });
+        if (availableSkills.length === 0) continue;
+
+        const pluginPath = path.join(runtimeRoot, installation.id);
+        const skillsPath = path.join(pluginPath, "skills");
+        await this.makeManagedDirectory(skillsPath);
+        const copiedSkillNames: string[] = [];
+        const pluginUsage: SnapshotUsage = { files: 0, bytes: 0, entries: 0 };
+        for (const skill of availableSkills) {
+          const destination = path.join(skillsPath, skill.name);
+          try {
+            const skillUsage = await this.copySkillSnapshot(
+              installation.sourcePath,
+              skill.path,
+              destination,
+              pluginUsage,
+            );
+            const snapshotError = await validateAgentPluginSkillSnapshot(
+              pluginPath,
+              destination,
+              skill.name,
+            );
+            if (snapshotError) throw new Error(snapshotError);
+            pluginUsage.files += skillUsage.files;
+            pluginUsage.bytes += skillUsage.bytes;
+            pluginUsage.entries += skillUsage.entries;
+            copiedSkillNames.push(skill.name);
+          } catch {
+            await this.removeManagedPath(destination);
+            onSkillSkipped(preview.manifest.name, skill.name);
+          }
         }
-        claimedSkillNames.add(skill.name);
-        return true;
-      });
-      if (availableSkills.length === 0) continue;
-
-      const pluginPath = path.join(runtimeRoot, installation.id);
-      const skillsPath = path.join(pluginPath, "skills");
-      await this.makeManagedDirectory(skillsPath);
-      const copiedSkillNames: string[] = [];
-      const pluginUsage: SnapshotUsage = { files: 0, bytes: 0, entries: 0 };
-      for (const skill of availableSkills) {
-        const destination = path.join(skillsPath, skill.name);
-        try {
-          const skillUsage = await this.copySkillSnapshot(
-            installation.sourcePath,
-            skill.path,
-            destination,
-            pluginUsage,
-          );
-          const snapshotError = await validateAgentPluginSkillSnapshot(
-            pluginPath,
-            destination,
-            skill.name,
-          );
-          if (snapshotError) throw new Error(snapshotError);
-          pluginUsage.files += skillUsage.files;
-          pluginUsage.bytes += skillUsage.bytes;
-          pluginUsage.entries += skillUsage.entries;
-          copiedSkillNames.push(skill.name);
-        } catch {
-          await this.removeManagedPath(destination);
-          onSkillSkipped(preview.manifest.name, skill.name);
+        if (copiedSkillNames.length === 0) {
+          await this.removeManagedPath(pluginPath);
+          continue;
         }
-      }
-      if (copiedSkillNames.length === 0) {
-        await this.removeManagedPath(pluginPath);
-        continue;
-      }
 
-      await this.writeManagedFile(
-        path.join(pluginPath, "plugin.json"),
-        `${JSON.stringify({
-          name: preview.manifest.name,
-          ...(preview.manifest.version
-            ? { version: preview.manifest.version }
-            : {}),
-          ...(preview.manifest.description
-            ? { description: preview.manifest.description }
-            : {}),
-        })}\n`,
-      );
-      plugins.push({ pluginPath, skillsPath });
+        await this.writeManagedFile(
+          path.join(pluginPath, "plugin.json"),
+          `${JSON.stringify({
+            name: preview.manifest.name,
+            ...(preview.manifest.version
+              ? { version: preview.manifest.version }
+              : {}),
+            ...(preview.manifest.description
+              ? { description: preview.manifest.description }
+              : {}),
+          })}\n`,
+        );
+        plugins.push({ pluginPath, skillsPath });
+      }
+      return plugins;
+    } catch (error) {
+      await this.removeManagedPath(runtimeRoot).catch(() => undefined);
+      throw error;
     }
-    return plugins;
   }
 
   async cleanupRuntimePlugins(taskRunId: string): Promise<void> {

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/identifiers.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/identifiers.ts
@@ -1,0 +1,3 @@
+export const AGENT_PLUGINS_SERVICE = Symbol.for(
+  "posthog.workspace.agentPluginsService",
+);

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/loader.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/loader.ts
@@ -224,14 +224,19 @@ async function validateSkillTree(
     });
     for (const entry of entries) {
       const entryPath = path.join(resolvedDirectory, entry.name);
+      const lstat = await fs.promises.lstat(entryPath);
+      if (lstat.isSymbolicLink()) {
+        return "Skill directories cannot contain symbolic links.";
+      }
       const resolvedEntry = await fs.promises.realpath(entryPath);
       if (!isPathContained(pluginRoot, resolvedEntry)) {
         return "Skill files must remain inside the plugin directory.";
       }
-      const stat = await fs.promises.stat(resolvedEntry);
-      if (stat.isDirectory()) {
+      if (lstat.isDirectory()) {
         const error = await walk(resolvedEntry);
         if (error) return error;
+      } else if (!lstat.isFile()) {
+        return "Skill directories can contain only regular files and directories.";
       }
     }
     return null;
@@ -355,7 +360,18 @@ async function loadSkills(
   });
   const skills: AgentPluginSkill[] = [];
   for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
-    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+    if (entry.isSymbolicLink()) {
+      diagnostics.push(
+        diagnostic(
+          "error",
+          "invalid_skill",
+          `Skipped ${entry.name}: skill directories cannot be symbolic links.`,
+          `skills/${entry.name}`,
+        ),
+      );
+      continue;
+    }
+    if (!entry.isDirectory()) continue;
     const skillDirectory = path.join(resolvedSkillsPath, entry.name);
     const skillMdPath = path.join(skillDirectory, "SKILL.md");
 
@@ -391,8 +407,23 @@ async function loadSkills(
         );
         continue;
       }
-      const skillMdStat = await fs.promises.stat(resolvedSkillMd);
-      if (!skillMdStat.isFile()) continue;
+      const skillDirectoryStat = await fs.promises.lstat(skillDirectory);
+      const skillMdStat = await fs.promises.lstat(skillMdPath);
+      if (
+        skillDirectoryStat.isSymbolicLink() ||
+        skillMdStat.isSymbolicLink() ||
+        !skillMdStat.isFile()
+      ) {
+        diagnostics.push(
+          diagnostic(
+            "error",
+            "invalid_skill",
+            `Skipped ${entry.name}: SKILL.md must be a regular file.`,
+            `skills/${entry.name}/SKILL.md`,
+          ),
+        );
+        continue;
+      }
 
       const treeError = await validateSkillTree(
         pluginRoot,

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/loader.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/loader.ts
@@ -309,6 +309,27 @@ function parseSkillFrontmatter(
   return { name, description };
 }
 
+export async function validateAgentPluginSkillSnapshot(
+  pluginRoot: string,
+  skillRoot: string,
+  skillName: string,
+): Promise<string | null> {
+  const resolvedPluginRoot = await fs.promises.realpath(pluginRoot);
+  const resolvedSkillRoot = await fs.promises.realpath(skillRoot);
+  const treeError = await validateSkillTree(
+    resolvedPluginRoot,
+    resolvedSkillRoot,
+  );
+  if (treeError) return treeError;
+
+  const content = await fs.promises.readFile(
+    path.join(resolvedSkillRoot, "SKILL.md"),
+    "utf8",
+  );
+  const frontmatter = parseSkillFrontmatter(content, skillName);
+  return typeof frontmatter === "string" ? frontmatter : null;
+}
+
 async function loadSkills(
   pluginRoot: string,
   diagnostics: AgentPluginDiagnostic[],
@@ -342,22 +363,34 @@ async function loadSkills(
     return [];
   }
 
-  const skillsStat = await fs.promises.stat(resolvedSkillsPath);
-  if (!skillsStat.isDirectory()) {
+  let entries: fs.Dirent[];
+  try {
+    const skillsStat = await fs.promises.stat(resolvedSkillsPath);
+    if (!skillsStat.isDirectory()) {
+      diagnostics.push(
+        diagnostic(
+          "error",
+          "invalid_skills",
+          "skills must be a directory.",
+          "skills",
+        ),
+      );
+      return [];
+    }
+    entries = await fs.promises.readdir(resolvedSkillsPath, {
+      withFileTypes: true,
+    });
+  } catch {
     diagnostics.push(
       diagnostic(
         "error",
         "invalid_skills",
-        "skills must be a directory.",
+        "Could not read the skills directory.",
         "skills",
       ),
     );
     return [];
   }
-
-  const entries = await fs.promises.readdir(resolvedSkillsPath, {
-    withFileTypes: true,
-  });
   const skills: AgentPluginSkill[] = [];
   for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
     if (entry.isSymbolicLink()) {

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/loader.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/loader.ts
@@ -1,0 +1,551 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { parseDocument } from "yaml";
+import {
+  AGENT_PLUGINS_MANIFEST_SCHEMA,
+  type AgentPluginDiagnostic,
+  type AgentPluginManifest,
+  type AgentPluginPreview,
+  type AgentPluginSkill,
+} from "./schemas";
+
+const PLUGIN_NAME_PATTERN =
+  /^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/;
+const SKILL_NAME_PATTERN = /^(?!.*--)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+const MANIFEST_FIELDS = new Set([
+  "$schema",
+  "name",
+  "version",
+  "description",
+  "author",
+  "homepage",
+  "repository",
+  "license",
+  "keywords",
+  "extensions",
+]);
+const AUTHOR_FIELDS = new Set(["name", "email", "url"]);
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isPathContained(root: string, candidate: string): boolean {
+  const relativePath = path.relative(root, candidate);
+  return (
+    relativePath === "" ||
+    (!relativePath.startsWith(`..${path.sep}`) &&
+      relativePath !== ".." &&
+      !path.isAbsolute(relativePath))
+  );
+}
+
+function diagnostic(
+  severity: AgentPluginDiagnostic["severity"],
+  code: string,
+  message: string,
+  diagnosticPath?: string,
+): AgentPluginDiagnostic {
+  return {
+    severity,
+    code,
+    message,
+    ...(diagnosticPath ? { path: diagnosticPath } : {}),
+  };
+}
+
+function validateOptionalString(
+  raw: Record<string, unknown>,
+  field: string,
+  diagnostics: AgentPluginDiagnostic[],
+): string | undefined {
+  const value = raw[field];
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") {
+    diagnostics.push(
+      diagnostic("error", "invalid_manifest", `${field} must be a string.`),
+    );
+    return undefined;
+  }
+  return value;
+}
+
+function parseManifest(
+  value: unknown,
+  diagnostics: AgentPluginDiagnostic[],
+): AgentPluginManifest | null {
+  if (!isObject(value)) {
+    diagnostics.push(
+      diagnostic(
+        "error",
+        "invalid_manifest",
+        "plugin.json must contain an object.",
+      ),
+    );
+    return null;
+  }
+
+  for (const field of Object.keys(value)) {
+    if (!MANIFEST_FIELDS.has(field)) {
+      diagnostics.push(
+        diagnostic(
+          "warning",
+          "unknown_manifest_field",
+          `Ignored unknown plugin.json field: ${field}.`,
+        ),
+      );
+    }
+  }
+
+  if (value.extensions !== undefined && !isObject(value.extensions)) {
+    diagnostics.push(
+      diagnostic(
+        "warning",
+        "invalid_extensions",
+        "Ignored extensions because it is not an object.",
+      ),
+    );
+  }
+
+  if (value.$schema !== AGENT_PLUGINS_MANIFEST_SCHEMA) {
+    diagnostics.push(
+      diagnostic(
+        "error",
+        "unsupported_schema",
+        `plugin.json must target ${AGENT_PLUGINS_MANIFEST_SCHEMA}.`,
+      ),
+    );
+  }
+
+  const name = value.name;
+  if (
+    typeof name !== "string" ||
+    name.length < 1 ||
+    name.length > 64 ||
+    !PLUGIN_NAME_PATTERN.test(name)
+  ) {
+    diagnostics.push(
+      diagnostic(
+        "error",
+        "invalid_manifest_name",
+        "Plugin name must use 1-64 lowercase letters, numbers, hyphens, or periods without repeated separators.",
+      ),
+    );
+  }
+
+  const version = validateOptionalString(value, "version", diagnostics);
+  const description = validateOptionalString(value, "description", diagnostics);
+  const homepage = validateOptionalString(value, "homepage", diagnostics);
+  const repository = validateOptionalString(value, "repository", diagnostics);
+  const license = validateOptionalString(value, "license", diagnostics);
+
+  let author: AgentPluginManifest["author"];
+  if (value.author !== undefined) {
+    if (!isObject(value.author)) {
+      diagnostics.push(
+        diagnostic("error", "invalid_manifest", "author must be an object."),
+      );
+    } else {
+      for (const field of Object.keys(value.author)) {
+        if (!AUTHOR_FIELDS.has(field)) {
+          diagnostics.push(
+            diagnostic(
+              "error",
+              "invalid_manifest",
+              `author contains unknown field: ${field}.`,
+            ),
+          );
+        }
+      }
+      const nameValue = validateOptionalString(
+        value.author,
+        "name",
+        diagnostics,
+      );
+      const email = validateOptionalString(value.author, "email", diagnostics);
+      const url = validateOptionalString(value.author, "url", diagnostics);
+      author = {
+        ...(nameValue !== undefined ? { name: nameValue } : {}),
+        ...(email !== undefined ? { email } : {}),
+        ...(url !== undefined ? { url } : {}),
+      };
+    }
+  }
+
+  let keywords: string[] | undefined;
+  if (value.keywords !== undefined) {
+    if (
+      !Array.isArray(value.keywords) ||
+      !value.keywords.every((keyword) => typeof keyword === "string")
+    ) {
+      diagnostics.push(
+        diagnostic(
+          "error",
+          "invalid_manifest",
+          "keywords must be an array of strings.",
+        ),
+      );
+    } else {
+      keywords = value.keywords;
+    }
+  }
+
+  if (diagnostics.some((item) => item.severity === "error")) return null;
+
+  return {
+    $schema: AGENT_PLUGINS_MANIFEST_SCHEMA,
+    name: name as string,
+    ...(version !== undefined ? { version } : {}),
+    ...(description !== undefined ? { description } : {}),
+    ...(author !== undefined ? { author } : {}),
+    ...(homepage !== undefined ? { homepage } : {}),
+    ...(repository !== undefined ? { repository } : {}),
+    ...(license !== undefined ? { license } : {}),
+    ...(keywords !== undefined ? { keywords } : {}),
+  };
+}
+
+async function validateSkillTree(
+  pluginRoot: string,
+  skillRoot: string,
+): Promise<string | null> {
+  const visited = new Set<string>();
+
+  const walk = async (directory: string): Promise<string | null> => {
+    const resolvedDirectory = await fs.promises.realpath(directory);
+    if (!isPathContained(pluginRoot, resolvedDirectory)) {
+      return "Skill files must remain inside the plugin directory.";
+    }
+    if (visited.has(resolvedDirectory)) return null;
+    visited.add(resolvedDirectory);
+
+    const entries = await fs.promises.readdir(resolvedDirectory, {
+      withFileTypes: true,
+    });
+    for (const entry of entries) {
+      const entryPath = path.join(resolvedDirectory, entry.name);
+      const resolvedEntry = await fs.promises.realpath(entryPath);
+      if (!isPathContained(pluginRoot, resolvedEntry)) {
+        return "Skill files must remain inside the plugin directory.";
+      }
+      const stat = await fs.promises.stat(resolvedEntry);
+      if (stat.isDirectory()) {
+        const error = await walk(resolvedEntry);
+        if (error) return error;
+      }
+    }
+    return null;
+  };
+
+  return walk(skillRoot);
+}
+
+function parseSkillFrontmatter(
+  content: string,
+  directoryName: string,
+): { name: string; description: string } | string {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!match) return "SKILL.md must start with YAML frontmatter.";
+
+  const document = parseDocument(match[1], { prettyErrors: false });
+  if (document.errors.length > 0)
+    return "SKILL.md frontmatter is not valid YAML.";
+  const value: unknown = document.toJS();
+  if (!isObject(value)) return "SKILL.md frontmatter must be an object.";
+
+  const name = value.name;
+  if (
+    typeof name !== "string" ||
+    name.length < 1 ||
+    name.length > 64 ||
+    !SKILL_NAME_PATTERN.test(name)
+  ) {
+    return "Skill name must use 1-64 lowercase letters, numbers, or hyphens without repeated hyphens.";
+  }
+  if (name !== directoryName) {
+    return "Skill name must match its parent directory name.";
+  }
+
+  const description = value.description;
+  if (
+    typeof description !== "string" ||
+    description.length < 1 ||
+    description.length > 1024
+  ) {
+    return "Skill description must contain 1-1024 characters.";
+  }
+
+  if (value.license !== undefined && typeof value.license !== "string") {
+    return "Skill license must be a string.";
+  }
+  if (
+    value.compatibility !== undefined &&
+    (typeof value.compatibility !== "string" ||
+      value.compatibility.length < 1 ||
+      value.compatibility.length > 500)
+  ) {
+    return "Skill compatibility must contain 1-500 characters.";
+  }
+  if (value.metadata !== undefined) {
+    if (
+      !isObject(value.metadata) ||
+      !Object.values(value.metadata).every((entry) => typeof entry === "string")
+    ) {
+      return "Skill metadata must map strings to strings.";
+    }
+  }
+  if (
+    value["allowed-tools"] !== undefined &&
+    typeof value["allowed-tools"] !== "string"
+  ) {
+    return "Skill allowed-tools must be a string.";
+  }
+
+  return { name, description };
+}
+
+async function loadSkills(
+  pluginRoot: string,
+  diagnostics: AgentPluginDiagnostic[],
+): Promise<AgentPluginSkill[]> {
+  const skillsPath = path.join(pluginRoot, "skills");
+  let resolvedSkillsPath: string;
+  try {
+    resolvedSkillsPath = await fs.promises.realpath(skillsPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    diagnostics.push(
+      diagnostic(
+        "error",
+        "invalid_skills",
+        "Could not read the skills directory.",
+        "skills",
+      ),
+    );
+    return [];
+  }
+
+  if (!isPathContained(pluginRoot, resolvedSkillsPath)) {
+    diagnostics.push(
+      diagnostic(
+        "error",
+        "skills_escape",
+        "The skills directory resolves outside the plugin directory.",
+        "skills",
+      ),
+    );
+    return [];
+  }
+
+  const skillsStat = await fs.promises.stat(resolvedSkillsPath);
+  if (!skillsStat.isDirectory()) {
+    diagnostics.push(
+      diagnostic(
+        "error",
+        "invalid_skills",
+        "skills must be a directory.",
+        "skills",
+      ),
+    );
+    return [];
+  }
+
+  const entries = await fs.promises.readdir(resolvedSkillsPath, {
+    withFileTypes: true,
+  });
+  const skills: AgentPluginSkill[] = [];
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+    const skillDirectory = path.join(resolvedSkillsPath, entry.name);
+    const skillMdPath = path.join(skillDirectory, "SKILL.md");
+
+    let resolvedSkillMd: string;
+    try {
+      resolvedSkillMd = await fs.promises.realpath(skillMdPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+      diagnostics.push(
+        diagnostic(
+          "error",
+          "invalid_skill",
+          `Skipped ${entry.name}: SKILL.md could not be read.`,
+          `skills/${entry.name}/SKILL.md`,
+        ),
+      );
+      continue;
+    }
+
+    try {
+      const resolvedSkillDirectory = await fs.promises.realpath(skillDirectory);
+      if (
+        !isPathContained(pluginRoot, resolvedSkillDirectory) ||
+        !isPathContained(pluginRoot, resolvedSkillMd)
+      ) {
+        diagnostics.push(
+          diagnostic(
+            "error",
+            "skill_escape",
+            "Skipped skill because it resolves outside the plugin directory.",
+            `skills/${entry.name}`,
+          ),
+        );
+        continue;
+      }
+      const skillMdStat = await fs.promises.stat(resolvedSkillMd);
+      if (!skillMdStat.isFile()) continue;
+
+      const treeError = await validateSkillTree(
+        pluginRoot,
+        resolvedSkillDirectory,
+      );
+      if (treeError) {
+        diagnostics.push(
+          diagnostic(
+            "error",
+            "skill_escape",
+            `Skipped ${entry.name}: ${treeError}`,
+            `skills/${entry.name}`,
+          ),
+        );
+        continue;
+      }
+
+      const content = await fs.promises.readFile(resolvedSkillMd, "utf8");
+      const frontmatter = parseSkillFrontmatter(content, entry.name);
+      if (typeof frontmatter === "string") {
+        diagnostics.push(
+          diagnostic(
+            "error",
+            "invalid_skill",
+            `Skipped ${entry.name}: ${frontmatter}`,
+            `skills/${entry.name}/SKILL.md`,
+          ),
+        );
+        continue;
+      }
+      skills.push({
+        name: frontmatter.name,
+        description: frontmatter.description,
+        path: resolvedSkillDirectory,
+      });
+    } catch {
+      diagnostics.push(
+        diagnostic(
+          "error",
+          "invalid_skill",
+          `Skipped ${entry.name}: the skill could not be read.`,
+          `skills/${entry.name}`,
+        ),
+      );
+    }
+  }
+  return skills;
+}
+
+export async function loadAgentPlugin(
+  sourcePath: string,
+): Promise<AgentPluginPreview> {
+  const diagnostics: AgentPluginDiagnostic[] = [];
+  let pluginRoot: string;
+  try {
+    pluginRoot = await fs.promises.realpath(path.resolve(sourcePath));
+    const rootStat = await fs.promises.stat(pluginRoot);
+    if (!rootStat.isDirectory()) {
+      diagnostics.push(
+        diagnostic(
+          "error",
+          "invalid_root",
+          "The selected path is not a directory.",
+        ),
+      );
+      return {
+        valid: false,
+        sourcePath: path.resolve(sourcePath),
+        manifest: null,
+        skills: [],
+        diagnostics,
+      };
+    }
+  } catch {
+    diagnostics.push(
+      diagnostic(
+        "error",
+        "invalid_root",
+        "The selected directory could not be read.",
+      ),
+    );
+    return {
+      valid: false,
+      sourcePath: path.resolve(sourcePath),
+      manifest: null,
+      skills: [],
+      diagnostics,
+    };
+  }
+
+  const manifestPath = path.join(pluginRoot, "plugin.json");
+  let rawManifest: unknown;
+  try {
+    const resolvedManifestPath = await fs.promises.realpath(manifestPath);
+    if (!isPathContained(pluginRoot, resolvedManifestPath)) {
+      diagnostics.push(
+        diagnostic(
+          "error",
+          "manifest_escape",
+          "plugin.json resolves outside the plugin directory.",
+          "plugin.json",
+        ),
+      );
+      return {
+        valid: false,
+        sourcePath: pluginRoot,
+        manifest: null,
+        skills: [],
+        diagnostics,
+      };
+    }
+    const stat = await fs.promises.stat(resolvedManifestPath);
+    if (!stat.isFile()) throw new Error("not a file");
+    rawManifest = JSON.parse(
+      await fs.promises.readFile(resolvedManifestPath, "utf8"),
+    );
+  } catch (error) {
+    diagnostics.push(
+      diagnostic(
+        "error",
+        "invalid_manifest",
+        error instanceof SyntaxError
+          ? "plugin.json is not valid JSON."
+          : "plugin.json is missing or is not a regular file.",
+        "plugin.json",
+      ),
+    );
+    return {
+      valid: false,
+      sourcePath: pluginRoot,
+      manifest: null,
+      skills: [],
+      diagnostics,
+    };
+  }
+
+  const manifest = parseManifest(rawManifest, diagnostics);
+  if (!manifest) {
+    return {
+      valid: false,
+      sourcePath: pluginRoot,
+      manifest: null,
+      skills: [],
+      diagnostics,
+    };
+  }
+
+  const skills = await loadSkills(pluginRoot, diagnostics);
+  return {
+    valid: true,
+    sourcePath: pluginRoot,
+    manifest,
+    skills,
+    diagnostics,
+  };
+}

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/loader.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/loader.ts
@@ -25,6 +25,57 @@ const MANIFEST_FIELDS = new Set([
   "extensions",
 ]);
 const AUTHOR_FIELDS = new Set(["name", "email", "url"]);
+const MAX_PLUGIN_TEXT_FILE_BYTES = 1024 * 1024;
+export const MAX_SKILL_TREE_ENTRIES = 512;
+export const MAX_SKILL_TREE_DEPTH = 32;
+const FILE_READ_CHUNK_BYTES = 64 * 1024;
+
+class AgentPluginFileTooLargeError extends Error {}
+
+async function readTextFileWithinLimit(filePath: string): Promise<string> {
+  const noFollow = fs.constants.O_NOFOLLOW ?? 0;
+  const handle = await fs.promises.open(
+    filePath,
+    fs.constants.O_RDONLY | noFollow,
+  );
+  try {
+    const initialStat = await handle.stat();
+    if (!initialStat.isFile()) throw new Error("not a regular file");
+    if (initialStat.size > MAX_PLUGIN_TEXT_FILE_BYTES) {
+      throw new AgentPluginFileTooLargeError();
+    }
+
+    const chunks: Buffer[] = [];
+    let bytesRead = 0;
+    while (bytesRead <= MAX_PLUGIN_TEXT_FILE_BYTES) {
+      const remaining = MAX_PLUGIN_TEXT_FILE_BYTES + 1 - bytesRead;
+      const chunk = Buffer.allocUnsafe(
+        Math.min(FILE_READ_CHUNK_BYTES, remaining),
+      );
+      const result = await handle.read(chunk, 0, chunk.byteLength, null);
+      if (result.bytesRead === 0) break;
+      bytesRead += result.bytesRead;
+      if (bytesRead > MAX_PLUGIN_TEXT_FILE_BYTES) {
+        throw new AgentPluginFileTooLargeError();
+      }
+      chunks.push(chunk.subarray(0, result.bytesRead));
+    }
+
+    const finalStat = await handle.stat();
+    if (
+      initialStat.dev !== finalStat.dev ||
+      initialStat.ino !== finalStat.ino ||
+      initialStat.size !== finalStat.size ||
+      initialStat.mtimeMs !== finalStat.mtimeMs ||
+      bytesRead !== finalStat.size
+    ) {
+      throw new Error("file changed while it was read");
+    }
+    return Buffer.concat(chunks, bytesRead).toString("utf8");
+  } finally {
+    await handle.close();
+  }
+}
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -210,8 +261,15 @@ async function validateSkillTree(
   skillRoot: string,
 ): Promise<string | null> {
   const visited = new Set<string>();
+  let entryCount = 0;
 
-  const walk = async (directory: string): Promise<string | null> => {
+  const walk = async (
+    directory: string,
+    depth: number,
+  ): Promise<string | null> => {
+    if (depth > MAX_SKILL_TREE_DEPTH) {
+      return "Skill directories are nested too deeply.";
+    }
     const resolvedDirectory = await fs.promises.realpath(directory);
     if (!isPathContained(pluginRoot, resolvedDirectory)) {
       return "Skill files must remain inside the plugin directory.";
@@ -223,6 +281,10 @@ async function validateSkillTree(
       withFileTypes: true,
     });
     for (const entry of entries) {
+      entryCount += 1;
+      if (entryCount > MAX_SKILL_TREE_ENTRIES) {
+        return "A skill contains too many files or directories.";
+      }
       const entryPath = path.join(resolvedDirectory, entry.name);
       const lstat = await fs.promises.lstat(entryPath);
       if (lstat.isSymbolicLink()) {
@@ -233,7 +295,7 @@ async function validateSkillTree(
         return "Skill files must remain inside the plugin directory.";
       }
       if (lstat.isDirectory()) {
-        const error = await walk(resolvedEntry);
+        const error = await walk(resolvedEntry, depth + 1);
         if (error) return error;
       } else if (!lstat.isFile()) {
         return "Skill directories can contain only regular files and directories.";
@@ -242,7 +304,7 @@ async function validateSkillTree(
     return null;
   };
 
-  return walk(skillRoot);
+  return walk(skillRoot, 0);
 }
 
 function parseSkillFrontmatter(
@@ -322,9 +384,8 @@ export async function validateAgentPluginSkillSnapshot(
   );
   if (treeError) return treeError;
 
-  const content = await fs.promises.readFile(
+  const content = await readTextFileWithinLimit(
     path.join(resolvedSkillRoot, "SKILL.md"),
-    "utf8",
   );
   const frontmatter = parseSkillFrontmatter(content, skillName);
   return typeof frontmatter === "string" ? frontmatter : null;
@@ -474,7 +535,7 @@ async function loadSkills(
         continue;
       }
 
-      const content = await fs.promises.readFile(resolvedSkillMd, "utf8");
+      const content = await readTextFileWithinLimit(resolvedSkillMd);
       const frontmatter = parseSkillFrontmatter(content, entry.name);
       if (typeof frontmatter === "string") {
         diagnostics.push(
@@ -492,12 +553,14 @@ async function loadSkills(
         description: frontmatter.description,
         path: resolvedSkillDirectory,
       });
-    } catch {
+    } catch (error) {
       diagnostics.push(
         diagnostic(
           "error",
           "invalid_skill",
-          `Skipped ${entry.name}: the skill could not be read.`,
+          error instanceof AgentPluginFileTooLargeError
+            ? `Skipped ${entry.name}: SKILL.md exceeds the 1 MiB limit.`
+            : `Skipped ${entry.name}: the skill could not be read.`,
           `skills/${entry.name}`,
         ),
       );
@@ -571,7 +634,7 @@ export async function loadAgentPlugin(
     const stat = await fs.promises.stat(resolvedManifestPath);
     if (!stat.isFile()) throw new Error("not a file");
     rawManifest = JSON.parse(
-      await fs.promises.readFile(resolvedManifestPath, "utf8"),
+      await readTextFileWithinLimit(resolvedManifestPath),
     );
   } catch (error) {
     diagnostics.push(
@@ -580,7 +643,9 @@ export async function loadAgentPlugin(
         "invalid_manifest",
         error instanceof SyntaxError
           ? "plugin.json is not valid JSON."
-          : "plugin.json is missing or is not a regular file.",
+          : error instanceof AgentPluginFileTooLargeError
+            ? "plugin.json exceeds the 1 MiB limit."
+            : "plugin.json is missing or is not a regular file.",
         "plugin.json",
       ),
     );

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/schemas.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+
+export const AGENT_PLUGINS_MANIFEST_SCHEMA =
+  "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json";
+
+export const agentPluginDiagnostic = z.object({
+  severity: z.enum(["warning", "error"]),
+  code: z.string(),
+  message: z.string(),
+  path: z.string().optional(),
+});
+
+export const agentPluginManifest = z.object({
+  $schema: z.literal(AGENT_PLUGINS_MANIFEST_SCHEMA),
+  name: z.string(),
+  version: z.string().optional(),
+  description: z.string().optional(),
+  author: z
+    .object({
+      name: z.string().optional(),
+      email: z.string().optional(),
+      url: z.string().optional(),
+    })
+    .optional(),
+  homepage: z.string().optional(),
+  repository: z.string().optional(),
+  license: z.string().optional(),
+  keywords: z.array(z.string()).optional(),
+});
+
+export const agentPluginSkill = z.object({
+  name: z.string(),
+  description: z.string(),
+  path: z.string(),
+});
+
+export const agentPluginPreview = z.object({
+  valid: z.boolean(),
+  sourcePath: z.string(),
+  manifest: agentPluginManifest.nullable(),
+  skills: z.array(agentPluginSkill),
+  diagnostics: z.array(agentPluginDiagnostic),
+});
+
+export const agentPluginInstallation = z.object({
+  id: z.string(),
+  sourcePath: z.string(),
+  enabled: z.boolean(),
+  manifest: agentPluginManifest,
+  skills: z.array(agentPluginSkill),
+  diagnostics: z.array(agentPluginDiagnostic),
+});
+
+export const listAgentPluginsOutput = z.array(agentPluginInstallation);
+export const previewAgentPluginInput = z.object({ sourcePath: z.string() });
+export const selectAgentPluginOutput = agentPluginPreview.nullable();
+export const registerAgentPluginInput = z.object({ sourcePath: z.string() });
+export const agentPluginIdInput = z.object({ id: z.string() });
+export const setAgentPluginEnabledInput = z.object({
+  id: z.string(),
+  enabled: z.boolean(),
+});
+
+export const agentPluginState = z.object({
+  version: z.literal(1),
+  installations: z.array(
+    z.object({
+      id: z.string(),
+      sourcePath: z.string(),
+      enabled: z.boolean(),
+      manifest: agentPluginManifest,
+      skills: z.array(agentPluginSkill),
+      diagnostics: z.array(agentPluginDiagnostic),
+    }),
+  ),
+});
+
+export type AgentPluginDiagnostic = z.infer<typeof agentPluginDiagnostic>;
+export type AgentPluginManifest = z.infer<typeof agentPluginManifest>;
+export type AgentPluginSkill = z.infer<typeof agentPluginSkill>;
+export type AgentPluginPreview = z.infer<typeof agentPluginPreview>;
+export type AgentPluginInstallation = z.infer<typeof agentPluginInstallation>;

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/schemas.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export const AGENT_PLUGINS_MANIFEST_SCHEMA =
   "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json";
+export const AGENT_PLUGIN_INSTALLATION_ID_PATTERN = /^[a-f0-9]{16}$/;
 
 export const agentPluginDiagnostic = z.object({
   severity: z.enum(["warning", "error"]),
@@ -44,7 +45,7 @@ export const agentPluginPreview = z.object({
 });
 
 export const agentPluginInstallation = z.object({
-  id: z.string(),
+  id: z.string().regex(AGENT_PLUGIN_INSTALLATION_ID_PATTERN),
   sourcePath: z.string(),
   enabled: z.boolean(),
   manifest: agentPluginManifest,
@@ -57,9 +58,11 @@ export const selectAgentPluginOutput = agentPluginPreview.nullable();
 export const registerAgentPluginInput = z.object({
   selectionToken: z.string().uuid(),
 });
-export const agentPluginIdInput = z.object({ id: z.string() });
+export const agentPluginIdInput = z.object({
+  id: z.string().regex(AGENT_PLUGIN_INSTALLATION_ID_PATTERN),
+});
 export const setAgentPluginEnabledInput = z.object({
-  id: z.string(),
+  id: z.string().regex(AGENT_PLUGIN_INSTALLATION_ID_PATTERN),
   enabled: z.boolean(),
 });
 
@@ -67,7 +70,7 @@ export const agentPluginState = z.object({
   version: z.literal(1),
   installations: z.array(
     z.object({
-      id: z.string().regex(/^[a-f0-9]{16}$/),
+      id: z.string().regex(AGENT_PLUGIN_INSTALLATION_ID_PATTERN),
       sourcePath: z.string(),
       enabled: z.boolean(),
       manifest: agentPluginManifest,

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/schemas.ts
@@ -40,6 +40,7 @@ export const agentPluginPreview = z.object({
   manifest: agentPluginManifest.nullable(),
   skills: z.array(agentPluginSkill),
   diagnostics: z.array(agentPluginDiagnostic),
+  selectionToken: z.string().uuid().optional(),
 });
 
 export const agentPluginInstallation = z.object({
@@ -52,9 +53,10 @@ export const agentPluginInstallation = z.object({
 });
 
 export const listAgentPluginsOutput = z.array(agentPluginInstallation);
-export const previewAgentPluginInput = z.object({ sourcePath: z.string() });
 export const selectAgentPluginOutput = agentPluginPreview.nullable();
-export const registerAgentPluginInput = z.object({ sourcePath: z.string() });
+export const registerAgentPluginInput = z.object({
+  selectionToken: z.string().uuid(),
+});
 export const agentPluginIdInput = z.object({ id: z.string() });
 export const setAgentPluginEnabledInput = z.object({
   id: z.string(),
@@ -65,7 +67,7 @@ export const agentPluginState = z.object({
   version: z.literal(1),
   installations: z.array(
     z.object({
-      id: z.string(),
+      id: z.string().regex(/^[a-f0-9]{16}$/),
       sourcePath: z.string(),
       enabled: z.boolean(),
       manifest: agentPluginManifest,

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
@@ -187,6 +187,10 @@ function createMockDependencies() {
     posthogPluginService: {
       getPluginPath: vi.fn(() => "/mock/plugin"),
     },
+    agentPluginsService: {
+      prepareRuntimePlugins: vi.fn().mockResolvedValue([]),
+      cleanupRuntimePlugins: vi.fn().mockResolvedValue(undefined),
+    },
     agentAuthAdapter: {
       getCurrentCredentials: vi.fn().mockResolvedValue(null),
       gatewayAuthToken: vi.fn().mockResolvedValue("gateway-token"),
@@ -281,6 +285,7 @@ describe("AgentService", () => {
       deps.sleepService as never,
       deps.fsService as never,
       deps.posthogPluginService as never,
+      deps.agentPluginsService as never,
       deps.agentAuthAdapter as never,
       deps.mcpAppsService as never,
       deps.powerManager as never,

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.ts
@@ -103,6 +103,7 @@ import type {
   AgentScopedLogger,
   AgentSleepCoordinator,
 } from "./ports";
+import { getReservedSkillSourcePaths } from "./reserved-skills";
 import {
   AgentServiceEvent,
   type AgentServiceEvents,
@@ -871,11 +872,13 @@ If a repository is required, call \`list_repos\` to find it, then use \`clone_re
         });
       }
 
-      const reservedSkillNames = new Set(await findSkillDirs(bundledSkillsDir));
-      for (const plugin of externalPlugins) {
-        for (const skillName of await findSkillDirs(
-          join(plugin.path, "skills"),
-        )) {
+      const reservedSkillNames = new Set<string>();
+      for (const skillsPath of getReservedSkillSourcePaths({
+        adapter: adapter ?? "claude",
+        bundledSkillsDir,
+        externalPluginPaths: externalPlugins.map((plugin) => plugin.path),
+      })) {
+        for (const skillName of await findSkillDirs(skillsPath)) {
           reservedSkillNames.add(skillName);
         }
       }
@@ -888,6 +891,12 @@ If a repository is required, call \`list_repos\` to find it, then use \`clone_re
           await this.agentPluginsService.prepareRuntimePlugins(
             taskRunId,
             reservedSkillNames,
+            (pluginName, skillName) =>
+              this.log.warn("Skipped Agent Plugin skill name collision", {
+                pluginName,
+                skillName,
+                adapter,
+              }),
           );
       } catch (err) {
         this.log.warn("Failed to prepare Agent Plugins", {

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.ts
@@ -77,11 +77,14 @@ import {
 import { inject, injectable, preDestroy } from "inversify";
 import { WORKSPACE_REPOSITORY } from "../../db/identifiers";
 import type { IWorkspaceRepository } from "../../db/repositories/workspace-repository";
+import type { AgentPluginsService } from "../agent-plugins/agent-plugins";
+import { AGENT_PLUGINS_SERVICE } from "../agent-plugins/identifiers";
 import { POSTHOG_PLUGIN_SERVICE } from "../posthog-plugin/identifiers";
 import type { PosthogPluginService } from "../posthog-plugin/posthog-plugin";
 import { PROCESS_TRACKING_SERVICE } from "../process-tracking/identifiers";
 import type { ProcessTrackingService } from "../process-tracking/process-tracking";
 import { loadSessionEnvOverrides } from "../session-env/loader";
+import { findSkillDirs } from "../skills/skill-discovery";
 import { isScratchPath } from "../workspace/scratch";
 import type { AgentAuthAdapter, McpToolInstallations } from "./auth-adapter";
 import { cleanupCodexHome, prepareCodexHome } from "./codex-home";
@@ -400,6 +403,7 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
   private sleepService: AgentSleepCoordinator;
   private fsService: AgentRepoFiles;
   private posthogPluginService: PosthogPluginService;
+  private agentPluginsService: AgentPluginsService;
   private agentAuthAdapter: AgentAuthAdapter;
   private mcpAppsService: AgentMcpApps;
   private readonly log: AgentScopedLogger;
@@ -414,6 +418,8 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
     fsService: AgentRepoFiles,
     @inject(POSTHOG_PLUGIN_SERVICE)
     posthogPluginService: PosthogPluginService,
+    @inject(AGENT_PLUGINS_SERVICE)
+    agentPluginsService: AgentPluginsService,
     @inject(AGENT_AUTH_ADAPTER)
     agentAuthAdapter: AgentAuthAdapter,
     @inject(AGENT_MCP_APPS)
@@ -438,6 +444,7 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
     this.sleepService = sleepService;
     this.fsService = fsService;
     this.posthogPluginService = posthogPluginService;
+    this.agentPluginsService = agentPluginsService;
     this.agentAuthAdapter = agentAuthAdapter;
     this.mcpAppsService = mcpAppsService;
     this.log = loggerFactory.scope("agent-service");
@@ -847,6 +854,47 @@ If a repository is required, call \`list_repos\` to find it, then use \`clone_re
         "skills",
       );
 
+      let externalPlugins: Awaited<ReturnType<typeof discoverExternalPlugins>> =
+        [];
+      try {
+        externalPlugins = await discoverExternalPlugins(
+          {
+            userDataDir: this.storagePaths.appDataPath,
+            repoPath,
+            bundledSkillsDir,
+          },
+          this.log,
+        );
+      } catch (err) {
+        this.log.warn("Failed to discover external plugins", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+
+      const reservedSkillNames = new Set(await findSkillDirs(bundledSkillsDir));
+      for (const plugin of externalPlugins) {
+        for (const skillName of await findSkillDirs(
+          join(plugin.path, "skills"),
+        )) {
+          reservedSkillNames.add(skillName);
+        }
+      }
+
+      let runtimeAgentPlugins: Awaited<
+        ReturnType<AgentPluginsService["prepareRuntimePlugins"]>
+      > = [];
+      try {
+        runtimeAgentPlugins =
+          await this.agentPluginsService.prepareRuntimePlugins(
+            taskRunId,
+            reservedSkillNames,
+          );
+      } catch (err) {
+        this.log.warn("Failed to prepare Agent Plugins", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+
       let codexHome: string | undefined;
       if (adapter === "codex") {
         try {
@@ -854,6 +902,9 @@ If a repository is required, call \`list_repos\` to find it, then use \`clone_re
             appDataPath: this.storagePaths.appDataPath,
             taskRunId,
             bundledSkillsDir,
+            additionalSkillsDirs: runtimeAgentPlugins.map(
+              (plugin) => plugin.skillsPath,
+            ),
             log: this.log,
           });
         } catch (err) {
@@ -961,28 +1012,16 @@ If a repository is required, call \`list_repos\` to find it, then use \`clone_re
           ? await this.filterReachableMcpServers(mcpServers, taskRunId)
           : mcpServers;
 
-      let externalPlugins: Awaited<ReturnType<typeof discoverExternalPlugins>> =
-        [];
-      try {
-        externalPlugins = await discoverExternalPlugins(
-          {
-            userDataDir: this.storagePaths.appDataPath,
-            repoPath,
-            bundledSkillsDir,
-          },
-          this.log,
-        );
-      } catch (err) {
-        this.log.warn("Failed to discover external plugins", {
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
       const plugins = [
         {
           type: "local" as const,
           path: this.posthogPluginService.getPluginPath(),
         },
         ...externalPlugins,
+        ...runtimeAgentPlugins.map((plugin) => ({
+          type: "local" as const,
+          path: plugin.pluginPath,
+        })),
       ];
       const claudeCodeOptions = buildClaudeCodeOptions({
         additionalDirectories,
@@ -1753,6 +1792,11 @@ For git operations while detached:
       await cleanupCodexHome(this.storagePaths.appDataPath, taskRunId).catch(
         () => this.log.debug("Codex home cleanup failed", { taskRunId }),
       );
+      await this.agentPluginsService
+        .cleanupRuntimePlugins(taskRunId)
+        .catch(() =>
+          this.log.debug("Agent Plugin cleanup failed", { taskRunId }),
+        );
 
       this.sessions.delete(taskRunId);
 

--- a/products/desktop/packages/workspace-server/src/services/agent/codex-home.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/codex-home.test.ts
@@ -84,6 +84,31 @@ describe("prepareCodexHome", () => {
     );
   });
 
+  it("loads portable plugin skills after bundled and user skills", async () => {
+    const pluginSkillsDir = path.join(root, "portable", "skills");
+    await createSkill(bundledSkillsDir, "bundled");
+    await createSkill(userSkillsDir, "shared", "user body");
+    await createSkill(pluginSkillsDir, "shared", "plugin body");
+    await createSkill(pluginSkillsDir, "plugin-only");
+
+    const codexHome = await prepareCodexHome({
+      appDataPath,
+      taskRunId,
+      bundledSkillsDir,
+      additionalSkillsDirs: [pluginSkillsDir],
+      log: noopLog,
+    });
+
+    const skillsDir = path.join(codexHome, "skills");
+    expect(existsSync(path.join(skillsDir, "plugin-only", "SKILL.md"))).toBe(
+      true,
+    );
+    const sharedLink = await readlink(path.join(skillsDir, "shared"));
+    expect(readFileSync(path.join(sharedLink, "SKILL.md"), "utf-8")).toBe(
+      "user body",
+    );
+  });
+
   it("symlinks the user's ~/.codex/config.toml when present", async () => {
     const codexConfigDir = path.join(testHome.dir, ".codex");
     await mkdir(codexConfigDir, { recursive: true });

--- a/products/desktop/packages/workspace-server/src/services/agent/codex-home.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/codex-home.ts
@@ -39,9 +39,9 @@ export async function cleanupCodexHome(
 }
 
 /**
- * Builds a private CODEX_HOME for PostHog's own Codex sessions, so they
- * load the bundled PostHog catalog and the user's `~/.claude/skills` — without
- * ever writing into the shared cross-agent `~/.agents/skills`.
+ * Builds a private CODEX_HOME for PostHog's own Codex sessions, so they load
+ * the bundled catalog, user skills, and validated portable plugin skills without
+ * writing into the shared cross-agent `~/.agents/skills`.
  *
  * codex scans `$CODEX_HOME/skills` plus `$HOME/.agents/skills`. By pointing
  * CODEX_HOME at this app-private dir we feed our skills through the former while
@@ -55,6 +55,7 @@ export async function prepareCodexHome(options: {
   appDataPath: string;
   taskRunId: string;
   bundledSkillsDir: string;
+  additionalSkillsDirs?: string[];
   log: AgentScopedLogger;
 }): Promise<string> {
   const codexHome = getCodexHomeDir(options.appDataPath, options.taskRunId);
@@ -64,9 +65,13 @@ export async function prepareCodexHome(options: {
   await fs.promises.rm(skillsDir, { recursive: true, force: true });
   await fs.promises.mkdir(skillsDir, { recursive: true });
 
-  // Bundled catalog first, then the user's Claude skills. Bundled wins on a
-  // name collision so the curated catalog is never shadowed.
-  const sources = [options.bundledSkillsDir, getUserSkillsDir()];
+  // Earlier sources win collisions, keeping curated and user-owned skills from
+  // being shadowed by portable plugins.
+  const sources = [
+    options.bundledSkillsDir,
+    getUserSkillsDir(),
+    ...(options.additionalSkillsDirs ?? []),
+  ];
   const linked = new Set<string>();
   for (const sourceDir of sources) {
     const names = (await findSkillDirs(sourceDir)).filter(

--- a/products/desktop/packages/workspace-server/src/services/agent/reserved-skills.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/reserved-skills.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { getReservedSkillSourcePaths } from "./reserved-skills";
+
+describe("Agent Plugin reserved skill sources", () => {
+  it("does not reserve Claude-only plugin skills for Codex", () => {
+    expect(
+      getReservedSkillSourcePaths({
+        adapter: "codex",
+        bundledSkillsDir: "/bundled/skills",
+        externalPluginPaths: ["/claude-marketplace/plugin"],
+        userSkillsDir: "/user/claude/skills",
+        codexSkillsDir: "/user/codex/skills",
+      }),
+    ).toEqual(["/bundled/skills", "/user/claude/skills", "/user/codex/skills"]);
+  });
+
+  it("reserves every Claude plugin skill source for Claude", () => {
+    expect(
+      getReservedSkillSourcePaths({
+        adapter: "claude",
+        bundledSkillsDir: "/bundled/skills",
+        externalPluginPaths: ["/repo/plugin", "/marketplace/plugin"],
+      }),
+    ).toEqual([
+      "/bundled/skills",
+      "/repo/plugin/skills",
+      "/marketplace/plugin/skills",
+    ]);
+  });
+});

--- a/products/desktop/packages/workspace-server/src/services/agent/reserved-skills.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/reserved-skills.ts
@@ -1,0 +1,26 @@
+import * as path from "node:path";
+import type { Adapter } from "@posthog/shared";
+import { getCodexSkillsDir } from "../posthog-plugin/codex-mirror";
+import { getUserSkillsDir } from "../skills/skill-discovery";
+
+export function getReservedSkillSourcePaths(args: {
+  adapter: Adapter;
+  bundledSkillsDir: string;
+  externalPluginPaths: string[];
+  userSkillsDir?: string;
+  codexSkillsDir?: string;
+}): string[] {
+  if (args.adapter === "codex") {
+    return [
+      args.bundledSkillsDir,
+      args.userSkillsDir ?? getUserSkillsDir(),
+      args.codexSkillsDir ?? getCodexSkillsDir(),
+    ];
+  }
+  return [
+    args.bundledSkillsDir,
+    ...args.externalPluginPaths.map((pluginPath) =>
+      path.join(pluginPath, "skills"),
+    ),
+  ];
+}

--- a/products/desktop/pnpm-lock.yaml
+++ b/products/desktop/pnpm-lock.yaml
@@ -1680,6 +1680,9 @@ importers:
       superjson:
         specifier: 'catalog:'
         version: 2.2.6
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
       zod:
         specifier: 4.4.3
         version: 4.4.3


### PR DESCRIPTION
## Problem

PostHog Desktop users cannot install portable Agent Plugin skills from a local plugin directory.

Existing skill discovery understands Claude and Codex layouts, not Agent Plugins 1.0 packages.

## Changes

- Adds a Plugins tab where users can preview, enable, disable, and remove local Agent Plugins.
- Validates Agent Plugins 1.0 manifests and immediate-child Agent Skills with isolated diagnostics.
- Bounds metadata size, skill tree depth, and total files and directories before loading plugin content.
- Copies validated skills into bounded runtime snapshots and removes partial snapshots when preparation fails.
- Loads portable skills into Claude and Codex with deterministic collision handling.
- Persists enabled installations through a host-neutral client boundary.
- Documents local installation, supported components, and current limitations.

![Agent Plugins skills settings](https://raw.githubusercontent.com/PostHog/pr-assets/c4f556ca0de4c681a7df5c7b1d5016bcf84cff70/2026/08/1dd7ab71-eb58-47f9-89f4-1983ec799476.png)

## How did you test this code?

- Unit tests cover metadata size, tree limits, path escapes, failed preparation cleanup, concurrent mutations, collisions, and both adapter preparations.
- Component tests cover loading states, diagnostics, and registration errors.
- `pnpm build`, `pnpm typecheck`, `pnpm lint`, and the host-boundary check passed.
- Electron QA verified Settings → Skills → Plugins and cancellation of the local directory picker.
- `hogli ci:preflight --fix` passed against current `master`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Added `docs/AGENT-PLUGINS.md` with local installation, skills support, security behavior, and limitations.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Pi worker and reviewer agents implemented and independently reviewed the change. Agent-browser verified the Electron surface.
- Skills invoked: `/posthog-desktop`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, and `quill-code`.
- PR workflow skills: `/stacking-prs`, `/writing-pr-descriptions`, `/running-ci-preflight`, and `test-electron-app`.
- Security review changed runtime loading from source symlinks to bounded snapshots with serialized state transitions.


