### PR TITLE
fix(replay): save comments made at the start of a recording

### DIFF
--- a/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.test.ts
@@ -71,11 +71,9 @@ describe('playerFrameCommentOverlayLogic', () => {
         expect(membersLogic.values.meFirstMembers).toHaveLength(mockMembers.length)
     })
 
-    // Regression test: the overlay logic mounts with the player toolbar, before the recording has
-    // loaded, and only refreshes its timestamp when the formatted (second resolution) playhead
-    // time changes. Commenting without moving the playhead off 00:00 therefore submitted the
-    // `dayjs(null)` Invalid Date captured at mount, which threw inside the kea-forms submit - and
-    // kea-forms swallows that, so Save made no request and reported nothing.
+    // Regression test: currentTimestamp is unset until the player seeks, so a comment made before
+    // the playhead moves off 00:00 used to submit an invalid date and fail silently inside the
+    // kea-forms submit, saving nothing and reporting nothing.
     it('saves a comment made while the playhead is still at the start', async () => {
         const createSpy = jest.spyOn(api.comments, 'create').mockResolvedValue({} as CommentType)
 

--- a/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.test.ts
@@ -2,10 +2,16 @@ import { MOCK_DEFAULT_BASIC_USER, MOCK_SECOND_BASIC_USER } from 'lib/api.mock'
 
 import { expectLogic } from 'kea-test-utils'
 
+import api from 'lib/api'
+import { dayjs } from 'lib/dayjs'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { membersLogic } from 'scenes/organization/membersLogic'
+import { sessionRecordingDataCoordinatorLogic } from 'scenes/session-recordings/player/sessionRecordingDataCoordinatorLogic'
 import { sessionRecordingPlayerLogic } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 
+import { CommentType } from '~/types'
+
+import { recordingMetaJson } from '../../__mocks__/recording_meta'
 import { setupSessionRecordingTest } from '../__mocks__/test-setup'
 import { playerCommentOverlayLogic } from './playerFrameCommentOverlayLogic'
 
@@ -63,6 +69,36 @@ describe('playerFrameCommentOverlayLogic', () => {
         }).toDispatchActions(['ensureAllMembersLoaded', 'loadAllMembers', 'loadAllMembersSuccess'])
 
         expect(membersLogic.values.meFirstMembers).toHaveLength(mockMembers.length)
+    })
+
+    // Regression test: the overlay logic mounts with the player toolbar, before the recording has
+    // loaded, and only refreshes its timestamp when the formatted (second resolution) playhead
+    // time changes. Commenting without moving the playhead off 00:00 therefore submitted the
+    // `dayjs(null)` Invalid Date captured at mount, which threw inside the kea-forms submit - and
+    // kea-forms swallows that, so Save made no request and reported nothing.
+    it('saves a comment made while the playhead is still at the start', async () => {
+        const createSpy = jest.spyOn(api.comments, 'create').mockResolvedValue({} as CommentType)
+
+        await expectLogic(sessionRecordingPlayerLogic(playerLogicProps)).toDispatchActions([
+            sessionRecordingDataCoordinatorLogic({ sessionRecordingId: '1' }).actionTypes.loadRecordingMetaSuccess,
+        ])
+        expect(logic.values.currentPlayerTime).toBe(0)
+
+        logic.actions.setIsCommenting(true)
+        logic.actions.setRichContent({
+            type: 'doc',
+            content: [{ type: 'paragraph', content: [{ type: 'text', text: 'a comment' }] }],
+        })
+
+        await expectLogic(logic, () => {
+            logic.actions.submitRecordingComment()
+        }).toDispatchActions(['submitRecordingCommentSuccess'])
+
+        expect(createSpy).toHaveBeenCalledTimes(1)
+        expect(createSpy.mock.calls[0][0].item_context).toMatchObject({
+            milliseconds_into_recording: 0,
+            time_in_recording: dayjs(recordingMetaJson.start_time).toISOString(),
+        })
     })
 
     it('does not load all members again when the overlay closes', async () => {

--- a/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.ts
@@ -270,6 +270,11 @@ export const playerCommentOverlayLogic = kea<playerCommentOverlayLogicType>([
                 lemonToast.error(`Emoji comments must be emojis 🙈, this string was too long: "${emoji}"`)
                 return
             }
+            const dateForTimestamp = values.dateForCurrentTimestamp
+            if (!dateForTimestamp) {
+                lemonToast.error('Could not save your comment: the recording has no timestamp yet.')
+                return
+            }
             const loadingTimeout = setTimeout(() => {
                 actions.setLoading(true)
             }, 250)
@@ -281,12 +286,14 @@ export const playerCommentOverlayLogic = kea<playerCommentOverlayLogicType>([
                     item_id: props.recordingId,
                     item_context: {
                         is_emoji: true,
-                        time_in_recording: dayjs(values.currentTimestamp).toISOString(),
+                        time_in_recording: dateForTimestamp.toISOString(),
                         milliseconds_into_recording: values.currentPlayerTime,
                     },
                     slug: `/replay/${props.recordingId}#panel=discussion`,
                 })
                 playerCommentModel.actions.commentEdited(props.recordingId)
+            } catch (e) {
+                lemonToast.error(`Could not save your comment: ${(e as Error).message}`)
             } finally {
                 if (loadingTimeout) {
                     clearTimeout(loadingTimeout)

--- a/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.ts
@@ -208,9 +208,8 @@ export const playerCommentOverlayLogic = kea<playerCommentOverlayLogicType>([
                 return colonDelimitedDuration(currentPlayerTime / 1000, timestampUnits)
             },
         ],
-        // The player only publishes currentTimestamp once it has seeked, so it is null while the
-        // playhead still sits at the start. Falling back to the recording start plus the playhead
-        // offset keeps a comment made before playback from having no date to anchor to.
+        // currentTimestamp is unset until the player seeks, so fall back to the recording start
+        // plus the playhead offset rather than leaving a comment with no date to anchor to
         dateForCurrentTimestamp: [
             (s) => [s.currentTimestamp, s.currentPlayerTime, s.sessionPlayerData],
             (
@@ -323,11 +322,9 @@ export const playerCommentOverlayLogic = kea<playerCommentOverlayLogicType>([
             submit: async (data) => {
                 const { commentId, content, richContent } = data
 
-                // the form only snapshots the timestamp when the player's formatted time changes,
-                // so read the player's live position whenever that snapshot is missing or stale
-                const dateForTimestamp = data.dateForTimestamp?.isValid()
-                    ? data.dateForTimestamp
-                    : values.dateForCurrentTimestamp
+                // the form's copy only refreshes on whole-second changes, so read the live position
+                // to keep this in step with milliseconds_into_recording below
+                const dateForTimestamp = values.dateForCurrentTimestamp
 
                 if (!dateForTimestamp) {
                     throw new Error('Cannot comment without a timestamp.')
@@ -359,11 +356,10 @@ export const playerCommentOverlayLogic = kea<playerCommentOverlayLogicType>([
         },
     })),
     listeners(({ values }) => ({
-        // kea-forms swallows anything thrown while submitting, so without this a comment that
-        // fails to save looks exactly like a dead button
+        // kea-forms discards anything thrown in submit, so a failed save is otherwise silent
         submitRecordingCommentFailure: ({ error }) => {
             if (values.recordingCommentHasErrors) {
-                // the form already renders these against the field
+                // already rendered against the field
                 return
             }
             lemonToast.error(`Could not save your comment: ${error.message}`)

--- a/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.ts
@@ -41,6 +41,7 @@ export interface playerCommentOverlayLogicValues {
     currentTimestamp: number | undefined // sessionRecordingPlayerLogic
     sessionPlayerData: SessionPlayerData // sessionRecordingPlayerLogic
     asTask: boolean
+    dateForCurrentTimestamp: Dayjs | null
     formattedTimestamp: string
     isEmpty: boolean
     isLoading: boolean
@@ -132,6 +133,11 @@ export interface playerCommentOverlayLogicMeta {
     __keaTypeGenInternalSelectorTypes: {
         timestampUnits: (sessionPlayerData: SessionPlayerData) => 2 | 3
         formattedTimestamp: (currentPlayerTime: number, timestampUnits: 2 | 3) => string
+        dateForCurrentTimestamp: (
+            currentTimestamp: number | undefined,
+            currentPlayerTime: number,
+            sessionPlayerData: SessionPlayerData
+        ) => Dayjs | null
     }
 }
 
@@ -202,13 +208,29 @@ export const playerCommentOverlayLogic = kea<playerCommentOverlayLogicType>([
                 return colonDelimitedDuration(currentPlayerTime / 1000, timestampUnits)
             },
         ],
+        // The player only publishes currentTimestamp once it has seeked, so it is null while the
+        // playhead still sits at the start. Falling back to the recording start plus the playhead
+        // offset keeps a comment made before playback from having no date to anchor to.
+        dateForCurrentTimestamp: [
+            (s) => [s.currentTimestamp, s.currentPlayerTime, s.sessionPlayerData],
+            (
+                currentTimestamp: number | undefined,
+                currentPlayerTime: number,
+                sessionPlayerData: SessionPlayerData
+            ): Dayjs | null => {
+                if (currentTimestamp) {
+                    return dayjs(currentTimestamp)
+                }
+                return sessionPlayerData?.start ? sessionPlayerData.start.add(currentPlayerTime, 'milliseconds') : null
+            },
+        ],
     }),
     subscriptions(({ actions, values }) => ({
         formattedTimestamp: (formattedTimestamp) => {
             // as the timestamp from the player changes we track three representations of it
             actions.setRecordingCommentValue('timeInRecording', formattedTimestamp)
             actions.setRecordingCommentValue('timestampInRecording', values.currentPlayerTime)
-            actions.setRecordingCommentValue('dateForTimestamp', dayjs(values.currentTimestamp))
+            actions.setRecordingCommentValue('dateForTimestamp', values.dateForCurrentTimestamp)
         },
     })),
     listeners(({ actions, props, values }) => ({
@@ -292,7 +314,13 @@ export const playerCommentOverlayLogic = kea<playerCommentOverlayLogicType>([
                 }
             },
             submit: async (data) => {
-                const { commentId, content, richContent, dateForTimestamp } = data
+                const { commentId, content, richContent } = data
+
+                // the form only snapshots the timestamp when the player's formatted time changes,
+                // so read the player's live position whenever that snapshot is missing or stale
+                const dateForTimestamp = data.dateForTimestamp?.isValid()
+                    ? data.dateForTimestamp
+                    : values.dateForCurrentTimestamp
 
                 if (!dateForTimestamp) {
                     throw new Error('Cannot comment without a timestamp.')
@@ -321,6 +349,17 @@ export const playerCommentOverlayLogic = kea<playerCommentOverlayLogicType>([
                 actions.setAsTask(false)
                 actions.setIsCommenting(false)
             },
+        },
+    })),
+    listeners(({ values }) => ({
+        // kea-forms swallows anything thrown while submitting, so without this a comment that
+        // fails to save looks exactly like a dead button
+        submitRecordingCommentFailure: ({ error }) => {
+            if (values.recordingCommentHasErrors) {
+                // the form already renders these against the field
+                return
+            }
+            lemonToast.error(`Could not save your comment: ${error.message}`)
         },
     })),
 ])


### PR DESCRIPTION
## Problem

Anyone commenting on a session replay could hit a Save button that did nothing — no request, no error, no toast. It reproduced for several people in #team-replay.

The in-player comment form keeps the commented-at date in form state, written by a subscription that only fires when the *formatted* (second resolution) playhead time changes. That logic mounts with the player toolbar, before the recording has loaded, so the first value it writes is `dayjs(null)` — an Invalid Date. If the playhead never moves off 00:00 the subscription never fires again, so that Invalid Date is what gets submitted. It slips past the `if (!dateForTimestamp)` guard, then throws in `toISOString()`, and kea-forms swallows anything thrown inside `submit`. Hence a completely silent no-op.

## Changes

- Derive the comment date from the player's live position at submit time instead of trusting the snapshot, falling back to the recording start plus the playhead offset when the player has not published a timestamp yet. A comment at 00:00 now anchors to the recording start, which is what it should have been all along.
- The subscription writes that same derived value, so an Invalid Date can no longer reach form state.
- Surface submit failures with a toast. This is the part that made the bug so hard to pin down: kea-forms discards submit errors, so *any* failed save — including a 500 from the API — looked exactly like a dead button. Field validation errors are left alone since the form already renders those inline.

## How did you test this code?

Added a regression test in `playerFrameCommentOverlayLogic.test.ts` covering the exact reported case: recording loaded, playhead still at 00:00, Save must POST with the recording start as `time_in_recording`. It times out against `master` and passes with this change.

I also confirmed by hand (in a throwaway test, not committed) that the pre-fix `dateForTimestamp` is an invalid dayjs, and that the new failure listener fires with the API's error message when `api.comments.create` rejects.

Ran the `session-recordings/player/commenting` and `scenes/comments` Jest suites plus a full frontend typecheck. I did not exercise this in a browser — no rendered verification of the overlay.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing docs describe this behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app from a bug report in Slack. Started by tracing the Save path in `PlayerFrameCommentOverlay.tsx` and `playerFrameCommentOverlayLogic.ts`, then reproduced it in a scratch Jest test rather than reasoning from the code — worth it, because two plausible-looking suspects turned out to be red herrings. The `content` field of the kea form is never populated by typing (`LemonRichContentEditor` ignores the `value`/`onChange` props `LemonField` injects), and the `errors` validator's `Object.keys(richContent ?? {}).length` check is always truthy for a tiptap doc, so an empty comment can be submitted. Neither is the reported bug, and both are left untouched here.

The scratch test printed `dateForTimestamp: null` after typing, which pointed at `dayjs(values.currentTimestamp)` — `currentTimestamp` is `null` until the player seeks, and kea reducers cannot default to `undefined`.

Two alternatives considered and rejected: validating `dateForTimestamp` and bailing out (correct, but Save would still refuse to work at 00:00), and setting `dateForTimestamp` from the payload in the `editComment` listener (the inspector's Edit button deliberately relies on the click seeking the player first, so that would change edit behavior for no benefit).

No skills were invoked.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1786358092923439?thread_ts=1786358092.923439&cid=C0ACRAMJUAG)*
