### PR TITLE
feat(ci): publish ordered release aliases for posthog-cloud

### DIFF
--- a/.github/actions/docker-meta/action.yml
+++ b/.github/actions/docker-meta/action.yml
@@ -38,6 +38,10 @@ inputs:
         required: false
         default: 'true'
         description: 'Whether to push to AWS ECR (and assume the AWS role). Set to false for images consumed only via GHCR (e.g. sandbox-host images Modal pulls directly). When false, the AWS configure-credentials + ECR-login steps are skipped, the ECR tag is omitted from the images list, and ecr-registry output is empty.'
+    generate-ordered-release-tag:
+        required: false
+        default: 'false'
+        description: 'Generate a source-ordered release tag for the default branch. Unshallowing registers origin as a promisor remote and marks the checkout as a partial clone; this is inert on ephemeral hosted runners but persists in self-hosted or reused checkouts.'
 
 outputs:
     tags:
@@ -52,6 +56,9 @@ outputs:
     ecr-registry:
         description: 'ECR registry URL'
         value: ${{ steps.aws-ecr.outputs.registry }}
+    ordered-release-tag:
+        description: 'Source-ordered release tag, or empty when disabled or unavailable.'
+        value: ${{ steps.ordered-release.outputs.tag }}
 
 runs:
     using: 'composite'
@@ -169,3 +176,70 @@ runs:
                 printf 'index:com.posthog.image.commit-timestamp=%s\n' "$TIMESTAMP"
                 echo "ANNOTATIONS_EOF"
               } >> "$GITHUB_OUTPUT"
+
+        - name: Fetch source history for ordered release tag
+          id: ordered-history
+          if: inputs.generate-ordered-release-tag == 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+          continue-on-error: true
+          shell: bash
+          run: |
+              set -euo pipefail
+              # The runner supplies -e; expected failures are captured explicitly.
+              if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+                fetch_status=0
+                timeout --kill-after=5s 40s git fetch \
+                  --no-tags \
+                  --prune \
+                  --no-recurse-submodules \
+                  --unshallow \
+                  --filter=tree:0 \
+                  origin \
+                  "+${GITHUB_REF}:refs/remotes/origin/${GITHUB_REF_NAME}" || fetch_status=$?
+                if [ "$fetch_status" -ne 0 ]; then
+                  echo "::warning::Source history for the ordered release tag could not be fetched (status $fetch_status). The ordered release tag will be skipped."
+                  exit 0
+                fi
+              fi
+
+        - name: Compute ordered release tag
+          id: ordered-release
+          if: inputs.generate-ordered-release-tag == 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+          continue-on-error: true
+          shell: bash
+          env:
+              ORDERED_RELEASE_TAG_REGEX: ^r[0-9]{12}-[0-9a-f]{6}$
+          run: |
+              set -uo pipefail
+              echo "tag=" >> "$GITHUB_OUTPUT"
+
+              if [ "$(git rev-parse --is-shallow-repository 2>/dev/null)" != "false" ]; then
+                echo "::warning::Skipping ordered release tag because complete source history is unavailable"
+                exit 0
+              fi
+
+              if ! head_revision="$(git rev-parse HEAD)" || [ "$head_revision" != "$GITHUB_SHA" ]; then
+                echo "::warning::Skipping ordered release tag because the checked-out revision does not match GITHUB_SHA"
+                exit 0
+              fi
+
+              if ! position="$(git rev-list --first-parent --count "$GITHUB_SHA")"; then
+                echo "::warning::Skipping ordered release tag because the source position could not be computed"
+                exit 0
+              fi
+
+              if ! [[ "$position" =~ ^[1-9][0-9]{0,11}$ ]]; then
+                echo "::warning::Skipping ordered release tag because the source position is out of range"
+                exit 0
+              fi
+
+              if ! printf -v tag 'r%012d-%.6s' "$position" "$GITHUB_SHA"; then
+                echo "::warning::Skipping ordered release tag because the source position could not be formatted"
+                exit 0
+              fi
+
+              if ! [[ "$tag" =~ $ORDERED_RELEASE_TAG_REGEX ]]; then
+                echo "::warning::Skipping ordered release tag because $tag does not match the required format"
+                exit 0
+              fi
+
+              echo "tag=${tag}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/docker-meta/action.yml
+++ b/.github/actions/docker-meta/action.yml
@@ -38,10 +38,6 @@ inputs:
         required: false
         default: 'true'
         description: 'Whether to push to AWS ECR (and assume the AWS role). Set to false for images consumed only via GHCR (e.g. sandbox-host images Modal pulls directly). When false, the AWS configure-credentials + ECR-login steps are skipped, the ECR tag is omitted from the images list, and ecr-registry output is empty.'
