### PR TITLE
feat(slack): unfurl task links in public channels

### DIFF
--- a/products/slack_app/backend/slack_link_unfurl.py
+++ b/products/slack_app/backend/slack_link_unfurl.py
@@ -262,23 +262,30 @@ def _ticket_unfurl_payload(*, url: str, ticket: Ticket, requester: str, opening_
     return {"blocks": blocks}
 
 
-def _is_normal_public_channel(slack: SlackIntegration, channel: str) -> bool:
+def _is_normal_public_channel(slack: SlackIntegration, channel: str, cache: dict[str, bool]) -> bool:
+    if channel in cache:
+        return cache[channel]
     try:
         conversation = slack.client.conversations_info(channel=channel).get("channel") or {}
     except Exception:
         logger.exception("slack_task_reference_channel_lookup_failed", channel=channel)
+        cache[channel] = False
         return False
-    return bool(
+    cache[channel] = bool(
         conversation.get("is_channel")
         and not conversation.get("is_private")
         and not conversation.get("is_shared")
         and not conversation.get("is_ext_shared")
         and not conversation.get("is_org_shared")
     )
+    return cache[channel]
 
 
 def _task_owner_can_view_public_slack_channel(
-    slack: SlackIntegration, integration: Integration, task: TaskSlackUnfurlDTO
+    slack: SlackIntegration,
+    integration: Integration,
+    task: TaskSlackUnfurlDTO,
+    cache: dict[str, bool],
 ) -> bool:
     if task.created_by_id is None:
         return False
@@ -293,12 +300,18 @@ def _task_owner_can_view_public_slack_channel(
     )
     if owner_link is None:
         return False
+    if owner_link.integration_id in cache:
+        return cache[owner_link.integration_id]
     try:
         owner = slack.client.users_info(user=owner_link.integration_id).get("user") or {}
     except Exception:
         logger.exception("slack_task_reference_owner_lookup_failed", task_id=str(task.id))
+        cache[owner_link.integration_id] = False
         return False
-    return bool(not owner.get("deleted") and not owner.get("is_restricted") and not owner.get("is_ultra_restricted"))
+    cache[owner_link.integration_id] = bool(
+        not owner.get("deleted") and not owner.get("is_restricted") and not owner.get("is_ultra_restricted")
+    )
+    return cache[owner_link.integration_id]
 
 
 def _attach_public_slack_thread_reference(
@@ -308,6 +321,8 @@ def _attach_public_slack_thread_reference(
     task: TaskSlackUnfurlDTO,
     event: dict,
     shared_by_slack_user_id: str,
+    public_channel_cache: dict[str, bool],
+    owner_access_cache: dict[str, bool],
 ) -> None:
     if event.get("source") != "conversations_history":
         return
@@ -315,14 +330,21 @@ def _attach_public_slack_thread_reference(
     message_ts = event.get("message_ts")
     if not isinstance(channel, str) or not isinstance(message_ts, str):
         return
-    if not _is_normal_public_channel(slack, channel):
-        return
-    if not _task_owner_can_view_public_slack_channel(slack, integration, task):
-        return
-
     thread_ts = event.get("thread_ts")
     if not isinstance(thread_ts, str):
         thread_ts = message_ts
+    if tasks_facade.has_slack_thread_reference(
+        task_id=task.id,
+        team_id=integration.team_id,
+        slack_workspace_id=integration.integration_id,
+        channel=channel,
+        thread_ts=thread_ts,
+    ):
+        return
+    if not _is_normal_public_channel(slack, channel, public_channel_cache):
+        return
+    if not _task_owner_can_view_public_slack_channel(slack, integration, task, owner_access_cache):
+        return
     tasks_facade.attach_slack_thread_reference(
         task_id=task.id,
         team_id=integration.team_id,
@@ -349,6 +371,8 @@ def handle_posthog_link_unfurl(event: dict, integration: Integration) -> None:
     unfurl_id = event.get("unfurl_id")
     source = event.get("source")
     links = event.get("links") or []
+    public_channel_cache: dict[str, bool] = {}
+    owner_access_cache: dict[str, bool] = {}
 
     if not channel or not message_ts or not slack_user_id or not links:
         logger.info("slack_link_unfurl_skip_missing_fields", has_channel=bool(channel), has_ts=bool(message_ts))
@@ -440,7 +464,7 @@ def handle_posthog_link_unfurl(event: dict, integration: Integration) -> None:
             if task is None:
                 continue
             label = "Task" if task.latest_run_status is None else f"Task · {task.latest_run_status}"
-            unfurls[raw_url] = _unfurl_payload(resource_label=label, title=task.title, description=None)
+            unfurls[raw_url] = _unfurl_payload(resource_label=label, title=_escape_mrkdwn(task.title), description=None)
             try:
                 _attach_public_slack_thread_reference(
                     slack=slack,
@@ -448,6 +472,8 @@ def handle_posthog_link_unfurl(event: dict, integration: Integration) -> None:
                     task=task,
                     event=event,
                     shared_by_slack_user_id=slack_user_id,
+                    public_channel_cache=public_channel_cache,
+                    owner_access_cache=owner_access_cache,
                 )
             except Exception:
                 logger.exception("slack_task_reference_attach_failed", task_id=str(task.id), team_id=team.pk)

--- a/products/slack_app/backend/slack_link_unfurl.py
+++ b/products/slack_app/backend/slack_link_unfurl.py
@@ -7,8 +7,6 @@ from urllib.parse import urlparse
 from uuid import UUID
 
 from django.core.exceptions import ValidationError
-from django.db import transaction
-from django.utils import timezone
 
 import structlog
 
@@ -21,8 +19,8 @@ from posthog.rbac.user_access_control import UserAccessControl, access_level_sat
 from products.conversations.backend.models.ticket import Ticket
 from products.dashboards.backend.models.dashboard import Dashboard
 from products.product_analytics.backend.models.insight import Insight
-from products.tasks.backend.models import Task
-from products.tasks.backend.visibility import task_visibility_q
+from products.tasks.backend.facade import api as tasks_facade
+from products.tasks.backend.facade.contracts import TaskSlackUnfurlDTO
 
 logger = structlog.get_logger(__name__)
 
@@ -279,7 +277,9 @@ def _is_normal_public_channel(slack: SlackIntegration, channel: str) -> bool:
     )
 
 
-def _task_owner_can_view_public_slack_channel(slack: SlackIntegration, integration: Integration, task: Task) -> bool:
+def _task_owner_can_view_public_slack_channel(
+    slack: SlackIntegration, integration: Integration, task: TaskSlackUnfurlDTO
+) -> bool:
     if task.created_by_id is None:
         return False
     owner_link = (
@@ -305,7 +305,7 @@ def _attach_public_slack_thread_reference(
     *,
     slack: SlackIntegration,
     integration: Integration,
-    task: Task,
+    task: TaskSlackUnfurlDTO,
     event: dict,
     shared_by_slack_user_id: str,
 ) -> None:
@@ -320,30 +320,17 @@ def _attach_public_slack_thread_reference(
     if not _task_owner_can_view_public_slack_channel(slack, integration, task):
         return
 
-    thread_ts = event.get("thread_ts") if isinstance(event.get("thread_ts"), str) else message_ts
-    reference = {
-        "slack_workspace_id": integration.integration_id,
-        "channel": channel,
-        "thread_ts": thread_ts,
-        "shared_by_slack_user_id": shared_by_slack_user_id,
-        "created_at": timezone.now().isoformat(),
-    }
-    with transaction.atomic():
-        locked_task = Task.objects.select_for_update().get(id=task.id, team_id=integration.team_id)
-        state = dict(locked_task.state or {})
-        references = list(state.get("slack_thread_references") or [])
-        if any(
-            item.get("slack_workspace_id") == integration.integration_id
-            and item.get("channel") == channel
-            and item.get("thread_ts") == thread_ts
-            for item in references
-            if isinstance(item, dict)
-        ):
-            return
-        references.append(reference)
-        state["slack_thread_references"] = references
-        locked_task.state = state
-        locked_task.save(update_fields=["state", "updated_at"])
+    thread_ts = event.get("thread_ts")
+    if not isinstance(thread_ts, str):
+        thread_ts = message_ts
+    tasks_facade.attach_slack_thread_reference(
+        task_id=task.id,
+        team_id=integration.team_id,
+        slack_workspace_id=integration.integration_id,
+        channel=channel,
+        thread_ts=thread_ts,
+        shared_by_slack_user_id=shared_by_slack_user_id,
+    )
 
 
 def handle_posthog_link_unfurl(event: dict, integration: Integration) -> None:
@@ -449,15 +436,10 @@ def handle_posthog_link_unfurl(event: dict, integration: Integration) -> None:
             url_team_id = _url_team_id(raw_url)
             if url_team_id is not None and url_team_id != team.pk:
                 continue
-            task = (
-                Task.objects.filter(task_visibility_q(user.id), id=ref, team_id=team.pk, deleted=False, internal=False)
-                .select_related("created_by")
-                .first()
-            )
+            task = tasks_facade.get_task_for_slack_unfurl(ref, team.pk, user.id)
             if task is None:
                 continue
-            latest_run = task.runs.order_by("-created_at").only("status").first()
-            label = "Task" if latest_run is None else f"Task · {latest_run.get_status_display()}"
+            label = "Task" if task.latest_run_status is None else f"Task · {task.latest_run_status}"
             unfurls[raw_url] = _unfurl_payload(resource_label=label, title=task.title, description=None)
             try:
                 _attach_public_slack_thread_reference(

--- a/products/slack_app/backend/slack_link_unfurl.py
+++ b/products/slack_app/backend/slack_link_unfurl.py
@@ -1,4 +1,4 @@
-"""Slack link unfurling for PostHog insight, dashboard, and support ticket URLs (metadata only)."""
+"""Slack link unfurling for PostHog resource URLs (metadata only)."""
 
 from __future__ import annotations
 
@@ -7,17 +7,22 @@ from urllib.parse import urlparse
 from uuid import UUID
 
 from django.core.exceptions import ValidationError
+from django.db import transaction
+from django.utils import timezone
 
 import structlog
 
 from posthog.models import Team
 from posthog.models.comment import Comment
 from posthog.models.integration import Integration, SlackIntegration
+from posthog.models.user_integration import UserIntegration
 from posthog.rbac.user_access_control import UserAccessControl, access_level_satisfied_for_resource
 
 from products.conversations.backend.models.ticket import Ticket
 from products.dashboards.backend.models.dashboard import Dashboard
 from products.product_analytics.backend.models.insight import Insight
+from products.tasks.backend.models import Task
+from products.tasks.backend.visibility import task_visibility_q
 
 logger = structlog.get_logger(__name__)
 
@@ -63,7 +68,9 @@ def _truncate(text: str, max_len: int) -> str:
     return text[: max_len - 1] + "…"
 
 
-def parse_posthog_resource_link(url: str) -> tuple[Literal["insight", "dashboard", "ticket"], str | int] | None:
+def parse_posthog_resource_link(
+    url: str,
+) -> tuple[Literal["insight", "dashboard", "ticket", "task"], str | int] | None:
     """
     Parse a PostHog app URL into (resource kind, reference id).
 
@@ -109,6 +116,13 @@ def parse_posthog_resource_link(url: str) -> tuple[Literal["insight", "dashboard
         if ref == "new":
             return None
         return ("ticket", ref)
+
+    if len(parts) > idx and parts[idx] == "tasks" and len(parts) > idx + 1:
+        try:
+            task_id = UUID(parts[idx + 1])
+        except ValueError:
+            return None
+        return ("task", str(task_id))
 
     return None
 
@@ -250,9 +264,91 @@ def _ticket_unfurl_payload(*, url: str, ticket: Ticket, requester: str, opening_
     return {"blocks": blocks}
 
 
+def _is_normal_public_channel(slack: SlackIntegration, channel: str) -> bool:
+    try:
+        conversation = slack.client.conversations_info(channel=channel).get("channel") or {}
+    except Exception:
+        logger.exception("slack_task_reference_channel_lookup_failed", channel=channel)
+        return False
+    return bool(
+        conversation.get("is_channel")
+        and not conversation.get("is_private")
+        and not conversation.get("is_shared")
+        and not conversation.get("is_ext_shared")
+        and not conversation.get("is_org_shared")
+    )
+
+
+def _task_owner_can_view_public_slack_channel(slack: SlackIntegration, integration: Integration, task: Task) -> bool:
+    if task.created_by_id is None:
+        return False
+    owner_link = (
+        UserIntegration.objects.filter(
+            user_id=task.created_by_id,
+            kind=UserIntegration.IntegrationKind.SLACK,
+            config__slack_team_id=integration.integration_id,
+        )
+        .order_by("-created_at")
+        .first()
+    )
+    if owner_link is None:
+        return False
+    try:
+        owner = slack.client.users_info(user=owner_link.integration_id).get("user") or {}
+    except Exception:
+        logger.exception("slack_task_reference_owner_lookup_failed", task_id=str(task.id))
+        return False
+    return bool(not owner.get("deleted") and not owner.get("is_restricted") and not owner.get("is_ultra_restricted"))
+
+
+def _attach_public_slack_thread_reference(
+    *,
+    slack: SlackIntegration,
+    integration: Integration,
+    task: Task,
+    event: dict,
+    shared_by_slack_user_id: str,
+) -> None:
+    if event.get("source") != "conversations_history":
+        return
+    channel = event.get("channel")
+    message_ts = event.get("message_ts")
+    if not isinstance(channel, str) or not isinstance(message_ts, str):
+        return
+    if not _is_normal_public_channel(slack, channel):
+        return
+    if not _task_owner_can_view_public_slack_channel(slack, integration, task):
+        return
+
+    thread_ts = event.get("thread_ts") if isinstance(event.get("thread_ts"), str) else message_ts
+    reference = {
+        "slack_workspace_id": integration.integration_id,
+        "channel": channel,
+        "thread_ts": thread_ts,
+        "shared_by_slack_user_id": shared_by_slack_user_id,
+        "created_at": timezone.now().isoformat(),
+    }
+    with transaction.atomic():
+        locked_task = Task.objects.select_for_update().get(id=task.id, team_id=integration.team_id)
+        state = dict(locked_task.state or {})
+        references = list(state.get("slack_thread_references") or [])
+        if any(
+            item.get("slack_workspace_id") == integration.integration_id
+            and item.get("channel") == channel
+            and item.get("thread_ts") == thread_ts
+            for item in references
+            if isinstance(item, dict)
+        ):
+            return
+        references.append(reference)
+        state["slack_thread_references"] = references
+        locked_task.state = state
+        locked_task.save(update_fields=["state", "updated_at"])
+
+
 def handle_posthog_link_unfurl(event: dict, integration: Integration) -> None:
     """
-    Unfurl PostHog insight, dashboard, and support ticket links with title and description.
+    Unfurl supported PostHog resource links with metadata.
 
     Scope is always the Slack-connected project (`integration.team`); `resolve_slack_user` enforces
     that the sharer can access it. Insights, dashboards, and tickets add a per-resource
@@ -347,6 +443,32 @@ def handle_posthog_link_unfurl(event: dict, integration: Integration) -> None:
                 requester=_escape_mrkdwn(_ticket_requester(team, ticket)),
                 opening_message=_ticket_opening_message(team.pk, ticket.id),
             )
+        elif kind == "task":
+            if not isinstance(ref, str):
+                continue
+            url_team_id = _url_team_id(raw_url)
+            if url_team_id is not None and url_team_id != team.pk:
+                continue
+            task = (
+                Task.objects.filter(task_visibility_q(user.id), id=ref, team_id=team.pk, deleted=False, internal=False)
+                .select_related("created_by")
+                .first()
+            )
+            if task is None:
+                continue
+            latest_run = task.runs.order_by("-created_at").only("status").first()
+            label = "Task" if latest_run is None else f"Task · {latest_run.get_status_display()}"
+            unfurls[raw_url] = _unfurl_payload(resource_label=label, title=task.title, description=None)
+            try:
+                _attach_public_slack_thread_reference(
+                    slack=slack,
+                    integration=integration,
+                    task=task,
+                    event=event,
+                    shared_by_slack_user_id=slack_user_id,
+                )
+            except Exception:
+                logger.exception("slack_task_reference_attach_failed", task_id=str(task.id), team_id=team.pk)
 
     if not unfurls:
         return

--- a/products/slack_app/backend/tests/test_link_unfurl.py
+++ b/products/slack_app/backend/tests/test_link_unfurl.py
@@ -203,13 +203,16 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
         assert "Review Slack task links" in text
         assert "Sensitive prompt" not in text
         task.refresh_from_db()
-        assert task.state["slack_thread_references"] == [
+        state = task.state or {}
+        references = state.get("slack_thread_references")
+        assert isinstance(references, list)
+        assert references == [
             {
                 "slack_workspace_id": self.integration.integration_id,
                 "channel": "C_PUBLIC",
                 "thread_ts": "120.000",
                 "shared_by_slack_user_id": "U_SHARER",
-                "created_at": task.state["slack_thread_references"][0]["created_at"],
+                "created_at": references[0]["created_at"],
             }
         ]
 
@@ -244,7 +247,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
 
         mock_client.chat_unfurl.assert_called_once()
         task.refresh_from_db()
-        assert "slack_thread_references" not in task.state
+        assert "slack_thread_references" not in (task.state or {})
 
     @patch("products.slack_app.backend.api.resolve_slack_user")
     @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")

--- a/products/slack_app/backend/tests/test_link_unfurl.py
+++ b/products/slack_app/backend/tests/test_link_unfurl.py
@@ -15,6 +15,7 @@ from posthog.models.comment import Comment
 from posthog.models.integration import Integration
 from posthog.models.organization import Organization
 from posthog.models.team.team import Team
+from posthog.models.user_integration import UserIntegration
 
 from products.conversations.backend.models.ticket import Ticket
 from products.dashboards.backend.models.dashboard import Dashboard
@@ -27,6 +28,7 @@ from products.slack_app.backend.slack_link_unfurl import (
     handle_posthog_link_unfurl,
     parse_posthog_resource_link,
 )
+from products.tasks.backend.models import Task
 
 from ee.models.rbac.access_control import AccessControl
 
@@ -58,6 +60,16 @@ class TestParsePosthogResourceLink:
             "ticket",
             "abc-uuid",
         )
+
+    def test_task(self):
+        task_id = "c76f58f4-4c64-4cd7-825d-4ef89f6dd4ac"
+        assert parse_posthog_resource_link(f"https://us.posthog.com/project/42/tasks/{task_id}") == (
+            "task",
+            task_id,
+        )
+
+    def test_rejects_invalid_task_id(self):
+        assert parse_posthog_resource_link("https://us.posthog.com/project/42/tasks/not-a-uuid") is None
 
     def test_skips_ticket_new(self):
         assert parse_posthog_resource_link("https://x.com/support/tickets/new") is None
@@ -146,6 +158,93 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
         assert "Trends insight" in text
         assert "Weekly active users" in text
         assert "A test description" in text
+
+    @patch("products.slack_app.backend.api.resolve_slack_user")
+    @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")
+    def test_unfurls_task_and_attaches_public_thread_once(
+        self, mock_slack_integration_class: MagicMock, mock_resolve: MagicMock
+    ) -> None:
+        task = Task.objects.create(
+            team=self.team,
+            created_by=self.user,
+            title="Review Slack task links",
+            description="Sensitive prompt that must not appear",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+        UserIntegration.objects.create(
+            user=self.user,
+            kind=UserIntegration.IntegrationKind.SLACK,
+            integration_id="U_OWNER",
+            config={"slack_team_id": self.integration.integration_id},
+        )
+        mock_resolve.return_value = MagicMock(user=self.user)
+        mock_client = MagicMock()
+        mock_client.conversations_info.return_value = {
+            "channel": {"is_channel": True, "is_private": False, "is_shared": False}
+        }
+        mock_client.users_info.return_value = {
+            "user": {"deleted": False, "is_restricted": False, "is_ultra_restricted": False}
+        }
+        mock_slack_integration_class.return_value.client = mock_client
+        url = f"http://testserver/project/{self.team.pk}/tasks/{task.id}"
+        event = {
+            "channel": "C_PUBLIC",
+            "message_ts": "123.456",
+            "thread_ts": "120.000",
+            "user": "U_SHARER",
+            "source": "conversations_history",
+            "links": [{"url": url}],
+        }
+
+        handle_posthog_link_unfurl(event, self.integration)
+        handle_posthog_link_unfurl(event, self.integration)
+
+        text = mock_client.chat_unfurl.call_args.kwargs["unfurls"][url]["blocks"][0]["text"]["text"]
+        assert "Review Slack task links" in text
+        assert "Sensitive prompt" not in text
+        task.refresh_from_db()
+        assert task.state["slack_thread_references"] == [
+            {
+                "slack_workspace_id": self.integration.integration_id,
+                "channel": "C_PUBLIC",
+                "thread_ts": "120.000",
+                "shared_by_slack_user_id": "U_SHARER",
+                "created_at": task.state["slack_thread_references"][0]["created_at"],
+            }
+        ]
+
+    @patch("products.slack_app.backend.api.resolve_slack_user")
+    @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")
+    def test_private_channel_unfurls_task_without_attaching_reference(
+        self, mock_slack_integration_class: MagicMock, mock_resolve: MagicMock
+    ) -> None:
+        task = Task.objects.create(
+            team=self.team,
+            created_by=self.user,
+            title="Private discussion",
+            description="",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+        mock_resolve.return_value = MagicMock(user=self.user)
+        mock_client = MagicMock()
+        mock_client.conversations_info.return_value = {"channel": {"is_channel": True, "is_private": True}}
+        mock_slack_integration_class.return_value.client = mock_client
+        url = f"http://testserver/project/{self.team.pk}/tasks/{task.id}"
+
+        handle_posthog_link_unfurl(
+            {
+                "channel": "C_PRIVATE",
+                "message_ts": "123.456",
+                "user": "U_OWNER",
+                "source": "conversations_history",
+                "links": [{"url": url}],
+            },
+            self.integration,
+        )
+
+        mock_client.chat_unfurl.assert_called_once()
+        task.refresh_from_db()
+        assert "slack_thread_references" not in task.state
 
     @patch("products.slack_app.backend.api.resolve_slack_user")
     @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")

--- a/products/slack_app/backend/tests/test_link_unfurl.py
+++ b/products/slack_app/backend/tests/test_link_unfurl.py
@@ -167,7 +167,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
         task = Task.objects.create(
             team=self.team,
             created_by=self.user,
-            title="Review Slack task links",
+            title="Review <https://example.com|Slack task links>",
             description="Sensitive prompt that must not appear",
             origin_product=Task.OriginProduct.USER_CREATED,
         )
@@ -200,8 +200,11 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
         handle_posthog_link_unfurl(event, self.integration)
 
         text = mock_client.chat_unfurl.call_args.kwargs["unfurls"][url]["blocks"][0]["text"]["text"]
-        assert "Review Slack task links" in text
+        assert "Review &lt;https://example.com|Slack task links&gt;" in text
+        assert "<https://example.com|Slack task links>" not in text
         assert "Sensitive prompt" not in text
+        mock_client.conversations_info.assert_called_once_with(channel="C_PUBLIC")
+        mock_client.users_info.assert_called_once_with(user="U_OWNER")
         task.refresh_from_db()
         state = task.state or {}
         references = state.get("slack_thread_references")

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -472,9 +472,25 @@ def attach_slack_thread_reference(
         ):
             return
         references.append(reference)
-        state["slack_thread_references"] = references
+        # Keep a rolling window to bound task state and API response size.
+        state["slack_thread_references"] = references[-30:]
         task.state = state
         task.save(update_fields=["state", "updated_at"])
+
+
+def has_slack_thread_reference(
+    *, task_id: str | UUID, team_id: int, slack_workspace_id: str, channel: str, thread_ts: str
+) -> bool:
+    task = Task.objects.filter(id=task_id, team_id=team_id).only("state").first()
+    if task is None:
+        return False
+    return any(
+        item.get("slack_workspace_id") == slack_workspace_id
+        and item.get("channel") == channel
+        and item.get("thread_ts") == thread_ts
+        for item in (task.state or {}).get("slack_thread_references", [])
+        if isinstance(item, dict)
+    )
 
 
 def _task_detail_to_dto(

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -406,6 +406,25 @@ class _LatestRunUnset:
 _LATEST_RUN_UNSET = _LatestRunUnset()
 
 
+def _task_slack_thread_references(task: Task) -> list[contracts.SlackThreadReferenceDTO]:
+    references: list[contracts.SlackThreadReferenceDTO] = []
+    for item in (task.state or {}).get("slack_thread_references", []):
+        if not isinstance(item, dict):
+            continue
+        channel = item.get("channel")
+        thread_ts = item.get("thread_ts")
+        if not isinstance(channel, str) or not isinstance(thread_ts, str):
+            continue
+        references.append(
+            contracts.SlackThreadReferenceDTO(
+                url=f"https://slack.com/archives/{channel}/p{thread_ts.replace('.', '')}",
+                channel=channel,
+                created_at=item.get("created_at") if isinstance(item.get("created_at"), str) else None,
+            )
+        )
+    return references
+
+
 def _task_detail_to_dto(
     task: Task,
     *,
@@ -447,6 +466,7 @@ def _task_detail_to_dto(
         created_by=_user_basic_info(task.created_by if task.created_by_id else None),
         latest_run_id=latest_run_id,
         channel=task.channel_id,
+        slack_thread_references=_task_slack_thread_references(task),
     )
 
 

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -425,6 +425,58 @@ def _task_slack_thread_references(task: Task) -> list[contracts.SlackThreadRefer
     return references
 
 
+def get_task_for_slack_unfurl(task_id: str | UUID, team_id: int, user_id: int) -> contracts.TaskSlackUnfurlDTO | None:
+    task = (
+        _visible_task_qs(team_id, user_id)
+        .filter(id=task_id, internal=False)
+        .only("id", "title", "created_by_id")
+        .first()
+    )
+    if task is None:
+        return None
+    latest_run = task.runs.order_by("-created_at").only("status").first()
+    return contracts.TaskSlackUnfurlDTO(
+        id=task.id,
+        title=task.title,
+        created_by_id=task.created_by_id,
+        latest_run_status=latest_run.get_status_display() if latest_run else None,
+    )
+
+
+def attach_slack_thread_reference(
+    *,
+    task_id: str | UUID,
+    team_id: int,
+    slack_workspace_id: str,
+    channel: str,
+    thread_ts: str,
+    shared_by_slack_user_id: str,
+) -> None:
+    reference = {
+        "slack_workspace_id": slack_workspace_id,
+        "channel": channel,
+        "thread_ts": thread_ts,
+        "shared_by_slack_user_id": shared_by_slack_user_id,
+        "created_at": django_timezone.now().isoformat(),
+    }
+    with transaction.atomic():
+        task = Task.objects.select_for_update().get(id=task_id, team_id=team_id)
+        state = dict(task.state or {})
+        references = list(state.get("slack_thread_references") or [])
+        if any(
+            item.get("slack_workspace_id") == slack_workspace_id
+            and item.get("channel") == channel
+            and item.get("thread_ts") == thread_ts
+            for item in references
+            if isinstance(item, dict)
+        ):
+            return
+        references.append(reference)
+        state["slack_thread_references"] = references
+        task.state = state
+        task.save(update_fields=["state", "updated_at"])
+
+
 def _task_detail_to_dto(
     task: Task,
     *,

--- a/products/tasks/backend/facade/contracts.py
+++ b/products/tasks/backend/facade/contracts.py
@@ -131,6 +131,15 @@ class WarmRunDTO:
 
 
 @dataclass(frozen=True)
+class SlackThreadReferenceDTO:
+    """A passive link from a task to a public Slack discussion."""
+
+    url: str
+    channel: str
+    created_at: str | None = None
+
+
+@dataclass(frozen=True)
 class TaskDetailDTO:
     """The HTTP detail representation of a task.
 
@@ -167,6 +176,7 @@ class TaskDetailDTO:
     created_by: "TaskUserBasicInfo | None" = None
     latest_run_id: UUID | None = None
     channel: UUID | None = None
+    slack_thread_references: list[SlackThreadReferenceDTO] = Field(default_factory=list)
 
 
 @dataclass(frozen=True)

--- a/products/tasks/backend/facade/contracts.py
+++ b/products/tasks/backend/facade/contracts.py
@@ -140,6 +140,16 @@ class SlackThreadReferenceDTO:
 
 
 @dataclass(frozen=True)
+class TaskSlackUnfurlDTO:
+    """The task metadata needed to build a Slack unfurl."""
+
+    id: UUID
+    title: str
+    created_by_id: int | None
+    latest_run_status: str | None
+
+
+@dataclass(frozen=True)
 class TaskDetailDTO:
     """The HTTP detail representation of a task.
 

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -30,6 +30,7 @@ from products.tasks.backend.facade.contracts import (
     ChannelInstructionsDTO,
     SandboxCustomImageDTO,
     SandboxEnvironmentDTO,
+    SlackThreadReferenceDTO,
     TaskActivityDTO,
     TaskActivityPageDTO,
     TaskAutomationDTO,
@@ -134,6 +135,11 @@ class TaskUserBasicInfoSerializer(DataclassSerializer):
 
     class Meta:
         dataclass = TaskUserBasicInfo
+
+
+class SlackThreadReferenceSerializer(DataclassSerializer):
+    class Meta:
+        dataclass = SlackThreadReferenceDTO
 
 
 TASK_RUN_ARTIFACT_MAX_SIZE_BYTES = 30 * 1024 * 1024
@@ -400,6 +406,7 @@ class TaskSerializer(DataclassSerializer):
 
     latest_run = TaskRunDetailSerializer(allow_null=True, required=False, help_text="Latest run details for this task")
     created_by = TaskUserBasicInfoSerializer(allow_null=True, required=False)
+    slack_thread_references = SlackThreadReferenceSerializer(many=True, read_only=True)
     runtime = serializers.ChoiceField(
         choices=tasks_facade.TaskRuntime.choices,
         read_only=True,
@@ -432,6 +439,7 @@ class TaskSerializer(DataclassSerializer):
             "created_by",
             "ci_prompt",
             "channel",
+            "slack_thread_references",
         ]
 
 

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -360,6 +360,26 @@ class TestTaskCreatorScoping(BaseTaskAPITest):
             ],
         )
 
+    def test_passive_slack_thread_references_keep_latest_thirty(self):
+        task = self.create_task()
+
+        for index in range(31):
+            tasks_facade.attach_slack_thread_reference(
+                task_id=task.id,
+                team_id=self.team.id,
+                slack_workspace_id="T123",
+                channel="C123",
+                thread_ts=f"{index}.000",
+                shared_by_slack_user_id="U123",
+            )
+
+        task.refresh_from_db()
+        references = (task.state or {}).get("slack_thread_references")
+        assert isinstance(references, list)
+        self.assertEqual(len(references), 30)
+        self.assertEqual(references[0]["thread_ts"], "1.000")
+        self.assertEqual(references[-1]["thread_ts"], "30.000")
+
     def test_retrieve_signal_report_task_owned_by_another_user_is_visible(self):
         # Signals-generated tasks are team-scoped artifacts; the pipeline picks
         # a system user as `created_by` purely to mint an OAuth token. Any team

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -333,6 +333,33 @@ class TestTaskCreatorScoping(BaseTaskAPITest):
         response = self.client.get(f"/api/projects/@current/tasks/{task.id}/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    def test_retrieve_includes_passive_slack_thread_references(self):
+        task = self.create_task()
+        task.state = {
+            "slack_thread_references": [
+                {
+                    "channel": "C123",
+                    "thread_ts": "1234.5678",
+                    "created_at": "2026-08-09T10:00:00+00:00",
+                }
+            ]
+        }
+        task.save(update_fields=["state"])
+
+        response = self.client.get(f"/api/projects/@current/tasks/{task.id}/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.json()["slack_thread_references"],
+            [
+                {
+                    "url": "https://slack.com/archives/C123/p12345678",
+                    "channel": "C123",
+                    "created_at": "2026-08-09T10:00:00+00:00",
+                }
+            ],
+        )
+
     def test_retrieve_signal_report_task_owned_by_another_user_is_visible(self):
         # Signals-generated tasks are team-scoped artifacts; the pipeline picks
         # a system user as `created_by` purely to mint an OAuth token. Any team

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -1528,6 +1528,13 @@ export interface TaskRunDetailDTOApi {
     completed_at?: string | null
 }
 
+export interface SlackThreadReferenceDTOApi {
+    url: string
+    channel: string
+    /** @nullable */
+    created_at?: string | null
+}
+
 /**
  * @nullable
  */
@@ -1580,6 +1587,7 @@ export interface TaskDetailDTOApi {
     ci_prompt: string | null
     /** @nullable */
     channel?: string | null
+    readonly slack_thread_references: readonly SlackThreadReferenceDTOApi[]
 }
 
 export interface PaginatedTaskDetailDTOListApi {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -50351,6 +50351,13 @@ export namespace Schemas {
       completed_at?: string | null;
     }
 
+    export interface SlackThreadReferenceDTO {
+      url: string;
+      channel: string;
+      /** @nullable */
+      created_at?: string | null;
+    }
+
     /**
      * @nullable
      */
@@ -50403,6 +50410,7 @@ export namespace Schemas {
       ci_prompt: string | null;
       /** @nullable */
       channel?: string | null;
+      readonly slack_thread_references: readonly SlackThreadReferenceDTO[];
     }
 
     export interface PaginatedTaskDetailDTOList {


### PR DESCRIPTION
## Problem

People sharing a PostHog task in Slack see a bare URL and the task retains no reference to the resulting public discussion.

## Changes

- Unfurl visible task links with the task title and latest run status.
- Save an idempotent, passive thread reference only for ordinary public Slack channels.
- Keep private channels, DMs, shared channels, task content, and message synchronization out of scope.
- Keep unfurling independent: reference validation or storage failures cannot suppress the preview.

## How did you test this code?

- Added regression tests for task URL parsing, permission-scoped unfurls, idempotent public references, private-channel exclusion, and task API serialization.
- Ran the focused Slack unfurl suite and task API regression test.
- Ran Ruff lint/format, mypy preflight, generated task API clients, and checked the diff for whitespace errors.
- Full OpenAPI MCP generation could not run because the local MCP workspace dependency is not linked; frontend task client generation completed.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with PostHog Code. Used the `working-with-task-comments` skill to incorporate artifact feedback.

The design intentionally uses passive task-state references instead of `SlackThreadTaskMapping`, avoiding reply forwarding, output relaying, migrations, and synchronization semantics. Test data is invented.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*