### PR TITLE
feat(tasks): book self-driving sandboxes in their own modal app

### DIFF
--- a/docs/internal/sandboxes-setup-guide.md
+++ b/docs/internal/sandboxes-setup-guide.md
@@ -223,10 +223,9 @@ Self-driving membership is derived from the task's `origin_product` (`SELF_DRIVI
 The split is for metering only: same image, same resources, same isolation, and images and snapshots are
 workspace-scoped in Modal, so a self-driving box still restores a snapshot baked under the default app.
 
-The `MODAL_DOCKER` and `MODAL_EVALS` providers shadow the default, notebook, and self-driving names
-(`posthog-sandbox-modal-docker-*`, `posthog-sandbox-evals`), so those runs stay out of the production apps.
-`STREAMLIT_BASE` is the exception: its app name is a module constant with no per-provider override, so a local
-or eval Streamlit box still lands in `posthog-sandbox-streamlit`.
+Each name above is a class attribute on `ModalSandbox`, and the `MODAL_DOCKER` and `MODAL_EVALS` providers
+override all four (`posthog-sandbox-modal-docker-*`, `posthog-sandbox-evals`), so local and eval runs never land
+in a production app. A new app name has to be a class attribute for that to keep holding.
 
 ### Sandbox templates
 

--- a/docs/internal/sandboxes-setup-guide.md
+++ b/docs/internal/sandboxes-setup-guide.md
@@ -223,8 +223,10 @@ Self-driving membership is derived from the task's `origin_product` (`SELF_DRIVI
 The split is for metering only: same image, same resources, same isolation, and images and snapshots are
 workspace-scoped in Modal, so a self-driving box still restores a snapshot baked under the default app.
 
-The `MODAL_DOCKER` and `MODAL_EVALS` providers shadow these names (`posthog-sandbox-modal-docker-*`,
-`posthog-sandbox-evals`) so local and eval runs never land in a production app.
+The `MODAL_DOCKER` and `MODAL_EVALS` providers shadow the default, notebook, and self-driving names
+(`posthog-sandbox-modal-docker-*`, `posthog-sandbox-evals`), so those runs stay out of the production apps.
+`STREAMLIT_BASE` is the exception: its app name is a module constant with no per-provider override, so a local
+or eval Streamlit box still lands in `posthog-sandbox-streamlit`.
 
 ### Sandbox templates
 

--- a/docs/internal/sandboxes-setup-guide.md
+++ b/docs/internal/sandboxes-setup-guide.md
@@ -206,6 +206,26 @@ pnpm --dir products/desktop --filter @posthog/agent... build
 | `MODAL_DOCKER`    | `SANDBOX_PROVIDER=MODAL_DOCKER` | **Local development with Modal.** Same as `modal` but uses a separate Modal app (`posthog-sandbox-modal-docker-*`) so local image builds don't pollute the production app cache. When `LOCAL_POSTHOG_CODE_MONOREPO_ROOT` is set, each local package's external runtime dependencies are installed and its compiled output is overlaid onto the image. |
 | `docker`          | `SANDBOX_PROVIDER=docker`       | Local-only Docker containers (`DEBUG=True` required). No Modal account needed. Uses the published agent by default and builds local agent packages when `LOCAL_POSTHOG_CODE_MONOREPO_ROOT` is set. This is the recommended option for local development.                                                                                              |
 
+### Modal apps
+
+Every sandbox is booked against a Modal app, which is what groups it in the Modal dashboard and attributes its cost.
+The app is picked from the template first, and from `SandboxConfig.workload` when the template has no app of its own.
+
+| App                            | Owned by                                                                                      |
+| ------------------------------ | --------------------------------------------------------------------------------------------- |
+| `posthog-sandbox-default`      | Everything not claimed below — user-created tasks, loops, onboarding, image builds            |
+| `posthog-sandbox-self-driving` | The self-driving fleet: Signals report research and repo selection, Signals scouts, ReviewHog |
+| `posthog-sandbox-notebook`     | `NOTEBOOK_BASE` template                                                                      |
+| `posthog-sandbox-streamlit`    | `STREAMLIT_BASE` template                                                                     |
+
+Self-driving membership is derived from the task's `origin_product` (`SELF_DRIVING_ORIGIN_PRODUCTS` in
+`logic/services/sandbox.py`), so a product joins the fleet by adding its origin there — no caller changes.
+The split is for metering only: same image, same resources, same isolation, and images and snapshots are
+workspace-scoped in Modal, so a self-driving box still restores a snapshot baked under the default app.
+
+The `MODAL_DOCKER` and `MODAL_EVALS` providers shadow these names (`posthog-sandbox-modal-docker-*`,
+`posthog-sandbox-evals`) so local and eval runs never land in a production app.
+
 ### Sandbox templates
 
 Each sandbox is created from a template that determines its base image and capabilities.

