### PR TITLE
feat(tasks): add desktop task comment reads

### DIFF
--- a/posthog/api/test/test_comments.py
+++ b/posthog/api/test/test_comments.py
@@ -137,7 +137,7 @@ class TestComments(APIBaseTest, QueryMatchingTest):
             source_comment=root,
             content="Done",
         )
-        Comment.objects.create(
+        latest_reply = Comment.objects.create(
             team=self.team,
             created_by=self.user,
             scope="task_artifact",
@@ -162,21 +162,24 @@ class TestComments(APIBaseTest, QueryMatchingTest):
         }
 
         comments = client.get(
-            f"/api/projects/{self.team.id}/tasks/{task.id}/comments/?artifact_id=artifact-1",
+            f"/api/projects/{self.team.id}/tasks/{task.id}/comments/",
+            {"artifact_id": "artifact-1", "include_thread": True},
         )
         assert comments.status_code == status.HTTP_200_OK
-        assert comments.json()["comments"] == [
-            {
-                "id": str(root.id),
-                "target": {"id": "artifact-1", "type": "artifact", "name": "latest-report.md"},
-                "content": "Please tighten this section",
-                "content_truncated": False,
-                "selected_text": "important output",
-                "created_at": root.created_at.isoformat().replace("+00:00", "Z"),
-                "reply_count": 2,
-                "resolved": False,
-            }
+        summary = comments.json()["comments"][0]
+        assert summary["id"] == str(root.id)
+        assert summary["target"] == {"id": "artifact-1", "type": "artifact", "name": "latest-report.md"}
+        assert summary["selected_text"] == "important output"
+        assert summary["last_activity_at"] == latest_reply.created_at.isoformat().replace("+00:00", "Z")
+        assert summary["reply_count"] == 2
+        assert summary["resolved"] is False
+        assert summary["comments_truncated"] is False
+        assert [entry["content"] for entry in summary["comments"]] == [
+            "Please tighten this section",
+            "Done",
+            "Malformed state is still a reply",
         ]
+        assert all(entry["created_by_id"] == self.user.id for entry in summary["comments"])
 
         detail = client.get(f"/api/projects/{self.team.id}/tasks/{task.id}/comments/{root.id}/")
         assert detail.status_code == status.HTTP_200_OK
@@ -195,6 +198,47 @@ class TestComments(APIBaseTest, QueryMatchingTest):
         }
         assert detail.json()["comments"][0]["canvas_version_id"] == "version-2"
         assert detail.json()["next"] is None
+
+    def test_visible_users_can_list_task_comments_and_counts(self) -> None:
+        task = self._task_artifact_target()
+        open_root = Comment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            scope="task_artifact",
+            item_id="artifact-1",
+            item_context={"taskId": str(task.id)},
+            content="Open",
+        )
+        resolved_root = Comment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            scope="task_artifact",
+            item_id="artifact-1",
+            item_context={"taskId": str(task.id)},
+            content="Resolved",
+        )
+        Comment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            scope="task_artifact",
+            item_id="artifact-1",
+            item_context={"taskId": str(task.id), "threadState": "resolved"},
+            source_comment=resolved_root,
+            content="Resolved this thread",
+        )
+
+        listed = self.client.get(f"/api/projects/{self.team.id}/tasks/{task.id}/comments/")
+        counts = self.client.get(f"/api/projects/{self.team.id}/tasks/{task.id}/comments/counts/")
+
+        assert listed.status_code == status.HTTP_200_OK
+        assert [row["id"] for row in listed.json()["comments"]] == [str(open_root.id)]
+        assert counts.status_code == status.HTTP_200_OK
+        assert counts.json() == {"counts": [{"item_id": "artifact-1", "count": 1}]}
+
+        other = User.objects.create_and_join(self.organization, "private-comment-owner@posthog.com", "password")
+        private_task = self._task_artifact_target(public=False, creator=other)
+        denied = self.client.get(f"/api/projects/{self.team.id}/tasks/{private_task.id}/comments/")
+        assert denied.status_code == status.HTTP_404_NOT_FOUND
 
     def test_task_comment_retrieval_tolerates_malformed_stored_context(self) -> None:
         task = self._task_artifact_target()
@@ -514,6 +558,18 @@ class TestComments(APIBaseTest, QueryMatchingTest):
         )
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["results"] == []
+
+        Comment.objects.create(
+            team=self.team,
+            created_by=other,
+            content="Private canvas comment",
+            scope="desktop_canvas",
+            item_id=str(canvas.id),
+            item_context={"taskId": str(task.id)},
+        )
+        task_response = self.client.get(f"/api/projects/{self.team.id}/tasks/{task.id}/comments/")
+        assert task_response.status_code == status.HTTP_200_OK
+        assert task_response.json()["comments"] == []
 
     def test_comment_without_a_mention_notifies_the_task_owner(self) -> None:
         task = self._task_artifact_target()

--- a/posthog/api/test/test_comments.py
+++ b/posthog/api/test/test_comments.py
@@ -572,6 +572,24 @@ class TestComments(APIBaseTest, QueryMatchingTest):
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["results"] == []
 
+        private_comment = Comment.objects.create(
+            team=self.team,
+            created_by=other,
+            scope="desktop_canvas",
+            item_id=str(canvas.id),
+            item_context={"anchor": {"kind": "document"}, "taskId": str(task.id)},
+            content="Private canvas comment",
+        )
+        listed = self.client.get(f"/api/projects/{self.team.id}/tasks/{task.id}/comments/")
+        counts = self.client.get(f"/api/projects/{self.team.id}/tasks/{task.id}/comments/counts/")
+        detail = self.client.get(f"/api/projects/{self.team.id}/tasks/{task.id}/comments/{private_comment.id}/")
+
+        assert listed.status_code == status.HTTP_200_OK
+        assert listed.json()["comments"] == []
+        assert counts.status_code == status.HTTP_200_OK
+        assert counts.json()["counts"] == []
+        assert detail.status_code == status.HTTP_404_NOT_FOUND
+
     def test_comment_without_a_mention_notifies_the_task_owner(self) -> None:
         task = self._task_artifact_target()
         owner = User.objects.create_and_join(self.organization, "owner@posthog.com", "password")

--- a/posthog/api/test/test_comments.py
+++ b/posthog/api/test/test_comments.py
@@ -123,7 +123,14 @@ class TestComments(APIBaseTest, QueryMatchingTest):
             item_id="artifact-1",
             item_context={
                 "taskId": str(task.id),
-                "anchor": {"kind": "text", "quote": "important output", "start": 0, "end": 16},
+                "anchor": {
+                    "kind": "text",
+                    "quote": "important output",
+                    "prefix": "p" * 2000,
+                    "suffix": "s" * 2000,
+                    "start": 0,
+                    "end": 16,
+                },
                 "canvasVersionId": "version-2",
             },
             content="Please tighten this section",
@@ -180,6 +187,8 @@ class TestComments(APIBaseTest, QueryMatchingTest):
             "Malformed state is still a reply",
         ]
         assert all(entry["created_by_id"] == self.user.id for entry in summary["comments"])
+        assert summary["comments"][0]["anchor"]["prefix"] == "p" * 1024
+        assert summary["comments"][0]["anchor"]["suffix"] == "s" * 1024
 
         detail = client.get(f"/api/projects/{self.team.id}/tasks/{task.id}/comments/{root.id}/")
         assert detail.status_code == status.HTTP_200_OK
@@ -193,8 +202,10 @@ class TestComments(APIBaseTest, QueryMatchingTest):
         assert detail.json()["comments"][0]["anchor"] == {
             "end": 16,
             "kind": "text",
+            "prefix": "p" * 1024,
             "quote": "important output",
             "start": 0,
+            "suffix": "s" * 1024,
         }
         assert detail.json()["comments"][0]["canvas_version_id"] == "version-2"
         assert detail.json()["next"] is None
@@ -259,13 +270,14 @@ class TestComments(APIBaseTest, QueryMatchingTest):
 
     def test_task_comment_bodies_are_byte_bounded_and_continuable(self) -> None:
         task = self._task_artifact_target()
+        content = "a" * (64 * 1024 - 1) + "é" + "tail"
         root = Comment.objects.create(
             team=self.team,
             created_by=self.user,
             scope="task_artifact",
             item_id="artifact-1",
             item_context={"taskId": str(task.id), "anchor": {"kind": "document"}},
-            content="é" * 40_000,
+            content=content,
         )
         client = self._sandbox_task_comment_client(task.id)
 
@@ -286,6 +298,7 @@ class TestComments(APIBaseTest, QueryMatchingTest):
         assert continuation["content"]
         assert continuation["content_truncated"] is False
         assert continuation["content_next_offset"] is None
+        assert first_chunk["content"] + continuation["content"] == content
 
     def test_task_comments_use_an_opaque_cursor(self) -> None:
         task = self._task_artifact_target()

--- a/posthog/api/test/test_comments.py
+++ b/posthog/api/test/test_comments.py
@@ -559,18 +559,6 @@ class TestComments(APIBaseTest, QueryMatchingTest):
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["results"] == []
 
