### PR TITLE
fix(ci): split the conversations product tests across three shards

### DIFF
--- a/.github/scripts/turbo-discover-sharding.test.js
+++ b/.github/scripts/turbo-discover-sharding.test.js
@@ -1,0 +1,58 @@
+// Run with: node --test .github/scripts/turbo-discover-sharding.test.js
+//
+// Unit tests for the product sharding decisions in turbo-discover.js: buildMatrix.
+// Uses synthetic product names and durations throughout, and injects shard floors
+// rather than reading MIN_SHARDS_BY_PRODUCT, so these never turn into
+// change-detector tests that break when a product is added to or dropped from
+// the floor list.
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { buildMatrix, PRODUCT_TARGET_WALL_SECONDS } = require('./turbo-discover')
+
+// Cheap enough that duration-based sharding would never split it, and cheap
+// enough that two of them still fit one bucket.
+function cheapDurations(...products) {
+    const durations = {}
+    for (const product of products) {
+        durations[`products/${product}/backend/tests/test_thing.py::test_one`] = 5
+    }
+    return durations
+}
+
+function groups(matrix) {
+    return matrix.map((entry) => entry.group)
+}
+
+test('a floored product splits to its floor even when its duration is far under target', () => {
+    const matrix = buildMatrix(['alpha', 'beta'], cheapDurations('alpha', 'beta'), { alpha: 3 })
+
+    assert.deepEqual(
+        groups(matrix).filter((g) => g.startsWith('alpha')).sort(),
+        ['alpha (1/3)', 'alpha (2/3)', 'alpha (3/3)']
+    )
+    // The point of the floor is fewer tests per pytest session, so the shards must
+    // carry pytest-split args and must not be packed alongside another product.
+    for (const entry of matrix.filter((e) => e.group.startsWith('alpha'))) {
+        assert.match(entry.pytest_args, /--splits 3 --group \d --splitting-algorithm optimal_chunks/)
+        assert.equal(entry.filters, '--filter=@posthog/products-alpha')
+    }
+    assert.ok(!groups(matrix).some((g) => g.includes(',') && g.includes('alpha')))
+})
+
+test('an unfloored product under target is still packed with its bucket-mates', () => {
+    const matrix = buildMatrix(['alpha', 'beta'], cheapDurations('alpha', 'beta'), {})
+
+    assert.deepEqual(groups(matrix), ['alpha, beta'])
+})
+
+test('duration wins when it demands more shards than the floor', () => {
+    // Four times the target, so duration-based sharding asks for 4 — the floor of 2
+    // must not cap it back down.
+    const durations = { 'products/alpha/backend/tests/test_big.py::test_one': PRODUCT_TARGET_WALL_SECONDS * 4 }
+    const matrix = buildMatrix(['alpha'], durations, { alpha: 2 })
+
+    assert.equal(matrix.length, 5)
+    assert.ok(groups(matrix).every((g) => g.endsWith('/5)')))
+})

