### PR TITLE
fix(data-warehouse): give unpartitioned repartition targets an md5 bucket count

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition.py
@@ -340,9 +340,11 @@ def select_repartition_target(
 
     Computes the target directly from measured bytes so one repartition lands under budget rather
     than stepping blindly: md5 grows the bucket count, numerical shrinks the row-size, datetime steps
-    one format tier finer. When no target is chosen the reason explains why (reported in metrics so a
-    skipped table is diagnosable): `within_budget`, `datetime_at_finest_tier`, `numerical_cannot_shrink`,
-    `numerical_no_size`, or `unpartitionable_no_keys`. A chosen target carries reason `selected`.
+    one format tier finer. An unpartitioned table gets an auto target, which sizes its bucket count
+    the same way so md5 is reachable whatever its keys turn out to be. When no target is chosen the
+    reason explains why (reported in metrics so a skipped table is diagnosable): `within_budget`,
+    `datetime_at_finest_tier`, `numerical_cannot_shrink`, `numerical_no_size`, or
+    `unpartitionable_no_keys`. A chosen target carries reason `selected`.
     """
     if not partition_bytes:
         return None, "no_partitions"
@@ -395,7 +397,18 @@ def select_repartition_target(
     # Unpartitioned but over budget: attempt to enable partitioning via auto-detection. Needs keys.
     if not keys:
         return None, "unpartitionable_no_keys"
-    return RepartitionTarget(partition_keys=keys, trigger_reason="", partition_mode=None), "selected"
+    # Carry a bucket count so md5 is always reachable. Auto-detection prefers numerical, then
+    # datetime, and falls through to md5 only when neither applies — but md5 needs a count, and
+    # without one a table whose keys suit none of the detectors (a UUID primary key and no
+    # `created_at`-style column) has no scheme at all. It flags as over budget every day, fails the
+    # rewrite with "No supported partition mode", and grows unbounded. Hashed keys bucket any key
+    # type, and a primary key never changes, so a row keeps its bucket across merges.
+    return RepartitionTarget(
+        partition_keys=keys,
+        trigger_reason="",
+        partition_mode=None,
+        partition_count=max(1, math.ceil(total_bytes / target_partition_bytes)),
+    ), "selected"
 
 
 # Coarsening (the reverse direction) rebuilds an over-fragmented table into fewer, larger partitions.

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition.py
@@ -211,7 +211,8 @@ class TestSelectRepartitionTarget:
                 {"partition_mode": None, "primary_key_columns": ["id"]},
                 {None: 5000},
                 1000,
-                {"partition_mode": None, "partition_keys": ["id"]},
+                # The sized count is what makes md5 reachable when auto-detection finds nothing else.
+                {"partition_mode": None, "partition_keys": ["id"], "partition_count": 5},
             ),
             (
                 "unpartitioned_without_keys_noop",
@@ -648,6 +649,72 @@ class TestRewriteIntoTemp:
         )
 
         assert rows_written == rows
+        assert resolved.partition_mode == "datetime"
+        assert resolved.partition_keys == ["created_at"]
+
+    def test_uuid_key_without_a_datetime_column_resolves_md5(self, tmp_path):
+        # The production failure: a UUID primary key and no `created_at`-style column matches none of
+        # the detectors, so the rewrite died with "No supported partition mode" and the table stayed
+        # unpartitioned, over budget, and OOM-killing its pod on every merge.
+        rows = 10
+        table = pa.table(
+            {
+                "id": pa.array([f"0198d931-1efe-73b9-aad5-feb84ed767{i:02d}" for i in range(rows)], type=pa.string()),
+                "endTimestamp": pa.array(
+                    [datetime.datetime(2024, 1, (i % 27) + 1) for i in range(rows)], type=pa.timestamp("us")
+                ),
+            }
+        )
+        deltalake.write_deltalake(str(tmp_path / "src"), table)
+        old_delta = deltalake.DeltaTable(str(tmp_path / "src"))
+
+        rows_written, resolved = asyncio.run(
+            _rewrite_into_temp(
+                old_delta=old_delta,
+                temp_uri=str(tmp_path / "tmp"),
+                storage_options={},
+                target=RepartitionTarget(
+                    partition_keys=["id"], trigger_reason="test", partition_mode=None, partition_count=4
+                ),
+                batch_size=3,
+                logger=logger,
+            )
+        )
+
+        assert rows_written == rows
+        assert resolved.partition_mode == "md5"
+        # Hashing the primary key, not the timestamp: a primary key never changes, so a row keeps its
+        # bucket when a later merge updates it.
+        assert resolved.partition_keys == ["id"]
+
+    def test_datetime_still_wins_over_the_md5_fallback(self, tmp_path):
+        # The count only supplies a floor. A table auto-detection can partition properly must still
+        # get that scheme, or every table would collapse onto hashed buckets.
+        rows = 10
+        table = pa.table(
+            {
+                "id": pa.array([f"0198d931-1efe-73b9-aad5-feb84ed767{i:02d}" for i in range(rows)], type=pa.string()),
+                "created_at": pa.array(
+                    [datetime.datetime(2024, 1, (i % 27) + 1) for i in range(rows)], type=pa.timestamp("us")
+                ),
+            }
+        )
+        deltalake.write_deltalake(str(tmp_path / "src"), table)
+        old_delta = deltalake.DeltaTable(str(tmp_path / "src"))
+
+        _rows_written, resolved = asyncio.run(
+            _rewrite_into_temp(
+                old_delta=old_delta,
+                temp_uri=str(tmp_path / "tmp"),
+                storage_options={},
+                target=RepartitionTarget(
+                    partition_keys=["id"], trigger_reason="test", partition_mode=None, partition_count=4
+                ),
+                batch_size=3,
+                logger=logger,
+            )
+        )
+
         assert resolved.partition_mode == "datetime"
         assert resolved.partition_keys == ["created_at"]
 


### PR DESCRIPTION
## Problem

53 warehouse tables can never be repartitioned, so they grow without limit. 13 of them OOM-kill their worker pod on every sync, 266 times in the last 7 days.

Each one flags as over budget, starts a rewrite, then fails it and repeats the next day:

```
warehouse_repartition_flagged   proactive_threshold, 2,934,586,674 bytes
warehouse_repartition_started
warehouse_repartition_skipped   "No supported partition mode for keys=['id']"
```

- Auto-detection picks numerical for an integer key, datetime for a column named `created_at`, `inserted_at`, or `createdAt`, and md5 for anything else.
- md5 needs a bucket count, and the target built for an unpartitioned table carried none. A table matching neither of the first two resolves no scheme at all.
- A UUID primary key with no `created_at`-style column is exactly that table, and `keys=['id']` alone accounts for 32 of the 53.
- The skip stamps the 24-hour cooldown, which is deliberate so it stops re-alerting. The table then repeats the cycle daily.

The worst case has failed every sync since 30 July while growing about 50 MB a day, from 2.68 GB to 2.93 GB. Its merges read that one partition into the worker and peak at 13.3 GB, against 86 MB in the pipeline's own buffer, so the memory is inside the Delta merge.

## Changes

Size the auto target's bucket count from measured bytes, the same way the md5 branch already does.

- Auto-detection still prefers numerical, then datetime. The count only supplies a floor for tables that reach neither.
- md5 hashes the primary key, which never changes, so a row keeps its bucket when a later merge updates it. A timestamp column can move a row between partitions and leave the old copy behind.
- md5 joins multiple keys, so the multi-key variants in the skip list are covered too.
- `unpartitionable_no_keys` is untouched: 79 schemas have no keys at all and still cannot be partitioned.

For the worst table this yields 6 buckets of roughly 490 MB against the 500 MB target.

> [!NOTE]
> This starts real rewrites for tables that have only been skipping. The existing cooldown and `MAX_REPARTITION_ATTEMPTS` still bound how often each one retries.

## How did you test this code?

New coverage and the regression each catches:

- An unpartitioned table's target carries a bucket count sized from its bytes. Confirmed this assertion fails against master, where the count is `None`.
- A UUID key with no datetime column resolves md5 through the rewrite rather than raising `RepartitionUnpartitionableError`. This is the production failure.
- A table with a real `created_at` column still resolves datetime on that column. Without this the count would quietly collapse every table onto hashed buckets.

Not verified: no rewrite ran against a real oversized table. Whether 500 MB partitions are small enough to keep this table's merge inside memory is untested — the partitions get it under the budget the controller enforces, and the budget itself is unchanged by this PR. The at-rest size under-counts the merge's working set for wide nested JSON, which `maybe_flag_for_repartition` already notes, and this table is exactly that shape. It may need a second cycle, or a smaller budget, to actually stop OOMing.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing configuration changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, Opus 5) wrote this. It came out of investigating a table that was OOMing on every sync. The diagnosis ran through the OOM events (phase `merge`, not `extract`, which ruled out the extraction path), then the repartition telemetry, which showed the same skip reason every day for weeks.

Two fixes were on the table. Partitioning on the schema's configured incremental field would give better merge pruning, and that field is already validated, but it is only monotonic for reads rather than immutable, so a row whose timestamp changes moves partitions and a merge matching on primary key can leave a duplicate behind. md5 on the primary key is stable by construction and unblocks all 53, so it went first. The hardcoded `created_at` list looks like the same caution already encoded.

No skills applied to the change itself. The PR body followed `/writing-pr-descriptions`.

The affected team and table identifiers stayed out of the diff, the commit message, and this description. The test fixtures are invented.
