### PR TITLE
chore(flags): link duplicate-key error toast to existing flag

### DIFF
--- a/frontend/src/initKea.ts
+++ b/frontend/src/initKea.ts
@@ -156,6 +156,8 @@ export function initKea({
                     // with this code is form validation (e.g. inviting an outside-domain email)
                     // and must keep the generic error toast.
                     const isVerifiedDomainError = error.code === 'verified_domain_required' && error.status === 403
+                    const isFeatureFlagDuplicateKey =
+                        actionKey === 'saveFeatureFlag' && error.code === 'unique' && error.attr === 'key'
 
                     if (!errorMessage && error.status === 404) {
                         errorMessage = 'URL not found'
@@ -168,8 +170,13 @@ export function initKea({
                     ) {
                         errorMessage = `Rate limit exceeded. Please try again ${error.formattedRetryAfter}.`
                     }
-                    if (isTwoFactorError || isSensitiveActionError || isVerifiedDomainError) {
-                        // These get their own dedicated toast in apiStatusLogic.
+                    if (
+                        isTwoFactorError ||
+                        isSensitiveActionError ||
+                        isVerifiedDomainError ||
+                        isFeatureFlagDuplicateKey
+                    ) {
+                        // These are handled by their own dedicated toasts elsewhere.
                         errorMessage = null
                     }
                     if (errorMessage) {

--- a/frontend/src/initKea.ts
+++ b/frontend/src/initKea.ts
@@ -58,6 +58,12 @@ other failures on these actions still toast.
 const ACCESS_DENIED_SELF_HANDLED = new Set(['saveFeatureFlag'])
 
 /*
+Write actions whose own logic toasts the duplicate-key 400 (code `unique` on attr `key`), so the
+generic toast would be a second one. Owned by featureFlagLogic's saveFeatureFlagFailure listener.
+*/
+const DUPLICATE_KEY_SELF_HANDLED = new Set(['saveFeatureFlag'])
+
+/*
 Transient gateway/proxy errors. These are infrastructure-level failures (the gateway can't
 reach the backend), not application bugs, so we still toast the user a retryable failure but
 don't report them to error tracking — otherwise sporadic 5xxs surface as noisy code-regression
@@ -157,7 +163,9 @@ export function initKea({
                     // and must keep the generic error toast.
                     const isVerifiedDomainError = error.code === 'verified_domain_required' && error.status === 403
                     const isFeatureFlagDuplicateKey =
-                        actionKey === 'saveFeatureFlag' && error.code === 'unique' && error.attr === 'key'
+                        error.code === 'unique' &&
+                        error.attr === 'key' &&
+                        DUPLICATE_KEY_SELF_HANDLED.has(String(actionKey))
 
                     if (!errorMessage && error.status === 404) {
                         errorMessage = 'URL not found'

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
@@ -318,6 +318,93 @@ describe('featureFlagLogic', () => {
                 toastSpy.mockRestore()
             }
         })
+
+        it('links the duplicate-key toast to the flag already using that key', async () => {
+            useMocks({
+                patch: {
+                    [`/api/projects/${MOCK_DEFAULT_PROJECT.id}/feature_flags/${MOCK_FEATURE_FLAG.id}/`]: () => [
+                        400,
+                        {
+                            type: 'validation_error',
+                            code: 'unique',
+                            attr: 'key',
+                            detail: 'There is already a feature flag with this key.',
+                        },
+                    ],
+                },
+                get: {
+                    [`/api/projects/${MOCK_DEFAULT_PROJECT.id}/feature_flags/`]: () => [
+                        200,
+                        { results: [{ ...MOCK_FEATURE_FLAG, id: 42 }], count: 1 },
+                    ],
+                },
+            })
+            const toastSpy = jest.spyOn(lemonToast, 'error').mockReturnValue('toast-id')
+            const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null)
+            try {
+                await expectLogic(logic, () => {
+                    logic.actions.saveFeatureFlag(logic.values.featureFlag)
+                })
+                    .toDispatchActions(['saveFeatureFlagFailure'])
+                    .toFinishAllListeners()
+
+                // One toast means the generic loaders toast stayed suppressed (initKea.ts) and this
+                // listener produced the only message; two would mean the suppression broke.
+                expect(toastSpy).toHaveBeenCalledTimes(1)
+                const [message, options] = toastSpy.mock.calls[0] as [
+                    string,
+                    { button?: { label: string; action: () => void } } | undefined,
+                ]
+                expect(message).toBe('Save feature flag failed: There is already a feature flag with this key.')
+                expect(options?.button?.label).toBe('View existing flag')
+
+                options?.button?.action()
+                expect(openSpy).toHaveBeenCalledWith(urls.featureFlag(42), '_blank')
+            } finally {
+                toastSpy.mockRestore()
+                openSpy.mockRestore()
+            }
+        })
+
+        it.each([
+            ['the list returns no matching flag', 200, { results: [], count: 0 }],
+            ['the lookup request fails', 500, { type: 'server_error', detail: 'boom' }],
+        ])('shows a plain duplicate-key toast when %s', async (_desc, listStatus, listBody) => {
+            useMocks({
+                patch: {
+                    [`/api/projects/${MOCK_DEFAULT_PROJECT.id}/feature_flags/${MOCK_FEATURE_FLAG.id}/`]: () => [
+                        400,
+                        {
+                            type: 'validation_error',
+                            code: 'unique',
+                            attr: 'key',
+                            detail: 'There is already a feature flag with this key.',
+                        },
+                    ],
+                },
+                get: {
+                    [`/api/projects/${MOCK_DEFAULT_PROJECT.id}/feature_flags/`]: () => [listStatus, listBody],
+                },
+            })
+            const toastSpy = jest.spyOn(lemonToast, 'error').mockReturnValue('toast-id')
+            const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null)
+            try {
+                await expectLogic(logic, () => {
+                    logic.actions.saveFeatureFlag(logic.values.featureFlag)
+                })
+                    .toDispatchActions(['saveFeatureFlagFailure'])
+                    .toFinishAllListeners()
+
+                expect(toastSpy).toHaveBeenCalledTimes(1)
+                expect(toastSpy).toHaveBeenCalledWith(
+                    'Save feature flag failed: There is already a feature flag with this key.'
+                )
+                expect(openSpy).not.toHaveBeenCalled()
+            } finally {
+                toastSpy.mockRestore()
+                openSpy.mockRestore()
+            }
+        })
     })
 
     describe('setMultivariateEnabled functionality', () => {

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -2885,6 +2885,29 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
                             error.detail ||
                                 "You don't have permission to edit this feature flag. Contact your administrator to request editing rights."
                         )
+                    } else if (error.code === 'unique' && error.attr === 'key') {
+                        const message = `Save feature flag failed: ${
+                            error.detail ?? 'There is already a feature flag with this key.'
+                        }`
+                        const key = preparedFlag.key ?? updatedFlag.key ?? ''
+                        const existing = await api
+                            .get(
+                                `api/projects/${values.currentProjectId}/feature_flags/?key=${encodeURIComponent(key)}`
+                            )
+                            .catch(() => null)
+                        const existingFlagId: number | null = existing?.results?.[0]?.id ?? null
+                        if (existingFlagId) {
+                            lemonToast.error(message, {
+                                button: {
+                                    label: 'View existing flag',
+                                    action: () => {
+                                        window.open(urls.featureFlag(existingFlagId), '_blank')
+                                    },
+                                },
+                            })
+                        } else {
+                            lemonToast.error(message)
+                        }
                     }
                     throw error
                 }

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -87,6 +87,7 @@ import { TEMPLATE_NAMES } from 'products/feature_flags/frontend/featureFlagTempl
 import {
     featureFlagsCopyFlagsCreate,
     featureFlagsCopyFlagsDependencyRequirementsCreate,
+    featureFlagsList,
 } from 'products/feature_flags/frontend/generated/api'
 import type { CopyFlagsDependencyRequirementsResponseApi } from 'products/feature_flags/frontend/generated/api.schemas'
 
@@ -2885,30 +2886,9 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
                             error.detail ||
                                 "You don't have permission to edit this feature flag. Contact your administrator to request editing rights."
                         )
-                    } else if (error.code === 'unique' && error.attr === 'key') {
-                        const message = `Save feature flag failed: ${
-                            error.detail ?? 'There is already a feature flag with this key.'
-                        }`
-                        const key = preparedFlag.key ?? updatedFlag.key ?? ''
-                        const existing = await api
-                            .get(
-                                `api/projects/${values.currentProjectId}/feature_flags/?key=${encodeURIComponent(key)}`
-                            )
-                            .catch(() => null)
-                        const existingFlagId: number | null = existing?.results?.[0]?.id ?? null
-                        if (existingFlagId) {
-                            lemonToast.error(message, {
-                                button: {
-                                    label: 'View existing flag',
-                                    action: () => {
-                                        window.open(urls.featureFlag(existingFlagId), '_blank')
-                                    },
-                                },
-                            })
-                        } else {
-                            lemonToast.error(message)
-                        }
                     }
+                    // Duplicate-key (`unique`/`key`) is toasted in the saveFeatureFlagFailure listener so
+                    // the throw runs immediately and the form doesn't stay skeletoned during the lookup.
                     throw error
                 }
             },
@@ -3527,12 +3507,38 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
             // Set all completed tasks at once to avoid conflicts
             globalSetupLogic.findMounted()?.actions.markTaskAsCompleted(completedTasks)
         },
-        saveFeatureFlagFailure: ({ errorObject }) => {
+        saveFeatureFlagFailure: async ({ errorObject }) => {
             if (values.featureFlag.id && handleApprovalRequired(errorObject, 'feature_flag', values.featureFlag.id)) {
                 // Redirect to detail page so user can see the CR banner
                 router.actions.replace(urls.featureFlag(values.featureFlag.id))
                 actions.editFeatureFlag(false)
                 return
+            }
+
+            if (errorObject?.code !== 'unique' || errorObject?.attr !== 'key') {
+                return
+            }
+            const message = `Save feature flag failed: ${errorObject.detail}`
+            const key = values.featureFlag.key
+            if (!key) {
+                lemonToast.error(message)
+                return
+            }
+            // The backend rejects on an exact key match, so pick the exact match out of the
+            // case-insensitive list rather than trusting its newest-first ordering.
+            const existing = await featureFlagsList(String(values.currentProjectId), { key }).catch(() => null)
+            const existingFlagId = existing?.results?.find((flag) => flag.key === key)?.id ?? null
+            if (existingFlagId) {
+                lemonToast.error(message, {
+                    button: {
+                        label: 'View existing flag',
+                        action: () => {
+                            window.open(urls.featureFlag(existingFlagId), '_blank')
+                        },
+                    },
+                })
+            } else {
+                lemonToast.error(message)
             }
         },
         updateFeatureFlagActiveSuccess: ({ featureFlagActiveUpdate }) => {


### PR DESCRIPTION
## Problem

Saving a feature flag whose key already exists shows an error toast whose only action is a generic "Get help" link. It points at support docs, not at the flag already using that key, so there's no quick way to reach the conflict.

## Changes

- The duplicate-key toast now offers a "View existing flag" button that opens the conflicting flag in a new tab, leaving your in-progress form intact.
- Falls back to the previous "Get help" toast when the flag can't be resolved.

## How did you test this code?
Locally tested 

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None needed. This only changes an error-toast affordance, no documented workflow.

## 🤖 Agent context
