### PR TITLE
fix(slack): unfurl links against the project named in the URL

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -2236,7 +2236,9 @@ def route_posthog_code_event_to_relevant_region(
             ):
                 logger.info("slack_link_unfurl_channel_unapproved", slack_team_id=slack_team_id, channel=channel_id)
                 return ROUTE_HANDLED_LOCALLY
-            handle_posthog_link_unfurl(event, local_match)
+            # Every connected project is in play: the handler picks per link, from the URL's
+            # `/project/:id` where present.
+            handle_posthog_link_unfurl(event, link_result.candidates)
         return ROUTE_HANDLED_LOCALLY
     return _route_to_other_region_or_drop(request, slack_team_id, proxied=proxied, other_domain=other_domain)
 

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -2236,8 +2236,6 @@ def route_posthog_code_event_to_relevant_region(
             ):
                 logger.info("slack_link_unfurl_channel_unapproved", slack_team_id=slack_team_id, channel=channel_id)
                 return ROUTE_HANDLED_LOCALLY
-            # Every connected project is in play: the handler picks per link, from the URL's
-            # `/project/:id` where present.
             handle_posthog_link_unfurl(event, link_result.candidates)
         return ROUTE_HANDLED_LOCALLY
     return _route_to_other_region_or_drop(request, slack_team_id, proxied=proxied, other_domain=other_domain)

--- a/products/slack_app/backend/slack_link_unfurl.py
+++ b/products/slack_app/backend/slack_link_unfurl.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from dataclasses import dataclass, field
+from typing import Literal
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -14,18 +15,22 @@ from posthog.models import Team, User
 from posthog.models.comment import Comment
 from posthog.models.integration import Integration, SlackIntegration
 from posthog.models.user_integration import UserIntegration
-from posthog.rbac.user_access_control import UserAccessControl, access_level_satisfied_for_resource
+from posthog.rbac.user_access_control import UserAccessControl
 
 from products.conversations.backend.models.ticket import Ticket
 from products.dashboards.backend.models.dashboard import Dashboard
 from products.product_analytics.backend.models.insight import Insight
+from products.slack_app.backend.services.integration_resolver import ResolutionResult, resolve_user_for_workspace
 from products.tasks.backend.facade import api as tasks_facade
 from products.tasks.backend.facade.contracts import TaskSlackUnfurlDTO
 
-if TYPE_CHECKING:
-    from products.slack_app.backend.api import SlackUserContext
-
 logger = structlog.get_logger(__name__)
+
+ResourceKind = Literal["insight", "dashboard", "ticket", "task"]
+
+# Kinds whose reference is only unique within a project — ticket numbers restart per project — so a
+# link naming a project must resolve there or not at all.
+_PROJECT_SCOPED_REFS: frozenset[ResourceKind] = frozenset({"ticket"})
 
 _MAX_DESCRIPTION_CHARS = 2800
 # Keep title + status + message under Slack's 3000-char section limit; the client shows "Show more".
@@ -69,17 +74,15 @@ def _truncate(text: str, max_len: int) -> str:
     return text[: max_len - 1] + "…"
 
 
-def parse_posthog_resource_link(
-    url: str,
-) -> tuple[Literal["insight", "dashboard", "ticket", "task"], str | int] | None:
+def parse_posthog_resource_link(url: str) -> tuple[ResourceKind, str | int] | None:
     """
     Parse a PostHog app URL into (resource kind, reference id).
 
     Reference is insight short_id (str), dashboard primary key (int), or ticket ref (str — ticket
     number or UUID).
 
-    If the path includes `/project/:id`, that segment is ignored — lookup is always scoped to the
-    Slack-connected project and the resolved PostHog user, not to any project id in the URL.
+    The `/project/:id` segment is skipped here; `_url_team_id` reads it separately to pick which
+    connected project a link resolves against.
 
     Related: `removeProjectIdIfPresent` + `urlToResource` (`router-utils.ts`, `urls.ts`); legacy paths in `get_target_queryset` (`middleware.py`).
     """
