### PR TITLE
fix(desktop): fix download link query for latest desktop version

### DIFF
--- a/products/desktop/README.md
+++ b/products/desktop/README.md
@@ -1,7 +1,7 @@
 > [!IMPORTANT]
 > Interested in the PostHog desktop app? [Join the waitlist](https://posthog.com/code) or hop into our [Discord](https://discord.gg/aSrHKVNVdR).
 
-**[Download the latest version](https://github.com/PostHog/posthog/releases?q=desktop-v)**
+**[Download the latest version](https://github.com/PostHog/posthog/releases?q=desktop-)**
 
 Found a bug or want to share feedback? [Open an issue](https://github.com/PostHog/posthog/issues/new) on GitHub.
 


### PR DESCRIPTION
## Problem

The "Download latest" link goes to the release page filtered for `desktop-v`, but surprisingly that does not return the desired releases.

## Changes

Link with only `desktop-`, which does return the correct releases: https://github.com/PostHog/posthog/releases?q=desktop-&expanded=true

## How did you test this code?

- Opened the linked URL manually, observed it showing the correct releases.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No.