### PR TITLE
fix(desktop): stop replies re-ranking the comment thread you are reading

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/TaskCommentsList.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskCommentsList.test.tsx
@@ -762,6 +762,14 @@ describe("TaskCommentsList", () => {
         context: { anchor: { kind: "document" } },
       }),
     );
+    // The list is ordered by when a thread started, so the new one lands at the
+    // top, away from the composer it was written in.
+    expect(
+      useCommentNavigationStore.getState().focusByTask["task-1"],
+    ).toMatchObject({
+      target: { scope: "task", itemId: "task-1" },
+      threadId: "created-comment",
+    });
   });
 
   it("polls at most 20 artifact comment targets plus the task", () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskCommentsList.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskCommentsList.tsx
@@ -34,7 +34,7 @@ import {
   taskCommentTarget,
 } from "@posthog/ui/features/canvas/components/taskArtifactRows";
 import {
-  byNewestActivity,
+  byNewestThread,
   prCommentThreads,
   resourceCommentThreads,
   type SourceKind,
@@ -405,7 +405,6 @@ export function TaskCommentsList({
 
   const taskTarget = useMemo(() => taskCommentTarget(task.id), [task.id]);
   const composerTarget = onlySource?.target ?? taskTarget;
-  const composerSourceKey = commentTargetKey(composerTarget);
   const createComment = useCreateComment(composerTarget, task.id);
 
   const threads = useMemo(() => {
@@ -423,7 +422,7 @@ export function TaskCommentsList({
         conversationByUrl.get(prUrl) ?? [],
       ),
     );
-    return [...resourceThreads, ...prThreads].sort(byNewestActivity);
+    return [...resourceThreads, ...prThreads].sort(byNewestThread);
   }, [
     commentsQuery.data,
     sources,
@@ -732,7 +731,7 @@ export function TaskCommentsList({
           value={draft}
           onValueChange={setDraft}
           onSubmit={async (content, mentions) => {
-            await createComment.mutateAsync({
+            const created = await createComment.mutateAsync({
               content,
               context: {
                 anchor: { kind: "document" },
@@ -741,15 +740,10 @@ export function TaskCommentsList({
               mentions,
             });
             setDraft("");
-            // Show the thread that was just opened: open state, and a source
-            // filter that isn't hiding the task's own comments.
-            setStateFilter("open");
-            if (
-              sourceFilter !== ALL_SOURCES &&
-              sourceFilter !== composerSourceKey
-            ) {
-              setSourceFilter(ALL_SOURCES);
-            }
+            // Show the thread that was just opened. The list is ordered by when
+            // a thread started, so a new one lands at the top, away from the
+            // composer — focusing it clears the filters hiding it and scrolls.
+            requestCommentFocus(task.id, composerTarget, created.id);
           }}
           members={members}
           placeholder={`Comment on this ${onlySource ? "canvas" : "task"}… Type @ to mention someone`}

--- a/products/desktop/packages/ui/src/features/canvas/components/taskCommentThreads.test.ts
+++ b/products/desktop/packages/ui/src/features/canvas/components/taskCommentThreads.test.ts
@@ -3,7 +3,7 @@ import type { PrConversationComment, PrReviewThread } from "@posthog/shared";
 import { describe, expect, it } from "vitest";
 import type { CommentSource } from "./taskArtifactRows";
 import {
-  byNewestActivity,
+  byNewestThread,
   prCommentThreads,
   resourceCommentThreads,
   threadSourceOptions,
@@ -59,6 +59,9 @@ describe("resourceCommentThreads", () => {
       "root",
       "reply",
     ]);
+    // The reply is newer, but ordering follows the root: replying must not move
+    // the thread out from under whoever is reading it.
+    expect(threads[0].startedAt).toBe("2024-01-01T00:00:00Z");
   });
 
   // A resolve/reopen reply is thread state, not something anyone said.
@@ -82,7 +85,7 @@ describe("resourceCommentThreads", () => {
 
     expect(threads[0].resolved).toBe(true);
     expect(threads[0].entries).toHaveLength(1);
-    expect(threads[0].lastActivityAt).toBe("2024-01-01T00:00:00Z");
+    expect(threads[0].startedAt).toBe("2024-01-01T00:00:00Z");
   });
 });
 
@@ -148,7 +151,8 @@ describe("prCommentThreads", () => {
       threadNodeId: "node-1",
       filePath: "src/App.tsx",
     });
-    expect(thread.lastActivityAt).toBe("2024-01-01T00:05:00Z");
+    // The thread's own start, so a reply can't re-rank it in the list.
+    expect(thread.startedAt).toBe("2024-01-01T00:00:00Z");
   });
 
   it("makes each conversation comment its own unresolvable thread", () => {
@@ -194,7 +198,7 @@ describe("prCommentThreads", () => {
   });
 });
 
-describe("threadSourceOptions / byNewestActivity", () => {
+describe("threadSourceOptions / byNewestThread", () => {
   it("lists each source once and sorts newest first", () => {
     const threads = [
       ...resourceCommentThreads(
@@ -216,7 +220,7 @@ describe("threadSourceOptions / byNewestActivity", () => {
           },
         ],
       ),
-    ].sort(byNewestActivity);
+    ].sort(byNewestThread);
 
     expect(threads[0].entries[0].body).toBe("new");
     // Options follow list order, which is newest-first, and carry the kind so
@@ -251,7 +255,7 @@ describe("threadSourceOptions / byNewestActivity", () => {
         ],
         [fileSource, taskSource],
       ),
-    ].sort(byNewestActivity);
+    ].sort(byNewestThread);
 
     expect(threadSourceOptions(threads).map((option) => option.kind)).toEqual([
       "task",

--- a/products/desktop/packages/ui/src/features/canvas/components/taskCommentThreads.ts
+++ b/products/desktop/packages/ui/src/features/canvas/components/taskCommentThreads.ts
@@ -53,8 +53,9 @@ export type TaskCommentThread = {
   sourceKind: "file" | "canvas" | "task" | "pr";
   entries: CommentEntry[];
   resolved: boolean;
-  /** Newest comment in the thread, for ordering the list. */
-  lastActivityAt: string;
+  /** When the thread was opened, for ordering the list. Ordering on the newest
+   *  reply instead would re-rank a thread the moment someone replies to it. */
+  startedAt: string;
   origin: ThreadOrigin;
 };
 
@@ -103,8 +104,7 @@ export function resourceCommentThreads(
         sourceKind: source.kind,
         entries: [thread.root, ...visibleReplies].map(resourceEntry),
         resolved: thread.resolved,
-        lastActivityAt:
-          visibleReplies.at(-1)?.created_at ?? thread.root.created_at,
+        startedAt: thread.root.created_at,
         origin: { kind: "resource", source, root: thread.root },
       },
     ];
@@ -145,7 +145,8 @@ export function prCommentThreads(
           format: "markdown" as const,
         })),
         resolved: thread.isResolved,
-        lastActivityAt: humanComments.at(-1)?.created_at ?? root.created_at,
+        // The visible root: a bot may have opened the thread, and bots are filtered out.
+        startedAt: humanComments[0].created_at,
         origin: {
           kind: "pr-review" as const,
           prUrl,
@@ -178,7 +179,7 @@ export function prCommentThreads(
         },
       ],
       resolved: false,
-      lastActivityAt: comment.createdAt,
+      startedAt: comment.createdAt,
       origin: { kind: "pr-conversation", prUrl, url: comment.url },
     });
   }
@@ -186,11 +187,12 @@ export function prCommentThreads(
   return threads;
 }
 
-export function byNewestActivity(
+export function byNewestThread(
   a: TaskCommentThread,
   b: TaskCommentThread,
 ): number {
-  return b.lastActivityAt.localeCompare(a.lastActivityAt);
+  // Total, so threads opened in the same second can't swap places between renders.
+  return b.startedAt.localeCompare(a.startedAt) || a.id.localeCompare(b.id);
 }
 
 export type SourceKind = TaskCommentThread["sourceKind"];


### PR DESCRIPTION
## Problem

Replying in the task comments pane throws the thread you are reading to the top of the list. The card jumps away mid-conversation, and the reply you just wrote goes with it.

- `TaskCommentsList` sorted threads by `lastActivityAt`, the timestamp of the thread's newest comment.
- `useCreateComment` writes the reply into the cache optimistically, so the sort key becomes "now" the moment you hit Reply.
- The other comment surfaces, `ArtifactPreview` and `FreeformCanvasView`, call `buildCommentThreads()` directly and already order by root `created_at`. The pane was the only surface that re-ranked.

## Changes

- Threads now sort by `startedAt`, the root comment's `created_at`. A reply never moves a card.
- Posting from the composer focuses the new thread through the existing `requestCommentFocus` channel, which clears the filters hiding it, scrolls to it, and pulses it. New threads sort to the top, away from the composer at the bottom, so they need the scroll.
- That focus call replaces the hand-rolled filter reset the composer ran on submit. It did the same two things and did not scroll.
- `byNewestActivity` becomes `byNewestThread` and breaks ties on thread id, so threads opened in the same second hold a fixed order across renders.

Ordering stays newest-thread-first. Oldest-first would pair better with the bottom composer, but it buries live threads behind settled ones on a long task and flips the pane's reading direction.

Sorting stays on the client. The pane merges PostHog comments with GitHub PR review and conversation comments fetched in the browser, so no server holds the whole list. The comment API already returns a stable `-created_at` order; what was unstable was the client's thread sort key.

No screenshot: the change is which position a card holds over time, which a still frame cannot show.

## How did you test this code?

Automated only. I did not run the desktop app.

- `packages/ui`: `vitest run` over `taskCommentThreads.test.ts` and `TaskCommentsList.test.tsx`, 32 tests passed.
- `packages/ui`: `tsc --noEmit` clean.
- New assertions, one each, for regressions no existing test covered:
  - `resourceCommentThreads` keeps a thread's sort key at the root when a newer reply exists. This is the bug.
  - `prCommentThreads` does the same for a PR review thread with a reply.
  - Posting on the task requests focus on the created comment, so a future refactor cannot drop the scroll and leave new threads off-screen.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Opus 4.5 in PostHog Code. Skills invoked: `/writing-pr-descriptions`, `/writing-code-comments`, `/writing-simplified-technical-english`.

The reported symptom was a card moving while typing. Reading the code found two distinct movements: the reply bump fixed here, and a smaller shift when the bottom composer auto-grows and shrinks the scroll viewport. This PR fixes the first one only.

Before coding, I built a throwaway HTML prototype of four ordering rules and the requester picked this one over plain newest-first and over chat-style oldest-first. The prototype is not part of the diff.
