### PR TITLE
fix(error-tracking): commit exception suppression properties

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicGroupsContext.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicGroupsContext.test.tsx
@@ -7,6 +7,7 @@ import { actionsModel } from '~/models/actionsModel'
 import { groupsModel } from '~/models/groupsModel'
 import { performQuery } from '~/queries/query'
 import { initKeaTests } from '~/test/init'
+import { PropertyFilterType } from '~/types'
 
 import { TaxonomicFilterGroupType } from '../types'
 import { buildTaxonomicGroups } from '../utils/buildTaxonomicGroups'
@@ -132,6 +133,19 @@ describe('useTaxonomicGroupsContext', () => {
         expect(types.has(TaxonomicFilterGroupType.Cohorts)).toBe(true)
         expect(types.has(TaxonomicFilterGroupType.HogQLExpression)).toBe(true)
         expect(types.has(TaxonomicFilterGroupType.SuggestedFilters)).toBe(true)
+    })
+
+    it('makes exception properties commit as event property filters', () => {
+        const { result } = renderHook(() => useTaxonomicGroupsContext({}), { wrapper })
+        const exceptionGroup = buildTaxonomicGroups(result.current).find(
+            (group) => group.type === TaxonomicFilterGroupType.ErrorTrackingProperties
+        )
+        const exceptionValue = exceptionGroup?.options?.find((option) => option.name === '$exception_values') as
+            | { name: string; propertyFilterType: PropertyFilterType }
+            | undefined
+
+        expect(exceptionGroup?.getValue?.(exceptionValue)).toBe('$exception_values')
+        expect(exceptionValue?.propertyFilterType).toBe(PropertyFilterType.Event)
     })
 
     it.each([

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
@@ -1470,6 +1470,29 @@ describe('taxonomicFilterLogic', () => {
         })
     })
 
+    describe('exception property selection', () => {
+        it('provides the value and event filter type needed to commit an exception property', () => {
+            const exceptionLogic = taxonomicFilterLogic({
+                taxonomicFilterLogicKey: 'exceptionPropertySelection',
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.ErrorTrackingProperties],
+                onChange: jest.fn(),
+            })
+            exceptionLogic.mount()
+
+            const group = exceptionLogic.values.taxonomicGroups.find(
+                (candidate) => candidate.type === TaxonomicFilterGroupType.ErrorTrackingProperties
+            )
+            const option = group?.options?.find((candidate) => candidate.name === '$exception_values') as
+                | { name: string; propertyFilterType: PropertyFilterType }
+                | undefined
+
+            expect(group?.getValue?.(option)).toBe('$exception_values')
+            expect(option?.propertyFilterType).toBe(PropertyFilterType.Event)
+
+            exceptionLogic.unmount()
+        })
+    })
+
     describe('event feature flag properties are a separate group from event properties', () => {
         let splitLogic: ReturnType<typeof taxonomicFilterLogic.build>
 

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -1291,15 +1291,19 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                                 name: value,
                                 value,
                                 group: TaxonomicFilterGroupType.EventProperties,
+                                propertyFilterType: PropertyFilterType.Event,
                             })),
                             ...(currentTeam?.person_display_name_properties
                                 ? currentTeam.person_display_name_properties.map((property) => ({
                                       name: property,
                                       value: property,
                                       group: TaxonomicFilterGroupType.PersonProperties,
+                                      propertyFilterType: PropertyFilterType.Person,
                                   }))
                                 : []),
                         ],
+                        getName: (option) => option.name,
+                        getValue: (option) => option.value,
                         getIcon: getPropertyDefinitionIcon,
                         getPopoverHeader: () => 'Exception properties',
                     },

--- a/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
@@ -487,15 +487,19 @@ export function buildTaxonomicGroups(ctx: BuildTaxonomicGroupsContext): Taxonomi
                     name: value,
                     value,
                     group: TaxonomicFilterGroupType.EventProperties,
+                    propertyFilterType: PropertyFilterType.Event,
                 })),
                 ...(currentTeam?.person_display_name_properties
                     ? currentTeam.person_display_name_properties.map((property) => ({
                           name: property,
                           value: property,
                           group: TaxonomicFilterGroupType.PersonProperties,
+                          propertyFilterType: PropertyFilterType.Person,
                       }))
                     : []),
             ],
+            getName: (option) => option.name,
+            getValue: (option) => option.value,
             getIcon: getPropertyDefinitionIcon,
             getPopoverHeader: () => 'Exception properties',
         },


### PR DESCRIPTION
## Problem

People cannot select exception properties when they create error tracking suppression rules, so the UI cannot author useful rules.

## Changes

- Exception property rows now commit their property key and correct event or person filter type.
- The fix covers the legacy picker and rebuilt menu.
- No screenshot: this fixes selection behavior without changing the layout.

## How did you test this code?

- Added regression coverage for both picker implementations. It catches exception rows that preview but do not commit.
- Ran the focused TaxonomicFilter Jest suites.
- Ran frontend formatting, lint fixes, and the full TypeScript check.
- Not run: `hogli ci:preflight --fix`, because this VM has neither `hogli` nor `flox`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The user workflow and labels are unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code implemented and verified this fix. Skills invoked: `/modifying-taxonomic-filter`, `/writing-tests`, `/running-ci-preflight`, and `/writing-pr-descriptions`.

The change mirrors the exception-group contract across both live picker implementations.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*