### PR TITLE
fix(bigquery): stop retrying when token_uri is egress-denied

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
@@ -229,6 +229,15 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # user must fix their key file; retrying can't recover. Matched on ngrok's stable
             # offline-endpoint code rather than the volatile tunnel subdomain in the page.
             "ERR_NGROK_3200": "We couldn't authenticate with BigQuery — your service account key's token_uri points at an offline endpoint, not Google's OAuth token endpoint. Please re-upload your service account key file and verify its token_uri.",
+            # A service-account key whose `token_uri` points at a non-globally-routable address
+            # (for example a cloud metadata endpoint). PostHog's egress proxy denies the request
+            # before it leaves our network and google-auth surfaces that denial as a `RefreshError`
+            # naming the proxy's stable rule. The proxy rejects the same non-public host on every
+            # retry, so retrying just hammers a request that can never succeed. Google's real OAuth
+            # token endpoint is always a public host, so this is a misconfigured `token_uri` — the
+            # user must fix their key file. Matched on the proxy's stable rule name rather than the
+            # volatile denied host.
+            "denied by rule 'Deny: Not Global Unicast'": "We couldn't authenticate with BigQuery — your service account key's token_uri points at an address PostHog can't reach. Please re-upload your service account key file and verify its token_uri is Google's OAuth token endpoint.",
             # Raised as a `Forbidden` (403, reason `quotaExceeded`) when the customer's BigQuery
             # project hits an administrator-configured custom cost control, e.g. "Custom quota
             # exceeded: Your usage exceeded the custom quota for QueryUsagePerDay, which is set by

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -725,6 +725,28 @@ def test_non_retryable_errors_match_offline_token_uri_endpoint(observed_error):
 @pytest.mark.parametrize(
     "observed_error",
     [
+        # token_uri pointed at the cloud metadata endpoint — PostHog's egress proxy denies it.
+        "RefreshError: Egress proxying is denied to host '169.254.169.254': no valid IP found "
+        "among resolved addresses - 169.254.169.254 denied by rule 'Deny: Not Global Unicast'. .",
+        # Different denied host — the match must not rely on the volatile host/IP.
+        "RefreshError: Egress proxying is denied to host '10.0.0.5': no valid IP found "
+        "among resolved addresses - 10.0.0.5 denied by rule 'Deny: Not Global Unicast'. .",
+    ],
+)
+def test_non_retryable_errors_match_egress_denied_token_uri_endpoint(observed_error):
+    """A service account whose `token_uri` points at a non-globally-routable address (e.g. a
+    cloud metadata endpoint) makes our egress proxy deny the request, and google-auth surfaces
+    that denial as a `RefreshError` — a misconfigured key the user must fix, so the sync must be
+    disabled rather than retried forever."""
+    non_retryable_errors = BigQuerySource().get_non_retryable_errors()
+    matching = [key for key in non_retryable_errors if key in observed_error]
+    assert matching, "Egress-denied token_uri endpoint error should be recognised as non-retryable"
+    assert all(non_retryable_errors[key] is not None for key in matching)
+
+
+@pytest.mark.parametrize(
+    "observed_error",
+    [
         # Corrupted/truncated private key body in the uploaded service account JSON.
         "Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. InvalidData(InvalidPadding)",
         "ValueError: Unable to load PEM file. InvalidData(InvalidByte(1, 45))",


### PR DESCRIPTION
## Problem

A BigQuery sync retries forever, and spams error tracking, when a service account's `token_uri` points at a non-globally-routable address such as a cloud metadata endpoint.

PostHog's egress proxy denies the outbound token refresh before it leaves our network. `google-auth` surfaces that denial as a `RefreshError` from [`bigquery.py`](https://github.com/PostHog/posthog/blob/master/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py#L1184), the same call site as [error tracking issue 019fe3cb-d112-7360-b38e-762681afa25b](https://us.posthog.com/project/2/error_tracking/019fe3cb-d112-7360-b38e-762681afa25b). The proxy rejects the same non-public host on every retry, so the sync can never recover on its own.

## Changes

- Add the egress proxy's stable denial-rule name to `BigQuerySource.get_non_retryable_errors`, alongside the existing `token_uri`-related entries for a bad token response and an offline ngrok tunnel.
- Match on the proxy's rule name rather than the denied host, since the host varies with whichever non-public address the `token_uri` resolves to.

## How did you test this code?

Added a parameterized case to `test_non_retryable_errors_match_egress_denied_token_uri_endpoint` in `products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py`, covering two different denied hosts to guard against a match that accidentally keys on the volatile IP. Ran the full `test_source.py` non-retryable-error suite (46 cases) and `mypy` on the changed file; both pass.

Not run: a live BigQuery sync against an actual egress-denied `token_uri`, since that requires reproducing the proxy's network-level denial.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via the PostHog error-tracking MCP tools (issue details, stack trace, sampled events) to confirm the failure originates in `bigquery.py`'s `get_columns`. Searched open PRs (including the maintainer's) for a duplicate fix and found none. Invoked `/writing-tests` before adding the test and `/writing-pr-descriptions` before writing this body.