### PR TITLE
fix(slack_app): make App Home tab controls respond

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -1829,7 +1829,9 @@ def _route_app_home_opened(
     if region_route is not None:
         return region_route
 
-    integration = result.integration if result.integration in result.candidates else result.candidates[0]
+    integration = result.resolved_or_first()
+    if integration is None:
+        return ROUTE_NO_INTEGRATION
     try:
         _handle_app_home_opened(event, slack_team_id, integration=integration)
     except Exception:

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -78,18 +78,8 @@ from products.slack_app.backend.services.integration_resolver import (
     user_resolution_failure_reply,
 )
 from products.slack_app.backend.services.slack_app_home import (
-    ACTION_EDIT_PERSONAL,
-    ACTION_RESET_PERSONAL,
-    ACTION_RESET_PROJECT_PERSONAL,
-    ACTION_SET_PROJECT_PERSONAL,
-    ACTION_SET_PROJECT_WORKSPACE,
-    ACTION_TASKS_FILTER_REPO,
-    ACTION_TASKS_FILTER_STATUS,
-    ACTION_TASKS_PAGE_NEXT,
-    ACTION_TASKS_PAGE_PREV,
-    ACTION_TASKS_REFRESH,
-    ACTION_UNLINK_ACCOUNT,
     EDIT_MODAL_PERSONAL_CALLBACK_ID,
+    HOME_ACTION_IDS,
     MODAL_ACTION_MODEL,
     MODAL_ACTION_RUNTIME_ADAPTER,
     handle_ai_preferences_block_action as _handle_ai_preferences_block_action,
@@ -3088,23 +3078,10 @@ def _extract_context_token(payload: dict) -> str:
     return payload.get("message", {}).get("metadata", {}).get("event_payload", {}).get("context_token", "")
 
 
-_AI_PREFERENCES_ACTION_IDS = frozenset(
-    {
-        ACTION_EDIT_PERSONAL,
-        ACTION_RESET_PERSONAL,
-        ACTION_RESET_PROJECT_PERSONAL,
-        ACTION_SET_PROJECT_PERSONAL,
-        ACTION_SET_PROJECT_WORKSPACE,
-        ACTION_TASKS_FILTER_REPO,
-        ACTION_TASKS_FILTER_STATUS,
-        ACTION_TASKS_PAGE_NEXT,
-        ACTION_TASKS_PAGE_PREV,
-        ACTION_TASKS_REFRESH,
-        ACTION_UNLINK_ACCOUNT,
-        MODAL_ACTION_RUNTIME_ADAPTER,
-        MODAL_ACTION_MODEL,
-    }
-)
+# Every Home tab control, plus the two modal selects that re-render the edit modal.
+# Sourced from `HOME_ACTION_IDS` rather than re-listed, so a control added to the tab
+# is routable here the moment it exists.
+_AI_PREFERENCES_ACTION_IDS = HOME_ACTION_IDS | {MODAL_ACTION_RUNTIME_ADAPTER, MODAL_ACTION_MODEL}
 _AI_PREFERENCES_CALLBACK_IDS = frozenset({EDIT_MODAL_PERSONAL_CALLBACK_ID})
 
 

--- a/products/slack_app/backend/services/integration_resolver.py
+++ b/products/slack_app/backend/services/integration_resolver.py
@@ -62,6 +62,17 @@ class ResolutionResult:
     source: ResolutionSource
     candidates: list[Integration] = field(default_factory=list)
 
+    def resolved_or_first(self) -> Integration | None:
+        """The resolved integration, falling back to the first candidate.
+
+        Surfaces that must act on *some* integration rather than prompt for one share this
+        tie-break, so a workspace's traffic is answered for the same project whichever
+        surface handles it. `candidates` is ordered, so the fallback is stable.
+        """
+        if self.integration is not None and self.integration in self.candidates:
+            return self.integration
+        return self.candidates[0] if self.candidates else None
+
 
 def format_project_candidate_list(candidates: list[Integration]) -> str:
     return "\n".join(f"• `{c.team_id}` — {c.team.organization.name} · {c.team.name}" for c in candidates)

--- a/products/slack_app/backend/services/integration_resolver.py
+++ b/products/slack_app/backend/services/integration_resolver.py
@@ -63,15 +63,17 @@ class ResolutionResult:
     candidates: list[Integration] = field(default_factory=list)
 
     def resolved_or_first(self) -> Integration | None:
-        """The resolved integration, falling back to the first candidate.
+        """The resolved integration, falling back to the workspace's oldest install.
 
         Surfaces that must act on *some* integration rather than prompt for one share this
-        tie-break, so a workspace's traffic is answered for the same project whichever
-        surface handles it. `candidates` is ordered, so the fallback is stable.
+        tie-break, so a workspace with no saved pick is answered for the same project
+        whichever surface handles it. Ordered by id rather than taken off the front of
+        `candidates`: the auth filter sorts that list freshest-verdict-first, which
+        reshuffles as cache entries expire and would make the fallback drift.
         """
         if self.integration is not None and self.integration in self.candidates:
             return self.integration
-        return self.candidates[0] if self.candidates else None
+        return min(self.candidates, key=lambda candidate: candidate.id, default=None)
 
 
 def format_project_candidate_list(candidates: list[Integration]) -> str:

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -25,7 +25,7 @@ from django.http import HttpResponse, JsonResponse
 
 import structlog
 
-from posthog.models.integration import Integration, SlackIntegration
+from posthog.models.integration import SLACK_INTEGRATION_KINDS, Integration, SlackIntegration
 from posthog.models.organization import OrganizationMembership
 from posthog.models.user_integration import UserIntegration
 from posthog.user_permissions import UserPermissions
@@ -1422,7 +1422,7 @@ def handle_ai_preferences_block_action(payload: dict, action: dict) -> HttpRespo
     if action_id in (MODAL_ACTION_RUNTIME_ADAPTER, MODAL_ACTION_MODEL):
         # Modal re-render: a runtime / model change updates which downstream
         # blocks (model list, effort options) are valid. Push an updated view.
-        return _update_modal_after_input_change(payload)
+        return _update_modal_after_input_change(payload, integration)
 
     return HttpResponse(status=200)
 
@@ -1469,27 +1469,21 @@ def handle_app_home_view_submission(payload: dict) -> HttpResponse | JsonRespons
 
 
 def _resolve_interaction_integration(slack_team_id: str, slack_user_id: str) -> Integration | None:
-    """The integration an interaction with the Home tab belongs to.
+    """The integration the viewer's Home tab is rendered against.
 
-    Resolved through the same ladder `_route_app_home_opened` uses to decide which
-    integration the tab is *rendered* against — thread mapping, then the viewer's project
-    pick, then the workspace default — so a click is answered for the project the viewer
-    was looking at. Picking any row of the workspace instead would answer against an
-    arbitrary organization, and everything keyed on it (the rollout flag, the task list,
-    the account link) would disagree with what the tab shows.
+    Same resolver the publish path runs, so a click is answered for the project the viewer
+    was looking at. Any row of the workspace would do for fetching a bot token, but the
+    rollout flag is scoped to an organization and the task list to a team, so answering
+    against an arbitrary one makes the tab disagree with itself.
     """
     if not slack_team_id:
         return None
     result = load_integrations(
         slack_team_id=slack_team_id,
-        kinds=["slack"],
+        kinds=list(SLACK_INTEGRATION_KINDS),
         slack_user_id=slack_user_id,
     )
-    if not result.candidates:
-        return None
-    # `candidates` is ordered, so the no-default case still lands on the same row the
-    # publish would have chosen rather than whatever the database returns first.
-    return result.integration if result.integration in result.candidates else result.candidates[0]
+    return result.resolved_or_first()
 
 
 def _load_user_row(integration: Integration, slack_user_id: str) -> SlackSettings | None:
@@ -1558,7 +1552,7 @@ def _render_unavailable_modal() -> dict:
     }
 
 
-def _update_modal_after_input_change(payload: dict) -> HttpResponse:
+def _update_modal_after_input_change(payload: dict, integration: Integration) -> HttpResponse:
     """Re-render the modal in response to a runtime_adapter or model change.
 
     Reads the in-flight state from `payload["view"]`, drops whatever the change
@@ -1575,12 +1569,6 @@ def _update_modal_after_input_change(payload: dict) -> HttpResponse:
     supported = _supported_efforts(current.runtime_adapter, current.model)
 
     updated_view = render_edit_modal(current=current, supported_efforts=supported)
-
-    slack_team_id = (payload.get("team") or {}).get("id", "")
-    slack_user_id = (payload.get("user") or {}).get("id", "")
-    integration = _resolve_interaction_integration(slack_team_id, slack_user_id)
-    if integration is None:
-        return HttpResponse(status=200)
 
     slack = SlackIntegration(integration)
     try:

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass, replace
 from datetime import datetime, timedelta
 from typing import Any
 
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.http import HttpResponse, JsonResponse
 
@@ -356,6 +357,7 @@ def render_home_view(
     project_state: ProjectState | None = None,
     tasks_state: TasksState | None = None,
     stats_state: StatsState | None = None,
+    has_project_access: bool = True,
 ) -> dict:
     """Render the Block Kit payload for `views.publish` on the App Home tab."""
 
@@ -363,6 +365,14 @@ def render_home_view(
     blocks: list[dict] = []
 
     blocks.extend(_header_blocks())
+
+    # Nothing below the fold means anything to someone who can't reach a project: the
+    # cards are scoped to one, and mentioning @PostHog won't work either. Say so once
+    # and stop, rather than drawing empty cards that read as "you have no tasks yet".
+    if not has_project_access:
+        blocks.append({"type": "divider"})
+        blocks.extend(_no_project_access_blocks())
+        return {"type": "home", "callback_id": HOME_CALLBACK_ID, "blocks": blocks}
 
     # Section 1 — workspace activity: aggregates across everyone's Slack-started work,
     # rather than the calling user's own. Admin-only, and first because it's the reason
@@ -468,6 +478,45 @@ def _header_blocks() -> list[dict]:
             "Tune how @PostHog mentions get routed and answered from this Slack workspace.",
         ),
     ]
+
+
+def _no_project_access_blocks() -> list[dict]:
+    """Shown when the viewer can't reach any PostHog project connected to this workspace.
+
+    Covers both halves of the same dead end — no project is connected yet, or one is but
+    the viewer isn't a member of its organization — because from Slack the two are
+    indistinguishable and the next step is the same page either way.
+    """
+    site_url = (settings.SITE_URL or "").rstrip("/")
+    blocks: list[dict] = [
+        _section_title(
+            "🔒 No project to show yet",
+            "This Slack workspace isn't connected to a PostHog project you can see, "
+            "so there's nothing to set up here and @PostHog mentions won't run.",
+        ),
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": ("Connect a project in PostHog, or ask an admin to add you to one that's already connected."),
+            },
+        },
+    ]
+    if site_url:
+        blocks.append(
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "url": f"{site_url}/settings/project-integrations",
+                        "text": {"type": "plain_text", "text": "Connect PostHog to Slack", "emoji": True},
+                        "style": "primary",
+                    }
+                ],
+            }
+        )
+    return blocks
 
 
 def _active_model_blocks(effective: AIPreferences, source: PreferenceSource) -> list[dict]:
@@ -1314,6 +1363,7 @@ def handle_app_home_opened(event: dict, slack_team_id: str, *, integration: Inte
         project_state=project_state,
         tasks_state=tasks_state,
         stats_state=stats_state,
+        has_project_access=bool(accessible),
     )
     try:
         slack.client.views_publish(user_id=slack_user_id, view=view)
@@ -1688,6 +1738,7 @@ def _republish_home(
         project_state=project_state,
         tasks_state=tasks_state,
         stats_state=stats_state,
+        has_project_access=bool(accessible),
     )
     try:
         slack.client.views_publish(user_id=slack_user_id, view=view)
@@ -1734,7 +1785,6 @@ def _resolve_tasks_state(
     accessible-team scoping) does not generalise.
     """
 
-    from django.conf import settings
     from django.utils import timezone as django_timezone
 
     from products.slack_app.backend.models import SlackThreadTaskMapping

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -86,6 +86,28 @@ ACTION_TASKS_PAGE_NEXT = "slack_app_home:tasks_page_next"
 ACTION_STATS_WINDOW = "slack_app_home:stats_window"
 ACTION_STATS_REFRESH = "slack_app_home:stats_refresh"
 
+# Every control the Home tab renders, in one place. The interactivity endpoint reads
+# this to claim region ownership and to dispatch, so a control that isn't listed here
+# renders as a button that silently does nothing. Adding an action id above without
+# adding it here is the failure this set exists to prevent.
+HOME_ACTION_IDS: frozenset[str] = frozenset(
+    {
+        ACTION_EDIT_PERSONAL,
+        ACTION_RESET_PERSONAL,
+        ACTION_UNLINK_ACCOUNT,
+        ACTION_SET_PROJECT_PERSONAL,
+        ACTION_SET_PROJECT_WORKSPACE,
+        ACTION_RESET_PROJECT_PERSONAL,
+        ACTION_TASKS_FILTER_REPO,
+        ACTION_TASKS_FILTER_STATUS,
+        ACTION_TASKS_REFRESH,
+        ACTION_TASKS_PAGE_PREV,
+        ACTION_TASKS_PAGE_NEXT,
+        ACTION_STATS_WINDOW,
+        ACTION_STATS_REFRESH,
+    }
+)
+
 # Single block_id for the whole controls row. Block Kit only persists
 # state in `view.state.values` under blocks that carry a `block_id`, so
 # both the repo and the status dropdowns live under the same key here and
@@ -1448,9 +1470,13 @@ def handle_app_home_view_submission(payload: dict) -> HttpResponse | JsonRespons
 def _get_slack_integration(slack_team_id: str) -> Integration | None:
     if not slack_team_id:
         return None
+    # Ordered so a workspace connected to several projects resolves to the same row on
+    # every request. An unordered `first()` can hand back a different integration — and
+    # so a different organization — between rendering the tab and handling a click on it.
     return (
         Integration.objects.select_related("team", "team__organization")
         .filter(kind="slack", integration_id=slack_team_id)
+        .order_by("id")
         .first()
     )
 
@@ -1667,6 +1693,20 @@ def _republish_home(
         slack.client.views_publish(user_id=slack_user_id, view=view)
     except Exception:
         logger.exception("slack_app_home_republish_failed")
+        return
+    # Carries the controls the click resolved to, so a report of "the filter does
+    # nothing" can be told apart from a click that never reached us at all.
+    logger.info(
+        "slack_app_home_republished",
+        slack_user_id=slack_user_id,
+        slack_team_id=integration.integration_id,
+        slack_app_home_tasks_page=tasks_state.page,
+        slack_app_home_tasks_total_pages=tasks_state.total_pages,
+        slack_app_home_tasks_shown=len(tasks_state.items),
+        slack_app_home_selected_repo=view_state.selected_repo,
+        slack_app_home_selected_status=view_state.selected_status,
+        slack_app_home_stats_window_days=view_state.stats_window_days,
+    )
 
 
 _TASKS_PAGE_SIZE = 10

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -32,6 +32,7 @@ from posthog.user_permissions import UserPermissions
 
 from products.slack_app.backend.feature_flags import is_slack_app_home_enabled, is_slack_app_oauth_enabled
 from products.slack_app.backend.models import SlackSettings, SlackUserProfileCache
+from products.slack_app.backend.services.integration_resolver import load_integrations
 from products.slack_app.backend.services.model_catalogue import (
     REASONING_EFFORT_DISPLAY_NAMES,
     RUNTIME_ADAPTER_DISPLAY_NAMES,
@@ -1338,7 +1339,7 @@ def handle_ai_preferences_block_action(payload: dict, action: dict) -> HttpRespo
     slack_user_id = (payload.get("user") or {}).get("id", "")
     trigger_id = payload.get("trigger_id")
 
-    integration = _get_slack_integration(slack_team_id)
+    integration = _resolve_interaction_integration(slack_team_id, slack_user_id)
     if integration is None:
         return HttpResponse(status=200)
 
@@ -1436,7 +1437,7 @@ def handle_app_home_view_submission(payload: dict) -> HttpResponse | JsonRespons
     slack_team_id = (payload.get("team") or {}).get("id", "")
     slack_user_id = (payload.get("user") or {}).get("id", "")
 
-    integration = _get_slack_integration(slack_team_id)
+    integration = _resolve_interaction_integration(slack_team_id, slack_user_id)
     if integration is None:
         return _modal_error_response("This Slack workspace is no longer connected to PostHog.")
 
@@ -1467,18 +1468,28 @@ def handle_app_home_view_submission(payload: dict) -> HttpResponse | JsonRespons
 # ---------------------------------------------------------------------------
 
 
-def _get_slack_integration(slack_team_id: str) -> Integration | None:
+def _resolve_interaction_integration(slack_team_id: str, slack_user_id: str) -> Integration | None:
+    """The integration an interaction with the Home tab belongs to.
+
+    Resolved through the same ladder `_route_app_home_opened` uses to decide which
+    integration the tab is *rendered* against — thread mapping, then the viewer's project
+    pick, then the workspace default — so a click is answered for the project the viewer
+    was looking at. Picking any row of the workspace instead would answer against an
+    arbitrary organization, and everything keyed on it (the rollout flag, the task list,
+    the account link) would disagree with what the tab shows.
+    """
     if not slack_team_id:
         return None
-    # Ordered so a workspace connected to several projects resolves to the same row on
-    # every request. An unordered `first()` can hand back a different integration — and
-    # so a different organization — between rendering the tab and handling a click on it.
-    return (
-        Integration.objects.select_related("team", "team__organization")
-        .filter(kind="slack", integration_id=slack_team_id)
-        .order_by("id")
-        .first()
+    result = load_integrations(
+        slack_team_id=slack_team_id,
+        kinds=["slack"],
+        slack_user_id=slack_user_id,
     )
+    if not result.candidates:
+        return None
+    # `candidates` is ordered, so the no-default case still lands on the same row the
+    # publish would have chosen rather than whatever the database returns first.
+    return result.integration if result.integration in result.candidates else result.candidates[0]
 
 
 def _load_user_row(integration: Integration, slack_user_id: str) -> SlackSettings | None:
@@ -1566,7 +1577,8 @@ def _update_modal_after_input_change(payload: dict) -> HttpResponse:
     updated_view = render_edit_modal(current=current, supported_efforts=supported)
 
     slack_team_id = (payload.get("team") or {}).get("id", "")
-    integration = _get_slack_integration(slack_team_id)
+    slack_user_id = (payload.get("user") or {}).get("id", "")
+    integration = _resolve_interaction_integration(slack_team_id, slack_user_id)
     if integration is None:
         return HttpResponse(status=200)
 

--- a/products/slack_app/backend/tests/services/test_slack_app_home.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home.py
@@ -30,10 +30,10 @@ from products.slack_app.backend.services.slack_app_home import (
     ACTION_EDIT_PERSONAL,
     ACTION_RESET_PERSONAL,
     ACTION_RESET_PROJECT_PERSONAL,
-    ACTION_STATS_WINDOW,
     ACTION_TASKS_FILTER_REPO,
     ACTION_TASKS_PAGE_NEXT,
     ACTION_TASKS_PAGE_PREV,
+    ACTION_UNLINK_ACCOUNT,
     BLOCK_TASKS_CONTROLS,
     EDIT_MODAL_PERSONAL_CALLBACK_ID,
     HOME_ACTION_IDS,
@@ -341,6 +341,23 @@ def _block_action_payload(
     }
 
 
+def _tasks_click_payload(action_id: str, *, value: str | None = None, repo: str | None = None) -> dict:
+    """A Home tab Tasks click: the page rides on the button's value, the filter on view state."""
+    action: dict[str, Any] = {"action_id": action_id}
+    if value is not None:
+        action["value"] = value
+    controls: dict[str, Any] = {}
+    if repo:
+        controls[ACTION_TASKS_FILTER_REPO] = {"selected_option": {"value": repo}}
+    return {
+        "type": "block_actions",
+        "team": {"id": SLACK_WORKSPACE_ID},
+        "user": {"id": "U001"},
+        "actions": [action],
+        "view": {"id": "V1", "hash": "H1", "type": "home", "state": {"values": {BLOCK_TASKS_CONTROLS: controls}}},
+    }
+
+
 def _view_submission_payload(
     *,
     callback_id: str,
@@ -438,16 +455,10 @@ class TestRenderHomeView:
             stats_state=StatsState(tasks_started=4, tasks_with_pr=2, tasks_merged=1, active_people=2),
         )
 
-        rendered = set(_action_ids(view))
-        # Sanity: the fixture above must actually exercise every card, otherwise the
-        # subset check below passes trivially on a half-rendered tab.
-        assert {
-            ACTION_TASKS_FILTER_REPO,
-            ACTION_TASKS_PAGE_PREV,
-            ACTION_TASKS_PAGE_NEXT,
-            ACTION_STATS_WINDOW,
-        } <= rendered
-        assert rendered <= HOME_ACTION_IDS, f"unroutable controls: {sorted(rendered - HOME_ACTION_IDS)}"
+        # Equality both ways: an unroutable control fails on the left, and a card that
+        # stopped rendering fails on the right instead of passing a subset check trivially.
+        # Unlink only renders once an account is linked, which this fixture deliberately isn't.
+        assert set(_action_ids(view)) == HOME_ACTION_IDS - {ACTION_UNLINK_ACCOUNT}
 
     def test_source_resolution_is_atomic(self):
         # A user row missing half the pair isn't a real override.
@@ -780,8 +791,9 @@ class TestTasksControlsRepublishTheList:
     joins them: a real `block_actions` payload in, the `views.publish` payload out.
     """
 
-    def _seed(self, integration, count: int = 12) -> None:
-        for index in range(count):
+    def _seed(self, integration) -> None:
+        # More than one page, so a Next click has somewhere to go.
+        for index in range(12):
             task = Task.objects.create(
                 team=integration.team,
                 title=f"Task {index}",
@@ -801,21 +813,6 @@ class TestTasksControlsRepublishTheList:
                 mentioning_slack_user_id="U001",
             )
 
-    def _click(self, action_id: str, *, value: str | None = None, repo: str | None = None) -> dict:
-        action: dict[str, Any] = {"action_id": action_id}
-        if value is not None:
-            action["value"] = value
-        controls: dict[str, Any] = {}
-        if repo:
-            controls[ACTION_TASKS_FILTER_REPO] = {"selected_option": {"value": repo}}
-        return {
-            "type": "block_actions",
-            "team": {"id": SLACK_WORKSPACE_ID},
-            "user": {"id": "U001"},
-            "actions": [action],
-            "view": {"id": "V1", "hash": "H1", "type": "home", "state": {"values": {BLOCK_TASKS_CONTROLS: controls}}},
-        }
-
     def _published_titles(self, view: dict) -> list[str]:
         titles = []
         for block in view["blocks"]:
@@ -830,15 +827,15 @@ class TestTasksControlsRepublishTheList:
         self._seed(slack_integration)
 
         with patch("products.slack_app.backend.services.slack_app_home.is_slack_workspace_admin", return_value=False):
-            first = self._click(ACTION_TASKS_PAGE_NEXT, value="0")
+            first = _tasks_click_payload(ACTION_TASKS_PAGE_NEXT, value="0")
             handle_ai_preferences_block_action(first, first["actions"][0])
             page_one = self._published_titles(mock_slack_client.views_publish.call_args.kwargs["view"])
 
-            second = self._click(ACTION_TASKS_PAGE_NEXT, value="1")
+            second = _tasks_click_payload(ACTION_TASKS_PAGE_NEXT, value="1")
             handle_ai_preferences_block_action(second, second["actions"][0])
             page_two = self._published_titles(mock_slack_client.views_publish.call_args.kwargs["view"])
 
-            narrowed = self._click(ACTION_TASKS_FILTER_REPO, repo="posthog/other")
+            narrowed = _tasks_click_payload(ACTION_TASKS_FILTER_REPO, repo="posthog/other")
             handle_ai_preferences_block_action(narrowed, narrowed["actions"][0])
             filtered = self._published_titles(mock_slack_client.views_publish.call_args.kwargs["view"])
 
@@ -855,21 +852,6 @@ class TestTasksControlsResolveViewState:
     `value` and the filters ride on the view's input state. These lock that decoding,
     which is otherwise only observable through a full publish.
     """
-
-    def _payload(self, action_id: str, *, value: str | None = None, repo: str | None = None) -> dict:
-        action: dict[str, Any] = {"action_id": action_id}
-        if value is not None:
-            action["value"] = value
-        controls: dict[str, Any] = {}
-        if repo:
-            controls[ACTION_TASKS_FILTER_REPO] = {"selected_option": {"value": repo}}
-        return {
-            "type": "block_actions",
-            "team": {"id": SLACK_WORKSPACE_ID},
-            "user": {"id": "U001"},
-            "actions": [action],
-            "view": {"id": "V1", "hash": "H1", "type": "home", "state": {"values": {BLOCK_TASKS_CONTROLS: controls}}},
-        }
 
     def _resolved_state(self, monkeypatch, payload: dict):
         captured: dict[str, Any] = {}
@@ -896,19 +878,21 @@ class TestTasksControlsResolveViewState:
         ],
     )
     def test_page_comes_off_the_clicked_button(self, monkeypatch, action_id, value, expected_page):
-        state = self._resolved_state(monkeypatch, self._payload(action_id, value=value))
+        state = self._resolved_state(monkeypatch, _tasks_click_payload(action_id, value=value))
         assert state.tasks_page == expected_page
 
     def test_paging_keeps_the_active_repo_filter(self, monkeypatch):
         # Paging must not silently widen the list back to every repo.
         state = self._resolved_state(
-            monkeypatch, self._payload(ACTION_TASKS_PAGE_NEXT, value="1", repo="posthog/posthog")
+            monkeypatch, _tasks_click_payload(ACTION_TASKS_PAGE_NEXT, value="1", repo="posthog/posthog")
         )
         assert (state.selected_repo, state.tasks_page) == ("posthog/posthog", 1)
 
     def test_changing_the_filter_returns_to_the_first_page(self, monkeypatch):
         # Otherwise a narrower result set leaves the viewer stranded past its last page.
-        state = self._resolved_state(monkeypatch, self._payload(ACTION_TASKS_FILTER_REPO, repo="posthog/posthog"))
+        state = self._resolved_state(
+            monkeypatch, _tasks_click_payload(ACTION_TASKS_FILTER_REPO, repo="posthog/posthog")
+        )
         assert (state.selected_repo, state.tasks_page) == ("posthog/posthog", 0)
 
 
@@ -1143,31 +1127,14 @@ class TestInteractionResolvesTheViewersIntegration:
             sensitive_config={"access_token": "xoxb-other"},
         )
 
-    def test_click_uses_the_project_the_viewer_routed_to(
-        self, slack_integration, mock_slack_client, flag_on, admin_user
-    ):
-        # `slack_integration` is created first, so an unordered lookup returns it; the
-        # viewer's saved pick is the *other* one.
+    # Personal pick and workspace default are separate rungs of the ladder; both must beat
+    # row order, since `slack_integration` is created first and any unordered lookup wins with it.
+    @pytest.mark.parametrize("pick_owner", ["U001", None])
+    def test_the_saved_project_pick_beats_row_order(self, slack_integration, pick_owner):
         preferred = self._second_org_integration()
         SlackSettings.objects.create(
             slack_workspace_id=SLACK_WORKSPACE_ID,
-            slack_user_id="U001",
-            default_integration=preferred,
-        )
-
-        resolved = slack_app_home._resolve_interaction_integration(SLACK_WORKSPACE_ID, "U001")
-
-        assert resolved is not None
-        assert resolved.id == preferred.id
-        assert resolved.team.organization_id == preferred.team.organization_id
-
-    def test_workspace_default_applies_when_the_viewer_has_no_pick(
-        self, slack_integration, mock_slack_client, flag_on, admin_user
-    ):
-        preferred = self._second_org_integration()
-        SlackSettings.objects.create(
-            slack_workspace_id=SLACK_WORKSPACE_ID,
-            slack_user_id=None,
+            slack_user_id=pick_owner,
             default_integration=preferred,
         )
 

--- a/products/slack_app/backend/tests/services/test_slack_app_home.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home.py
@@ -873,7 +873,7 @@ class TestTasksControlsResolveViewState:
 
     def _resolved_state(self, monkeypatch, payload: dict):
         captured: dict[str, Any] = {}
-        monkeypatch.setattr(slack_app_home, "_get_slack_integration", lambda team_id: object())
+        monkeypatch.setattr(slack_app_home, "_resolve_interaction_integration", lambda team_id, user_id: object())
         monkeypatch.setattr(slack_app_home, "is_slack_app_home_enabled", lambda integration: True)
         monkeypatch.setattr(
             slack_app_home,
@@ -1122,3 +1122,58 @@ class TestRetiredWorkspaceModal:
         response = handle_app_home_view_submission(payload)
         assert response.status_code == 200
         assert not SlackSettings.objects.exists()
+
+
+class TestInteractionResolvesTheViewersIntegration:
+    """A workspace connected to two organizations must answer clicks for the right one.
+
+    Everything the tab is keyed on hangs off the resolved integration — the rollout flag
+    is scoped to an organization, and the task list, project card and account link are all
+    scoped to its team. Answering a click against an arbitrary row of the workspace makes
+    the tab disagree with itself, which reads as a control that does nothing.
+    """
+
+    def _second_org_integration(self) -> Integration:
+        organization = Organization.objects.create(name="Other Org")
+        team = Team.objects.create(organization=organization, name="Other Team")
+        return Integration.objects.create(
+            team=team,
+            kind="slack",
+            integration_id=SLACK_WORKSPACE_ID,
+            sensitive_config={"access_token": "xoxb-other"},
+        )
+
+    def test_click_uses_the_project_the_viewer_routed_to(
+        self, slack_integration, mock_slack_client, flag_on, admin_user
+    ):
+        # `slack_integration` is created first, so an unordered lookup returns it; the
+        # viewer's saved pick is the *other* one.
+        preferred = self._second_org_integration()
+        SlackSettings.objects.create(
+            slack_workspace_id=SLACK_WORKSPACE_ID,
+            slack_user_id="U001",
+            default_integration=preferred,
+        )
+
+        resolved = slack_app_home._resolve_interaction_integration(SLACK_WORKSPACE_ID, "U001")
+
+        assert resolved is not None
+        assert resolved.id == preferred.id
+        assert resolved.team.organization_id == preferred.team.organization_id
+
+    def test_workspace_default_applies_when_the_viewer_has_no_pick(
+        self, slack_integration, mock_slack_client, flag_on, admin_user
+    ):
+        preferred = self._second_org_integration()
+        SlackSettings.objects.create(
+            slack_workspace_id=SLACK_WORKSPACE_ID,
+            slack_user_id=None,
+            default_integration=preferred,
+        )
+
+        resolved = slack_app_home._resolve_interaction_integration(SLACK_WORKSPACE_ID, "U001")
+
+        assert resolved is not None and resolved.id == preferred.id
+
+    def test_unknown_workspace_resolves_to_nothing(self, db):
+        assert slack_app_home._resolve_interaction_integration("T_NOT_CONNECTED", "U001") is None

--- a/products/slack_app/backend/tests/services/test_slack_app_home.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home.py
@@ -24,7 +24,7 @@ from posthog.models.integration import Integration
 from posthog.models.organization import Organization
 from posthog.models.team.team import Team
 
-from products.slack_app.backend.models import SlackSettings
+from products.slack_app.backend.models import SlackSettings, SlackThreadTaskMapping
 from products.slack_app.backend.services import slack_app_home
 from products.slack_app.backend.services.slack_app_home import (
     ACTION_EDIT_PERSONAL,
@@ -59,6 +59,7 @@ from products.slack_app.backend.services.slack_app_home import (
     resolve_source,
 )
 from products.slack_app.backend.services.slack_settings import AIPreferences
+from products.tasks.backend.models import Task, TaskRun
 
 SLACK_WORKSPACE_ID = "T_HOME"
 
@@ -769,6 +770,82 @@ class TestParseModalSubmission:
 # ---------------------------------------------------------------------------
 # Handler tests — Tasks card controls
 # ---------------------------------------------------------------------------
+
+
+class TestTasksControlsRepublishTheList:
+    """A click has to reach Slack as a different view, or the tab looks frozen.
+
+    The rest of the Tasks coverage stops at a boundary — the renderer takes a
+    hand-built `TasksState`, the decoding tests stop at the resolved view state. This
+    joins them: a real `block_actions` payload in, the `views.publish` payload out.
+    """
+
+    def _seed(self, integration, count: int = 12) -> None:
+        for index in range(count):
+            task = Task.objects.create(
+                team=integration.team,
+                title=f"Task {index}",
+                description="d",
+                origin_product=Task.OriginProduct.SLACK,
+                repository="posthog/posthog" if index % 2 == 0 else "posthog/other",
+            )
+            run = TaskRun.objects.create(task=task, team=integration.team, status=TaskRun.Status.IN_PROGRESS)
+            SlackThreadTaskMapping.objects.create(
+                team=integration.team,
+                integration=integration,
+                slack_workspace_id=SLACK_WORKSPACE_ID,
+                channel="C1",
+                thread_ts=f"170000000.{index:06d}",
+                task=task,
+                task_run=run,
+                mentioning_slack_user_id="U001",
+            )
+
+    def _click(self, action_id: str, *, value: str | None = None, repo: str | None = None) -> dict:
+        action: dict[str, Any] = {"action_id": action_id}
+        if value is not None:
+            action["value"] = value
+        controls: dict[str, Any] = {}
+        if repo:
+            controls[ACTION_TASKS_FILTER_REPO] = {"selected_option": {"value": repo}}
+        return {
+            "type": "block_actions",
+            "team": {"id": SLACK_WORKSPACE_ID},
+            "user": {"id": "U001"},
+            "actions": [action],
+            "view": {"id": "V1", "hash": "H1", "type": "home", "state": {"values": {BLOCK_TASKS_CONTROLS: controls}}},
+        }
+
+    def _published_titles(self, view: dict) -> list[str]:
+        titles = []
+        for block in view["blocks"]:
+            text = (block.get("text") or {}).get("text", "")
+            if text.startswith("*<") and "/tasks/" in text:
+                titles.append(text.split("|", 1)[1].rstrip(">*"))
+        return titles
+
+    def test_next_publishes_a_different_page_and_the_filter_narrows_it(
+        self, slack_integration, mock_slack_client, flag_on
+    ):
+        self._seed(slack_integration)
+
+        with patch("products.slack_app.backend.services.slack_app_home.is_slack_workspace_admin", return_value=False):
+            first = self._click(ACTION_TASKS_PAGE_NEXT, value="0")
+            handle_ai_preferences_block_action(first, first["actions"][0])
+            page_one = self._published_titles(mock_slack_client.views_publish.call_args.kwargs["view"])
+
+            second = self._click(ACTION_TASKS_PAGE_NEXT, value="1")
+            handle_ai_preferences_block_action(second, second["actions"][0])
+            page_two = self._published_titles(mock_slack_client.views_publish.call_args.kwargs["view"])
+
+            narrowed = self._click(ACTION_TASKS_FILTER_REPO, repo="posthog/other")
+            handle_ai_preferences_block_action(narrowed, narrowed["actions"][0])
+            filtered = self._published_titles(mock_slack_client.views_publish.call_args.kwargs["view"])
+
+        assert len(page_one) == 10
+        assert page_two and not set(page_two) & set(page_one)
+        # Odd indices carry posthog/other, so the filter must leave only those.
+        assert filtered and all(int(title.split()[1]) % 2 == 1 for title in filtered)
 
 
 class TestTasksControlsResolveViewState:

--- a/products/slack_app/backend/tests/services/test_slack_app_home.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home.py
@@ -1144,3 +1144,19 @@ class TestInteractionResolvesTheViewersIntegration:
 
     def test_unknown_workspace_resolves_to_nothing(self, db):
         assert slack_app_home._resolve_interaction_integration("T_NOT_CONNECTED", "U001") is None
+
+    def test_no_pick_falls_back_to_the_same_install_regardless_of_candidate_order(self, slack_integration):
+        # The auth filter hands back candidates freshest-verdict-first, so the fallback
+        # can't take the front of that list and stay put across cache expiries.
+        newer = self._second_org_integration()
+        oldest = min(slack_integration.id, newer.id)
+
+        first = slack_app_home._resolve_interaction_integration(SLACK_WORKSPACE_ID, "U001")
+        with patch(
+            "products.slack_app.backend.services.slack_auth.check_integrations_auth_and_filter",
+            side_effect=lambda candidates, **_: list(reversed(candidates)),
+        ):
+            reordered = slack_app_home._resolve_interaction_integration(SLACK_WORKSPACE_ID, "U001")
+
+        assert first is not None and reordered is not None
+        assert first.id == reordered.id == oldest

--- a/products/slack_app/backend/tests/services/test_slack_app_home.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home.py
@@ -1160,3 +1160,51 @@ class TestInteractionResolvesTheViewersIntegration:
 
         assert first is not None and reordered is not None
         assert first.id == reordered.id == oldest
+
+
+class TestNoProjectAccessCard:
+    """What someone sees when no PostHog project connected here is visible to them.
+
+    Without this the tab draws its normal cards against nothing: no project picker, and a
+    Tasks card inviting them to mention @PostHog — which won't run either, for the same
+    reason. The regression to catch is a card reappearing in that state.
+    """
+
+    def _view(self, **overrides) -> dict:
+        kwargs: dict[str, Any] = {
+            "effective": AIPreferences(),
+            "user_row": None,
+            "is_admin": True,
+            "has_project_access": False,
+            "tasks_state": TasksState(),
+            "stats_state": StatsState(tasks_started=4),
+            "account_state": AccountState(enabled=True, link_url="https://app/link"),
+            "project_state": ProjectState(candidates=(ProjectChoice(team_id=1, label="Org · Team"),)),
+        }
+        kwargs.update(overrides)
+        return render_home_view(**kwargs)
+
+    def test_explains_the_dead_end_and_links_to_the_settings_page(self):
+        text = _all_text(self._view())
+
+        assert "No project to show yet" in text
+        assert "ask an admin" in text
+        urls = [
+            element["url"]
+            for block in self._view()["blocks"]
+            for element in block.get("elements", []) or []
+            if "url" in element
+        ]
+        assert urls == ["http://localhost:8010/settings/project-integrations"]
+
+    def test_suppresses_every_card_that_needs_a_project(self):
+        # Each of these would otherwise render from the states passed above.
+        text = _all_text(self._view())
+
+        assert "🦔 Tasks" not in text
+        assert "Workspace activity" not in text
+        assert "Project routing" not in text
+        assert not _action_ids(self._view())
+
+    def test_normal_tab_is_untouched_when_a_project_is_reachable(self):
+        assert "No project to show yet" not in _all_text(self._view(has_project_access=True))

--- a/products/slack_app/backend/tests/services/test_slack_app_home.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home.py
@@ -29,14 +29,23 @@ from products.slack_app.backend.services.slack_app_home import (
     ACTION_EDIT_PERSONAL,
     ACTION_RESET_PERSONAL,
     ACTION_RESET_PROJECT_PERSONAL,
+    ACTION_STATS_WINDOW,
+    ACTION_TASKS_FILTER_REPO,
+    ACTION_TASKS_PAGE_NEXT,
+    ACTION_TASKS_PAGE_PREV,
     EDIT_MODAL_PERSONAL_CALLBACK_ID,
+    HOME_ACTION_IDS,
     MODAL_ACTION_MODEL,
     MODAL_ACTION_REASONING_EFFORT,
     MODAL_ACTION_RUNTIME_ADAPTER,
     MODAL_BLOCK_MODEL,
     MODAL_BLOCK_REASONING_EFFORT,
     MODAL_BLOCK_RUNTIME_ADAPTER,
+    AccountState,
     PreferenceSource,
+    ProjectChoice,
+    ProjectState,
+    StatsState,
     TaskItem,
     TasksState,
     handle_ai_preferences_block_action,
@@ -389,6 +398,53 @@ class TestRenderHomeView:
         # Friendly label rather than raw model id; source attribution visible.
         assert "Claude Opus 4.7" in text_blob
         assert "Your personal override" in _all_text(view)
+
+    def test_every_control_the_tab_renders_is_routable(self):
+        # The interactivity endpoint claims region ownership and dispatches off
+        # HOME_ACTION_IDS, so a control missing from it renders as a button that
+        # silently does nothing. Render every card at once and check the whole set.
+        view = render_home_view(
+            effective=AIPreferences(runtime_adapter="claude", model="claude-opus-4-7"),
+            user_row=_make_row(runtime_adapter="claude", model="claude-opus-4-7"),
+            is_admin=True,
+            account_state=AccountState(enabled=True, link_url="https://app/link"),
+            project_state=ProjectState(
+                candidates=(ProjectChoice(team_id=1, label="Org · Team"),),
+                personal_team_id=1,
+                workspace_team_id=1,
+                workspace_team_label="Org · Team",
+            ),
+            tasks_state=TasksState(
+                items=(
+                    TaskItem(
+                        title="Fix flaky retention test",
+                        posthog_url="https://app/project/1/tasks/abc",
+                        status="in_progress",
+                        repository="posthog/posthog",
+                        pr_url=None,
+                        thread_url=None,
+                        updated_at_label="5m ago",
+                    ),
+                ),
+                available_repos=("posthog/posthog",),
+                has_any_tasks=True,
+                page=1,
+                total_pages=3,
+                total_filtered=25,
+            ),
+            stats_state=StatsState(tasks_started=4, tasks_with_pr=2, tasks_merged=1, active_people=2),
+        )
+
+        rendered = set(_action_ids(view))
+        # Sanity: the fixture above must actually exercise every card, otherwise the
+        # subset check below passes trivially on a half-rendered tab.
+        assert {
+            ACTION_TASKS_FILTER_REPO,
+            ACTION_TASKS_PAGE_PREV,
+            ACTION_TASKS_PAGE_NEXT,
+            ACTION_STATS_WINDOW,
+        } <= rendered
+        assert rendered <= HOME_ACTION_IDS, f"unroutable controls: {sorted(rendered - HOME_ACTION_IDS)}"
 
     def test_source_resolution_is_atomic(self):
         # A user row missing half the pair isn't a real override.

--- a/products/slack_app/backend/tests/services/test_slack_app_home.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home.py
@@ -25,6 +25,7 @@ from posthog.models.organization import Organization
 from posthog.models.team.team import Team
 
 from products.slack_app.backend.models import SlackSettings
+from products.slack_app.backend.services import slack_app_home
 from products.slack_app.backend.services.slack_app_home import (
     ACTION_EDIT_PERSONAL,
     ACTION_RESET_PERSONAL,
@@ -33,6 +34,7 @@ from products.slack_app.backend.services.slack_app_home import (
     ACTION_TASKS_FILTER_REPO,
     ACTION_TASKS_PAGE_NEXT,
     ACTION_TASKS_PAGE_PREV,
+    BLOCK_TASKS_CONTROLS,
     EDIT_MODAL_PERSONAL_CALLBACK_ID,
     HOME_ACTION_IDS,
     MODAL_ACTION_MODEL,
@@ -762,6 +764,75 @@ class TestParseModalSubmission:
     def test_partial_state_returns_partial_tuple(self):
         view = _build_submission(runtime_adapter="claude")
         assert parse_modal_submission(view) == ("claude", None, None)
+
+
+# ---------------------------------------------------------------------------
+# Handler tests — Tasks card controls
+# ---------------------------------------------------------------------------
+
+
+class TestTasksControlsResolveViewState:
+    """What the Tasks controls ask the resolver for, without touching the database.
+
+    The Home tab holds no server-side state: the page rides on the clicked button's
+    `value` and the filters ride on the view's input state. These lock that decoding,
+    which is otherwise only observable through a full publish.
+    """
+
+    def _payload(self, action_id: str, *, value: str | None = None, repo: str | None = None) -> dict:
+        action: dict[str, Any] = {"action_id": action_id}
+        if value is not None:
+            action["value"] = value
+        controls: dict[str, Any] = {}
+        if repo:
+            controls[ACTION_TASKS_FILTER_REPO] = {"selected_option": {"value": repo}}
+        return {
+            "type": "block_actions",
+            "team": {"id": SLACK_WORKSPACE_ID},
+            "user": {"id": "U001"},
+            "actions": [action],
+            "view": {"id": "V1", "hash": "H1", "type": "home", "state": {"values": {BLOCK_TASKS_CONTROLS: controls}}},
+        }
+
+    def _resolved_state(self, monkeypatch, payload: dict):
+        captured: dict[str, Any] = {}
+        monkeypatch.setattr(slack_app_home, "_get_slack_integration", lambda team_id: object())
+        monkeypatch.setattr(slack_app_home, "is_slack_app_home_enabled", lambda integration: True)
+        monkeypatch.setattr(
+            slack_app_home,
+            "_republish_home",
+            lambda integration, slack_user_id, *, view_state=None: captured.update(state=view_state),
+        )
+        handle_ai_preferences_block_action(payload, payload["actions"][0])
+        assert "state" in captured, "the click never reached a republish"
+        return captured["state"]
+
+    @pytest.mark.parametrize(
+        "action_id,value,expected_page",
+        [
+            (ACTION_TASKS_PAGE_NEXT, "1", 1),
+            (ACTION_TASKS_PAGE_PREV, "0", 0),
+            (ACTION_TASKS_PAGE_NEXT, "7", 7),
+            # A button that somehow arrives without a usable page falls back to the first.
+            (ACTION_TASKS_PAGE_NEXT, None, 0),
+            (ACTION_TASKS_PAGE_NEXT, "not-a-number", 0),
+        ],
+    )
+    def test_page_comes_off_the_clicked_button(self, monkeypatch, action_id, value, expected_page):
+        state = self._resolved_state(monkeypatch, self._payload(action_id, value=value))
+        assert state.tasks_page == expected_page
+
+    def test_paging_keeps_the_active_repo_filter(self, monkeypatch):
+        # Paging must not silently widen the list back to every repo.
+        state = self._resolved_state(
+            monkeypatch, self._payload(ACTION_TASKS_PAGE_NEXT, value="1", repo="posthog/posthog")
+        )
+        assert (state.selected_repo, state.tasks_page) == ("posthog/posthog", 1)
+
+    def test_changing_the_filter_returns_to_the_first_page(self, monkeypatch):
+        # Otherwise a narrower result set leaves the viewer stranded past its last page.
+        state = self._resolved_state(monkeypatch, self._payload(ACTION_TASKS_FILTER_REPO, repo="posthog/posthog"))
+        assert (state.selected_repo, state.tasks_page) == ("posthog/posthog", 0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Controls on the Slack App Home tab do nothing when clicked — the view doesn't change, Slack shows no error, nothing lands in the logs. Two independent causes:

- The Workspace activity card's window picker and Refresh were never registered with the interactivity endpoint, so those clicks matched no dispatch branch.
- Every other control looked up the workspace's integration as an arbitrary row rather than the one the tab was rendered against. The `slack-app-home` flag is scoped to an organization, so on a workspace connected to more than one, a click can evaluate the feature as off and return 200 without publishing, logging, or failing.

## Changes

- `HOME_ACTION_IDS` is exported next to the action ids and `api.py` derives its routing set from it, so a control added to the tab is routable as soon as it exists.
- Interactions resolve their integration through `load_integrations` — the same ladder the publish path uses.
- The no-pick fallback takes the oldest install. The auth filter returns candidates freshest-verdict-first, so taking the front of that list drifted as its cache expired.
- `ResolutionResult.resolved_or_first()` replaces the tie-break that was written out at each call site.
- A viewer with no PostHog project they can reach gets one card explaining it and a link to settings, instead of cards that quietly render empty. (Can't cover a workspace with *no* integration row — publishing needs that row's bot token.)
- `_republish_home` logs what each click resolved to; it was silent on success.

## How did you test this code?

Manual

13 new cases: a guard that every control the tab renders is routable (verified failing pre-fix, naming both dead controls); click decoding including malformed page values and filter/paging interaction; a click→`views.publish` test against real task rows, asserting the list Slack receives actually changed; integration resolution with two orgs on one workspace; and the no-access card.

Full `products/slack_app/backend/tests` suite passes locally (819), plus ruff and repo-wide mypy.

The second cause needs the workspace's integrations to span more than one org — inferred from logs, not confirmed by a lookup. The fix stands either way: publish and interaction resolving differently is a bug regardless.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5). Skills invoked: `/writing-tests`, `/simplify`.

