### PR TITLE
fix(google_sheets): don't report exhausted network retries as errors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
@@ -85,6 +85,13 @@ class GoogleSheetsSource(SimpleSource[GoogleSheetsSourceConfig]):
             "APIError: [502]",
             "APIError: [503]",
             "APIError: [504]",
+            # `_retry_on_transient_api_error` also retries a dropped connection or read timeout
+            # (`requests.exceptions.ConnectionError`/`Timeout`/`ChunkedEncodingError`) before
+            # re-raising once that budget is exhausted. urllib3 wraps all of those as "... Max
+            # retries exceeded with url: ..." regardless of the underlying cause (refused
+            # connection, read timeout, dropped socket), so match that stable prefix rather than
+            # the per-request URL or nested error detail.
+            "Max retries exceeded with url",
         }
 
     def get_schemas(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
@@ -507,6 +507,33 @@ def test_error_string_matches_a_retryable_key(status_code):
 
 
 @pytest.mark.parametrize(
+    "error_message",
+    [
+        pytest.param(
+            "HTTPSConnectionPool(host='sheets.googleapis.com', port=443): Max retries exceeded with url: "
+            '/v4/spreadsheets/abc123/values/Sheet1%211%3A1 (Caused by ReadTimeoutError("HTTPSConnectionPool'
+            "(host='sheets.googleapis.com', port=443): Read timed out. (read timeout=120.0)\"))",
+            id="read_timeout_after_retries_exhausted",
+        ),
+        pytest.param(
+            "HTTPSConnectionPool(host='sheets.googleapis.com', port=443): Max retries exceeded with url: "
+            "/v4/spreadsheets/abc123 (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection "
+            "object at 0x7f0000000000>: Failed to establish a new connection: [Errno 110] Connection timed out'))",
+            id="connection_refused_after_retries_exhausted",
+        ),
+    ],
+)
+def test_error_string_matches_a_retryable_key_for_network_errors(error_message):
+    """`_retry_on_transient_api_error` also retries `requests.exceptions.ConnectionError`/`Timeout`/
+    `ChunkedEncodingError` in-process; once that budget is exhausted, urllib3 re-raises them wrapped
+    as "Max retries exceeded with url". If that prefix drops out of `get_retryable_errors()`, a
+    transient network blip starts polluting error tracking even though Temporal still retries it."""
+    retryable_errors = GoogleSheetsSource().get_retryable_errors()
+
+    assert any(key in error_message for key in retryable_errors)
+
+
+@pytest.mark.parametrize(
     "call_site",
     [
         pytest.param(


### PR DESCRIPTION
## Problem

A slow or dropped connection to the Google Sheets API shows up in error tracking as an unclassified exception, even though the sync recovers on its own. [This issue](https://us.posthog.com/project/2/error_tracking/019feb32-1f7b-7300-8462-bc28f7cb99eb) fired for a read timeout while reading a spreadsheet's header row.

`_retry_on_transient_api_error` already retries a `ConnectionError`/`Timeout`/`ChunkedEncodingError` in process before re-raising once its attempt budget is exhausted. Once exhausted, urllib3 re-raises the error wrapped as "Max retries exceeded with url", and Temporal retries the whole sync activity regardless. `get_retryable_errors()` didn't recognize that message, so the exhausted-but-self-recovering retry got logged as a fresh exception instead of a warning.

This is a transient infrastructure error, not a customer credential or configuration problem, so it belongs in the retryable-error list rather than the non-retryable one.

## Changes

- Add `"Max retries exceeded with url"` to `GoogleSheetsSource.get_retryable_errors()`, matching the stable urllib3 prefix instead of the per-request URL.
- This only changes reporting: the sync still retries exactly as before; the failure now logs as a warning instead of an exception.
- Mirrors the same pattern already used by the Notion, Shopify, Postgres, and MongoDB sources for their own transient network errors.

## How did you test this code?

- Added `test_error_string_matches_a_retryable_key_for_network_errors`, parameterized over a read-timeout message and a connection-refused message, asserting both match `get_retryable_errors()`. Catches a future edit that narrows or removes this prefix.
- Ran `test_google_sheets.py` locally: 80 passed.
- `hogli ci:preflight --fix`: lint and format clean; mypy on the 2 changed files passed.
- Not run: a live sync against the Google Sheets API.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

This PR was produced by an agent triaging a error tracking issue delivered by webhook. Skills invoked: `investigating-error-issue` (pulled the issue, sample exception event, and full stack trace), `writing-tests` (gate before adding the regression test), `writing-pr-descriptions` (this body).

Decision: classified as a transient infrastructure error (network read timeout that already exhausted an in-process retry budget), not a user/upstream credential or config problem, so the fix extends `get_retryable_errors()` rather than `get_non_retryable_errors()`. Confirmed no open human-authored PR already addresses this by searching by exception type, message substring, and module path, and by checking the maintainer's own open PRs.