### PR TITLE
fix(storybook): deflake auth domains story

### DIFF
--- a/frontend/src/scenes/settings/organization/VerifiedDomains/VerifiedDomains.stories.tsx
+++ b/frontend/src/scenes/settings/organization/VerifiedDomains/VerifiedDomains.stories.tsx
@@ -2,7 +2,6 @@ import { MOCK_DEFAULT_ORGANIZATION, MOCK_DEFAULT_TEAM, MOCK_DEFAULT_USER } from 
 
 import type { Meta, StoryObj } from '@storybook/react'
 import { router } from 'kea-router'
-import { useEffect } from 'react'
 
 import { STORYBOOK_FEATURE_FLAGS } from 'lib/constants'
 import { App } from 'scenes/App'
@@ -118,9 +117,11 @@ const meta: Meta<typeof App> = {
         }),
     ],
     render: () => {
-        useEffect(() => {
-            router.actions.push(urls.settings('organization-authentication'))
-        }, [])
+        // Navigate synchronously before <App /> mounts so it renders the settings scene directly,
+        // never the project homepage. A useEffect push fires after the first paint, so the snapshot
+        // can race and capture the homepage frame instead.
+        router.actions.push(urls.settings('organization-authentication'))
+
         return <App />
     },
 }


### PR DESCRIPTION
## Problem

Ten open PRs sit red on `PostHog Visual Review / storybook` with the same two changed snapshots, none of which they touched.

- The stored baseline for the authentication domains story is a screenshot of the project homepage, not the settings page.
- The story pushes its route inside a `useEffect`, which runs after the first paint.
- The story sets no `waitForSelector`, so nothing holds the screenshot back until the settings scene mounts.
- A run that renders the settings page correctly then fails against a homepage baseline.

Two stories share one baseline image, which no two stories can legitimately do:

| Identifier | Baseline image | Shows |
| --- | --- | --- |
| `one-unverified-domain--light` | `0c40bb53` | homepage |
| `one-unverified-domain--dark` | `d2354aea` | homepage |
| `boost-needs-upgrade--dark` | `d2354aea` | the same homepage image |

## Changes

- The story pushes its route during render, before `<App />` mounts.
- The four sibling settings story files already navigate this way. They carry a comment describing this exact race.
- Three baselines will read as changed on the next run. Approving them is correct, because they will finally capture the settings page.

## How did you test this code?

No new tests. This changes a story's navigation timing.

- I (actually Claude) rebuilt Storybook and sampled every animation frame across 10 loads, before and after the change.
- Both runs showed zero homepage frames. The local A/B did not reproduce the race, so it does not prove the fix.
- The evidence for the bug is the stored artifacts, not my local run.
- [PR 79923's run](https://us.posthog.com/project/2/visual_review/runs/f86440fa-ff1e-44fb-8d08-6ead4784f059) and [PR 80300's run](https://us.posthog.com/project/2/visual_review/runs/c0199c4d-b90f-4e49-9033-9f1a7d295f36) hold the identical changed pair, with the same artifact IDs and diff percentages.
- Not checked: the Storybook test-runner does not run natively on macOS, so I did not exercise the CI capture path.

No product UI changes. Only what the snapshot captures changes, so there is nothing to screenshot.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5). Skills invoked: `/writing-pr-descriptions`.
- Found while investigating why the Visual Review gate was red on [repair the repo overview trend panels](https://github.com/PostHog/posthog/pull/79923). My first hypothesis was a flaky 4px height shift. Downloading the baseline images showed the baseline was the wrong page.
- I considered fixing the shared `withPageUrl` decorator instead, which would immunize all seven exposed stories at once. I left it out because it changes navigation timing for every `pageUrl` story and can shift unrelated baselines. It deserves its own PR.
