### PR TITLE
fix(search): put an exact name match first in command search

### DIFF
--- a/frontend/src/lib/components/Search/Search.tsx
+++ b/frontend/src/lib/components/Search/Search.tsx
@@ -20,7 +20,7 @@ import { IconDay, IconNight, IconSearch, IconSparkles, IconX } from '@posthog/ic
 import { LemonTag, Link, Spinner } from '@posthog/lemon-ui'
 
 import { KeyboardShortcut } from 'lib/components/KeyboardShortcut/KeyboardShortcut'
-import { filterSearchItems, promoteExactMatch } from 'lib/components/Search/utils'
+import { filterSearchItems, rotateToExactMatch } from 'lib/components/Search/utils'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
 import { themeLogic } from 'lib/logic/themeLogic'
@@ -218,6 +218,8 @@ interface SearchContextValue {
     setSearchValue: (value: string) => void
     filteredItems: SearchItem[]
     groupedItems: { category: string; items: SearchItem[]; isLoading?: boolean }[]
+    /** Position of each result in the autocomplete's navigation order, which the display order can differ from. */
+    navigationIndexByItem: Map<SearchItem, number>
     isSearching: boolean
     isActive: boolean
     inputRef: RefObject<HTMLInputElement>
@@ -603,20 +605,21 @@ function SearchRoot({
 
     // Re-rank: pin the incumbent first item so async results don't shift what's highlighted.
     // Promotes the incumbent's group to the front if needed.
-    const reRankedGroupedItems = useReRankedGroupedItems(debouncedGroupedItems, searchValue, reRankEnabled)
+    const stableGroupedItems = useReRankedGroupedItems(debouncedGroupedItems, searchValue, reRankEnabled)
 
-    // Applied last so an exact name match wins over both the fixed category order and the
-    // incumbent pinned above, including when it only arrives with late async results.
-    const stableGroupedItems = useMemo(
-        () => promoteExactMatch(reRankedGroupedItems, searchValue),
-        [reRankedGroupedItems, searchValue]
-    )
-
-    // Derive a flat item list from groupedItems so the order passed to Autocomplete.Root
-    // exactly matches the DOM render order. Without this, Base UI's keyboard navigation
-    // breaks at group boundaries where the two orderings diverge.
+    // Derive a flat item list from groupedItems so it matches the DOM render order.
     const orderedItems = useMemo(() => stableGroupedItems.flatMap((g) => g.items), [stableGroupedItems])
     orderedItemsRef.current = orderedItems
+
+    // Base UI highlights whichever result it holds at index 0, so an exact name match becomes the
+    // default selection by starting the navigation order on it. Display order stays put; each item
+    // gets its navigation position back through the `index` prop so the two stay in step, which
+    // Base UI's keyboard navigation needs at group boundaries.
+    const navigationItems = useMemo(() => rotateToExactMatch(orderedItems, searchValue), [orderedItems, searchValue])
+    const navigationIndexByItem = useMemo(
+        () => new Map(navigationItems.map((item, index): [SearchItem, number] => [item, index])),
+        [navigationItems]
+    )
 
     const contextValue: SearchContextValue = useMemo(
         () => ({
@@ -625,6 +628,7 @@ function SearchRoot({
             setSearchValue,
             filteredItems: orderedItems,
             groupedItems: stableGroupedItems,
+            navigationIndexByItem,
             isSearching,
             isActive,
             inputRef,
@@ -638,6 +642,7 @@ function SearchRoot({
             searchValue,
             orderedItems,
             stableGroupedItems,
+            navigationIndexByItem,
             isSearching,
             isActive,
             handleItemClick,
@@ -652,7 +657,7 @@ function SearchRoot({
                 className={`flex flex-col overflow-hidden ${className} group/colorful-product-icons colorful-product-icons-true`}
             >
                 <Autocomplete.Root
-                    items={orderedItems}
+                    items={navigationItems}
                     mode="none"
                     itemToStringValue={(item) => item?.name ?? ''}
                     actionsRef={actionsRef}
@@ -859,7 +864,8 @@ function SearchResults({
     listClassName?: string
     groupLabelClassName?: string
 }): JSX.Element {
-    const { groupedItems, handleItemClick, highlightedItemRef, isSearching, searchValue } = useSearchContext()
+    const { groupedItems, handleItemClick, highlightedItemRef, isSearching, navigationIndexByItem, searchValue } =
+        useSearchContext()
 
     // Don't show "no results" while any category is still loading
     const isAnyLoading = groupedItems.some((g) => g.isLoading)
@@ -925,6 +931,7 @@ function SearchResults({
                                                     <ContextMenuTrigger asChild>
                                                         <Autocomplete.Item
                                                             value={item}
+                                                            index={navigationIndexByItem.get(item)}
                                                             onClick={(e) => {
                                                                 // Plain clicks only. LinkPrimitive returns early on
                                                                 // metaKey/ctrlKey, so modifier clicks never get here and

--- a/frontend/src/lib/components/Search/Search.tsx
+++ b/frontend/src/lib/components/Search/Search.tsx
@@ -1,4 +1,5 @@
 import { Autocomplete } from '@base-ui/react/autocomplete'
+import type { BaseUIEvent } from '@base-ui/react/types'
 import { useActions, useValues } from 'kea'
 import { capitalizeFirstLetter } from 'kea-forms'
 import { router } from 'kea-router'
@@ -705,7 +706,14 @@ function SearchInput({ autoFocus, className }: SearchInputProps): JSX.Element {
     )
 
     const handleInputKeyDown = useCallback(
-        (e: React.KeyboardEvent) => {
+        (e: BaseUIEvent<React.KeyboardEvent>) => {
+            // Home and End move the caret within the query, which is what they do in every other
+            // text input. Base UI would otherwise jump the highlight to the ends of its own
+            // navigation order, and that order starts on the exact match rather than the top row.
+            if (e.key === 'Home' || e.key === 'End') {
+                e.preventBaseUIHandler()
+                return
+            }
             if (e.key === 'Tab' && showAskAiLink && searchValue.trim()) {
                 e.preventDefault()
                 onAskAiClick?.()

--- a/frontend/src/lib/components/Search/Search.tsx
+++ b/frontend/src/lib/components/Search/Search.tsx
@@ -20,7 +20,7 @@ import { IconDay, IconNight, IconSearch, IconSparkles, IconX } from '@posthog/ic
 import { LemonTag, Link, Spinner } from '@posthog/lemon-ui'
 
 import { KeyboardShortcut } from 'lib/components/KeyboardShortcut/KeyboardShortcut'
-import { filterSearchItems } from 'lib/components/Search/utils'
+import { filterSearchItems, promoteExactMatch } from 'lib/components/Search/utils'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
 import { themeLogic } from 'lib/logic/themeLogic'
@@ -603,7 +603,14 @@ function SearchRoot({
 
     // Re-rank: pin the incumbent first item so async results don't shift what's highlighted.
     // Promotes the incumbent's group to the front if needed.
-    const stableGroupedItems = useReRankedGroupedItems(debouncedGroupedItems, searchValue, reRankEnabled)
+    const reRankedGroupedItems = useReRankedGroupedItems(debouncedGroupedItems, searchValue, reRankEnabled)
+
+    // Applied last so an exact name match wins over both the fixed category order and the
+    // incumbent pinned above, including when it only arrives with late async results.
+    const stableGroupedItems = useMemo(
+        () => promoteExactMatch(reRankedGroupedItems, searchValue),
+        [reRankedGroupedItems, searchValue]
+    )
 
     // Derive a flat item list from groupedItems so the order passed to Autocomplete.Root
     // exactly matches the DOM render order. Without this, Base UI's keyboard navigation

--- a/frontend/src/lib/components/Search/utils.test.ts
+++ b/frontend/src/lib/components/Search/utils.test.ts
@@ -1,4 +1,4 @@
-import { SETTINGS_THEME_ITEM_ID, canOpenInNewTab, filterSearchItems, promoteExactMatch } from './utils'
+import { SETTINGS_THEME_ITEM_ID, canOpenInNewTab, filterSearchItems, rotateToExactMatch } from './utils'
 
 interface TestItem {
     name: string
@@ -105,39 +105,36 @@ describe('filterSearchItems', () => {
     })
 })
 
-// The first item of the first group is what gets highlighted and opened on Enter, so anything
-// that leaves an exact match behind a fuzzy one sends the user to the wrong scene.
-describe('promoteExactMatch', () => {
-    const groups = [
-        { category: 'tools', items: [makeItem('Evaluations'), makeItem('Error tracking')] },
-        { category: 'data-management', items: [makeItem('Annotations'), makeItem('Actions')] },
-    ]
+// The result at navigation index 0 is what gets highlighted and opened on Enter, so anything that
+// leaves an exact match behind a fuzzy one sends the user to the wrong scene.
+describe('rotateToExactMatch', () => {
+    const results = [makeItem('Evaluations'), makeItem('Error tracking'), makeItem('Actions'), makeItem('Annotations')]
 
-    const flatten = (result: typeof groups): string[] => result.flatMap((g) => g.items.map((i) => i.name))
+    const names = (items: typeof results): string[] => items.map((i) => i.name)
 
-    it('hoists an exact match out of a later group, keeping the rest of the order', () => {
-        const result = promoteExactMatch(groups, 'actions')
-
-        expect(result.map((g) => g.category)).toEqual(['data-management', 'tools'])
-        expect(flatten(result)).toEqual(['Actions', 'Annotations', 'Evaluations', 'Error tracking'])
+    it('starts the order on the exact match and wraps the results above it round to the end', () => {
+        expect(names(rotateToExactMatch(results, 'actions'))).toEqual([
+            'Actions',
+            'Annotations',
+            'Evaluations',
+            'Error tracking',
+        ])
     })
 
     it('matches on displayName', () => {
-        const withDisplayName = [
-            { category: 'tools', items: [makeItem('Evaluations')] },
-            { category: 'recents', items: [makeItem('insight-42', 'recents', { displayName: 'Actions' })] },
-        ]
+        const withDisplayName = [makeItem('Evaluations'), makeItem('insight-42', 'recents', { displayName: 'Actions' })]
 
-        expect(flatten(promoteExactMatch(withDisplayName, 'Actions'))).toEqual(['insight-42', 'Evaluations'])
+        expect(names(rotateToExactMatch(withDisplayName, 'Actions'))).toEqual(['insight-42', 'Evaluations'])
     })
 
     const noOpCases: [label: string, query: string][] = [
-        ['leaves order alone when nothing matches exactly', 'action'],
-        ['leaves order alone for an empty query', '   '],
+        ['leaves the order alone when nothing matches exactly', 'action'],
+        ['leaves the order alone for an empty query', '   '],
+        ['leaves the order alone when the exact match is already first', 'evaluations'],
     ]
 
     it.each(noOpCases)('%s', (_label, query) => {
-        expect(promoteExactMatch(groups, query)).toBe(groups)
+        expect(rotateToExactMatch(results, query)).toBe(results)
     })
 })
 

--- a/frontend/src/lib/components/Search/utils.test.ts
+++ b/frontend/src/lib/components/Search/utils.test.ts
@@ -110,8 +110,6 @@ describe('filterSearchItems', () => {
 describe('rotateToExactMatch', () => {
     const results = [makeItem('Evaluations'), makeItem('Error tracking'), makeItem('Actions'), makeItem('Annotations')]
 
-    const names = (items: typeof results): string[] => items.map((i) => i.name)
-
     it('starts the order on the exact match and wraps the results above it round to the end', () => {
         expect(names(rotateToExactMatch(results, 'actions'))).toEqual([
             'Actions',

--- a/frontend/src/lib/components/Search/utils.test.ts
+++ b/frontend/src/lib/components/Search/utils.test.ts
@@ -1,4 +1,4 @@
-import { SETTINGS_THEME_ITEM_ID, canOpenInNewTab, filterSearchItems } from './utils'
+import { SETTINGS_THEME_ITEM_ID, canOpenInNewTab, filterSearchItems, promoteExactMatch } from './utils'
 
 interface TestItem {
     name: string
@@ -102,6 +102,42 @@ describe('filterSearchItems', () => {
             const results = filterSearchItems(items, 'xyzzyplugh')
             expect(results).toEqual([])
         })
+    })
+})
+
+// The first item of the first group is what gets highlighted and opened on Enter, so anything
+// that leaves an exact match behind a fuzzy one sends the user to the wrong scene.
+describe('promoteExactMatch', () => {
+    const groups = [
+        { category: 'tools', items: [makeItem('Evaluations'), makeItem('Error tracking')] },
+        { category: 'data-management', items: [makeItem('Annotations'), makeItem('Actions')] },
+    ]
+
+    const flatten = (result: typeof groups): string[] => result.flatMap((g) => g.items.map((i) => i.name))
+
+    it('hoists an exact match out of a later group, keeping the rest of the order', () => {
+        const result = promoteExactMatch(groups, 'actions')
+
+        expect(result.map((g) => g.category)).toEqual(['data-management', 'tools'])
+        expect(flatten(result)).toEqual(['Actions', 'Annotations', 'Evaluations', 'Error tracking'])
+    })
+
+    it('matches on displayName', () => {
+        const withDisplayName = [
+            { category: 'tools', items: [makeItem('Evaluations')] },
+            { category: 'recents', items: [makeItem('insight-42', 'recents', { displayName: 'Actions' })] },
+        ]
+
+        expect(flatten(promoteExactMatch(withDisplayName, 'Actions'))).toEqual(['insight-42', 'Evaluations'])
+    })
+
+    const noOpCases: [label: string, query: string][] = [
+        ['leaves order alone when nothing matches exactly', 'action'],
+        ['leaves order alone for an empty query', '   '],
+    ]
+
+    it.each(noOpCases)('%s', (_label, query) => {
+        expect(promoteExactMatch(groups, query)).toBe(groups)
     })
 })
 

--- a/frontend/src/lib/components/Search/utils.ts
+++ b/frontend/src/lib/components/Search/utils.ts
@@ -42,38 +42,27 @@ interface ExactMatchCandidate {
 }
 
 /**
- * Hoist a result whose name is exactly what was typed to the very front. Fuzzy scoring and the
- * fixed category order otherwise let something like "Evaluations" outrank "Actions" for the query
- * "actions", and the front of the first group is what gets highlighted and opened on Enter.
+ * Rotate the list so a result whose name is exactly what was typed comes first. The autocomplete
+ * highlights whichever result it holds at index 0, so this is how an exact match becomes the default
+ * selection without moving any row on screen. Rotating, rather than lifting the one result out,
+ * keeps the arrow keys walking the list in the order a person sees it.
  */
-export function promoteExactMatch<G extends { items: ExactMatchCandidate[] }>(groups: G[], query: string): G[] {
+export function rotateToExactMatch<T extends ExactMatchCandidate>(items: T[], query: string): T[] {
     const normalizedQuery = query.trim().toLowerCase()
     if (!normalizedQuery) {
-        return groups
+        return items
     }
 
-    for (let groupIndex = 0; groupIndex < groups.length; groupIndex++) {
-        const { items } = groups[groupIndex]
-        for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
-            const item = items[itemIndex]
-            const isExact =
-                item.name.trim().toLowerCase() === normalizedQuery ||
-                item.displayName?.trim().toLowerCase() === normalizedQuery
-            if (!isExact) {
-                continue
-            }
-            if (groupIndex === 0 && itemIndex === 0) {
-                return groups
-            }
-            const promotedGroup = {
-                ...groups[groupIndex],
-                items: [item, ...items.slice(0, itemIndex), ...items.slice(itemIndex + 1)],
-            }
-            return [promotedGroup, ...groups.filter((_, index) => index !== groupIndex)]
-        }
+    const matchIndex = items.findIndex(
+        (item) =>
+            item.name.trim().toLowerCase() === normalizedQuery ||
+            item.displayName?.trim().toLowerCase() === normalizedQuery
+    )
+    if (matchIndex <= 0) {
+        return items
     }
 
-    return groups
+    return [...items.slice(matchIndex), ...items.slice(0, matchIndex)]
 }
 
 /** Structural so this module avoids importing searchLogic, which imports this one. */

--- a/frontend/src/lib/components/Search/utils.ts
+++ b/frontend/src/lib/components/Search/utils.ts
@@ -36,6 +36,46 @@ export function filterSearchItems<T extends FuseSearchable>(items: T[], query: s
     return fuse.search(trimmed).map((r) => r.item)
 }
 
+interface ExactMatchCandidate {
+    name: string
+    displayName?: string
+}
+
+/**
+ * Hoist a result whose name is exactly what was typed to the very front. Fuzzy scoring and the
+ * fixed category order otherwise let something like "Evaluations" outrank "Actions" for the query
+ * "actions", and the front of the first group is what gets highlighted and opened on Enter.
+ */
+export function promoteExactMatch<G extends { items: ExactMatchCandidate[] }>(groups: G[], query: string): G[] {
+    const normalizedQuery = query.trim().toLowerCase()
+    if (!normalizedQuery) {
+        return groups
+    }
+
+    for (let groupIndex = 0; groupIndex < groups.length; groupIndex++) {
+        const { items } = groups[groupIndex]
+        for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
+            const item = items[itemIndex]
+            const isExact =
+                item.name.trim().toLowerCase() === normalizedQuery ||
+                item.displayName?.trim().toLowerCase() === normalizedQuery
+            if (!isExact) {
+                continue
+            }
+            if (groupIndex === 0 && itemIndex === 0) {
+                return groups
+            }
+            const promotedGroup = {
+                ...groups[groupIndex],
+                items: [item, ...items.slice(0, itemIndex), ...items.slice(itemIndex + 1)],
+            }
+            return [promotedGroup, ...groups.filter((_, index) => index !== groupIndex)]
+        }
+    }
+
+    return groups
+}
+
 /** Structural so this module avoids importing searchLogic, which imports this one. */
 interface NewTabCandidate {
     id: string

--- a/frontend/src/lib/components/Search/utils.ts
+++ b/frontend/src/lib/components/Search/utils.ts
@@ -58,6 +58,7 @@ export function rotateToExactMatch<T extends ExactMatchCandidate>(items: T[], qu
             item.name.trim().toLowerCase() === normalizedQuery ||
             item.displayName?.trim().toLowerCase() === normalizedQuery
     )
+    // -1 means no exact match; 0 means it's already first. Either way, there's nothing to rotate.
     if (matchIndex <= 0) {
         return items
     }


### PR DESCRIPTION
## Problem

Typing a scene's full name into Cmd+K can select a different scene, so Enter opens the wrong one. Typing `actions` selects "Evaluations" under Tools, while "Actions" sits further down under Data management.

Result groups render in a fixed order, and the autocomplete selects the first result of the first group. Fuzzy scoring only ranks results within a group, so an exact match cannot beat a fuzzy one that sits in an earlier group.

## Changes

- A result whose name equals the query is now the default selection, wherever it sits in the list.
- The displayed order does not change, so no row moves on screen.
- Matching is case-insensitive and also checks the display name, so a recent item titled "Actions" qualifies.
- The autocomplete selects whatever it holds at index 0 of its navigation order, so that order rotates to start on the exact match and each row gets its navigation position back through the `index` prop. Rotating, rather than lifting the one result out, keeps the arrow keys walking the list in the order a person sees it.
- Home and End now move the caret within the query instead of driving the list. The autocomplete's End handler otherwise jumped the highlight to the row above the exact match. Home already behaved this way, so the pair is now consistent.

![cmdk-exact-match](https://raw.githubusercontent.com/PostHog/pr-assets/15efca96a426bb170f48dcaf3378377ef9c321ba/2026/08/f54e4c5e-4a57-47cc-a194-8761b9ff616e.png)

## How did you test this code?

- Drove the `Components/Search` Storybook story in headless Chromium. Typing `actions` leaves the rows in place, selects "Actions", and Enter activates "Actions". Arrow down moves to the next row on screen, and two arrow ups walk back up through "Actions" to "Evaluations".
- Added five `rotateToExactMatch` cases to `frontend/src/lib/components/Search/utils.test.ts`. They catch an exact match stranded behind a fuzzy hit. No existing test covered which result is selected.
- Drove Home and End in the same story, comparing master against this branch, after a Codex review comment flagged them. Home never drove the list on either side; End did regress and now leaves the highlight alone.
- No unit test covers the Home/End fix. Reproducing it needs a real browser, and a component render for one key handler sits too high on the cost ladder.
- Not checked: whether an exact match below the fold scrolls into view. Base UI scrolls the selected item into view on every selection change, and I could not build a story long enough to force the case.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually the PostHog Slack app) wrote this from a Slack thread reporting that an exact match was not selected on Enter. Skills invoked: `/writing-tests` and `/writing-pr-descriptions`.

The first version reordered the groups so the exact match rendered first. That was rejected, because only the selection should move. Base UI exposes no way to set the selected index, so the navigation order carries the change instead and the `index` prop keeps it in step with the rendered order. Storybook also surfaced a separate pre-existing problem, unrelated to this change: with the mocked recents, some queries end up with nothing selected at all. I confirmed that on master and left it alone.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08499A7REU/p1786270884180919)*