@@ -90,7 +93,7 @@ def parse_posthog_resource_link(
 
     idx = 0
     if len(parts) >= 2 and parts[0] == "project":
-        # Skip project/{anything} — do not use for authorization (see handle_posthog_link_unfurl).
+        # Picking a project is not authorization — see handle_posthog_link_unfurl.
         idx = 2
 
     if len(parts) > idx and parts[idx] == "i" and len(parts) > idx + 1:
@@ -358,48 +361,46 @@ def _attach_public_slack_thread_reference(
     )
 
 
-def _integrations_for_link(url: str, integrations: list[Integration]) -> list[Integration]:
-    """Order a workspace's connected projects for one link, most likely first.
+def _candidates_for_link(
+    kind: ResourceKind, url_team_id: int | None, candidates: list[Integration]
+) -> list[Integration]:
+    """The connected projects to try for one link: the one its URL names, else all of them.
 
-    A workspace can connect many projects, so "the connected project" is not a single thing. App
-    URLs carry `/project/:id`, which names the project the resource actually lives in — the only
-    signal available before hitting the database. When the segment is absent (short `/i/:short_id`
-    links) or names a project this workspace hasn't connected, fall back to trying every candidate.
-
-    Selecting a candidate is not authorization: the caller still resolves the sharer against the
-    chosen project and runs the per-resource access check.
+    A link with no `/project/:id`, or one naming a project this workspace hasn't connected, falls
+    back to every candidate — except for kinds whose reference only means something within a
+    project. Picking a project is not authorization; the per-resource check still runs.
     """
-    url_team_id = _url_team_id(url)
     if url_team_id is None:
-        return integrations
-    return [i for i in integrations if i.team_id == url_team_id] or integrations
+        return candidates
+    named = [c for c in candidates if c.team_id == url_team_id]
+    return named if named or kind in _PROJECT_SCOPED_REFS else candidates
+
+
+@dataclass(frozen=True, kw_only=True)
+class _UnfurlContext:
+    """Everything constant across the links in one `link_shared` event."""
+
+    slack: SlackIntegration
+    user: User
+    event: dict
+    shared_by_slack_user_id: str
+    access_by_team: dict[int, UserAccessControl]
+    public_channel_cache: dict[str, bool] = field(default_factory=dict)
+    owner_access_cache: dict[str, bool] = field(default_factory=dict)
 
 
 def _unfurl_for_resource(
-    *,
-    raw_url: str,
-    kind: str,
-    ref: str | int,
-    integration: Integration,
-    user: User,
-    slack: SlackIntegration,
-    event: dict,
-    slack_user_id: str,
-    public_channel_cache: dict[str, bool],
-    owner_access_cache: dict[str, bool],
+    ctx: _UnfurlContext, *, integration: Integration, raw_url: str, kind: ResourceKind, ref: str | int
 ) -> dict | None:
     """Build the unfurl payload for one link against one project, or None if it doesn't resolve there."""
     team = integration.team
-    uac = UserAccessControl(user, team=team)
+    uac = ctx.access_by_team[team.pk]
 
     if kind == "insight":
         if not isinstance(ref, str):
             return None
         insight = Insight.objects.filter(team_id=team.pk, short_id=ref).first()
-        if not insight:
-            return None
-        level = uac.get_user_access_level(insight)
-        if not level or not access_level_satisfied_for_resource("insight", level, "viewer"):
+        if not insight or not uac.check_access_level_for_object(insight, required_level="viewer"):
             return None
         title = insight.name or insight.derived_name or "Untitled"
         desc = (insight.description or "").strip() or None
@@ -409,10 +410,7 @@ def _unfurl_for_resource(
         if not isinstance(ref, int):
             return None
         dashboard = Dashboard.objects.filter(pk=ref, team_id=team.pk).first()
-        if not dashboard:
-            return None
-        level = uac.get_user_access_level(dashboard)
-        if not level or not access_level_satisfied_for_resource("dashboard", level, "viewer"):
+        if not dashboard or not uac.check_access_level_for_object(dashboard, required_level="viewer"):
             return None
         title = dashboard.name or "Untitled"
         desc = (dashboard.description or "").strip() or None
@@ -420,13 +418,6 @@ def _unfurl_for_resource(
 
     if kind == "ticket":
         if not isinstance(ref, str):
-            return None
-        # Ticket numbers are per-project sequential, so the same number exists in every project.
-        # Unlike insights/dashboards (globally-unique ids, safe to resolve within any candidate), a
-        # link that names a different project must not resolve to this project's ticket of the same
-        # number — refuse rather than show the wrong ticket.
-        url_team_id = _url_team_id(raw_url)
-        if url_team_id is not None and url_team_id != team.pk:
             return None
         ticket = _find_ticket(team.pk, ref)
         if not ticket or not uac.check_access_level_for_object(ticket, required_level="viewer"):
@@ -441,61 +432,77 @@ def _unfurl_for_resource(
     if kind == "task":
         if not isinstance(ref, str):
             return None
-        task = tasks_facade.get_task_for_slack_unfurl(ref, team.pk, user.id)
+        task = tasks_facade.get_task_for_slack_unfurl(ref, team.pk, ctx.user.id)
         if task is None:
             return None
         label = "Task" if task.latest_run_status is None else f"Task · {task.latest_run_status}"
         payload = _unfurl_payload(resource_label=label, title=_escape_mrkdwn(task.title), description=None)
         try:
             _attach_public_slack_thread_reference(
-                slack=slack,
+                slack=ctx.slack,
                 integration=integration,
                 task=task,
-                event=event,
-                shared_by_slack_user_id=slack_user_id,
-                public_channel_cache=public_channel_cache,
-                owner_access_cache=owner_access_cache,
+                event=ctx.event,
+                shared_by_slack_user_id=ctx.shared_by_slack_user_id,
+                public_channel_cache=ctx.public_channel_cache,
+                owner_access_cache=ctx.owner_access_cache,
             )
         except Exception:
             logger.exception("slack_task_reference_attach_failed", task_id=str(task.id), team_id=team.pk)
         return payload
-
-    return None
 
 
 def handle_posthog_link_unfurl(event: dict, integrations: list[Integration]) -> None:
     """
     Unfurl supported PostHog resource links with metadata.
 
-    ``integrations`` is every project this Slack workspace has connected. Each link is resolved
-    against the project its URL names, falling back to trying all of them; `resolve_slack_user`
-    enforces that the sharer can access whichever project answers, and insights, dashboards, and
-    tickets add a per-resource access-control check on top.
+    ``integrations`` is every project this Slack workspace has connected. Each link resolves against
+    the project its URL names, falling back to trying all of them. The sharer is resolved once for
+    the workspace, which drops projects they can't reach, and each resource gets its own access
+    check on top.
     """
     if not integrations:
         return
 
-    # Any of the workspace's integrations carries a bot token for the same workspace, so the client
-    # is interchangeable — only the project scope differs between candidates.
-    slack = SlackIntegration(integrations[0])
     channel = event.get("channel")
     message_ts = event.get("message_ts")
     slack_user_id = event.get("user")
     unfurl_id = event.get("unfurl_id")
     source = event.get("source")
     links = event.get("links") or []
-    public_channel_cache: dict[str, bool] = {}
-    owner_access_cache: dict[str, bool] = {}
 
     if not channel or not message_ts or not slack_user_id or not links:
         logger.info("slack_link_unfurl_skip_missing_fields", has_channel=bool(channel), has_ts=bool(message_ts))
         return
 
     # Imported here to avoid circular import with api (api imports this module at load time).
-    from products.slack_app.backend.api import resolve_slack_user
+    from products.slack_app.backend.api import SLACK_PLACEHOLDER_USER_ID
 
-    # One `users.info` round-trip per project, not per link.
-    user_contexts: dict[int, SlackUserContext | None] = {}
+    if slack_user_id == SLACK_PLACEHOLDER_USER_ID:
+        # Slack couldn't attribute the message to a real user, so there is nobody to authorize as.
+        return
+
+    slack_team_id = integrations[0].integration_id
+    resolution = resolve_user_for_workspace(
+        workspace_result=ResolutionResult(integration=None, source="needs_picker", candidates=integrations),
+        slack_team_id=slack_team_id,
+        slack_user_id=slack_user_id,
+    )
+    if resolution.user is None or not resolution.candidates:
+        return
+
+    candidates = resolution.candidates
+    # Any of the workspace's integrations carries a bot token for the same workspace, so the client
+    # is interchangeable — only the project scope differs between candidates.
+    ctx = _UnfurlContext(
+        slack=SlackIntegration(candidates[0]),
+        user=resolution.user,
+        event=event,
+        shared_by_slack_user_id=slack_user_id,
+        access_by_team=UserAccessControl(resolution.user, team=candidates[0].team).for_team_ids(
+            [c.team_id for c in candidates]
+        ),
+    )
     unfurls: dict[str, dict] = {}
 
     for link_obj in links:
@@ -508,34 +515,12 @@ def handle_posthog_link_unfurl(event: dict, integrations: list[Integration]) -> 
             continue
 
         kind, ref = parsed
-        candidates = _integrations_for_link(raw_url, integrations)
+        url_team_id = _url_team_id(raw_url)
+        link_candidates = _candidates_for_link(kind, url_team_id, candidates)
         payload: dict | None = None
 
-        for integration in candidates:
-            if integration.id not in user_contexts:
-                user_contexts[integration.id] = resolve_slack_user(
-                    slack,
-                    integration,
-                    slack_user_id,
-                    channel,
-                    message_ts,
-                    post_feedback=False,
-                )
-            user_context = user_contexts[integration.id]
-            if not user_context:
-                continue
-            payload = _unfurl_for_resource(
-                raw_url=raw_url,
-                kind=kind,
-                ref=ref,
-                integration=integration,
-                user=user_context.user,
-                slack=slack,
-                event=event,
-                slack_user_id=slack_user_id,
-                public_channel_cache=public_channel_cache,
-                owner_access_cache=owner_access_cache,
-            )
+        for integration in link_candidates:
+            payload = _unfurl_for_resource(ctx, integration=integration, raw_url=raw_url, kind=kind, ref=ref)
             if payload is not None:
                 break
 
@@ -544,8 +529,8 @@ def handle_posthog_link_unfurl(event: dict, integrations: list[Integration]) -> 
                 "slack_link_unfurl_unresolved",
                 resource_type=kind,
                 resource_ref=str(ref),
-                url_team_id=_url_team_id(raw_url),
-                candidate_team_ids=[i.team_id for i in candidates],
+                url_team_id=url_team_id,
+                candidate_team_ids=[i.team_id for i in link_candidates],
             )
             continue
 
@@ -561,10 +546,6 @@ def handle_posthog_link_unfurl(event: dict, integrations: list[Integration]) -> 
         unfurl_kwargs["source"] = source
 
     try:
-        slack.client.chat_unfurl(**unfurl_kwargs)
+        ctx.slack.client.chat_unfurl(**unfurl_kwargs)
     except Exception:
-        logger.exception(
-            "slack_link_unfurl_chat_unfurl_failed",
-            slack_team_id=integrations[0].integration_id,
-            channel=channel,
-        )
+        logger.exception("slack_link_unfurl_chat_unfurl_failed", slack_team_id=slack_team_id, channel=channel)

--- a/products/slack_app/backend/slack_link_unfurl.py
+++ b/products/slack_app/backend/slack_link_unfurl.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -10,7 +10,7 @@ from django.core.exceptions import ValidationError
 
 import structlog
 
-from posthog.models import Team
+from posthog.models import Team, User
 from posthog.models.comment import Comment
 from posthog.models.integration import Integration, SlackIntegration
 from posthog.models.user_integration import UserIntegration
@@ -21,6 +21,9 @@ from products.dashboards.backend.models.dashboard import Dashboard
 from products.product_analytics.backend.models.insight import Insight
 from products.tasks.backend.facade import api as tasks_facade
 from products.tasks.backend.facade.contracts import TaskSlackUnfurlDTO
+
+if TYPE_CHECKING:
+    from products.slack_app.backend.api import SlackUserContext
 
 logger = structlog.get_logger(__name__)
 
@@ -355,16 +358,126 @@ def _attach_public_slack_thread_reference(
     )
 
 
-def handle_posthog_link_unfurl(event: dict, integration: Integration) -> None:
+def _integrations_for_link(url: str, integrations: list[Integration]) -> list[Integration]:
+    """Order a workspace's connected projects for one link, most likely first.
+
+    A workspace can connect many projects, so "the connected project" is not a single thing. App
+    URLs carry `/project/:id`, which names the project the resource actually lives in — the only
+    signal available before hitting the database. When the segment is absent (short `/i/:short_id`
+    links) or names a project this workspace hasn't connected, fall back to trying every candidate.
+
+    Selecting a candidate is not authorization: the caller still resolves the sharer against the
+    chosen project and runs the per-resource access check.
+    """
+    url_team_id = _url_team_id(url)
+    if url_team_id is None:
+        return integrations
+    return [i for i in integrations if i.team_id == url_team_id] or integrations
+
+
+def _unfurl_for_resource(
+    *,
+    raw_url: str,
+    kind: str,
+    ref: str | int,
+    integration: Integration,
+    user: User,
+    slack: SlackIntegration,
+    event: dict,
+    slack_user_id: str,
+    public_channel_cache: dict[str, bool],
+    owner_access_cache: dict[str, bool],
+) -> dict | None:
+    """Build the unfurl payload for one link against one project, or None if it doesn't resolve there."""
+    team = integration.team
+    uac = UserAccessControl(user, team=team)
+
+    if kind == "insight":
+        if not isinstance(ref, str):
+            return None
+        insight = Insight.objects.filter(team_id=team.pk, short_id=ref).first()
+        if not insight:
+            return None
+        level = uac.get_user_access_level(insight)
+        if not level or not access_level_satisfied_for_resource("insight", level, "viewer"):
+            return None
+        title = insight.name or insight.derived_name or "Untitled"
+        desc = (insight.description or "").strip() or None
+        return _unfurl_payload(resource_label=_insight_resource_label(insight), title=title, description=desc)
+
+    if kind == "dashboard":
+        if not isinstance(ref, int):
+            return None
+        dashboard = Dashboard.objects.filter(pk=ref, team_id=team.pk).first()
+        if not dashboard:
+            return None
+        level = uac.get_user_access_level(dashboard)
+        if not level or not access_level_satisfied_for_resource("dashboard", level, "viewer"):
+            return None
+        title = dashboard.name or "Untitled"
+        desc = (dashboard.description or "").strip() or None
+        return _unfurl_payload(resource_label="Dashboard", title=title, description=desc)
+
+    if kind == "ticket":
+        if not isinstance(ref, str):
+            return None
+        # Ticket numbers are per-project sequential, so the same number exists in every project.
+        # Unlike insights/dashboards (globally-unique ids, safe to resolve within any candidate), a
+        # link that names a different project must not resolve to this project's ticket of the same
+        # number — refuse rather than show the wrong ticket.
+        url_team_id = _url_team_id(raw_url)
+        if url_team_id is not None and url_team_id != team.pk:
+            return None
+        ticket = _find_ticket(team.pk, ref)
+        if not ticket or not uac.check_access_level_for_object(ticket, required_level="viewer"):
+            return None
+        return _ticket_unfurl_payload(
+            url=raw_url,
+            ticket=ticket,
+            requester=_escape_mrkdwn(_ticket_requester(team, ticket)),
+            opening_message=_ticket_opening_message(team.pk, ticket.id),
+        )
+
+    if kind == "task":
+        if not isinstance(ref, str):
+            return None
+        task = tasks_facade.get_task_for_slack_unfurl(ref, team.pk, user.id)
+        if task is None:
+            return None
+        label = "Task" if task.latest_run_status is None else f"Task · {task.latest_run_status}"
+        payload = _unfurl_payload(resource_label=label, title=_escape_mrkdwn(task.title), description=None)
+        try:
+            _attach_public_slack_thread_reference(
+                slack=slack,
+                integration=integration,
+                task=task,
+                event=event,
+                shared_by_slack_user_id=slack_user_id,
+                public_channel_cache=public_channel_cache,
+                owner_access_cache=owner_access_cache,
+            )
+        except Exception:
+            logger.exception("slack_task_reference_attach_failed", task_id=str(task.id), team_id=team.pk)
+        return payload
+
+    return None
+
+
+def handle_posthog_link_unfurl(event: dict, integrations: list[Integration]) -> None:
     """
     Unfurl supported PostHog resource links with metadata.
 
-    Scope is always the Slack-connected project (`integration.team`); `resolve_slack_user` enforces
-    that the sharer can access it. Insights, dashboards, and tickets add a per-resource
-    access-control check. Ticket links naming a different project are also refused because ticket
-    numbers are per-project and could otherwise resolve to the wrong ticket.
+    ``integrations`` is every project this Slack workspace has connected. Each link is resolved
+    against the project its URL names, falling back to trying all of them; `resolve_slack_user`
+    enforces that the sharer can access whichever project answers, and insights, dashboards, and
+    tickets add a per-resource access-control check on top.
     """
-    slack = SlackIntegration(integration)
+    if not integrations:
+        return
+
+    # Any of the workspace's integrations carries a bot token for the same workspace, so the client
+    # is interchangeable — only the project scope differs between candidates.
+    slack = SlackIntegration(integrations[0])
     channel = event.get("channel")
     message_ts = event.get("message_ts")
     slack_user_id = event.get("user")
@@ -381,21 +494,8 @@ def handle_posthog_link_unfurl(event: dict, integration: Integration) -> None:
     # Imported here to avoid circular import with api (api imports this module at load time).
     from products.slack_app.backend.api import resolve_slack_user
 
-    user_context = resolve_slack_user(
-        slack,
-        integration,
-        slack_user_id,
-        channel,
-        message_ts,
-        post_feedback=False,
-    )
-    if not user_context:
-        return
-
-    user = user_context.user
-    team = integration.team
-    uac = UserAccessControl(user, team=team)
-
+    # One `users.info` round-trip per project, not per link.
+    user_contexts: dict[int, SlackUserContext | None] = {}
     unfurls: dict[str, dict] = {}
 
     for link_obj in links:
@@ -408,75 +508,48 @@ def handle_posthog_link_unfurl(event: dict, integration: Integration) -> None:
             continue
 
         kind, ref = parsed
+        candidates = _integrations_for_link(raw_url, integrations)
+        payload: dict | None = None
 
-        if kind == "insight":
-            if not isinstance(ref, str):
-                continue
-            insight = Insight.objects.filter(team_id=team.pk, short_id=ref).first()
-            if not insight:
-                continue
-            level = uac.get_user_access_level(insight)
-            if not level or not access_level_satisfied_for_resource("insight", level, "viewer"):
-                continue
-            title = insight.name or insight.derived_name or "Untitled"
-            desc = (insight.description or "").strip() or None
-            unfurls[raw_url] = _unfurl_payload(
-                resource_label=_insight_resource_label(insight), title=title, description=desc
-            )
-        elif kind == "dashboard":
-            if not isinstance(ref, int):
-                continue
-            dashboard = Dashboard.objects.filter(pk=ref, team_id=team.pk).first()
-            if not dashboard:
-                continue
-            level = uac.get_user_access_level(dashboard)
-            if not level or not access_level_satisfied_for_resource("dashboard", level, "viewer"):
-                continue
-            title = dashboard.name or "Untitled"
-            desc = (dashboard.description or "").strip() or None
-            unfurls[raw_url] = _unfurl_payload(resource_label="Dashboard", title=title, description=desc)
-        elif kind == "ticket":
-            if not isinstance(ref, str):
-                continue
-            # Ticket numbers are per-project sequential, so the same number exists in every project.
-            # Unlike insights/dashboards (globally-unique ids, safe to resolve within the connected
-            # project), a link that names a different project must not resolve to our project's ticket
-            # of the same number — refuse rather than show the wrong ticket.
-            url_team_id = _url_team_id(raw_url)
-            if url_team_id is not None and url_team_id != team.pk:
-                continue
-            ticket = _find_ticket(team.pk, ref)
-            if not ticket or not uac.check_access_level_for_object(ticket, required_level="viewer"):
-                continue
-            unfurls[raw_url] = _ticket_unfurl_payload(
-                url=raw_url,
-                ticket=ticket,
-                requester=_escape_mrkdwn(_ticket_requester(team, ticket)),
-                opening_message=_ticket_opening_message(team.pk, ticket.id),
-            )
-        elif kind == "task":
-            if not isinstance(ref, str):
-                continue
-            url_team_id = _url_team_id(raw_url)
-            if url_team_id is not None and url_team_id != team.pk:
-                continue
-            task = tasks_facade.get_task_for_slack_unfurl(ref, team.pk, user.id)
-            if task is None:
-                continue
-            label = "Task" if task.latest_run_status is None else f"Task · {task.latest_run_status}"
-            unfurls[raw_url] = _unfurl_payload(resource_label=label, title=_escape_mrkdwn(task.title), description=None)
-            try:
-                _attach_public_slack_thread_reference(
-                    slack=slack,
-                    integration=integration,
-                    task=task,
-                    event=event,
-                    shared_by_slack_user_id=slack_user_id,
-                    public_channel_cache=public_channel_cache,
-                    owner_access_cache=owner_access_cache,
+        for integration in candidates:
+            if integration.id not in user_contexts:
+                user_contexts[integration.id] = resolve_slack_user(
+                    slack,
+                    integration,
+                    slack_user_id,
+                    channel,
+                    message_ts,
+                    post_feedback=False,
                 )
-            except Exception:
-                logger.exception("slack_task_reference_attach_failed", task_id=str(task.id), team_id=team.pk)
+            user_context = user_contexts[integration.id]
+            if not user_context:
+                continue
+            payload = _unfurl_for_resource(
+                raw_url=raw_url,
+                kind=kind,
+                ref=ref,
+                integration=integration,
+                user=user_context.user,
+                slack=slack,
+                event=event,
+                slack_user_id=slack_user_id,
+                public_channel_cache=public_channel_cache,
+                owner_access_cache=owner_access_cache,
+            )
+            if payload is not None:
+                break
+
+        if payload is None:
+            logger.info(
+                "slack_link_unfurl_unresolved",
+                resource_type=kind,
+                resource_ref=str(ref),
+                url_team_id=_url_team_id(raw_url),
+                candidate_team_ids=[i.team_id for i in candidates],
+            )
+            continue
+
+        unfurls[raw_url] = payload
 
     if not unfurls:
         return
@@ -490,4 +563,8 @@ def handle_posthog_link_unfurl(event: dict, integration: Integration) -> None:
     try:
         slack.client.chat_unfurl(**unfurl_kwargs)
     except Exception:
-        logger.exception("slack_link_unfurl_chat_unfurl_failed", team_id=team.pk)
+        logger.exception(
+            "slack_link_unfurl_chat_unfurl_failed",
+            slack_team_id=integrations[0].integration_id,
+            channel=channel,
+        )

--- a/products/slack_app/backend/tests/test_link_unfurl.py
+++ b/products/slack_app/backend/tests/test_link_unfurl.py
@@ -129,12 +129,12 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
             query={"kind": "InsightVizNode", "source": {"kind": "TrendsQuery"}},
         )
 
-    @patch("products.slack_app.backend.api.resolve_slack_user")
+    @patch("products.slack_app.backend.api.resolve_posthog_user_from_event")
     @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")
     def test_unfurls_insight_when_user_resolved(
         self, mock_slack_integration_class: MagicMock, mock_resolve: MagicMock
     ) -> None:
-        mock_resolve.return_value = MagicMock(user=self.user)
+        mock_resolve.return_value = self.user
         mock_client = MagicMock()
         mock_slack_integration_class.return_value.client = mock_client
 
@@ -159,7 +159,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
         assert "Weekly active users" in text
         assert "A test description" in text
 
-    @patch("products.slack_app.backend.api.resolve_slack_user")
+    @patch("products.slack_app.backend.api.resolve_posthog_user_from_event")
     @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")
     def test_unfurls_task_and_attaches_public_thread_once(
         self, mock_slack_integration_class: MagicMock, mock_resolve: MagicMock
@@ -177,7 +177,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
             integration_id="U_OWNER",
             config={"slack_team_id": self.integration.integration_id},
         )
-        mock_resolve.return_value = MagicMock(user=self.user)
+        mock_resolve.return_value = self.user
         mock_client = MagicMock()
         mock_client.conversations_info.return_value = {
             "channel": {"is_channel": True, "is_private": False, "is_shared": False}
@@ -219,7 +219,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
             }
         ]
 
-    @patch("products.slack_app.backend.api.resolve_slack_user")
+    @patch("products.slack_app.backend.api.resolve_posthog_user_from_event")
     @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")
     def test_private_channel_unfurls_task_without_attaching_reference(
         self, mock_slack_integration_class: MagicMock, mock_resolve: MagicMock
@@ -231,7 +231,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
             description="",
             origin_product=Task.OriginProduct.USER_CREATED,
         )
-        mock_resolve.return_value = MagicMock(user=self.user)
+        mock_resolve.return_value = self.user
         mock_client = MagicMock()
         mock_client.conversations_info.return_value = {"channel": {"is_channel": True, "is_private": True}}
         mock_slack_integration_class.return_value.client = mock_client
@@ -252,7 +252,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
         task.refresh_from_db()
         assert "slack_thread_references" not in (task.state or {})
 
-    @patch("products.slack_app.backend.api.resolve_slack_user")
+    @patch("products.slack_app.backend.api.resolve_posthog_user_from_event")
     @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")
     def test_skips_when_user_not_resolved(
         self, mock_slack_integration_class: MagicMock, mock_resolve: MagicMock
@@ -273,13 +273,13 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
 
         mock_client.chat_unfurl.assert_not_called()
 
-    @patch("products.slack_app.backend.api.resolve_slack_user")
+    @patch("products.slack_app.backend.api.resolve_posthog_user_from_event")
     @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")
     def test_unfurls_insight_when_project_segment_mismatched(
         self, mock_slack_integration_class: MagicMock, mock_resolve: MagicMock
     ) -> None:
-        """A project id the workspace hasn't connected falls back to trying the candidates."""
-        mock_resolve.return_value = MagicMock(user=self.user)
+        # A project id the workspace hasn't connected falls back to trying the candidates.
+        mock_resolve.return_value = self.user
         mock_client = MagicMock()
         mock_slack_integration_class.return_value.client = mock_client
 
@@ -306,14 +306,14 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
             sensitive_config={"access_token": "xoxb-test"},
         )
 
-    @patch("products.slack_app.backend.api.resolve_slack_user")
+    @patch("products.slack_app.backend.api.resolve_posthog_user_from_event")
     @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")
     def test_unfurls_resource_from_project_named_in_url(
         self, mock_slack_integration_class: MagicMock, mock_resolve: MagicMock
     ) -> None:
         other = self._connect_second_project()
         dashboard = Dashboard.objects.create(team=other.team, name="Second board")
-        mock_resolve.return_value = MagicMock(user=self.user)
+        mock_resolve.return_value = self.user
         mock_client = MagicMock()
         mock_slack_integration_class.return_value.client = mock_client
 
@@ -326,7 +326,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
         text = mock_client.chat_unfurl.call_args.kwargs["unfurls"][url]["blocks"][0]["text"]["text"]
         assert "Second board" in text
 
-    @patch("products.slack_app.backend.api.resolve_slack_user")
+    @patch("products.slack_app.backend.api.resolve_posthog_user_from_event")
     @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")
     def test_unfurls_short_link_by_trying_every_connected_project(
         self, mock_slack_integration_class: MagicMock, mock_resolve: MagicMock
@@ -334,7 +334,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
         # `/i/:short_id` carries no project segment, so the only way to find it is to try each project.
         other = self._connect_second_project()
         insight = Insight.objects.create(team=other.team, short_id="insight2", name="Signups", saved=True)
-        mock_resolve.return_value = MagicMock(user=self.user)
+        mock_resolve.return_value = self.user
         mock_client = MagicMock()
         mock_slack_integration_class.return_value.client = mock_client
 
@@ -347,11 +347,11 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
         text = mock_client.chat_unfurl.call_args.kwargs["unfurls"][url]["blocks"][0]["text"]["text"]
         assert "Signups" in text
 
-    @patch("products.slack_app.backend.api.resolve_slack_user")
+    @patch("products.slack_app.backend.api.resolve_posthog_user_from_event")
     @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")
     def test_unfurls_dashboard(self, mock_slack_integration_class: MagicMock, mock_resolve: MagicMock) -> None:
         dashboard = Dashboard.objects.create(team=self.team, name="Main board", description="Overview")
-        mock_resolve.return_value = MagicMock(user=self.user)
+        mock_resolve.return_value = self.user
         mock_client = MagicMock()
         mock_slack_integration_class.return_value.client = mock_client
 
@@ -383,7 +383,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
                 parts.extend(element["text"] for element in block["elements"])
         return "\n".join(parts)
 
-    @patch("products.slack_app.backend.api.resolve_slack_user")
+    @patch("products.slack_app.backend.api.resolve_posthog_user_from_event")
     @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")
     def test_unfurls_ticket(self, mock_slack_integration_class: MagicMock, mock_resolve: MagicMock) -> None:
         ticket = Ticket.objects.create(
@@ -394,7 +394,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
             # Default display-name settings prefer email over name.
             anonymous_traits={"name": "John Doe", "email": "john@example.com"},
         )
-        mock_resolve.return_value = MagicMock(user=self.user)
+        mock_resolve.return_value = self.user
         mock_client = MagicMock()
         mock_slack_integration_class.return_value.client = mock_client
 
@@ -411,7 +411,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
         assert "New" in text  # default status, humanized
 
     @parameterized.expand([("resource",), ("object",)])
-    @patch("products.slack_app.backend.api.resolve_slack_user")
+    @patch("products.slack_app.backend.api.resolve_posthog_user_from_event")
     @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")
     def test_skips_ticket_without_viewer_access(
         self,
@@ -435,7 +435,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
                 team=self.team,
                 access_level="none",
             )
-        mock_resolve.return_value = MagicMock(user=member)
+        mock_resolve.return_value = member
         mock_client = MagicMock()
         mock_slack_integration_class.return_value.client = mock_client
 
@@ -447,14 +447,14 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
 
         mock_client.chat_unfurl.assert_not_called()
 
-    @patch("products.slack_app.backend.api.resolve_slack_user")
+    @patch("products.slack_app.backend.api.resolve_posthog_user_from_event")
     @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")
     def test_skips_ticket_from_another_project(
         self, mock_slack_integration_class: MagicMock, mock_resolve: MagicMock
     ) -> None:
         # ticket_number is per-project — a link naming a different project must not resolve to our #1.
         ticket = Ticket.objects.create(team=self.team, ticket_number=1, widget_session_id="s9", distinct_id="d9")
-        mock_resolve.return_value = MagicMock(user=self.user)
+        mock_resolve.return_value = self.user
         mock_client = MagicMock()
         mock_slack_integration_class.return_value.client = mock_client
 
@@ -466,7 +466,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
 
         mock_client.chat_unfurl.assert_not_called()
 
-    @patch("products.slack_app.backend.api.resolve_slack_user")
+    @patch("products.slack_app.backend.api.resolve_posthog_user_from_event")
     @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")
     def test_ticket_requester_follows_display_name_setting(
         self, mock_slack_integration_class: MagicMock, mock_resolve: MagicMock
@@ -481,7 +481,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
             distinct_id="d3",
             anonymous_traits={"name": "John Doe", "email": "john@example.com"},
         )
-        mock_resolve.return_value = MagicMock(user=self.user)
+        mock_resolve.return_value = self.user
         mock_client = MagicMock()
         mock_slack_integration_class.return_value.client = mock_client
 
@@ -494,7 +494,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
         text = self._unfurl_text(mock_client.chat_unfurl.call_args.kwargs["unfurls"][url])
         assert "Requested by:* John Doe" in text
 
-    @patch("products.slack_app.backend.api.resolve_slack_user")
+    @patch("products.slack_app.backend.api.resolve_posthog_user_from_event")
     @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")
     def test_unfurls_ticket_with_opening_message(
         self, mock_slack_integration_class: MagicMock, mock_resolve: MagicMock
@@ -508,7 +508,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
                 )
             ]
         )
-        mock_resolve.return_value = MagicMock(user=self.user)
+        mock_resolve.return_value = self.user
         mock_client = MagicMock()
         mock_slack_integration_class.return_value.client = mock_client
 
@@ -527,7 +527,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
             ("soft_deleted", {"deleted": True}),
         ]
     )
