### PR TITLE
fix(postgres): give a clear message for a rejected database password

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -81,6 +81,14 @@ _HOST_UNREACHABLE_ERROR = (
     "firewall allowlist, then try again."
 )
 
+# Wrong username or password reported by libpq's standard wording or the SCRAM exchange. The raw
+# driver string is prefixed with "connection to server at <host>, port <port> failed", so surface a
+# clean, host-free message on the non-retryable sync path instead of storing that raw prefix.
+_INVALID_CREDENTIALS_ERROR = (
+    "The database rejected the username or password. Check the user and password configured for "
+    "this source, then re-enable the sync."
+)
+
 PostgresErrors = {
     "password authentication failed for user": "Invalid user or password",
     # libpq reports a bad password via SCRAM with a different wording than the line above.
@@ -337,7 +345,7 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 '"postgres.<project-ref>"). Update the user for this source to the pooler username '
                 "shown in your Supabase dashboard, then re-enable the sync."
             ),
-            "error received from server in SCRAM exchange: Wrong password": None,
+            "error received from server in SCRAM exchange: Wrong password": _INVALID_CREDENTIALS_ERROR,
             # The server (commonly Supabase's Supavisor transaction pooler on port 6543) rejects the
             # SASL/SCRAM credential exchange with "FATAL: SASL authentication failed" instead of
             # PostgreSQL's "password authentication failed for user" — so none of the password keys
@@ -368,14 +376,14 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
             ),
             "could not translate host name": None,
             "timeout expired connection to server at": None,
-            "password authentication failed for user": None,
+            "password authentication failed for user": _INVALID_CREDENTIALS_ERROR,
             # Some providers (observed on a Neon-style pooler) report the same auth rejection without
             # libpq's "for user" wording, putting the role on its own line instead: "password
             # authentication failed\nuser \"<role>\"". The key above requires "for user" right after
             # "failed", so it doesn't substring-match this variant and Temporal keeps retrying a
             # credential mismatch only the customer can fix. Match the stable, wording-independent
             # fragment shared by both forms.
-            "password authentication failed": None,
+            "password authentication failed": _INVALID_CREDENTIALS_ERROR,
             # AWS RDS Proxy reports bad credentials with its own wording instead of PostgreSQL's
             # "password authentication failed for user" — it validates against Secrets Manager and
             # returns "The password that was provided for the role <role> is wrong." None of the

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -769,6 +769,23 @@ class TestPostgresSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            'connection to server at "203.0.113.30", port 5432 failed: FATAL:  password authentication failed for user "u"',
+            'connection to server at "203.0.113.30", port 5432 failed: FATAL:  password authentication failed\nuser "u"',
+            "connection failed: error received from server in SCRAM exchange: Wrong password",
+        ],
+    )
+    def test_password_authentication_failure_surfaces_a_host_free_message(self, source, error_msg):
+        # The raw driver string embeds the host/IP and port; the surfaced message must be actionable
+        # and carry neither. Guards a regression back to the raw error (value `None`).
+        non_retryable = source.get_non_retryable_errors()
+        friendly = [reason for pattern, reason in non_retryable.items() if pattern in error_msg and reason]
+        assert friendly, "A rejected password should surface an actionable message"
+        assert "username or password" in friendly[0]
+        assert "203.0.113.30" not in friendly[0]
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             "Cannot build decimal array from values",
             "ValueError: Cannot build decimal array from values",
         ],


### PR DESCRIPTION
## Problem

- A Postgres or Supabase source with a wrong username or password fails every run and shows the raw driver error as `latest_error`. That string is prefixed with the host and port and reads like a driver internal, not something to act on.
- The failure was already classified non-retryable, so the sync stops correctly. Only the surfaced message was poor.

## Changes

- Map the password-auth-failure patterns (libpq's standard wording, the wording-independent variant, and the SCRAM "Wrong password" form) to one actionable message instead of surfacing the raw error.
- The message names the fix (check the user and password, then re-enable) and contains no host or port.
- Supabase inherits this through `PostgresSource`.

## How did you test this code?

- Added a parameterized test asserting the three password-auth wordings surface an actionable message with no host in it — the regression is the message reverting to the raw driver string.
- Ran the Postgres and Supabase source suites locally. The live-database tests in the Postgres suite error out here because this sandbox has no Postgres; the classification and message tests all pass.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a batch of data-warehouse sync failure classes; a Supabase auth-failure class surfaced the raw driver string. I (Claude) confirmed the pattern was already non-retryable and that the poor message came from the map entries being `None`. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
