### PR TITLE
fix(notion): retry responses with an empty or non-JSON body

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/notion/notion.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/notion/notion.py
@@ -205,7 +205,15 @@ def _request(
         logger.error(f"Notion API error: status={response.status_code}, body={response.text}, url={url}")
         response.raise_for_status()
 
-    return response.json()
+    try:
+        return response.json()
+    except requests.exceptions.JSONDecodeError as e:
+        # A 2xx with an empty or non-JSON body is a truncated/garbled response (a proxy hiccup, or the
+        # connection dropped after the status line) rather than real Notion output — every success
+        # path returns JSON. Treat it like the other transient response failures and retry.
+        raise NotionRetryableError(
+            f"Notion returned a non-JSON response: status={response.status_code}, url={url}"
+        ) from e
 
 
 def validate_credentials(token: str, api_version: str) -> tuple[bool, str | None]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/notion/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/notion/source.py
@@ -58,6 +58,10 @@ class NotionSource(ResumableSource[NotionSourceConfig, NotionResumeConfig]):
         return {
             "Notion API error (retryable)",
             "Notion rate limited",
+            # A 2xx whose body is empty or non-JSON is a truncated/garbled response, retried in-process
+            # by `_request`. If those retries exhaust, the condition is transient and self-recovering,
+            # so let Temporal retry the activity instead of surfacing it as tracked exception noise.
+            "Notion returned a non-JSON response",
             # `_request`'s tenacity retry also covers `requests.ConnectionError` (which
             # `requests.exceptions.SSLError` subclasses) and `requests.ReadTimeout`. urllib3
             # wraps both as "... Max retries exceeded with url: ..." regardless of the underlying

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/notion/tests/test_notion.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/notion/tests/test_notion.py
@@ -36,14 +36,23 @@ MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.notio
 
 
 class FakeResponse:
-    def __init__(self, json_data: Any, status_code: int = 200, headers: Optional[dict[str, str]] = None) -> None:
+    def __init__(
+        self,
+        json_data: Any,
+        status_code: int = 200,
+        headers: Optional[dict[str, str]] = None,
+        json_exc: Optional[Exception] = None,
+    ) -> None:
         self._json = json_data
+        self._json_exc = json_exc
         self.status_code = status_code
         self.headers = headers or {}
         self.ok = 200 <= status_code < 400
         self.text = ""
 
     def json(self) -> Any:
+        if self._json_exc is not None:
+            raise self._json_exc
         return self._json
 
     def raise_for_status(self) -> None:
@@ -308,6 +317,49 @@ class TestNotion:
 
         with mock.patch(f"{MODULE}._wait_strategy", return_value=0):
             result = _request(cast(requests.Session, session), "GET", "/v1/comments", mock.MagicMock(), params={})
+
+        assert result == {"results": []}
+        assert attempts["count"] == 2
+
+    def test_request_non_json_2xx_raises_retryable(self) -> None:
+        # A 2xx whose body is empty or non-JSON makes response.json() raise JSONDecodeError. That is a
+        # truncated/garbled response, not real Notion output, so it must surface as the retryable type
+        # carrying the stable phrase get_retryable_errors matches — not crash the sync.
+        session = FakeSession(
+            [
+                FakeResponse(
+                    None,
+                    status_code=200,
+                    json_exc=requests.exceptions.JSONDecodeError("Expecting value: line 1 column 1 (char 0)", "", 0),
+                )
+            ]
+        )
+        with pytest.raises(NotionRetryableError) as exc_info:
+            cast(Any, _request).__wrapped__(
+                cast(requests.Session, session), "GET", "/v1/users", mock.MagicMock(), params={}
+            )
+        assert "Notion returned a non-JSON response" in str(exc_info.value)
+
+    def test_request_retries_non_json_response(self) -> None:
+        # An empty/non-JSON 2xx body is transient like a broken connection: the retry must recover
+        # rather than propagate JSONDecodeError as a fatal sync error.
+        attempts = {"count": 0}
+
+        def request(*_args: Any, **_kwargs: Any) -> FakeResponse:
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                return FakeResponse(
+                    None,
+                    status_code=200,
+                    json_exc=requests.exceptions.JSONDecodeError("Expecting value: line 1 column 1 (char 0)", "", 0),
+                )
+            return FakeResponse({"results": []})
+
+        session = mock.MagicMock()
+        session.request.side_effect = request
+
+        with mock.patch(f"{MODULE}._wait_strategy", return_value=0):
+            result = _request(cast(requests.Session, session), "GET", "/v1/users", mock.MagicMock(), params={})
 
         assert result == {"results": []}
         assert attempts["count"] == 2

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/notion/tests/test_notion_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/notion/tests/test_notion_source.py
@@ -172,6 +172,10 @@ class TestNotionSource:
                 "/v1/search (Caused by ReadTimeoutError(\"HTTPSConnectionPool(host='api.notion.com', "
                 'port=443): Read timed out."))',
             ),
+            (
+                "non_json_response_after_tenacity_exhausted",
+                "Notion returned a non-JSON response: status=200, url=https://api.notion.com/v1/search",
+            ),
         ]
     )
     def test_retryable_marker_matches_raised_message(self, _name: str, error_message: str) -> None:


### PR DESCRIPTION
## Problem

- A Notion data-warehouse import fails the whole sync when Notion returns a 2xx response with an empty or non-JSON body.
- `_request` calls `response.json()` on any 2xx, so an empty body raises `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` and crashes the import.
- An empty body on a success status is a truncated or garbled response (a proxy hiccup, or a connection dropped after the status line), not real Notion output. Every real success path returns JSON.
- Error tracking issue: https://us.posthog.com/project/2/error_tracking/019fe0aa-e7ab-7603-9ed5-ce775ab26cc9

## Changes

- `_request` now catches `requests.exceptions.JSONDecodeError` and raises the existing `NotionRetryableError`, so tenacity retries the request instead of crashing.
- `get_retryable_errors` now matches this message, so if the in-process retries exhaust, Temporal retries the activity rather than surfacing tracked-exception noise.
- This mirrors the existing handling for `ChunkedEncodingError`, the other mid-response transient failure the source already retries.

## How did you test this code?

- Added `test_request_non_json_2xx_raises_retryable`: an empty-body 2xx maps to `NotionRetryableError` carrying the phrase `get_retryable_errors` matches. Guards the classification the retry set depends on.
- Added `test_request_retries_non_json_response`: an empty-body 2xx on the first attempt recovers on retry. Guards that the failure is retried, not propagated.
- Added a case to `test_retryable_marker_matches_raised_message` locking the raised message against the marker.
- Ran the two Notion test files locally and repo-wide mypy; both clean. Did not run the wider warehouse-sources suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior, API, or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triage of an error-tracking issue, done by an agent (Claude) via Claude Code. No human drove the work.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Decided this is a fixable fragility bug, not a user or upstream error: an empty body on a 2xx is transient, so it stays retryable rather than moving to `NonRetryableErrors`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