-        Comment.objects.create(
-            team=self.team,
-            created_by=other,
-            content="Private canvas comment",
-            scope="desktop_canvas",
-            item_id=str(canvas.id),
-            item_context={"taskId": str(task.id)},
-        )
-        task_response = self.client.get(f"/api/projects/{self.team.id}/tasks/{task.id}/comments/")
-        assert task_response.status_code == status.HTTP_200_OK
-        assert task_response.json()["comments"] == []
-
     def test_comment_without_a_mention_notifies_the_task_owner(self) -> None:
         task = self._task_artifact_target()
         owner = User.objects.create_and_join(self.organization, "owner@posthog.com", "password")

--- a/posthog/models/comment/task_access.py
+++ b/posthog/models/comment/task_access.py
@@ -1,0 +1,9 @@
+from uuid import UUID
+
+
+def visible_task_canvas_ids(*, team_id: int, task_id: UUID, user_id: int | None) -> list[str]:
+    from products.canvas.backend.comment_access import (  # noqa: PLC0415 — keeps the shared comment model importable without loading the Canvas product
+        visible_canvas_ids_for_task,
+    )
+
+    return visible_canvas_ids_for_task(team_id=team_id, task_id=task_id, user_id=user_id)

--- a/products/canvas/backend/comment_access.py
+++ b/products/canvas/backend/comment_access.py
@@ -20,6 +20,18 @@ def canvas_belongs_to_task(*, team_id: int, user_id: int | None, canvas_id: str,
         return False
 
 
+def visible_canvas_ids_for_task(*, team_id: int, user_id: int | None, task_id: UUID) -> list[str]:
+    return [
+        str(canvas_id)
+        for canvas_id in Canvas.objects.for_team(team_id)
+        .filter(deleted=False)
+        .filter(tasks_facade.visible_channels_q(user_id, relation="channel"))
+        .filter(Q(generation_task_id=task_id) | Q(source_versions__task_id=task_id))
+        .values_list("id", flat=True)
+        .distinct()
+    ]
+
+
 def canvas_owner_id(*, team_id: int, canvas_id: str) -> int | None:
     try:
         return (

--- a/products/canvas/backend/comment_access.py
+++ b/products/canvas/backend/comment_access.py
@@ -20,6 +20,18 @@ def canvas_belongs_to_task(*, team_id: int, user_id: int | None, canvas_id: str,
         return False
 
 
+def visible_canvas_ids_for_task(*, team_id: int, user_id: int | None, task_id: UUID) -> list[str]:
+    return [
+        str(canvas_id)
+        for canvas_id in Canvas.objects.for_team(team_id)
+        .filter(deleted=False)
+        .filter(tasks_facade.visible_channels_q(user_id, relation="channel"))
+        .filter(Q(generation_task_id=task_id) | Q(source_versions__task_id=task_id))
+        .distinct()
+        .values_list("id", flat=True)
+    ]
+
+
 def canvas_owner_id(*, team_id: int, canvas_id: str) -> int | None:
     try:
         return (

--- a/products/canvas/backend/comment_access.py
+++ b/products/canvas/backend/comment_access.py
@@ -20,18 +20,6 @@ def canvas_belongs_to_task(*, team_id: int, user_id: int | None, canvas_id: str,
         return False
 
 
-def visible_canvas_ids_for_task(*, team_id: int, user_id: int | None, task_id: UUID) -> list[str]:
-    return [
-        str(canvas_id)
-        for canvas_id in Canvas.objects.for_team(team_id)
-        .filter(deleted=False)
-        .filter(tasks_facade.visible_channels_q(user_id, relation="channel"))
-        .filter(Q(generation_task_id=task_id) | Q(source_versions__task_id=task_id))
-        .distinct()
-        .values_list("id", flat=True)
-    ]
-
-
 def canvas_owner_id(*, team_id: int, canvas_id: str) -> int | None:
     try:
         return (

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -38,6 +38,7 @@ import posthoganalytics
 
 from posthog.event_usage import groups
 from posthog.models import Team, User
+from posthog.models.comment.task_access import visible_task_canvas_ids as _visible_task_canvas_ids
 from posthog.models.integration import Integration
 from posthog.utils import absolute_uri
 
@@ -6263,11 +6264,7 @@ def list_task_artifacts(*, team_id: int, task_id: UUID) -> list[contracts.TaskAr
 
 
 def visible_task_canvas_ids(*, team_id: int, task_id: UUID, user_id: int | None) -> list[str]:
-    from products.canvas.backend.comment_access import (
-        visible_canvas_ids_for_task,  # noqa: PLC0415 — avoids the canvas/tasks facade import cycle
-    )
-
-    return visible_canvas_ids_for_task(team_id=team_id, task_id=task_id, user_id=user_id)
+    return _visible_task_canvas_ids(team_id=team_id, task_id=task_id, user_id=user_id)
 
 
 def list_task_comments(

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -238,6 +238,7 @@ __all__ = [
     "task_comment_mentions_allowed",
     "list_task_artifacts",
     "list_task_comments",
+    "count_open_task_comments",
     "retrieve_task_comment",
     "update_sandbox_environment",
     "update_task",
@@ -6265,8 +6266,10 @@ def list_task_comments(
     *,
     team_id: int,
     task_id: UUID,
+    user_id: int | None,
     artifact_id: str | None,
     include_resolved: bool,
+    include_thread: bool,
     limit: int,
     cursor: str | None,
 ) -> contracts.TaskCommentPageDTO:
@@ -6276,8 +6279,10 @@ def list_task_comments(
         return list_comments(
             team_id=team_id,
             task_id=task_id,
+            user_id=user_id,
             artifact_id=artifact_id,
             include_resolved=include_resolved,
+            include_thread=include_thread,
             limit=limit,
             cursor=cursor,
         )
@@ -6285,10 +6290,17 @@ def list_task_comments(
         raise ValueError("Invalid task comment cursor") from None
 
 
+def count_open_task_comments(*, team_id: int, task_id: UUID, user_id: int | None) -> contracts.TaskCommentCountsDTO:
+    from products.tasks.backend.logic.services.task_comments import count_open_comments
+
+    return count_open_comments(team_id=team_id, task_id=task_id, user_id=user_id)
+
+
 def retrieve_task_comment(
     *,
     team_id: int,
     task_id: UUID,
+    user_id: int | None,
     comment_id: UUID,
     limit: int,
     cursor: str | None,
@@ -6301,6 +6313,7 @@ def retrieve_task_comment(
         return retrieve_comment(
             team_id=team_id,
             task_id=task_id,
+            user_id=user_id,
             comment_id=comment_id,
             limit=limit,
             cursor=cursor,

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -6266,7 +6266,6 @@ def list_task_comments(
     *,
     team_id: int,
     task_id: UUID,
-    user_id: int | None,
     artifact_id: str | None,
     include_resolved: bool,
     include_thread: bool,
@@ -6279,7 +6278,6 @@ def list_task_comments(
         return list_comments(
             team_id=team_id,
             task_id=task_id,
-            user_id=user_id,
             artifact_id=artifact_id,
             include_resolved=include_resolved,
             include_thread=include_thread,
@@ -6290,17 +6288,16 @@ def list_task_comments(
         raise ValueError("Invalid task comment cursor") from None
 
 
-def count_open_task_comments(*, team_id: int, task_id: UUID, user_id: int | None) -> contracts.TaskCommentCountsDTO:
+def count_open_task_comments(*, team_id: int, task_id: UUID) -> contracts.TaskCommentCountsDTO:
     from products.tasks.backend.logic.services.task_comments import count_open_comments
 
-    return count_open_comments(team_id=team_id, task_id=task_id, user_id=user_id)
+    return count_open_comments(team_id=team_id, task_id=task_id)
 
 
 def retrieve_task_comment(
     *,
     team_id: int,
     task_id: UUID,
-    user_id: int | None,
     comment_id: UUID,
     limit: int,
     cursor: str | None,
@@ -6313,7 +6310,6 @@ def retrieve_task_comment(
         return retrieve_comment(
             team_id=team_id,
             task_id=task_id,
-            user_id=user_id,
             comment_id=comment_id,
             limit=limit,
             cursor=cursor,

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -6262,10 +6262,19 @@ def list_task_artifacts(*, team_id: int, task_id: UUID) -> list[contracts.TaskAr
     return list_artifacts(team_id=team_id, task_id=task_id)
 
 
+def visible_task_canvas_ids(*, team_id: int, task_id: UUID, user_id: int | None) -> list[str]:
+    from products.canvas.backend.comment_access import (
+        visible_canvas_ids_for_task,  # noqa: PLC0415 — avoids the canvas/tasks facade import cycle
+    )
+
+    return visible_canvas_ids_for_task(team_id=team_id, task_id=task_id, user_id=user_id)
+
+
 def list_task_comments(
     *,
     team_id: int,
     task_id: UUID,
+    visible_canvas_ids: Sequence[str],
     artifact_id: str | None,
     include_resolved: bool,
     include_thread: bool,
@@ -6278,6 +6287,7 @@ def list_task_comments(
         return list_comments(
             team_id=team_id,
             task_id=task_id,
+            visible_canvas_ids=visible_canvas_ids,
             artifact_id=artifact_id,
             include_resolved=include_resolved,
             include_thread=include_thread,
@@ -6288,16 +6298,19 @@ def list_task_comments(
         raise ValueError("Invalid task comment cursor") from None
 
 
-def count_open_task_comments(*, team_id: int, task_id: UUID) -> contracts.TaskCommentCountsDTO:
+def count_open_task_comments(
+    *, team_id: int, task_id: UUID, visible_canvas_ids: Sequence[str]
+) -> contracts.TaskCommentCountsDTO:
     from products.tasks.backend.logic.services.task_comments import count_open_comments
 
-    return count_open_comments(team_id=team_id, task_id=task_id)
+    return count_open_comments(team_id=team_id, task_id=task_id, visible_canvas_ids=visible_canvas_ids)
 
 
 def retrieve_task_comment(
     *,
     team_id: int,
     task_id: UUID,
+    visible_canvas_ids: Sequence[str],
     comment_id: UUID,
     limit: int,
     cursor: str | None,
@@ -6310,6 +6323,7 @@ def retrieve_task_comment(
         return retrieve_comment(
             team_id=team_id,
             task_id=task_id,
+            visible_canvas_ids=visible_canvas_ids,
             comment_id=comment_id,
             limit=limit,
             cursor=cursor,

--- a/products/tasks/backend/facade/contracts.py
+++ b/products/tasks/backend/facade/contracts.py
@@ -290,6 +290,19 @@ class TaskCommentTargetDTO:
 
 
 @dataclass(frozen=True)
+class TaskCommentEntryDTO:
+    id: UUID
+    content: str
+    content_truncated: bool
+    content_next_offset: int | None
+    author: str | None
+    created_by_id: int | None
+    created_at: datetime
+    anchor: dict | None
+    canvas_version_id: str | None
+
+
+@dataclass(frozen=True)
 class TaskCommentSummaryDTO:
     id: UUID
     target: TaskCommentTargetDTO
@@ -297,8 +310,11 @@ class TaskCommentSummaryDTO:
     content_truncated: bool
     selected_text: str | None
     created_at: datetime
+    last_activity_at: datetime
     reply_count: int
     resolved: bool
+    comments: list[TaskCommentEntryDTO] | None
+    comments_truncated: bool
 
 
 @dataclass(frozen=True)
@@ -308,15 +324,14 @@ class TaskCommentPageDTO:
 
 
 @dataclass(frozen=True)
-class TaskCommentEntryDTO:
-    id: UUID
-    content: str
-    content_truncated: bool
-    content_next_offset: int | None
-    author: str | None
-    created_at: datetime
-    anchor: dict | None
-    canvas_version_id: str | None
+class TaskCommentCountDTO:
+    item_id: str
+    count: int
+
+
+@dataclass(frozen=True)
+class TaskCommentCountsDTO:
+    counts: list[TaskCommentCountDTO]
 
 
 @dataclass(frozen=True)

--- a/products/tasks/backend/logic/services/task_comments.py
+++ b/products/tasks/backend/logic/services/task_comments.py
@@ -25,6 +25,7 @@ LIST_THREAD_CONTENT_LIMIT_CHARS = 4096
 LIST_THREAD_REPLY_LIMIT = 20
 ANCHOR_CONTEXT_BYTES = 1024
 ANCHOR_QUOTE_BYTES = 4096
+CANVAS_VERSION_ID_BYTES = 256
 
 
 class InvalidTaskCommentCursor(ValueError):
@@ -52,23 +53,27 @@ def _bounded_anchor(comment: Comment) -> dict | None:
     allowed_fields_by_kind: dict[str, tuple[str, ...]] = {
         "text": ("prefix", "suffix", "start", "end"),
         "region": ("x", "y", "width", "height"),
+        "document": (),
     }
     if not isinstance(kind, str) or kind not in allowed_fields_by_kind:
         return None
-    bounded = {"kind": kind}
-    allowed_fields = allowed_fields_by_kind[kind]
-    for field in allowed_fields:
-        if field not in anchor:
-            continue
-        value = anchor[field]
-        bounded[field] = (
-            _content_chunk(value, limit=ANCHOR_CONTEXT_BYTES)[0]
-            if field in {"prefix", "suffix"} and isinstance(value, str)
-            else value
-        )
+    bounded: dict[str, object] = {"kind": kind}
+    for field in allowed_fields_by_kind[kind]:
+        value = anchor.get(field)
+        if field in {"prefix", "suffix"} and isinstance(value, str):
+            bounded[field] = _content_chunk(value, limit=ANCHOR_CONTEXT_BYTES)[0]
+        elif field not in {"prefix", "suffix"} and isinstance(value, int | float) and not isinstance(value, bool):
+            bounded[field] = value
     if kind == "text" and isinstance(anchor.get("quote"), str):
         bounded["quote"] = _content_chunk(anchor["quote"], limit=ANCHOR_QUOTE_BYTES)[0]
     return bounded
+
+
+def _bounded_canvas_version_id(comment: Comment) -> str | None:
+    canvas_version_id = _item_context(comment).get("canvasVersionId")
+    if not isinstance(canvas_version_id, str):
+        return None
+    return _content_chunk(canvas_version_id, limit=CANVAS_VERSION_ID_BYTES)[0]
 
 
 def _artifact_names(*, team_id: int, task_id: UUID, artifact_ids: Sequence[str]) -> dict[str, str]:
@@ -156,13 +161,18 @@ def _decode_cursor(cursor: str) -> tuple[datetime, UUID]:
         raise InvalidTaskCommentCursor from None
 
 
-def _comments(team_id: int, task_id: UUID) -> QuerySet[Comment]:
+def _comments(team_id: int, task_id: UUID, visible_canvas_ids: Sequence[str]) -> QuerySet[Comment]:
     task_id_string = str(task_id)
     return (
         Comment.objects.filter(team_id=team_id, deleted=False)
         .filter(
             Q(scope="task", item_id=task_id_string)
-            | Q(scope__in=["task_artifact", "desktop_canvas"], item_context__taskId=task_id_string)
+            | Q(scope="task_artifact", item_context__taskId=task_id_string)
+            | Q(
+                scope="desktop_canvas",
+                item_context__taskId=task_id_string,
+                item_id__in=visible_canvas_ids,
+            )
         )
         .filter(Q(item_context__isnull=True) | ~Q(item_context__has_key="is_emoji") | Q(item_context__is_emoji=False))
     )
@@ -274,13 +284,14 @@ def list_comments(
     *,
     team_id: int,
     task_id: UUID,
+    visible_canvas_ids: Sequence[str],
     artifact_id: str | None,
     include_resolved: bool,
     include_thread: bool,
     limit: int,
     cursor: str | None,
 ) -> contracts.TaskCommentPageDTO:
-    comments_qs = _comments(team_id, task_id)
+    comments_qs = _comments(team_id, task_id, visible_canvas_ids)
     roots_qs = comments_qs.filter(source_comment_id__isnull=True)
     if artifact_id:
         roots_qs = roots_qs.filter(scope__in=["task_artifact", "desktop_canvas"], item_id=artifact_id)
@@ -358,16 +369,17 @@ def list_comments(
                     anchor_bytes = len(
                         json.dumps(_bounded_anchor(comment), separators=(",", ":"), default=str).encode("utf-8")
                     )
-                    if remaining_thread_content_bytes < anchor_bytes + 4:
+                    metadata_bytes = anchor_bytes + len((_bounded_canvas_version_id(comment) or "").encode("utf-8"))
+                    if remaining_thread_content_bytes < metadata_bytes + 4:
                         comments_truncated = True
                         break
                     entry = _entry(
                         comment,
-                        content_budget=remaining_thread_content_bytes - anchor_bytes,
+                        content_budget=remaining_thread_content_bytes - metadata_bytes,
                         content_override=_preview_content(comment),
                         original_content_length=_preview_content_length(comment),
                     )
-                    remaining_thread_content_bytes -= anchor_bytes + len(entry.content.encode("utf-8"))
+                    remaining_thread_content_bytes -= metadata_bytes + len(entry.content.encode("utf-8"))
                     comments_truncated = comments_truncated or entry.content_truncated
                     thread_comments.append(entry)
                 comments_truncated = (
@@ -399,8 +411,10 @@ def list_comments(
     return contracts.TaskCommentPageDTO(comments=result, next=next_cursor)
 
 
-def count_open_comments(*, team_id: int, task_id: UUID) -> contracts.TaskCommentCountsDTO:
-    comments_qs = _comments(team_id, task_id)
+def count_open_comments(
+    *, team_id: int, task_id: UUID, visible_canvas_ids: Sequence[str]
+) -> contracts.TaskCommentCountsDTO:
+    comments_qs = _comments(team_id, task_id, visible_canvas_ids)
     roots = list(comments_qs.filter(source_comment_id__isnull=True).values_list("id", "item_id", "completed_at"))
     latest_states = {
         source_comment_id: item_context.get("threadState")
@@ -453,7 +467,7 @@ def _entry(
         created_by_id=comment.created_by_id,
         created_at=comment.created_at,
         anchor=_bounded_anchor(comment),
-        canvas_version_id=_item_context(comment).get("canvasVersionId"),
+        canvas_version_id=_bounded_canvas_version_id(comment),
     )
 
 
@@ -461,13 +475,14 @@ def retrieve_comment(
     *,
     team_id: int,
     task_id: UUID,
+    visible_canvas_ids: Sequence[str],
     comment_id: UUID,
     limit: int,
     cursor: str | None,
     content_comment_id: UUID | None,
     content_offset: int,
 ) -> contracts.TaskCommentDetailDTO | None:
-    comments_qs = _comments(team_id, task_id)
+    comments_qs = _comments(team_id, task_id, visible_canvas_ids)
     root = comments_qs.select_related("created_by").filter(id=comment_id, source_comment_id__isnull=True).first()
     if root is None:
         return None

--- a/products/tasks/backend/logic/services/task_comments.py
+++ b/products/tasks/backend/logic/services/task_comments.py
@@ -40,10 +40,6 @@ def _content_chunk(content: str, *, limit: int, offset: int = 0) -> tuple[str, i
     end = min(len(encoded), offset + limit)
     while end > offset and end < len(encoded) and encoded[end] & 0b11000000 == 0b10000000:
         end -= 1
-    if end == offset and offset < len(encoded) and limit > 0:
-        end += 1
-        while end < len(encoded) and encoded[end] & 0b11000000 == 0b10000000:
-            end += 1
     chunk = encoded[offset:end].decode("utf-8")
     return chunk, end if end < len(encoded) else None
 
@@ -362,7 +358,7 @@ def list_comments(
                     anchor_bytes = len(
                         json.dumps(_bounded_anchor(comment), separators=(",", ":"), default=str).encode("utf-8")
                     )
-                    if remaining_thread_content_bytes <= anchor_bytes:
+                    if remaining_thread_content_bytes < anchor_bytes + 4:
                         comments_truncated = True
                         break
                     entry = _entry(

--- a/products/tasks/backend/logic/services/task_comments.py
+++ b/products/tasks/backend/logic/services/task_comments.py
@@ -1,9 +1,11 @@
 from base64 import urlsafe_b64decode, urlsafe_b64encode
+from collections import defaultdict
 from collections.abc import Sequence
 from datetime import datetime
 from uuid import UUID
 
-from django.db.models import Count, Q, QuerySet
+from django.db.models import Count, F, Max, Q, QuerySet, Window
+from django.db.models.functions import RowNumber
 
 from posthog.models import Comment
 
@@ -17,6 +19,8 @@ CANVAS_EVENT_LIMIT = 500
 LIST_CONTENT_BYTES = 1024
 SELECTED_TEXT_BYTES = 1024
 DETAIL_CONTENT_BUDGET_BYTES = 64 * 1024
+LIST_THREAD_CONTENT_BUDGET_BYTES = 256 * 1024
+LIST_THREAD_REPLY_LIMIT = 20
 ANCHOR_QUOTE_BYTES = 4096
 
 
@@ -93,6 +97,14 @@ def _is_state_event(comment: Comment) -> bool:
     return _item_context(comment).get("threadState") in COMMENT_STATES
 
 
+def _human_replies(queryset: QuerySet[Comment]) -> QuerySet[Comment]:
+    return queryset.filter(
+        Q(item_context__isnull=True)
+        | ~Q(item_context__has_key="threadState")
+        | ~Q(item_context__threadState__in=COMMENT_STATES)
+    )
+
+
 def _encode_cursor(created_at: datetime, comment_id: UUID) -> str:
     return urlsafe_b64encode(f"{created_at.isoformat()}|{comment_id}".encode()).decode().rstrip("=")
 
@@ -111,16 +123,25 @@ def _decode_cursor(cursor: str) -> tuple[datetime, UUID]:
         raise InvalidTaskCommentCursor from None
 
 
-def _comments(team_id: int, task_id: UUID) -> QuerySet[Comment]:
+def _comments(team_id: int, task_id: UUID, visible_canvas_ids: Sequence[str]) -> QuerySet[Comment]:
     task_id_string = str(task_id)
     return (
         Comment.objects.filter(team_id=team_id, deleted=False)
         .filter(
             Q(scope="task", item_id=task_id_string)
-            | Q(scope__in=["task_artifact", "desktop_canvas"], item_context__taskId=task_id_string)
+            | Q(scope="task_artifact", item_context__taskId=task_id_string)
+            | Q(scope="desktop_canvas", item_context__taskId=task_id_string, item_id__in=visible_canvas_ids)
         )
         .filter(Q(item_context__isnull=True) | ~Q(item_context__has_key="is_emoji") | Q(item_context__is_emoji=False))
     )
+
+
+def _visible_canvas_ids(*, team_id: int, task_id: UUID, user_id: int | None) -> list[str]:
+    from products.canvas.backend.comment_access import (
+        visible_canvas_ids_for_task,  # noqa: PLC0415 — avoids the canvas/tasks facade cycle
+    )
+
+    return visible_canvas_ids_for_task(team_id=team_id, user_id=user_id, task_id=task_id)
 
 
 def _canvas_names(*, team_id: int, task_id: UUID, canvas_ids: Sequence[str]) -> dict[str, str]:
@@ -229,36 +250,47 @@ def list_comments(
     *,
     team_id: int,
     task_id: UUID,
+    user_id: int | None,
     artifact_id: str | None,
     include_resolved: bool,
+    include_thread: bool,
     limit: int,
     cursor: str | None,
 ) -> contracts.TaskCommentPageDTO:
-    roots_qs = _comments(team_id, task_id).filter(source_comment_id__isnull=True)
+    comments_qs = _comments(
+        team_id,
+        task_id,
+        _visible_canvas_ids(team_id=team_id, task_id=task_id, user_id=user_id),
+    )
+    roots_qs = comments_qs.filter(source_comment_id__isnull=True)
     if artifact_id:
         roots_qs = roots_qs.filter(scope__in=["task_artifact", "desktop_canvas"], item_id=artifact_id)
     scan_cursor = _decode_cursor(cursor) if cursor else None
     result: list[contracts.TaskCommentSummaryDTO] = []
     next_cursor = None
+    remaining_thread_content_bytes = LIST_THREAD_CONTENT_BUDGET_BYTES
     while len(result) < limit:
         batch_qs = roots_qs
         if scan_cursor:
             before, before_id = scan_cursor
             batch_qs = batch_qs.filter(Q(created_at__lt=before) | Q(created_at=before, id__lt=before_id))
         remaining = limit - len(result)
+        if include_thread:
+            batch_qs = batch_qs.select_related("created_by")
         batch = list(batch_qs.order_by("-created_at", "-id")[: remaining + 1])
         has_more = len(batch) > remaining
         roots = batch[:remaining]
         if not roots:
             break
         root_ids = [root.id for root in roots]
-        reply_qs = _comments(team_id, task_id).filter(source_comment_id__in=root_ids)
-        human_replies = reply_qs.filter(
-            Q(item_context__isnull=True)
-            | ~Q(item_context__has_key="threadState")
-            | ~Q(item_context__threadState__in=COMMENT_STATES)
-        )
-        reply_counts = dict(human_replies.values_list("source_comment_id").annotate(count=Count("id")))
+        reply_qs = comments_qs.filter(source_comment_id__in=root_ids)
+        human_replies = _human_replies(reply_qs)
+        reply_stats = {
+            source_comment_id: (count, last_activity_at)
+            for source_comment_id, count, last_activity_at in human_replies.values("source_comment_id")
+            .annotate(count=Count("id"), last_activity_at=Max("created_at"))
+            .values_list("source_comment_id", "count", "last_activity_at")
+        }
         latest_states = {
             source_comment_id: item_context.get("threadState")
             for source_comment_id, item_context in reply_qs.filter(item_context__threadState__in=COMMENT_STATES)
@@ -267,6 +299,23 @@ def list_comments(
             .values_list("source_comment_id", "item_context")
             if isinstance(item_context, dict)
         }
+        replies_by_root: dict[UUID, list[Comment]] = defaultdict(list)
+        if include_thread:
+            preview_replies = (
+                human_replies.select_related("created_by")
+                .annotate(
+                    thread_row=Window(
+                        expression=RowNumber(),
+                        partition_by=[F("source_comment_id")],
+                        order_by=[F("created_at").asc(), F("id").asc()],
+                    )
+                )
+                .filter(thread_row__lte=LIST_THREAD_REPLY_LIMIT)
+                .order_by("source_comment_id", "created_at", "id")
+            )
+            for reply in preview_replies:
+                if reply.source_comment_id is not None:
+                    replies_by_root[reply.source_comment_id].append(reply)
         target_names = _target_names_for_roots(team_id=team_id, task_id=task_id, roots=roots)
         for root in roots:
             resolved = _resolved(root, latest_states.get(root.id))
@@ -279,6 +328,17 @@ def list_comments(
                 selected_text = _content_chunk(selected_text, limit=SELECTED_TEXT_BYTES)[0]
             else:
                 selected_text = None
+            reply_count, reply_activity_at = reply_stats.get(root.id, (0, None))
+            thread_comments = None
+            comments_truncated = False
+            if include_thread:
+                thread_comments = []
+                for comment in [root, *replies_by_root[root.id]]:
+                    entry = _entry(comment, content_budget=max(remaining_thread_content_bytes, 0))
+                    remaining_thread_content_bytes -= len(entry.content.encode("utf-8"))
+                    comments_truncated = comments_truncated or entry.content_truncated
+                    thread_comments.append(entry)
+                comments_truncated = comments_truncated or reply_count > len(replies_by_root[root.id])
             result.append(
                 contracts.TaskCommentSummaryDTO(
                     id=root.id,
@@ -287,8 +347,11 @@ def list_comments(
                     content_truncated=content_next_offset is not None,
                     selected_text=selected_text,
                     created_at=root.created_at,
-                    reply_count=reply_counts.get(root.id, 0),
+                    last_activity_at=reply_activity_at or root.created_at,
+                    reply_count=reply_count,
                     resolved=resolved,
+                    comments=thread_comments,
+                    comments_truncated=comments_truncated,
                 )
             )
         scan_cursor = (roots[-1].created_at, roots[-1].id)
@@ -298,6 +361,34 @@ def list_comments(
         if not has_more:
             break
     return contracts.TaskCommentPageDTO(comments=result, next=next_cursor)
+
+
+def count_open_comments(*, team_id: int, task_id: UUID, user_id: int | None) -> contracts.TaskCommentCountsDTO:
+    comments_qs = _comments(
+        team_id,
+        task_id,
+        _visible_canvas_ids(team_id=team_id, task_id=task_id, user_id=user_id),
+    )
+    roots = list(comments_qs.filter(source_comment_id__isnull=True))
+    latest_states = {
+        source_comment_id: item_context.get("threadState")
+        for source_comment_id, item_context in comments_qs.filter(
+            source_comment_id__in=[root.id for root in roots], item_context__threadState__in=COMMENT_STATES
+        )
+        .order_by("source_comment_id", "-created_at", "-id")
+        .distinct("source_comment_id")
+        .values_list("source_comment_id", "item_context")
+        if isinstance(item_context, dict)
+    }
+    counts: dict[str, int] = defaultdict(int)
+    for root in roots:
+        if root.item_id and not _resolved(root, latest_states.get(root.id)):
+            counts[root.item_id] += 1
+    return contracts.TaskCommentCountsDTO(
+        counts=[
+            contracts.TaskCommentCountDTO(item_id=item_id, count=count) for item_id, count in sorted(counts.items())
+        ]
+    )
 
 
 def _entry(comment: Comment, *, content_budget: int, content_offset: int = 0) -> contracts.TaskCommentEntryDTO:
@@ -310,6 +401,7 @@ def _entry(comment: Comment, *, content_budget: int, content_offset: int = 0) ->
         content_truncated=content_next_offset is not None,
         content_next_offset=content_next_offset,
         author=author,
+        created_by_id=comment.created_by_id,
         created_at=comment.created_at,
         anchor=_bounded_anchor(comment),
         canvas_version_id=_item_context(comment).get("canvasVersionId"),
@@ -320,35 +412,31 @@ def retrieve_comment(
     *,
     team_id: int,
     task_id: UUID,
+    user_id: int | None,
     comment_id: UUID,
     limit: int,
     cursor: str | None,
     content_comment_id: UUID | None,
     content_offset: int,
 ) -> contracts.TaskCommentDetailDTO | None:
-    root = (
-        _comments(team_id, task_id)
-        .select_related("created_by")
-        .filter(id=comment_id, source_comment_id__isnull=True)
-        .first()
+    comments_qs = _comments(
+        team_id,
+        task_id,
+        _visible_canvas_ids(team_id=team_id, task_id=task_id, user_id=user_id),
     )
+    root = comments_qs.select_related("created_by").filter(id=comment_id, source_comment_id__isnull=True).first()
     if root is None:
         return None
     latest_state_reply = (
-        _comments(team_id, task_id)
-        .filter(source_comment_id=root.id, item_context__threadState__in=COMMENT_STATES)
+        comments_qs.filter(source_comment_id=root.id, item_context__threadState__in=COMMENT_STATES)
         .order_by("-created_at", "-id")
         .first()
     )
-    thread_comments_qs = (
-        _comments(team_id, task_id)
-        .filter(Q(id=root.id) | Q(source_comment_id=root.id))
-        .filter(
-            Q(id=root.id)
-            | Q(item_context__isnull=True)
-            | ~Q(item_context__has_key="threadState")
-            | ~Q(item_context__threadState__in=COMMENT_STATES)
-        )
+    thread_comments_qs = comments_qs.filter(Q(id=root.id) | Q(source_comment_id=root.id)).filter(
+        Q(id=root.id)
+        | Q(item_context__isnull=True)
+        | ~Q(item_context__has_key="threadState")
+        | ~Q(item_context__threadState__in=COMMENT_STATES)
     )
     if content_comment_id is not None:
         content_comment = thread_comments_qs.select_related("created_by").filter(id=content_comment_id).first()

--- a/products/tasks/backend/logic/services/task_comments.py
+++ b/products/tasks/backend/logic/services/task_comments.py
@@ -123,25 +123,16 @@ def _decode_cursor(cursor: str) -> tuple[datetime, UUID]:
         raise InvalidTaskCommentCursor from None
 
 
-def _comments(team_id: int, task_id: UUID, visible_canvas_ids: Sequence[str]) -> QuerySet[Comment]:
+def _comments(team_id: int, task_id: UUID) -> QuerySet[Comment]:
     task_id_string = str(task_id)
     return (
         Comment.objects.filter(team_id=team_id, deleted=False)
         .filter(
             Q(scope="task", item_id=task_id_string)
-            | Q(scope="task_artifact", item_context__taskId=task_id_string)
-            | Q(scope="desktop_canvas", item_context__taskId=task_id_string, item_id__in=visible_canvas_ids)
+            | Q(scope__in=["task_artifact", "desktop_canvas"], item_context__taskId=task_id_string)
         )
         .filter(Q(item_context__isnull=True) | ~Q(item_context__has_key="is_emoji") | Q(item_context__is_emoji=False))
     )
-
-
-def _visible_canvas_ids(*, team_id: int, task_id: UUID, user_id: int | None) -> list[str]:
-    from products.canvas.backend.comment_access import (
-        visible_canvas_ids_for_task,  # noqa: PLC0415 — avoids the canvas/tasks facade cycle
-    )
-
-    return visible_canvas_ids_for_task(team_id=team_id, user_id=user_id, task_id=task_id)
 
 
 def _canvas_names(*, team_id: int, task_id: UUID, canvas_ids: Sequence[str]) -> dict[str, str]:
@@ -250,18 +241,13 @@ def list_comments(
     *,
     team_id: int,
     task_id: UUID,
-    user_id: int | None,
     artifact_id: str | None,
     include_resolved: bool,
     include_thread: bool,
     limit: int,
     cursor: str | None,
 ) -> contracts.TaskCommentPageDTO:
-    comments_qs = _comments(
-        team_id,
-        task_id,
-        _visible_canvas_ids(team_id=team_id, task_id=task_id, user_id=user_id),
-    )
+    comments_qs = _comments(team_id, task_id)
     roots_qs = comments_qs.filter(source_comment_id__isnull=True)
     if artifact_id:
         roots_qs = roots_qs.filter(scope__in=["task_artifact", "desktop_canvas"], item_id=artifact_id)
@@ -363,12 +349,8 @@ def list_comments(
     return contracts.TaskCommentPageDTO(comments=result, next=next_cursor)
 
 
-def count_open_comments(*, team_id: int, task_id: UUID, user_id: int | None) -> contracts.TaskCommentCountsDTO:
-    comments_qs = _comments(
-        team_id,
-        task_id,
-        _visible_canvas_ids(team_id=team_id, task_id=task_id, user_id=user_id),
-    )
+def count_open_comments(*, team_id: int, task_id: UUID) -> contracts.TaskCommentCountsDTO:
+    comments_qs = _comments(team_id, task_id)
     roots = list(comments_qs.filter(source_comment_id__isnull=True))
     latest_states = {
         source_comment_id: item_context.get("threadState")
@@ -412,18 +394,13 @@ def retrieve_comment(
     *,
     team_id: int,
     task_id: UUID,
-    user_id: int | None,
     comment_id: UUID,
     limit: int,
     cursor: str | None,
     content_comment_id: UUID | None,
     content_offset: int,
 ) -> contracts.TaskCommentDetailDTO | None:
-    comments_qs = _comments(
-        team_id,
-        task_id,
-        _visible_canvas_ids(team_id=team_id, task_id=task_id, user_id=user_id),
-    )
+    comments_qs = _comments(team_id, task_id)
     root = comments_qs.select_related("created_by").filter(id=comment_id, source_comment_id__isnull=True).first()
     if root is None:
         return None

--- a/products/tasks/backend/logic/services/task_comments.py
+++ b/products/tasks/backend/logic/services/task_comments.py
@@ -1,11 +1,12 @@
+import json
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 from collections import defaultdict
 from collections.abc import Sequence
 from datetime import datetime
 from uuid import UUID
 
-from django.db.models import Count, F, Max, Q, QuerySet, Window
-from django.db.models.functions import RowNumber
+from django.db.models import Count, F, Max, Q, QuerySet, TextField, Value, Window
+from django.db.models.functions import Coalesce, Left, Length, RowNumber
 
 from posthog.models import Comment
 
@@ -20,7 +21,9 @@ LIST_CONTENT_BYTES = 1024
 SELECTED_TEXT_BYTES = 1024
 DETAIL_CONTENT_BUDGET_BYTES = 64 * 1024
 LIST_THREAD_CONTENT_BUDGET_BYTES = 256 * 1024
+LIST_THREAD_CONTENT_LIMIT_CHARS = 4096
 LIST_THREAD_REPLY_LIMIT = 20
+ANCHOR_CONTEXT_BYTES = 1024
 ANCHOR_QUOTE_BYTES = 4096
 
 
@@ -35,7 +38,13 @@ def _item_context(comment: Comment) -> dict:
 def _content_chunk(content: str, *, limit: int, offset: int = 0) -> tuple[str, int | None]:
     encoded = content.encode("utf-8")
     end = min(len(encoded), offset + limit)
-    chunk = encoded[offset:end].decode("utf-8", errors="ignore")
+    while end > offset and end < len(encoded) and encoded[end] & 0b11000000 == 0b10000000:
+        end -= 1
+    if end == offset and offset < len(encoded) and limit > 0:
+        end += 1
+        while end < len(encoded) and encoded[end] & 0b11000000 == 0b10000000:
+            end += 1
+    chunk = encoded[offset:end].decode("utf-8")
     return chunk, end if end < len(encoded) else None
 
 
@@ -53,8 +62,14 @@ def _bounded_anchor(comment: Comment) -> dict | None:
     bounded = {"kind": kind}
     allowed_fields = allowed_fields_by_kind[kind]
     for field in allowed_fields:
-        if field in anchor:
-            bounded[field] = anchor[field]
+        if field not in anchor:
+            continue
+        value = anchor[field]
+        bounded[field] = (
+            _content_chunk(value, limit=ANCHOR_CONTEXT_BYTES)[0]
+            if field in {"prefix", "suffix"} and isinstance(value, str)
+            else value
+        )
     if kind == "text" and isinstance(anchor.get("quote"), str):
         bounded["quote"] = _content_chunk(anchor["quote"], limit=ANCHOR_QUOTE_BYTES)[0]
     return bounded
@@ -103,6 +118,28 @@ def _human_replies(queryset: QuerySet[Comment]) -> QuerySet[Comment]:
         | ~Q(item_context__has_key="threadState")
         | ~Q(item_context__threadState__in=COMMENT_STATES)
     )
+
+
+def _with_bounded_content(queryset: QuerySet[Comment]) -> QuerySet[Comment]:
+    return queryset.defer("content", "rich_content").annotate(
+        preview_content=Left(
+            Coalesce("content", Value("", output_field=TextField()), output_field=TextField()),
+            LIST_THREAD_CONTENT_LIMIT_CHARS,
+        ),
+        preview_content_length=Length(
+            Coalesce("content", Value("", output_field=TextField()), output_field=TextField())
+        ),
+    )
+
+
+def _preview_content(comment: Comment) -> str:
+    value = getattr(comment, "preview_content", None)
+    return value if isinstance(value, str) else (comment.content or "")
+
+
+def _preview_content_length(comment: Comment) -> int | None:
+    value = getattr(comment, "preview_content_length", None)
+    return value if isinstance(value, int) else None
 
 
 def _encode_cursor(created_at: datetime, comment_id: UUID) -> str:
@@ -262,7 +299,7 @@ def list_comments(
             batch_qs = batch_qs.filter(Q(created_at__lt=before) | Q(created_at=before, id__lt=before_id))
         remaining = limit - len(result)
         if include_thread:
-            batch_qs = batch_qs.select_related("created_by")
+            batch_qs = _with_bounded_content(batch_qs.select_related("created_by"))
         batch = list(batch_qs.order_by("-created_at", "-id")[: remaining + 1])
         has_more = len(batch) > remaining
         roots = batch[:remaining]
@@ -288,7 +325,7 @@ def list_comments(
         replies_by_root: dict[UUID, list[Comment]] = defaultdict(list)
         if include_thread:
             preview_replies = (
-                human_replies.select_related("created_by")
+                _with_bounded_content(human_replies.select_related("created_by"))
                 .annotate(
                     thread_row=Window(
                         expression=RowNumber(),
@@ -307,7 +344,8 @@ def list_comments(
             resolved = _resolved(root, latest_states.get(root.id))
             if resolved and not include_resolved:
                 continue
-            content, content_next_offset = _content_chunk(root.content or "", limit=LIST_CONTENT_BYTES)
+            root_content = _preview_content(root) if include_thread else (root.content or "")
+            content, content_next_offset = _content_chunk(root_content, limit=LIST_CONTENT_BYTES)
             anchor = _item_context(root).get("anchor")
             selected_text = anchor.get("quote") if isinstance(anchor, dict) else None
             if isinstance(selected_text, str):
@@ -319,12 +357,28 @@ def list_comments(
             comments_truncated = False
             if include_thread:
                 thread_comments = []
-                for comment in [root, *replies_by_root[root.id]]:
-                    entry = _entry(comment, content_budget=max(remaining_thread_content_bytes, 0))
-                    remaining_thread_content_bytes -= len(entry.content.encode("utf-8"))
+                preview_models = [root, *replies_by_root[root.id]]
+                for comment in preview_models:
+                    anchor_bytes = len(
+                        json.dumps(_bounded_anchor(comment), separators=(",", ":"), default=str).encode("utf-8")
+                    )
+                    if remaining_thread_content_bytes <= anchor_bytes:
+                        comments_truncated = True
+                        break
+                    entry = _entry(
+                        comment,
+                        content_budget=remaining_thread_content_bytes - anchor_bytes,
+                        content_override=_preview_content(comment),
+                        original_content_length=_preview_content_length(comment),
+                    )
+                    remaining_thread_content_bytes -= anchor_bytes + len(entry.content.encode("utf-8"))
                     comments_truncated = comments_truncated or entry.content_truncated
                     thread_comments.append(entry)
-                comments_truncated = comments_truncated or reply_count > len(replies_by_root[root.id])
+                comments_truncated = (
+                    comments_truncated
+                    or len(thread_comments) < len(preview_models)
+                    or reply_count > len(replies_by_root[root.id])
+                )
             result.append(
                 contracts.TaskCommentSummaryDTO(
                     id=root.id,
@@ -351,11 +405,12 @@ def list_comments(
 
 def count_open_comments(*, team_id: int, task_id: UUID) -> contracts.TaskCommentCountsDTO:
     comments_qs = _comments(team_id, task_id)
-    roots = list(comments_qs.filter(source_comment_id__isnull=True))
+    roots = list(comments_qs.filter(source_comment_id__isnull=True).values_list("id", "item_id", "completed_at"))
     latest_states = {
         source_comment_id: item_context.get("threadState")
         for source_comment_id, item_context in comments_qs.filter(
-            source_comment_id__in=[root.id for root in roots], item_context__threadState__in=COMMENT_STATES
+            source_comment_id__in=[root_id for root_id, _, _ in roots],
+            item_context__threadState__in=COMMENT_STATES,
         )
         .order_by("source_comment_id", "-created_at", "-id")
         .distinct("source_comment_id")
@@ -363,9 +418,11 @@ def count_open_comments(*, team_id: int, task_id: UUID) -> contracts.TaskComment
         if isinstance(item_context, dict)
     }
     counts: dict[str, int] = defaultdict(int)
-    for root in roots:
-        if root.item_id and not _resolved(root, latest_states.get(root.id)):
-            counts[root.item_id] += 1
+    for root_id, item_id, completed_at in roots:
+        latest_state = latest_states.get(root_id)
+        resolved = latest_state == "resolved" if latest_state is not None else completed_at is not None
+        if item_id and not resolved:
+            counts[item_id] += 1
     return contracts.TaskCommentCountsDTO(
         counts=[
             contracts.TaskCommentCountDTO(item_id=item_id, count=count) for item_id, count in sorted(counts.items())
@@ -373,10 +430,24 @@ def count_open_comments(*, team_id: int, task_id: UUID) -> contracts.TaskComment
     )
 
 
-def _entry(comment: Comment, *, content_budget: int, content_offset: int = 0) -> contracts.TaskCommentEntryDTO:
+def _entry(
+    comment: Comment,
+    *,
+    content_budget: int,
+    content_offset: int = 0,
+    content_override: str | None = None,
+    original_content_length: int | None = None,
+) -> contracts.TaskCommentEntryDTO:
     creator = comment.created_by
     author = " ".join(filter(None, [creator.first_name, creator.last_name])) or None if creator is not None else None
-    content, content_next_offset = _content_chunk(comment.content or "", limit=content_budget, offset=content_offset)
+    source_content = content_override if content_override is not None else (comment.content or "")
+    content, content_next_offset = _content_chunk(source_content, limit=content_budget, offset=content_offset)
+    if (
+        content_next_offset is None
+        and original_content_length is not None
+        and original_content_length > len(source_content)
+    ):
+        content_next_offset = len(source_content.encode("utf-8"))
     return contracts.TaskCommentEntryDTO(
         id=comment.id,
         content=content,

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -1891,6 +1891,11 @@ class TaskCommentsQuerySerializer(serializers.Serializer):
         default=False,
         help_text="Whether to include resolved comment threads.",
     )
+    include_thread = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text="Whether to include a bounded root-and-replies preview for each thread.",
+    )
     limit = serializers.IntegerField(
         required=False,
         default=50,
@@ -1939,22 +1944,6 @@ class TaskCommentTargetSerializer(serializers.Serializer):
     name = serializers.CharField(help_text="Display name of the comment target.")
 
 
-class TaskCommentSummarySerializer(serializers.Serializer):
-    id = serializers.UUIDField(help_text="Root comment id.")
-    target = TaskCommentTargetSerializer(help_text="Task, artifact, or canvas receiving the comment.")
-    content = serializers.CharField(help_text="Bounded excerpt of the root comment body.")
-    content_truncated = serializers.BooleanField(help_text="Whether the root comment body has more content.")
-    selected_text = serializers.CharField(allow_null=True, help_text="Text selected when the comment was created.")
-    created_at = serializers.DateTimeField(help_text="When the root comment was created.")
-    reply_count = serializers.IntegerField(help_text="Number of human replies.")
-    resolved = serializers.BooleanField(help_text="Whether the comment is resolved.")
-
-
-class TaskCommentsResponseSerializer(serializers.Serializer):
-    comments = TaskCommentSummarySerializer(many=True, help_text="Root comments, newest first.")
-    next = serializers.CharField(allow_null=True, help_text="Opaque cursor for the next page, or null.")
-
-
 class TaskCommentAnchorSerializer(serializers.Serializer):
     kind = serializers.CharField(required=False, help_text="Anchor kind.")
     quote = serializers.CharField(required=False, help_text="Selected text.")
@@ -1977,9 +1966,42 @@ class TaskCommentEntrySerializer(serializers.Serializer):
         help_text="Byte offset for the next body chunk, or null when complete.",
     )
     author = serializers.CharField(allow_null=True, help_text="Comment author's display name.")
+    created_by_id = serializers.IntegerField(allow_null=True, help_text="Comment author id, or null if deleted.")
     created_at = serializers.DateTimeField(help_text="When the comment was created.")
     anchor = TaskCommentAnchorSerializer(allow_null=True, help_text="Normalized text or document anchor.")
     canvas_version_id = serializers.CharField(allow_null=True, help_text="Canvas version receiving the comment.")
+
+
+class TaskCommentSummarySerializer(serializers.Serializer):
+    id = serializers.UUIDField(help_text="Root comment id.")
+    target = TaskCommentTargetSerializer(help_text="Task, artifact, or canvas receiving the comment.")
+    content = serializers.CharField(help_text="Bounded excerpt of the root comment body.")
+    content_truncated = serializers.BooleanField(help_text="Whether the root comment body has more content.")
+    selected_text = serializers.CharField(allow_null=True, help_text="Text selected when the comment was created.")
+    created_at = serializers.DateTimeField(help_text="When the root comment was created.")
+    last_activity_at = serializers.DateTimeField(help_text="When the latest visible reply was created.")
+    reply_count = serializers.IntegerField(help_text="Number of human replies.")
+    resolved = serializers.BooleanField(help_text="Whether the comment is resolved.")
+    comments = TaskCommentEntrySerializer(
+        many=True,
+        allow_null=True,
+        help_text="Bounded root-and-replies preview, or null when not requested.",
+    )
+    comments_truncated = serializers.BooleanField(help_text="Whether the preview omits content or replies.")
+
+
+class TaskCommentsResponseSerializer(serializers.Serializer):
+    comments = TaskCommentSummarySerializer(many=True, help_text="Root comments, newest first.")
+    next = serializers.CharField(allow_null=True, help_text="Opaque cursor for the next page, or null.")
+
+
+class TaskCommentCountSerializer(serializers.Serializer):
+    item_id = serializers.CharField(help_text="Task, artifact, or canvas id.")
+    count = serializers.IntegerField(help_text="Number of open comment threads.")
+
+
+class TaskCommentCountsResponseSerializer(serializers.Serializer):
+    counts = TaskCommentCountSerializer(many=True, help_text="Open thread counts grouped by target id.")
 
 
 class TaskCommentDetailSerializer(serializers.Serializer):

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -395,10 +395,14 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         params = TaskCommentsQuerySerializer(data=request.query_params)
         params.is_valid(raise_exception=True)
         task_id = self._comment_task_id(request, pk)
+        visible_canvas_ids = tasks_facade.visible_task_canvas_ids(
+            team_id=self.team_id, task_id=task_id, user_id=self._user_id()
+        )
         try:
             page = tasks_facade.list_task_comments(
                 team_id=self.team_id,
                 task_id=task_id,
+                visible_canvas_ids=visible_canvas_ids,
                 artifact_id=params.validated_data.get("artifact_id"),
                 include_resolved=params.validated_data["include_resolved"],
                 include_thread=params.validated_data["include_thread"],
@@ -414,7 +418,12 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     @action(detail=True, methods=["get"], url_path="comments/counts", required_scopes=["comment:read"])
     def comment_counts(self, request, pk=None, **kwargs):
         task_id = self._comment_task_id(request, pk)
-        counts = tasks_facade.count_open_task_comments(team_id=self.team_id, task_id=task_id)
+        visible_canvas_ids = tasks_facade.visible_task_canvas_ids(
+            team_id=self.team_id, task_id=task_id, user_id=self._user_id()
+        )
+        counts = tasks_facade.count_open_task_comments(
+            team_id=self.team_id, task_id=task_id, visible_canvas_ids=visible_canvas_ids
+        )
         return Response(TaskCommentCountsResponseSerializer(counts).data)
 
     @extend_schema(
@@ -432,6 +441,9 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         params = TaskCommentDetailQuerySerializer(data=request.query_params)
         params.is_valid(raise_exception=True)
         task_id = self._comment_task_id(request, pk)
+        visible_canvas_ids = tasks_facade.visible_task_canvas_ids(
+            team_id=self.team_id, task_id=task_id, user_id=self._user_id()
+        )
         try:
             parsed_comment_id = UUID(root_comment_id)
         except (TypeError, ValueError):
@@ -440,6 +452,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             comment = tasks_facade.retrieve_task_comment(
                 team_id=self.team_id,
                 task_id=task_id,
+                visible_canvas_ids=visible_canvas_ids,
                 comment_id=parsed_comment_id,
                 limit=params.validated_data["limit"],
                 cursor=params.validated_data.get("cursor"),

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -97,6 +97,7 @@ from products.tasks.backend.presentation.serializers import (
     TaskArtifactsResponseSerializer,
     TaskAutomationSerializer,
     TaskAutomationWriteSerializer,
+    TaskCommentCountsResponseSerializer,
     TaskCommentDetailQuerySerializer,
     TaskCommentDetailSerializer,
     TaskCommentsQuerySerializer,
@@ -311,6 +312,17 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             raise NotFound()
         return parsed_task_id
 
+    def _comment_task_id(self, request, task_id: str) -> UUID:
+        if isinstance(request.successful_authenticator, OAuthAccessTokenAuthentication):
+            return self._sandbox_bound_task_id(request, task_id)
+        try:
+            parsed_task_id = UUID(task_id)
+        except ValueError:
+            raise NotFound()
+        if not tasks_facade.task_visible(parsed_task_id, self.team_id, self._user_id()):
+            raise NotFound()
+        return parsed_task_id
+
     def _write_serializer(
         self,
         data,
@@ -382,13 +394,15 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     def comments(self, request, pk=None, **kwargs):
         params = TaskCommentsQuerySerializer(data=request.query_params)
         params.is_valid(raise_exception=True)
-        task_id = self._sandbox_bound_task_id(request, pk)
+        task_id = self._comment_task_id(request, pk)
         try:
             page = tasks_facade.list_task_comments(
                 team_id=self.team_id,
                 task_id=task_id,
+                user_id=self._user_id(),
                 artifact_id=params.validated_data.get("artifact_id"),
                 include_resolved=params.validated_data["include_resolved"],
+                include_thread=params.validated_data["include_thread"],
                 limit=params.validated_data["limit"],
                 cursor=params.validated_data.get("cursor"),
             )
@@ -397,18 +411,28 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         data = TaskCommentsResponseSerializer(page).data
         return Response(data)
 
+    @extend_schema(operation_id="tasks_comments_counts", responses=TaskCommentCountsResponseSerializer)
+    @action(detail=True, methods=["get"], url_path="comments/counts", required_scopes=["comment:read"])
+    def comment_counts(self, request, pk=None, **kwargs):
+        task_id = self._comment_task_id(request, pk)
+        counts = tasks_facade.count_open_task_comments(team_id=self.team_id, task_id=task_id, user_id=self._user_id())
+        return Response(TaskCommentCountsResponseSerializer(counts).data)
+
     @extend_schema(
         operation_id="tasks_comments_retrieve",
         parameters=[OpenApiParameter("root_comment_id", UUID, OpenApiParameter.PATH), TaskCommentDetailQuerySerializer],
         responses=TaskCommentDetailSerializer,
     )
     @action(
-        detail=True, methods=["get"], url_path=r"comments/(?P<root_comment_id>[^/.]+)", required_scopes=["comment:read"]
+        detail=True,
+        methods=["get"],
+        url_path=r"comments/(?P<root_comment_id>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})",
+        required_scopes=["comment:read"],
     )
     def comment(self, request, pk=None, root_comment_id=None, **kwargs):
         params = TaskCommentDetailQuerySerializer(data=request.query_params)
         params.is_valid(raise_exception=True)
-        task_id = self._sandbox_bound_task_id(request, pk)
+        task_id = self._comment_task_id(request, pk)
         try:
             parsed_comment_id = UUID(root_comment_id)
         except (TypeError, ValueError):
@@ -417,6 +441,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             comment = tasks_facade.retrieve_task_comment(
                 team_id=self.team_id,
                 task_id=task_id,
+                user_id=self._user_id(),
                 comment_id=parsed_comment_id,
                 limit=params.validated_data["limit"],
                 cursor=params.validated_data.get("cursor"),

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -399,7 +399,6 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             page = tasks_facade.list_task_comments(
                 team_id=self.team_id,
                 task_id=task_id,
-                user_id=self._user_id(),
                 artifact_id=params.validated_data.get("artifact_id"),
                 include_resolved=params.validated_data["include_resolved"],
                 include_thread=params.validated_data["include_thread"],
@@ -415,7 +414,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     @action(detail=True, methods=["get"], url_path="comments/counts", required_scopes=["comment:read"])
     def comment_counts(self, request, pk=None, **kwargs):
         task_id = self._comment_task_id(request, pk)
-        counts = tasks_facade.count_open_task_comments(team_id=self.team_id, task_id=task_id, user_id=self._user_id())
+        counts = tasks_facade.count_open_task_comments(team_id=self.team_id, task_id=task_id)
         return Response(TaskCommentCountsResponseSerializer(counts).data)
 
     @extend_schema(
@@ -441,7 +440,6 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             comment = tasks_facade.retrieve_task_comment(
                 team_id=self.team_id,
                 task_id=task_id,
-                user_id=self._user_id(),
                 comment_id=parsed_comment_id,
                 limit=params.validated_data["limit"],
                 cursor=params.validated_data.get("cursor"),

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -2056,38 +2056,6 @@ export interface TaskCommentTargetApi {
     name: string
 }
 
-export interface TaskCommentSummaryApi {
-    /** Root comment id. */
-    id: string
-    /** Task, artifact, or canvas receiving the comment. */
-    target: TaskCommentTargetApi
-    /** Bounded excerpt of the root comment body. */
-    content: string
-    /** Whether the root comment body has more content. */
-    content_truncated: boolean
-    /**
-     * Text selected when the comment was created.
-     * @nullable
-     */
-    selected_text: string | null
-    /** When the root comment was created. */
-    created_at: string
-    /** Number of human replies. */
-    reply_count: number
-    /** Whether the comment is resolved. */
-    resolved: boolean
-}
-
-export interface TaskCommentsResponseApi {
-    /** Root comments, newest first. */
-    comments: TaskCommentSummaryApi[]
-    /**
-     * Opaque cursor for the next page, or null.
-     * @nullable
-     */
-    next: string | null
-}
-
 export interface TaskCommentAnchorApi {
     /** Anchor kind. */
     kind?: string
@@ -2150,6 +2118,11 @@ export interface TaskCommentEntryApi {
      * @nullable
      */
     author: string | null
+    /**
+     * Comment author id, or null if deleted.
+     * @nullable
+     */
+    created_by_id: number | null
     /** When the comment was created. */
     created_at: string
     /** Normalized text or document anchor. */
@@ -2159,6 +2132,47 @@ export interface TaskCommentEntryApi {
      * @nullable
      */
     canvas_version_id: string | null
+}
+
+export interface TaskCommentSummaryApi {
+    /** Root comment id. */
+    id: string
+    /** Task, artifact, or canvas receiving the comment. */
+    target: TaskCommentTargetApi
+    /** Bounded excerpt of the root comment body. */
+    content: string
+    /** Whether the root comment body has more content. */
+    content_truncated: boolean
+    /**
+     * Text selected when the comment was created.
+     * @nullable
+     */
+    selected_text: string | null
+    /** When the root comment was created. */
+    created_at: string
+    /** When the latest visible reply was created. */
+    last_activity_at: string
+    /** Number of human replies. */
+    reply_count: number
+    /** Whether the comment is resolved. */
+    resolved: boolean
+    /**
+     * Bounded root-and-replies preview, or null when not requested.
+     * @nullable
+     */
+    comments: TaskCommentEntryApi[] | null
+    /** Whether the preview omits content or replies. */
+    comments_truncated: boolean
+}
+
+export interface TaskCommentsResponseApi {
+    /** Root comments, newest first. */
+    comments: TaskCommentSummaryApi[]
+    /**
+     * Opaque cursor for the next page, or null.
+     * @nullable
+     */
+    next: string | null
 }
 
 export interface TaskCommentDetailApi {
@@ -2175,6 +2189,18 @@ export interface TaskCommentDetailApi {
      * @nullable
      */
     next: string | null
+}
+
+export interface TaskCommentCountApi {
+    /** Task, artifact, or canvas id. */
+    item_id: string
+    /** Number of open comment threads. */
+    count: number
+}
+
+export interface TaskCommentCountsResponseApi {
+    /** Open thread counts grouped by target id. */
+    counts: TaskCommentCountApi[]
 }
 
 export interface TaskPinRequestApi {
@@ -4290,6 +4316,10 @@ export type TasksCommentsListParams = {
      * Whether to include resolved comment threads.
      */
     include_resolved?: boolean
+    /**
+     * Whether to include a bounded root-and-replies preview for each thread.
+     */
+    include_thread?: boolean
     /**
      * Maximum number of root comments to return.
      * @minimum 1

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -73,6 +73,7 @@ import type {
     TaskAutomationsListParams,
     TaskChannelsFeedListParams,
     TaskChannelsListParams,
+    TaskCommentCountsResponseApi,
     TaskCommentDetailApi,
     TaskCommentsResponseApi,
     TaskCreateApi,
@@ -1411,6 +1412,24 @@ export const tasksCommentsRetrieve = async (
     options?: RequestInit
 ): Promise<TaskCommentDetailApi> => {
     return apiMutator<TaskCommentDetailApi>(getTasksCommentsRetrieveUrl(projectId, id, rootCommentId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getTasksCommentsCountsUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/tasks/${id}/comments/counts/`
+}
+
+/**
+ * API for managing tasks within a project. Tasks represent units of work to be performed by an agent.
+ */
+export const tasksCommentsCounts = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<TaskCommentCountsResponseApi> => {
+    return apiMutator<TaskCommentCountsResponseApi>(getTasksCommentsCountsUrl(projectId, id), {
         ...options,
         method: 'GET',
     })

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -314,6 +314,9 @@ tools:
     tasks-artifacts-list:
         operation: tasks_artifacts_list
         enabled: false
+    tasks-comments-counts:
+        operation: tasks_comments_counts
+        enabled: false
     tasks-comments-list:
         operation: tasks_comments_list
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -73949,6 +73949,18 @@ export namespace Schemas {
       height?: number;
     }
 
+    export interface TaskCommentCount {
+      /** Task, artifact, or canvas id. */
+      item_id: string;
+      /** Number of open comment threads. */
+      count: number;
+    }
+
+    export interface TaskCommentCountsResponse {
+      /** Open thread counts grouped by target id. */
+      counts: TaskCommentCount[];
+    }
+
     export interface TaskCommentTarget {
       /** Stable target id. */
       id: string;
@@ -73975,6 +73987,11 @@ export namespace Schemas {
          * @nullable
          */
       author: string | null;
+      /**
+         * Comment author id, or null if deleted.
+         * @nullable
+         */
+      created_by_id: number | null;
       /** When the comment was created. */
       created_at: string;
       /** Normalized text or document anchor. */
@@ -74018,10 +74035,19 @@ export namespace Schemas {
       selected_text: string | null;
       /** When the root comment was created. */
       created_at: string;
+      /** When the latest visible reply was created. */
+      last_activity_at: string;
       /** Number of human replies. */
       reply_count: number;
       /** Whether the comment is resolved. */
       resolved: boolean;
+      /**
+         * Bounded root-and-replies preview, or null when not requested.
+         * @nullable
+         */
+      comments: TaskCommentEntry[] | null;
+      /** Whether the preview omits content or replies. */
+      comments_truncated: boolean;
     }
 
     export interface TaskCommentsResponse {
@@ -87480,6 +87506,10 @@ export namespace Schemas {
      * Whether to include resolved comment threads.
      */
     include_resolved?: boolean;
+    /**
+     * Whether to include a bounded root-and-replies preview for each thread.
+     */
+    include_thread?: boolean;
     /**
      * Maximum number of root comments to return.
      * @minimum 1


### PR DESCRIPTION
## Problem

Desktop users need one bounded task-wide comment read instead of one request per artifact or canvas.

The existing task comments API only accepts sandbox-bound agent tokens, so the desktop cannot use its aggregate safely.

## Changes

- Allow session and personal API key callers to read comments on visible tasks.
- Keep sandbox tokens bound to their current task.
- Return an optional bounded thread preview from the existing task comments endpoint.
- Add open thread counts grouped by target for artifact badges.
- Keep the generic comments API unchanged.

This PR has no visible UI changes.

## How did you test this code?

- Extended the comments API tests to cover desktop access, private tasks, thread previews, and grouped counts.
- Ran the four affected database-backed API cases locally.
- Ran Ruff, Tach, OpenAPI generation, and `hogli ci:preflight --fix`.
- Repository-wide mypy exceeded the development VM memory limit and exited with code 137.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The generated OpenAPI schema documents the additive request and response fields. Existing MCP behavior remains unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

GPT-5.6 implemented this change with pi. It used `/stacking-prs`, `/improving-drf-endpoints`, `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, and `/writing-pr-descriptions`.

The design reuses the existing task-owned read API instead of extending the generic comments endpoint. The committed fixtures contain only invented data.
