### PR TITLE
feat(warehouse_sources): support Braintree API version 2026-08-04

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/braintree.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/braintree.py
@@ -22,6 +22,7 @@ BRAINTREE_HOSTS = {
 # GraphQL API version (date-versioned header, required). Opaque vendor labels — never parsed.
 BRAINTREE_VERSION_2019_01_01 = "2019-01-01"
 BRAINTREE_VERSION_2026_07_14 = "2026-07-14"
+BRAINTREE_VERSION_2026_08_04 = "2026-08-04"
 # Braintree's GraphQL search fields reject `first` above 50, so this is a vendor
 # ceiling rather than a tuning knob.
 MAX_PAGE_SIZE = 50

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/source.py
@@ -14,6 +14,7 @@ from posthog.schema import (
 from products.warehouse_sources.backend.temporal.data_imports.sources.braintree.braintree import (
     BRAINTREE_VERSION_2019_01_01,
     BRAINTREE_VERSION_2026_07_14,
+    BRAINTREE_VERSION_2026_08_04,
     BraintreeResumeConfig,
     braintree_source,
     validate_credentials as validate_braintree_credentials,
@@ -42,8 +43,8 @@ from products.warehouse_sources.backend.types import ExternalDataSourceType
 @SourceRegistry.register
 class BraintreeSource(ResumableSource[BraintreeSourceConfig, BraintreeResumeConfig]):
     lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
-    supported_versions = (BRAINTREE_VERSION_2019_01_01, BRAINTREE_VERSION_2026_07_14)
-    default_version = BRAINTREE_VERSION_2026_07_14
+    supported_versions = (BRAINTREE_VERSION_2019_01_01, BRAINTREE_VERSION_2026_07_14, BRAINTREE_VERSION_2026_08_04)
+    default_version = BRAINTREE_VERSION_2026_08_04
     api_docs_url = "https://graphql.braintreepayments.com/"
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/tests/test_braintree.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/tests/test_braintree.py
@@ -7,6 +7,7 @@ from unittest import mock
 from products.warehouse_sources.backend.temporal.data_imports.sources.braintree.braintree import (
     BRAINTREE_VERSION_2019_01_01,
     BRAINTREE_VERSION_2026_07_14,
+    BRAINTREE_VERSION_2026_08_04,
     MAX_PAGE_SIZE,
     BraintreeGraphQLError,
     BraintreeResumeConfig,
@@ -194,7 +195,10 @@ class TestGetRows:
         with pytest.raises(BraintreeGraphQLError):
             list(get_rows("production", "pub", "priv", "transactions", _VERSION, mock.MagicMock(), manager))
 
-    @pytest.mark.parametrize("api_version", [BRAINTREE_VERSION_2019_01_01, BRAINTREE_VERSION_2026_07_14])
+    @pytest.mark.parametrize(
+        "api_version",
+        [BRAINTREE_VERSION_2019_01_01, BRAINTREE_VERSION_2026_07_14, BRAINTREE_VERSION_2026_08_04],
+    )
     @mock.patch(f"{_MODULE}.make_tracked_session")
     def test_session_uses_basic_auth_and_version_header(self, mock_session, api_version):
         mock_session.return_value.post.return_value = _search_response("transactions", [])

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/tests/test_braintree_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/tests/test_braintree_source.py
@@ -6,6 +6,7 @@ from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInp
 from products.warehouse_sources.backend.temporal.data_imports.sources.braintree.braintree import (
     BRAINTREE_VERSION_2019_01_01,
     BRAINTREE_VERSION_2026_07_14,
+    BRAINTREE_VERSION_2026_08_04,
     BraintreeResumeConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.braintree.settings import (
@@ -117,7 +118,7 @@ class TestBraintreeSource:
 
         assert is_valid is expected_valid
         assert error_message == expected_message
-        mock_validate.assert_called_once_with("production", "pub", "priv", "2026-07-14")
+        mock_validate.assert_called_once_with("production", "pub", "priv", "2026-08-04")
 
     def test_get_resumable_source_manager_binds_resume_config(self):
         inputs = mock.MagicMock()
@@ -158,9 +159,9 @@ class TestBraintreeSource:
         assert mock_bt_source.call_args.kwargs["db_incremental_field_last_value"] is None
 
     def test_supported_versions_and_default(self):
-        assert self.source.supported_versions == ("2019-01-01", "2026-07-14")
+        assert self.source.supported_versions == ("2019-01-01", "2026-07-14", "2026-08-04")
         # New sources start on the latest version; the default must stay in supported.
-        assert self.source.default_version == "2026-07-14"
+        assert self.source.default_version == "2026-08-04"
         assert self.source.default_version in self.source.supported_versions
 
     @pytest.mark.parametrize(
@@ -168,8 +169,9 @@ class TestBraintreeSource:
         [
             ("2019-01-01", "2019-01-01"),
             ("2026-07-14", "2026-07-14"),
-            (None, "2026-07-14"),
-            ("", "2026-07-14"),
+            ("2026-08-04", "2026-08-04"),
+            (None, "2026-08-04"),
+            ("", "2026-08-04"),
         ],
     )
     def test_resolve_api_version(self, pinned, expected):
@@ -180,7 +182,8 @@ class TestBraintreeSource:
         [
             ("2019-01-01", "2019-01-01"),
             ("2026-07-14", "2026-07-14"),
-            (None, "2026-07-14"),
+            ("2026-08-04", "2026-08-04"),
+            (None, "2026-08-04"),
         ],
     )
     @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.braintree.source.braintree_source")
@@ -202,6 +205,7 @@ class TestValidateCredentialsResolvedPin:
             # The no-pin (None -> default) case is already covered by test_validate_credentials.
             (BRAINTREE_VERSION_2019_01_01, BRAINTREE_VERSION_2019_01_01),
             (BRAINTREE_VERSION_2026_07_14, BRAINTREE_VERSION_2026_07_14),
+            (BRAINTREE_VERSION_2026_08_04, BRAINTREE_VERSION_2026_08_04),
         ],
     )
     @mock.patch(


### PR DESCRIPTION
## Problem

- A team connecting Braintree today lands on the `2026-07-14` API version. Braintree has since published `2026-08-04`, and new sources should start on the current version.
- Braintree's GraphQL API pins a version through the `Braintree-Version` request header, so supporting a version means the source can send that exact label.

## Changes

- Add `2026-08-04` to the source's `supported_versions` and make it the `default_version`, so new sources are created on it.
- Keep `2019-01-01` and `2026-07-14` fully working. Their request path is unchanged.
- No per-version branching. The `2026-08-04` changelog only adds fields to merchant-account objects; the transactions, refunds, and disputes streams this source reads are unchanged, so the version flows through as the header value only.
- Existing sources keep their pin and are unaffected. A source with no pin resolves to the new default, which is request-identical for these streams.

## How did you test this code?

- Extended the existing parameterized version tests to cover `2026-08-04` alongside the current versions: version resolution, the new default, the resolved pin reaching the pipeline, the credential probe, and the `Braintree-Version` header on the request session.
- Catches a regression where a supported version stops resolving, or the default flip fails to reach the request layer.
- Ran the braintree source tests and the registry-invariant suite (`test_source_versions.py`) locally; all passed.
- Not run: database-backed and live-sync suites. There is no Braintree sandbox in this environment, so verification is docs-only against the vendor changelog.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) made this change. I invoked the `/warehouse-source-new-version` skill for the version-declaration and dispatch conventions, `/writing-tests` before touching the tests, and `/writing-pr-descriptions` for this body.

I diffed the vendor changelog between `2026-07-14` and `2026-08-04` per the skill's gate: the only additions are `MerchantAccountCapabilities`, a `MerchantAccountType` enum, new `CreditCardBrandCode` values, and `accountType`/`capabilities` on `MerchantAccount`. None touch the transactions, refunds, or disputes search fields, so the change stays declaration-only plus the header thread that already existed. I confirmed no human-authored open PR already adds this version.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
