### PR TITLE
fix(llm-gateway): report OpenAI prompt cache tokens on $ai_generation

### DIFF
--- a/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
@@ -240,10 +240,22 @@ class PostHogCallback(InstrumentedCallback):
         # cache, OpenAI o-series for reasoning). Emit the fields only when
         # present so providers that don't report them don't pollute events with
         # zeros, matching the schema in posthog/models/ai_events/sql.py and the
-        # parity established by posthoganalytics' langchain CallbackHandler.
+        # convention in posthoganalytics' posthog/ai/utils.py.
         cache_read_input_tokens = usage_object.get("cache_read_input_tokens")
         if cache_read_input_tokens is not None:
             properties["$ai_cache_read_input_tokens"] = cache_read_input_tokens
+        else:
+            # `cache_read_input_tokens` is Anthropic's spelling, and LiteLLM only
+            # populates it from Anthropic-shaped usage. OpenAI reports its cached
+            # prompt tokens on `prompt_tokens_details.cached_tokens` for both Chat
+            # Completions and the Responses API, because LiteLLM normalizes the
+            # Responses API's `input_tokens_details` onto that same field. Zero here
+            # means the request missed the cache rather than the provider not
+            # reporting, so it is dropped to keep the property meaning "a cache read
+            # happened", which is how posthoganalytics treats non-Anthropic providers.
+            cached_tokens = (usage_object.get("prompt_tokens_details") or {}).get("cached_tokens")
+            if cached_tokens:
+                properties["$ai_cache_read_input_tokens"] = cached_tokens
         cache_creation_input_tokens = usage_object.get("cache_creation_input_tokens")
         if cache_creation_input_tokens is not None:
             properties["$ai_cache_creation_input_tokens"] = cache_creation_input_tokens

--- a/services/llm-gateway/tests/callbacks/test_posthog.py
+++ b/services/llm-gateway/tests/callbacks/test_posthog.py
@@ -28,6 +28,11 @@ def _run_sync(executor, fn, *args):
     fn(*args)
 
 
+# Distinguishes an omitted property from one explicitly captured as 0, which is the
+# difference between "the provider reports no cache" and "the request missed the cache".
+_ABSENT = object()
+
+
 class TestPostHogCallback:
     @pytest.fixture
     def callback(self):
@@ -436,23 +441,59 @@ class TestPostHogCallback:
     def test_callback_name_is_posthog(self, callback: PostHogCallback) -> None:
         assert callback.callback_name == "posthog"
 
+    @pytest.mark.parametrize(
+        "model,provider,usage_object,expected",
+        [
+            pytest.param(
+                "claude-sonnet-4-6",
+                "anthropic",
+                {"cache_read_input_tokens": 60, "cache_creation_input_tokens": 30},
+                {"$ai_cache_read_input_tokens": 60, "$ai_cache_creation_input_tokens": 30},
+                id="anthropic_reports_cache_read_and_write",
+            ),
+            pytest.param(
+                "claude-sonnet-4-6",
+                "anthropic",
+                {"cache_read_input_tokens": 0, "cache_creation_input_tokens": 0},
+                {"$ai_cache_read_input_tokens": 0, "$ai_cache_creation_input_tokens": 0},
+                id="anthropic_keeps_explicit_zeros",
+            ),
+            pytest.param(
+                "gpt-5.2",
+                "openai",
+                {"prompt_tokens_details": {"cached_tokens": 60}},
+                {"$ai_cache_read_input_tokens": 60},
+                id="openai_reports_cached_tokens_on_details",
+            ),
+            pytest.param(
+                "gpt-5.2",
+                "openai",
+                {"prompt_tokens_details": {"cached_tokens": 0}},
+                {},
+                id="openai_drops_cache_miss",
+            ),
+            pytest.param("gpt-5.2", "openai", {}, {}, id="provider_reports_no_cache_usage"),
+        ],
+    )
     @pytest.mark.asyncio
