### PR TITLE
feat(batch-exports): Export person_properties by default 

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -7039,9 +7039,9 @@ snapshots:
     scenes-app-settings-authentication-domains--no-domains--light:
         hash: v1.k794b7964.37755257eeeb09bcb190a4623e6554e356ffcc6b4e61086b8d2427a3796af34b.eJhnmp6Mqw_TfNQhRHgzZylOtfr8VMwxaRjOdzUHuiI
     scenes-app-settings-authentication-domains--one-unverified-domain--dark:
-        hash: v1.k794b7964.d2354aea8e40abfcfeb18691d15e48abc24724460dbc0118185c750d3f8ce6d1.Gcj1tCTTgepeyP-Ep4JIhieodM8RlFeAjTQGNkP2UeQ
+        hash: v1.k794b7964.ba64063f3c9c93c5f26f1ef7b83800afeb7a63aec7008d369e2cd7538c4d760b.w4icGggF4i9ltix044heGQLCxuyCXP0irKyWwkKl6Fs
     scenes-app-settings-authentication-domains--one-unverified-domain--light:
-        hash: v1.k794b7964.0c40bb5374be5247d5c0e2d73a2118c34d8083775cce447d3faf00ab4012f187.rqLTqwCSkMm5b7tey65wa2ycrn4lTsv8Rw4ASlNuCKs
+        hash: v1.k794b7964.9f4f53aee807047bda1de6e3898a5c784bca50bb1f0cbf1d3333e3323e056b41.1g_1hgiCN3qaOaI0lA8Ajwhb8mZhXu95OkHJq1dGfv0
     scenes-app-settings-environment--settings-environment-access-control--dark:
         hash: v1.k794b7964.cdbb2694b5d5524628e578f807f3282a0e458c45172c29b79e2b6e7c06eac09f.HqYn6cyhm9cm_fXbavd2nlYeqoTVNd7ODjvCMKlAsIc
     scenes-app-settings-environment--settings-environment-access-control--light:

--- a/frontend/src/scenes/data-pipelines/batch-exports/destinations/azureblob.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/destinations/azureblob.tsx
@@ -3,7 +3,13 @@ import { LemonInput } from '@posthog/lemon-ui'
 import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/IntegrationChoice'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 
-import { CompressionField, FileFormatField, MaxFileSizeField, validateAzureContainerName } from './common'
+import {
+    CompressionField,
+    FileFormatField,
+    MaxFileSizeField,
+    PERSON_PROPERTIES_EVENT_FIELD,
+    validateAzureContainerName,
+} from './common'
 import type { DestinationDefinition } from './types'
 
 export const azureBlobDefinition: DestinationDefinition = {
@@ -19,6 +25,7 @@ export const azureBlobDefinition: DestinationDefinition = {
         container_name: validateAzureContainerName(formValues.container_name),
     }),
     eventTableOverrides: { teamIdHogql: 'team_id' },
