### PR TITLE
feat(warehouse-sources): incremental sync for Decagon conversations

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/canonical_descriptions.py
@@ -13,6 +13,7 @@ CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
             "conversation_id": "Unique identifier for the conversation.",
             "user_id": "Identifier of the end user who had the conversation.",
             "created_at": "Timestamp at which the conversation was created.",
+            "updated_at": "Timestamp at which the conversation was last updated. Advances whenever the conversation receives new messages.",
             "destination": "Channel the conversation was handled on (e.g. AI).",
             "messages": "All messages in the conversation; each message has text, a role (USER or AI), and a created_at timestamp.",
             "csat_rating": "Customer satisfaction rating the user gave the conversation, if any.",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/decagon.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/decagon.py
@@ -1,6 +1,7 @@
 import time
 import dataclasses
 from collections.abc import Iterator
+from datetime import UTC, date, datetime
 from typing import Any, Optional
 
 import requests
@@ -31,6 +32,16 @@ NEXT_CURSOR_KEYS = ("next_page_cursor", "next_cursor", "next_page_updated_after"
 # than relying on 429 backoff alone.
 MIN_SECONDS_BETWEEN_REQUESTS = 1.0
 
+# Maps a conversation row column to the `timestamp_filter` enum value that makes the
+# export's min_timestamp/max_timestamp params bound that column. The filter for the
+# `last_message_at` column is named `last_message_time`; both spellings are the
+# vendor's, not a typo.
+TIMESTAMP_FILTER_BY_FIELD: dict[str, str] = {
+    "created_at": "created_at",
+    "updated_at": "updated_at",
+    "last_message_at": "last_message_time",
+}
+
 
 class DecagonRetryableError(Exception):
     pass
@@ -40,6 +51,13 @@ class DecagonRetryableError(Exception):
 class DecagonResumeConfig:
     # The next-page export cursor returned by Decagon (see NEXT_CURSOR_KEYS).
     cursor: str
+    # The incremental window the cursor belongs to. A resumed run must reissue exactly
+    # these params alongside the cursor: the stored watermark can advance while a walk
+    # is in flight, and pairing a recomputed min_timestamp with a cursor positioned
+    # inside the old window would skip rows at the window boundary. Optional so states
+    # saved before these fields existed still parse.
+    min_timestamp: Optional[int] = None
+    timestamp_filter: Optional[str] = None
 
 
 class RequestThrottle:
@@ -62,6 +80,22 @@ def _get_headers(api_key: str) -> dict[str, str]:
         "Authorization": f"Bearer {api_key}",
         "Accept": "application/json",
     }
+
+
+def _to_epoch_seconds(value: Any) -> int:
+    """Coerce an incremental watermark to Unix epoch seconds for the `min_timestamp` param.
+
+    The watermark is stored from the ISO 8601 `updated_at` column, but the pipeline may hand
+    it back as a datetime, a date, or an epoch number depending on how it round-tripped
+    through storage. int() truncates any sub-second part, so the boundary second is
+    re-fetched and the merge dedupes it on the primary key.
+    """
+    if isinstance(value, datetime):
+        dt = value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
+        return int(dt.timestamp())
+    if isinstance(value, date):
+        return int(datetime.combine(value, datetime.min.time(), tzinfo=UTC).timestamp())
+    return int(value)
 
 
 def _next_cursor(data: dict[str, Any]) -> Optional[str]:
@@ -94,6 +128,9 @@ def get_rows(
     endpoint: str,
     logger: FilteringBoundLogger,
     resumable_source_manager: ResumableSourceManager[DecagonResumeConfig],
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Optional[Any] = None,
+    incremental_field: Optional[str] = None,
 ) -> Iterator[list[dict[str, Any]]]:
     config = DECAGON_ENDPOINTS[endpoint]
     headers = _get_headers(api_key)