-    @patch("products.slack_app.backend.api.resolve_slack_user")
+    @patch("products.slack_app.backend.api.resolve_posthog_user_from_event")
     @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")
     def test_ticket_hidden_opening_message_not_surfaced(
         self, _name: str, overrides: dict, mock_slack_integration_class: MagicMock, mock_resolve: MagicMock
@@ -544,7 +544,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
                 )
             ]
         )
-        mock_resolve.return_value = MagicMock(user=self.user)
+        mock_resolve.return_value = self.user
         mock_client = MagicMock()
         mock_slack_integration_class.return_value.client = mock_client
 

--- a/products/slack_app/backend/tests/test_link_unfurl.py
+++ b/products/slack_app/backend/tests/test_link_unfurl.py
@@ -148,7 +148,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
                 "user": "U1",
                 "links": [{"url": url, "domain": "testserver"}],
             },
-            self.integration,
+            [self.integration],
         )
 
         mock_client.chat_unfurl.assert_called_once()
@@ -196,8 +196,8 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
             "links": [{"url": url}],
         }
 
-        handle_posthog_link_unfurl(event, self.integration)
-        handle_posthog_link_unfurl(event, self.integration)
+        handle_posthog_link_unfurl(event, [self.integration])
+        handle_posthog_link_unfurl(event, [self.integration])
 
         text = mock_client.chat_unfurl.call_args.kwargs["unfurls"][url]["blocks"][0]["text"]["text"]
         assert "Review &lt;https://example.com|Slack task links&gt;" in text