--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -57,6 +57,15 @@ const PRODUCTS_RUNNING_TEMPORAL_IN_JOB = new Set(['managed-warehouse', 'warehous
 // others — isolates a flaky/hang-prone product so it can't cancel bucket-mates
 // at the job timeout. Trade-off: a dedicated runner.
 const DEDICATED_BUCKET_PRODUCTS = new Set(['batch-exports'])
+// Products whose pytest session exhausts the runner long before it exhausts the wall
+// clock: what kills them is memory accumulated across a session of many hundreds of
+// tests, not test work. The runner dies mid-step and GitHub reports "the self-hosted
+// runner lost communication with the server", so there is no pytest failure to read
+// and the job's logs are gone. Duration-based sharding is blind to that, so these
+// products get a shard floor regardless of how cheap their tests look. Trade-off:
+// extra runners and duplicate Docker setup for a product well under the wall-clock
+// target. Raise a floor if a product still dies; drop it once the leak is fixed.
+const MIN_SHARDS_BY_PRODUCT = { conversations: 3 }
 
 // --- Staleness detection for .test_durations ---
 // When a product's test files on disk significantly outnumber what .test_durations
@@ -591,7 +600,9 @@ function buildDjangoShards(durations) {
     return result
 }
 
-function buildMatrix(products, durations) {
+// shardFloors is a seam for unit tests, so they can exercise the floor behavior
+// without asserting against whichever products happen to be listed today.
+function buildMatrix(products, durations, shardFloors = MIN_SHARDS_BY_PRODUCT) {
     const matrix = []
     const packable = []
 
@@ -624,9 +635,13 @@ function buildMatrix(products, durations) {
             }
         }
 
-        if (raw > PRODUCT_TARGET_WALL_SECONDS) {
-            const shards = Math.ceil(raw / PRODUCT_TARGET_WALL_SECONDS)
-            console.error(`  ${product}: ${(raw / 60).toFixed(1)} min raw → split across ${shards} shards`)
+        const durationShards = raw > PRODUCT_TARGET_WALL_SECONDS ? Math.ceil(raw / PRODUCT_TARGET_WALL_SECONDS) : 1
+        const shardFloor = shardFloors[product] || 1
+        const shards = Math.max(durationShards, shardFloor)
+
+        if (shards > 1) {
+            const reason = shards > durationShards ? `shard floor of ${shardFloor}` : `${(raw / 60).toFixed(1)} min raw`
+            console.error(`  ${product}: ${reason} → split across ${shards} shards`)
             const filters = `--filter=@posthog/products-${product}`
             // optimal_chunks (PostHog pytest-split fork) makes the same contiguous,
             // order-preserving cuts as duration_based_chunks but balances them
@@ -672,6 +687,9 @@ module.exports = {
     checkProductStaleness,
     productPrefix,
     productEffectiveCost,
+    buildMatrix,
+    MIN_SHARDS_BY_PRODUCT,
+    PRODUCT_TARGET_WALL_SECONDS,
     STALENESS_COVERAGE_THRESHOLD,
     STALENESS_FALLBACK_SECONDS_PER_FILE,
     parseTachModules,

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -76,5 +76,10 @@ jobs:
             - name: Turbo-discover dependent-cascade tests (Node)
               run: node --test .github/scripts/turbo-discover-cascade.test.js
 
+            # hashFiles guard: branches that predate this file must not fail here.
+            - name: Turbo-discover sharding tests (Node)
+              if: ${{ hashFiles('.github/scripts/turbo-discover-sharding.test.js') != '' }}
+              run: node --test .github/scripts/turbo-discover-sharding.test.js
+
             - name: Trunk impacted-targets tests (Node)
               run: node --test .github/scripts/trunk-impacted-targets.test.js


### PR DESCRIPTION
## Problem

Anyone merging to master hits a red Backend CI that names no failing test. The `Product tests (conversations, ...)` job dies partway through `Run product tests`, and GitHub reports "the self-hosted runner lost communication with the server ... anything that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error."

- The job's logs return `BlobNotFound`, so there is nothing to read and nothing reaches the CI failure tables.
- Failing runs take 1520-1650s; passing runs on the same job take 1080-1360s. The runner dies late, not early.
- The shape has held on every one of these since Saturday, including [this one](https://github.com/PostHog/posthog/actions/runs/31322507595/job/93267886806) on master. It reaches back to July 31.
- The bucket conversations packs into varies, and it dies alone too, so conversations is the common factor rather than a bucket-mate.

## Changes

- `turbo-discover.js` gets a shard floor per product, applied whatever the measured duration says.
- Conversations goes on that floor at three shards, so each pytest session collects roughly a third of the tests it does today.
- Splitting also takes conversations out of bin packing, so it can no longer take a bucket-mate down with it.

The floor is separate from `DEDICATED_BUCKET_PRODUCTS` on purpose. A dedicated bucket only stops a product from cancelling its bucket-mates; it still runs one long session on one runner, and the failure above happened with conversations alone in its bucket. Duration-based sharding cannot see this either, because conversations measures about 4 minutes against a 10 minute target.

Three shards is a starting point, not a measurement. Raise the floor if the runner still dies; drop conversations from the map once the underlying memory growth is fixed.

> [!NOTE]
> This costs two extra runners per Backend CI run for a product well under the wall-clock target.

## How did you test this code?

- `node --test .github/scripts/turbo-discover-sharding.test.js` passes, covering three regressions no existing test caught: a floored product splits despite a cheap duration, a floored product is not packed into a shared bucket, and a floor never caps a product that duration says needs more shards.
- `node --test .github/scripts/turbo-discover-cascade.test.js .github/scripts/turbo-discover-staleness.test.js` still passes.
- I ran `buildMatrix` against the committed `.test_durations` and it emits `conversations (1/3)`, `(2/3)`, `(3/3)` with the expected pytest-split args, and leaves the other products packed as before.
- Not checked: whether three shards is enough to keep the runner alive. That only shows up on master over a few days, and I have no memory profile of the job to size it from.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually the PostHog Slack app, running Claude) did this from a Slack thread that started with the DevEx bot reporting master red. I traced the weekend's master failures through the engineering analytics CI views and the GitHub API, found two independent causes, and was asked to fix this one. The other is a separate flake in the S3 batch-export tests against local object storage and is not touched here.

Skills invoked: `/investigating-ci-failures`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

`buildMatrix` gained an optional `shardFloors` parameter so the tests exercise floor behavior with synthetic products, rather than asserting against whichever products are on the real list and breaking when that list changes.

The new test step in `ci-scripts.yml` is guarded with `hashFiles`, matching the existing weekly-flaky-report step, so open PRs that predate the test file do not fail on it.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AS64N6DJL/p1786294846743759?thread_ts=1786294846.743759&cid=C0AS64N6DJL)*
