### PR TITLE
fix(signals): honor base branch setting on the inbox Create PR button

### DIFF
--- a/products/signals/backend/auto_start.py
+++ b/products/signals/backend/auto_start.py
@@ -689,9 +689,7 @@ async def maybe_autostart_implementation_task(
         )
         return
 
-    base_branch = None
-    if repository and team_config:
-        base_branch = (team_config.autostart_base_branches or {}).get(repository.lower())
+    base_branch = team_config.base_branch_for(repository) if team_config else None
 
     source_references = await database_sync_to_async(_fetch_source_references, thread_sensitive=False)(
         team_id, report_id

--- a/products/signals/backend/facade/api.py
+++ b/products/signals/backend/facade/api.py
@@ -152,6 +152,19 @@ def persisted_repo_selection(report_id: str) -> "RepoSelectionResult | None":
     return persisted_repo_selection_impl(report_id)
 
 
+def autostart_base_branch_for_repository(team_id: int, repository: str | None) -> str | None:
+    """Team's configured base branch for ``repository``, for callers outside the signals product."""
+    if not repository:
+        return None
+
+    from products.signals.backend.models import (
+        SignalTeamConfig,  # noqa: PLC0415 — avoids importing model layer at facade import time
+    )
+
+    config = SignalTeamConfig.objects.filter(team_id=team_id).only("autostart_base_branches").first()
+    return config.base_branch_for(repository) if config is not None else None
+
+
 def get_default_slack_notification_channel(team_id: int) -> str | None:
     """Team-default Slack channel for signal notifications, stored as "<channel_id>|#name"."""
     from products.signals.backend.models import (

--- a/products/signals/backend/models.py
+++ b/products/signals/backend/models.py
@@ -148,6 +148,17 @@ class SignalTeamConfig(UUIDModel):
         verbose_name = "Signal team config"
         verbose_name_plural = "Signal team configs"
 
+    def base_branch_for(self, repository: str | None) -> str | None:
+        """Configured base branch for ``repository`` ("organization/repository"), if any.
+
+        Keys are stored lowercased by the serializer, so the lookup lowercases to match.
+        Every path that opens a self-driving pull request resolves through here, so that
+        auto-start and the inbox "Create PR" button cannot disagree on the branch.
+        """
+        if not repository or not isinstance(self.autostart_base_branches, dict):
+            return None
+        return self.autostart_base_branches.get(repository.lower()) or None
+
 
 register_team_extension_signal(SignalTeamConfig, logger=logger)
 

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -5203,6 +5203,19 @@ def run_task(
     pending_user_artifact_ids = validated_data.get("pending_user_artifact_ids") or []
     is_pi_task = task.runtime == Task.Runtime.PI
 
+    if branch is None and not resume_from_run_id and task.origin_product == Task.OriginProduct.SIGNAL_REPORT:
+        # The inbox "Create PR" button sends no branch, so without this the run would target the
+        # repository's GitHub default branch. Auto-start resolves the same setting when it builds
+        # its task. This sits before the warm-run reuse check below, so that a sandbox idling on
+        # the default branch is not reused for a run that needs the configured branch.
+        from products.signals.backend.facade.api import (  # noqa: PLC0415 — cross-product read kept off the api import path
+            autostart_base_branch_for_repository,
+        )
+
+        branch = autostart_base_branch_for_repository(
+            team_id, task.repositories[0] if task.repositories else task.repository
+        )
+
     if not resume_from_run_id:
         warm_run = _idling_warm_run_for_task(task)
         if warm_run is not None and (branch or None) == (warm_run.branch or None):

--- a/products/tasks/backend/tests/test_facade.py
+++ b/products/tasks/backend/tests/test_facade.py
@@ -13,6 +13,7 @@ from parameterized import parameterized
 from posthog.models import Integration, Organization, Team
 from posthog.models.user import User
 
+from products.signals.backend.models import SignalTeamConfig
 from products.tasks.backend.facade import (
     api as facade,
     contracts,
@@ -466,6 +467,57 @@ class TestFacadeReadsAndMappers(TestCase):
         assert result is not None and result.error is None
         new_run = task.runs.exclude(id=previous_run.id).get()
         self.assertEqual(new_run.state.get("self_driving_head_branch"), "posthog-self-driving/fix-abc123")
+
+    @parameterized.expand(
+        [
+            # The inbox "Create PR" button sends no branch, so the team's configured base branch is
+            # the only thing that can keep the PR off the repo's GitHub default branch. Repo casing
+            # differs from the stored key because GitHub preserves it while the serializer lowercases.
+            ("configured_branch_applied", {"acme/web": "dev"}, {}, "dev"),
+            # A caller that picked a branch already decided; re-resolving would discard that choice.
+            ("explicit_branch_wins", {"acme/web": "dev"}, {"branch": "hotfix"}, "hotfix"),
+            # Another repo's entry must never be borrowed, because that lands the PR on a
+            # branch belonging to a different repository.
+            ("other_repo_not_borrowed", {"acme/api": "staging"}, {}, None),
+        ]
+    )
+    def test_run_task_applies_configured_base_branch(
+        self, _name: str, overrides: dict, extra_validated_data: dict, expected_branch: str | None
+    ):
+        SignalTeamConfig.objects.update_or_create(team=self.team, defaults={"autostart_base_branches": overrides})
+        task = self._make_task(repository="Acme/Web", origin_product=Task.OriginProduct.SIGNAL_REPORT)
+
+        with patch("products.tasks.backend.facade.api._trigger_task_processing_workflow"):
+            result = facade.run_task(
+                task.id,
+                self.team.id,
+                self.user.id,
+                validated_data={"mode": "interactive", "run_source": "signal_report", **extra_validated_data},
+            )
+
+        assert result is not None and result.error is None
+        run = task.runs.get()
+        self.assertEqual(run.branch, expected_branch)
+        self.assertEqual((run.state or {}).get("pr_base_branch"), expected_branch)
+
+    def test_run_task_leaves_branch_unset_for_user_created_tasks(self):
+        # The override is scoped to self-driving tasks. A user-created task keeps targeting the repo
+        # default, so broadening the resolution would silently redirect unrelated task runs.
+        SignalTeamConfig.objects.update_or_create(
+            team=self.team, defaults={"autostart_base_branches": {"acme/web": "dev"}}
+        )
+        task = self._make_task(repository="Acme/Web", origin_product=Task.OriginProduct.USER_CREATED)
+
+        with patch("products.tasks.backend.facade.api._trigger_task_processing_workflow"):
+            result = facade.run_task(
+                task.id,
+                self.team.id,
+                self.user.id,
+                validated_data={"mode": "interactive", "run_source": "signal_report"},
+            )
+
+        assert result is not None and result.error is None
+        self.assertIsNone(task.runs.get().branch)
 
     def test_stale_queued_created_at_hard_cap(self):
         task = self._make_task()


### PR DESCRIPTION
## Problem

Self-driving opens a pull request against the wrong branch when someone uses the "Create PR" button on an inbox report. The team configured a base branch for that repository, and the pull request targets the repository's GitHub default branch instead.

- Self-driving opens implementation pull requests two ways. Auto-start reads the team's base branch setting. The inbox button does not.
- The button's kickoff request carries the report link and the prompt, and no branch.
- The run stores no branch, so the sandbox clones the repository at its own default branch and the pull request targets that.
- The setting reached the web app in #73967, so a team can configure a value that applies to some of its pull requests and not others.
- The failure is silent and it writes to the team's repository. The settings page shows the branch configured, and only GitHub shows where the pull request went.

This affects any team that configured the setting and then used the button instead of waiting for auto-start.

## Changes

- The inbox "Create PR" button now opens its pull request against the team's configured base branch.
- `run_task` resolves the branch when the caller sends none, the run is not a resume, and the task came from a signal report.
- The resolution sits before the warm-run reuse check, so a sandbox idling on the default branch cannot serve a run that needs the configured branch.
- An explicit branch from the caller still wins, so the desktop app and resumed runs keep their own value.
- Auto-start and the button now share `SignalTeamConfig.base_branch_for`, replacing two copies of the same lookup.

Why the backend resolves this rather than the frontend:

- The frontend cannot resolve the branch, because it omits the repository on purpose and the backend picks it for report-linked tasks.
- No `Task` field holds a branch, so the run is the only place the value can land.

> [!NOTE]
> A configured branch that does not exist in the repository now fails at sandbox checkout. Before this change the run silently used the default branch. Auto-start already behaves this way, and #73967 added branch pickers that keep the configured value valid.

## How did you test this code?

Not manually tested. This sandbox has no GitHub integration, so no run opened a real pull request. A click-through against a connected repository is worth doing before merge. I also did not exercise the Temporal sandbox path end to end.

Four cases added to `products/tasks/backend/tests/test_facade.py`. No existing test covered the manual kickoff path.

- **The configured branch reaches the run.** Reverting the fix fails this case with `None != 'dev'`, which is the reported symptom.
- **An explicit branch is not overwritten.** The desktop app sends its own branch on a signal-report run, so re-resolving would discard the caller's choice.
- **Another repository's entry is not borrowed.** Guards the map lookup against targeting a branch that belongs to a different repository.
- **A user-created task is never redirected.** Bounds the setting to self-driving, so unrelated task runs keep the default branch.

Only the first case fails when the fix is reverted. The other three hold either way and bound the scope.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None needed. No doc describes the scope of this setting.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Christiaan asked me (Claude, via PostHog Code) to check whether the inbox "Create PR" button honors the self-driving branch setting, after a support ticket reported pull requests landing on the wrong branch. Tracing the three kickoff paths showed auto-start and the desktop app both read the setting, and the web inbox reads nothing.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

- **Scoped to `origin_product == SIGNAL_REPORT` rather than the run source.** This also covers a re-run of an inbox task, and leaves tasks created in the Tasks product alone.
- **Deduplicated the lookup instead of adding a second copy.** [#79221](https://github.com/PostHog/posthog/pull/79221) adds `pr_open_settings` and wires it into `auto_start.py` only, so the same divergence is set to recur with a second setting. That one is worth wiring through the manual path before it merges.
- **Left instrumentation out.** The `create_pr` capture never records the resolved branch, which is why this surfaced as a support ticket rather than in data. It belongs in its own change.

Public artifact: this work started from a support conversation. No customer name, repository, project, or ticket content appears in the diff or this description. The test fixtures use invented values (`acme/web`, `dev`, `staging`).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