@@ -245,7 +245,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
                 "source": "conversations_history",
                 "links": [{"url": url}],
             },
-            self.integration,
+            [self.integration],
         )
 
         mock_client.chat_unfurl.assert_called_once()
@@ -268,7 +268,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
                 "user": "U1",
                 "links": [{"url": f"http://testserver/project/{self.team.pk}/insights/{self.insight.short_id}"}],
             },
-            self.integration,
+            [self.integration],
         )
 
         mock_client.chat_unfurl.assert_not_called()
@@ -278,7 +278,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
     def test_unfurls_insight_when_project_segment_mismatched(
         self, mock_slack_integration_class: MagicMock, mock_resolve: MagicMock
     ) -> None:
-        """Project id in the URL is ignored; lookup uses the connected team + short_id only."""
+        """A project id the workspace hasn't connected falls back to trying the candidates."""
         mock_resolve.return_value = MagicMock(user=self.user)
         mock_client = MagicMock()
         mock_slack_integration_class.return_value.client = mock_client
@@ -291,11 +291,61 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
                 "user": "U1",
                 "links": [{"url": url}],
             },
-            self.integration,
+            [self.integration],
         )
 
         mock_client.chat_unfurl.assert_called_once()
         assert url in mock_client.chat_unfurl.call_args.kwargs["unfurls"]
