### PR TITLE
feat(comments): load whole discussion threads past the 100 cap

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2808,6 +2808,17 @@ const api = {
             return new ApiRequest().comments().withQueryString(params).get()
         },
 
+        // A discussion thread is shown in full, so callers that render one want every comment, not the
+        // first page. Asks for the largest page the server allows and follows the cursor for the rest,
+        // so a thread over 100 comments no longer silently truncates. Bounded by loadPaginatedResults.
+        async listAll(params: Partial<CommentType> = {}): Promise<CommentType[]> {
+            const url = new ApiRequest()
+                .comments()
+                .withQueryString({ ...params, page_size: 500 })
+                .assembleFullUrl()
+            return api.loadPaginatedResults<CommentType>(url)
+        },
+
         async getCount(
             params: Partial<CommentType> & {
                 exclude_emoji_reactions?: boolean

--- a/frontend/src/scenes/comments/commentsLogic.ts
+++ b/frontend/src/scenes/comments/commentsLogic.ts
@@ -520,12 +520,10 @@ export const commentsLogic = kea<commentsLogicType>([
                         return []
                     }
 
-                    const response = await api.comments.list({
+                    return await api.comments.listAll({
                         scope: props.scope,
                         item_id: props.item_id,
                     })
-
-                    return response.results
                 },
                 sendComposedContent: async ({ asTask }) => {
                     const existingComments = values.comments ?? []
@@ -622,11 +620,10 @@ export const commentsLogic = kea<commentsLogicType>([
                             // loader value this handler returns, and our return would supersede its result.
                             // A refetch failure isn't a Slack failure: fall through to the optimistic append.
                             try {
-                                const response = await api.comments.list({
+                                return await api.comments.listAll({
                                     scope: props.scope,
                                     item_id: props.item_id,
                                 })
-                                return response.results
                             } catch {
                                 // fall through
                             }

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingCommentsLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingCommentsLogic.ts
@@ -136,13 +136,15 @@ export const sessionRecordingCommentsLogic = kea<sessionRecordingCommentsLogicTy
 
                     // Pass scope so Postgres can use the (team_id, scope, item_id, ...) composite index.
                     // All historical 'recording' comments were migrated to 'Replay' in migration 0870.
-                    const response = await api.comments.list({
+                    // listAll, not list: every comment on the recording is shown at once, so a recording
+                    // with over 100 must not stop at the first page.
+                    const comments = await api.comments.listAll({
                         scope: 'Replay',
                         item_id: props.sessionRecordingId,
                     })
                     breakpoint()
 
-                    return response.results || empty
+                    return comments || empty
                 },
                 deleteComment: async (id, breakpoint): Promise<CommentType[]> => {
                     await breakpoint(25)

--- a/posthog/api/comments.py
+++ b/posthog/api/comments.py
@@ -583,6 +583,11 @@ class CommentErrorSerializer(serializers.Serializer):
 class CommentPagination(pagination.CursorPagination):
     ordering = "-created_at"
     page_size = 100
+    # A discussion thread is rendered whole, not browsed a page at a time, so its client asks for the
+    # lot in as few round-trips as it can. Opt into a client-chosen size, capped so one request can
+    # never pull an unbounded thread into memory.
+    page_size_query_param = "page_size"
+    max_page_size = 500
 
 
 class CommentListQueryParamsSerializer(serializers.Serializer):

--- a/posthog/api/test/test_comments.py
+++ b/posthog/api/test/test_comments.py
@@ -907,6 +907,35 @@ class TestComments(APIBaseTest, QueryMatchingTest):
             assert response.json()["results"][0]["content"] == "comment other reply"
             assert response.json()["results"][1]["content"] == "comment reply"
 
+    def test_list_page_size_is_client_choosable_and_capped(self) -> None:
+        Comment.objects.bulk_create(
+            Comment(team=self.team, created_by=self.user, scope="Notebook", item_id="big", content=f"c{i}")
+            for i in range(120)
+        )
+
+        # Default page size still stops at 100, so the whole thread does not arrive by accident.
+        default = self.client.get(f"/api/projects/{self.team.id}/comments?scope=Notebook&item_id=big").json()
+        assert len(default["results"]) == 100
+        assert default["next"] is not None
+
+        # A client that renders the thread whole can ask for all of it in one request.
+        whole = self.client.get(
+            f"/api/projects/{self.team.id}/comments?scope=Notebook&item_id=big&page_size=500"
+        ).json()
+        assert len(whole["results"]) == 120
+        assert whole["next"] is None
+
+        # The cap holds: asking for more than the max never returns more than the max in one page.
+        Comment.objects.bulk_create(
+            Comment(team=self.team, created_by=self.user, scope="Notebook", item_id="huge", content=f"h{i}")
+            for i in range(510)
+        )
+        capped = self.client.get(
+            f"/api/projects/{self.team.id}/comments?scope=Notebook&item_id=huge&page_size=100000"
+        ).json()
+        assert len(capped["results"]) == 500
+        assert capped["next"] is not None
+
     @parameterized.expand(
         [
             ("no_comments", [], "", 0),

--- a/products/platform_features/frontend/generated/api.schemas.ts
+++ b/products/platform_features/frontend/generated/api.schemas.ts
@@ -1579,6 +1579,10 @@ export type CommentsListParams = {
      */
     kind?: CommentsListKind
     /**
+     * Number of results to return per page.
+     */
+    page_size?: number
+    /**
      * Filter by resource type (e.g. Dashboard, FeatureFlag, Insight, Replay). Support-ticket scopes (Ticket, conversations_ticket) additionally require ticket API scope access.
      * @minLength 1
      */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -80512,6 +80512,10 @@ export namespace Schemas {
      */
     kind?: CommentsListKind;
     /**
+     * Number of results to return per page.
+     */
+    page_size?: number;
+    /**
      * Filter by resource type (e.g. Dashboard, FeatureFlag, Insight, Replay). Support-ticket scopes (Ticket, conversations_ticket) additionally require ticket API scope access.
      * @minLength 1
      */

--- a/services/mcp/src/generated/platform_features/api.ts
+++ b/services/mcp/src/generated/platform_features/api.ts
@@ -384,6 +384,7 @@ export const CommentsListQueryParams = /* @__PURE__ */ zod.object({
         .describe(
             "Filter by comment kind. 'task' returns only items intentionally created as actionable. 'comment' excludes tasks. Defaults to 'any' (no filter).\n\n\* `any` - any\n\* `comment` - comment\n\* `task` - task"
         ),
+    page_size: zod.number().optional().describe('Number of results to return per page.'),
     scope: zod
         .string()
         .min(1)

--- a/services/mcp/src/tools/generated/platform_features.ts
+++ b/services/mcp/src/tools/generated/platform_features.ts
@@ -487,6 +487,7 @@ const commentsList = (): ToolBase<typeof CommentsListSchema, Schemas.PaginatedCo
                 cursor: params.cursor,
                 item_id: params.item_id,
                 kind: params.kind,
+                page_size: params.page_size,
                 scope: params.scope,
                 search: params.search,
                 source_comment: params.source_comment,


### PR DESCRIPTION
## Problem

- Someone reading a discussion with more than 100 comments sees replies attributed to "Deleted comment" that nobody deleted.
- The list endpoint pages at 100 newest-first, and the thread logic reads only the first page and ignores the cursor.
- A thread whose root falls off that page keeps its replies, so the UI renders the thread with a missing root, which it labels as deleted.
- A discussion's Slack mirror is stored on its root, so the "Open in Slack" link disappears from the busiest threads — the ones most likely to have one.
- Session recording comments truncate the same way, silently.

## Changes

- `CommentPagination` accepts a client-chosen `page_size`, capped at 500.
- The default stays 100, so callers that browse a page at a time are unaffected.
- New `api.comments.listAll` requests the largest page and follows the cursor for any remainder.
- The discussion panel and the recording comments use it, because both render a thread whole.
- The data-management comment browser keeps its paged list, which is the right shape for a searchable admin view.

```diff
 class CommentPagination(pagination.CursorPagination):
     ordering = "-created_at"
     page_size = 100
+    page_size_query_param = "page_size"
+    max_page_size = 500
```

Two decisions worth a reviewer's attention:

- `listAll` follows the cursor rather than only raising the page size. Raising it alone moves the silent truncation from 100 to 500 instead of removing it. `loadPaginatedResults` bounds the walk at 10 pages, so a pathological thread cannot spin.
- Every caller that renders one thread had to move together. Leaving one on `list` would let a background refresh truncate a thread that had already loaded in full, and the reader would watch it shrink.

No visual change. This corrects what a long thread contains, not how it looks.

> [!NOTE]
> The cost of a fetch now tracks the thread's real size. That is correct, and on a typical thread of a few comments nothing changes. If a summary shape is ever needed for cards that show only a count and an excerpt, the trigger is payload size on a polled surface, not the comment count.

## How did you test this code?

- `test_list_page_size_is_client_choosable_and_capped` covers all three behaviours the change introduces: the default still stops at 100 and offers a cursor, `page_size=500` returns a 120-comment thread whole, and `page_size=100000` is capped at 500 rather than honoured. No existing test asserted any of them.
- I ran it locally, plus the existing comment and recording-comment frontend suites (18 tests), typecheck and lint. The pre-commit hook ran `ty check` clean.

Not checked:

- Any manual run. I (actually Claude) did not open a thread over 100 comments in a browser.
- Whether a thread that large exists in production today. The bug is reachable by construction; I have no evidence about how often it is currently hit.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. `page_size` is a standard DRF paging parameter on an endpoint whose behaviour is otherwise unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I am Claude, running as PostHog Code. Luke directed the work and is the DRI.

- Skills invoked: `/writing-pr-descriptions` for this body. No other repo skill was used.
- This came out of review on #79709, which adds discussion cards to support tickets. I found the cap while looking for edge cases in that PR and first argued it needed a new summary endpoint. Luke pushed back that overcoming the limit should be easy. He was right: `CursorPagination` already supports a client-chosen page size and the repo already has both a precedent for enabling it and a cursor-following helper.
- Kept separate from #79709 on purpose. This is a shared endpoint used by four products, and that PR is flag-gated frontend work already carrying two rounds of review. Neither depends on the other.
- Public artifact: nothing here came from outside this repository. The test builds its own comments.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
