### PR TITLE
fix(desktop): inherit Opus 5 for delegated agents

### DIFF
--- a/products/desktop/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/claude-agent.ts
@@ -2089,6 +2089,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       onEnsureLocalToolsConnected: () =>
         this.ensureLocalToolsConnected("guard-hook"),
       taskState,
+      getCurrentModelId: () => this.session?.modelId,
       gatewayEnv: this.options?.gatewayEnv,
       onTaskStateChange: async () => {
         await this.client.sessionUpdate({

--- a/products/desktop/packages/agent/src/adapters/claude/hooks.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/hooks.test.ts
@@ -14,6 +14,7 @@ import {
   createReadEnrichmentHook,
   createReadImageGuardHook,
   createSignedCommitGuardHook,
+  createSubagentRewriteHook,
   createTaskHook,
   type EnrichedReadCache,
 } from "./hooks";
@@ -348,6 +349,87 @@ function buildSettingsManagerStub(
     checkPermission: () => result,
   } as unknown as SettingsManager;
 }
+
+describe("createSubagentRewriteHook", () => {
+  const logger = new Logger({ debug: false });
+
+  test("inherits the exact parent model when opus means Claude Opus 5", async () => {
+    const hook = createSubagentRewriteHook(
+      logger,
+      new Set(),
+      () => "claude-opus-5",
+    );
+
+    const result = await hook(
+      buildPreToolUseHookInput("Agent", {
+        subagent_type: "code-reviewer",
+        model: "opus",
+      }),
+      undefined,
+      { signal: new AbortController().signal },
+    );
+
+    expect(result).toMatchObject({
+      continue: true,
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        updatedInput: {
+          subagent_type: "code-reviewer",
+          model: "inherit",
+        },
+      },
+    });
+  });
+
+  test.each([
+    ["claude-opus-4-8", "opus"],
+    ["claude-opus-5", "sonnet"],
+    [undefined, "opus"],
+  ])("leaves parent %s with model %s unchanged", async (parentModel, model) => {
+    const hook = createSubagentRewriteHook(
+      logger,
+      new Set(),
+      () => parentModel,
+    );
+
+    const result = await hook(
+      buildPreToolUseHookInput("Agent", {
+        subagent_type: "code-reviewer",
+        model,
+      }),
+      undefined,
+      { signal: new AbortController().signal },
+    );
+
+    expect(result).toEqual({ continue: true });
+  });
+
+  test("combines model and subagent type rewrites", async () => {
+    const hook = createSubagentRewriteHook(
+      logger,
+      new Set(["ph-explore"]),
+      () => "claude-opus-5",
+    );
+
+    const result = await hook(
+      buildPreToolUseHookInput("Agent", {
+        subagent_type: "Explore",
+        model: "opus",
+      }),
+      undefined,
+      { signal: new AbortController().signal },
+    );
+
+    expect(result).toMatchObject({
+      hookSpecificOutput: {
+        updatedInput: {
+          subagent_type: "ph-explore",
+          model: "inherit",
+        },
+      },
+    });
+  });
+});
 
 describe("createPreToolUseHook", () => {
   const logger = new Logger({ debug: false });

--- a/products/desktop/packages/agent/src/adapters/claude/hooks.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/hooks.ts
@@ -268,7 +268,11 @@ export const SUBAGENT_REWRITES: Record<string, string> = {
 };
 
 export const createSubagentRewriteHook =
-  (logger: Logger, registeredAgents: ReadonlySet<string>): HookCallback =>
+  (
+    logger: Logger,
+    registeredAgents: ReadonlySet<string>,
+    getCurrentModelId?: () => string | undefined,
+  ): HookCallback =>
   async (input: HookInput, _toolUseID: string | undefined) => {
     if (input.hook_event_name !== "PreToolUse") {
       return { continue: true };
@@ -279,30 +283,50 @@ export const createSubagentRewriteHook =
     }
 
     const toolInput = input.tool_input as Record<string, unknown> | undefined;
-    const subagentType = toolInput?.subagent_type;
-    if (typeof subagentType !== "string" || !SUBAGENT_REWRITES[subagentType]) {
+    if (!toolInput) {
       return { continue: true };
     }
 
-    const target = SUBAGENT_REWRITES[subagentType];
-    if (!registeredAgents.has(target)) {
-      logger.warn(
-        `[SubagentRewriteHook] Skipping rewrite ${subagentType} → ${target}: target agent not registered for this session. Falling back to built-in ${subagentType}.`,
+    const updatedInput = { ...toolInput };
+    let changed = false;
+    const subagentType = toolInput.subagent_type;
+    if (typeof subagentType === "string" && SUBAGENT_REWRITES[subagentType]) {
+      const target = SUBAGENT_REWRITES[subagentType];
+      if (registeredAgents.has(target)) {
+        logger.info(
+          `[SubagentRewriteHook] Rewriting subagent_type: ${subagentType} → ${target}`,
+        );
+        updatedInput.subagent_type = target;
+        changed = true;
+      } else {
+        logger.warn(
+          `[SubagentRewriteHook] Skipping rewrite ${subagentType} → ${target}: target agent not registered for this session. Falling back to built-in ${subagentType}.`,
+        );
+      }
+    }
+
+    // The SDK's Agent tool exposes family aliases rather than canonical model
+    // IDs. Its `opus` alias can lag behind the parent session's selected Opus
+    // generation, while `inherit` preserves that exact selection.
+    if (
+      toolInput.model === "opus" &&
+      getCurrentModelId?.() === "claude-opus-5"
+    ) {
+      logger.info(
+        "[SubagentRewriteHook] Rewriting model: opus → inherit for Claude Opus 5 parent",
       );
-      return { continue: true };
+      updatedInput.model = "inherit";
+      changed = true;
     }
 
-    logger.info(
-      `[SubagentRewriteHook] Rewriting subagent_type: ${subagentType} → ${target}`,
-    );
+    if (!changed) return { continue: true };
 
     return {
       continue: true,
       hookSpecificOutput: {
         hookEventName: "PreToolUse" as const,
         updatedInput: {
-          ...toolInput,
-          subagent_type: target,
+          ...updatedInput,
         },
       },
     };

--- a/products/desktop/packages/agent/src/adapters/claude/session/options.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/options.ts
@@ -99,6 +99,8 @@ export interface BuildOptionsParams {
   /** Called after createTaskHook mutates taskState so callers can emit a plan
    * sessionUpdate to the client. */
   onTaskStateChange?: () => Promise<void>;
+  /** Returns the canonical model selected for the live parent session. */
+  getCurrentModelId?: () => string | undefined;
   /** Explicit gateway config — prevents global process.env mutation. */
   gatewayEnv?: GatewayEnv;
 }
@@ -264,6 +266,7 @@ function buildHooks(
   enrichmentDeps: FileEnrichmentDeps | undefined,
   enrichedReadCache: EnrichedReadCache | undefined,
   registeredAgents: ReadonlySet<string>,
+  getCurrentModelId: (() => string | undefined) | undefined,
   cloudMode: boolean,
   onEnsureLocalToolsConnected: (() => Promise<boolean>) | undefined,
   taskState: TaskState,
@@ -285,7 +288,7 @@ function buildHooks(
 
   const preToolUseHooks = [
     createPreToolUseHook(settingsManager, logger, posthogExecPermissionRegex),
-    createSubagentRewriteHook(logger, registeredAgents),
+    createSubagentRewriteHook(logger, registeredAgents, getCurrentModelId),
   ];
   if (cloudMode) {
     preToolUseHooks.push(
@@ -522,6 +525,7 @@ export function buildSessionOptions(params: BuildOptionsParams): Options {
       params.enrichmentDeps,
       params.enrichedReadCache,
       registeredAgentNames,
+      params.getCurrentModelId,
       params.cloudMode ?? false,
       params.onEnsureLocalToolsConnected,
       params.taskState,


### PR DESCRIPTION
## Problem

Delegated Claude reviews can run on an older Opus generation when the parent session uses Claude Opus 5 and the Agent call requests the `opus` alias.

**Why:** Fresh-context reviews should use the requested parent model tier instead of silently selecting an older family alias.

## Changes

- Rewrite Agent calls from `opus` to `inherit` only when the parent selected `claude-opus-5`
- Preserve explicit model choices and existing behavior for older Opus parents