+
+    def _connect_second_project(self) -> Integration:
+        other_team = Team.objects.create(organization=self.organization, name="Second project")
+        return Integration.objects.create(
+            team=other_team,
+            kind="slack",
+            integration_id=self.integration.integration_id,
+            sensitive_config={"access_token": "xoxb-test"},
+        )
+
+    @patch("products.slack_app.backend.api.resolve_slack_user")
+    @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")
+    def test_unfurls_resource_from_project_named_in_url(
+        self, mock_slack_integration_class: MagicMock, mock_resolve: MagicMock
+    ) -> None:
+        other = self._connect_second_project()
+        dashboard = Dashboard.objects.create(team=other.team, name="Second board")
+        mock_resolve.return_value = MagicMock(user=self.user)
+        mock_client = MagicMock()
+        mock_slack_integration_class.return_value.client = mock_client
+
+        url = f"http://testserver/project/{other.team_id}/dashboard/{dashboard.pk}"
+        handle_posthog_link_unfurl(
+            {"channel": "C1", "message_ts": "1.2", "user": "U1", "links": [{"url": url}]},
+            [self.integration, other],
+        )
+
+        text = mock_client.chat_unfurl.call_args.kwargs["unfurls"][url]["blocks"][0]["text"]["text"]
+        assert "Second board" in text
+
+    @patch("products.slack_app.backend.api.resolve_slack_user")
+    @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")
+    def test_unfurls_short_link_by_trying_every_connected_project(
+        self, mock_slack_integration_class: MagicMock, mock_resolve: MagicMock
+    ) -> None:
+        # `/i/:short_id` carries no project segment, so the only way to find it is to try each project.
+        other = self._connect_second_project()
+        insight = Insight.objects.create(team=other.team, short_id="insight2", name="Signups", saved=True)
+        mock_resolve.return_value = MagicMock(user=self.user)
+        mock_client = MagicMock()
+        mock_slack_integration_class.return_value.client = mock_client
+
+        url = f"http://testserver/i/{insight.short_id}"
+        handle_posthog_link_unfurl(
+            {"channel": "C1", "message_ts": "1.2", "user": "U1", "links": [{"url": url}]},
+            [self.integration, other],
+        )
+
+        text = mock_client.chat_unfurl.call_args.kwargs["unfurls"][url]["blocks"][0]["text"]["text"]
+        assert "Signups" in text
 
     @patch("products.slack_app.backend.api.resolve_slack_user")
     @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")
