### PR TITLE
fix(data-imports): stop reporting v3 queue-sweep pool timeouts as errors

### DIFF
--- a/products/data_warehouse/backend/logic/external_data_source/jobs.py
+++ b/products/data_warehouse/backend/logic/external_data_source/jobs.py
@@ -3,6 +3,7 @@ from functools import partial
 
 from django.db import transaction
 
+import psycopg
 from prometheus_client import Counter
 from structlog.types import FilteringBoundLogger
 
@@ -136,6 +137,18 @@ def update_external_job_status(
     return model
 
 
+def _is_transient_queue_pool_timeout(error: BaseException) -> bool:
+    """Whether `error` is PgBouncer's own "query waited too long for a free server
+    connection" rejection on the v3 queue's Postgres pool, not a genuine queue-DB failure.
+
+    The queue talks over a raw psycopg connection (see `_sweep_v3_queue_batches`), so a
+    saturated pool surfaces as a bare `ProtocolViolation` rather than Django's
+    `OperationalError`. Matching on message, not just type, keeps other `ProtocolViolation`
+    causes (e.g. a cached login failure) reported.
+    """
+    return isinstance(error, psycopg.errors.ProtocolViolation) and "query_wait_timeout" in str(error)
+
+
 def _sweep_v3_queue_batches_swallowing_errors(
     *, job_id: str, status: ExternalDataJob.Status, logger: FilteringBoundLogger
 ) -> None:
@@ -145,6 +158,11 @@ def _sweep_v3_queue_batches_swallowing_errors(
         _sweep_v3_queue_batches(job_id=job_id, status=status, logger=logger)
     except Exception as e:
         FINALIZE_QUEUE_SWEEP_ERRORS.inc()
+        if _is_transient_queue_pool_timeout(e):
+            # A pool-saturation blip, not a sweep bug — the stale-stranded reconcile sweep
+            # already retries what this misses, so it isn't worth paging anyone over.
+            logger.warning("dwh_finalize_queue_sweep_pool_timeout", job_id=job_id)
+            return
         logger.exception("dwh_finalize_queue_sweep_failed", job_id=job_id)
         capture_exception(e)
 

--- a/products/data_warehouse/backend/logic/external_data_source/jobs.py
+++ b/products/data_warehouse/backend/logic/external_data_source/jobs.py
@@ -157,12 +157,12 @@ def _sweep_v3_queue_batches_swallowing_errors(
     try:
         _sweep_v3_queue_batches(job_id=job_id, status=status, logger=logger)
     except Exception as e:
-        FINALIZE_QUEUE_SWEEP_ERRORS.inc()
         if _is_transient_queue_pool_timeout(e):
             # A pool-saturation blip, not a sweep bug — the stale-stranded reconcile sweep
             # already retries what this misses, so it isn't worth paging anyone over.
             logger.warning("dwh_finalize_queue_sweep_pool_timeout", job_id=job_id)
             return
+        FINALIZE_QUEUE_SWEEP_ERRORS.inc()
         logger.exception("dwh_finalize_queue_sweep_failed", job_id=job_id)
         capture_exception(e)
 

--- a/products/data_warehouse/backend/logic/external_data_source/test/test_jobs.py
+++ b/products/data_warehouse/backend/logic/external_data_source/test/test_jobs.py
@@ -3,6 +3,8 @@ import uuid
 import pytest
 from unittest.mock import MagicMock, patch
 
+import psycopg
+
 from posthog.models import Organization, Team
 
 from products.data_warehouse.backend.logic.external_data_source.jobs import update_external_job_status
@@ -502,3 +504,68 @@ class TestFinalizeQueueSweep:
         db_job = ExternalDataJob.objects.get(id=job.id)
         assert db_job.status == ExternalDataJob.Status.FAILED
         assert db_job.finished_at is not None
+
+    def test_queue_sweep_pool_timeout_not_reported_as_exception(self, django_capture_on_commit_callbacks):
+        # A saturated PgBouncer pool rejects the sweep's query with a bare
+        # `ProtocolViolation("query_wait_timeout")` — a transient blip the stale-stranded
+        # reconcile sweep already retries, not a bug worth paging on.
+        team, _source, _schema, job = _create_org_team_source_schema_job(
+            pipeline_version=ExternalDataJob.PipelineVersion.V3
+        )
+
+        with (
+            patch("products.data_warehouse.backend.logic.external_data_source.jobs.emit_data_import_app_metrics"),
+            patch(
+                "products.data_warehouse.backend.logic.external_data_source.jobs.schedule_external_data_failure_digest"
+            ),
+            patch(
+                "products.data_warehouse.backend.logic.external_data_source.jobs._sweep_v3_queue_batches",
+                side_effect=psycopg.errors.ProtocolViolation("query_wait_timeout"),
+            ) as mock_sweep,
+            patch("products.data_warehouse.backend.logic.external_data_source.jobs.capture_exception") as mock_capture,
+            django_capture_on_commit_callbacks(execute=True),
+        ):
+            logger = MagicMock()
+            update_external_job_status(
+                job_id=str(job.id),
+                team_id=team.pk,
+                status=ExternalDataJob.Status.FAILED,
+                logger=logger,
+                latest_error="boom",
+            )
+
+        mock_sweep.assert_called_once()
+        mock_capture.assert_not_called()
+        logger.exception.assert_not_called()
+        logger.warning.assert_called_once()
+
+    def test_queue_sweep_unrelated_protocol_violation_still_reported(self, django_capture_on_commit_callbacks):
+        # A ProtocolViolation can also carry a cached-login-failure message, which is a real,
+        # actionable failure, not a pool-saturation blip. Matching on message keeps this case
+        # reported instead of being swallowed by the query_wait_timeout classification above.
+        team, _source, _schema, job = _create_org_team_source_schema_job(
+            pipeline_version=ExternalDataJob.PipelineVersion.V3
+        )
+
+        with (
+            patch("products.data_warehouse.backend.logic.external_data_source.jobs.emit_data_import_app_metrics"),
+            patch(
+                "products.data_warehouse.backend.logic.external_data_source.jobs.schedule_external_data_failure_digest"
+            ),
+            patch(
+                "products.data_warehouse.backend.logic.external_data_source.jobs._sweep_v3_queue_batches",
+                side_effect=psycopg.errors.ProtocolViolation("server login has been failing"),
+            ) as mock_sweep,
+            patch("products.data_warehouse.backend.logic.external_data_source.jobs.capture_exception") as mock_capture,
+            django_capture_on_commit_callbacks(execute=True),
+        ):
+            update_external_job_status(
+                job_id=str(job.id),
+                team_id=team.pk,
+                status=ExternalDataJob.Status.FAILED,
+                logger=MagicMock(),
+                latest_error="boom",
+            )
+
+        mock_sweep.assert_called_once()
+        mock_capture.assert_called_once()


### PR DESCRIPTION
## Problem

A v3 sync job's queue-sweep step reported a `ProtocolViolation: query_wait_timeout` to error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019feab2-83fa-7c20-bedd-3e78e11838cd)), even though it's a transient pool blip with its own retry path.

- The v3 pipeline's job queue (`BatchQueue`) writes over a raw psycopg connection, never Django's ORM.
- A saturated connection pool rejects the finalize-time sweep query past PgBouncer's `query_wait_timeout` and disconnects with a bare `psycopg.errors.ProtocolViolation`.
- `_sweep_v3_queue_batches_swallowing_errors` catches every exception from the sweep and reports it via `capture_exception`, including this one, even though its own comment says the stale-stranded reconcile sweep on the loader already retries what it misses.

## Changes

- Classify a `psycopg.errors.ProtocolViolation` carrying a `query_wait_timeout` message as a pool-saturation blip: log a warning and return instead of logging an exception and calling `capture_exception`.
- The match is on message, not just type, so an unrelated `ProtocolViolation` (e.g. a cached login failure) still gets reported.
- This mirrors the classification [#80208](https://github.com/PostHog/posthog/pull/80208) added for the same `ProtocolViolation`/`query_wait_timeout` case at a different call site (the in-flight sync activity, not this finalize-time sweep).
- [#79794](https://github.com/PostHog/posthog/pull/79794) is also open against this same function, handling activity cancellations rather than pool timeouts; the two changes are independent.

## How did you test this code?

- Added `test_queue_sweep_pool_timeout_not_reported_as_exception`, asserting `capture_exception` is not called and a warning is logged instead of an exception for this case.
- Added `test_queue_sweep_unrelated_protocol_violation_still_reported`, guarding against widening the match to swallow other `ProtocolViolation` causes.
- Ran `TestFinalizeQueueSweep` (11 passed) and a repo-wide `mypy --cache-fine-grained .` (clean, 17952 files).
- Not run: an end-to-end sweep against a saturated connection pool, since reproducing PgBouncer pool exhaustion isn't practical locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal error-classification change, no user-facing behavior or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via a PostHog error-tracking issue delivered by webhook, using the `investigating-error-issue`, `writing-tests`, and `writing-pr-descriptions` skills. Traced the stack trace to the finalize-time queue-sweep path in `products/data_warehouse/backend/logic/external_data_source/jobs.py`, confirmed the raw psycopg `ProtocolViolation` bypasses the sync-activity classifier entirely, and checked open PRs #80208 and #79794 for overlap before scoping this fix to the sweep's own swallow-and-report wrapper.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*