### PR TITLE
fix(data-warehouse): stop the v3 reconcile sweep from starving the claim path

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
@@ -12,6 +12,7 @@ import asyncio
 from collections.abc import Callable, Coroutine
 from datetime import datetime
 from typing import Any
+from uuid import uuid4
 
 from django.db import close_old_connections
 
@@ -318,6 +319,20 @@ class DeltaBatchConsumerAdapter:
         # Piggyback the reconcile cadence for the queue-freshness gauge: same
         # connection, same periodicity, and isolated so it can't break the sweep.
         await self._observe_queue_freshness(conn)
+
+        # Single-flight everything below fleet-wide: the sweeps reconcile global
+        # queue state, so N pods running them do N times the work of one for zero
+        # extra correctness — and their cost scales with the failure backlog,
+        # which is exactly when concurrent copies on every pod can saturate the
+        # queue DB and starve the claim path (the 2026-08-09 loader stall: 36
+        # concurrent sweep queries, claim polls timing out fleet-wide). The
+        # freshness probe above deliberately stays outside the slot: every pod
+        # must keep its own gauge current, or max() across the fleet pins stale
+        # values. The token is throwaway — the slot is never verified or
+        # released, it just expires into the next pod's hands.
+        if not await BatchQueue.try_acquire_reconcile_sweep_slot(conn, owner_token=str(uuid4())):
+            logger.debug("reconcile_sweep_slot_held_elsewhere")
+            return
 
         refs = await BatchQueue.get_failed_runs(
             conn,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
@@ -36,6 +36,16 @@ LEASE_TABLE = "sourcegrouplease"
 # sweep fire together.
 LEASE_TTL_SECONDS = 300
 
+# Sentinel lease row that single-flights the reconcile sweep across the fleet.
+# Real groups have team_id >= 1 and UUID schema ids, so this key can never
+# collide with (or be claimed/unlocked as) an actual group. The slot TTL sits
+# just under the engine's 300s reconcile interval so single-flighting never
+# makes reconcile latency worse than the old every-pod cadence: the first pod
+# whose timer fires after expiry wins the next sweep.
+RECONCILE_SWEEP_LEASE_TEAM_ID = 0
+RECONCILE_SWEEP_LEASE_SCHEMA_ID = "__reconcile-sweep__"
+RECONCILE_SWEEP_SLOT_TTL_SECONDS = 240
+
 # Partition pruning hint: only scan partitions within this window.
 # Set to 2x the retention period so the planner can skip dropped
 # partitions. Not a correctness filter -- older partitions are already
@@ -794,6 +804,46 @@ class BatchQueue:
         return bool(row and row[0])
 
     @staticmethod
+    async def try_acquire_reconcile_sweep_slot(
+        conn: psycopg.AsyncConnection[Any],
+        *,
+        owner_token: str,
+        ttl_seconds: int = RECONCILE_SWEEP_SLOT_TTL_SECONDS,
+    ) -> bool:
+        """Claim the fleet-wide reconcile-sweep slot; True means this pod runs the sweep.
+
+        A sentinel row in the group-lease table, CAS-acquired only when expired.
+        There is deliberately no release and no same-owner re-entrancy clause:
+        the TTL *is* the fleet-wide sweep cadence, so at most one sweep starts
+        per TTL no matter how many pods (or how many startup sweeps after a
+        restart wave) race for it. A lease row rather than a session advisory
+        lock for the same reason as group claiming: a lingering pgbouncer
+        session must not be able to hold the slot forever — a crashed winner's
+        slot frees itself at expiry.
+        """
+        async with conn.cursor() as cur:
+            await cur.execute(
+                f"""
+                INSERT INTO {LEASE_TABLE} (team_id, schema_id, owner_token, expires_at, acquired_at, updated_at)
+                VALUES (%(team_id)s, %(schema_id)s, %(owner)s, now() + make_interval(secs => %(ttl)s), now(), now())
+                ON CONFLICT (team_id, schema_id) DO UPDATE
+                    SET owner_token = excluded.owner_token,
+                        expires_at = excluded.expires_at,
+                        acquired_at = now(),
+                        updated_at = now()
+                    WHERE {LEASE_TABLE}.expires_at < now()
+                RETURNING id
+                """,
+                {
+                    "team_id": RECONCILE_SWEEP_LEASE_TEAM_ID,
+                    "schema_id": RECONCILE_SWEEP_LEASE_SCHEMA_ID,
+                    "owner": owner_token,
+                    "ttl": ttl_seconds,
+                },
+            )
+            return await cur.fetchone() is not None
+
+    @staticmethod
     async def renew_lease(
         conn: psycopg.AsyncConnection[Any],
         *,
@@ -1039,6 +1089,16 @@ class BatchQueue:
                     WHERE
                         b.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
                         AND b.latest_state = 'failed'
+                        -- Implied by the s.created_at lower bound (the denormalizing
+                        -- status CTEs set state_changed_at to exactly the terminal
+                        -- status row's created_at), so it changes no semantics: it
+                        -- exists purely to prune the outer scan BEFORE the DISTINCT ON
+                        -- sort and the per-row lateral probes. Without it the sort
+                        -- input is every failed batch in the pruning window — 1.36M
+                        -- rows during the 2026-08 failure storm, a minutes-long disk
+                        -- spill at work_mem=4MB that, run by every pod concurrently,
+                        -- starved the claim path (the 2026-08-09 loader stall).
+                        AND b.state_changed_at >= now() - make_interval(secs => %(lookback)s)
                         AND s.job_state = 'failed'
                         AND s.created_at <= now() - make_interval(secs => %(grace)s)
                         AND s.created_at >= now() - make_interval(secs => %(lookback)s)

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
@@ -831,7 +831,7 @@ class BatchQueue:
                         expires_at = excluded.expires_at,
                         acquired_at = now(),
                         updated_at = now()
-                    WHERE {LEASE_TABLE}.expires_at < now()
+                    WHERE {LEASE_TABLE}.expires_at <= now()
                 RETURNING id
                 """,
                 {
@@ -1098,7 +1098,11 @@ class BatchQueue:
                         -- rows during the 2026-08 failure storm, a minutes-long disk
                         -- spill at work_mem=4MB that, run by every pod concurrently,
                         -- starved the claim path (the 2026-08-09 loader stall).
-                        AND b.state_changed_at >= now() - make_interval(secs => %(lookback)s)
+                        -- state_changed_at is nullable; NULL rows must stay visible or a
+                        -- failed run could strand until the retention prune (the stranded
+                        -- sweep skips runs that have a failed batch).
+                        AND (b.state_changed_at IS NULL
+                             OR b.state_changed_at >= now() - make_interval(secs => %(lookback)s))
                         AND s.job_state = 'failed'
                         AND s.created_at <= now() - make_interval(secs => %(grace)s)
                         AND s.created_at >= now() - make_interval(secs => %(lookback)s)

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
@@ -1291,6 +1291,43 @@ class TestDeadJobSkip:
 
 
 class TestReconcileFailedRuns:
+    @pytest.fixture(autouse=True)
+    def _hold_sweep_slot(self):
+        """Grant the fleet-wide sweep slot by default — these tests exercise the sweep body, not the slot."""
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.try_acquire_reconcile_sweep_slot",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            yield
+
+    @pytest.mark.asyncio
+    async def test_slot_held_elsewhere_skips_sweep_but_still_probes_freshness(self):
+        # Single-flighting must never silence the freshness gauge: every pod
+        # reports it, only the slot winner runs the sweep body.
+        consumer = _make_consumer()
+
+        with (
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.try_acquire_reconcile_sweep_slot",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_oldest_unclaimed_batch_age_seconds",
+                new_callable=AsyncMock,
+                return_value=42.0,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_failed_runs",
+                new_callable=AsyncMock,
+            ) as mock_failed_runs,
+        ):
+            await consumer._reconcile_failed_runs()
+
+        assert OLDEST_UNCLAIMED_BATCH_SECONDS._value.get() == 42.0
+        mock_failed_runs.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_reconcile_reports_queue_freshness_gauge(self):
         # The gauge feeds the loader's data-freshness alert; if a reconcile

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
@@ -196,6 +196,23 @@ def sync_conn(_db_url: str):
 
 
 @pytest.mark.django_db(transaction=True)
+class TestReconcileSweepSlot:
+    @pytest.mark.asyncio
+    async def test_first_acquire_wins_and_slot_is_not_reentrant(self, conn, conn_b):
+        assert await BatchQueue.try_acquire_reconcile_sweep_slot(conn, owner_token="pod-a") is True
+        assert await BatchQueue.try_acquire_reconcile_sweep_slot(conn_b, owner_token="pod-b") is False
+        # Same owner is refused too: the slot paces the fleet-wide cadence, it
+        # is not an ownership lock — re-entrancy would let one pod sweep in a
+        # tight loop, which is exactly the stampede the slot exists to prevent.
+        assert await BatchQueue.try_acquire_reconcile_sweep_slot(conn, owner_token="pod-a") is False
+
+    @pytest.mark.asyncio
+    async def test_expired_slot_is_reacquirable(self, conn, conn_b):
+        assert await BatchQueue.try_acquire_reconcile_sweep_slot(conn, owner_token="pod-a", ttl_seconds=0) is True
+        assert await BatchQueue.try_acquire_reconcile_sweep_slot(conn_b, owner_token="pod-b") is True
+
+
+@pytest.mark.django_db(transaction=True)
 class TestBatchQueueInsert:
     @pytest.mark.asyncio
     async def test_insert_returns_uuid(self, conn):


### PR DESCRIPTION
## Problem

Customers' warehouse source syncs stopped landing on prod-us on 2026-08-09: the v3 loader claimed zero batches fleet-wide (`WarehouseSourcesLoaderStalled`), with 161k pending batches queued. The cause was the loader's own reconcile sweep.

`get_failed_runs`' 24h lookback only applies to `s.created_at` *inside* the lateral join, so the outer scan reads every `latest_state='failed'` batch in the 14-day partition window and sorts it before `DISTINCT ON` can reduce. A six-day failure storm (Aug 3–8, peaking at 329k failed batches/day against a single-digits-per-hour baseline) grew that scan to 1.36M rows — a 1.2M-row × ~508B sort against `work_mem=4MB`, spilling to disk for 2–5 minutes per run.

Every pod runs the sweep every 300s **and immediately on startup**. Measured mid-incident: 36 concurrent copies, all in `IO/BufFileWrite`, saturating the queue DB. Claim polls then blew their 180s ceiling fleet-wide, pods tripped the poll-failure liveness threshold, and each restart fired another sweep — a self-sustaining stampede. Sweep cost scales with the failure backlog, so the sweep gets most expensive exactly when the fleet can least afford it.

Mitigated short-term by capping `--sweep-timeout` at 15s in PostHog/charts#14090; this PR is the durable fix.

## Changes

**1. Bound `get_failed_runs`' outer scan by `state_changed_at`** (`jobs_db.py`)

The new predicate is implied by the existing `s.created_at >= now() - lookback` bound — the denormalizing status CTEs set `state_changed_at` to exactly the terminal status row's `created_at` — so the result set is unchanged; it exists purely to prune the outer scan before the sort and the per-row lateral probes.

Verified on prod-us: 0 failed rows with NULL `state_changed_at`; `state_changed_at` == latest status `created_at` for 266,561/266,561 sampled failed batches; old vs new query returned **identical result sets**, 84.1s → 16.0s mid-incident (the gap widens on a healthy DB — the new query prunes before the sort instead of spilling).

**2. Single-flight the sweep fleet-wide** (`jobs_db.py`, `consumer.py`)

A sentinel row `(team_id=0, schema_id='__reconcile-sweep__')` in the group-lease table, CAS-acquired only when expired. Deliberate properties:

- **No release, no same-owner re-entrancy**: the 240s TTL *is* the fleet-wide cadence — at most one sweep starts per TTL regardless of pod count or restart waves (the startup-sweep stampede becomes a no-op). TTL sits under the 300s per-pod timer so reconcile latency never gets worse than the old every-pod cadence; a crashed winner frees itself at expiry.
- **Lease row, not a session advisory lock** — same reasoning as group claiming (this module removed session advisory locks because a lingering PgBouncer session could hold them forever).
- **The freshness-gauge probe stays outside the slot**: every pod must keep reporting `warehouse_pg_queue_oldest_unclaimed_batch_seconds`, or `max()` across the fleet would pin stale values from non-winning pods.
- Sentinel can't collide with real groups (team ids ≥ 1, UUID schema ids) and never matches the claim/recovery joins, which drive from `sourcebatch` rows.

## How did you test this code?

I'm an agent. Automated tests added; what I ran and couldn't run:

- `test_consumer.py::TestReconcileFailedRuns` — passes locally (9 tests: 8 existing under a new autouse slot-granting fixture, plus a new test that a non-winning pod skips the sweep body but still reports the freshness gauge — the regression that would silently blind the freshness alert).
- `test_jobs_db.py::TestReconcileSweepSlot` — two new real-DB tests (first-acquire wins / not re-entrant; expired slot reacquirable). **Not run locally** (no local test DB with migrations); the identical assertions were exercised against a scratch Postgres 15 via the actual `BatchQueue.try_acquire_reconcile_sweep_slot` code path, all passing. CI runs the real ones.
- Query equivalence and timing verified against prod-us mid-incident (identical 100-run result sets, 84.1s → 16.0s above).
- `ruff check` / `ruff format --check` clean.

Not checked: prod-eu (no access from this session); interaction with the duckgres sink's separate reconcile path (untouched — the slot lives in the delta adapter only).

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

Authored by Claude (Fable 5) via Claude Code during the prod-us loader stall investigation (paged on `WarehouseSourcesLoaderStalled`). Diagnosis chain: `active_groups=0` → PgBouncer showing queries-never-return (not pool exhaustion) → `pg_stat_activity` full of reconcile queries in `BufFileWrite` → `EXPLAIN` showing the 1.2M-row spilling sort.

Design decisions: rejected a session advisory lock for single-flighting (contradicts this module's documented move to lease rows); rejected raising `work_mem` (600MB × 36 concurrent); rejected restructuring the query around `sourcebatchstatus` (changes semantics of a function that feeds `mark_job_failed_if_not_terminal` and lock release — the additive predicate is provably equivalent instead). TTL=240s chosen below the 300s reconcile interval so single-flighting never worsens reconcile latency vs. the old per-pod cadence.

Follow-ups deliberately not here: root cause of the Aug 3–8 failure storm (300k+ failures/day — likely supersede churn, needs its own investigation); the freshness gauge's 48h window understating backlog age 4.4x mid-incident; reverting the charts `--sweep-timeout 15` mitigation once this lands.
