### PR TITLE
fix(data-imports): retry postgres connects blocked by a pooler credential circuit breaker

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -247,6 +247,16 @@ _CONNECTION_DROPPED_ERROR_SUBSTRINGS = (
     # activity. Match the stable code, distinct from genuine credential-rejection wordings
     # ("password authentication failed", "SASL authentication failed").
     "(eauthquery)",
+    # Supavisor caches the per-tenant database credentials it needs to authenticate and proxy
+    # connections; when it can't fetch them (e.g. its own metadata store is briefly unreachable) it
+    # retries internally and, after exhausting those attempts, trips an internal circuit breaker
+    # that rejects new connects outright rather than retrying forever: a bare OperationalError
+    # carrying "(ECIRCUITBREAKER) failed to retrieve database credentials after multiple attempts,
+    # new connections are temporarily blocked". Same class as EAUTHQUERY above — the pooler's own
+    # bookkeeping failing, not a rejection of the client's credentials — and the breaker resets once
+    # the fetch succeeds again, so a fresh connect after backoff typically recovers. Match the
+    # stable code, distinct from genuine credential-rejection wordings.
+    "(ecircuitbreaker)",
     # pgcat (a Rust Postgres pooler) refuses to hand out a backend when every server in the pool is
     # currently banned/down — a failed health check bans a server and pgcat auto-unbans it after
     # `ban_time` — reporting it as SQLSTATE 58000 ("could not get connection from the pool -

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1665,6 +1665,15 @@ class TestIsConnectionDroppedError:
                 'connection failed: connection to server at "10.0.0.1", port 5432 failed: '
                 "FATAL:  (EAUTHQUERY) auth_query secret check timed out"
             ),
+            # Supavisor's own credential fetch fails repeatedly and trips its internal circuit
+            # breaker, rejecting new connects with a bare OperationalError carrying its
+            # "(ECIRCUITBREAKER)" code. Same transient pooler-bookkeeping class as EAUTHQUERY —
+            # recovers once the breaker resets — so the reconnect must catch it.
+            psycopg.OperationalError(
+                'connection failed: connection to server at "10.0.0.1", port 5432 failed: '
+                "FATAL:  (ECIRCUITBREAKER) failed to retrieve database credentials after multiple "
+                "attempts, new connections are temporarily blocked"
+            ),
             # pgcat refuses to hand out a backend when every pooled server is banned/down, reporting
             # it as SQLSTATE 58000 (psycopg's SystemError, an OperationalError) rather than the
             # Supavisor XX000 InternalError_ codes above. Transient — a banned server rejoins on a


### PR DESCRIPTION
## Problem

A Postgres or Supabase sync fails outright when the connection pooler's own
credential-fetch circuit breaker trips, instead of retrying and recovering.

Surfaced by an [error tracking issue](https://us.posthog.com/project/2/error_tracking/019fe768-7727-7370-af04-bed6a6157200):
`OperationalError: ... FATAL: (ECIRCUITBREAKER) failed to retrieve database
credentials after multiple attempts, new connections are temporarily blocked`.

## Changes

- Supavisor (Supabase's connection pooler) caches per-tenant database
  credentials. When it can't fetch them, it retries internally and, once
  exhausted, trips a circuit breaker that rejects new connects with an
  `(ECIRCUITBREAKER)`-coded `OperationalError`.
- This is the same class of failure as the already-handled `(EAUTHQUERY)`
  case: the pooler's own bookkeeping failing, not a rejection of the client's
  credentials. The breaker resets once the fetch succeeds again, so it belongs
  with the other transient pooler-drop signatures the in-process reconnect
  already retries, not with the permanent credential-rejection errors.
- Added the `(ECIRCUITBREAKER)` code to `_CONNECTION_DROPPED_ERROR_SUBSTRINGS`
  in `postgres.py`, next to the equivalent `EAUTHQUERY` entry.

## How did you test this code?

Added one parametrized case to `test_connection_dropped_errors_are_detected`
asserting an `(ECIRCUITBREAKER)` `OperationalError` is classified as a
retryable connection drop, mirroring the existing `EAUTHQUERY` case. Ran the
full `TestIsConnectionDroppedError` class locally (35 passed), plus `ruff
check` and `ruff format --check` on both changed files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

This PR was authored by an agent triaging a live PostHog error tracking issue
end to end: pulling the stack trace and event properties, reading the
existing pooler-error handling conventions in `postgres.py`, and adding the
new signature and test in the same style as the neighboring `EAUTHQUERY`
entry. No other skills were invoked beyond `/writing-tests` and
`/writing-pr-descriptions`.