### PR TITLE
fix(max): mark events the project has never captured

### DIFF
--- a/ee/hogai/utils/helpers.py
+++ b/ee/hogai/utils/helpers.py
@@ -77,6 +77,12 @@ _CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 # blow up every team member's prompt. The taxonomy already bounds the number of events per prompt.
 MAX_EVENT_DESCRIPTION_LENGTH = 500
 
+NOT_SEEN_RECENTLY_MARKER = "(not seen in the last 30 days)"
+NOT_SEEN_RECENTLY_LEGEND = (
+    f"Events marked {NOT_SEEN_RECENTLY_MARKER} are listed for reference only. This project has sent none of them "
+    "recently, so never present them as data it is collecting."
+)
+
 
 def sanitize_event_description(text: str) -> str:
     """Neutralize an untrusted event description before it goes into the model's context.
@@ -211,6 +217,10 @@ def _process_events_data(
 
     has_more = bool(response.hasMore)
 
+    # The runner pads its results with well-known event names at count 0, so a zero count means the
+    # project has no such event in the query window — not that the event is merely rare.
+    not_seen_recently = {item.event for item in response.results if item.count == 0}
+
     events: list[str] = [
         # Add "All events" to the mapping
         "All events",
@@ -237,7 +247,9 @@ def _process_events_data(
 
     processed_events = []
     for event_name in events:
-        event_data = {"name": event_name}
+        event_data: dict[str, Any] = {"name": event_name}
+        if event_name in not_seen_recently:
+            event_data["not_seen_recently"] = True
 
         if event_core_definition := CORE_FILTER_DEFINITIONS_BY_GROUP["events"].get(event_name):
             # Only skip if it's not in context (context events should always be included)
@@ -328,6 +340,8 @@ def format_events_xml(events_in_context: list[MaxEventContext], team: Team, user
         if "description" in event_data:
             desc_tag = ET.SubElement(event_tag, "description")
             desc_tag.text = event_data["description"]
+        if event_data.get("not_seen_recently"):
+            ET.SubElement(event_tag, "not_seen_recently").text = "true"
 
     return ET.tostring(root, encoding="unicode")
 
@@ -342,10 +356,18 @@ def format_events_yaml(
     processed_events, _, has_more = _process_events_data(events_in_context, team, user, limit=limit, offset=offset)
 
     formatted_events = ["events:"]
+    any_not_seen_recently = False
     for event_data in processed_events:
         name = event_data["name"]
         description = event_data.get("description", "")
-        formatted_events.append(f"- `{name}` - {description}" if description else f"- `{name}`")
+        line = f"- `{name}` - {description}" if description else f"- `{name}`"
+        if event_data.get("not_seen_recently"):
+            any_not_seen_recently = True
+            line += f" {NOT_SEEN_RECENTLY_MARKER}"
+        formatted_events.append(line)
+
+    if any_not_seen_recently:
+        formatted_events.append(f"\n# {NOT_SEEN_RECENTLY_LEGEND}")
 
     if has_more:
         next_offset = (offset or 0) + (limit or 500)

--- a/ee/hogai/utils/test/test_format_events_prompt.py
+++ b/ee/hogai/utils/test/test_format_events_prompt.py
@@ -4,11 +4,19 @@ import xml.etree.ElementTree as ET
 from posthog.test.base import BaseTest
 from unittest.mock import ANY, Mock, patch
 
+from parameterized import parameterized
+
 from posthog.schema import CachedTeamTaxonomyQueryResponse, MaxEventContext, TeamTaxonomyItem, TeamTaxonomyQuery
 
 from posthog.hogql_queries.query_runner import ExecutionMode
 
-from ee.hogai.utils.helpers import MAX_EVENT_DESCRIPTION_LENGTH, format_events_xml
+from ee.hogai.utils.helpers import (
+    MAX_EVENT_DESCRIPTION_LENGTH,
+    NOT_SEEN_RECENTLY_LEGEND,
+    NOT_SEEN_RECENTLY_MARKER,
+    format_events_xml,
+    format_events_yaml,
+)
 from ee.models.event_definition import EnterpriseEventDefinition
 
 # Mock CORE_FILTER_DEFINITIONS_BY_GROUP for consistent testing
@@ -470,3 +478,24 @@ class TestFormatEventsPrompt(BaseTest):
             ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
             analytics_props=ANY,
         )
+
+    @parameterized.expand(
+        [
+            ("never captured", [("$pageview", 100), ("$ai_trace", 0)], True),
+            ("captured", [("$pageview", 100), ("$ai_trace", 12)], False),
+        ]
+    )
+    @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")
+    def test_format_events_yaml_marks_events_with_no_recent_data(
+        self, _name, events_with_counts, expected_marker, mock_runner_class
+    ):
+        self._setup_mock_runner(mock_runner_class, self._create_taxonomy_items(events_with_counts))
+
+        result = format_events_yaml([], self.team, self.user)
+        lines = result.splitlines()
+        ai_trace_line = next(line for line in lines if line.startswith("- `$ai_trace`"))
+        pageview_line = next(line for line in lines if line.startswith("- `$pageview`"))
+
+        self.assertEqual(NOT_SEEN_RECENTLY_MARKER in ai_trace_line, expected_marker)
+        self.assertEqual(NOT_SEEN_RECENTLY_LEGEND in result, expected_marker)
+        self.assertNotIn(NOT_SEEN_RECENTLY_MARKER, pageview_line)


### PR DESCRIPTION
## Problem

- Max tells a user that their project captures events it has never sent, so a project with no data hears that its SDKs are live.
- `TeamTaxonomyQueryRunner` appends every well-known event name at count 0 once the results fit on one page.
- `_process_events_data` keeps only the name and description, so the count that marks an event as unseen is dropped.
- Max reads a padded `$ai_trace` and a real `$pageview` as identical lines.
- Projects with more than 500 distinct events are unaffected, because the padding is skipped while more pages remain.

## Changes

- Events with a zero count now render as `(not seen in the last 30 days)` in the list Max reads.
- A legend line tells the model never to present those events as data the project collects.
- `_process_events_data` carries the flag. `format_events_yaml` and `format_events_xml` render it.
- The padding stays, so the model still learns that a documented event name exists and can plan a query against it.
- I rejected flagging the AI events as `ignored_in_assistant`. That hides them from projects that do send them.
- No frontend change, so nothing looks different.

## How did you test this code?

- Added one parameterized test to `test_format_events_prompt.py`. A zero-count event gets the marker and the legend, a captured event gets neither. No existing test asserted on the count, which is why the padding could go unlabelled.
- Ran `ee/hogai/utils/test/test_format_events_prompt.py`, `ee/hogai/tools/read_taxonomy`, and `ee/hogai/chat_agent/taxonomy/test` locally against Postgres and ClickHouse containers, plus mypy on the changed module.
- Not run: the rest of the backend suite. Not done: any manual check against a real project, so the rendered prompt has only been read in test output.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually the PostHog Slack app, running Claude Code) wrote this from a Slack thread asking why Max reports AI events that the AI observability dashboard says are absent. The dashboard is right: it checks event definitions and falls back to a direct events query, while Max reads the padded taxonomy list.

I first considered dropping the padding entirely, then kept it. The padding was added deliberately in #52546 so the model knows a documented event name exists even when the project has not sent it, and removing it would regress that.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

The PR is unassigned because I could not verify the requester's GitHub handle from the thread. The person who asked for this should assign themselves as DRI.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BCHQJBJR5/p1786131949945609?thread_ts=1786131949.945609&cid=C0BCHQJBJR5)*
