### PR TITLE
fix(data-imports): stop reporting transient object-store blips from the statistics activity

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/compute_table_statistics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/compute_table_statistics.py
@@ -30,6 +30,7 @@ from posthog.exceptions_capture import capture_exception
 from posthog.models import Team
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.base import PostHogWorkflow
+from posthog.temporal.common.errors import NonReportableError
 from posthog.temporal.common.heartbeat import LivenessHeartbeater as Heartbeater
 
 from products.warehouse_sources.backend.models.column_statistics import WarehouseColumnStatistics
@@ -281,7 +282,11 @@ async def compute_table_statistics_activity(inputs: ComputeTableStatisticsInputs
                 inputs.team_id, inputs.schema_id
             )
         except Exception as e:
-            capture_exception(e)
+            # get_delta_table already re-raises known-transient object-store blips as
+            # NonReportableError (see DeltaTableRef._capture_unless_transient) and intentionally
+            # skips reporting them itself — don't undo that here.
+            if not isinstance(e, NonReportableError):
+                capture_exception(e)
             try:
                 posthoganalytics.capture(
                     distinct_id=f"team-{inputs.team_id}",

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_compute_table_statistics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_compute_table_statistics.py
@@ -21,6 +21,9 @@ from products.warehouse_sources.backend.models.external_data_job import External
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 from products.warehouse_sources.backend.models.table import DataWarehouseTable
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.errors import (
+    TransientObjectStoreError,
+)
 from products.warehouse_sources.backend.temporal.data_imports.workflow_activities import (
     compute_table_statistics as comp,
 )
@@ -307,10 +310,30 @@ class TestComputeTableStatisticsActivity:
         mock_sync.assert_called_once()
 
     async def test_activity_reraises_on_failure(self) -> None:
-        with patch.object(comp, "compute_table_statistics_sync", side_effect=ValueError("boom")):
+        with (
+            patch.object(comp, "compute_table_statistics_sync", side_effect=ValueError("boom")),
+            patch.object(comp, "capture_exception") as mock_capture,
+        ):
             inputs = ComputeTableStatisticsInputs(team_id=1, schema_id=uuid.uuid4())
             with pytest.raises(ValueError, match="boom"):
                 await ActivityEnvironment().run(compute_table_statistics_activity, inputs)
+        mock_capture.assert_called_once()
+
+    async def test_activity_does_not_report_transient_object_store_error(self) -> None:
+        # get_delta_table re-raises known-transient object-store blips (S3 connect timeouts, IMDS/STS
+        # credential hiccups) as TransientObjectStoreError specifically so they don't mint a fresh
+        # error-tracking issue per blip. The activity's own except block must respect that contract
+        # instead of unconditionally calling capture_exception on every exception.
+        with (
+            patch.object(
+                comp, "compute_table_statistics_sync", side_effect=TransientObjectStoreError("connect timeout")
+            ),
+            patch.object(comp, "capture_exception") as mock_capture,
+        ):
+            inputs = ComputeTableStatisticsInputs(team_id=1, schema_id=uuid.uuid4())
+            with pytest.raises(TransientObjectStoreError):
+                await ActivityEnvironment().run(compute_table_statistics_activity, inputs)
+        mock_capture.assert_not_called()
 
 
 class TestComputeTableStatisticsWorkflow:


### PR DESCRIPTION
## Problem

The column-statistics activity mints a fresh error-tracking issue for every transient S3 blip it hits, even though that class of error is already designed to stay out of tracking.

[Error tracking issue](https://us.posthog.com/project/2/error_tracking/019fe0c3-849e-7360-8d92-cb0bc7fd7528): a single occurrence, `TransientObjectStoreError` from an S3 connect timeout while opening the Delta table for statistics.

## Changes

- `get_delta_table` already re-raises known-transient object-store errors (S3 connect timeouts, IMDS/STS credential hiccups) as `TransientObjectStoreError`, a `NonReportableError` subclass, specifically so a retry-and-recover blip doesn't mint an issue per occurrence.
- `compute_table_statistics_activity`'s own `except` block called `capture_exception` on every exception, unconditionally, so it undid that suppression at this call site.
- Guard the call with `isinstance(e, NonReportableError)`, the same pattern `idempotency.py` already uses for this exact contract.
- Retries are unaffected: `NonReportableError` only controls error-tracking reporting, and the activity still re-raises.

## How did you test this code?

- Added `test_activity_does_not_report_transient_object_store_error`, asserting `capture_exception` is not called when the sync activity raises `TransientObjectStoreError`, and that it still re-raises for retry.
- Extended `test_activity_reraises_on_failure` to assert `capture_exception` **is** called for a genuine (non-transient) failure, so the guard doesn't over-suppress.
- Ran the full `test_compute_table_statistics.py` suite (25 tests) and a repo-wide `mypy --cache-fine-grained .`; both clean.
- Confirmed no open human-authored PR already fixes this — searched by exception type, module path, and the maintainer's own open PRs. [#79796](https://github.com/PostHog/posthog/pull/79796) is close by title but fixes a different bug (a delta-log checkpoint race), not this activity's reporting guard.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal error-classification fix, no user-facing or documented behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error-tracking MCP tools (issue details, sampled event with stack trace) to find the exact failing frame, then read the shared Delta pipeline code (`table.py`, `errors.py`) and an existing precedent (`idempotency.py`) for the `NonReportableError` guard pattern. `/writing-tests` and `/writing-pr-descriptions` were invoked before adding tests and writing this description, per this repo's CLAUDE.md.