### PR TITLE
fix(data-warehouse): clarify the sync error shown after a lock takeover

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/metrics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/metrics.py
@@ -31,7 +31,12 @@ TERMINAL_JOB_STATUSES: frozenset[str] = frozenset(_TERMINAL_STATUS_TO_METRIC)
 
 # latest_error written when lock takeover force-fails a stuck-RUNNING job; sentinel that
 # lets update_external_job_status permit Failed -> Completed for takeover-failed jobs only.
-LOCK_TAKEOVER_LATEST_ERROR = "Lock takeover: workflow terminated but job was stuck in RUNNING"
+# Shown to the customer verbatim, so keep it plain; the exact string is the recovery sentinel,
+# so all comparisons must go through this constant rather than the literal.
+LOCK_TAKEOVER_LATEST_ERROR = (
+    "A previous sync run did not shut down cleanly and was still marked as running. "
+    "PostHog cleaned it up so syncing can continue. No action is needed."
+)
 
 
 def get_data_import_finished_metric(source_type: str | None, status: str) -> MetricCounter:


### PR DESCRIPTION
## Problem

- A customer sees the error "Lock takeover: workflow terminated but job was stuck in RUNNING" against a source when a previous sync run's worker died without finalizing the job.
- The wording describes PostHog's internal lock and worker mechanics and offers no next step, even though the situation self-heals: a new run takes over and syncing continues.
- This is stamped across many teams and source types whenever extraction workers restart, so customers read it fairly often.

## Changes

- Replace the `LOCK_TAKEOVER_LATEST_ERROR` wording with a plain message: a previous run did not shut down cleanly, PostHog cleaned it up, no action is needed.
- No behavior change. The string is also the recovery sentinel that lets `update_external_job_status` unseal `Failed -> Completed` for a taken-over job; every comparison already routes through this constant, so the sentinel still matches.

## How did you test this code?

- Ruff passes on the changed file.
- No test asserts the literal wording; the takeover and unseal tests reference the constant, so the sentinel match is preserved.
- Not run: the database-backed takeover tests, because this sandbox has no database.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- I (Claude, via PostHog Code) triaged a batch of warehouse-source sync failures and found this recovery message is internal jargon surfaced verbatim to customers for a situation that self-heals.
- I confirmed the string doubles as the takeover recovery sentinel and that every comparison uses the constant, not the literal, so the wording change does not affect recovery.
- Skills invoked: `/writing-user-facing-copy`, `/writing-pr-descriptions`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
