### PR TITLE
fix(desktop): prevent artifact version flicker

### DIFF
--- a/products/desktop/packages/ui/src/features/sessions/components/ArtifactPreview.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ArtifactPreview.test.tsx
@@ -1024,11 +1024,24 @@ describe("ArtifactPreview", () => {
         ],
       },
     ];
-    useQuery.mockReturnValue({
-      data: editablePreview(),
-      isLoading: false,
-      isError: false,
-    });
+    const currentPreview = editablePreview();
+    useQuery.mockImplementation(
+      (options: {
+        queryKey: unknown[];
+        placeholderData?: (previousData: unknown) => unknown;
+      }) => {
+        const isLoadingOlderVersion = options.queryKey.includes("artifact-0");
+        const data = isLoadingOlderVersion
+          ? options.placeholderData?.(currentPreview)
+          : currentPreview;
+        return {
+          data,
+          isLoading: data === undefined,
+          isError: false,
+          isPlaceholderData: isLoadingOlderVersion && data !== undefined,
+        };
+      },
+    );
 
     render(
       <ArtifactPreview
@@ -1047,8 +1060,12 @@ describe("ArtifactPreview", () => {
     fireEvent.click(screen.getByRole("button", { name: "Older version" }));
 
     expect(screen.getByText("v1/2")).toBeInTheDocument();
+    expect(screen.getByText("Report")).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Older version" }),
+    ).toHaveAttribute("aria-disabled", "true");
+    expect(
+      screen.getByRole("button", { name: "Newer version" }),
     ).toHaveAttribute("aria-disabled", "true");
     let lastCall = useQuery.mock.calls.at(-1)?.[0] as {
       queryKey: unknown[];

--- a/products/desktop/packages/ui/src/features/sessions/components/ArtifactPreview.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ArtifactPreview.test.tsx
@@ -250,7 +250,7 @@ describe("ArtifactPreview", () => {
     vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
   });
 
-  it("scopes cached previews to the authenticated identity", () => {
+  it("scopes cached previews to the identity and artifact name", () => {
     render(
       <ArtifactPreview
         taskId="task-1"
@@ -266,6 +266,7 @@ describe("ArtifactPreview", () => {
           "artifactPreview",
           "auth-1",
           "task-1",
+          "report.html",
           "run-1",
           "artifact-1",
         ],
@@ -273,6 +274,24 @@ describe("ArtifactPreview", () => {
         meta: { authScoped: true },
       }),
     );
+    const queryOptions = useQuery.mock.calls[0]?.[0] as {
+      placeholderData: (
+        previousData: unknown,
+        previousQuery: { queryKey: unknown[] },
+      ) => unknown;
+    };
+    expect(
+      queryOptions.placeholderData("previous preview", {
+        queryKey: [
+          "artifactPreview",
+          "auth-1",
+          "task-1",
+          "other.html",
+          "run-1",
+          "artifact-0",
+        ],
+      }),
+    ).toBeUndefined();
   });
 
   it("starts the manifest and preview URL requests together", async () => {
@@ -1024,26 +1043,50 @@ describe("ArtifactPreview", () => {
         ],
       },
     ];
-    const currentPreview = editablePreview();
+    const currentPreview = editablePreview({
+      storage_path: "runs/1/report-v2.md",
+    });
+    const olderPreview = editablePreview({
+      id: "artifact-0",
+      storage_path: "runs/1/report-v1.md",
+      uploaded_at: "2026-08-06T10:00:00Z",
+    });
+    let olderVersionLoaded = false;
     useQuery.mockImplementation(
       (options: {
         queryKey: unknown[];
-        placeholderData?: (previousData: unknown) => unknown;
+        placeholderData?: (
+          previousData: unknown,
+          previousQuery: { queryKey: unknown[] },
+        ) => unknown;
       }) => {
-        const isLoadingOlderVersion = options.queryKey.includes("artifact-0");
-        const data = isLoadingOlderVersion
-          ? options.placeholderData?.(currentPreview)
-          : currentPreview;
+        const isOlderVersion = options.queryKey.includes("artifact-0");
+        const data =
+          isOlderVersion && !olderVersionLoaded
+            ? options.placeholderData?.(currentPreview, {
+                queryKey: [
+                  "artifactPreview",
+                  "auth-1",
+                  "task-1",
+                  "report.md",
+                  "run-1",
+                  "artifact-1",
+                ],
+              })
+            : isOlderVersion
+              ? olderPreview
+              : currentPreview;
         return {
           data,
           isLoading: data === undefined,
           isError: false,
-          isPlaceholderData: isLoadingOlderVersion && data !== undefined,
+          isPlaceholderData:
+            isOlderVersion && !olderVersionLoaded && data !== undefined,
         };
       },
     );
 
-    render(
+    const { rerender } = render(
       <ArtifactPreview
         taskId="task-1"
         runId="run-1"
@@ -1053,20 +1096,40 @@ describe("ArtifactPreview", () => {
     );
 
     expect(screen.getByText("v2/2")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Newer version" }),
     ).toHaveAttribute("aria-disabled", "true");
 
     fireEvent.click(screen.getByRole("button", { name: "Older version" }));
 
-    expect(screen.getByText("v1/2")).toBeInTheDocument();
+    expect(screen.getByText("v2/2")).toBeInTheDocument();
     expect(screen.getByText("Report")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Edit" })).toBeNull();
     expect(
       screen.getByRole("button", { name: "Older version" }),
     ).toHaveAttribute("aria-disabled", "true");
     expect(
       screen.getByRole("button", { name: "Newer version" }),
     ).toHaveAttribute("aria-disabled", "true");
+    expect(
+      screen.getByRole("button", { name: "Comment…" }),
+    ).toBeInTheDocument();
+
+    olderVersionLoaded = true;
+    rerender(
+      <ArtifactPreview
+        taskId="task-1"
+        runId="run-1"
+        artifactId="artifact-1"
+        name="report.md"
+      />,
+    );
+
+    expect(screen.getByText("v1/2")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Newer version" }),
+    ).not.toHaveAttribute("aria-disabled", "true");
     let lastCall = useQuery.mock.calls.at(-1)?.[0] as {
       queryKey: unknown[];
     };

--- a/products/desktop/packages/ui/src/features/sessions/components/ArtifactPreview.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ArtifactPreview.tsx
@@ -122,19 +122,42 @@ export function ArtifactPreview({
     null,
   );
   const activeArtifactId = selectedVersionId ?? artifactId;
-  const versionIndex = versions.findIndex(
+  const activeVersionIndex = versions.findIndex(
     (version) => version.id === activeArtifactId,
   );
   const activeRunId =
-    versionIndex >= 0 ? (versions[versionIndex]?.runId ?? runId) : runId;
+    activeVersionIndex >= 0
+      ? (versions[activeVersionIndex]?.runId ?? runId)
+      : runId;
   const markdownRootRef = useRef<HTMLDivElement>(null);
   const markdownContainerRef = useRef<HTMLDivElement>(null);
   const [imageError, setImageError] = useState(false);
   const [imageCommenting, setImageCommenting] = useState(false);
   const authIdentity = useAuthStateValue(getAuthIdentity);
+  const {
+    artifactResult,
+    previewData,
+    previewUrl,
+    isLoading,
+    isError,
+    isPlaceholderData,
+  } = useArtifactPreviewData({
+    sessionService,
+    authIdentity,
+    taskId,
+    runId: activeRunId,
+    artifactId: activeArtifactId,
+    name,
+  });
+  const displayedArtifactId = artifactResult?.artifact.id ?? activeArtifactId;
+  const versionIndex = versions.findIndex(
+    (version) => version.id === displayedArtifactId,
+  );
+  const displayedRunId =
+    versionIndex >= 0 ? (versions[versionIndex]?.runId ?? runId) : runId;
   const commentTarget = useMemo<CommentTarget>(
-    () => ({ scope: "task_artifact", itemId: activeArtifactId }),
-    [activeArtifactId],
+    () => ({ scope: "task_artifact", itemId: displayedArtifactId }),
+    [displayedArtifactId],
   );
   const commentsQuery = useCommentsQuery(commentTarget, taskId, {
     enabled: commentsEnabled,
@@ -159,21 +182,6 @@ export function ArtifactPreview({
     }
     setSelectedVersionId(focus.target.itemId);
   }, [activeArtifactId, focus, versions]);
-  const {
-    artifactResult,
-    previewData,
-    previewUrl,
-    isLoading,
-    isError,
-    isPlaceholderData,
-  } = useArtifactPreviewData({
-    sessionService,
-    authIdentity,
-    taskId,
-    runId: activeRunId,
-    artifactId: activeArtifactId,
-    name,
-  });
   const editing = useArtifactEditing({
     sessionService,
     artifactResult,
@@ -182,7 +190,7 @@ export function ArtifactPreview({
     versionsLoading: runsLoading || isPlaceholderData,
     refreshVersions,
     taskId,
-    runId: activeRunId,
+    runId: displayedRunId,
     name,
     authIdentity,
     openArtifactTab,
@@ -322,7 +330,7 @@ export function ArtifactPreview({
       versionNav={versionNav}
       taskId={taskId}
       commentTarget={commentTarget}
-      commentsEnabled={commentsEnabled && !isPlaceholderData}
+      commentsEnabled={commentsEnabled}
       canEdit={editing.canEdit}
       beginEditing={editing.beginEditing}
       previewData={previewData}

--- a/products/desktop/packages/ui/src/features/sessions/components/ArtifactPreview.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ArtifactPreview.tsx
@@ -159,21 +159,27 @@ export function ArtifactPreview({
     }
     setSelectedVersionId(focus.target.itemId);
   }, [activeArtifactId, focus, versions]);
-  const { artifactResult, previewData, previewUrl, isLoading, isError } =
-    useArtifactPreviewData({
-      sessionService,
-      authIdentity,
-      taskId,
-      runId: activeRunId,
-      artifactId: activeArtifactId,
-      name,
-    });
+  const {
+    artifactResult,
+    previewData,
+    previewUrl,
+    isLoading,
+    isError,
+    isPlaceholderData,
+  } = useArtifactPreviewData({
+    sessionService,
+    authIdentity,
+    taskId,
+    runId: activeRunId,
+    artifactId: activeArtifactId,
+    name,
+  });
   const editing = useArtifactEditing({
     sessionService,
     artifactResult,
     versions:
       versions.length > 0 ? versions : (artifactResult?.artifacts ?? []),
-    versionsLoading: runsLoading,
+    versionsLoading: runsLoading || isPlaceholderData,
     refreshVersions,
     taskId,
     runId: activeRunId,
@@ -252,7 +258,7 @@ export function ArtifactPreview({
           size="icon"
           variant="default"
           aria-label="Older version"
-          disabled={versionIndex >= versions.length - 1}
+          disabled={isPlaceholderData || versionIndex >= versions.length - 1}
           onClick={() => {
             const older = versions[versionIndex + 1];
             if (older?.id) setSelectedVersionId(older.id);
@@ -267,7 +273,7 @@ export function ArtifactPreview({
           size="icon"
           variant="default"
           aria-label="Newer version"
-          disabled={versionIndex <= 0}
+          disabled={isPlaceholderData || versionIndex <= 0}
           onClick={() => {
             const newer = versions[versionIndex - 1];
             if (newer?.id) setSelectedVersionId(newer.id);
@@ -316,7 +322,7 @@ export function ArtifactPreview({
       versionNav={versionNav}
       taskId={taskId}
       commentTarget={commentTarget}
-      commentsEnabled={commentsEnabled}
+      commentsEnabled={commentsEnabled && !isPlaceholderData}
       canEdit={editing.canEdit}
       beginEditing={editing.beginEditing}
       previewData={previewData}

--- a/products/desktop/packages/ui/src/features/sessions/components/useArtifactPreviewData.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/useArtifactPreviewData.ts
@@ -89,8 +89,9 @@ export function useArtifactPreviewData({
   previewUrl: string | null;
   isLoading: boolean;
   isError: boolean;
+  isPlaceholderData: boolean;
 } {
-  const { data, isLoading, isError } = useQuery<
+  const { data, isLoading, isError, isPlaceholderData } = useQuery<
     PreviewData | ArtifactPreviewResult
   >({
     queryKey: ["artifactPreview", authIdentity, taskId, runId, artifactId],
@@ -135,6 +136,7 @@ export function useArtifactPreviewData({
     },
     enabled: authIdentity !== null,
     staleTime: Infinity,
+    placeholderData: (previousData) => previousData,
     retry: false,
     meta: AUTH_SCOPED_QUERY_META,
   });
@@ -154,5 +156,12 @@ export function useArtifactPreviewData({
     return () => URL.revokeObjectURL(objectUrl);
   }, [previewData]);
 
-  return { artifactResult, previewData, previewUrl, isLoading, isError };
+  return {
+    artifactResult,
+    previewData,
+    previewUrl,
+    isLoading,
+    isError,
+    isPlaceholderData,
+  };
 }

--- a/products/desktop/packages/ui/src/features/sessions/components/useArtifactPreviewData.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/useArtifactPreviewData.ts
@@ -94,7 +94,14 @@ export function useArtifactPreviewData({
   const { data, isLoading, isError, isPlaceholderData } = useQuery<
     PreviewData | ArtifactPreviewResult
   >({
-    queryKey: ["artifactPreview", authIdentity, taskId, runId, artifactId],
+    queryKey: [
+      "artifactPreview",
+      authIdentity,
+      taskId,
+      name,
+      runId,
+      artifactId,
+    ],
     queryFn: async () => {
       const [artifacts, url] = await Promise.all([
         sessionService.getCloudRunArtifacts(taskId, runId),
@@ -136,7 +143,12 @@ export function useArtifactPreviewData({
     },
     enabled: authIdentity !== null,
     staleTime: Infinity,
-    placeholderData: (previousData) => previousData,
+    placeholderData: (previousData, previousQuery) =>
+      previousQuery?.queryKey[1] === authIdentity &&
+      previousQuery.queryKey[2] === taskId &&
+      previousQuery.queryKey[3] === name
+        ? previousData
+        : undefined,
     retry: false,
     meta: AUTH_SCOPED_QUERY_META,
   });


### PR DESCRIPTION
## Problem

People switching artifact versions see the preview pane flash to a spinner the first time each version loads.

## Changes

- Keep the current preview visible until the selected version is ready.
- Keep comments bound to the displayed version, and disable navigation and editing during the transition.
- Reuse cached data only for versions with the same identity, task, and artifact name.
- No screenshot: this changes a transient loading state. The steady state is unchanged.

## How did you test this code?

- Extended `ArtifactPreview.test.tsx` to cover the loading state, its completion, guarded editing, stable comments, and unrelated artifacts.
- Ran the focused Vitest suite, the `@posthog/ui` type check, desktop Biome, host boundaries, and `ci:preflight`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This change does not affect a documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

An OpenAI coding agent worked through pi. It used `/writing-tests`, `/writing-pr-descriptions`, `/writing-simplified-technical-english`, and `/working-with-task-comments`. The session link is unavailable.