### PR TITLE
feat(capture-load-gen): add person update and merge traffic percentages

### DIFF
--- a/rust/capture-load-gen/README.md
+++ b/rust/capture-load-gen/README.md
@@ -37,7 +37,14 @@ requests.
 | `--distinct-ids` | `10000` | Synthetic-user cardinality |
 | `--event-name` | `$pageview`, `$autocapture`, `custom_event` | Event names to pick from (repeatable) |
 | `--prop-bytes` | `256` | Approx filler bytes per event |
+| `--percent-person-updates` | `0` | Percentage of events carrying a `$set` payload (person update) |
+| `--percent-merges` | `0` | Percentage of events that are `$identify` merges of a fresh anon distinct id |
 | `--dry-run` | off | Print one sample batch as JSON and exit |
+
+`--percent-person-updates` and `--percent-merges` must sum to at most 100;
+the rest of the events are plain (no person-pipeline work beyond creation).
+Each merge claims a unique anonymous distinct id, so every `$identify` exercises
+the merge path instead of re-merging an already-folded pair.
 
 Output is a once-per-second throughput line plus a final summary with
 HdrHistogram latency percentiles (p50/p95/p99).

--- a/rust/capture-load-gen/src/event.rs
+++ b/rust/capture-load-gen/src/event.rs
@@ -10,15 +10,25 @@ use uuid::Uuid;
 ///
 /// Distinct IDs are drawn from a fixed pool so person cardinality is
 /// controllable, and each event is padded with filler properties to roughly
