### PR TITLE
feat(desktop): support Agent Plugin HTTP MCP

### DIFF
--- a/products/desktop/apps/code/src/main/di/bindings.ts
+++ b/products/desktop/apps/code/src/main/di/bindings.ts
@@ -144,7 +144,11 @@ import type {
   AGENT_SLEEP_COORDINATOR,
 } from "@posthog/workspace-server/services/agent/identifiers";
 import type { AgentPluginsService } from "@posthog/workspace-server/services/agent-plugins/agent-plugins";
-import type { AGENT_PLUGINS_SERVICE } from "@posthog/workspace-server/services/agent-plugins/identifiers";
+import type { AgentPluginHttpProxy } from "@posthog/workspace-server/services/agent-plugins/http-proxy";
+import type {
+  AGENT_PLUGIN_HTTP_PROXY,
+  AGENT_PLUGINS_SERVICE,
+} from "@posthog/workspace-server/services/agent-plugins/identifiers";
 import type {
   ARCHIVE_FILE_WATCHER,
   ARCHIVE_SESSION_CANCELLER,
@@ -517,6 +521,7 @@ export interface MainBindings {
   [FS_SERVICE]: FsCapability;
 
   // Typed container.get-only tokens (bound via loaded modules)
+  [AGENT_PLUGIN_HTTP_PROXY]: AgentPluginHttpProxy;
   [AGENT_PLUGINS_SERVICE]: AgentPluginsService;
   [AGENT_SERVICE]: AgentService;
   [OAUTH_SERVICE]: OAuthService;

--- a/products/desktop/docs/AGENT-PLUGINS.md
+++ b/products/desktop/docs/AGENT-PLUGINS.md
@@ -53,7 +53,7 @@ Streamable HTTP MCP servers use the canonical MCP schema:
 }
 ```
 
-Invalid MCP configuration does not disable valid skills. Each server is validated independently, so one invalid or unsupported server does not disable its valid siblings. PostHog Desktop sends configured headers only to the server's original origin when following redirects.
+Invalid MCP configuration does not disable valid skills. Each server is validated independently, so one invalid or unsupported server does not disable its valid siblings. PostHog Desktop follows same-origin redirects only. Configured header values stay in the privileged plugin loader and are not stored in the installation registry or returned to the app UI.
 
 ## Current limitations
 

--- a/products/desktop/docs/AGENT-PLUGINS.md
+++ b/products/desktop/docs/AGENT-PLUGINS.md
@@ -53,7 +53,7 @@ Streamable HTTP MCP servers use the canonical MCP schema:
 }
 ```
 
-Invalid MCP configuration does not disable valid skills. Each server is validated independently, so one invalid or unsupported server does not disable its valid siblings. PostHog Desktop follows same-origin redirects only. Configured header values stay in the privileged plugin loader and are not stored in the installation registry or returned to the app UI.
+Invalid MCP configuration does not disable valid skills. Each server is validated independently, so one invalid or unsupported server does not disable its valid siblings. PostHog Desktop reads up to 1 MiB from `mcp.json`. The loopback proxy accepts request bodies up to 2 MiB and returns an HTTP 413 response for larger requests. PostHog Desktop follows same-origin redirects only. Configured header values stay in the privileged plugin loader and are not stored in the installation registry or returned to the app UI.
 
 ## Current limitations
 

--- a/products/desktop/docs/AGENT-PLUGINS.md
+++ b/products/desktop/docs/AGENT-PLUGINS.md
@@ -39,6 +39,22 @@ Each skill must follow the [Agent Skills specification](https://agentskills.io/s
 
 Session snapshots are limited to 256 files and 8 MiB per skill, with a 1 MiB limit for each file. A plugin can contribute up to 1,024 files and 32 MiB across its skill snapshots. Skills that exceed these limits are skipped.
 
+Streamable HTTP MCP servers use the canonical MCP schema:
+
+```json
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "example": {
+      "type": "streamable-http",
+      "url": "https://mcp.example.com/mcp"
+    }
+  }
+}
+```
+
+Invalid MCP configuration does not disable valid skills. Each server is validated independently, so one invalid or unsupported server does not disable its valid siblings. PostHog Desktop sends configured headers only to the server's original origin when following redirects.
+
 ## Current limitations
 
 - Only local directory installation is available.

--- a/products/desktop/packages/core/src/agent-plugins/agentPluginsClient.ts
+++ b/products/desktop/packages/core/src/agent-plugins/agentPluginsClient.ts
@@ -27,11 +27,10 @@ export interface AgentPluginSkill {
   path: string;
 }
 
-export interface AgentPluginHttpMcpServer {
+export interface AgentPluginMcpServerSummary {
   name: string;
-  type: "streamable-http";
-  url: string;
-  headers?: Record<string, string>;
+  type: "streamable-http" | "stdio" | "sse";
+  supported: boolean;
 }
 
 export interface AgentPluginPreview {
@@ -39,7 +38,7 @@ export interface AgentPluginPreview {
   sourcePath: string;
   manifest: AgentPluginManifest | null;
   skills: AgentPluginSkill[];
-  mcpServers: AgentPluginHttpMcpServer[];
+  mcpServers: AgentPluginMcpServerSummary[];
   diagnostics: AgentPluginDiagnostic[];
   selectionToken?: string;
 }
@@ -50,7 +49,7 @@ export interface AgentPluginInstallation {
   enabled: boolean;
   manifest: AgentPluginManifest;
   skills: AgentPluginSkill[];
-  mcpServers: AgentPluginHttpMcpServer[];
+  mcpServers: AgentPluginMcpServerSummary[];
   diagnostics: AgentPluginDiagnostic[];
 }
 

--- a/products/desktop/packages/core/src/agent-plugins/agentPluginsClient.ts
+++ b/products/desktop/packages/core/src/agent-plugins/agentPluginsClient.ts
@@ -27,11 +27,19 @@ export interface AgentPluginSkill {
   path: string;
 }
 
+export interface AgentPluginHttpMcpServer {
+  name: string;
+  type: "streamable-http";
+  url: string;
+  headers?: Record<string, string>;
+}
+
 export interface AgentPluginPreview {
   valid: boolean;
   sourcePath: string;
   manifest: AgentPluginManifest | null;
   skills: AgentPluginSkill[];
+  mcpServers: AgentPluginHttpMcpServer[];
   diagnostics: AgentPluginDiagnostic[];
   selectionToken?: string;
 }
@@ -42,6 +50,7 @@ export interface AgentPluginInstallation {
   enabled: boolean;
   manifest: AgentPluginManifest;
   skills: AgentPluginSkill[];
+  mcpServers: AgentPluginHttpMcpServer[];
   diagnostics: AgentPluginDiagnostic[];
 }
 

--- a/products/desktop/packages/core/src/agent-plugins/agentPluginsClient.ts
+++ b/products/desktop/packages/core/src/agent-plugins/agentPluginsClient.ts
@@ -30,7 +30,6 @@ export interface AgentPluginSkill {
 export interface AgentPluginMcpServerSummary {
   name: string;
   type: "streamable-http" | "stdio" | "sse";
-  supported: boolean;
 }
 
 export interface AgentPluginPreview {

--- a/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.test.tsx
+++ b/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.test.tsx
@@ -80,6 +80,7 @@ describe("AgentPluginsView", () => {
             name: "example-plugin",
           },
           skills: [],
+          mcpServers: [],
           diagnostics: [
             {
               severity: "error",

--- a/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.tsx
+++ b/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.tsx
@@ -57,8 +57,8 @@ export function AgentPluginsView(): ReactElement {
           <div className="flex flex-col gap-1">
             <Text weight="semibold">Agent Plugins</Text>
             <Text size="sm" variant="muted">
-              Add local Agent Plugins that provide portable skills. MCP servers
-              are not supported yet.
+              Add local Agent Plugins that provide portable skills and
+              Streamable HTTP MCP servers.
             </Text>
           </div>
           <Button
@@ -93,15 +93,27 @@ export function AgentPluginsView(): ReactElement {
                 {preview.manifest?.description && (
                   <Text size="sm">{preview.manifest.description}</Text>
                 )}
-                <div className="flex flex-wrap gap-2">
-                  {preview.skills.map((skill) => (
-                    <Badge key={skill.path}>{skill.name}</Badge>
-                  ))}
-                  {preview.skills.length === 0 && (
-                    <Text size="sm" variant="muted">
-                      No valid skills found
-                    </Text>
-                  )}
+                <div className="flex flex-col gap-2">
+                  <Text size="xs" variant="muted">
+                    {preview.skills.length} valid skill
+                    {preview.skills.length === 1 ? "" : "s"}
+                  </Text>
+                  <div className="flex flex-wrap gap-2">
+                    {preview.skills.map((skill) => (
+                      <Badge key={skill.path}>{skill.name}</Badge>
+                    ))}
+                  </div>
+                  <Text size="xs" variant="muted">
+                    {preview.mcpServers.length} Streamable HTTP MCP server
+                    {preview.mcpServers.length === 1 ? "" : "s"}
+                  </Text>
+                  <div className="flex flex-wrap gap-2">
+                    {preview.mcpServers.map((server) => (
+                      <Badge key={server.name} variant="info">
+                        {server.name}
+                      </Badge>
+                    ))}
+                  </div>
                 </div>
                 {preview.diagnostics.length > 0 && (
                   <div className="flex flex-col gap-2 rounded-md border border-border p-3">
@@ -198,8 +210,10 @@ export function AgentPluginsView(): ReactElement {
                           variant="muted"
                           className="block break-all"
                         >
-                          {plugin.skills.length} valid skill
-                          {plugin.skills.length === 1 ? "" : "s"} from{" "}
+                          {plugin.skills.length} skill
+                          {plugin.skills.length === 1 ? "" : "s"} and{" "}
+                          {plugin.mcpServers.length} MCP server
+                          {plugin.mcpServers.length === 1 ? "" : "s"} from{" "}
                           {plugin.sourcePath}
                         </Text>
                       </div>
@@ -262,8 +276,8 @@ export function AgentPluginsView(): ReactElement {
               </EmptyMedia>
               <EmptyTitle>No Agent Plugins added</EmptyTitle>
               <EmptyDescription>
-                Choose a local plugin directory to make its valid skills
-                available to agents.
+                Choose a local plugin directory to make its valid skills and MCP
+                servers available to agents.
               </EmptyDescription>
             </EmptyHeader>
           </Empty>

--- a/products/desktop/packages/ui/src/features/agent-plugins/useAgentPlugins.test.tsx
+++ b/products/desktop/packages/ui/src/features/agent-plugins/useAgentPlugins.test.tsx
@@ -42,6 +42,7 @@ describe("useAgentPlugins", () => {
       enabled: false,
       manifest: { $schema: "schema", name: "example" },
       skills: [],
+      mcpServers: [],
       diagnostics: [],
     });
     const wrapper = ({ children }: { children: ReactNode }) => (

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.module.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.module.ts
@@ -1,7 +1,11 @@
 import { ContainerModule } from "inversify";
 import { AgentPluginsService } from "./agent-plugins";
-import { AGENT_PLUGINS_SERVICE } from "./identifiers";
+import { AgentPluginHttpProxyService } from "./http-proxy";
+import { AGENT_PLUGIN_HTTP_PROXY, AGENT_PLUGINS_SERVICE } from "./identifiers";
 
 export const agentPluginsModule = new ContainerModule(({ bind }) => {
+  bind(AGENT_PLUGIN_HTTP_PROXY)
+    .to(AgentPluginHttpProxyService)
+    .inSingletonScope();
   bind(AGENT_PLUGINS_SERVICE).to(AgentPluginsService).inSingletonScope();
 });

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
@@ -6,7 +6,10 @@ import {
   AgentPluginsService,
   agentPluginRuntimeMcpName,
 } from "./agent-plugins";
-import type { AgentPluginHttpProxy } from "./http-proxy";
+import type {
+  AgentPluginHttpProxy,
+  AgentPluginHttpProxyRegistration,
+} from "./http-proxy";
 import { loadAgentPlugin } from "./loader";
 import {
   AGENT_PLUGINS_MANIFEST_SCHEMA,
@@ -72,6 +75,53 @@ function createHttpProxy(): AgentPluginHttpProxy {
     register: vi.fn(async ({ id }: { id: string }) => `http://127.0.0.1/${id}`),
     unregisterRun: vi.fn(),
     unregisterInstallation: vi.fn(),
+  };
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve = (): void => {};
+  const promise = new Promise<void>((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
+}
+
+function createDeferredHttpProxy(): {
+  proxy: AgentPluginHttpProxy;
+  active: Map<string, AgentPluginHttpProxyRegistration>;
+  registrationStarted: Promise<void>;
+  releaseRegistration: () => void;
+} {
+  const active = new Map<string, AgentPluginHttpProxyRegistration>();
+  const started = deferred();
+  const release = deferred();
+  let registrationCount = 0;
+  const proxy: AgentPluginHttpProxy = {
+    register: vi.fn(async (registration) => {
+      registrationCount += 1;
+      if (registrationCount === 1) {
+        started.resolve();
+        await release.promise;
+      }
+      active.set(registration.id, registration);
+      return `http://127.0.0.1/${registration.id}`;
+    }),
+    unregisterRun: vi.fn((runId) => {
+      for (const [id, registration] of active) {
+        if (registration.runId === runId) active.delete(id);
+      }
+    }),
+    unregisterInstallation: vi.fn((installationId) => {
+      for (const [id, registration] of active) {
+        if (registration.installationId === installationId) active.delete(id);
+      }
+    }),
+  };
+  return {
+    proxy,
+    active,
+    registrationStarted: started.promise,
+    releaseRegistration: release.resolve,
   };
 }
 
@@ -858,5 +908,103 @@ describe("Agent Plugins skills support", () => {
     expect(httpProxy.unregisterInstallation).toHaveBeenCalledWith(
       installation.id,
     );
+  });
+
+  it("serializes disable behind an in-flight MCP activation", async () => {
+    const pluginDirectory = path.join(root, "plugin-disable-race");
+    await writePlugin(pluginDirectory);
+    await writeMcp(pluginDirectory, {
+      analytics: {
+        type: "streamable-http",
+        url: "https://mcp.example.com/mcp",
+      },
+    });
+    const deferredProxy = createDeferredHttpProxy();
+    const service = createService(
+      path.join(root, "app-data-disable-race"),
+      [pluginDirectory],
+      deferredProxy.proxy,
+    );
+    const installation = await registerSelectedPlugin(service);
+
+    const activation = service.prepareRuntimeMcpServers("run-1", new Set());
+    await deferredProxy.registrationStarted;
+    const disable = service.setEnabled(installation.id, false);
+    expect(deferredProxy.proxy.unregisterInstallation).not.toHaveBeenCalled();
+
+    deferredProxy.releaseRegistration();
+    await activation;
+    await disable;
+
+    expect(deferredProxy.active.size).toBe(0);
+    expect(deferredProxy.proxy.unregisterInstallation).toHaveBeenCalledWith(
+      installation.id,
+    );
+    await expect(
+      service.prepareRuntimeMcpServers("run-2", new Set()),
+    ).resolves.toEqual([]);
+    expect(deferredProxy.proxy.register).toHaveBeenCalledTimes(1);
+  });
+
+  it("serializes removal behind an in-flight MCP activation", async () => {
+    const pluginDirectory = path.join(root, "plugin-remove-race");
+    await writePlugin(pluginDirectory);
+    await writeMcp(pluginDirectory, {
+      analytics: {
+        type: "streamable-http",
+        url: "https://mcp.example.com/mcp",
+      },
+    });
+    const deferredProxy = createDeferredHttpProxy();
+    const service = createService(
+      path.join(root, "app-data-remove-race"),
+      [pluginDirectory],
+      deferredProxy.proxy,
+    );
+    const installation = await registerSelectedPlugin(service);
+
+    const activation = service.prepareRuntimeMcpServers("run-1", new Set());
+    await deferredProxy.registrationStarted;
+    const removal = service.unregister(installation.id);
+    expect(deferredProxy.proxy.unregisterInstallation).not.toHaveBeenCalled();
+
+    deferredProxy.releaseRegistration();
+    await activation;
+    await removal;
+
+    expect(deferredProxy.active.size).toBe(0);
+    expect(deferredProxy.proxy.unregisterInstallation).toHaveBeenCalledWith(
+      installation.id,
+    );
+    await expect(service.list()).resolves.toEqual([]);
+  });
+
+  it("serializes concurrent MCP activations without leaking targets", async () => {
+    const pluginDirectory = path.join(root, "plugin-concurrent-race");
+    await writePlugin(pluginDirectory);
+    await writeMcp(pluginDirectory, {
+      analytics: {
+        type: "streamable-http",
+        url: "https://mcp.example.com/mcp",
+      },
+    });
+    const deferredProxy = createDeferredHttpProxy();
+    const service = createService(
+      path.join(root, "app-data-concurrent-race"),
+      [pluginDirectory],
+      deferredProxy.proxy,
+    );
+    await registerSelectedPlugin(service);
+
+    const first = service.prepareRuntimeMcpServers("run-1", new Set());
+    await deferredProxy.registrationStarted;
+    const second = service.prepareRuntimeMcpServers("run-1", new Set());
+    expect(deferredProxy.proxy.register).toHaveBeenCalledTimes(1);
+
+    deferredProxy.releaseRegistration();
+    await Promise.all([first, second]);
+
+    expect(deferredProxy.proxy.register).toHaveBeenCalledTimes(2);
+    expect(deferredProxy.active.size).toBe(1);
   });
 });

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
@@ -2,9 +2,16 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { AgentPluginsService } from "./agent-plugins";
+import {
+  AgentPluginsService,
+  agentPluginRuntimeMcpName,
+} from "./agent-plugins";
+import type { AgentPluginHttpProxy } from "./http-proxy";
 import { loadAgentPlugin } from "./loader";
-import { AGENT_PLUGINS_MANIFEST_SCHEMA } from "./schemas";
+import {
+  AGENT_PLUGINS_MANIFEST_SCHEMA,
+  AGENT_PLUGINS_MCP_SCHEMA,
+} from "./schemas";
 
 let root: string;
 
@@ -31,6 +38,21 @@ async function writeSparseFile(filePath: string, size: number): Promise<void> {
   }
 }
 
+async function writeMcp(
+  pluginDirectory: string,
+  mcpServers: Record<string, unknown>,
+  extra: Record<string, unknown> = {},
+): Promise<void> {
+  await fs.promises.writeFile(
+    path.join(pluginDirectory, "mcp.json"),
+    JSON.stringify({
+      $schema: AGENT_PLUGINS_MCP_SCHEMA,
+      mcpServers,
+      ...extra,
+    }),
+  );
+}
+
 async function writeSkill(
   pluginDirectory: string,
   name: string,
@@ -48,6 +70,10 @@ async function writeSkill(
 function createService(
   appDataPath: string,
   selectedPaths: string[] = [],
+  httpProxy: AgentPluginHttpProxy = {
+    register: async ({ id }) => `http://127.0.0.1/${id}`,
+    unregisterRun() {},
+  },
 ): AgentPluginsService {
   return new AgentPluginsService(
     {
@@ -62,6 +88,7 @@ function createService(
         return selectedPath ? [selectedPath] : [];
       },
     },
+    httpProxy,
   );
 }
 
@@ -631,5 +658,187 @@ describe("Agent Plugins skills support", () => {
     await expect(
       service.register(preview?.selectionToken ?? ""),
     ).rejects.toThrow("Choose the Agent Plugin directory again");
+  });
+
+  it("isolates a top-level MCP failure from valid skills", async () => {
+    const pluginDirectory = path.join(root, "plugin");
+    await writePlugin(pluginDirectory);
+    await writeSkill(pluginDirectory, "summarize");
+    await writeMcp(
+      pluginDirectory,
+      {
+        analytics: {
+          type: "streamable-http",
+          url: "https://mcp.example.com/mcp",
+        },
+      },
+      { unknown: true },
+    );
+
+    const preview = await loadAgentPlugin(pluginDirectory);
+
+    expect(preview.valid).toBe(true);
+    expect(preview.skills.map((skill) => skill.name)).toEqual(["summarize"]);
+    expect(preview.mcpServers).toEqual([]);
+    expect(preview.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "invalid_mcp_config" }),
+      ]),
+    );
+  });
+
+  it("isolates invalid and unsupported MCP entries from valid siblings", async () => {
+    const pluginDirectory = path.join(root, "plugin");
+    await writePlugin(pluginDirectory);
+    await writeMcp(pluginDirectory, {
+      valid: {
+        type: "streamable-http",
+        url: "https://mcp.example.com/mcp",
+      },
+      invalid: {
+        type: "streamable-http",
+        url: "http://mcp.example.com/mcp",
+      },
+      local: { type: "stdio", command: "node", args: ["server.js"] },
+      legacy: { type: "sse", url: "https://mcp.example.com/sse" },
+    });
+
+    const preview = await loadAgentPlugin(pluginDirectory);
+
+    expect(preview.mcpServers.map((server) => server.name)).toEqual(["valid"]);
+    expect(preview.diagnostics.map((item) => item.code)).toEqual(
+      expect.arrayContaining([
+        "invalid_mcp_server",
+        "unsupported_mcp_transport",
+        "unsupported_mcp_transport",
+      ]),
+    );
+  });
+
+  it.each([
+    ["HTTPS", "https://mcp.example.com/mcp", true],
+    ["localhost HTTP", "http://localhost:3000/mcp", true],
+    ["IPv4 loopback HTTP", "http://127.1.2.3:3000/mcp", true],
+    ["IPv6 loopback HTTP", "http://[::1]:3000/mcp", true],
+    ["non-loopback HTTP", "http://mcp.example.com/mcp", false],
+    ["relative URL", "./mcp", false],
+    ["userinfo", "https://user:password@mcp.example.com/mcp", false],
+    ["fragment", "https://mcp.example.com/mcp#tools", false],
+  ])("validates %s MCP URLs", async (_label, url, valid) => {
+    const pluginDirectory = path.join(root, _label.replaceAll(" ", "-"));
+    await writePlugin(pluginDirectory);
+    await writeMcp(pluginDirectory, {
+      server: { type: "streamable-http", url },
+    });
+
+    const preview = await loadAgentPlugin(pluginDirectory);
+
+    expect(preview.mcpServers).toHaveLength(valid ? 1 : 0);
+  });
+
+  it("rejects case-insensitive duplicate and invalid HTTP headers", async () => {
+    const pluginDirectory = path.join(root, "plugin");
+    await writePlugin(pluginDirectory);
+    await writeMcp(pluginDirectory, {
+      duplicate: {
+        type: "streamable-http",
+        url: "https://mcp.example.com/mcp",
+        headers: { Authorization: "one", authorization: "two" },
+      },
+      invalidName: {
+        type: "streamable-http",
+        url: "https://mcp.example.com/mcp",
+        headers: { "bad header": "value" },
+      },
+      invalidValue: {
+        type: "streamable-http",
+        url: "https://mcp.example.com/mcp",
+        headers: { "X-Test": "line\nbreak" },
+      },
+    });
+
+    const preview = await loadAgentPlugin(pluginDirectory);
+
+    expect(preview.mcpServers).toEqual([]);
+    expect(
+      preview.diagnostics.filter((item) => item.code === "invalid_mcp_server"),
+    ).toHaveLength(3);
+  });
+
+  it("prepares deterministic MCP names and surfaces reserved-name collisions", async () => {
+    const pluginDirectory = path.join(root, "plugin");
+    const appDataPath = path.join(root, "app-data");
+    await writePlugin(pluginDirectory);
+    await writeMcp(pluginDirectory, {
+      analytics: {
+        type: "streamable-http",
+        url: "https://mcp.example.com/mcp",
+        headers: { "X-Plugin": "example" },
+      },
+    });
+    const register = vi.fn(
+      async ({ id }: { id: string }) => `http://127.0.0.1/${id}`,
+    );
+    const service = createService(appDataPath, [pluginDirectory], {
+      register,
+      unregisterRun: vi.fn(),
+    });
+    const installation = await registerSelectedPlugin(service);
+    const expectedName = agentPluginRuntimeMcpName(
+      installation.id,
+      installation.manifest.name,
+      "analytics",
+    );
+
+    const runtime = await service.prepareRuntimeMcpServers("run-1", new Set());
+    expect(runtime).toEqual([
+      expect.objectContaining({ name: expectedName, type: "http" }),
+    ]);
+    expect(register).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-1",
+        url: "https://mcp.example.com/mcp",
+        headers: { "X-Plugin": "example" },
+      }),
+    );
+
+    const collided = await service.prepareRuntimeMcpServers(
+      "run-2",
+      new Set([expectedName]),
+    );
+    expect(collided).toEqual([]);
+    const [listed] = await service.list();
+    expect(listed.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "mcp_name_collision" }),
+      ]),
+    );
+  });
+
+  it("excludes disabled plugins from MCP runtime preparation", async () => {
+    const pluginDirectory = path.join(root, "plugin");
+    const register = vi.fn(async () => "http://127.0.0.1/mcp");
+    await writePlugin(pluginDirectory);
+    await writeMcp(pluginDirectory, {
+      analytics: {
+        type: "streamable-http",
+        url: "https://mcp.example.com/mcp",
+      },
+    });
+    const service = createService(
+      path.join(root, "app-data"),
+      [pluginDirectory],
+      {
+        register,
+        unregisterRun: vi.fn(),
+      },
+    );
+    const installation = await registerSelectedPlugin(service);
+    await service.setEnabled(installation.id, false);
+
+    expect(await service.prepareRuntimeMcpServers("run-1", new Set())).toEqual(
+      [],
+    );
+    expect(register).not.toHaveBeenCalled();
   });
 });

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
@@ -882,6 +882,29 @@ describe("Agent Plugins skills support", () => {
     );
   });
 
+  it("orders skill diagnostics before MCP diagnostics", async () => {
+    const pluginDirectory = path.join(root, "plugin");
+    await writePlugin(pluginDirectory);
+    const skillDirectory = await writeSkill(pluginDirectory, "invalid-skill");
+    await fs.promises.writeFile(
+      path.join(skillDirectory, "SKILL.md"),
+      "Missing frontmatter.",
+    );
+    await writeMcp(pluginDirectory, {
+      invalid: {
+        type: "streamable-http",
+        url: "http://mcp.example.com/mcp",
+      },
+    });
+
+    const preview = await loadAgentPlugin(pluginDirectory);
+
+    expect(preview.diagnostics.map((item) => item.code)).toEqual([
+      "invalid_skill",
+      "invalid_mcp_server",
+    ]);
+  });
+
   it("isolates invalid and unsupported MCP entries from valid siblings", async () => {
     const pluginDirectory = path.join(root, "plugin");
     await writePlugin(pluginDirectory);
@@ -946,7 +969,7 @@ describe("Agent Plugins skills support", () => {
 
     const preview = await service.selectDirectory();
     expect(preview?.mcpServers).toEqual([
-      { name: "analytics", type: "streamable-http", supported: true },
+      { name: "analytics", type: "streamable-http" },
     ]);
     const installation = await service.register(preview?.selectionToken ?? "");
     expect(installation.mcpServers).toEqual(preview?.mcpServers);

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
@@ -29,15 +29,6 @@ async function writePlugin(
   );
 }
 
-async function writeSparseFile(filePath: string, size: number): Promise<void> {
-  const handle = await fs.promises.open(filePath, "w");
-  try {
-    await handle.truncate(size);
-  } finally {
-    await handle.close();
-  }
-}
-
 async function writeMcp(
   pluginDirectory: string,
   mcpServers: Record<string, unknown>,
@@ -51,6 +42,15 @@ async function writeMcp(
       ...extra,
     }),
   );
+}
+
+async function writeSparseFile(filePath: string, size: number): Promise<void> {
+  const handle = await fs.promises.open(filePath, "w");
+  try {
+    await handle.truncate(size);
+  } finally {
+    await handle.close();
+  }
 }
 
 async function writeSkill(
@@ -67,13 +67,18 @@ async function writeSkill(
   return skillDirectory;
 }
 
+function createHttpProxy(): AgentPluginHttpProxy {
+  return {
+    register: vi.fn(async ({ id }: { id: string }) => `http://127.0.0.1/${id}`),
+    unregisterRun: vi.fn(),
+    unregisterInstallation: vi.fn(),
+  };
+}
+
 function createService(
   appDataPath: string,
   selectedPaths: string[] = [],
-  httpProxy: AgentPluginHttpProxy = {
-    register: async ({ id }) => `http://127.0.0.1/${id}`,
-    unregisterRun() {},
-  },
+  httpProxy: AgentPluginHttpProxy = createHttpProxy(),
 ): AgentPluginsService {
   return new AgentPluginsService(
     {
@@ -736,36 +741,66 @@ describe("Agent Plugins skills support", () => {
     expect(preview.mcpServers).toHaveLength(valid ? 1 : 0);
   });
 
-  it("rejects case-insensitive duplicate and invalid HTTP headers", async () => {
+  it("does not expose or persist HTTP header values", async () => {
     const pluginDirectory = path.join(root, "plugin");
+    const appDataPath = path.join(root, "app-data");
     await writePlugin(pluginDirectory);
     await writeMcp(pluginDirectory, {
-      duplicate: {
+      analytics: {
         type: "streamable-http",
         url: "https://mcp.example.com/mcp",
-        headers: { Authorization: "one", authorization: "two" },
+        headers: { Authorization: "secret-value" },
       },
-      invalidName: {
-        type: "streamable-http",
-        url: "https://mcp.example.com/mcp",
-        headers: { "bad header": "value" },
-      },
-      invalidValue: {
-        type: "streamable-http",
-        url: "https://mcp.example.com/mcp",
-        headers: { "X-Test": "line\nbreak" },
-      },
+    });
+    const service = createService(appDataPath, [pluginDirectory]);
+
+    const preview = await service.selectDirectory();
+    expect(preview?.mcpServers).toEqual([
+      { name: "analytics", type: "streamable-http", supported: true },
+    ]);
+    const installation = await service.register(preview?.selectionToken ?? "");
+    expect(installation.mcpServers).toEqual(preview?.mcpServers);
+    const state = await fs.promises.readFile(
+      path.join(appDataPath, "agent-plugins", "installations.json"),
+      "utf8",
+    );
+    expect(state).not.toContain("secret-value");
+    expect(state).not.toContain("Authorization");
+  });
+
+  it("rejects plugin-relative stdio command and cwd symlink escapes", async () => {
+    const pluginDirectory = path.join(root, "plugin");
+    const outsideDirectory = path.join(root, "outside");
+    await writePlugin(pluginDirectory);
+    await fs.promises.mkdir(outsideDirectory);
+    await fs.promises.writeFile(path.join(outsideDirectory, "server"), "bin");
+    await fs.promises.mkdir(path.join(outsideDirectory, "cwd"));
+    await fs.promises.symlink(
+      path.join(outsideDirectory, "server"),
+      path.join(pluginDirectory, "server"),
+    );
+    await fs.promises.symlink(
+      path.join(outsideDirectory, "cwd"),
+      path.join(pluginDirectory, "cwd"),
+    );
+    await writeMcp(pluginDirectory, {
+      escapedCommand: { type: "stdio", command: "./server" },
+      escapedCwd: { type: "stdio", command: "node", cwd: "./cwd" },
     });
 
     const preview = await loadAgentPlugin(pluginDirectory);
 
-    expect(preview.mcpServers).toEqual([]);
     expect(
       preview.diagnostics.filter((item) => item.code === "invalid_mcp_server"),
-    ).toHaveLength(3);
+    ).toHaveLength(2);
+    expect(
+      preview.diagnostics.filter(
+        (item) => item.code === "unsupported_mcp_transport",
+      ),
+    ).toHaveLength(0);
   });
 
-  it("prepares deterministic MCP names and surfaces reserved-name collisions", async () => {
+  it("prepares deterministic MCP names and revokes disabled installations", async () => {
     const pluginDirectory = path.join(root, "plugin");
     const appDataPath = path.join(root, "app-data");
     await writePlugin(pluginDirectory);
@@ -776,13 +811,8 @@ describe("Agent Plugins skills support", () => {
         headers: { "X-Plugin": "example" },
       },
     });
-    const register = vi.fn(
-      async ({ id }: { id: string }) => `http://127.0.0.1/${id}`,
-    );
-    const service = createService(appDataPath, [pluginDirectory], {
-      register,
-      unregisterRun: vi.fn(),
-    });
+    const httpProxy = createHttpProxy();
+    const service = createService(appDataPath, [pluginDirectory], httpProxy);
     const installation = await registerSelectedPlugin(service);
     const expectedName = agentPluginRuntimeMcpName(
       installation.id,
@@ -794,51 +824,39 @@ describe("Agent Plugins skills support", () => {
     expect(runtime).toEqual([
       expect.objectContaining({ name: expectedName, type: "http" }),
     ]);
-    expect(register).toHaveBeenCalledWith(
+    expect(httpProxy.register).toHaveBeenCalledWith(
       expect.objectContaining({
         runId: "run-1",
+        installationId: installation.id,
         url: "https://mcp.example.com/mcp",
         headers: { "X-Plugin": "example" },
       }),
     );
 
-    const collided = await service.prepareRuntimeMcpServers(
-      "run-2",
-      new Set([expectedName]),
+    await service.setEnabled(installation.id, false);
+    expect(httpProxy.unregisterInstallation).toHaveBeenCalledWith(
+      installation.id,
     );
-    expect(collided).toEqual([]);
-    const [listed] = await service.list();
-    expect(listed.diagnostics).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ code: "mcp_name_collision" }),
-      ]),
+    expect(await service.prepareRuntimeMcpServers("run-2", new Set())).toEqual(
+      [],
     );
   });
 
-  it("excludes disabled plugins from MCP runtime preparation", async () => {
+  it("revokes HTTP targets when an installation is removed", async () => {
     const pluginDirectory = path.join(root, "plugin");
-    const register = vi.fn(async () => "http://127.0.0.1/mcp");
+    const httpProxy = createHttpProxy();
     await writePlugin(pluginDirectory);
-    await writeMcp(pluginDirectory, {
-      analytics: {
-        type: "streamable-http",
-        url: "https://mcp.example.com/mcp",
-      },
-    });
     const service = createService(
       path.join(root, "app-data"),
       [pluginDirectory],
-      {
-        register,
-        unregisterRun: vi.fn(),
-      },
+      httpProxy,
     );
     const installation = await registerSelectedPlugin(service);
-    await service.setEnabled(installation.id, false);
 
-    expect(await service.prepareRuntimeMcpServers("run-1", new Set())).toEqual(
-      [],
+    await service.unregister(installation.id);
+
+    expect(httpProxy.unregisterInstallation).toHaveBeenCalledWith(
+      installation.id,
     );
-    expect(register).not.toHaveBeenCalled();
   });
 });

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
@@ -240,7 +240,7 @@ export class AgentPluginsService {
     });
   }
 
-  async prepareRuntimeMcpServers(
+  prepareRuntimeMcpServers(
     taskRunId: string,
     reservedServerNames: ReadonlySet<string>,
   ): Promise<McpServerConnection[]> {
@@ -248,8 +248,26 @@ export class AgentPluginsService {
       throw new Error(`Unsafe taskRunId: ${JSON.stringify(taskRunId)}`);
     }
 
+    return this.withStateTransaction(async () => {
+      this.httpProxy.unregisterRun(taskRunId);
+      try {
+        return await this.prepareRuntimeMcpServersLocked(
+          taskRunId,
+          reservedServerNames,
+        );
+      } catch (error) {
+        this.httpProxy.unregisterRun(taskRunId);
+        throw error;
+      }
+    });
+  }
+
+  private async prepareRuntimeMcpServersLocked(
+    taskRunId: string,
+    reservedServerNames: ReadonlySet<string>,
+  ): Promise<McpServerConnection[]> {
     const claimedServerNames = new Set(reservedServerNames);
-    const state = await this.withStateTransaction(() => this.readState());
+    const state = await this.readState();
     const installations = state.installations
       .filter((installation) => installation.enabled)
       .sort(
@@ -314,7 +332,7 @@ export class AgentPluginsService {
     return runtimeServers;
   }
 
-  async prepareRuntimePlugins(
+  prepareRuntimePlugins(
     taskRunId: string,
     reservedSkillNames: ReadonlySet<string>,
     onSkillSkipped: (pluginName: string, skillName: string) => void = () => {},
@@ -323,12 +341,31 @@ export class AgentPluginsService {
       throw new Error(`Unsafe taskRunId: ${JSON.stringify(taskRunId)}`);
     }
 
-    const runtimeRoot = this.runtimeRoot(taskRunId);
-    await this.removeManagedPath(runtimeRoot);
-    await this.makeManagedDirectory(runtimeRoot);
+    return this.withStateTransaction(async () => {
+      const runtimeRoot = this.runtimeRoot(taskRunId);
+      await this.removeManagedPath(runtimeRoot);
+      await this.makeManagedDirectory(runtimeRoot);
+      try {
+        return await this.prepareRuntimePluginsLocked(
+          taskRunId,
+          reservedSkillNames,
+          onSkillSkipped,
+        );
+      } catch (error) {
+        await this.removeManagedPath(runtimeRoot);
+        throw error;
+      }
+    });
+  }
 
+  private async prepareRuntimePluginsLocked(
+    taskRunId: string,
+    reservedSkillNames: ReadonlySet<string>,
+    onSkillSkipped: (pluginName: string, skillName: string) => void,
+  ): Promise<RuntimeAgentPlugin[]> {
+    const runtimeRoot = this.runtimeRoot(taskRunId);
     const claimedSkillNames = new Set(reservedSkillNames);
-    const state = await this.withStateTransaction(() => this.readState());
+    const state = await this.readState();
     const installations = state.installations
       .filter((installation) => installation.enabled)
       .sort(
@@ -409,10 +446,12 @@ export class AgentPluginsService {
     return plugins;
   }
 
-  async cleanupRuntimePlugins(taskRunId: string): Promise<void> {
-    if (!isSafePathSegment(taskRunId)) return;
-    this.httpProxy.unregisterRun(taskRunId);
-    await this.removeManagedPath(this.runtimeRoot(taskRunId));
+  cleanupRuntimePlugins(taskRunId: string): Promise<void> {
+    if (!isSafePathSegment(taskRunId)) return Promise.resolve();
+    return this.withStateTransaction(async () => {
+      this.httpProxy.unregisterRun(taskRunId);
+      await this.removeManagedPath(this.runtimeRoot(taskRunId));
+    });
   }
 
   private addRuntimeDiagnostic(

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
@@ -6,8 +6,11 @@ import {
   type IStoragePaths,
   STORAGE_PATHS_SERVICE,
 } from "@posthog/platform/storage-paths";
+import type { McpServerConnection } from "@posthog/shared";
 import { inject, injectable } from "inversify";
 import { isSafePathSegment } from "../skills/skill-discovery";
+import type { AgentPluginHttpProxy } from "./http-proxy";
+import { AGENT_PLUGIN_HTTP_PROXY } from "./identifiers";
 import {
   isPathContained,
   loadAgentPlugin,
@@ -15,6 +18,7 @@ import {
 } from "./loader";
 import {
   AGENT_PLUGIN_INSTALLATION_ID_PATTERN,
+  type AgentPluginDiagnostic,
   type AgentPluginInstallation,
   type AgentPluginPreview,
   agentPluginState,
@@ -28,6 +32,20 @@ interface RuntimeAgentPlugin {
 interface PersistedState {
   version: 1;
   installations: AgentPluginInstallation[];
+}
+
+export function agentPluginRuntimeMcpName(
+  installationId: string,
+  pluginName: string,
+  serverName: string,
+): string {
+  const pluginSlug = pluginName.replaceAll(".", "-").slice(0, 32);
+  const serverHash = crypto
+    .createHash("sha256")
+    .update(serverName)
+    .digest("hex")
+    .slice(0, 8);
+  return `agent-plugin-${pluginSlug}-${installationId.slice(0, 8)}-${serverHash}`;
 }
 
 interface PendingSelection {
@@ -52,12 +70,18 @@ const SNAPSHOT_READ_CHUNK_BYTES = 64 * 1024;
 export class AgentPluginsService {
   private stateQueue: Promise<void> = Promise.resolve();
   private readonly pendingSelections = new Map<string, PendingSelection>();
+  private readonly runtimeDiagnostics = new Map<
+    string,
+    AgentPluginDiagnostic[]
+  >();
 
   constructor(
     @inject(STORAGE_PATHS_SERVICE)
     private readonly storagePaths: IStoragePaths,
     @inject(DIALOG_SERVICE)
     private readonly dialog: IDialog,
+    @inject(AGENT_PLUGIN_HTTP_PROXY)
+    private readonly httpProxy: AgentPluginHttpProxy,
   ) {}
 
   list(): Promise<AgentPluginInstallation[]> {
@@ -75,8 +99,13 @@ export class AgentPluginsService {
                 ? preview.manifest
                 : installation.manifest,
             skills: sourceUnchanged && preview.valid ? preview.skills : [],
+            mcpServers:
+              sourceUnchanged && preview.valid ? preview.mcpServers : [],
             diagnostics: sourceUnchanged
-              ? preview.diagnostics
+              ? [
+                  ...preview.diagnostics,
+                  ...(this.runtimeDiagnostics.get(installation.id) ?? []),
+                ]
               : [
                   ...preview.diagnostics,
                   {
@@ -142,12 +171,14 @@ export class AgentPluginsService {
         enabled: existing?.enabled ?? true,
         manifest,
         skills: preview.skills,
+        mcpServers: preview.mcpServers,
         diagnostics: preview.diagnostics,
       };
       const installations = state.installations.filter(
         (item) => item.id !== installation.id,
       );
       installations.push(installation);
+      this.runtimeDiagnostics.delete(installation.id);
       await this.writeState({ version: 1, installations });
       return installation;
     });
@@ -178,11 +209,84 @@ export class AgentPluginsService {
       if (!state.installations.some((item) => item.id === id)) {
         throw new Error("Agent Plugin installation not found.");
       }
+      this.runtimeDiagnostics.delete(id);
       await this.writeState({
         version: 1,
         installations: state.installations.filter((item) => item.id !== id),
       });
     });
+  }
+
+  async prepareRuntimeMcpServers(
+    taskRunId: string,
+    reservedServerNames: ReadonlySet<string>,
+  ): Promise<McpServerConnection[]> {
+    if (!isSafePathSegment(taskRunId)) {
+      throw new Error(`Unsafe taskRunId: ${JSON.stringify(taskRunId)}`);
+    }
+
+    this.runtimeDiagnostics.clear();
+    const claimedServerNames = new Set(reservedServerNames);
+    const state = await this.withStateTransaction(() => this.readState());
+    const installations = state.installations
+      .filter((installation) => installation.enabled)
+      .sort(
+        (left, right) =>
+          left.manifest.name.localeCompare(right.manifest.name) ||
+          left.id.localeCompare(right.id),
+      );
+
+    const runtimeServers: McpServerConnection[] = [];
+    for (const installation of installations) {
+      const preview = await loadAgentPlugin(installation.sourcePath);
+      if (
+        !preview.valid ||
+        !preview.manifest ||
+        preview.sourcePath !== installation.sourcePath
+      )
+        continue;
+
+      for (const server of preview.mcpServers) {
+        const runtimeName = agentPluginRuntimeMcpName(
+          installation.id,
+          preview.manifest.name,
+          server.name,
+        );
+        if (claimedServerNames.has(runtimeName)) {
+          this.addRuntimeDiagnostic(installation.id, {
+            severity: "error",
+            code: "mcp_name_collision",
+            message: `Skipped MCP server ${server.name} because its runtime name conflicts with another server.`,
+            path: `mcp.json/mcpServers/${server.name}`,
+          });
+          continue;
+        }
+
+        try {
+          const url = await this.httpProxy.register({
+            id: `${taskRunId}:${runtimeName}`,
+            runId: taskRunId,
+            url: server.url,
+            headers: server.headers ?? {},
+          });
+          claimedServerNames.add(runtimeName);
+          runtimeServers.push({
+            type: "http",
+            name: runtimeName,
+            url,
+            headers: [],
+          });
+        } catch {
+          this.addRuntimeDiagnostic(installation.id, {
+            severity: "error",
+            code: "mcp_proxy_failed",
+            message: `Skipped MCP server ${server.name} because its local connection could not be prepared.`,
+            path: `mcp.json/mcpServers/${server.name}`,
+          });
+        }
+      }
+    }
+    return runtimeServers;
   }
 
   async prepareRuntimePlugins(
@@ -282,7 +386,17 @@ export class AgentPluginsService {
 
   async cleanupRuntimePlugins(taskRunId: string): Promise<void> {
     if (!isSafePathSegment(taskRunId)) return;
+    this.httpProxy.unregisterRun(taskRunId);
     await this.removeManagedPath(this.runtimeRoot(taskRunId));
+  }
+
+  private addRuntimeDiagnostic(
+    installationId: string,
+    diagnostic: AgentPluginDiagnostic,
+  ): void {
+    const diagnostics = this.runtimeDiagnostics.get(installationId) ?? [];
+    diagnostics.push(diagnostic);
+    this.runtimeDiagnostics.set(installationId, diagnostics);
   }
 
   private takeSelection(selectionToken: string): PendingSelection {

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
@@ -19,7 +19,9 @@ import {
 import {
   AGENT_PLUGIN_INSTALLATION_ID_PATTERN,
   type AgentPluginDiagnostic,
+  type AgentPluginHttpMcpServer,
   type AgentPluginInstallation,
+  type AgentPluginMcpServerSummary,
   type AgentPluginPreview,
   agentPluginState,
 } from "./schemas";
@@ -32,20 +34,6 @@ interface RuntimeAgentPlugin {
 interface PersistedState {
   version: 1;
   installations: AgentPluginInstallation[];
-}
-
-export function agentPluginRuntimeMcpName(
-  installationId: string,
-  pluginName: string,
-  serverName: string,
-): string {
-  const pluginSlug = pluginName.replaceAll(".", "-").slice(0, 32);
-  const serverHash = crypto
-    .createHash("sha256")
-    .update(serverName)
-    .digest("hex")
-    .slice(0, 8);
-  return `agent-plugin-${pluginSlug}-${installationId.slice(0, 8)}-${serverHash}`;
 }
 
 interface PendingSelection {
@@ -65,6 +53,30 @@ const MAX_SKILL_SNAPSHOT_BYTES = 8 * 1024 * 1024;
 const MAX_PLUGIN_SNAPSHOT_FILES = 1024;
 const MAX_PLUGIN_SNAPSHOT_BYTES = 32 * 1024 * 1024;
 const SNAPSHOT_READ_CHUNK_BYTES = 64 * 1024;
+
+function summarizeMcpServers(
+  servers: AgentPluginHttpMcpServer[],
+): AgentPluginMcpServerSummary[] {
+  return servers.map((server) => ({
+    name: server.name,
+    type: server.type,
+    supported: true,
+  }));
+}
+
+export function agentPluginRuntimeMcpName(
+  installationId: string,
+  pluginName: string,
+  serverName: string,
+): string {
+  const pluginSlug = pluginName.replaceAll(".", "-").slice(0, 32);
+  const serverHash = crypto
+    .createHash("sha256")
+    .update(serverName)
+    .digest("hex")
+    .slice(0, 8);
+  return `agent-plugin-${pluginSlug}-${installationId.slice(0, 8)}-${serverHash}`;
+}
 
 @injectable()
 export class AgentPluginsService {
@@ -100,21 +112,23 @@ export class AgentPluginsService {
                 : installation.manifest,
             skills: sourceUnchanged && preview.valid ? preview.skills : [],
             mcpServers:
-              sourceUnchanged && preview.valid ? preview.mcpServers : [],
-            diagnostics: sourceUnchanged
-              ? [
-                  ...preview.diagnostics,
-                  ...(this.runtimeDiagnostics.get(installation.id) ?? []),
-                ]
-              : [
-                  ...preview.diagnostics,
-                  {
-                    severity: "error",
-                    code: "source_changed",
-                    message:
-                      "The Agent Plugin directory changed. Remove it and add it again.",
-                  },
-                ],
+              sourceUnchanged && preview.valid
+                ? summarizeMcpServers(preview.mcpServers)
+                : [],
+            diagnostics: [
+              ...(sourceUnchanged
+                ? preview.diagnostics
+                : [
+                    ...preview.diagnostics,
+                    {
+                      severity: "error" as const,
+                      code: "source_changed",
+                      message:
+                        "The Agent Plugin directory changed. Remove it and add it again.",
+                    },
+                  ]),
+              ...(this.runtimeDiagnostics.get(installation.id) ?? []),
+            ],
           } satisfies AgentPluginInstallation;
         }),
       );
@@ -131,14 +145,18 @@ export class AgentPluginsService {
     if (!sourcePath) return null;
 
     const preview = await loadAgentPlugin(sourcePath);
-    if (!preview.valid) return preview;
+    const publicPreview: AgentPluginPreview = {
+      ...preview,
+      mcpServers: summarizeMcpServers(preview.mcpServers),
+    };
+    if (!preview.valid) return publicPreview;
 
     const selectionToken = crypto.randomUUID();
     this.pendingSelections.set(selectionToken, {
       sourcePath: preview.sourcePath,
       expiresAt: Date.now() + SELECTION_TTL_MS,
     });
-    return { ...preview, selectionToken };
+    return { ...publicPreview, selectionToken };
   }
 
   async register(selectionToken: string): Promise<AgentPluginInstallation> {
@@ -171,7 +189,7 @@ export class AgentPluginsService {
         enabled: existing?.enabled ?? true,
         manifest,
         skills: preview.skills,
-        mcpServers: preview.mcpServers,
+        mcpServers: summarizeMcpServers(preview.mcpServers),
         diagnostics: preview.diagnostics,
       };
       const installations = state.installations.filter(
@@ -198,6 +216,10 @@ export class AgentPluginsService {
           item.id === id ? updated : item,
         ),
       });
+      if (!enabled) {
+        this.runtimeDiagnostics.delete(id);
+        this.httpProxy.unregisterInstallation(id);
+      }
       return updated;
     });
   }
@@ -209,11 +231,12 @@ export class AgentPluginsService {
       if (!state.installations.some((item) => item.id === id)) {
         throw new Error("Agent Plugin installation not found.");
       }
-      this.runtimeDiagnostics.delete(id);
       await this.writeState({
         version: 1,
         installations: state.installations.filter((item) => item.id !== id),
       });
+      this.runtimeDiagnostics.delete(id);
+      this.httpProxy.unregisterInstallation(id);
     });
   }
 
@@ -225,7 +248,6 @@ export class AgentPluginsService {
       throw new Error(`Unsafe taskRunId: ${JSON.stringify(taskRunId)}`);
     }
 
-    this.runtimeDiagnostics.clear();
     const claimedServerNames = new Set(reservedServerNames);
     const state = await this.withStateTransaction(() => this.readState());
     const installations = state.installations
@@ -238,13 +260,15 @@ export class AgentPluginsService {
 
     const runtimeServers: McpServerConnection[] = [];
     for (const installation of installations) {
+      this.runtimeDiagnostics.delete(installation.id);
       const preview = await loadAgentPlugin(installation.sourcePath);
       if (
         !preview.valid ||
         !preview.manifest ||
         preview.sourcePath !== installation.sourcePath
-      )
+      ) {
         continue;
+      }
 
       for (const server of preview.mcpServers) {
         const runtimeName = agentPluginRuntimeMcpName(
@@ -266,6 +290,7 @@ export class AgentPluginsService {
           const url = await this.httpProxy.register({
             id: `${taskRunId}:${runtimeName}`,
             runId: taskRunId,
+            installationId: installation.id,
             url: server.url,
             headers: server.headers ?? {},
           });

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
@@ -64,7 +64,6 @@ function summarizeMcpServers(
   return servers.map((server) => ({
     name: server.name,
     type: server.type,
-    supported: true,
   }));
 }
 

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/http-proxy.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/http-proxy.test.ts
@@ -11,21 +11,61 @@ const logger = {
   }),
 };
 
-function requestProxy(url: string): Promise<number | undefined> {
+interface ProxyRequestOptions {
+  body?: Buffer;
+  headers?: Record<string, string>;
+  method?: string;
+}
+
+function requestProxy(
+  url: string,
+  options: ProxyRequestOptions = {},
+): Promise<{ status: number | undefined; body: string }> {
   return new Promise((resolve, reject) => {
     const request = http.request(
       url,
       {
-        method: "POST",
-        headers: { accept: "application/json, text/event-stream" },
+        method: options.method ?? "POST",
+        headers: {
+          accept: "application/json, text/event-stream",
+          ...options.headers,
+        },
       },
       (response) => {
-        response.resume();
-        response.on("end", () => resolve(response.statusCode));
+        const chunks: Buffer[] = [];
+        response.on("data", (chunk: Buffer) => chunks.push(chunk));
+        response.on("end", () =>
+          resolve({
+            status: response.statusCode,
+            body: Buffer.concat(chunks).toString("utf8"),
+          }),
+        );
       },
     );
     request.on("error", reject);
-    request.end();
+    request.end(options.body);
+  });
+}
+
+function registration(
+  overrides: Partial<
+    Parameters<AgentPluginHttpProxyService["register"]>[0]
+  > = {},
+): Parameters<AgentPluginHttpProxyService["register"]>[0] {
+  return {
+    id: "run-1:server",
+    runId: "run-1",
+    installationId: "installation-1",
+    url: "https://origin.example.com/mcp",
+    headers: { "X-Plugin": "example" },
+    ...overrides,
+  };
+}
+
+function okResponse(): Response {
+  return new Response("ok", {
+    status: 200,
+    headers: { "content-type": "application/json" },
   });
 }
 
@@ -35,55 +75,200 @@ describe("AgentPluginHttpProxyService", () => {
     vi.restoreAllMocks();
   });
 
-  it("removes configured headers before following a cross-origin redirect", async () => {
+  it.each([
+    ["cross-origin", "https://other.example.com/mcp"],
+    ["HTTPS downgrade", "http://origin.example.com/mcp"],
+    ["loopback", "https://127.0.0.1/mcp"],
+    ["private IPv4", "https://10.0.0.1/mcp"],
+    ["link-local", "https://169.254.1.1/mcp"],
+    ["userinfo", "https://user:pass@origin.example.com/mcp"],
+    ["fragment", "https://origin.example.com/mcp#fragment"],
+  ])(
+    "blocks a %s redirect before another request",
+    async (_label, location) => {
+      const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+        new Response(null, {
+          status: 307,
+          headers: { location },
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      const proxy = new AgentPluginHttpProxyService(logger as never);
+
+      try {
+        const proxyUrl = await proxy.register(registration());
+
+        expect((await requestProxy(proxyUrl)).status).toBe(502);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      } finally {
+        await proxy.stop();
+      }
+    },
+  );
+
+  it("follows same-origin redirects without exposing configured headers elsewhere", async () => {
     const fetchMock = vi
       .fn<typeof fetch>()
       .mockResolvedValueOnce(
         new Response(null, {
           status: 307,
-          headers: { location: "https://other.example.com/mcp" },
+          headers: { location: "/next" },
         }),
       )
-      .mockResolvedValueOnce(
-        new Response("ok", {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      );
+      .mockResolvedValueOnce(okResponse());
     vi.stubGlobal("fetch", fetchMock);
     const proxy = new AgentPluginHttpProxyService(logger as never);
 
     try {
-      const proxyUrl = await proxy.register({
-        id: "run-1:server",
-        runId: "run-1",
-        url: "https://origin.example.com/mcp",
-        headers: {
-          Authorization: "Bearer visible-package-value",
-          "X-Plugin": "example",
-          Accept: "configured-value",
-        },
-      });
+      const proxyUrl = await proxy.register(
+        registration({ headers: { Authorization: "visible-value" } }),
+      );
 
-      expect(await requestProxy(proxyUrl)).toBe(200);
+      expect((await requestProxy(proxyUrl)).status).toBe(200);
       expect(fetchMock).toHaveBeenCalledTimes(2);
-      const firstHeaders = new Headers(fetchMock.mock.calls[0][1]?.headers);
-      expect(firstHeaders.get("authorization")).toBe(
-        "Bearer visible-package-value",
+      expect(new URL(fetchMock.mock.calls[1][0] as URL).toString()).toBe(
+        "https://origin.example.com/next",
       );
-      expect(firstHeaders.get("x-plugin")).toBe("example");
-      expect(firstHeaders.get("accept")).toBe(
-        "application/json, text/event-stream",
-      );
-
       const redirectedHeaders = new Headers(
         fetchMock.mock.calls[1][1]?.headers,
       );
-      expect(redirectedHeaders.has("authorization")).toBe(false);
-      expect(redirectedHeaders.has("x-plugin")).toBe(false);
-      expect(redirectedHeaders.get("accept")).toBe(
-        "application/json, text/event-stream",
-      );
+      expect(redirectedHeaders.get("authorization")).toBe("visible-value");
+    } finally {
+      await proxy.stop();
+    }
+  });
+
+  it("detects redirect loops and enforces the hop limit", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(null, {
+        status: 307,
+        headers: { location: "/mcp" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const proxy = new AgentPluginHttpProxyService(logger as never);
+
+    try {
+      const proxyUrl = await proxy.register(registration());
+
+      expect((await requestProxy(proxyUrl)).status).toBe(502);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      await proxy.stop();
+    }
+  });
+
+  it("uses an unguessable route and rejects browser-origin requests", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+    const proxy = new AgentPluginHttpProxyService(logger as never);
+
+    try {
+      const proxyUrl = await proxy.register(registration());
+      const token = new URL(proxyUrl).pathname.slice(1);
+
+      expect(token).not.toContain("run-1");
+      expect(token.length).toBeGreaterThanOrEqual(40);
+      expect(
+        (
+          await requestProxy(proxyUrl, {
+            headers: { Origin: "https://attacker.example.com" },
+          })
+        ).status,
+      ).toBe(403);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      await proxy.stop();
+    }
+  });
+
+  it("rejects oversized request bodies before fetching upstream", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+    const proxy = new AgentPluginHttpProxyService(logger as never);
+
+    try {
+      const proxyUrl = await proxy.register(registration());
+      const result = await requestProxy(proxyUrl, {
+        body: Buffer.alloc(2 * 1024 * 1024 + 1),
+      });
+
+      expect(result.status).toBe(413);
+      expect(result.body).toContain("too large");
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      await proxy.stop();
+    }
+  });
+
+  it("aborts body collection when a run is unregistered", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+    const proxy = new AgentPluginHttpProxyService(logger as never);
+
+    try {
+      const proxyUrl = await proxy.register(registration());
+      const result = new Promise<number | undefined>((resolve, reject) => {
+        const request = http.request(
+          proxyUrl,
+          { method: "POST" },
+          (response) => {
+            response.resume();
+            response.on("end", () => resolve(response.statusCode));
+          },
+        );
+        request.on("error", reject);
+        request.write("partial");
+        setImmediate(() => proxy.unregisterRun("run-1"));
+      });
+
+      expect(await result).toBe(404);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      await proxy.stop();
+    }
+  });
+
+  it("does not return an upstream response after the target is removed", async () => {
+    let resolveFetch: ((response: Response) => void) | undefined;
+    let notifyFetchStarted: (() => void) | undefined;
+    const fetchStarted = new Promise<void>((resolve) => {
+      notifyFetchStarted = resolve;
+    });
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+          notifyFetchStarted?.();
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const proxy = new AgentPluginHttpProxyService(logger as never);
+
+    try {
+      const proxyUrl = await proxy.register(registration());
+      const result = requestProxy(proxyUrl);
+      await fetchStarted;
+      proxy.unregisterInstallation("installation-1");
+      resolveFetch?.(okResponse());
+
+      expect((await result).status).toBe(404);
+    } finally {
+      await proxy.stop();
+    }
+  });
+
+  it("revokes active routes by installation", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+    const proxy = new AgentPluginHttpProxyService(logger as never);
+
+    try {
+      const proxyUrl = await proxy.register(registration());
+      proxy.unregisterInstallation("installation-1");
+
+      expect((await requestProxy(proxyUrl)).status).toBe(404);
+      expect(fetchMock).not.toHaveBeenCalled();
     } finally {
       await proxy.stop();
     }

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/http-proxy.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/http-proxy.test.ts
@@ -1,0 +1,91 @@
+import http from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgentPluginHttpProxyService } from "./http-proxy";
+
+const logger = {
+  scope: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+};
+
+function requestProxy(url: string): Promise<number | undefined> {
+  return new Promise((resolve, reject) => {
+    const request = http.request(
+      url,
+      {
+        method: "POST",
+        headers: { accept: "application/json, text/event-stream" },
+      },
+      (response) => {
+        response.resume();
+        response.on("end", () => resolve(response.statusCode));
+      },
+    );
+    request.on("error", reject);
+    request.end();
+  });
+}
+
+describe("AgentPluginHttpProxyService", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("removes configured headers before following a cross-origin redirect", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 307,
+          headers: { location: "https://other.example.com/mcp" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response("ok", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const proxy = new AgentPluginHttpProxyService(logger as never);
+
+    try {
+      const proxyUrl = await proxy.register({
+        id: "run-1:server",
+        runId: "run-1",
+        url: "https://origin.example.com/mcp",
+        headers: {
+          Authorization: "Bearer visible-package-value",
+          "X-Plugin": "example",
+          Accept: "configured-value",
+        },
+      });
+
+      expect(await requestProxy(proxyUrl)).toBe(200);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const firstHeaders = new Headers(fetchMock.mock.calls[0][1]?.headers);
+      expect(firstHeaders.get("authorization")).toBe(
+        "Bearer visible-package-value",
+      );
+      expect(firstHeaders.get("x-plugin")).toBe("example");
+      expect(firstHeaders.get("accept")).toBe(
+        "application/json, text/event-stream",
+      );
+
+      const redirectedHeaders = new Headers(
+        fetchMock.mock.calls[1][1]?.headers,
+      );
+      expect(redirectedHeaders.has("authorization")).toBe(false);
+      expect(redirectedHeaders.has("x-plugin")).toBe(false);
+      expect(redirectedHeaders.get("accept")).toBe(
+        "application/json, text/event-stream",
+      );
+    } finally {
+      await proxy.stop();
+    }
+  });
+});

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/http-proxy.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/http-proxy.ts
@@ -1,0 +1,320 @@
+import http from "node:http";
+import {
+  ROOT_LOGGER,
+  type RootLogger,
+  type ScopedLogger,
+} from "@posthog/di/logger";
+import { inject, injectable, preDestroy } from "inversify";
+import { streamBodyToResponse } from "../proxy-stream/proxy-stream";
+
+interface ProxyTarget {
+  runId: string;
+  url: string;
+  headers: Record<string, string>;
+}
+
+export interface AgentPluginHttpProxyRegistration {
+  id: string;
+  runId: string;
+  url: string;
+  headers: Record<string, string>;
+}
+
+export interface AgentPluginHttpProxy {
+  register(registration: AgentPluginHttpProxyRegistration): Promise<string>;
+  unregisterRun(runId: string): void;
+}
+
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "content-length",
+  "host",
+  "proxy-authorization",
+  "transfer-encoding",
+]);
+const SENSITIVE_REDIRECT_HEADERS = new Set([
+  "authorization",
+  "cookie",
+  "proxy-authorization",
+]);
+
+function mergeRequestHeaders(
+  configured: Record<string, string>,
+  incoming: http.IncomingHttpHeaders,
+): Headers {
+  const headers = new Headers();
+  for (const [name, value] of Object.entries(configured)) {
+    if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) {
+      headers.set(name, value);
+    }
+  }
+  for (const [name, value] of Object.entries(incoming)) {
+    if (HOP_BY_HOP_HEADERS.has(name.toLowerCase()) || value === undefined) {
+      continue;
+    }
+    headers.set(name, Array.isArray(value) ? value.join(", ") : value);
+  }
+  return headers;
+}
+
+export function headersAfterRedirect(
+  headers: Headers,
+  configuredHeaderNames: ReadonlySet<string>,
+  previousUrl: URL,
+  nextUrl: URL,
+): Headers {
+  const redirectedHeaders = new Headers(headers);
+  if (previousUrl.origin === nextUrl.origin) return redirectedHeaders;
+
+  for (const name of configuredHeaderNames) {
+    redirectedHeaders.delete(name);
+  }
+  for (const name of SENSITIVE_REDIRECT_HEADERS) {
+    redirectedHeaders.delete(name);
+  }
+  return redirectedHeaders;
+}
+
+function responseHeaders(response: Response): Record<string, string> {
+  const headers: Record<string, string> = {};
+  response.headers.forEach((value, name) => {
+    if (
+      name !== "content-encoding" &&
+      name !== "content-length" &&
+      name !== "transfer-encoding"
+    ) {
+      headers[name] = value;
+    }
+  });
+  return headers;
+}
+
+@injectable()
+export class AgentPluginHttpProxyService implements AgentPluginHttpProxy {
+  private server: http.Server | null = null;
+  private port: number | null = null;
+  private startPromise: Promise<void> | null = null;
+  private readonly targets = new Map<string, ProxyTarget>();
+  private readonly activeRequests = new Map<string, Set<AbortController>>();
+  private readonly log: ScopedLogger;
+
+  constructor(@inject(ROOT_LOGGER) logger: RootLogger) {
+    this.log = logger.scope("agent-plugin-http-proxy");
+  }
+
+  async register(
+    registration: AgentPluginHttpProxyRegistration,
+  ): Promise<string> {
+    await this.start();
+    this.targets.set(registration.id, {
+      runId: registration.runId,
+      url: registration.url,
+      headers: registration.headers,
+    });
+    return `http://127.0.0.1:${this.port}/${encodeURIComponent(registration.id)}`;
+  }
+
+  unregisterRun(runId: string): void {
+    for (const [id, target] of this.targets) {
+      if (target.runId === runId) this.targets.delete(id);
+    }
+    for (const controller of this.activeRequests.get(runId) ?? []) {
+      controller.abort();
+    }
+    this.activeRequests.delete(runId);
+  }
+
+  @preDestroy()
+  async stop(): Promise<void> {
+    for (const controllers of this.activeRequests.values()) {
+      for (const controller of controllers) controller.abort();
+    }
+    this.activeRequests.clear();
+    this.targets.clear();
+    if (!this.server) return;
+
+    const server = this.server;
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+      server.closeAllConnections();
+    });
+    this.server = null;
+    this.port = null;
+    this.startPromise = null;
+  }
+
+  private async start(): Promise<void> {
+    if (this.server && this.port !== null) return;
+    if (this.startPromise) return this.startPromise;
+    this.startPromise = this.startServer().catch((error) => {
+      this.startPromise = null;
+      throw error;
+    });
+    return this.startPromise;
+  }
+
+  private async startServer(): Promise<void> {
+    const server = http.createServer((request, response) => {
+      void this.handleRequest(request, response).catch((error) => {
+        this.log.warn("Agent Plugin MCP proxy request failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        if (!response.headersSent) {
+          response.writeHead(502, {
+            "x-posthog-agent-plugin-proxy-error": "1",
+          });
+        }
+        response.end("Agent Plugin MCP proxy error");
+      });
+    });
+    this.server = server;
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", reject);
+        const address = server.address();
+        if (typeof address !== "object" || address === null) {
+          reject(new Error("Failed to start Agent Plugin HTTP proxy."));
+          return;
+        }
+        this.port = address.port;
+        server.on("error", (error) => {
+          this.log.error("Agent Plugin MCP proxy server failed", error);
+        });
+        resolve();
+      });
+    });
+  }
+
+  private async handleRequest(
+    request: http.IncomingMessage,
+    response: http.ServerResponse,
+  ): Promise<void> {
+    const incomingUrl = new URL(request.url ?? "/", "http://localhost");
+    const [rawId, ...suffixSegments] = incomingUrl.pathname
+      .split("/")
+      .filter(Boolean);
+    const id = rawId ? decodeURIComponent(rawId) : "";
+    const target = this.targets.get(id);
+    if (!target) {
+      response.writeHead(404);
+      response.end("Unknown Agent Plugin MCP target");
+      return;
+    }
+
+    const targetUrl = new URL(target.url);
+    const suffix = suffixSegments.join("/");
+    if (suffix) {
+      targetUrl.pathname = `${targetUrl.pathname.replace(/\/+$/, "")}/${suffix}`;
+    }
+    for (const [name, value] of incomingUrl.searchParams) {
+      targetUrl.searchParams.append(name, value);
+    }
+    const body = await this.readRequestBody(request);
+    const controller = new AbortController();
+    const active = this.activeRequests.get(target.runId) ?? new Set();
+    active.add(controller);
+    this.activeRequests.set(target.runId, active);
+    response.on("close", () => {
+      if (!response.writableEnded) controller.abort();
+    });
+
+    try {
+      const incomingHeaderNames = new Set(
+        Object.keys(request.headers).map((name) => name.toLowerCase()),
+      );
+      const configuredHeaderNames = new Set(
+        Object.keys(target.headers)
+          .map((name) => name.toLowerCase())
+          .filter((name) => !incomingHeaderNames.has(name)),
+      );
+      const upstream = await this.fetchWithRedirects(
+        targetUrl,
+        {
+          method: request.method ?? "GET",
+          headers: mergeRequestHeaders(target.headers, request.headers),
+          ...(body.length > 0 ? { body: Uint8Array.from(body).buffer } : {}),
+          signal: controller.signal,
+        },
+        configuredHeaderNames,
+      );
+      response.writeHead(upstream.status, responseHeaders(upstream));
+      await streamBodyToResponse(upstream.body, response);
+    } catch (error) {
+      if (!controller.signal.aborted) {
+        this.log.warn("Agent Plugin MCP proxy request failed", {
+          target: id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      if (!response.headersSent) {
+        response.writeHead(502, {
+          "x-posthog-agent-plugin-proxy-error": "1",
+        });
+      }
+      response.end("Agent Plugin MCP proxy error");
+    } finally {
+      active.delete(controller);
+      if (active.size === 0) this.activeRequests.delete(target.runId);
+    }
+  }
+
+  private async fetchWithRedirects(
+    initialUrl: URL,
+    initialOptions: RequestInit,
+    configuredHeaderNames: ReadonlySet<string>,
+  ): Promise<Response> {
+    let url = initialUrl;
+    let method = initialOptions.method ?? "GET";
+    let body = initialOptions.body;
+    let headers = new Headers(initialOptions.headers);
+
+    for (let redirectCount = 0; redirectCount <= 5; redirectCount += 1) {
+      const response = await fetch(url, {
+        ...initialOptions,
+        method,
+        headers,
+        ...(body !== undefined ? { body } : { body: undefined }),
+        redirect: "manual",
+      });
+      if (![301, 302, 303, 307, 308].includes(response.status)) {
+        return response;
+      }
+      const location = response.headers.get("location");
+      if (!location || redirectCount === 5) {
+        throw new Error("Agent Plugin MCP redirect could not be followed.");
+      }
+
+      const nextUrl = new URL(location, url);
+      headers = headersAfterRedirect(
+        headers,
+        configuredHeaderNames,
+        url,
+        nextUrl,
+      );
+      if (
+        response.status === 303 ||
+        ((response.status === 301 || response.status === 302) &&
+          method.toUpperCase() === "POST")
+      ) {
+        method = "GET";
+        body = undefined;
+        headers.delete("content-type");
+      }
+      url = nextUrl;
+    }
+    throw new Error("Agent Plugin MCP redirect limit exceeded.");
+  }
+
+  private readRequestBody(request: http.IncomingMessage): Promise<Buffer> {
+    if (request.method === "GET" || request.method === "HEAD") {
+      return Promise.resolve(Buffer.alloc(0));
+    }
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      request.on("data", (chunk: Buffer) => chunks.push(chunk));
+      request.on("end", () => resolve(Buffer.concat(chunks)));
+      request.on("error", reject);
+    });
+  }
+}

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/http-proxy.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/http-proxy.ts
@@ -1,4 +1,6 @@
+import * as crypto from "node:crypto";
 import http from "node:http";
+import * as net from "node:net";
 import {
   ROOT_LOGGER,
   type RootLogger,
@@ -8,14 +10,23 @@ import { inject, injectable, preDestroy } from "inversify";
 import { streamBodyToResponse } from "../proxy-stream/proxy-stream";
 
 interface ProxyTarget {
+  registrationId: string;
   runId: string;
+  installationId: string;
   url: string;
   headers: Record<string, string>;
+}
+
+interface ActiveRequest {
+  controller: AbortController;
+  target: ProxyTarget;
+  routeToken: string;
 }
 
 export interface AgentPluginHttpProxyRegistration {
   id: string;
   runId: string;
+  installationId: string;
   url: string;
   headers: Record<string, string>;
 }
@@ -23,6 +34,7 @@ export interface AgentPluginHttpProxyRegistration {
 export interface AgentPluginHttpProxy {
   register(registration: AgentPluginHttpProxyRegistration): Promise<string>;
   unregisterRun(runId: string): void;
+  unregisterInstallation(installationId: string): void;
 }
 
 const HOP_BY_HOP_HEADERS = new Set([
@@ -37,6 +49,26 @@ const SENSITIVE_REDIRECT_HEADERS = new Set([
   "cookie",
   "proxy-authorization",
 ]);
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const MAX_REDIRECTS = 5;
+const MAX_REQUEST_BODY_BYTES = 2 * 1024 * 1024;
+
+function isLoopbackHostname(hostname: string): boolean {
+  if (hostname === "localhost") return true;
+  const ipVersion = net.isIP(hostname);
+  if (ipVersion === 4) return hostname.startsWith("127.");
+  if (ipVersion === 6) return hostname === "::1";
+  return false;
+}
+
+function assertAllowedMcpUrl(url: URL): void {
+  if (url.username || url.password || url.hash) {
+    throw new Error("Agent Plugin MCP URL contains forbidden URL components.");
+  }
+  if (url.protocol === "https:") return;
+  if (url.protocol === "http:" && isLoopbackHostname(url.hostname)) return;
+  throw new Error("Agent Plugin MCP URL must use HTTPS unless it is loopback.");
+}
 
 function mergeRequestHeaders(
   configured: Record<string, string>,
@@ -89,13 +121,18 @@ function responseHeaders(response: Response): Record<string, string> {
   return headers;
 }
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 @injectable()
 export class AgentPluginHttpProxyService implements AgentPluginHttpProxy {
   private server: http.Server | null = null;
   private port: number | null = null;
   private startPromise: Promise<void> | null = null;
   private readonly targets = new Map<string, ProxyTarget>();
-  private readonly activeRequests = new Map<string, Set<AbortController>>();
+  private readonly routeByRegistration = new Map<string, string>();
+  private readonly activeRequests = new Set<ActiveRequest>();
   private readonly log: ScopedLogger;
 
   constructor(@inject(ROOT_LOGGER) logger: RootLogger) {
@@ -105,32 +142,39 @@ export class AgentPluginHttpProxyService implements AgentPluginHttpProxy {
   async register(
     registration: AgentPluginHttpProxyRegistration,
   ): Promise<string> {
+    const parsedUrl = new URL(registration.url);
+    assertAllowedMcpUrl(parsedUrl);
     await this.start();
-    this.targets.set(registration.id, {
+
+    const existingRoute = this.routeByRegistration.get(registration.id);
+    if (existingRoute) this.unregisterRoute(existingRoute);
+
+    const routeToken = crypto.randomBytes(32).toString("base64url");
+    this.targets.set(routeToken, {
+      registrationId: registration.id,
       runId: registration.runId,
-      url: registration.url,
+      installationId: registration.installationId,
+      url: parsedUrl.toString(),
       headers: registration.headers,
     });
-    return `http://127.0.0.1:${this.port}/${encodeURIComponent(registration.id)}`;
+    this.routeByRegistration.set(registration.id, routeToken);
+    return `http://127.0.0.1:${this.port}/${routeToken}`;
   }
 
   unregisterRun(runId: string): void {
-    for (const [id, target] of this.targets) {
-      if (target.runId === runId) this.targets.delete(id);
-    }
-    for (const controller of this.activeRequests.get(runId) ?? []) {
-      controller.abort();
-    }
-    this.activeRequests.delete(runId);
+    this.unregisterWhere((target) => target.runId === runId);
+  }
+
+  unregisterInstallation(installationId: string): void {
+    this.unregisterWhere((target) => target.installationId === installationId);
   }
 
   @preDestroy()
   async stop(): Promise<void> {
-    for (const controllers of this.activeRequests.values()) {
-      for (const controller of controllers) controller.abort();
-    }
+    for (const request of this.activeRequests) request.controller.abort();
     this.activeRequests.clear();
     this.targets.clear();
+    this.routeByRegistration.clear();
     if (!this.server) return;
 
     const server = this.server;
@@ -143,10 +187,32 @@ export class AgentPluginHttpProxyService implements AgentPluginHttpProxy {
     this.startPromise = null;
   }
 
+  private unregisterWhere(predicate: (target: ProxyTarget) => boolean): void {
+    for (const [routeToken, target] of this.targets) {
+      if (predicate(target)) this.unregisterRoute(routeToken);
+    }
+    for (const request of this.activeRequests) {
+      if (predicate(request.target)) request.controller.abort();
+    }
+  }
+
+  private unregisterRoute(routeToken: string): void {
+    const target = this.targets.get(routeToken);
+    if (!target) return;
+    this.targets.delete(routeToken);
+    if (this.routeByRegistration.get(target.registrationId) === routeToken) {
+      this.routeByRegistration.delete(target.registrationId);
+    }
+  }
+
   private async start(): Promise<void> {
     if (this.server && this.port !== null) return;
     if (this.startPromise) return this.startPromise;
     this.startPromise = this.startServer().catch((error) => {
+      this.server?.closeAllConnections();
+      this.server?.close();
+      this.server = null;
+      this.port = null;
       this.startPromise = null;
       throw error;
     });
@@ -157,7 +223,7 @@ export class AgentPluginHttpProxyService implements AgentPluginHttpProxy {
     const server = http.createServer((request, response) => {
       void this.handleRequest(request, response).catch((error) => {
         this.log.warn("Agent Plugin MCP proxy request failed", {
-          error: error instanceof Error ? error.message : String(error),
+          error: errorMessage(error),
         });
         if (!response.headersSent) {
           response.writeHead(502, {
@@ -190,36 +256,52 @@ export class AgentPluginHttpProxyService implements AgentPluginHttpProxy {
     request: http.IncomingMessage,
     response: http.ServerResponse,
   ): Promise<void> {
+    if (request.headers.origin || request.headers["sec-fetch-site"]) {
+      response.writeHead(403);
+      response.end("Browser requests are not allowed");
+      return;
+    }
+
     const incomingUrl = new URL(request.url ?? "/", "http://localhost");
-    const [rawId, ...suffixSegments] = incomingUrl.pathname
+    const [routeToken, ...suffixSegments] = incomingUrl.pathname
       .split("/")
       .filter(Boolean);
-    const id = rawId ? decodeURIComponent(rawId) : "";
-    const target = this.targets.get(id);
-    if (!target) {
+    const target = routeToken ? this.targets.get(routeToken) : undefined;
+    if (!routeToken || !target) {
       response.writeHead(404);
       response.end("Unknown Agent Plugin MCP target");
       return;
     }
 
-    const targetUrl = new URL(target.url);
-    const suffix = suffixSegments.join("/");
-    if (suffix) {
-      targetUrl.pathname = `${targetUrl.pathname.replace(/\/+$/, "")}/${suffix}`;
-    }
-    for (const [name, value] of incomingUrl.searchParams) {
-      targetUrl.searchParams.append(name, value);
-    }
-    const body = await this.readRequestBody(request);
     const controller = new AbortController();
-    const active = this.activeRequests.get(target.runId) ?? new Set();
-    active.add(controller);
-    this.activeRequests.set(target.runId, active);
+    const activeRequest: ActiveRequest = {
+      controller,
+      target,
+      routeToken,
+    };
+    this.activeRequests.add(activeRequest);
     response.on("close", () => {
       if (!response.writableEnded) controller.abort();
     });
 
     try {
+      const targetUrl = new URL(target.url);
+      const suffix = suffixSegments.join("/");
+      if (suffix) {
+        targetUrl.pathname = `${targetUrl.pathname.replace(/\/+$/, "")}/${suffix}`;
+      }
+      for (const [name, value] of incomingUrl.searchParams) {
+        targetUrl.searchParams.append(name, value);
+      }
+
+      const body = await this.readRequestBody(request, controller.signal);
+      if (
+        controller.signal.aborted ||
+        this.targets.get(routeToken) !== target
+      ) {
+        throw new Error("Agent Plugin MCP target was removed.");
+      }
+
       const incomingHeaderNames = new Set(
         Object.keys(request.headers).map((name) => name.toLowerCase()),
       );
@@ -238,24 +320,39 @@ export class AgentPluginHttpProxyService implements AgentPluginHttpProxy {
         },
         configuredHeaderNames,
       );
+      if (
+        controller.signal.aborted ||
+        this.targets.get(routeToken) !== target
+      ) {
+        throw new Error("Agent Plugin MCP target was removed.");
+      }
       response.writeHead(upstream.status, responseHeaders(upstream));
       await streamBodyToResponse(upstream.body, response);
     } catch (error) {
       if (!controller.signal.aborted) {
         this.log.warn("Agent Plugin MCP proxy request failed", {
-          target: id,
-          error: error instanceof Error ? error.message : String(error),
+          target: target.registrationId,
+          error: errorMessage(error),
         });
       }
       if (!response.headersSent) {
-        response.writeHead(502, {
+        const status =
+          error instanceof RequestBodyTooLargeError
+            ? 413
+            : controller.signal.aborted
+              ? 404
+              : 502;
+        response.writeHead(status, {
           "x-posthog-agent-plugin-proxy-error": "1",
         });
       }
-      response.end("Agent Plugin MCP proxy error");
+      response.end(
+        error instanceof RequestBodyTooLargeError
+          ? "Agent Plugin MCP request body is too large"
+          : "Agent Plugin MCP proxy error",
+      );
     } finally {
-      active.delete(controller);
-      if (active.size === 0) this.activeRequests.delete(target.runId);
+      this.activeRequests.delete(activeRequest);
     }
   }
 
@@ -264,12 +361,24 @@ export class AgentPluginHttpProxyService implements AgentPluginHttpProxy {
     initialOptions: RequestInit,
     configuredHeaderNames: ReadonlySet<string>,
   ): Promise<Response> {
+    assertAllowedMcpUrl(initialUrl);
+    const approvedOrigin = initialUrl.origin;
+    const visited = new Set<string>();
     let url = initialUrl;
     let method = initialOptions.method ?? "GET";
     let body = initialOptions.body;
     let headers = new Headers(initialOptions.headers);
 
-    for (let redirectCount = 0; redirectCount <= 5; redirectCount += 1) {
+    for (
+      let redirectCount = 0;
+      redirectCount <= MAX_REDIRECTS;
+      redirectCount += 1
+    ) {
+      if (visited.has(url.toString())) {
+        throw new Error("Agent Plugin MCP redirect loop detected.");
+      }
+      visited.add(url.toString());
+
       const response = await fetch(url, {
         ...initialOptions,
         method,
@@ -277,15 +386,17 @@ export class AgentPluginHttpProxyService implements AgentPluginHttpProxy {
         ...(body !== undefined ? { body } : { body: undefined }),
         redirect: "manual",
       });
-      if (![301, 302, 303, 307, 308].includes(response.status)) {
-        return response;
-      }
-      const location = response.headers.get("location");
-      if (!location || redirectCount === 5) {
-        throw new Error("Agent Plugin MCP redirect could not be followed.");
-      }
+      if (!REDIRECT_STATUSES.has(response.status)) return response;
 
+      const location = response.headers.get("location");
+      if (!location || redirectCount === MAX_REDIRECTS) {
+        throw new Error("Agent Plugin MCP redirect limit exceeded.");
+      }
       const nextUrl = new URL(location, url);
+      assertAllowedMcpUrl(nextUrl);
+      if (nextUrl.origin !== approvedOrigin) {
+        throw new Error("Agent Plugin MCP cross-origin redirect was blocked.");
+      }
       headers = headersAfterRedirect(
         headers,
         configuredHeaderNames,
@@ -306,15 +417,58 @@ export class AgentPluginHttpProxyService implements AgentPluginHttpProxy {
     throw new Error("Agent Plugin MCP redirect limit exceeded.");
   }
 
-  private readRequestBody(request: http.IncomingMessage): Promise<Buffer> {
+  private readRequestBody(
+    request: http.IncomingMessage,
+    signal: AbortSignal,
+  ): Promise<Buffer> {
     if (request.method === "GET" || request.method === "HEAD") {
       return Promise.resolve(Buffer.alloc(0));
     }
     return new Promise((resolve, reject) => {
       const chunks: Buffer[] = [];
-      request.on("data", (chunk: Buffer) => chunks.push(chunk));
-      request.on("end", () => resolve(Buffer.concat(chunks)));
-      request.on("error", reject);
+      let size = 0;
+      const onAbort = (): void => {
+        cleanup();
+        reject(new Error("Agent Plugin MCP request was aborted."));
+      };
+      const onData = (chunk: Buffer): void => {
+        size += chunk.length;
+        if (size > MAX_REQUEST_BODY_BYTES) {
+          cleanup();
+          reject(new RequestBodyTooLargeError());
+          return;
+        }
+        chunks.push(chunk);
+      };
+      const onEnd = (): void => {
+        cleanup();
+        resolve(Buffer.concat(chunks));
+      };
+      const onError = (error: Error): void => {
+        cleanup();
+        reject(error);
+      };
+      const cleanup = (): void => {
+        signal.removeEventListener("abort", onAbort);
+        request.off("data", onData);
+        request.off("end", onEnd);
+        request.off("error", onError);
+      };
+
+      if (signal.aborted) {
+        onAbort();
+        return;
+      }
+      signal.addEventListener("abort", onAbort, { once: true });
+      request.on("data", onData);
+      request.on("end", onEnd);
+      request.on("error", onError);
     });
+  }
+}
+
+class RequestBodyTooLargeError extends Error {
+  constructor() {
+    super("Agent Plugin MCP request body is too large.");
   }
 }

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/identifiers.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/identifiers.ts
@@ -1,3 +1,6 @@
 export const AGENT_PLUGINS_SERVICE = Symbol.for(
   "posthog.workspace.agentPluginsService",
 );
+export const AGENT_PLUGIN_HTTP_PROXY = Symbol.for(
+  "posthog.workspace.agentPluginHttpProxy",
+);

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/loader.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/loader.ts
@@ -1013,9 +1013,11 @@ export async function loadAgentPlugin(
     };
   }
 
+  const skillDiagnostics: AgentPluginDiagnostic[] = [];
+  const mcpDiagnostics: AgentPluginDiagnostic[] = [];
   const [skills, mcpServers] = await Promise.all([
-    loadSkills(pluginRoot, diagnostics),
-    loadMcpServers(pluginRoot, diagnostics),
+    loadSkills(pluginRoot, skillDiagnostics),
+    loadMcpServers(pluginRoot, mcpDiagnostics),
   ]);
   return {
     valid: true,
@@ -1023,6 +1025,6 @@ export async function loadAgentPlugin(
     manifest,
     skills,
     mcpServers,
-    diagnostics,
+    diagnostics: [...diagnostics, ...skillDiagnostics, ...mcpDiagnostics],
   };
 }

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/loader.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/loader.ts
@@ -1,9 +1,12 @@
 import * as fs from "node:fs";
+import * as net from "node:net";
 import * as path from "node:path";
 import { parseDocument } from "yaml";
 import {
   AGENT_PLUGINS_MANIFEST_SCHEMA,
+  AGENT_PLUGINS_MCP_SCHEMA,
   type AgentPluginDiagnostic,
+  type AgentPluginHttpMcpServer,
   type AgentPluginManifest,
   type AgentPluginPreview,
   type AgentPluginSkill,
@@ -25,6 +28,13 @@ const MANIFEST_FIELDS = new Set([
   "extensions",
 ]);
 const AUTHOR_FIELDS = new Set(["name", "email", "url"]);
+const MCP_TOP_LEVEL_FIELDS = new Set(["$schema", "mcpServers"]);
+const REMOTE_MCP_FIELDS = new Set(["type", "url", "headers"]);
+const STDIO_MCP_FIELDS = new Set(["type", "command", "args", "env", "cwd"]);
+const HTTP_HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+const HTTP_HEADER_VALUE_PATTERN = /^[\t\x20-\x7e\x80-\xff]*$/;
+const PLUGIN_ROOT_PLACEHOLDER = `\${PLUGIN_ROOT}`;
+const PLUGIN_DATA_PLACEHOLDER = `\${PLUGIN_DATA}`;
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -506,6 +516,307 @@ async function loadSkills(
   return skills;
 }
 
+function hasOnlyFields(
+  value: Record<string, unknown>,
+  allowedFields: ReadonlySet<string>,
+): boolean {
+  return Object.keys(value).every((field) => allowedFields.has(field));
+}
+
+function parseHttpHeaders(value: unknown): Record<string, string> | null {
+  if (value === undefined) return {};
+  if (!isObject(value)) return null;
+
+  const headers: Record<string, string> = {};
+  const names = new Set<string>();
+  for (const [name, headerValue] of Object.entries(value)) {
+    const normalizedName = name.toLowerCase();
+    if (
+      names.has(normalizedName) ||
+      !HTTP_HEADER_NAME_PATTERN.test(name) ||
+      typeof headerValue !== "string" ||
+      !HTTP_HEADER_VALUE_PATTERN.test(headerValue)
+    ) {
+      return null;
+    }
+    names.add(normalizedName);
+    headers[name] = headerValue;
+  }
+  return headers;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  if (hostname === "localhost") return true;
+  const unwrappedHostname =
+    hostname.startsWith("[") && hostname.endsWith("]")
+      ? hostname.slice(1, -1)
+      : hostname;
+  const ipVersion = net.isIP(unwrappedHostname);
+  if (ipVersion === 4) {
+    return unwrappedHostname.startsWith("127.");
+  }
+  return ipVersion === 6 && unwrappedHostname === "::1";
+}
+
+function parseRemoteMcpServer(
+  serverName: string,
+  value: Record<string, unknown>,
+): AgentPluginHttpMcpServer | null {
+  if (!hasOnlyFields(value, REMOTE_MCP_FIELDS)) return null;
+  if (value.type !== "streamable-http" && value.type !== "sse") {
+    return null;
+  }
+  if (typeof value.url !== "string") return null;
+
+  let url: URL;
+  try {
+    url = new URL(value.url);
+  } catch {
+    return null;
+  }
+  if (
+    (url.protocol !== "http:" && url.protocol !== "https:") ||
+    url.username !== "" ||
+    url.password !== "" ||
+    url.hash !== "" ||
+    (url.protocol === "http:" && !isLoopbackHostname(url.hostname))
+  ) {
+    return null;
+  }
+
+  const headers = parseHttpHeaders(value.headers);
+  if (!headers) return null;
+  if (value.type === "sse") return null;
+
+  return {
+    name: serverName,
+    type: "streamable-http",
+    url: url.toString(),
+    ...(Object.keys(headers).length > 0 ? { headers } : {}),
+  };
+}
+
+function isContainedPluginPath(pluginRoot: string, value: string): boolean {
+  return (
+    value.startsWith("./") &&
+    isPathContained(pluginRoot, path.resolve(pluginRoot, value))
+  );
+}
+
+function isValidStdioCwd(pluginRoot: string, value: string): boolean {
+  if (value.startsWith("./")) return isContainedPluginPath(pluginRoot, value);
+  for (const placeholder of [
+    PLUGIN_ROOT_PLACEHOLDER,
+    PLUGIN_DATA_PLACEHOLDER,
+  ]) {
+    if (value === placeholder) return true;
+    if (value.startsWith(`${placeholder}/`)) {
+      const normalizedValue = path.posix.normalize(
+        value.slice(placeholder.length + 1),
+      );
+      return (
+        normalizedValue !== ".." &&
+        !normalizedValue.startsWith("../") &&
+        !path.posix.isAbsolute(normalizedValue)
+      );
+    }
+  }
+  return false;
+}
+
+function isValidUnsupportedMcpServer(
+  pluginRoot: string,
+  value: Record<string, unknown>,
+): value is Record<string, unknown> & { type: "stdio" | "sse" } {
+  if (value.type === "sse") {
+    if (!hasOnlyFields(value, REMOTE_MCP_FIELDS)) return false;
+    if (typeof value.url !== "string") return false;
+    const headers = parseHttpHeaders(value.headers);
+    if (!headers) return false;
+    try {
+      const url = new URL(value.url);
+      return (
+        (url.protocol === "http:" || url.protocol === "https:") &&
+        url.username === "" &&
+        url.password === "" &&
+        url.hash === "" &&
+        (url.protocol === "https:" || isLoopbackHostname(url.hostname))
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  if (value.type !== "stdio" || !hasOnlyFields(value, STDIO_MCP_FIELDS)) {
+    return false;
+  }
+  if (typeof value.command !== "string" || value.command.length === 0) {
+    return false;
+  }
+  const isPluginCommand = value.command.startsWith("./");
+  const isBareCommand =
+    !value.command.includes("/") &&
+    !value.command.includes("\\") &&
+    !/\s/.test(value.command);
+  if (
+    (isPluginCommand && !isContainedPluginPath(pluginRoot, value.command)) ||
+    (!isPluginCommand && !isBareCommand)
+  ) {
+    return false;
+  }
+  if (
+    value.args !== undefined &&
+    (!Array.isArray(value.args) ||
+      !value.args.every((argument) => typeof argument === "string"))
+  ) {
+    return false;
+  }
+  if (value.env !== undefined) {
+    if (
+      !isObject(value.env) ||
+      Object.keys(value.env).some(
+        (name) => name === "PLUGIN_ROOT" || name === "PLUGIN_DATA",
+      ) ||
+      !Object.values(value.env).every(
+        (environmentValue) => typeof environmentValue === "string",
+      )
+    ) {
+      return false;
+    }
+  }
+  return (
+    value.cwd === undefined ||
+    (typeof value.cwd === "string" && isValidStdioCwd(pluginRoot, value.cwd))
+  );
+}
+
+async function loadMcpServers(
+  pluginRoot: string,
+  diagnostics: AgentPluginDiagnostic[],
+): Promise<AgentPluginHttpMcpServer[]> {
+  const mcpPath = path.join(pluginRoot, "mcp.json");
+  let resolvedMcpPath: string;
+  try {
+    resolvedMcpPath = await fs.promises.realpath(mcpPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    diagnostics.push(
+      diagnostic(
+        "error",
+        "invalid_mcp_config",
+        "Could not read mcp.json. MCP servers from this plugin are disabled.",
+        "mcp.json",
+      ),
+    );
+    return [];
+  }
+
+  if (!isPathContained(pluginRoot, resolvedMcpPath)) {
+    diagnostics.push(
+      diagnostic(
+        "error",
+        "mcp_escape",
+        "mcp.json resolves outside the plugin directory. MCP servers from this plugin are disabled.",
+        "mcp.json",
+      ),
+    );
+    return [];
+  }
+
+  let rawMcp: unknown;
+  try {
+    const stat = await fs.promises.stat(resolvedMcpPath);
+    if (!stat.isFile()) throw new Error("not a file");
+    rawMcp = JSON.parse(await fs.promises.readFile(resolvedMcpPath, "utf8"));
+  } catch (error) {
+    diagnostics.push(
+      diagnostic(
+        "error",
+        "invalid_mcp_config",
+        error instanceof SyntaxError
+          ? "mcp.json is not valid JSON. MCP servers from this plugin are disabled."
+          : "mcp.json is not a regular file. MCP servers from this plugin are disabled.",
+        "mcp.json",
+      ),
+    );
+    return [];
+  }
+
+  if (
+    !isObject(rawMcp) ||
+    !hasOnlyFields(rawMcp, MCP_TOP_LEVEL_FIELDS) ||
+    rawMcp.$schema !== AGENT_PLUGINS_MCP_SCHEMA ||
+    !isObject(rawMcp.mcpServers)
+  ) {
+    diagnostics.push(
+      diagnostic(
+        "error",
+        "invalid_mcp_config",
+        `mcp.json must target ${AGENT_PLUGINS_MCP_SCHEMA} and contain only an mcpServers object. MCP servers from this plugin are disabled.`,
+        "mcp.json",
+      ),
+    );
+    return [];
+  }
+
+  const servers: AgentPluginHttpMcpServer[] = [];
+  for (const [serverName, rawServer] of Object.entries(rawMcp.mcpServers).sort(
+    ([left], [right]) => left.localeCompare(right),
+  )) {
+    const serverPath = `mcp.json/mcpServers/${serverName}`;
+    if (!isObject(rawServer)) {
+      diagnostics.push(
+        diagnostic(
+          "error",
+          "invalid_mcp_server",
+          `Skipped MCP server ${serverName} because its configuration is invalid.`,
+          serverPath,
+        ),
+      );
+      continue;
+    }
+
+    if (rawServer.type === "streamable-http") {
+      const server = parseRemoteMcpServer(serverName, rawServer);
+      if (server) {
+        servers.push(server);
+      } else {
+        diagnostics.push(
+          diagnostic(
+            "error",
+            "invalid_mcp_server",
+            `Skipped MCP server ${serverName} because its Streamable HTTP configuration is invalid.`,
+            serverPath,
+          ),
+        );
+      }
+      continue;
+    }
+
+    if (isValidUnsupportedMcpServer(pluginRoot, rawServer)) {
+      diagnostics.push(
+        diagnostic(
+          "warning",
+          "unsupported_mcp_transport",
+          `Skipped MCP server ${serverName} because ${rawServer.type} transport is not supported yet.`,
+          serverPath,
+        ),
+      );
+      continue;
+    }
+
+    diagnostics.push(
+      diagnostic(
+        "error",
+        "invalid_mcp_server",
+        `Skipped MCP server ${serverName} because its configuration is invalid.`,
+        serverPath,
+      ),
+    );
+  }
+  return servers;
+}
+
 export async function loadAgentPlugin(
   sourcePath: string,
 ): Promise<AgentPluginPreview> {
@@ -527,6 +838,7 @@ export async function loadAgentPlugin(
         sourcePath: path.resolve(sourcePath),
         manifest: null,
         skills: [],
+        mcpServers: [],
         diagnostics,
       };
     }
@@ -543,6 +855,7 @@ export async function loadAgentPlugin(
       sourcePath: path.resolve(sourcePath),
       manifest: null,
       skills: [],
+      mcpServers: [],
       diagnostics,
     };
   }
@@ -565,6 +878,7 @@ export async function loadAgentPlugin(
         sourcePath: pluginRoot,
         manifest: null,
         skills: [],
+        mcpServers: [],
         diagnostics,
       };
     }
@@ -589,6 +903,7 @@ export async function loadAgentPlugin(
       sourcePath: pluginRoot,
       manifest: null,
       skills: [],
+      mcpServers: [],
       diagnostics,
     };
   }
@@ -600,16 +915,21 @@ export async function loadAgentPlugin(
       sourcePath: pluginRoot,
       manifest: null,
       skills: [],
+      mcpServers: [],
       diagnostics,
     };
   }
 
-  const skills = await loadSkills(pluginRoot, diagnostics);
+  const [skills, mcpServers] = await Promise.all([
+    loadSkills(pluginRoot, diagnostics),
+    loadMcpServers(pluginRoot, diagnostics),
+  ]);
   return {
     valid: true,
     sourcePath: pluginRoot,
     manifest,
     skills,
+    mcpServers,
     diagnostics,
   };
 }

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/loader.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/loader.ts
@@ -8,8 +8,8 @@ import {
   type AgentPluginDiagnostic,
   type AgentPluginHttpMcpServer,
   type AgentPluginManifest,
-  type AgentPluginPreview,
   type AgentPluginSkill,
+  type LoadedAgentPlugin,
 } from "./schemas";
 
 const PLUGIN_NAME_PATTERN =
@@ -624,10 +624,10 @@ function isValidStdioCwd(pluginRoot: string, value: string): boolean {
   return false;
 }
 
-function isValidUnsupportedMcpServer(
+async function isValidUnsupportedMcpServer(
   pluginRoot: string,
   value: Record<string, unknown>,
-): value is Record<string, unknown> & { type: "stdio" | "sse" } {
+): Promise<boolean> {
   if (value.type === "sse") {
     if (!hasOnlyFields(value, REMOTE_MCP_FIELDS)) return false;
     if (typeof value.url !== "string") return false;
@@ -658,11 +658,18 @@ function isValidUnsupportedMcpServer(
     !value.command.includes("/") &&
     !value.command.includes("\\") &&
     !/\s/.test(value.command);
-  if (
-    (isPluginCommand && !isContainedPluginPath(pluginRoot, value.command)) ||
-    (!isPluginCommand && !isBareCommand)
-  ) {
-    return false;
+  if (!isPluginCommand && !isBareCommand) return false;
+  if (isPluginCommand) {
+    if (!isContainedPluginPath(pluginRoot, value.command)) return false;
+    try {
+      const resolvedCommand = await fs.promises.realpath(
+        path.resolve(pluginRoot, value.command),
+      );
+      if (!isPathContained(pluginRoot, resolvedCommand)) return false;
+      if (!(await fs.promises.stat(resolvedCommand)).isFile()) return false;
+    } catch {
+      return false;
+    }
   }
   if (
     value.args !== undefined &&
@@ -684,10 +691,29 @@ function isValidUnsupportedMcpServer(
       return false;
     }
   }
-  return (
-    value.cwd === undefined ||
-    (typeof value.cwd === "string" && isValidStdioCwd(pluginRoot, value.cwd))
-  );
+  if (value.cwd === undefined) return true;
+  if (
+    typeof value.cwd !== "string" ||
+    !isValidStdioCwd(pluginRoot, value.cwd)
+  ) {
+    return false;
+  }
+  if (value.cwd.startsWith(PLUGIN_DATA_PLACEHOLDER)) return true;
+
+  const relativeCwd = value.cwd.startsWith(PLUGIN_ROOT_PLACEHOLDER)
+    ? `.${value.cwd.slice(PLUGIN_ROOT_PLACEHOLDER.length)}`
+    : value.cwd;
+  try {
+    const resolvedCwd = await fs.promises.realpath(
+      path.resolve(pluginRoot, relativeCwd),
+    );
+    return (
+      isPathContained(pluginRoot, resolvedCwd) &&
+      (await fs.promises.stat(resolvedCwd)).isDirectory()
+    );
+  } catch {
+    return false;
+  }
 }
 
 async function loadMcpServers(
@@ -793,7 +819,7 @@ async function loadMcpServers(
       continue;
     }
 
-    if (isValidUnsupportedMcpServer(pluginRoot, rawServer)) {
+    if (await isValidUnsupportedMcpServer(pluginRoot, rawServer)) {
       diagnostics.push(
         diagnostic(
           "warning",
@@ -819,7 +845,7 @@ async function loadMcpServers(
 
 export async function loadAgentPlugin(
   sourcePath: string,
-): Promise<AgentPluginPreview> {
+): Promise<LoadedAgentPlugin> {
   const diagnostics: AgentPluginDiagnostic[] = [];
   let pluginRoot: string;
   try {

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/schemas.ts
@@ -44,12 +44,18 @@ export const agentPluginHttpMcpServer = z.object({
   headers: z.record(z.string(), z.string()).optional(),
 });
 
+export const agentPluginMcpServerSummary = z.object({
+  name: z.string(),
+  type: z.enum(["streamable-http", "stdio", "sse"]),
+  supported: z.boolean(),
+});
+
 export const agentPluginPreview = z.object({
   valid: z.boolean(),
   sourcePath: z.string(),
   manifest: agentPluginManifest.nullable(),
   skills: z.array(agentPluginSkill),
-  mcpServers: z.array(agentPluginHttpMcpServer),
+  mcpServers: z.array(agentPluginMcpServerSummary),
   diagnostics: z.array(agentPluginDiagnostic),
   selectionToken: z.string().uuid().optional(),
 });
@@ -60,7 +66,7 @@ export const agentPluginInstallation = z.object({
   enabled: z.boolean(),
   manifest: agentPluginManifest,
   skills: z.array(agentPluginSkill),
-  mcpServers: z.array(agentPluginHttpMcpServer),
+  mcpServers: z.array(agentPluginMcpServerSummary),
   diagnostics: z.array(agentPluginDiagnostic),
 });
 
@@ -80,14 +86,9 @@ export const setAgentPluginEnabledInput = z.object({
 export const agentPluginState = z.object({
   version: z.literal(1),
   installations: z.array(
-    z.object({
+    agentPluginInstallation.extend({
       id: z.string().regex(AGENT_PLUGIN_INSTALLATION_ID_PATTERN),
-      sourcePath: z.string(),
-      enabled: z.boolean(),
-      manifest: agentPluginManifest,
-      skills: z.array(agentPluginSkill),
-      mcpServers: z.array(agentPluginHttpMcpServer).default([]),
-      diagnostics: z.array(agentPluginDiagnostic),
+      mcpServers: z.array(agentPluginMcpServerSummary).default([]),
     }),
   ),
 });
@@ -96,5 +97,20 @@ export type AgentPluginDiagnostic = z.infer<typeof agentPluginDiagnostic>;
 export type AgentPluginManifest = z.infer<typeof agentPluginManifest>;
 export type AgentPluginSkill = z.infer<typeof agentPluginSkill>;
 export type AgentPluginHttpMcpServer = z.infer<typeof agentPluginHttpMcpServer>;
+export type AgentPluginMcpServerSummary = z.infer<
+  typeof agentPluginMcpServerSummary
+>;
 export type AgentPluginPreview = z.infer<typeof agentPluginPreview>;
 export type AgentPluginInstallation = z.infer<typeof agentPluginInstallation>;
+export type AgentPluginPersistedInstallation = z.infer<
+  typeof agentPluginState
+>["installations"][number];
+
+export interface LoadedAgentPlugin {
+  valid: boolean;
+  sourcePath: string;
+  manifest: AgentPluginManifest | null;
+  skills: AgentPluginSkill[];
+  mcpServers: AgentPluginHttpMcpServer[];
+  diagnostics: AgentPluginDiagnostic[];
+}

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/schemas.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 
 export const AGENT_PLUGINS_MANIFEST_SCHEMA =
   "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json";
+export const AGENT_PLUGINS_MCP_SCHEMA =
+  "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json";
 export const AGENT_PLUGIN_INSTALLATION_ID_PATTERN = /^[a-f0-9]{16}$/;
 
 export const agentPluginDiagnostic = z.object({
@@ -35,11 +37,19 @@ export const agentPluginSkill = z.object({
   path: z.string(),
 });
 
+export const agentPluginHttpMcpServer = z.object({
+  name: z.string(),
+  type: z.literal("streamable-http"),
+  url: z.string(),
+  headers: z.record(z.string(), z.string()).optional(),
+});
+
 export const agentPluginPreview = z.object({
   valid: z.boolean(),
   sourcePath: z.string(),
   manifest: agentPluginManifest.nullable(),
   skills: z.array(agentPluginSkill),
+  mcpServers: z.array(agentPluginHttpMcpServer),
   diagnostics: z.array(agentPluginDiagnostic),
   selectionToken: z.string().uuid().optional(),
 });
@@ -50,6 +60,7 @@ export const agentPluginInstallation = z.object({
   enabled: z.boolean(),
   manifest: agentPluginManifest,
   skills: z.array(agentPluginSkill),
+  mcpServers: z.array(agentPluginHttpMcpServer),
   diagnostics: z.array(agentPluginDiagnostic),
 });
 
@@ -75,6 +86,7 @@ export const agentPluginState = z.object({
       enabled: z.boolean(),
       manifest: agentPluginManifest,
       skills: z.array(agentPluginSkill),
+      mcpServers: z.array(agentPluginHttpMcpServer).default([]),
       diagnostics: z.array(agentPluginDiagnostic),
     }),
   ),
@@ -83,5 +95,6 @@ export const agentPluginState = z.object({
 export type AgentPluginDiagnostic = z.infer<typeof agentPluginDiagnostic>;
 export type AgentPluginManifest = z.infer<typeof agentPluginManifest>;
 export type AgentPluginSkill = z.infer<typeof agentPluginSkill>;
+export type AgentPluginHttpMcpServer = z.infer<typeof agentPluginHttpMcpServer>;
 export type AgentPluginPreview = z.infer<typeof agentPluginPreview>;
 export type AgentPluginInstallation = z.infer<typeof agentPluginInstallation>;

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/schemas.ts
@@ -47,7 +47,6 @@ export const agentPluginHttpMcpServer = z.object({
 export const agentPluginMcpServerSummary = z.object({
   name: z.string(),
   type: z.enum(["streamable-http", "stdio", "sse"]),
-  supported: z.boolean(),
 });
 
 export const agentPluginPreview = z.object({

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
@@ -647,6 +647,26 @@ describe("AgentService", () => {
       ]);
     });
 
+    it("cleans Agent Plugin runtime resources when session startup fails", async () => {
+      deps.agentPluginsService.prepareRuntimeMcpServers.mockResolvedValue([
+        {
+          name: "agent-plugin-example-12345678-abcdef12",
+          type: "http",
+          url: "http://127.0.0.1:4567/server",
+          headers: [],
+        },
+      ]);
+      mockNewSession.mockRejectedValueOnce(new Error("startup failed"));
+
+      await expect(
+        service.startSession({ ...baseSessionParams, adapter: "claude" }),
+      ).rejects.toThrow("startup failed");
+
+      expect(
+        deps.agentPluginsService.cleanupRuntimePlugins,
+      ).toHaveBeenCalledWith("run-1");
+    });
+
     it("passes identical MCP servers to both adapters when all servers are reachable", async () => {
       await service.startSession({
         ...baseSessionParams,

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
@@ -189,6 +189,7 @@ function createMockDependencies() {
     },
     agentPluginsService: {
       prepareRuntimePlugins: vi.fn().mockResolvedValue([]),
+      prepareRuntimeMcpServers: vi.fn().mockResolvedValue([]),
       cleanupRuntimePlugins: vi.fn().mockResolvedValue(undefined),
     },
     agentAuthAdapter: {
@@ -586,6 +587,64 @@ describe("AgentService", () => {
           }),
         ]),
       );
+    });
+
+    it.each(["claude", "codex"] as const)(
+      "passes Agent Plugin HTTP MCP servers to the %s adapter",
+      async (adapter) => {
+        deps.agentPluginsService.prepareRuntimeMcpServers.mockResolvedValue([
+          {
+            name: "agent-plugin-example-12345678-abcdef12",
+            type: "http",
+            url: "http://127.0.0.1:4567/server",
+            headers: [],
+          },
+        ]);
+
+        await service.startSession({ ...baseSessionParams, adapter });
+
+        expect(mockNewSession.mock.calls[0][0].mcpServers).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              name: "agent-plugin-example-12345678-abcdef12",
+              type: "http",
+              url: "http://127.0.0.1:4567/server",
+            }),
+          ]),
+        );
+        expect(
+          deps.agentPluginsService.prepareRuntimeMcpServers,
+        ).toHaveBeenCalledWith("run-1", new Set(["posthog"]));
+      },
+    );
+
+    it("drops an unreachable Agent Plugin proxy from Codex without dropping reachable servers", async () => {
+      deps.agentPluginsService.prepareRuntimeMcpServers.mockResolvedValue([
+        {
+          name: "agent-plugin-example-12345678-abcdef12",
+          type: "http",
+          url: "http://127.0.0.1:4567/server",
+          headers: [],
+        },
+      ]);
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: string | URL | Request) => {
+          if (String(input).includes("127.0.0.1:4567")) {
+            return new Response("proxy error", {
+              status: 502,
+              headers: { "x-posthog-agent-plugin-proxy-error": "1" },
+            });
+          }
+          return new Response("reachable", { status: 401 });
+        }),
+      );
+
+      await service.startSession({ ...baseSessionParams, adapter: "codex" });
+
+      expect(mockNewSession.mock.calls[0][0].mcpServers).toEqual([
+        expect.objectContaining({ name: "posthog" }),
+      ]);
     });
 
     it("passes identical MCP servers to both adapters when all servers are reachable", async () => {

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.ts
@@ -1260,6 +1260,19 @@ If a repository is required, call \`list_repos\` to find it, then use \`clone_re
           taskRunId,
         });
       }
+      await this.agentPluginsService
+        .cleanupRuntimePlugins(taskRunId)
+        .catch(() =>
+          this.log.debug("Agent Plugin cleanup failed during error handling", {
+            taskRunId,
+          }),
+        );
+      await cleanupCodexHome(this.storagePaths.appDataPath, taskRunId).catch(
+        () =>
+          this.log.debug("Codex home cleanup failed during error handling", {
+            taskRunId,
+          }),
+      );
 
       if (!isRetry && isAuthError(err)) {
         this.log.warn(

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.ts
@@ -891,12 +891,6 @@ If a repository is required, call \`list_repos\` to find it, then use \`clone_re
           await this.agentPluginsService.prepareRuntimePlugins(
             taskRunId,
             reservedSkillNames,
-            (pluginName, skillName) =>
-              this.log.warn("Skipped Agent Plugin skill name collision", {
-                pluginName,
-                skillName,
-                adapter,
-              }),
           );
       } catch (err) {
         this.log.warn("Failed to prepare Agent Plugins", {
@@ -1011,15 +1005,29 @@ If a repository is required, call \`list_repos\` to find it, then use \`clone_re
         })),
       );
 
+      let pluginMcpServers: McpServerConnection[] = [];
+      try {
+        pluginMcpServers =
+          await this.agentPluginsService.prepareRuntimeMcpServers(
+            taskRunId,
+            new Set(mcpServers.map((server) => server.name)),
+          );
+      } catch (err) {
+        this.log.warn("Failed to prepare Agent Plugin MCP servers", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+
       // codex-acp connects to every MCP server eagerly during session creation
       // and treats an unreachable one as fatal, which kills the session
       // ("ACP connection closed") and makes the host silently fall back to a
       // Claude/Opus session. Claude connects lazily and is unaffected, so only
       // the Codex server list is pruned to the reachable ones.
+      const allMcpServers = [...mcpServers, ...pluginMcpServers];
       const sessionMcpServers =
         adapter === "codex"
-          ? await this.filterReachableMcpServers(mcpServers, taskRunId)
-          : mcpServers;
+          ? await this.filterReachableMcpServers(allMcpServers, taskRunId)
+          : allMcpServers;
 
       const plugins = [
         {
@@ -1398,10 +1406,11 @@ If a repository is required, call \`list_repos\` to find it, then use \`clone_re
       } catch {
         // ignore body cleanup failures
       }
-      // Any HTTP response means the endpoint is reachable. codex-acp only treats
-      // transport failures (connection refused, DNS, timeout) as fatal; HTTP or
-      // JSON-RPC error responses are handled gracefully.
-      return true;
+      // The neutral Agent Plugin proxy marks upstream transport failures. Other
+      // HTTP responses still prove that codex-acp can establish the transport.
+      return (
+        response.headers?.get?.("x-posthog-agent-plugin-proxy-error") !== "1"
+      );
     } catch (err) {
       this.log.debug("MCP server reachability probe failed", {
         url: server.url,


### PR DESCRIPTION
## Problem

The [skills layer](https://github.com/PostHog/posthog/pull/80055) loads portable instructions, but Agent Plugins still cannot connect agents to remote MCP servers.

## Changes

- Loads valid `streamable-http` entries from the Agent Plugins 1.0 `mcp.json` format.
- Isolates invalid configuration and connection failures from valid skills and sibling servers.
- Returns skill and MCP diagnostics in a deterministic order.
- Routes connections through a neutral loopback proxy that never injects PostHog credentials.
- Restricts redirects to the approved origin and revokes active routes when plugins are disabled or removed.
- Limits `mcp.json` to 1 MiB and proxy request bodies to 2 MiB.
- Adds secret-redacted renderer data and serialized activation.
- Connects validated servers to Claude and Codex with deterministic names and Codex reachability checks.
- Updates the Plugins tab and documentation with Streamable HTTP support.

![Agent Plugins HTTP MCP settings](https://raw.githubusercontent.com/PostHog/pr-assets/fac4105fb6eb3402ca92151d7d88ea044642c110/2026/08/be2fe3f6-c48a-4227-81be-bea9f3d865fa.png)

## How did you test this code?

- Unit tests cover deterministic diagnostics, MCP failure isolation, validation, redirects, request limits, revocation, races, and adapter integration.
- Component tests cover the displayed MCP capability and redacted plugin metadata.
- `pnpm build`, `pnpm typecheck`, `pnpm lint`, and the host-boundary check passed on the complete stack.
- Electron QA verified the HTTP capability in Settings → Skills → Plugins.
- `hogli ci:preflight --fix` passed against current `master`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated `docs/AGENT-PLUGINS.md` with Streamable HTTP configuration, transport rules, request limits, authorization behavior, and current limitations.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Pi worker and reviewer agents implemented and independently reviewed this stack layer.
- Skills invoked: `/posthog-desktop`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, and `quill-code`.
- PR workflow skills: `/stacking-prs`, `/writing-pr-descriptions`, `/running-ci-preflight`, and `test-electron-app`.
- Security review added a neutral redirect-safe proxy, activation serialization, request revocation, and renderer data minimization.

