### PR TITLE
chore(skills): prefer dashboard subscriptions for recurring reports

### DIFF
--- a/products/posthog_ai/skills/managing-subscriptions/SKILL.md
+++ b/products/posthog_ai/skills/managing-subscriptions/SKILL.md
@@ -15,6 +15,7 @@ Use this skill when the user:
 - Wants to "track", "follow", "subscribe to", or "get updates" about an insight or dashboard
 - Asks for "daily updates", "weekly reports", or "send me this every morning"
 - Wants an **AI-written summary** attached to each delivery of an insight or dashboard (see step 6)
+- Asks to "post", "send", or "share" the key numbers from an existing dashboard or insight to a channel on a schedule — even when phrased as "set up a scout/bot to post this daily" (this is a dashboard/insight subscription, not a Signals scout)
 - Wants to know what subscriptions they have
 - Asks to stop, pause, or unsubscribe from something
 - Wants to change who receives an update or how often
@@ -28,6 +29,18 @@ Subscriptions and alerts serve different purposes:
 
 If the user says "notify me when this drops below 100", use alerts.
 If the user says "send me this every morning", use subscriptions.
+
+## The happy path: recurring numbers from a dashboard or insight
+
+When someone wants the **key numbers from an existing dashboard or insight** posted to a channel on a schedule — "post the top-line from this dashboard in #launch once a day", "send the team these metrics every morning", or even "set up a scout/bot to post this daily" — the right tool is a **dashboard (or insight) subscription with the AI summary enabled**:
+
+- Set `dashboard` (or `insight`), pick the tiles via `dashboard_export_insights`, deliver to Slack or email, and set `summary_enabled: true` so each delivery carries a short written summary alongside the snapshot.
+- This sends the **actual rendered tiles**, so the quoted numbers are exact — no LLM re-deriving them.
+
+Do **not** reach for a **prompt subscription** (`creating-ai-subscription`) or a **Signals scout** for this.
+A prompt subscription composes its own HogQL and can drift from the dashboard's numbers; use it only when the user specifically asks for a free-text AI report, or no existing insight/dashboard covers the ask.
+A scout is for open-ended watching that decides what's worth surfacing — not scheduled delivery of a fixed, user-specified metric set.
+If a scout request is really "deliver these dashboard numbers on a schedule", build the subscription instead.
 
 ## Workflow
 
