### PR TITLE
fix(data-imports): stop reporting App Store Connect network blips as noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/source.py
@@ -119,6 +119,13 @@ Sales and subscription reports also need your vendor number (App Store Connect â
             "403 Client Error: Forbidden for url: https://api.appstoreconnect.apple.com": "Your App Store Connect API key does not have access to this data. Give the key a role that can read it (Finance or Sales for reports), then reconnect.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # `_get` has no retry loop of its own â€” it relies on the tracked session's urllib3 adapter
+        # to retry a connection failure or read timeout. Once that budget is exhausted, Temporal
+        # retries the whole activity, so this is transient and self-recovering. The host is fixed
+        # (never user input), so matching on it doesn't risk swallowing an unrelated failure.
+        return {"HTTPSConnectionPool(host='api.appstoreconnect.apple.com'"}
+
     def get_schemas(
         self,
         config: AppStoreConnectSourceConfig,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/tests/test_app_store_connect_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/tests/test_app_store_connect_source.py
@@ -201,3 +201,23 @@ class TestAppStoreConnectSource:
         assert any("401" in key for key in errors)
         assert any("403" in key for key in errors)
         assert all(message for message in errors.values())
+
+    @parameterized.expand(
+        [
+            (
+                "connection_error",
+                "HTTPSConnectionPool(host='api.appstoreconnect.apple.com', port=443): Max retries exceeded "
+                'with url: /v1/apps?limit=200 (Caused by ReadTimeoutError("HTTPSConnectionPool'
+                "(host='api.appstoreconnect.apple.com', port=443): Read timed out. (read timeout=60)\"))",
+            ),
+            (
+                "read_timeout",
+                "HTTPSConnectionPool(host='api.appstoreconnect.apple.com', port=443): Read timed out. (read timeout=60)",
+            ),
+        ]
+    )
+    def test_retryable_errors_match_transient_network_failures(self, _name: str, observed_error: str) -> None:
+        # `_get` has no retry loop of its own — it relies on the tracked session's urllib3 adapter.
+        # Once that's exhausted, this keeps the benign, self-recovering failure out of error tracking.
+        retryable_errors = AppStoreConnectSource().get_retryable_errors()
+        assert any(key in observed_error for key in retryable_errors)


### PR DESCRIPTION
## Problem

A sync against Apple's App Store Connect API that hits a connection failure or read timeout mints a fresh error-tracking issue on every occurrence, even though the sync already retries and recovers on its own.

[Error tracking issue](https://us.posthog.com/project/2/error_tracking/019fe181-f3d8-7c30-9135-9ec1e105080c): a `ConnectionError`/`ReadTimeoutError` while listing app IDs (`/v1/apps`) for a `subscription_groups` sync.

## Changes

- `AppStoreConnectSource` had no `get_retryable_errors()` override, so the shared `_handle_import_error` handler fell through to its default path: log at `exception` level and let `capture_exception` create an issue.
- `app_store_connect.py`'s `_get`/`_send` have no retry loop of their own — they rely on the shared tracked session's urllib3 adapter (`Retry(total=3)`) to retry a connection failure or read timeout. Once that budget is exhausted, Temporal retries the whole activity, so the failure is transient and self-recovering.
- Added `get_retryable_errors()` matching the fixed `api.appstoreconnect.apple.com` host. This is the same contract `VercelSource`/`NotionSource` already use for the identical urllib3 pool-error shape, keyed on a host that's never user input, so it can't swallow an unrelated failure.
- No retry policy changes: the activity still fails and Temporal still retries per its existing policy. Only whether the escaping exception gets reported to error tracking changes (via the existing `NonReportableError` marker).

## How did you test this code?

- Added `test_retryable_errors_match_transient_network_failures` (2 cases: the wrapped `ConnectionError` message and the bare `ReadTimeoutError` message) to `test_app_store_connect_source.py`, mirroring the existing Vercel test for the same failure shape. Catches a regression where this classification is removed and the noise comes back.
- Ran `products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/tests/test_app_store_connect_source.py` — 25 passed, including the 2 new cases.
- Ran `ruff check --fix` and `ruff format` on the touched files — clean.
- Did not complete a full repo-wide `mypy --cache-fine-grained .` locally (the run didn't converge in this sandbox within a reasonable time); the change is a two-line addition with the same shape and return type as the already-typechecked `VercelSource.get_retryable_errors`, and CI runs the same mypy command as a gate.
- Searched open PRs (excluding the automation bot, and the maintainer's own PRs) for this exception type, module path, and host — found no existing PR addressing this issue.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal error-classification change, no user-facing or documented behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error-tracking MCP tools (issue details, sampled event with full stack trace, and a HogQL query for the `warehouse_sources_*` correlation properties) to identify the exact failing frame and confirm this was a single, low-frequency occurrence. Read the shared pipeline retry/reporting code (`transport.py`, `import_data_sync.py`'s `_handle_import_error`) and the `NonReportableError` precedent (`RESTClientRetryableError`, `VercelSource.get_retryable_errors`) to confirm the right integration point before writing the fix. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*