### PR TITLE
fix(tasks): terminalize runs when sandbox relay closes

### DIFF
--- a/products/tasks/backend/temporal/execute_sandbox/tests/test_execute_sandbox_workflow.py
+++ b/products/tasks/backend/temporal/execute_sandbox/tests/test_execute_sandbox_workflow.py
@@ -738,6 +738,19 @@ class TestPersistSandboxId:
 
 
 class TestRun:
+    async def test_relay_detected_sandbox_loss_marks_sandbox_gone(self, monkeypatch, silent_workflow_logger):
+        workflow = ExecuteSandboxWorkflow()
+        workflow._context = _build_context()
+        execute_activity_mock = AsyncMock(return_value=True)
+        monkeypatch.setattr(execute_sandbox_workflow_module.workflow, "execute_activity", execute_activity_mock)
+
+        await workflow._relay_sandbox_events(
+            StartAgentServerOutput(sandbox_url="https://sandbox.example", connect_token="token"),
+            "sandbox-123",
+        )
+
+        assert workflow._sandbox_gone is True
+
     async def test_credential_refresh_exit_marks_sandbox_gone(self, monkeypatch, silent_workflow_logger):
         workflow = ExecuteSandboxWorkflow()
         workflow._context = _build_context()

--- a/products/tasks/backend/temporal/execute_sandbox/workflow.py
+++ b/products/tasks/backend/temporal/execute_sandbox/workflow.py
@@ -1384,7 +1384,7 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
         agent_server_output: StartAgentServerOutput,
         sandbox_id: str | None = None,
     ) -> None:
