### PR TITLE
fix(warehouse-sources): sync plausible entry and exit page reports

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/canonical_descriptions.py
@@ -1,6 +1,7 @@
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
     CanonicalDescriptions,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.plausible.settings import EVENT_SCOPED_METRICS
 
 _DOCS_URL = "https://plausible.io/docs/stats-api"
 
@@ -14,6 +15,10 @@ _STANDARD_METRIC_COLUMNS = {
     "visit_duration": "Average visit duration in seconds.",
     "events": "Number of events (pageviews plus custom events).",
 }
+
+# Entry and exit page reports break down by a session-only dimension, so they omit the
+# event-scoped metrics Plausible refuses to return alongside one.
+_SESSION_METRIC_COLUMNS = {k: v for k, v in _STANDARD_METRIC_COLUMNS.items() if k not in EVENT_SCOPED_METRICS}
 
 CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
     "timeseries": {
@@ -64,12 +69,12 @@ CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
     "entry_pages": {
         "description": "Daily traffic metrics broken down by the first page of each visit.",
         "docs_url": _DOCS_URL,
-        "columns": {**_STANDARD_METRIC_COLUMNS, "entry_page": "The first page path visited in a session."},
+        "columns": {**_SESSION_METRIC_COLUMNS, "entry_page": "The first page path visited in a session."},
     },
     "exit_pages": {
         "description": "Daily traffic metrics broken down by the last page of each visit.",
         "docs_url": _DOCS_URL,
-        "columns": {**_STANDARD_METRIC_COLUMNS, "exit_page": "The last page path visited in a session."},
+        "columns": {**_SESSION_METRIC_COLUMNS, "exit_page": "The last page path visited in a session."},
     },
     "countries": {
         "description": "Daily traffic metrics broken down by visitor country.",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/plausible.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/plausible.py
@@ -78,11 +78,11 @@ def _to_date(value: Any) -> Optional[date]:
 def _normalize_row(config: PlausibleEndpointConfig, result: dict[str, Any]) -> dict[str, Any]:
     """Flatten a Stats API result ({dimensions: [...], metrics: [...]}) into a named-column dict."""
     row: dict[str, Any] = {}
-    # Direct access (not .get) so a malformed response missing dimensions — and therefore the `date`
-    # primary key — fails fast instead of ingesting unkeyed rows.
-    for name, value in zip(config.column_names, result["dimensions"]):
+    # Direct access (not .get) and strict zips so a malformed response fails fast instead of
+    # ingesting rows missing the `date` primary key or silently dropping metric columns.
+    for name, value in zip(config.column_names, result["dimensions"], strict=True):
         row[name] = value
-    for name, value in zip(config.metrics, result["metrics"]):
+    for name, value in zip(config.metrics, result["metrics"], strict=True):
         row[name] = value
     return row
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/plausible.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/plausible.py
@@ -11,6 +11,9 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.res
     rest_api_resource,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import BasePaginator
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClientNonRetryableError,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.sync_window import SyncWindow
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.typings import SourceResponse
@@ -77,12 +80,22 @@ def _to_date(value: Any) -> Optional[date]:
 
 def _normalize_row(config: PlausibleEndpointConfig, result: dict[str, Any]) -> dict[str, Any]:
     """Flatten a Stats API result ({dimensions: [...], metrics: [...]}) into a named-column dict."""
+    # Direct access (not .get) so a response missing either list fails instead of ingesting rows
+    # without the `date` primary key.
+    dimensions, metrics = result["dimensions"], result["metrics"]
+    # Both lists are positional, so a count mismatch would drop trailing columns. Raise the
+    # classified error rather than letting `zip` raise a bare ValueError: a bare one matches no
+    # classifier, so the schema replays this same page for all 15 resumable attempts.
+    if len(dimensions) != len(config.column_names) or len(metrics) != len(config.metrics):
+        raise RESTClientNonRetryableError(
+            f"Plausible returned {len(dimensions)} dimensions and {len(metrics)} metrics for report "
+            f"'{config.name}', expected {len(config.column_names)} and {len(config.metrics)}"
+        )
+
     row: dict[str, Any] = {}
-    # Direct access (not .get) and strict zips so a malformed response fails fast instead of
-    # ingesting rows missing the `date` primary key or silently dropping metric columns.
-    for name, value in zip(config.column_names, result["dimensions"], strict=True):
+    for name, value in zip(config.column_names, dimensions, strict=True):
         row[name] = value
-    for name, value in zip(config.metrics, result["metrics"], strict=True):
+    for name, value in zip(config.metrics, metrics, strict=True):
         row[name] = value
     return row
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/settings.py
@@ -13,6 +13,18 @@ DEFAULT_BACKFILL_DAYS = 365
 # endpoints because they aren't valid for the generic breakdowns.
 DEFAULT_METRICS = ["visitors", "visits", "pageviews", "bounce_rate", "visit_duration", "events"]
 
+# Plausible resolves each metric and dimension against either its events table or its sessions
+# table, and rejects a query that pairs an event-scoped metric with a session-only dimension
+# ("Event metric(s) ... cannot be queried along with session dimension(s) ...", HTTP 400).
+EVENT_SCOPED_METRICS = frozenset({"pageviews", "events"})
+
+# The only dimensions Plausible keeps solely on the sessions table. Every other `visit:*` dimension
+# is denormalized onto events, which is why they pair with the full metric set.
+SESSION_ONLY_DIMENSIONS = frozenset({"visit:entry_page", "visit:exit_page"})
+
+# The generic set minus the event-scoped metrics, for reports broken down by a session-only dimension.
+SESSION_SCOPED_METRICS = [m for m in DEFAULT_METRICS if m not in EVENT_SCOPED_METRICS]
+
 # The day bucket every report is grouped by — must be the first dimension so `order_by` can sort
 # on it and the pipeline can slide the date window incrementally.
 TIME_DIMENSION = "time:day"
@@ -76,8 +88,17 @@ PLAUSIBLE_ENDPOINTS: dict[str, PlausibleEndpointConfig] = {
     "utm_terms": PlausibleEndpointConfig(name="utm_terms", breakdown_dimensions=["visit:utm_term"]),
     "utm_contents": PlausibleEndpointConfig(name="utm_contents", breakdown_dimensions=["visit:utm_content"]),
     "pages": PlausibleEndpointConfig(name="pages", breakdown_dimensions=["event:page"]),
-    "entry_pages": PlausibleEndpointConfig(name="entry_pages", breakdown_dimensions=["visit:entry_page"]),
-    "exit_pages": PlausibleEndpointConfig(name="exit_pages", breakdown_dimensions=["visit:exit_page"]),
+    # Entry/exit pages break down by a session-only dimension, so they carry the reduced metric set.
+    "entry_pages": PlausibleEndpointConfig(
+        name="entry_pages",
+        breakdown_dimensions=["visit:entry_page"],
+        metrics=list(SESSION_SCOPED_METRICS),
+    ),
+    "exit_pages": PlausibleEndpointConfig(
+        name="exit_pages",
+        breakdown_dimensions=["visit:exit_page"],
+        metrics=list(SESSION_SCOPED_METRICS),
+    ),
     "countries": PlausibleEndpointConfig(name="countries", breakdown_dimensions=["visit:country"]),
     "regions": PlausibleEndpointConfig(name="regions", breakdown_dimensions=["visit:region"]),
     "cities": PlausibleEndpointConfig(name="cities", breakdown_dimensions=["visit:city"]),

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/settings.py
@@ -14,13 +14,17 @@ DEFAULT_BACKFILL_DAYS = 365
 DEFAULT_METRICS = ["visitors", "visits", "pageviews", "bounce_rate", "visit_duration", "events"]
 
 # Plausible resolves metrics and dimensions against either its events table or its sessions table,
-# and answers 400 when a query pairs an event-scoped metric with a session-only dimension. Both sets
-# mirror `metric_partitioner` and `dimension_partitioner` in Plausible's `TableDecider`; every other
-# `visit:*` dimension is denormalized onto events, so it pairs with metrics from either table.
+# and answers 400 when a query mixes one table's metric with the other's dimension. These sets mirror
+# `metric_partitioner` and `dimension_partitioner` in Plausible's `TableDecider`; any `visit:*`
+# dimension not listed here is denormalized onto events, so it pairs with metrics from either table.
 EVENT_SCOPED_METRICS = frozenset({"pageviews", "events", "scroll_depth", "time_on_page"})
+SESSION_SCOPED_METRICS = frozenset({"bounce_rate", "visit_duration", "views_per_visit", "exit_rate"})
 SESSION_ONLY_DIMENSIONS = frozenset(
     {"visit:entry_page", "visit:entry_page_hostname", "visit:exit_page", "visit:exit_page_hostname"}
 )
+# Plausible exempts a breakdown by `event:page`, optionally alongside `event:hostname`, from the
+# session-metric rule, which is why `pages` keeps the full metric set.
+EVENT_DIMENSIONS_ALLOWING_SESSION_METRICS = frozenset({"event:page", "event:hostname"})
 
 # The day bucket every report is grouped by — must be the first dimension so `order_by` can sort
 # on it and the pipeline can slide the date window incrementally.
@@ -39,12 +43,19 @@ _DATE_INCREMENTAL_FIELDS: list[IncrementalField] = [
 def compatible_metrics(metrics: list[str], breakdown_dimensions: list[str]) -> list[str]:
     """Drop the metrics Plausible refuses to return alongside these breakdown dimensions.
 
-    Models only the event-metric/session-dimension rule. Plausible also rejects session metrics
-    under an event dimension other than `event:page`, which no report here hits.
+    Plausible checks the page-breakdown exemption first and accepts the query outright, then applies
+    its two rules independently, so a breakdown that trips both loses both metric sets.
     """
-    if not any(d in SESSION_ONLY_DIMENSIONS for d in breakdown_dimensions):
+    event_dimensions = {d for d in breakdown_dimensions if d.startswith("event:")}
+    if "event:page" in event_dimensions and not (event_dimensions - EVENT_DIMENSIONS_ALLOWING_SESSION_METRICS):
         return list(metrics)
-    return [m for m in metrics if m not in EVENT_SCOPED_METRICS]
+
+    excluded: set[str] = set()
+    if event_dimensions:
+        excluded |= SESSION_SCOPED_METRICS
+    if any(d in SESSION_ONLY_DIMENSIONS for d in breakdown_dimensions):
+        excluded |= EVENT_SCOPED_METRICS
+    return [m for m in metrics if m not in excluded]
 
 
 def dimension_to_column(dimension: str) -> str:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/settings.py
@@ -13,17 +13,14 @@ DEFAULT_BACKFILL_DAYS = 365
 # endpoints because they aren't valid for the generic breakdowns.
 DEFAULT_METRICS = ["visitors", "visits", "pageviews", "bounce_rate", "visit_duration", "events"]
 
-# Plausible resolves each metric and dimension against either its events table or its sessions
-# table, and rejects a query that pairs an event-scoped metric with a session-only dimension
-# ("Event metric(s) ... cannot be queried along with session dimension(s) ...", HTTP 400).
-EVENT_SCOPED_METRICS = frozenset({"pageviews", "events"})
-
-# The only dimensions Plausible keeps solely on the sessions table. Every other `visit:*` dimension
-# is denormalized onto events, which is why they pair with the full metric set.
-SESSION_ONLY_DIMENSIONS = frozenset({"visit:entry_page", "visit:exit_page"})
-
-# The generic set minus the event-scoped metrics, for reports broken down by a session-only dimension.
-SESSION_SCOPED_METRICS = [m for m in DEFAULT_METRICS if m not in EVENT_SCOPED_METRICS]
+# Plausible resolves metrics and dimensions against either its events table or its sessions table,
+# and answers 400 when a query pairs an event-scoped metric with a session-only dimension. Both sets
+# mirror `metric_partitioner` and `dimension_partitioner` in Plausible's `TableDecider`; every other
+# `visit:*` dimension is denormalized onto events, so it pairs with metrics from either table.
+EVENT_SCOPED_METRICS = frozenset({"pageviews", "events", "scroll_depth", "time_on_page"})
+SESSION_ONLY_DIMENSIONS = frozenset(
+    {"visit:entry_page", "visit:entry_page_hostname", "visit:exit_page", "visit:exit_page_hostname"}
+)
 
 # The day bucket every report is grouped by — must be the first dimension so `order_by` can sort
 # on it and the pipeline can slide the date window incrementally.
@@ -37,6 +34,17 @@ _DATE_INCREMENTAL_FIELDS: list[IncrementalField] = [
         "field_type": IncrementalFieldType.Date,
     },
 ]
+
+
+def compatible_metrics(metrics: list[str], breakdown_dimensions: list[str]) -> list[str]:
+    """Drop the metrics Plausible refuses to return alongside these breakdown dimensions.
+
+    Models only the event-metric/session-dimension rule. Plausible also rejects session metrics
+    under an event dimension other than `event:page`, which no report here hits.
+    """
+    if not any(d in SESSION_ONLY_DIMENSIONS for d in breakdown_dimensions):
+        return list(metrics)
+    return [m for m in metrics if m not in EVENT_SCOPED_METRICS]
 
 
 def dimension_to_column(dimension: str) -> str:
@@ -58,6 +66,15 @@ class PlausibleEndpointConfig:
     breakdown_dimensions: list[str] = field(default_factory=list)
     metrics: list[str] = field(default_factory=lambda: list(DEFAULT_METRICS))
     should_sync_default: bool = True
+
+    def __post_init__(self) -> None:
+        # Derived rather than declared per report, because a forgotten exclusion 400s permanently and
+        # a permanent failure disables the schema until someone re-enables it by hand.
+        self.metrics = compatible_metrics(self.metrics, self.breakdown_dimensions)
+        if not self.metrics:
+            raise ValueError(
+                f"Plausible report '{self.name}' has no metrics compatible with {self.breakdown_dimensions}"
+            )
 
     @property
     def dimensions(self) -> list[str]:
@@ -88,17 +105,8 @@ PLAUSIBLE_ENDPOINTS: dict[str, PlausibleEndpointConfig] = {
     "utm_terms": PlausibleEndpointConfig(name="utm_terms", breakdown_dimensions=["visit:utm_term"]),
     "utm_contents": PlausibleEndpointConfig(name="utm_contents", breakdown_dimensions=["visit:utm_content"]),
     "pages": PlausibleEndpointConfig(name="pages", breakdown_dimensions=["event:page"]),
-    # Entry/exit pages break down by a session-only dimension, so they carry the reduced metric set.
-    "entry_pages": PlausibleEndpointConfig(
-        name="entry_pages",
-        breakdown_dimensions=["visit:entry_page"],
-        metrics=list(SESSION_SCOPED_METRICS),
-    ),
-    "exit_pages": PlausibleEndpointConfig(
-        name="exit_pages",
-        breakdown_dimensions=["visit:exit_page"],
-        metrics=list(SESSION_SCOPED_METRICS),
-    ),
+    "entry_pages": PlausibleEndpointConfig(name="entry_pages", breakdown_dimensions=["visit:entry_page"]),
+    "exit_pages": PlausibleEndpointConfig(name="exit_pages", breakdown_dimensions=["visit:exit_page"]),
     "countries": PlausibleEndpointConfig(name="countries", breakdown_dimensions=["visit:country"]),
     "regions": PlausibleEndpointConfig(name="regions", breakdown_dimensions=["visit:region"]),
     "cities": PlausibleEndpointConfig(name="cities", breakdown_dimensions=["visit:city"]),

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/source.py
@@ -54,10 +54,10 @@ class PlausibleSource(ResumableSource[PlausibleSourceConfig, PlausibleResumeConf
         return {
             "401 Client Error": "Your Plausible API key is invalid or has been revoked. Create a new key in your Plausible account settings, then reconnect.",
             "403 Client Error": "Your Plausible API key is missing the stats read scope needed to sync this data. Grant it in your Plausible account settings, then reconnect.",
-            # Plausible rejects the query as malformed for this site (a permanent 400 — auth and
-            # missing-site cases are 401/403/404 and handled above). Retrying resends the same
-            # request, so stop. Match the status text, not the self-hosted URL, which varies.
-            "400 Client Error": "Plausible rejected the request for this site. Check that the site domain is correct and that your Plausible account can access its stats, then reconnect.",
+            # A permanent 400: auth and missing-site cases are 401/403/404 and handled above, so
+            # retrying resends the same rejected query. Match the status text, not the self-hosted
+            # URL, which varies.
+            "400 Client Error": "Plausible rejected this request. Check that the site domain is correct and that your Plausible account can read its stats. If both look right, contact support so we can take a look.",
         }
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/tests/test_plausible.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/tests/test_plausible.py
@@ -19,11 +19,14 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.plausible.
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.plausible.settings import (
+    DEFAULT_METRICS,
     ENDPOINTS,
     EVENT_SCOPED_METRICS,
     PLAUSIBLE_ENDPOINTS,
     REPORT_LOOKBACK_DAYS,
     SESSION_ONLY_DIMENSIONS,
+    PlausibleEndpointConfig,
+    compatible_metrics,
 )
 
 _MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.plausible.plausible"
@@ -134,6 +137,20 @@ class TestNormalizeRow:
 
         assert row["date"] == "2024-01-01"
         assert "source" not in row
+
+    @pytest.mark.parametrize(
+        "dimensions, metrics",
+        [
+            (["2024-01-01"], [10, 12, 30, 0.5, 60]),
+            (["2024-01-01"], [10, 12, 30, 0.5, 60, 40, 99]),
+            ([], [10, 12, 30, 0.5, 60, 40]),
+        ],
+    )
+    def test_a_response_of_the_wrong_shape_raises_instead_of_dropping_columns(self, dimensions, metrics):
+        config = PLAUSIBLE_ENDPOINTS["timeseries"]
+
+        with pytest.raises(ValueError):
+            _normalize_row(config, _result(dimensions, metrics))
 
 
 class TestValidateCredentials:
@@ -283,6 +300,31 @@ class TestMetricDimensionScoping:
         assert not (conflicting_metrics and session_only_dimensions), (
             f"Plausible rejects {sorted(conflicting_metrics)} broken down by {sorted(session_only_dimensions)}"
         )
+
+    @pytest.mark.parametrize(
+        "breakdown_dimensions, expected",
+        [
+            ([], DEFAULT_METRICS),
+            (["visit:source"], DEFAULT_METRICS),
+            (["event:page"], DEFAULT_METRICS),
+            (["visit:entry_page"], ["visitors", "visits", "bounce_rate", "visit_duration"]),
+            (["visit:exit_page"], ["visitors", "visits", "bounce_rate", "visit_duration"]),
+            # No report breaks down by the hostname variants yet, so these cases are what prove the
+            # rule covers every session-only dimension rather than the two currently in use.
+            (["visit:entry_page_hostname"], ["visitors", "visits", "bounce_rate", "visit_duration"]),
+            (["visit:exit_page_hostname"], ["visitors", "visits", "bounce_rate", "visit_duration"]),
+        ],
+    )
+    def test_incompatible_metrics_are_dropped_per_breakdown(self, breakdown_dimensions, expected):
+        assert compatible_metrics(list(DEFAULT_METRICS), breakdown_dimensions) == expected
+
+    def test_a_report_left_with_no_metrics_is_rejected(self):
+        with pytest.raises(ValueError, match="no metrics compatible"):
+            PlausibleEndpointConfig(
+                name="entry_page_events",
+                breakdown_dimensions=["visit:entry_page"],
+                metrics=["pageviews", "events"],
+            )
 
     @pytest.mark.parametrize(
         "endpoint, dimension, column",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/tests/test_plausible.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/tests/test_plausible.py
@@ -20,8 +20,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.plausible.
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.plausible.settings import (
     ENDPOINTS,
+    EVENT_SCOPED_METRICS,
     PLAUSIBLE_ENDPOINTS,
     REPORT_LOOKBACK_DAYS,
+    SESSION_ONLY_DIMENSIONS,
 )
 
 _MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.plausible.plausible"
@@ -269,6 +271,52 @@ class TestGetRows:
 
         with pytest.raises(Exception, match="400"):
             _rows(_source(endpoint="timeseries"))
+
+
+class TestMetricDimensionScoping:
+    @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
+    def test_no_report_pairs_event_metrics_with_a_session_only_dimension(self, endpoint):
+        config = PLAUSIBLE_ENDPOINTS[endpoint]
+        conflicting_metrics = EVENT_SCOPED_METRICS.intersection(config.metrics)
+        session_only_dimensions = SESSION_ONLY_DIMENSIONS.intersection(config.dimensions)
+
+        assert not (conflicting_metrics and session_only_dimensions), (
+            f"Plausible rejects {sorted(conflicting_metrics)} broken down by {sorted(session_only_dimensions)}"
+        )
+
+    @pytest.mark.parametrize(
+        "endpoint, dimension, column",
+        [
+            ("entry_pages", "visit:entry_page", "entry_page"),
+            ("exit_pages", "visit:exit_page", "exit_page"),
+        ],
+    )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_page_reports_request_session_metrics_only(self, MockSession, endpoint, dimension, column):
+        session = MockSession.return_value
+        bodies = _wire(
+            session,
+            [
+                _response(
+                    {"results": [_result(["2024-01-01", "/pricing"], [10, 12, 0.5, 60])], "meta": {"total_rows": 1}}
+                )
+            ],
+        )
+
+        rows = _rows(_source(endpoint=endpoint))
+
+        assert bodies[0]["dimensions"] == ["time:day", dimension]
+        assert bodies[0]["metrics"] == ["visitors", "visits", "bounce_rate", "visit_duration"]
+        assert rows == [
+            {
+                "date": "2024-01-01",
+                column: "/pricing",
+                "visitors": 10,
+                "visits": 12,
+                "bounce_rate": 0.5,
+                "visit_duration": 60,
+            }
+        ]
 
 
 class TestPlausibleSourceResponse:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/tests/test_plausible.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/tests/test_plausible.py
@@ -8,6 +8,9 @@ from unittest import mock
 
 from requests import Response
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
+    RESTClientNonRetryableError,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.plausible import plausible as plausible_module
 from products.warehouse_sources.backend.temporal.data_imports.sources.plausible.plausible import (
     PlausibleResumeConfig,
@@ -21,10 +24,12 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.plausible.
 from products.warehouse_sources.backend.temporal.data_imports.sources.plausible.settings import (
     DEFAULT_METRICS,
     ENDPOINTS,
+    EVENT_DIMENSIONS_ALLOWING_SESSION_METRICS,
     EVENT_SCOPED_METRICS,
     PLAUSIBLE_ENDPOINTS,
     REPORT_LOOKBACK_DAYS,
     SESSION_ONLY_DIMENSIONS,
+    SESSION_SCOPED_METRICS,
     PlausibleEndpointConfig,
     compatible_metrics,
 )
@@ -149,7 +154,9 @@ class TestNormalizeRow:
     def test_a_response_of_the_wrong_shape_raises_instead_of_dropping_columns(self, dimensions, metrics):
         config = PLAUSIBLE_ENDPOINTS["timeseries"]
 
-        with pytest.raises(ValueError):
+        # Classified, so the import stops on the first attempt rather than replaying the same page
+        # for every resumable retry, and names the report so the failure is actionable.
+        with pytest.raises(RESTClientNonRetryableError, match="report 'timeseries'"):
             _normalize_row(config, _result(dimensions, metrics))
 
 
@@ -290,6 +297,12 @@ class TestGetRows:
             _rows(_source(endpoint="timeseries"))
 
 
+def _page_breakdown_is_exempt(dimensions: list[str]) -> bool:
+    """Plausible accepts a page breakdown outright, which clears both of its scope rules."""
+    event_dimensions = {d for d in dimensions if d.startswith("event:")}
+    return "event:page" in event_dimensions and not (event_dimensions - EVENT_DIMENSIONS_ALLOWING_SESSION_METRICS)
+
+
 class TestMetricDimensionScoping:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
     def test_no_report_pairs_event_metrics_with_a_session_only_dimension(self, endpoint):
@@ -297,8 +310,18 @@ class TestMetricDimensionScoping:
         conflicting_metrics = EVENT_SCOPED_METRICS.intersection(config.metrics)
         session_only_dimensions = SESSION_ONLY_DIMENSIONS.intersection(config.dimensions)
 
-        assert not (conflicting_metrics and session_only_dimensions), (
-            f"Plausible rejects {sorted(conflicting_metrics)} broken down by {sorted(session_only_dimensions)}"
+        assert not (
+            conflicting_metrics and session_only_dimensions and not _page_breakdown_is_exempt(config.dimensions)
+        ), f"Plausible rejects {sorted(conflicting_metrics)} broken down by {sorted(session_only_dimensions)}"
+
+    @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
+    def test_no_report_pairs_session_metrics_with_a_non_exempt_event_dimension(self, endpoint):
+        config = PLAUSIBLE_ENDPOINTS[endpoint]
+        conflicting_metrics = SESSION_SCOPED_METRICS.intersection(config.metrics)
+        event_dimensions = {d for d in config.dimensions if d.startswith("event:")}
+
+        assert not (conflicting_metrics and event_dimensions and not _page_breakdown_is_exempt(config.dimensions)), (
+            f"Plausible rejects {sorted(conflicting_metrics)} broken down by {sorted(event_dimensions)}"
         )
 
     @pytest.mark.parametrize(
@@ -306,13 +329,19 @@ class TestMetricDimensionScoping:
         [
             ([], DEFAULT_METRICS),
             (["visit:source"], DEFAULT_METRICS),
-            (["event:page"], DEFAULT_METRICS),
             (["visit:entry_page"], ["visitors", "visits", "bounce_rate", "visit_duration"]),
             (["visit:exit_page"], ["visitors", "visits", "bounce_rate", "visit_duration"]),
             # No report breaks down by the hostname variants yet, so these cases are what prove the
             # rule covers every session-only dimension rather than the two currently in use.
             (["visit:entry_page_hostname"], ["visitors", "visits", "bounce_rate", "visit_duration"]),
             (["visit:exit_page_hostname"], ["visitors", "visits", "bounce_rate", "visit_duration"]),
+            # Event dimensions lose the session metrics instead, except under the page exemption.
+            (["event:page"], DEFAULT_METRICS),
+            (["event:page", "event:hostname"], DEFAULT_METRICS),
+            (["event:goal"], ["visitors", "visits", "pageviews", "events"]),
+            (["event:hostname"], ["visitors", "visits", "pageviews", "events"]),
+            # Tripping both rules drops both sets rather than whichever is checked first.
+            (["visit:entry_page", "event:goal"], ["visitors", "visits"]),
         ],
     )
     def test_incompatible_metrics_are_dropped_per_breakdown(self, breakdown_dimensions, expected):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/tests/test_plausible_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/tests/test_plausible_source.py
@@ -155,3 +155,12 @@ class TestCanonicalDescriptions:
         for entry in descriptions.values():
             assert entry.get("description")
             assert "date" in entry.get("columns", {})
+
+    @pytest.mark.parametrize("endpoint", list(PLAUSIBLE_ENDPOINTS))
+    def test_columns_match_the_columns_the_report_actually_returns(self, endpoint):
+        # A report's columns are its dimensions plus the metrics it requests, so a description
+        # listing anything else advertises a column the synced table won't have.
+        config = PLAUSIBLE_ENDPOINTS[endpoint]
+        described = PlausibleSource().get_canonical_descriptions()[endpoint]["columns"]
+
+        assert set(described) == {*config.column_names, *config.metrics}


### PR DESCRIPTION
## Problem

- The `entry_pages` and `exit_pages` tables of a Plausible source never sync. They sit in `Failed` while every other table in the same source works.
- A retry fails the same way. The rejection is permanent, so the sync stops instead of backing off.
- Plausible rejects the query:

  ```text
  Event metric(s) `pageviews`, `events` cannot be queried along with session dimension(s) `visit:entry_page`
  ```

- We request `pageviews` and `events` on every report, and Plausible resolves both against its events table.
- Plausible resolves `visit:entry_page` and `visit:exit_page` against its sessions table instead. [`TableDecider`](https://github.com/plausible/analytics/blob/607f3c733fd068ed58fc7bed3385a47c755adb06/lib/plausible/stats/table_decider.ex#L169-L176) partitions every other `visit:*` dimension as `:either`, because Plausible denormalizes those onto events.

## Changes

- `entry_pages` and `exit_pages` now request `visitors`, `visits`, `bounce_rate` and `visit_duration`.
- `PlausibleEndpointConfig` derives the compatible metric set from the breakdown dimensions, instead of each report declaring it. A new session-only report cannot reintroduce the 400 by omitting a keyword argument.
- The derivation covers both directions of the rule. A breakdown by an event dimension other than `event:page` drops the session metrics instead.
- A report left with no compatible metrics raises at import rather than failing permanently at sync time.
- A response whose dimension or metric count does not match the report raises `RESTClientNonRetryableError`. `import_data_sync` routes that type as terminal, so the import stops instead of replaying the same pinned page for all 15 resumable attempts.
- The canonical descriptions drop the two columns they advertised for these tables.

> [!IMPORTANT]
> Affected connections do not resume on their own. The permanent 400 already set `should_sync=False` and paused the schedule for both tables, and nothing here re-enables them. Affected users need to switch `entry_pages` and `exit_pages` back on in the source's table list.

> [!NOTE]
> Both tables sync four metric columns rather than six. Plausible does not return `pageviews` or `events` per entry or exit page.

## How did you test this code?

I did not test against a live Plausible account. The diagnosis comes from Plausible's [`TableDecider`](https://github.com/plausible/analytics/blob/607f3c733fd068ed58fc7bed3385a47c755adb06/lib/plausible/stats/table_decider.ex#L169-L176) and [the cases its own suite asserts](https://github.com/plausible/analytics/blob/607f3c733fd068ed58fc7bed3385a47c755adb06/test/plausible/stats/table_decider_test.exs#L212-L233).

I reverted each change in turn and confirmed the tests fail without it. The regressions each group catches:

- `test_incompatible_metrics_are_dropped_per_breakdown` covers both rules and the page exemption. It catches a shrunken `SESSION_ONLY_DIMENSIONS`, and it covers the two hostname dimensions no report uses yet.
- The two invariant tests hold all 18 reports to the rule, so a report that reintroduces either conflict fails CI.
- `test_a_response_of_the_wrong_shape_raises_instead_of_dropping_columns` catches a downgrade to a bare `ValueError`, which no classifier matches.
- `test_columns_match_the_columns_the_report_actually_returns` catches a description that advertises a column the synced table will not have.

Not checked: whether any team already has one of these tables materialized with the old six-column set. That needs project data I cannot reach.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The source doc on posthog.com renders table descriptions from `canonical_descriptions.py`, which this PR updates.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, running as PostHog Code) diagnosed and wrote this. A support engineer directed the work after a user reported that these two tables would not sync.

- Skills invoked: `/qa-team`, `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.
- I found the cause by reading Plausible's source and test suite, not by reproducing against a live account. No existing test covered either report.
- The reviewers caught a real gap in my first attempt. I modelled only the event-metric direction, so an `event:name` report passed the whole suite while it would have 400ed on its first sync. `event:hostname` and `event:props:{key}` are both listed as planned tables in `COVERAGE_GAPS_APPENDIX.md`, so the second direction now matters.
- I declined a suggestion to drop `include.total_rows` from the paginator. It saves a count aggregation per page, but it also removes one of two independent stop conditions, and an earlier attempt at that change produced a worse failure mode.
- Public artifact: nothing in the diff, the comments, the commit messages, or this description carries material from the agent session. The constants and test data come from Plausible's public source.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
