### PR TITLE
feat(data-warehouse): promote Customer.io source to GA

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/customer_io/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/customer_io/source.py
@@ -147,8 +147,7 @@ class CustomerIOSource(
                     ),
                 ],
             ),
-            releaseStatus=ReleaseStatus.BETA,
-            featureFlag="dwh-customer-io",
+            releaseStatus=ReleaseStatus.GA,
             webhookSetupCaption=(
                 "PostHog tries to register the reporting webhook for you using your App API Key. "
                 "Customer.io doesn't return the signing key in the API response, so you still need "


### PR DESCRIPTION
## Problem

Teams connecting a data warehouse source saw Customer.io labelled Beta, and it only appeared for teams on the `dwh-customer-io` feature flag. The source has met the promotion bar, so both the label and the gate now understate it.

- Live 3.1 months with a 0.0% import error rate over the last 7 days (bar: 100 teams or 3 months live, and under 2.5% error rate).

## Changes

- Customer.io now ships as GA to every team, no feature flag required.
- Set `releaseStatus` from `ReleaseStatus.BETA` to `ReleaseStatus.GA`.
- Removed `featureFlag="dwh-customer-io"`. No GA source in the tree keeps a feature flag — the flag gates a source to flagged teams, which contradicts general availability.
- No connector behaviour, schema, or sync logic changed. This is a status promotion only.

## How did you test this code?

- Ran the source-class suite for this source: `test_customer_io_source.py`. No test asserts the release status or feature flag, and none referenced `dwh-customer-io` elsewhere in the repo.
- I (Claude) did not exercise a live Customer.io sync; the change touches only static source metadata.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The public docs render release status from the API, so no doc file changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (actually Claude) made this change. I invoked the `/implementing-warehouse-sources` skill to confirm where release status and gating live and how GA sources handle the feature flag, and `/writing-pr-descriptions` for this body. I checked open PRs (including the maintainer's own) for an existing Customer.io promotion before opening this one and found none. The decision to remove the feature flag rather than leave it follows the convention that every existing GA source ships without one.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