--- a/products/review_hog/ARCHITECTURE.md
+++ b/products/review_hog/ARCHITECTURE.md
@@ -321,6 +321,12 @@ session** per chunk via the sibling helpers `start_sandbox_session` / `continue_
 `run_oneshot_review(...)` in `backend/reviewer/sandbox/direct_llm.py` (same call shape minus
 `repository`/`branch`; one gateway Messages call, structured outputs, no sandbox).
 
+Every sandbox opened here lands in the `posthog-sandbox-self-driving` Modal app rather than the default one,
+because its tasks carry `origin_product=REVIEW_HOG` (see `SELF_DRIVING_ORIGIN_PRODUCTS` in
+`products/tasks/backend/logic/services/sandbox.py`). ReviewHog owns no sandbox code, so this needs nothing here:
+the app is resolved inside the Tasks provisioning activity. Same image and resources as any other run — the split
+only separates the fleet's Modal cost from user-driven runs.
+
 `run_sandbox_review(team_id, user_id, repository, branch, prompt, system_prompt, model_to_validate, step_name) -> Model | None`:
 
 1. Does **not** own concurrency — the caller bounds it: each fan-out child workflow wraps its per-unit sandbox

--- a/products/signals/ARCHITECTURE.md
+++ b/products/signals/ARCHITECTURE.md
@@ -992,6 +992,14 @@ That said, **not all “LLM-ish” behavior in Signals goes through `call_llm()`
 - **Repository selection** runs via the sandbox agent flow, not `call_llm()`
 - **Agentic report research** runs via `MultiTurnSession` in `report_generation/research.py`, not `call_llm()`
 
+The sandbox-backed paths (repo selection, report research, scout runs, and the coding runs autonomy auto-starts) all
+land in the `posthog-sandbox-self-driving` Modal app rather than the default one, because their tasks carry
+`origin_product=signal_report` / `signals_scout` (see `SELF_DRIVING_ORIGIN_PRODUCTS` in
+`products/tasks/backend/logic/services/sandbox.py`). The app is resolved inside the Tasks provisioning activity, so
+nothing in Signals selects it. Same image, resources, and egress policy as any other run — the split only separates
+the fleet's Modal cost from user-driven runs. Egress is still governed by the `SandboxEnvironment` each caller
+upserts (`temporal/agentic/__init__.py`).
+
 ### `call_llm()` (`backend/temporal/llm.py`)
 
 A generic helper that abstracts the retry / validate / append-errors pattern used by direct LLM calls. It takes a system prompt, user prompt, validation function, and options like `thinking`, `temperature`, and retries.

--- a/products/tasks/backend/logic/services/modal_sandbox.py
+++ b/products/tasks/backend/logic/services/modal_sandbox.py
@@ -638,6 +638,7 @@ class ModalSandbox(SandboxBase):
     provision_diagnostics: SandboxProvisionDiagnostics | None
     DEFAULT_APP_NAME = DEFAULT_MODAL_APP_NAME
     NOTEBOOK_APP_NAME = NOTEBOOK_MODAL_APP_NAME
+    STREAMLIT_APP_NAME = STREAMLIT_MODAL_APP_NAME
     SELF_DRIVING_APP_NAME = SELF_DRIVING_MODAL_APP_NAME
 
     def __init__(self, sandbox: modal.Sandbox, config: SandboxConfig, sandbox_url: str | None = None):
@@ -662,10 +663,8 @@ class ModalSandbox(SandboxBase):
         """
         if template == SandboxTemplate.NOTEBOOK_BASE:
             return cls.NOTEBOOK_APP_NAME
-        # Unlike the class-attribute names, this constant has no per-provider override, so local
-        # and eval Streamlit boxes share the production Streamlit app.
         if template == SandboxTemplate.STREAMLIT_BASE:
-            return STREAMLIT_MODAL_APP_NAME
+            return cls.STREAMLIT_APP_NAME
         return None
 
     @classmethod

--- a/products/tasks/backend/logic/services/modal_sandbox.py
+++ b/products/tasks/backend/logic/services/modal_sandbox.py
@@ -96,13 +96,25 @@ from products.tasks.backend.logic.services.sandbox import (
 )
 from products.tasks.backend.models import SandboxSnapshot
 
-from .sandbox import AgentServerResult, ExecutionResult, ExecutionStream, SandboxConfig, SandboxStatus, SandboxTemplate
+from .sandbox import (
+    AgentServerResult,
+    ExecutionResult,
+    ExecutionStream,
+    SandboxConfig,
+    SandboxStatus,
+    SandboxTemplate,
+    SandboxWorkload,
+)
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_MODAL_APP_NAME = "posthog-sandbox-default"
 NOTEBOOK_MODAL_APP_NAME = "posthog-sandbox-notebook"
 STREAMLIT_MODAL_APP_NAME = "posthog-sandbox-streamlit"
+# Self-driving runs boot the same default image as a user's task, so only the app separates them.
+# Images and snapshots are workspace-scoped in Modal, not app-scoped, so a box here still restores
+# a snapshot baked under the default app.
+SELF_DRIVING_MODAL_APP_NAME = "posthog-sandbox-self-driving"
 
 SANDBOX_BASE_IMAGE = "ghcr.io/posthog/posthog-sandbox-base"
 SANDBOX_NOTEBOOK_IMAGE = "ghcr.io/posthog/posthog-sandbox-notebook"
@@ -626,12 +638,13 @@ class ModalSandbox(SandboxBase):
     provision_diagnostics: SandboxProvisionDiagnostics | None
     DEFAULT_APP_NAME = DEFAULT_MODAL_APP_NAME
     NOTEBOOK_APP_NAME = NOTEBOOK_MODAL_APP_NAME
+    SELF_DRIVING_APP_NAME = SELF_DRIVING_MODAL_APP_NAME
 
     def __init__(self, sandbox: modal.Sandbox, config: SandboxConfig, sandbox_url: str | None = None):
         self.id = sandbox.object_id
         self.config = config
         self._sandbox = sandbox
-        self._app = type(self)._get_app_for_template(config.template)
+        self._app = type(self)._get_app_for_config(config)
         self._sandbox_url = sandbox_url
         self.provision_diagnostics = None
 
@@ -641,22 +654,37 @@ class ModalSandbox(SandboxBase):
         return self._sandbox_url
 
     @classmethod
-    def _get_default_app(cls) -> modal.App:
-        return modal.App.lookup(cls.DEFAULT_APP_NAME, create_if_missing=True)
+    def _template_app_name(cls, template: SandboxTemplate) -> str | None:
+        """App a template owns outright, or None when it shares the general-purpose apps.
+
+        Notebook and Streamlit boxes are their own products with their own images, so they stay
+        in their own app whatever the workload — neither is ever self-driving.
+        """
+        if template == SandboxTemplate.NOTEBOOK_BASE:
+            return cls.NOTEBOOK_APP_NAME
+        if template == SandboxTemplate.STREAMLIT_BASE:
+            return STREAMLIT_MODAL_APP_NAME
+        return None
 
     @classmethod
     def _get_app_for_template(cls, template: SandboxTemplate) -> modal.App:
-        if template == SandboxTemplate.NOTEBOOK_BASE:
-            return modal.App.lookup(cls.NOTEBOOK_APP_NAME, create_if_missing=True)
-        if template == SandboxTemplate.STREAMLIT_BASE:
-            return modal.App.lookup(STREAMLIT_MODAL_APP_NAME, create_if_missing=True)
-        return cls._get_default_app()
+        """App for a template alone, ignoring workload. For image builds, where the built image
+        is visible to every app in the workspace and so has no workload of its own."""
+        return modal.App.lookup(cls._template_app_name(template) or cls.DEFAULT_APP_NAME, create_if_missing=True)
+
+    @classmethod
+    def _get_app_for_config(cls, config: SandboxConfig) -> modal.App:
+        """App that owns this sandbox: the template's when it has one, otherwise the workload's."""
+        app_name = cls._template_app_name(config.template)
+        if app_name is None and config.workload == SandboxWorkload.SELF_DRIVING:
+            app_name = cls.SELF_DRIVING_APP_NAME
+        return modal.App.lookup(app_name or cls.DEFAULT_APP_NAME, create_if_missing=True)
 
     @classmethod
     def create(cls, config: SandboxConfig) -> ModalSandbox:
         try:
             modal.enable_output()
-            app = cls._get_app_for_template(config.template)
+            app = cls._get_app_for_config(config)
             base_image = _get_template_image(config.template)
             custom_image_bare: modal.Image | None = None
             custom_image: modal.Image | None = None
@@ -864,7 +892,10 @@ class ModalSandbox(SandboxBase):
             if modal_output is not None:
                 sandbox.provision_diagnostics = summarize_modal_output(modal_output.getvalue())
 
-            logger.info(f"Created sandbox {sandbox.id} for {config.name}")
+            logger.info(
+                f"Created sandbox {sandbox.id} for {config.name}",
+                extra={"modal_app": getattr(app, "name", None), "workload": config.workload.value},
+            )
 
             return sandbox
 

--- a/products/tasks/backend/logic/services/modal_sandbox.py
+++ b/products/tasks/backend/logic/services/modal_sandbox.py
@@ -662,6 +662,8 @@ class ModalSandbox(SandboxBase):
         """
         if template == SandboxTemplate.NOTEBOOK_BASE:
             return cls.NOTEBOOK_APP_NAME
+        # Unlike the class-attribute names, this constant has no per-provider override, so local
+        # and eval Streamlit boxes share the production Streamlit app.
         if template == SandboxTemplate.STREAMLIT_BASE:
             return STREAMLIT_MODAL_APP_NAME
         return None

--- a/products/tasks/backend/logic/services/sandbox.py
+++ b/products/tasks/backend/logic/services/sandbox.py
@@ -74,6 +74,43 @@ class SandboxTemplate(str, Enum):
     CANVAS_BUILD = "canvas_build"
 
 
+class SandboxWorkload(str, Enum):
+    """Which provider-side project a sandbox is booked against, independent of its image.
+
+    Modal groups sandboxes and their cost by app. The template already picks an app for the
+    product-specific images; this picks one for workloads that share an image but should be
+    metered apart.
+    """
+
+    DEFAULT = "default"
+    SELF_DRIVING = "self_driving"
+
+
+SELF_DRIVING_ORIGIN_PRODUCTS: frozenset[str] = frozenset(
+    {
+        # Signals report research + repo selection
+        "signal_report",
+        # Headless Signals scouts
+        "signals_scout",
+        # ReviewHog's per-chunk review, blind-spot, and validation sandboxes
+        "review_hog",
+    }
+)
+"""Origin products whose sandboxes are booked against the self-driving provider project.
+
+Wider than the self-driving *quota* gate (`enforce_self_driving_quota.py`), which only covers the
+billable implementation-PR run: this is every sandbox the fleet opens, research and review included.
+Held as strings rather than ``Task.OriginProduct`` members to keep the model layer off this module's
+import path; a test pins them to the enum so a rename can't drop a product off the fleet.
+"""
+
+
+def workload_for_origin_product(origin_product: str | None) -> SandboxWorkload:
+    if origin_product in SELF_DRIVING_ORIGIN_PRODUCTS:
+        return SandboxWorkload.SELF_DRIVING
+    return SandboxWorkload.DEFAULT
+
+
 class ExecutionResult(BaseModel):
     stdout: str
     stderr: str
@@ -99,6 +136,9 @@ class SandboxResources:
 class SandboxConfig(BaseModel):
     name: str
     template: SandboxTemplate = SandboxTemplate.DEFAULT_BASE
+    # Decides which Modal app owns the box, and with it how its cost is attributed. Changes
+    # nothing about the box itself — same image, same resources, same isolation.
+    workload: SandboxWorkload = SandboxWorkload.DEFAULT
     default_execution_timeout_seconds: int = 10 * 60  # 10 minutes
     environment_variables: dict[str, str] | None = None
     snapshot_id: str | None = None
@@ -635,6 +675,7 @@ def _get_modal_docker_sandbox_class() -> SandboxClass:
     class ModalDockerSandbox(ModalSandbox):
         DEFAULT_APP_NAME = "posthog-sandbox-modal-docker-default"
         NOTEBOOK_APP_NAME = "posthog-sandbox-modal-docker-notebook"
+        SELF_DRIVING_APP_NAME = "posthog-sandbox-modal-docker-self-driving"
 
     return ModalDockerSandbox
 
@@ -648,6 +689,8 @@ def _get_modal_evals_sandbox_class() -> SandboxClass:
     class ModalEvalsSandbox(ModalSandbox):
         DEFAULT_APP_NAME = "posthog-sandbox-evals"
         NOTEBOOK_APP_NAME = "posthog-sandbox-evals"
+        # Evals are their own cost centre already — a self-driving eval stays in the evals app.
+        SELF_DRIVING_APP_NAME = "posthog-sandbox-evals"
 
     return ModalEvalsSandbox
 

--- a/products/tasks/backend/logic/services/sandbox.py
+++ b/products/tasks/backend/logic/services/sandbox.py
@@ -675,6 +675,7 @@ def _get_modal_docker_sandbox_class() -> SandboxClass:
     class ModalDockerSandbox(ModalSandbox):
         DEFAULT_APP_NAME = "posthog-sandbox-modal-docker-default"
         NOTEBOOK_APP_NAME = "posthog-sandbox-modal-docker-notebook"
+        STREAMLIT_APP_NAME = "posthog-sandbox-modal-docker-streamlit"
         SELF_DRIVING_APP_NAME = "posthog-sandbox-modal-docker-self-driving"
 
     return ModalDockerSandbox
@@ -689,6 +690,7 @@ def _get_modal_evals_sandbox_class() -> SandboxClass:
     class ModalEvalsSandbox(ModalSandbox):
         DEFAULT_APP_NAME = "posthog-sandbox-evals"
         NOTEBOOK_APP_NAME = "posthog-sandbox-evals"
+        STREAMLIT_APP_NAME = "posthog-sandbox-evals"
         # Evals are their own cost centre already — a self-driving eval stays in the evals app.
         SELF_DRIVING_APP_NAME = "posthog-sandbox-evals"
 

--- a/products/tasks/backend/logic/services/test_modal_sandbox.py
+++ b/products/tasks/backend/logic/services/test_modal_sandbox.py
@@ -18,6 +18,7 @@ from products.tasks.backend.logic.services.sandbox import (
     SandboxConfig,
     SandboxTemplate,
     SandboxWorkload,
+    get_sandbox_class_for_backend,
     workload_for_origin_product,
 )
 from products.tasks.backend.models import Task
@@ -124,6 +125,15 @@ class TestModalSandboxDirectorySnapshotMount:
 
 
 class TestModalSandboxAppRouting:
+    PRODUCTION_APP_NAMES = frozenset(
+        {
+            DEFAULT_MODAL_APP_NAME,
+            NOTEBOOK_MODAL_APP_NAME,
+            STREAMLIT_MODAL_APP_NAME,
+            SELF_DRIVING_MODAL_APP_NAME,
+        }
+    )
+
     @pytest.fixture
     def app_lookup(self, mocker):
         return mocker.patch("modal.App.lookup", return_value=MagicMock())
@@ -156,6 +166,27 @@ class TestModalSandboxAppRouting:
 
         app_lookup.assert_any_call(SELF_DRIVING_MODAL_APP_NAME, create_if_missing=True)
         assert create.call_args.kwargs["app"] is app_lookup.return_value
+
+    @pytest.mark.parametrize("backend", ["modal_docker", "modal_evals"])
+    @pytest.mark.parametrize(
+        "template",
+        [
+            SandboxTemplate.DEFAULT_BASE,
+            SandboxTemplate.VM_BASE,
+            SandboxTemplate.NOTEBOOK_BASE,
+            SandboxTemplate.STREAMLIT_BASE,
+        ],
+    )
+    @pytest.mark.parametrize("workload", [SandboxWorkload.DEFAULT, SandboxWorkload.SELF_DRIVING])
+    def test_local_and_eval_providers_never_resolve_a_production_app(self, app_lookup, backend, template, workload):
+        # Every app name has to be a class attribute for the provider subclasses to shadow it.
+        # A module constant read directly would leak local and eval boxes into a production app.
+        sandbox_cls = get_sandbox_class_for_backend(backend)
+        assert issubclass(sandbox_cls, ModalSandbox)
+
+        sandbox_cls._get_app_for_config(SandboxConfig(name="test", template=template, workload=workload))
+
+        assert app_lookup.call_args.args[0] not in self.PRODUCTION_APP_NAMES
 
 
 class TestSelfDrivingWorkloadMapping:

--- a/products/tasks/backend/logic/services/test_modal_sandbox.py
+++ b/products/tasks/backend/logic/services/test_modal_sandbox.py
@@ -6,8 +6,21 @@ from products.tasks.backend.constants import (
     SNAPSHOT_KIND_DIRECTORY,
     SNAPSHOT_KIND_FILESYSTEM,
 )
-from products.tasks.backend.logic.services.modal_sandbox import ModalSandbox
-from products.tasks.backend.logic.services.sandbox import SandboxConfig, SandboxTemplate
+from products.tasks.backend.logic.services.modal_sandbox import (
+    DEFAULT_MODAL_APP_NAME,
+    NOTEBOOK_MODAL_APP_NAME,
+    SELF_DRIVING_MODAL_APP_NAME,
+    STREAMLIT_MODAL_APP_NAME,
+    ModalSandbox,
+)
+from products.tasks.backend.logic.services.sandbox import (
+    SELF_DRIVING_ORIGIN_PRODUCTS,
+    SandboxConfig,
+    SandboxTemplate,
+    SandboxWorkload,
+    workload_for_origin_product,
+)
+from products.tasks.backend.models import Task
 
 
 @pytest.fixture
@@ -15,7 +28,7 @@ def patched_modal(mocker):
     fake_sandbox = MagicMock()
     fake_sandbox.object_id = "sb-test"
 
-    mocker.patch.object(ModalSandbox, "_get_app_for_template", return_value=MagicMock())
+    mocker.patch.object(ModalSandbox, "_get_app_for_config", return_value=MagicMock())
     mocker.patch(
         "products.tasks.backend.logic.services.modal_sandbox._get_template_image",
         return_value=MagicMock(),
@@ -108,3 +121,62 @@ class TestModalSandboxDirectorySnapshotMount:
         wedged.terminate.assert_called_once()
         assert sandbox.id == "sb-fresh"
         assert sandbox.config.snapshot_restored is False
+
+
+class TestModalSandboxAppRouting:
+    @pytest.fixture
+    def app_lookup(self, mocker):
+        return mocker.patch("modal.App.lookup", return_value=MagicMock())
+
+    @pytest.mark.parametrize(
+        "template, workload, expected_app",
+        [
+            (SandboxTemplate.DEFAULT_BASE, SandboxWorkload.DEFAULT, DEFAULT_MODAL_APP_NAME),
+            (SandboxTemplate.DEFAULT_BASE, SandboxWorkload.SELF_DRIVING, SELF_DRIVING_MODAL_APP_NAME),
+            # Self-driving runs on the VM runtime stay in the self-driving app.
+            (SandboxTemplate.VM_BASE, SandboxWorkload.SELF_DRIVING, SELF_DRIVING_MODAL_APP_NAME),
+            # Product templates own their app regardless of workload.
+            (SandboxTemplate.NOTEBOOK_BASE, SandboxWorkload.SELF_DRIVING, NOTEBOOK_MODAL_APP_NAME),
+            (SandboxTemplate.STREAMLIT_BASE, SandboxWorkload.SELF_DRIVING, STREAMLIT_MODAL_APP_NAME),
+        ],
+    )
+    def test_app_resolution(self, app_lookup, template, workload, expected_app):
+        ModalSandbox._get_app_for_config(SandboxConfig(name="test", template=template, workload=workload))
+
+        app_lookup.assert_called_once_with(expected_app, create_if_missing=True)
+
+    def test_created_sandbox_is_booked_against_the_workload_app(self, mocker, app_lookup):
+        mocker.patch(
+            "products.tasks.backend.logic.services.modal_sandbox._get_template_image",
+            return_value=MagicMock(),
+        )
+        create = mocker.patch("modal.Sandbox.create", return_value=MagicMock(object_id="sb-test"))
+
+        ModalSandbox.create(SandboxConfig(name="test", workload=SandboxWorkload.SELF_DRIVING))
+
+        app_lookup.assert_any_call(SELF_DRIVING_MODAL_APP_NAME, create_if_missing=True)
+        assert create.call_args.kwargs["app"] is app_lookup.return_value
+
+
+class TestSelfDrivingWorkloadMapping:
+    @pytest.mark.parametrize(
+        "origin_product, expected",
+        [
+            (Task.OriginProduct.SIGNAL_REPORT, SandboxWorkload.SELF_DRIVING),
+            (Task.OriginProduct.SIGNALS_SCOUT, SandboxWorkload.SELF_DRIVING),
+            (Task.OriginProduct.REVIEW_HOG, SandboxWorkload.SELF_DRIVING),
+            (Task.OriginProduct.USER_CREATED, SandboxWorkload.DEFAULT),
+            (Task.OriginProduct.SLACK, SandboxWorkload.DEFAULT),
+            (Task.OriginProduct.LOOP, SandboxWorkload.DEFAULT),
+            (None, SandboxWorkload.DEFAULT),
+        ],
+    )
+    def test_workload_for_origin_product(self, origin_product, expected):
+        value = origin_product.value if origin_product is not None else None
+
+        assert workload_for_origin_product(value) == expected
+
+    def test_every_self_driving_origin_is_a_real_origin_product(self):
+        # The set is held as strings to keep the sandbox layer model-free, so a renamed or
+        # removed OriginProduct would otherwise silently drop that product out of the fleet.
+        assert SELF_DRIVING_ORIGIN_PRODUCTS <= {choice.value for choice in Task.OriginProduct}

--- a/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
@@ -429,7 +429,7 @@ class TestModalSandboxAgentServer:
         mock_modal_sandbox.create_connect_token.return_value = mock_credentials
 
         config = SandboxConfig(name="test-sandbox")
-        with patch.object(ModalSandbox, "_get_app_for_template", return_value=MagicMock()):
+        with patch.object(ModalSandbox, "_get_app_for_config", return_value=MagicMock()):
             return ModalSandbox(sandbox=mock_modal_sandbox, config=config)
 
     @pytest.fixture(autouse=True)
@@ -1161,7 +1161,7 @@ class TestModalSandboxCreateAllowlist:
         mock_sb.object_id = "sb-created"
         with (
             patch("products.tasks.backend.logic.services.modal_sandbox.modal.enable_output"),
-            patch.object(ModalSandbox, "_get_app_for_template", return_value=MagicMock()),
+            patch.object(ModalSandbox, "_get_app_for_config", return_value=MagicMock()),
             patch("products.tasks.backend.logic.services.modal_sandbox._get_template_image", return_value=MagicMock()),
             patch(
                 "products.tasks.backend.logic.services.modal_sandbox.modal.Sandbox.create", return_value=mock_sb
@@ -1213,7 +1213,7 @@ class TestModalSandboxCreateImageFallback:
 
         with (
             patch("products.tasks.backend.logic.services.modal_sandbox.modal.enable_output"),
-            patch.object(ModalSandbox, "_get_app_for_template", return_value=MagicMock()),
+            patch.object(ModalSandbox, "_get_app_for_config", return_value=MagicMock()),
             patch(
                 "products.tasks.backend.logic.services.modal_sandbox._get_template_image",
                 return_value=MagicMock(name="base"),
@@ -1283,7 +1283,7 @@ class TestModalSandboxCreateImageFallback:
 
         with (
             patch("products.tasks.backend.logic.services.modal_sandbox.modal.enable_output"),
-            patch.object(ModalSandbox, "_get_app_for_template", return_value=MagicMock()),
+            patch.object(ModalSandbox, "_get_app_for_config", return_value=MagicMock()),
             patch(
                 "products.tasks.backend.logic.services.modal_sandbox._get_template_image",
                 return_value=MagicMock(name="base"),
@@ -1421,7 +1421,7 @@ class TestLaunchDevStackBootstrap:
             snapshot_restored=snapshot_restored,
             **({"snapshot_kind": snapshot_kind} if snapshot_kind is not None else {}),
         )
-        with patch.object(ModalSandbox, "_get_app_for_template", return_value=MagicMock()):
+        with patch.object(ModalSandbox, "_get_app_for_config", return_value=MagicMock()):
             return ModalSandbox(sandbox=mock_modal_sandbox, config=config)
 
     @pytest.mark.parametrize(
@@ -1599,7 +1599,7 @@ class TestModalSandboxCreateSnapshot:
         mock_modal_sandbox.poll.return_value = None  # None => still running
 
         config = SandboxConfig(name="test-sandbox")
-        with patch.object(ModalSandbox, "_get_app_for_template", return_value=MagicMock()):
+        with patch.object(ModalSandbox, "_get_app_for_config", return_value=MagicMock()):
             return ModalSandbox(sandbox=mock_modal_sandbox, config=config)
 
     def test_create_snapshot_success(self, mock_sandbox: Any):

--- a/products/tasks/backend/temporal/process_task/activities/create_sandbox_from_snapshot.py
+++ b/products/tasks/backend/temporal/process_task/activities/create_sandbox_from_snapshot.py
@@ -13,7 +13,12 @@ from products.tasks.backend.exceptions import (
     SnapshotNotReadyError,
     TaskNotFoundError,
 )
-from products.tasks.backend.logic.services.sandbox import Sandbox, SandboxConfig, SandboxTemplate
+from products.tasks.backend.logic.services.sandbox import (
+    Sandbox,
+    SandboxConfig,
+    SandboxTemplate,
+    workload_for_origin_product,
+)
 from products.tasks.backend.models import SandboxSnapshot, Task
 from products.tasks.backend.temporal.oauth import create_oauth_access_token_for_run
 from products.tasks.backend.temporal.observability import emit_agent_log, log_activity_execution
@@ -133,6 +138,7 @@ def create_sandbox_from_snapshot(input: CreateSandboxFromSnapshotInput) -> Creat
         config = SandboxConfig(
             name=get_sandbox_name_for_task(ctx.task_id),
             template=SandboxTemplate.DEFAULT_BASE,
+            workload=workload_for_origin_product(ctx.origin_product),
             environment_variables=environment_variables,
             snapshot_id=str(snapshot.id),
             metadata={"task_id": ctx.task_id},

--- a/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
@@ -27,6 +27,7 @@ from products.tasks.backend.logic.services.sandbox import (
     SandboxConfig,
     SandboxTemplate,
     parse_sandbox_repo_mount_map,
+    workload_for_origin_product,
 )
 from products.tasks.backend.logic.services.sandbox_usage import measure_sandbox_cpu_usage, open_sandbox_session
 from products.tasks.backend.models import SandboxSnapshot, Task, TaskRun
@@ -302,6 +303,7 @@ def get_sandbox_for_repository(input: GetSandboxForRepositoryInput) -> GetSandbo
         config = SandboxConfig(
             name=get_sandbox_name_for_task(ctx.task_id),
             template=SandboxTemplate.VM_BASE if use_vm_sandbox else SandboxTemplate.DEFAULT_BASE,
+            workload=workload_for_origin_product(ctx.origin_product),
             custom_image_name=custom_image_name,
             vm_runtime=use_vm_sandbox,
             environment_variables=environment_variables,

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -41,6 +41,7 @@ from products.tasks.backend.logic.services.sandbox import (
     SandboxTemplate,
     get_sandbox_class,
     sandbox_repo_path,
+    workload_for_origin_product,
 )
 from products.tasks.backend.logic.services.sandbox_usage import measure_sandbox_cpu_usage, open_sandbox_session
 from products.tasks.backend.models import SandboxSnapshot, Task, TaskRun
@@ -631,6 +632,7 @@ def _create_sandbox_for_repository(input: CreateSandboxForRepositoryInput) -> Cr
         config = SandboxConfig(
             name=prepared.sandbox_name,
             template=SandboxTemplate.VM_BASE if use_vm_sandbox else SandboxTemplate.DEFAULT_BASE,
+            workload=workload_for_origin_product(ctx.origin_product),
             custom_image_name=ctx.custom_image_name if use_vm_sandbox else None,
             environment_variables=prepared.environment_variables,
             snapshot_id=prepared.snapshot_id,


### PR DESCRIPTION
## Problem

Anyone reading Modal costs for the self-driving fleet cannot separate it from user work.
Signals report research, Signals scouts, and ReviewHog all provision sandboxes through the Tasks runtime, and they land in `posthog-sandbox-default` next to user-created tasks, loops, and onboarding runs.

- The three products boot the same default image as a user's task, so the image told them apart no better than the app did.
- Modal groups sandboxes and their cost by app, so one shared app is one shared bill.

## Changes

- Self-driving sandboxes now land in a new `posthog-sandbox-self-driving` Modal app.
- `SandboxConfig` carries a `workload`, and `ModalSandbox` resolves the app from the template first, the workload second.
- The provisioning activities derive the workload from the task's origin product, so no caller in Signals or ReviewHog changes.
- `SELF_DRIVING_ORIGIN_PRODUCTS` holds the fleet: `signal_report`, `signals_scout`, `review_hog`. A product joins by adding its origin there.
- The `MODAL_DOCKER` and `MODAL_EVALS` providers shadow the new name, so local and eval runs stay out of the production app.

| App | Owned by |
| --- | --- |
| `posthog-sandbox-default` | User-created tasks, loops, onboarding, image builds |
| `posthog-sandbox-self-driving` | Signals research and repo selection, Signals scouts, ReviewHog |
| `posthog-sandbox-notebook` | `NOTEBOOK_BASE` template |
| `posthog-sandbox-streamlit` | `STREAMLIT_BASE` template |

> [!NOTE]
> The split is metering only. A self-driving box gets the same image, resources, and egress policy it gets today. Modal scopes images and snapshots to the workspace rather than the app, so a self-driving box still restores a snapshot baked under the default app, and the custom-image builder keeps building in the template's app.

Origin product drives the routing rather than an explicit flag on each caller, because the three products own no sandbox code. They hand a prompt to `MultiTurnSession` and the Tasks provisioning activity resolves everything else. A per-caller flag would need a change in each product and would drift the first time a fourth joins.

Modal creates the app on first use (`create_if_missing=True`), so this needs no Modal-side setup.

## How did you test this code?

Automated only. This sandbox has no Postgres and no Docker, so I ran the suites that need neither.

- New tests cover the two regressions the change can cause: a sandbox routed to the wrong app (per template and workload pair, including a self-driving VM box and the notebook and Streamlit templates that must ignore workload), and an origin product silently dropping out of the fleet, which a rename of `Task.OriginProduct` would otherwise do quietly.
- Ran the sandbox and image-build suites, plus repo-wide `uv run mypy --cache-fine-grained .`.
- Not run: the database-backed activity suites (`test_provision_sandbox.py`, `test_warm.py`) and the Docker sandbox integration tests. Both fail at setup here for missing Postgres and Docker, on master too. CI covers them.
- Not verified: that a real sandbox appears under the new app in the Modal dashboard. That needs Modal credentials and a live run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- `docs/internal/sandboxes-setup-guide.md` gains a "Modal apps" section listing the apps and how one is chosen.
- The Signals and ReviewHog architecture docs note which app their sandboxes land in and that nothing in those products selects it.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with PostHog Code (Claude). Skills invoked: `/writing-code-comments`, `/writing-pr-descriptions`.

The session started as a read-only question about which self-driving features run on sandboxes, which produced the map this change acts on: one runtime in `products/tasks`, borrowed through `facade/agents.py` by Signals, scouts, and ReviewHog.

Two decisions worth a reviewer's attention:

- Modal app, not Modal environment. An environment would isolate harder, but images and snapshots are environment-scoped, so self-driving boxes would rebuild images and lose access to published custom images. An app gives the cost separation without that cost. Say the word if you want the harder boundary instead.
- `_get_app_for_template` stayed as a template-only resolver for the custom-image builder, which builds an image with no workload of its own. `_get_app_for_config` sits above it for sandbox creation.

Scope question for the reviewer: `support_reply` (Conversations draft replies) and `stamphog` run on the same runtime and are arguably fleet members. I left them in the default app because the request named Signals, scouts, and ReviewHog. Adding either is one line in `SELF_DRIVING_ORIGIN_PRODUCTS`.

Nothing in this PR draws on anything outside this repository.
