### PR TITLE
fix(error-tracking): reload issue events

### DIFF
--- a/products/error_tracking/frontend/components/DataSourceTable/types.ts
+++ b/products/error_tracking/frontend/components/DataSourceTable/types.ts
@@ -1,6 +1,6 @@
 import { KeyType, Logic } from 'kea'
 
-import { DataNode } from '~/queries/schema/schema-general'
+import type { DataNode, RefreshType } from '~/queries/schema/schema-general'
 
 export interface DataSourceLogic<T> extends Logic {
     values: {
@@ -11,7 +11,7 @@ export interface DataSourceLogic<T> extends Logic {
     }
     actions: {
         setQuery: (query: DataNode) => void
-        loadData: () => void
+        loadData: (refresh?: RefreshType) => void
         loadNextData: () => void
     }
 }

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/IssueEventsPanel.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/IssueEventsPanel.tsx
@@ -36,7 +36,7 @@ function LoadedIssueEventsPanel(): JSX.Element {
     return (
         <IssueEventsLayout
             loading={itemsLoading}
-            onReload={loadData}
+            onReload={() => loadData('force_blocking')}
             onScrollNearEnd={() => {
                 if (canLoadNextData && !itemsLoading) {
                     loadNextData()


### PR DESCRIPTION
## Problem

People viewing an error-tracking issue cannot reload its exception list.

The button forwards its click event as the query refresh mode, which prevents a valid reload request.

## Changes

- Call the events query with `force_blocking` without forwarding the click event.
- Extend the shared data-source action type to accept query refresh modes.
- No visual change.

## How did you test this code?

- Targeted Oxfmt and Oxlint checks passed.
- `./bin/hogli ci:preflight --fix` passed.
- The frontend typecheck remains blocked by unrelated stale generated type errors.
- No manual browser test was run.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented this targeted fix with GPT-5.6 and React Doctor.

Skills invoked: `/error-tracking`, `/writing-tests`, `/react-doctor`, `/writing-kea-logics`, `/writing-pr-descriptions`, `/running-ci-preflight`, and `/pr`.
