### PR TITLE
fix(bigquery): treat missing selected fields as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
@@ -304,6 +304,16 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # selection or incremental field to match the table's current schema. Matched on
             # BigQuery's stable wording, not the volatile column name or [row:col] location.
             "Unrecognized name:": "BigQuery couldn't run a query for this source because it referenced a column that no longer exists on the table — usually the configured incremental field, or a column selected for syncing, was renamed or removed. Retrying won't help — please update the source's column selection or incremental field to match the table's current schema, then reconnect the source.",
+            # Raised from the Storage Read API's `create_read_session` (see `get_rows` in
+            # `bigquery.py`) when a column selected for syncing no longer exists on the live table —
+            # the direct-read counterpart of "Unrecognized name:" above, which covers the same drift
+            # on the query-job path (incremental / view / row-filtered reads). The google.api_core
+            # InvalidArgument stringifies as "request failed: The following selected fields do not
+            # exist in the table schema: <col1>, <col2>, ...". It's a deterministic mismatch between
+            # our stored config and the customer's live schema: the same read fails identically on
+            # every retry. The user must update the source's column selection to match the table's
+            # current schema. Matched on the stable wording, not the volatile list of column names.
+            "do not exist in the table schema": "BigQuery couldn't read this table because it referenced columns that no longer exist on it — usually columns selected for syncing were renamed or removed. Retrying won't help — please update the source's column selection to match the table's current schema, then reconnect the source.",
         }
 
     def validate_credentials(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -779,6 +779,24 @@ def test_bigquery_unrecognized_column_name_is_non_retryable(observed_error):
 
 
 @pytest.mark.parametrize(
+    "observed_error",
+    [
+        # A single enabled column renamed/dropped from the source table (direct-read path).
+        "request failed: The following selected fields do not exist in the table schema: FOO",
+        # Multiple columns — the match must not rely on the specific field names or their count.
+        "request failed: The following selected fields do not exist in the table schema: FOO, BAR, BAZ",
+    ],
+)
+def test_bigquery_missing_selected_fields_is_non_retryable(observed_error):
+    """A column selected for syncing via the Storage Read API's direct-read path that was renamed
+    or dropped from the live table makes every retry fail identically."""
+    non_retryable_errors = BigQuerySource().get_non_retryable_errors()
+    matching = [key for key in non_retryable_errors if key in observed_error]
+    assert matching, "Missing selected-fields error should be recognised as non-retryable"
+    assert all(non_retryable_errors[key] is not None for key in matching)
+
+
+@pytest.mark.parametrize(
     "transient_error",
     [
         # A token refresh that failed for a transient reason must stay retryable.


### PR DESCRIPTION
## Problem

A BigQuery data-warehouse sync retries forever, never recovers, and keeps spamming error tracking when a column selected for syncing was renamed or dropped from the live table after the source was configured.

- [Error tracking issue](https://us.posthog.com/project/2/error_tracking/019fe0d0-e9f3-7562-8ff9-d68c57ec0784): `InvalidArgument: request failed: The following selected fields do not exist in the table schema: ...`
- Raised from the Storage Read API's `create_read_session` call in `get_rows` (`bigquery.py`), on the direct-read path used when a sync has no incremental field, view, or row filters.

## Changes

- Add `"do not exist in the table schema"` to `BigQuerySource.get_non_retryable_errors`, so this stops retrying and surfaces an actionable message telling the user to update their column selection.
- This mirrors the existing `"Unrecognized name:"` entry, which already covers the same schema-drift condition on the query-job path (incremental / view / row-filtered reads) — this is the direct-read counterpart for the same class of problem.
- It's a deterministic mismatch between our stored config and the customer's live schema, not a transient failure, so retrying can never recover it.

## How did you test this code?

- Added `test_bigquery_missing_selected_fields_is_non_retryable`, parametrized over one and multiple missing columns, following the existing pattern for `"Unrecognized name:"`. Catches a regression where this wording stops being classified non-retryable and the sync goes back to retrying an unrecoverable error forever.
- Ran the full `bigquery/tests/test_source.py` suite locally (172 passed) and `ruff check`/`ruff format --check` on the changed files.
- Not run: an end-to-end sync against a real BigQuery project (no live credentials in this environment).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged directly from a webhook-delivered PostHog error tracking issue. Read the issue's full stack trace and a sample event via the PostHog MCP error-tracking tools, then read `bigquery.py`'s `get_rows` and the existing `get_non_retryable_errors` map in `source.py` to confirm this is the same class of problem as the already-handled `"Unrecognized name:"` query-job case, just on the direct Storage Read API path. No other skills were invoked beyond `/writing-tests` and `/writing-pr-descriptions` per repo convention.