### PR TITLE
fix(redshift): propagate a dropped connection during the duplicate-key check

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/redshift.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/redshift.py
@@ -1038,6 +1038,12 @@ class RedshiftImplementation(SQLSourceImplementation[RedshiftSourceConfig, psyco
             return row is not None
         except psycopg.errors.QueryCanceled:
             raise
+        except psycopg.OperationalError:
+            # A connection-level failure (e.g. the SSL connection dropping mid-query) means the
+            # probe never ran — swallowing it as "no duplicate keys" would be a false negative.
+            # Propagate it so the activity's retry path handles it; these are transient and stay
+            # retryable. Mirrors the equivalent Postgres source.
+            raise
         except Exception as e:
             # A Redshift system-requested query abort (error code 1020, "system requested abort")
             # is the cluster's WLM/QMR cancelling the query — the same transient, non-actionable

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/tests/test_redshift.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/tests/test_redshift.py
@@ -794,6 +794,20 @@ class TestHasDuplicatePrimaryKeys:
             assert impl.has_duplicate_primary_keys(cursor, "public", "t", ["id"], logger) is False
         mock_capture.assert_called_once()
 
+    def test_operational_error_is_propagated(self, impl, cursor, logger):
+        # A connection-level failure (e.g. the SSL connection dropping mid-query) means the probe
+        # never ran — swallowing it as "no duplicate keys" would be a false negative, so it must
+        # propagate instead of being reported to error tracking and defaulted to False.
+        cursor.execute.side_effect = psycopg.OperationalError(
+            "consuming input failed: SSL connection has been closed unexpectedly"
+        )
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.redshift.redshift.capture_exception"
+        ) as mock_capture:
+            with pytest.raises(psycopg.OperationalError):
+                impl.has_duplicate_primary_keys(cursor, "public", "t", ["id"], logger)
+        mock_capture.assert_not_called()
+
     def test_system_requested_abort_is_not_reported(self, impl, cursor, logger):
         # Redshift WLM/QMR aborts (code 1020, "system requested abort") surface as `InternalError_`
         # and are expected, non-actionable noise — skip gracefully without reporting to error tracking.


### PR DESCRIPTION
## Problem

- A dropped Redshift connection during the duplicate-primary-key check gets reported as "no duplicate keys found", even though the check never ran.
- The probe swallows every exception except a query abort, so a transient connection loss (surfaced in [error tracking](https://us.posthog.com/project/2/error_tracking/019fe595-5959-79c3-89a7-4230c0ac92ba) as `OperationalError: consuming input failed: SSL connection has been closed unexpectedly`) silently defaults to `False` and gets sent to error tracking as noise.

## Changes

- `has_duplicate_primary_keys` re-raises `psycopg.OperationalError` instead of swallowing it, mirroring the sibling Postgres source, so a dropped connection triggers the activity's existing retry path instead of a false "no duplicates" result.
- Added a regression test covering an `OperationalError` raised mid-probe: asserts it propagates and is not sent to error tracking.

## How did you test this code?

- Ran the redshift test suite locally: `pytest products/warehouse_sources/backend/temporal/data_imports/sources/redshift/tests/test_redshift.py` — all 127 tests passed.
- Added `test_operational_error_is_propagated` to `TestHasDuplicatePrimaryKeys`. No existing case exercised a connection-level failure: `test_returns_false_on_exception` uses a generic `RuntimeError`, and `test_system_requested_abort_is_not_reported` uses a Redshift query-abort `InternalError`.
- Not run: an actual sync against a live Redshift cluster.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via the PostHog MCP error-tracking tools: pulled the issue, its stack trace, and a representative event, which showed the exception originates in `has_duplicate_primary_keys` (redshift.py) rather than the top-level connection/retry classification. Compared against the sibling Postgres source (`postgres.py`), which already re-raises `psycopg.OperationalError` in the equivalent probe for the same false-negative reason, and mirrored that pattern here instead of inventing a new one. Confirmed no open human-authored PR already covers this (checked PRs mentioning `has_duplicate_primary_keys`, redshift, and the maintainer's own open PRs).

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

Tools: Claude Code, PostHog MCP (error-tracking query tools).