### PR TITLE
fix(data-warehouse): guide Pipedrive users to enter just the subdomain

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pipedrive/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pipedrive/source.py
@@ -105,6 +105,7 @@ You can find your personal API token in Pipedrive under **Settings > Personal pr
                         type=SourceFieldInputConfigType.TEXT,
                         required=True,
                         placeholder="mycompany",
+                        caption="Enter just your Pipedrive subdomain, not a full URL. For acme.pipedrive.com, enter acme.",
                         secret=False,
                     ),
                     SourceFieldInputConfig(


### PR DESCRIPTION
## Problem

- A user connecting Pipedrive pastes a full URL or their website domain into the "Company domain" field, so setup fails with "Invalid Pipedrive company domain" before they can continue.
- The field takes only the Pipedrive subdomain (the part before `.pipedrive.com`), but the label "Company domain" and the bare `mycompany` placeholder do not say so until the error appears.

## Changes

- Add a help caption under the field: "Enter just your Pipedrive subdomain, not a full URL. For acme.pipedrive.com, enter acme."
- Copy only. Validation already normalizes pasted URLs and returns a clear error, so this just moves the guidance ahead of the mistake.

## How did you test this code?

- Ran the Pipedrive source tests: `pytest products/warehouse_sources/backend/temporal/data_imports/sources/pipedrive/tests/test_pipedrive_source.py`.
- No frontend code changed. The caption renders through the existing per-field `caption` support in the source form, the same path AskNicely and other sources use.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The connector docs already describe the subdomain format.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (actually Claude, via PostHog Code) made this change while reviewing data-warehouse new-source onboarding sessions for recurring friction. Sessions showed a user pasting a full URL into the Pipedrive domain field and hitting the validation error. The backend already normalizes URLs and returns a good error, so the fix is a proactive help caption rather than a validation change.

Skills invoked: `/writing-user-facing-copy`, `/writing-pr-descriptions`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