@@ -315,7 +365,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
                 "user": "U1",
                 "links": [{"url": url}],
             },
-            self.integration,
+            [self.integration],
         )
 
         mock_client.chat_unfurl.assert_called_once()
@@ -351,7 +401,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
         url = f"http://testserver/project/{self.team.pk}/support/tickets/{ticket.ticket_number}"
         handle_posthog_link_unfurl(
             {"channel": "C1", "message_ts": "123.456", "user": "U1", "links": [{"url": url}]},
-            self.integration,
+            [self.integration],
         )
 
         mock_client.chat_unfurl.assert_called_once()
@@ -392,7 +442,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
         url = f"http://testserver/project/{self.team.pk}/support/tickets/{ticket.ticket_number}"
         handle_posthog_link_unfurl(
             {"channel": "C1", "message_ts": "1.2", "user": "U1", "links": [{"url": url}]},
-            self.integration,
+            [self.integration],
         )
 
         mock_client.chat_unfurl.assert_not_called()
@@ -411,7 +461,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
         url = f"http://testserver/project/{self.team.pk + 1}/support/tickets/{ticket.ticket_number}"
         handle_posthog_link_unfurl(
             {"channel": "C1", "message_ts": "1.2", "user": "U1", "links": [{"url": url}]},
-            self.integration,
+            [self.integration],
         )
 
         mock_client.chat_unfurl.assert_not_called()