-    generate-ordered-release-tag:
-        required: false
-        default: 'false'
-        description: 'Generate a source-ordered release tag for the default branch. Unshallowing registers origin as a promisor remote and marks the checkout as a partial clone; this is inert on ephemeral hosted runners but persists in self-hosted or reused checkouts.'
 
 outputs:
     tags:
@@ -56,9 +52,6 @@ outputs:
     ecr-registry:
         description: 'ECR registry URL'
         value: ${{ steps.aws-ecr.outputs.registry }}
-    ordered-release-tag:
-        description: 'Source-ordered release tag, or empty when disabled or unavailable.'
-        value: ${{ steps.ordered-release.outputs.tag }}
 
 runs:
     using: 'composite'
@@ -176,70 +169,3 @@ runs:
                 printf 'index:com.posthog.image.commit-timestamp=%s\n' "$TIMESTAMP"
                 echo "ANNOTATIONS_EOF"
               } >> "$GITHUB_OUTPUT"
-
-        - name: Fetch source history for ordered release tag
-          id: ordered-history
-          if: inputs.generate-ordered-release-tag == 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-          continue-on-error: true
-          shell: bash
-          run: |
-              set -euo pipefail
-              # The runner supplies -e; expected failures are captured explicitly.
-              if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
-                fetch_status=0
-                timeout --kill-after=5s 40s git fetch \
-                  --no-tags \
-                  --prune \
-                  --no-recurse-submodules \
-                  --unshallow \
-                  --filter=tree:0 \
-                  origin \
-                  "+${GITHUB_REF}:refs/remotes/origin/${GITHUB_REF_NAME}" || fetch_status=$?
-                if [ "$fetch_status" -ne 0 ]; then
-                  echo "::warning::Source history for the ordered release tag could not be fetched (status $fetch_status). The ordered release tag will be skipped."
-                  exit 0
-                fi
-              fi
-
-        - name: Compute ordered release tag
-          id: ordered-release
-          if: inputs.generate-ordered-release-tag == 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-          continue-on-error: true
-          shell: bash
-          env:
-              ORDERED_RELEASE_TAG_REGEX: ^r[0-9]{12}-[0-9a-f]{6}$
-          run: |
-              set -uo pipefail
-              echo "tag=" >> "$GITHUB_OUTPUT"
-
-              if [ "$(git rev-parse --is-shallow-repository 2>/dev/null)" != "false" ]; then
-                echo "::warning::Skipping ordered release tag because complete source history is unavailable"
-                exit 0
-              fi
-
-              if ! head_revision="$(git rev-parse HEAD)" || [ "$head_revision" != "$GITHUB_SHA" ]; then
-                echo "::warning::Skipping ordered release tag because the checked-out revision does not match GITHUB_SHA"
-                exit 0
-              fi
-
-              if ! position="$(git rev-list --first-parent --count "$GITHUB_SHA")"; then
-                echo "::warning::Skipping ordered release tag because the source position could not be computed"
-                exit 0
-              fi
-
-              if ! [[ "$position" =~ ^[1-9][0-9]{0,11}$ ]]; then
-                echo "::warning::Skipping ordered release tag because the source position is out of range"
-                exit 0
-              fi
-
-              if ! printf -v tag 'r%012d-%.6s' "$position" "$GITHUB_SHA"; then
-                echo "::warning::Skipping ordered release tag because the source position could not be formatted"
-                exit 0
-              fi
-
-              if ! [[ "$tag" =~ $ORDERED_RELEASE_TAG_REGEX ]]; then
-                echo "::warning::Skipping ordered release tag because $tag does not match the required format"
-                exit 0
-              fi
-
-              echo "tag=${tag}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -34,6 +34,11 @@ concurrency:
 jobs:
     posthog_build:
         name: Build and push PostHog
