### PR TITLE
feat(warehouse_sources): support Loop Returns API version 2026-07

### DIFF
--- a/products/warehouse_sources/backend/migrations/0130_repin_loop_returns_api_version.py
+++ b/products/warehouse_sources/backend/migrations/0130_repin_loop_returns_api_version.py
@@ -1,0 +1,36 @@
+from django.db import migrations
+
+# Loop is phasing out the `v1` alias, which resolves to the `2026-07` GA release. The source now
+# defaults new instances to `2026-07`; this repins existing source-level pins from the alias to
+# the explicit date version so they stop tracking the alias. `v1` and `2026-07` serve identical
+# responses (the alias resolves to that exact release), so the repin is behavior-preserving.
+LOOP_RETURNS_SOURCE_TYPE = "LoopReturns"
+OLD_VERSION = "v1"
+NEW_VERSION = "2026-07"
+
+
+def repin_loop_returns_v1_to_2026_07(apps, schema_editor):
+    ExternalDataSource = apps.get_model("warehouse_sources", "ExternalDataSource")
+
+    # Only the source-level pin is touched. Schema-level `ExternalDataSchema.api_version`
+    # overrides are user-managed (a customer intentionally pinned that schema) and are left
+    # alone — the schema-level deprecation warning prompts the user to migrate those.
+    #
+    # NULL pins already resolve to the source's `default_version` (now `2026-07`), so they need
+    # no update. Matching only `api_version="v1"` keeps this idempotent: a second run matches
+    # nothing.
+    ExternalDataSource.objects.filter(source_type=LOOP_RETURNS_SOURCE_TYPE, api_version=OLD_VERSION).update(
+        api_version=NEW_VERSION
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("warehouse_sources", "0129_pin_openweather_v2_5"),
+    ]
+
+    operations = [
+        # Reverse is a no-op: nulling or downgrading pins would move customers back onto the
+        # deprecated alias and clobber any deliberate post-migration pins.
+        migrations.RunPython(repin_loop_returns_v1_to_2026_07, migrations.RunPython.noop, elidable=False),
+    ]

--- a/products/warehouse_sources/backend/migrations/max_migration.txt
+++ b/products/warehouse_sources/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0129_pin_openweather_v2_5
+0130_repin_loop_returns_api_version

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/loop_returns/loop_returns.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/loop_returns/loop_returns.py
@@ -34,6 +34,12 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.loop_retur
 
 logger = logging.getLogger(__name__)
 
+# Loop versions its API by date in the URL path (`/api/2026-07/...`). `v1` is a legacy
+# convenience alias for the `2026-07` GA release, kept for backward compatibility and being
+# phased out; new integrations pin the explicit date version.
+API_VERSION_V1 = "v1"
+API_VERSION_2026_07 = "2026-07"
+
 API_HOST = "https://api.loopreturns.com"
 AUTH_HEADER = "X-Authorization"
 PROBE_TIMEOUT_SECONDS = 30

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/loop_returns/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/loop_returns/source.py
@@ -9,7 +9,11 @@ from posthog.schema import (
     SourceFieldInputConfigType,
 )
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import (
+    FieldType,
+    ResumableSource,
+    VersionDeprecation,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
     CanonicalDescriptions,
 )
