### PR TITLE
fix(data-imports): don't report a dropped app-db connection during repartition detection

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
@@ -32,10 +32,10 @@ from posthog.temporal.common.utils import retry_on_db_connection_drop
 
 from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.table import (
-    DeltaTableRef,
-    is_transient_object_store_error,
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.errors import (
+    is_transient_maintenance_error,
 )
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.table import DeltaTableRef
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.repartition import (
     RepartitionBudgetExceededError,
     RepartitionSupersededError,
@@ -197,10 +197,12 @@ def _maybe_flag_pre_extraction(
     except Exception as e:
         # Detection is best-effort; a failure here must not block the sync. `get_delta_table` re-raises
         # transient object-store blips (S3/credential-provider timeouts) rather than swallowing them —
-        # see its own docstring — so this is the layer that must apply is_transient_object_store_error
-        # before reporting, same as the other best-effort call sites around this table.
-        if is_transient_object_store_error(e):
-            logger.warning("repartition: pre-extraction detection failed with a transient object-store error")
+        # see its own docstring — and resolving `job.folder_path()` on a pooled app-DB connection can
+        # raise OperationalError/InterfaceError the same way. `is_transient_maintenance_error` covers
+        # both, so this is the layer that must apply it before reporting, same as the other best-effort
+        # call sites around this table.
+        if is_transient_maintenance_error(e):
+            logger.warning("repartition: pre-extraction detection failed with a transient infra error")
         else:
             logger.warning("repartition: pre-extraction detection failed", exc_info=True)
             capture_exception(e)

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
@@ -5,6 +5,8 @@ import contextvars
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from django.db import InterfaceError, OperationalError
+
 from parameterized import parameterized
 
 from posthog.exceptions_capture import ambient_exception_properties
@@ -318,6 +320,28 @@ class TestMaybeFlagPreExtraction:
         schema = _schema(name="stripe_charge", s3_folder_name=None)
         helper = MagicMock()
         helper.get_delta_table = AsyncMock(side_effect=TransientObjectStoreError(message))
+
+        result = _maybe_flag_pre_extraction(schema, MagicMock(), helper, MagicMock(), enabled=True)
+
+        assert result is None
+        mock_capture.assert_not_called()
+
+    @parameterized.expand(
+        [
+            ("operational_error", OperationalError("consuming input failed: server closed the connection")),
+            ("interface_error", InterfaceError("connection already closed")),
+        ]
+    )
+    @patch(f"{MODULE}.capture_exception")
+    def test_transient_db_connection_drop_is_not_reported(
+        self, _name: str, error: Exception, mock_capture: MagicMock
+    ) -> None:
+        # `get_delta_table` resolves `job.folder_path()` on a pooled app-DB connection (see
+        # `DeltaTableRef._get_delta_table_uri`), which can raise these on a stale pooled connection —
+        # not the object-store errors `is_transient_object_store_error` alone would catch.
+        schema = _schema(name="stripe_charge", s3_folder_name=None)
+        helper = MagicMock()
+        helper.get_delta_table = AsyncMock(side_effect=error)
 
         result = _maybe_flag_pre_extraction(schema, MagicMock(), helper, MagicMock(), enabled=True)
 


### PR DESCRIPTION
## Problem

- Pre-extraction repartition detection reports a false failure to error tracking when PostHog's own app-database connection drops while resolving a sync job's Delta table folder.
- Seen live: [error tracking issue](https://us.posthog.com/project/2/error_tracking/019fe26b-da3b-7012-8060-bab068925898), raised from `folder_path` in `external_data_job.py`, reached via `get_delta_table` inside `_maybe_flag_pre_extraction` in `repartition_table.py`.
- The lookup lazily loads `job.schema` on a pooled Postgres connection recycled by pgbouncer; a stale connection there is a known infra blip, not a repartition bug.

## Changes

- `_maybe_flag_pre_extraction`'s exception handler classified transient failures with `is_transient_object_store_error`, which only recognizes S3/credential-provider blips and misses `OperationalError`/`InterfaceError` from the app database.
- Switched to `is_transient_maintenance_error`, a superset already covering `OperationalError`/`InterfaceError` for exactly this call path per its own docstring - the same reclassification already applied at every other best-effort site around this Delta table.

## How did you test this code?

- Added `test_transient_db_connection_drop_is_not_reported` (`OperationalError`/`InterfaceError` cases) to `TestMaybeFlagPreExtraction` in `test_repartition_table.py`. Before the fix, `_maybe_flag_pre_extraction` would call `capture_exception` on these; after, it doesn't - the gap the linked issue hit.
- Ran `products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py`: 21 passed.
- Ran `products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_delta_errors.py`: 30 passed.
- `ruff check`/`ruff format --check` and repo-wide `mypy --cache-fine-grained .` on the changed file: clean.
- Not run: an end-to-end Temporal worker pass (no live Stripe source or dev stack imports in this sandbox).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal error-classification fix, no user-facing or API behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a live error-tracking issue in PostHog's data-warehouse import pipeline with Claude Code, using the PostHog error-tracking MCP tools to pull the issue, stack trace, and event properties, then read the surrounding pipeline code to trace the call graph from `_maybe_flag_pre_extraction` through `get_delta_table` to the failing `job.schema` lookup. Invoked `/writing-tests` before adding the regression test and `/writing-pr-descriptions` before writing this body.

Decision: classified this as a gap in an already-established pattern - `is_transient_maintenance_error` exists specifically to cover app-DB connection drops from `job.folder_path()` (per its docstring) and is already used at other best-effort call sites around this table, but `_maybe_flag_pre_extraction` was still checking the narrower `is_transient_object_store_error`. Fixed the gap rather than widening `NonRetryableErrors` or changing retry policy.

Checked for duplicates before opening this: [#80133](https://github.com/PostHog/posthog/pull/80133) and [#80110](https://github.com/PostHog/posthog/pull/80110) fix related but distinct app-DB blip gaps in this pipeline (a different flag-lookup crash site and CDC setup, respectively) - neither touches `_maybe_flag_pre_extraction` or the delta-table error classifier.