### PR TITLE
fix: label internal analytics with instance region (#77403)

### DIFF
--- a/posthog/ph_client.py
+++ b/posthog/ph_client.py
@@ -61,6 +61,10 @@ def get_regional_ph_client(**kwargs: Any):
     return get_client(region, **kwargs)
 
 
+def _get_internal_analytics_client() -> Any:
+    return get_client(event_region=get_instance_region() or "US")
+
+
 class ScopedCapture:
     """The callable `ph_scoped_capture` yields: enqueues events, and exposes `flush()`.
 
@@ -108,7 +112,7 @@ def ph_scoped_capture():
         with ph_scoped_capture() as capture:
             capture(distinct_id="...", event="my_event", properties={...})
     """
-    ph_client = get_client()
+    ph_client = _get_internal_analytics_client()
 
     # Flush even when the caller's block raises — events already captured
     # before the exception shouldn't be dropped with the buffer.
@@ -135,7 +139,7 @@ def ph_background_capture() -> ScopedCapture:
     if _background_client is None:
         with _background_client_lock:
             if _background_client is None:
-                _background_client = get_client()
+                _background_client = _get_internal_analytics_client()
                 # The SDK's own atexit hook only joins the consumer mid-batch without
                 # draining the queue. atexit is LIFO, so this flush (registered after
                 # the client's hook) runs first and drains what a graceful shutdown
@@ -145,7 +149,7 @@ def ph_background_capture() -> ScopedCapture:
     return ScopedCapture(_background_client)
 
 
-def get_client(region: str = "US", **kwargs: Any):
+def get_client(region: str = "US", *, event_region: str | None = None, **kwargs: Any):
     from posthoganalytics import Posthog
 
     api_key = None
@@ -162,7 +166,7 @@ def get_client(region: str = "US", **kwargs: Any):
     return Posthog(
         api_key,
         host=host,
-        super_properties={"region": region},
+        super_properties={"region": event_region or region},
         _use_ai_lane=True,
         _enable_multimodal_capture=True,
         **kwargs,

--- a/posthog/test/test_ph_client.py
+++ b/posthog/test/test_ph_client.py
@@ -3,8 +3,32 @@ from unittest.mock import MagicMock
 from django.test import SimpleTestCase
 
 import posthoganalytics
+from parameterized import parameterized
 
-from posthog.ph_client import ScopedCapture, get_client
+from posthog.ph_client import PH_US_API_KEY, PH_US_HOST, ScopedCapture, get_client
+
+
+class TestCaptureClientRegion(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("EU", "EU"),
+            (None, "US"),
+        ]
+    )
+    def test_event_region_does_not_change_the_destination(
+        self, event_region: str | None, expected_event_region: str
+    ) -> None:
+        client = get_client(
+            region="US",
+            event_region=event_region,
+            send=False,
+            enable_local_evaluation=False,
+        )
+        self.addCleanup(client.shutdown)
+
+        self.assertEqual(client.api_key, PH_US_API_KEY)
+        self.assertEqual(client.host, PH_US_HOST)
+        self.assertEqual(client.super_properties, {"region": expected_event_region})
 
 
 class TestAILaneOptIn(SimpleTestCase):


### PR DESCRIPTION
## Problem

`ph_scoped_capture()` in `posthog/ph_client.py` stamps `region='US'` on every event it captures, regardless of which instance the worker is actually running on.

The fix separates routing from attribution, so internal analytics still reach the US project while each event records its originating instance region.

Closes #77403

## Changes

- Internal analytics keep the central US destination while reporting the worker's actual instance region.
- Deployments without an instance region continue to report US.
- Scoped and background capture share one internal analytics client policy.

## How did you test this code?

- Added a focused unit test for US routing with EU attribution and the unset-region fallback.
- Ran `hogli test posthog/test/test_ph_client.py`.
- Ran Ruff lint and format checks for the changed files.
- Ran `hogli ci:preflight --fix`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes. This fixes internal analytics metadata without changing a public interface or workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex implemented the change with human direction using Git and repository shell tooling.
- Skills: `/writing-tests`, `/writing-code-comments`, `/running-ci-preflight`, `/writing-pr-descriptions`, and `/writing-user-facing-copy`.
- The final design separates destination routing from event attribution and centralizes the internal analytics client policy.
