### PR TITLE
chore(hobby): smoke test exception captures

### DIFF
--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -331,7 +331,11 @@ jobs:
             - name: Smoke test event ingestion
               if: env.TEST_EXIT_CODE == '0' && env.PREVIEW_MODE == 'false'
               timeout-minutes: 10
-              run: uv run bin/hobby-ci.py smoke-test-ingestion
+              run: |
+                  set +e
+                  uv run bin/hobby-ci.py smoke-test-ingestion
+                  echo "TEST_EXIT_CODE=$?" >> $GITHUB_ENV
+                  exit 0
               env:
                   DIGITALOCEAN_TOKEN: ${{ secrets.DIGITAL_OCEAN_HOBBY_TOKEN }}
                   DIGITALOCEAN_SSH_PRIVATE_KEY: ${{ secrets.DO_DEPLOY_SSH_PRIVATE_KEY }}

--- a/bin/hobby-ci-setup-user.py
+++ b/bin/hobby-ci-setup-user.py
@@ -36,6 +36,6 @@ PersonalAPIKey.objects.create(
     label="ci-smoke-test",
     secure_value=hash_key_value(raw_key),
     mask_value=mask_key_value(raw_key),
-    scopes=["query:read", "logs:read"],
+    scopes=["query:read", "logs:read", "error_tracking:read"],
 )
 print(f"{team.api_token}|||{raw_key}")  # noqa: T201

--- a/bin/hobby-ci.py
+++ b/bin/hobby-ci.py
@@ -475,7 +475,7 @@ runcmd:
                             "type": "HobbyCISmokeTestError",
                             "value": "Exception capture smoke test",
                             "mechanism": {"handled": True, "synthetic": True},
-                            "stacktrace": {"frames": []},
+                            "stacktrace": {"type": "raw", "frames": []},
                         }
                     ],
                 },

--- a/bin/hobby-ci.py
+++ b/bin/hobby-ci.py
@@ -14,6 +14,7 @@ import re
 import sys
 import json
 import time
+import uuid
 import shlex
 import base64
 import datetime
@@ -458,53 +459,77 @@ runcmd:
             return False, f"Could not parse API keys from output: {result['stdout'][:200]}"
         project_api_token, personal_api_key = output_line[-1].split("|||")
 
