### PR TITLE
feat(desktop): make default branch prefix configurable (Fixes #76277)

### DIFF
--- a/products/desktop/packages/core/src/git-interaction/branchName.test.ts
+++ b/products/desktop/packages/core/src/git-interaction/branchName.test.ts
@@ -112,4 +112,20 @@ describe("suggestBranchName", () => {
       ]),
     ).toBe("posthog-code/fix-bug-4");
   });
+
+  it("uses custom prefix when provided", () => {
+    expect(suggestBranchName("Fix bug", "abc", [], "custom/")).toBe(
+      "custom/fix-bug",
+    );
+  });
+
+  it("appends -2 on collision with custom prefix", () => {
+    expect(
+      suggestBranchName("Fix bug", "abc", ["custom/fix-bug"], "custom/"),
+    ).toBe("custom/fix-bug-2");
+  });
+
+  it("uses empty prefix when provided", () => {
+    expect(suggestBranchName("Fix bug", "abc", [], "")).toBe("fix-bug");
+  });
 });

--- a/products/desktop/packages/core/src/git-interaction/branchName.ts
+++ b/products/desktop/packages/core/src/git-interaction/branchName.ts
@@ -54,7 +54,8 @@ export function validateBranchName(name: string): string | null {
   return null;
 }
 
-export function deriveBranchName(title: string, fallbackId: string): string {
+export function deriveBranchName(title: string, fallbackId: string, prefix?: string): string {
+  const pfx = prefix ?? BRANCH_PREFIX;
   const slug = title
     .toLowerCase()
     .trim()
@@ -64,16 +65,17 @@ export function deriveBranchName(title: string, fallbackId: string): string {
     .slice(0, 60)
     .replace(/-$/, "");
 
-  if (!slug) return `${BRANCH_PREFIX}task-${fallbackId}`;
-  return `${BRANCH_PREFIX}${slug}`;
+  if (!slug) return `${pfx}task-${fallbackId}`;
+  return `${pfx}${slug}`;
 }
 
 export function suggestBranchName(
   title: string,
   fallbackId: string,
   existingBranches: string[],
+  prefix?: string,
 ): string {
-  const base = deriveBranchName(title, fallbackId);
+  const base = deriveBranchName(title, fallbackId, prefix);
 
   if (!existingBranches.includes(base)) return base;
 

--- a/products/desktop/packages/core/src/git-interaction/deriveBranchName.test.ts
+++ b/products/desktop/packages/core/src/git-interaction/deriveBranchName.test.ts
@@ -48,4 +48,16 @@ describe("deriveBranchName", () => {
       "posthog-code/task-abc123",
     );
   });
+
+  it("uses custom prefix when provided", () => {
+    expect(deriveBranchName("Fix bug", "abc", "custom/")).toBe("custom/fix-bug");
+  });
+
+  it("uses empty prefix when provided", () => {
+    expect(deriveBranchName("Fix bug", "abc", "")).toBe("fix-bug");
+  });
+
+  it("uses custom prefix with empty title", () => {
+    expect(deriveBranchName("", "xyz", "myorg/")).toBe("myorg/task-xyz");
+  });
 });

--- a/products/desktop/packages/ui/src/features/git-interaction/utils/getSuggestedBranchName.ts
+++ b/products/desktop/packages/ui/src/features/git-interaction/utils/getSuggestedBranchName.ts
@@ -4,6 +4,7 @@ import {
 } from "@posthog/core/git-interaction/branchName";
 import type { Task } from "@posthog/shared/domain-types";
 import type { QueryClient } from "@tanstack/react-query";
