### PR TITLE
feat(data-warehouse): report file-upload outcomes so the catalog funnel isn't blind

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/fileUploadSource.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/fileUploadSource.ts
@@ -29,6 +29,17 @@ export const FILE_UPLOAD_FORMATS: { format: FileUploadFormat; label: string; key
     { format: 'parquet', label: 'Parquet file', keywords: ['parquet', 'pqt', 'columnar', 'upload'] },
 ]
 
+/**
+ * Identifier for one format's catalog tile, e.g. `FileUpload-csv`.
+ *
+ * The catalog tile and the analytics events both key off this, so a pick and the table it produced
+ * join on one value. There is no external data source row to join against instead — an upload
+ * becomes a self-managed table — so this string is the only link between the two halves.
+ */
+export function fileUploadSourceType(format: FileUploadFormat): string {
+    return `${FILE_UPLOAD_SOURCE_NAME}-${format}`
+}
+
 export function fileUploadSourceUrl(format: FileUploadFormat): string {
     const url = urls.dataWarehouseSourceNew(FILE_UPLOAD_SOURCE_NAME)
     return `${url}${url.includes('?') ? '&' : '?'}format=${format}`

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/fileUploadSourceLogic.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/fileUploadSourceLogic.tsx
@@ -2,6 +2,7 @@ import { MakeLogicType, actions, connect, kea, listeners, path, reducers } from 
 import { forms } from 'kea-forms'
 import type { DeepPartial, DeepPartialMap, FieldName, ValidationErrorType } from 'kea-forms'
 import { router, urlToAction } from 'kea-router'
+import posthog from 'posthog-js'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
@@ -9,7 +10,7 @@ import api from 'lib/api'
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
 import { urls } from 'scenes/urls'
 
-import { FileUploadFormat } from './fileUploadSource'
+import { FileUploadFormat, fileUploadSourceType } from './fileUploadSource'
 
 // Mirrors MAX_FILE_UPLOAD_SIZE_BYTES on the backend. Checked here too so an oversized file fails
 // instantly instead of after uploading 50MB+ only to be rejected.
@@ -39,6 +40,20 @@ const EXTENSION_FORMATS: Record<string, FileUploadFormat> = {
 }
 
 const SPREADSHEET_EXTENSIONS = new Set(['xlsx', 'xls', 'xlsm', 'xlsb', 'ods', 'numbers'])
+
+/** Which step of the two-request upload failed. */
+type FileUploadStage = 'upload' | 'create_table'
+
+function captureFileUploadFailed(format: FileUploadFormat, stage: FileUploadStage, error: any): void {
+    posthog.capture('warehouse file upload failed', {
+        sourceType: fileUploadSourceType(format),
+        stage,
+        status: error?.status ?? null,
+        // Every message this endpoint returns is a fixed server-authored string, so it names the
+        // reason without carrying the filename or anything read out of the file.
+        error: error?.data?.message ?? error?.message ?? 'unknown',
+    })
+}
 
 function fileExtension(filename: string): string {
     const match = /\.([^.]+)$/.exec(filename.toLowerCase())
@@ -234,6 +249,7 @@ export const fileUploadSourceLogic = kea<fileUploadSourceLogicType>([
                 try {
                     upload = await api.dataWarehouseTables.uploadFile(formData)
                 } catch (e: any) {
+                    captureFileUploadFailed(file_format, 'upload', e)
                     lemonToast.error(e.data?.message ?? e.message ?? 'Could not upload the file.')
                     return
                 }
@@ -246,10 +262,12 @@ export const fileUploadSourceLogic = kea<fileUploadSourceLogicType>([
                         table_name,
                     })
                 } catch (e: any) {
+                    captureFileUploadFailed(file_format, 'create_table', e)
                     lemonToast.error(e.data?.message ?? e.message ?? 'Could not create the table.')
                     return
                 }
 
+                posthog.capture('source created', { sourceType: fileUploadSourceType(file_format) })
                 lemonToast.success(`Table ${table_name} created`)
                 actions.loadDatabase()
                 router.actions.replace(urls.sources())

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceCatalogLogic.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceCatalogLogic.ts
@@ -27,6 +27,7 @@ import {
     FILE_UPLOAD_FORMATS,
     FILE_UPLOAD_SOURCE_CONFIG,
     FILE_UPLOAD_SOURCE_NAME,
+    fileUploadSourceType,
     fileUploadSourceUrl,
 } from './fileUploadSource'
 import { sourceWizardLogic } from './sourceWizardLogic'
@@ -1577,7 +1578,7 @@ export const sourceCatalogLogic = kea<sourceCatalogLogicType>([
                 // three tiles, one per format, since users search for "CSV" rather than "File upload".
                 const fileUpload = FILE_UPLOAD_FORMATS.map(
                     ({ format, label, keywords }): CatalogItem => ({
-                        name: `${FILE_UPLOAD_SOURCE_NAME}-${format}`,
+                        name: fileUploadSourceType(format),
                         label,
                         iconType: FILE_UPLOAD_SOURCE_NAME,
                         category: MANUAL_SOURCE_CATEGORY,


### PR DESCRIPTION
## Problem

Everyone who uploads a CSV, JSON, or Parquet file counts as a user who gave up. The path works, and none of its volume reaches any new-source figure.

- Picking one of the three file tiles fires `selected source type`, the same as every other connector.
- The upload that follows fires nothing at all, in either the success or the failure path.
- An uploaded file becomes a self-managed table, not an external data source row, so counting source rows misses it too.
- The self-managed bucket-link path beside it already captures `source created` with `sourceType: 'Manual'`, so this is an inconsistency rather than a deliberate omission.

The measured effect is large enough to distort the catalog conversion rate. File tiles were about 18 of the roughly 190 weekly alpha-connector picks in early August, all recorded as failures.

## Changes

- Capture `source created` with `sourceType: 'FileUpload-csv'` (or `-json`, `-parquet`) once the table exists.
- Capture `warehouse file upload failed` when either request fails, tagged with `stage` so a rejected upload reads differently from a rejected table creation.
- Move the tile identifier into `fileUploadSourceType(format)` and call it from both the catalog and the events. The pick and the outcome now join on one string, and there is no source row to fall back on if they drift.

The failure event carries the server's message. Every message this endpoint returns is a fixed server-authored string, so it names the reason without carrying the filename or anything read out of the file.

No visual change. Nothing in the upload form or the catalog renders differently.

> [!NOTE]
> `source created` now fires for something that creates no `ExternalDataSource` row. That already happens for `sourceType: 'Manual'`, so any query joining this event to the source table already tolerates it, but a new breakdown by `sourceType` will show the three `FileUpload-*` values for the first time.

## How did you test this code?

Automated only. I did not upload a file through the browser.

- No new tests. The change fires two analytics events and extracts a string helper; a test asserting `posthog.capture` was called would pin the call rather than any behavior, and the helper is a one-line concatenation.
- Ran the existing `sourceCatalogLogic` suite, which covers the tile identifier the helper now produces.
- Not checked: that the events arrive with the expected shape in a real project. That needs a browser upload against a live backend.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude Opus 5) found this while investigating why new data warehouse sources fell in early August. Catalog conversion for alpha connectors looked like it had regressed; a good part of the apparent drop was these tiles, which cannot convert by construction.

I considered a separate event name for the upload path and rejected it. The funnel question is "did the pick produce a warehouse table", and `source created` already answers that for the self-managed path, so a second name would need every consumer to know about both.

Skills invoked: `/writing-tests` (which is why this PR adds none), `/writing-pr-descriptions` for this body.
