### PR TITLE
fix(data-imports): skip webhook files already consumed by another run

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_webhook_s3.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_webhook_s3.py
@@ -347,6 +347,42 @@ class TestWebhookSourceManager:
         assert tables[0].column_names == ["id"]
         transformer.assert_called_once()
 
+    async def test_get_items_skips_file_deleted_before_read(self):
+        schema_id = "test-schema"
+        manager = _make_manager(team_id=1, schema_id=schema_id)
+
+        payloads = [{"id": "2", "value": "b"}]
+        parquet_bytes = _make_webhook_parquet_bytes(payloads, team_id=1, schema_id=schema_id)
+
+        mock_file = AsyncMock()
+        mock_file.read = AsyncMock(return_value=parquet_bytes)
+        mock_s3 = AsyncMock()
+        # First file's read raises as if a concurrent run already consumed and deleted it;
+        # the second file still yields normally.
+        first_open = AsyncMock()
+        first_open.__aenter__ = AsyncMock(side_effect=FileNotFoundError("The specified key does not exist."))
+        first_open.__aexit__ = AsyncMock(return_value=False)
+        second_open = AsyncMock()
+        second_open.__aenter__ = AsyncMock(return_value=mock_file)
+        second_open.__aexit__ = AsyncMock(return_value=False)
+        mock_s3.open_async = AsyncMock(side_effect=[first_open, second_open])
+        mock_s3._rm = AsyncMock()
+
+        with (
+            patch.object(
+                manager,
+                "_list_webhook_parquet_files",
+                return_value=["s3://bucket/gone.parquet", "s3://bucket/file.parquet"],
+            ),
+            _mock_s3_context(mock_s3),
+        ):
+            tables = [table async for table in manager.get_items()]
+
+        assert len(tables) == 1
+        assert tables[0].column("id").to_pylist() == ["2"]
+        # Only the successfully read file is removed; the vanished one was never touched.
+        mock_s3._rm.assert_awaited_once_with("bucket/file.parquet")
+
     async def test_get_items_yields_nothing_when_no_files(self):
         manager = _make_manager()
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/webhook_s3.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/webhook_s3.py
@@ -154,9 +154,16 @@ class WebhookSourceManager:
                 path = self._strip_s3_protocol(file)
 
                 await self._logger.adebug(f"Webhook source reading file {path}")
-                async with await s3.open_async(path, "rb") as f:
-                    data = await f.read()
-                    table = pq.read_table(pa.BufferReader(data))
+                try:
+                    async with await s3.open_async(path, "rb") as f:
+                        data = await f.read()
+                        table = pq.read_table(pa.BufferReader(data))
+                except FileNotFoundError:
+                    # A concurrent run (or a retry of this same activity) can have already
+                    # read and deleted this file between our listing and this open, since
+                    # this is a plain listing snapshot, not a lease on the listed files.
+                    await self._logger.adebug("webhook_file_already_consumed", path=path)
+                    continue
 
                 table = await self._validate_webhook_table(table)
                 if table.num_rows == 0:


### PR DESCRIPTION
## Problem

A webhook-fed data warehouse sync can fail outright and report a spurious error when a queued file was already read and deleted elsewhere. This showed up on a Stripe sync's `Charge` table ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019fe58c-ba2e-7341-bf7b-41bf9723ab14)), but the code is shared across every source that supports webhook-delivered syncs.

`WebhookSourceManager.get_items` lists all pending parquet files once, then opens and deletes each in turn. That listing is a snapshot, not a lease on the files.

- A retried attempt of the same sync activity, or a second run for the same schema, can delete a listed file before this run opens it.
- The resulting `FileNotFoundError` (wrapping S3's `NoSuchKey`) was uncaught, failing the whole sync and reaching error tracking as a raw exception.

## Changes

- `get_items` now catches `FileNotFoundError` around the per-file read and skips that file, treating it as already consumed rather than a failure.
- This matches the tolerance `_list_webhook_parquet_files` already has for a missing prefix (`FileNotFoundError` on `_ls` returns no files instead of raising).

## How did you test this code?

- Added `test_get_items_skips_file_deleted_before_read`: two listed files, the first raises `FileNotFoundError` on open, asserts the batch still yields the second file's rows and only the successfully-read file is deleted.
- Ran the full `TestWebhookSourceManager` suite locally (26 passed), plus `ruff` and `mypy` on the changed files.
- Not run: the MinIO-backed integration tests in the same file (no live object store in this environment).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal pipeline error handling, no user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error-tracking MCP tools (issue details, sampled event stack trace, and `warehouse_sources_*` properties) to confirm the exact failing frame and sync context, then read the shared webhook ingestion code to find the race. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.