+        outputs:
+            ordered-release-tag-generation-enabled: ${{ env.ORDERED_RELEASE_TAG_GENERATION_ENABLED }}
+            ordered-release-tag: ${{ steps.docker-meta.outputs.ordered-release-tag }}
+            image-digest: ${{ steps.image.outputs.digest }}
+            ecr-registry: ${{ steps.docker-meta.outputs.ecr-registry }}
         # Production build/deploy runs only from the canonical deploy repo (CD_DEPLOY_ENABLED).
         if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true'
         runs-on: depot-ubuntu-24.04
@@ -43,6 +48,8 @@ jobs:
             id-token: write # allow issuing OIDC tokens for this workflow run
             contents: read # allow at least reading the repo contents, add other permissions if necessary
             packages: write # allow push to ghcr.io
+        env:
+            ORDERED_RELEASE_TAG_GENERATION_ENABLED: 'true'
 
         steps:
             - name: Check out
@@ -67,6 +74,7 @@ jobs:
                   # PUBLIC_IMAGE_PUSH_PAUSED is set (deploy is unaffected — ECR still pushes).
                   push-to-dockerhub: ${{ vars.PUBLIC_IMAGE_PUSH_PAUSED != 'true' }}
                   push-to-ghcr: ${{ vars.PUBLIC_IMAGE_PUSH_PAUSED != 'true' }}
