### PR TITLE
fix(data-warehouse): validate uploaded file against selected format before upload

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/fileUploadSourceLogic.test.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/fileUploadSourceLogic.test.ts
@@ -1,0 +1,35 @@
+import { FileUploadFormat } from './fileUploadSource'
+import { fileFormatMismatchError, fileUploadFormErrors } from './fileUploadSourceLogic'
+
+describe('file upload format validation', () => {
+    it.each<[string, FileUploadFormat]>([
+        ['data.xlsx', 'csv'],
+        ['data.xls', 'json'],
+        ['report.numbers', 'parquet'],
+    ])('rejects spreadsheet file %s regardless of selected format', (filename, format) => {
+        expect(fileFormatMismatchError(filename, format)).toContain('Spreadsheet files')
+    })
+
+    it('flags a file whose extension belongs to a different supported format', () => {
+        expect(fileFormatMismatchError('events.json', 'csv')).toContain('looks like a JSON file')
+    })
+
+    it.each<[string, FileUploadFormat]>([
+        ['events.csv', 'csv'],
+        ['events.ndjson', 'json'],
+        ['events.parquet', 'parquet'],
+    ])('accepts %s when the matching format is selected', (filename, format) => {
+        expect(fileFormatMismatchError(filename, format)).toBeUndefined()
+    })
+
+    it('leaves an unrecognized extension alone so a valid file is not blocked', () => {
+        // A CSV exported as .txt is still parseable; we only block confident mismatches.
+        expect(fileFormatMismatchError('export.txt', 'csv')).toBeUndefined()
+    })
+
+    it('surfaces the mismatch as a files error so submission is blocked', () => {
+        const file = new File(['a,b'], 'sheet.xlsx')
+        const errors = fileUploadFormErrors({ files: [file], table_name: 'my_table', file_format: 'csv' })
+        expect(errors.files).toContain('Spreadsheet files')
+    })
+})

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/fileUploadSourceLogic.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/fileUploadSourceLogic.tsx
@@ -21,6 +21,48 @@ export const FILE_UPLOAD_ACCEPT: Record<FileUploadFormat, string> = {
     parquet: '.parquet',
 }
 
+const FORMAT_LABELS: Record<FileUploadFormat, string> = {
+    csv: 'CSV',
+    json: 'JSON',
+    parquet: 'Parquet',
+}
+
+// Extensions we can confidently map to a supported format. Anything not listed (e.g. .txt) is left
+// alone so a validly-formatted file with an unusual extension isn't blocked.
+const EXTENSION_FORMATS: Record<string, FileUploadFormat> = {
+    csv: 'csv',
+    json: 'json',
+    ndjson: 'json',
+    jsonl: 'json',
+    parquet: 'parquet',
+    pqt: 'parquet',
+}
+
+const SPREADSHEET_EXTENSIONS = new Set(['xlsx', 'xls', 'xlsm', 'xlsb', 'ods', 'numbers'])
+
+function fileExtension(filename: string): string {
+    const match = /\.([^.]+)$/.exec(filename.toLowerCase())
+    return match ? match[1] : ''
+}
+
+// The `accept` attribute only hints the file picker; a mismatched file can still be dragged in or
+// left selected after switching format. Catch the confident cases here so the user gets clear
+// guidance instead of an opaque column-read failure after a wasted upload round-trip.
+export function fileFormatMismatchError(filename: string, format: FileUploadFormat): string | undefined {
+    const ext = fileExtension(filename)
+    if (!ext) {
+        return undefined
+    }
+    if (SPREADSHEET_EXTENSIONS.has(ext)) {
+        return "Spreadsheet files like Excel can't be uploaded directly. Export to CSV, JSON, or Parquet first, then upload that."
+    }
+    const extFormat = EXTENSION_FORMATS[ext]
+    if (extFormat && extFormat !== format) {
+        return `This looks like a ${FORMAT_LABELS[extFormat]} file, but you selected the ${FORMAT_LABELS[format]} format. Set the format to ${FORMAT_LABELS[extFormat]}, or choose a ${FORMAT_LABELS[format]} file.`
+    }
+    return undefined
+}
+
 const HOGQL_TABLE_NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_]*$/
 
 export interface FileUploadForm {
@@ -46,14 +88,20 @@ export function parseFileUploadFormat(value: string | undefined): FileUploadForm
     return normalized === 'csv' || normalized === 'json' || normalized === 'parquet' ? normalized : null
 }
 
-export function fileUploadFormErrors({ files, table_name }: Partial<FileUploadForm>): Record<string, unknown> {
+export function fileUploadFormErrors({
+    files,
+    table_name,
+    file_format,
+}: Partial<FileUploadForm>): Record<string, unknown> {
     const file = files?.[0]
     return {
         files: !file
             ? 'Please choose a file to upload.'
             : file.size > MAX_FILE_UPLOAD_SIZE_BYTES
               ? 'This file is larger than 50MB. For bigger files, connect the bucket they live in as a self-managed source instead.'
-              : undefined,
+              : file_format
+                ? fileFormatMismatchError(file.name, file_format)
+                : undefined,
         table_name: !table_name
             ? 'Please enter a table name.'
             : !HOGQL_TABLE_NAME_REGEX.test(table_name)
@@ -170,6 +218,11 @@ export const fileUploadSourceLogic = kea<fileUploadSourceLogicType>([
                 }
                 if (file.size > MAX_FILE_UPLOAD_SIZE_BYTES) {
                     lemonToast.error('This file is larger than the 50MB upload limit.')
+                    return
+                }
+                const formatMismatch = fileFormatMismatchError(file.name, file_format)
+                if (formatMismatch) {
+                    lemonToast.error(formatMismatch)
                     return
                 }
 


### PR DESCRIPTION
## Problem

A user uploading a spreadsheet or a file that does not match the selected format in the data warehouse new-source wizard only found out after the whole file uploaded. The upload then failed with a column-read error that read like the file was corrupt, with no hint that the format dropdown was the problem.

- The `accept` attribute on the file input is only a picker hint. A file dragged in, or left selected after switching format, bypasses it.
- The mismatch was caught server-side, after a full upload round-trip, when the columns failed to parse.

## Changes

- The wizard now checks the chosen file against the selected format before uploading, and blocks the step with a clear message.
- A spreadsheet file (`.xlsx`, `.xls`, and similar) is told to export to CSV, JSON, or Parquet first.
- A file whose extension is a different supported format (for example a `.json` file with CSV selected) says which format to switch to.
- An unknown extension (for example `.txt`) still uploads, so a valid file with an unusual extension is not blocked.

No visual change beyond the new inline error and toast copy, so no screenshot.

## How did you test this code?

- Added `fileUploadSourceLogic.test.ts` over the pure validation function. Regression it catches: without the pre-check, an Excel-as-CSV upload passes client validation and fails opaquely server-side. No existing test exercised the file-upload validation path.
- Ran that jest suite locally. Ran oxlint and oxfmt over the touched files. Ran `tsgo` (typescript:check): no errors in the touched files; the pre-existing errors elsewhere are the unbuilt `@posthog/quill` workspace and are unrelated.
- Not run: the app end-to-end. This sandbox has no running dev stack.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (actually Claude) wrote this while reviewing data warehouse new-source onboarding friction surfaced by a Replay Vision scan. Sessions showed a user upload a file with the wrong format selected and hit an unclear failure after the upload finished. The fix validates client-side first.

Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`.

The friction that motivated this came from summaries of real user sessions. Nothing from those summaries is in the code, tests, or this description; the test fixtures use invented filenames.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
