### PR TITLE
fix(desktop): make plan & usage scroll and match other settings pages

### DIFF
--- a/products/desktop/packages/ui/src/features/inbox/components/ConfigureAgentsSection.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ConfigureAgentsSection.tsx
@@ -38,6 +38,7 @@ import {
 } from "@posthog/ui/features/integrations/useIntegrations";
 import { toastError } from "@posthog/ui/features/notifications/errorDetails";
 import { ScoutsFleetSection } from "@posthog/ui/features/scouts/components/ScoutsFleetSection";
+import { SettingsSubsection } from "@posthog/ui/features/settings/components/SettingsSubsection";
 import { GitHubIntegrationSection } from "@posthog/ui/features/settings/sections/GitHubIntegrationSection";
 import { SlackInboxNotificationsSettings } from "@posthog/ui/features/settings/sections/SlackInboxNotificationsSettings";
 import {
@@ -53,7 +54,7 @@ import { logger } from "@posthog/ui/shell/logger";
 import { Box, Flex, Text, Tooltip } from "@radix-ui/themes";
 import { useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
-import { type ReactNode, useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 const AUTONOMY_SETUP_PROMPT = `Set up PostHog Self-driving for this product.
 
@@ -122,7 +123,7 @@ export function ConfigureAgentsSection() {
     <Flex direction="column" gap="8">
       {showSetupTask ? <SetupTaskSection /> : null}
 
-      <Subsection
+      <SettingsSubsection
         title="Connections"
         description="Foundational integrations agents read from and write to."
       >
@@ -131,9 +132,9 @@ export function ConfigureAgentsSection() {
           isLoading={isLoadingIntegrations}
           showBottomBorder={false}
         />
-      </Subsection>
+      </SettingsSubsection>
 
-      <Subsection
+      <SettingsSubsection
         title="Scouts"
         description={
           <>
@@ -152,9 +153,9 @@ export function ConfigureAgentsSection() {
         }
       >
         <ScoutsFleetSection />
-      </Subsection>
+      </SettingsSubsection>
 
-      <Subsection
+      <SettingsSubsection
         title="Signal sources"
         description="Each source watches for signals and spins up work when something matters."
       >
@@ -192,9 +193,9 @@ export function ConfigureAgentsSection() {
             </Box>
           </Tooltip>
         )}
-      </Subsection>
+      </SettingsSubsection>
 
-      <Subsection
+      <SettingsSubsection
         title="Slack"
         description="Post reports to channels and ping suggested reviewers. Invite PostHog with /invite @PostHog in each channel you use."
       >
@@ -203,9 +204,9 @@ export function ConfigureAgentsSection() {
           showHeader={false}
           showTopBorder={false}
         />
-      </Subsection>
+      </SettingsSubsection>
 
-      <Subsection
+      <SettingsSubsection
         title="MCP servers"
         description="External tools agents can read from. PostHog data is always available; this is everything else."
       >
@@ -233,7 +234,7 @@ export function ConfigureAgentsSection() {
           </Flex>
           <ArrowSquareOutIcon size={14} className="shrink-0 text-gray-10" />
         </Link>
-      </Subsection>
+      </SettingsSubsection>
     </Flex>
   );
 }
@@ -405,7 +406,7 @@ function SetupTaskSection() {
   ]);
 
   return (
-    <Subsection
+    <SettingsSubsection
       title="Setup"
       description="We'll run an agent to inspect your product and figure out what Self-driving should pay attention to first."
     >
@@ -447,36 +448,6 @@ function SetupTaskSection() {
           {isStartingSetupTask ? "Starting..." : "Run setup agent"}
         </Button>
       </Flex>
-    </Subsection>
-  );
-}
-
-interface SubsectionProps {
-  title: string;
-  description?: ReactNode;
-  children: ReactNode;
-}
-
-function Subsection({ title, description, children }: SubsectionProps) {
-  return (
-    <Flex
-      direction="column"
-      gap="4"
-      className="border-(--gray-5) border-t pt-8 first:border-t-0 first:pt-0"
-    >
-      <Flex direction="column" gap="1">
-        <Flex align="center" gap="2" wrap="wrap">
-          <Text className="font-semibold text-[13px] text-gray-12">
-            {title}
-          </Text>
-        </Flex>
-        {description ? (
-          <Text className="max-w-2xl text-[12.5px] text-gray-11 leading-snug">
-            {description}
-          </Text>
-        ) : null}
-      </Flex>
-      {children}
-    </Flex>
+    </SettingsSubsection>
   );
 }

--- a/products/desktop/packages/ui/src/features/settings/components/SettingsPageContent.tsx
+++ b/products/desktop/packages/ui/src/features/settings/components/SettingsPageContent.tsx
@@ -47,11 +47,7 @@ function defineSettingsPage(
 const SETTINGS_PAGES: Record<SettingsCategory, SettingsPageDefinition> = {
   general: defineSettingsPage("General", GeneralSettings),
   notifications: defineSettingsPage("Notifications", NotificationsSettings),
-  "plan-usage": defineSettingsPage(
-    "Plan & usage",
-    PlanUsageSettings,
-    SETTINGS_PAGE_LAYOUT.FULL_BLEED,
-  ),
+  "plan-usage": defineSettingsPage("Plan & usage", PlanUsageSettings),
   workspaces: defineSettingsPage("Workspaces", WorkspacesSettings),
   worktrees: defineSettingsPage("Worktrees", WorktreesSettings),
   environments: defineSettingsPage("Environments", EnvironmentsSettings),

--- a/products/desktop/packages/ui/src/features/settings/components/SettingsSubsection.tsx
+++ b/products/desktop/packages/ui/src/features/settings/components/SettingsSubsection.tsx
@@ -1,0 +1,47 @@
+import { Flex, Text } from "@radix-ui/themes";
+import type { ReactNode } from "react";
+
+interface SettingsSubsectionProps {
+  title: string;
+  description?: ReactNode;
+  /** Optional trailing control, right-aligned with the title. */
+  actions?: ReactNode;
+  children: ReactNode;
+}
+
+/**
+ * Section header shared by the settings pages that group content into blocks
+ * rather than rows of controls (Agents, Plan & usage), so every page keeps the
+ * same heading scale and divider rhythm.
+ */
+export function SettingsSubsection({
+  title,
+  description,
+  actions,
+  children,
+}: SettingsSubsectionProps) {
+  return (
+    <Flex
+      direction="column"
+      gap="4"
+      className="border-(--gray-5) border-t pt-8 first:border-t-0 first:pt-0"
+    >
+      <Flex align="start" justify="between" gap="4" wrap="wrap">
+        <Flex direction="column" gap="1">
+          <Flex align="center" gap="2" wrap="wrap">
+            <Text className="font-semibold text-[13px] text-gray-12">
+              {title}
+            </Text>
+          </Flex>
+          {description ? (
+            <Text className="max-w-2xl text-[12.5px] text-gray-11 leading-snug">
+              {description}
+            </Text>
+          ) : null}
+        </Flex>
+        {actions ? <div className="shrink-0">{actions}</div> : null}
+      </Flex>
+      {children}
+    </Flex>
+  );
+}

--- a/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
@@ -1,7 +1,7 @@
 import {
   ArrowSquareOut,
   CaretDown,
-  CaretRight,
+  CaretUp,
   CreditCard,
   WarningCircle,
 } from "@phosphor-icons/react";
@@ -27,6 +27,7 @@ import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { UsageMeter } from "@posthog/ui/features/billing/UsageMeter";
 import { useUsage } from "@posthog/ui/features/billing/useUsage";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
+import { SettingsSubsection } from "@posthog/ui/features/settings/components/SettingsSubsection";
 import { SpendAnalysisSection } from "@posthog/ui/features/usage/components/SpendAnalysisSection";
 import { useSpendAnalysisEnabled } from "@posthog/ui/features/usage/useSpendAnalysisEnabled";
 import { useTrackUsageViewed } from "@posthog/ui/features/usage/useTrackUsageViewed";
@@ -117,9 +118,30 @@ export function PlanUsageContent({
   }
 
   return (
-    <Flex direction="column" gap="5">
+    <Flex direction="column" gap="8">
       {billingEnabled && (
-        <>
+        <SettingsSubsection
+          title="Organization usage"
+          description="Combined token and cloud-compute spend counts toward your organization's shared allowance and limit."
+          actions={
+            <Button
+              size="1"
+              variant={freeTier ? "solid" : "outline"}
+              disabled={!billingUrl}
+              onClick={() => {
+                if (freeTier) {
+                  track(ANALYTICS_EVENTS.UPGRADE_PROMPT_CLICKED, {
+                    surface: "plan_page_card",
+                  });
+                }
+                openBilling();
+              }}
+            >
+              {freeTier ? "Add payment method" : "Manage billing and limits"}
+              <ArrowSquareOut size={12} />
+            </Button>
+          }
+        >
           {orgLimitReached && (
             <Callout.Root color="red" size="1">
               <Callout.Icon>
@@ -147,102 +169,71 @@ export function PlanUsageContent({
             </Callout.Root>
           )}
 
-          <Flex
-            direction="column"
-            gap="4"
-            p="4"
-            className="rounded-(--radius-3) border border-(--gray-5)"
-          >
-            <Flex align="start" justify="between" gap="4" wrap="wrap">
-              <Flex direction="column" gap="1">
-                <Text className="font-bold text-base">Organization usage</Text>
-                <Text className="text-(--gray-11) text-sm">
-                  Combined token and cloud-compute spend counts toward your
-                  organization's shared allowance and limit.
-                </Text>
-              </Flex>
-              <Button
-                size="1"
-                variant={freeTier ? "solid" : "outline"}
-                disabled={!billingUrl}
-                onClick={() => {
-                  if (freeTier) {
-                    track(ANALYTICS_EVENTS.UPGRADE_PROMPT_CLICKED, {
-                      surface: "plan_page_card",
-                    });
-                  }
-                  openBilling();
-                }}
-              >
-                {freeTier ? "Add payment method" : "Manage billing and limits"}
-                <ArrowSquareOut size={12} />
-              </Button>
+          {usageLoading ? (
+            <Flex
+              align="center"
+              justify="center"
+              p="4"
+              className="rounded-(--radius-3) border border-(--gray-5) bg-(--color-panel-solid)"
+            >
+              <Spinner size="2" />
             </Flex>
-            {usageLoading ? (
-              <Flex
-                align="center"
-                justify="center"
-                p="4"
-                className="rounded-(--radius-3) border border-(--gray-5)"
-              >
-                <Spinner size="2" />
-              </Flex>
-            ) : meter.kind === "dollars" ? (
-              <UsageMeter
-                label={freeTier ? "Monthly free usage" : "Usage this period"}
-                percent={meter.percent}
-                valueLabel={`${formatUsdAmount(meter.usedUsd)} of ${formatUsdAmount(meter.limitUsd)}${freeTier ? " included" : ""}`}
-                detail={`${meter.exceeded ? "Limit exceeded. " : ""}${formatResetTime(meter.resetAt, { label: "Billing period ends" })}`}
-                breakdown={
-                  meter.breakdown
-                    ? { ...meter.breakdown, usedUsd: meter.usedUsd }
-                    : undefined
-                }
-                color={meter.exceeded ? "red" : undefined}
-              />
-            ) : meter.kind === "bucket" ? (
-              <UsageMeter
-                label="Monthly free usage"
-                percent={meter.bucket.used_percent}
-                valueLabel={`${meter.bucket.used_percent.toFixed(2)}%`}
-                detail={`${meter.bucket.exceeded ? "Limit exceeded. " : ""}${formatResetTime(meter.bucket.reset_at)}`}
-                color={meter.bucket.exceeded ? "red" : undefined}
-              />
-            ) : (
-              <Flex
-                align="center"
-                justify="between"
-                p="4"
-                className="rounded-(--radius-3) border border-(--gray-5)"
-              >
-                <Text color="gray" className="text-sm">
-                  {usage
-                    ? "Usage is billed to your organization. View detailed usage and spend in PostHog."
-                    : "Unable to load usage data"}
-                </Text>
-                {usage && (
-                  <Button
-                    size="1"
-                    variant="outline"
-                    disabled={!billingUrl}
-                    onClick={openBilling}
-                  >
-                    View usage
-                    <ArrowSquareOut size={12} />
-                  </Button>
-                )}
-              </Flex>
-            )}
-            {!usageLoading && (
-              <Flex direction="column" gap="3">
-                {hasUsageMix && <UsageMix components={components} />}
-                <Text className="text-(--gray-9) text-[13px]">
-                  Usage reporting may be delayed by 15–20 minutes.
-                </Text>
-              </Flex>
-            )}
-          </Flex>
-        </>
+          ) : meter.kind === "dollars" ? (
+            <UsageMeter
+              label={freeTier ? "Monthly free usage" : "Usage this period"}
+              percent={meter.percent}
+              valueLabel={`${formatUsdAmount(meter.usedUsd)} of ${formatUsdAmount(meter.limitUsd)}${freeTier ? " included" : ""}`}
+              detail={`${meter.exceeded ? "Limit exceeded. " : ""}${formatResetTime(meter.resetAt, { label: "Billing period ends" })}`}
+              breakdown={
+                meter.breakdown
+                  ? { ...meter.breakdown, usedUsd: meter.usedUsd }
+                  : undefined
+              }
+              color={meter.exceeded ? "red" : undefined}
+            />
+          ) : meter.kind === "bucket" ? (
+            <UsageMeter
+              label="Monthly free usage"
+              percent={meter.bucket.used_percent}
+              valueLabel={`${meter.bucket.used_percent.toFixed(2)}%`}
+              detail={`${meter.bucket.exceeded ? "Limit exceeded. " : ""}${formatResetTime(meter.bucket.reset_at)}`}
+              color={meter.bucket.exceeded ? "red" : undefined}
+            />
+          ) : (
+            <Flex
+              align="center"
+              justify="between"
+              gap="4"
+              p="4"
+              className="rounded-(--radius-3) border border-(--gray-5) bg-(--color-panel-solid)"
+            >
+              <Text color="gray" className="text-[13px]">
+                {usage
+                  ? "Usage is billed to your organization. View detailed usage and spend in PostHog."
+                  : "Unable to load usage data"}
+              </Text>
+              {usage && (
+                <Button
+                  size="1"
+                  variant="outline"
+                  disabled={!billingUrl}
+                  onClick={openBilling}
+                >
+                  View usage
+                  <ArrowSquareOut size={12} />
+                </Button>
+              )}
+            </Flex>
+          )}
+          {!usageLoading && (
+            <Flex direction="column" gap="3">
+              {hasUsageMix && <UsageMix components={components} />}
+              <Text className="text-[12px] text-gray-10">
+                Usage reporting may be delayed by 15–20 minutes.
+              </Text>
+            </Flex>
+          )}
+        </SettingsSubsection>
       )}
 
       {spendAnalysisEnabled && (
@@ -278,9 +269,9 @@ function UsageMix({
       direction="column"
       gap="3"
       p="4"
-      className="rounded-(--radius-3) bg-(--gray-a2)"
+      className="rounded-(--radius-3) border border-(--gray-5) bg-(--color-panel-solid)"
     >
-      <Text className="font-medium text-sm">Usage mix</Text>
+      <Text className="font-medium text-[13px] text-gray-12">Usage mix</Text>
       <div
         role="img"
         aria-label={`${roundedTokenPercent}% tokens and ${totalUsd > 0 ? 100 - roundedTokenPercent : 0}% cloud compute`}
@@ -310,7 +301,7 @@ function UsageMix({
           value={formatUsdAmount(computeUsd)}
         />
       </Flex>
-      <Text className="text-(--gray-9) text-xs">
+      <Text className="text-[12px] text-gray-10">
         Compute resources: {computeDetails}
       </Text>
     </Flex>
@@ -318,32 +309,27 @@ function UsageMix({
 }
 
 function PersonalSpendDisclosure({ children }: { children: ReactNode }) {
+  // Collapsed by default so opening the page doesn't fire the spend query.
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <Flex
-      direction="column"
-      className="overflow-hidden rounded-(--radius-3) border border-(--gray-5)"
+    <SettingsSubsection
+      title="Your spend"
+      description="Near-real-time analysis of your activity, separate from organization billing."
+      actions={
+        <Button
+          size="1"
+          variant="outline"
+          aria-expanded={expanded}
+          onClick={() => setExpanded((value) => !value)}
+        >
+          {expanded ? "Hide" : "Show"}
+          {expanded ? <CaretUp size={12} /> : <CaretDown size={12} />}
+        </Button>
+      }
     >
-      <button
-        type="button"
-        aria-expanded={expanded}
-        onClick={() => setExpanded((value) => !value)}
-        className="flex w-full items-center justify-between gap-4 p-4 text-left hover:bg-(--gray-a2) focus-visible:outline-(--accent-8) focus-visible:outline-2"
-      >
-        <Flex direction="column" gap="1">
-          <Text className="font-medium text-sm">Your spend</Text>
-          <Text className="text-(--gray-11) text-xs">
-            Near-real-time analysis of your activity, separate from organization
-            billing.
-          </Text>
-        </Flex>
-        {expanded ? <CaretDown size={16} /> : <CaretRight size={16} />}
-      </button>
-      {expanded && children && (
-        <div className="border-(--gray-5) border-t p-4">{children}</div>
-      )}
-    </Flex>
+      {expanded ? children : null}
+    </SettingsSubsection>
   );
 }
 
@@ -361,9 +347,9 @@ function MixLegend({
   return (
     <Flex align="center" gap="2">
       <span className={`size-2 rounded-full ${color}`} />
-      <Text className="text-sm">
+      <Text className="text-[13px]">
         <strong>{percent}%</strong> {label}
-        <span className="text-(--gray-9)"> · {value}</span>
+        <span className="text-gray-10"> · {value}</span>
       </Text>
     </Flex>
   );

--- a/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
@@ -98,7 +98,7 @@ export function PlanUsageContent({
     components?.tokenUsd != null && components.computeUsd != null;
 
   const openBilling = () => {
-    if (billingUrl) window.open(billingUrl, "_blank");
+    if (billingUrl) window.open(billingUrl, "_blank", "noopener,noreferrer");
   };
 
   if (!billingEnabled && !spendAnalysisEnabled) {

--- a/products/desktop/packages/ui/src/features/usage/components/SpendAnalysisSection.tsx
+++ b/products/desktop/packages/ui/src/features/usage/components/SpendAnalysisSection.tsx
@@ -88,7 +88,7 @@ export function SpendAnalysisSection() {
             rows={data.by_model.items}
             scopedCostUsd={data.summary.scoped_cost_usd}
           />
-          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <div className="grid grid-cols-1 items-start gap-4 lg:grid-cols-2">
             <ToolBreakdownCard rows={data.by_tool.items} />
             <ProductBreakdownCard rows={data.by_product.items} />
           </div>

--- a/products/desktop/packages/ui/src/features/usage/components/SpendAnalysisSection.tsx
+++ b/products/desktop/packages/ui/src/features/usage/components/SpendAnalysisSection.tsx
@@ -88,10 +88,8 @@ export function SpendAnalysisSection() {
             rows={data.by_model.items}
             scopedCostUsd={data.summary.scoped_cost_usd}
           />
-          <div className="grid grid-cols-1 items-start gap-4 lg:grid-cols-2">
-            <ToolBreakdownCard rows={data.by_tool.items} />
-            <ProductBreakdownCard rows={data.by_product.items} />
-          </div>
+          <ToolBreakdownCard rows={data.by_tool.items} />
+          <ProductBreakdownCard rows={data.by_product.items} />
           <SpendInsights data={data} />
         </>
       ) : null}

--- a/products/desktop/packages/ui/src/features/usage/components/SpendBreakdownTables.tsx
+++ b/products/desktop/packages/ui/src/features/usage/components/SpendBreakdownTables.tsx
@@ -7,16 +7,20 @@ import type {
   SpendAnalysisProductRow,
   SpendAnalysisToolRow,
 } from "@posthog/core/billing/spendAnalysisTypes";
-import { Table, Text } from "@radix-ui/themes";
+import { Table } from "@radix-ui/themes";
 import { UsageCard } from "./UsageCard";
 
+interface BreakdownColumn {
+  label: string;
+  width: string;
+  numeric?: boolean;
+}
+
 function BreakdownTable({
-  headers,
-  widths,
+  columns,
   children,
 }: {
-  headers: string[];
-  widths: string[];
+  columns: BreakdownColumn[];
   children: React.ReactNode;
 }) {
   return (
@@ -26,19 +30,38 @@ function BreakdownTable({
     >
       <Table.Header>
         <Table.Row>
-          {headers.map((h, i) => (
+          {columns.map((column) => (
             <Table.ColumnHeaderCell
-              key={h}
-              className="font-normal text-[12px] text-gray-11"
-              style={{ width: widths[i] }}
+              key={column.label}
+              className={`!text-gray-11 whitespace-nowrap font-normal text-[12px] ${column.numeric ? "text-right" : ""}`}
+              style={{ width: column.width }}
             >
-              {h}
+              {column.label}
             </Table.ColumnHeaderCell>
           ))}
         </Table.Row>
       </Table.Header>
       <Table.Body>{children}</Table.Body>
     </Table.Root>
+  );
+}
+
+/** Long tool and product names truncate; the full value stays in the title. */
+function NameCell({ value }: { value: string }) {
+  return (
+    <Table.Cell>
+      <span className="block truncate" title={value}>
+        {value}
+      </span>
+    </Table.Cell>
+  );
+}
+
+function NumericCell({ value }: { value: string }) {
+  return (
+    <Table.Cell className="whitespace-nowrap text-right tabular-nums">
+      {value}
+    </Table.Cell>
   );
 }
 
@@ -50,15 +73,19 @@ export function ToolBreakdownCard({ rows }: { rows: SpendAnalysisToolRow[] }) {
       title="By tool"
     >
       <BreakdownTable
-        headers={["Tool", "Generations", "Avg input", "Cost"]}
-        widths={["40%", "20%", "20%", "20%"]}
+        columns={[
+          { label: "Tool", width: "44%" },
+          { label: "Gens", width: "16%", numeric: true },
+          { label: "Avg input", width: "20%", numeric: true },
+          { label: "Cost", width: "20%", numeric: true },
+        ]}
       >
         {rows.slice(0, 10).map((r) => (
           <Table.Row key={r.tool ?? "(null)"}>
-            <Table.Cell>{r.tool ?? "Text response"}</Table.Cell>
-            <Table.Cell>{r.generation_count.toLocaleString()}</Table.Cell>
-            <Table.Cell>{formatTokens(r.avg_input_tokens)}</Table.Cell>
-            <Table.Cell>{formatUsd(r.cost_usd)}</Table.Cell>
+            <NameCell value={r.tool ?? "Text response"} />
+            <NumericCell value={r.generation_count.toLocaleString()} />
+            <NumericCell value={formatTokens(r.avg_input_tokens)} />
+            <NumericCell value={formatUsd(r.cost_usd)} />
           </Table.Row>
         ))}
       </BreakdownTable>
@@ -78,16 +105,17 @@ export function ProductBreakdownCard({
       title="By product"
     >
       <BreakdownTable
-        headers={["Product", "Events", "Cost"]}
-        widths={["50%", "25%", "25%"]}
+        columns={[
+          { label: "Product", width: "50%" },
+          { label: "Events", width: "25%", numeric: true },
+          { label: "Cost", width: "25%", numeric: true },
+        ]}
       >
         {rows.map((r) => (
           <Table.Row key={r.product ?? "(null)"}>
-            <Table.Cell>
-              <Text className="truncate">{r.product ?? "(none)"}</Text>
-            </Table.Cell>
-            <Table.Cell>{r.event_count.toLocaleString()}</Table.Cell>
-            <Table.Cell>{formatUsd(r.cost_usd)}</Table.Cell>
+            <NameCell value={r.product ?? "(none)"} />
+            <NumericCell value={r.event_count.toLocaleString()} />
+            <NumericCell value={formatUsd(r.cost_usd)} />
           </Table.Row>
         ))}
       </BreakdownTable>

--- a/products/desktop/packages/ui/src/features/usage/components/SpendBreakdownTables.tsx
+++ b/products/desktop/packages/ui/src/features/usage/components/SpendBreakdownTables.tsx
@@ -23,17 +23,19 @@ function BreakdownTable({
   columns: BreakdownColumn[];
   children: React.ReactNode;
 }) {
+  // Cells render at the page's 13px body size; headers stay at the 12px muted
+  // label size the KPI tiles use.
   return (
     <Table.Root
       size="1"
-      className="[&_td]:!py-1.5 [&_th]:!py-1.5 [&_table]:w-full [&_table]:table-fixed [&_td]:overflow-hidden [&_td]:align-middle [&_th]:align-middle"
+      className="[&_table]:w-full [&_table]:table-fixed [&_td]:overflow-hidden [&_td]:py-2 [&_td]:align-middle [&_td]:text-[13px] [&_td]:text-gray-12 [&_th]:py-2 [&_th]:align-middle [&_th]:font-normal [&_th]:text-[12px] [&_th]:text-gray-11"
     >
       <Table.Header>
         <Table.Row>
           {columns.map((column) => (
             <Table.ColumnHeaderCell
               key={column.label}
-              className={`!text-gray-11 whitespace-nowrap font-normal text-[12px] ${column.numeric ? "text-right" : ""}`}
+              className={`whitespace-nowrap ${column.numeric ? "text-right" : ""}`}
               style={{ width: column.width }}
             >
               {column.label}
@@ -74,10 +76,10 @@ export function ToolBreakdownCard({ rows }: { rows: SpendAnalysisToolRow[] }) {
     >
       <BreakdownTable
         columns={[
-          { label: "Tool", width: "44%" },
-          { label: "Gens", width: "16%", numeric: true },
-          { label: "Avg input", width: "20%", numeric: true },
-          { label: "Cost", width: "20%", numeric: true },
+          { label: "Tool", width: "52%" },
+          { label: "Generations", width: "16%", numeric: true },
+          { label: "Avg input", width: "16%", numeric: true },
+          { label: "Cost", width: "16%", numeric: true },
         ]}
       >
         {rows.slice(0, 10).map((r) => (
@@ -106,9 +108,9 @@ export function ProductBreakdownCard({
     >
       <BreakdownTable
         columns={[
-          { label: "Product", width: "50%" },
-          { label: "Events", width: "25%", numeric: true },
-          { label: "Cost", width: "25%", numeric: true },
+          { label: "Product", width: "52%" },
+          { label: "Events", width: "24%", numeric: true },
+          { label: "Cost", width: "24%", numeric: true },
         ]}
       >
         {rows.map((r) => (

--- a/products/desktop/packages/ui/src/features/usage/components/SpendKpiStrip.tsx
+++ b/products/desktop/packages/ui/src/features/usage/components/SpendKpiStrip.tsx
@@ -6,23 +6,16 @@ import {
 } from "@posthog/core/billing/spendAnalysisFormat";
 import type { SpendAnalysisResponse } from "@posthog/core/billing/spendAnalysisTypes";
 import { MetricCard, useChartTheme } from "@posthog/quill-charts";
-import { Flex } from "@radix-ui/themes";
 import type { ReactNode } from "react";
 import { spendDayLabel } from "./spendDayLabel";
 
 const tileTitle = (label: string): ReactNode => (
-  <span className="text-[11px] text-gray-10 uppercase tracking-wide">
-    {label}
-  </span>
+  <span className="text-[12px] text-gray-11">{label}</span>
 );
 
-function KpiCell({ children, last }: { children: ReactNode; last?: boolean }) {
+function KpiCell({ children }: { children: ReactNode }) {
   return (
-    <div
-      className={`min-w-0 flex-1 px-4 py-3 ${last ? "" : "border-(--gray-5) border-r"}`}
-    >
-      {children}
-    </div>
+    <div className="min-w-0 bg-(--color-panel-solid) px-4 py-3">{children}</div>
   );
 }
 
@@ -40,8 +33,10 @@ export function SpendKpiStrip({ data, filledDays }: SpendKpiStripProps) {
   const latestDay = filledDays?.at(-1);
   const windowLabel = formatWindow(summary.date_from, summary.date_to);
 
+  // gap-px over the panel background draws the cell separators, so the tiles
+  // stay separated when the grid wraps to two columns in the settings pane.
   return (
-    <Flex className="overflow-hidden rounded-(--radius-3) border border-(--gray-5) bg-(--color-panel-solid)">
+    <div className="grid grid-cols-2 gap-px overflow-hidden rounded-(--radius-3) border border-(--gray-5) bg-(--gray-5) md:grid-cols-4">
       <KpiCell>
         <MetricCard
           title={tileTitle("Total spend")}
@@ -78,7 +73,7 @@ export function SpendKpiStrip({ data, filledDays }: SpendKpiStripProps) {
           sparklineHeight={28}
         />
       </KpiCell>
-      <KpiCell last>
+      <KpiCell>
         {latestDay ? (
           <MetricCard
             title={tileTitle("Latest day")}
@@ -98,6 +93,6 @@ export function SpendKpiStrip({ data, filledDays }: SpendKpiStripProps) {
           />
         )}
       </KpiCell>
-    </Flex>
+    </div>
   );
 }


### PR DESCRIPTION
## Problem

The Plan & usage page in PostHog Code settings does not scroll. Once the spend analysis is open, the daily spend chart, the model and tool breakdowns, and the insights card sit below the window and stay unreachable.

The page also looks unlike every other settings page. It stretched edge to edge, carried a bordered page header, wrapped its content in an extra card, and used its own heading sizes and panel fills.

## Changes

- Plan & usage now uses the contained settings layout, so it scrolls in a scroll area and sits in the same 800px column as General, Workspaces, and Agents.
- The page header loses its border and matches the header on every other settings page.
- Section headers move into a shared `SettingsSubsection` component, reused from the Agents page, so both pages keep one heading scale and divider rhythm.
- The wrapper card around Organization usage is gone. The billing button moves up next to the section title.
- The usage mix panel and the spend KPI tiles use the standard bordered panel treatment instead of a flat gray fill.
- The spend KPI tiles wrap to two columns in a narrow pane, and their labels drop the uppercase styling that no other settings page uses.
- The by-tool and by-product tables now stack at full width instead of sitting side by side in half-width cards.
- Those tables stop wrapping: numbers right-align on one line with tabular figures, and long tool names truncate with the full value in the title.
- Table typography matches the page: 13px cells in gray-12, 12px normal-weight headers in gray-11.
- Behavior is unchanged: "Your spend" still starts collapsed, so opening the page still does not fire the spend query.

## How did you test this code?

I did not run the Electron app. I rendered the page in Storybook with a headless browser and measured the layout before and after, using a temporary story that mounted the page in each settings layout with mock usage and mock spend data.

- Before: content height 1882px in an 820px viewport, and zero scrollable containers. The overflow was unreachable.
- After: one scroll area, content height 1975px against an 820px viewport, so the page scrolls.
- After: content column measures 800px, no element overflows horizontally, and both section headings resolve to the shared 13px semibold style.

Automated checks I ran: `pnpm turbo typecheck --filter=@posthog/ui`, `pnpm --filter=@posthog/ui test`, `biome check`, and `node scripts/check-host-boundaries.mjs`. No new tests: the change is layout only, and the existing Plan & usage stories already cover the page's states.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A user reported that the page would not scroll and looked out of place next to the other settings pages. Written with PostHog Code (Claude). No repo skills applied to this diff; I read `/writing-pr-descriptions` and `/writing-simplified-technical-english` for this description.

Two decisions worth a reviewer's attention. First, the fix could have been a scroll container inside the full-bleed layout, but the page had no reason to be full-bleed: it is a settings form, not a data table like Skills or MCP servers, so it moves onto the shared contained layout instead. Second, the Agents page already had the section-header pattern this page needed, so that component was extracted rather than copied, and the Agents page now renders from the shared version.