+                  generate-ordered-release-tag: ${{ env.ORDERED_RELEASE_TAG_GENERATION_ENABLED }}
                   aws-role-to-assume: ${{ vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   dockerhub-username: ${{ secrets.DOCKERHUB_USER }}
@@ -1151,3 +1159,113 @@ jobs:
                         "labels": ${{ toJson(steps.labels.outputs.labels) }},
                         "timestamp": "${{ github.event.head_commit.timestamp }}"
                       }
+
+    ordered_image_alias:
+        name: Publish ordered image alias
+        needs: posthog_build
+        if: ${{ !cancelled() && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && needs.posthog_build.outputs.ordered-release-tag-generation-enabled == 'true' }}
+        runs-on: ubuntu-24.04
+        timeout-minutes: 5
+        permissions:
+            id-token: write
+            contents: read
+
+        steps:
+            - name: Warn when ordered image alias tag is unavailable
+              if: ${{ !cancelled() && needs.posthog_build.outputs.ordered-release-tag == '' }}
+              continue-on-error: true
+              shell: bash
+              run: echo "::warning title=Ordered image alias tag unavailable::Ordered image alias publication was skipped because no ordered release tag was generated."
+
+            - name: Warn when ordered image digest is unavailable
+              if: ${{ !cancelled() && needs.posthog_build.outputs.ordered-release-tag != '' && needs.posthog_build.outputs.image-digest == '' }}
+              continue-on-error: true
+              shell: bash
+              run: echo "::warning title=Ordered image alias source digest unavailable::Ordered image alias publication was skipped because no image digest was resolved."
+
+            - name: Set up Docker Buildx for ordered image alias
+              if: ${{ !cancelled() && needs.posthog_build.outputs.ordered-release-tag != '' && needs.posthog_build.outputs.image-digest != '' }}
+              continue-on-error: true
+              uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+            - name: Configure AWS credentials for ordered image alias
+              if: ${{ !cancelled() && needs.posthog_build.outputs.ordered-release-tag != '' && needs.posthog_build.outputs.image-digest != '' }}
+              continue-on-error: true
+              uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+              with:
+                  role-to-assume: ${{ vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE }}
+                  aws-region: us-east-1
+
+            - name: Log in to Amazon ECR for ordered image alias
+              id: ordered-alias-ecr
+              if: ${{ !cancelled() && needs.posthog_build.outputs.ordered-release-tag != '' && needs.posthog_build.outputs.image-digest != '' }}
+              continue-on-error: true
+              uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
+
+            - name: Publish and read back ordered image alias
+              id: ordered-alias
+              if: ${{ !cancelled() && needs.posthog_build.outputs.ordered-release-tag != '' && needs.posthog_build.outputs.image-digest != '' }}
+              continue-on-error: true
+              timeout-minutes: 2
+              shell: bash
+              env:
+                  ECR_REGISTRY: ${{ needs.posthog_build.outputs.ecr-registry }}
+                  ECR_REPO: posthog-cloud
+                  EXPECTED_DIGEST: ${{ needs.posthog_build.outputs.image-digest }}
+                  ORDERED_ALIAS: ${{ needs.posthog_build.outputs.ordered-release-tag }}
+              run: |
+                  set -uo pipefail
+                  # The runner supplies -e; expected failures are captured explicitly.
+
+                  SOURCE_IMAGE="${ECR_REGISTRY}/${ECR_REPO}@${EXPECTED_DIGEST}"
+                  TARGET_IMAGE="${ECR_REGISTRY}/${ECR_REPO}:${ORDERED_ALIAS}"
+
+                  publication_status=0
+                  timeout --kill-after=5s 40s docker buildx imagetools create \
+                      --prefer-index=false \
+                      --tag "$TARGET_IMAGE" \
+                      "$SOURCE_IMAGE" || publication_status=$?
+                  if [ "$publication_status" -ne 0 ]; then
+                      echo "::warning::Ordered alias publication exited with status $publication_status"
+                  fi
+
+                  readback_status=0
+                  resolved_digest="$(timeout --kill-after=5s 40s aws ecr batch-get-image \
+                      --repository-name "$ECR_REPO" \
+                      --image-ids imageTag="$ORDERED_ALIAS" \
+                      --accepted-media-types \
+                          "application/vnd.oci.image.index.v1+json" \
+                          "application/vnd.docker.distribution.manifest.list.v2+json" \
+                          "application/vnd.oci.image.manifest.v1+json" \
+                          "application/vnd.docker.distribution.manifest.v2+json" \
+                      --query 'images[0].imageId.imageDigest' \
+                      --output text)" || readback_status=$?
+
+                  if [ "$readback_status" -ne 0 ]; then
+                      result=unknown
+                  elif [ "$resolved_digest" = "None" ]; then
+                      result=absent
+                  elif [[ "$resolved_digest" =~ ^sha256:[0-9a-f]{64}$ ]] && [ "$resolved_digest" = "$EXPECTED_DIGEST" ]; then
+                      result=present-at-expected-digest
+                  elif [[ "$resolved_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+                      result=integrity-mismatch
+                  else
+                      result=unknown
+                  fi
+
+                  case "$result" in
+                      present-at-expected-digest)
+                          echo "::notice title=Ordered image alias present::The ordered image alias resolves to the expected image digest."
+                          ;;
+                      absent)
+                          echo "::warning title=Ordered image alias absent::The ordered image alias is absent after publication."
+                          ;;
+                      integrity-mismatch)
+                          echo "::error title=Ordered image alias integrity mismatch::The ordered image alias resolves to a different image digest."
+                          ;;
+                      unknown)
+                          echo "::error title=Ordered image alias read-back unavailable::The ordered image alias could not be read back from ECR."
+                          ;;
+                  esac
+
+                  echo "result=$result" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -35,10 +35,9 @@ jobs:
     posthog_build:
         name: Build and push PostHog
         outputs:
-            ordered-release-tag-generation-enabled: ${{ env.ORDERED_RELEASE_TAG_GENERATION_ENABLED }}
-            ordered-release-tag: ${{ steps.docker-meta.outputs.ordered-release-tag }}
             image-digest: ${{ steps.image.outputs.digest }}
             ecr-registry: ${{ steps.docker-meta.outputs.ecr-registry }}
