### PR TITLE
fix(data-warehouse): don't treat a persistent S3 403 as a retryable blip

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/errors.py
@@ -20,6 +20,16 @@ TRANSIENT_OBJECT_STORE_ERRORS = (
     "Please reduce your request rate",
 )
 
+# delta-rs's `object_store` crate wraps every S3-side error in the same "Generic S3 error" prefix
+# above, including a persistent bucket/IAM policy denial — not just the credential-provider hiccups
+# that needle is meant to catch. These mark a response that will never clear on retry, so they take
+# priority over the blanket "Generic S3 error" match.
+PERSISTENT_AUTH_ERROR_NEEDLES = (
+    "403 Forbidden",
+    "401 Unauthorized",
+    "<Code>AccessDenied</Code>",
+)
+
 
 class TransientObjectStoreError(NonReportableError):
     """A known-transient object-store blip (see is_transient_object_store_error), re-raised as this
@@ -43,6 +53,10 @@ def is_transient_object_store_error(error: BaseException) -> bool:
     `object_store` crate. `NoCredentialsError`'s message is a fixed, generic string (no needle to
     match), but hitting our own instance-role-authenticated bucket always means the same transient
     resolution hiccup, so it's recognized by type rather than by message.
+
+    A 403/401 is excluded even though it's also wrapped in "Generic S3 error" text (see
+    PERSISTENT_AUTH_ERROR_NEEDLES) — a denied bucket/IAM policy doesn't clear on retry, so treating
+    it as a self-recovering blip would silently retry it forever instead of surfacing it.
     """
     if isinstance(error, TransientObjectStoreError | botocore.exceptions.NoCredentialsError):
         # Already classified and wrapped by a prior call to this same function (see
@@ -50,9 +64,12 @@ def is_transient_object_store_error(error: BaseException) -> bool:
         # re-runs this classifier on the wrapper, rather than the original OSError/DeltaError it
         # wraps, must still treat it as transient.
         return True
-    return isinstance(error, OSError | deltalake.exceptions.DeltaError) and any(
-        needle in str(error) for needle in TRANSIENT_OBJECT_STORE_ERRORS
-    )
+    if not isinstance(error, OSError | deltalake.exceptions.DeltaError):
+        return False
+    error_text = str(error)
+    if any(needle in error_text for needle in PERSISTENT_AUTH_ERROR_NEEDLES):
+        return False
+    return any(needle in error_text for needle in TRANSIENT_OBJECT_STORE_ERRORS)
 
 
 # `optimize.compact` plans its rewrite against the file list at the start of its scan, then reads

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_delta_errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_delta_errors.py
@@ -35,6 +35,40 @@ class TestIsTransientObjectStoreError:
                 True,
             ),
             ("unrelated_exception_type", ValueError("some other unrelated failure"), False),
+            # delta-rs's object_store crate wraps a persistent 403 (denied bucket/IAM policy) in the
+            # same "Generic S3 error" prefix used for self-recovering blips — without the exclusion,
+            # this would match on that prefix alone and get treated as transient, retrying forever
+            # instead of surfacing that access is denied.
+            (
+                "forbidden_list_request_os_error",
+                OSError(
+                    "Generic S3 error: Error performing list request: Error performing GET "
+                    "https://s3.example.com/bucket?list-type=2&prefix=data-warehouse%2F in 7ms - "
+                    "Server returned non-2xx status code: 403 Forbidden: "
+                    "<Error><Code>Forbidden</Code><Message>Forbidden</Message></Error>"
+                ),
+                False,
+            ),
+            (
+                "access_denied_os_error",
+                OSError(
+                    "Generic S3 error: Error performing list request: Server returned non-2xx status "
+                    "code: 403 Forbidden: <Error><Code>AccessDenied</Code></Error>"
+                ),
+                False,
+            ),
+            (
+                "unauthorized_os_error",
+                OSError("Generic S3 error: Server returned non-2xx status code: 401 Unauthorized"),
+                False,
+            ),
+            # A dispatch timeout wrapped in the same "Generic S3 error" prefix, with none of the
+            # persistent-auth-error markers above, must still classify as transient.
+            (
+                "dispatch_timeout_os_error",
+                OSError("Generic S3 error: Error getting list response body: operation timed out"),
+                True,
+            ),
             # `get_delta_table` re-raises a recognized transient blip as this wrapper (see
             # `_capture_unless_transient`) instead of the original OSError/DeltaError. A caller
             # further up the stack that catches broadly and re-runs this classifier on the caught


### PR DESCRIPTION
## Problem

A data-warehouse sync whose destination bucket answers with `403 Forbidden` is treated the same as a self-recovering credential blip, so it retries indefinitely instead of failing fast and staying visible.

- `is_transient_object_store_error` flags any error containing the substring `"Generic S3 error"`. That phrase is the generic wrapper delta-rs's `object_store` crate puts on every S3-side failure, not just credential-provider hiccups, so a persistent 403 matches it too.
- Found while triaging an error-tracking issue for a Postgres source, where `DeltaTableRef.get_delta_table` (`pipelines/core/delta/table.py`) hit exactly this response while listing a table's `_delta_log` prefix.

## Changes

- `pipelines/core/delta/errors.py`: exclude S3 responses carrying a `403 Forbidden`, `401 Unauthorized`, or `<Code>AccessDenied</Code>` marker from `is_transient_object_store_error`, so they stay reported and retried under Temporal's normal policy instead of being silently classified as a self-recovering blip.
- Other `TRANSIENT_OBJECT_STORE_ERRORS` matches (credential-provider hiccups, dispatch timeouts, S3 throttling) are unaffected.

## How did you test this code?

- Added parameterized cases to `TestIsTransientObjectStoreError` in `test_delta_errors.py`: a `403 Forbidden` list response, an `AccessDenied` response, a `401 Unauthorized` response (all now classified non-transient), and a dispatch-timeout `Generic S3 error` with no auth marker (still classified transient) — guards the exact misclassification this PR fixes.
- Ran `pytest products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_delta_errors.py`: 35 passed.
- Not run: `test_table.py`'s `TestGetDeltaTableUnrecoverableErrors` suite, which needs a live object-storage container unavailable in this sandbox. Confirmed those failures are pre-existing on `master` before this change and unrelated to this diff.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal error-classification logic, no user-facing behavior or API change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Investigated with PostHog's error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) and `execute-sql` to pull the stack trace, exception properties, and confirm every sampled event hit the same delta-log listing path for a Postgres source.
- Delegated code discovery to a subagent to map the (since-renamed) modules named in the stack trace onto their current location under `pipelines/core/delta/`.
- Invoked `/writing-tests` before adding test cases and `/writing-pr-descriptions` before writing this body.
- Checked for a duplicate by searching open PR titles/diffs for `Generic S3 error`, `delta_table_helper`, and `is_transient_object_store_error`, and reviewing the maintainer's own open PRs — none touch this classifier.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*