### PR TITLE
fix(signals): stop scout dispatch waves merging into one tick

### DIFF
--- a/products/signals/backend/scout_harness/AGENTS.md
+++ b/products/signals/backend/scout_harness/AGENTS.md
@@ -114,7 +114,12 @@ In production it is driven by `SignalsScoutCoordinatorWorkflow` (periodic tick e
 ## Where the rest of the system meets this directory
 
 - **Coordinator** — `temporal/agentic/scout_coordinator.py` and `scout_scheduler.py`.
-  Polls every `COORDINATOR_INTERVAL_MINUTES = 30`; dispatches each scout whose per-scout schedule (`run_interval_minutes`, default every 24 hours, or an optional project-local cron `run_cron_schedule` that takes precedence) is due, most-overdue first, hard cap `MAX_RUNS_PER_TICK = 50` per tick, `ScheduleOverlapPolicy.SKIP` to drop ticks rather than queue them.
+  Polls every `COORDINATOR_INTERVAL_MINUTES = 30`; dispatches each scout whose per-scout schedule (`run_interval_minutes`, default every 24 hours, or an optional project-local cron `run_cron_schedule` that takes precedence) is due, most-overdue first, hard cap `MAX_RUNS_PER_TICK` per tick (flag-tunable via `max_runs_per_tick_global`), `ScheduleOverlapPolicy.SKIP` to drop ticks rather than queue them.
+  A dispatched rolling-interval scout has its `last_run_at` stamped at its own stable slot on the tick grid (`_slot_anchor`, keyed on a digest of the config id), not at the post-fan-out wall clock.
+  That is what keeps dispatch spread across the day: a wall-clock anchor accumulated each tick's planning and fan-out latency, so a cohort eventually slipped onto the next tick and merged into that tick's cohort, and every merge made the resulting wave slower to fan out and more likely to slip again.
+  Anchoring on the grid also returns a run deferred by a per-team cap or a missed tick to the slot it was meant to have, instead of re-anchoring wherever it happened to land.
+  `slot_aligned_dispatch: false` in the flag payload reverts to wall-clock stamping.
+  Cron scouts and breaker-paused lanes under probe keep the wall clock, because their `last_run_at` is a croniter reference and a probe cooldown clock respectively, not a schedule anchor.
   A lane paused by the failure-streak breaker (`status=paused_by_system`, `pause_reason=repeated_failures`) is excluded by the `enabled=True` dispatch filter like any other pause; the coordinator additionally dispatches one probe per `AUTO_PAUSE_PROBE_INTERVAL_S` to such lanes (`_collect_probe_runs`).
 - **Models** — `SignalScoutConfig`, `SignalScoutRun`, `SignalScratchpad`, `SignalScoutNote`, `SignalProjectProfile` in `../models.py`.
 - **Source variant** — `SignalSourceConfig.SourceProduct.SIGNALS_SCOUT` paired with `SourceType.CROSS_SOURCE_ISSUE`.

--- a/products/signals/backend/scout_harness/team_limits.py
+++ b/products/signals/backend/scout_harness/team_limits.py
@@ -323,6 +323,25 @@ def _resolve_global_max_runs_per_tick(payload: dict | None, default: int) -> int
     return default
 
 
+# Flag payload key toggling slot-aligned dispatch anchors (the coordinator's `_slot_anchor`). On,
+# a dispatched scout's `last_run_at` is stamped at its own stable slot on the tick grid, so tick
+# latency stops pushing whole cohorts onto later ticks and merging them into ever larger waves.
+# Set `false` to fall back to stamping the wall clock, which is the only way back to the previous
+# behaviour without a deploy. Absent / malformed → on.
+SLOT_ALIGNED_DISPATCH_KEY = "slot_aligned_dispatch"
+
+
+def _resolve_slot_aligned_dispatch(payload: dict | None) -> bool:
+    """Whether the coordinator stamps slot-aligned dispatch anchors. Only a literal boolean is
+    honored, so a typo'd override can't silently flip the fleet's dispatch spread either way."""
+    if payload is None:
+        return True
+    override = payload.get(SLOT_ALIGNED_DISPATCH_KEY)
+    if isinstance(override, bool):
+        return override
+    return True
+
+
 def _resolve_github_read_access(team_id: int, team_configs: dict[int, dict], default_team_config: dict) -> bool:
     """Whether report-channel scouts on this team get the `gh` evidence prompt guidance,
     most-specific layer first: `team_configs[team_id]` → `default_team_config` → on. Only a

--- a/products/signals/backend/temporal/agentic/scout_coordinator.py
+++ b/products/signals/backend/temporal/agentic/scout_coordinator.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import json
 import asyncio
+import hashlib
 from dataclasses import dataclass
-from datetime import datetime, timedelta, tzinfo
+from datetime import UTC, datetime, timedelta, tzinfo
+from uuid import UUID
 
 from django.db.models import Q
 from django.utils import timezone
@@ -36,6 +38,7 @@ from products.signals.backend.scout_harness.team_limits import (
     _resolve_global_max_runs_per_tick,
     _resolve_max_runs_per_day,
     _resolve_max_runs_per_tick,
+    _resolve_slot_aligned_dispatch,
     _resolve_withheld_skills,
     _runs_today_by_team,
     _team_configs,
@@ -57,6 +60,8 @@ COORDINATOR_INTERVAL_MINUTES = 30
 # Slack on the due-check so a scout that's a few seconds short at a tick still counts as due —
 # else stamp jitter makes it skip every other tick (a 60-min scout runs every 2h).
 DUE_GRACE_SECONDS = 60
+
+TICK_SECONDS = COORDINATOR_INTERVAL_MINUTES * 60
 
 
 @dataclass
@@ -143,19 +148,96 @@ async def stamp_dispatched_signals_scout_runs_activity(
     — far less harmful than a day of suppression, and bounded by the activity retry policy.
     """
     async with Heartbeater():
-        await database_sync_to_async(_stamp_dispatched_runs, thread_sensitive=False)(stamp_input.dispatched_runs)
+        # Same off-the-DB-pool read as planning: the SDK call can block on a cold cache, and
+        # `database_sync_to_async`'s pool is sized for DB-bound work.
+        payload = await asyncio.to_thread(_read_flag_payload)
+        slot_aligned = _resolve_slot_aligned_dispatch(payload)
+        await database_sync_to_async(_stamp_dispatched_runs, thread_sensitive=False)(
+            stamp_input.dispatched_runs, slot_aligned=slot_aligned
+        )
 
 
-def _stamp_dispatched_runs(dispatched_runs: list[PlannedRun]) -> None:
+def _dispatch_slot(config_pk: str, run_interval_minutes: int) -> int:
+    """The config's stable slot within its interval, as a count of coordinator ticks.
+
+    Derived from a digest of the config's primary key so it never moves: the same scout keeps the
+    same slot across restarts, redeploys, and re-enrolments, and the fleet's slots are spread by
+    the digest's uniformity rather than by whenever each scout happened to be enabled.
+    """
+    ticks_per_interval = _ticks_per_interval(run_interval_minutes)
+    digest = hashlib.sha256(str(config_pk).encode("utf-8"), usedforsecurity=False).digest()
+    return int.from_bytes(digest[:8], "big") % ticks_per_interval
+
+
+def _ticks_per_interval(run_interval_minutes: int) -> int:
+    """How many coordinator ticks fit in one run interval, floored at 1.
+
+    An interval shorter than a tick (or one that isn't a whole number of ticks) collapses to a
+    single slot, which makes the anchor the plain tick start: dispatch is quantized to the tick
+    grid either way, so there is nothing finer to spread such a scout across.
+    """
+    return max(1, run_interval_minutes // COORDINATOR_INTERVAL_MINUTES)
+
+
+def _slot_anchor(config_pk: str, run_interval_minutes: int, dispatched_at: datetime) -> datetime:
+    """The schedule anchor to stamp: the config's own slot, at or before this tick.
+
+    Stamping `timezone.now()` here instead made `last_run_at` absorb the tick's planning and
+    fan-out latency, so the next due time crept later every run. Once that creep passed
+    `DUE_GRACE_SECONDS` a scout missed its usual tick and re-anchored on the next one, merging its
+    cohort into that tick's cohort. The bigger merged wave then took longer to fan out, which made
+    the next slip more likely, so waves only ever grew.
+
+    Snapping back to the config's own slot removes both halves of that. Latency never accumulates,
+    because the anchor is a grid point rather than a measured time. A run deferred past its slot by
+    a per-team cap or a missed tick anchors on the slot it was meant to have, so cohorts drift back
+    together on the grid instead of ratcheting forward off it.
+
+    The snapped anchor always lands in `(this tick - interval, this tick]`, which puts the next due
+    time in `(this tick, this tick + interval]`. So no scout can come due again immediately, and
+    none waits more than one extra interval, including on the first stamp after this rolled out.
+    """
+    ticks_per_interval = _ticks_per_interval(run_interval_minutes)
+    slot = _dispatch_slot(config_pk, run_interval_minutes)
+    tick_index = int(dispatched_at.timestamp()) // TICK_SECONDS
+    snapped_index = tick_index - ((tick_index - slot) % ticks_per_interval)
+    return datetime.fromtimestamp(snapped_index * TICK_SECONDS, tz=UTC)
+
+
+def _stamp_dispatched_runs(dispatched_runs: list[PlannedRun], *, slot_aligned: bool = True) -> None:
     """Sync bulk stamp. `.update()` bypasses save(), so this per-tick write never hits the
-    activity log."""
+    activity log.
+
+    Rolling-interval scouts are stamped with their slot anchor (see `_slot_anchor`), which means
+    one `.update()` per distinct anchor rather than one for the whole tick. Two kinds of config are
+    stamped with the wall clock instead:
+
+    - A cron scout, because `_overdue_seconds` feeds `last_run_at` to croniter as the reference for
+      the next slot. Cron slots are already absolute, so that path never had the drift, and moving
+      the reference backwards could re-select the slot this dispatch just fulfilled.
+    - A disabled config, which here is a lane the failure breaker paused and the coordinator is
+      probing. Its `last_run_at` is the probe cooldown clock rather than a schedule anchor, so
+      backdating it would shorten the cooldown the breaker is counting.
+    """
     if not dispatched_runs:
         return
     now = timezone.now()
     predicate = Q()
     for run in dispatched_runs:
         predicate |= Q(team_id=run.team_id, skill_name=run.skill_name)
-    SignalScoutConfig.all_teams.filter(predicate).update(last_run_at=now)
+    dispatched = SignalScoutConfig.all_teams.filter(predicate)
+    if not slot_aligned:
+        dispatched.update(last_run_at=now)
+        return
+
+    pks_by_anchor: dict[datetime, list[UUID]] = {}
+    for pk, enabled, cron_schedule, interval_minutes in dispatched.values_list(
+        "pk", "enabled", "run_cron_schedule", "run_interval_minutes"
+    ):
+        anchor = _slot_anchor(str(pk), interval_minutes, now) if enabled and not cron_schedule else now
+        pks_by_anchor.setdefault(anchor, []).append(pk)
+    for anchor, pks in pks_by_anchor.items():
+        SignalScoutConfig.all_teams.filter(pk__in=pks).update(last_run_at=anchor)
 
 
 @dataclass

--- a/products/signals/backend/temporal/agentic/scout_coordinator.py
+++ b/products/signals/backend/temporal/agentic/scout_coordinator.py
@@ -172,14 +172,18 @@ def _dispatch_slot(config_pk: str, run_interval_minutes: int) -> int:
 def _ticks_per_interval(run_interval_minutes: int) -> int:
     """The scout's dispatch period, as a count of coordinator ticks.
 
-    Rounded UP, because that is the cadence the tick grid already imposes: a scout is dispatched at
-    the first tick at or after it comes due, so a 75-minute interval has always run every 90
-    minutes. Rounding down would make the anchor period shorter than the real cadence and dispatch
-    that scout every 60 minutes instead, which is more often than its owner configured.
-    `run_interval_minutes` is validated to 30..43200 with no multiple-of-30 constraint, so
-    non-grid intervals are ordinary rather than exotic.
+    This has to be the cadence the grid actually produces, or the anchor pulls the scout onto a
+    schedule its owner did not configure: an anchor period shorter than the real cadence snaps
+    every dispatch back far enough that the scout comes due again early, forever. So it accounts
+    for both effects the grid applies. A scout comes due `DUE_GRACE_SECONDS` short of its interval,
+    and is then dispatched at the first tick at or after that, which is why the interval is
+    rounded up rather than down and why the grace is subtracted before rounding.
+
+    `run_interval_minutes` is validated to 30..43200 with no multiple-of-30 constraint, so an
+    interval that lands off the grid is allowed even though the fleet does not use one today.
     """
-    return max(1, -(-run_interval_minutes // COORDINATOR_INTERVAL_MINUTES))
+    due_after_seconds = run_interval_minutes * 60 - DUE_GRACE_SECONDS
+    return max(1, -(-due_after_seconds // TICK_SECONDS))
 
 
 def _slot_anchor(config_pk: str, run_interval_minutes: int, dispatched_at: datetime) -> datetime:
@@ -198,12 +202,15 @@ def _slot_anchor(config_pk: str, run_interval_minutes: int, dispatched_at: datet
 
     The snapped anchor always lands in `(this tick - period, this tick]`, where the period is the
     scout's cadence from `_ticks_per_interval`. Once a scout is dispatched on its own slot the
-    anchor is exactly that tick, so its cadence is the configured one forever after. Before then
-    the anchor can sit up to one period back, which shortens that single gap: the scout runs once
-    earlier than it otherwise would, and is then on its slot. That borrows the run from the next
-    period rather than adding one, so the fleet's total run count is unchanged. It is the
-    transition cost of moving a scout onto its slot, and it is paid once per scout, on rollout and
-    again after any interval edit.
+    anchor is exactly that tick, so its cadence is the configured one forever after.
+
+    Before then the anchor can sit up to one period back, which shortens that single gap and costs
+    the scout ONE EXTRA RUN. The shift is permanent rather than repaid: the scout keeps its new
+    phase and its normal cadence from there, so it never skips a later run to make up for the early
+    one. Each scout pays it once, when it first lands on its slot, and again after an interval edit
+    (which changes its period, and so its slot). Accepted deliberately: it buys a de-merge that
+    needs no migration and no backfill command, and the extra runs spread across every tick in the
+    period rather than landing in the wave this is meant to break up.
     """
     ticks_per_interval = _ticks_per_interval(run_interval_minutes)
     slot = _dispatch_slot(config_pk, run_interval_minutes)
@@ -543,11 +550,17 @@ def _collect_probe_runs(paused_configs: list[SignalScoutConfig], live_skills: se
     for config in paused_configs:
         if config.skill_name not in live_skills:
             continue
-        # `last_run_at` is stamped on every dispatch, including the failed run that tripped the
-        # breaker, so the first probe lands one full cooldown after the trip. A null (possible
-        # only through manual row surgery) probes immediately rather than never.
+        # The cooldown runs from the later of the lane's last dispatch and the moment it was
+        # paused. `last_run_at` alone is not enough: the run that trips the breaker was dispatched
+        # while the lane was still enabled, so it was stamped with a slot anchor that can sit up to
+        # a full period before the trip, and the cooldown would then read as already elapsed and
+        # probe on the next tick. `status_changed_at` alone is not enough either, because a failed
+        # probe leaves the status untouched and only `last_run_at` advances to restart the
+        # cooldown. Neither set (possible only through manual row surgery) probes immediately
+        # rather than never.
+        cooldown_anchors = [moment for moment in (config.last_run_at, config.status_changed_at) if moment is not None]
         cooldown_elapsed_s = (
-            (now - config.last_run_at).total_seconds() if config.last_run_at else float(AUTO_PAUSE_PROBE_INTERVAL_S)
+            (now - max(cooldown_anchors)).total_seconds() if cooldown_anchors else float(AUTO_PAUSE_PROBE_INTERVAL_S)
         )
         overdue_s = cooldown_elapsed_s - AUTO_PAUSE_PROBE_INTERVAL_S
         if overdue_s < 0:

--- a/products/signals/backend/temporal/agentic/scout_coordinator.py
+++ b/products/signals/backend/temporal/agentic/scout_coordinator.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta, tzinfo
 from uuid import UUID
 
-from django.db.models import Q
+from django.db.models import Case, DateTimeField, Q, Value, When
 from django.utils import timezone
 
 import structlog
@@ -170,13 +170,16 @@ def _dispatch_slot(config_pk: str, run_interval_minutes: int) -> int:
 
 
 def _ticks_per_interval(run_interval_minutes: int) -> int:
-    """How many coordinator ticks fit in one run interval, floored at 1.
+    """The scout's dispatch period, as a count of coordinator ticks.
 
-    An interval shorter than a tick (or one that isn't a whole number of ticks) collapses to a
-    single slot, which makes the anchor the plain tick start: dispatch is quantized to the tick
-    grid either way, so there is nothing finer to spread such a scout across.
+    Rounded UP, because that is the cadence the tick grid already imposes: a scout is dispatched at
+    the first tick at or after it comes due, so a 75-minute interval has always run every 90
+    minutes. Rounding down would make the anchor period shorter than the real cadence and dispatch
+    that scout every 60 minutes instead, which is more often than its owner configured.
+    `run_interval_minutes` is validated to 30..43200 with no multiple-of-30 constraint, so
+    non-grid intervals are ordinary rather than exotic.
     """
-    return max(1, run_interval_minutes // COORDINATOR_INTERVAL_MINUTES)
+    return max(1, -(-run_interval_minutes // COORDINATOR_INTERVAL_MINUTES))
 
 
 def _slot_anchor(config_pk: str, run_interval_minutes: int, dispatched_at: datetime) -> datetime:
@@ -193,9 +196,14 @@ def _slot_anchor(config_pk: str, run_interval_minutes: int, dispatched_at: datet
     a per-team cap or a missed tick anchors on the slot it was meant to have, so cohorts drift back
     together on the grid instead of ratcheting forward off it.
 
-    The snapped anchor always lands in `(this tick - interval, this tick]`, which puts the next due
-    time in `(this tick, this tick + interval]`. So no scout can come due again immediately, and
-    none waits more than one extra interval, including on the first stamp after this rolled out.
+    The snapped anchor always lands in `(this tick - period, this tick]`, where the period is the
+    scout's cadence from `_ticks_per_interval`. Once a scout is dispatched on its own slot the
+    anchor is exactly that tick, so its cadence is the configured one forever after. Before then
+    the anchor can sit up to one period back, which shortens that single gap: the scout runs once
+    earlier than it otherwise would, and is then on its slot. That borrows the run from the next
+    period rather than adding one, so the fleet's total run count is unchanged. It is the
+    transition cost of moving a scout onto its slot, and it is paid once per scout, on rollout and
+    again after any interval edit.
     """
     ticks_per_interval = _ticks_per_interval(run_interval_minutes)
     slot = _dispatch_slot(config_pk, run_interval_minutes)
@@ -208,9 +216,12 @@ def _stamp_dispatched_runs(dispatched_runs: list[PlannedRun], *, slot_aligned: b
     """Sync bulk stamp. `.update()` bypasses save(), so this per-tick write never hits the
     activity log.
 
-    Rolling-interval scouts are stamped with their slot anchor (see `_slot_anchor`), which means
-    one `.update()` per distinct anchor rather than one for the whole tick. Two kinds of config are
-    stamped with the wall clock instead:
+    Rolling-interval scouts are stamped with their slot anchor (see `_slot_anchor`). Anchors differ
+    per config, so they are applied through a single `CASE` expression rather than one `.update()`
+    per anchor: at the global tick cap a per-anchor loop would be up to `MAX_RUNS_PER_TICK`
+    sequential round trips inside an activity whose timeout is a minute, and a timeout there lands
+    after the children have already launched. Two kinds of config are stamped with the wall clock
+    instead:
 
     - A cron scout, because `_overdue_seconds` feeds `last_run_at` to croniter as the reference for
       the next slot. Cron slots are already absolute, so that path never had the drift, and moving
@@ -236,8 +247,15 @@ def _stamp_dispatched_runs(dispatched_runs: list[PlannedRun], *, slot_aligned: b
     ):
         anchor = _slot_anchor(str(pk), interval_minutes, now) if enabled and not cron_schedule else now
         pks_by_anchor.setdefault(anchor, []).append(pk)
-    for anchor, pks in pks_by_anchor.items():
-        SignalScoutConfig.all_teams.filter(pk__in=pks).update(last_run_at=anchor)
+    if not pks_by_anchor:
+        return
+    dispatched.update(
+        last_run_at=Case(
+            *(When(pk__in=pks, then=Value(anchor)) for anchor, pks in pks_by_anchor.items()),
+            default=Value(now),
+            output_field=DateTimeField(),
+        )
+    )
 
 
 @dataclass

--- a/products/signals/backend/test/test_scout_coordinator.py
+++ b/products/signals/backend/test/test_scout_coordinator.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import random
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from zoneinfo import ZoneInfo
 
 import pytest
+from freezegun import freeze_time
 from unittest.mock import AsyncMock, patch
 
 from django.test import override_settings
@@ -40,10 +41,12 @@ from products.signals.backend.scout_harness.team_limits import (
     _resolve_github_read_access,
     _resolve_global_max_runs_per_tick,
     _resolve_max_runs_per_day,
+    _resolve_slot_aligned_dispatch,
     _resolve_withheld_skills,
     _team_configs,
 )
 from products.signals.backend.temporal.agentic.scout_coordinator import (
+    COORDINATOR_INTERVAL_MINUTES,
     MAX_RUNS_PER_TICK,
     CoordinatorWorkflowInput,
     CoordinatorWorkflowOutput,
@@ -54,8 +57,10 @@ from products.signals.backend.temporal.agentic.scout_coordinator import (
     _allocate_tick_budget,
     _breaker_paused_configs_by_team,
     _collect_probe_runs,
+    _dispatch_slot,
     _DueRun,
     _overdue_seconds,
+    _slot_anchor,
     fetch_enabled_signals_scout_runs_activity,
     stamp_dispatched_signals_scout_runs_activity,
 )
@@ -63,6 +68,23 @@ from products.skills.backend.models.skills import LLMSkill
 
 _PAYLOAD_PATH = "products.signals.backend.scout_harness.team_limits.posthoganalytics.get_feature_flag_payload"
 _IS_CLOUD_PATH = "products.signals.backend.scout_harness.team_limits.is_cloud"
+
+# A dispatch instant deliberately off the tick grid, so a stamp that reaches the wall clock is
+# distinguishable from one that snapped to a slot.
+_DISPATCHED_AT = datetime(2026, 8, 8, 16, 31, 12, tzinfo=UTC)
+
+# Config ids drawn once and pinned, so slot spread and stability are asserted against fixed input
+# rather than a fresh sample per run.
+_SLOT_TEST_PKS = [
+    "97599cd0-c5d8-457d-ac65-139f71a1eb41",
+    "cbbfeb14-54e5-4dc3-b5cc-5f6341e40e36",
+    "c01ddd7f-dffa-44f8-88fc-a99c7d8b8302",
+    "2d3aee44-2ea5-4e35-bd94-125664596ff4",
+    "f6011ab7-2cf9-4488-9bb8-81fbc47e94fb",
+    "fcb15539-9802-4a2d-99aa-09fd0103ac53",
+    "9fc3e630-5d1a-4836-b102-ca8e7a4633ee",
+    "53892108-7c13-4518-bc63-f3e82903ae05",
+]
 
 # Enrollment is driven by the `signals-scout` flag payload allowlist. These async tests commit
 # (no transaction rollback across the worker thread), so leftover teams from other modules can
@@ -751,6 +773,66 @@ async def test_due_check_grace_boundary(ateam, seconds_short, expected_skill_nam
     assert [p.skill_name for p in planned] == expected_skill_names
 
 
+class TestSlotAlignedDispatchAnchors:
+    # Dispatch used to anchor on the post-fan-out wall clock, which made `last_run_at` absorb each
+    # tick's latency: once the creep passed `DUE_GRACE_SECONDS` a cohort missed its usual tick and
+    # re-anchored on the next one, merging into that tick's cohort, and the larger wave then made
+    # the next slip more likely. These pin the two properties that replace it — anchors land on the
+    # tick grid, and a cohort sharing a tick is spread over the interval rather than kept together.
+
+    @parameterized.expand([(1440,), (720,), (60,), (45,), (15,)])
+    def test_anchor_is_a_grid_point_no_more_than_one_interval_behind_the_tick(self, interval: int) -> None:
+        # The bound is what makes the next due time land in `(this tick, this tick + interval]`: an
+        # anchor in the future would stall the scout, one further back would re-dispatch it at once.
+        tick_start = datetime(2026, 8, 8, 16, 30, tzinfo=UTC)
+        for config_pk in _SLOT_TEST_PKS:
+            anchor = _slot_anchor(config_pk, interval, tick_start + timedelta(seconds=97))
+            assert anchor <= tick_start
+            assert tick_start - anchor < timedelta(minutes=interval)
+            assert int(anchor.timestamp()) % (COORDINATOR_INTERVAL_MINUTES * 60) == 0
+
+    def test_slot_does_not_move_between_processes(self) -> None:
+        # Pinned rather than recomputed: a switch to the builtin `hash()` would still be stable
+        # within one worker and reshuffle the whole fleet on every restart.
+        assert _dispatch_slot("97599cd0-c5d8-457d-ac65-139f71a1eb41", 1440) == 28
+
+    def test_a_cohort_sharing_one_tick_is_spread_across_the_interval(self) -> None:
+        dispatched_at = datetime(2026, 8, 8, 16, 31, 12, tzinfo=UTC)
+        anchors = {_slot_anchor(config_pk, 1440, dispatched_at) for config_pk in _SLOT_TEST_PKS}
+        assert len(anchors) > len(_SLOT_TEST_PKS) / 2
+
+    def test_dispatch_at_its_own_slot_re_anchors_on_that_slot(self) -> None:
+        # The steady state, and the property the ratchet lacked: a scout dispatched at its slot
+        # anchors exactly there however long planning and fan-out took, so nothing accumulates.
+        config_pk = _SLOT_TEST_PKS[0]
+        slot_start = _slot_anchor(config_pk, 1440, datetime(2026, 8, 8, 16, 30, tzinfo=UTC))
+        assert _slot_anchor(config_pk, 1440, slot_start + timedelta(days=1, seconds=214)) == slot_start + timedelta(
+            days=1
+        )
+
+    def test_a_deferred_dispatch_anchors_back_on_the_slot_it_missed(self) -> None:
+        # A run held back by a per-team cap or a missed tick used to re-anchor wherever it landed,
+        # which is how cohorts merged; it now returns to its own slot.
+        config_pk = _SLOT_TEST_PKS[0]
+        slot_start = _slot_anchor(config_pk, 1440, datetime(2026, 8, 8, 16, 30, tzinfo=UTC))
+        assert _slot_anchor(config_pk, 1440, slot_start + timedelta(hours=3)) == slot_start
+
+
+@pytest.mark.parametrize(
+    "payload,expected",
+    [
+        (None, True),
+        ({}, True),
+        ({"slot_aligned_dispatch": False}, False),
+        ({"slot_aligned_dispatch": True}, True),
+        ({"slot_aligned_dispatch": "false"}, True),  # not a literal bool → the default posture
+        ({"slot_aligned_dispatch": 0}, True),
+    ],
+)
+def test_resolve_slot_aligned_dispatch(payload, expected):
+    assert _resolve_slot_aligned_dispatch(payload) is expected
+
+
 @pytest.mark.asyncio
 @pytest.mark.django_db
 async def test_overdue_config_is_planned_without_stamping(ateam):
@@ -772,22 +854,79 @@ async def test_overdue_config_is_planned_without_stamping(ateam):
 
 @pytest.mark.asyncio
 @pytest.mark.django_db
-async def test_stamp_activity_advances_dispatched_configs(ateam):
+async def test_stamp_activity_advances_dispatched_configs_to_their_slot_anchor(ateam):
+    # The stamp must advance the schedule, and must land on the config's slot rather than the wall
+    # clock: stamping `now()` let fan-out latency accumulate on `last_run_at` until whole cohorts
+    # slipped onto a later tick and merged there.
     await database_sync_to_async(_create_skill)(ateam, "signals-scout-foo")
-    old = timezone.now() - timedelta(minutes=2000)
+    old = _DISPATCHED_AT - timedelta(minutes=2000)
     config = await database_sync_to_async(_create_config)(
         ateam, "signals-scout-foo", enabled=True, run_interval_minutes=1440, last_run_at=old
     )
 
-    before = timezone.now()
-    env = ActivityEnvironment()
-    await env.run(
-        stamp_dispatched_signals_scout_runs_activity,
-        StampDispatchedRunsInput(dispatched_runs=[PlannedRun(team_id=ateam.id, skill_name="signals-scout-foo")]),
-    )
+    with freeze_time(_DISPATCHED_AT):
+        env = ActivityEnvironment()
+        await env.run(
+            stamp_dispatched_signals_scout_runs_activity,
+            StampDispatchedRunsInput(dispatched_runs=[PlannedRun(team_id=ateam.id, skill_name="signals-scout-foo")]),
+        )
 
     refreshed = await database_sync_to_async(SignalScoutConfig.all_teams.get)(pk=config.pk)
-    assert refreshed.last_run_at is not None and refreshed.last_run_at >= before
+    assert refreshed.last_run_at == _slot_anchor(str(config.pk), 1440, _DISPATCHED_AT)
+    assert refreshed.last_run_at != _DISPATCHED_AT
+    assert refreshed.last_run_at > old
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "config_kwargs",
+    [
+        # A cron scout's `last_run_at` is the reference croniter picks the next slot from, so
+        # moving it back could re-select the slot this dispatch just fulfilled and double the run.
+        {"enabled": True, "run_cron_schedule": "30 16 * * *"},
+        # A disabled config here is a lane the failure breaker paused and the coordinator is
+        # probing; its `last_run_at` is the probe cooldown clock, which backdating would shorten.
+        {"enabled": False},
+    ],
+)
+async def test_stamp_activity_keeps_the_wall_clock_for_cron_and_probed_configs(ateam, config_kwargs):
+    await database_sync_to_async(_create_skill)(ateam, "signals-scout-foo")
+    config = await database_sync_to_async(_create_config)(
+        ateam, "signals-scout-foo", run_interval_minutes=1440, **config_kwargs
+    )
+
+    with freeze_time(_DISPATCHED_AT):
+        env = ActivityEnvironment()
+        await env.run(
+            stamp_dispatched_signals_scout_runs_activity,
+            StampDispatchedRunsInput(dispatched_runs=[PlannedRun(team_id=ateam.id, skill_name="signals-scout-foo")]),
+        )
+
+    refreshed = await database_sync_to_async(SignalScoutConfig.all_teams.get)(pk=config.pk)
+    assert refreshed.last_run_at == _DISPATCHED_AT
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_stamp_activity_falls_back_to_the_wall_clock_when_slot_alignment_is_off(ateam):
+    # `slot_aligned_dispatch: false` is the only way back to the previous stamping behaviour
+    # without a deploy, so it has to reach the write.
+    await database_sync_to_async(_create_skill)(ateam, "signals-scout-foo")
+    config = await database_sync_to_async(_create_config)(
+        ateam, "signals-scout-foo", enabled=True, run_interval_minutes=1440
+    )
+    payload = {**_allowlist_payload(), "slot_aligned_dispatch": False}
+
+    with freeze_time(_DISPATCHED_AT), patch(_PAYLOAD_PATH, side_effect=lambda *a, **k: payload):
+        env = ActivityEnvironment()
+        await env.run(
+            stamp_dispatched_signals_scout_runs_activity,
+            StampDispatchedRunsInput(dispatched_runs=[PlannedRun(team_id=ateam.id, skill_name="signals-scout-foo")]),
+        )
+
+    refreshed = await database_sync_to_async(SignalScoutConfig.all_teams.get)(pk=config.pk)
+    assert refreshed.last_run_at == _DISPATCHED_AT
 
 
 @pytest.mark.asyncio

--- a/products/signals/backend/test/test_scout_coordinator.py
+++ b/products/signals/backend/test/test_scout_coordinator.py
@@ -47,6 +47,7 @@ from products.signals.backend.scout_harness.team_limits import (
 )
 from products.signals.backend.temporal.agentic.scout_coordinator import (
     COORDINATOR_INTERVAL_MINUTES,
+    DUE_GRACE_SECONDS,
     MAX_RUNS_PER_TICK,
     CoordinatorWorkflowInput,
     CoordinatorWorkflowOutput,
@@ -773,6 +774,12 @@ async def test_due_check_grace_boundary(ateam, seconds_short, expected_skill_nam
     assert [p.skill_name for p in planned] == expected_skill_names
 
 
+def _ceil_to_tick(moment: datetime) -> datetime:
+    tick = timedelta(minutes=COORDINATOR_INTERVAL_MINUTES)
+    ticks = -(-int(moment.timestamp()) // int(tick.total_seconds()))
+    return datetime.fromtimestamp(ticks * tick.total_seconds(), tz=UTC)
+
+
 class TestSlotAlignedDispatchAnchors:
     # Dispatch used to anchor on the post-fan-out wall clock, which made `last_run_at` absorb each
     # tick's latency: once the creep passed `DUE_GRACE_SECONDS` a cohort missed its usual tick and
@@ -790,6 +797,20 @@ class TestSlotAlignedDispatchAnchors:
             assert anchor <= tick_start
             assert tick_start - anchor < timedelta(minutes=interval)
             assert int(anchor.timestamp()) % (COORDINATOR_INTERVAL_MINUTES * 60) == 0
+
+    @parameterized.expand([(30, 30), (45, 60), (60, 60), (75, 90), (100, 120), (720, 720), (1440, 1440)])
+    def test_steady_state_cadence_matches_the_tick_grid(self, interval: int, expected_gap: int) -> None:
+        # `run_interval_minutes` takes any value in 30..43200, so an interval that is not a whole
+        # number of ticks is ordinary. Deriving the slot period by rounding DOWN shortened the
+        # cadence for those: a 75-minute scout ran hourly and a 100-minute scout every 90 minutes,
+        # both more often than configured.
+        config_pk = _SLOT_TEST_PKS[0]
+        dispatched_at = _slot_anchor(config_pk, interval, datetime(2026, 8, 8, 16, 30, tzinfo=UTC))
+        for _ in range(4):
+            due_at = dispatched_at + timedelta(minutes=interval, seconds=-DUE_GRACE_SECONDS)
+            next_tick = _ceil_to_tick(due_at)
+            assert next_tick - dispatched_at == timedelta(minutes=expected_gap)
+            dispatched_at = _slot_anchor(config_pk, interval, next_tick)
 
     def test_slot_does_not_move_between_processes(self) -> None:
         # Pinned rather than recomputed: a switch to the builtin `hash()` would still be stable

--- a/products/signals/backend/test/test_scout_coordinator.py
+++ b/products/signals/backend/test/test_scout_coordinator.py
@@ -588,6 +588,29 @@ class TestFailureStreakProbeCollection:
 
         assert [p.skill_name for p in probes] == (["signals-scout-general"] if expect_probe else [])
 
+    def test_a_lane_paused_after_a_backdated_stamp_still_serves_its_full_cooldown(self) -> None:
+        # The run that trips the breaker is dispatched while the lane is still enabled, so it is
+        # stamped with a slot anchor that can sit up to a full period before the trip. Reading the
+        # cooldown off `last_run_at` alone then makes a lane paused seconds ago look a day cold,
+        # and it probes on the very next tick instead of serving the cooldown.
+        now = timezone.now()
+        team = Team.objects.create(organization=Organization.objects.create(name="probe-org"), name="probe-team")
+        with team_scope(team.id, canonical=True):
+            _create_config(
+                team,
+                "signals-scout-general",
+                status=SignalScoutConfig.Status.PAUSED_BY_SYSTEM,
+                pause_reason=SignalScoutConfig.PauseReason.REPEATED_FAILURES,
+                consecutive_failure_count=5,
+                last_run_at=now - timedelta(seconds=AUTO_PAUSE_PROBE_INTERVAL_S + 3600),
+                status_changed_at=now - timedelta(minutes=5),
+            )
+
+        paused_by_team = _breaker_paused_configs_by_team()
+        probes = _collect_probe_runs(paused_by_team.get(team.id, []), {"signals-scout-general"}, now)
+
+        assert probes == []
+
 
 @pytest.mark.asyncio
 @pytest.mark.django_db
@@ -798,12 +821,15 @@ class TestSlotAlignedDispatchAnchors:
             assert tick_start - anchor < timedelta(minutes=interval)
             assert int(anchor.timestamp()) % (COORDINATOR_INTERVAL_MINUTES * 60) == 0
 
-    @parameterized.expand([(30, 30), (45, 60), (60, 60), (75, 90), (100, 120), (720, 720), (1440, 1440)])
+    @parameterized.expand(
+        [(30, 30), (31, 30), (45, 60), (60, 60), (61, 60), (75, 90), (100, 120), (720, 720), (1440, 1440)]
+    )
     def test_steady_state_cadence_matches_the_tick_grid(self, interval: int, expected_gap: int) -> None:
-        # `run_interval_minutes` takes any value in 30..43200, so an interval that is not a whole
-        # number of ticks is ordinary. Deriving the slot period by rounding DOWN shortened the
-        # cadence for those: a 75-minute scout ran hourly and a 100-minute scout every 90 minutes,
-        # both more often than configured.
+        # The slot period has to equal the gap the grid actually produces, or the anchor drags the
+        # scout onto a shorter schedule than its owner configured, every dispatch, forever. Two
+        # ways to get it wrong, both caught here: rounding the interval down (a 75-minute scout
+        # dispatches hourly) and ignoring DUE_GRACE_SECONDS (a 31-minute scout comes due at 30
+        # minutes exactly, so its period is one tick, not two).
         config_pk = _SLOT_TEST_PKS[0]
         dispatched_at = _slot_anchor(config_pk, interval, datetime(2026, 8, 8, 16, 30, tzinfo=UTC))
         for _ in range(4):


### PR DESCRIPTION
## Problem

Scouts that should run through the day all fire in the same minute instead, and the wave keeps growing. One tick recently launched roughly 317 runs at once, up from about 100, and every LLM stream those runs opened landed on the gateway together.

- The coordinator dispatches on an epoch-aligned 30-minute grid, and about 96% of the fleet runs a 1440-minute interval, so whole cohorts share a tick.
- `stamp_dispatched_signals_scout_runs_activity` writes `last_run_at = timezone.now()` after the whole fan-out, so the anchor absorbs that tick's planning and fan-out latency.
- A scout is due when `now >= last_run_at + interval - 60s`, so once the accumulated latency passes that 60 second grace the scout misses its usual tick.
- The scout re-anchors on the next tick permanently, merging its cohort into that tick's cohort.
- A larger wave takes longer to fan out, stamps later, and slips again. Nothing ever moves a scout back to an earlier tick.

## Changes

- A dispatched scout now anchors on its own stable slot on the tick grid, so cohorts spread back across the interval instead of merging.
- `_slot_anchor` picks the slot occurrence at or before the dispatch tick. The slot comes from a sha256 digest of the config id, so it never moves across restarts or redeploys.
- Latency stops accumulating, because the anchor is a grid point rather than a measured time.
- A run deferred by a per-team cap or a missed tick returns to the slot it was meant to have, rather than re-anchoring where it landed.
- The dispatch period is the gap the grid actually produces: a scout comes due a 60-second grace short of its interval, and runs at the first tick at or after that. So a 75-minute scout runs every 90 minutes and a 31-minute one every 30.
- The snapped anchor lands in `(this tick - period, this tick]`, so a scout never comes due again at the tick it just ran.
- Once a scout is dispatched on its own slot the anchor is exactly that tick, so its cadence is the configured one from then on.
- Before then the anchor can sit up to one period back, which shortens that single gap and costs the scout one extra run.
- The shift is permanent rather than repaid, so the scout keeps its new phase and never skips a later run to make up for the early one. Each scout pays it once, on rollout and again after an interval edit.
- At current fleet volume of roughly 8,000 runs a day, the rollout therefore costs on the order of 8,000 extra runs, once. I am accepting that rather than adding a schedule-anchor column to avoid it.
- Those extra runs do not land in the wave this PR exists to break up. On transition day the peak tick is the existing merged wave, unchanged, and the extra runs spread across all 48 ticks at roughly 21 per tick.
- `last_run_at` reads up to one period early over the same window, and the config API, the fleet UI, and `assess_health.py` all render it as the last dispatch. In steady state it is the exact dispatch tick, so the skew is bounded to the transition and to interval edits.
- The existing merged wave needs no migration or backfill. Each scout re-slots on its next dispatch, so the fleet spreads within one interval.
- Cron scouts keep the wall clock, because `_overdue_seconds` feeds `last_run_at` to croniter as the reference for the next slot, and moving it back could re-select the slot the dispatch just fulfilled.
- Breaker-paused lanes under probe keep the wall clock, because their `last_run_at` is the probe cooldown clock rather than a schedule anchor.
- `slot_aligned_dispatch: false` in the `signals-scout` flag payload reverts to wall-clock stamping with no deploy.
- Anchors differ per config, so the stamp applies them through a single `CASE` expression. The write stays one round trip, as it was before this PR.

I chose slot anchoring over the smaller fix of quantizing the stamp to the tick grid without a per-config slot. That also stops the growth, but it leaves the merged wave merged forever and needs a separate one-off command to break it up, which would write a future-dated `last_run_at` that the config API, the fleet UI, and the health scripts all surface as the scout's last run.

No workflow body changed, so this needs no `workflow.patched` gate. The activity implementation and its call site are the whole change.

> [!NOTE]
> This does not flatten a single cohort's burst. A de-merged tick still launches its own cohort in one minute. Harness-side smoothing is a separate conversation with the gateway owners.

## How did you test this code?

`products/signals/backend/test/test_scout_coordinator.py`, plus `uv run mypy --cache-fine-grained .` repo-wide.

New coverage, and the regression each group catches:

- `TestSlotAlignedDispatchAnchors` pins the anchor bound. An off-by-one in the snap that puts the anchor in the future stalls the scout; one that puts it further than a period back re-dispatches it immediately. Neither is visible without this assertion.
- `test_steady_state_cadence_matches_the_tick_grid` pins the dispatch gap for nine intervals. A period shorter than the real cadence makes the anchor drag a scout onto a faster schedule every dispatch, forever, and there are two ways to get it wrong: rounding the interval down sends a 75-minute scout hourly, and ignoring the grace sends a 31-minute scout to 30. `run_interval_minutes` accepts any value in 30..43200, and nothing else in the suite reads a scout's gap over successive dispatches.
- `test_a_lane_paused_after_a_backdated_stamp_still_serves_its_full_cooldown` catches the breaker probing early. A lane trips while it is still enabled, so it carries a slot anchor that can predate the pause by a period, and reading the cooldown off that alone probes a just-paused lane on the next tick.
- `test_slot_does_not_move_between_processes` pins one config id to its slot. A switch to the builtin `hash()` stays stable inside one worker and reshuffles the whole fleet on every restart, which no other test would catch.
- `test_a_cohort_sharing_one_tick_is_spread_across_the_interval` catches a slot that stops varying per config, which is the whole de-merge.
- `test_dispatch_at_its_own_slot_re_anchors_on_that_slot` and `test_a_deferred_dispatch_anchors_back_on_the_slot_it_missed` catch a return to latency-accumulating anchors.
- `test_stamp_activity_keeps_the_wall_clock_for_cron_and_probed_configs` catches backdating a croniter reference, which doubles a cron scout's daily runs.
- `test_stamp_activity_falls_back_to_the_wall_clock_when_slot_alignment_is_off` catches a kill switch that does not reach the write.

`test_stamp_activity_advances_dispatched_configs` asserted `last_run_at >= before`, which slot anchoring makes false by design. I rewrote it to assert the slot anchor.

I did not run this against a live coordinator. I simulated the transition instead, over a 1000-config cohort sharing one tick. The peak tick drops from 1000 runs to 31 within one interval, spread over all 48 ticks. Volume in 24-hour windows measured from the wave:

| 24h window from the wave | before | after |
|---|---|---|
| 0 | 1000 | 1984 |
| 1 | 1000 | 1000 |
| 2 | 1000 | 1000 |
| total over 8 days | 7000 | 7984 |

An earlier revision of this description claimed the pull-forward added no runs. That was wrong: I had anchored the windows at an arbitrary origin, which split the wave from the pulled-forward runs across adjacent windows and made each read as normal. Codex caught it in review.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`products/signals/backend/scout_harness/AGENTS.md` gains the anchoring rule under Coordinator, and drops a stale `MAX_RUNS_PER_TICK = 50`. No user-facing docs change, because dispatch timing is internal.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude Opus 5, via Claude Code) wrote this. Andy directed it and picked the approach.

Skills invoked: `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.

I presented four options for the anchor fix, from a one-line grace bump to full slot anchoring, and Andy picked slot anchoring. The first commit derived the dispatch period by rounding the interval down; Greptile and Codex both caught that this dispatches non-grid intervals more often than configured, and the second commit rounds up instead. A third commit derives the period from the real due boundary (the grace made a 31-minute interval come due exactly on a tick) and runs the breaker's probe cooldown from the later of the last dispatch and the pause, since a lane trips while still enabled and so carries a backdated anchor. I also offered to add jittered child starts to flatten a single cohort's burst; he deferred that, since it needs a timer inside `RunSignalsScoutWorkflow` and carries Temporal versioning risk that this change avoids entirely.

Everything committed is derived from this repository and from a simulation I wrote. The test config ids are freshly generated UUIDs, not real ones.