+import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import type { GitCacheKeyProvider } from "../gitCacheProvider";
 
 export function getSuggestedBranchName(
@@ -24,12 +25,14 @@ export function getSuggestedBranchName(
     ? String(task.task_number)
     : (task?.slug ?? taskId);
 
-  if (!repoPath) return deriveBranchName(task?.title ?? "", fallbackId);
+  const { branchPrefix } = useSettingsStore.getState();
+
+  if (!repoPath) return deriveBranchName(task?.title ?? "", fallbackId, branchPrefix);
 
   const cached =
     queryClient.getQueryData<string[]>(
       provider.gitQueryKey("getAllBranches", { directoryPath: repoPath }),
     ) ?? [];
 
-  return suggestBranchName(task?.title ?? "", fallbackId, cached);
+  return suggestBranchName(task?.title ?? "", fallbackId, cached, branchPrefix);
 }

--- a/products/desktop/packages/ui/src/features/settings/sections/GeneralSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/GeneralSettings.tsx
@@ -22,11 +22,12 @@ import {
   type SendMessagesWith,
   useSettingsStore,
 } from "@posthog/ui/features/settings/settingsStore";
+import { BRANCH_PREFIX } from "@posthog/shared";
 import { track } from "@posthog/ui/shell/analytics";
 import type { ThemePreference } from "@posthog/ui/shell/themeStore";
 import { useThemeStore } from "@posthog/ui/shell/themeStore";
 import { useHostCapabilities } from "@posthog/ui/shell/useHostCapabilities";
-import { Button, Flex, Link, Select, Switch, Text } from "@radix-ui/themes";
+import { Button, Flex, Link, Select, Switch, Text, TextField } from "@radix-ui/themes";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect } from "react";
 
@@ -53,6 +54,7 @@ export function GeneralSettings() {
   const { localWorkspaces } = useHostCapabilities();
   const { preventSleepWhileRunning, setPreventSleepWhileRunning } =
     useSettingsStore();
+  const { branchPrefix, setBranchPrefix } = useSettingsStore();
   const { data: serverPreventSleep } = useQuery(
     hostTRPC.sleep.getEnabled.queryOptions(undefined, {
       enabled: localWorkspaces,
@@ -411,6 +413,19 @@ export function GeneralSettings() {
       <Text className="mb-2 block border-gray-6 border-t pt-4 font-medium text-sm">
         Editor
       </Text>
+
+      <SettingRow
+        label="Branch prefix"
+        description={`Default branch name prefix when creating branches from PostHog (default: "${BRANCH_PREFIX}"). Set to empty for no prefix.`}
+      >
+        <TextField.Input
+          value={branchPrefix}
+          onChange={(e) => setBranchPrefix(e.target.value)}
+          placeholder={BRANCH_PREFIX}
+          size="1"
+          className="min-w-[200px]"
+        />
+      </SettingRow>
 
       <SettingRow
         label="Open diffs in"

--- a/products/desktop/packages/ui/src/features/settings/settingsStore.ts
+++ b/products/desktop/packages/ui/src/features/settings/settingsStore.ts
@@ -263,6 +263,10 @@ interface SettingsStore {
   recordHintShown: (key: string) => void;
   markHintLearned: (key: string) => void;
 
+  // Branch naming
+  branchPrefix: string;
+  setBranchPrefix: (prefix: string) => void;
+
   _hasHydrated: boolean;
   setHasHydrated: (hydrated: boolean) => void;
 }
@@ -517,6 +521,10 @@ export const useSettingsStore = create<SettingsStore>()(
           };
         }),
 
+      // Branch naming
+      branchPrefix: "posthog-code/",
+      setBranchPrefix: (prefix) => set({ branchPrefix: prefix }),
+
       _hasHydrated: false,
       setHasHydrated: (hydrated) => set({ _hasHydrated: hydrated }),
     }),
@@ -615,6 +623,9 @@ export const useSettingsStore = create<SettingsStore>()(
 
         // Onboarding hints
         hints: state.hints,
+
+        // Branch naming
+        branchPrefix: state.branchPrefix,
       }),
       onRehydrateStorage: () => (state, error) => {
         if (error) {


### PR DESCRIPTION
Closes #76277

## What
Allow users to set the default branch name prefix (currently hardcoded as `posthog-code/`) to a custom value or empty string.

## Why
Users on shared/org repos want their created branches prefixed with their org name (or nothing), instead of the hardcoded `posthog-code/`. This makes the branch prefix configurable.

## How
- Add `branchPrefix` to the UI settings store (default: `posthog-code/`)
- Add a text field under **General → Editor** to configure the prefix
- Make `deriveBranchName` and `suggestBranchName` accept an optional `prefix` parameter (defaults to the `BRANCH_PREFIX` constant)
- Wire `getSuggestedBranchName` to read the custom prefix from settings
- Add tests for custom prefix / empty prefix behavior

## Checklist
- [x] Tests pass for custom prefix, empty prefix, and collision cases
- [x] No new dependencies
- [x] Settings persist via `partialize`