### PR TITLE
fix(planetscale): stop reporting an exhausted connection retry as a bug during validation

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/planetscale/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/planetscale/source.py
@@ -54,6 +54,15 @@ _HOST_NOT_RESOLVED_ERROR = (
 
 _GENERIC_CONNECTION_ERROR = "Could not connect to PlanetScale. Please check all connection details are valid."
 
+# `get_schemas` already retried a transient connect-time drop in-process (`_connect_with_transient_retry`
+# in mysql.py) before this exhausted every attempt, so the sync path treats the same message as benign via
+# `get_retryable_errors` and never reports it. Mirror that here so a brief blip surfaced during interactive
+# validation doesn't get captured as an unexpected bug.
+_TRANSIENT_CONNECTION_ERROR = (
+    "Lost the connection to PlanetScale while checking your credentials. This is usually a brief network "
+    "blip rather than a configuration problem. Please try again."
+)
+
 # Create-time refinement of pymysql's catch-all connect error (2003), which collapses a bad host,
 # a closed port, and a firewall drop into one message. Mirrors the MySQL source's handling with
 # PlanetScale's own guidance. Kept out of `get_non_retryable_errors`, which the sync path also
@@ -210,6 +219,9 @@ class PlanetScaleSource(MySQLSource):
             for pattern, friendly_error in self.get_non_retryable_errors().items():
                 if pattern in error_msg:
                     return False, friendly_error or _GENERIC_CONNECTION_ERROR
+            for pattern in self.get_retryable_errors():
+                if pattern in error_msg:
+                    return False, _TRANSIENT_CONNECTION_ERROR
 
             capture_exception(e)
             return False, _GENERIC_CONNECTION_ERROR

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/planetscale/test_planetscale_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/planetscale/test_planetscale_source.py
@@ -193,6 +193,35 @@ def test_connection_failures_map_to_actionable_messages(raw_error, expected_frag
     capture.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "raw_error",
+    [
+        "(2013, 'Lost connection to MySQL server during query')",
+        "(1040, 'Too many connections')",
+        "(1105, 'reparent operation in progress')",
+    ],
+)
+def test_retryable_sync_errors_are_not_captured_during_validation(raw_error):
+    # `get_schemas` already retried these in-process (`_connect_with_transient_retry`) before
+    # exhausting its budget and re-raising. The sync path treats them as benign via
+    # `get_retryable_errors`; validation must not report them as unexpected bugs either.
+    with (
+        mock.patch.object(PlanetScaleSource, "is_database_host_valid", return_value=(True, None)),
+        mock.patch.object(PlanetScaleSource, "get_schemas", side_effect=Exception(raw_error)),
+        mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.planetscale.source.capture_exception"
+        ) as capture,
+    ):
+        success, error = PlanetScaleSource().validate_credentials(_config(), team_id=1)
+
+    assert success is False
+    assert error == (
+        "Lost the connection to PlanetScale while checking your credentials. This is usually a brief "
+        "network blip rather than a configuration problem. Please try again."
+    )
+    capture.assert_not_called()
+
+
 def test_unrecognized_failure_is_captured_and_reported_generically():
     with (
         mock.patch.object(PlanetScaleSource, "is_database_host_valid", return_value=(True, None)),


### PR DESCRIPTION
## Problem

Checking PlanetScale credentials reports a bug to error tracking when the underlying database connection drops mid-handshake, even though that same drop is a known, self-recovering condition everywhere else in this source.

- `get_schemas()` opens a connection through `_connect_with_transient_retry`, which already retries a transient drop (for example MySQL error 2013, "Lost connection to MySQL server during query") up to 5 times before giving up.
- The sync path lists that exact message in `get_retryable_errors()` and never reports it once the in-process retry exhausts.
- `PlanetScaleSource.validate_credentials` never checks `get_retryable_errors()`. Once the connection retry is exhausted, the exception falls through to `capture_exception`, so a brief network blip during interactive validation is captured as an unexpected code defect. That is what produced [this error tracking issue](https://us.posthog.com/project/2/error_tracking/019fe2e9-3b0e-7633-aa6d-1cc0d773ecc1).

## Changes

- `validate_credentials` now also checks `get_retryable_errors()` before capturing. A match returns a friendly "please try again" message without calling `capture_exception`.
- This mirrors the existing handling for `get_non_retryable_errors()` a few lines above, which already skips capture for known user/config errors.

## How did you test this code?

- Added `test_retryable_sync_errors_are_not_captured_during_validation`, parametrized over the three messages in `MySQLSource.get_retryable_errors()` (`Lost connection to MySQL server during query`, `Too many connections`, `reparent operation in progress`). Asserts each returns the friendly message and that `capture_exception` is not called. No existing test exercised this branch.
- Ran the full `test_planetscale_source.py` suite locally (28 passed) and repo-wide `mypy --cache-fine-grained .` (clean).
- Not run: a live sync or validation against a real PlanetScale branch.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or API changed beyond the error message shown on a specific transient failure.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error tracking webhook for issue `019fe2e9-3b0e-7633-aa6d-1cc0d773ecc1`. I (Claude) pulled the issue's stack trace and sample event via the PostHog MCP error-tracking tools, traced the failure to `validate_credentials` → `get_schemas` → `connect` → `_connect_with_transient_retry`, and confirmed the same error string is already classified retryable for the sync path via `MySQLSource.get_retryable_errors`, just not consulted during interactive validation. Checked for duplicate open PRs (none found) before opening this one. Skills invoked: `/investigating-error-issue`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-pr-descriptions`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*