### PR TITLE
fix(data-imports): stop reporting v3 job-queue pool timeouts as errors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -8,6 +8,7 @@ from typing import Any, NoReturn, Optional
 from django.db import InterfaceError, OperationalError
 from django.db.models import Prefetch
 
+import psycopg
 from jsonpath_ng.exceptions import JSONPathError
 from requests.exceptions import HTTPError
 from structlog.contextvars import bind_contextvars
@@ -474,6 +475,17 @@ async def _handle_import_error(
     if isinstance(error, OperationalError | InterfaceError):
         await logger.awarning(error_msg)
         await logger.adebug("Transient app-DB error - re-raising for Temporal retry")
+        raise NonReportableError(error_msg) from error
+
+    # The v3 pipeline's Postgres-backed job queue (PostgresProducer/BatchQueue) talks to
+    # WAREHOUSE_SOURCES_DATABASE_URL over a raw psycopg connection, never Django's ORM, so a
+    # `query_wait_timeout` here can't be wrapped as the Django OperationalError/InterfaceError
+    # above - psycopg surfaces PgBouncer's own "query waited too long for a free server
+    # connection" rejection as a bare ProtocolViolation. Same transient pool-saturation class,
+    # so classify it the same way rather than letting it fall through to a reported exception.
+    if isinstance(error, psycopg.errors.ProtocolViolation) and "query_wait_timeout" in error_msg:
+        await logger.awarning(error_msg)
+        await logger.adebug("Transient Postgres job-queue pool timeout - re-raising for Temporal retry")
         raise NonReportableError(error_msg) from error
 
     # Cross-source non-retryable errors (missing primary key on an incremental table, bad SSH tunnel

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -9,6 +9,7 @@ from unittest import mock
 
 from django.db import InterfaceError, OperationalError
 
+import psycopg
 from jsonpath_ng.exceptions import JsonPathParserError
 from parameterized import parameterized
 from requests.exceptions import HTTPError
@@ -372,6 +373,58 @@ async def test_app_db_connection_error_reraised_as_non_reportable(_name: str, er
     assert exc_info.value.__cause__ is error
     logger.awarning.assert_awaited_once()
     logger.aexception.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_postgres_job_queue_wait_timeout_reraised_as_non_reportable():
+    # PostgresProducer/BatchQueue (the v3 pipeline's job queue) talk to
+    # WAREHOUSE_SOURCES_DATABASE_URL over a raw psycopg connection, never Django's ORM, so a
+    # PgBouncer query_wait_timeout here surfaces as a bare psycopg ProtocolViolation rather than
+    # the Django OperationalError/InterfaceError case above. It's the same transient pool-blip
+    # class, so it must be re-raised as NonReportableError rather than the bare exception, which
+    # the activity interceptor would still capture.
+    error = psycopg.errors.ProtocolViolation("query_wait_timeout")
+    source = mock.MagicMock(spec=SimpleSource)
+    source.get_non_retryable_errors.return_value = {}
+    source.get_retryable_errors.return_value = set()
+
+    logger = mock.MagicMock()
+    logger.awarning = mock.AsyncMock()
+    logger.aexception = mock.AsyncMock()
+    logger.adebug = mock.AsyncMock()
+
+    with mock.patch.object(module.SourceRegistry, "get_source", return_value=source):
+        with pytest.raises(NonReportableError) as exc_info:
+            await module._handle_import_error(mock.MagicMock(), logger, error)
+
+    assert exc_info.value.__cause__ is error
+    logger.awarning.assert_awaited_once()
+    logger.aexception.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_protocol_violation_with_unrelated_message_still_reported():
+    # A ProtocolViolation can also carry PgBouncer's cached-login-failure message (see
+    # postgres.py's `_is_connection_limit_error`), which is a real, actionable failure, not a
+    # pool-saturation blip. The query_wait_timeout classification above must match on the message,
+    # not just the type, or it would swallow this as non-reportable too.
+    error = psycopg.errors.ProtocolViolation(
+        "server login has been failing, cached error: FATAL: password authentication failed"
+    )
+    source = mock.MagicMock(spec=SimpleSource)
+    source.get_non_retryable_errors.return_value = {}
+    source.get_retryable_errors.return_value = set()
+
+    logger = mock.MagicMock()
+    logger.awarning = mock.AsyncMock()
+    logger.aexception = mock.AsyncMock()
+    logger.adebug = mock.AsyncMock()
+
+    with mock.patch.object(module.SourceRegistry, "get_source", return_value=source):
+        with pytest.raises(psycopg.errors.ProtocolViolation):
+            await module._handle_import_error(mock.MagicMock(), logger, error)
+
+    logger.aexception.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

A ConvertKit sync's v3 pipeline reported a `ProtocolViolation: query_wait_timeout` to error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019fe58f-d4e5-7222-b13c-fc8cec70a883)), even though it's a transient pool blip that Temporal already retries fine.

- The v3 pipeline's Postgres job queue (`PostgresProducer`/`BatchQueue`) writes over a raw `psycopg` connection, never Django's ORM.
- A saturated connection pool rejects a query past PgBouncer's `query_wait_timeout` and disconnects with a bare `psycopg.errors.ProtocolViolation`.
- `_handle_import_error` already treats the Django-wrapped version of this same blip (`OperationalError`/`InterfaceError`) as non-reportable, but the raw psycopg type escaped that check and got reported.

## Changes

- Classify `psycopg.errors.ProtocolViolation` carrying a `query_wait_timeout` message the same way as the existing Django DB-blip case: log a warning and re-raise as `NonReportableError` so Temporal keeps retrying without the exception reaching error tracking.
- The match is on message, not just type, so an unrelated `ProtocolViolation` (e.g. a cached login failure) still gets reported.

## How did you test this code?

- Added `test_postgres_job_queue_wait_timeout_reraised_as_non_reportable`, which fails without the fix (the bare exception would propagate and be logged as an exception instead of a warning).
- Added `test_protocol_violation_with_unrelated_message_still_reported` to guard against widening the match to swallow other `ProtocolViolation` causes.
- Ran `products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py` (22 passed, 1 pre-existing failure unrelated to this change: a DB-backed test that needs a running Postgres server not available in this sandbox).
- Ran `ruff check`/`format` and a full-repo `mypy --cache-fine-grained .` (clean) via `hogli ci:preflight --fix`.
- Not run: an end-to-end sync against a saturated connection pool, since reproducing PgBouncer pool exhaustion isn't practical locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal error-classification change, no user-facing behavior or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via a PostHog error-tracking issue delivered by webhook. Used the `investigating-error-issue` and `writing-tests`/`writing-pr-descriptions` skills. Traced the stack trace to the v3 pipeline's Postgres job-queue writer, confirmed `psycopg.errors.ProtocolViolation` is a subclass of `psycopg.OperationalError` distinct from Django's DB-error hierarchy, and found the existing Django-side classification this mirrors in `_handle_import_error`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*