### PR TITLE
fix(azure-devops): surface the specific reason when credential validation fails

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/azure_devops/azure_devops.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/azure_devops/azure_devops.py
@@ -95,21 +95,51 @@ def _flatten_revision(item: dict[str, Any]) -> dict[str, Any]:
     return item
 
 
-def validate_credentials(organization: str, personal_access_token: str, api_version: str) -> bool:
-    """Confirm the PAT and organization are valid with a cheap projects probe.
+# Actionable reasons returned by the create-time credential probe. The sync-time equivalents live in
+# AzureDevOpsSource.get_non_retryable_errors, keyed on the raw HTTP error text raise_for_status emits.
+_INVALID_ORGANIZATION_MESSAGE = "That doesn't look like a valid Azure DevOps organization name. Enter just the organization name, for example myorg."
+_INVALID_PAT_MESSAGE = (
+    "Azure DevOps authentication failed. Please check your personal access token (it may have expired)."
+)
+_FORBIDDEN_MESSAGE = (
+    "Azure DevOps denied access. Please check that your personal access token has read scopes for this data."
+)
+_ORGANIZATION_NOT_FOUND_MESSAGE = "Azure DevOps organization not found. Please check the organization name."
+_UNREACHABLE_MESSAGE = "Couldn't reach Azure DevOps to validate your credentials. Please try again in a few minutes."
+_GENERIC_INVALID_MESSAGE = "Invalid Azure DevOps credentials"
+
+
+def validate_credentials(organization: str, personal_access_token: str, api_version: str) -> tuple[bool, str | None]:
+    """Confirm the PAT and organization are valid with a cheap projects probe, reporting an
+    actionable reason on failure rather than collapsing every cause into one generic message.
 
     Azure DevOps answers an invalid PAT with a 203 + HTML sign-in page rather
     than a 401, so only an exact 200 counts."""
     try:
         org = _validate_organization(organization)
+    except ValueError:
+        return False, _INVALID_ORGANIZATION_MESSAGE
+
+    try:
         wire_version = wire_api_version(api_version)
         response = _get_session(personal_access_token).get(
             f"{AZURE_DEVOPS_BASE_URL}/{quote(org)}/_apis/projects?{urlencode({'$top': 1, 'api-version': wire_version})}",
             timeout=10,
         )
-        return response.status_code == 200
     except Exception:
-        return False
+        return False, _UNREACHABLE_MESSAGE
+
+    status_code = response.status_code
+    if status_code == 200:
+        return True, None
+    # An invalid or expired PAT yields a 203 + HTML sign-in page rather than a 401.
+    if status_code in (203, 401):
+        return False, _INVALID_PAT_MESSAGE
+    if status_code == 403:
+        return False, _FORBIDDEN_MESSAGE
+    if status_code == 404:
+        return False, _ORGANIZATION_NOT_FOUND_MESSAGE
+    return False, _GENERIC_INVALID_MESSAGE
 
 
 def get_rows(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/azure_devops/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/azure_devops/source.py
@@ -126,12 +126,9 @@ Your organization is the first path segment of your Azure DevOps URL — for `de
         api_version: str | None = None,
     ) -> tuple[bool, str | None]:
         # Pre-creation calls pass no pin and resolve to default_version — the version new rows start on.
-        if validate_azure_devops_credentials(
+        return validate_azure_devops_credentials(
             config.organization, config.personal_access_token, self.resolve_api_version(api_version)
-        ):
-            return True, None
-
-        return False, "Invalid Azure DevOps credentials"
+        )
 
     def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[AzureDevOpsResumeConfig]:
         return ResumableSourceManager[AzureDevOpsResumeConfig](inputs, AzureDevOpsResumeConfig)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/azure_devops/tests/test_azure_devops.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/azure_devops/tests/test_azure_devops.py
@@ -5,7 +5,14 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 from unittest import mock
 
+import requests
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.azure_devops.azure_devops import (
+    _FORBIDDEN_MESSAGE,
+    _INVALID_ORGANIZATION_MESSAGE,
+    _INVALID_PAT_MESSAGE,
+    _ORGANIZATION_NOT_FOUND_MESSAGE,
+    _UNREACHABLE_MESSAGE,
     AZURE_DEVOPS_VERSION_7_2,
     AZURE_DEVOPS_VERSION_LEGACY,
     AzureDevOpsAuthError,
@@ -88,11 +95,12 @@ class TestValidateCredentials:
     @pytest.mark.parametrize(
         "status_code, expected",
         [
-            (200, True),
-            # An invalid PAT yields a 203 + HTML sign-in page, not a 401.
-            (203, False),
-            (401, False),
-            (404, False),
+            (200, (True, None)),
+            # An invalid or expired PAT yields a 203 + HTML sign-in page, not a 401.
+            (203, (False, _INVALID_PAT_MESSAGE)),
+            (401, (False, _INVALID_PAT_MESSAGE)),
+            (403, (False, _FORBIDDEN_MESSAGE)),
+            (404, (False, _ORGANIZATION_NOT_FOUND_MESSAGE)),
         ],
     )
     @mock.patch(
@@ -103,14 +111,29 @@ class TestValidateCredentials:
         response.status_code = status_code
         mock_session.return_value.get.return_value = response
 
-        assert validate_credentials("myorg", "pat", AZURE_DEVOPS_VERSION_7_2) is expected
+        assert validate_credentials("myorg", "pat", AZURE_DEVOPS_VERSION_7_2) == expected
 
     @mock.patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.azure_devops.azure_devops.make_tracked_session"
     )
     def test_validate_credentials_rejects_bad_org_without_request(self, mock_session):
-        assert validate_credentials("my org!", "pat", AZURE_DEVOPS_VERSION_7_2) is False
+        assert validate_credentials("my org!", "pat", AZURE_DEVOPS_VERSION_7_2) == (
+            False,
+            _INVALID_ORGANIZATION_MESSAGE,
+        )
         mock_session.return_value.get.assert_not_called()
+
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.azure_devops.azure_devops.make_tracked_session"
+    )
+    def test_validate_credentials_reports_unreachable_on_transport_error(self, mock_session):
+        mock_session.return_value.get.side_effect = requests.ConnectionError("boom")
+
+        is_valid, error = validate_credentials("myorg", "pat", AZURE_DEVOPS_VERSION_7_2)
+
+        assert is_valid is False
+        assert error == _UNREACHABLE_MESSAGE
+        assert "boom" not in (error or "")
 
     @pytest.mark.parametrize("version, wire", [(AZURE_DEVOPS_VERSION_LEGACY, "7.1"), (AZURE_DEVOPS_VERSION_7_2, "7.2")])
     @mock.patch(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/azure_devops/tests/test_azure_devops_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/azure_devops/tests/test_azure_devops_source.py
@@ -103,22 +103,24 @@ class TestAzureDevOpsSource:
         assert self.source.get_schemas(self.config, self.team_id, names=["nope"]) == []
 
     @pytest.mark.parametrize(
-        "mock_return, expected_valid, expected_message",
+        "probe_result",
         [
-            (True, True, None),
-            (False, False, "Invalid Azure DevOps credentials"),
+            (True, None),
+            (
+                False,
+                "Azure DevOps denied access. Please check that your personal access token has read scopes for this data.",
+            ),
         ],
     )
     @mock.patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.azure_devops.source.validate_azure_devops_credentials"
     )
-    def test_validate_credentials(self, mock_validate, mock_return, expected_valid, expected_message):
-        mock_validate.return_value = mock_return
+    def test_validate_credentials_passes_probe_result_through(self, mock_validate, probe_result):
+        mock_validate.return_value = probe_result
 
-        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
-
-        assert is_valid is expected_valid
-        assert error_message == expected_message
+        # The specific failure reason from the probe must reach the caller unchanged, not be
+        # collapsed into a single generic message.
+        assert self.source.validate_credentials(self.config, self.team_id) == probe_result
         # No pin at creation time resolves to default_version.
         mock_validate.assert_called_once_with("myorg", "pat", AZURE_DEVOPS_VERSION_7_2)
 


### PR DESCRIPTION
## Problem

- Someone connecting an Azure DevOps source saw the same "Invalid Azure DevOps credentials" toast whether their token was wrong, their token lacked read scopes, the organization name was wrong, or Azure was briefly unreachable. The message gave them nothing to act on.
- `validate_credentials` in `azure_devops.py` returned a bare `bool`, so the create/validate path threw away the real cause.
- The source already had granular, actionable messages in `get_non_retryable_errors`, but those only match raised exception text on the sync path, so they never reached a user during setup.

## Changes

- The probe now returns `(bool, reason)` and maps each outcome to an actionable message: bad or expired token, missing read scopes, organization not found, or a transient "couldn't reach Azure DevOps" retry hint.
- A malformed organization is rejected before any network call.
- A transport error surfaces the retry hint, not a credential error, so a valid token is not blamed for a network blip.
- The reasons reuse the wording already in `get_non_retryable_errors`, so the setup and sync paths read the same. `get_non_retryable_errors` is unchanged.
- The raw exception text is never surfaced.

## How did you test this code?

- Extended the probe unit tests to assert the status-to-message mapping (200/203/401/403/404), the malformed-organization short-circuit with no request made, and that a transport error returns the retry hint without leaking the raw error.
- The source-level test now asserts the probe's reason passes through unchanged rather than being collapsed into a generic string.
- Ran the `azure_devops` suites locally; `mypy` clean on the changed modules.
- Not run: the full database-backed API suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing docs describe these validation messages.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) made this change while triaging a batch of data-warehouse source-creation failures. Most source types already had clear, actionable messages and needed no change; Azure DevOps stood out because it discarded the specific cause on the exact path a user hits during setup.

Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`.

The message wording is reused from the existing `get_non_retryable_errors` map rather than invented, so setup and sync stay consistent and no new copy needed review.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