+    eventTableExtraFields: { ...PERSON_PROPERTIES_EVENT_FIELD },
     Fields: function AzureBlobFields({ formValues }) {
         return (
             <>

--- a/frontend/src/scenes/data-pipelines/batch-exports/destinations/bigquery.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/destinations/bigquery.tsx
@@ -4,6 +4,7 @@ import { LemonCheckbox, LemonInput, Tooltip } from '@posthog/lemon-ui'
 import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/IntegrationChoice'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 
+import { PERSON_PROPERTIES_EVENT_FIELD } from './common'
 import type { DestinationDefinition } from './types'
 
 export const bigqueryDefinition: DestinationDefinition = {
@@ -15,6 +16,7 @@ export const bigqueryDefinition: DestinationDefinition = {
     configKeys: ['dataset_id', 'table_id', 'use_json_type'],
     eventTableOverrides: { teamIdHogql: 'team_id' },
     eventTableExtraFields: {
+        ...PERSON_PROPERTIES_EVENT_FIELD,
         bq_ingested_timestamp: {
             name: 'bq_ingested_timestamp',
             hogql_value: 'NOW64()',

--- a/frontend/src/scenes/data-pipelines/batch-exports/destinations/common.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/destinations/common.tsx
@@ -262,6 +262,17 @@ export function MaxFileSizeField(): JSX.Element {
     )
 }
 
+// Included in every destination's event table preview except HTTP, which posts capture-format
+// payloads and does not export the column.
+export const PERSON_PROPERTIES_EVENT_FIELD: Record<string, DatabaseSchemaField> = {
+    person_properties: {
+        name: 'person_properties',
+        hogql_value: "nullIf(person_properties, '')",
+        type: 'string',
+        schema_valid: true,
+    },
+}
+
 // Event table preview columns shared by every S3-family destination (S3, AwsS3, S3Compatible).
 export const S3_FAMILY_EVENT_TABLE_EXTRA_FIELDS: Record<string, DatabaseSchemaField> = {
     person_id: {
@@ -270,12 +281,7 @@ export const S3_FAMILY_EVENT_TABLE_EXTRA_FIELDS: Record<string, DatabaseSchemaFi
         type: 'string',
         schema_valid: true,
     },
-    person_properties: {
-        name: 'person_properties',
-        hogql_value: "nullIf(person_properties, '')",
-        type: 'string',
-        schema_valid: true,
-    },
+    ...PERSON_PROPERTIES_EVENT_FIELD,
     created_at: {
         name: 'created_at',
         hogql_value: 'created_at',

--- a/frontend/src/scenes/data-pipelines/batch-exports/destinations/databricks.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/destinations/databricks.tsx
@@ -4,6 +4,7 @@ import { LemonCheckbox, LemonInput, Link, Tooltip } from '@posthog/lemon-ui'
 import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/IntegrationChoice'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 
+import { PERSON_PROPERTIES_EVENT_FIELD } from './common'
 import type { DestinationDefinition } from './types'
 
 export const databricksDefinition: DestinationDefinition = {
@@ -23,6 +24,7 @@ export const databricksDefinition: DestinationDefinition = {
             type: 'integer',
             schema_valid: true,
         },
+        ...PERSON_PROPERTIES_EVENT_FIELD,
         databricks_ingested_timestamp: {
             name: 'databricks_ingested_timestamp',
             hogql_value: 'NOW64()',

--- a/frontend/src/scenes/data-pipelines/batch-exports/destinations/postgres.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/destinations/postgres.tsx
@@ -4,6 +4,7 @@ import { LemonBanner, LemonCheckbox, LemonInput, Tooltip } from '@posthog/lemon-
 import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/IntegrationChoice'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 
+import { PERSON_PROPERTIES_EVENT_FIELD } from './common'
 import type { DestinationDefinition } from './types'
 
 export const postgresDefinition: DestinationDefinition = {
@@ -21,6 +22,7 @@ export const postgresDefinition: DestinationDefinition = {
         return ['host', 'port', 'database', 'schema', 'table_name']
     },
     eventTableOverrides: { teamIdHogql: 'toInt32(team_id)' },
+    eventTableExtraFields: { ...PERSON_PROPERTIES_EVENT_FIELD },
     Fields: function PostgresFields({ isNew, formValues }) {
         const useIntegration = isNew || !!formValues.integration_id
 

--- a/frontend/src/scenes/data-pipelines/batch-exports/destinations/redshift.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/destinations/redshift.tsx
@@ -2,7 +2,7 @@ import { LemonInput, LemonSelect } from '@posthog/lemon-ui'
 
 import { LemonField } from 'lib/lemon-ui/LemonField'
 
-import { AWS_ONLY_REGION_OPTIONS, validateBucketName } from './common'
+import { AWS_ONLY_REGION_OPTIONS, PERSON_PROPERTIES_EVENT_FIELD, validateBucketName } from './common'
 import type { DestinationDefinition } from './types'
 
 // Redshift is the only destination with a non-trivial form ↔ payload mapping.
@@ -112,6 +112,7 @@ export const redshiftDefinition: DestinationDefinition = {
         return result
     },
     eventTableOverrides: { teamIdHogql: 'toInt32(team_id)' },
+    eventTableExtraFields: { ...PERSON_PROPERTIES_EVENT_FIELD },
     Fields: function RedshiftFields({ isNew, formValues }) {
         return (
             <>

--- a/frontend/src/scenes/data-pipelines/batch-exports/destinations/snowflake.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/destinations/snowflake.tsx
@@ -3,6 +3,7 @@ import { LemonBanner, LemonInput, LemonSelect, LemonTextArea } from '@posthog/le
 import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/IntegrationChoice'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 
+import { PERSON_PROPERTIES_EVENT_FIELD } from './common'
 import type { DestinationDefinition } from './types'
 
 // New Snowflake exports must store credentials in a linked Integration. Exports created before
@@ -39,6 +40,7 @@ export const snowflakeDefinition: DestinationDefinition = {
         setOnceName: 'people_set_once',
     },
     eventTableExtraFields: {
+        ...PERSON_PROPERTIES_EVENT_FIELD,
         snowflake_ingested_timestamp: {
             name: 'snowflake_ingested_timestamp',
             hogql_value: 'NOW64()',

--- a/products/batch_exports/backend/temporal/batch_exports.py
+++ b/products/batch_exports/backend/temporal/batch_exports.py
@@ -157,6 +157,7 @@ def default_fields() -> list[BatchExportField]:
             expression="set_once",
             alias="set_once",
         ),
+        BatchExportField(expression="person_properties", alias="person_properties"),
     ]
 
 
@@ -174,6 +175,7 @@ def events_model_default_fields() -> list[BatchExportField]:
         BatchExportField(expression="event", alias="event"),
         BatchExportField(expression="properties", alias="properties"),
         BatchExportField(expression="distinct_id", alias="distinct_id"),
+        BatchExportField(expression="person_properties", alias="person_properties"),
     ]
 
 

--- a/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
@@ -1035,6 +1035,7 @@ def _get_databricks_table_settings(
             ("uuid", "STRING"),
             ("event", "STRING"),
             ("properties", json_type),
+            ("person_properties", json_type),
             ("distinct_id", "STRING"),
             ("team_id", "BIGINT"),
             ("timestamp", "TIMESTAMP"),
@@ -1325,6 +1326,16 @@ async def insert_into_databricks_activity_from_stage(inputs: DatabricksInsertInp
             # client before it reaches this point)
             statement_timeout_seconds=long_running_query_timeout + ONE_MINUTE,
         ).connect() as databricks_client:
+            if not requires_merge and inputs.use_automatic_schema_evolution is False:
+                # Without a stage table, COPY INTO copies directly into the final table,
+                # and with schema evolution disabled it fails on any column an existing
+                # table lacks, so skip such columns. A missing table returns no columns.
+                existing_columns = await databricks_client.aget_table_columns(inputs.table_name)
+                if existing_columns:
+                    filtered_fields = [field for field in table_fields if field[0] in existing_columns]
+                    if filtered_fields:
+                        table_fields = filtered_fields
+
             async with manage_resources(
                 client=databricks_client,
                 volume_name=volume_name,

--- a/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
@@ -805,6 +805,7 @@ def _get_table_fields(
             ("ip", "VARCHAR(200)"),
             ("site_url", "VARCHAR(200)"),
             ("timestamp", "TIMESTAMP WITH TIME ZONE"),
+            ("person_properties", "JSONB"),
         ]
     else:
         return get_postgres_fields_from_record_schema(

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -61,7 +61,11 @@ from products.batch_exports.backend.temporal.pipeline.transformer import (
 )
 from products.batch_exports.backend.temporal.pipeline.types import BatchExportResult
 from products.batch_exports.backend.temporal.queue import RecordBatchQueue, wait_for_schema_or_producer
-from products.batch_exports.backend.temporal.utils import JsonType, handle_non_retryable_errors
+from products.batch_exports.backend.temporal.utils import (
+    JsonType,
+    cast_record_batch_schema_json_columns,
+    handle_non_retryable_errors,
+)
 
 LOGGER = get_write_only_logger(__name__)
 EXTERNAL_LOGGER = get_logger()
@@ -1387,6 +1391,28 @@ async def copy_into_redshift_activity_from_stage(inputs: RedshiftCopyActivityInp
             if merge_settings.requires_merge
             else inputs.table.name
         )
+
+        if not merge_settings.requires_merge:
+            # Without a stage table, Parquet files are copied directly into the final
+            # table, and the COPY column list names every column in the files. Pre-set
+            # the transformer's schema to drop columns missing from an existing table,
+            # as COPY would otherwise fail on them.
+            try:
+                async with RedshiftClient.from_inputs(
+                    inputs.connection, database=inputs.connection.database
+                ).connect() as redshift_client:
+                    existing_columns = set(
+                        await redshift_client.aget_table_columns(inputs.table.schema_name, inputs.table.name)
+                    )
+            except (psycopg.errors.UndefinedTable, psycopg.errors.InternalError_):
+                pass
+            else:
+                filtered_fields = [field for field in record_batch_schema if field.name in existing_columns]
+
+                if 0 < len(filtered_fields) < len(record_batch_schema):
+                    transformer.schema = cast_record_batch_schema_json_columns(
+                        pa.schema(filtered_fields), json_columns=table_schemas.super_columns
+                    )
 
         async with s3_client(
             credentials.aws_access_key_id,

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -793,6 +793,7 @@ def _get_table_schemas(
             ("ip", "VARCHAR(200)"),
             ("site_url", "VARCHAR(200)"),
             ("timestamp", "TIMESTAMP WITH TIME ZONE"),
+            ("person_properties", properties_type),
         ]
 
     else:

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -260,7 +260,6 @@ def s3_default_fields() -> list[BatchExportField]:
     """
     batch_export_fields = default_fields()
     batch_export_fields.append({"expression": "elements_chain", "alias": "elements_chain"})
-    batch_export_fields.append({"expression": "person_properties", "alias": "person_properties"})
     batch_export_fields.append({"expression": "person_id", "alias": "person_id"})
 
     # Again, in contrast to other destinations, and for historical reasons, we do not include these fields.

--- a/products/batch_exports/backend/tests/temporal/destinations/databricks/test_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/databricks/test_workflow.py
@@ -361,9 +361,45 @@ class TestDatabricksBatchExportWorkflow(CommonWorkflowTests):
         )
 
     @pytest.mark.parametrize("use_automatic_schema_evolution", [True, False])
+    @pytest.mark.parametrize(
+        "model_name,missing_column,pre_created_table_columns",
+        [
+            pytest.param(
+                "persons",
+                "created_at",
+                [
+                    ("team_id", "BIGINT"),
+                    ("distinct_id", "STRING"),
+                    ("person_id", "STRING"),
+                    ("properties", "VARIANT"),
+                    ("person_distinct_id_version", "BIGINT"),
+                    ("person_version", "BIGINT"),
+                    ("is_deleted", "BOOLEAN"),
+                ],
+                id="persons-missing-created_at",
+            ),
+            pytest.param(
+                "events",
+                "person_properties",
+                [
+                    ("uuid", "STRING"),
+                    ("event", "STRING"),
+                    ("properties", "VARIANT"),
+                    ("distinct_id", "STRING"),
+                    ("team_id", "BIGINT"),
+                    ("timestamp", "TIMESTAMP"),
+                    ("databricks_ingested_timestamp", "TIMESTAMP"),
+                ],
+                id="events-missing-person_properties",
+            ),
+        ],
+    )
     async def test_workflow_handles_model_schema_changes(
         self,
         use_automatic_schema_evolution: bool,
+        model_name: str,
+        missing_column: str,
+        pre_created_table_columns: list[tuple[str, str]],
         destination_test: DatabricksDestinationTest,
         interval: str,
         generate_test_data,
@@ -378,34 +414,29 @@ class TestDatabricksBatchExportWorkflow(CommonWorkflowTests):
 
         If we update the schema of the model we export, we should still be able to export the data without breaking
         existing exports.
-        To replicate this situation we first export the data with the original schema, then delete a column in the
-        destination and then rerun the export.
+        To replicate this situation we create the destination table with a schema that predates `missing_column`
+        and then run the export.
 
         Databricks supports automatic schema evolution, which means the target table will automatically be updated with
-        the schema of the source table (no columns will ever be dropped from the target table however).
+        the schema of the source table (no columns will ever be dropped from the target table however). For the persons
+        model this happens in the MERGE, for the events model in the COPY INTO.
 
-        If `use_automatic_schema_evolution` is True, we will use `WITH SCHEMA EVOLUTION` to enable automatic schema
-        evolution. In this case, the target table will automatically be updated with the new column.
+        If `use_automatic_schema_evolution` is True, the target table will automatically be updated with the new
+        column.
 
-        If `use_automatic_schema_evolution` is False, we will not use `WITH SCHEMA EVOLUTION` and the target table will
-        not be updated with the new column.
-
+        If `use_automatic_schema_evolution` is False, the target table will not be updated with the new column, and
+        the export should proceed without it.
         """
 
-        # create the table manually, specifically without the created_at column
+        # create the table manually, specifically without `missing_column`
         destination_config = batch_export_for_destination.destination.config
         catalog = destination_config["catalog"]
         schema = destination_config["schema"]
         table_name = destination_config["table_name"]
+        column_ddl = ",\n".join(f"`{name}` {field_type}" for name, field_type in pre_created_table_columns)
         query = f"""
         CREATE TABLE IF NOT EXISTS `{catalog}`.`{schema}`.`{table_name}` (
-            `team_id` BIGINT,
-            `distinct_id` STRING,
-            `person_id` STRING,
-            `properties` VARIANT,
-            `person_distinct_id_version` BIGINT,
-            `person_version` BIGINT,
-            `is_deleted` BOOLEAN
+            {column_ddl}
         )
         USING DELTA
         COMMENT 'PostHog generated table'
@@ -413,7 +444,7 @@ class TestDatabricksBatchExportWorkflow(CommonWorkflowTests):
         with destination_test.cursor(ateam.pk, integration) as cursor:
             cursor.execute(query)
 
-        batch_export_model = BatchExportModel(name="persons", schema=None)
+        batch_export_model = BatchExportModel(name=model_name, schema=None)
 
         inputs = destination_test.create_batch_export_inputs(
             team_id=ateam.pk,
@@ -431,8 +462,9 @@ class TestDatabricksBatchExportWorkflow(CommonWorkflowTests):
         )
 
         assert run.status == "Completed"
-        _, persons_to_export_created = generate_test_data
-        assert run.records_completed == len(persons_to_export_created)
+        events_to_export_created, persons_to_export_created = generate_test_data
+        expected_records = persons_to_export_created if model_name == "persons" else events_to_export_created
+        assert run.records_completed == len(expected_records)
         await assert_clickhouse_records_in_destination(
             destination_test=destination_test,
             team_id=ateam.pk,
@@ -442,20 +474,20 @@ class TestDatabricksBatchExportWorkflow(CommonWorkflowTests):
             exclude_events=None,
             inputs=inputs,
             integration=integration,
-            # if `use_automatic_schema_evolution` is False, we expect the created_at column to be dropped
-            fields_to_exclude=["created_at"] if use_automatic_schema_evolution is False else [],
+            # if `use_automatic_schema_evolution` is False, we expect `missing_column` to be dropped
+            fields_to_exclude=[missing_column] if use_automatic_schema_evolution is False else [],
         )
 
-        # check that the created_at column is present or not in the destination
+        # check that `missing_column` is present or not in the destination
         records_from_destination = await destination_test.get_inserted_records(
             team_id=ateam.pk,
             json_columns=destination_test.get_json_columns(inputs),
             integration=integration,
         )
         if use_automatic_schema_evolution is True:
-            assert "created_at" in records_from_destination[0]
+            assert missing_column in records_from_destination[0]
         else:
-            assert "created_at" not in records_from_destination[0]
+            assert missing_column not in records_from_destination[0]
 
     async def test_workflow_raises_incompatible_schema_error_when_target_table_schema_is_wrong(
         self,

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/test_copy_activity.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/test_copy_activity.py
@@ -672,6 +672,85 @@ async def test_copy_into_redshift_activity_inserts_data_with_extra_columns(
 @pytest.mark.parametrize("exclude_events", [None], indirect=True)
 @pytest.mark.parametrize("properties_data_type", ["varchar"], indirect=True)
 @pytest.mark.parametrize("model", [TEST_MODELS[1]])
+async def test_copy_into_redshift_activity_handles_events_table_missing_columns(
+    clickhouse_client,
+    activity_environment,
+    psycopg_connection,
+    redshift_config,
+    bucket_name,
+    bucket_region,
+    exclude_events,
+    model: BatchExportModel,
+    generate_test_data,
+    data_interval_start,
+    data_interval_end,
+    properties_data_type,
+    aws_credentials,
+    key_prefix,
+    ateam,
+):
+    """Test the events model export succeeds with a table missing selected columns.
+
+    Without a merge, files are copied directly into the final table, and the COPY
+    column list names every column in the files. So, columns missing from an existing
+    table must be excluded from the files we upload.
+
+    To replicate this situation, we create the destination table without the
+    'site_url' column, as if it had been created before 'site_url' was exported.
+    """
+    table_name = f"test_copy_activity_missing_columns_table__{ateam.pk}"
+    table_fields = [
+        ("uuid", "VARCHAR(200)"),
+        ("event", "VARCHAR(200)"),
+        ("properties", "VARCHAR(65535)"),
+        ("elements", "VARCHAR(65535)"),
+        ("set", "VARCHAR(65535)"),
+        ("set_once", "VARCHAR(65535)"),
+        ("distinct_id", "VARCHAR(200)"),
+        ("team_id", "INTEGER"),
+        ("ip", "VARCHAR(200)"),
+        ("timestamp", "TIMESTAMP WITH TIME ZONE"),
+    ]
+
+    async with psycopg_connection.transaction():
+        async with psycopg_connection.cursor() as cursor:
+            await cursor.execute(
+                sql.SQL("CREATE TABLE {table} ({fields})").format(
+                    table=sql.Identifier(redshift_config["schema"], table_name),
+                    fields=sql.SQL(",").join(
+                        sql.SQL("{field} {type}").format(field=sql.Identifier(field), type=sql.SQL(field_type))
+                        for field, field_type in table_fields
+                    ),
+                )
+            )
+
+    table_column_names = {field for field, _ in table_fields}
+    expected_fields = [field["alias"] for field in redshift_default_fields() if field["alias"] in table_column_names]
+
+    await _run_activity(
+        activity_environment,
+        redshift_connection=psycopg_connection,
+        clickhouse_client=clickhouse_client,
+        team=ateam,
+        table_name=table_name,
+        bucket_name=bucket_name,
+        bucket_region=bucket_region,
+        key_prefix=key_prefix,
+        credentials=aws_credentials,
+        properties_data_type=properties_data_type,
+        data_interval_start=data_interval_start,
+        data_interval_end=data_interval_end,
+        exclude_events=exclude_events,
+        batch_export_model=model,
+        redshift_config=redshift_config,
+        sort_key="event",
+        expected_fields=expected_fields,
+    )
+
+
+@pytest.mark.parametrize("exclude_events", [None], indirect=True)
+@pytest.mark.parametrize("properties_data_type", ["varchar"], indirect=True)
+@pytest.mark.parametrize("model", [TEST_MODELS[1]])
 async def test_copy_into_redshift_activity_handles_data_over_string_limit(
     clickhouse_client,
     activity_environment,


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

We don't export `person_properties` in batch exports. We need them, as `$set` and `$set_once` may be going away soon (as first revealed in this public PR https://github.com/PostHog/posthog.com/pull/19328).

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

* Adds `person_properties` to default fields.
* Adds field to frontend in to all destinations.
* Remove `person_properties` from S3 since the field is now default.
  * This is *mostly* a no-op: The column order of the parquet file will change. This is a breaking change, but I am assuming with limited impact.
* In databricks, we do not merge event data, so additionally added handling of schema differences there.
* Similarly, in Redshift COPY, we do not support `Table` abstractions, so columns missing have to be handled more manually.

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added new tests were relevant (databricks/redshift). Ran all other tests.
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [x] Publish to changelog?

## Docs update

Yes.
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

I had the robot update the frontend + look for test gaps.

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->
