### PR TITLE
fix(replay-vision): don't set tool_config alongside cached_content

### DIFF
--- a/products/replay_vision/backend/temporal/activities/call_scanner_provider.py
+++ b/products/replay_vision/backend/temporal/activities/call_scanner_provider.py
@@ -421,6 +421,8 @@ async def _run_steps(
             step=step,
             convo=convo,
             cache_name=cache_name,
+            video_part=video_part,
+            preamble_text=preamble_text,
             dispatch=dispatch,
             team_id=team_id,
             metric_labels=metric_labels,
@@ -458,6 +460,8 @@ async def _run_step(
     step: MissionStep,
     convo: list[Any],
     cache_name: str | None,
+    video_part: types.Part,
+    preamble_text: str,
     dispatch: Any,
     team_id: int,
     metric_labels: dict[str, str],
@@ -469,6 +473,9 @@ async def _run_step(
     """
     config = _step_config(step, cache_name)
     forced_config = _step_config(step, cache_name, allow_tools=False)
+    # The forced final turn runs inline (it can't reuse the cache, which pins the tool on). When the run is cached,
+    # `convo` omits the video + preamble prefix — those live in the cache — so re-supply them inline for that turn.
+    forced_prefix = [video_part, types.Part(text=preamble_text)] if cache_name else []
 
     async def _generate(c: list[Any], cfg: types.GenerateContentConfig = config) -> Any:
         return await client.models.generate_content(
@@ -498,7 +505,10 @@ async def _run_step(
                 )
                 started = time.monotonic()
                 response = await _force_final_answer(
-                    generate=lambda c: _generate(c, forced_config), convo=convo, exhausted=response, dispatch=dispatch
+                    generate=lambda c: _generate(forced_prefix + c, forced_config),
+                    convo=convo,
+                    exhausted=response,
+                    dispatch=dispatch,
                 )
         except Exception:
             record_provider_call(**metric_labels, outcome="provider_error", seconds=time.monotonic() - started)
@@ -585,20 +595,22 @@ async def _force_final_answer(*, generate: Any, convo: list[Any], exhausted: Any
 def _step_config(step: MissionStep, cache_name: str | None, *, allow_tools: bool = True) -> types.GenerateContentConfig:
     """Generation config for one step: its JSON schema, plus the events tool (from the cache when cached).
 
-    `allow_tools=False` is the forced final turn after the tool budget runs out — the model must answer from what it
-    has, so calling is suppressed: omit the tool inline, or disable function-calling on the cached tool.
+    Normal turns offer the tool — from the cache when the video is cached (the tool lives there alongside it), or
+    inline otherwise. The forced final turn (`allow_tools=False`, after the tool budget runs out) must answer from
+    what it has, so no tool is offered. It never references the cache: Gemini rejects a `GenerateContent` request
+    that sets `tools`, `tool_config`, or `system_instruction` alongside `cached_content`, so there's no way to
+    disable the cached tool per-request. That turn always runs inline with the tool simply absent — the caller
+    re-supplies the video + preamble inline for it (see `forced_prefix` in `_run_step`).
     """
     kwargs: dict[str, Any] = {
         "response_mime_type": "application/json",
         "response_json_schema": step.response_model.model_json_schema(),
     }
+    if not allow_tools:
+        return types.GenerateContentConfig(**kwargs)  # inline, no tool to call — the model must answer now
     if cache_name:
         kwargs["cached_content"] = cache_name  # video, preamble, and the tool all live in the cache
-        if not allow_tools:
-            kwargs["tool_config"] = types.ToolConfig(
-                function_calling_config=types.FunctionCallingConfig(mode=types.FunctionCallingConfigMode.NONE)
-            )
-    elif allow_tools:
+    else:
         kwargs["tools"] = [events_tool()]
     return types.GenerateContentConfig(**kwargs)
 

--- a/products/replay_vision/backend/tests/test_call_scanner_provider.py
+++ b/products/replay_vision/backend/tests/test_call_scanner_provider.py
@@ -137,6 +137,28 @@ async def test_tool_budget_exhaustion_forces_a_final_tool_free_answer() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cached_tool_budget_exhaustion_forces_an_inline_tool_free_answer() -> None:
+    # With the video cached, the forced final turn can't reuse the cache (Gemini rejects tools/tool_config alongside
+    # cached_content). It must run inline with no tool and the video + preamble re-supplied — otherwise every
+    # budget-exhausting cached scan hits a hard 400 and produces no observation.
+    steps = [MissionStep(name="core", instruction="c", response_model=_Core)]
+    responses = [_Resp(function_call=_fc("get_events_around", {"rec_t": 5})) for _ in range(7)]
+    responses.append(_Resp(text='{"verdict":"yes"}'))
+    client = _FakeClient(responses)
+    out = await _run(client, steps, dispatch=lambda fc: {"events": []}, cache_name="caches/abc")
+    assert out["core"].verdict == "yes"
+
+    cached_turn, forced_turn = client.models.calls[0], client.models.calls[-1]
+    assert cached_turn["config"].cached_content == "caches/abc"  # normal turns still use the cache
+    assert cached_turn["contents"][0] != _VIDEO  # video lives in the cache, not inline
+
+    assert forced_turn["config"].cached_content is None  # forced turn drops the cache...
+    assert forced_turn["config"].tools is None and forced_turn["config"].tool_config is None  # ...and offers no tool
+    assert forced_turn["contents"][0] == _VIDEO  # video + preamble re-supplied inline so context isn't lost
+    assert forced_turn["contents"][1].text == "PRE"
+
+
+@pytest.mark.asyncio
 async def test_step_survives_a_response_with_no_candidates() -> None:
     # Gemini can return zero candidates (safety filter / content policy); the step must fail cleanly rather than
     # IndexError on candidates[0].
@@ -334,6 +356,18 @@ class TestStepConfig:
         # Tools live in the cache; re-declaring them in the config alongside cached_content is rejected by Gemini.
         assert config.tools is None
         assert config.cached_content == "caches/abc"
+        assert config.response_json_schema is not None
+
+    @pytest.mark.parametrize("cache_name", [None, "caches/abc"])
+    def test_forced_turn_never_references_the_cache_or_sets_tool_config(self, cache_name: str | None) -> None:
+        # Gemini rejects a request that sets tools, tool_config, or system_instruction alongside cached_content with
+        # a hard 400. The forced final turn must run inline with the tool simply absent, even on a cached run.
+        config = _step_config(
+            MissionStep(name="core", instruction="c", response_model=_Core), cache_name=cache_name, allow_tools=False
+        )
+        assert config.tools is None
+        assert config.tool_config is None
+        assert config.cached_content is None
         assert config.response_json_schema is not None
 
 


### PR DESCRIPTION
## Problem

Replay Vision scans fail whenever a step uses up its event-lookup budget on a cached video conversation, and the scan produces no observation. It affects every scanner type in both regions, and has since scanners became multi-turn video conversations in #64842 (2026-06-25).

When the tool loop runs out of round-trips and the model still wants another `get_events_around` lookup, the scanner forces one final tool-free turn by setting `tool_config` (function calling `NONE`) on the request. On a cached run that request also carries `cached_content`, and Gemini rejects that combination outright, before generating any tokens:

> `CachedContent can not be used with GenerateContent request setting system_instruction, tools or tool_config.`

`_run_pass` treats the 400 as a cache-shaped failure and re-runs the entire mission inline, re-sending the video uncached. That masks the bug when the retry succeeds and fails the observation with `provider_rejected` when it doesn't. It is deterministic client-side API misuse, not provider weather.

## Changes

- The forced final turn now runs inline with the events tool simply absent, so the model has nothing to call and must answer from what it has seen.
- A cached conversation keeps the video and preamble in the cache and omits them from `contents`, so the forced turn re-supplies them inline and doesn't lose context.
- Normal turns are unchanged: they still reference the cache and offer the tool from it.
- `tool_config` is gone. Gemini gives no way to disable a cached tool per-request, so there is nothing to keep.

This restores [#67903](https://github.com/PostHog/posthog/pull/67903), which reached the same diagnosis on 2026-07-02, sat unreviewed, and was auto-closed as stale. Rebased on current master and re-tested.

> [!NOTE]
> The forced turn costs a video re-upload on cached runs. That is strictly cheaper than today's behavior, where the same failure re-runs every step of the mission inline.

## How did you test this code?

Automated tests only — I did not run a scanner against a real recording or call Gemini.

- `test_cached_tool_budget_exhaustion_forces_an_inline_tool_free_answer` drives the full budget-exhaustion path with a cache set. It catches the regression this PR fixes: a forced turn that references the cache, offers a tool, or drops the video prefix.
- `test_forced_turn_never_references_the_cache_or_sets_tool_config` pins the config shape for both cached and inline runs. The existing `TestStepConfig` cases only covered `allow_tools=True`, which is how the bug shipped.
- Both fail on master and pass here. `products/replay_vision/backend/tests/` passes locally except for tests needing Postgres, which this sandbox has no database for.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from the PostHog Slack app after an AI observability digest flagged the normalized Gemini error as benign, [in this thread](https://posthog.slack.com/archives/C0BCHQJBJR5/p1786291487355039?thread_ts=1786291487.355039&cid=C0BCHQJBJR5). Traced from AI observability generation errors to the code path, confirmed the trigger is the tool-budget-exhausted turn rather than a token threshold or transient provider issue.

The first fix I wrote just dropped `tool_config` and relied on the out-of-lookups prompt nudge, keeping the cache. I replaced it after finding #67903: leaving the tool declared in the cache means the model can still call it, and a non-compliant turn burns a retry attempt. Offering no tool at all is deterministic, so I adopted that approach and its tests.

Skills invoked: `/exploring-ai-failures`, `/writing-tests`, `/writing-pr-descriptions`.

---

*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BCHQJBJR5/p1786291487355039?thread_ts=1786291487.355039&cid=C0BCHQJBJR5)*
