### PR TITLE
fix(data-warehouse): give a clear message when a sync run is interrupted

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
@@ -72,7 +72,12 @@ FRESHNESS_PROBE_TIMEOUT_SECONDS = 30.0
 
 # Stamped on a run the loader abandoned: its extraction ended without a final batch, so nothing
 # finalized it and there is no failed queue batch for the failed-run reconcile to key on.
-STRANDED_RUN_ERROR = "run abandoned before completion (no loader progress; reconciled from queue)"
+# Shown to the customer verbatim as latest_error, so keep it plain and reassuring rather than
+# describing the internal queue mechanics.
+STRANDED_RUN_ERROR = (
+    "This sync run stopped before it finished, so it did not complete. "
+    "The next scheduled sync retries automatically. No action is needed."
+)
 
 # Errors that fail identically on every attempt. Substring-matched because they
 # surface as generic exceptions; keep entries specific so transients can't match.


### PR DESCRIPTION
## Problem

- A customer whose data-warehouse sync run is interrupted before it finishes sees the error "run abandoned before completion (no loader progress; reconciled from queue)" against the source.
- The wording describes PostHog's internal queue reconciliation and gives the customer no next step, even though the run self-heals: the schema stays enabled and the next scheduled sync retries.
- The reconcile sweep stamps this message across many teams and several source types when extraction workers restart, so it is a common thing for customers to read.

## Changes

- Replace the `STRANDED_RUN_ERROR` wording with a plain message: the run was interrupted, the next scheduled sync retries automatically, no action is needed.
- No behavior change. The constant is only the queue failure reason and the job `latest_error`; retryability, schema state, and the reconcile logic are untouched.

## How did you test this code?

- Ruff passes on the changed file.
- No test asserts the literal wording; the tests that touch this path reference the constant, not the string.
- Not run: the queue-Postgres reconcile integration tests, because this sandbox has no database.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- I (Claude, via PostHog Code) triaged a batch of warehouse-source sync failures and found this message is internal jargon surfaced verbatim to customers for a run that actually self-heals.
- Skills invoked: `/writing-user-facing-copy`, `/writing-pr-descriptions`.
- The change is a static string; no data from the triage source is in the diff.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
