### PR TITLE
fix(vercel): give an actionable message when the access token is rejected

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/tests/test_vercel_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/tests/test_vercel_source.py
@@ -108,7 +108,16 @@ class TestVercelSource:
         assert [s.name for s in schemas] == ["deployments"]
 
     @parameterized.expand(
-        [("valid", (True, None)), ("invalid", (False, "Invalid or unauthorized Vercel access token"))]
+        [
+            ("valid", (True, None)),
+            (
+                "invalid",
+                (
+                    False,
+                    "Your Vercel access token is invalid or has been revoked. Create a new token in your Vercel account settings, then reconnect.",
+                ),
+            ),
+        ]
     )
     def test_validate_credentials_delegates(self, _name: str, result: tuple) -> None:
         with mock.patch.object(vercel_source_module, "validate_vercel_credentials", lambda token: result):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/vercel.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/vercel.py
@@ -161,8 +161,16 @@ def validate_credentials(access_token: str) -> tuple[bool, str | None]:
 
     if response.status_code == 200:
         return True, None
-    if response.status_code in (401, 403):
-        return False, "Invalid or unauthorized Vercel access token"
+    if response.status_code == 401:
+        return (
+            False,
+            "Your Vercel access token is invalid or has been revoked. Create a new token in your Vercel account settings, then reconnect.",
+        )
+    if response.status_code == 403:
+        return (
+            False,
+            "Your Vercel access token is not authorized for this resource. Check the token's scope (and team access), then reconnect.",
+        )
     # 429 (rate limit) and 5xx are transient Vercel-side problems, not a bad token, so surface a
     # retry hint rather than telling the user to fix credentials they can't fix.
     if response.status_code == 429 or response.status_code >= 500:


### PR DESCRIPTION
## Problem

- Someone connecting a Vercel source with a bad or unscoped token saw "Invalid or unauthorized Vercel access token", which gave no next step and conflated an invalid token with an unauthorized one.
- Every other Vercel validation path (unreachable, unexpected status, sync-time 401/403) already returns an actionable message, so this was the odd one out.

## Changes

- The 401 branch tells the user their token is invalid or revoked and to create a new one, then reconnect.
- The 403 branch tells the user the token is not authorized for the resource and to check its scope and team access, then reconnect.
- Both messages reuse the wording already in `get_non_retryable_errors`, so the setup and sync paths read the same.
- Behavior is unchanged: the same statuses still fail validation.

## How did you test this code?

- Updated the `vercel` unit tests for the new 401 and 403 messages. The status-to-outcome mapping test still guards that both statuses fail validation.
- Ran the `vercel` suites locally; `mypy` clean on the changed module.
- Not run: the full database-backed API suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing docs describe this validation message.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) made this change while triaging a batch of data-warehouse source-creation failures. Most source types already had clear, actionable messages and needed no change; this Vercel branch was the exception.

Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
