### PR TITLE
fix(devex): skip feedback from cloud agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@
 - New product: `bin/hogli product:bootstrap <name>`
 - LSP: Pyright is configured against the flox venv. Prefer LSP (`goToDefinition`, `findReferences`, `hover`) over grep when navigating or refactoring Python code.
 - Dev experience feedback: `hogli devex:feedback "<message>"` sends feedback about repo tooling — hogli, the dev stack, tests, CI, migrations, this setup — straight to the devex team as a `hogli_feedback` event (add `-c bug|idea|praise|question`).
-  **Agents must use it too**: when a hogli command or dev workflow is broken, slow, or confusing, run it — e.g. `hogli devex:feedback -c bug "migrations:run failed with <error>"`. Agent-sent feedback is tagged as such, and it's the fastest signal the devex team gets, so use it liberally rather than suffering friction silently.
+  **Local agents must use it too**: when a hogli command or local dev workflow is broken, slow, or confusing, run it — e.g. `hogli devex:feedback -c bug "migrations:run failed with <error>"`. Do not run it from cloud tasks or agent-server sandboxes; the command is a no-op there.
 
 ## Commits and Pull Requests
 

--- a/tools/hogli-commands/hogli_commands/feedback.py
+++ b/tools/hogli-commands/hogli_commands/feedback.py
@@ -29,6 +29,12 @@ from hogli.manifest import get_manifest
 _EVENT = "hogli_feedback"
 _DEFAULT_HOST = "https://us.i.posthog.com"
 _CATEGORIES = ("bug", "idea", "praise", "question", "other")
+_CLOUD_TASK_ENV_VARS = ("POSTHOG_TASK_ID", "POSTHOG_TASK_RUN_ID")
+
+
+def _is_cloud_task() -> bool:
+    """Whether hogli is running inside a PostHog cloud agent task."""
+    return any(os.environ.get(name) for name in _CLOUD_TASK_ENV_VARS)
 
 
 def _endpoint() -> tuple[str, str]:
@@ -141,6 +147,15 @@ def devex_feedback(message: tuple[str, ...], category: str | None, yes: bool) ->
     environment context hogli telemetry already attaches. Run interactively to
     confirm before sending.
     """
+    # This command is for local development feedback. Cloud agents inherit the
+    # repository's AGENTS.md and may otherwise treat its encouragement as an
+    # instruction to send feedback from the agent-server sandbox. Silently skip
+    # there: a successful no-op prevents retries while guaranteeing no network or
+    # telemetry side effects.
+    if _is_cloud_task():
+        click.secho("Skipping devex feedback in a cloud agent task.", fg="yellow", err=True)
+        return
+
     interactive = _stdin_is_tty()
     text = " ".join(message).strip()
 

--- a/tools/hogli-commands/hogli_commands/tests/test_feedback.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_feedback.py
@@ -17,6 +17,12 @@ from click.testing import CliRunner
 from hogli_commands import feedback
 
 
+@pytest.fixture(autouse=True)
+def local_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    for env_var in feedback._CLOUD_TASK_ENV_VARS:
+        monkeypatch.delenv(env_var, raising=False)
+
+
 @pytest.fixture
 def isolated_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # Keep get_anonymous_id() off the real ~/.config and pin a deterministic key.
@@ -77,6 +83,21 @@ def test_send_returns_error_on_network_failure(isolated_config: None) -> None:
         ok, err = feedback._send("hi", None, {})
     assert ok is False
     assert err
+
+
+@pytest.mark.parametrize("env_var", feedback._CLOUD_TASK_ENV_VARS)
+def test_cloud_task_skips_feedback(monkeypatch: pytest.MonkeyPatch, env_var: str) -> None:
+    monkeypatch.setenv(env_var, "task-123")
+    with (
+        patch.object(feedback, "_context_properties") as context,
+        patch.object(feedback, "_send") as send,
+    ):
+        result = CliRunner().invoke(feedback.devex_feedback, ["the message"])
+
+    assert result.exit_code == 0
+    assert "Skipping devex feedback" in result.output
+    context.assert_not_called()
+    send.assert_not_called()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

Cloud agents can follow repository guidance intended for local development and send `hogli devex:feedback` from agent-server sandboxes.

**Why:** Feedback should describe local developer experience, without cloud agents producing unintended outbound events.

## Changes

- Treat `POSTHOG_TASK_ID` and `POSTHOG_TASK_RUN_ID` as cloud-task markers.
- Return successfully before reading stdin, collecting context, or sending telemetry.
- Clarify that the repository guidance applies only to local agents.