@@ -438,7 +488,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
         url = f"http://testserver/support/tickets/{ticket.ticket_number}"
         handle_posthog_link_unfurl(
             {"channel": "C1", "message_ts": "1.2", "user": "U1", "links": [{"url": url}]},
-            self.integration,
+            [self.integration],
         )
 
         text = self._unfurl_text(mock_client.chat_unfurl.call_args.kwargs["unfurls"][url])
@@ -465,7 +515,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
         url = f"http://testserver/support/tickets/{ticket.ticket_number}"
         handle_posthog_link_unfurl(
             {"channel": "C1", "message_ts": "1.2", "user": "U1", "links": [{"url": url}]},
-            self.integration,
+            [self.integration],
         )
 
         text = self._unfurl_text(mock_client.chat_unfurl.call_args.kwargs["unfurls"][url])
@@ -501,7 +551,7 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
         url = f"http://testserver/support/tickets/{ticket.ticket_number}"
         handle_posthog_link_unfurl(
             {"channel": "C1", "message_ts": "1.2", "user": "U1", "links": [{"url": url}]},
-            self.integration,
+            [self.integration],
         )
 
         text = self._unfurl_text(mock_client.chat_unfurl.call_args.kwargs["unfurls"][url])

--- a/products/slack_app/backend/tests/test_posthog_code_event_handler.py
+++ b/products/slack_app/backend/tests/test_posthog_code_event_handler.py
@@ -716,8 +716,8 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
 
         assert result == ROUTE_HANDLED_LOCALLY
         mock_unfurl.assert_called_once()
