### PR TITLE
fix(sentry): stop burning jobs on a rejected stats-summary request

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/sentry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/sentry.py
@@ -580,6 +580,22 @@ _MISSING_PROJECT_RESOURCE_STATUSES = (403, 404)
 # project membership in the org, even though the token itself is otherwise valid.
 _NO_PROJECTS_AVAILABLE_DETAIL = "No projects available"
 
+# Any other 400 from the stats-summary endpoint is a deterministic rejection of the request we
+# build (most often the requested window falling outside the org's plan retention), so retrying
+# replays it identically. Surface a credential-safe message the source classifies as non-retryable
+# (see `SentrySource.get_non_retryable_errors`) instead of burning retries on the raw HTTPError,
+# whose URL embeds the org slug. The wording never interpolates the org, URL, or response body.
+STATS_SUMMARY_REJECTED_MESSAGE = (
+    "Sentry rejected PostHog's request for your per-project usage stats (the "
+    "organization_stats_summary table) with an HTTP 400. This usually means the requested date "
+    "range is outside your Sentry plan's data retention. Remove that table from this source's "
+    "selected tables, then re-enable the sync."
+)
+
+
+class SentryStatsSummaryRejectedError(Exception):
+    """The stats-summary endpoint rejected our request with a non-recoverable 400."""
+
 
 def _iter_rows_tolerating_unavailable(
     rows: Iterator[dict[str, Any]],
@@ -742,6 +758,7 @@ def _iter_organization_stats_summary_rows(
                     organization_slug=organization_slug,
                 )
                 return
+            raise SentryStatsSummaryRejectedError(STATS_SUMMARY_REJECTED_MESSAGE) from exc
         raise
 
     period_start = payload.get("start")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/source.py
@@ -21,6 +21,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.sch
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.typings import SourceInputs, SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.sentry import SentrySourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.sentry.sentry import (
+    STATS_SUMMARY_REJECTED_MESSAGE,
     SentryResumeConfig,
     _normalize_organization_slug,
     sentry_source,
@@ -122,6 +123,10 @@ class SentrySource(ResumableSource[SentrySourceConfig, SentryResumeConfig]):
             + ", ".join(REQUIRED_SENTRY_SCOPES)
             + ".",
             "404 Client Error": "Sentry organization not found. Verify your organization slug.",
+            # Raised as `SentryStatsSummaryRejectedError` for any stats-summary 400 other than the
+            # skipped no-projects case (see sentry.py). Deterministic for the request we build, so
+            # stop retrying; the message is defined at the raise site so it stays credential-safe.
+            STATS_SUMMARY_REJECTED_MESSAGE: None,
         }
 
     def get_schemas(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
@@ -7,11 +7,13 @@ from unittest.mock import Mock, patch
 from parameterized import parameterized
 from requests.exceptions import HTTPError, JSONDecodeError
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import error_message_matches
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.sentry import SentrySourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.sentry.sentry import (
     SentryPaginator,
     SentryResumeConfig,
+    SentryStatsSummaryRejectedError,
     _custom_endpoint_rows,
     _normalize_api_base_url,
     _normalize_organization_slug,
@@ -1524,7 +1526,10 @@ class TestSentryCustomIteratorEndpoints:
         assert list(cast(Any, resp.items())) == []
 
     @patch("products.warehouse_sources.backend.temporal.data_imports.sources.sentry.sentry._request_with_retry")
-    def test_stats_summary_propagates_other_400_errors(self, mock_request) -> None:
+    def test_stats_summary_other_400_is_classified_non_retryable(self, mock_request) -> None:
+        # Any stats-summary 400 that isn't the skipped no-projects case is deterministic, so it must
+        # fail fast with a credential-safe message the source classifies non-retryable — not burn
+        # retries on the raw HTTPError (whose URL embeds the org slug).
         mock_request.return_value = _response({"detail": 'Invalid field: "bogus"'}, status_code=400)
 
         resp = sentry_source(
@@ -1536,8 +1541,12 @@ class TestSentryCustomIteratorEndpoints:
             job_id="job-id",
         )
 
-        with pytest.raises(HTTPError):
+        with pytest.raises(SentryStatsSummaryRejectedError) as exc_info:
             list(cast(Any, resp.items()))
+
+        message = str(exc_info.value)
+        assert "acme" not in message and "sentry.io" not in message
+        assert error_message_matches(message, SentrySource().get_non_retryable_errors())
 
     @patch("products.warehouse_sources.backend.temporal.data_imports.sources.sentry.sentry._request_with_retry")
     def test_trace_item_attributes_stamps_dataset_and_skips_unavailable_ones(self, mock_request) -> None:


### PR DESCRIPTION
## Problem

- A Sentry source that syncs the per-project usage stats table (`organization_stats_summary`) fails every scheduled run when Sentry rejects our request with an HTTP 400. Seen across many teams on the same request shape, so it reads as a request we build rather than 15 separate misconfigurations.
- We already skip the one known 400 (the token has no project membership). Every other 400 was re-raised as the raw `HTTPError`.
- That raw error matches no entry in the source's error policy, so Temporal retries it and the schema keeps re-running, burning jobs. The stored `latest_error` is the raw HTTP message, whose URL embeds the org slug.

## Changes

- A stats-summary 400 that is not the no-projects case now raises a dedicated error with a fixed, actionable message.
- `SentrySource.get_non_retryable_errors` classifies that message non-retryable, so this table's sync stops instead of retrying, and the customer sees a clear reason.
- The message never interpolates the org, URL, or response body, so it can't leak the org slug the raw error carried.

## How did you test this code?

- Reworked the existing "other 400" test to assert the new error is raised, that its message carries no org or host, and that the source classifies it non-retryable — the regression is a 400 slipping back to a raw, retried `HTTPError`.
- Ran the Sentry source suite locally. Not run: the database-backed and Temporal end-to-end suites (no dev stack in this sandbox).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a batch of data-warehouse sync failure classes. I (Claude) investigated where the stats-summary request is built and how source errors are classified, then confirmed the request matches Sentry's documented contract, so the defect is the missing non-retryable classification, not the request shape. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`. A reviewer may additionally want to check whether Sentry now enforces a tighter date range on this endpoint than our assumed retention window.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
