### PR TITLE
feat(desktop): add Slack DM settings for code comments

### DIFF
--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -1739,6 +1739,74 @@ export class PostHogAPIClient {
     }
   }
 
+  /** The user's linked Slack identities. Empty until they run the Sign-in-with-Slack flow. */
+  async listSlackUserIntegrations(): Promise<
+    {
+      slack_user_id: string;
+      slack_team_id: string;
+      slack_team_name: string | null;
+    }[]
+  > {
+    const urlPath = `/api/users/@me/integrations/`;
+    const url = new URL(`${this.api.baseUrl}${urlPath}`);
+    url.searchParams.set("kind", "slack");
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url,
+      path: urlPath,
+    });
+    if (!response.ok) {
+      return [];
+    }
+    const data = (await response.json()) as {
+      results?: {
+        slack_user_id: string;
+        slack_team_id: string;
+        slack_team_name: string | null;
+      }[];
+    };
+    return data.results ?? [];
+  }
+
+  /**
+   * `POST .../integrations/slack/start`. Returns the Sign-in-with-Slack URL; Slack tells the
+   * callback which user authorized, so nobody types a Slack ID.
+   */
+  async startSlackUserIntegrationConnect(
+    teamId?: number,
+  ): Promise<{ install_url: string }> {
+    const id = teamId ?? (await this.getTeamId());
+    const urlPath = `/api/users/@me/integrations/slack/start/`;
+    const url = new URL(`${this.api.baseUrl}${urlPath}`);
+    const response = await this.api.fetcher.fetch({
+      method: "post",
+      url,
+      path: urlPath,
+      overrides: { body: JSON.stringify({ team_id: id }) },
+    });
+    if (!response.ok) {
+      const err = (await response.json().catch(() => ({}))) as {
+        detail?: unknown;
+      };
+      throw new Error(
+        typeof err.detail === "string"
+          ? err.detail
+          : `Failed to start Slack connect: ${response.statusText}`,
+      );
+    }
+    return (await response.json()) as { install_url: string };
+  }
+
+  /** Patch the user's server-side notification settings. Merged server-side, so pass only the keys you change. */
+  async updateNotificationSettings(
+    settings: Record<string, unknown>,
+  ): Promise<void> {
+    await this.api.patch("/api/users/{uuid}/", {
+      path: { uuid: "@me" },
+      body: { notification_settings: settings } as Record<string, unknown>,
+    });
+  }
+
   async switchOrganization(orgId: string): Promise<void> {
     await this.api.patch("/api/users/{uuid}/", {
       path: { uuid: "@me" },

--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -1756,7 +1756,9 @@ export class PostHogAPIClient {
       path: urlPath,
     });
     if (!response.ok) {
-      return [];
+      throw new Error(
+        `Failed to list Slack integrations: ${response.statusText}`,
+      );
     }
     const data = (await response.json()) as {
       results?: {

--- a/products/desktop/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
@@ -15,6 +15,7 @@ import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFla
 import { NotificationBus } from "@posthog/ui/features/notifications/notifications";
 import { SettingRow } from "@posthog/ui/features/settings/SettingRow";
 import { AddCustomSoundDialog } from "@posthog/ui/features/settings/sections/AddCustomSoundDialog";
+import { SlackCommentNotificationsSettings } from "@posthog/ui/features/settings/sections/SlackCommentNotificationsSettings";
 import {
   type CompletionSound,
   type CustomSound,
@@ -385,6 +386,8 @@ export function NotificationsSettings() {
       )}
 
       {spokenNarrationEnabled && <SpokenNotificationsSection />}
+
+      <SlackCommentNotificationsSettings />
 
       <NotificationTestHarness
         bus={bus}

--- a/products/desktop/packages/ui/src/features/settings/sections/SlackCommentNotificationsSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/SlackCommentNotificationsSettings.tsx
@@ -33,6 +33,10 @@ export function SlackCommentNotificationsSettings() {
       onSuccess: () => {
         void queryClient.invalidateQueries({ queryKey: ["me"] });
       },
+      onError: (error) =>
+        toast.error("Couldn't update Slack notifications", {
+          description: error.message,
+        }),
     },
   );
 
@@ -48,6 +52,11 @@ export function SlackCommentNotificationsSettings() {
       openExternalUrl(install_url);
     },
     {
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey: ["slack-user-integrations"],
+        });
+      },
       // The endpoint refuses when the project has no Slack app connected, or when the org is
       // outside the rollout. Without this the button does nothing, which reads as a broken build.
       onError: (error) =>

--- a/products/desktop/packages/ui/src/features/settings/sections/SlackCommentNotificationsSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/SlackCommentNotificationsSettings.tsx
@@ -2,6 +2,7 @@ import { useMeQuery } from "@posthog/ui/features/auth/useMeQuery";
 import { SettingRow } from "@posthog/ui/features/settings/SettingRow";
 import { useAuthenticatedMutation } from "@posthog/ui/hooks/useAuthenticatedMutation";
 import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
+import { toast } from "@posthog/ui/primitives/toast";
 import { openExternalUrl } from "@posthog/ui/shell/openExternal";
 import { Button, Flex, Switch, Text } from "@radix-ui/themes";
 import { useQueryClient } from "@tanstack/react-query";
@@ -41,10 +42,20 @@ export function SlackCommentNotificationsSettings() {
     void,
     Error,
     void
-  >(async (client) => {
-    const { install_url } = await client.startSlackUserIntegrationConnect();
-    openExternalUrl(install_url);
-  });
+  >(
+    async (client) => {
+      const { install_url } = await client.startSlackUserIntegrationConnect();
+      openExternalUrl(install_url);
+    },
+    {
+      // The endpoint refuses when the project has no Slack app connected, or when the org is
+      // outside the rollout. Without this the button does nothing, which reads as a broken build.
+      onError: (error) =>
+        toast.error("Couldn't start Slack linking", {
+          description: error.message,
+        }),
+    },
+  );
 
   return (
     <>
@@ -60,13 +71,13 @@ export function SlackCommentNotificationsSettings() {
         label="Slack account"
         description={
           linked
-            ? `Connected to ${links?.[0]?.slack_team_name ?? "Slack"}`
-            : "Connect your Slack account so we know who to message"
+            ? `Linked to ${links?.[0]?.slack_team_name ?? "Slack"}`
+            : "Only needed when your Slack email differs from your PostHog email. Otherwise we find you by email."
         }
       >
         {linked ? (
           <Text color="gray" className="text-[13px]">
-            Connected
+            Linked
           </Text>
         ) : (
           <Button
@@ -74,7 +85,7 @@ export function SlackCommentNotificationsSettings() {
             disabled={connecting || linksLoading}
             onClick={() => connect()}
           >
-            {connecting ? "Opening Slack…" : "Connect Slack"}
+            {connecting ? "Opening Slack…" : "Link Slack account"}
           </Button>
         )}
       </SettingRow>
@@ -85,10 +96,12 @@ export function SlackCommentNotificationsSettings() {
         noBorder
       >
         <Flex align="center" gap="2">
+          {/* Deliberately not gated on a link: an unlinked recipient is matched to Slack by
+              email, so gating here would hide a path that works. */}
           <Switch
             checked={enabled}
             onCheckedChange={(next) => mutate(next)}
-            disabled={isLoading || isPending || !linked}
+            disabled={isLoading || isPending}
             size="1"
           />
         </Flex>

--- a/products/desktop/packages/ui/src/features/settings/sections/SlackCommentNotificationsSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/SlackCommentNotificationsSettings.tsx
@@ -1,0 +1,98 @@
+import { useMeQuery } from "@posthog/ui/features/auth/useMeQuery";
+import { SettingRow } from "@posthog/ui/features/settings/SettingRow";
+import { useAuthenticatedMutation } from "@posthog/ui/hooks/useAuthenticatedMutation";
+import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
+import { openExternalUrl } from "@posthog/ui/shell/openExternal";
+import { Button, Flex, Switch, Text } from "@radix-ui/themes";
+import { useQueryClient } from "@tanstack/react-query";
+
+// Server-side, unlike the toggles above it: the DM is sent by a worker, so the preference has to
+// be readable when this app is closed.
+const SETTING_KEY = "code_comments_slack_dm";
+
+export function SlackCommentNotificationsSettings() {
+  const queryClient = useQueryClient();
+  const { data: me, isLoading } = useMeQuery();
+  const { data: links, isLoading: linksLoading } = useAuthenticatedQuery(
+    ["slack-user-integrations"],
+    async (client) => await client.listSlackUserIntegrations(),
+  );
+
+  const enabled = Boolean(
+    (me?.notification_settings as Record<string, unknown> | undefined)?.[
+      SETTING_KEY
+    ],
+  );
+  const linked = (links?.length ?? 0) > 0;
+
+  const { mutate, isPending } = useAuthenticatedMutation<void, Error, boolean>(
+    async (client, next) =>
+      await client.updateNotificationSettings({ [SETTING_KEY]: next }),
+    {
+      onSuccess: () => {
+        void queryClient.invalidateQueries({ queryKey: ["me"] });
+      },
+    },
+  );
+
+  // Slack's OAuth callback tells us which Slack user authorized, so the link is established
+  // without anyone entering an ID.
+  const { mutate: connect, isPending: connecting } = useAuthenticatedMutation<
+    void,
+    Error,
+    void
+  >(async (client) => {
+    const { install_url } = await client.startSlackUserIntegrationConnect();
+    openExternalUrl(install_url);
+  });
+
+  return (
+    <>
+      <Text className="mt-4 mb-1 block border-gray-6 border-t pt-4 font-medium text-sm">
+        Slack
+      </Text>
+      <Text color="gray" className="mb-1 text-[13px]">
+        Comment notifications can also reach you in Slack, so you hear about
+        them when PostHog Code isn't open.
+      </Text>
+
+      <SettingRow
+        label="Slack account"
+        description={
+          linked
+            ? `Connected to ${links?.[0]?.slack_team_name ?? "Slack"}`
+            : "Connect your Slack account so we know who to message"
+        }
+      >
+        {linked ? (
+          <Text color="gray" className="text-[13px]">
+            Connected
+          </Text>
+        ) : (
+          <Button
+            size="1"
+            disabled={connecting || linksLoading}
+            onClick={() => connect()}
+          >
+            {connecting ? "Opening Slack…" : "Connect Slack"}
+          </Button>
+        )}
+      </SettingRow>
+
+      <SettingRow
+        label="Slack DMs for comments"
+        description="Get a direct message when someone mentions you, replies to your comment, or comments on something you own"
+        noBorder
+      >
+        <Flex align="center" gap="2">
+          <Switch
+            checked={enabled}
+            onCheckedChange={(next) => mutate(next)}
+            disabled={isLoading || isPending || !linked}
+            size="1"
+          />
+        </Flex>
+      </SettingRow>
+    </>
+  );
+}


### PR DESCRIPTION
## Problem

- A PostHog Code user who wants comment mentions in Slack has no way to turn them on from the app.
- The backend sends the DMs already, but the only switch lives in the web app's user settings, and the Slack account link lives on a different web page again.
- Settings > Notifications is where someone looks for this: it already holds push notifications, dock badge, and in-app toasts.

## Changes

- Settings > Notifications gains a Slack section with two rows: the account link and a DM toggle.
- The Connect button starts the existing Sign-in-with-Slack flow in the browser. Slack's callback reports which user authorized, so nobody types or guesses a Slack user ID.
- The toggle stays disabled until an account is linked, so it cannot be on while nothing can be delivered.
- The toggle writes a **server-side** user setting, unlike every other row on that page. A worker sends the DM, so the preference has to be readable when the app is closed. `SignalUserAutonomyConfig` set the precedent for per-user Slack delivery preferences edited from these settings.

Stacked on [#80302](https://github.com/PostHog/posthog/pull/80302), which adds the setting key and the delivery path. Split because a PR cannot touch both `products/desktop/**` and backend paths — desktop auto-updates on its own schedule, so this client must not ship before that backend is deployed.

## How did you test this code?

Ran locally against a real Slack workspace, driving the full path: toggle on in Settings > Notifications, comment from a second account mentioning the first, DM delivered.

Automated: `pnpm turbo typecheck --filter @posthog/ui` and biome. No new unit tests — the component is a settings row over an existing query and mutation, and a test of it would assert the wiring rather than a regression.

Not tested: the Connect button against a deployed environment. Locally, Slack requires https for OIDC redirect URLs, so the flow was exercised by writing the same `UserIntegration` row the callback writes.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code. Skills invoked: `/writing-pr-descriptions`, `/writing-user-facing-copy`.

Started life inside #80302 and moved out when the `Desktop backend coupling` check failed. The Connect button was added after local testing showed the toggle pointed at a flow that only existed in the web app, which left a desktop user with nothing to click.
