### PR TITLE
fix(data-imports): don't crash repartition detection on a persistent app-db blip

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition_controller.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition_controller.py
@@ -12,6 +12,7 @@ import asyncio
 from typing import TYPE_CHECKING, Any
 
 from django.conf import settings
+from django.db import InterfaceError, OperationalError
 from django.utils import timezone
 
 import deltalake as deltalake
@@ -113,6 +114,13 @@ def _is_flag_enabled(schema: ExternalDataSchema, flag: str) -> bool:
     try:
         team = retry_on_db_connection_drop(lambda: Team.objects.only("uuid", "organization_id").get(id=schema.team_id))
     except Team.DoesNotExist:
+        return False
+    except (OperationalError, InterfaceError) as e:
+        # retry_on_db_connection_drop already retried once; a second failure is a genuinely degraded
+        # DB, not a bug here. Some callers (repartition_table.py) evaluate this flag with no enclosing
+        # try/except, so this function's contract of "never raises, defaults to disabled" must hold on
+        # its own.
+        capture_exception(e)
         return False
     try:
         return bool(

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition_controller.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition_controller.py
@@ -248,6 +248,23 @@ class TestIsAutoRepartitionEnabled:
 
         assert mock_queryset.get.call_count == 2
 
+    def test_returns_false_when_db_connection_stays_down(self, team):
+        # If the connection is still down on the retry, is_auto_repartition_enabled must not raise —
+        # repartition_table.py calls it with no enclosing try/except, so an uncaught OperationalError
+        # here crashes the whole activity instead of just leaving the flag resolved as disabled.
+        schema = _make_schema(team, {})
+        mock_queryset = MagicMock()
+        mock_queryset.get.side_effect = OperationalError("server closed the connection unexpectedly")
+
+        with (
+            patch("posthog.models.Team.objects.only", return_value=mock_queryset),
+            patch.object(ctrl, "capture_exception") as mock_capture_exception,
+        ):
+            assert ctrl.is_auto_repartition_enabled(schema) is False
+
+        assert mock_queryset.get.call_count == 2
+        mock_capture_exception.assert_called_once()
+
 
 class TestRepartitionOOMHistoryTrigger:
     def _detect(self, team, schema: ExternalDataSchema, delta: deltalake.DeltaTable) -> None:


### PR DESCRIPTION
## Problem

- The auto-repartition/coarsen rollout-flag check can crash the sync activity instead of falling back to "disabled" when PostHog's own database connection drops and stays down.
- Seen live: [error tracking issue](https://us.posthog.com/project/2/error_tracking/019fe203-28bf-7dc3-8fc2-352073e3a216), raised from `Team.objects.get(...)` inside `_is_flag_enabled` in `repartition_controller.py`.
- `repartition_table.py` calls `is_auto_repartition_enabled`/`is_auto_coarsen_enabled` directly with no enclosing try/except, so an uncaught `OperationalError` there crashes `maybe_repartition_table_activity`.
- The occurrence linked above happened to route through a caller that already has a catch-all handler, so it was reported but not fatal that time; the unguarded caller was still exposed to the same failure.

## Changes

- Catch `OperationalError`/`InterfaceError` around the `Team` lookup in `_is_flag_enabled`, matching the existing fallback already used a few lines below for a failed `feature_enabled` call: report via `capture_exception` and return `False`.
- `retry_on_db_connection_drop` already retries the lookup once; this only covers the case where that retry also fails, which is a genuinely degraded connection rather than a repartition bug.
- No change to retry behavior or `NonRetryableErrors` - the connection drop stays retryable, this only stops it from escaping a function whose contract is "never raise, default to disabled".

## How did you test this code?

- Added `test_returns_false_when_db_connection_stays_down` to `TestIsAutoRepartitionEnabled`, covering the case the existing `test_retries_once_on_transient_db_connection_drop` doesn't: both attempts fail. Before this fix, it raises `OperationalError` out of `is_auto_repartition_enabled`; after, it returns `False` and reports once via `capture_exception`.
- Ran `products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition_controller.py -k TestIsAutoRepartitionEnabled` locally against a live Postgres in this sandbox: 2 passed.
- `ruff check` / `ruff format --check` on both changed files: clean.
- Not run: an end-to-end Temporal worker pass (no live GoogleAds source or dev stack imports run in this sandbox).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal error-handling fix, no user-facing or API behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a live error-tracking issue in PostHog's data-warehouse import pipeline with Claude Code, using the PostHog error-tracking MCP tools to pull the issue, stack trace, and event properties, then read the surrounding pipeline code to trace the call graph and find the gap. Invoked `/writing-tests` before adding the regression test and `/writing-pr-descriptions` before writing this body.

Decision: classified this as a gap in an already-established pattern in the same function (best-effort flag check that must never raise) rather than a customer/upstream issue, so no `NonRetryableErrors` change was made and the DB-connection retry stays untouched.