### PR TITLE
fix(tasks): bind PRs from signed commit branches

### DIFF
--- a/products/desktop/packages/agent/src/adapters/local-tools/tools/signed-commit.test.ts
+++ b/products/desktop/packages/agent/src/adapters/local-tools/tools/signed-commit.test.ts
@@ -113,6 +113,7 @@ describe("signed-commit tool handler", () => {
     expect(reportTaskRunBranch).toHaveBeenCalledWith({
       taskId: "task-1",
       taskRunId: "run-1",
+      repository: "x/y",
       branch: "posthog-code/feature",
       updateCheckoutBranch: true,
     });
@@ -132,6 +133,7 @@ describe("signed-commit tool handler", () => {
     expect(reportTaskRunBranch).toHaveBeenCalledWith({
       taskId: "task-1",
       taskRunId: "run-1",
+      repository: "x/y",
       branch: "posthog-code/feature",
       updateCheckoutBranch: true,
     });
@@ -154,6 +156,7 @@ describe("signed-commit tool handler", () => {
     expect(reportTaskRunBranch).toHaveBeenCalledWith({
       taskId: "task-1",
       taskRunId: "run-1",
+      repository: "x/y",
       branch: "posthog-code/feature",
       updateCheckoutBranch: false,
     });

--- a/products/desktop/packages/agent/src/adapters/local-tools/tools/signed-commit.test.ts
+++ b/products/desktop/packages/agent/src/adapters/local-tools/tools/signed-commit.test.ts
@@ -114,6 +114,7 @@ describe("signed-commit tool handler", () => {
       taskId: "task-1",
       taskRunId: "run-1",
       branch: "posthog-code/feature",
+      updateCheckoutBranch: true,
     });
   });
 
@@ -132,10 +133,11 @@ describe("signed-commit tool handler", () => {
       taskId: "task-1",
       taskRunId: "run-1",
       branch: "posthog-code/feature",
+      updateCheckoutBranch: true,
     });
   });
 
-  it("does not persist a branch created in a sibling repository", async () => {
+  it("reports a sibling repository branch without changing the checkout branch", async () => {
     await signedCommitTool.handler(
       {
         cwd: "/tmp/workspace/repos/posthog/code",
@@ -149,7 +151,12 @@ describe("signed-commit tool handler", () => {
       },
     );
 
-    expect(reportTaskRunBranch).not.toHaveBeenCalled();
+    expect(reportTaskRunBranch).toHaveBeenCalledWith({
+      taskId: "task-1",
+      taskRunId: "run-1",
+      branch: "posthog-code/feature",
+      updateCheckoutBranch: false,
+    });
   });
 
   it("returns the no-token error without invoking createSignedCommit", async () => {

--- a/products/desktop/packages/agent/src/adapters/signed-commit-shared.ts
+++ b/products/desktop/packages/agent/src/adapters/signed-commit-shared.ts
@@ -184,13 +184,15 @@ export function runSignedCommitTool(
       // repository on resume. A task can also commit to sibling repositories by
       // passing `cwd`; persisting one of those branches here makes the next run
       // try to clone the task repository at a branch that only exists elsewhere.
-      if (ctx.cwd === ctx.taskRepositoryCwd) {
-        await reportTaskRunBranch({
-          taskId: ctx.taskId,
-          taskRunId: ctx.taskRunId,
-          branch: result.branch,
-        });
-      }
+      await reportTaskRunBranch({
+        taskId: ctx.taskId,
+        taskRunId: ctx.taskRunId,
+        branch: result.branch,
+        // Only the task repository branch controls the next checkout. The
+        // reported head branch still lets PR webhooks bind commits made from a
+        // workspace root or a sibling repository to this run.
+        updateCheckoutBranch: ctx.cwd === ctx.taskRepositoryCwd,
+      });
       // The "commit hook": every pushed commit becomes a `commit` artefact on the signal
       // reports this task is associated with. Best-effort and awaited inside the tool's
       // try/catch-free success path — reportCommitArtefacts never throws, so a failed

--- a/products/desktop/packages/agent/src/adapters/signed-commit-shared.ts
+++ b/products/desktop/packages/agent/src/adapters/signed-commit-shared.ts
@@ -187,6 +187,7 @@ export function runSignedCommitTool(
       await reportTaskRunBranch({
         taskId: ctx.taskId,
         taskRunId: ctx.taskRunId,
+        repository: result.repository,
         branch: result.branch,
         // Only the task repository branch controls the next checkout. The
         // reported head branch still lets PR webhooks bind commits made from a

--- a/products/desktop/packages/agent/src/signed-commit-artefacts.test.ts
+++ b/products/desktop/packages/agent/src/signed-commit-artefacts.test.ts
@@ -372,6 +372,7 @@ describe("reportTaskRunBranch", () => {
     await reportTaskRunBranch({
       taskId: "task-1",
       taskRunId: "run-1",
+      repository: "PostHog/PostHog",
       branch: "posthog-code/fix-foo",
       env: ENV,
       envFilePath: NO_ENV_FILE,
@@ -387,7 +388,15 @@ describe("reportTaskRunBranch", () => {
       method: "PATCH",
       body: JSON.stringify({
         branch: "posthog-code/fix-foo",
-        output: { head_branch: "posthog-code/fix-foo" },
+        output: {
+          head_branch: "posthog-code/fix-foo",
+          head_branches: [
+            {
+              repository: "posthog/posthog",
+              branch: "posthog-code/fix-foo",
+            },
+          ],
+        },
       }),
     });
   });
@@ -403,6 +412,7 @@ describe("reportTaskRunBranch", () => {
     await reportTaskRunBranch({
       taskId: "task-1",
       taskRunId: "run-1",
+      repository: "PostHog/PostHog",
       branch: "posthog-code/fix-foo",
       updateCheckoutBranch: false,
       env: ENV,
@@ -414,7 +424,15 @@ describe("reportTaskRunBranch", () => {
     expect(init).toMatchObject({
       method: "PATCH",
       body: JSON.stringify({
-        output: { head_branch: "posthog-code/fix-foo" },
+        output: {
+          head_branch: "posthog-code/fix-foo",
+          head_branches: [
+            {
+              repository: "posthog/posthog",
+              branch: "posthog-code/fix-foo",
+            },
+          ],
+        },
       }),
     });
   });

--- a/products/desktop/packages/agent/src/signed-commit-artefacts.test.ts
+++ b/products/desktop/packages/agent/src/signed-commit-artefacts.test.ts
@@ -391,4 +391,31 @@ describe("reportTaskRunBranch", () => {
       }),
     });
   });
+
+  it("can report a PR head branch without changing the checkout branch", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await reportTaskRunBranch({
+      taskId: "task-1",
+      taskRunId: "run-1",
+      branch: "posthog-code/fix-foo",
+      updateCheckoutBranch: false,
+      env: ENV,
+      envFilePath: NO_ENV_FILE,
+      oauthEnvFilePath: TEST_OAUTH_ENV_FILE,
+    });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init).toMatchObject({
+      method: "PATCH",
+      body: JSON.stringify({
+        output: { head_branch: "posthog-code/fix-foo" },
+      }),
+    });
+  });
 });

--- a/products/desktop/packages/agent/src/signed-commit-artefacts.ts
+++ b/products/desktop/packages/agent/src/signed-commit-artefacts.ts
@@ -142,6 +142,7 @@ export async function reportTaskRunBranch(opts: {
   taskId: string | undefined;
   taskRunId: string | undefined;
   branch: string;
+  updateCheckoutBranch?: boolean;
   env?: Record<string, string | undefined>;
   envFilePath?: string;
   oauthEnvFilePath?: string;
@@ -159,7 +160,7 @@ export async function reportTaskRunBranch(opts: {
       return;
     }
     await client.updateTaskRun(opts.taskId, opts.taskRunId, {
-      branch: opts.branch,
+      ...(opts.updateCheckoutBranch !== false && { branch: opts.branch }),
       output: { head_branch: opts.branch },
     });
   } catch (err) {

--- a/products/desktop/packages/agent/src/signed-commit-artefacts.ts
+++ b/products/desktop/packages/agent/src/signed-commit-artefacts.ts
@@ -141,6 +141,7 @@ export async function reportCommitArtefacts(opts: {
 export async function reportTaskRunBranch(opts: {
   taskId: string | undefined;
   taskRunId: string | undefined;
+  repository: string;
   branch: string;
   updateCheckoutBranch?: boolean;
   env?: Record<string, string | undefined>;
@@ -161,7 +162,15 @@ export async function reportTaskRunBranch(opts: {
     }
     await client.updateTaskRun(opts.taskId, opts.taskRunId, {
       ...(opts.updateCheckoutBranch !== false && { branch: opts.branch }),
-      output: { head_branch: opts.branch },
+      output: {
+        head_branch: opts.branch,
+        head_branches: [
+          {
+            repository: opts.repository.trim().toLowerCase(),
+            branch: opts.branch,
+          },
+        ],
+      },
     });
   } catch (err) {
     warn(`failed to attach branch ${opts.branch} to task run: ${err}`);

--- a/products/tasks/backend/pr_urls.py
+++ b/products/tasks/backend/pr_urls.py
@@ -9,9 +9,35 @@ def read_pr_urls(output: object) -> list[str]:
     return list(dict.fromkeys(url for url in candidates if isinstance(url, str) and url))
 
 
+def read_head_branches(output: object) -> list[dict[str, str]]:
+    if not isinstance(output, dict):
+        return []
+
+    raw_branches = output.get("head_branches")
+    branches: list[object] = raw_branches if isinstance(raw_branches, list) else []
+    normalized: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for candidate in branches:
+        if not isinstance(candidate, dict):
+            continue
+        repository = candidate.get("repository")
+        branch = candidate.get("branch")
+        if not isinstance(repository, str) or not repository or not isinstance(branch, str) or not branch:
+            continue
+        pair = (repository.strip().lower(), branch)
+        if pair in seen:
+            continue
+        seen.add(pair)
+        normalized.append({"repository": pair[0], "branch": pair[1]})
+    return normalized
+
+
 def merge_pr_output(existing: object, incoming: dict) -> dict:
     current = existing if isinstance(existing, dict) else {}
     merged = {**current, **incoming}
+    head_branches = [*read_head_branches(incoming), *read_head_branches(current)]
+    if head_branches:
+        merged["head_branches"] = read_head_branches({"head_branches": head_branches})
     urls = list(dict.fromkeys([*read_pr_urls(incoming), *read_pr_urls(current)]))
     if not urls:
         return merged

--- a/products/tasks/backend/tests/test_pr_urls.py
+++ b/products/tasks/backend/tests/test_pr_urls.py
@@ -1,0 +1,33 @@
+from products.tasks.backend.pr_urls import merge_pr_output, read_head_branches
+
+
+def test_merge_pr_output_preserves_distinct_head_branches() -> None:
+    existing = {
+        "head_branches": [{"repository": "posthog/posthog", "branch": "posthog-code/first"}],
+    }
+    incoming = {
+        "head_branches": [{"repository": "PostHog/Code", "branch": "posthog-code/second"}],
+    }
+
+    merged = merge_pr_output(existing, incoming)
+
+    assert merged["head_branches"] == [
+        {"repository": "posthog/code", "branch": "posthog-code/second"},
+        {"repository": "posthog/posthog", "branch": "posthog-code/first"},
+    ]
+
+
+def test_read_head_branches_deduplicates_normalized_pairs() -> None:
+    assert read_head_branches(
+        {
+            "head_branches": [
+                {"repository": " PostHog/PostHog ", "branch": "posthog-code/fix"},
+                {"repository": "posthog/posthog", "branch": "posthog-code/fix"},
+                {"repository": "posthog/posthog", "branch": "posthog-code/other"},
+                {"repository": "posthog/posthog"},
+            ]
+        }
+    ) == [
+        {"repository": "posthog/posthog", "branch": "posthog-code/fix"},
+        {"repository": "posthog/posthog", "branch": "posthog-code/other"},
+    ]

--- a/products/tasks/backend/tests/test_webhooks.py
+++ b/products/tasks/backend/tests/test_webhooks.py
@@ -1101,6 +1101,26 @@ class TestFindTaskRun(TestCase):
         result = find_task_run(branch="feature/my-branch", repository="posthog/posthog")
         self.assertEqual(result, task_run)
 
+    def test_finds_by_signed_commit_head_branch(self):
+        task_run = TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.IN_PROGRESS,
+            branch="master",
+            output={"head_branch": "posthog-code/feature"},
+        )
+        result = find_task_run(branch="posthog-code/feature", repository="posthog/posthog")
+        self.assertEqual(result, task_run)
+
+    def test_signed_commit_head_branch_requires_matching_repository(self):
+        TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.IN_PROGRESS,
+            output={"head_branch": "posthog-code/feature"},
+        )
+        self.assertIsNone(find_task_run(branch="posthog-code/feature", repository="acme/other"))
+
     def test_finds_multi_repository_run_from_snapshot(self):
         self.task.repositories = ["posthog/posthog", "posthog/code"]
         self.task.save(update_fields=["repositories"])

--- a/products/tasks/backend/tests/test_webhooks.py
+++ b/products/tasks/backend/tests/test_webhooks.py
@@ -1107,7 +1107,10 @@ class TestFindTaskRun(TestCase):
             team=self.team,
             status=TaskRun.Status.IN_PROGRESS,
             branch="master",
-            output={"head_branch": "posthog-code/feature"},
+            output={
+                "head_branch": "posthog-code/feature",
+                "head_branches": [{"repository": "posthog/posthog", "branch": "posthog-code/feature"}],
+            },
         )
         result = find_task_run(branch="posthog-code/feature", repository="posthog/posthog")
         self.assertEqual(result, task_run)
@@ -1117,9 +1120,23 @@ class TestFindTaskRun(TestCase):
             task=self.task,
             team=self.team,
             status=TaskRun.Status.IN_PROGRESS,
-            output={"head_branch": "posthog-code/feature"},
+            output={
+                "head_branch": "posthog-code/feature",
+                "head_branches": [{"repository": "posthog/posthog", "branch": "posthog-code/feature"}],
+            },
         )
         self.assertIsNone(find_task_run(branch="posthog-code/feature", repository="acme/other"))
+
+    def test_signed_commit_head_branch_requires_repository_pair(self):
+        TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.IN_PROGRESS,
+            output={
+                "head_branches": [{"repository": "posthog/code", "branch": "posthog-code/feature"}],
+            },
+        )
+        self.assertIsNone(find_task_run(branch="posthog-code/feature", repository="posthog/posthog"))
 
     def test_finds_multi_repository_run_from_snapshot(self):
         self.task.repositories = ["posthog/posthog", "posthog/code"]

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -88,6 +88,21 @@ def find_task_run(
         if task_run:
             return task_run
 
+        # Signed commits report their pushed branch separately from ``branch``.
+        # The latter controls which branch provisioning checks out and cannot
+        # represent a repository nested below a multi-repo workspace root.
+        task_run = (
+            TaskRun.objects.filter(
+                _run_repository_filter(repository),
+                output__head_branch=branch,
+                state__wizard_head_branch__isnull=True,
+            )
+            .select_related(*TASK_RUN_SELECT_RELATED)
+            .first()
+        )
+        if task_run:
+            return task_run
+
         # Wizard cloud runs push to a server-generated head branch stored in run state.
         # The prefix check keeps this leg off the hot path for ordinary PR webhooks, and
         # terminal runs are excluded so a reopened branch can't fire events on a dead run

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -88,13 +88,14 @@ def find_task_run(
         if task_run:
             return task_run
 
-        # Signed commits report their pushed branch separately from ``branch``.
-        # The latter controls which branch provisioning checks out and cannot
-        # represent a repository nested below a multi-repo workspace root.
+        # Signed commits report every pushed repository/branch pair separately
+        # from ``branch``. The latter controls provisioning's next checkout and
+        # cannot represent nested repositories or multiple PR branches.
+        head_branch = {"repository": repository.lower(), "branch": branch}
         task_run = (
             TaskRun.objects.filter(
                 _run_repository_filter(repository),
-                output__head_branch=branch,
+                output__head_branches__contains=[head_branch],
                 state__wizard_head_branch__isnull=True,
             )
             .select_related(*TASK_RUN_SELECT_RELATED)


### PR DESCRIPTION
## Problem

Pull requests created from repositories nested under a cloud task workspace can be missing from the originating task.

The signed commit tool only reported a branch when the commit working directory matched the session root. Multi-repository tasks start at a workspace root and commit inside a repository subdirectory, so the tool skipped the report and the GitHub webhook could not associate the PR with the run.

## Changes

- Report every branch produced by the signed commit tool.
- Change the resume checkout branch only when committing from the task repository root.
- Match PR webhooks against the reported head branch while retaining repository and internal-branch safeguards.