-        await workflow.execute_activity(
+        sandbox_gone = await workflow.execute_activity(
             relay_sandbox_events,
             RelaySandboxEventsInput(
                 run_id=self.context.run_id,
@@ -1415,6 +1415,8 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
             ),
             cancellation_type=workflow.ActivityCancellationType.TRY_CANCEL,
         )
+        if sandbox_gone and not self._task_completed:
+            self._sandbox_gone = True
 
     @staticmethod
     async def _cancel_relay(relay_task: "asyncio.Task[None]") -> None:

--- a/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
@@ -529,7 +529,9 @@ async def _relay_loop(
                         run_id=run_id,
                         status_code=status,
                     )
-                    await redis_stream.mark_error(f"Sandbox returned HTTP {status}")
+                    await _mark_sandbox_error_best_effort(
+                        redis_stream, run_id, f"Sandbox returned HTTP {status}"
+                    )
                     return True
                 # 5xx — transient server error, worth retrying
                 reconnect_count += 1
@@ -561,8 +563,10 @@ async def _relay_loop(
                 await asyncio.sleep(min(reconnect_count * 2, 10))
 
         # Exhausted reconnect attempts
-        await redis_stream.mark_error(
-            f"Lost connection to sandbox after {MAX_RECONNECT_ATTEMPTS} reconnection attempts"
+        await _mark_sandbox_error_best_effort(
+            redis_stream,
+            run_id,
+            f"Lost connection to sandbox after {MAX_RECONNECT_ATTEMPTS} reconnection attempts",
         )
         return True
     finally:
@@ -572,6 +576,19 @@ async def _relay_loop(
             await heartbeat_task
         except asyncio.CancelledError:
             pass
+
+
+async def _mark_sandbox_error_best_effort(
+    redis_stream: TaskRunRedisStream, run_id: str, message: str
+) -> None:
+    try:
+        await redis_stream.mark_error(message)
+    except Exception as error:
+        logger.exception(
+            "relay_sandbox_events_mark_error_failed",
+            run_id=run_id,
+            error=str(error),
+        )
 
 
 def _is_session_update(event_data: dict) -> bool:

--- a/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
@@ -503,7 +503,8 @@ async def _relay_loop(
                         run_id=run_id,
                         reconnect_count=reconnect_count,
                     )
-                    await asyncio.sleep(min(reconnect_count * 2, 10))
+                    if reconnect_count <= MAX_RECONNECT_ATTEMPTS:
+                        await asyncio.sleep(min(reconnect_count * 2, 10))
 
             except httpx.ReadTimeout:
                 reconnect_count += 1

--- a/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
@@ -529,9 +529,7 @@ async def _relay_loop(
                         run_id=run_id,
                         status_code=status,
                     )
-                    await _mark_sandbox_error_best_effort(
-                        redis_stream, run_id, f"Sandbox returned HTTP {status}"
-                    )
+                    await _mark_sandbox_error_best_effort(redis_stream, run_id, f"Sandbox returned HTTP {status}")
                     return True
                 # 5xx — transient server error, worth retrying
                 reconnect_count += 1
@@ -578,9 +576,7 @@ async def _relay_loop(
             pass
 
 
-async def _mark_sandbox_error_best_effort(
-    redis_stream: TaskRunRedisStream, run_id: str, message: str
-) -> None:
+async def _mark_sandbox_error_best_effort(redis_stream: TaskRunRedisStream, run_id: str, message: str) -> None:
     try:
         await redis_stream.mark_error(message)
     except Exception as error:

--- a/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
@@ -492,12 +492,18 @@ async def _relay_loop(
                                     await redis_stream.mark_complete()
                                 return False
 
-                    # SSE stream ended normally (sandbox closed connection)
-                    await _flush_pending_text(workflow_handle, pending_text_parts, last_text_flush)
-                    if finalize_stream_on_exit:
-                        await redis_stream.mark_complete()
-                    logger.info("relay_sandbox_events_stream_closed", run_id=run_id)
-                    return True
+                    # A clean HTTP close does not prove the sandbox stopped. Reconnect before
+                    # declaring it gone; proxies and agent-server restarts can close a healthy stream.
+                    reconnect_count += 1
+                    agent_active[0] = False
+                    pending_text_parts.clear()
+                    final_message_tracker.reset()
+                    logger.warning(
+                        "relay_sandbox_events_stream_closed",
+                        run_id=run_id,
+                        reconnect_count=reconnect_count,
+                    )
+                    await asyncio.sleep(min(reconnect_count * 2, 10))
 
             except httpx.ReadTimeout:
                 reconnect_count += 1

--- a/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
@@ -97,17 +97,17 @@ class RelaySandboxEventsInput:
 
 @activity.defn
 @close_db_connections
-async def relay_sandbox_events(input: RelaySandboxEventsInput) -> None:
-    await _relay_sandbox_events(input, finalize_stream_on_exit=True)
+async def relay_sandbox_events(input: RelaySandboxEventsInput) -> bool:
+    return await _relay_sandbox_events(input, finalize_stream_on_exit=True)
 
 
 @activity.defn
 @close_db_connections
-async def relay_sandbox_events_deferred_completion(input: RelaySandboxEventsInput) -> None:
-    await _relay_sandbox_events(input, finalize_stream_on_exit=False)
+async def relay_sandbox_events_deferred_completion(input: RelaySandboxEventsInput) -> bool:
+    return await _relay_sandbox_events(input, finalize_stream_on_exit=False)
 
 
-async def _relay_sandbox_events(input: RelaySandboxEventsInput, *, finalize_stream_on_exit: bool) -> None:
+async def _relay_sandbox_events(input: RelaySandboxEventsInput, *, finalize_stream_on_exit: bool) -> bool:
     """Long-running activity that relays SSE events from a sandbox agent to a Redis stream.
 
     Connects to the sandbox's GET /events SSE endpoint and writes each event
@@ -169,7 +169,7 @@ async def _relay_sandbox_events(input: RelaySandboxEventsInput, *, finalize_stre
         )
 
     try:
-        await _relay_loop(
+        return await _relay_loop(
             events_url=events_url,
             headers=headers,
             params=params,
@@ -199,7 +199,7 @@ async def _relay_sandbox_events(input: RelaySandboxEventsInput, *, finalize_stre
         # harness). Exit quietly — logger and Redis are already unusable here,
         # so touching them would cascade into "I/O on closed file" noise.
         if "cannot schedule new futures after shutdown" in str(e):
-            return
+            return False
         logger.exception("relay_sandbox_events_failed", run_id=input.run_id, error=str(e))
         await redis_stream.mark_error(str(e)[:500])
         # The stream now carries an error sentinel — a retried attempt would
@@ -322,7 +322,7 @@ async def _relay_loop(
     slack_thread_context: dict[str, Any] | None = None,
     is_agent_design_enabled: bool = False,
     finalize_stream_on_exit: bool = True,
-) -> None:
+) -> bool:
     """Connect to sandbox SSE and relay events to Redis. Reconnects on transient failures."""
     reconnect_count = 0
 
@@ -490,14 +490,14 @@ async def _relay_loop(
                                 await _flush_pending_text(workflow_handle, pending_text_parts, last_text_flush)
                                 if finalize_stream_on_exit:
                                     await redis_stream.mark_complete()
-                                return
+                                return False
 
                     # SSE stream ended normally (sandbox closed connection)
                     await _flush_pending_text(workflow_handle, pending_text_parts, last_text_flush)
                     if finalize_stream_on_exit:
                         await redis_stream.mark_complete()
                     logger.info("relay_sandbox_events_stream_closed", run_id=run_id)
-                    return
+                    return True
 
             except httpx.ReadTimeout:
                 reconnect_count += 1
@@ -523,7 +523,7 @@ async def _relay_loop(
                         status_code=status,
                     )
                     await redis_stream.mark_error(f"Sandbox returned HTTP {status}")
-                    return
+                    return True
                 # 5xx — transient server error, worth retrying
                 reconnect_count += 1
                 agent_active[0] = False  # missed-end_of_turn guard (see ReadTimeout above)
@@ -557,6 +557,7 @@ async def _relay_loop(
         await redis_stream.mark_error(
             f"Lost connection to sandbox after {MAX_RECONNECT_ATTEMPTS} reconnection attempts"
         )
+        return True
     finally:
         stop_heartbeat.set()
         heartbeat_task.cancel()

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
@@ -26,6 +26,7 @@ from products.tasks.backend.temporal.process_task.activities.relay_sandbox_event
     _is_keepalive_event,
     _is_session_update,
     _mark_error_unless_run_is_terminal,
+    _mark_sandbox_error_best_effort,
     _persist_final_message,
     _relay_loop,
     relay_sandbox_events,
@@ -372,6 +373,22 @@ class TestRelaySandboxEventsMissingActor:
 
 
 class TestRelaySandboxEventsErrorHandling:
+    async def test_confirmed_sandbox_loss_survives_redis_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        redis_stream = SimpleNamespace(mark_error=AsyncMock(side_effect=RuntimeError("redis unavailable")))
+        logger_mock = MagicMock()
+        monkeypatch.setattr(relay_sandbox_events_module, "logger", logger_mock)
+
+        await _mark_sandbox_error_best_effort(
+            cast(TaskRunRedisStream, redis_stream), "run-id", "Sandbox returned HTTP 404"
+        )
+
+        redis_stream.mark_error.assert_awaited_once_with("Sandbox returned HTTP 404")
+        logger_mock.exception.assert_called_once_with(
+            "relay_sandbox_events_mark_error_failed",
+            run_id="run-id",
+            error="redis unavailable",
+        )
+
     @parameterized.expand(
         [
             ("read_error", httpx.ReadError),
@@ -712,8 +729,8 @@ class TestRelaySandboxEventsErrorHandling:
                 return None
 
             async def aiter_sse(self):
-                if False:
-                    yield
+                if getattr(self, "emit_event", False):
+                    yield SimpleNamespace()
 
         def fake_connect_sse(*_args: object, **_kwargs: object) -> EmptyEventSource:
             nonlocal connect_attempts

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
@@ -430,7 +430,7 @@ class TestRelaySandboxEventsErrorHandling:
             monkeypatch.setattr(relay_sandbox_events_module.asyncio, "sleep", sleep_mock)
             monkeypatch.setattr(relay_sandbox_events_module, "_background_heartbeat", fake_background_heartbeat)
 
-            await _relay_loop(
+            sandbox_gone = await _relay_loop(
                 events_url="https://sandbox.example/events",
                 headers={"Authorization": "Bearer token"},
                 params={},
@@ -440,6 +440,7 @@ class TestRelaySandboxEventsErrorHandling:
             )
 
         assert connect_attempts == 2
+        assert sandbox_gone is False
         sleep_mock.assert_awaited_once_with(2)
         redis_stream.write_event.assert_awaited_once()
         redis_stream.mark_complete.assert_awaited_once()
@@ -478,7 +479,7 @@ class TestRelaySandboxEventsErrorHandling:
         monkeypatch.setattr(relay_sandbox_events_module.httpx_sse, "aconnect_sse", fake_connect_sse)
         monkeypatch.setattr(relay_sandbox_events_module, "_background_heartbeat", fake_background_heartbeat)
 
-        await _relay_loop(
+        sandbox_gone = await _relay_loop(
             events_url="https://sandbox.example/events",
             headers={"Authorization": "Bearer token"},
             params={},
@@ -488,6 +489,7 @@ class TestRelaySandboxEventsErrorHandling:
         )
 
         redis_stream.write_event.assert_awaited_once_with(terminal_event)
+        assert sandbox_gone is False
         redis_stream.mark_complete.assert_awaited_once()
         redis_stream.mark_error.assert_not_awaited()
 
@@ -664,7 +666,7 @@ class TestRelaySandboxEventsErrorHandling:
         monkeypatch.setattr(relay_sandbox_events_module.asyncio, "sleep", sleep_mock)
         monkeypatch.setattr(relay_sandbox_events_module, "_background_heartbeat", fake_background_heartbeat)
 
-        await _relay_loop(
+        sandbox_gone = await _relay_loop(
             events_url="https://sandbox.example/events",
             headers={"Authorization": "Bearer token"},
             params={},
@@ -674,6 +676,7 @@ class TestRelaySandboxEventsErrorHandling:
         )
 
         assert connect_attempts == 1
+        assert sandbox_gone is True
         sleep_mock.assert_not_awaited()
         redis_stream.write_event.assert_not_awaited()
         redis_stream.mark_complete.assert_awaited_once()
@@ -825,7 +828,9 @@ class TestRelaySandboxEventsWorkflowOptions:
             _branch="feature-branch",
         )
         execute_activity_mock = AsyncMock()
+        execute_activity_mock.return_value = True
         monkeypatch.setattr(process_task_workflow_module.workflow, "execute_activity", execute_activity_mock)
+        monkeypatch.setattr(process_task_workflow_module.workflow, "logger", MagicMock())
 
         await workflow._relay_sandbox_events(
             "https://sandbox.example",
@@ -837,6 +842,7 @@ class TestRelaySandboxEventsWorkflowOptions:
         args, kwargs = execute_activity_mock.await_args
         assert args[0] is relay_sandbox_events_module.relay_sandbox_events_deferred_completion
         assert kwargs["start_to_close_timeout"] == RELAY_SANDBOX_EVENTS_START_TO_CLOSE_TIMEOUT
+        assert workflow._sandbox_gone is True
 
 
 def _agent_chunk_event(text: str) -> dict:

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
@@ -631,7 +631,7 @@ class TestRelaySandboxEventsErrorHandling:
         redis_stream_mock.mark_complete.assert_not_awaited()
         redis_stream_mock.mark_error.assert_not_awaited()
 
-    async def test_normal_stream_close_marks_stream_complete(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_normal_stream_close_reconnects_before_terminal_event(self, monkeypatch: pytest.MonkeyPatch) -> None:
         redis_stream = SimpleNamespace(
             write_event=AsyncMock(),
             mark_complete=AsyncMock(),
@@ -654,10 +654,19 @@ class TestRelaySandboxEventsErrorHandling:
                 for event in events:
                     yield event
 
+        terminal_event = {
+            "type": "notification",
+            "notification": {"method": "_posthog/task_complete"},
+        }
+
+        class TerminalEventSource(EmptyEventSource):
+            async def aiter_sse(self):
+                yield SimpleNamespace(data=json.dumps(terminal_event))
+
         def fake_connect_sse(*_args: object, **_kwargs: object) -> EmptyEventSource:
             nonlocal connect_attempts
             connect_attempts += 1
-            return EmptyEventSource()
+            return EmptyEventSource() if connect_attempts == 1 else TerminalEventSource()
 
         async def fake_background_heartbeat(*_args: object, **_kwargs: object) -> None:
             return None
@@ -675,10 +684,10 @@ class TestRelaySandboxEventsErrorHandling:
             task_id="task-id",
         )
 
-        assert connect_attempts == 1
-        assert sandbox_gone is True
-        sleep_mock.assert_not_awaited()
-        redis_stream.write_event.assert_not_awaited()
+        assert connect_attempts == 2
+        assert sandbox_gone is False
+        sleep_mock.assert_awaited_once_with(2)
+        redis_stream.write_event.assert_awaited_once_with(terminal_event)
         redis_stream.mark_complete.assert_awaited_once()
         redis_stream.mark_error.assert_not_awaited()
 

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
@@ -691,6 +691,58 @@ class TestRelaySandboxEventsErrorHandling:
         redis_stream.mark_complete.assert_awaited_once()
         redis_stream.mark_error.assert_not_awaited()
 
+    async def test_normal_stream_close_marks_sandbox_gone_after_reconnects_exhausted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        redis_stream = SimpleNamespace(
+            write_event=AsyncMock(),
+            mark_complete=AsyncMock(),
+            mark_error=AsyncMock(),
+        )
+        sleep_mock = AsyncMock()
+        connect_attempts = 0
+
+        class EmptyEventSource:
+            response = SimpleNamespace(raise_for_status=lambda: None)
+
+            async def __aenter__(self) -> "EmptyEventSource":
+                return self
+
+            async def __aexit__(self, *_args: object) -> None:
+                return None
+
+            async def aiter_sse(self):
+                if False:
+                    yield
+
+        def fake_connect_sse(*_args: object, **_kwargs: object) -> EmptyEventSource:
+            nonlocal connect_attempts
+            connect_attempts += 1
+            return EmptyEventSource()
+
+        async def fake_background_heartbeat(*_args: object, **_kwargs: object) -> None:
+            return None
+
+        monkeypatch.setattr(relay_sandbox_events_module.httpx_sse, "aconnect_sse", fake_connect_sse)
+        monkeypatch.setattr(relay_sandbox_events_module.asyncio, "sleep", sleep_mock)
+        monkeypatch.setattr(relay_sandbox_events_module, "_background_heartbeat", fake_background_heartbeat)
+
+        sandbox_gone = await _relay_loop(
+            events_url="https://sandbox.example/events",
+            headers={"Authorization": "Bearer token"},
+            params={},
+            redis_stream=cast(TaskRunRedisStream, redis_stream),
+            run_id="run-id",
+            task_id="task-id",
+        )
+
+        assert connect_attempts == relay_sandbox_events_module.MAX_RECONNECT_ATTEMPTS + 1
+        assert sandbox_gone is True
+        assert [awaited.args[0] for awaited in sleep_mock.await_args_list] == [2, 4, 6, 8, 10]
+        redis_stream.write_event.assert_not_awaited()
+        redis_stream.mark_complete.assert_not_awaited()
+        redis_stream.mark_error.assert_awaited_once_with("Lost connection to sandbox after 5 reconnection attempts")
+
     async def test_in_progress_run_marks_stream_error_on_relay_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         redis_stream_mock = SimpleNamespace(mark_complete=AsyncMock(), mark_error=AsyncMock())
         redis_stream = cast(TaskRunRedisStream, redis_stream_mock)

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -1951,7 +1951,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             relay_activity = (
                 relay_sandbox_events_deferred_completion if _defer_run_stream_completion() else relay_sandbox_events
             )
-            await workflow.execute_activity(
+            sandbox_gone = await workflow.execute_activity(
                 relay_activity,
                 relay_input,
                 start_to_close_timeout=RELAY_SANDBOX_EVENTS_START_TO_CLOSE_TIMEOUT,
@@ -1974,6 +1974,12 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 ),
                 cancellation_type=workflow.ActivityCancellationType.TRY_CANCEL,
             )
+            if sandbox_gone is True and not self._task_completed:
+                workflow.logger.warning(
+                    "relay_sandbox_events_reported_sandbox_gone",
+                    extra={"run_id": self.context.run_id},
+                )
+                self._sandbox_gone = True
         except asyncio.CancelledError:
             raise
         except Exception as e:


### PR DESCRIPTION
## Problem

A closed sandbox relay must update the run lifecycle before another message is routed to the unavailable agent server. Regression found from https://github.com/PostHog/posthog/pull/74038

## Changes

- Return whether the relay ended because the sandbox became unavailable.
- Mark the workflow's sandbox as gone after unexpected stream closure, permanent HTTP errors, or exhausted reconnects.
- Keep terminal agent events classified as normal completion.
