### PR TITLE
fix(mcp): describe connected MCP servers so agents can find their tools

### DIFF
--- a/ee/clickhouse/models/test/__snapshots__/test_property.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_property.ambr
@@ -58,7 +58,7 @@
 # ---
 # name: test_parse_groups_persons_edge_case_with_single_filter
   tuple(
-    'AND (  has(%(vglobalperson_0)s, "pmat_email"))',
+    'AND (  has(%(vglobalperson_0)s, replaceRegexpAll(JSONExtractRaw(person_props, %(kglobalperson_0)s), \'^"|"$\', \'\')))',
     dict({
       'kglobalperson_0': 'email',
       'vglobalperson_0': list([
@@ -121,7 +121,7 @@
 # ---
 # name: test_parse_prop_clauses_defaults.2
   tuple(
-    'AND (   has(%(vglobal_0)s, replaceRegexpAll(JSONExtractRaw(properties, %(kglobal_0)s), \'^"|"$\', \'\'))  AND argMax(person."pmat_email", version) ILIKE %(vpersonquery_global_1)s)',
+    'AND (   has(%(vglobal_0)s, replaceRegexpAll(JSONExtractRaw(properties, %(kglobal_0)s), \'^"|"$\', \'\'))  AND replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), %(kpersonquery_global_1)s), \'^"|"$\', \'\') ILIKE %(vpersonquery_global_1)s)',
     dict({
       'kglobal_0': 'event_prop',
       'kpersonquery_global_1': 'email',

--- a/ee/clickhouse/models/test/__snapshots__/test_property.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_property.ambr
@@ -58,7 +58,7 @@
 # ---
 # name: test_parse_groups_persons_edge_case_with_single_filter
   tuple(
-    'AND (  has(%(vglobalperson_0)s, replaceRegexpAll(JSONExtractRaw(person_props, %(kglobalperson_0)s), \'^"|"$\', \'\')))',
+    'AND (  has(%(vglobalperson_0)s, "pmat_email"))',
     dict({
       'kglobalperson_0': 'email',
       'vglobalperson_0': list([
@@ -121,7 +121,7 @@
 # ---
 # name: test_parse_prop_clauses_defaults.2
   tuple(
-    'AND (   has(%(vglobal_0)s, replaceRegexpAll(JSONExtractRaw(properties, %(kglobal_0)s), \'^"|"$\', \'\'))  AND replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), %(kpersonquery_global_1)s), \'^"|"$\', \'\') ILIKE %(vpersonquery_global_1)s)',
+    'AND (   has(%(vglobal_0)s, replaceRegexpAll(JSONExtractRaw(properties, %(kglobal_0)s), \'^"|"$\', \'\'))  AND argMax(person."pmat_email", version) ILIKE %(vpersonquery_global_1)s)',
     dict({
       'kglobal_0': 'event_prop',
       'kpersonquery_global_1': 'email',

--- a/products/desktop/packages/agent/src/pi/rpc-client.test.ts
+++ b/products/desktop/packages/agent/src/pi/rpc-client.test.ts
@@ -50,6 +50,39 @@ describe("createRuntimeMcpServers", () => {
     });
   });
 
+  it("carries a server description so search finds it before it connects", () => {
+    // Lazy servers hold no tool metadata until first use, so pi's `mcp` search matches
+    // them on name and description alone.
+    expect(
+      createRuntimeMcpServers([
+        {
+          name: "Linear",
+          type: "http",
+          url: "https://mcp.example/linear",
+          headers: [],
+          description: "Manage Linear issues, projects, and workflows.",
+        },
+      ]),
+    ).toMatchObject({
+      Linear: {
+        description: "Manage Linear issues, projects, and workflows.",
+      },
+    });
+  });
+
+  it("omits the description key for servers without one", () => {
+    expect(
+      createRuntimeMcpServers([
+        {
+          name: "plain",
+          type: "http",
+          url: "https://mcp.example/mcp",
+          headers: [],
+        },
+      ]).plain,
+    ).not.toHaveProperty("description");
+  });
+
   it("maps local tools to an eager direct stdio server", () => {
     expect(
       createRuntimeMcpStdioServers([

--- a/products/desktop/packages/agent/src/pi/rpc-client.ts
+++ b/products/desktop/packages/agent/src/pi/rpc-client.ts
@@ -114,6 +114,9 @@ export function createRuntimeMcpServers(
         lifecycle: "lazy" as const,
         args: [],
         directTools: false,
+        // Lazy servers hold no tool metadata until first use, so this is what the
+        // model's tool search matches on until then.
+        ...(server.description ? { description: server.description } : {}),
       },
     ]),
   );

--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -2056,6 +2056,34 @@ describe("AgentServer HTTP Mode", () => {
       testServer.session = null;
     });
 
+    it("strips pi-only descriptions before forwarding to the ACP adapter", async () => {
+      // claude and codex validate session params against the ACP schema, which does not
+      // declare a server description; only pi reads it.
+      const testServer = exposeRefresh(createServer());
+      const extMethod = vi.fn(async () => ({ refreshed: true }));
+      testServer.session = { clientConnection: { extMethod } };
+      testServer.mcpRelayServer = null;
+
+      await testServer.executeCommand("refresh_session", {
+        mcpServers: [
+          {
+            type: "http",
+            name: "posthog",
+            url: "https://mcp",
+            headers: [],
+            description: "Query PostHog insights and dashboards.",
+          },
+        ],
+      });
+
+      const forwarded = (extMethod.mock.calls[0] as unknown[])[1] as {
+        mcpServers: Array<Record<string, unknown>>;
+      };
+      expect(forwarded.mcpServers[0]).not.toHaveProperty("description");
+
+      testServer.session = null;
+    });
+
     it("does not duplicate a relay entry already present in the refresh list", async () => {
       const testServer = exposeRefresh(createServer());
       const extMethod = vi.fn(async () => ({ refreshed: true }));

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -18,6 +18,7 @@ import { execGh } from "@posthog/git/gh";
 import { getCurrentBranch, getRemoteUrl } from "@posthog/git/queries";
 import { ghTokenEnv } from "@posthog/git/signed-commit";
 import {
+  type AcpMcpServer,
   type Adapter,
   buildPrOutput,
   getErrorMessage,
@@ -29,6 +30,7 @@ import {
   readMcpToolDescriptor,
   readPrUrls,
   sleepWithBackoff,
+  toAcpMcpServers,
 } from "@posthog/shared";
 import {
   buildPosthogPropertiesHeaderLines,
@@ -1590,7 +1592,7 @@ export class AgentServer {
 
         return await this.session.clientConnection.extMethod(
           POSTHOG_METHODS.REFRESH_SESSION,
-          { mcpServers: refreshedMcpServers },
+          { mcpServers: toAcpMcpServers(refreshedMcpServers) },
         );
       }
 
@@ -2065,10 +2067,10 @@ export class AgentServer {
             sessionCwd,
             initialPermissionMode,
           );
-          const preparedMcpServers: McpServerConnection[] = [
+          const preparedMcpServers: AcpMcpServer[] = toAcpMcpServers([
             ...(this.config.mcpServers ?? []),
             ...(await this.startMcpRelayServer()),
-          ];
+          ]);
           return [preparedNativeResume, preparedMcpServers] as const;
         } finally {
           if (existingPrCheckoutPromise) {
@@ -2132,7 +2134,6 @@ export class AgentServer {
         return sessionId;
       },
     );
-
     this.evaluatedPrUrls.clear();
     this.prAttributionChain = Promise.resolve();
 
@@ -2876,7 +2877,7 @@ export class AgentServer {
     try {
       const response = await this.session.clientConnection.newSession({
         cwd: this.config.repositoryPath ?? "/tmp/workspace",
-        mcpServers: this.config.mcpServers ?? [],
+        mcpServers: toAcpMcpServers(this.config.mcpServers ?? []),
         _meta: this.session.sessionMeta,
       });
       this.session.acpSessionId = response.sessionId;

--- a/products/desktop/packages/agent/src/server/schemas.test.ts
+++ b/products/desktop/packages/agent/src/server/schemas.test.ts
@@ -27,6 +27,21 @@ describe("mcpServersSchema", () => {
     ]);
   });
 
+  it("keeps a server description so pi can surface it in tool search", () => {
+    const result = mcpServersSchema.safeParse([
+      {
+        type: "http",
+        name: "Linear",
+        url: "https://mcp.linear.app/mcp",
+        description: "Manage Linear issues, projects, and workflows.",
+      },
+    ]);
+    expect(result.success).toBe(true);
+    expect(result.data?.[0].description).toBe(
+      "Manage Linear issues, projects, and workflows.",
+    );
+  });
+
   it("accepts a valid SSE server", () => {
     const result = mcpServersSchema.safeParse([
       {

--- a/products/desktop/packages/agent/src/server/schemas.ts
+++ b/products/desktop/packages/agent/src/server/schemas.ts
@@ -13,6 +13,7 @@ const remoteMcpServerSchema: z.ZodType<McpServerConnection> = z.object({
   name: z.string().min(1, "MCP server name is required"),
   url: z.url({ error: "MCP server url must be a valid URL" }),
   headers: z.array(httpHeaderSchema).default([]),
+  description: z.string().optional(),
 });
 
 export const mcpServersSchema = z.array(remoteMcpServerSchema);

--- a/products/desktop/packages/shared/src/index.ts
+++ b/products/desktop/packages/shared/src/index.ts
@@ -230,12 +230,14 @@ export {
 } from "./inbox-types";
 export { EXTERNAL_LINKS } from "./links";
 export type {
+  AcpMcpServer,
   CloudMcpServerRelayDesignation,
   LocalMcpServerDescriptor,
   LocalMcpServerScope,
   LocalMcpTransport,
   McpServerConnection,
 } from "./local-mcp-domain";
+export { toAcpMcpServers } from "./local-mcp-domain";
 export {
   MCP_TOOL_PERMISSION_OPTIONS,
   type McpToolApprovalState,

--- a/products/desktop/packages/shared/src/local-mcp-domain.ts
+++ b/products/desktop/packages/shared/src/local-mcp-domain.ts
@@ -38,6 +38,23 @@ export interface McpServerConnection {
   name: string;
   url: string;
   headers: Array<{ name: string; value: string }>;
+  /**
+   * One line on what the server does. pi's `mcp` tool matches this when the model
+   * searches for tools, which is the only way a server that has never been connected
+   * can be found — its tool list isn't known yet. Strip it before handing servers to
+   * claude or codex: those go over ACP, whose McpServer schema doesn't declare it.
+   */
+  description?: string;
+}
+
+/** The subset of a server config the ACP `McpServer` schema declares. */
+export type AcpMcpServer = Omit<McpServerConnection, "description">;
+
+/** Drop the pi-only fields, leaving the shape claude and codex accept over ACP. */
+export function toAcpMcpServers(
+  servers: McpServerConnection[],
+): AcpMcpServer[] {
+  return servers.map(({ description: _description, ...server }) => server);
 }
 
 /**

--- a/products/desktop/packages/workspace-server/src/services/agent/auth-adapter.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/auth-adapter.test.ts
@@ -275,6 +275,56 @@ describe("AgentAuthAdapter", () => {
     ]);
   });
 
+  it("describes runtime servers so an agent finds them before connecting", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            results: [
+              {
+                id: "inst-linear",
+                url: "https://mcp.linear.app/mcp",
+                proxy_url: "https://proxy.posthog.com/inst-linear/",
+                name: "Linear",
+                display_name: "Linear",
+                description: "Manage Linear issues, projects, and workflows.",
+                auth_type: "oauth",
+                is_enabled: true,
+                pending_oauth: false,
+                needs_reauth: false,
+              },
+            ],
+          }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            results: [
+              { tool_name: "create_issue", approval_state: "needs_approval" },
+            ],
+          }),
+      });
+
+    const { servers } = await adapter.getMcpRuntimeConfiguration();
+
+    expect(
+      servers.find((server) => server.name === "Linear")?.description,
+    ).toBe("Manage Linear issues, projects, and workflows.");
+    expect(
+      servers.find((server) => server.name === "posthog")?.description,
+    ).toMatch(/insight/i);
+  });
+
+  it("keeps descriptions out of the servers handed to the ACP adapters", async () => {
+    // Only pi understands a server description; claude and codex receive this list as ACP
+    // session params, which reject fields their schema does not declare.
+    const { servers } = await adapter.buildMcpServers(baseCredentials);
+
+    expect(servers.every((server) => !("description" in server))).toBe(true);
+  });
+
   it("omits runtime servers whose tool policies cannot be loaded", async () => {
     mockFetch
       .mockResolvedValueOnce({

--- a/products/desktop/packages/workspace-server/src/services/agent/auth-adapter.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/auth-adapter.ts
@@ -16,14 +16,14 @@ import type { AgentAuth, AgentLogger, AgentScopedLogger } from "./ports";
 import type { Credentials } from "./schemas";
 
 /**
- * Read before the agent has connected to the PostHog MCP, so it names the capabilities
- * someone would search for rather than describing the server. Mirrors
- * POSTHOG_MCP_DESCRIPTION in products/tasks (the cloud-run equivalent).
+ * Names capabilities rather than describing the server, because the agent's tool search
+ * reads this before the PostHog MCP has ever connected. Mirrors POSTHOG_MCP_DESCRIPTION
+ * in products/tasks, which does the same for cloud runs.
  */
 const POSTHOG_MCP_DESCRIPTION =
-  "PostHog: query product data and manage the project — events, insights, dashboards, " +
-  "SQL queries, feature flags, experiments, surveys, error tracking, session replay, " +
-  "logs, LLM analytics, and the data warehouse.";
+  "Query and manage a PostHog project: events, insights, dashboards, SQL queries, " +
+  "feature flags, experiments, surveys, error tracking, session replay, logs, " +
+  "LLM analytics, and the data warehouse.";
 
 const VALID_APPROVAL_STATES = new Set([
   "approved",

--- a/products/desktop/packages/workspace-server/src/services/agent/auth-adapter.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/auth-adapter.ts
@@ -15,6 +15,16 @@ import { AGENT_AUTH, AGENT_LOGGER } from "./identifiers";
 import type { AgentAuth, AgentLogger, AgentScopedLogger } from "./ports";
 import type { Credentials } from "./schemas";
 
+/**
+ * Read before the agent has connected to the PostHog MCP, so it names the capabilities
+ * someone would search for rather than describing the server. Mirrors
+ * POSTHOG_MCP_DESCRIPTION in products/tasks (the cloud-run equivalent).
+ */
+const POSTHOG_MCP_DESCRIPTION =
+  "PostHog: query product data and manage the project — events, insights, dashboards, " +
+  "SQL queries, feature flags, experiments, surveys, error tracking, session replay, " +
+  "logs, LLM analytics, and the data warehouse.";
+
 const VALID_APPROVAL_STATES = new Set([
   "approved",
   "needs_approval",
@@ -100,9 +110,15 @@ export class AgentAuthAdapter {
     const policyInstallationIds = new Set(
       configuration.toolPolicies.map((policy) => policy.installationId),
     );
-    const servers = configuration.servers.filter((server) => {
+    // pi mounts these lazily and never dials one to answer "what can it do", so a server
+    // without a description is only findable by searching its exact name.
+    const servers = configuration.servers.flatMap((server) => {
       const installationId = configuration.serverInstallationIds.get(server);
-      return !installationId || policyInstallationIds.has(installationId);
+      if (installationId && !policyInstallationIds.has(installationId)) {
+        return [];
+      }
+      const description = configuration.serverDescriptions.get(server);
+      return [description ? { ...server, description } : server];
     });
 
     return { servers, policies: configuration.toolPolicies };
@@ -117,9 +133,13 @@ export class AgentAuthAdapter {
     toolInstallations: McpToolInstallations;
     toolPolicies: McpToolPolicy[];
     serverInstallationIds: Map<McpServerConnection, string>;
+    serverDescriptions: Map<McpServerConnection, string>;
   }> {
     const servers: McpServerConnection[] = [];
     const serverInstallationIds = new Map<McpServerConnection, string>();
+    // Kept beside the servers rather than on them: this list also goes to claude and
+    // codex as ACP session params, whose McpServer schema doesn't declare a description.
+    const serverDescriptions = new Map<McpServerConnection, string>();
     const mcpUrl = this.getPostHogMcpUrl(credentials.apiHost);
     // Warm the token so authenticatedFetch() has something cached, but do not
     // bake it into the MCP config — the proxy injects a fresh one on every
@@ -129,7 +149,7 @@ export class AgentAuthAdapter {
     await this.mcpProxy.start();
     const proxiedPosthogUrl = this.mcpProxy.register("posthog", mcpUrl);
 
-    servers.push({
+    const posthogServer: McpServerConnection = {
       name: "posthog",
       type: "http",
       url: proxiedPosthogUrl,
@@ -141,7 +161,9 @@ export class AgentAuthAdapter {
         { name: "x-posthog-mcp-version", value: "2" },
         { name: "x-posthog-mcp-consumer", value: "posthog-code" },
       ],
-    });
+    };
+    servers.push(posthogServer);
+    serverDescriptions.set(posthogServer, POSTHOG_MCP_DESCRIPTION);
 
     const installations = await this.fetchMcpInstallations(credentials);
 
@@ -164,6 +186,9 @@ export class AgentAuthAdapter {
       };
       servers.push(server);
       serverInstallationIds.set(server, installation.id);
+      if (installation.description) {
+        serverDescriptions.set(server, installation.description);
+      }
     }
 
     const {
@@ -182,6 +207,7 @@ export class AgentAuthAdapter {
       toolInstallations,
       toolPolicies,
       serverInstallationIds,
+      serverDescriptions,
     };
   }
 
@@ -408,6 +434,7 @@ export class AgentAuthAdapter {
       proxy_url: string;
       name: string;
       display_name: string;
+      description?: string;
       auth_type: string;
     }>
   > {
@@ -435,6 +462,7 @@ export class AgentAuthAdapter {
           proxy_url?: string;
           name: string;
           display_name: string;
+          description?: string;
           auth_type: string;
           is_enabled?: boolean;
           pending_oauth: boolean;

--- a/products/mcp_store/README.md
+++ b/products/mcp_store/README.md
@@ -147,6 +147,8 @@ There are two ways a caller uses a connection, and they differ in who speaks MCP
 
 Agents mount a connection without connecting to it, so an installation's `description` (copied from the catalog entry at install time) travels with the server config and is what the agent's tool search matches on until the first call.
 A connection with no description is only findable by searching its exact name.
+Cloud runs read it through `get_installations_for_sandbox`, which falls back to the template's description; desktop runs read it from the installation serializer.
+Either way the description is for pi only, so the agent server drops it before passing servers to claude or codex.
 
 Both paths resolve policy through the same `resolve_call_decision` / `_gateway_decision` in `backend/proxy.py` and write the same `MCPAuditEvent` rows, so approval state and the audit trail cannot diverge between them.
 `needs_approval` and `do_not_use` tools are refused before any upstream request.

--- a/products/mcp_store/README.md
+++ b/products/mcp_store/README.md
@@ -145,6 +145,9 @@ There are two ways a caller uses a connection, and they differ in who speaks MCP
   When two connections share a display name, both slugs carry a fragment of their installation id (`linear-a1b2c3`), and that ambiguity is decided over every connection the caller can address rather than only the reachable ones — otherwise an expiring token could re-point a tool name at a different connection between refreshes.
   The `exec` side lives in `services/mcp/src/lib/gateway-tools.ts` and is gated on the `mcp-gateway` flag.
 
+Agents mount a connection without connecting to it, so an installation's `description` (copied from the catalog entry at install time) travels with the server config and is what the agent's tool search matches on until the first call.
+A connection with no description is only findable by searching its exact name.
+
 Both paths resolve policy through the same `resolve_call_decision` / `_gateway_decision` in `backend/proxy.py` and write the same `MCPAuditEvent` rows, so approval state and the audit trail cannot diverge between them.
 `needs_approval` and `do_not_use` tools are refused before any upstream request.
 

--- a/products/mcp_store/backend/facade/api.py
+++ b/products/mcp_store/backend/facade/api.py
@@ -116,6 +116,14 @@ def _resolve_name(installation: MCPServerInstallation) -> str:
     return installation.url
 
 
+def _resolve_description(installation: MCPServerInstallation) -> str:
+    if installation.description:
+        return installation.description
+    if installation.template and installation.template.description:
+        return installation.template.description
+    return ""
+
+
 def _is_oauth_ready(installation: MCPServerInstallation) -> bool:
     if installation.auth_type != "oauth":
         return True
@@ -132,6 +140,7 @@ def _to_info(installation: MCPServerInstallation, team_id: int) -> ActiveInstall
         id=str(installation.id),
         name=_resolve_name(installation),
         proxy_path=f"/api/environments/{team_id}/mcp_server_installations/{installation.id}/proxy/",
+        description=_resolve_description(installation),
         scope=installation.scope,
     )
 

--- a/products/mcp_store/backend/facade/contracts.py
+++ b/products/mcp_store/backend/facade/contracts.py
@@ -15,6 +15,9 @@ class ActiveInstallation:
     id: str
     name: str
     proxy_path: str
+    # What the server does, in one line. Agents mount connectors without connecting to them,
+    # so until the first call this is all their tool search has to match on.
+    description: str = ""
     scope: str = "personal"
     # Set only for credentials delegated to a built-in agent. Kept out of reprs so the
     # short-lived bearer cannot accidentally land in logs.

--- a/products/mcp_store/backend/presentation/views.py
+++ b/products/mcp_store/backend/presentation/views.py
@@ -279,6 +279,9 @@ class MCPServerInstallationSerializer(serializers.ModelSerializer):
     needs_reauth = serializers.SerializerMethodField()
     pending_oauth = serializers.SerializerMethodField()
     name = serializers.SerializerMethodField()
+    description = serializers.SerializerMethodField(
+        help_text="Installation description, falling back to the linked template description."
+    )
     icon_domain = serializers.CharField(
         source="template.icon_domain",
         read_only=True,
@@ -339,6 +342,13 @@ class MCPServerInstallationSerializer(serializers.ModelSerializer):
             return obj.display_name
         if obj.template:
             return obj.template.name
+        return ""
+
+    def get_description(self, obj: MCPServerInstallation) -> str:
+        if obj.description:
+            return obj.description
+        if obj.template:
+            return obj.template.description
         return ""
 
     def get_needs_reauth(self, obj: MCPServerInstallation) -> bool:

--- a/products/mcp_store/backend/test/test_api.py
+++ b/products/mcp_store/backend/test/test_api.py
@@ -2464,6 +2464,29 @@ class TestMCPServerInstallationAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchi
         assert response.json()["results"][0]["icon_domain"] == "notion.example"
         assert response.json()["results"][0]["icon_key"] == "posthog_mcp"
 
+    def test_list_installation_description_falls_back_to_template(self):
+        template = MCPServerTemplate.objects.create(
+            name="Linear",
+            url="https://mcp.linear.example/mcp",
+            description="Manage issues and projects",
+            auth_type="api_key",
+            is_active=True,
+        )
+        MCPServerInstallation.objects.create(
+            team=self.team,
+            user=self.user,
+            template=template,
+            display_name="",
+            description="",
+            url=template.url,
+            auth_type="api_key",
+        )
+
+        response = self.client.get(f"/api/environments/{self.team.id}/mcp_server_installations/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["results"][0]["description"] == "Manage issues and projects"
+
     def test_uninstall_server(self):
         installation = MCPServerInstallation.objects.create(
             team=self.team,

--- a/products/mcp_store/backend/test/test_facade.py
+++ b/products/mcp_store/backend/test/test_facade.py
@@ -112,6 +112,29 @@ class TestGetActiveInstallations(BaseTest):
 
         assert results[0].name == "https://mcp.notion.com/mcp"
 
+    def test_returns_description_for_agent_discovery(self) -> None:
+        # Agents match a never-connected MCP server on this text alone, so an empty
+        # description leaves the server findable only by its exact name.
+        self._create_installation(description="Manage Linear issues, projects, teams, and workflows.")
+
+        results = get_active_installations(self.team.id, self.user.id)
+
+        assert results[0].description == "Manage Linear issues, projects, teams, and workflows."
+
+    def test_description_falls_back_to_template(self) -> None:
+        template = MCPServerTemplate.objects.create(
+            name="Described Template",
+            url="https://mcp.described-template.example.com/mcp",
+            description="Search and edit pages and databases.",
+            auth_type="oauth",
+            created_by=self.user,
+        )
+        self._create_installation(description="", template=template, url=template.url)
+
+        results = get_active_installations(self.team.id, self.user.id)
+
+        assert results[0].description == "Search and edit pages and databases."
+
     def test_only_returns_for_given_user(self) -> None:
         from posthog.models import User
 
@@ -226,6 +249,15 @@ class TestGetInstallationsForSandbox(BaseTest):
         assert len(results) == 1
         assert results[0].id == str(shared.id)
         assert results[0].scope == "shared"
+
+    def test_returns_description_for_agent_discovery(self) -> None:
+        # A sandbox agent searches its MCP servers by capability before connecting to any of
+        # them, and this text is all it has to match against.
+        self._create_installation(scope="shared", description="Manage Linear issues, projects, and workflows.")
+
+        results = get_installations_for_sandbox(self.team.id)
+
+        assert results[0].description == "Manage Linear issues, projects, and workflows."
 
     def test_personal_excluded_by_default(self) -> None:
         self._create_installation(scope="personal")

--- a/products/mcp_store/frontend/generated/api.schemas.ts
+++ b/products/mcp_store/frontend/generated/api.schemas.ts
@@ -869,7 +869,8 @@ export interface MCPServerInstallationApi {
     display_name?: string
     /** @maxLength 2048 */
     url?: string
-    description?: string
+    /** Installation description, falling back to the linked template description. */
+    readonly description: string
     auth_type?: MCPAuthTypeEnumApi
     is_enabled?: boolean
     readonly scope: MCPServerInstallationScopeEnumApi

--- a/products/mcp_store/frontend/generated/api.zod.ts
+++ b/products/mcp_store/frontend/generated/api.zod.ts
@@ -409,7 +409,6 @@ export const mcpServerInstallationsCreateBodyUrlMax = 2048
 export const McpServerInstallationsCreateBody = /* @__PURE__ */ zod.object({
     display_name: zod.string().max(mcpServerInstallationsCreateBodyDisplayNameMax).optional(),
     url: zod.url().max(mcpServerInstallationsCreateBodyUrlMax).optional(),
-    description: zod.string().optional(),
     auth_type: zod.enum(['api_key', 'oauth']).optional().describe('\* `api_key` - API Key\n\* `oauth` - OAuth'),
     is_enabled: zod.boolean().optional(),
 })
@@ -421,7 +420,6 @@ export const mcpServerInstallationsUpdateBodyUrlMax = 2048
 export const McpServerInstallationsUpdateBody = /* @__PURE__ */ zod.object({
     display_name: zod.string().max(mcpServerInstallationsUpdateBodyDisplayNameMax).optional(),
     url: zod.url().max(mcpServerInstallationsUpdateBodyUrlMax).optional(),
-    description: zod.string().optional(),
     auth_type: zod.enum(['api_key', 'oauth']).optional().describe('\* `api_key` - API Key\n\* `oauth` - OAuth'),
     is_enabled: zod.boolean().optional(),
 })
@@ -459,7 +457,6 @@ export const mcpServerInstallationsProxyCreateBodyUrlMax = 2048
 export const McpServerInstallationsProxyCreateBody = /* @__PURE__ */ zod.object({
     display_name: zod.string().max(mcpServerInstallationsProxyCreateBodyDisplayNameMax).optional(),
     url: zod.url().max(mcpServerInstallationsProxyCreateBodyUrlMax).optional(),
-    description: zod.string().optional(),
     auth_type: zod.enum(['api_key', 'oauth']).optional().describe('\* `api_key` - API Key\n\* `oauth` - OAuth'),
     is_enabled: zod.boolean().optional(),
 })
@@ -478,7 +475,6 @@ export const mcpServerInstallationsToolsRefreshCreateBodyUrlMax = 2048
 export const McpServerInstallationsToolsRefreshCreateBody = /* @__PURE__ */ zod.object({
     display_name: zod.string().max(mcpServerInstallationsToolsRefreshCreateBodyDisplayNameMax).optional(),
     url: zod.url().max(mcpServerInstallationsToolsRefreshCreateBodyUrlMax).optional(),
-    description: zod.string().optional(),
     auth_type: zod.enum(['api_key', 'oauth']).optional().describe('\* `api_key` - API Key\n\* `oauth` - OAuth'),
     is_enabled: zod.boolean().optional(),
 })

--- a/products/mcp_store/frontend/mcpStoreLogic.test.ts
+++ b/products/mcp_store/frontend/mcpStoreLogic.test.ts
@@ -13,6 +13,7 @@ function installation(id: string, url?: string): MCPServerInstallationApi {
         id,
         template_id: null,
         name: id,
+        description: '',
         icon_key: '',
         icon_domain: '',
         url,

--- a/products/tasks/backend/temporal/process_task/tests/test_utils.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_utils.py
@@ -12,6 +12,7 @@ from products.tasks.backend.constants import (
 )
 from products.tasks.backend.models import Task
 from products.tasks.backend.temporal.process_task.utils import (
+    POSTHOG_MCP_DESCRIPTION,
     GitHubCredentialSource,
     McpServerConfig,
     RunState,
@@ -191,6 +192,7 @@ class TestGetSandboxMcpConfigs(TestCase):
                     name="posthog",
                     url=expected_mcp_url,
                     headers=self._expected_headers(),
+                    description=POSTHOG_MCP_DESCRIPTION,
                 )
             ]
 
@@ -205,6 +207,7 @@ class TestGetSandboxMcpConfigs(TestCase):
                     name="posthog",
                     url="https://custom-mcp.example.com/mcp",
                     headers=self._expected_headers(),
+                    description=POSTHOG_MCP_DESCRIPTION,
                 )
             ]
 
@@ -219,6 +222,7 @@ class TestGetSandboxMcpConfigs(TestCase):
                     name="posthog",
                     url="https://mcp.posthog.com/mcp",
                     headers=self._expected_headers(read_only=False),
+                    description=POSTHOG_MCP_DESCRIPTION,
                 )
             ]
 
@@ -235,6 +239,7 @@ class TestGetSandboxMcpConfigs(TestCase):
                     name="posthog",
                     url="https://mcp.posthog.com/mcp",
                     headers=self._expected_headers(read_only=False),
+                    description=POSTHOG_MCP_DESCRIPTION,
                 )
             ]
 
@@ -251,6 +256,7 @@ class TestGetSandboxMcpConfigs(TestCase):
                     name="posthog",
                     url="https://mcp.posthog.com/mcp",
                     headers=self._expected_headers(read_only=True),
+                    description=POSTHOG_MCP_DESCRIPTION,
                 )
             ]
 
@@ -280,6 +286,7 @@ class TestGetSandboxMcpConfigs(TestCase):
                     name="posthog",
                     url="http://host.docker.internal:8787/mcp",
                     headers=self._expected_headers(),
+                    description=POSTHOG_MCP_DESCRIPTION,
                 )
             ]
 
@@ -306,6 +313,18 @@ class TestGetSandboxMcpConfigs(TestCase):
             configs = get_sandbox_ph_mcp_configs(self.TOKEN, self.PROJECT_ID)
             assert all(h["name"] != "X-PostHog-Task-Id" for h in configs[0].headers)
 
+    def test_describes_posthog_capabilities_for_agent_discovery(self) -> None:
+        # A pi agent searches its configured servers before connecting to any of them, matching
+        # only the server name and this description. Without capability words, an agent looking
+        # for "insights" or "feature flags" concludes it has no PostHog tools.
+        with patch("products.tasks.backend.temporal.process_task.utils.settings") as mock_settings:
+            mock_settings.SANDBOX_MCP_URL = None
+            mock_settings.SITE_URL = "https://app.posthog.com"
+            description = get_sandbox_ph_mcp_configs(self.TOKEN, self.PROJECT_ID)[0].description or ""
+
+        for capability in ("insight", "dashboard", "feature flag", "experiment", "error", "sql"):
+            assert capability in description.lower()
+
     @parameterized.expand(
         [
             (None, "posthog-code"),
@@ -329,11 +348,23 @@ class TestGetSandboxMcpConfigs(TestCase):
                     name="posthog",
                     url="https://mcp.posthog.com/mcp",
                     headers=self._expected_headers(consumer=expected_consumer),
+                    description=POSTHOG_MCP_DESCRIPTION,
                 )
             ]
 
 
 class TestMcpServerConfigToDict(TestCase):
+    def test_description_is_serialized_for_the_sandbox(self) -> None:
+        # The agent server drops keys the schema doesn't declare, so an unserialized
+        # description never reaches the agent's tool search.
+        config = McpServerConfig(
+            type="http",
+            name="Linear",
+            url="https://mcp.example.com/mcp",
+            description="Manage Linear issues, projects, and workflows.",
+        )
+        assert config.to_dict()["description"] == "Manage Linear issues, projects, and workflows."
+
     def test_minimal_config(self) -> None:
         config = McpServerConfig(type="http", name="posthog", url="https://mcp.posthog.com/mcp")
         assert config.to_dict() == {
@@ -409,6 +440,20 @@ class TestFetchUserMcpServerConfigs(TestCase):
                 headers=self._expected_user_headers(),
             )
         ]
+
+    @patch(MOCK_API_URL)
+    @patch(MOCK_FACADE)
+    def test_carries_the_installation_description_for_agent_discovery(self, mock_facade, mock_api_url) -> None:
+        # Connectors are mounted unconnected, so the agent's tool search matches them on this
+        # description; without it "Linear" is only findable by literally searching "linear".
+        mock_api_url.return_value = self.API_BASE
+        mock_facade.return_value = [
+            self._make_installation(description="Manage Linear issues, projects, and workflows.")
+        ]
+
+        configs = get_user_mcp_server_configs(self.TOKEN, self.TEAM_ID, self.USER_ID)
+
+        assert configs[0].description == "Manage Linear issues, projects, and workflows."
 
     @patch(MOCK_API_URL)
     @patch(MOCK_FACADE)

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -787,12 +787,12 @@ def _resolve_mcp_consumer(interaction_origin: str | None) -> str:
     return "posthog-code"
 
 
-# Read before the agent has connected to the PostHog MCP, so it has to name the capabilities
-# someone would search for rather than describe the server.
+# Names capabilities rather than describing the server, because the agent's tool search reads
+# this before the PostHog MCP has ever connected.
 POSTHOG_MCP_DESCRIPTION = (
-    "PostHog: query product data and manage the project — events, insights, dashboards, "
-    "SQL queries, feature flags, experiments, surveys, error tracking, session replay, "
-    "logs, LLM analytics, and the data warehouse."
+    "Query and manage a PostHog project: events, insights, dashboards, SQL queries, "
+    "feature flags, experiments, surveys, error tracking, session replay, logs, "
+    "LLM analytics, and the data warehouse."
 )
 
 

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -548,20 +548,26 @@ class McpServerConfig:
     - name: server identifier
     - url: server endpoint
     - headers: list of {name, value} pairs
+    - description: one-line summary of what the server does (pi only; the agent server
+      strips it before handing the list to claude or codex over ACP)
     """
 
     type: str
     name: str
     url: str
     headers: list[dict[str, str]] = field(default_factory=list)
+    description: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        config: dict[str, Any] = {
             "type": self.type,
             "name": self.name,
             "url": self.url,
             "headers": self.headers,
         }
+        if self.description:
+            config["description"] = self.description
+        return config
 
 
 def get_sandbox_api_url() -> str:
@@ -661,6 +667,7 @@ def get_user_mcp_server_configs(
                 name=installation.name,
                 url=f"{api_base}{installation.proxy_path}",
                 headers=headers,
+                description=installation.description or None,
             )
         )
 
@@ -780,6 +787,15 @@ def _resolve_mcp_consumer(interaction_origin: str | None) -> str:
     return "posthog-code"
 
 
+# Read before the agent has connected to the PostHog MCP, so it has to name the capabilities
+# someone would search for rather than describe the server.
+POSTHOG_MCP_DESCRIPTION = (
+    "PostHog: query product data and manage the project — events, insights, dashboards, "
+    "SQL queries, feature flags, experiments, surveys, error tracking, session replay, "
+    "logs, LLM analytics, and the data warehouse."
+)
+
+
 def get_sandbox_ph_mcp_configs(
     token: str,
     project_id: int,
@@ -813,7 +829,15 @@ def get_sandbox_ph_mcp_configs(
     ]
     if task_id:
         headers.append({"name": "X-PostHog-Task-Id", "value": str(task_id)})
-    return [McpServerConfig(type="http", name="posthog", url=url, headers=headers)]
+    return [
+        McpServerConfig(
+            type="http",
+            name="posthog",
+            url=url,
+            headers=headers,
+            description=POSTHOG_MCP_DESCRIPTION,
+        )
+    ]
 
 
 def get_github_token(github_integration_id: int) -> Optional[str]:

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -49385,7 +49385,8 @@ export namespace Schemas {
       display_name?: string;
       /** @maxLength 2048 */
       url?: string;
-      description?: string;
+      /** Installation description, falling back to the linked template description. */
+      readonly description: string;
       auth_type?: MCPAuthTypeEnum;
       is_enabled?: boolean;
       readonly scope: MCPServerInstallationScopeEnum;


### PR DESCRIPTION
## Problem

A person connects Linear in PostHog desktop, starts a task, and the agent reports that it cannot find any MCP tools.
The same happens for the PostHog MCP itself.

- Runs mount the PostHog MCP and every connected MCP store server as lazy servers, so no tool list is known yet.
- pi's `mcp` search then matches those servers on their name and their config description.
- No producer sets a description, so only a search containing the literal server name hits.
- I reproduced both cases inside a cloud task run:

<details>
<summary>Search transcript from a cloud run before the fix</summary>

```
mcp({ search: "linear issue" })
→ Linear (server, not connected) — MCP server "Linear" — not yet connected, tools unknown

mcp({ search: "create ticket project management" })
→ (no Linear hit)

mcp({ search: "query events insights dashboards feature flags" })
→ mcp: no matching tools or servers. Try different keywords.
```

</details>

## Changes

- Every mounted MCP server now carries a one-line description, so capability searches reach it before any connection.
- The MCP store facade reads that line from the installation and falls back to its catalog template, which already ships a keyword-rich summary per server.
- The PostHog MCP config carries a fixed description naming its surfaces, since it has no installation row to read.
- The agent server strips the field before it hands servers to claude or codex over ACP, whose `McpServer` schema does not declare it.
- Cloud runs and local runs are wired separately, so both paths set the description: `products/tasks` for the sandbox, `auth-adapter.ts` for the desktop.

Descriptions live beside the server list in the desktop path rather than on it, because that same list goes to the ACP adapters.
Seeding pi's tool cache from the tool names the backend already stores would make each individual tool searchable too, which is a follow-up.

> [!NOTE]
> The two halves ship in either order, which is why this PR carries `skip-desktop-backend-check`. A desktop build that lands first reads a `description` the backend does not send yet, so servers keep their current name-only search. A backend deploy that lands first sends a key the agent server's zod schema strips.

> [!NOTE]
> Two findings from the same session are not in this PR. Connecting the reproduction's Linear server fails with `401 {"error": "Authentication failed"}` from the store proxy, which is an OAuth refresh failure, and nothing marks the installation `needs_reauth` when a refresh fails, so the UI keeps showing it as connected and every run keeps mounting it.

## How did you test this code?

- Reproduced the missing hits with `mcp({ search })` inside a cloud task run, transcript above.
- Added a red test per producer first, then the fix: `get_sandbox_ph_mcp_configs` and `get_user_mcp_server_configs` (`products/tasks`), `get_installations_for_sandbox` and `get_active_installations` (`products/mcp_store`), `createRuntimeMcpServers`, `mcpServersSchema`, and `getMcpRuntimeConfiguration`.
- The `agent-server.ts` test covers the ACP boundary: a description on an incoming server must not reach the forwarded session params.
- Ran the touched suites plus `mypy` repo-wide locally. Not run: the desktop app end to end, and no run of a real deployed sandbox with the fix in place, so the searches above are not re-measured after the change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`products/mcp_store/README.md` gains two lines on the description in the agent-facing section.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I am an agent (pi, in a PostHog Code cloud task). @k11kirky reported that MCP servers connected in desktop were invisible to both a cloud and a local task agent.

- I diagnosed it from inside my own run, which has the same MCP wiring as the reported one, by calling `mcp({ search })` and `mcp({ tool })` directly.
- I first suspected the servers never reached the run at all. The search output disproved that: Linear was configured, just unfindable by capability.
- I considered seeding pi's tool cache from the per-installation tool rows, which would make individual tools searchable, and kept it out to hold the diff to the one cause.
- Skills invoked: `/writing-pr-descriptions`, `/writing-code-comments`.
- Nothing here comes from outside this repository. The sample descriptions in tests are the public catalog strings or invented.