-        passed_integration = mock_unfurl.call_args[0][1]
-        assert passed_integration.id == self.posthog_code_integration.id
+        passed_candidates = mock_unfurl.call_args[0][1]
+        assert [c.id for c in passed_candidates] == [self.posthog_code_integration.id]
 
     @patch("products.slack_app.backend.api.handle_posthog_link_unfurl")
     @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
@@ -739,10 +739,8 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
 
         assert result == ROUTE_HANDLED_LOCALLY
         mock_unfurl.assert_called_once()
-        # Don't assert on which integration row was passed: "first row by id" picking is a known
-        # limitation for multi-team workspaces and shouldn't be baked into the test contract.
-        passed_integration = mock_unfurl.call_args[0][1]
-        assert passed_integration.integration_id == "T12345"
+        passed_candidates = mock_unfurl.call_args[0][1]
+        assert [c.integration_id for c in passed_candidates] == ["T12345"]
 
     @patch("products.slack_app.backend.api._proxy_event_and_return_route")
     @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")


### PR DESCRIPTION
## Problem

- Someone who pastes a PostHog dashboard or insight link in Slack gets no unfurl at all, whenever their workspace connects more than one PostHog project.
- `handle_posthog_link_unfurl` resolved every link against one integration, which the caller picked as `candidates[0]` — the lowest-id row for the workspace.
- Resources in any other connected project miss the team-scoped lookup and the link stays bare.
- The loop skipped those links with a bare `continue`, so nothing reached the logs. [#72756](https://github.com/PostHog/posthog/pull/72756) added a callback log, and it showed the callback arriving with the resource parsed correctly.

## Changes

- Each link now resolves against the project its `/project/:id` segment names.
- A link with no project segment, such as `/i/:short_id`, tries every connected project in turn.
- A link naming a project the workspace has not connected falls back the same way.
- Routing happens per link, so one message can unfurl resources from different projects.
- A link that resolves nowhere logs `slack_link_unfurl_unresolved` with the resource and the projects tried.
- The sharer resolves once for the workspace through `resolve_user_for_workspace`, which drops projects they cannot reach. The per-resource viewer check still runs on top.
- Ticket links still refuse when the URL names a different project, because ticket numbers repeat across projects. That rule now sits in `_PROJECT_SCOPED_REFS` beside candidate selection, so a future project-scoped entity is one set entry.

The alternative was to keep one integration per event and choose it better. Routing per link is what the URL already supports, it costs one lookup on the common path, and it covers project-level entities we add later without another change here.

> [!NOTE]
> The upstream half is not fixed here. Our own Slack workspace receives no `link_shared` callbacks at all, while other workspaces on the same Slack app do. That is a Slack-side configuration question, not a code path.

## How did you test this code?

- `test_unfurls_resource_from_project_named_in_url` catches the regression above: a dashboard in the second connected project, with the first project listed ahead of it. It fails on `candidates[0]`.
- `test_unfurls_short_link_by_trying_every_connected_project` covers the fallback, where the URL carries no project id and only a sweep can find the insight.
- No existing case built a workspace with two connected projects, so neither path had coverage.
- `test_skips_ticket_from_another_project` now exercises the fallback path and still asserts the refusal, which keeps the cross-project ticket guard honest.
- Not run: I could not confirm the behavior by hand in Slack, and I have no `link_shared` callback to replay against our workspace.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing copy or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via the PostHog Slack app) started from a report that a dashboard link did not unfurl, raised in a [Slack thread](https://posthog.slack.com/archives/CU54W0FK8/p1786363609671859?thread_ts=1786363609.671859&cid=CU54W0FK8). Reading production logs ruled out signature rejection and confirmed the parse was correct, which pointed at the integration the handler resolved against rather than at parsing.

The first theory was a missing `links:read` grant. Checking the stored install config disproved it, and the multi-project resolution bug surfaced from there. The reviewer directed the design: route on the URL's project id, then fall back to the accessible candidates, generically rather than per resource type.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/simplify`.

The first version resolved the sharer once per candidate project, which cost a Slack `users.info` call per project on a fallback sweep. The `/simplify` pass replaced that with `resolve_user_for_workspace`, which already resolves a Slack user across every connected org in one pass. The same pass moved `UserAccessControl` construction to one instance per team.

---

*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/CU54W0FK8/p1786363609671859?thread_ts=1786363609.671859&cid=CU54W0FK8)*