+            ecr-repository: ${{ env.ECR_REPOSITORY }}
         # Production build/deploy runs only from the canonical deploy repo (CD_DEPLOY_ENABLED).
         if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true'
         runs-on: depot-ubuntu-24.04
@@ -49,7 +48,7 @@ jobs:
             contents: read # allow at least reading the repo contents, add other permissions if necessary
             packages: write # allow push to ghcr.io
         env:
-            ORDERED_RELEASE_TAG_GENERATION_ENABLED: 'true'
+            ECR_REPOSITORY: posthog-cloud
 
         steps:
             - name: Check out
@@ -68,13 +67,12 @@ jobs:
               uses: ./.github/actions/docker-meta
               with:
                   image-name: posthog
-                  ecr-image-name: posthog-cloud
+                  ecr-image-name: ${{ env.ECR_REPOSITORY }}
                   # Public registries (DockerHub + ghcr) hold the OSS image; prod deploys
                   # from the private ECR `posthog-cloud`. Pause the public push when
                   # PUBLIC_IMAGE_PUSH_PAUSED is set (deploy is unaffected — ECR still pushes).
                   push-to-dockerhub: ${{ vars.PUBLIC_IMAGE_PUSH_PAUSED != 'true' }}
                   push-to-ghcr: ${{ vars.PUBLIC_IMAGE_PUSH_PAUSED != 'true' }}