@@ -24,6 +28,8 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.generated_
     LoopReturnsSourceConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.loop_returns.loop_returns import (
+    API_VERSION_2026_07,
+    API_VERSION_V1,
     LoopReturnsResumeConfig,
     endpoint_permissions,
     loop_returns_source,
@@ -41,11 +47,12 @@ from products.warehouse_sources.backend.types import ExternalDataSourceType
 class LoopReturnsSource(ResumableSource[LoopReturnsSourceConfig, LoopReturnsResumeConfig]):
     lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
 
-    # Loop versions its API by date (`2026-07`) and documents `v1` as an alias of that release,
-    # kept for backward compatibility. The returns OpenAPI spec and the warehouse endpoint pages
-    # all serve from `/api/v1`, so that is the path this source calls and the version it pins.
-    supported_versions = ("v1",)
-    default_version = "v1"
+    # Loop versions its API by date in the URL path (`/api/2026-07/...`). `v1` is a legacy alias
+    # for the `2026-07` GA release that Loop is phasing out, so new sources pin the explicit date
+    # version and `v1` is marked deprecated. No calendar sunset date is published for the alias.
+    supported_versions = (API_VERSION_V1, API_VERSION_2026_07)
+    default_version = API_VERSION_2026_07
+    deprecated_versions = (VersionDeprecation(version=API_VERSION_V1, sunset_at=None),)
     api_docs_url = "https://docs.loopreturns.com/api-reference/versioning"
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/loop_returns/tests/test_loop_returns.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/loop_returns/tests/test_loop_returns.py
@@ -396,6 +396,38 @@ class TestLoopReturnsSource:
 
         assert [row["id"] for row in rows] == expected_ids * states
 
+    @pytest.mark.parametrize("api_version", ["v1", "2026-07"])
+    def test_the_pinned_version_is_the_url_path_segment(self, api_version: str) -> None:
+        # Loop carries the version in the URL path, so the resolved pin must land in every request:
+        # a v1-pinned source keeps hitting `/api/v1` and a 2026-07 source hits `/api/2026-07`.
+        sent_urls: list[str] = []
+
+        def fake_send(request: Any, *_args: Any, **_kwargs: Any) -> Response:
+            sent_urls.append(request.url)
+            return _http_response({"destinations": []})
+
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+        ) as MockSession:
+            mock_session = MockSession.return_value
+            mock_session.headers = {}
+            mock_session.prepare_request.side_effect = lambda req: req
+            mock_session.send.side_effect = fake_send
+
+            source_response = loop_returns_source(
+                api_key=API_KEY,
+                endpoint="destinations",
+                team_id=1,
+                job_id="job-1",
+                api_version=api_version,
+                resumable_source_manager=FakeResumableSourceManager(),
+                now=WINDOW_START,
+            )
+            list(cast(Iterable[Any], source_response.items()))
+
+        assert sent_urls
+        assert all(url.startswith(f"https://api.loopreturns.com/api/{api_version}/") for url in sent_urls)
+
     def test_a_returns_sync_covers_every_state(self) -> None:
         sent_params, _, _ = self._drive(
             "returns",
@@ -550,6 +582,17 @@ class TestCredentialValidation:
 
         assert (is_valid, error) == (True, None)
         assert session.get.call_args.args[0] == "https://api.loopreturns.com/api/v1/destinations"
+
+    @pytest.mark.parametrize("api_version", ["v1", "2026-07"])
+    def test_probe_uses_the_pinned_version_in_the_url(self, api_version: str) -> None:
+        session = self._session([_http_response({"returns": [], "nextPageUrl": None})])
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.loop_returns.loop_returns.make_tracked_session",
+            return_value=session,
+        ):
+            probe_endpoint(API_KEY, api_version, "returns")
+
+        assert session.get.call_args.args[0] == f"https://api.loopreturns.com/api/{api_version}/warehouse/return/list"
 
     def test_a_network_failure_is_reported_not_raised(self) -> None:
         session = MagicMock()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/loop_returns/tests/test_loop_returns_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/loop_returns/tests/test_loop_returns_source.py
@@ -119,12 +119,36 @@ class TestLoopReturnsSource:
             for key in self.source.get_non_retryable_errors()
         )
 
+    @pytest.mark.parametrize(
+        ("pinned", "expected_version"),
+        [
+            # No pin resolves to the default (the current GA date version), a `v1` pin is honored
+            # verbatim so a customer still on the alias keeps hitting `/api/v1`, and an explicit
+            # `2026-07` pin passes straight through. A broken dispatch would move a pinned source.
+            (None, "2026-07"),
+            ("v1", "v1"),
+            ("2026-07", "2026-07"),
+        ],
+    )
     @mock.patch(VALIDATE_PATH)
