### PR TITLE
fix(semver): treat missing minor/patch as zero in diffVersions

### DIFF
--- a/frontend/src/lib/utils/semver.test.ts
+++ b/frontend/src/lib/utils/semver.test.ts
@@ -26,6 +26,19 @@ describe('semver', () => {
             expect(isSupportedVersion('7.8.9')).toEqual(true)
             expect(isSupportedVersion('4.5.6-alpha')).toEqual(false)
         })
+
+        it('treats missing minor/patch as zero when comparing against the requirement', () => {
+            // A requirement written with fewer components (e.g. "1.99") must still be
+            // satisfied by the equal version spelled out in full (e.g. "1.99.0").
+            const isSupportedVersion = createVersionChecker('1.99')
+            expect(isSupportedVersion('1.99')).toEqual(true)
+            expect(isSupportedVersion('1.99.0')).toEqual(true)
+            expect(isSupportedVersion('1.99.1')).toEqual(true)
+            expect(isSupportedVersion('1.98.9')).toEqual(false)
+
+            const isSupportedFullVersion = createVersionChecker('1.99.0')
+            expect(isSupportedFullVersion('1.99')).toEqual(true)
+        })
     })
 
     describe('isValidSemverValue', () => {

--- a/frontend/src/lib/utils/semver.ts
+++ b/frontend/src/lib/utils/semver.ts
@@ -63,10 +63,10 @@ export function diffVersions(a: string | SemanticVersion, b: string | SemanticVe
     if (pa.major !== pb.major) {
         return { kind: 'major', diff: pa.major - pb.major }
     }
-    if (pa.minor !== pb.minor) {
+    if ((pa.minor ?? 0) !== (pb.minor ?? 0)) {
         return { kind: 'minor', diff: (pa.minor ?? 0) - (pb.minor ?? 0) }
     }
-    if (pa.patch !== pb.patch) {
+    if ((pa.patch ?? 0) !== (pb.patch ?? 0)) {
         return { kind: 'patch', diff: (pa.patch ?? 0) - (pb.patch ?? 0) }
     }
     if (pa.extra !== pb.extra) {


### PR DESCRIPTION
## Problem

`diffVersions` in `frontend/src/lib/utils/semver.ts` reports two equal versions as different when they are written with a different number of components.

`parseVersion` leaves omitted components undefined, so `parseVersion("1.99")` has `patch: undefined` while `parseVersion("1.99.0")` has `patch: 0`. The minor and patch checks used strict inequality (`pa.patch !== pb.patch`), and `undefined !== 0`, so the function returned a diff object instead of `null` for versions that are actually the same.

The diff value itself was already normalised with `?? 0`, so it came back as `0`, but the returned object is still truthy. That is the part that bites callers.

`createVersionChecker` returns `!diff || diff.diff > 0`. When the requirement has fewer components than the version being checked, an equal version produces a truthy diff whose `diff.diff` is `0`, so the check returns `false` and treats an equal version as below the minimum.

This is not just theoretical. `doesVersionSupportScrollDepth` in the toolbar is defined as `createVersionChecker('1.99')`, so the very first 1.99 patch release reported as `"1.99.0"` was wrongly treated as not supporting scroll depth.

## Reproduction

```ts
const isSupported = createVersionChecker('1.99')
isSupported('1.99.0') // false, but 1.99.0 == 1.99 so it should be true
diffVersions('1.99', '1.99.0') // { kind: 'patch', diff: 0 } instead of null
```

## Fix

Normalise the components with `?? 0` inside the comparisons as well, matching what the diff value already does. Equal versions now return `null` regardless of how many components each side was written with, and ordering between genuinely different versions is unchanged.

Added regression tests to `semver.test.ts` covering a requirement written with fewer components than the version under test, in both directions.
