### PR TITLE
fix(supabase): stop masking a clear connection error with the IPv4 hint

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/supabase/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/supabase/source.py
@@ -19,7 +19,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.reg
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.postgres import (
     PostgresSourceConfig,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.source import PostgresSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.source import (
+    _HOST_UNREACHABLE_ERROR,
+    PostgresSource,
+)
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 _SourceField = (
@@ -126,10 +129,12 @@ class SupabaseSource(PostgresSource):
 
         # The direct host (IPv6-only by default) is the only host that supports logical
         # replication, so CDC users need it. We let the real connection attempt decide
-        # reachability — it succeeds when the IPv4 add-on is enabled — and only swap in a
-        # clearer message when it fails, since the generic Postgres error is opaque.
+        # reachability — it succeeds when the IPv4 add-on is enabled. Only the unreachable
+        # failure is the IPv4 case, so swap in Supabase-specific pooler guidance there; other
+        # failures (bad password, missing database, SSL) already have clear messages, and
+        # blaming them on IPv4 would misdirect the user.
         is_direct_host = bool(_SUPABASE_DIRECT_HOST_RE.match((config.host or "").strip()))
         success, error = super().validate_credentials(config, team_id, schema_name=schema_name)
-        if not success and is_direct_host:
+        if not success and is_direct_host and error == _HOST_UNREACHABLE_ERROR:
             return False, _SUPABASE_DIRECT_HOST_IPV4_HINT
         return success, error

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/supabase/test_supabase_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/supabase/test_supabase_source.py
@@ -3,7 +3,10 @@ from unittest import mock
 
 from posthog.schema import ReleaseStatus, SourceFieldInputConfig
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.source import PostgresSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.source import (
+    _HOST_UNREACHABLE_ERROR,
+    PostgresSource,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.supabase.source import SupabaseSource
 
 
@@ -47,17 +50,36 @@ def test_supabase_host_field_points_at_the_pooler():
         "  db.abcdefgh.supabase.co  ",
     ],
 )
-def test_direct_host_failure_surfaces_ipv4_addon_hint(host):
+def test_direct_host_unreachable_surfaces_ipv4_addon_hint(host):
     # The direct host is the only one that supports logical replication (CDC), so we let the
-    # connection attempt run; on failure we explain the IPv4 add-on requirement.
+    # connection attempt run; an unreachable host is the IPv6 case, so explain the IPv4 add-on.
     config = mock.MagicMock(host=host)
 
-    with mock.patch.object(PostgresSource, "validate_credentials", return_value=(False, "could not connect")):
+    with mock.patch.object(PostgresSource, "validate_credentials", return_value=(False, _HOST_UNREACHABLE_ERROR)):
         success, error = SupabaseSource().validate_credentials(config, team_id=1)
 
     assert success is False
     assert error is not None
     assert "ipv4 add-on" in error.lower()
+
+
+@pytest.mark.parametrize(
+    "postgres_error",
+    [
+        "Invalid user or password",
+        "Database does not exist",
+    ],
+)
+def test_direct_host_non_reachability_error_is_not_masked(postgres_error):
+    # A clear failure like a bad password must reach the user unchanged — overwriting it with the
+    # IPv4 hint would tell someone whose add-on is already enabled to fix a non-existent problem.
+    config = mock.MagicMock(host="db.abcdefghijklmnop.supabase.co")
+
+    with mock.patch.object(PostgresSource, "validate_credentials", return_value=(False, postgres_error)):
+        success, error = SupabaseSource().validate_credentials(config, team_id=1)
+
+    assert success is False
+    assert error == postgres_error
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

- A user setting up a Supabase source on the direct host (`db.<ref>.supabase.co`) saw the "enable the IPv4 add-on" hint no matter what actually failed.
- `SupabaseSource.validate_credentials` replaced the result of every failed connection on the direct host with that one hint.
- A wrong password, a missing database, or an SSL problem was therefore reported as an IPv4 add-on problem, sending the user to fix something unrelated. Someone who already has the add-on enabled is told to enable it again.

## Changes

- The IPv4 add-on hint now shows only when the connection failed because the host was unreachable, which is the IPv6 case the hint is about.
- Every other failure keeps the Postgres error message it already had (for example "Invalid user or password" or "Database does not exist").
- The unreachable case is matched against the shared `_HOST_UNREACHABLE_ERROR` constant the Postgres source returns for `ENETUNREACH`/`EHOSTUNREACH`, so the two stay in sync if that message changes.

## How did you test this code?

- Added `test_direct_host_non_reachability_error_is_not_masked`: a bad password or missing database on the direct host now reaches the user unchanged. This catches the regression where a clear error was overwritten with the IPv4 hint; no existing test covered a non-reachability failure on the direct host.
- Updated `test_direct_host_unreachable_surfaces_ipv4_addon_hint`: the hint still fires, now driven by the real unreachable error rather than a generic stand-in.
- Ran the `supabase` source test module locally.
- Not run: the wider warehouse-sources suites and any database-backed tests.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing copy or documented workflow changed; the same messages are shown, only in the right situations.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- I (Claude) made this change while triaging data-warehouse source-creation failures. The Supabase direct-host message stood out: the code produces it for any failure on that host, not only the reachability failure it describes.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/writing-code-comments`.
- No customer data is included. The failure that prompted this was echoed-back user input, and nothing from it appears in the code, tests, or this description.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
