### PR TITLE
fix(checkout_com): stop tracking transient payments-search 503s as bugs

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/source.py
@@ -130,6 +130,18 @@ class CheckoutComSource(ResumableSource[CheckoutComSourceConfig, CheckoutComResu
             )
         return errors
 
+    def get_retryable_errors(self) -> set[str]:
+        # `/payments/search` has no internal retry wrapper — the shared session's retry adapter only
+        # covers GET/HEAD/OPTIONS, since POSTs aren't safe to blindly retry in general — but a search
+        # request has no side effects, so a 503 here is a transient upstream blip, not a bug. Temporal
+        # retries the whole activity, so this stays out of tracked exception noise. Matched on the full
+        # status+reason phrase (not just "for url: .../payments/search") so a 4xx on the same endpoint —
+        # which would be a real bug, e.g. a malformed request body — is never swallowed the same way.
+        return {
+            "503 Server Error: Service Unavailable for url: https://api.checkout.com/payments/search",
+            "503 Server Error: Service Unavailable for url: https://api.sandbox.checkout.com/payments/search",
+        }
+
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/tests/test_checkout_com_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/tests/test_checkout_com_source.py
@@ -94,6 +94,32 @@ class TestCheckoutComSource:
         non_retryable_errors = self.source.get_non_retryable_errors()
         assert not any(key in other_error for key in non_retryable_errors)
 
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            "503 Server Error: Service Unavailable for url: https://api.checkout.com/payments/search",
+            "503 Server Error: Service Unavailable for url: https://api.sandbox.checkout.com/payments/search",
+        ],
+    )
+    def test_retryable_errors_match_payments_search_503(self, observed_error):
+        retryable_errors = self.source.get_retryable_errors()
+        assert any(key in observed_error for key in retryable_errors)
+
+    @pytest.mark.parametrize(
+        "other_error",
+        [
+            # A 5xx from a different (potentially non-idempotent) endpoint must stay untouched.
+            "503 Server Error: Service Unavailable for url: https://api.checkout.com/payments/pay_1/actions",
+            "503 Server Error: Service Unavailable for url: https://api.checkout.com/reports",
+            # A 4xx on the search endpoint itself is a real bug (e.g. a malformed request), not a
+            # transient blip, and must not be classified as retryable.
+            "400 Client Error: Bad Request for url: https://api.checkout.com/payments/search",
+        ],
+    )
+    def test_retryable_errors_does_not_match_other_endpoints(self, other_error):
+        retryable_errors = self.source.get_retryable_errors()
+        assert not any(key in other_error for key in retryable_errors)
+
     @mock.patch(DISCOVER_PATCH)
     def test_get_schemas_static_catalog(self, mock_discover):
         mock_discover.return_value = {}


### PR DESCRIPTION
## Problem

- Checkout.com's `POST /payments/search` returned a 503 during one customer's sync, and PostHog's error tracking logged it as an exception even though nothing on our side is broken. Reported in [error tracking issue 019fe5c0-2ef2-7a12-9452-52eb785ad17a](https://us.posthog.com/project/2/error_tracking/019fe5c0-2ef2-7a12-9452-52eb785ad17a) (a single occurrence, one user).
- The search endpoint has no request-level retry: the shared HTTP session only auto-retries GET/HEAD/OPTIONS, so a POST 5xx fails the whole sync attempt on the first try.

## Changes

- `CheckoutComSource.get_retryable_errors()` now classifies a 503 from `/payments/search` (production and sandbox hosts) as a known-transient, self-recovering failure, the same pattern roughly 20 other sources already use for their own vendor 5xx blips.
- Temporal still retries the whole activity exactly as before; the only change is that this specific error now logs as a warning instead of a tracked exception.
- The match is scoped to the exact status and endpoint, so a 4xx on the same endpoint (a real bug, e.g. a malformed request) or a 5xx on a different, potentially non-idempotent endpoint still gets tracked.

## How did you test this code?

- Added `test_retryable_errors_match_payments_search_503` and `test_retryable_errors_does_not_match_other_endpoints` in `test_checkout_com_source.py` — they fail if the 503 match regresses or if it widens to swallow an unrelated 4xx or a different endpoint.
- Ran the full `checkout_com` suite locally: 103 passed.
- Ran `ruff check --fix`, `ruff format`, and repo-wide `mypy --cache-fine-grained .` — all clean.
- Not verified against a live Checkout.com account.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: PostHog Code, triaging a real error-tracking webhook. Skills invoked: /writing-tests, /writing-pr-descriptions.
- Considered adding this to `get_non_retryable_errors` instead, but a 503 is a Checkout.com-side infrastructure blip, not a customer credential or config problem, so the sync should keep retrying rather than pause.
- Considered widening the shared session's retry adapter to cover POST requests, but scoped the fix to the existing noise-reduction classification instead, keeping the change minimal and consistent with the rest of the codebase.
- Checked for a duplicate fix first: PR #79119 (human-authored, open) touches the same files but fixes an unrelated 422 (`payments/search` needs a required `query` field), not this 503.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*