### PR TITLE
fix(github): classify exhausted rate limits as retryable, not tracked errors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/source.py
@@ -299,6 +299,12 @@ If automatic creation failed, your token needs webhook permissions — the **adm
             "Missing integration ID": "Integration ID is not configured. Please reconnect your GitHub account.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # A GitHubRateLimitError that survives _fetch_page's own rate-limit-aware tenacity retry
+        # still gets picked up by Temporal's activity retry; classify it as retryable so it's
+        # logged as a warning rather than tracked as an exception. Mirrors Stripe's equivalent case.
+        return {"GitHub API rate limit exceeded"}
+
     def get_oauth_accounts(
         self, integration_id: int, team_id: int, search: str | None = None
     ) -> list[IntegrationAccount]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_source_class.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_source_class.py
@@ -120,6 +120,15 @@ class TestGithubSource:
     def test_non_retryable_errors(self, expected_key):
         assert expected_key in self.source.get_non_retryable_errors()
 
+    def test_rate_limit_error_is_retryable_not_non_retryable(self):
+        # A GitHubRateLimitError that exhausts _fetch_page's tenacity retry must stay retryable
+        # so it never gets classified as a permanent failure that disables the source.
+        observed_error = "GitHub API rate limit exceeded (resets at 1786360951)"
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert not any(key in observed_error for key in non_retryable_errors)
+        retryable_errors = self.source.get_retryable_errors()
+        assert error_message_matches(observed_error, retryable_errors)
+
     @pytest.mark.parametrize(
         "raised_message,expected_key",
         [


### PR DESCRIPTION
## Problem

A GitHub warehouse sync hit its API rate limit, and once the in-process retry gave up, the sync logged it as a tracked exception instead of a routine, self-recovering warning ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019feb5e-dc1f-7e73-a2b2-0da958070146)).

`_fetch_page` already retries `GitHubRateLimitError` with a rate-limit-aware backoff (sleeps until GitHub's advertised reset, capped at 300s, 5 attempts). If a rate limit outlives that budget, the error reaches `_handle_import_error` for classification. `GithubSource` had no `get_retryable_errors` override, so the message didn't match anything there and fell through to the unclassified branch: `logger.aexception` plus a plain re-raise. `StripeSource.get_retryable_errors` already solves this for Stripe's equivalent rate-limit case.

## Changes

- Add `GithubSource.get_retryable_errors`, matching the stable `"GitHub API rate limit exceeded"` prefix (the message also carries a reset timestamp, which is excluded from the match).
- Temporal still retries the activity either way; this only changes how the exhausted-retry case is logged and reported.

## How did you test this code?

- Added `test_rate_limit_error_is_retryable_not_non_retryable` to `test_github_source_class.py`, asserting the rate-limit message matches `get_retryable_errors` and not `get_non_retryable_errors`. No existing test covered this classification.
- Ran the full `test_github_source_class.py` suite locally: 88 passed.
- Ran `ruff check --fix`, `ruff format`, and `mypy` on the changed files: clean.
- Not run: a live GitHub rate-limit reproduction, since this only changes logging/error-tracking classification, not retry behavior.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a webhook-delivered error tracking alert. I (Claude, via the PostHog error-tracking MCP tools) pulled the issue's stack trace and a representative event, confirmed the failure originates in `products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py`, and read the retry/classification code path (`_fetch_page`'s tenacity decorator, `_handle_import_error`) to find the gap. Compared against `StripeSource.get_retryable_errors` for the existing pattern before writing the fix. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/writing-code-comments`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*