-    def test_validate_credentials_passes_the_schema_through(self, mock_validate: mock.MagicMock) -> None:
+    def test_validate_credentials_threads_the_resolved_version(
+        self, mock_validate: mock.MagicMock, pinned: Optional[str], expected_version: str
+    ) -> None:
         mock_validate.return_value = (True, None)
 
-        assert self.source.validate_credentials(self.config, self.team_id, schema_name="destinations") == (True, None)
-        mock_validate.assert_called_once_with("loop_test_key", "v1", schema_name="destinations")
+        assert self.source.validate_credentials(
+            self.config, self.team_id, schema_name="destinations", api_version=pinned
+        ) == (True, None)
+        mock_validate.assert_called_once_with("loop_test_key", expected_version, schema_name="destinations")
+
+    def test_v1_is_deprecated_without_a_sunset_date(self) -> None:
+        # Loop publishes no calendar sunset for the alias, so the pin stays fully supported; the
+        # metadata only lights up the generic in-product deprecation warning.
+        deprecation = self.source.get_version_deprecation("v1")
+
+        assert deprecation is not None
+        assert deprecation.sunset_at is None
+        assert self.source.get_version_deprecation("2026-07") is None
 
     @pytest.mark.parametrize("start_date", ["not-a-date", "2024-13-01", "1000-01-01"])
     @mock.patch(VALIDATE_PATH)


### PR DESCRIPTION
## Problem

- Customers syncing Loop Returns pin the `v1` API version, which Loop is phasing out as a legacy alias.
- Loop now versions its API by date in the URL path (`/api/2026-07/...`). `v1` is a convenience alias that resolves to the `2026-07` GA release and will be removed once `2026-07` sunsets.
- The source only supported `v1`, so new sources kept adopting the alias and existing pins had no supported version to move to.

## Changes

- Added `2026-07` to the source's supported versions and made it the default, so new sources pin the explicit date version.
- Marked `v1` deprecated in the source's version metadata. Loop publishes no calendar sunset date, so `sunset_at` is `None` and the pin stays fully supported; this only lights up the generic in-product deprecation warning.
- Left the request path unchanged: the version is a URL path segment, so the already-resolved pin flows into every request. A `v1`-pinned source keeps hitting `/api/v1`; a `2026-07` source hits `/api/2026-07`.
- Added a written-not-run data migration repinning source-level `ExternalDataSource.api_version` from `v1` to `2026-07`. It matches only `api_version="v1"` (idempotent), leaves `NULL` pins to resolve to the new default, and its reverse is a no-op.

> [!NOTE]
> The migration is behavior-preserving because `v1` and `2026-07` serve identical responses (the alias resolves to that exact release). It touches only the source-level pin. Schema-level `ExternalDataSchema.api_version` overrides are user-managed and untouched; the schema-level deprecation warning prompts users to migrate those. A human reviews and runs the migration.

## How did you test this code?

- I (Claude) added and ran source tests: the resolved pin reaches the request URL path for both `v1` and `2026-07` (sync and credential-probe paths), the default resolves to `2026-07` when no pin is set, and `v1` reports as deprecated with no sunset date.
- Ran the loop_returns test suite and the registry version-invariant suite (`test_source_versions.py`) locally; both pass.
- Not run: DB-backed migration application — the sandbox has no database. The migration is written, not run, for human review; I verified the migration graph is linear and the module parses.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored by Claude (PostHog Code). Skills invoked: `/warehouse-source-new-version`, `/django-migrations`, `/writing-tests`, `/writing-pr-descriptions`.
- Decision: no per-version code branch was added. Because `v1` is a pure alias for `2026-07` (identical wire, version carried only as a URL path segment), the existing threading of the resolved pin already dispatches correctly; adding branches would be inert scaffolding.
- Decision: a repin migration was written even though the deprecation has no sunset date, because the alias-to-release repin is lossless and behavior-preserving. It is written-not-run for a human to review and execute.
- No customer data, secrets, or internal material is included; version facts come from Loop's public API docs.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