@@ -100,7 +113,7 @@ For an insight subscription via email:
 }
 ```
 
-For a dashboard subscription (requires selecting which insights to include, max 6):
+For a dashboard subscription (requires selecting which insights to include, max 10):
 
 ```json
 {
@@ -189,4 +202,4 @@ When the user doesn't specify details:
 - **Duplicate check**: If a subscription already exists for the same insight/dashboard and channel, inform the user and offer to update it rather than creating a duplicate
 - **Slack not connected**: If a Slack subscription is requested but no Slack integration exists, explain that Slack must be connected in [Project settings > Integrations](/settings/integrations) first, then offer email as an alternative. Do not attempt to create the subscription — it will fail with a validation error
 - **Slack integration wrong team**: The Slack integration must belong to the same PostHog team. If `integrations-list` returns Slack integrations but creation still fails, the integration may be misconfigured
-- **Dashboard insights**: Dashboard subscriptions require at least 1 and at most 6 insights selected via `dashboard_export_insights`. If the user doesn't specify which insights, fetch the dashboard with `dashboard-get` and select the first 6 insights from its tiles
+- **Dashboard insights**: Dashboard subscriptions require at least 1 and at most 10 insights selected via `dashboard_export_insights`. If the user doesn't specify which insights, fetch the dashboard with `dashboard-get` and select up to the first 10 insights from its tiles

--- a/products/posthog_ai/skills/managing-subscriptions/SKILL.md
+++ b/products/posthog_ai/skills/managing-subscriptions/SKILL.md
@@ -15,7 +15,7 @@ Use this skill when the user:
 - Wants to "track", "follow", "subscribe to", or "get updates" about an insight or dashboard
 - Asks for "daily updates", "weekly reports", or "send me this every morning"
 - Wants an **AI-written summary** attached to each delivery of an insight or dashboard (see step 6)
-- Asks to "post", "send", or "share" the key numbers from an existing dashboard or insight to a channel on a schedule — even when phrased as "set up a scout/bot to post this daily" (this is a dashboard/insight subscription, not a Signals scout)
+- Asks to "post", "send", or "share" the key numbers from an existing dashboard or insight to a channel on a schedule — even when phrased as "set up a scout/bot to post this daily" (a recurring message like this is usually a better fit for a dashboard/insight subscription than a Signals scout; when it's unclear which they want, confirm before building — see the happy path below)
 - Wants to know what subscriptions they have
 - Asks to stop, pause, or unsubscribe from something
 - Wants to change who receives an update or how often
@@ -37,10 +37,10 @@ When someone wants the **key numbers from an existing dashboard or insight** pos
 - Set `dashboard` (or `insight`), pick the tiles via `dashboard_export_insights`, deliver to Slack or email, and set `summary_enabled: true` so each delivery carries a short written summary alongside the snapshot.
 - This sends the **actual rendered tiles**, so the quoted numbers are exact — no LLM re-deriving them.
 
-Do **not** reach for a **prompt subscription** (`creating-ai-subscription`) or a **Signals scout** for this.
-A prompt subscription composes its own HogQL and can drift from the dashboard's numbers; use it only when the user specifically asks for a free-text AI report, or no existing insight/dashboard covers the ask.
-A scout is for open-ended watching that decides what's worth surfacing — not scheduled delivery of a fixed, user-specified metric set.
-If a scout request is really "deliver these dashboard numbers on a schedule", build the subscription instead.
+Usually a better fit than a **prompt subscription** (`creating-ai-subscription`) or a **Signals scout**.
+A prompt subscription composes its own HogQL and can drift from the dashboard's numbers; a scout is for open-ended watching that decides what's worth surfacing, not scheduled delivery of a fixed, user-specified metric set.
+Don't override a user who's certain they want one of those — but when the ask is ambiguous (e.g. "set up a scout to post this daily"), suggest the subscription and confirm before building: _"A dashboard subscription is a better fit for a recurring message. Want me to set that up?"_
+Reach for a prompt subscription when the user specifically asks for a free-text AI report, or when no existing insight/dashboard covers the ask.
 
 ## Workflow
 

--- a/products/posthog_ai/skills/managing-subscriptions/SKILL.md
+++ b/products/posthog_ai/skills/managing-subscriptions/SKILL.md
@@ -32,10 +32,11 @@ If the user says "send me this every morning", use subscriptions.
 
 ## The happy path: recurring numbers from a dashboard or insight
 
-When someone wants the **key numbers from an existing dashboard or insight** posted to a channel on a schedule — "post the top-line from this dashboard in #launch once a day", "send the team these metrics every morning", or even "set up a scout/bot to post this daily" — the right tool is a **dashboard (or insight) subscription with the AI summary enabled**:
+When someone wants the **key numbers from an existing dashboard or insight** posted to a channel on a schedule — "post the top-line from this dashboard in #launch once a day", "send the team these metrics every morning", or even "set up a scout/bot to post this daily" — the right tool is a **dashboard (or insight) subscription**, and an AI summary is its natural companion:
 
-- Set `dashboard` (or `insight`), pick the tiles via `dashboard_export_insights`, deliver to Slack or email, and set `summary_enabled: true` so each delivery carries a short written summary alongside the snapshot.
-- This sends the **actual rendered tiles**, so the quoted numbers are exact — no LLM re-deriving them.
+- Set `dashboard` (or `insight`) and deliver to Slack or email. For a **dashboard** subscription, pick the tiles via `dashboard_export_insights` — that field is dashboard-only, and an insight subscription is rejected if you send it (an insight subscription needs no tile list).
+- **Offer the AI summary, don't assume it.** Per step 6, ask before enabling it, then set `summary_enabled: true` once the user agrees — it has AI-consent, quota, and budget gates that can reject the create, so keep it opt-in.
+- The attached **tile snapshots are exact**. The AI summary text is model-written, so treat any figure it quotes as approximate (the same drift caveat as a prompt subscription) and lean on the snapshot for exact numbers.
 
 Usually a better fit than a **prompt subscription** (`creating-ai-subscription`) or a **Signals scout**.
 A prompt subscription composes its own HogQL and can drift from the dashboard's numbers; a scout is for open-ended watching that decides what's worth surfacing, not scheduled delivery of a fixed, user-specified metric set.

--- a/products/signals/skills/authoring-scouts/SKILL.md
+++ b/products/signals/skills/authoring-scouts/SKILL.md
@@ -33,7 +33,9 @@ A scout is just an `LLMSkill` whose name starts with `signals-scout-`.
 The harness discovers scouts by globbing `signals-scout-*` over the project's skills, loads the body **verbatim** as the agent's system prompt, and progressively reads any bundled reference files on demand.
 **The `signals-scout-` name prefix is load-bearing: a skill named anything else will never run as a scout.**
 
-> **Not everything phrased as a scout is a scout.** If the ask is to deliver the key numbers from an **existing dashboard or insight** to a channel on a fixed schedule ("set up a scout to post the top-line from this dashboard in #launch once a day"), that is a **dashboard (or insight) subscription with the AI summary enabled**, not a scout — route to `managing-subscriptions`. Scouts are for open-ended watching that decides what's worth surfacing, not scheduled delivery of a fixed, user-specified metric set.
+> **Not everything phrased as a scout is a scout.**
+> If the ask is to deliver the key numbers from an **existing dashboard or insight** to a channel on a fixed schedule ("set up a scout to post the top-line from this dashboard in #launch once a day"), a **dashboard (or insight) subscription with the AI summary enabled** is usually the better fit — scouts are for open-ended watching that decides what's worth surfacing, not scheduled delivery of a fixed, user-specified metric set.
+> Respect a user who's certain they want a scout; when it's ambiguous, suggest the subscription and confirm first ("A dashboard subscription is a better fit for a recurring message — want me to set that up?"), and route to `managing-subscriptions`.
 
 ## The job before the writing
 

--- a/products/signals/skills/authoring-scouts/SKILL.md
+++ b/products/signals/skills/authoring-scouts/SKILL.md
@@ -33,6 +33,8 @@ A scout is just an `LLMSkill` whose name starts with `signals-scout-`.
 The harness discovers scouts by globbing `signals-scout-*` over the project's skills, loads the body **verbatim** as the agent's system prompt, and progressively reads any bundled reference files on demand.
 **The `signals-scout-` name prefix is load-bearing: a skill named anything else will never run as a scout.**
 
+> **Not everything phrased as a scout is a scout.** If the ask is to deliver the key numbers from an **existing dashboard or insight** to a channel on a fixed schedule ("set up a scout to post the top-line from this dashboard in #launch once a day"), that is a **dashboard (or insight) subscription with the AI summary enabled**, not a scout — route to `managing-subscriptions`. Scouts are for open-ended watching that decides what's worth surfacing, not scheduled delivery of a fixed, user-specified metric set.
+
 ## The job before the writing
 
 Don't write a scout in the abstract.

--- a/products/signals/skills/working-with-scouts/SKILL.md
+++ b/products/signals/skills/working-with-scouts/SKILL.md
@@ -31,7 +31,9 @@ Three sibling skills carry the mechanics — reach for them when a workflow belo
 | `exploring-scouts`  | Read-only observability: the fleet roster, run history, scratchpad memory, health assessment        |
 | `inbox-exploration` | The inbox itself: triaging, drilling into, acting on, and resolving / dismissing / snoozing reports |
 
-> **Before delegating: is this actually a scout job?** If the user wants the key numbers from an **existing dashboard or insight** posted to a channel on a fixed schedule ("have a scout post the top-line from this dashboard in #launch once a day"), that is a **dashboard (or insight) subscription with the AI summary enabled**, not a scout — route to `managing-subscriptions`. Scouts are for open-ended watching that decides what's worth surfacing, not scheduled delivery of a fixed, user-specified metric set.
+> **Before delegating: is this actually a scout job?**
+> If the user wants the key numbers from an **existing dashboard or insight** posted to a channel on a fixed schedule ("have a scout post the top-line from this dashboard in #launch once a day"), a **dashboard (or insight) subscription with the AI summary enabled** is usually the better fit — scouts are for open-ended watching that decides what's worth surfacing, not scheduled delivery of a fixed, user-specified metric set.
+> Respect a user who's certain they want a scout; when it's ambiguous, suggest the subscription and confirm first ("A dashboard subscription is a better fit for a recurring message — want me to set that up?"), and route to `managing-subscriptions`.
 
 ## First: is the fleet running?
 

--- a/products/signals/skills/working-with-scouts/SKILL.md
+++ b/products/signals/skills/working-with-scouts/SKILL.md
@@ -31,6 +31,8 @@ Three sibling skills carry the mechanics — reach for them when a workflow belo
 | `exploring-scouts`  | Read-only observability: the fleet roster, run history, scratchpad memory, health assessment        |
 | `inbox-exploration` | The inbox itself: triaging, drilling into, acting on, and resolving / dismissing / snoozing reports |
 
+> **Before delegating: is this actually a scout job?** If the user wants the key numbers from an **existing dashboard or insight** posted to a channel on a fixed schedule ("have a scout post the top-line from this dashboard in #launch once a day"), that is a **dashboard (or insight) subscription with the AI summary enabled**, not a scout — route to `managing-subscriptions`. Scouts are for open-ended watching that decides what's worth surfacing, not scheduled delivery of a fixed, user-specified metric set.
+
 ## First: is the fleet running?
 
 Don't delegate to a fleet that isn't there.

--- a/products/subscriptions/skills/creating-ai-subscription/SKILL.md
+++ b/products/subscriptions/skills/creating-ai-subscription/SKILL.md
@@ -37,9 +37,11 @@ not a fixed chart they already built. For an insight/dashboard subscription, set
 > **specifically asks** for a free-text / AI-written report, or (b) no existing insight
 > or dashboard covers the ask and the value really is the analysis itself. If the user
 > wants the key numbers from an **existing dashboard or insight** delivered on a
-> schedule — even phrased as "set up a scout/bot to post this daily" — that is a
-> **dashboard (or insight) subscription with `summary_enabled: true`**, not a prompt
-> subscription. See `managing-subscriptions` for that happy path.
+> schedule — even phrased as "set up a scout/bot to post this daily" — a
+> **dashboard (or insight) subscription with `summary_enabled: true`** is usually the
+> better fit. Respect a user who's sure they want a prompt subscription, but when it's
+> ambiguous, suggest that and confirm first. See `managing-subscriptions` for the happy
+> path.
 
 This skill covers **creating** the subscription. Once it exists you manage its
 lifecycle with the same `subscriptions-*` tools (see below): list it, edit/disable/

--- a/products/subscriptions/skills/creating-ai-subscription/SKILL.md
+++ b/products/subscriptions/skills/creating-ai-subscription/SKILL.md
@@ -31,6 +31,16 @@ value is the _analysis itself_ (the LLM deciding what to query and writing it up
 not a fixed chart they already built. For an insight/dashboard subscription, set
 `insight`/`dashboard` instead of `prompt` and the AI gates below don't apply.
 
+> **Prefer a dashboard or insight subscription first.** A prompt subscription is the
+> heaviest option, and the LLM composes its own HogQL, so its numbers can drift from
+> what a saved insight or dashboard already shows. Reach for it only when (a) the user
+> **specifically asks** for a free-text / AI-written report, or (b) no existing insight
+> or dashboard covers the ask and the value really is the analysis itself. If the user
+> wants the key numbers from an **existing dashboard or insight** delivered on a
+> schedule — even phrased as "set up a scout/bot to post this daily" — that is a
+> **dashboard (or insight) subscription with `summary_enabled: true`**, not a prompt
+> subscription. See `managing-subscriptions` for that happy path.
+
 This skill covers **creating** the subscription. Once it exists you manage its
 lifecycle with the same `subscriptions-*` tools (see below): list it, edit/disable/
 re-enable it, send a test delivery, or delete it.


### PR DESCRIPTION
## Problem

An agent asked to "set up a scout to post the key top-line numbers from this dashboard to a Slack channel once a day" should build a dashboard subscription with the AI summary enabled. The skills didn't point there: nothing routed a scout-phrased or "post these numbers daily" request to a dashboard subscription, and `creating-ai-subscription` presented a prompt subscription as a first-class default. Agents therefore reached for a heavier prompt subscription (whose LLM re-derives the numbers and can drift) or a Signals scout, when a dashboard subscription delivers the exact rendered tiles.

## Changes

Prose-only edits to four canonical skills:

- `managing-subscriptions`: new "happy path" section naming the AI-summary-enabled dashboard/insight subscription as the default for recurring dashboard reports, plus a matching trigger bullet.
- `creating-ai-subscription`: guard to prefer a dashboard/insight subscription first; use a prompt subscription only when explicitly requested or when no existing insight/dashboard covers the ask.
- `authoring-scouts` and `working-with-scouts`: redirect a request to deliver a fixed dashboard/insight's numbers on a schedule to a subscription, not a scout.
- `managing-subscriptions`: fix a stale cap — `dashboard_export_insights` allows up to 10 tiles, not 6.

## How did you test this code?

These are markdown skill instructions; no automated tests apply. I reviewed the rendered markdown for each file. I (the agent) did not run the repo test suite or `hogli ci:preflight`. The `max 6 → 10` correction is empirical: creating a dashboard subscription with 8 tiles succeeded against the current API.

## Automatic notifications
- [ ] Publish to changelog?

## Docs update
None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by a PostHog engineer via the PostHog Slack app. In a live session a recurring "post this dashboard's top-line to a channel daily" request was first built as a loop, then a prompt subscription, before landing on the correct tool — an AI-summary-enabled dashboard subscription. This PR encodes that happy path so agents route there directly.

- Tool: PostHog Slack app (Claude).
- Skills consulted: `creating-ai-subscription`, `managing-subscriptions`, `authoring-scouts`, `working-with-scouts`, `working-with-skills`. `/writing-pr-descriptions` and `/writing-skills` are not registered as invokable skills in this environment, so their conventions were followed from CLAUDE.md by hand.
- Public artifact: nothing here carries private session material — no customer names, metrics, or Slack quotes; the guidance is generic.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B7TE4R8GH/p1786139989724859?thread_ts=1786139989.724859&cid=C0B7TE4R8GH)*
