### PR TITLE
fix(data-imports): don't report transient app-db blips in cdc setup

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/activities.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/activities.py
@@ -18,7 +18,7 @@ import datetime as dt
 import dataclasses
 from collections.abc import Callable
 
-from django.db import close_old_connections
+from django.db import InterfaceError, OperationalError, close_old_connections
 
 import psycopg
 import pyarrow as pa
@@ -28,6 +28,7 @@ from temporalio import activity
 
 from posthog.settings import WAREHOUSE_SOURCES_DATABASE_URL
 from posthog.temporal.common.activity_context import current_workflow_id, current_workflow_run_id
+from posthog.temporal.common.errors import NonReportableError
 from posthog.temporal.common.heartbeat_sync import HeartbeaterSync
 from posthog.utils import get_machine_id
 
@@ -711,8 +712,18 @@ class CDCExtractActivity:
         self._run_started_at = time.monotonic()
         self.log.info("cdc_extract_started")
 
-        if not self._setup():
-            return
+        try:
+            if not self._setup():
+                return
+        except (OperationalError, InterfaceError) as exc:
+            # `_setup` only reads our own app DB (source + schema rows), never a customer's — every
+            # CDC source is read over a raw driver connection, not Django's ORM — so this can only be
+            # a transient connection-pool blip on our side (e.g. PgBouncer dropping an idle
+            # connection), the same class already re-raised as `NonReportableError` for own-DB blips
+            # in import_data_sync.py. Temporal's retry policy isn't `NonRetryableException`-gated
+            # here, so it still retries; this only keeps a self-resolving blip out of error tracking.
+            self.log.warning("cdc_setup_transient_app_db_error", exc_info=True)
+            raise NonReportableError(str(exc)) from exc
 
         if self._previous_load_still_pending():
             return

--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_extract_activity.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_extract_activity.py
@@ -6,11 +6,13 @@ from typing import Literal
 import pytest
 from unittest.mock import MagicMock, patch
 
-from django.db.utils import OperationalError
+from django.db.utils import InterfaceError, OperationalError
 
 import pyarrow as pa
 import psycopg.errors
 from parameterized import parameterized
+
+from posthog.temporal.common.errors import NonReportableError
 
 from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
@@ -824,6 +826,37 @@ class TestCDCExtractActivity:
         inputs = CDCExtractInput(team_id=1, source_id=source.id)
         cdc_extract_activity(inputs)
 
+        mock_get_adapter.assert_not_called()
+
+    @parameterized.expand([("operational", OperationalError), ("interface", InterfaceError)])
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.activity")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.get_cdc_adapter")
+    @patch.object(CDCExtractActivity, "_get_cdc_schemas")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.ExternalDataSource")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.close_old_connections")
+    def test_setup_app_db_connection_blip_is_not_reported(
+        self,
+        _name,
+        exception_cls,
+        mock_close_conns,
+        MockSourceModel,
+        mock_get_schemas,
+        mock_get_adapter,
+        mock_activity,
+    ):
+        # `_setup` only reads our own app DB (never a customer's), so a dropped connection here
+        # (e.g. PgBouncer closing an idle connection) is a transient blip, not a broken sync. It
+        # must still be retried by Temporal, but shouldn't page as a fresh, reportable bug on
+        # every attempt.
+        MockSourceModel.DoesNotExist = ExternalDataSource.DoesNotExist
+        MockSourceModel.objects.get.side_effect = exception_cls("server closed the connection unexpectedly")
+
+        inputs = CDCExtractInput(team_id=1, source_id=uuid.uuid4())
+
+        with pytest.raises(NonReportableError, match="server closed the connection unexpectedly"):
+            cdc_extract_activity(inputs)
+
+        mock_get_schemas.assert_not_called()
         mock_get_adapter.assert_not_called()
 
     @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.activity")


### PR DESCRIPTION
## Problem

- The CDC extraction activity's setup step reads PostHog's own database to look up the source and its schemas.
- A dropped connection there (a connection-pool blip on our side) surfaces as a Django `OperationalError`/`InterfaceError` and is reported to error tracking on every attempt, even though Temporal already retries the activity and the blip resolves on its own.
- Seen live: [error tracking issue](https://us.posthog.com/project/2/error_tracking/019fe140-8b88-7bc2-b5b0-7072d1158819), raised from `ExternalDataSource.objects.get(...)` in `_setup()`.

## Changes

- Catch `OperationalError`/`InterfaceError` around `_setup()` in `cdc/activities.py` and re-raise as `NonReportableError`.
- Temporal's retry policy for this activity isn't gated on that type, so retries are unaffected; only reporting stops.
- This matches the reclassification already used for the identical own-database blip elsewhere in the same pipeline (`import_data_sync.py`, `repartition_table.py`) - `_setup()` was the one path missing it.

## How did you test this code?

- Added a parameterized regression test covering both `OperationalError` and `InterfaceError` from the source lookup, asserting the activity raises `NonReportableError` instead of the raw exception and never proceeds to load schemas.
- Ran `products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_extract_activity.py`: 73 passed. 7 pre-existing errors need a live Postgres connection this sandbox doesn't have, and fail identically on master.
- Ran `ruff check`/`ruff format` and repo-wide `mypy --cache-fine-grained .`: both clean.
- Not run: an end-to-end Temporal worker pass (no local Temporal/dev stack in this sandbox).

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal error-handling change, no user-facing or API behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a live error-tracking issue in PostHog's data-warehouse CDC pipeline with Claude Code, using the PostHog error-tracking MCP tools to pull the issue, stack trace, and event properties, then read the surrounding pipeline code to find the fix. Invoked `/writing-tests` before adding the regression test and `/writing-pr-descriptions` before writing this body.

Decision: classified this as a gap in an already-established pattern (own-app-DB connection blips reclassified as non-reportable) rather than a customer/upstream issue, so no `NonRetryableErrors` change was made and retries stay untouched.