@@ -103,8 +140,29 @@ def get_rows(
 
     resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
     cursor: Optional[str] = resume_config.cursor if resume_config else None
-    if cursor:
+
+    min_timestamp: Optional[int] = None
+    timestamp_filter: Optional[str] = None
+    if resume_config:
+        # Resume the walk exactly where it stopped: same window, same cursor. See the
+        # DecagonResumeConfig field comments for why the window is not recomputed here.
+        min_timestamp = resume_config.min_timestamp
+        timestamp_filter = resume_config.timestamp_filter
         logger.debug(f"Decagon: resuming {endpoint} from saved cursor")
+    elif should_use_incremental_field and db_incremental_field_last_value is not None and incremental_field:
+        filter_name = TIMESTAMP_FILTER_BY_FIELD.get(incremental_field)
+        if filter_name:
+            # min_timestamp takes epoch seconds (the vendor's own example is
+            # `?min_timestamp=1782864000`). Whether the bound is inclusive is undocumented;
+            # the truncation in _to_epoch_seconds re-fetches the boundary second either way,
+            # and the merge dedupes it on the primary key.
+            min_timestamp = _to_epoch_seconds(db_incremental_field_last_value)
+            timestamp_filter = filter_name
+        else:
+            logger.warning(
+                f"Decagon: incremental field {incremental_field} has no server-side timestamp "
+                f"filter; walking the full export instead"
+            )
 
     @retry(
         retry=retry_if_exception_type((DecagonRetryableError, requests.ReadTimeout, requests.ConnectionError)),
@@ -129,12 +187,18 @@ def get_rows(
     # A conversation that receives new messages re-enters the export stream on a later
     # page, so a single walk can emit the same conversation twice. Full-refresh writes
     # are plain appends (no primary-key merge), so re-emissions are skipped client-side;
-    # the next sync picks up the newer version.
-    seen_ids: set[str] = set()
+    # the next sync picks up the newer version. Incremental writes merge on the primary
+    # key and the writer keeps the last occurrence per key within a batch, so there the
+    # re-emission must flow through (dropping it would keep the stale version) and the
+    # set, which grows unboundedly across a large export, is not needed.
+    seen_ids: Optional[set[str]] = None if should_use_incremental_field else set()
 
     while True:
         # An omitted cursor starts the stream at the oldest conversations.
-        params = {"cursor": cursor} if cursor else {}
+        params: dict[str, str] = {"cursor": cursor} if cursor else {}
+        if min_timestamp is not None and timestamp_filter is not None:
+            params["min_timestamp"] = str(min_timestamp)
+            params["timestamp_filter"] = timestamp_filter
         data = fetch_page(params)
 
         items = data.get(config.data_key) or []
@@ -146,18 +210,26 @@ def get_rows(
             # without one should fail the sync loudly rather than land in the warehouse
             # unkeyed and undeduplicatable.
             item_id = item["conversation_id"]
-            if item_id in seen_ids:
-                continue
-            seen_ids.add(item_id)
+            if seen_ids is not None:
+                if item_id in seen_ids:
+                    continue
+                seen_ids.add(item_id)
             fresh.append(item)
 
         if fresh:
             yield fresh
             # Save state only after yielding, so a crash re-yields the last batch rather
             # than skipping it (the duplicate rows a resumed re-yield can produce are
-            # bounded to one page and cleaned up by the next full refresh).
+            # bounded to one page, and are cleaned up by the next full refresh or merged
+            # away on the primary key).
             if next_cursor:
-                resumable_source_manager.save_state(DecagonResumeConfig(cursor=next_cursor))
+                resumable_source_manager.save_state(
+                    DecagonResumeConfig(
+                        cursor=next_cursor,
+                        min_timestamp=min_timestamp,
+                        timestamp_filter=timestamp_filter,
+                    )
+                )
 
         # The next-page cursor is null once the stream is exhausted. Also stop if the
         # server ever returns the cursor we just used, to guard against spinning on
@@ -182,6 +254,9 @@ def decagon_source(
     endpoint: str,
     logger: FilteringBoundLogger,
     resumable_source_manager: ResumableSourceManager[DecagonResumeConfig],
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Optional[Any] = None,
+    incremental_field: Optional[str] = None,
 ) -> SourceResponse:
     config = DECAGON_ENDPOINTS[endpoint]
 
@@ -192,6 +267,9 @@ def decagon_source(
             endpoint=endpoint,
             logger=logger,
             resumable_source_manager=resumable_source_manager,
+            should_use_incremental_field=should_use_incremental_field,
+            db_incremental_field_last_value=db_incremental_field_last_value,
+            incremental_field=incremental_field,
         ),
         primary_keys=config.primary_keys,
         partition_count=1,
@@ -199,4 +277,7 @@ def decagon_source(
         partition_mode="datetime",
         partition_format="month",
         partition_keys=[config.partition_key],
+        # The export walks oldest to newest (`order` defaults to asc), so the pipeline can
+        # checkpoint the incremental watermark as batches arrive.
+        sort_mode="asc",
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/settings.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from products.warehouse_sources.backend.types import IncrementalField
+from products.warehouse_sources.backend.types import IncrementalField, IncrementalFieldType
 
 
 @dataclass
@@ -15,6 +15,10 @@ class DecagonEndpointConfig:
     # Stable datetime field used for partitioning. Must never change for a row
     # (so `created_at`, never `updated_at`).
     partition_key: str
+    # Whether the append sync type is offered alongside incremental. Streams whose
+    # rows mutate in place must leave this False: appends would accumulate one copy
+    # per mutation, and only a merge keeps the table at one row per primary key.
+    supports_append: bool = False
 
 
 # Decagon's syncable surface is a single stream: /conversation/export returns
@@ -22,18 +26,29 @@ class DecagonEndpointConfig:
 # per page. Pagination is a `cursor` request param fed from a next-page response
 # field whose name varies across Decagon's own docs (see NEXT_CURSOR_KEYS in
 # decagon.py); it is null once the stream is exhausted. The export also accepts
-# optional min_timestamp/max_timestamp filters on a conversation's last-updated
-# time, but rows expose no last-updated column our incremental machinery could
-# store as a watermark (only created_at, and a conversation re-enters the stream
-# whenever it receives new messages), so the stream is full refresh only.
+# min_timestamp/max_timestamp filters (epoch seconds), with `timestamp_filter`
+# selecting the field they bound: created_at (the default), updated_at, or
+# last_message_time. Rows always carry `updated_at` (ISO 8601), so the stream
+# syncs incrementally by filtering on updated_at and merging on conversation_id.
+# A conversation re-enters the export whenever it receives new messages, which is
+# why the vendor recommends upserting on conversation_id rather than appending.
 DECAGON_ENDPOINTS: dict[str, DecagonEndpointConfig] = {
     "conversations": DecagonEndpointConfig(
         name="conversations",
         path="/conversation/export",
         data_key="conversations",
         primary_keys=["conversation_id"],
-        incremental_fields=[],
+        incremental_fields=[
+            {
+                "label": "updated_at",
+                "type": IncrementalFieldType.DateTime,
+                "field": "updated_at",
+                "field_type": IncrementalFieldType.DateTime,
+            }
+        ],
         partition_key="created_at",
+        # A conversation row mutates in place whenever new messages arrive.
+        supports_append=False,
     ),
 }
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/source.py
@@ -23,6 +23,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.decagon.de
     validate_credentials as validate_decagon_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.decagon.settings import (
+    DECAGON_ENDPOINTS,
     ENDPOINTS,
     INCREMENTAL_FIELDS,
 )
@@ -102,7 +103,8 @@ You can find your API key on the **Developer** page of the [Decagon dashboard](h
             SourceSchema(
                 name=endpoint,
                 supports_incremental=len(INCREMENTAL_FIELDS.get(endpoint, [])) > 0,
-                supports_append=len(INCREMENTAL_FIELDS.get(endpoint, [])) > 0,
+                supports_append=DECAGON_ENDPOINTS[endpoint].supports_append
+                and len(INCREMENTAL_FIELDS.get(endpoint, [])) > 0,
                 incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
             )
             for endpoint in ENDPOINTS
@@ -140,4 +142,9 @@ You can find your API key on the **Developer** page of the [Decagon dashboard](h
             endpoint=inputs.schema_name,
             logger=inputs.logger,
             resumable_source_manager=resumable_source_manager,
+            should_use_incremental_field=inputs.should_use_incremental_field,
+            db_incremental_field_last_value=inputs.db_incremental_field_last_value
+            if inputs.should_use_incremental_field
+            else None,
+            incremental_field=inputs.incremental_field,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/tests/test_decagon.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/tests/test_decagon.py
@@ -1,4 +1,5 @@
 import json
+from datetime import UTC, date, datetime
 from typing import Any
 
 from unittest.mock import MagicMock, patch
@@ -10,6 +11,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.res
 from products.warehouse_sources.backend.temporal.data_imports.sources.decagon.decagon import (
     DECAGON_BASE_URL,
     DecagonResumeConfig,
+    _to_epoch_seconds,
     decagon_source,
     get_rows,
     validate_credentials,
@@ -59,7 +61,9 @@ class TestValidateCredentials:
 
 
 class TestGetRows:
-    def _drive(self, manager: MagicMock, responses: list[Response]) -> tuple[list[dict[str, Any]], list[list[str]]]:
+    def _drive(
+        self, manager: MagicMock, responses: list[Response], **incremental_kwargs: Any
+    ) -> tuple[list[dict[str, Any]], list[list[str]]]:
         """Drive get_rows with a mocked session; return (params sent per page, ids yielded per batch)."""
         sent_params: list[dict[str, Any]] = []
         response_iter = iter(responses)
@@ -79,6 +83,7 @@ class TestGetRows:
                     endpoint="conversations",
                     logger=MagicMock(),
                     resumable_source_manager=manager,
+                    **incremental_kwargs,
                 )
             )
         yielded_ids = [[item["conversation_id"] for item in batch] for batch in batches]
@@ -176,6 +181,84 @@ class TestGetRows:
         assert sent_params == [{}, {"cursor": "cur-1"}]
         assert yielded_ids == [["c1"]]
 
+    def test_incremental_walk_sends_window_on_every_page_and_saves_it(self) -> None:
+        manager = self._fresh_manager()
+        watermark = datetime(2026, 1, 15, 12, 0, 5, tzinfo=UTC)
+        epoch = str(int(watermark.timestamp()))
+        responses = [
+            _make_response({"conversations": [_conversation("c1")], "next_page_cursor": "cur-1"}),
+            _make_response({"conversations": [_conversation("c2")], "next_page_cursor": None}),
+        ]
+        sent_params, yielded_ids = self._drive(
+            manager,
+            responses,
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=watermark,
+            incremental_field="updated_at",
+        )
+
+        assert sent_params == [
+            {"min_timestamp": epoch, "timestamp_filter": "updated_at"},
+            {"cursor": "cur-1", "min_timestamp": epoch, "timestamp_filter": "updated_at"},
+        ]
+        assert yielded_ids == [["c1"], ["c2"]]
+        saved = [call.args[0] for call in manager.save_state.call_args_list]
+        assert saved == [DecagonResumeConfig(cursor="cur-1", min_timestamp=int(epoch), timestamp_filter="updated_at")]
+
+    def test_first_incremental_sync_without_watermark_walks_the_full_export(self) -> None:
+        manager = self._fresh_manager()
+        responses = [_make_response({"conversations": [_conversation("c1")], "next_page_cursor": None})]
+        sent_params, yielded_ids = self._drive(
+            manager,
+            responses,
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=None,
+            incremental_field="updated_at",
+        )
+        assert sent_params == [{}]
+        assert yielded_ids == [["c1"]]
+
+    def test_incremental_walk_reemits_reappearing_conversations_for_the_merge(self) -> None:
+        # Incremental writes merge on conversation_id and keep the last occurrence, so the
+        # re-emission carries the newer version. Skipping it client-side (the full-refresh
+        # dedupe) would persist the stale first copy.
+        manager = self._fresh_manager()
+        responses = [
+            _make_response({"conversations": [_conversation("c1"), _conversation("c2")], "next_page_cursor": "cur-1"}),
+            _make_response({"conversations": [_conversation("c2"), _conversation("c3")], "next_page_cursor": None}),
+        ]
+        _, yielded_ids = self._drive(
+            manager,
+            responses,
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=datetime(2026, 1, 1, tzinfo=UTC),
+            incremental_field="updated_at",
+        )
+        assert yielded_ids == [["c1", "c2"], ["c2", "c3"]]
+
+    def test_resumed_incremental_run_reuses_the_saved_window(self) -> None:
+        # The stored watermark advances as batches land, so recomputing the window on resume
+        # would pair a fresh min_timestamp with a cursor positioned inside the old window and
+        # skip rows at the boundary.
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = True
+        manager.load_state.return_value = DecagonResumeConfig(
+            cursor="cur-resumed", min_timestamp=1768478405, timestamp_filter="updated_at"
+        )
+
+        responses = [_make_response({"conversations": [_conversation("c9")], "next_page_cursor": None})]
+        sent_params, _ = self._drive(
+            manager,
+            responses,
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=datetime(2026, 6, 1, tzinfo=UTC),
+            incremental_field="updated_at",
+        )
+
+        assert sent_params == [
+            {"cursor": "cur-resumed", "min_timestamp": "1768478405", "timestamp_filter": "updated_at"}
+        ]
+
     @parameterized.expand([("rate_limited", 429), ("server_error", 500)])
     def test_retryable_status_is_retried_then_succeeds(self, _name: str, status_code: int) -> None:
         manager = self._fresh_manager()
@@ -195,6 +278,27 @@ class TestGetRows:
             raise AssertionError("expected HTTPError")
         except HTTPError as e:
             assert e.response.status_code == 401
+
+
+class TestToEpochSeconds:
+    # The pipeline hands the DateTime watermark back as a datetime, a date, or an epoch
+    # number depending on how it round-tripped through storage; the request boundary must
+    # coerce all of them to the epoch seconds min_timestamp takes.
+    @parameterized.expand(
+        [
+            ("aware_datetime", datetime(2026, 1, 15, 12, 0, 5, tzinfo=UTC), 1768478405),
+            ("naive_datetime_read_as_utc", datetime(2026, 1, 15, 12, 0, 5), 1768478405),
+            (
+                "subsecond_truncated_to_overlap_the_boundary",
+                datetime(2026, 1, 15, 12, 0, 5, 999999, tzinfo=UTC),
+                1768478405,
+            ),
+            ("date", date(2026, 1, 15), 1768435200),
+            ("epoch_number_passthrough", 1768478405.9, 1768478405),
+        ]
+    )
+    def test_coerces_watermark_types(self, _name: str, value: Any, expected: int) -> None:
+        assert _to_epoch_seconds(value) == expected
 
 
 class TestDecagonSource:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/tests/test_decagon_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/tests/test_decagon_source.py
@@ -1,6 +1,9 @@
+from datetime import UTC, datetime
 from typing import Any
 
 from unittest import mock
+
+from parameterized import parameterized
 
 from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
 
@@ -17,6 +20,9 @@ from products.warehouse_sources.backend.types import ExternalDataSourceType
 def _make_inputs(**overrides: Any) -> mock.MagicMock:
     inputs = mock.MagicMock()
     inputs.schema_name = overrides.get("schema_name", "conversations")
+    inputs.should_use_incremental_field = overrides.get("should_use_incremental_field", False)
+    inputs.db_incremental_field_last_value = overrides.get("db_incremental_field_last_value")
+    inputs.incremental_field = overrides.get("incremental_field")
     return inputs
 
 
@@ -43,16 +49,18 @@ class TestDecagonSource:
         assert api_key_field.type == SourceFieldInputConfigType.PASSWORD
         assert api_key_field.required is True
 
-    def test_get_schemas_is_full_refresh_only(self) -> None:
+    def test_get_schemas_advertises_incremental_but_not_append(self) -> None:
         schemas = self.source.get_schemas(self.config, self.team_id)
 
         assert {s.name for s in schemas} == set(ENDPOINTS)
         conversations = next(s for s in schemas if s.name == "conversations")
-        # /conversation/export has no server-side timestamp filter, so incremental
-        # sync must never be advertised for it.
-        assert conversations.supports_incremental is False
+        # The export filters server-side on updated_at (min_timestamp + timestamp_filter),
+        # so incremental sync is real. Append stays off: a conversation re-enters the
+        # export whenever it receives new messages, so an append sync would accumulate one
+        # copy per mutation instead of merging them.
+        assert conversations.supports_incremental is True
         assert conversations.supports_append is False
-        assert conversations.incremental_fields == []
+        assert [f["field"] for f in conversations.incremental_fields] == ["updated_at"]
 
     def test_get_schemas_filtered_by_names(self) -> None:
         assert [s.name for s in self.source.get_schemas(self.config, self.team_id, names=["conversations"])] == [
@@ -84,9 +92,30 @@ class TestDecagonSource:
         assert isinstance(manager, ResumableSourceManager)
         assert manager._data_class is DecagonResumeConfig
 
+    # The second case guards the null-out: a watermark left over from an earlier
+    # incremental configuration must not window a sync that is no longer incremental,
+    # or the full refresh silently drops every row older than the stale watermark.
+    @parameterized.expand(
+        [
+            ("incremental", True, datetime(2026, 1, 1, tzinfo=UTC), datetime(2026, 1, 1, tzinfo=UTC)),
+            ("full_refresh_ignores_stale_watermark", False, datetime(2026, 1, 1, tzinfo=UTC), None),
+        ]
+    )
     @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.decagon.source.decagon_source")
-    def test_source_for_pipeline_passes_arguments(self, mock_decagon_source: mock.MagicMock) -> None:
-        inputs = _make_inputs(schema_name="conversations")
+    def test_source_for_pipeline_passes_arguments(
+        self,
+        _name: str,
+        should_use_incremental_field: bool,
+        last_value: datetime,
+        expected_last_value: datetime | None,
+        mock_decagon_source: mock.MagicMock,
+    ) -> None:
+        inputs = _make_inputs(
+            schema_name="conversations",
+            should_use_incremental_field=should_use_incremental_field,
+            db_incremental_field_last_value=last_value,
+            incremental_field="updated_at",
+        )
         manager = mock.MagicMock(spec=ResumableSourceManager)
 
         self.source.source_for_pipeline(self.config, manager, inputs)
@@ -95,3 +124,6 @@ class TestDecagonSource:
         assert kwargs["api_key"] == self.config.api_key
         assert kwargs["endpoint"] == "conversations"
         assert kwargs["resumable_source_manager"] is manager
+        assert kwargs["should_use_incremental_field"] is should_use_incremental_field
+        assert kwargs["db_incremental_field_last_value"] == expected_last_value
+        assert kwargs["incremental_field"] == "updated_at"


### PR DESCRIPTION
## Problem

- Every Decagon sync re-walks the entire conversation history at the vendor's 1 request/second cap, so sync time grows without bound as history accumulates.
- The stream was marked full refresh only because of a claim that conversation rows expose no last-updated column. The vendor's API spec contradicts that: `updated_at` is a required ISO 8601 field on every exported conversation.

Closes #80156

## Changes

- The conversations stream now offers incremental sync: the walk starts at the stored `updated_at` watermark instead of at the beginning of history.
- Incremental requests carry `min_timestamp` (epoch seconds) with `timestamp_filter=updated_at`. The watermark converts to epoch seconds at the request boundary.
- Incremental writes merge on `conversation_id`, matching the vendor's upsert recommendation (a conversation re-enters the export whenever it receives new messages). Append is not offered: appends would accumulate one copy per mutation.
- On the merge path, re-emitted conversations flow through so the newest version wins. The unbounded client-side `seen_ids` set stays on the full-refresh path only, whose writes are plain appends.
- Resume state now stores the window (`min_timestamp`, `timestamp_filter`) alongside the cursor. A resumed walk reissues the exact window it stopped in, because the stored watermark can advance mid-walk.
- Partitioning stays on `created_at`. The incremental cursor is `updated_at`; an updated field would move rows across partitions.
- Corrects the stale `settings.py` comment (and the test asserting it) that claimed no last-updated column exists.

> [!NOTE]
> No live Decagon credentials were available to this run. The `updated_at` column, the epoch-seconds unit of `min_timestamp`, and the `timestamp_filter` enum are verified against the vendor's OpenAPI spec and export reference only (customer-supplied; Decagon's docs are auth-gated). Whether `min_timestamp` is inclusive is undocumented: the watermark truncates to whole seconds, so the boundary second re-fetches and the merge dedupes it either way. Whether `updated_at` advances for every mutation that matters is unconfirmed; `last_message_time` is the documented fallback filter if it does not.

## How did you test this code?

Ran locally with the repo venv (no live API calls; mypy left to CI):

- `ruff check --fix` and `ruff format` over `products/warehouse_sources/`.
- pytest over the Decagon source tests and the cross-source registry gates in `sources/tests/`.

New tests and the regression each catches:

- Window tests: the epoch window missing from page 2 onward (unbounded walk after the first page), and a first sync with no watermark being wrongly windowed.
- Merge-path test: client-side dedupe reapplied on the incremental path, which would persist the stale first copy of a re-entered conversation.
- Resume test: a resumed run recomputing its window from an advanced watermark, which would skip rows at the window boundary.
- Watermark coercion: parameterized over datetime, date, and epoch inputs, catching an ISO string or naive-datetime shift reaching `min_timestamp`.
- Full-refresh null-out: a stale watermark windowing a sync that is no longer incremental, silently dropping older rows.

Not run: live Decagon API calls (no credentials), database-backed suites, mypy.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The posthog.com Decagon page renders its table list from the public source configs API, so no docs change is needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored by Claude Code (PostHog Code cloud task) from the public issue; left unassigned for the owning team to triage.
- Skills invoked: `/implementing-warehouse-sources`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/writing-user-facing-copy`.
- The vendor spec files referenced by the issue were not attached to this run; field names and parameter semantics come from the issue's spec-derived research findings, and nothing was filled in from other sources.
- Session decision: `supports_append` gates off per endpoint config rather than deriving from incremental fields, so a mutating stream can be incremental without offering append.
- All fixtures and sample data are invented.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
