### PR TITLE
fix(desktop): clear stale PR status on task switch

### DIFF
--- a/products/desktop/packages/ui/src/features/sidebar/useTaskPrStatus.test.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/useTaskPrStatus.test.ts
@@ -108,4 +108,14 @@ describe("useTaskPrStatus", () => {
     );
     expect(lastQueryOptions?.enabled).toBe(true);
   });
+
+  it("ignores placeholder data when the query is disabled", () => {
+    queryData = { prState: "open", hasDiff: true };
+    const { result } = renderHook(() =>
+      useTaskPrStatus(
+        makeTask({ taskRunEnvironment: "cloud", cloudPrUrl: null }),
+      ),
+    );
+    expect(result.current).toEqual({ prState: null, hasDiff: false });
+  });
 });

--- a/products/desktop/packages/ui/src/features/sidebar/useTaskPrStatus.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/useTaskPrStatus.ts
@@ -35,6 +35,8 @@ export function useTaskPrStatus(task: {
     ),
   );
 
-  if (!data || (!data.prState && !data.hasDiff)) return EMPTY;
+  // A disabled query can retain placeholder data from the previously selected
+  // task. Ignore it so a cloud task without a PR never shows stale PR status.
+  if (skipQuery || !data || (!data.prState && !data.hasDiff)) return EMPTY;
   return data;
 }


### PR DESCRIPTION
## Problem

Switching from a cloud task with a pull request to a fresh cloud task can leave the previous task’s PR status visible.

**Why:** Each task should show only its own pull request state, so users are not sent to an unrelated PR or shown misleading CI status.
