### PR TITLE
fix(wordpress): stop retrying a TLS hostname/certificate mismatch

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/source.py
@@ -106,6 +106,12 @@ To sync private content or authenticate, create an [Application Password](https:
             # a security or caching plugin) can't be turned into rows by retrying. Matches the stable
             # prefix RESTClientNonRetryableError uses, not the variable URL that follows.
             "Non-JSON response from": "The WordPress site returned a non-JSON response (for example an HTML error, login, or maintenance page) instead of data. Confirm the REST API is enabled and reachable at this URL and isn't blocked by a security or caching plugin, then try again.",
+            # The site's TLS certificate doesn't cover its own hostname — common on shared hosting
+            # platforms whose default certificate doesn't include the customer's custom domain. The
+            # cert is wrong every time, not just this request, so retrying can't help. Match the
+            # exception class name that `ssl_match_hostname.match_hostname` raises, not the hostname
+            # or cert names that follow it in the message.
+            "CertificateError": "The WordPress site's TLS certificate doesn't match its domain. This is often caused by a hosting platform's default certificate not covering a custom domain. Ask your hosting provider to install a certificate for this domain, then try again.",
         }
 
     def get_canonical_descriptions(self) -> CanonicalDescriptions:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/tests/test_wordpress_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/tests/test_wordpress_source.py
@@ -52,7 +52,8 @@ class TestWordpressSource:
         assert pass_field.secret is True
 
     @pytest.mark.parametrize(
-        "expected_key", ["401 Client Error", "403 Client Error", "404 Client Error", "Non-JSON response from"]
+        "expected_key",
+        ["401 Client Error", "403 Client Error", "404 Client Error", "Non-JSON response from", "CertificateError"],
     )
     def test_non_retryable_errors(self, expected_key):
         assert expected_key in self.source.get_non_retryable_errors()
@@ -62,6 +63,19 @@ class TestWordpressSource:
         # the stable prefix, so the variable URL must not stop it being recognised as non-retryable.
         errors = self.source.get_non_retryable_errors()
         raised = "Non-JSON response from https://example.com/wp-json/wp/v2/posts"
+        matches = [friendly for key, friendly in errors.items() if key in raised]
+        assert matches and matches[0] is not None
+
+    def test_certificate_error_message_matches_non_retryable_error(self):
+        # requests wraps a hostname/cert mismatch as an SSLError whose message embeds the
+        # underlying CertificateError; the classifier matches on that class name, so the variable
+        # hostname and cert names around it must not stop it being recognised as non-retryable.
+        errors = self.source.get_non_retryable_errors()
+        raised = (
+            "HTTPSConnectionPool(host='example.com', port=443): Max retries exceeded with url: "
+            "/wp-json/wp/v2/categories (Caused by SSLError(CertificateError(\"hostname 'example.com' "
+            "doesn't match either of '*.example-host.test', 'example-host.test'\")))"
+        )
         matches = [friendly for key, friendly in errors.items() if key in raised]
         assert matches and matches[0] is not None
 


### PR DESCRIPTION
## Problem

A WordPress sync keeps retrying when the site's TLS certificate doesn't cover its own hostname, a permanent config problem the customer's hosting provider has to fix, not something a retry can resolve.

This happens on shared hosting platforms (for example Cloudways) whose default certificate only covers the platform's own wildcard domain, not a customer's custom domain pointed at it. Every request to that site fails with the same `SSLError`/`CertificateError`, confirmed in [error tracking](https://us.posthog.com/project/2/error_tracking/019fe947-a8d3-7d23-a2f5-7bd8a4d63e8f) with a stack trace rooted in `wordpress.py`'s `fetch_page`.

## Changes

- Add a `CertificateError` entry to `WordpressSource.get_non_retryable_errors()`, matching the stable exception class name `requests`/`urllib3` embed in the message rather than the variable hostname or certificate names around it.
- The friendly message tells the customer to get their hosting provider to install a certificate for their domain.

## How did you test this code?

Added `test_certificate_error_message_matches_non_retryable_error`, asserting a realistic wrapped `SSLError` message (hostname and cert names varied) still matches the new non-retryable entry. Extended the existing `test_non_retryable_errors` parametrized case with the new key.

Ran the full `wordpress` test suite locally: 115 passed. Not run: an end-to-end Temporal sync against a live misconfigured site, since this sandbox has no such site to point at.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None; this changes retry classification only, no documented behavior.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error tracking MCP tools to pull the issue's stack trace and confirm the failure originates in `products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/wordpress.py`. Read `stripe/source.py` and several other sources' (`metabase`, `grafana`, `gerrit`, `argocd`) existing `SSLError`/`get_non_retryable_errors` handling for precedent before picking the `CertificateError` match key. Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`.