-    async def test_on_success_emits_cache_tokens_when_present(
-        self, callback: PostHogCallback, auth_user: AuthenticatedUser, mock_posthog_client: tuple
+    async def test_on_success_maps_cache_tokens_for_each_provider_usage_shape(
+        self,
+        callback: PostHogCallback,
+        auth_user: AuthenticatedUser,
+        mock_posthog_client: tuple,
+        model: str,
+        provider: str,
+        usage_object: dict,
+        expected: dict,
     ) -> None:
         _, mock_client = mock_posthog_client
         kwargs = {
             "standard_logging_object": {
-                "model": "claude-sonnet-4-6",
-                "custom_llm_provider": "anthropic",
+                "model": model,
+                "custom_llm_provider": provider,
                 "prompt_tokens": 100,
                 "completion_tokens": 20,
-                "metadata": {
-                    "usage_object": {
-                        "cache_read_input_tokens": 60,
-                        "cache_creation_input_tokens": 30,
-                    },
-                },
+                "metadata": {"usage_object": usage_object},
             },
             "litellm_params": {},
         }
@@ -464,29 +505,8 @@ class TestPostHogCallback:
             await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
 
         props = mock_client.capture.call_args.kwargs["properties"]
-        assert props["$ai_cache_read_input_tokens"] == 60
-        assert props["$ai_cache_creation_input_tokens"] == 30
-
-    @pytest.mark.asyncio
-    async def test_on_success_omits_cache_tokens_when_absent(
-        self,
-        callback: PostHogCallback,
-        auth_user: AuthenticatedUser,
-        standard_logging_object: dict,
-        mock_posthog_client: tuple,
-    ) -> None:
-        _, mock_client = mock_posthog_client
-        kwargs = {"standard_logging_object": standard_logging_object, "litellm_params": {}}
-
-        with (
-            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
-            patch("llm_gateway.callbacks.posthog.get_product", return_value="slack_app"),
-        ):
-            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
-
-        props = mock_client.capture.call_args.kwargs["properties"]
-        assert "$ai_cache_read_input_tokens" not in props
-        assert "$ai_cache_creation_input_tokens" not in props
+        for key in ("$ai_cache_read_input_tokens", "$ai_cache_creation_input_tokens"):
+            assert props.get(key, _ABSENT) == expected.get(key, _ABSENT), key
 
     @pytest.mark.parametrize(
         "cost_breakdown,expected_props",

--- a/services/llm-gateway/tests/callbacks/test_posthog.py
+++ b/services/llm-gateway/tests/callbacks/test_posthog.py
@@ -28,11 +28,6 @@ def _run_sync(executor, fn, *args):
     fn(*args)
 
 
-# Distinguishes an omitted property from one explicitly captured as 0, which is the
-# difference between "the provider reports no cache" and "the request missed the cache".
-_ABSENT = object()
-
-
 class TestPostHogCallback:
     @pytest.fixture
     def callback(self):
@@ -505,8 +500,11 @@ class TestPostHogCallback:
             await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
 
         props = mock_client.capture.call_args.kwargs["properties"]
-        for key in ("$ai_cache_read_input_tokens", "$ai_cache_creation_input_tokens"):
-            assert props.get(key, _ABSENT) == expected.get(key, _ABSENT), key
+        assert {
+            key: props[key]
+            for key in ("$ai_cache_read_input_tokens", "$ai_cache_creation_input_tokens")
+            if key in props
+        } == expected
 
     @pytest.mark.parametrize(
         "cost_breakdown,expected_props",


### PR DESCRIPTION
## Problem

- Anyone measuring prompt-cache effectiveness for a PostHog product that runs on OpenAI through the LLM gateway cannot. Those `$ai_generation` events carry no `$ai_cache_read_input_tokens`.
- The property is absent rather than zero, so a dashboard cannot separate a cache miss from missing instrumentation.
- Caching itself works. The same events carry a positive `$ai_cache_read_cost_usd`, which LiteLLM derives from the cached-token count the event drops.
- The callback reads `cache_read_input_tokens`, which is Anthropic's spelling. LiteLLM only populates it from Anthropic-shaped usage.
- Anthropic traffic through the same callback reports normally, so the gap follows the provider rather than the product or the calling path.

## Changes

- The callback falls back to `prompt_tokens_details.cached_tokens` when the Anthropic key is absent. LiteLLM normalizes the Responses API's `input_tokens_details` onto that field, so one lookup covers both OpenAI wire formats.
- Zero stays omitted on that fallback, matching the non-Anthropic branch of posthoganalytics' `posthog/ai/utils.py`. A present property now means a cache read happened.
- Anthropic keeps its current behavior, including explicit zeros.
- One change in the shared callback covers every gateway caller on OpenAI.
- `services/llm-gateway` is under a code freeze. This is a reliability fix for first-party callers that `PARITY.md` still lists as Python-only, and it adds no feature.

> [!NOTE]
> The Go `ai-gateway` is out of scope here and may carry the same gap. Worth checking before more traffic moves.

## How did you test this code?

- I replaced two single-shape cache tests with one parameterized test over the provider usage shapes.
- The `openai_reports_cached_tokens_on_details` case catches this bug. It fails on master and passes with the fix.
- The Anthropic cases pass with and without the fix, which is what shows the fallback left Anthropic behavior alone.
- I made no live provider call myself. The OpenAI usage shape comes from LiteLLM's own normalization and cost-breakdown code, cross-checked against `$ai_generation` events in AI observability.
- That gap is now closed by [a live run against real OpenAI](https://github.com/PostHog/posthog/pull/80321#issuecomment-5238349013), which recorded a genuine cache hit reported on this branch and dropped on master.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- I (actually Claude, via Claude Code) investigated why agent LLM runs reported no prompt-cache tokens, then wrote this fix.
- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- The investigation started on the assumption that the agent-server emission path was at fault. Event data showed the split runs by provider inside a single product, which moved the search to the gateway callback's key lookup.
- I read `posthog-python` to confirm the field mapping and the zero-omission rule. An earlier draft of this fix emitted zero for OpenAI; the SDK omits it, so this matches the SDK.
- The comment on the changed block cited the langchain `CallbackHandler` as its parity reference. That handler emits the property unconditionally, so the citation now points at `posthog/ai/utils.py`, which is the convention the code actually follows.
- Nothing in this PR carries material from the session that is not already public.


---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

