### PR TITLE
perf(ci): skip semgrep-python on desktop-only changes

### DIFF
--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -62,6 +62,8 @@ jobs:
                         - 'ee/**'
                         - 'posthog/**'
                         - 'products/**'
+                        # the scan --excludes products/desktop (semgrep-desktop covers it)
+                        - '!products/desktop/**'
                         - 'services/llm-gateway/**'
                         - 'services/stripe-mock/**'
                         - '.semgrep/rules/security/**'


### PR DESCRIPTION
## Problem

- Desktop-only PRs wait 13-16 minutes on the required Security check for a scan whose verdict they cannot change.
- The `python` trigger filter matches bare [`products/**`](https://github.com/PostHog/posthog/blob/29880c9cb785bd8645aee2b5c4ff0c341cc82e31/.github/workflows/ci-security.yaml#L64), so a diff touching only `products/desktop/**` runs the full semgrep-python scan.
- The scan already [excludes `products/desktop`](https://github.com/PostHog/posthog/blob/29880c9cb785bd8645aee2b5c4ff0c341cc82e31/.github/workflows/ci-security.yaml#L162); [`semgrep-desktop`](https://github.com/PostHog/posthog/blob/29880c9cb785bd8645aee2b5c4ff0c341cc82e31/.github/workflows/ci-security.yaml#L475) covers that tree instead.
- Four recent PRs with no files outside `products/desktop/`:

| PR | semgrep-python wall time |
| --- | --- |
| #80229 | [15.9 min](https://github.com/PostHog/posthog/actions/runs/31320125229/job/93261681336) |
| #80137 | [13.4 min](https://github.com/PostHog/posthog/actions/runs/31269620146/job/93133322099) |
| #80109 | [16.3 min](https://github.com/PostHog/posthog/actions/runs/31257818929/job/93103882458) |
| #80100 | [15.7 min](https://github.com/PostHog/posthog/actions/runs/31254361081/job/93095464921) |

## Changes

- Add a `!products/desktop/**` exclude to the `python` filter, mirroring the scan's own exclude.
- The [vendored paths-filter](https://github.com/PostHog/posthog/blob/29880c9cb785bd8645aee2b5c4ff0c341cc82e31/.github/actions/paths-filter/README.md#L27-L35) treats top-level `!` entries as vetoes over the OR-ed includes, built for exactly this shape.

> [!NOTE]
> Desktop is not losing security scanning. [`semgrep-desktop`](https://github.com/PostHog/posthog/blob/29880c9cb785bd8645aee2b5c4ff0c341cc82e31/.github/workflows/ci-security.yaml#L477) runs the same universal security packs on `products/desktop/` and stays in the required gate. This PR only stops desktop-only diffs from triggering a job whose scan already ignores their files.

## How did you test this code?

- `bin/hogli lint:workflows` (including WF003, dorny negation safety) and `actionlint` pass locally.
- Not run: a live demonstration of the skip. This PR edits `ci-security.yaml`, which the `python` filter also matches, so semgrep-python still runs on this PR by design.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code; found by measuring Security job durations across recent desktop PRs with the Actions API.
- Skills invoked: /authoring-ci-workflows, /writing-pr-descriptions.
- Rejected alternative: scoping the filter to `products/**/*.py`. The job runs universal packs (owasp, security-audit, trailofbits) over every language under `products/`, so extension scoping would drop real trigger coverage.
