### PR TITLE
fix(mistral_ai): stop retrying when fine-tuning jobs access is gone

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mistral_ai/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mistral_ai/source.py
@@ -86,6 +86,10 @@ You can create an API key in [La Plateforme](https://console.mistral.ai/api-keys
             # stable status text and base host, not the per-request path/query.
             "401 Client Error: Unauthorized for url: https://api.mistral.ai": "Your Mistral AI API key is invalid or has been revoked. Create a new key in La Plateforme, then reconnect.",
             "403 Client Error: Forbidden for url: https://api.mistral.ai": "Your Mistral AI API key is missing the permissions needed to sync this data. Check the key's permissions in La Plateforme, then reconnect.",
+            # Mistral returns 410 (permanently gone, not a transient 404/5xx) when fine-tuning is not
+            # available for the workspace — retrying can never make a gone resource reappear. Match the
+            # base path, not the page/page_size query, so it catches the error on every page.
+            "410 Client Error: Gone for url: https://api.mistral.ai/v1/fine_tuning/jobs": "Fine-tuning is not available for your Mistral AI workspace, so the Fine tuning jobs table can't sync. Disable that table, or check your workspace's fine-tuning access in La Plateforme.",
         }
 
     def get_schemas(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mistral_ai/tests/test_mistral_ai_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mistral_ai/tests/test_mistral_ai_source.py
@@ -108,6 +108,23 @@ class TestNonRetryableErrors:
 
     @parameterized.expand(
         [
+            (
+                "page_zero",
+                "410 Client Error: Gone for url: https://api.mistral.ai/v1/fine_tuning/jobs?page=0&page_size=100",
+            ),
+            (
+                "later_page",
+                "410 Client Error: Gone for url: https://api.mistral.ai/v1/fine_tuning/jobs?page=3&page_size=100",
+            ),
+        ]
+    )
+    def test_fine_tuning_gone_is_non_retryable(self, _name: str, observed: str) -> None:
+        # Mistral's 410 means fine-tuning is unavailable for the workspace, not a page-specific fluke,
+        # so the match must hold regardless of which page the pagination loop was on.
+        assert any(key in observed for key in MistralAISource().get_non_retryable_errors())
+
+    @parameterized.expand(
+        [
             ("rate_limited", "429 Client Error: Too Many Requests for url: https://api.mistral.ai/v1/files"),
             ("server_error", "500 Server Error: Internal Server Error for url: https://api.mistral.ai/v1/files"),
         ]


### PR DESCRIPTION
## Problem

The Mistral AI fine-tuning jobs table fails to sync for workspaces without fine-tuning access, and the sync keeps retrying instead of failing with a clear message.

Mistral's `GET /v1/fine_tuning/jobs` returns `410 Client Error: Gone` for these workspaces. The source's retry logic only treats 429/5xx as retryable and 401/403 as terminal, so a 410 falls through neither bucket and the sync exhausts its retry budget before failing with a raw HTTP error.

Confirmed via [error tracking issue 019fe6cd-55d0-7892-ba3a-385e6b76bad5](https://us.posthog.com/project/2/error_tracking/019fe6cd-55d0-7892-ba3a-385e6b76bad5), raised in `_fetch_page` (`mistral_ai.py`).

## Changes

- Add the `410 Client Error: Gone` message for `/v1/fine_tuning/jobs` to `MistralAISource.get_non_retryable_errors`, following the existing 401/403 pattern.
- Match on the base path, not the `page`/`page_size` query string, so it catches the error regardless of which page failed.
- Mistral's own docs still list `GET /v1/fine_tuning/jobs` as a live, non-deprecated endpoint, so this is workspace-specific (fine-tuning unavailable for that account) rather than a global API removal — retrying can't fix it, so this is a terminal, user-facing error rather than a code bug.

## How did you test this code?

Added 2 parameterized cases to `test_fine_tuning_gone_is_non_retryable` (page 0 and a later page) — guards against the entry only matching the first page's query string, and locks in that the new mapping is recognized. Ran the full `mistral_ai` test suite locally: 63 passed. Also ran mypy on the changed file: clean.

Not run: a live sync against the Mistral API (no test credentials in this environment).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — this only changes internal retry classification, not documented behavior.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) triaged this from an error-tracking webhook alert, read the stack trace and the source code, and determined the 410 is workspace-specific (Mistral's docs still list the endpoint as active) rather than a code bug. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.