### PR TITLE
feat(desktop): support Agent Plugin stdio MCP

### DIFF
--- a/products/desktop/apps/code/src/main/di/bindings.ts
+++ b/products/desktop/apps/code/src/main/di/bindings.ts
@@ -147,8 +147,10 @@ import type { AgentPluginsService } from "@posthog/workspace-server/services/age
 import type { AgentPluginHttpProxy } from "@posthog/workspace-server/services/agent-plugins/http-proxy";
 import type {
   AGENT_PLUGIN_HTTP_PROXY,
+  AGENT_PLUGIN_STDIO_BRIDGE,
   AGENT_PLUGINS_SERVICE,
 } from "@posthog/workspace-server/services/agent-plugins/identifiers";
+import type { AgentPluginStdioBridge } from "@posthog/workspace-server/services/agent-plugins/stdio-bridge";
 import type {
   ARCHIVE_FILE_WATCHER,
   ARCHIVE_SESSION_CANCELLER,
@@ -522,6 +524,7 @@ export interface MainBindings {
 
   // Typed container.get-only tokens (bound via loaded modules)
   [AGENT_PLUGIN_HTTP_PROXY]: AgentPluginHttpProxy;
+  [AGENT_PLUGIN_STDIO_BRIDGE]: AgentPluginStdioBridge;
   [AGENT_PLUGINS_SERVICE]: AgentPluginsService;
   [AGENT_SERVICE]: AgentService;
   [OAUTH_SERVICE]: OAuthService;

--- a/products/desktop/apps/code/src/renderer/di/container.ts
+++ b/products/desktop/apps/code/src/renderer/di/container.ts
@@ -196,6 +196,8 @@ container.bind(AGENT_PLUGINS_CLIENT).toConstantValue({
     hostTrpcClient.agentPlugins.register.mutate({ selectionToken }),
   setEnabled: (id: string, enabled: boolean) =>
     hostTrpcClient.agentPlugins.setEnabled.mutate({ id, enabled }),
+  approveStdio: (id: string) =>
+    hostTrpcClient.agentPlugins.approveStdio.mutate({ id }),
   unregister: async (id: string) => {
     await hostTrpcClient.agentPlugins.unregister.mutate({ id });
   },

--- a/products/desktop/apps/web/src/web-container.ts
+++ b/products/desktop/apps/web/src/web-container.ts
@@ -717,6 +717,9 @@ container.bind(AGENT_PLUGINS_CLIENT).toConstantValue({
   setEnabled: async () => {
     throw new Error("Agent Plugins are not available on the web");
   },
+  approveStdio: async () => {
+    throw new Error("Agent Plugins are not available on the web");
+  },
   unregister: async () => {
     throw new Error("Agent Plugins are not available on the web");
   },

--- a/products/desktop/docs/AGENT-PLUGINS.md
+++ b/products/desktop/docs/AGENT-PLUGINS.md
@@ -14,6 +14,8 @@ PostHog Desktop keeps a reference to the selected directory. When an agent sessi
 
 You can disable a plugin without removing it. Disabling a plugin stops its running stdio MCP servers but preserves its app-managed plugin data. Removing a plugin stops its stdio MCP servers and deletes its app-managed plugin data. It does not delete the source directory.
 
+Adding a plugin approves the stdio command, arguments, environment values, and working directory shown in the preview. PostHog Desktop stores only a digest of each approved definition. If an executable definition is added or changed later, that server is skipped until you review the display-safe details and select **Approve stdio commands**. Environment values remain in the source `mcp.json` and are never returned to the app UI or stored in the installation registry.
+
 ## Supported format
 
 A plugin must target Agent Plugins 1.0.0 and can provide Agent Skills in the standard location:
@@ -74,7 +76,7 @@ Stdio MCP servers can use a bare executable name or a bundled executable path be
 }
 ```
 
-PostHog Desktop starts stdio commands without a shell and makes them available to Claude and Codex through a local managed bridge. A server that fails to start is skipped without stopping sibling servers or skills. Running processes stop when the agent session ends, the plugin is disabled or removed, or the app shuts down.
+PostHog Desktop starts stdio commands without a shell and makes them available to Claude and Codex through a local managed bridge. The bridge binds to loopback, uses an unguessable route for each server, rejects browser requests, and limits request bodies. A server that fails to initialize or later disconnects is skipped or restarted without stopping sibling servers or skills. Running processes stop when the agent session ends, session startup fails, the plugin is disabled or removed, or the app shuts down.
 
 Every installed plugin gets a stable writable `PLUGIN_DATA` directory. Its contents persist across plugin source updates and while the plugin is disabled. Removing the plugin deletes this directory. `PLUGIN_ROOT` points to the resolved source directory.
 

--- a/products/desktop/docs/AGENT-PLUGINS.md
+++ b/products/desktop/docs/AGENT-PLUGINS.md
@@ -1,6 +1,6 @@
 # Agent Plugins
 
-PostHog Desktop supports skills from local [Agent Plugins 1.0.0](https://agent-plugins.org/).
+PostHog Desktop supports skills, Streamable HTTP MCP servers, and stdio MCP servers from local [Agent Plugins 1.0.0](https://agent-plugins.org/).
 
 ## Add a local plugin
 
@@ -12,7 +12,7 @@ PostHog Desktop supports skills from local [Agent Plugins 1.0.0](https://agent-p
 
 PostHog Desktop keeps a reference to the selected directory. When an agent session starts, it validates the plugin again and copies valid skill files into temporary app storage for that session. The temporary copy is removed when the session ends.
 
-You can disable a plugin without removing it. Removing a plugin only removes its registration from PostHog Desktop and does not delete the source directory.
+You can disable a plugin without removing it. Disabling a plugin stops its running stdio MCP servers but preserves its app-managed plugin data. Removing a plugin stops its stdio MCP servers and deletes its app-managed plugin data. It does not delete the source directory.
 
 ## Supported format
 
@@ -55,10 +55,37 @@ Streamable HTTP MCP servers use the canonical MCP schema:
 
 Invalid MCP configuration does not disable valid skills. Each server is validated independently, so one invalid or unsupported server does not disable its valid siblings. PostHog Desktop follows same-origin redirects only. Configured header values stay in the privileged plugin loader and are not stored in the installation registry or returned to the app UI.
 
+Stdio MCP servers can use a bare executable name or a bundled executable path beginning with `./`:
+
+```json
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "local-tools": {
+      "type": "stdio",
+      "command": "./bin/server",
+      "args": ["--data", "${PLUGIN_DATA}"],
+      "env": {
+        "CONFIG": "${PLUGIN_ROOT}/config.json"
+      },
+      "cwd": "${PLUGIN_ROOT}"
+    }
+  }
+}
+```
+
+PostHog Desktop starts stdio commands without a shell and makes them available to Claude and Codex through a local managed bridge. A server that fails to start is skipped without stopping sibling servers or skills. Running processes stop when the agent session ends, the plugin is disabled or removed, or the app shuts down.
+
+Every installed plugin gets a stable writable `PLUGIN_DATA` directory. Its contents persist across plugin source updates and while the plugin is disabled. Removing the plugin deletes this directory. `PLUGIN_ROOT` points to the resolved source directory.
+
+Only `${PLUGIN_ROOT}` and `${PLUGIN_DATA}` are expanded, and only in `args`, `env` values, and `cwd`. Expansion is single-pass. The command is never expanded or interpreted as a shell command. Explicit working directories must remain within `PLUGIN_ROOT` or `PLUGIN_DATA`.
+
+Stdio processes receive a minimal host environment needed to find executables and basic user directories. Configured `env` values are applied next, then PostHog Desktop sets `PLUGIN_ROOT` and `PLUGIN_DATA`. Other app environment variables and PostHog credentials are not inherited. Do not place secrets directly in `mcp.json` because it is visible plugin data.
+
 ## Current limitations
 
 - Only local directory installation is available.
-- Agent Skills are supported in Claude and Codex sessions.
-- `mcp.json` is not loaded yet.
+- Agent Skills, Streamable HTTP MCP servers, and stdio MCP servers are supported in Claude and Codex sessions.
+- Legacy SSE MCP transport is skipped with a diagnostic.
 - Agent Plugins does not define portable commands, hooks, or agents. PostHog Desktop does not load those components from a portable plugin.
 - Plugin updates and registries are not supported. Edit or update the source directory directly.

--- a/products/desktop/docs/AGENT-PLUGINS.md
+++ b/products/desktop/docs/AGENT-PLUGINS.md
@@ -88,4 +88,4 @@ Stdio processes receive a minimal host environment needed to find executables an
 
 - Only local directory installation is available.
 - Legacy SSE MCP transport is skipped with a diagnostic.
-- Plugin updates and registries are not supported. Edit or update the source directory directly.
+- PostHog Desktop does not download or update plugins. Manage plugin files in the installed local directory.

--- a/products/desktop/docs/AGENT-PLUGINS.md
+++ b/products/desktop/docs/AGENT-PLUGINS.md
@@ -87,7 +87,6 @@ Stdio processes receive a minimal host environment needed to find executables an
 ## Current limitations
 
 - Only local directory installation is available.
-- Agent Skills, Streamable HTTP MCP servers, and stdio MCP servers are supported in Claude and Codex sessions.
 - Legacy SSE MCP transport is skipped with a diagnostic.
 - Agent Plugins does not define portable commands, hooks, or agents. PostHog Desktop does not load those components from a portable plugin.
 - Plugin updates and registries are not supported. Edit or update the source directory directly.

--- a/products/desktop/docs/AGENT-PLUGINS.md
+++ b/products/desktop/docs/AGENT-PLUGINS.md
@@ -88,5 +88,4 @@ Stdio processes receive a minimal host environment needed to find executables an
 
 - Only local directory installation is available.
 - Legacy SSE MCP transport is skipped with a diagnostic.
-- Agent Plugins does not define portable commands, hooks, or agents. PostHog Desktop does not load those components from a portable plugin.
 - Plugin updates and registries are not supported. Edit or update the source directory directly.

--- a/products/desktop/docs/AGENT-PLUGINS.md
+++ b/products/desktop/docs/AGENT-PLUGINS.md
@@ -86,6 +86,6 @@ Stdio processes receive a minimal host environment needed to find executables an
 
 ## Current limitations
 
-- Only local directory installation is available.
+- Plugins must be installed from a directory on this device. Installation from URLs, Git repositories, archives, and registries is not supported.
 - Legacy SSE MCP transport is skipped with a diagnostic.
 - PostHog Desktop does not download or update plugins. Manage plugin files in the installed local directory.

--- a/products/desktop/docs/AGENT-PLUGINS.md
+++ b/products/desktop/docs/AGENT-PLUGINS.md
@@ -87,5 +87,5 @@ Stdio processes receive a minimal host environment needed to find executables an
 ## Current limitations
 
 - Plugins must be installed from a directory on this device. Installation from URLs, Git repositories, archives, and registries is not supported.
-- Legacy SSE MCP transport is skipped with a diagnostic.
+- Only the `stdio` and `streamable-http` MCP transports are supported. PostHog Desktop reports the deprecated `sse` transport as unsupported without affecting other plugin components.
 - PostHog Desktop does not download or update plugins. Manage plugin files in the installed local directory.

--- a/products/desktop/packages/core/src/agent-plugins/agentPluginsClient.ts
+++ b/products/desktop/packages/core/src/agent-plugins/agentPluginsClient.ts
@@ -31,6 +31,12 @@ export interface AgentPluginMcpServerSummary {
   name: string;
   type: "streamable-http" | "stdio" | "sse";
   supported: boolean;
+  command?: string;
+  args?: string[];
+  cwd?: string;
+  envNames?: string[];
+  digest?: string;
+  approval: "not-required" | "approved" | "required";
 }
 
 export interface AgentPluginPreview {
@@ -51,6 +57,7 @@ export interface AgentPluginInstallation {
   skills: AgentPluginSkill[];
   mcpServers: AgentPluginMcpServerSummary[];
   diagnostics: AgentPluginDiagnostic[];
+  stdioApprovalRequired: boolean;
 }
 
 export interface AgentPluginsClient {
@@ -58,5 +65,6 @@ export interface AgentPluginsClient {
   select(): Promise<AgentPluginPreview | null>;
   register(selectionToken: string): Promise<AgentPluginInstallation>;
   setEnabled(id: string, enabled: boolean): Promise<AgentPluginInstallation>;
+  approveStdio(id: string): Promise<AgentPluginInstallation>;
   unregister(id: string): Promise<void>;
 }

--- a/products/desktop/packages/core/src/agent-plugins/agentPluginsClient.ts
+++ b/products/desktop/packages/core/src/agent-plugins/agentPluginsClient.ts
@@ -35,7 +35,6 @@ export interface AgentPluginMcpServerSummary {
   args?: string[];
   cwd?: string;
   envNames?: string[];
-  digest?: string;
   approval: "not-required" | "approved" | "required";
 }
 

--- a/products/desktop/packages/host-router/src/routers/agent-plugins.router.ts
+++ b/products/desktop/packages/host-router/src/routers/agent-plugins.router.ts
@@ -4,6 +4,7 @@ import { AGENT_PLUGINS_SERVICE } from "@posthog/workspace-server/services/agent-
 import {
   agentPluginIdInput,
   agentPluginInstallation,
+  approveAgentPluginStdioInput,
   listAgentPluginsOutput,
   registerAgentPluginInput,
   selectAgentPluginOutput,
@@ -38,6 +39,14 @@ export const agentPluginsRouter = router({
       ctx.container
         .get<AgentPluginsService>(AGENT_PLUGINS_SERVICE)
         .setEnabled(input.id, input.enabled),
+    ),
+  approveStdio: publicProcedure
+    .input(approveAgentPluginStdioInput)
+    .output(agentPluginInstallation)
+    .mutation(({ ctx, input }) =>
+      ctx.container
+        .get<AgentPluginsService>(AGENT_PLUGINS_SERVICE)
+        .approveStdio(input.id),
     ),
   unregister: publicProcedure
     .input(agentPluginIdInput)

--- a/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.test.tsx
+++ b/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.test.tsx
@@ -1,7 +1,8 @@
+import type { AgentPluginInstallation } from "@posthog/core/agent-plugins/agentPluginsClient";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { AgentPluginsView } from "./AgentPluginsView";
+import { AgentPluginsView, escapeApprovalToken } from "./AgentPluginsView";
 
 const mocks = vi.hoisted(() => ({
   list: vi.fn(),
@@ -11,7 +12,39 @@ const mocks = vi.hoisted(() => ({
   approveStdio: vi.fn(),
   setEnabled: vi.fn(),
   unregister: vi.fn(),
+  unregisterPending: false,
+  unregisterVariables: undefined as { id: string } | undefined,
 }));
+
+function installedPlugin(
+  overrides: Partial<AgentPluginInstallation> = {},
+): AgentPluginInstallation {
+  return {
+    id: "0123456789abcdef",
+    sourcePath: "/plugins/example",
+    enabled: true,
+    manifest: {
+      $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+      name: "example-plugin",
+    },
+    skills: [],
+    mcpServers: [],
+    stdioApprovalRequired: false,
+    diagnostics: [],
+    ...overrides,
+  };
+}
+
+function mockPluginList(plugin: AgentPluginInstallation): void {
+  mocks.list.mockReturnValue({
+    data: [plugin],
+    error: null,
+    isError: false,
+    isFetching: false,
+    isLoading: false,
+    refetch: mocks.refetch,
+  });
+}
 
 vi.mock("./useAgentPlugins", () => ({
   useAgentPlugins: () => mocks.list(),
@@ -40,8 +73,8 @@ vi.mock("./useAgentPlugins", () => ({
   }),
   useUnregisterAgentPlugin: () => ({
     error: null,
-    isPending: false,
-    variables: undefined,
+    isPending: mocks.unregisterPending,
+    variables: mocks.unregisterVariables,
     mutate: mocks.unregister,
   }),
 }));
@@ -49,6 +82,8 @@ vi.mock("./useAgentPlugins", () => ({
 describe("AgentPluginsView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.unregisterPending = false;
+    mocks.unregisterVariables = undefined;
   });
 
   it("shows a retry action when the installed plugin list fails", async () => {
@@ -72,6 +107,80 @@ describe("AgentPluginsView", () => {
     ).not.toBeInTheDocument();
     await userEvent.click(screen.getByText("Try again"));
     expect(mocks.refetch).toHaveBeenCalledOnce();
+  });
+
+  it("renders stdio approval values as separate escaped tokens", () => {
+    const command = "node tool\n\u202etail";
+    const firstArgument = "argument one";
+    const secondArgument = "--flag=two words";
+    const cwd = "./working directory";
+    const environmentName = "CONFIG\u2066NAME";
+    mockPluginList(
+      installedPlugin({
+        stdioApprovalRequired: true,
+        mcpServers: [
+          {
+            name: "local-server",
+            type: "stdio",
+            supported: true,
+            command,
+            args: [firstArgument, secondArgument],
+            cwd,
+            envNames: [environmentName],
+            digest: "digest",
+            approval: "required",
+          },
+        ],
+      }),
+    );
+
+    render(<AgentPluginsView />);
+
+    expect(escapeApprovalToken(command)).toBe('"node tool\\n\\u202etail"');
+    for (const token of [
+      command,
+      firstArgument,
+      secondArgument,
+      cwd,
+      environmentName,
+    ]) {
+      expect(screen.getByText(escapeApprovalToken(token))).toBeInTheDocument();
+    }
+    expect(screen.getByText("Argument 1")).toBeInTheDocument();
+    expect(screen.getByText("Argument 2")).toBeInTheDocument();
+    expect(screen.queryByText(`${firstArgument} ${secondArgument}`)).toBeNull();
+  });
+
+  it("confirms removal and blocks submission while removal is pending", async () => {
+    mockPluginList(installedPlugin());
+    const view = render(<AgentPluginsView />);
+
+    await userEvent.click(screen.getByLabelText("Remove example-plugin"));
+    expect(screen.getByText("Remove example-plugin?")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "The plugin's source files remain on disk. PostHog Desktop permanently removes its app-managed plugin data.",
+      ),
+    ).toBeInTheDocument();
+
+    mocks.unregisterPending = true;
+    mocks.unregisterVariables = { id: "0123456789abcdef" };
+    view.rerender(<AgentPluginsView />);
+    expect(screen.getByText("Remove plugin")).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+    await userEvent.click(screen.getByText("Remove plugin"));
+    expect(mocks.unregister).not.toHaveBeenCalled();
+
+    mocks.unregisterPending = false;
+    view.rerender(<AgentPluginsView />);
+    await userEvent.click(screen.getByText("Remove plugin"));
+    expect(mocks.unregister).toHaveBeenCalledOnce();
+    expect(mocks.unregister).toHaveBeenCalledWith(
+      { id: "0123456789abcdef" },
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
   });
 
   it("shows diagnostic paths and messages for installed plugins", () => {

--- a/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.test.tsx
+++ b/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.test.tsx
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   refetch: vi.fn(),
   select: vi.fn(),
   register: vi.fn(),
+  approveStdio: vi.fn(),
   setEnabled: vi.fn(),
   unregister: vi.fn(),
 }));
@@ -25,6 +26,12 @@ vi.mock("./useAgentPlugins", () => ({
     error: null,
     isPending: false,
     mutate: mocks.register,
+  }),
+  useApproveAgentPluginStdio: () => ({
+    error: null,
+    isPending: false,
+    variables: undefined,
+    mutate: mocks.approveStdio,
   }),
   useSetAgentPluginEnabled: () => ({
     error: null,
@@ -81,6 +88,7 @@ describe("AgentPluginsView", () => {
           },
           skills: [],
           mcpServers: [],
+          stdioApprovalRequired: false,
           diagnostics: [
             {
               severity: "error",

--- a/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.test.tsx
+++ b/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.test.tsx
@@ -127,7 +127,6 @@ describe("AgentPluginsView", () => {
             args: [firstArgument, secondArgument],
             cwd,
             envNames: [environmentName],
-            digest: "digest",
             approval: "required",
           },
         ],

--- a/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.test.tsx
+++ b/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.test.tsx
@@ -114,7 +114,7 @@ describe("AgentPluginsView", () => {
     const firstArgument = "argument one";
     const secondArgument = "--flag=two words";
     const cwd = "./working directory";
-    const environmentName = "CONFIG\u2066NAME";
+    const environmentName = "CONFIG\u061cNAME\u2066";
     mockPluginList(
       installedPlugin({
         stdioApprovalRequired: true,
@@ -137,6 +137,9 @@ describe("AgentPluginsView", () => {
     render(<AgentPluginsView />);
 
     expect(escapeApprovalToken(command)).toBe('"node tool\\n\\u202etail"');
+    expect(escapeApprovalToken(environmentName)).toBe(
+      '"CONFIG\\u061cNAME\\u2066"',
+    );
     for (const token of [
       command,
       firstArgument,

--- a/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.tsx
+++ b/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.tsx
@@ -57,8 +57,8 @@ export function AgentPluginsView(): ReactElement {
           <div className="flex flex-col gap-1">
             <Text weight="semibold">Agent Plugins</Text>
             <Text size="sm" variant="muted">
-              Add local Agent Plugins that provide portable skills and
-              Streamable HTTP MCP servers.
+              Add local Agent Plugins that provide portable skills, Streamable
+              HTTP MCP servers, and stdio MCP servers.
             </Text>
           </div>
           <Button
@@ -104,16 +104,26 @@ export function AgentPluginsView(): ReactElement {
                     ))}
                   </div>
                   <Text size="xs" variant="muted">
-                    {preview.mcpServers.length} Streamable HTTP MCP server
+                    {preview.mcpServers.length} MCP server
                     {preview.mcpServers.length === 1 ? "" : "s"}
                   </Text>
                   <div className="flex flex-wrap gap-2">
                     {preview.mcpServers.map((server) => (
                       <Badge key={server.name} variant="info">
-                        {server.name}
+                        {server.name} ·{" "}
+                        {server.type === "stdio" ? "stdio" : "HTTP"}
                       </Badge>
                     ))}
                   </div>
+                  {preview.mcpServers.some(
+                    (server) => server.type === "stdio",
+                  ) && (
+                    <Text size="xs" variant="muted">
+                      Stdio MCP servers run local commands. Review their
+                      command, arguments, and environment in mcp.json before
+                      adding this plugin.
+                    </Text>
+                  )}
                 </div>
                 {preview.diagnostics.length > 0 && (
                   <div className="flex flex-col gap-2 rounded-md border border-border p-3">

--- a/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.tsx
+++ b/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.tsx
@@ -43,7 +43,8 @@ function diagnosticText(item: { message: string; path?: string }): string {
   return item.path ? `${item.path}: ${item.message}` : item.message;
 }
 
-const DIRECTIONAL_CONTROL_PATTERN = /[\u200e\u200f\u202a-\u202e\u2066-\u2069]/g;
+const DIRECTIONAL_CONTROL_PATTERN =
+  /[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/g;
 
 export function escapeApprovalToken(value: string): string {
   return JSON.stringify(value).replace(

--- a/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.tsx
+++ b/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.tsx
@@ -1,5 +1,13 @@
 import { FolderOpen, Package, Trash, Warning } from "@phosphor-icons/react";
+import type { AgentPluginMcpServerSummary } from "@posthog/core/agent-plugins/agentPluginsClient";
 import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
   Badge,
   Button,
   Card,
@@ -17,7 +25,7 @@ import {
   Switch,
   Text,
 } from "@posthog/quill";
-import type { ReactElement } from "react";
+import { type ReactElement, useState } from "react";
 import {
   useAgentPlugins,
   useApproveAgentPluginStdio,
@@ -35,6 +43,91 @@ function diagnosticText(item: { message: string; path?: string }): string {
   return item.path ? `${item.path}: ${item.message}` : item.message;
 }
 
+const DIRECTIONAL_CONTROL_PATTERN = /[\u200e\u200f\u202a-\u202e\u2066-\u2069]/g;
+
+export function escapeApprovalToken(value: string): string {
+  return JSON.stringify(value).replace(
+    DIRECTIONAL_CONTROL_PATTERN,
+    (control) => `\\u${control.charCodeAt(0).toString(16).padStart(4, "0")}`,
+  );
+}
+
+function ApprovalToken({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}): ReactElement {
+  return (
+    <div className="flex min-w-0 items-start gap-2">
+      <Text size="xs" variant="muted" className="shrink-0">
+        {label}
+      </Text>
+      <code
+        dir="ltr"
+        className="max-h-20 min-w-0 overflow-auto whitespace-pre-wrap break-all rounded bg-muted px-1 text-xs [unicode-bidi:isolate]"
+      >
+        {escapeApprovalToken(value)}
+      </code>
+    </div>
+  );
+}
+
+function StdioApprovalDetails({
+  server,
+}: {
+  server: AgentPluginMcpServerSummary;
+}): ReactElement {
+  return (
+    <div className="flex flex-col gap-1 rounded-md border border-border p-3">
+      <div className="flex items-center justify-between gap-2">
+        <Text size="xs" weight="medium">
+          {server.name}
+        </Text>
+        {server.approval !== "not-required" && (
+          <Badge
+            variant={server.approval === "approved" ? "success" : "warning"}
+          >
+            {server.approval === "approved" ? "Approved" : "Review required"}
+          </Badge>
+        )}
+      </div>
+      <ApprovalToken label="Command" value={server.command ?? ""} />
+      {(server.args ?? []).length > 0 ? (
+        server.args?.map((argument, index) => (
+          <ApprovalToken
+            key={`${server.name}-argument-${index}`}
+            label={`Argument ${index + 1}`}
+            value={argument}
+          />
+        ))
+      ) : (
+        <Text size="xs" variant="muted">
+          No arguments
+        </Text>
+      )}
+      <ApprovalToken
+        label="Working directory"
+        value={server.cwd ?? "${PLUGIN_ROOT}"}
+      />
+      {(server.envNames ?? []).length > 0 ? (
+        server.envNames?.map((name) => (
+          <ApprovalToken
+            key={`${server.name}-environment-${name}`}
+            label="Environment variable"
+            value={name}
+          />
+        ))
+      ) : (
+        <Text size="xs" variant="muted">
+          No environment variables
+        </Text>
+      )}
+    </div>
+  );
+}
+
 export function AgentPluginsView(): ReactElement {
   const plugins = useAgentPlugins();
   const selectPlugin = useSelectAgentPlugin();
@@ -43,6 +136,10 @@ export function AgentPluginsView(): ReactElement {
   const setEnabled = useSetAgentPluginEnabled();
   const unregister = useUnregisterAgentPlugin();
   const preview = selectPlugin.data;
+  const [removeTarget, setRemoveTarget] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
 
   const handleRegister = (): void => {
     if (!preview?.selectionToken) return;
@@ -52,300 +149,106 @@ export function AgentPluginsView(): ReactElement {
     );
   };
 
+  const handleRemove = (): void => {
+    if (!removeTarget || unregister.isPending) return;
+    unregister.mutate(
+      { id: removeTarget.id },
+      { onSuccess: () => setRemoveTarget(null) },
+    );
+  };
+
   return (
-    <div className="h-full min-h-0 overflow-y-auto">
-      <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 p-4">
-        <div className="flex items-start justify-between gap-4">
-          <div className="flex flex-col gap-1">
-            <Text weight="semibold">Agent Plugins</Text>
-            <Text size="sm" variant="muted">
-              Add local Agent Plugins that provide portable skills, Streamable
-              HTTP MCP servers, and stdio MCP servers.
-            </Text>
+    <>
+      <div className="h-full min-h-0 overflow-y-auto">
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 p-4">
+          <div className="flex items-start justify-between gap-4">
+            <div className="flex flex-col gap-1">
+              <Text weight="semibold">Agent Plugins</Text>
+              <Text size="sm" variant="muted">
+                Add local Agent Plugins that provide portable skills, Streamable
+                HTTP MCP servers, and stdio MCP servers.
+              </Text>
+            </div>
+            <Button
+              variant="primary"
+              loading={selectPlugin.isPending}
+              onClick={() => selectPlugin.mutate()}
+            >
+              <FolderOpen />
+              Add local plugin
+            </Button>
           </div>
-          <Button
-            variant="primary"
-            loading={selectPlugin.isPending}
-            onClick={() => selectPlugin.mutate()}
-          >
-            <FolderOpen />
-            Add local plugin
-          </Button>
-        </div>
 
-        {preview && (
-          <Card>
-            <CardHeader>
-              <div className="flex items-start justify-between gap-4">
-                <div className="flex flex-col gap-1">
-                  <CardTitle>
-                    {preview.manifest?.name ?? "Invalid Agent Plugin"}
-                  </CardTitle>
-                  <CardDescription className="break-all">
-                    {preview.sourcePath}
-                  </CardDescription>
+          {preview && (
+            <Card>
+              <CardHeader>
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex flex-col gap-1">
+                    <CardTitle>
+                      {preview.manifest?.name ?? "Invalid Agent Plugin"}
+                    </CardTitle>
+                    <CardDescription className="break-all">
+                      {preview.sourcePath}
+                    </CardDescription>
+                  </div>
+                  <Badge variant={preview.valid ? "success" : "destructive"}>
+                    {preview.valid ? "Ready to add" : "Invalid"}
+                  </Badge>
                 </div>
-                <Badge variant={preview.valid ? "success" : "destructive"}>
-                  {preview.valid ? "Ready to add" : "Invalid"}
-                </Badge>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <div className="flex flex-col gap-4">
-                {preview.manifest?.description && (
-                  <Text size="sm">{preview.manifest.description}</Text>
-                )}
-                <div className="flex flex-col gap-2">
-                  <Text size="xs" variant="muted">
-                    {preview.skills.length} valid skill
-                    {preview.skills.length === 1 ? "" : "s"}
-                  </Text>
-                  <div className="flex flex-wrap gap-2">
-                    {preview.skills.map((skill) => (
-                      <Badge key={skill.path}>{skill.name}</Badge>
-                    ))}
-                  </div>
-                  <Text size="xs" variant="muted">
-                    {preview.mcpServers.length} MCP server
-                    {preview.mcpServers.length === 1 ? "" : "s"}
-                  </Text>
-                  <div className="flex flex-wrap gap-2">
-                    {preview.mcpServers.map((server) => (
-                      <Badge key={server.name} variant="info">
-                        {server.name} ·{" "}
-                        {server.type === "stdio" ? "stdio" : "HTTP"}
-                      </Badge>
-                    ))}
-                  </div>
-                  {preview.mcpServers
-                    .filter((server) => server.type === "stdio")
-                    .map((server) => (
-                      <div
-                        key={server.name}
-                        className="flex flex-col gap-1 rounded-md border border-border p-3"
-                      >
-                        <Text size="xs" weight="medium">
-                          {server.name}
-                        </Text>
-                        <Text size="xs" className="break-all">
-                          Command: {server.command}{" "}
-                          {(server.args ?? []).join(" ")}
-                        </Text>
-                        <Text size="xs" variant="muted" className="break-all">
-                          Working directory: {server.cwd}
-                        </Text>
-                        <Text size="xs" variant="muted" className="break-all">
-                          Environment names:{" "}
-                          {server.envNames?.join(", ") || "None"}
-                        </Text>
-                        <Text size="xs" variant="muted" className="break-all">
-                          Digest: {server.digest}
-                        </Text>
-                      </div>
-                    ))}
-                  {preview.mcpServers.some(
-                    (server) => server.type === "stdio",
-                  ) && (
-                    <Text size="xs" variant="muted">
-                      Adding this plugin approves the stdio commands shown
-                      above. PostHog Desktop will ask again if they change.
-                    </Text>
+              </CardHeader>
+              <CardContent>
+                <div className="flex flex-col gap-4">
+                  {preview.manifest?.description && (
+                    <Text size="sm">{preview.manifest.description}</Text>
                   )}
-                </div>
-                {preview.diagnostics.length > 0 && (
-                  <div className="flex flex-col gap-2 rounded-md border border-border p-3">
-                    {preview.diagnostics.map((item, index) => (
-                      <div
-                        key={`${item.code}-${item.path ?? "root"}-${index}`}
-                        className="flex items-start gap-2"
-                      >
-                        <Warning className="mt-0.5 shrink-0" />
-                        <Text
-                          size="xs"
-                          variant={
-                            item.severity === "error" ? "destructive" : "muted"
-                          }
-                          className="break-all"
-                        >
-                          {diagnosticText(item)}
-                        </Text>
-                      </div>
-                    ))}
-                  </div>
-                )}
-                <div className="flex justify-end gap-2">
-                  <Button
-                    variant="outline"
-                    onClick={() => selectPlugin.reset()}
-                  >
-                    Cancel
-                  </Button>
-                  <Button
-                    variant="primary"
-                    loading={registerPlugin.isPending}
-                    disabled={!preview.valid || !preview.selectionToken}
-                    onClick={handleRegister}
-                  >
-                    Add plugin
-                  </Button>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        )}
-
-        {(errorMessage(selectPlugin.error) ||
-          errorMessage(registerPlugin.error) ||
-          errorMessage(approveStdio.error) ||
-          errorMessage(setEnabled.error) ||
-          errorMessage(unregister.error)) && (
-          <Text variant="destructive" size="sm">
-            {errorMessage(selectPlugin.error) ??
-              errorMessage(registerPlugin.error) ??
-              errorMessage(approveStdio.error) ??
-              errorMessage(setEnabled.error) ??
-              errorMessage(unregister.error)}
-          </Text>
-        )}
-
-        {plugins.isLoading ? (
-          <div className="flex justify-center p-8">
-            <Spinner />
-          </div>
-        ) : plugins.isError ? (
-          <Empty>
-            <EmptyHeader>
-              <EmptyMedia variant="icon">
-                <Warning />
-              </EmptyMedia>
-              <EmptyTitle>Could not load Agent Plugins</EmptyTitle>
-              <EmptyDescription>
-                {plugins.error.message} Try again. If it keeps happening,
-                contact support.
-              </EmptyDescription>
-            </EmptyHeader>
-            <EmptyContent>
-              <Button
-                variant="outline"
-                loading={plugins.isFetching}
-                onClick={() => void plugins.refetch()}
-              >
-                Try again
-              </Button>
-            </EmptyContent>
-          </Empty>
-        ) : plugins.data?.length ? (
-          <div className="flex flex-col gap-2">
-            {plugins.data.map((plugin) => (
-              <Card key={plugin.id} size="sm">
-                <CardContent>
                   <div className="flex flex-col gap-2">
-                    <div className="flex items-center gap-3">
-                      <Package className="shrink-0" />
-                      <div className="min-w-0 flex-1">
-                        <Text weight="medium">{plugin.manifest.name}</Text>
-                        <Text
-                          size="xs"
-                          variant="muted"
-                          className="block break-all"
-                        >
-                          {plugin.skills.length} skill
-                          {plugin.skills.length === 1 ? "" : "s"} and{" "}
-                          {plugin.mcpServers.length} MCP server
-                          {plugin.mcpServers.length === 1 ? "" : "s"} from{" "}
-                          {plugin.sourcePath}
-                        </Text>
-                      </div>
-                      {plugin.diagnostics.length > 0 && (
-                        <Badge variant="warning">
-                          {plugin.diagnostics.length} diagnostic
-                          {plugin.diagnostics.length === 1 ? "" : "s"}
-                        </Badge>
-                      )}
-                      <Switch
-                        checked={plugin.enabled}
-                        disabled={
-                          setEnabled.isPending ||
-                          (!plugin.enabled && plugin.stdioApprovalRequired)
-                        }
-                        aria-label={`Enable ${plugin.manifest.name}`}
-                        onCheckedChange={(enabled) =>
-                          setEnabled.mutate({ id: plugin.id, enabled })
-                        }
-                      />
-                      <Button
-                        variant="destructive"
-                        size="icon-sm"
-                        loading={
-                          unregister.isPending &&
-                          unregister.variables?.id === plugin.id
-                        }
-                        disabled={unregister.isPending}
-                        aria-label={`Remove ${plugin.manifest.name}`}
-                        onClick={() => unregister.mutate({ id: plugin.id })}
-                      >
-                        <Trash />
-                      </Button>
+                    <Text size="xs" variant="muted">
+                      {preview.skills.length} valid skill
+                      {preview.skills.length === 1 ? "" : "s"}
+                    </Text>
+                    <div className="flex flex-wrap gap-2">
+                      {preview.skills.map((skill) => (
+                        <Badge key={skill.path}>{skill.name}</Badge>
+                      ))}
                     </div>
-                    {plugin.mcpServers
+                    <Text size="xs" variant="muted">
+                      {preview.mcpServers.length} MCP server
+                      {preview.mcpServers.length === 1 ? "" : "s"}
+                    </Text>
+                    <div className="flex flex-wrap gap-2">
+                      {preview.mcpServers.map((server) => (
+                        <Badge key={server.name} variant="info">
+                          {server.name} ·{" "}
+                          {server.type === "stdio" ? "stdio" : "HTTP"}
+                        </Badge>
+                      ))}
+                    </div>
+                    {preview.mcpServers
                       .filter((server) => server.type === "stdio")
                       .map((server) => (
-                        <div
+                        <StdioApprovalDetails
                           key={server.name}
-                          className="flex flex-col gap-1 rounded-md border border-border p-3"
-                        >
-                          <div className="flex items-center justify-between gap-2">
-                            <Text size="xs" weight="medium">
-                              {server.name}
-                            </Text>
-                            <Badge
-                              variant={
-                                server.approval === "approved"
-                                  ? "success"
-                                  : "warning"
-                              }
-                            >
-                              {server.approval === "approved"
-                                ? "Approved"
-                                : "Review required"}
-                            </Badge>
-                          </div>
-                          <Text size="xs" className="break-all">
-                            Command: {server.command}{" "}
-                            {(server.args ?? []).join(" ")}
-                          </Text>
-                          <Text size="xs" variant="muted" className="break-all">
-                            Working directory: {server.cwd}
-                          </Text>
-                          <Text size="xs" variant="muted" className="break-all">
-                            Environment names:{" "}
-                            {server.envNames?.join(", ") || "None"}
-                          </Text>
-                          <Text size="xs" variant="muted" className="break-all">
-                            Digest: {server.digest}
-                          </Text>
-                        </div>
+                          server={server}
+                        />
                       ))}
-                    {plugin.stdioApprovalRequired && (
-                      <div className="flex justify-end">
-                        <Button
-                          variant="primary"
-                          loading={
-                            approveStdio.isPending &&
-                            approveStdio.variables?.id === plugin.id
-                          }
-                          disabled={approveStdio.isPending}
-                          onClick={() => approveStdio.mutate({ id: plugin.id })}
-                        >
-                          Approve stdio commands
-                        </Button>
-                      </div>
+                    {preview.mcpServers.some(
+                      (server) => server.type === "stdio",
+                    ) && (
+                      <Text size="xs" variant="muted">
+                        Adding this plugin approves the stdio commands shown
+                        above. PostHog Desktop will ask again if they change.
+                      </Text>
                     )}
-                    {plugin.diagnostics.length > 0 && (
-                      <div className="flex flex-col gap-1 rounded-md border border-border p-3">
-                        {plugin.diagnostics.map((item, index) => (
+                  </div>
+                  {preview.diagnostics.length > 0 && (
+                    <div className="flex flex-col gap-2 rounded-md border border-border p-3">
+                      {preview.diagnostics.map((item, index) => (
+                        <div
+                          key={`${item.code}-${item.path ?? "root"}-${index}`}
+                          className="flex items-start gap-2"
+                        >
+                          <Warning className="mt-0.5 shrink-0" />
                           <Text
-                            key={`${item.code}-${item.path ?? "root"}-${index}`}
                             size="xs"
                             variant={
                               item.severity === "error"
@@ -356,29 +259,225 @@ export function AgentPluginsView(): ReactElement {
                           >
                             {diagnosticText(item)}
                           </Text>
-                        ))}
-                      </div>
-                    )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                  <div className="flex justify-end gap-2">
+                    <Button
+                      variant="outline"
+                      onClick={() => selectPlugin.reset()}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      variant="primary"
+                      loading={registerPlugin.isPending}
+                      disabled={!preview.valid || !preview.selectionToken}
+                      onClick={handleRegister}
+                    >
+                      Add plugin
+                    </Button>
                   </div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        ) : (
-          <Empty>
-            <EmptyHeader>
-              <EmptyMedia variant="icon">
-                <Package />
-              </EmptyMedia>
-              <EmptyTitle>No Agent Plugins added</EmptyTitle>
-              <EmptyDescription>
-                Choose a local plugin directory to make its valid skills and MCP
-                servers available to agents.
-              </EmptyDescription>
-            </EmptyHeader>
-          </Empty>
-        )}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {(errorMessage(selectPlugin.error) ||
+            errorMessage(registerPlugin.error) ||
+            errorMessage(approveStdio.error) ||
+            errorMessage(setEnabled.error) ||
+            errorMessage(unregister.error)) && (
+            <Text variant="destructive" size="sm">
+              {errorMessage(selectPlugin.error) ??
+                errorMessage(registerPlugin.error) ??
+                errorMessage(approveStdio.error) ??
+                errorMessage(setEnabled.error) ??
+                errorMessage(unregister.error)}
+            </Text>
+          )}
+
+          {plugins.isLoading ? (
+            <div className="flex justify-center p-8">
+              <Spinner />
+            </div>
+          ) : plugins.isError ? (
+            <Empty>
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  <Warning />
+                </EmptyMedia>
+                <EmptyTitle>Could not load Agent Plugins</EmptyTitle>
+                <EmptyDescription>
+                  {plugins.error.message} Try again. If it keeps happening,
+                  contact support.
+                </EmptyDescription>
+              </EmptyHeader>
+              <EmptyContent>
+                <Button
+                  variant="outline"
+                  loading={plugins.isFetching}
+                  onClick={() => void plugins.refetch()}
+                >
+                  Try again
+                </Button>
+              </EmptyContent>
+            </Empty>
+          ) : plugins.data?.length ? (
+            <div className="flex flex-col gap-2">
+              {plugins.data.map((plugin) => (
+                <Card key={plugin.id} size="sm">
+                  <CardContent>
+                    <div className="flex flex-col gap-2">
+                      <div className="flex items-center gap-3">
+                        <Package className="shrink-0" />
+                        <div className="min-w-0 flex-1">
+                          <Text weight="medium">{plugin.manifest.name}</Text>
+                          <Text
+                            size="xs"
+                            variant="muted"
+                            className="block break-all"
+                          >
+                            {plugin.skills.length} skill
+                            {plugin.skills.length === 1 ? "" : "s"} and{" "}
+                            {plugin.mcpServers.length} MCP server
+                            {plugin.mcpServers.length === 1 ? "" : "s"} from{" "}
+                            {plugin.sourcePath}
+                          </Text>
+                        </div>
+                        {plugin.diagnostics.length > 0 && (
+                          <Badge variant="warning">
+                            {plugin.diagnostics.length} diagnostic
+                            {plugin.diagnostics.length === 1 ? "" : "s"}
+                          </Badge>
+                        )}
+                        <Switch
+                          checked={plugin.enabled}
+                          disabled={
+                            setEnabled.isPending ||
+                            (!plugin.enabled && plugin.stdioApprovalRequired)
+                          }
+                          aria-label={`Enable ${plugin.manifest.name}`}
+                          onCheckedChange={(enabled) =>
+                            setEnabled.mutate({ id: plugin.id, enabled })
+                          }
+                        />
+                        <Button
+                          variant="destructive"
+                          size="icon-sm"
+                          disabled={unregister.isPending}
+                          aria-label={`Remove ${plugin.manifest.name}`}
+                          onClick={() =>
+                            setRemoveTarget({
+                              id: plugin.id,
+                              name: plugin.manifest.name,
+                            })
+                          }
+                        >
+                          <Trash />
+                        </Button>
+                      </div>
+                      {plugin.mcpServers
+                        .filter((server) => server.type === "stdio")
+                        .map((server) => (
+                          <StdioApprovalDetails
+                            key={server.name}
+                            server={server}
+                          />
+                        ))}
+                      {plugin.stdioApprovalRequired && (
+                        <div className="flex justify-end">
+                          <Button
+                            variant="primary"
+                            loading={
+                              approveStdio.isPending &&
+                              approveStdio.variables?.id === plugin.id
+                            }
+                            disabled={approveStdio.isPending}
+                            onClick={() =>
+                              approveStdio.mutate({ id: plugin.id })
+                            }
+                          >
+                            Approve stdio commands
+                          </Button>
+                        </div>
+                      )}
+                      {plugin.diagnostics.length > 0 && (
+                        <div className="flex flex-col gap-1 rounded-md border border-border p-3">
+                          {plugin.diagnostics.map((item, index) => (
+                            <Text
+                              key={`${item.code}-${item.path ?? "root"}-${index}`}
+                              size="xs"
+                              variant={
+                                item.severity === "error"
+                                  ? "destructive"
+                                  : "muted"
+                              }
+                              className="break-all"
+                            >
+                              {diagnosticText(item)}
+                            </Text>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          ) : (
+            <Empty>
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  <Package />
+                </EmptyMedia>
+                <EmptyTitle>No Agent Plugins added</EmptyTitle>
+                <EmptyDescription>
+                  Choose a local plugin directory to make its valid skills and
+                  MCP servers available to agents.
+                </EmptyDescription>
+              </EmptyHeader>
+            </Empty>
+          )}
+        </div>
       </div>
-    </div>
+
+      <AlertDialog
+        open={removeTarget !== null}
+        onOpenChange={(open) => {
+          if (!open && !unregister.isPending) setRemoveTarget(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Remove {removeTarget?.name ?? "this Agent Plugin"}?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              The plugin's source files remain on disk. PostHog Desktop
+              permanently removes its app-managed plugin data.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogClose
+              render={
+                <Button variant="outline" disabled={unregister.isPending}>
+                  Cancel
+                </Button>
+              }
+            />
+            <Button
+              variant="destructive"
+              loading={unregister.isPending}
+              disabled={unregister.isPending}
+              onClick={handleRemove}
+            >
+              Remove plugin
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.tsx
+++ b/products/desktop/packages/ui/src/features/agent-plugins/AgentPluginsView.tsx
@@ -20,6 +20,7 @@ import {
 import type { ReactElement } from "react";
 import {
   useAgentPlugins,
+  useApproveAgentPluginStdio,
   useRegisterAgentPlugin,
   useSelectAgentPlugin,
   useSetAgentPluginEnabled,
@@ -38,6 +39,7 @@ export function AgentPluginsView(): ReactElement {
   const plugins = useAgentPlugins();
   const selectPlugin = useSelectAgentPlugin();
   const registerPlugin = useRegisterAgentPlugin();
+  const approveStdio = useApproveAgentPluginStdio();
   const setEnabled = useSetAgentPluginEnabled();
   const unregister = useUnregisterAgentPlugin();
   const preview = selectPlugin.data;
@@ -115,13 +117,38 @@ export function AgentPluginsView(): ReactElement {
                       </Badge>
                     ))}
                   </div>
+                  {preview.mcpServers
+                    .filter((server) => server.type === "stdio")
+                    .map((server) => (
+                      <div
+                        key={server.name}
+                        className="flex flex-col gap-1 rounded-md border border-border p-3"
+                      >
+                        <Text size="xs" weight="medium">
+                          {server.name}
+                        </Text>
+                        <Text size="xs" className="break-all">
+                          Command: {server.command}{" "}
+                          {(server.args ?? []).join(" ")}
+                        </Text>
+                        <Text size="xs" variant="muted" className="break-all">
+                          Working directory: {server.cwd}
+                        </Text>
+                        <Text size="xs" variant="muted" className="break-all">
+                          Environment names:{" "}
+                          {server.envNames?.join(", ") || "None"}
+                        </Text>
+                        <Text size="xs" variant="muted" className="break-all">
+                          Digest: {server.digest}
+                        </Text>
+                      </div>
+                    ))}
                   {preview.mcpServers.some(
                     (server) => server.type === "stdio",
                   ) && (
                     <Text size="xs" variant="muted">
-                      Stdio MCP servers run local commands. Review their
-                      command, arguments, and environment in mcp.json before
-                      adding this plugin.
+                      Adding this plugin approves the stdio commands shown
+                      above. PostHog Desktop will ask again if they change.
                     </Text>
                   )}
                 </div>
@@ -169,11 +196,13 @@ export function AgentPluginsView(): ReactElement {
 
         {(errorMessage(selectPlugin.error) ||
           errorMessage(registerPlugin.error) ||
+          errorMessage(approveStdio.error) ||
           errorMessage(setEnabled.error) ||
           errorMessage(unregister.error)) && (
           <Text variant="destructive" size="sm">
             {errorMessage(selectPlugin.error) ??
               errorMessage(registerPlugin.error) ??
+              errorMessage(approveStdio.error) ??
               errorMessage(setEnabled.error) ??
               errorMessage(unregister.error)}
           </Text>
@@ -235,7 +264,10 @@ export function AgentPluginsView(): ReactElement {
                       )}
                       <Switch
                         checked={plugin.enabled}
-                        disabled={setEnabled.isPending}
+                        disabled={
+                          setEnabled.isPending ||
+                          (!plugin.enabled && plugin.stdioApprovalRequired)
+                        }
                         aria-label={`Enable ${plugin.manifest.name}`}
                         onCheckedChange={(enabled) =>
                           setEnabled.mutate({ id: plugin.id, enabled })
@@ -255,6 +287,60 @@ export function AgentPluginsView(): ReactElement {
                         <Trash />
                       </Button>
                     </div>
+                    {plugin.mcpServers
+                      .filter((server) => server.type === "stdio")
+                      .map((server) => (
+                        <div
+                          key={server.name}
+                          className="flex flex-col gap-1 rounded-md border border-border p-3"
+                        >
+                          <div className="flex items-center justify-between gap-2">
+                            <Text size="xs" weight="medium">
+                              {server.name}
+                            </Text>
+                            <Badge
+                              variant={
+                                server.approval === "approved"
+                                  ? "success"
+                                  : "warning"
+                              }
+                            >
+                              {server.approval === "approved"
+                                ? "Approved"
+                                : "Review required"}
+                            </Badge>
+                          </div>
+                          <Text size="xs" className="break-all">
+                            Command: {server.command}{" "}
+                            {(server.args ?? []).join(" ")}
+                          </Text>
+                          <Text size="xs" variant="muted" className="break-all">
+                            Working directory: {server.cwd}
+                          </Text>
+                          <Text size="xs" variant="muted" className="break-all">
+                            Environment names:{" "}
+                            {server.envNames?.join(", ") || "None"}
+                          </Text>
+                          <Text size="xs" variant="muted" className="break-all">
+                            Digest: {server.digest}
+                          </Text>
+                        </div>
+                      ))}
+                    {plugin.stdioApprovalRequired && (
+                      <div className="flex justify-end">
+                        <Button
+                          variant="primary"
+                          loading={
+                            approveStdio.isPending &&
+                            approveStdio.variables?.id === plugin.id
+                          }
+                          disabled={approveStdio.isPending}
+                          onClick={() => approveStdio.mutate({ id: plugin.id })}
+                        >
+                          Approve stdio commands
+                        </Button>
+                      </div>
+                    )}
                     {plugin.diagnostics.length > 0 && (
                       <div className="flex flex-col gap-1 rounded-md border border-border p-3">
                         {plugin.diagnostics.map((item, index) => (

--- a/products/desktop/packages/ui/src/features/agent-plugins/useAgentPlugins.test.tsx
+++ b/products/desktop/packages/ui/src/features/agent-plugins/useAgentPlugins.test.tsx
@@ -9,6 +9,7 @@ const mockClient = vi.hoisted<AgentPluginsClient>(() => ({
   select: vi.fn(),
   register: vi.fn(),
   setEnabled: vi.fn(),
+  approveStdio: vi.fn(),
   unregister: vi.fn(),
 }));
 
@@ -44,6 +45,7 @@ describe("useAgentPlugins", () => {
       skills: [],
       mcpServers: [],
       diagnostics: [],
+      stdioApprovalRequired: false,
     });
     const wrapper = ({ children }: { children: ReactNode }) => (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>

--- a/products/desktop/packages/ui/src/features/agent-plugins/useAgentPlugins.ts
+++ b/products/desktop/packages/ui/src/features/agent-plugins/useAgentPlugins.ts
@@ -67,6 +67,19 @@ export function useSetAgentPluginEnabled(): UseMutationResult<
   });
 }
 
+export function useApproveAgentPluginStdio(): UseMutationResult<
+  AgentPluginInstallation,
+  Error,
+  { id: string }
+> {
+  const client = useService<AgentPluginsClient>(AGENT_PLUGINS_CLIENT);
+  const invalidate = useInvalidateAgentPlugins();
+  return useMutation({
+    mutationFn: ({ id }) => client.approveStdio(id),
+    onSuccess: invalidate,
+  });
+}
+
 export function useUnregisterAgentPlugin(): UseMutationResult<
   void,
   Error,

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.module.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.module.ts
@@ -1,11 +1,19 @@
 import { ContainerModule } from "inversify";
 import { AgentPluginsService } from "./agent-plugins";
 import { AgentPluginHttpProxyService } from "./http-proxy";
-import { AGENT_PLUGIN_HTTP_PROXY, AGENT_PLUGINS_SERVICE } from "./identifiers";
+import {
+  AGENT_PLUGIN_HTTP_PROXY,
+  AGENT_PLUGIN_STDIO_BRIDGE,
+  AGENT_PLUGINS_SERVICE,
+} from "./identifiers";
+import { AgentPluginStdioBridgeService } from "./stdio-bridge";
 
 export const agentPluginsModule = new ContainerModule(({ bind }) => {
   bind(AGENT_PLUGIN_HTTP_PROXY)
     .to(AgentPluginHttpProxyService)
+    .inSingletonScope();
+  bind(AGENT_PLUGIN_STDIO_BRIDGE)
+    .to(AgentPluginStdioBridgeService)
     .inSingletonScope();
   bind(AGENT_PLUGINS_SERVICE).to(AgentPluginsService).inSingletonScope();
 });

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
@@ -15,6 +15,7 @@ import {
   AGENT_PLUGINS_MANIFEST_SCHEMA,
   AGENT_PLUGINS_MCP_SCHEMA,
 } from "./schemas";
+import type { AgentPluginStdioBridge } from "./stdio-bridge";
 
 let root: string;
 
@@ -125,10 +126,19 @@ function createDeferredHttpProxy(): {
   };
 }
 
+function createStdioBridge(): AgentPluginStdioBridge {
+  return {
+    register: vi.fn(async ({ id }: { id: string }) => `http://127.0.0.1/${id}`),
+    unregisterRun: vi.fn(async () => undefined),
+    unregisterInstallation: vi.fn(async () => undefined),
+  };
+}
+
 function createService(
   appDataPath: string,
   selectedPaths: string[] = [],
   httpProxy: AgentPluginHttpProxy = createHttpProxy(),
+  stdioBridge: AgentPluginStdioBridge = createStdioBridge(),
 ): AgentPluginsService {
   return new AgentPluginsService(
     {
@@ -144,6 +154,7 @@ function createService(
       },
     },
     httpProxy,
+    stdioBridge,
   );
 }
 
@@ -760,11 +771,13 @@ describe("Agent Plugins skills support", () => {
 
     const preview = await loadAgentPlugin(pluginDirectory);
 
-    expect(preview.mcpServers.map((server) => server.name)).toEqual(["valid"]);
+    expect(preview.mcpServers.map((server) => server.name)).toEqual([
+      "local",
+      "valid",
+    ]);
     expect(preview.diagnostics.map((item) => item.code)).toEqual(
       expect.arrayContaining([
         "invalid_mcp_server",
-        "unsupported_mcp_transport",
         "unsupported_mcp_transport",
       ]),
     );

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
@@ -1218,12 +1218,14 @@ describe("Agent Plugins skills support", () => {
     });
     expect(installation.mcpServers[0]).not.toHaveProperty("digest");
     expect(JSON.stringify(installation)).not.toContain("not-for-renderer");
-    expect(
-      await fs.promises.readFile(
-        path.join(appDataPath, "agent-plugins", "installations.json"),
-        "utf8",
-      ),
-    ).not.toContain("not-for-renderer");
+    const persistedState = await fs.promises.readFile(
+      path.join(appDataPath, "agent-plugins", "installations.json"),
+      "utf8",
+    );
+    expect(persistedState).not.toContain("not-for-renderer");
+    expect(JSON.parse(persistedState).installations[0]).not.toHaveProperty(
+      "mcpServers",
+    );
 
     await writeMcp(pluginDirectory, {
       local: { type: "stdio", command: "node", args: ["two"] },
@@ -1259,5 +1261,42 @@ describe("Agent Plugins skills support", () => {
     const removed = (await service.list())[0];
     expect(removed.stdioApprovalRequired).toBe(false);
     expect(removed.mcpServers).toEqual([]);
+  });
+
+  it("keeps active HTTP servers registered when approving stdio changes", async () => {
+    const pluginDirectory = path.join(root, "mixed-plugin");
+    const appDataPath = path.join(root, "mixed-app-data");
+    await writePlugin(pluginDirectory);
+    await writeMcp(pluginDirectory, {
+      remote: {
+        type: "streamable-http",
+        url: "https://mcp.example.com/mcp",
+      },
+      local: { type: "stdio", command: "node", args: ["one"] },
+    });
+    const httpProxy = createHttpProxy();
+    const stdioBridge = createStdioBridge();
+    const service = createService(
+      appDataPath,
+      [pluginDirectory],
+      httpProxy,
+      stdioBridge,
+    );
+    const installation = await registerSelectedPlugin(service);
+    await service.prepareRuntimeMcpServers("task-1", "run-1", new Set());
+
+    await writeMcp(pluginDirectory, {
+      remote: {
+        type: "streamable-http",
+        url: "https://mcp.example.com/mcp",
+      },
+      local: { type: "stdio", command: "node", args: ["two"] },
+    });
+    await service.approveStdio(installation.id);
+
+    expect(httpProxy.unregisterInstallation).not.toHaveBeenCalled();
+    expect(stdioBridge.unregisterInstallation).toHaveBeenCalledWith(
+      installation.id,
+    );
   });
 });

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
@@ -1216,6 +1216,7 @@ describe("Agent Plugins skills support", () => {
       envNames: ["PRIVATE_VALUE"],
       approval: "approved",
     });
+    expect(installation.mcpServers[0]).not.toHaveProperty("digest");
     expect(JSON.stringify(installation)).not.toContain("not-for-renderer");
     expect(
       await fs.promises.readFile(

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
@@ -1009,6 +1009,27 @@ describe("Agent Plugins skills support", () => {
     ).toHaveLength(0);
   });
 
+  it("rejects case-insensitive duplicate stdio environment names", async () => {
+    const pluginDirectory = path.join(root, "plugin");
+    await writePlugin(pluginDirectory);
+    await writeMcp(pluginDirectory, {
+      local: {
+        type: "stdio",
+        command: "node",
+        env: { NODE_OPTIONS: "first", Node_Options: "second" },
+      },
+    });
+
+    const preview = await loadAgentPlugin(pluginDirectory);
+
+    expect(preview.mcpServers).toEqual([]);
+    expect(preview.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "invalid_mcp_server" }),
+      ]),
+    );
+  });
+
   it("prepares deterministic MCP names and revokes disabled installations", async () => {
     const pluginDirectory = path.join(root, "plugin");
     const appDataPath = path.join(root, "app-data");

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
@@ -1316,8 +1316,10 @@ describe("Agent Plugins skills support", () => {
       "Review and approve",
     );
     const approved = await service.approveStdio(installation.id);
-    expect(approved.enabled).toBe(true);
+    expect(approved.enabled).toBe(false);
     expect(approved.stdioApprovalRequired).toBe(false);
+    const enabled = await service.setEnabled(installation.id, true);
+    expect(enabled.enabled).toBe(true);
     await service.prepareRuntimeMcpServers("task-1", "run-2", new Set());
     const bridgeRegistration = vi.mocked(stdioBridge.register).mock
       .calls[0]?.[0];

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
@@ -819,7 +819,12 @@ describe("Agent Plugins skills support", () => {
 
     const preview = await service.selectDirectory();
     expect(preview?.mcpServers).toEqual([
-      { name: "analytics", type: "streamable-http", supported: true },
+      {
+        name: "analytics",
+        type: "streamable-http",
+        supported: true,
+        approval: "not-required",
+      },
     ]);
     const installation = await service.register(preview?.selectionToken ?? "");
     expect(installation.mcpServers).toEqual(preview?.mcpServers);
@@ -883,7 +888,11 @@ describe("Agent Plugins skills support", () => {
       "analytics",
     );
 
-    const runtime = await service.prepareRuntimeMcpServers("run-1", new Set());
+    const runtime = await service.prepareRuntimeMcpServers(
+      "task-1",
+      "run-1",
+      new Set(),
+    );
     expect(runtime).toEqual([
       expect.objectContaining({ name: expectedName, type: "http" }),
     ]);
@@ -900,9 +909,9 @@ describe("Agent Plugins skills support", () => {
     expect(httpProxy.unregisterInstallation).toHaveBeenCalledWith(
       installation.id,
     );
-    expect(await service.prepareRuntimeMcpServers("run-2", new Set())).toEqual(
-      [],
-    );
+    expect(
+      await service.prepareRuntimeMcpServers("task-1", "run-2", new Set()),
+    ).toEqual([]);
   });
 
   it("revokes HTTP targets when an installation is removed", async () => {
@@ -1019,5 +1028,76 @@ describe("Agent Plugins skills support", () => {
 
     expect(deferredProxy.proxy.register).toHaveBeenCalledTimes(2);
     expect(deferredProxy.active.size).toBe(1);
+  it("requires fresh approval when stdio definitions change", async () => {
+    const pluginDirectory = path.join(root, "plugin-consent");
+    const appDataPath = path.join(root, "app-data-consent");
+    await writePlugin(pluginDirectory);
+    await writeMcp(pluginDirectory, {
+      local: {
+        type: "stdio",
+        command: "node",
+        args: ["one"],
+        env: { PRIVATE_VALUE: "not-for-renderer" },
+        cwd: "${PLUGIN_ROOT}",
+      },
+    });
+    const stdioBridge = createStdioBridge();
+    const service = createService(
+      appDataPath,
+      [pluginDirectory],
+      createHttpProxy(),
+      stdioBridge,
+    );
+    const installation = await registerSelectedPlugin(service);
+
+    expect(installation.stdioApprovalRequired).toBe(false);
+    expect(installation.mcpServers[0]).toMatchObject({
+      command: "node",
+      args: ["one"],
+      envNames: ["PRIVATE_VALUE"],
+      approval: "approved",
+    });
+    expect(JSON.stringify(installation)).not.toContain("not-for-renderer");
+    expect(
+      await fs.promises.readFile(
+        path.join(appDataPath, "agent-plugins", "installations.json"),
+        "utf8",
+      ),
+    ).not.toContain("not-for-renderer");
+
+    await writeMcp(pluginDirectory, {
+      local: { type: "stdio", command: "node", args: ["two"] },
+    });
+    const changed = (await service.list())[0];
+    expect(changed.stdioApprovalRequired).toBe(true);
+    expect(changed.mcpServers[0]?.approval).toBe("required");
+    expect(
+      await service.prepareRuntimeMcpServers("task-1", "run-1", new Set()),
+    ).toEqual([]);
+    expect(stdioBridge.register).not.toHaveBeenCalled();
+
+    await service.setEnabled(installation.id, false);
+    await expect(service.setEnabled(installation.id, true)).rejects.toThrow(
+      "Review and approve",
+    );
+    const approved = await service.approveStdio(installation.id);
+    expect(approved.enabled).toBe(true);
+    expect(approved.stdioApprovalRequired).toBe(false);
+    await service.prepareRuntimeMcpServers("task-1", "run-2", new Set());
+    const bridgeRegistration = vi.mocked(stdioBridge.register).mock
+      .calls[0]?.[0];
+    expect(bridgeRegistration).toBeDefined();
+
+    await writeMcp(pluginDirectory, {
+      local: { type: "stdio", command: "node", args: ["three"] },
+    });
+    await expect(bridgeRegistration?.prepare()).rejects.toThrow(
+      "changed after it was approved",
+    );
+
+    await writeMcp(pluginDirectory, {});
+    const removed = (await service.list())[0];
+    expect(removed.stdioApprovalRequired).toBe(false);
+    expect(removed.mcpServers).toEqual([]);
   });
 });

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.test.ts
@@ -697,6 +697,37 @@ describe("Agent Plugins skills support", () => {
     },
   );
 
+  it("leaves installation state and managed data intact for a parent ID", async () => {
+    const appDataPath = path.join(root, "app-data");
+    const pluginDirectory = path.join(root, "plugin");
+    await writePlugin(pluginDirectory);
+    const service = createService(appDataPath, [pluginDirectory]);
+    const installation = await registerSelectedPlugin(service);
+    const dataDirectory = path.join(
+      appDataPath,
+      "agent-plugins",
+      "data",
+      installation.id,
+    );
+    await fs.promises.mkdir(dataDirectory, { recursive: true });
+    const sentinelPath = path.join(dataDirectory, "sentinel.json");
+    await fs.promises.writeFile(sentinelPath, "{}", "utf8");
+
+    await expect(service.unregister("..")).rejects.toThrow(
+      "Invalid Agent Plugin installation ID",
+    );
+
+    expect((await service.list()).map((plugin) => plugin.id)).toContain(
+      installation.id,
+    );
+    await expect(fs.promises.readFile(sentinelPath, "utf8")).resolves.toBe(
+      "{}",
+    );
+    await expect(
+      fs.promises.stat(path.join(appDataPath, "agent-plugins")),
+    ).resolves.toBeDefined();
+  });
+
   it("rejects removal of a missing installation", async () => {
     const service = createService(path.join(root, "app-data"));
 
@@ -949,7 +980,11 @@ describe("Agent Plugins skills support", () => {
     );
     const installation = await registerSelectedPlugin(service);
 
-    const activation = service.prepareRuntimeMcpServers("run-1", new Set());
+    const activation = service.prepareRuntimeMcpServers(
+      "task-1",
+      "run-1",
+      new Set(),
+    );
     await deferredProxy.registrationStarted;
     const disable = service.setEnabled(installation.id, false);
     expect(deferredProxy.proxy.unregisterInstallation).not.toHaveBeenCalled();
@@ -963,7 +998,7 @@ describe("Agent Plugins skills support", () => {
       installation.id,
     );
     await expect(
-      service.prepareRuntimeMcpServers("run-2", new Set()),
+      service.prepareRuntimeMcpServers("task-1", "run-2", new Set()),
     ).resolves.toEqual([]);
     expect(deferredProxy.proxy.register).toHaveBeenCalledTimes(1);
   });
@@ -985,7 +1020,11 @@ describe("Agent Plugins skills support", () => {
     );
     const installation = await registerSelectedPlugin(service);
 
-    const activation = service.prepareRuntimeMcpServers("run-1", new Set());
+    const activation = service.prepareRuntimeMcpServers(
+      "task-1",
+      "run-1",
+      new Set(),
+    );
     await deferredProxy.registrationStarted;
     const removal = service.unregister(installation.id);
     expect(deferredProxy.proxy.unregisterInstallation).not.toHaveBeenCalled();
@@ -1018,9 +1057,17 @@ describe("Agent Plugins skills support", () => {
     );
     await registerSelectedPlugin(service);
 
-    const first = service.prepareRuntimeMcpServers("run-1", new Set());
+    const first = service.prepareRuntimeMcpServers(
+      "task-1",
+      "run-1",
+      new Set(),
+    );
     await deferredProxy.registrationStarted;
-    const second = service.prepareRuntimeMcpServers("run-1", new Set());
+    const second = service.prepareRuntimeMcpServers(
+      "task-1",
+      "run-1",
+      new Set(),
+    );
     expect(deferredProxy.proxy.register).toHaveBeenCalledTimes(1);
 
     deferredProxy.releaseRegistration();
@@ -1028,6 +1075,8 @@ describe("Agent Plugins skills support", () => {
 
     expect(deferredProxy.proxy.register).toHaveBeenCalledTimes(2);
     expect(deferredProxy.active.size).toBe(1);
+  });
+
   it("requires fresh approval when stdio definitions change", async () => {
     const pluginDirectory = path.join(root, "plugin-consent");
     const appDataPath = path.join(root, "app-data-consent");

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
@@ -25,8 +25,11 @@ import {
   type AgentPluginInstallation,
   type AgentPluginMcpServer,
   type AgentPluginMcpServerSummary,
+  type AgentPluginPersistedInstallation,
   type AgentPluginPreview,
+  type AgentPluginStdioMcpServer,
   agentPluginState,
+  type LoadedAgentPlugin,
 } from "./schemas";
 import {
   type AgentPluginStdioBridge,
@@ -41,7 +44,7 @@ interface RuntimeAgentPlugin {
 
 interface PersistedState {
   version: 1;
-  installations: AgentPluginInstallation[];
+  installations: AgentPluginPersistedInstallation[];
 }
 
 interface PendingSelection {
@@ -62,14 +65,81 @@ const MAX_PLUGIN_SNAPSHOT_FILES = 1024;
 const MAX_PLUGIN_SNAPSHOT_BYTES = 32 * 1024 * 1024;
 const SNAPSHOT_READ_CHUNK_BYTES = 64 * 1024;
 
+export function agentPluginStdioDigest(
+  installationId: string,
+  pluginName: string,
+  server: AgentPluginStdioMcpServer,
+): string {
+  const normalizedEnvironment = Object.fromEntries(
+    Object.entries(server.env ?? {}).sort(([left], [right]) =>
+      left.localeCompare(right),
+    ),
+  );
+  return crypto
+    .createHash("sha256")
+    .update(
+      JSON.stringify({
+        installationId,
+        pluginName,
+        serverName: server.name,
+        command: server.command,
+        args: server.args ?? [],
+        env: normalizedEnvironment,
+        cwd: server.cwd ?? "${PLUGIN_ROOT}",
+      }),
+    )
+    .digest("hex");
+}
+
+function stdioDigests(
+  installationId: string,
+  pluginName: string,
+  servers: AgentPluginMcpServer[],
+): Record<string, string> {
+  return Object.fromEntries(
+    servers
+      .filter(
+        (server): server is AgentPluginStdioMcpServer =>
+          server.type === "stdio",
+      )
+      .map((server) => [
+        server.name,
+        agentPluginStdioDigest(installationId, pluginName, server),
+      ]),
+  );
+}
+
 function summarizeMcpServers(
   servers: AgentPluginMcpServer[],
+  installationId: string,
+  pluginName: string,
+  approvedStdioDigests: Readonly<Record<string, string>>,
 ): AgentPluginMcpServerSummary[] {
-  return servers.map((server) => ({
-    name: server.name,
-    type: server.type,
-    supported: true,
-  }));
+  return servers.map((server) => {
+    if (server.type === "streamable-http") {
+      return {
+        name: server.name,
+        type: server.type,
+        supported: true,
+        approval: "not-required" as const,
+      };
+    }
+    const digest = agentPluginStdioDigest(installationId, pluginName, server);
+    return {
+      name: server.name,
+      type: server.type,
+      supported: true,
+      command: server.command,
+      args: server.args ?? [],
+      cwd: server.cwd ?? "${PLUGIN_ROOT}",
+      envNames: Object.keys(server.env ?? {}).sort(),
+      digest,
+      approval:
+        approvedStdioDigests[server.name] === digest
+          ? ("approved" as const)
+          : ("required" as const),
+    };
+  });
 }
 
 export function agentPluginRuntimeMcpName(
@@ -109,41 +179,14 @@ export class AgentPluginsService {
   list(): Promise<AgentPluginInstallation[]> {
     return this.withStateTransaction(async () => {
       const state = await this.readState();
-      const installations = await Promise.all(
-        state.installations.map(async (installation) => {
-          const preview = await loadAgentPlugin(installation.sourcePath);
-          const sourceUnchanged =
-            preview.sourcePath === installation.sourcePath;
-          return {
-            ...installation,
-            manifest:
-              sourceUnchanged && preview.manifest
-                ? preview.manifest
-                : installation.manifest,
-            skills: sourceUnchanged && preview.valid ? preview.skills : [],
-            mcpServers:
-              sourceUnchanged && preview.valid
-                ? summarizeMcpServers(preview.mcpServers)
-                : [],
-            diagnostics: [
-              ...(sourceUnchanged
-                ? preview.diagnostics
-                : [
-                    ...preview.diagnostics,
-                    {
-                      severity: "error" as const,
-                      code: "source_changed",
-                      message:
-                        "The Agent Plugin directory changed. Remove it and add it again.",
-                    },
-                  ]),
-              ...(this.runtimeDiagnostics.get(installation.id) ?? []),
-            ],
-          } satisfies AgentPluginInstallation;
-        }),
+      return Promise.all(
+        state.installations.map(async (installation) =>
+          this.toPublicInstallation(
+            installation,
+            await loadAgentPlugin(installation.sourcePath),
+          ),
+        ),
       );
-      await this.writeState({ version: 1, installations });
-      return installations;
     });
   }
 
@@ -157,7 +200,14 @@ export class AgentPluginsService {
     const preview = await loadAgentPlugin(sourcePath);
     const publicPreview: AgentPluginPreview = {
       ...preview,
-      mcpServers: summarizeMcpServers(preview.mcpServers),
+      mcpServers: preview.manifest
+        ? summarizeMcpServers(
+            preview.mcpServers,
+            this.installationId(preview.sourcePath),
+            preview.manifest.name,
+            {},
+          )
+        : [],
     };
     if (!preview.valid) return publicPreview;
 
@@ -193,14 +243,26 @@ export class AgentPluginsService {
       const existing = state.installations.find(
         (installation) => installation.id === id,
       );
-      const installation: AgentPluginInstallation = {
+      const approvedStdioDigests = stdioDigests(
+        id,
+        manifest.name,
+        preview.mcpServers,
+      );
+      const installation: AgentPluginPersistedInstallation = {
         id,
         sourcePath: preview.sourcePath,
         enabled: existing?.enabled ?? true,
         manifest,
         skills: preview.skills,
-        mcpServers: summarizeMcpServers(preview.mcpServers),
+        mcpServers: summarizeMcpServers(
+          preview.mcpServers,
+          id,
+          manifest.name,
+          approvedStdioDigests,
+        ),
         diagnostics: preview.diagnostics,
+        stdioApprovalRequired: false,
+        approvedStdioDigests,
       };
       const installations = state.installations.filter(
         (item) => item.id !== installation.id,
@@ -208,7 +270,7 @@ export class AgentPluginsService {
       installations.push(installation);
       this.runtimeDiagnostics.delete(installation.id);
       await this.writeState({ version: 1, installations });
-      return installation;
+      return this.toPublicInstallation(installation, preview);
     });
   }
 
@@ -217,8 +279,19 @@ export class AgentPluginsService {
       this.assertInstallationId(id);
       const state = await this.readState();
       const installation = state.installations.find((item) => item.id === id);
-      if (!installation)
+      if (!installation) {
         throw new Error("Agent Plugin installation not found.");
+      }
+      const preview = await loadAgentPlugin(installation.sourcePath);
+      const publicInstallation = this.toPublicInstallation(
+        installation,
+        preview,
+      );
+      if (enabled && publicInstallation.stdioApprovalRequired) {
+        throw new Error(
+          "Review and approve the current stdio commands before enabling this plugin.",
+        );
+      }
       const updated = { ...installation, enabled };
       await this.writeState({
         version: 1,
@@ -231,7 +304,48 @@ export class AgentPluginsService {
         this.httpProxy.unregisterInstallation(id);
         await this.stdioBridge.unregisterInstallation(id);
       }
-      return updated;
+      return this.toPublicInstallation(updated, preview);
+    });
+  }
+
+  approveStdio(id: string): Promise<AgentPluginInstallation> {
+    return this.withStateTransaction(async () => {
+      const state = await this.readState();
+      const installation = state.installations.find((item) => item.id === id);
+      if (!installation) {
+        throw new Error("Agent Plugin installation not found.");
+      }
+      const preview = await loadAgentPlugin(installation.sourcePath);
+      if (
+        !preview.valid ||
+        !preview.manifest ||
+        preview.sourcePath !== installation.sourcePath
+      ) {
+        throw new Error(
+          "The Agent Plugin could not be validated. Fix it before approving stdio commands.",
+        );
+      }
+      const approvedStdioDigests = stdioDigests(
+        installation.id,
+        preview.manifest.name,
+        preview.mcpServers,
+      );
+      const updated: AgentPluginPersistedInstallation = {
+        ...installation,
+        enabled: true,
+        approvedStdioDigests,
+        stdioApprovalRequired: false,
+      };
+      await this.writeState({
+        version: 1,
+        installations: state.installations.map((item) =>
+          item.id === id ? updated : item,
+        ),
+      });
+      this.runtimeDiagnostics.delete(id);
+      this.httpProxy.unregisterInstallation(id);
+      await this.stdioBridge.unregisterInstallation(id);
+      return this.toPublicInstallation(updated, preview);
     });
   }
 
@@ -254,6 +368,7 @@ export class AgentPluginsService {
   }
 
   prepareRuntimeMcpServers(
+    taskId: string,
     taskRunId: string,
     reservedServerNames: ReadonlySet<string>,
   ): Promise<McpServerConnection[]> {
@@ -265,6 +380,7 @@ export class AgentPluginsService {
       this.httpProxy.unregisterRun(taskRunId);
       try {
         return await this.prepareRuntimeMcpServersLocked(
+          taskId,
           taskRunId,
           reservedServerNames,
         );
@@ -276,6 +392,7 @@ export class AgentPluginsService {
   }
 
   private async prepareRuntimeMcpServersLocked(
+    taskId: string,
     taskRunId: string,
     reservedServerNames: ReadonlySet<string>,
   ): Promise<McpServerConnection[]> {
@@ -336,20 +453,34 @@ export class AgentPluginsService {
             continue;
           }
 
-          const resolved = await resolveStdioServer(
-            preview.sourcePath,
-            this.pluginDataPath(installation.id),
+          const approvedDigest = installation.approvedStdioDigests[server.name];
+          const currentDigest = agentPluginStdioDigest(
+            installation.id,
+            preview.manifest.name,
             server,
           );
+          if (approvedDigest !== currentDigest) {
+            this.addRuntimeDiagnostic(installation.id, {
+              severity: "error",
+              code: "mcp_stdio_approval_required",
+              message: `Skipped MCP server ${server.name} because its executable configuration needs approval.`,
+              path: `mcp.json/mcpServers/${server.name}`,
+            });
+            continue;
+          }
+
           const url = await this.stdioBridge.register({
             id: `${taskRunId}:${runtimeName}`,
+            taskId,
             runId: taskRunId,
             installationId: installation.id,
             runtimeName,
-            command: resolved.command,
-            args: resolved.args,
-            env: resolved.env,
-            cwd: resolved.cwd,
+            prepare: () =>
+              this.resolveApprovedStdioServer(
+                installation,
+                server.name,
+                currentDigest,
+              ),
             onFailure: () => {
               this.addRuntimeDiagnostic(installation.id, {
                 severity: "error",
@@ -503,6 +634,100 @@ export class AgentPluginsService {
       await this.stdioBridge.unregisterRun(taskRunId);
       await this.removeManagedPath(this.runtimeRoot(taskRunId));
     });
+  }
+
+  private toPublicInstallation(
+    installation: AgentPluginPersistedInstallation,
+    preview: LoadedAgentPlugin,
+  ): AgentPluginInstallation {
+    const sourceUnchanged = preview.sourcePath === installation.sourcePath;
+    const manifest =
+      sourceUnchanged && preview.manifest
+        ? preview.manifest
+        : installation.manifest;
+    const mcpServers =
+      sourceUnchanged && preview.valid
+        ? summarizeMcpServers(
+            preview.mcpServers,
+            installation.id,
+            manifest.name,
+            installation.approvedStdioDigests,
+          )
+        : [];
+    const diagnostics: AgentPluginDiagnostic[] = [
+      ...(sourceUnchanged
+        ? preview.diagnostics
+        : [
+            ...preview.diagnostics,
+            {
+              severity: "error" as const,
+              code: "source_changed",
+              message:
+                "The Agent Plugin directory changed. Remove it and add it again.",
+            },
+          ]),
+      ...(this.runtimeDiagnostics.get(installation.id) ?? []),
+    ];
+    const stdioApprovalRequired = mcpServers.some(
+      (server) => server.approval === "required",
+    );
+    if (stdioApprovalRequired) {
+      diagnostics.push({
+        severity: "warning",
+        code: "mcp_stdio_approval_required",
+        message:
+          "Review and approve the current stdio commands before they can run.",
+        path: "mcp.json",
+      });
+    }
+    return {
+      id: installation.id,
+      sourcePath: installation.sourcePath,
+      enabled: installation.enabled,
+      manifest,
+      skills: sourceUnchanged && preview.valid ? preview.skills : [],
+      mcpServers,
+      diagnostics,
+      stdioApprovalRequired,
+    };
+  }
+
+  private async resolveApprovedStdioServer(
+    installation: AgentPluginPersistedInstallation,
+    serverName: string,
+    approvedDigest: string,
+  ): Promise<Awaited<ReturnType<typeof resolveStdioServer>>> {
+    const preview = await loadAgentPlugin(installation.sourcePath);
+    if (
+      !preview.valid ||
+      !preview.manifest ||
+      preview.sourcePath !== installation.sourcePath
+    ) {
+      throw new Error(
+        "The Agent Plugin changed before its stdio server started.",
+      );
+    }
+    const server = preview.mcpServers.find(
+      (candidate): candidate is AgentPluginStdioMcpServer =>
+        candidate.type === "stdio" && candidate.name === serverName,
+    );
+    if (
+      !server ||
+      installation.approvedStdioDigests[serverName] !== approvedDigest ||
+      agentPluginStdioDigest(installation.id, preview.manifest.name, server) !==
+        approvedDigest
+    ) {
+      throw new Error(
+        "The stdio executable configuration changed after it was approved.",
+      );
+    }
+    const pluginData = this.pluginDataPath(installation.id);
+    await this.makeManagedDirectory(pluginData);
+    return resolveStdioServer(
+      preview.sourcePath,
+      await this.assertManagedPath(pluginData),
+      server,
+    );
   }
 
   private addRuntimeDiagnostic(

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
@@ -257,14 +257,7 @@ export class AgentPluginsService {
         enabled: existing?.enabled ?? true,
         manifest,
         skills: preview.skills,
-        mcpServers: summarizeMcpServers(
-          preview.mcpServers,
-          id,
-          manifest.name,
-          approvedStdioDigests,
-        ),
         diagnostics: preview.diagnostics,
-        stdioApprovalRequired: false,
         approvedStdioDigests,
       };
       const installations = state.installations.filter(
@@ -337,7 +330,6 @@ export class AgentPluginsService {
         ...installation,
         enabled: true,
         approvedStdioDigests,
-        stdioApprovalRequired: false,
       };
       await this.writeState({
         version: 1,
@@ -346,7 +338,6 @@ export class AgentPluginsService {
         ),
       });
       this.runtimeDiagnostics.delete(id);
-      this.httpProxy.unregisterInstallation(id);
       await this.stdioBridge.unregisterInstallation(id);
       return this.toPublicInstallation(updated, preview);
     });

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
@@ -137,7 +137,6 @@ function summarizeMcpServers(
       args: server.args ?? [],
       cwd: server.cwd ?? "${PLUGIN_ROOT}",
       envNames: Object.keys(server.env ?? {}).sort(),
-      digest,
       approval:
         approvedStdioDigests[server.name] === digest
           ? ("approved" as const)

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
@@ -10,7 +10,10 @@ import type { McpServerConnection } from "@posthog/shared";
 import { inject, injectable } from "inversify";
 import { isSafePathSegment } from "../skills/skill-discovery";
 import type { AgentPluginHttpProxy } from "./http-proxy";
-import { AGENT_PLUGIN_HTTP_PROXY } from "./identifiers";
+import {
+  AGENT_PLUGIN_HTTP_PROXY,
+  AGENT_PLUGIN_STDIO_BRIDGE,
+} from "./identifiers";
 import {
   isPathContained,
   loadAgentPlugin,
@@ -19,12 +22,17 @@ import {
 import {
   AGENT_PLUGIN_INSTALLATION_ID_PATTERN,
   type AgentPluginDiagnostic,
-  type AgentPluginHttpMcpServer,
   type AgentPluginInstallation,
+  type AgentPluginMcpServer,
   type AgentPluginMcpServerSummary,
   type AgentPluginPreview,
   agentPluginState,
 } from "./schemas";
+import {
+  type AgentPluginStdioBridge,
+  STDIO_BRIDGE_MARKER_HEADER,
+} from "./stdio-bridge";
+import { resolveStdioServer } from "./stdio-runtime";
 
 interface RuntimeAgentPlugin {
   pluginPath: string;
@@ -55,7 +63,7 @@ const MAX_PLUGIN_SNAPSHOT_BYTES = 32 * 1024 * 1024;
 const SNAPSHOT_READ_CHUNK_BYTES = 64 * 1024;
 
 function summarizeMcpServers(
-  servers: AgentPluginHttpMcpServer[],
+  servers: AgentPluginMcpServer[],
 ): AgentPluginMcpServerSummary[] {
   return servers.map((server) => ({
     name: server.name,
@@ -94,6 +102,8 @@ export class AgentPluginsService {
     private readonly dialog: IDialog,
     @inject(AGENT_PLUGIN_HTTP_PROXY)
     private readonly httpProxy: AgentPluginHttpProxy,
+    @inject(AGENT_PLUGIN_STDIO_BRIDGE)
+    private readonly stdioBridge: AgentPluginStdioBridge,
   ) {}
 
   list(): Promise<AgentPluginInstallation[]> {
@@ -219,6 +229,7 @@ export class AgentPluginsService {
       if (!enabled) {
         this.runtimeDiagnostics.delete(id);
         this.httpProxy.unregisterInstallation(id);
+        await this.stdioBridge.unregisterInstallation(id);
       }
       return updated;
     });
@@ -237,6 +248,8 @@ export class AgentPluginsService {
       });
       this.runtimeDiagnostics.delete(id);
       this.httpProxy.unregisterInstallation(id);
+      await this.stdioBridge.unregisterInstallation(id);
+      await this.removeManagedPath(this.pluginDataPath(id));
     });
   }
 
@@ -305,24 +318,61 @@ export class AgentPluginsService {
         }
 
         try {
-          const url = await this.httpProxy.register({
+          if (server.type === "streamable-http") {
+            const url = await this.httpProxy.register({
+              id: `${taskRunId}:${runtimeName}`,
+              runId: taskRunId,
+              installationId: installation.id,
+              url: server.url,
+              headers: server.headers ?? {},
+            });
+            claimedServerNames.add(runtimeName);
+            runtimeServers.push({
+              type: "http",
+              name: runtimeName,
+              url,
+              headers: [],
+            });
+            continue;
+          }
+
+          const resolved = await resolveStdioServer(
+            preview.sourcePath,
+            this.pluginDataPath(installation.id),
+            server,
+          );
+          const url = await this.stdioBridge.register({
             id: `${taskRunId}:${runtimeName}`,
             runId: taskRunId,
             installationId: installation.id,
-            url: server.url,
-            headers: server.headers ?? {},
+            runtimeName,
+            command: resolved.command,
+            args: resolved.args,
+            env: resolved.env,
+            cwd: resolved.cwd,
+            onFailure: () => {
+              this.addRuntimeDiagnostic(installation.id, {
+                severity: "error",
+                code: "mcp_stdio_failed",
+                message: `MCP server ${server.name} stopped. Check its command and configuration, then start a new agent session.`,
+                path: `mcp.json/mcpServers/${server.name}`,
+              });
+            },
           });
           claimedServerNames.add(runtimeName);
           runtimeServers.push({
             type: "http",
             name: runtimeName,
             url,
-            headers: [],
+            headers: [{ name: STDIO_BRIDGE_MARKER_HEADER, value: "1" }],
           });
         } catch {
           this.addRuntimeDiagnostic(installation.id, {
             severity: "error",
-            code: "mcp_proxy_failed",
+            code:
+              server.type === "stdio"
+                ? "mcp_stdio_prepare_failed"
+                : "mcp_proxy_failed",
             message: `Skipped MCP server ${server.name} because its local connection could not be prepared.`,
             path: `mcp.json/mcpServers/${server.name}`,
           });
@@ -450,6 +500,7 @@ export class AgentPluginsService {
     if (!isSafePathSegment(taskRunId)) return Promise.resolve();
     return this.withStateTransaction(async () => {
       this.httpProxy.unregisterRun(taskRunId);
+      await this.stdioBridge.unregisterRun(taskRunId);
       await this.removeManagedPath(this.runtimeRoot(taskRunId));
     });
   }
@@ -497,6 +548,10 @@ export class AgentPluginsService {
     if (!AGENT_PLUGIN_INSTALLATION_ID_PATTERN.test(id)) {
       throw new Error("Invalid Agent Plugin installation ID.");
     }
+  }
+
+  private pluginDataPath(installationId: string): string {
+    return path.join(this.managedRoot(), "data", installationId);
   }
 
   private installationId(sourcePath: string): string {

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/agent-plugins.ts
@@ -326,7 +326,6 @@ export class AgentPluginsService {
       );
       const updated: AgentPluginPersistedInstallation = {
         ...installation,
-        enabled: true,
         approvedStdioDigests,
       };
       await this.writeState({

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/fixtures/echo-mcp-server.mjs
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/fixtures/echo-mcp-server.mjs
@@ -1,0 +1,37 @@
+import readline from "node:readline";
+
+const input = readline.createInterface({ input: process.stdin });
+
+input.on("line", (line) => {
+  let message;
+  try {
+    message = JSON.parse(line);
+  } catch {
+    process.exitCode = 1;
+    input.close();
+    return;
+  }
+  if (message.id === undefined) return;
+
+  const result =
+    message.method === "initialize"
+      ? {
+          protocolVersion: "2025-06-18",
+          capabilities: { tools: {} },
+          serverInfo: { name: "fixture", version: "1.0.0" },
+        }
+      : message.method === "tools/list"
+        ? {
+            tools: [
+              {
+                name: "echo",
+                description: "Echo text",
+                inputSchema: { type: "object" },
+              },
+            ],
+          }
+        : {};
+  process.stdout.write(
+    `${JSON.stringify({ jsonrpc: "2.0", id: message.id, result })}\n`,
+  );
+});

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/identifiers.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/identifiers.ts
@@ -4,3 +4,6 @@ export const AGENT_PLUGINS_SERVICE = Symbol.for(
 export const AGENT_PLUGIN_HTTP_PROXY = Symbol.for(
   "posthog.workspace.agentPluginHttpProxy",
 );
+export const AGENT_PLUGIN_STDIO_BRIDGE = Symbol.for(
+  "posthog.workspace.agentPluginStdioBridge",
+);

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/loader.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/loader.ts
@@ -98,6 +98,13 @@ function isReservedStdioEnvironmentName(name: string): boolean {
   return normalized === "PLUGIN_ROOT" || normalized === "PLUGIN_DATA";
 }
 
+function hasCaseInsensitiveDuplicateKeys(
+  value: Record<string, unknown>,
+): boolean {
+  const normalizedKeys = Object.keys(value).map((name) => name.toUpperCase());
+  return new Set(normalizedKeys).size !== normalizedKeys.length;
+}
+
 export function isPathContained(root: string, candidate: string): boolean {
   const relativePath = path.relative(root, candidate);
   return (
@@ -756,6 +763,7 @@ async function parseStdioMcpServer(
   if (
     value.env !== undefined &&
     (!isObject(value.env) ||
+      hasCaseInsensitiveDuplicateKeys(value.env) ||
       Object.keys(value.env).some(isReservedStdioEnvironmentName) ||
       !Object.values(value.env).every(
         (environmentValue) => typeof environmentValue === "string",

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/loader.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/loader.ts
@@ -8,7 +8,9 @@ import {
   type AgentPluginDiagnostic,
   type AgentPluginHttpMcpServer,
   type AgentPluginManifest,
+  type AgentPluginMcpServer,
   type AgentPluginSkill,
+  type AgentPluginStdioMcpServer,
   type LoadedAgentPlugin,
 } from "./schemas";
 
@@ -38,6 +40,11 @@ const PLUGIN_DATA_PLACEHOLDER = `\${PLUGIN_DATA}`;
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isReservedStdioEnvironmentName(name: string): boolean {
+  const normalized = process.platform === "win32" ? name.toUpperCase() : name;
+  return normalized === "PLUGIN_ROOT" || normalized === "PLUGIN_DATA";
 }
 
 export function isPathContained(root: string, candidate: string): boolean {
@@ -624,102 +631,116 @@ function isValidStdioCwd(pluginRoot: string, value: string): boolean {
   return false;
 }
 
-async function isValidUnsupportedMcpServer(
-  pluginRoot: string,
-  value: Record<string, unknown>,
-): Promise<boolean> {
-  if (value.type === "sse") {
-    if (!hasOnlyFields(value, REMOTE_MCP_FIELDS)) return false;
-    if (typeof value.url !== "string") return false;
-    const headers = parseHttpHeaders(value.headers);
-    if (!headers) return false;
-    try {
-      const url = new URL(value.url);
-      return (
-        (url.protocol === "http:" || url.protocol === "https:") &&
-        url.username === "" &&
-        url.password === "" &&
-        url.hash === "" &&
-        (url.protocol === "https:" || isLoopbackHostname(url.hostname))
-      );
-    } catch {
-      return false;
-    }
-  }
-
-  if (value.type !== "stdio" || !hasOnlyFields(value, STDIO_MCP_FIELDS)) {
+function isValidUnsupportedSseServer(value: Record<string, unknown>): boolean {
+  if (value.type !== "sse" || !hasOnlyFields(value, REMOTE_MCP_FIELDS)) {
     return false;
   }
-  if (typeof value.command !== "string" || value.command.length === 0) {
-    return false;
-  }
-  const isPluginCommand = value.command.startsWith("./");
-  const isBareCommand =
-    !value.command.includes("/") &&
-    !value.command.includes("\\") &&
-    !/\s/.test(value.command);
-  if (!isPluginCommand && !isBareCommand) return false;
-  if (isPluginCommand) {
-    if (!isContainedPluginPath(pluginRoot, value.command)) return false;
-    try {
-      const resolvedCommand = await fs.promises.realpath(
-        path.resolve(pluginRoot, value.command),
-      );
-      if (!isPathContained(pluginRoot, resolvedCommand)) return false;
-      if (!(await fs.promises.stat(resolvedCommand)).isFile()) return false;
-    } catch {
-      return false;
-    }
-  }
-  if (
-    value.args !== undefined &&
-    (!Array.isArray(value.args) ||
-      !value.args.every((argument) => typeof argument === "string"))
-  ) {
-    return false;
-  }
-  if (value.env !== undefined) {
-    if (
-      !isObject(value.env) ||
-      Object.keys(value.env).some(
-        (name) => name === "PLUGIN_ROOT" || name === "PLUGIN_DATA",
-      ) ||
-      !Object.values(value.env).every(
-        (environmentValue) => typeof environmentValue === "string",
-      )
-    ) {
-      return false;
-    }
-  }
-  if (value.cwd === undefined) return true;
-  if (
-    typeof value.cwd !== "string" ||
-    !isValidStdioCwd(pluginRoot, value.cwd)
-  ) {
-    return false;
-  }
-  if (value.cwd.startsWith(PLUGIN_DATA_PLACEHOLDER)) return true;
-
-  const relativeCwd = value.cwd.startsWith(PLUGIN_ROOT_PLACEHOLDER)
-    ? `.${value.cwd.slice(PLUGIN_ROOT_PLACEHOLDER.length)}`
-    : value.cwd;
+  if (typeof value.url !== "string") return false;
+  const headers = parseHttpHeaders(value.headers);
+  if (!headers) return false;
   try {
-    const resolvedCwd = await fs.promises.realpath(
-      path.resolve(pluginRoot, relativeCwd),
-    );
+    const url = new URL(value.url);
     return (
-      isPathContained(pluginRoot, resolvedCwd) &&
-      (await fs.promises.stat(resolvedCwd)).isDirectory()
+      (url.protocol === "http:" || url.protocol === "https:") &&
+      url.username === "" &&
+      url.password === "" &&
+      url.hash === "" &&
+      (url.protocol === "https:" || isLoopbackHostname(url.hostname))
     );
   } catch {
     return false;
   }
 }
 
+async function parseStdioMcpServer(
+  pluginRoot: string,
+  serverName: string,
+  value: Record<string, unknown>,
+): Promise<AgentPluginStdioMcpServer | null> {
+  if (value.type !== "stdio" || !hasOnlyFields(value, STDIO_MCP_FIELDS)) {
+    return null;
+  }
+  if (typeof value.command !== "string" || value.command.length === 0) {
+    return null;
+  }
+
+  const isPluginCommand = value.command.startsWith("./");
+  const isBareCommand =
+    !value.command.includes("/") &&
+    !value.command.includes("\\") &&
+    !/\s/.test(value.command);
+  if (!isPluginCommand && !isBareCommand) return null;
+  if (isPluginCommand) {
+    if (!isContainedPluginPath(pluginRoot, value.command)) return null;
+    try {
+      const commandPath = path.resolve(pluginRoot, value.command);
+      const commandLstat = await fs.promises.lstat(commandPath);
+      if (commandLstat.isSymbolicLink() || !commandLstat.isFile()) return null;
+      const resolvedCommand = await fs.promises.realpath(commandPath);
+      if (!isPathContained(pluginRoot, resolvedCommand)) return null;
+    } catch {
+      return null;
+    }
+  }
+
+  if (
+    value.args !== undefined &&
+    (!Array.isArray(value.args) ||
+      !value.args.every((argument) => typeof argument === "string"))
+  ) {
+    return null;
+  }
+  if (
+    value.env !== undefined &&
+    (!isObject(value.env) ||
+      Object.keys(value.env).some(isReservedStdioEnvironmentName) ||
+      !Object.values(value.env).every(
+        (environmentValue) => typeof environmentValue === "string",
+      ))
+  ) {
+    return null;
+  }
+  if (
+    value.cwd !== undefined &&
+    (typeof value.cwd !== "string" || !isValidStdioCwd(pluginRoot, value.cwd))
+  ) {
+    return null;
+  }
+
+  if (
+    typeof value.cwd === "string" &&
+    !value.cwd.startsWith(PLUGIN_DATA_PLACEHOLDER)
+  ) {
+    const relativeCwd = value.cwd.startsWith(PLUGIN_ROOT_PLACEHOLDER)
+      ? `.${value.cwd.slice(PLUGIN_ROOT_PLACEHOLDER.length)}`
+      : value.cwd;
+    try {
+      const cwdPath = path.resolve(pluginRoot, relativeCwd);
+      const cwdLstat = await fs.promises.lstat(cwdPath);
+      if (cwdLstat.isSymbolicLink() || !cwdLstat.isDirectory()) return null;
+      const resolvedCwd = await fs.promises.realpath(cwdPath);
+      if (!isPathContained(pluginRoot, resolvedCwd)) return null;
+    } catch {
+      return null;
+    }
+  }
+
+  return {
+    name: serverName,
+    type: "stdio",
+    command: value.command,
+    ...(value.args !== undefined ? { args: value.args as string[] } : {}),
+    ...(value.env !== undefined
+      ? { env: value.env as Record<string, string> }
+      : {}),
+    ...(value.cwd !== undefined ? { cwd: value.cwd } : {}),
+  };
+}
+
 async function loadMcpServers(
   pluginRoot: string,
   diagnostics: AgentPluginDiagnostic[],
-): Promise<AgentPluginHttpMcpServer[]> {
+): Promise<AgentPluginMcpServer[]> {
   const mcpPath = path.join(pluginRoot, "mcp.json");
   let resolvedMcpPath: string;
   try {
@@ -785,7 +806,7 @@ async function loadMcpServers(
     return [];
   }
 
-  const servers: AgentPluginHttpMcpServer[] = [];
+  const servers: AgentPluginMcpServer[] = [];
   for (const [serverName, rawServer] of Object.entries(rawMcp.mcpServers).sort(
     ([left], [right]) => left.localeCompare(right),
   )) {
@@ -819,12 +840,33 @@ async function loadMcpServers(
       continue;
     }
 
-    if (await isValidUnsupportedMcpServer(pluginRoot, rawServer)) {
+    if (rawServer.type === "stdio") {
+      const server = await parseStdioMcpServer(
+        pluginRoot,
+        serverName,
+        rawServer,
+      );
+      if (server) {
+        servers.push(server);
+      } else {
+        diagnostics.push(
+          diagnostic(
+            "error",
+            "invalid_mcp_server",
+            `Skipped MCP server ${serverName} because its stdio configuration is invalid.`,
+            serverPath,
+          ),
+        );
+      }
+      continue;
+    }
+
+    if (isValidUnsupportedSseServer(rawServer)) {
       diagnostics.push(
         diagnostic(
           "warning",
           "unsupported_mcp_transport",
-          `Skipped MCP server ${serverName} because ${rawServer.type} transport is not supported yet.`,
+          `Skipped MCP server ${serverName} because sse transport is not supported.`,
           serverPath,
         ),
       );

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/mcp-probe.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/mcp-probe.test.ts
@@ -3,9 +3,43 @@ import { probeMcpInitialize } from "./mcp-probe";
 
 const MARKER = "x-posthog-agent-plugin-stdio-bridge";
 const PROBE = "x-posthog-agent-plugin-stdio-probe";
+const encoder = new TextEncoder();
 
-function requestId(init?: RequestInit): string {
-  return (JSON.parse(String(init?.body)) as { id: string }).id;
+function requestPayload(init?: RequestInit): Record<string, unknown> {
+  return JSON.parse(String(init?.body)) as Record<string, unknown>;
+}
+
+function initializeResult(id: unknown): Record<string, unknown> {
+  return {
+    jsonrpc: "2.0",
+    id,
+    result: {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      serverInfo: { name: "probe-test", version: "1.0.0" },
+    },
+  };
+}
+
+function mcpFetch(
+  initializeResponse: (
+    id: unknown,
+    init?: RequestInit,
+  ) => Promise<Response> | Response,
+): ReturnType<typeof vi.fn> {
+  return vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+    if (init?.method === "DELETE") {
+      return new Response(null, { status: 200 });
+    }
+    const payload = requestPayload(init);
+    if (payload.method === "notifications/initialized") {
+      return new Response(null, { status: 202 });
+    }
+    if (payload.method === "initialize") {
+      return initializeResponse(payload.id, init);
+    }
+    return new Response(null, { status: 404 });
+  });
 }
 
 describe("Agent Plugin MCP initialize probe", () => {
@@ -13,97 +47,92 @@ describe("Agent Plugin MCP initialize probe", () => {
     vi.unstubAllGlobals();
   });
 
-  it("accepts a complete response with the matching request id", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (_url: string, init?: RequestInit) =>
-        Response.json({
-          jsonrpc: "2.0",
-          id: requestId(init),
-          result: { protocolVersion: "2025-06-18" },
-        }),
-      ),
+  it("completes the SDK handshake and terminates a returned session", async () => {
+    const fetchMock = mcpFetch((id) =>
+      Response.json(initializeResult(id), {
+        headers: { "mcp-session-id": "probe-session" },
+      }),
     );
+    vi.stubGlobal("fetch", fetchMock);
 
     await expect(
       probeMcpInitialize("https://example.com/mcp", [], MARKER, PROBE),
     ).resolves.toBe(true);
+
+    expect(
+      fetchMock.mock.calls.some((call) => call[1]?.method === "DELETE"),
+    ).toBe(true);
+    expect(
+      fetchMock.mock.calls.some(
+        (call) =>
+          call[1]?.body !== undefined &&
+          requestPayload(call[1]).method === "notifications/initialized",
+      ),
+    ).toBe(true);
   });
 
-  it("accepts a matching initialize response delivered as SSE", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(
-        async (_url: string, init?: RequestInit) =>
-          new Response(
-            `event: message\ndata: ${JSON.stringify({
-              jsonrpc: "2.0",
-              id: requestId(init),
-              result: { protocolVersion: "2025-06-18" },
-            })}\n\n`,
-            { headers: { "content-type": "text/event-stream" } },
-          ),
-      ),
+  it("accepts a valid initialize event without waiting for SSE EOF", async () => {
+    const fetchMock = mcpFetch(
+      (id) =>
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(
+                encoder.encode(
+                  `event: message\ndata: ${JSON.stringify(initializeResult(id))}\n\n`,
+                ),
+              );
+            },
+          }),
+          { headers: { "content-type": "text/event-stream" } },
+        ),
     );
+    vi.stubGlobal("fetch", fetchMock);
 
     await expect(
       probeMcpInitialize("https://example.com/mcp", [], MARKER, PROBE),
     ).resolves.toBe(true);
+    expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
   });
 
   it.each([
-    ["mismatched request id", { jsonrpc: "2.0", id: "wrong", result: {} }],
-    ["JSON-RPC error", { jsonrpc: "2.0", id: "dynamic", error: {} }],
-    ["malformed response", "not json"],
-  ])("rejects a %s", async (_label, payload) => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (_url: string, init?: RequestInit) => {
-        const body =
-          typeof payload === "string"
-            ? payload
-            : JSON.stringify({
-                ...payload,
-                ...(payload.id === "dynamic" ? { id: requestId(init) } : {}),
-              });
-        return new Response(body, {
-          headers: { "content-type": "application/json" },
-        });
-      }),
+    ["empty result", {}],
+    ["malformed result", { protocolVersion: "2025-06-18" }],
+    ["JSON-RPC error", null],
+  ])("rejects an %s initialize response", async (_label, result) => {
+    const fetchMock = mcpFetch((id) =>
+      result === null
+        ? Response.json({
+            jsonrpc: "2.0",
+            id,
+            error: { code: -32603, message: "failed" },
+          })
+        : Response.json({ jsonrpc: "2.0", id, result }),
     );
+    vi.stubGlobal("fetch", fetchMock);
 
     await expect(
       probeMcpInitialize("https://example.com/mcp", [], MARKER, PROBE),
     ).resolves.toBe(false);
   });
 
-  it("times out when the response stream stays silent", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(
-        async () =>
-          new Response(
-            new ReadableStream({
-              start() {},
-            }),
-            { headers: { "content-type": "text/event-stream" } },
-          ),
-      ),
+  it("times out when an SSE stream stays silent", async () => {
+    const fetchMock = mcpFetch(
+      () =>
+        new Response(new ReadableStream({ start() {} }), {
+          headers: { "content-type": "text/event-stream" },
+        }),
     );
+    vi.stubGlobal("fetch", fetchMock);
 
     await expect(
       probeMcpInitialize("https://example.com/mcp", [], MARKER, PROBE, 10),
-    ).rejects.toBeDefined();
+    ).rejects.toThrow("timed out");
+    expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
   });
 
   it("marks disposable stdio bridge probes", async () => {
-    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) =>
-      Response.json({
-        jsonrpc: "2.0",
-        id: requestId(init),
-        result: {},
-      }),
-    );
+    const fetchMock = mcpFetch((id) => Response.json(initializeResult(id)));
     vi.stubGlobal("fetch", fetchMock);
 
     await probeMcpInitialize(
@@ -113,9 +142,8 @@ describe("Agent Plugin MCP initialize probe", () => {
       PROBE,
     );
 
-    expect(fetchMock.mock.calls[0]?.[1]?.headers).toMatchObject({
-      [MARKER]: "1",
-      [PROBE]: "1",
-    });
+    const headers = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
+    expect(headers.get(MARKER)).toBe("1");
+    expect(headers.get(PROBE)).toBe("1");
   });
 });

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/mcp-probe.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/mcp-probe.test.ts
@@ -44,6 +44,7 @@ function mcpFetch(
 
 describe("Agent Plugin MCP initialize probe", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -69,6 +70,54 @@ describe("Agent Plugin MCP initialize probe", () => {
           requestPayload(call[1]).method === "notifications/initialized",
       ),
     ).toBe(true);
+  });
+
+  it("aborts session termination when it reaches the probe deadline", async () => {
+    vi.useFakeTimers();
+    let markDeleteStarted: (() => void) | undefined;
+    const deleteStarted = new Promise<void>((resolve) => {
+      markDeleteStarted = resolve;
+    });
+    let deleteSignal: AbortSignal | undefined;
+    const fetchMock = vi.fn(
+      async (_url: string | URL | Request, init?: RequestInit) => {
+        if (init?.method === "DELETE") {
+          deleteSignal = init.signal ?? undefined;
+          markDeleteStarted?.();
+          return new Promise<Response>((_resolve, reject) => {
+            deleteSignal?.addEventListener(
+              "abort",
+              () => reject(deleteSignal?.reason),
+              { once: true },
+            );
+          });
+        }
+        const payload = requestPayload(init);
+        if (payload.method === "notifications/initialized") {
+          return new Response(null, { status: 202 });
+        }
+        if (payload.method === "initialize") {
+          return Response.json(initializeResult(payload.id), {
+            headers: { "mcp-session-id": "probe-session" },
+          });
+        }
+        return new Response(null, { status: 404 });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const probe = probeMcpInitialize(
+      "https://example.com/mcp",
+      [],
+      MARKER,
+      PROBE,
+      10,
+    );
+    await deleteStarted;
+    await vi.advanceTimersByTimeAsync(10);
+
+    await expect(probe).resolves.toBe(true);
+    expect(deleteSignal?.aborted).toBe(true);
   });
 
   it("accepts a valid initialize event without waiting for SSE EOF", async () => {

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/mcp-probe.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/mcp-probe.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { probeMcpInitialize } from "./mcp-probe";
+
+const MARKER = "x-posthog-agent-plugin-stdio-bridge";
+const PROBE = "x-posthog-agent-plugin-stdio-probe";
+
+function requestId(init?: RequestInit): string {
+  return (JSON.parse(String(init?.body)) as { id: string }).id;
+}
+
+describe("Agent Plugin MCP initialize probe", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("accepts a complete response with the matching request id", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) =>
+        Response.json({
+          jsonrpc: "2.0",
+          id: requestId(init),
+          result: { protocolVersion: "2025-06-18" },
+        }),
+      ),
+    );
+
+    await expect(
+      probeMcpInitialize("https://example.com/mcp", [], MARKER, PROBE),
+    ).resolves.toBe(true);
+  });
+
+  it("accepts a matching initialize response delivered as SSE", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async (_url: string, init?: RequestInit) =>
+          new Response(
+            `event: message\ndata: ${JSON.stringify({
+              jsonrpc: "2.0",
+              id: requestId(init),
+              result: { protocolVersion: "2025-06-18" },
+            })}\n\n`,
+            { headers: { "content-type": "text/event-stream" } },
+          ),
+      ),
+    );
+
+    await expect(
+      probeMcpInitialize("https://example.com/mcp", [], MARKER, PROBE),
+    ).resolves.toBe(true);
+  });
+
+  it.each([
+    ["mismatched request id", { jsonrpc: "2.0", id: "wrong", result: {} }],
+    ["JSON-RPC error", { jsonrpc: "2.0", id: "dynamic", error: {} }],
+    ["malformed response", "not json"],
+  ])("rejects a %s", async (_label, payload) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        const body =
+          typeof payload === "string"
+            ? payload
+            : JSON.stringify({
+                ...payload,
+                ...(payload.id === "dynamic" ? { id: requestId(init) } : {}),
+              });
+        return new Response(body, {
+          headers: { "content-type": "application/json" },
+        });
+      }),
+    );
+
+    await expect(
+      probeMcpInitialize("https://example.com/mcp", [], MARKER, PROBE),
+    ).resolves.toBe(false);
+  });
+
+  it("times out when the response stream stays silent", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            new ReadableStream({
+              start() {},
+            }),
+            { headers: { "content-type": "text/event-stream" } },
+          ),
+      ),
+    );
+
+    await expect(
+      probeMcpInitialize("https://example.com/mcp", [], MARKER, PROBE, 10),
+    ).rejects.toBeDefined();
+  });
+
+  it("marks disposable stdio bridge probes", async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) =>
+      Response.json({
+        jsonrpc: "2.0",
+        id: requestId(init),
+        result: {},
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await probeMcpInitialize(
+      "http://127.0.0.1/mcp",
+      [{ name: MARKER, value: "1" }],
+      MARKER,
+      PROBE,
+    );
+
+    expect(fetchMock.mock.calls[0]?.[1]?.headers).toMatchObject({
+      [MARKER]: "1",
+      [PROBE]: "1",
+    });
+  });
+});

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/mcp-probe.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/mcp-probe.ts
@@ -23,13 +23,15 @@ export async function probeMcpInitialize(
   }
 
   const controller = new AbortController();
-  const timeout = setTimeout(() => {
-    controller.abort(new Error("MCP initialize probe timed out."));
-  }, timeoutMs);
   const transport = new StreamableHTTPClientTransport(new URL(url), {
     requestInit: { headers },
   });
   const client = new Client(CLIENT_INFO, { capabilities: {} });
+  const timeout = setTimeout(() => {
+    controller.abort(new Error("MCP initialize probe timed out."));
+    void client.close().catch(() => undefined);
+    void transport.close().catch(() => undefined);
+  }, timeoutMs);
 
   try {
     await client.connect(transport, {
@@ -44,11 +46,14 @@ export async function probeMcpInitialize(
     }
     return false;
   } finally {
-    clearTimeout(timeout);
-    if (transport.sessionId) {
-      await transport.terminateSession().catch(() => undefined);
+    try {
+      if (transport.sessionId) {
+        await transport.terminateSession().catch(() => undefined);
+      }
+    } finally {
+      await client.close().catch(() => undefined);
+      await transport.close().catch(() => undefined);
+      clearTimeout(timeout);
     }
-    await client.close().catch(() => undefined);
-    await transport.close().catch(() => undefined);
   }
 }

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/mcp-probe.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/mcp-probe.ts
@@ -1,0 +1,130 @@
+import * as crypto from "node:crypto";
+
+const MAX_PROBE_RESPONSE_BYTES = 256 * 1024;
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isMatchingInitializeResponse(
+  value: unknown,
+  requestId: string,
+): boolean {
+  return (
+    isObject(value) &&
+    value.jsonrpc === "2.0" &&
+    value.id === requestId &&
+    isObject(value.result) &&
+    !("error" in value)
+  );
+}
+
+function parseJsonCandidate(text: string, requestId: string): boolean {
+  try {
+    return isMatchingInitializeResponse(JSON.parse(text), requestId);
+  } catch {
+    return false;
+  }
+}
+
+function hasMatchingSseEvent(text: string, requestId: string): boolean {
+  for (const event of text.split(/\r?\n\r?\n/)) {
+    const data = event
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice(5).trimStart())
+      .join("\n");
+    if (data && parseJsonCandidate(data, requestId)) return true;
+  }
+  return false;
+}
+
+async function readBoundedBody(
+  response: Response,
+  signal: AbortSignal,
+): Promise<string> {
+  if (!response.body) return "";
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  if (signal.aborted) throw signal.reason;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    signal.addEventListener(
+      "abort",
+      () => reject(signal.reason ?? new Error("MCP probe timed out.")),
+      { once: true },
+    );
+  });
+  try {
+    while (true) {
+      const result = await Promise.race([reader.read(), aborted]);
+      if (result.done) break;
+      size += result.value.byteLength;
+      if (size > MAX_PROBE_RESPONSE_BYTES) {
+        throw new Error("MCP probe response is too large.");
+      }
+      chunks.push(result.value);
+    }
+  } finally {
+    await reader.cancel().catch(() => undefined);
+  }
+  const body = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(body);
+}
+
+export async function probeMcpInitialize(
+  url: string,
+  configuredHeaders: ReadonlyArray<{ name: string; value: string }>,
+  markerHeaderName: string,
+  probeHeaderName: string,
+  timeoutMs = 2_000,
+): Promise<boolean> {
+  const requestId = crypto.randomUUID();
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    accept: "application/json, text/event-stream",
+  };
+  for (const header of configuredHeaders) headers[header.name] = header.value;
+  if (
+    configuredHeaders.some(
+      (header) => header.name.toLowerCase() === markerHeaderName,
+    )
+  ) {
+    headers[probeHeaderName] = "1";
+  }
+
+  const signal = AbortSignal.timeout(timeoutMs);
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: requestId,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "posthog-code", version: "1.0.0" },
+      },
+    }),
+    signal,
+  });
+  if (
+    !response.ok ||
+    response.headers.get("x-posthog-agent-plugin-proxy-error") === "1"
+  ) {
+    await response.body?.cancel().catch(() => undefined);
+    return false;
+  }
+
+  const body = await readBoundedBody(response, signal);
+  const contentType = response.headers.get("content-type") ?? "";
+  return contentType.includes("text/event-stream")
+    ? hasMatchingSseEvent(body, requestId)
+    : parseJsonCandidate(body, requestId);
+}

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/mcp-probe.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/mcp-probe.ts
@@ -1,81 +1,7 @@
-import * as crypto from "node:crypto";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
-const MAX_PROBE_RESPONSE_BYTES = 256 * 1024;
-
-function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isMatchingInitializeResponse(
-  value: unknown,
-  requestId: string,
-): boolean {
-  return (
-    isObject(value) &&
-    value.jsonrpc === "2.0" &&
-    value.id === requestId &&
-    isObject(value.result) &&
-    !("error" in value)
-  );
-}
-
-function parseJsonCandidate(text: string, requestId: string): boolean {
-  try {
-    return isMatchingInitializeResponse(JSON.parse(text), requestId);
-  } catch {
-    return false;
-  }
-}
-
-function hasMatchingSseEvent(text: string, requestId: string): boolean {
-  for (const event of text.split(/\r?\n\r?\n/)) {
-    const data = event
-      .split(/\r?\n/)
-      .filter((line) => line.startsWith("data:"))
-      .map((line) => line.slice(5).trimStart())
-      .join("\n");
-    if (data && parseJsonCandidate(data, requestId)) return true;
-  }
-  return false;
-}
-
-async function readBoundedBody(
-  response: Response,
-  signal: AbortSignal,
-): Promise<string> {
-  if (!response.body) return "";
-  const reader = response.body.getReader();
-  const chunks: Uint8Array[] = [];
-  let size = 0;
-  if (signal.aborted) throw signal.reason;
-  const aborted = new Promise<never>((_resolve, reject) => {
-    signal.addEventListener(
-      "abort",
-      () => reject(signal.reason ?? new Error("MCP probe timed out.")),
-      { once: true },
-    );
-  });
-  try {
-    while (true) {
-      const result = await Promise.race([reader.read(), aborted]);
-      if (result.done) break;
-      size += result.value.byteLength;
-      if (size > MAX_PROBE_RESPONSE_BYTES) {
-        throw new Error("MCP probe response is too large.");
-      }
-      chunks.push(result.value);
-    }
-  } finally {
-    await reader.cancel().catch(() => undefined);
-  }
-  const body = new Uint8Array(size);
-  let offset = 0;
-  for (const chunk of chunks) {
-    body.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return new TextDecoder().decode(body);
-}
+const CLIENT_INFO = { name: "posthog-code", version: "1.0.0" };
 
 export async function probeMcpInitialize(
   url: string,
@@ -84,47 +10,45 @@ export async function probeMcpInitialize(
   probeHeaderName: string,
   timeoutMs = 2_000,
 ): Promise<boolean> {
-  const requestId = crypto.randomUUID();
-  const headers: Record<string, string> = {
-    "content-type": "application/json",
-    accept: "application/json, text/event-stream",
-  };
-  for (const header of configuredHeaders) headers[header.name] = header.value;
+  const headers = new Headers();
+  for (const header of configuredHeaders) {
+    headers.set(header.name, header.value);
+  }
   if (
     configuredHeaders.some(
       (header) => header.name.toLowerCase() === markerHeaderName,
     )
   ) {
-    headers[probeHeaderName] = "1";
+    headers.set(probeHeaderName, "1");
   }
 
-  const signal = AbortSignal.timeout(timeoutMs);
-  const response = await fetch(url, {
-    method: "POST",
-    headers,
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      id: requestId,
-      method: "initialize",
-      params: {
-        protocolVersion: "2025-06-18",
-        capabilities: {},
-        clientInfo: { name: "posthog-code", version: "1.0.0" },
-      },
-    }),
-    signal,
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort(new Error("MCP initialize probe timed out."));
+  }, timeoutMs);
+  const transport = new StreamableHTTPClientTransport(new URL(url), {
+    requestInit: { headers },
   });
-  if (
-    !response.ok ||
-    response.headers.get("x-posthog-agent-plugin-proxy-error") === "1"
-  ) {
-    await response.body?.cancel().catch(() => undefined);
-    return false;
-  }
+  const client = new Client(CLIENT_INFO, { capabilities: {} });
 
-  const body = await readBoundedBody(response, signal);
-  const contentType = response.headers.get("content-type") ?? "";
-  return contentType.includes("text/event-stream")
-    ? hasMatchingSseEvent(body, requestId)
-    : parseJsonCandidate(body, requestId);
+  try {
+    await client.connect(transport, {
+      signal: controller.signal,
+      timeout: timeoutMs,
+      maxTotalTimeout: timeoutMs,
+    });
+    return true;
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw controller.signal.reason ?? error;
+    }
+    return false;
+  } finally {
+    clearTimeout(timeout);
+    if (transport.sessionId) {
+      await transport.terminateSession().catch(() => undefined);
+    }
+    await client.close().catch(() => undefined);
+    await transport.close().catch(() => undefined);
+  }
 }

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/schemas.ts
@@ -62,6 +62,14 @@ export const agentPluginMcpServerSummary = z.object({
   name: z.string(),
   type: z.enum(["streamable-http", "stdio", "sse"]),
   supported: z.boolean(),
+  command: z.string().optional(),
+  args: z.array(z.string()).optional(),
+  cwd: z.string().optional(),
+  envNames: z.array(z.string()).optional(),
+  digest: z.string().optional(),
+  approval: z
+    .enum(["not-required", "approved", "required"])
+    .default("not-required"),
 });
 
 export const agentPluginPreview = z.object({
@@ -82,6 +90,7 @@ export const agentPluginInstallation = z.object({
   skills: z.array(agentPluginSkill),
   mcpServers: z.array(agentPluginMcpServerSummary),
   diagnostics: z.array(agentPluginDiagnostic),
+  stdioApprovalRequired: z.boolean(),
 });
 
 export const listAgentPluginsOutput = z.array(agentPluginInstallation);
@@ -90,6 +99,9 @@ export const registerAgentPluginInput = z.object({
   selectionToken: z.string().uuid(),
 });
 export const agentPluginIdInput = z.object({
+  id: z.string().regex(AGENT_PLUGIN_INSTALLATION_ID_PATTERN),
+});
+export const approveAgentPluginStdioInput = z.object({
   id: z.string().regex(AGENT_PLUGIN_INSTALLATION_ID_PATTERN),
 });
 export const setAgentPluginEnabledInput = z.object({
@@ -103,6 +115,8 @@ export const agentPluginState = z.object({
     agentPluginInstallation.extend({
       id: z.string().regex(AGENT_PLUGIN_INSTALLATION_ID_PATTERN),
       mcpServers: z.array(agentPluginMcpServerSummary).default([]),
+      stdioApprovalRequired: z.boolean().default(false),
+      approvedStdioDigests: z.record(z.string(), z.string()).default({}),
     }),
   ),
 });

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/schemas.ts
@@ -44,6 +44,20 @@ export const agentPluginHttpMcpServer = z.object({
   headers: z.record(z.string(), z.string()).optional(),
 });
 
+export const agentPluginStdioMcpServer = z.object({
+  name: z.string(),
+  type: z.literal("stdio"),
+  command: z.string(),
+  args: z.array(z.string()).optional(),
+  env: z.record(z.string(), z.string()).optional(),
+  cwd: z.string().optional(),
+});
+
+export const agentPluginMcpServer = z.discriminatedUnion("type", [
+  agentPluginHttpMcpServer,
+  agentPluginStdioMcpServer,
+]);
+
 export const agentPluginMcpServerSummary = z.object({
   name: z.string(),
   type: z.enum(["streamable-http", "stdio", "sse"]),
@@ -97,6 +111,10 @@ export type AgentPluginDiagnostic = z.infer<typeof agentPluginDiagnostic>;
 export type AgentPluginManifest = z.infer<typeof agentPluginManifest>;
 export type AgentPluginSkill = z.infer<typeof agentPluginSkill>;
 export type AgentPluginHttpMcpServer = z.infer<typeof agentPluginHttpMcpServer>;
+export type AgentPluginStdioMcpServer = z.infer<
+  typeof agentPluginStdioMcpServer
+>;
+export type AgentPluginMcpServer = z.infer<typeof agentPluginMcpServer>;
 export type AgentPluginMcpServerSummary = z.infer<
   typeof agentPluginMcpServerSummary
 >;
@@ -111,6 +129,6 @@ export interface LoadedAgentPlugin {
   sourcePath: string;
   manifest: AgentPluginManifest | null;
   skills: AgentPluginSkill[];
-  mcpServers: AgentPluginHttpMcpServer[];
+  mcpServers: AgentPluginMcpServer[];
   diagnostics: AgentPluginDiagnostic[];
 }

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/schemas.ts
@@ -111,12 +111,12 @@ export const setAgentPluginEnabledInput = z.object({
 export const agentPluginState = z.object({
   version: z.literal(1),
   installations: z.array(
-    agentPluginInstallation.extend({
-      id: z.string().regex(AGENT_PLUGIN_INSTALLATION_ID_PATTERN),
-      mcpServers: z.array(agentPluginMcpServerSummary).default([]),
-      stdioApprovalRequired: z.boolean().default(false),
-      approvedStdioDigests: z.record(z.string(), z.string()).default({}),
-    }),
+    agentPluginInstallation
+      .omit({ mcpServers: true, stdioApprovalRequired: true })
+      .extend({
+        id: z.string().regex(AGENT_PLUGIN_INSTALLATION_ID_PATTERN),
+        approvedStdioDigests: z.record(z.string(), z.string()).default({}),
+      }),
   ),
 });
 

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/schemas.ts
@@ -66,7 +66,6 @@ export const agentPluginMcpServerSummary = z.object({
   args: z.array(z.string()).optional(),
   cwd: z.string().optional(),
   envNames: z.array(z.string()).optional(),
-  digest: z.string().optional(),
   approval: z
     .enum(["not-required", "approved", "required"])
     .default("not-required"),

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/stdio-bridge.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/stdio-bridge.test.ts
@@ -1,11 +1,15 @@
+import http from "node:http";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 import type { RootLogger } from "@posthog/di/logger";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ProcessTrackingService } from "../process-tracking/process-tracking";
+import { ProcessTrackingService } from "../process-tracking/process-tracking";
 import {
   type AgentPluginStdioBridgeRegistration,
   AgentPluginStdioBridgeService,
+  type AgentPluginStdioLaunchConfig,
   STDIO_BRIDGE_MARKER_HEADER,
   STDIO_BRIDGE_PROBE_HEADER,
 } from "./stdio-bridge";
@@ -64,11 +68,11 @@ class TestBridge extends AgentPluginStdioBridgeService {
   private nextPid = 1000;
 
   protected override createStdioTransport(
-    registration: AgentPluginStdioBridgeRegistration,
+    config: AgentPluginStdioLaunchConfig,
   ): StdioClientTransport {
     const transport = new FakeStdioTransport(
       this.nextPid++,
-      registration.command === "fail",
+      config.command === "fail",
     );
     this.transports.push(transport);
     return transport as unknown as StdioClientTransport;
@@ -81,13 +85,16 @@ function registration(
 ): AgentPluginStdioBridgeRegistration {
   return {
     id,
+    taskId: "task-1",
     runId: "run-1",
     installationId: "installation-1",
     runtimeName: id,
-    command: "node",
-    args: [],
-    env: { PLUGIN_ROOT: "/plugin", PLUGIN_DATA: "/data" },
-    cwd: "/plugin",
+    prepare: async () => ({
+      command: "node",
+      args: [],
+      env: { PLUGIN_ROOT: "/plugin", PLUGIN_DATA: "/data" },
+      cwd: "/plugin",
+    }),
     onFailure: vi.fn(),
     ...overrides,
   };
@@ -127,7 +134,7 @@ async function initialize(url: string, probe = false): Promise<Response> {
 }
 
 describe("Agent Plugin stdio bridge", () => {
-  const services: TestBridge[] = [];
+  const services: AgentPluginStdioBridgeService[] = [];
 
   afterEach(async () => {
     await Promise.all(services.splice(0).map((service) => service.stop()));
@@ -156,8 +163,8 @@ describe("Agent Plugin stdio bridge", () => {
       1000,
       "child",
       "agent-plugin:server",
-      expect.objectContaining({ taskRunId: "run-1" }),
-      "run-1",
+      expect.objectContaining({ taskId: "task-1", taskRunId: "run-1" }),
+      "task-1",
     );
 
     await service.unregisterRun("run-1");
@@ -180,7 +187,12 @@ describe("Agent Plugin stdio bridge", () => {
   it("isolates one spawn failure from a sibling stdio server", async () => {
     const { service } = createBridge();
     const failed = registration("failed", {
-      command: "fail",
+      prepare: async () => ({
+        command: "fail",
+        args: [],
+        env: {},
+        cwd: "/plugin",
+      }),
       onFailure: vi.fn(),
     });
     const healthy = registration("healthy", { runId: "run-2" });
@@ -209,6 +221,97 @@ describe("Agent Plugin stdio bridge", () => {
     expect(crashed.onFailure).toHaveBeenCalledOnce();
     await service.unregisterRun("run-2");
     expect(processTracking.kill).toHaveBeenCalledWith(1001);
+  });
+
+  it.each(["error", "close"] as const)(
+    "restarts cleanly after a transport %s",
+    async (failure) => {
+      const { service, processTracking } = createBridge();
+      const failed = registration("restart", { onFailure: vi.fn() });
+      const url = await service.register(failed);
+      await initialize(url);
+
+      if (failure === "error") {
+        service.transports[0].onerror?.(new Error("malformed stdio output"));
+      } else {
+        service.transports[0].onclose?.();
+      }
+      await vi.waitFor(() => {
+        expect(processTracking.kill).toHaveBeenCalledWith(1000);
+      });
+
+      expect((await initialize(url)).status).toBe(200);
+      expect(service.transports).toHaveLength(2);
+    },
+  );
+
+  it("rejects browser requests without starting a child", async () => {
+    const { service } = createBridge();
+    const url = await service.register(registration("browser"));
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { origin: "https://example.com" },
+      body: "{}",
+    });
+
+    expect(response.status).toBe(403);
+    expect(service.transports).toHaveLength(0);
+  });
+
+  it("rejects oversized request bodies before starting a child", async () => {
+    const { service } = createBridge();
+    const url = new URL(await service.register(registration("large")));
+    const status = await new Promise<number>((resolve, reject) => {
+      const outgoing = http.request(
+        url,
+        {
+          method: "POST",
+          headers: { "content-length": String(2 * 1024 * 1024 + 1) },
+        },
+        (response) => {
+          response.resume();
+          response.on("end", () => resolve(response.statusCode ?? 0));
+        },
+      );
+      outgoing.on("error", reject);
+      outgoing.end("{}");
+    });
+
+    expect(status).toBe(413);
+    expect(service.transports).toHaveLength(0);
+  });
+
+  it("round-trips initialize through a real stdio server", async () => {
+    const processTracking = new ProcessTrackingService();
+    const service = new AgentPluginStdioBridgeService(
+      processTracking,
+      rootLogger,
+    );
+    services.push(service);
+    const fixturePath = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "fixtures",
+      "echo-mcp-server.mjs",
+    );
+    const url = await service.register(
+      registration("integration", {
+        prepare: async () => ({
+          command: process.execPath,
+          args: [fixturePath],
+          env: {},
+          cwd: path.dirname(fixturePath),
+        }),
+      }),
+    );
+
+    const initializeResponse = await initialize(url);
+
+    expect(initializeResponse.status).toBe(200);
+    expect(await initializeResponse.text()).toContain('"protocolVersion"');
+    expect(processTracking.getByTaskId("task-1")).toHaveLength(1);
+    await service.unregisterRun("run-1");
+    expect(processTracking.getByTaskId("task-1")).toEqual([]);
   });
 
   it("stops every process for a disabled installation", async () => {

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/stdio-bridge.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/stdio-bridge.test.ts
@@ -6,6 +6,7 @@ import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 import type { RootLogger } from "@posthog/di/logger";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ProcessTrackingService } from "../process-tracking/process-tracking";
+import { probeMcpInitialize } from "./mcp-probe";
 import {
   type AgentPluginStdioBridgeRegistration,
   AgentPluginStdioBridgeService,
@@ -25,17 +26,33 @@ const rootLogger: RootLogger = {
   scope: () => scopedLogger,
 };
 
+class Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve!: (value: T) => void;
+
+  constructor() {
+    this.promise = new Promise<T>((resolve) => {
+      this.resolve = resolve;
+    });
+  }
+}
+
 class FakeStdioTransport {
   onclose?: () => void;
   onerror?: (error: Error) => void;
   onmessage?: (message: JSONRPCMessage) => void;
   readonly stderr = null;
   readonly pid: number;
+  readonly started = new Deferred<void>();
+  private readonly closed = new Deferred<void>();
   readonly close = vi.fn(async () => {
+    this.closed.resolve();
     this.onclose?.();
   });
   readonly start = vi.fn(async () => {
+    this.started.resolve();
     if (this.failStart) throw new Error("spawn failed");
+    if (this.deferStart) await this.closed.promise;
   });
   readonly send = vi.fn(async (message: JSONRPCMessage) => {
     if (!("id" in message)) return;
@@ -58,6 +75,7 @@ class FakeStdioTransport {
   constructor(
     pid: number,
     private readonly failStart: boolean,
+    private readonly deferStart: boolean,
   ) {
     this.pid = pid;
   }
@@ -73,6 +91,7 @@ class TestBridge extends AgentPluginStdioBridgeService {
     const transport = new FakeStdioTransport(
       this.nextPid++,
       config.command === "fail",
+      config.command === "defer",
     );
     this.transports.push(transport);
     return transport as unknown as StdioClientTransport;
@@ -182,6 +201,95 @@ describe("Agent Plugin stdio bridge", () => {
     expect(service.transports[0].close).toHaveBeenCalledOnce();
     expect(service.transports[1].close).not.toHaveBeenCalled();
     expect(processTracking.kill).toHaveBeenCalledWith(1000);
+  });
+
+  it("waits for a disposable probe preparation before completing removal", async () => {
+    const { service, processTracking } = createBridge();
+    const prepareStarted = new Deferred<void>();
+    const releasePrepare = new Deferred<void>();
+    const url = await service.register(
+      registration("deferred-prepare", {
+        prepare: async () => {
+          prepareStarted.resolve();
+          await releasePrepare.promise;
+          return { command: "node", args: [], env: {}, cwd: "/plugin" };
+        },
+      }),
+    );
+
+    const probe = initialize(url, true);
+    await prepareStarted.promise;
+    let removalSettled = false;
+    const removal = service
+      .unregisterInstallation("installation-1")
+      .then(() => {
+        removalSettled = true;
+      });
+    await Promise.resolve();
+    expect(removalSettled).toBe(false);
+
+    releasePrepare.resolve();
+    await removal;
+    expect((await probe).status).toBe(502);
+    expect(service.transports).toHaveLength(0);
+    expect(processTracking.register).not.toHaveBeenCalled();
+  });
+
+  it("waits for an in-flight probe before replacing its target", async () => {
+    const { service, processTracking } = createBridge();
+    const prepareStarted = new Deferred<void>();
+    const releasePrepare = new Deferred<void>();
+    const firstUrl = await service.register(
+      registration("replace-target", {
+        prepare: async () => {
+          prepareStarted.resolve();
+          await releasePrepare.promise;
+          return { command: "node", args: [], env: {}, cwd: "/plugin" };
+        },
+      }),
+    );
+
+    const probe = initialize(firstUrl, true);
+    await prepareStarted.promise;
+    let replacementSettled = false;
+    const replacement = service
+      .register(registration("replace-target", { runId: "run-2" }))
+      .then((url) => {
+        replacementSettled = true;
+        return url;
+      });
+    await Promise.resolve();
+    expect(replacementSettled).toBe(false);
+
+    releasePrepare.resolve();
+    const replacementUrl = await replacement;
+    expect((await probe).status).toBe(502);
+    expect(replacementUrl).not.toBe(firstUrl);
+    expect(service.transports).toHaveLength(0);
+    expect(processTracking.register).not.toHaveBeenCalled();
+  });
+
+  it("aborts a disposable probe during transport startup", async () => {
+    const { service, processTracking } = createBridge();
+    const url = await service.register(
+      registration("deferred-start", {
+        prepare: async () => ({
+          command: "defer",
+          args: [],
+          env: {},
+          cwd: "/plugin",
+        }),
+      }),
+    );
+
+    const probe = initialize(url, true);
+    await vi.waitFor(() => expect(service.transports).toHaveLength(1));
+    await service.transports[0].started.promise;
+    await service.unregisterRun("run-1");
+
+    expect((await probe).status).toBe(502);
+    expect(service.transports[0].close).toHaveBeenCalled();
+    expect(processTracking.register).not.toHaveBeenCalled();
   });
 
   it("isolates one spawn failure from a sibling stdio server", async () => {
@@ -305,8 +413,17 @@ describe("Agent Plugin stdio bridge", () => {
       }),
     );
 
-    const initializeResponse = await initialize(url);
+    await expect(
+      probeMcpInitialize(
+        url,
+        [{ name: STDIO_BRIDGE_MARKER_HEADER, value: "1" }],
+        STDIO_BRIDGE_MARKER_HEADER,
+        STDIO_BRIDGE_PROBE_HEADER,
+      ),
+    ).resolves.toBe(true);
+    expect(processTracking.getByTaskId("task-1")).toEqual([]);
 
+    const initializeResponse = await initialize(url);
     expect(initializeResponse.status).toBe(200);
     expect(await initializeResponse.text()).toContain('"protocolVersion"');
     expect(processTracking.getByTaskId("task-1")).toHaveLength(1);

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/stdio-bridge.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/stdio-bridge.test.ts
@@ -1,0 +1,228 @@
+import type { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+import type { RootLogger } from "@posthog/di/logger";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ProcessTrackingService } from "../process-tracking/process-tracking";
+import {
+  type AgentPluginStdioBridgeRegistration,
+  AgentPluginStdioBridgeService,
+  STDIO_BRIDGE_MARKER_HEADER,
+  STDIO_BRIDGE_PROBE_HEADER,
+} from "./stdio-bridge";
+
+const scopedLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+const rootLogger: RootLogger = {
+  ...scopedLogger,
+  scope: () => scopedLogger,
+};
+
+class FakeStdioTransport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: JSONRPCMessage) => void;
+  readonly stderr = null;
+  readonly pid: number;
+  readonly close = vi.fn(async () => {
+    this.onclose?.();
+  });
+  readonly start = vi.fn(async () => {
+    if (this.failStart) throw new Error("spawn failed");
+  });
+  readonly send = vi.fn(async (message: JSONRPCMessage) => {
+    if (!("id" in message)) return;
+    const id = message.id;
+    if (typeof id !== "string" && typeof id !== "number") return;
+    this.onmessage?.({
+      jsonrpc: "2.0",
+      id,
+      result:
+        "method" in message && message.method === "initialize"
+          ? {
+              protocolVersion: "2025-06-18",
+              capabilities: {},
+              serverInfo: { name: "test-server", version: "1.0.0" },
+            }
+          : {},
+    });
+  });
+
+  constructor(
+    pid: number,
+    private readonly failStart: boolean,
+  ) {
+    this.pid = pid;
+  }
+}
+
+class TestBridge extends AgentPluginStdioBridgeService {
+  readonly transports: FakeStdioTransport[] = [];
+  private nextPid = 1000;
+
+  protected override createStdioTransport(
+    registration: AgentPluginStdioBridgeRegistration,
+  ): StdioClientTransport {
+    const transport = new FakeStdioTransport(
+      this.nextPid++,
+      registration.command === "fail",
+    );
+    this.transports.push(transport);
+    return transport as unknown as StdioClientTransport;
+  }
+}
+
+function registration(
+  id: string,
+  overrides: Partial<AgentPluginStdioBridgeRegistration> = {},
+): AgentPluginStdioBridgeRegistration {
+  return {
+    id,
+    runId: "run-1",
+    installationId: "installation-1",
+    runtimeName: id,
+    command: "node",
+    args: [],
+    env: { PLUGIN_ROOT: "/plugin", PLUGIN_DATA: "/data" },
+    cwd: "/plugin",
+    onFailure: vi.fn(),
+    ...overrides,
+  };
+}
+
+async function request(
+  url: string,
+  method: string,
+  probe = false,
+): Promise<Response> {
+  return fetch(url, {
+    method: "POST",
+    headers: {
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+      [STDIO_BRIDGE_MARKER_HEADER]: "1",
+      ...(probe ? { [STDIO_BRIDGE_PROBE_HEADER]: "1" } : {}),
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method,
+      params:
+        method === "initialize"
+          ? {
+              protocolVersion: "2025-06-18",
+              capabilities: {},
+              clientInfo: { name: "test", version: "1.0.0" },
+            }
+          : {},
+    }),
+  });
+}
+
+async function initialize(url: string, probe = false): Promise<Response> {
+  return request(url, "initialize", probe);
+}
+
+describe("Agent Plugin stdio bridge", () => {
+  const services: TestBridge[] = [];
+
+  afterEach(async () => {
+    await Promise.all(services.splice(0).map((service) => service.stop()));
+  });
+
+  function createBridge() {
+    const processTracking = {
+      register: vi.fn(),
+      unregister: vi.fn(),
+      kill: vi.fn(),
+    } as unknown as ProcessTrackingService;
+    const service = new TestBridge(processTracking, rootLogger);
+    services.push(service);
+    return { service, processTracking };
+  }
+
+  it("relays MCP over HTTP and tracks the managed child process", async () => {
+    const { service, processTracking } = createBridge();
+    const url = await service.register(registration("server"));
+
+    const response = await initialize(url);
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('"id":1');
+    expect(processTracking.register).toHaveBeenCalledWith(
+      1000,
+      "child",
+      "agent-plugin:server",
+      expect.objectContaining({ taskRunId: "run-1" }),
+      "run-1",
+    );
+
+    await service.unregisterRun("run-1");
+    expect(processTracking.kill).toHaveBeenCalledWith(1000);
+  });
+
+  it("uses a disposable process for the Codex reachability probe", async () => {
+    const { service, processTracking } = createBridge();
+    const url = await service.register(registration("server"));
+
+    expect((await initialize(url, true)).status).toBe(200);
+    expect((await initialize(url)).status).toBe(200);
+
+    expect(service.transports).toHaveLength(2);
+    expect(service.transports[0].close).toHaveBeenCalledOnce();
+    expect(service.transports[1].close).not.toHaveBeenCalled();
+    expect(processTracking.kill).toHaveBeenCalledWith(1000);
+  });
+
+  it("isolates one spawn failure from a sibling stdio server", async () => {
+    const { service } = createBridge();
+    const failed = registration("failed", {
+      command: "fail",
+      onFailure: vi.fn(),
+    });
+    const healthy = registration("healthy", { runId: "run-2" });
+    const failedUrl = await service.register(failed);
+    const healthyUrl = await service.register(healthy);
+
+    const failedResponse = await initialize(failedUrl);
+    const healthyResponse = await initialize(healthyUrl);
+
+    expect(failedResponse.status).toBe(502);
+    expect(failed.onFailure).toHaveBeenCalledOnce();
+    expect(healthyResponse.status).toBe(200);
+  });
+
+  it("reports an unexpected stdio crash without stopping a sibling", async () => {
+    const { service, processTracking } = createBridge();
+    const crashed = registration("crashed", { onFailure: vi.fn() });
+    const sibling = registration("sibling", { runId: "run-2" });
+    const crashedUrl = await service.register(crashed);
+    const siblingUrl = await service.register(sibling);
+    await initialize(crashedUrl);
+    await initialize(siblingUrl);
+
+    service.transports[0].onclose?.();
+
+    expect(crashed.onFailure).toHaveBeenCalledOnce();
+    await service.unregisterRun("run-2");
+    expect(processTracking.kill).toHaveBeenCalledWith(1001);
+  });
+
+  it("stops every process for a disabled installation", async () => {
+    const { service, processTracking } = createBridge();
+    const firstUrl = await service.register(registration("first"));
+    const secondUrl = await service.register(
+      registration("second", { runId: "run-2" }),
+    );
+    await initialize(firstUrl);
+    await initialize(secondUrl);
+
+    await service.unregisterInstallation("installation-1");
+
+    expect(processTracking.kill).toHaveBeenCalledWith(1000);
+    expect(processTracking.kill).toHaveBeenCalledWith(1001);
+  });
+});

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/stdio-bridge.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/stdio-bridge.ts
@@ -1,0 +1,352 @@
+import http from "node:http";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import type {
+  JSONRPCMessage,
+  RequestId,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  ROOT_LOGGER,
+  type RootLogger,
+  type ScopedLogger,
+} from "@posthog/di/logger";
+import { inject, injectable, preDestroy } from "inversify";
+import { PROCESS_TRACKING_SERVICE } from "../process-tracking/identifiers";
+import type { ProcessTrackingService } from "../process-tracking/process-tracking";
+
+export const STDIO_BRIDGE_MARKER_HEADER = "x-posthog-agent-plugin-stdio-bridge";
+export const STDIO_BRIDGE_PROBE_HEADER = "x-posthog-agent-plugin-stdio-probe";
+const BRIDGE_ERROR_HEADER = "x-posthog-agent-plugin-proxy-error";
+
+export interface AgentPluginStdioBridgeRegistration {
+  id: string;
+  runId: string;
+  installationId: string;
+  runtimeName: string;
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+  cwd: string;
+  onFailure: (message: string) => void;
+}
+
+export interface AgentPluginStdioBridge {
+  register(registration: AgentPluginStdioBridgeRegistration): Promise<string>;
+  unregisterRun(runId: string): Promise<void>;
+  unregisterInstallation(installationId: string): Promise<void>;
+}
+
+interface BridgeConnection {
+  stdio: StdioClientTransport;
+  http: StreamableHTTPServerTransport;
+  pid: number;
+  close: () => Promise<void>;
+}
+
+interface BridgeTarget extends AgentPluginStdioBridgeRegistration {
+  connection?: BridgeConnection;
+  connectionPromise?: Promise<BridgeConnection>;
+  failureReported: boolean;
+}
+
+function relatedRequestId(message: JSONRPCMessage): RequestId | undefined {
+  if (
+    "id" in message &&
+    ("result" in message || "error" in message) &&
+    message.id !== null
+  ) {
+    return message.id;
+  }
+  return undefined;
+}
+
+@injectable()
+export class AgentPluginStdioBridgeService implements AgentPluginStdioBridge {
+  private server: http.Server | null = null;
+  private port: number | null = null;
+  private startPromise: Promise<void> | null = null;
+  private readonly targets = new Map<string, BridgeTarget>();
+  private readonly log: ScopedLogger;
+
+  constructor(
+    @inject(PROCESS_TRACKING_SERVICE)
+    private readonly processTracking: ProcessTrackingService,
+    @inject(ROOT_LOGGER) logger: RootLogger,
+  ) {
+    this.log = logger.scope("agent-plugin-stdio-bridge");
+  }
+
+  async register(
+    registration: AgentPluginStdioBridgeRegistration,
+  ): Promise<string> {
+    await this.start();
+    const existing = this.targets.get(registration.id);
+    if (existing) await this.closeTarget(existing);
+    this.targets.set(registration.id, {
+      ...registration,
+      failureReported: false,
+    });
+    return `http://127.0.0.1:${this.port}/${encodeURIComponent(registration.id)}`;
+  }
+
+  async unregisterRun(runId: string): Promise<void> {
+    await this.unregisterMatching((target) => target.runId === runId);
+  }
+
+  async unregisterInstallation(installationId: string): Promise<void> {
+    await this.unregisterMatching(
+      (target) => target.installationId === installationId,
+    );
+  }
+
+  @preDestroy()
+  async stop(): Promise<void> {
+    await Promise.all(
+      [...this.targets.values()].map((target) => this.closeTarget(target)),
+    );
+    this.targets.clear();
+    if (!this.server) return;
+
+    const server = this.server;
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+      server.closeAllConnections();
+    });
+    this.server = null;
+    this.port = null;
+    this.startPromise = null;
+  }
+
+  protected createStdioTransport(
+    registration: AgentPluginStdioBridgeRegistration,
+  ): StdioClientTransport {
+    return new StdioClientTransport({
+      command: registration.command,
+      args: registration.args,
+      env: registration.env,
+      cwd: registration.cwd,
+      stderr: "pipe",
+    });
+  }
+
+  protected createHttpTransport(): StreamableHTTPServerTransport {
+    return new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+  }
+
+  private async unregisterMatching(
+    predicate: (target: BridgeTarget) => boolean,
+  ): Promise<void> {
+    const matches = [...this.targets.entries()].filter(([, target]) =>
+      predicate(target),
+    );
+    await Promise.all(
+      matches.map(async ([id, target]) => {
+        this.targets.delete(id);
+        await this.closeTarget(target);
+      }),
+    );
+  }
+
+  private async closeTarget(target: BridgeTarget): Promise<void> {
+    let connection = target.connection;
+    if (!connection && target.connectionPromise) {
+      try {
+        connection = await target.connectionPromise;
+      } catch {
+        return;
+      }
+    }
+    target.connection = undefined;
+    target.connectionPromise = undefined;
+    await connection?.close();
+  }
+
+  private async start(): Promise<void> {
+    if (this.server && this.port !== null) return;
+    if (this.startPromise) return this.startPromise;
+    this.startPromise = this.startServer().catch((error) => {
+      this.startPromise = null;
+      throw error;
+    });
+    return this.startPromise;
+  }
+
+  private async startServer(): Promise<void> {
+    const server = http.createServer((request, response) => {
+      void this.handleRequest(request, response).catch((error) => {
+        this.log.warn("Agent Plugin stdio bridge request failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        if (!response.headersSent) {
+          response.writeHead(502, { [BRIDGE_ERROR_HEADER]: "1" });
+        }
+        response.end("Agent Plugin stdio bridge error");
+      });
+    });
+    this.server = server;
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", reject);
+        const address = server.address();
+        if (typeof address !== "object" || address === null) {
+          reject(new Error("Failed to start Agent Plugin stdio bridge."));
+          return;
+        }
+        this.port = address.port;
+        server.on("error", (error) => {
+          this.log.error("Agent Plugin stdio bridge server failed", error);
+        });
+        resolve();
+      });
+    });
+  }
+
+  private async handleRequest(
+    request: http.IncomingMessage,
+    response: http.ServerResponse,
+  ): Promise<void> {
+    const incomingUrl = new URL(request.url ?? "/", "http://localhost");
+    const rawId = incomingUrl.pathname.split("/").filter(Boolean)[0];
+    const id = rawId ? decodeURIComponent(rawId) : "";
+    const target = this.targets.get(id);
+    if (!target) {
+      response.writeHead(404);
+      response.end("Unknown Agent Plugin stdio target");
+      return;
+    }
+
+    const isProbe = request.headers[STDIO_BRIDGE_PROBE_HEADER] === "1";
+    const connection = isProbe
+      ? await this.startConnection(target, true)
+      : await this.getOrStartConnection(target);
+    try {
+      await connection.http.handleRequest(request, response);
+    } finally {
+      if (isProbe) await connection.close();
+    }
+  }
+
+  private getOrStartConnection(
+    target: BridgeTarget,
+  ): Promise<BridgeConnection> {
+    if (target.connection) return Promise.resolve(target.connection);
+    if (target.connectionPromise) return target.connectionPromise;
+
+    target.connectionPromise = this.startConnection(target, false)
+      .then((connection) => {
+        target.connection = connection;
+        target.connectionPromise = undefined;
+        return connection;
+      })
+      .catch((error) => {
+        target.connectionPromise = undefined;
+        this.reportFailure(target, error);
+        throw error;
+      });
+    return target.connectionPromise;
+  }
+
+  private async startConnection(
+    target: BridgeTarget,
+    ephemeral: boolean,
+  ): Promise<BridgeConnection> {
+    const stdio = this.createStdioTransport(target);
+    const httpTransport = this.createHttpTransport();
+    let connection: BridgeConnection | undefined;
+    let intentionallyClosing = false;
+
+    httpTransport.onmessage = (message) => {
+      void stdio.send(message).catch((error) => {
+        this.reportFailure(target, error);
+        void httpTransport.close();
+      });
+    };
+    stdio.onmessage = (message) => {
+      const requestId = relatedRequestId(message);
+      void httpTransport
+        .send(
+          message,
+          requestId === undefined ? undefined : { relatedRequestId: requestId },
+        )
+        .catch((error) => {
+          if (requestId !== undefined || "id" in message) {
+            this.reportFailure(target, error);
+          } else {
+            this.log.debug(
+              "Dropped stdio MCP notification without a client stream",
+            );
+          }
+        });
+    };
+    stdio.onerror = (error) => this.reportFailure(target, error);
+    stdio.onclose = () => {
+      if (connection) {
+        this.processTracking.unregister(connection.pid, "mcp-exited");
+        if (!ephemeral && target.connection === connection) {
+          target.connection = undefined;
+        }
+      }
+      if (!intentionallyClosing) {
+        this.reportFailure(
+          target,
+          new Error("The stdio MCP server stopped unexpectedly."),
+        );
+      }
+      void httpTransport.close();
+    };
+
+    await httpTransport.start();
+    try {
+      await stdio.start();
+    } catch (error) {
+      await httpTransport.close();
+      this.reportFailure(target, error);
+      throw error;
+    }
+    const pid = stdio.pid;
+    if (pid === null) {
+      await Promise.all([stdio.close(), httpTransport.close()]);
+      throw new Error("Agent Plugin stdio server did not start.");
+    }
+
+    stdio.stderr?.on("data", () => undefined);
+    this.processTracking.register(
+      pid,
+      "child",
+      `agent-plugin:${target.runtimeName}`,
+      {
+        taskRunId: target.runId,
+        installationId: target.installationId,
+        server: target.runtimeName,
+      },
+      target.runId,
+    );
+
+    let closed = false;
+    connection = {
+      stdio,
+      http: httpTransport,
+      pid,
+      close: async () => {
+        if (closed) return;
+        closed = true;
+        intentionallyClosing = true;
+        await httpTransport.close();
+        this.processTracking.kill(pid);
+        await stdio.close();
+      },
+    };
+    return connection;
+  }
+
+  private reportFailure(target: BridgeTarget, error: unknown): void {
+    if (target.failureReported) return;
+    target.failureReported = true;
+    target.onFailure(
+      error instanceof Error && error.message
+        ? error.message
+        : "The stdio MCP server stopped unexpectedly.",
+    );
+  }
+}

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/stdio-bridge.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/stdio-bridge.ts
@@ -1,3 +1,4 @@
+import * as crypto from "node:crypto";
 import http from "node:http";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
@@ -17,16 +18,22 @@ import type { ProcessTrackingService } from "../process-tracking/process-trackin
 export const STDIO_BRIDGE_MARKER_HEADER = "x-posthog-agent-plugin-stdio-bridge";
 export const STDIO_BRIDGE_PROBE_HEADER = "x-posthog-agent-plugin-stdio-probe";
 const BRIDGE_ERROR_HEADER = "x-posthog-agent-plugin-proxy-error";
+const MAX_REQUEST_BODY_BYTES = 2 * 1024 * 1024;
 
-export interface AgentPluginStdioBridgeRegistration {
-  id: string;
-  runId: string;
-  installationId: string;
-  runtimeName: string;
+export interface AgentPluginStdioLaunchConfig {
   command: string;
   args: string[];
   env: Record<string, string>;
   cwd: string;
+}
+
+export interface AgentPluginStdioBridgeRegistration {
+  id: string;
+  taskId: string;
+  runId: string;
+  installationId: string;
+  runtimeName: string;
+  prepare: () => Promise<AgentPluginStdioLaunchConfig>;
   onFailure: (message: string) => void;
 }
 
@@ -44,9 +51,11 @@ interface BridgeConnection {
 }
 
 interface BridgeTarget extends AgentPluginStdioBridgeRegistration {
+  routeToken: string;
   connection?: BridgeConnection;
   connectionPromise?: Promise<BridgeConnection>;
   failureReported: boolean;
+  active: boolean;
 }
 
 function relatedRequestId(message: JSONRPCMessage): RequestId | undefined {
@@ -60,12 +69,21 @@ function relatedRequestId(message: JSONRPCMessage): RequestId | undefined {
   return undefined;
 }
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error && error.message
+    ? error.message
+    : "The stdio MCP server stopped unexpectedly.";
+}
+
+class RequestBodyTooLargeError extends Error {}
+
 @injectable()
 export class AgentPluginStdioBridgeService implements AgentPluginStdioBridge {
   private server: http.Server | null = null;
   private port: number | null = null;
   private startPromise: Promise<void> | null = null;
   private readonly targets = new Map<string, BridgeTarget>();
+  private readonly routeByRegistration = new Map<string, string>();
   private readonly log: ScopedLogger;
 
   constructor(
@@ -80,13 +98,19 @@ export class AgentPluginStdioBridgeService implements AgentPluginStdioBridge {
     registration: AgentPluginStdioBridgeRegistration,
   ): Promise<string> {
     await this.start();
-    const existing = this.targets.get(registration.id);
-    if (existing) await this.closeTarget(existing);
-    this.targets.set(registration.id, {
+    const existingRoute = this.routeByRegistration.get(registration.id);
+    if (existingRoute) await this.unregisterRoute(existingRoute);
+
+    const routeToken = crypto.randomBytes(32).toString("base64url");
+    const target: BridgeTarget = {
       ...registration,
+      routeToken,
       failureReported: false,
-    });
-    return `http://127.0.0.1:${this.port}/${encodeURIComponent(registration.id)}`;
+      active: true,
+    };
+    this.targets.set(routeToken, target);
+    this.routeByRegistration.set(registration.id, routeToken);
+    return `http://127.0.0.1:${this.port}/${routeToken}`;
   }
 
   async unregisterRun(runId: string): Promise<void> {
@@ -102,9 +126,10 @@ export class AgentPluginStdioBridgeService implements AgentPluginStdioBridge {
   @preDestroy()
   async stop(): Promise<void> {
     await Promise.all(
-      [...this.targets.values()].map((target) => this.closeTarget(target)),
+      [...this.targets.keys()].map((routeToken) =>
+        this.unregisterRoute(routeToken),
+      ),
     );
-    this.targets.clear();
     if (!this.server) return;
 
     const server = this.server;
@@ -118,13 +143,13 @@ export class AgentPluginStdioBridgeService implements AgentPluginStdioBridge {
   }
 
   protected createStdioTransport(
-    registration: AgentPluginStdioBridgeRegistration,
+    config: AgentPluginStdioLaunchConfig,
   ): StdioClientTransport {
     return new StdioClientTransport({
-      command: registration.command,
-      args: registration.args,
-      env: registration.env,
-      cwd: registration.cwd,
+      command: config.command,
+      args: config.args,
+      env: config.env,
+      cwd: config.cwd,
       stderr: "pipe",
     });
   }
@@ -136,15 +161,23 @@ export class AgentPluginStdioBridgeService implements AgentPluginStdioBridge {
   private async unregisterMatching(
     predicate: (target: BridgeTarget) => boolean,
   ): Promise<void> {
-    const matches = [...this.targets.entries()].filter(([, target]) =>
-      predicate(target),
-    );
+    const routes = [...this.targets.entries()]
+      .filter(([, target]) => predicate(target))
+      .map(([routeToken]) => routeToken);
     await Promise.all(
-      matches.map(async ([id, target]) => {
-        this.targets.delete(id);
-        await this.closeTarget(target);
-      }),
+      routes.map((routeToken) => this.unregisterRoute(routeToken)),
     );
+  }
+
+  private async unregisterRoute(routeToken: string): Promise<void> {
+    const target = this.targets.get(routeToken);
+    if (!target) return;
+    this.targets.delete(routeToken);
+    target.active = false;
+    if (this.routeByRegistration.get(target.id) === routeToken) {
+      this.routeByRegistration.delete(target.id);
+    }
+    await this.closeTarget(target);
   }
 
   private async closeTarget(target: BridgeTarget): Promise<void> {
@@ -165,6 +198,10 @@ export class AgentPluginStdioBridgeService implements AgentPluginStdioBridge {
     if (this.server && this.port !== null) return;
     if (this.startPromise) return this.startPromise;
     this.startPromise = this.startServer().catch((error) => {
+      this.server?.closeAllConnections();
+      this.server?.close();
+      this.server = null;
+      this.port = null;
       this.startPromise = null;
       throw error;
     });
@@ -175,12 +212,19 @@ export class AgentPluginStdioBridgeService implements AgentPluginStdioBridge {
     const server = http.createServer((request, response) => {
       void this.handleRequest(request, response).catch((error) => {
         this.log.warn("Agent Plugin stdio bridge request failed", {
-          error: error instanceof Error ? error.message : String(error),
+          error: errorMessage(error),
         });
         if (!response.headersSent) {
-          response.writeHead(502, { [BRIDGE_ERROR_HEADER]: "1" });
+          response.writeHead(
+            error instanceof RequestBodyTooLargeError ? 413 : 502,
+            { [BRIDGE_ERROR_HEADER]: "1" },
+          );
         }
-        response.end("Agent Plugin stdio bridge error");
+        response.end(
+          error instanceof RequestBodyTooLargeError
+            ? "Agent Plugin MCP request body is too large"
+            : "Agent Plugin stdio bridge error",
+        );
       });
     });
     this.server = server;
@@ -206,25 +250,70 @@ export class AgentPluginStdioBridgeService implements AgentPluginStdioBridge {
     request: http.IncomingMessage,
     response: http.ServerResponse,
   ): Promise<void> {
+    if (request.headers.origin || request.headers["sec-fetch-site"]) {
+      response.writeHead(403);
+      response.end("Browser requests are not allowed");
+      return;
+    }
+
     const incomingUrl = new URL(request.url ?? "/", "http://localhost");
-    const rawId = incomingUrl.pathname.split("/").filter(Boolean)[0];
-    const id = rawId ? decodeURIComponent(rawId) : "";
-    const target = this.targets.get(id);
-    if (!target) {
+    const routeToken = incomingUrl.pathname.split("/").filter(Boolean)[0];
+    const target = routeToken ? this.targets.get(routeToken) : undefined;
+    if (!target || !target.active) {
       response.writeHead(404);
       response.end("Unknown Agent Plugin stdio target");
       return;
     }
 
+    let parsedBody: unknown;
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      const body = await this.readRequestBody(request);
+      try {
+        parsedBody = JSON.parse(body.toString("utf8"));
+      } catch {
+        response.writeHead(400);
+        response.end("Agent Plugin MCP request body is not valid JSON");
+        return;
+      }
+    }
+
     const isProbe = request.headers[STDIO_BRIDGE_PROBE_HEADER] === "1";
     const connection = isProbe
-      ? await this.startConnection(target, true)
+      ? await this.startConnection(target)
       : await this.getOrStartConnection(target);
     try {
-      await connection.http.handleRequest(request, response);
+      await connection.http.handleRequest(request, response, parsedBody);
+    } catch (error) {
+      if (!isProbe) this.invalidateConnection(target, connection, error);
+      throw error;
     } finally {
       if (isProbe) await connection.close();
     }
+  }
+
+  private readRequestBody(request: http.IncomingMessage): Promise<Buffer> {
+    const contentLength = Number(request.headers["content-length"] ?? 0);
+    if (
+      Number.isFinite(contentLength) &&
+      contentLength > MAX_REQUEST_BODY_BYTES
+    ) {
+      return Promise.reject(new RequestBodyTooLargeError());
+    }
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      let size = 0;
+      request.on("data", (chunk: Buffer) => {
+        size += chunk.length;
+        if (size > MAX_REQUEST_BODY_BYTES) {
+          reject(new RequestBodyTooLargeError());
+          request.destroy();
+          return;
+        }
+        chunks.push(chunk);
+      });
+      request.on("end", () => resolve(Buffer.concat(chunks)));
+      request.on("error", reject);
+    });
   }
 
   private getOrStartConnection(
@@ -233,34 +322,51 @@ export class AgentPluginStdioBridgeService implements AgentPluginStdioBridge {
     if (target.connection) return Promise.resolve(target.connection);
     if (target.connectionPromise) return target.connectionPromise;
 
-    target.connectionPromise = this.startConnection(target, false)
-      .then((connection) => {
+    const startPromise = this.startConnection(target)
+      .then(async (connection) => {
+        if (!target.active) {
+          await connection.close();
+          throw new Error("Agent Plugin stdio target was removed.");
+        }
         target.connection = connection;
         target.connectionPromise = undefined;
+        target.failureReported = false;
         return connection;
       })
       .catch((error) => {
-        target.connectionPromise = undefined;
+        if (target.connectionPromise === startPromise) {
+          target.connectionPromise = undefined;
+        }
         this.reportFailure(target, error);
         throw error;
       });
-    return target.connectionPromise;
+    target.connectionPromise = startPromise;
+    return startPromise;
   }
 
   private async startConnection(
     target: BridgeTarget,
-    ephemeral: boolean,
   ): Promise<BridgeConnection> {
-    const stdio = this.createStdioTransport(target);
+    const config = await target.prepare();
+    if (!target.active) {
+      throw new Error("Agent Plugin stdio target was removed.");
+    }
+    const stdio = this.createStdioTransport(config);
     const httpTransport = this.createHttpTransport();
     let connection: BridgeConnection | undefined;
     let intentionallyClosing = false;
 
-    httpTransport.onmessage = (message) => {
-      void stdio.send(message).catch((error) => {
+    const fail = (error: unknown): void => {
+      if (intentionallyClosing) return;
+      if (connection) {
+        this.invalidateConnection(target, connection, error);
+      } else {
         this.reportFailure(target, error);
-        void httpTransport.close();
-      });
+      }
+    };
+
+    httpTransport.onmessage = (message) => {
+      void stdio.send(message).catch(fail);
     };
     stdio.onmessage = (message) => {
       const requestId = relatedRequestId(message);
@@ -271,7 +377,7 @@ export class AgentPluginStdioBridgeService implements AgentPluginStdioBridge {
         )
         .catch((error) => {
           if (requestId !== undefined || "id" in message) {
-            this.reportFailure(target, error);
+            fail(error);
           } else {
             this.log.debug(
               "Dropped stdio MCP notification without a client stream",
@@ -279,21 +385,12 @@ export class AgentPluginStdioBridgeService implements AgentPluginStdioBridge {
           }
         });
     };
-    stdio.onerror = (error) => this.reportFailure(target, error);
+    stdio.onerror = fail;
     stdio.onclose = () => {
       if (connection) {
         this.processTracking.unregister(connection.pid, "mcp-exited");
-        if (!ephemeral && target.connection === connection) {
-          target.connection = undefined;
-        }
       }
-      if (!intentionallyClosing) {
-        this.reportFailure(
-          target,
-          new Error("The stdio MCP server stopped unexpectedly."),
-        );
-      }
-      void httpTransport.close();
+      fail(new Error("The stdio MCP server stopped unexpectedly."));
     };
 
     await httpTransport.start();
@@ -306,7 +403,7 @@ export class AgentPluginStdioBridgeService implements AgentPluginStdioBridge {
     }
     const pid = stdio.pid;
     if (pid === null) {
-      await Promise.all([stdio.close(), httpTransport.close()]);
+      await Promise.allSettled([stdio.close(), httpTransport.close()]);
       throw new Error("Agent Plugin stdio server did not start.");
     }
 
@@ -316,11 +413,12 @@ export class AgentPluginStdioBridgeService implements AgentPluginStdioBridge {
       "child",
       `agent-plugin:${target.runtimeName}`,
       {
+        taskId: target.taskId,
         taskRunId: target.runId,
         installationId: target.installationId,
         server: target.runtimeName,
       },
-      target.runId,
+      target.taskId,
     );
 
     let closed = false;
@@ -332,21 +430,28 @@ export class AgentPluginStdioBridgeService implements AgentPluginStdioBridge {
         if (closed) return;
         closed = true;
         intentionallyClosing = true;
-        await httpTransport.close();
+        if (target.connection === connection) target.connection = undefined;
+        this.processTracking.unregister(pid, "mcp-closed");
         this.processTracking.kill(pid);
-        await stdio.close();
+        await Promise.allSettled([httpTransport.close(), stdio.close()]);
       },
     };
     return connection;
   }
 
+  private invalidateConnection(
+    target: BridgeTarget,
+    connection: BridgeConnection,
+    error: unknown,
+  ): void {
+    if (target.connection === connection) target.connection = undefined;
+    this.reportFailure(target, error);
+    void connection.close();
+  }
+
   private reportFailure(target: BridgeTarget, error: unknown): void {
     if (target.failureReported) return;
     target.failureReported = true;
-    target.onFailure(
-      error instanceof Error && error.message
-        ? error.message
-        : "The stdio MCP server stopped unexpectedly.",
-    );
+    target.onFailure(errorMessage(error));
   }
 }

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/stdio-bridge.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/stdio-bridge.ts
@@ -50,10 +50,16 @@ interface BridgeConnection {
   close: () => Promise<void>;
 }
 
+interface PendingLaunch {
+  abortController: AbortController;
+  promise: Promise<BridgeConnection>;
+}
+
 interface BridgeTarget extends AgentPluginStdioBridgeRegistration {
   routeToken: string;
   connection?: BridgeConnection;
   connectionPromise?: Promise<BridgeConnection>;
+  launches: Set<PendingLaunch>;
   failureReported: boolean;
   active: boolean;
 }
@@ -105,6 +111,7 @@ export class AgentPluginStdioBridgeService implements AgentPluginStdioBridge {
     const target: BridgeTarget = {
       ...registration,
       routeToken,
+      launches: new Set(),
       failureReported: false,
       active: true,
     };
@@ -177,6 +184,22 @@ export class AgentPluginStdioBridgeService implements AgentPluginStdioBridge {
     if (this.routeByRegistration.get(target.id) === routeToken) {
       this.routeByRegistration.delete(target.id);
     }
+
+    const launches = [...target.launches];
+    for (const launch of launches) {
+      launch.abortController.abort(
+        new Error("Agent Plugin stdio target was removed."),
+      );
+    }
+    const launchedConnections = await Promise.allSettled(
+      launches.map((launch) => launch.promise),
+    );
+    await Promise.allSettled(
+      launchedConnections.flatMap((result) =>
+        result.status === "fulfilled" ? [result.value.close()] : [],
+      ),
+    );
+    target.launches.clear();
     await this.closeTarget(target);
   }
 
@@ -186,7 +209,7 @@ export class AgentPluginStdioBridgeService implements AgentPluginStdioBridge {
       try {
         connection = await target.connectionPromise;
       } catch {
-        return;
+        connection = undefined;
       }
     }
     target.connection = undefined;
@@ -278,16 +301,25 @@ export class AgentPluginStdioBridgeService implements AgentPluginStdioBridge {
     }
 
     const isProbe = request.headers[STDIO_BRIDGE_PROBE_HEADER] === "1";
-    const connection = isProbe
-      ? await this.startConnection(target)
-      : await this.getOrStartConnection(target);
+    if (isProbe) {
+      const launch = this.beginConnection(target);
+      let connection: BridgeConnection | undefined;
+      try {
+        connection = await launch.promise;
+        await connection.http.handleRequest(request, response, parsedBody);
+      } finally {
+        await connection?.close();
+        target.launches.delete(launch);
+      }
+      return;
+    }
+
+    const connection = await this.getOrStartConnection(target);
     try {
       await connection.http.handleRequest(request, response, parsedBody);
     } catch (error) {
-      if (!isProbe) this.invalidateConnection(target, connection, error);
+      this.invalidateConnection(target, connection, error);
       throw error;
-    } finally {
-      if (isProbe) await connection.close();
     }
   }
 
@@ -322,18 +354,18 @@ export class AgentPluginStdioBridgeService implements AgentPluginStdioBridge {
     if (target.connection) return Promise.resolve(target.connection);
     if (target.connectionPromise) return target.connectionPromise;
 
-    const startPromise = this.startConnection(target)
+    const launch = this.beginConnection(target);
+    const startPromise = launch.promise
       .then(async (connection) => {
-        if (!target.active) {
-          await connection.close();
-          throw new Error("Agent Plugin stdio target was removed.");
-        }
+        this.assertLaunchActive(target, launch.abortController.signal);
         target.connection = connection;
         target.connectionPromise = undefined;
+        target.launches.delete(launch);
         target.failureReported = false;
         return connection;
       })
       .catch((error) => {
+        target.launches.delete(launch);
         if (target.connectionPromise === startPromise) {
           target.connectionPromise = undefined;
         }
@@ -344,13 +376,33 @@ export class AgentPluginStdioBridgeService implements AgentPluginStdioBridge {
     return startPromise;
   }
 
+  private beginConnection(target: BridgeTarget): PendingLaunch {
+    const abortController = new AbortController();
+    const launch = {
+      abortController,
+      promise: Promise.resolve().then(() =>
+        this.startConnection(target, abortController.signal),
+      ),
+    };
+    target.launches.add(launch);
+    return launch;
+  }
+
+  private assertLaunchActive(target: BridgeTarget, signal: AbortSignal): void {
+    if (!target.active || signal.aborted) {
+      throw (
+        signal.reason ?? new Error("Agent Plugin stdio target was removed.")
+      );
+    }
+  }
+
   private async startConnection(
     target: BridgeTarget,
+    signal: AbortSignal,
   ): Promise<BridgeConnection> {
+    this.assertLaunchActive(target, signal);
     const config = await target.prepare();
-    if (!target.active) {
-      throw new Error("Agent Plugin stdio target was removed.");
-    }
+    this.assertLaunchActive(target, signal);
     const stdio = this.createStdioTransport(config);
     const httpTransport = this.createHttpTransport();
     let connection: BridgeConnection | undefined;
@@ -393,50 +445,61 @@ export class AgentPluginStdioBridgeService implements AgentPluginStdioBridge {
       fail(new Error("The stdio MCP server stopped unexpectedly."));
     };
 
-    await httpTransport.start();
-    try {
-      await stdio.start();
-    } catch (error) {
-      await httpTransport.close();
-      this.reportFailure(target, error);
-      throw error;
-    }
-    const pid = stdio.pid;
-    if (pid === null) {
-      await Promise.allSettled([stdio.close(), httpTransport.close()]);
-      throw new Error("Agent Plugin stdio server did not start.");
-    }
-
-    stdio.stderr?.on("data", () => undefined);
-    this.processTracking.register(
-      pid,
-      "child",
-      `agent-plugin:${target.runtimeName}`,
-      {
-        taskId: target.taskId,
-        taskRunId: target.runId,
-        installationId: target.installationId,
-        server: target.runtimeName,
-      },
-      target.taskId,
-    );
-
-    let closed = false;
-    connection = {
-      stdio,
-      http: httpTransport,
-      pid,
-      close: async () => {
-        if (closed) return;
-        closed = true;
-        intentionallyClosing = true;
-        if (target.connection === connection) target.connection = undefined;
-        this.processTracking.unregister(pid, "mcp-closed");
-        this.processTracking.kill(pid);
-        await Promise.allSettled([httpTransport.close(), stdio.close()]);
-      },
+    const abortStartup = (): void => {
+      intentionallyClosing = true;
+      void Promise.allSettled([httpTransport.close(), stdio.close()]);
     };
-    return connection;
+    signal.addEventListener("abort", abortStartup, { once: true });
+
+    try {
+      await httpTransport.start();
+      this.assertLaunchActive(target, signal);
+      await stdio.start();
+      this.assertLaunchActive(target, signal);
+
+      const pid = stdio.pid;
+      if (pid === null) {
+        throw new Error("Agent Plugin stdio server did not start.");
+      }
+
+      stdio.stderr?.on("data", () => undefined);
+      this.processTracking.register(
+        pid,
+        "child",
+        `agent-plugin:${target.runtimeName}`,
+        {
+          taskId: target.taskId,
+          taskRunId: target.runId,
+          installationId: target.installationId,
+          server: target.runtimeName,
+        },
+        target.taskId,
+      );
+
+      let closed = false;
+      connection = {
+        stdio,
+        http: httpTransport,
+        pid,
+        close: async () => {
+          if (closed) return;
+          closed = true;
+          intentionallyClosing = true;
+          if (target.connection === connection) target.connection = undefined;
+          this.processTracking.unregister(pid, "mcp-closed");
+          this.processTracking.kill(pid);
+          await Promise.allSettled([httpTransport.close(), stdio.close()]);
+        },
+      };
+      return connection;
+    } catch (error) {
+      intentionallyClosing = true;
+      await Promise.allSettled([stdio.close(), httpTransport.close()]);
+      if (!signal.aborted) this.reportFailure(target, error);
+      throw error;
+    } finally {
+      signal.removeEventListener("abort", abortStartup);
+    }
   }
 
   private invalidateConnection(
@@ -450,7 +513,7 @@ export class AgentPluginStdioBridgeService implements AgentPluginStdioBridge {
   }
 
   private reportFailure(target: BridgeTarget, error: unknown): void {
-    if (target.failureReported) return;
+    if (!target.active || target.failureReported) return;
     target.failureReported = true;
     target.onFailure(errorMessage(error));
   }

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/stdio-runtime.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/stdio-runtime.test.ts
@@ -1,0 +1,178 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  buildStdioEnvironment,
+  expandPluginPlaceholders,
+  resolveStdioServer,
+} from "./stdio-runtime";
+
+let root: string;
+
+async function makePlugin(name: string): Promise<string> {
+  const pluginRoot = path.join(root, name);
+  await fs.promises.mkdir(path.join(pluginRoot, "bin"), { recursive: true });
+  await fs.promises.mkdir(path.join(pluginRoot, "work"), { recursive: true });
+  await fs.promises.writeFile(path.join(pluginRoot, "bin", "server"), "server");
+  return pluginRoot;
+}
+
+describe("Agent Plugin stdio runtime", () => {
+  beforeEach(async () => {
+    root = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "agent-plugin-stdio-runtime-"),
+    );
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(root, { recursive: true, force: true });
+  });
+
+  it("expands only the two exact placeholders in one pass", () => {
+    const pluginRoot = `/plugin/\${PLUGIN_DATA}`;
+    const pluginData = "/data";
+
+    expect(
+      expandPluginPlaceholders(
+        `\${PLUGIN_ROOT}:\${PLUGIN_DATA}:\${HOME}:\${PLUGIN_ROOTED}`,
+        pluginRoot,
+        pluginData,
+      ),
+    ).toBe(`/plugin/\${PLUGIN_DATA}:/data:\${HOME}:\${PLUGIN_ROOTED}`);
+  });
+
+  it("builds an allowlisted environment with configured values overlaid and roots set last", () => {
+    const environment = buildStdioEnvironment(
+      {
+        HOME: "/home/example",
+        PATH: "/usr/bin",
+        POSTHOG_API_KEY: "must-not-leak",
+      },
+      {
+        PATH: `\${PLUGIN_ROOT}/bin`,
+        CONFIG: `\${PLUGIN_DATA}/config.json`,
+        PLUGIN_ROOT: "/malicious",
+      },
+      "/plugin",
+      "/plugin-data",
+      "linux",
+    );
+
+    expect(environment).toMatchObject({
+      HOME: "/home/example",
+      PATH: "/plugin/bin",
+      CONFIG: "/plugin-data/config.json",
+      PLUGIN_ROOT: "/plugin",
+      PLUGIN_DATA: "/plugin-data",
+    });
+    expect(environment).not.toHaveProperty("POSTHOG_API_KEY");
+  });
+
+  it.each([
+    ["default", undefined, "plugin"],
+    ["plugin relative", "./work", "work"],
+    ["plugin root", `\${PLUGIN_ROOT}/work`, "work"],
+    ["plugin data", `\${PLUGIN_DATA}/cache/nested`, "data"],
+  ])("resolves the %s working directory", async (_label, cwd, expected) => {
+    const pluginRoot = await makePlugin(
+      `plugin-${_label.replaceAll(" ", "-")}`,
+    );
+    const pluginData = path.join(root, "data", _label.replaceAll(" ", "-"));
+
+    const resolved = await resolveStdioServer(
+      pluginRoot,
+      pluginData,
+      {
+        name: "server",
+        type: "stdio",
+        command: "./bin/server",
+        args: [`\${PLUGIN_ROOT}`, `\${PLUGIN_DATA}`],
+        env: { CONFIG: `\${PLUGIN_DATA}/config` },
+        ...(cwd === undefined ? {} : { cwd }),
+      },
+      { HOME: "/home/example", PATH: "/usr/bin" },
+    );
+
+    expect(resolved.command).toBe(
+      path.join(resolved.pluginRoot, "bin", "server"),
+    );
+    expect(resolved.args).toEqual([resolved.pluginRoot, resolved.pluginData]);
+    expect(resolved.env.CONFIG).toBe(`${resolved.pluginData}/config`);
+    expect(resolved.cwd).toBe(
+      expected === "plugin"
+        ? resolved.pluginRoot
+        : expected === "data"
+          ? path.join(resolved.pluginData, "cache", "nested")
+          : path.join(resolved.pluginRoot, expected),
+    );
+  });
+
+  it("keeps plugin data stable and isolated by installation path", async () => {
+    const pluginRoot = await makePlugin("plugin");
+    const firstData = path.join(root, "data", "installation-a");
+    const secondData = path.join(root, "data", "installation-b");
+
+    const first = await resolveStdioServer(pluginRoot, firstData, {
+      name: "server",
+      type: "stdio",
+      command: "node",
+    });
+    await fs.promises.writeFile(
+      path.join(first.pluginData, "state.json"),
+      "{}",
+    );
+    const restarted = await resolveStdioServer(pluginRoot, firstData, {
+      name: "server",
+      type: "stdio",
+      command: "node",
+    });
+    const isolated = await resolveStdioServer(pluginRoot, secondData, {
+      name: "server",
+      type: "stdio",
+      command: "node",
+    });
+
+    expect(restarted.pluginData).toBe(first.pluginData);
+    expect(
+      await fs.promises.readFile(
+        path.join(restarted.pluginData, "state.json"),
+        "utf8",
+      ),
+    ).toBe("{}");
+    expect(isolated.pluginData).not.toBe(first.pluginData);
+  });
+
+  it("rejects plugin data that escapes app-managed storage through a symlink", async () => {
+    const pluginRoot = await makePlugin("plugin");
+    const dataParent = path.join(root, "data");
+    const outside = path.join(root, "outside-data");
+    await fs.promises.mkdir(dataParent);
+    await fs.promises.mkdir(outside);
+    await fs.promises.symlink(outside, path.join(dataParent, "installation"));
+
+    await expect(
+      resolveStdioServer(pluginRoot, path.join(dataParent, "installation"), {
+        name: "server",
+        type: "stdio",
+        command: "node",
+      }),
+    ).rejects.toThrow("escapes app-managed storage");
+  });
+
+  it("rejects a working directory that escapes through a symlink", async () => {
+    const pluginRoot = await makePlugin("plugin");
+    const outside = path.join(root, "outside");
+    await fs.promises.mkdir(outside);
+    await fs.promises.symlink(outside, path.join(pluginRoot, "escape"));
+
+    await expect(
+      resolveStdioServer(pluginRoot, path.join(root, "data"), {
+        name: "server",
+        type: "stdio",
+        command: "node",
+        cwd: "./escape",
+      }),
+    ).rejects.toThrow("escapes its allowed root");
+  });
+});

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/stdio-runtime.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/stdio-runtime.test.ts
@@ -160,6 +160,27 @@ describe("Agent Plugin stdio runtime", () => {
     ).rejects.toThrow("escapes app-managed storage");
   });
 
+  it("does not create a plugin data working directory through a symlink", async () => {
+    const pluginRoot = await makePlugin("plugin-data-cwd");
+    const pluginData = path.join(root, "data", "installation");
+    const outside = path.join(root, "outside-data-cwd");
+    await fs.promises.mkdir(pluginData, { recursive: true });
+    await fs.promises.mkdir(outside);
+    await fs.promises.symlink(outside, path.join(pluginData, "escape"));
+
+    await expect(
+      resolveStdioServer(pluginRoot, pluginData, {
+        name: "server",
+        type: "stdio",
+        command: "node",
+        cwd: `\${PLUGIN_DATA}/escape/new`,
+      }),
+    ).rejects.toThrow("escapes its allowed root");
+    await expect(
+      fs.promises.lstat(path.join(outside, "new")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("rejects a working directory that escapes through a symlink", async () => {
     const pluginRoot = await makePlugin("plugin");
     const outside = path.join(root, "outside");

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/stdio-runtime.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/stdio-runtime.ts
@@ -1,0 +1,175 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { DEFAULT_INHERITED_ENV_VARS } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { isPathContained } from "./loader";
+import type { AgentPluginStdioMcpServer } from "./schemas";
+
+const PLUGIN_DATA_PLACEHOLDER = `\${PLUGIN_DATA}`;
+const PLACEHOLDER_PATTERN = /\$\{PLUGIN_(ROOT|DATA)\}/g;
+
+export interface ResolvedStdioServer {
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+  cwd: string;
+  pluginRoot: string;
+  pluginData: string;
+}
+
+export function expandPluginPlaceholders(
+  value: string,
+  pluginRoot: string,
+  pluginData: string,
+): string {
+  return value.replace(PLACEHOLDER_PATTERN, (_match, name: string) =>
+    name === "ROOT" ? pluginRoot : pluginData,
+  );
+}
+
+export function isReservedPluginEnvironmentName(
+  name: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  const normalized = platform === "win32" ? name.toUpperCase() : name;
+  return normalized === "PLUGIN_ROOT" || normalized === "PLUGIN_DATA";
+}
+
+function setEnvironmentValue(
+  environment: Record<string, string>,
+  name: string,
+  value: string,
+  platform: NodeJS.Platform,
+): void {
+  if (platform === "win32") {
+    const normalizedName = name.toUpperCase();
+    for (const existingName of Object.keys(environment)) {
+      if (existingName.toUpperCase() === normalizedName) {
+        delete environment[existingName];
+      }
+    }
+  }
+  environment[name] = value;
+}
+
+function ambientValue(
+  ambient: NodeJS.ProcessEnv,
+  name: string,
+  platform: NodeJS.Platform,
+): string | undefined {
+  if (platform !== "win32") return ambient[name];
+  const entry = Object.entries(ambient).find(
+    ([key]) => key.toUpperCase() === name.toUpperCase(),
+  );
+  return entry?.[1];
+}
+
+export function buildStdioEnvironment(
+  ambient: NodeJS.ProcessEnv,
+  configured: Record<string, string>,
+  pluginRoot: string,
+  pluginData: string,
+  platform: NodeJS.Platform = process.platform,
+): Record<string, string> {
+  const environment: Record<string, string> = {};
+  for (const name of DEFAULT_INHERITED_ENV_VARS) {
+    const value = ambientValue(ambient, name, platform);
+    if (value !== undefined && !value.startsWith("()")) {
+      setEnvironmentValue(environment, name, value, platform);
+    }
+  }
+  for (const [name, value] of Object.entries(configured)) {
+    if (isReservedPluginEnvironmentName(name, platform)) continue;
+    setEnvironmentValue(
+      environment,
+      name,
+      expandPluginPlaceholders(value, pluginRoot, pluginData),
+      platform,
+    );
+  }
+  setEnvironmentValue(environment, "PLUGIN_ROOT", pluginRoot, platform);
+  setEnvironmentValue(environment, "PLUGIN_DATA", pluginData, platform);
+  return environment;
+}
+
+async function resolveContainedDirectory(
+  root: string,
+  candidate: string,
+  create: boolean,
+): Promise<string> {
+  const absoluteCandidate = path.resolve(candidate);
+  if (!isPathContained(root, absoluteCandidate)) {
+    throw new Error("The stdio working directory escapes its allowed root.");
+  }
+  if (create) await fs.promises.mkdir(absoluteCandidate, { recursive: true });
+  const resolvedCandidate = await fs.promises.realpath(absoluteCandidate);
+  if (!isPathContained(root, resolvedCandidate)) {
+    throw new Error("The stdio working directory escapes its allowed root.");
+  }
+  const stat = await fs.promises.stat(resolvedCandidate);
+  if (!stat.isDirectory()) {
+    throw new Error("The stdio working directory is not a directory.");
+  }
+  return resolvedCandidate;
+}
+
+async function resolveWorkingDirectory(
+  configuredCwd: string | undefined,
+  pluginRoot: string,
+  pluginData: string,
+): Promise<string> {
+  if (configuredCwd === undefined) return pluginRoot;
+  const expanded = configuredCwd.startsWith("./")
+    ? path.resolve(pluginRoot, configuredCwd)
+    : expandPluginPlaceholders(configuredCwd, pluginRoot, pluginData);
+  if (
+    configuredCwd === PLUGIN_DATA_PLACEHOLDER ||
+    configuredCwd.startsWith(`${PLUGIN_DATA_PLACEHOLDER}/`)
+  ) {
+    return resolveContainedDirectory(pluginData, expanded, true);
+  }
+  return resolveContainedDirectory(pluginRoot, expanded, false);
+}
+
+export async function resolveStdioServer(
+  pluginSourcePath: string,
+  pluginDataPath: string,
+  server: AgentPluginStdioMcpServer,
+  ambient: NodeJS.ProcessEnv = process.env,
+): Promise<ResolvedStdioServer> {
+  const pluginRoot = await fs.promises.realpath(pluginSourcePath);
+  const pluginDataParentPath = path.dirname(pluginDataPath);
+  await fs.promises.mkdir(pluginDataParentPath, { recursive: true });
+  const pluginDataParent = await fs.promises.realpath(pluginDataParentPath);
+  await fs.promises.mkdir(pluginDataPath, { recursive: true });
+  const pluginData = await fs.promises.realpath(pluginDataPath);
+  if (!isPathContained(pluginDataParent, pluginData)) {
+    throw new Error("The plugin data directory escapes app-managed storage.");
+  }
+  await fs.promises.access(pluginData, fs.constants.W_OK);
+
+  let command = server.command;
+  if (command.startsWith("./")) {
+    command = await fs.promises.realpath(path.resolve(pluginRoot, command));
+    if (!isPathContained(pluginRoot, command)) {
+      throw new Error(
+        "The stdio command resolves outside the plugin directory.",
+      );
+    }
+    const stat = await fs.promises.stat(command);
+    if (!stat.isFile()) {
+      throw new Error("The stdio command is not a regular file.");
+    }
+  }
+
+  const cwd = await resolveWorkingDirectory(server.cwd, pluginRoot, pluginData);
+  const args = (server.args ?? []).map((argument) =>
+    expandPluginPlaceholders(argument, pluginRoot, pluginData),
+  );
+  const env = buildStdioEnvironment(
+    ambient,
+    server.env ?? {},
+    pluginRoot,
+    pluginData,
+  );
+  return { command, args, env, cwd, pluginRoot, pluginData };
+}

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/stdio-runtime.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/stdio-runtime.ts
@@ -91,24 +91,60 @@ export function buildStdioEnvironment(
   return environment;
 }
 
+async function createContainedDirectory(
+  root: string,
+  candidate: string,
+): Promise<void> {
+  const relativePath = path.relative(root, candidate);
+  let currentPath = root;
+  for (const segment of relativePath.split(path.sep).filter(Boolean)) {
+    currentPath = path.join(currentPath, segment);
+    try {
+      await fs.promises.mkdir(currentPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
+    const currentStat = await fs.promises.lstat(currentPath);
+    if (currentStat.isSymbolicLink() || !currentStat.isDirectory()) {
+      throw new Error(
+        "The stdio working directory escapes its allowed root through a symbolic link.",
+      );
+    }
+    const resolvedCurrentPath = await fs.promises.realpath(currentPath);
+    if (!isPathContained(root, resolvedCurrentPath)) {
+      throw new Error("The stdio working directory escapes its allowed root.");
+    }
+  }
+}
+
 async function resolveContainedDirectory(
   root: string,
   candidate: string,
   create: boolean,
 ): Promise<string> {
+  const absoluteRoot = path.resolve(root);
   const absoluteCandidate = path.resolve(candidate);
-  if (!isPathContained(root, absoluteCandidate)) {
+  if (!isPathContained(absoluteRoot, absoluteCandidate)) {
     throw new Error("The stdio working directory escapes its allowed root.");
   }
-  if (create) await fs.promises.mkdir(absoluteCandidate, { recursive: true });
-  const candidateStat = await fs.promises.lstat(absoluteCandidate);
+  const resolvedRoot = await fs.promises.realpath(absoluteRoot);
+  const candidateWithinResolvedRoot = path.join(
+    resolvedRoot,
+    path.relative(absoluteRoot, absoluteCandidate),
+  );
+  if (create) {
+    await createContainedDirectory(resolvedRoot, candidateWithinResolvedRoot);
+  }
+  const candidateStat = await fs.promises.lstat(candidateWithinResolvedRoot);
   if (candidateStat.isSymbolicLink()) {
     throw new Error(
       "The stdio working directory escapes its allowed root through a symbolic link.",
     );
   }
-  const resolvedCandidate = await fs.promises.realpath(absoluteCandidate);
-  if (!isPathContained(root, resolvedCandidate)) {
+  const resolvedCandidate = await fs.promises.realpath(
+    candidateWithinResolvedRoot,
+  );
+  if (!isPathContained(resolvedRoot, resolvedCandidate)) {
     throw new Error("The stdio working directory escapes its allowed root.");
   }
   const stat = await fs.promises.stat(resolvedCandidate);

--- a/products/desktop/packages/workspace-server/src/services/agent-plugins/stdio-runtime.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent-plugins/stdio-runtime.ts
@@ -101,6 +101,12 @@ async function resolveContainedDirectory(
     throw new Error("The stdio working directory escapes its allowed root.");
   }
   if (create) await fs.promises.mkdir(absoluteCandidate, { recursive: true });
+  const candidateStat = await fs.promises.lstat(absoluteCandidate);
+  if (candidateStat.isSymbolicLink()) {
+    throw new Error(
+      "The stdio working directory escapes its allowed root through a symbolic link.",
+    );
+  }
   const resolvedCandidate = await fs.promises.realpath(absoluteCandidate);
   if (!isPathContained(root, resolvedCandidate)) {
     throw new Error("The stdio working directory escapes its allowed root.");
@@ -137,19 +143,38 @@ export async function resolveStdioServer(
   ambient: NodeJS.ProcessEnv = process.env,
 ): Promise<ResolvedStdioServer> {
   const pluginRoot = await fs.promises.realpath(pluginSourcePath);
-  const pluginDataParentPath = path.dirname(pluginDataPath);
+  const absolutePluginDataPath = path.resolve(pluginDataPath);
+  const pluginDataParentPath = path.dirname(absolutePluginDataPath);
   await fs.promises.mkdir(pluginDataParentPath, { recursive: true });
   const pluginDataParent = await fs.promises.realpath(pluginDataParentPath);
-  await fs.promises.mkdir(pluginDataPath, { recursive: true });
-  const pluginData = await fs.promises.realpath(pluginDataPath);
-  if (!isPathContained(pluginDataParent, pluginData)) {
+  await fs.promises.mkdir(absolutePluginDataPath, { recursive: true });
+  const pluginDataStat = await fs.promises.lstat(absolutePluginDataPath);
+  if (pluginDataStat.isSymbolicLink() || !pluginDataStat.isDirectory()) {
+    throw new Error(
+      "The plugin data directory escapes app-managed storage or is unsafe.",
+    );
+  }
+  const pluginData = await fs.promises.realpath(absolutePluginDataPath);
+  const expectedPluginData = path.join(
+    pluginDataParent,
+    path.basename(absolutePluginDataPath),
+  );
+  if (
+    !isPathContained(pluginDataParent, pluginData) ||
+    path.resolve(pluginData) !== expectedPluginData
+  ) {
     throw new Error("The plugin data directory escapes app-managed storage.");
   }
   await fs.promises.access(pluginData, fs.constants.W_OK);
 
   let command = server.command;
   if (command.startsWith("./")) {
-    command = await fs.promises.realpath(path.resolve(pluginRoot, command));
+    const commandPath = path.resolve(pluginRoot, command);
+    const commandLstat = await fs.promises.lstat(commandPath);
+    if (commandLstat.isSymbolicLink() || !commandLstat.isFile()) {
+      throw new Error("The stdio command must be a regular file.");
+    }
+    command = await fs.promises.realpath(commandPath);
     if (!isPathContained(pluginRoot, command)) {
       throw new Error(
         "The stdio command resolves outside the plugin directory.",

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
@@ -261,6 +261,19 @@ function createMockDependencies() {
   };
 }
 
+function successfulMcpInitializeResponse(init?: RequestInit): Response {
+  const request = JSON.parse(String(init?.body)) as { id: string };
+  return Response.json({
+    jsonrpc: "2.0",
+    id: request.id,
+    result: {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      serverInfo: { name: "test", version: "1.0.0" },
+    },
+  });
+}
+
 const baseSessionParams = {
   taskId: "task-1",
   taskRunId: "run-1",
@@ -278,7 +291,12 @@ describe("AgentService", () => {
 
     // The Codex MCP reachability probe hits the network; default it to "reachable"
     // so unrelated session tests stay deterministic and offline-safe.
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ body: null }));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: string | URL | Request, init?: RequestInit) =>
+        successfulMcpInitializeResponse(init),
+      ),
+    );
 
     deps = createMockDependencies();
     service = new AgentService(
@@ -614,7 +632,7 @@ describe("AgentService", () => {
         );
         expect(
           deps.agentPluginsService.prepareRuntimeMcpServers,
-        ).toHaveBeenCalledWith("run-1", new Set(["posthog"]));
+        ).toHaveBeenCalledWith("task-1", "run-1", new Set(["posthog"]));
       },
     );
 
@@ -632,7 +650,10 @@ describe("AgentService", () => {
           ],
         },
       ]);
-      const fetchMock = vi.fn().mockResolvedValue({ body: null });
+      const fetchMock = vi.fn(
+        async (_input: string | URL | Request, init?: RequestInit) =>
+          successfulMcpInitializeResponse(init),
+      );
       vi.stubGlobal("fetch", fetchMock);
 
       await service.startSession({ ...baseSessionParams, adapter: "codex" });
@@ -664,14 +685,14 @@ describe("AgentService", () => {
       ]);
       vi.stubGlobal(
         "fetch",
-        vi.fn(async (input: string | URL | Request) => {
+        vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
           if (String(input).includes("127.0.0.1:4567")) {
             return new Response("proxy error", {
               status: 502,
               headers: { "x-posthog-agent-plugin-proxy-error": "1" },
             });
           }
-          return new Response("reachable", { status: 401 });
+          return successfulMcpInitializeResponse(init);
         }),
       );
 

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
@@ -618,6 +618,41 @@ describe("AgentService", () => {
       },
     );
 
+    it("uses a disposable stdio bridge probe before passing the server to Codex", async () => {
+      deps.agentPluginsService.prepareRuntimeMcpServers.mockResolvedValue([
+        {
+          name: "agent-plugin-example-12345678-abcdef12",
+          type: "http",
+          url: "http://127.0.0.1:4567/server",
+          headers: [
+            {
+              name: "x-posthog-agent-plugin-stdio-bridge",
+              value: "1",
+            },
+          ],
+        },
+      ]);
+      const fetchMock = vi.fn().mockResolvedValue({ body: null });
+      vi.stubGlobal("fetch", fetchMock);
+
+      await service.startSession({ ...baseSessionParams, adapter: "codex" });
+
+      const pluginProbe = fetchMock.mock.calls.find(([input]) =>
+        String(input).includes("127.0.0.1:4567"),
+      );
+      expect(pluginProbe?.[1]?.headers).toMatchObject({
+        "x-posthog-agent-plugin-stdio-bridge": "1",
+        "x-posthog-agent-plugin-stdio-probe": "1",
+      });
+      expect(mockNewSession.mock.calls[0][0].mcpServers).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: "agent-plugin-example-12345678-abcdef12",
+          }),
+        ]),
+      );
+    });
+
     it("drops an unreachable Agent Plugin proxy from Codex without dropping reachable servers", async () => {
       deps.agentPluginsService.prepareRuntimeMcpServers.mockResolvedValue([
         {

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
@@ -661,10 +661,9 @@ describe("AgentService", () => {
       const pluginProbe = fetchMock.mock.calls.find(([input]) =>
         String(input).includes("127.0.0.1:4567"),
       );
-      expect(pluginProbe?.[1]?.headers).toMatchObject({
-        "x-posthog-agent-plugin-stdio-bridge": "1",
-        "x-posthog-agent-plugin-stdio-probe": "1",
-      });
+      const probeHeaders = new Headers(pluginProbe?.[1]?.headers);
+      expect(probeHeaders.get("x-posthog-agent-plugin-stdio-bridge")).toBe("1");
+      expect(probeHeaders.get("x-posthog-agent-plugin-stdio-probe")).toBe("1");
       expect(mockNewSession.mock.calls[0][0].mcpServers).toEqual(
         expect.arrayContaining([
           expect.objectContaining({

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.ts
@@ -79,6 +79,7 @@ import { WORKSPACE_REPOSITORY } from "../../db/identifiers";
 import type { IWorkspaceRepository } from "../../db/repositories/workspace-repository";
 import type { AgentPluginsService } from "../agent-plugins/agent-plugins";
 import { AGENT_PLUGINS_SERVICE } from "../agent-plugins/identifiers";
+import { probeMcpInitialize } from "../agent-plugins/mcp-probe";
 import {
   STDIO_BRIDGE_MARKER_HEADER,
   STDIO_BRIDGE_PROBE_HEADER,
@@ -1013,6 +1014,7 @@ If a repository is required, call \`list_repos\` to find it, then use \`clone_re
       try {
         pluginMcpServers =
           await this.agentPluginsService.prepareRuntimeMcpServers(
+            taskId,
             taskRunId,
             new Set(mcpServers.map((server) => server.name)),
           );
@@ -1391,49 +1393,12 @@ If a repository is required, call \`list_repos\` to find it, then use \`clone_re
   private async isMcpServerReachable(
     server: Pick<McpServerConnection, "url" | "headers">,
   ): Promise<boolean> {
-    const PROBE_TIMEOUT_MS = 2_000;
     try {
-      const headers: Record<string, string> = {
-        "content-type": "application/json",
-        accept: "application/json, text/event-stream",
-      };
-      for (const header of server.headers) {
-        headers[header.name] = header.value;
-      }
-      if (
-        server.headers.some(
-          (header) => header.name.toLowerCase() === STDIO_BRIDGE_MARKER_HEADER,
-        )
-      ) {
-        headers[STDIO_BRIDGE_PROBE_HEADER] = "1";
-      }
-      const response = await fetch(server.url, {
-        method: "POST",
-        headers,
-        body: JSON.stringify({
-          jsonrpc: "2.0",
-          id: 0,
-          method: "initialize",
-          params: {
-            protocolVersion: "2025-06-18",
-            capabilities: {},
-            clientInfo: { name: "posthog-code", version: "1.0.0" },
-          },
-        }),
-        signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
-      });
-      // Release the body without draining it. A cancel rejection (e.g. an
-      // already-disturbed stream) is a cleanup detail, not a reachability
-      // signal, so it must not flip the result to unreachable.
-      try {
-        await response.body?.cancel();
-      } catch {
-        // ignore body cleanup failures
-      }
-      // The neutral Agent Plugin proxy marks upstream transport failures. Other
-      // HTTP responses still prove that codex-acp can establish the transport.
-      return (
-        response.headers?.get?.("x-posthog-agent-plugin-proxy-error") !== "1"
+      return await probeMcpInitialize(
+        server.url,
+        server.headers,
+        STDIO_BRIDGE_MARKER_HEADER,
+        STDIO_BRIDGE_PROBE_HEADER,
       );
     } catch (err) {
       this.log.debug("MCP server reachability probe failed", {

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.ts
@@ -79,6 +79,10 @@ import { WORKSPACE_REPOSITORY } from "../../db/identifiers";
 import type { IWorkspaceRepository } from "../../db/repositories/workspace-repository";
 import type { AgentPluginsService } from "../agent-plugins/agent-plugins";
 import { AGENT_PLUGINS_SERVICE } from "../agent-plugins/identifiers";
+import {
+  STDIO_BRIDGE_MARKER_HEADER,
+  STDIO_BRIDGE_PROBE_HEADER,
+} from "../agent-plugins/stdio-bridge";
 import { POSTHOG_PLUGIN_SERVICE } from "../posthog-plugin/identifiers";
 import type { PosthogPluginService } from "../posthog-plugin/posthog-plugin";
 import { PROCESS_TRACKING_SERVICE } from "../process-tracking/identifiers";
@@ -1395,6 +1399,13 @@ If a repository is required, call \`list_repos\` to find it, then use \`clone_re
       };
       for (const header of server.headers) {
         headers[header.name] = header.value;
+      }
+      if (
+        server.headers.some(
+          (header) => header.name.toLowerCase() === STDIO_BRIDGE_MARKER_HEADER,
+        )
+      ) {
+        headers[STDIO_BRIDGE_PROBE_HEADER] = "1";
       }
       const response = await fetch(server.url, {
         method: "POST",


### PR DESCRIPTION
## Problem

The [HTTP layer](https://github.com/PostHog/posthog/pull/80057) supports remote MCP servers, but Agent Plugins with local stdio servers still cannot run.

## Changes

- Loads valid stdio MCP definitions without invoking a shell.
- Starts servers through a managed loopback bridge with bounded requests and complete MCP initialization probes.
- Supplies a minimal environment plus isolated `PLUGIN_ROOT` and persistent `PLUGIN_DATA` directories.
- Requires explicit approval for executable definitions and blocks changed definitions until the user approves them again.
- Keeps approval digests and executable details out of renderer responses and the installation registry.
- Rejects case-insensitive environment collisions and validates directory ancestors before creating plugin-data paths.
- Keeps active HTTP servers connected when users approve unrelated stdio changes.
- Tracks child processes and closes them across failures, plugin changes, session cleanup, and shutdown.
- Escapes executable review tokens and confirms permanent plugin-data deletion before removal.
- Updates the Plugins tab and documentation with stdio support and security behavior.

![Agent Plugins stdio MCP settings](https://raw.githubusercontent.com/PostHog/pr-assets/ffee70a311dfc08cc7e7a4b918936e097633c1b2/2026/08/e21f3e17-c3b2-4182-84e7-f2b2aa5b0ee1.png)

## How did you test this code?

- Unit tests cover command and path validation, environment isolation, private approval state, mixed-server lifecycles, process cleanup, bridge races, and MCP probes.
- A local MCP fixture verifies initialization and tool discovery through the stdio bridge.
- Component tests cover approval tokens, confirmation, loading states, and redacted environment values.
- The workspace-server suite, full build, typecheck, lint, core import lint, and host-boundary check passed.
- Electron QA verified the complete Plugins settings surface.
- `hogli ci:preflight --fix` passed against current `master`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated `docs/AGENT-PLUGINS.md` with stdio configuration, approvals, environment isolation, plugin data, lifecycle behavior, and unsupported legacy SSE.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Pi worker and reviewer agents implemented and independently reviewed the complete stack. Agent-browser verified the final Electron surface.
- Skills invoked: `/posthog-desktop`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, and `quill-code`.
- PR workflow skills: `/stacking-prs`, `/writing-pr-descriptions`, `/running-ci-preflight`, and `test-electron-app`.
- Security review added durable execution approval, complete protocol probing, lifecycle race handling, and escaped configuration review.

