### PR TITLE
feat(desktop/spaces): flag a waiting session before you open it

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityHoverCard.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityHoverCard.tsx
@@ -13,7 +13,7 @@ import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
 import { ActivityRow } from "@posthog/ui/features/canvas/components/ActivityView";
-import { useBlockedTaskIds } from "@posthog/ui/features/canvas/hooks/useBlockedSessionCount";
+import { useAwaitingInputTaskIds } from "@posthog/ui/features/canvas/hooks/useBlockedSessionCount";
 import { useMarkTaskActivityRead } from "@posthog/ui/features/canvas/hooks/useMarkTaskActivityRead";
 import { useTaskActivity } from "@posthog/ui/features/canvas/hooks/useTaskActivity";
 import { useCommentsEnabled } from "@posthog/ui/features/sessions/useCommentsEnabled";
@@ -48,7 +48,7 @@ export function ActivityHoverCard({
     fetchNextPage,
   } = useTaskActivity();
   // Selected once for the feed, not once per row.
-  const blockedTaskIds = useBlockedTaskIds();
+  const blockedTaskIds = useAwaitingInputTaskIds();
   const [scrollRoot, setScrollRoot] = useState<HTMLDivElement | null>(null);
   const [loadMoreRef, loadMoreInView] = useInView<HTMLDivElement>({
     root: scrollRoot,

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityView.tsx
@@ -25,7 +25,7 @@ import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authCl
 import { UserAvatar } from "@posthog/ui/features/auth/UserAvatar";
 import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
 import { MentionText } from "@posthog/ui/features/canvas/components/MentionText";
-import { useBlockedTaskIds } from "@posthog/ui/features/canvas/hooks/useBlockedSessionCount";
+import { useAwaitingInputTaskIds } from "@posthog/ui/features/canvas/hooks/useBlockedSessionCount";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { useMarkTaskActivityRead } from "@posthog/ui/features/canvas/hooks/useMarkTaskActivityRead";
 import { useTaskActivity } from "@posthog/ui/features/canvas/hooks/useTaskActivity";
@@ -350,7 +350,7 @@ export function ActivityView() {
     fetchNextPage,
   } = useTaskActivity();
   // Selected once for the feed, not once per row.
-  const blockedTaskIds = useBlockedTaskIds();
+  const blockedTaskIds = useAwaitingInputTaskIds();
   const { mutate: markTasksRead, isPending: isMarkingRead } =
     useMarkTaskActivityRead();
   const visibleItems = useMemo(

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useBlockedSessionCount.test.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useBlockedSessionCount.test.ts
@@ -1,0 +1,48 @@
+import type { TaskActivityItem } from "@posthog/core/canvas/taskActivity";
+import { describe, expect, it } from "vitest";
+import { coldAwaitingInputRows } from "./useBlockedSessionCount";
+
+function item(overrides: Partial<TaskActivityItem>): TaskActivityItem {
+  return {
+    id: "activity-1",
+    taskId: "task-1",
+    taskTitle: "Ask a question",
+    channelId: "channel-1",
+    channelName: "me",
+    activityAt: "2026-08-10T00:00:00Z",
+    activityKind: "awaiting_input",
+    snippet: "",
+    author: null,
+    messageId: null,
+    isUnread: false,
+    ...overrides,
+  };
+}
+
+describe("coldAwaitingInputRows", () => {
+  it("takes the tasks whose run stopped for input", () => {
+    const ids = coldAwaitingInputRows(
+      [
+        item({ taskId: "waiting" }),
+        item({ taskId: "done", activityKind: "completed" }),
+        item({ taskId: "chatty", activityKind: "message" }),
+      ],
+      new Set(),
+    );
+
+    expect(ids.map((row) => row.taskId)).toEqual(["waiting"]);
+  });
+
+  // The row records that the agent asked at a moment in time. A mounted session
+  // knows whether it is still waiting, and answering a prompt does not write a
+  // new activity row — so a row kept over a live session would stay blue after
+  // the prompt was answered.
+  it("leaves a task to its own session while that session is mounted", () => {
+    const ids = coldAwaitingInputRows(
+      [item({ taskId: "warm" }), item({ taskId: "cold" })],
+      new Set(["warm"]),
+    );
+
+    expect(ids.map((row) => row.taskId)).toEqual(["cold"]);
+  });
+});

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useBlockedSessionCount.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useBlockedSessionCount.ts
@@ -1,5 +1,6 @@
-import { countSessionsByChannel } from "@posthog/core/canvas/channelUnread";
+import type { TaskActivityItem } from "@posthog/core/canvas/taskActivity";
 import { useArchivedTaskIds } from "@posthog/ui/features/archive/useArchivedTaskIds";
+import { useTaskActivity } from "@posthog/ui/features/canvas/hooks/useTaskActivity";
 import { useSessionStore } from "@posthog/ui/features/sessions/sessionStore";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
 import { useMemo } from "react";
@@ -7,14 +8,13 @@ import { useMemo } from "react";
 const NO_BLOCKED: ReadonlySet<string> = new Set();
 
 /**
- * The tasks whose session is waiting on an answer from you — what turns a row
- * blue, and what puts it at the top of its space.
+ * The tasks whose live session is holding a prompt — what a mounted session
+ * knows about itself.
  *
- * Blue is the one state a polled task can't report. "Blocked on you" is a
- * permission prompt an agent raised mid-turn, which lives in the session store
- * and nowhere else, so this reads the live sessions rather than the task list
- * the yellow count comes from. A session running somewhere else is therefore
- * never blue here — the app that holds the prompt is the app that can answer it.
+ * A permission prompt an agent raised mid-turn lives in the session store and
+ * nowhere else, so this reads the live sessions rather than the polled task
+ * list. A session running in another app is therefore absent here: the app that
+ * holds the prompt is the app that can answer it.
  *
  * Selected as a sorted key rather than the session map: the store's sessions
  * change identity on every streamed event, and this runs in the sidebar's own
@@ -36,9 +36,87 @@ export function useBlockedTaskIds(): ReadonlySet<string> {
   );
 }
 
+/** The tasks with a session in this app, whether or not it holds a prompt. */
+function useMountedTaskIds(): ReadonlySet<string> {
+  const mountedKey = useSessionStore((state) =>
+    Object.keys(state.taskIdIndex).sort().join(","),
+  );
+  return useMemo(
+    () => (mountedKey ? new Set(mountedKey.split(",")) : NO_BLOCKED),
+    [mountedKey],
+  );
+}
+
+/**
+ * The feed rows for tasks that are waiting, minus the ones a live session can
+ * speak for.
+ *
+ * Rows rather than ids, because a row also carries the space the task is filed
+ * in. That is what lets a space count its cold sessions without going through
+ * the task list, which it may not have loaded yet.
+ */
+export function coldAwaitingInputRows(
+  items: readonly TaskActivityItem[],
+  mounted: ReadonlySet<string>,
+): TaskActivityItem[] {
+  return items.filter(
+    (item) =>
+      item.activityKind === "awaiting_input" && !mounted.has(item.taskId),
+  );
+}
+
+/**
+ * Every task waiting on an answer from you, including the ones whose session is
+ * cold.
+ *
+ * A session that isn't mounted holds its prompt in the run log, which costs a
+ * fetch and a hydration to read — so before this, a space went blue only once
+ * you opened the session that was already waiting. The backend records the same
+ * fact when a run stops for input (`push_dispatcher.notify_task_run_awaiting_input`)
+ * as one activity row per task, newest wins, which the feed behind the bell
+ * already holds. No new request, and it survives a restart.
+ *
+ * A mounted session outranks its row. The session is live and clears the moment
+ * you answer, while the activity row only moves when the next activity lands, so
+ * trusting the row over a session that is present would keep a row blue after
+ * its prompt was answered.
+ *
+ * Local runs are the gap. Their prompt is announced client-side and never
+ * reaches the backend, so a local session that isn't mounted stays invisible
+ * here. Cloud runs, which is most of them, are covered.
+ */
+export function useAwaitingInputTaskIds(): ReadonlySet<string> {
+  const blocked = useBlockedTaskIds();
+  const mounted = useMountedTaskIds();
+  const { items } = useTaskActivity();
+  const coldKey = useMemo(
+    () =>
+      coldAwaitingInputRows(items, mounted)
+        .map((row) => row.taskId)
+        .sort()
+        .join(","),
+    [items, mounted],
+  );
+  return useMemo(() => {
+    if (!coldKey) return blocked;
+    const awaiting = new Set(blocked);
+    for (const taskId of coldKey.split(",")) awaiting.add(taskId);
+    return awaiting;
+  }, [blocked, coldKey]);
+}
+
 /**
  * How many sessions in a channel are waiting on an answer from you, by channel
  * id — the blue dot a space row wears beside its yellow one.
+ *
+ * Two passes over two sources, because they place a task differently. A live
+ * session gives an id and nothing else, so the task list says which space it is
+ * in. A cold one comes from the feed, whose row already carries the space, and
+ * reading it from there is what lets a space go blue before the task list has
+ * loaded — the row under it does not wait for that list either.
+ *
+ * Counted as a set of task ids per space, so a task that both sources know about
+ * is one session, not two.
  */
 export function useBlockedSessionCount(): (
   channelId: string | undefined,
@@ -47,18 +125,29 @@ export function useBlockedSessionCount(): (
   // shared and its rows carry no author filter.
   const { data: tasks } = useTasks({ showAllUsers: true });
   const blocked = useBlockedTaskIds();
+  const mounted = useMountedTaskIds();
+  const { items } = useTaskActivity();
   const archivedTaskIds = useArchivedTaskIds();
   const counts = useMemo(() => {
-    if (blocked.size === 0) return new Map<string, number>();
+    const bySpace = new Map<string, Set<string>>();
     // Archived alongside the yellow count, for the same reason: a space's
     // lists drop them, so a dot for one points at a row you cannot reach.
-    return countSessionsByChannel(
-      tasks ?? [],
-      (task) => blocked.has(task.id) && !archivedTaskIds.has(task.id),
-    );
-  }, [blocked, tasks, archivedTaskIds]);
+    const add = (spaceId: string | null, taskId: string) => {
+      if (!spaceId || archivedTaskIds.has(taskId)) return;
+      const inSpace = bySpace.get(spaceId) ?? new Set<string>();
+      inSpace.add(taskId);
+      bySpace.set(spaceId, inSpace);
+    };
+    for (const task of tasks ?? []) {
+      if (blocked.has(task.id)) add(task.channel ?? null, task.id);
+    }
+    for (const row of coldAwaitingInputRows(items, mounted)) {
+      add(row.channelId, row.taskId);
+    }
+    return bySpace;
+  }, [blocked, mounted, items, tasks, archivedTaskIds]);
   return useMemo(
-    () => (channelId) => (channelId ? (counts.get(channelId) ?? 0) : 0),
+    () => (channelId) => (channelId ? (counts.get(channelId)?.size ?? 0) : 0),
     [counts],
   );
 }

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTaskStatus.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTaskStatus.ts
@@ -1,4 +1,5 @@
 import type { ChannelItemModel } from "@posthog/core/canvas/channelItems";
+import { useAwaitingInputTaskIds } from "@posthog/ui/features/canvas/hooks/useBlockedSessionCount";
 import { useChannelTaskData } from "@posthog/ui/features/canvas/hooks/useChannelTaskData";
 import type { TaskStatusInput } from "@posthog/ui/features/sidebar/components/items/taskStatusVocabulary";
 import { useTaskPrStatus } from "@posthog/ui/features/sidebar/useTaskPrStatus";
@@ -30,6 +31,10 @@ export function useChannelTaskStatus(
   const task = item.task ?? undefined;
   const taskData = useChannelTaskData(task);
   const workspace = useWorkspace(task?.id);
+  // `deriveTaskData` reads the prompt off a live session, so a row whose session
+  // is cold reported nothing and stayed grey until you opened it. The backend
+  // recorded the same stop, and this set carries it.
+  const awaitingInput = useAwaitingInputTaskIds();
   const { prState, hasDiff } = useTaskPrStatus({
     // An empty id is the hook's own "nothing to look up", so this asks for no
     // query rather than one it throws away.
@@ -47,7 +52,8 @@ export function useChannelTaskStatus(
     isUnread: taskData.isUnread,
     isPinned: taskData.isPinned,
     isSuspended: taskData.isSuspended,
-    needsPermission: taskData.needsPermission,
+    needsPermission:
+      taskData.needsPermission || (!!task && awaitingInput.has(task.id)),
     taskRunStatus: taskData.taskRunStatus,
     runMode: taskData.runMode,
     originProduct: taskData.originProduct,

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useRecentSpaceTasks.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useRecentSpaceTasks.ts
@@ -6,7 +6,7 @@ import type { Task } from "@posthog/shared/domain-types";
 import { useArchivedTaskIds } from "@posthog/ui/features/archive/useArchivedTaskIds";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
-import { useBlockedTaskIds } from "@posthog/ui/features/canvas/hooks/useBlockedSessionCount";
+import { useAwaitingInputTaskIds } from "@posthog/ui/features/canvas/hooks/useBlockedSessionCount";
 import {
   type TaskTimestamps,
   wantsAttention,
@@ -150,7 +150,7 @@ export function useRecentSpaceTasks(
   const archivedTaskIds = useArchivedTaskIds();
   const { pinnedTaskIds } = usePinnedTasks();
   const { timestamps: viewedAt } = useTaskViewed();
-  const blockedTaskIds = useBlockedTaskIds();
+  const blockedTaskIds = useAwaitingInputTaskIds();
 
   const pagePerSpace = useQueries({
     queries: spaceIds.map((spaceId) => ({


### PR DESCRIPTION
## Problem

A session waiting on your answer looks the same as a finished one until you open it, which is when you no longer need telling.

- An agent stops and asks a question. That session is stuck until you answer.
- The blue "needs your input" mark reads the prompt off a loaded session, and the app loads a session only when you open it.
- So the space holding it shows nothing, its row sits grey among the finished work, and it does not sort to the top.
- Reopening the app is the worst case. Everything reads caught up while sessions sit waiting.

Follows #79997, which added the blue mark and the ordering this extends.

## Changes

- A task the backend recorded as waiting now counts, whether or not its session is loaded.
- That record is the activity row `push_dispatcher.notify_task_run_awaiting_input` writes, one per task, newest wins. The feed behind the bell already holds it, so this adds no request and survives a restart.
- The mark reaches all four surfaces: the session row, the space's blue dot, the tree's blocked tier, and the activity feed row.
- A loaded session outranks its row. The session clears the moment you answer; the row only moves when the next activity lands, so a row kept over a live session would stay blue after you answered.
- The space's count reads the space off the activity row rather than the task list. A cold session's row goes blue without that list, and the space above it should not wait for what its own rows do not.
- A task both sources know about counts once.

> [!NOTE]
> Cloud runs only. A local run announces its prompt client-side and never reaches the backend, so a cold local session stays quiet until you open it. Closing that needs a flag persisted host-side when the prompt fires.

**Screenshots:** none. I saw the session row go blue on a cold session in the running app, then broke that window driving it over CDP, so I have no capture. The space dot is reasoned from the code and not yet seen.

## How did you test this code?

I (actually Claude) wrote and ran the tests below. I did no manual testing beyond the one live observation named above.

- 2 new tests on `coldAwaitingInputRows`: it takes the rows whose run stopped for input, and leaves out a task whose session is loaded. The second is the precedence rule, and without it an answered prompt stays blue until the next activity row lands.

**Not checked:** the space's blue dot in the app, for the reason above. It shares its source with the row's dot, which I did see, but the count path is its own code.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing doc covers the space list's status marks.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I am Claude Opus 5, working in Claude Code. [Session](https://claude.ai/code/session_01SJBNYo5crBygv9Bbdc2MRb).

Skills invoked: `/posthog-desktop` for the tree's toolchain and scope, `/writing-tests` before adding the test, `/test-electron-app` to drive the running app over CDP, and `/writing-pr-descriptions` for this body.

Adam asked whether a sleeping session could be known to be waiting. I found the backend already records it, which is why this costs no new request. The first cut routed the space's count through the task list and produced a blue row under a bare space; reading the space off the activity row fixed it and removed the dependency.

**Public artifact:** nothing here draws on a customer conversation, ticket, or log.
