### PR TITLE
fix(conversations): stop reporting a closed support panel as a failed thread

### DIFF
--- a/products/conversations/frontend/components/SidePanel/sidepanelTicketsLogic.test.ts
+++ b/products/conversations/frontend/components/SidePanel/sidepanelTicketsLogic.test.ts
@@ -302,6 +302,44 @@ describe('sidepanelTicketsLogic', () => {
         expect(supportLogic.values.pendingViewTicket).toBeNull()
     })
 
+    // Closing the panel unmounts this logic, and kea removes its state from the store with it. The
+    // fetch still in flight then resumed against a store that no longer held the ticket it reads, and
+    // the error that threw was reported as a failed thread, so the customer got a "Failed to load
+    // messages" toast over a panel they had already closed.
+    it('stays quiet when the panel closes while a thread is still loading', async () => {
+        const errorToast = jest.spyOn(lemonToast, 'error').mockReturnValue('' as never)
+        let deliverMessages: (response: unknown) => void = () => {}
+        ;(posthog as any).conversations.getMessages = jest.fn(
+            () =>
+                new Promise((resolve) => {
+                    deliverMessages = resolve
+                })
+        )
+
+        logic = sidepanelTicketsLogic.build()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        ;(posthog.capture as jest.Mock).mockClear()
+
+        logic.actions.setCurrentTicket({
+            id: 'ticket-1',
+            status: 'open',
+            message_count: 1,
+            created_at: '2026-07-13T00:00:00Z',
+            unread_count: 0,
+            last_message_at: '2026-07-13T00:00:00Z',
+        })
+        logic.unmount()
+        deliverMessages({ messages: [], has_more: false })
+        await new Promise(process.nextTick)
+
+        expect(errorToast).not.toHaveBeenCalled()
+        expect(
+            (posthog.capture as jest.Mock).mock.calls.filter(([event]) => event === 'support widget load failed')
+        ).toHaveLength(0)
+        errorToast.mockRestore()
+    })
+
     // The panel already shows free plans the community and upgrade options, and they have no email
     // channel, so warning them the chat failed would offer support they don't actually get.
     it.each([

--- a/products/conversations/frontend/components/SidePanel/sidepanelTicketsLogic.ts
+++ b/products/conversations/frontend/components/SidePanel/sidepanelTicketsLogic.ts
@@ -421,7 +421,7 @@ export const sidepanelTicketsLogic = kea<sidepanelTicketsLogicType>([
                 document.addEventListener('visibilitychange', cache.onVisibilityChange)
             }
         },
-        loadTickets: async () => {
+        loadTickets: async (_, breakpoint) => {
             // We don't support self-hosted, and the conversations extension is cloud-only — both the
             // panel and the tickets scene already render a community-forum message instead. This logic
             // still mounts there (the scene declares it in its SceneExport), so without this it would
@@ -466,6 +466,10 @@ export const sidepanelTicketsLogic = kea<sidepanelTicketsLogicType>([
             actions.setTicketsLoading(true)
             try {
                 const response = await posthog.conversations.getTickets({ limit: 50 })
+                // Same unmount race as loadMessages: polling and the visibility listener keep this
+                // in flight while the panel can close under it, and kea has dropped the state the
+                // branches below read by then.
+                breakpoint()
                 if (response) {
                     actions.setTickets(response.results as ConversationTicket[])
                     if (response.results.length > 0) {
@@ -473,6 +477,9 @@ export const sidepanelTicketsLogic = kea<sidepanelTicketsLogicType>([
                     }
                 }
             } catch (e) {
+                // The request can also reject after the unmount, so re-check before reading values
+                // below and reporting a panel nobody has open as a failure the customer saw.
+                breakpoint()
                 console.error('Failed to load tickets:', e)
                 // Reported because a customer who can't see their tickets can't reply to support on
                 // them either, and the toast alone left us blind to how often that happens
@@ -506,7 +513,7 @@ export const sidepanelTicketsLogic = kea<sidepanelTicketsLogicType>([
                 cache.pollTimer = null
             }
         },
-        loadMessages: async ({ ticketId }) => {
+        loadMessages: async ({ ticketId }, breakpoint) => {
             if (!ticketId || !posthog.conversations) {
                 return
             }
@@ -519,6 +526,11 @@ export const sidepanelTicketsLogic = kea<sidepanelTicketsLogicType>([
                 // Fetch all pages of messages using `after` timestamp pagination
                 while (hasMore) {
                     const response = await (posthog.conversations.getMessages as any)(ticketId, after)
+                    // Closing the side panel unmounts this logic and kea drops its state from the
+                    // store, so the `values` read below would throw instead of returning a ticket.
+                    // Breaking out also discards the pages fetched so far, which is what we want:
+                    // nothing renders them, and reopening the panel loads the thread again.
+                    breakpoint()
                     // Check if we're still viewing the same ticket (avoid race condition when switching quickly)
                     if (!response || values.currentTicket?.id !== ticketId) {
                         return
@@ -543,6 +555,10 @@ export const sidepanelTicketsLogic = kea<sidepanelTicketsLogicType>([
                 actions.setMessages(transformedMessages)
                 actions.setHasMoreMessages(false)
             } catch (e) {
+                // The request can also reject after the unmount, so re-check before reporting.
+                // A thread nobody is looking at anymore is not a failure the customer saw, and
+                // counting it inflates the thread_load_failed rate we watch.
+                breakpoint()
                 console.error('Failed to load messages:', e)
                 // A thread that won't open is a customer who can't continue a conversation they
                 // already started, so it belongs in the same rate signal as a dead panel
@@ -560,6 +576,11 @@ export const sidepanelTicketsLogic = kea<sidepanelTicketsLogicType>([
             if (!content.trim() || values.messageSending) {
                 return
             }
+            // In "new" view we force creation of a new ticket. Read once up front, because the send
+            // can outlive the panel: closing it unmounts this logic and kea drops its state from the
+            // store, so reading `values.view` again after the await would throw and report a send
+            // that actually succeeded as a failure.
+            const isNewTicket = values.view === 'new'
             // Bailing quietly here left the button un-loaded and the typed message sitting in the box
             // with no explanation, which is the worst version of this now conversations is the only channel
             if (!posthog.conversations) {
@@ -567,7 +588,7 @@ export const sidepanelTicketsLogic = kea<sidepanelTicketsLogicType>([
                     surface: 'side_panel_composer',
                     reason: 'widget_unavailable',
                     message: content,
-                    is_new_ticket: values.view === 'new',
+                    is_new_ticket: isNewTicket,
                 })
                 warnSupportWidgetUnavailable()
                 return
@@ -577,19 +598,16 @@ export const sidepanelTicketsLogic = kea<sidepanelTicketsLogicType>([
                     surface: 'side_panel_composer',
                     reason: 'message_too_long',
                     message: content,
-                    is_new_ticket: values.view === 'new',
+                    is_new_ticket: isNewTicket,
                 })
                 return
             }
             actions.setMessageSending(true)
             try {
-                // If we're in "new" view, force creation of a new ticket
-                const forceNewTicket = values.view === 'new'
-
-                const response = await posthog.conversations.sendMessage(content, {}, forceNewTicket)
+                const response = await posthog.conversations.sendMessage(content, {}, isNewTicket)
                 if (response) {
                     // If we just created a new ticket, set it as current and switch to chat view
-                    if (values.view === 'new') {
+                    if (isNewTicket) {
                         actions.setCurrentTicket({
                             id: response.ticket_id,
                             status: response.ticket_status,
@@ -614,7 +632,7 @@ export const sidepanelTicketsLogic = kea<sidepanelTicketsLogicType>([
                         surface: 'side_panel_composer',
                         reason: 'widget_declined',
                         message: content,
-                        is_new_ticket: values.view === 'new',
+                        is_new_ticket: isNewTicket,
                     })
                     lemonToast.error('Failed to send message. Please try again.', {
                         button: EMAIL_SUPPORT_BUTTON,
@@ -627,7 +645,7 @@ export const sidepanelTicketsLogic = kea<sidepanelTicketsLogicType>([
                     reason: 'send_failed',
                     message: content,
                     error: e,
-                    is_new_ticket: values.view === 'new',
+                    is_new_ticket: isNewTicket,
                 })
                 lemonToast.error('Failed to send message. Please try again.', { button: EMAIL_SUPPORT_BUTTON })
             } finally {


### PR DESCRIPTION
## Problem

- Someone who opens a support ticket and then closes the side panel gets a "Failed to load messages. Please try again." toast over whatever page they are on.
- Closing the panel unmounts `sidepanelTicketsLogic`, and kea removes its state from the store.
- The message fetch is still in flight. It reads `values.currentTicket` on the way back, and that read throws once the state is gone.
- The catch treats that as a real thread failure, so it toasts and captures `support widget load failed` with reason `thread_load_failed`.
- The rate we watch for dead support threads therefore counts closed panels as failures.

## Changes

- `loadMessages` and `loadTickets` take a kea `breakpoint` and call it after each fetch, so an unmounted logic stops instead of reading state that is gone.
- Both catch blocks call `breakpoint()` first, so a request that rejects after the unmount is not toasted or captured.
- `sendMessage` reads the composer view once before the send, instead of re-reading it after the await. A send that outlives the panel now reports its own outcome correctly.
- Discarding the pages already fetched is intentional. Nothing renders them, and reopening the panel loads the thread again.

No visual change. The fix removes a toast in a case where it should never have appeared.

## How did you test this code?

- New Jest case in `sidepanelTicketsLogic.test.ts`: unmount the logic while a message fetch is pending, then resolve it. It asserts no error toast and no `support widget load failed` capture.
- I checked that the case fails without the fix. Reverting the two `breakpoint()` calls in `loadMessages` makes it fail on the toast assertion, with the exact message from the report.
- Not run: the rest of the frontend suite, and any manual or browser testing. I did not reproduce this in a running app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually the PostHog Slack app, running Claude Code) wrote this from a Slack thread where a session replay showed the toast firing twice with the support sidebar closed. The question was why the widget loads at all when the panel is shut. It does not. The load starts while the panel is open and only fails after it closes, and the toast is global, so it renders over the page behind it.

Skills invoked: `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.

I checked kea 4.0.0-pre.6's listener source to confirm the semantics this fix relies on: `beforeUnmount` bumps every listener breakpoint counter, so a bare `breakpoint()` throws after an unmount and not only when the action fires again. Dispatching an action on an unmounted logic is a no-op rather than an error, so only the `values` reads needed guarding.

The PR is unassigned because I could not verify the requester's GitHub handle, and I will not guess one. Assigning the person who raised this is the right follow-up.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AMXLYHZ8U/p1786115235005749?thread_ts=1786115235.005749&cid=C0AMXLYHZ8U)*