-        event_name = "hobby_ci_smoke_test"
-        print(f"📤 Sending test event '{event_name}'...", flush=True)
-        try:
-            capture_resp = requests.post(
-                f"{base_url}/capture/",  # nosemgrep: python.lang.security.audit.insecure-transport.requests.request-with-http.request-with-http
-                json={
-                    "api_key": project_api_token,
-                    "event": event_name,
-                    "properties": {"source": "hobby-ci"},
-                    "distinct_id": "ci-test-user",
+        capture_id = str(uuid.uuid4())
+        events = [
+            {
+                "event": "hobby_ci_smoke_test",
+                "properties": {"source": "hobby-ci", "capture_id": capture_id},
+            },
+            {
+                "event": "$exception",
+                "properties": {
+                    "source": "hobby-ci",
+                    "capture_id": capture_id,
+                    "$exception_list": [
+                        {
+                            "type": "HobbyCISmokeTestError",
+                            "value": "Exception capture smoke test",
+                            "mechanism": {"handled": True, "synthetic": True},
+                            "stacktrace": {"frames": []},
+                        }
+                    ],
                 },
-                timeout=30,
-            )
-        except requests.RequestException as e:
-            return False, f"Capture request failed: {e}"
-        if capture_resp.status_code != 200:
-            return False, f"Capture failed: HTTP {capture_resp.status_code} - {capture_resp.text[:200]}"
+            },
+        ]
+        for event in events:
+            print(f"📤 Sending test event '{event['event']}'...", flush=True)
+            try:
+                capture_resp = requests.post(
+                    f"{base_url}/capture/",  # nosemgrep: python.lang.security.audit.insecure-transport.requests.request-with-http.request-with-http
+                    json={"api_key": project_api_token, "distinct_id": "ci-test-user", **event},
+                    timeout=30,
+                )
+            except requests.RequestException as e:
+                return False, f"Capture request failed for {event['event']}: {e}"
+            if capture_resp.status_code != 200:
+                return (
+                    False,
+                    f"Capture failed for {event['event']}: HTTP {capture_resp.status_code} - {capture_resp.text[:200]}",
+                )
 
-        print(f"⏳ Polling for event (timeout {timeout_seconds}s)...", flush=True)
+        print(f"⏳ Polling for events (timeout {timeout_seconds}s)...", flush=True)
         headers = {"Authorization": f"Bearer {personal_api_key}"}
         deadline = time.time() + timeout_seconds
         attempt = 0
-        event_found = False
+        pending_event_names = {event["event"] for event in events}
         while time.time() < deadline:
             attempt += 1
-            try:
-                events_resp = requests.get(
-                    f"{base_url}/api/projects/@current/events/",  # nosemgrep: python.lang.security.audit.insecure-transport.requests.request-with-http.request-with-http
-                    params={"event": event_name},
-                    headers=headers,
-                    timeout=10,
-                )
-                if events_resp.status_code == 200:
-                    results = events_resp.json().get("results", [])
-                    if len(results) > 0:
-                        print(f"✅ Event found after {attempt} poll(s)", flush=True)
-                        event_found = True
-                        break
-                    print(f"   Poll {attempt}: no events yet", flush=True)
-                else:
-                    print(f"   Poll {attempt}: HTTP {events_resp.status_code}", flush=True)
-            except Exception as e:
-                print(f"   Poll {attempt}: {type(e).__name__}", flush=True)
+            for event_name in pending_event_names.copy():
+                try:
+                    events_resp = requests.get(
+                        f"{base_url}/api/projects/@current/events/",  # nosemgrep: python.lang.security.audit.insecure-transport.requests.request-with-http.request-with-http
+                        params={"event": event_name},
+                        headers=headers,
+                        timeout=10,
+                    )
+                    if events_resp.status_code == 200:
+                        results = events_resp.json().get("results", [])
+                        if any(result.get("properties", {}).get("capture_id") == capture_id for result in results):
+                            pending_event_names.remove(event_name)
+                            print(f"✅ Event '{event_name}' found after {attempt} poll(s)", flush=True)
+                        else:
+                            print(f"   Poll {attempt}: '{event_name}' not found yet", flush=True)
+                    else:
+                        print(f"   Poll {attempt}: '{event_name}' returned HTTP {events_resp.status_code}", flush=True)
+                except Exception as e:
+                    print(f"   Poll {attempt}: '{event_name}' returned {type(e).__name__}", flush=True)
+            if not pending_event_names:
+                break
             time.sleep(poll_interval)
 
-        if not event_found:
-            return False, f"Event did not appear within {timeout_seconds}s ({attempt} polls)"
+        if pending_event_names:
+            missing_events = ", ".join(sorted(pending_event_names))
+            return False, f"Events did not appear within {timeout_seconds}s ({attempt} polls): {missing_events}"
 
         log_body = f"hobby_ci_log_smoke_test_{time.time_ns()}"
         log_date_from = datetime.datetime.now(datetime.UTC).isoformat()
@@ -562,7 +587,7 @@ runcmd:
                     results = logs_resp.json().get("results", [])
                     if results:
                         print(f"✅ Log found after {attempt} poll(s)", flush=True)
-                        return True, "Event and log ingested successfully"
+                        return True, "Events and log ingested successfully"
                     print(f"   Poll {attempt}: no logs yet", flush=True)
                 else:
                     print(f"   Poll {attempt}: HTTP {logs_resp.status_code}", flush=True)

--- a/bin/hobby-ci.py
+++ b/bin/hobby-ci.py
@@ -460,6 +460,8 @@ runcmd:
         project_api_token, personal_api_key = output_line[-1].split("|||")
 
         capture_id = str(uuid.uuid4())
+        exception_value = f"hobby_ci_error_smoke_test_{time.time_ns()}"
+        error_date_from = datetime.datetime.now(datetime.UTC).isoformat()
         events = [
             {
                 "event": "hobby_ci_smoke_test",
@@ -473,7 +475,7 @@ runcmd:
                     "$exception_list": [
                         {
                             "type": "HobbyCISmokeTestError",
-                            "value": "Exception capture smoke test",
+                            "value": exception_value,
                             "mechanism": {"handled": True, "synthetic": True},
                             "stacktrace": {"type": "raw", "frames": []},
                         }
@@ -587,15 +589,47 @@ runcmd:
                     results = logs_resp.json().get("results", [])
                     if results:
                         print(f"✅ Log found after {attempt} poll(s)", flush=True)
-                        return True, "Events and log ingested successfully"
+                        break
                     print(f"   Poll {attempt}: no logs yet", flush=True)
                 else:
                     print(f"   Poll {attempt}: HTTP {logs_resp.status_code}", flush=True)
             except Exception as e:
                 print(f"   Poll {attempt}: {type(e).__name__}", flush=True)
             time.sleep(poll_interval)
+        else:
+            return False, f"Log did not appear within {timeout_seconds}s ({attempt} polls)"
 
-        return False, f"Log did not appear within {timeout_seconds}s ({attempt} polls)"
+        print(f"⏳ Polling for error tracking issue (timeout {timeout_seconds}s)...", flush=True)
+        deadline = time.time() + timeout_seconds
+        attempt = 0
+        while time.time() < deadline:
+            attempt += 1
+            try:
+                issues_resp = requests.post(
+                    f"{base_url}/api/projects/@current/error_tracking/query/issues",  # nosemgrep: python.lang.security.audit.insecure-transport.requests.request-with-http.request-with-http
+                    json={
+                        "status": "all",
+                        "filterTestAccounts": False,
+                        "dateRange": {"date_from": error_date_from},
+                        "searchQuery": exception_value,
+                        "limit": 1,
+                    },
+                    headers=headers,
+                    timeout=10,
+                )
+                if issues_resp.status_code == 200:
+                    results = issues_resp.json().get("results", [])
+                    if results:
+                        print(f"✅ Error tracking issue found after {attempt} poll(s)", flush=True)
+                        return True, "Events, log, and exception issue ingested successfully"
+                    print(f"   Poll {attempt}: no error tracking issue yet", flush=True)
+                else:
+                    print(f"   Poll {attempt}: HTTP {issues_resp.status_code}", flush=True)
+            except Exception as e:
+                print(f"   Poll {attempt}: {type(e).__name__}", flush=True)
+            time.sleep(poll_interval)
+
+        return False, f"Error tracking issue did not appear within {timeout_seconds}s ({attempt} polls)"
 
     @staticmethod
     def find_existing_droplet_for_pr(token, pr_number):

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -377,6 +377,7 @@ services:
         environment:
             ADDRESS: '0.0.0.0:3000'
             KAFKA_TOPIC: 'events_plugin_ingestion'
+            KAFKA_ERROR_TRACKING_TOPIC: 'ingestion-errortracking-main'
             KAFKA_HOSTS: 'kafka:9092'
             REDIS_URL: 'redis://redis7:6379/'
             CAPTURE_MODE: events


### PR DESCRIPTION
## Problem

Hobby deployment checks can pass when the dedicated exception ingestion path is broken.

## Changes

- Capture a valid `$exception` event alongside the existing smoke-test event.
- Tag each run uniquely and require both captured events to appear through the API.

**Why:** This makes Hobby deployment validation cover exception capture end to end.

## How did you test this code?

- `uv run ruff check bin/hobby-ci.py`
- `uv run ruff format --check bin/hobby-ci.py`
- `uv run python -m py_compile bin/hobby-ci.py`
- `uv run mypy --cache-fine-grained .`
- `uv run hogli ci:preflight --fix`

The remote Hobby deployment smoke test was not run locally because it requires provisioned infrastructure and credentials.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes are needed for this CI-only check.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with PostHog Code. No repo-provided skills were invoked. The synthetic exception fixture was written for this test and contains no external data.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*