-/// match a target serialized size.
+/// match a target serialized size. A configurable share of events exercises
+/// the person pipeline: person updates carry a `$set` payload, merges are
+/// `$identify` events claiming a fresh anonymous distinct id.
 pub struct EventFactory {
     distinct_ids: Vec<String>,
     event_names: Vec<String>,
     filler: String,
+    person_update_pct: u8,
+    merge_pct: u8,
 }
 
 impl EventFactory {
-    pub fn new(distinct_ids: u64, event_names: Vec<String>, prop_bytes: usize) -> Self {
+    pub fn new(
+        distinct_ids: u64,
+        event_names: Vec<String>,
+        prop_bytes: usize,
+        person_update_pct: u8,
+        merge_pct: u8,
+    ) -> Self {
         let distinct_ids = (0..distinct_ids.max(1))
             .map(|i| format!("loadgen-user-{i}"))
             .collect();
@@ -26,12 +36,13 @@ impl EventFactory {
             distinct_ids,
             event_names,
             filler: "x".repeat(prop_bytes),
+            person_update_pct,
+            merge_pct,
         }
     }
 
     fn next(&self, rng: &mut impl Rng) -> RawEvent {
         let distinct_id = &self.distinct_ids[rng.gen_range(0..self.distinct_ids.len())];
-        let event = &self.event_names[rng.gen_range(0..self.event_names.len())];
 
         let mut properties: HashMap<String, Value> = HashMap::new();
         properties.insert("$lib".to_string(), Value::String("capture-load-gen".into()));
@@ -39,12 +50,50 @@ impl EventFactory {
             properties.insert("filler".to_string(), Value::String(self.filler.clone()));
         }
 
-        RawEvent {
-            event: event.clone(),
+        let base = RawEvent {
             distinct_id: Some(Value::String(distinct_id.clone())),
             uuid: Some(Uuid::now_v7()),
             properties,
             ..Default::default()
+        };
+
+        let roll = rng.gen_range(0..100u8);
+        if roll < self.merge_pct {
+            return self.merge_event(base);
+        }
+        let event = self.event_names[rng.gen_range(0..self.event_names.len())].clone();
+        if roll < self.merge_pct + self.person_update_pct {
+            return Self::person_update_event(base, event);
+        }
+        RawEvent { event, ..base }
+    }
+
+    /// A merge: `$identify` folding a fresh anonymous distinct id into the
+    /// pool user. The anon id is unique per event so every merge exercises
+    /// the merge path instead of re-merging an already-folded pair.
+    fn merge_event(&self, mut base: RawEvent) -> RawEvent {
+        base.properties.insert(
+            "$anon_distinct_id".to_string(),
+            Value::String(format!("loadgen-anon-{}", Uuid::now_v7())),
+        );
+        RawEvent {
+            event: "$identify".to_string(),
+            ..base
+        }
+    }
+
+    /// A person update: a regular event carrying a `$set` payload. The value
+    /// is unique per event so every update actually changes the person.
+    fn person_update_event(base: RawEvent, event: String) -> RawEvent {
+        let mut set = HashMap::new();
+        set.insert(
+            "loadgen_last_update".to_string(),
+            Value::String(Uuid::now_v7().to_string()),
+        );
+        RawEvent {
+            event,
+            set: Some(set),
+            ..base
         }
     }
 
@@ -69,7 +118,7 @@ mod tests {
     use rand::SeedableRng;
 
     fn factory() -> EventFactory {
-        EventFactory::new(100, vec!["a".into(), "b".into()], 32)
+        EventFactory::new(100, vec!["a".into(), "b".into()], 32, 0, 0)
     }
 
     #[test]
@@ -109,9 +158,68 @@ mod tests {
 
     #[test]
     fn zero_prop_bytes_omits_filler() {
-        let f = EventFactory::new(10, vec!["x".into()], 0);
+        let f = EventFactory::new(10, vec!["x".into()], 0, 0, 0);
         let mut rng = StdRng::seed_from_u64(3);
         let batch = f.batch(1, &mut rng);
         assert!(!batch[0].properties.contains_key("filler"));
+    }
+
+    #[test]
+    fn merge_events_are_identifies_with_fresh_anon_ids() {
+        let f = EventFactory::new(10, vec!["x".into()], 0, 0, 100);
+        let mut rng = StdRng::seed_from_u64(4);
+        let batch = f.batch(20, &mut rng);
+
+        let mut anon_ids = Vec::new();
+        for event in &batch {
+            assert_eq!(event.event, "$identify");
+            assert!(event.set.is_none());
+            let anon = event.properties["$anon_distinct_id"].as_str().unwrap();
+            assert!(anon.starts_with("loadgen-anon-"));
+            anon_ids.push(anon.to_string());
+            let distinct_id = event.distinct_id.as_ref().unwrap().as_str().unwrap();
+            assert!(distinct_id.starts_with("loadgen-user-"));
+        }
+        anon_ids.sort();
+        anon_ids.dedup();
+        assert_eq!(
+            anon_ids.len(),
+            20,
+            "every merge should claim a fresh anon id"
+        );
+    }
+
+    #[test]
+    fn person_update_events_carry_a_changing_set_payload() {
+        let f = EventFactory::new(10, vec!["a".into(), "b".into()], 0, 100, 0);
+        let mut rng = StdRng::seed_from_u64(5);
+        let batch = f.batch(20, &mut rng);
+
+        let mut values = Vec::new();
+        for event in &batch {
+            assert!(["a", "b"].contains(&event.event.as_str()));
+            assert!(!event.properties.contains_key("$anon_distinct_id"));
+            let set = event.set.as_ref().unwrap();
+            values.push(set["loadgen_last_update"].as_str().unwrap().to_string());
+        }
+        values.sort();
+        values.dedup();
+        assert_eq!(values.len(), 20, "every update should change the person");
+    }
+
+    #[test]
+    fn mix_roughly_matches_the_configured_percentages() {
+        let f = EventFactory::new(100, vec!["a".into()], 0, 30, 20);
+        let mut rng = StdRng::seed_from_u64(6);
+        let batch = f.batch(2000, &mut rng);
+
+        let merges = batch.iter().filter(|e| e.event == "$identify").count();
+        let updates = batch.iter().filter(|e| e.set.is_some()).count();
+        let plain = batch.len() - merges - updates;
+
+        // Percentages are drawn per event; allow ±5 points on 2000 samples.
+        assert!((merges as i64 - 400).abs() < 100, "merges: {merges}");
+        assert!((updates as i64 - 600).abs() < 100, "updates: {updates}");
+        assert!((plain as i64 - 1000).abs() < 100, "plain: {plain}");
     }
 }

--- a/rust/capture-load-gen/src/main.rs
+++ b/rust/capture-load-gen/src/main.rs
@@ -83,6 +83,16 @@ struct Cli {
     #[arg(long, default_value_t = 256)]
     prop_bytes: usize,
 
+    /// Percentage of events that are person updates (carry a `$set` payload).
+    /// Together with `--percent-merges` must not exceed 100.
+    #[arg(long, default_value_t = 0, value_parser = clap::value_parser!(u8).range(0..=100))]
+    percent_person_updates: u8,
+
+    /// Percentage of events that are merges (`$identify` folding a fresh
+    /// anonymous distinct id into a pool user).
+    #[arg(long, default_value_t = 0, value_parser = clap::value_parser!(u8).range(0..=100))]
+    percent_merges: u8,
+
     /// Per-request HTTP timeout in seconds.
     #[arg(long, default_value_t = 30)]
     timeout_secs: u64,
@@ -238,11 +248,24 @@ async fn main() -> Result<()> {
     if cli.concurrency == 0 {
         bail!("--concurrency must be > 0");
     }
+    if cli
+        .percent_person_updates
+        .saturating_add(cli.percent_merges)
+        > 100
+    {
+        bail!(
+            "--percent-person-updates ({}) + --percent-merges ({}) must not exceed 100",
+            cli.percent_person_updates,
+            cli.percent_merges
+        );
+    }
 
     let factory = Arc::new(EventFactory::new(
         cli.distinct_ids,
         cli.event_names.clone(),
         cli.prop_bytes,
+        cli.percent_person_updates,
+        cli.percent_merges,
     ));
 
     if cli.dry_run {


### PR DESCRIPTION
## Problem

capture-load-gen only sends plain events, so a load test never exercises the person pipeline beyond initial person creation. There is no way to generate person property updates or merges at a controlled rate.

## Changes

- `--percent-person-updates` makes that share of events carry a `$set` payload with a per-event unique value, so every update really changes the person.
- `--percent-merges` makes that share of events `$identify` calls folding a fresh anonymous distinct id into a pool user, so every merge exercises the merge path instead of re-merging the same pair.
- The two flags must sum to at most 100; the remainder stays plain events.
- The `$set` key is constant (`loadgen_last_update`), so person documents do not grow across a run.

## How did you test this code?

- New unit tests cover the merge shape ($identify with unique anon ids), the update shape (changing `$set` payload), and that a 30/20 mix lands near the configured percentages.
- Verified the flag wiring end to end with `--dry-run` and checked the emitted batch JSON.
- Sum validation rejects `--percent-person-updates 60 --percent-merges 50` with a clear error.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: the crate README documents the new flags.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Skills invoked: /writing-pr-descriptions. The `$set` payload shape (fixed key, unique value) was chosen so updates always mutate the person without growing the document; a follow-up chart change exposes the flags as Argo workflow parameters.