-                  generate-ordered-release-tag: ${{ env.ORDERED_RELEASE_TAG_GENERATION_ENABLED }}
                   aws-role-to-assume: ${{ vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   dockerhub-username: ${{ secrets.DOCKERHUB_USER }}
@@ -92,7 +90,7 @@ jobs:
             - name: Check for existing image in ECR
               id: preflight
               env:
-                  ECR_REPO: posthog-cloud
+                  ECR_REPO: ${{ env.ECR_REPOSITORY }}
                   SHA: ${{ github.sha }}
               run: |
                   set -euo pipefail
@@ -164,7 +162,7 @@ jobs:
               id: preflight_retry
               if: steps.build.outcome == 'failure'
               env:
-                  ECR_REPO: posthog-cloud
+                  ECR_REPO: ${{ env.ECR_REPOSITORY }}
                   SHA: ${{ github.sha }}
               run: |
                   set -euo pipefail
@@ -208,7 +206,7 @@ jobs:
               id: reconcile
               if: steps.preflight.outputs.digest != '' || steps.preflight_retry.outputs.digest != ''
               env:
-                  SRC: ${{ steps.docker-meta.outputs.ecr-registry }}/posthog-cloud@${{ steps.preflight.outputs.digest || steps.preflight_retry.outputs.digest }}
+                  SRC: ${{ steps.docker-meta.outputs.ecr-registry }}/${{ env.ECR_REPOSITORY }}@${{ steps.preflight.outputs.digest || steps.preflight_retry.outputs.digest }}
                   TAGS: ${{ steps.docker-meta.outputs.tags }}
               run: |
                   set -euo pipefail
@@ -1163,59 +1161,111 @@ jobs:
     ordered_image_alias:
         name: Publish ordered image alias
         needs: posthog_build
-        if: ${{ !cancelled() && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && needs.posthog_build.outputs.ordered-release-tag-generation-enabled == 'true' }}
+        if: ${{ needs.posthog_build.result == 'success' && github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true' && vars.ORDERED_IMAGE_ALIAS_PAUSED != 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
         runs-on: ubuntu-24.04
         timeout-minutes: 5
+        continue-on-error: true
         permissions:
             id-token: write
             contents: read
 
         steps:
+            - name: Check out
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+            - name: Compute ordered release tag
+              id: ordered-release
+              timeout-minutes: 2
+              shell: bash
+              env:
+                  ORDERED_RELEASE_TAG_REGEX: ^r[0-9]{12}-[0-9a-f]{6}$
+              run: |
+                  set -uo pipefail
+
+                  if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+                      fetch_status=0
+                      timeout --kill-after=10s 90s git fetch \
+                          --no-tags \
+                          --prune \
+                          --no-recurse-submodules \
+                          --unshallow \
+                          --filter=tree:0 \
+                          origin \
+                          "+${GITHUB_REF}:refs/remotes/origin/${GITHUB_REF_NAME}" || fetch_status=$?
+                      if [ "$fetch_status" -ne 0 ]; then
+                          echo "::warning title=Ordered release tag skipped::Source history could not be fetched (status $fetch_status)."
+                          exit 0
+                      fi
+                  fi
+
+                  if [ "$(git rev-parse --is-shallow-repository 2>/dev/null)" != "false" ]; then
+                      echo "::warning title=Ordered release tag skipped::Complete source history is unavailable."
+                      exit 0
+                  fi
+
+                  if ! head_revision="$(git rev-parse HEAD)" || [ "$head_revision" != "$GITHUB_SHA" ]; then
+                      echo "::warning title=Ordered release tag skipped::The checked-out revision does not match GITHUB_SHA."
+                      exit 0
+                  fi
+
+                  if ! position="$(git rev-list --first-parent --count "$GITHUB_SHA")"; then
+                      echo "::warning title=Ordered release tag skipped::The source position could not be computed."
+                      exit 0
+                  fi
+
+                  if ! [[ "$position" =~ ^[1-9][0-9]{0,11}$ ]]; then
+                      echo "::warning title=Ordered release tag skipped::The source position is out of range."
+                      exit 0
+                  fi
+
+                  if ! printf -v tag 'r%012d-%.6s' "$position" "$GITHUB_SHA"; then
+                      echo "::warning title=Ordered release tag skipped::The source position could not be formatted."
+                      exit 0
+                  fi
+
+                  if ! [[ "$tag" =~ $ORDERED_RELEASE_TAG_REGEX ]]; then
+                      echo "::warning title=Ordered release tag skipped::${tag} does not match the required format."
+                      exit 0
+                  fi
+
+                  echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
             - name: Warn when ordered image alias tag is unavailable
-              if: ${{ !cancelled() && needs.posthog_build.outputs.ordered-release-tag == '' }}
-              continue-on-error: true
+              if: ${{ steps.ordered-release.outputs.tag == '' }}
               shell: bash
               run: echo "::warning title=Ordered image alias tag unavailable::Ordered image alias publication was skipped because no ordered release tag was generated."
 
-            - name: Warn when ordered image digest is unavailable
-              if: ${{ !cancelled() && needs.posthog_build.outputs.ordered-release-tag != '' && needs.posthog_build.outputs.image-digest == '' }}
-              continue-on-error: true
-              shell: bash
-              run: echo "::warning title=Ordered image alias source digest unavailable::Ordered image alias publication was skipped because no image digest was resolved."
-
             - name: Set up Docker Buildx for ordered image alias
-              if: ${{ !cancelled() && needs.posthog_build.outputs.ordered-release-tag != '' && needs.posthog_build.outputs.image-digest != '' }}
-              continue-on-error: true
+              if: ${{ steps.ordered-release.outputs.tag != '' }}
               uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
             - name: Configure AWS credentials for ordered image alias
-              if: ${{ !cancelled() && needs.posthog_build.outputs.ordered-release-tag != '' && needs.posthog_build.outputs.image-digest != '' }}
-              continue-on-error: true
+              if: ${{ steps.ordered-release.outputs.tag != '' }}
               uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
               with:
                   role-to-assume: ${{ vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE }}
                   aws-region: us-east-1
 
             - name: Log in to Amazon ECR for ordered image alias
-              id: ordered-alias-ecr
-              if: ${{ !cancelled() && needs.posthog_build.outputs.ordered-release-tag != '' && needs.posthog_build.outputs.image-digest != '' }}
-              continue-on-error: true
+              if: ${{ steps.ordered-release.outputs.tag != '' }}
               uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
 
             - name: Publish and read back ordered image alias
-              id: ordered-alias
-              if: ${{ !cancelled() && needs.posthog_build.outputs.ordered-release-tag != '' && needs.posthog_build.outputs.image-digest != '' }}
-              continue-on-error: true
+              if: ${{ steps.ordered-release.outputs.tag != '' }}
               timeout-minutes: 2
               shell: bash
               env:
                   ECR_REGISTRY: ${{ needs.posthog_build.outputs.ecr-registry }}
-                  ECR_REPO: posthog-cloud
+                  ECR_REPO: ${{ needs.posthog_build.outputs.ecr-repository }}
                   EXPECTED_DIGEST: ${{ needs.posthog_build.outputs.image-digest }}
-                  ORDERED_ALIAS: ${{ needs.posthog_build.outputs.ordered-release-tag }}
+                  ORDERED_ALIAS: ${{ steps.ordered-release.outputs.tag }}
               run: |
                   set -uo pipefail
-                  # The runner supplies -e; expected failures are captured explicitly.
+
+                  if [ -z "$EXPECTED_DIGEST" ]; then
+                      echo "::warning title=Ordered image alias source digest unavailable::Ordered image alias publication was skipped because no image digest was resolved."
+                      exit 0
+                  fi
 
                   SOURCE_IMAGE="${ECR_REGISTRY}/${ECR_REPO}@${EXPECTED_DIGEST}"
                   TARGET_IMAGE="${ECR_REGISTRY}/${ECR_REPO}:${ORDERED_ALIAS}"
@@ -1267,5 +1317,3 @@ jobs:
                           echo "::error title=Ordered image alias read-back unavailable::The ordered image alias could not be read back from ECR."
                           ;;
                   esac
-
-                  echo "result=$result" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

The rollout design needs to pick posthog-cloud images from ECR in source order, and nothing in the registry encodes that order today.
Image tags are content-addressed, so ordering releases means consulting git history, which deploy tooling cannot do from the registry alone.

## Changes

- Every successful master build now also publishes an ordered ECR alias, `r<12-digit first-parent position>-<sha6>`, for the image digest it just pushed. The aliases sort lexicographically in source order.
- A new `ordered_image_alias` job computes the position from full first-parent history in its own checkout, after the build job succeeds.
- The build and deploy path pays no extra time, and the shared docker-meta action is unchanged.
- The job publishes the alias with a digest-preserving `imagetools` copy, reads it back from ECR, and annotates one of four outcomes: present at the expected digest, absent, integrity mismatch, or read-back unavailable.
- Only builds that pass post-build verification get an alias, because the job is gated on build success.
- Setting the repo variable `ORDERED_IMAGE_ALIAS_PAUSED` to `true` pauses publication without a code change.
- The ECR repository name moves to one job-level definition shared by the preflight, reconcile, and alias steps.

> [!NOTE]
> The ordered path is fail-soft end to end: every failure becomes a titled warning or error annotation. Job-level continue-on-error keeps even a hang or timeout from failing the workflow run. Rollback is a revert, and the only external effect is one immutable tag per master build.

## How did you test this code?

Script-level tests, run by the agent in this session:

- The compute script, executed under the runner's bash invocation against a synthetic shallow clone, produced a correctly padded tag. The unreachable-origin and HEAD-mismatch paths warned and exited 0.
- The publish script's classification matrix, run with stubbed docker and aws, annotated all six outcomes correctly and exited 0, including a re-run against an existing immutable tag.
- The unshallow `--filter=tree:0` fetch and first-parent count were verified in throwaway repos, including a force-push that orphans the built sha.
- Not run: the workflow against real ECR. That needs a master push in the deploy repo, so the first post-merge run should be watched.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: internal CI change with no user-facing behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Codex, then reviewed and revised with PostHog Code (Claude): a multi-angle review with adversarial verification, fixes applied on request.
- Skills invoked: /authoring-ci-workflows, /gating-production-deploys, /writing-pr-descriptions.
- Decisions across the session: the ordered-tag computation originally lived inside the shared docker-meta action on the build job's critical path. Review moved it into the isolated alias job and added the build-success gate, the pause variable, and job-level continue-on-error.