### PR TITLE
feat(canvas): add unreads-only filter to activity surfaces

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityHoverCard.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityHoverCard.test.tsx
@@ -23,10 +23,29 @@ vi.mock("@posthog/quill", () => ({
   EmptyHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   EmptyMedia: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   EmptyTitle: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Label: ({ children, htmlFor }: { children: ReactNode; htmlFor?: string }) => (
+    <label htmlFor={htmlFor}>{children}</label>
+  ),
   PopoverContent: ({ children }: { children: ReactNode }) => (
     <div>{children}</div>
   ),
   Spinner: () => <div>Loading</div>,
+  Switch: ({
+    checked,
+    onCheckedChange,
+  }: {
+    checked: boolean;
+    onCheckedChange: (checked: boolean) => void;
+  }) => (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onCheckedChange(!checked)}
+    >
+      Unreads
+    </button>
+  ),
 }));
 vi.mock("@posthog/ui/features/auth/authClient", () => ({
   useOptionalAuthenticatedClient: () => ({}),
@@ -74,6 +93,7 @@ vi.mock("@posthog/ui/primitives/hooks/useInView", () => ({
 }));
 vi.mock("@posthog/ui/shell/analytics", () => ({ track: vi.fn() }));
 
+import { useActivityFilterStore } from "@posthog/ui/features/canvas/stores/activityFilterStore";
 import { ActivityHoverCard } from "./ActivityHoverCard";
 
 describe("ActivityHoverCard", () => {
@@ -83,6 +103,7 @@ describe("ActivityHoverCard", () => {
     mocks.isFetchingNextPage = false;
     mocks.items = [];
     mocks.commentsEnabled = true;
+    useActivityFilterStore.setState({ unreadsOnly: false });
   });
 
   it("loads the next page when the bottom sentinel is visible", async () => {
@@ -143,6 +164,32 @@ describe("ActivityHoverCard", () => {
     ];
 
     render(<ActivityHoverCard onClose={vi.fn()} />);
+
+    expect(screen.getAllByText("Activity row")).toHaveLength(1);
+  });
+
+  it("drops read activity while the unreads filter is on", () => {
+    mocks.items = [
+      {
+        id: "read-activity",
+        taskId: "task-1",
+        activityAt: "2026-08-07T00:00:00Z",
+        activityKind: "mention",
+        isUnread: false,
+      } as TaskActivityItem,
+      {
+        id: "unread-activity",
+        taskId: "task-2",
+        activityAt: "2026-08-07T00:01:00Z",
+        activityKind: "mention",
+        isUnread: true,
+      } as TaskActivityItem,
+    ];
+
+    render(<ActivityHoverCard onClose={vi.fn()} />);
+    expect(screen.getAllByText("Activity row")).toHaveLength(2);
+
+    fireEvent.click(screen.getByRole("switch"));
 
     expect(screen.getAllByText("Activity row")).toHaveLength(1);
   });

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityHoverCard.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityHoverCard.tsx
@@ -12,10 +12,12 @@ import {
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
+import { ActivityUnreadsToggle } from "@posthog/ui/features/canvas/components/ActivityUnreadsToggle";
 import { ActivityRow } from "@posthog/ui/features/canvas/components/ActivityView";
 import { useBlockedTaskIds } from "@posthog/ui/features/canvas/hooks/useBlockedSessionCount";
 import { useMarkTaskActivityRead } from "@posthog/ui/features/canvas/hooks/useMarkTaskActivityRead";
 import { useTaskActivity } from "@posthog/ui/features/canvas/hooks/useTaskActivity";
+import { useActivityFilterStore } from "@posthog/ui/features/canvas/stores/activityFilterStore";
 import { useCommentsEnabled } from "@posthog/ui/features/sessions/useCommentsEnabled";
 import { useInView } from "@posthog/ui/primitives/hooks/useInView";
 import { track } from "@posthog/ui/shell/analytics";
@@ -54,8 +56,10 @@ export function ActivityHoverCard({
     root: scrollRoot,
     rootMargin: "100px 0px",
   });
+  const unreadsOnly = useActivityFilterStore((state) => state.unreadsOnly);
   const visibleItems = getVisibleActivityItems(items, commentsEnabled);
   const unreadItems = getUnreadActivityItems(visibleItems);
+  const shownItems = unreadsOnly ? unreadItems : visibleItems;
   const { mutate: markTasksRead, isPending: isMarkingRead } =
     useMarkTaskActivityRead();
   useEffect(() => {
@@ -85,41 +89,48 @@ export function ActivityHoverCard({
       sideOffset={8}
       className="w-[380px] gap-0 overflow-hidden p-0"
     >
-      <div className="flex min-h-12 items-center justify-between border-border border-b px-3">
+      <div className="flex min-h-12 items-center gap-2 border-border border-b px-3">
         <span className="font-semibold text-sm">Activity</span>
-        {unreadItems.length > 0 && (
-          <Button
-            variant="default"
-            size="sm"
-            loading={isMarkingRead}
-            disabled={isMarkingRead}
-            onClick={markAllRead}
-          >
-            <ChecksIcon size={14} />
-            {markLoadedReadLabel(unreadItems.length, unreadCount)}
-          </Button>
-        )}
+        <div className="ml-auto flex shrink-0 items-center gap-2">
+          {unreadItems.length > 0 && (
+            <Button
+              variant="default"
+              size="sm"
+              loading={isMarkingRead}
+              disabled={isMarkingRead}
+              onClick={markAllRead}
+            >
+              <ChecksIcon size={14} />
+              {markLoadedReadLabel(unreadItems.length, unreadCount)}
+            </Button>
+          )}
+          <ActivityUnreadsToggle />
+        </div>
       </div>
       <div ref={setScrollRoot} className="max-h-[480px] overflow-y-auto p-1.5">
-        {isLoading && visibleItems.length === 0 ? (
+        {isLoading && shownItems.length === 0 ? (
           <div className="flex justify-center py-10">
             <Spinner />
           </div>
-        ) : visibleItems.length === 0 ? (
+        ) : shownItems.length === 0 ? (
           <Empty className="border-0 py-8">
             <EmptyHeader>
               <EmptyMedia variant="icon">
                 <BellIcon />
               </EmptyMedia>
-              <EmptyTitle>No recent activity</EmptyTitle>
+              <EmptyTitle>
+                {unreadsOnly ? "No unread activity" : "No recent activity"}
+              </EmptyTitle>
               <EmptyDescription>
-                New task updates will appear here.
+                {unreadsOnly
+                  ? "You're all caught up."
+                  : "New task updates will appear here."}
               </EmptyDescription>
             </EmptyHeader>
           </Empty>
         ) : (
           <div className="flex flex-col gap-0.5">
-            {visibleItems.map((item) => (
+            {shownItems.map((item) => (
               <ActivityRow
                 key={item.id}
                 item={item}

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityUnreadsToggle.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityUnreadsToggle.tsx
@@ -1,0 +1,24 @@
+import { Label, Switch } from "@posthog/quill";
+import { useActivityFilterStore } from "@posthog/ui/features/canvas/stores/activityFilterStore";
+import { useId } from "react";
+
+/** Narrows both Activity surfaces down to what hasn't been read yet. */
+export function ActivityUnreadsToggle() {
+  const switchId = useId();
+  const unreadsOnly = useActivityFilterStore((state) => state.unreadsOnly);
+  const setUnreadsOnly = useActivityFilterStore(
+    (state) => state.setUnreadsOnly,
+  );
+
+  return (
+    <div className="flex shrink-0 items-center gap-2">
+      <Label htmlFor={switchId}>Unreads</Label>
+      <Switch
+        id={switchId}
+        size="sm"
+        checked={unreadsOnly}
+        onCheckedChange={setUnreadsOnly}
+      />
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityView.tsx
@@ -24,11 +24,13 @@ import type { UserBasic } from "@posthog/shared/domain-types";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { UserAvatar } from "@posthog/ui/features/auth/UserAvatar";
 import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
+import { ActivityUnreadsToggle } from "@posthog/ui/features/canvas/components/ActivityUnreadsToggle";
 import { MentionText } from "@posthog/ui/features/canvas/components/MentionText";
 import { useBlockedTaskIds } from "@posthog/ui/features/canvas/hooks/useBlockedSessionCount";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { useMarkTaskActivityRead } from "@posthog/ui/features/canvas/hooks/useMarkTaskActivityRead";
 import { useTaskActivity } from "@posthog/ui/features/canvas/hooks/useTaskActivity";
+import { useActivityFilterStore } from "@posthog/ui/features/canvas/stores/activityFilterStore";
 import { useCanvasChatPanelStore } from "@posthog/ui/features/canvas/stores/canvasChatPanelStore";
 import { useThreadPanelStore } from "@posthog/ui/features/canvas/stores/threadPanelStore";
 import { copyChannelLink } from "@posthog/ui/features/canvas/utils/copyChannelLink";
@@ -361,6 +363,8 @@ export function ActivityView() {
     () => getUnreadActivityItems(visibleItems),
     [visibleItems],
   );
+  const unreadsOnly = useActivityFilterStore((state) => state.unreadsOnly);
+  const shownItems = unreadsOnly ? unreadItems : visibleItems;
   const visibleUnreadCount = activityUnreadTotalForLabel({
     commentsEnabled,
     unreadCount,
@@ -403,51 +407,65 @@ export function ActivityView() {
     </Button>
   );
 
+  // Sits below the rows and below the empty state alike: filtering to unreads can
+  // empty a page that still has unread activity waiting on the next one.
+  const loadMoreButton = hasNextPage && (
+    <div className="mt-3 flex justify-center">
+      <Button
+        variant="outline"
+        loading={isFetchingNextPage}
+        disabled={isFetchingNextPage}
+        onClick={() => void fetchNextPage()}
+      >
+        Load more
+      </Button>
+    </div>
+  );
+
   // The feed body is identical in both shells; only the empty-state copy tracks
   // the layout's naming ("spaces" vs "channels").
   const feed =
-    isLoading && visibleItems.length === 0 ? (
+    isLoading && shownItems.length === 0 ? (
       <div className="flex justify-center py-16">
         <Spinner />
       </div>
-    ) : visibleItems.length === 0 ? (
-      <Empty>
-        <EmptyHeader>
-          <EmptyMedia variant="icon">
-            <BellIcon size={20} />
-          </EmptyMedia>
-          <EmptyTitle>No activity yet</EmptyTitle>
-          <EmptyDescription>
-            Task updates and comment notifications across{" "}
-            {spacesLayout ? "spaces" : "channels"} appear here.
-          </EmptyDescription>
-        </EmptyHeader>
-      </Empty>
+    ) : shownItems.length === 0 ? (
+      <>
+        <Empty>
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <BellIcon size={20} />
+            </EmptyMedia>
+            <EmptyTitle>
+              {unreadsOnly ? "No unread activity" : "No activity yet"}
+            </EmptyTitle>
+            <EmptyDescription>
+              {unreadsOnly
+                ? "You're all caught up."
+                : `Task updates and comment notifications across ${spacesLayout ? "spaces" : "channels"} appear here.`}
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+        {loadMoreButton}
+      </>
     ) : (
-      <div className="flex flex-col gap-0.5">
-        {visibleItems.map((item) => (
-          <ActivityRow
-            key={item.id}
-            item={item}
-            channelId={item.channelId}
-            onOpen={markRead}
-            onMarkRead={markRead}
-            currentUser={currentUser}
-            blockedTaskIds={blockedTaskIds}
-          />
-        ))}
-        {hasNextPage && (
-          <Button
-            variant="outline"
-            className="mt-3 self-center"
-            loading={isFetchingNextPage}
-            disabled={isFetchingNextPage}
-            onClick={() => void fetchNextPage()}
-          >
-            Load more
-          </Button>
-        )}
-      </div>
+      <>
+        <div className="flex flex-col gap-0.5">
+          {shownItems.map((item) => (
+            <ActivityRow
+              key={item.id}
+              item={item}
+              channelId={item.channelId}
+              onOpen={markRead}
+              onMarkRead={markRead}
+              currentUser={currentUser}
+              blockedTaskIds={blockedTaskIds}
+            />
+          ))}
+        </div>
+        {loadMoreButton}
+      </>
+
     );
 
   if (spacesLayout) {
@@ -462,9 +480,10 @@ export function ActivityView() {
                   {unreadCount} unread
                 </PageHeaderChip>
               )}
-              {unreadCount > 0 && (
-                <PageHeaderActions>{markAllReadButton}</PageHeaderActions>
-              )}
+              <PageHeaderActions>
+                {unreadCount > 0 && markAllReadButton}
+                <ActivityUnreadsToggle />
+              </PageHeaderActions>
             </PageHeaderTitleRow>
             <PageHeaderDescription>
               Task updates and comment notifications across spaces.
@@ -491,7 +510,10 @@ export function ActivityView() {
               {spacesLayout ? "spaces" : "channels"}.
             </Text>
           </div>
-          {unreadCount > 0 && markAllReadButton}
+          <div className="flex shrink-0 items-center gap-2">
+            {unreadCount > 0 && markAllReadButton}
+            <ActivityUnreadsToggle />
+          </div>
         </div>
         <div className="mt-4">{feed}</div>
       </div>

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityView.tsx
@@ -465,7 +465,6 @@ export function ActivityView() {
         </div>
         {loadMoreButton}
       </>
-
     );
 
   if (spacesLayout) {

--- a/products/desktop/packages/ui/src/features/canvas/stores/activityFilterStore.ts
+++ b/products/desktop/packages/ui/src/features/canvas/stores/activityFilterStore.ts
@@ -1,0 +1,20 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface ActivityFilterStore {
+  /** Show only activity that hasn't been read yet. */
+  unreadsOnly: boolean;
+  setUnreadsOnly: (unreadsOnly: boolean) => void;
+}
+
+// Per-device preference shared by the Activity popover and the Activity page, so
+// the filter you set on one is the filter you find on the other.
+export const useActivityFilterStore = create<ActivityFilterStore>()(
+  persist(
+    (set) => ({
+      unreadsOnly: false,
+      setUnreadsOnly: (unreadsOnly) => set({ unreadsOnly }),
+    }),
+    { name: "activity-filter-storage" },
+  ),
+);


### PR DESCRIPTION
## Problem

Users viewing the Activity feed or popover see all activity items, including those they've already read. There's no way to focus on just unread activity, making it harder to catch up on what's new.

## Changes

Added an "Unreads" toggle that filters both the Activity page and Activity popover to show only unread items. The filter state persists across page reloads and is shared between both surfaces, so toggling it in one place affects the other.

- New `ActivityUnreadsToggle` component with a labeled switch
- New `activityFilterStore` (Zustand with persistence) to track the `unreadsOnly` filter state
- Updated `ActivityView` and `ActivityHoverCard` to:
  - Import and use the filter store
  - Display `shownItems` (filtered based on `unreadsOnly`) instead of all `visibleItems`
  - Show context-aware empty states ("No unread activity" vs "No activity yet")
  - Render the toggle in the header alongside the "Mark all read" button
  - Keep the "Load more" button visible even when the current page is empty but unread items exist on the next page

## Screenshots

Activity popover, toggle off and on:

| Off | On |
| --- | --- |
| <img src="https://raw.githubusercontent.com/PostHog/pr-assets/54e3a8b04a4e6fab90d033b3f01479a824dabaed/2026/08/2e3a876b-c74f-4865-99b4-e16e44e3d76a.png" width="380" alt="Activity popover with the unreads filter off"> | <img src="https://raw.githubusercontent.com/PostHog/pr-assets/54e3a8b04a4e6fab90d033b3f01479a824dabaed/2026/08/4d37b260-04a5-4f74-b802-6acb81b69cc1.png" width="380" alt="Activity popover with the unreads filter on"> |

Activity page, toggle off and on:

<img src="https://raw.githubusercontent.com/PostHog/pr-assets/54e3a8b04a4e6fab90d033b3f01479a824dabaed/2026/08/db1e58a1-f512-4656-b1f4-0834288131a6.png" width="760" alt="Activity page with the unreads filter off">

<img src="https://raw.githubusercontent.com/PostHog/pr-assets/54e3a8b04a4e6fab90d033b3f01479a824dabaed/2026/08/46f86942-8300-4efc-87ce-fd1bc4afcb80.png" width="760" alt="Activity page with the unreads filter on">

Screenshots are rendered from the real components with an invented activity feed — no customer data.

## How did you test this code?

Added a test case `ActivityHoverCard.test.tsx` that verifies filtering works: toggling the unreads switch hides read activity items while keeping unread ones visible. Existing tests continue to pass with the filter defaulting to `false` (show all activity).

https://claude.ai/code/session_01LKDh69FPqW7iWyrVePnzf9