### PR TITLE
fix(postgres): treat exhausted connection drops as retryable, not error noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -798,9 +798,22 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
         # `_is_dropped_or_connection_limit`. A slot frees the moment another connection closes, so a
         # sustained shortage that outlasts that budget is still transient — the same
         # reaches-here-only-after-internal-retries-exhaust case as the two entries above.
+        #
+        # A mid-stream or connect-time connection drop ("server closed the connection unexpectedly",
+        # the SSL-flavoured "SSL connection has been closed unexpectedly") is retried in-process by
+        # `_connect_with_dropped_retry` / the offset-chunking fallback (both keyed on
+        # `_CONNECTION_DROPPED_ERROR_SUBSTRINGS` in postgres.py). Once that budget is exhausted the
+        # raw psycopg `OperationalError` reaches `_handle_import_error`, which — without a match here
+        # — logs it at `exception` and reports it to error tracking on every occurrence, even though
+        # Temporal retries the whole activity and the drop is transient and self-recovering (a pooler
+        # idle cull, failover, or network blip). Classify it retryable so it logs as a warning
+        # instead. These stay clear of `get_non_retryable_errors` deliberately (see the note there),
+        # so the sync keeps retrying rather than being disabled.
         return {
             "terminating connection due to",
             "the database system is shutting down",
+            "server closed the connection unexpectedly",
+            "SSL connection has been closed unexpectedly",
             *_CONNECTION_LIMIT_ERROR_SUBSTRINGS,
         }
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -31,6 +31,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arr
     TemporaryFileSizeExceedsLimitException,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.consts import DEFAULT_CHUNK_SIZE
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import error_message_matches
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql.predicates import (
     ColumnTypeCategory,
     ValidatedRowFilter,
@@ -423,6 +424,21 @@ class TestPostgresSourceNonRetryableErrors:
         non_retryable = source.get_non_retryable_errors()
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert is_non_retryable, f"Permanent error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            'OperationalError: connection failed: connection to server at "db.example.com", port 5432 failed: server closed the connection unexpectedly',
+            'OperationalError: connection failed: connection to server at "db.example.com", port 5432 failed: SSL connection has been closed unexpectedly',
+        ],
+    )
+    def test_exhausted_connection_drops_are_classified_retryable(self, source, error_msg):
+        # These transient drops are retried in-process, then re-raised once that budget is exhausted.
+        # If they drop out of get_retryable_errors, _handle_import_error logs the self-recovering
+        # failure as a tracked exception again instead of a warning. They must also stay out of
+        # get_non_retryable_errors so the sync keeps retrying rather than being disabled.
+        assert error_message_matches(error_msg, source.get_retryable_errors())
+        assert not error_message_matches(error_msg, source.get_non_retryable_errors().keys())
 
     @pytest.mark.parametrize(
         "error_msg",


### PR DESCRIPTION
## Problem

- Customers on flaky Postgres connections get their sync run marked failed with a raw driver error, and the self-recovering failure floods our error tracking on every occurrence.
- A dropped or closed connection ("server closed the connection unexpectedly", the SSL-flavoured "SSL connection has been closed unexpectedly") is retried in-process by the connect and offset-chunking fallbacks.
- Once that in-process budget is exhausted, the raw `psycopg.OperationalError` reaches `_handle_import_error`. Neither signature was in `get_retryable_errors`, so it fell through to the catch-all and logged at `exception`.
- Temporal retries the whole activity regardless, and the drop is transient (a pooler idle cull, failover, or network blip), so the run recovers on its own.

## Changes

- Add "server closed the connection unexpectedly" and "SSL connection has been closed unexpectedly" to `PostgresSource.get_retryable_errors()`.
- Reporting only: the exhausted drop now logs as a warning instead of a tracked exception. Retry behaviour is unchanged.
- Both stay out of `get_non_retryable_errors` deliberately, so the sync keeps retrying rather than being disabled on a transient blip.
- Mirrors the same pattern already used for other transient network errors (for example the Google Sheets source's "Max retries exceeded with url").

No UI changes.

## How did you test this code?

- Added a parameterized case to `TestPostgresSourceNonRetryableErrors` asserting both drop signatures match a `get_retryable_errors` key and match no `get_non_retryable_errors` key. Catches a regression where either signature is dropped from the retryable set and transient drops start polluting error tracking again, or is wrongly added to the non-retryable set and disables a healthy sync.
- Ran `products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py::TestPostgresSourceNonRetryableErrors` locally; all cases pass.
- Not run: the database-backed and Temporal integration suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored by an agent (Claude) while triaging a batch of data-warehouse sync failure classes. This PR addresses the two highest-volume Postgres classes, both transient connection drops.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Decision: classified the drops as retryable (reporting fix) rather than mapping them to a friendly non-retryable message, because they are transient and self-recovering; making them non-retryable would disable a healthy sync on a blip.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
