### PR TITLE
fix(tasks): allow tasks without repositories

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/TaskRepositoryDialog.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskRepositoryDialog.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { TaskRepositoryDialog } from "./TaskRepositoryDialog";
+
+describe("TaskRepositoryDialog", () => {
+  it("applies an empty repository selection", async () => {
+    const user = userEvent.setup();
+    const onApply = vi.fn();
+
+    render(
+      <TaskRepositoryDialog
+        open
+        onOpenChange={vi.fn()}
+        cloud
+        repositories={["posthog/posthog"]}
+        integrationId={7}
+        folder=""
+        onApply={onApply}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Remove posthog/posthog" }),
+    );
+
+    const apply = screen.getByRole("button", { name: "Apply" });
+    expect(apply).not.toHaveAttribute("aria-disabled", "true");
+    await user.click(apply);
+
+    expect(onApply).toHaveBeenCalledWith({
+      repositories: [],
+      integrationId: null,
+      folder: "",
+      saveToSpace: false,
+    });
+  });
+});

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskRepositoryDialog.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskRepositoryDialog.tsx
@@ -152,7 +152,7 @@ export function TaskRepositoryDialog({
           </Button>
           <Button
             variant="primary"
-            disabled={cloud ? draftRepositories.length === 0 : !draftFolder}
+            disabled={!cloud && !draftFolder}
             onClick={() => {
               onApply({
                 repositories: draftRepositories,


### PR DESCRIPTION
## Problem

People cannot clear all repositories for a new cloud task because the repository dialog disables **Apply** after the final removal.

## Changes

- The repository dialog now permits an empty cloud repository selection.
- Local tasks still require a folder before the dialog enables **Apply**.
- No screenshot: the dialog appearance does not change.

## How did you test this code?

- Added a component test that removes the final repository and applies the empty selection.
- Ran the targeted Vitest test, the UI TypeScript check, and desktop Biome preflight.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change. This fix restores the existing option to create tasks without repositories.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code used pi with `gpt-5.6-sol` in task `7e9329c7-4d24-4afa-a790-0b19f097e48b`.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, and `/writing-simplified-technical-english`.
