### PR TITLE
fix(data-modeling): stop suspending models on our own failures

### DIFF
--- a/posthog/temporal/data_modeling/activities/get_dag_structure.py
+++ b/posthog/temporal/data_modeling/activities/get_dag_structure.py
@@ -7,10 +7,7 @@ from posthog.temporal.common.logger import get_logger
 
 from products.data_modeling.backend.facade.models import DataModelingJobEngine, Edge, Node, NodeType
 
-from .utils import (
-    is_node_suspended,
-    is_suspension_enforced as _is_suspension_enforced,
-)
+from .utils import is_node_suspended, is_suspension_enforced
 
 LOGGER = get_logger(__name__)
 
@@ -54,7 +51,7 @@ def _get_dag_structure_async(team_id: int, dag_id: str) -> DAG:
         .filter(team_id=team_id, dag_id=dag_id)
         .exclude(source__type=NodeType.TABLE)
     )
-    if _is_suspension_enforced(team_id):
+    if is_suspension_enforced(team_id):
         suspended_nodes = {
             engine.value: [str(n.id) for n in executable_nodes if is_node_suspended(n, engine)]
             for engine in DataModelingJobEngine

--- a/posthog/temporal/data_modeling/activities/get_dag_structure.py
+++ b/posthog/temporal/data_modeling/activities/get_dag_structure.py
@@ -2,34 +2,17 @@ import dataclasses
 
 from temporalio import activity
 
-from posthog.models import Team
-from posthog.ph_client import feature_enabled_or_false
 from posthog.sync import database_sync_to_async_pool
 from posthog.temporal.common.logger import get_logger
 
 from products.data_modeling.backend.facade.models import DataModelingJobEngine, Edge, Node, NodeType
 
-from .utils import is_node_suspended
+from .utils import (
+    is_node_suspended,
+    is_suspension_enforced as _is_suspension_enforced,
+)
 
 LOGGER = get_logger(__name__)
-
-SUSPENSION_ENFORCEMENT_FLAG = "data-modeling-suspend-failing-nodes"
-
-
-def _is_suspension_enforced(team_id: int) -> bool:
-    try:
-        team = Team.objects.only("organization_id").get(id=team_id)
-        return feature_enabled_or_false(
-            SUSPENSION_ENFORCEMENT_FLAG,
-            str(team_id),
-            groups={"organization": str(team.organization_id), "project": str(team_id)},
-            group_properties={"organization": {"id": str(team.organization_id)}, "project": {"id": str(team_id)}},
-            only_evaluate_locally=True,
-            send_feature_flag_events=False,
-        )
-    except Exception:
-        LOGGER.warning("Failed to evaluate suspension enforcement flag; treating as disabled", team_id=team_id)
-        return False
 
 
 @dataclasses.dataclass

--- a/posthog/temporal/data_modeling/activities/utils.py
+++ b/posthog/temporal/data_modeling/activities/utils.py
@@ -34,7 +34,7 @@ __all__ = [
     "bind_data_modeling_log_context",
     "clear_node_suspension",
     "clear_node_suspension_for_engine",
-    "is_infrastructure_error",
+    "is_externally_aborted",
     "is_node_suspended",
     "is_suspension_enforced",
     "mark_node_suspended",
@@ -50,20 +50,17 @@ CONSECUTIVE_FAILURES_TO_SUSPEND = 5
 
 SUSPENSION_ENFORCEMENT_FLAG = "data-modeling-suspend-failing-nodes"
 
-# Failures where the cluster was busy, restarting or unreachable. The customer's query is fine, so
-# there is nothing they could change to stop the streak.
-INFRASTRUCTURE_ERROR_MARKERS = (
-    "Code: 241",  # MEMORY_LIMIT_EXCEEDED
-    "Code: 202",  # TOO_MANY_SIMULTANEOUS_QUERIES
+# Failures where something outside the query stopped it: it was refused admission, could not reach
+# the cluster, or we killed it. The test to apply before adding a marker here is "was the query
+# denied the chance to fail on its own merits", NOT "was this our fault" - a query that exhausts
+# memory or wall-clock is one we do want suspended, however much the cluster's load contributed.
+EXTERNALLY_ABORTED_MARKERS = (
+    "Code: 202",  # TOO_MANY_SIMULTANEOUS_QUERIES - refused admission, never executed
     "Cannot connect to host",
     "Connection refused",
     "Preempted",
     ABANDONED_ERROR,
 )
-
-# A 241 raised by the customer's own query is their fault, unlike one raised by cluster pressure.
-# Same phrasings, and same fail-safe polarity, as errors.py: an unrecognized wording is pressure.
-PER_QUERY_MEMORY_LIMIT_PHRASINGS = ("(for query)", "Query memory limit exceeded")
 
 
 def is_suspension_enforced(team_id: int) -> bool:
@@ -82,10 +79,8 @@ def is_suspension_enforced(team_id: int) -> bool:
         return False
 
 
-def is_infrastructure_error(error: str) -> bool:
-    if any(phrasing in error for phrasing in PER_QUERY_MEMORY_LIMIT_PHRASINGS):
-        return False
-    return any(marker in error for marker in INFRASTRUCTURE_ERROR_MARKERS)
+def is_externally_aborted(error: str) -> bool:
+    return any(marker in error for marker in EXTERNALLY_ABORTED_MARKERS)
 
 
 def bind_data_modeling_log_context(team_id: int, saved_query_id: UUID | str) -> None:
@@ -161,9 +156,9 @@ def _count_leading_failures(saved_query_id: UUID, engine: str, *, since: str | N
     rows = jobs.order_by("-created_at").values_list("status", "error")[:CONSECUTIVE_FAILURES_TO_SUSPEND]
     count = 0
     for status, error in rows:
-        # Suspending on our own failures stops a model the customer cannot restart, because their
-        # query was never the problem.
-        if status != DataModelingJobStatus.FAILED or is_infrastructure_error(error or ""):
+        # A run that was blocked or killed says nothing about the query, so counting it would
+        # suspend a model on evidence it never produced.
+        if status != DataModelingJobStatus.FAILED or is_externally_aborted(error or ""):
             break
         count += 1
     return count

--- a/posthog/temporal/data_modeling/activities/utils.py
+++ b/posthog/temporal/data_modeling/activities/utils.py
@@ -58,7 +58,8 @@ EXTERNALLY_ABORTED_MARKERS = (
     "Code: 202",  # TOO_MANY_SIMULTANEOUS_QUERIES - refused admission, never executed
     "Cannot connect to host",
     "Connection refused",
-    "Preempted",
+    "QueueEmpty",  # no root node to start from, so the graph was refused rather than the query
+    "Preempted: ",  # the trailing colon keeps a customer's column of that name out of the match
     ABANDONED_ERROR,
 )
 

--- a/posthog/temporal/data_modeling/activities/utils.py
+++ b/posthog/temporal/data_modeling/activities/utils.py
@@ -50,12 +50,10 @@ CONSECUTIVE_FAILURES_TO_SUSPEND = 5
 
 SUSPENSION_ENFORCEMENT_FLAG = "data-modeling-suspend-failing-nodes"
 
-# Failures where something outside the query stopped it: it was refused admission, could not reach
-# the cluster, or we killed it. The test to apply before adding a marker here is "was the query
-# denied the chance to fail on its own merits", NOT "was this our fault" - a query that exhausts
-# memory or wall-clock is one we do want suspended, however much the cluster's load contributed.
+# The test before adding a marker is "was the query denied the chance to fail on its own merits",
+# NOT "was this our fault" - a query that exhausts memory is one we do want suspended.
 EXTERNALLY_ABORTED_MARKERS = (
-    "Code: 202",  # TOO_MANY_SIMULTANEOUS_QUERIES - refused admission, never executed
+    "Code: 202",  # TOO_MANY_SIMULTANEOUS_QUERIES
     "Cannot connect to host",
     "Connection refused",
     "QueueEmpty",  # no root node to start from, so the graph was refused rather than the query
@@ -157,8 +155,6 @@ def _count_leading_failures(saved_query_id: UUID, engine: str, *, since: str | N
     rows = jobs.order_by("-created_at").values_list("status", "error")[:CONSECUTIVE_FAILURES_TO_SUSPEND]
     count = 0
     for status, error in rows:
-        # A run that was blocked or killed says nothing about the query, so counting it would
-        # suspend a model on evidence it never produced.
         if status != DataModelingJobStatus.FAILED or is_externally_aborted(error or ""):
             break
         count += 1

--- a/posthog/temporal/data_modeling/activities/utils.py
+++ b/posthog/temporal/data_modeling/activities/utils.py
@@ -10,6 +10,7 @@ from posthog.models import Team
 from posthog.ph_client import feature_enabled_or_false
 from posthog.sync import database_sync_to_async_pool
 from posthog.temporal.common.logger import get_logger
+from posthog.temporal.data_modeling.activities.preempt_dag_run import ABANDONED_ERROR
 
 from products.data_modeling.backend.facade.api import (
     clear_node_suspension,
@@ -30,8 +31,6 @@ from products.data_modeling.backend.facade.models import (
 # API and DAG-sync paths that clear it. Re-exported so the activities keep importing from here.
 __all__ = [
     "CONSECUTIVE_FAILURES_TO_SUSPEND",
-    "INFRASTRUCTURE_ERROR_MARKERS",
-    "SUSPENSION_ENFORCEMENT_FLAG",
     "bind_data_modeling_log_context",
     "clear_node_suspension",
     "clear_node_suspension_for_engine",
@@ -56,15 +55,15 @@ SUSPENSION_ENFORCEMENT_FLAG = "data-modeling-suspend-failing-nodes"
 INFRASTRUCTURE_ERROR_MARKERS = (
     "Code: 241",  # MEMORY_LIMIT_EXCEEDED
     "Code: 202",  # TOO_MANY_SIMULTANEOUS_QUERIES
-    "MemoryLimitExceeded",
-    "TooManySimultaneousQueries",
-    "Too many simultaneous queries",
-    "QueueEmpty",
     "Cannot connect to host",
     "Connection refused",
-    "Workflow was cancelled",
     "Preempted",
+    ABANDONED_ERROR,
 )
+
+# A 241 raised by the customer's own query is their fault, unlike one raised by cluster pressure.
+# Same phrasings, and same fail-safe polarity, as errors.py: an unrecognized wording is pressure.
+PER_QUERY_MEMORY_LIMIT_PHRASINGS = ("(for query)", "Query memory limit exceeded")
 
 
 def is_suspension_enforced(team_id: int) -> bool:
@@ -84,7 +83,8 @@ def is_suspension_enforced(team_id: int) -> bool:
 
 
 def is_infrastructure_error(error: str) -> bool:
-    """Whether the failure was ours - a busy or unreachable cluster - rather than the customer's query."""
+    if any(phrasing in error for phrasing in PER_QUERY_MEMORY_LIMIT_PHRASINGS):
+        return False
     return any(marker in error for marker in INFRASTRUCTURE_ERROR_MARKERS)
 
 
@@ -161,8 +161,8 @@ def _count_leading_failures(saved_query_id: UUID, engine: str, *, since: str | N
     rows = jobs.order_by("-created_at").values_list("status", "error")[:CONSECUTIVE_FAILURES_TO_SUSPEND]
     count = 0
     for status, error in rows:
-        # An outage breaks the streak rather than extending it. Suspending on our own failures stops
-        # a model the customer cannot restart, because their query was never the problem.
+        # Suspending on our own failures stops a model the customer cannot restart, because their
+        # query was never the problem.
         if status != DataModelingJobStatus.FAILED or is_infrastructure_error(error or ""):
             break
         count += 1

--- a/posthog/temporal/data_modeling/activities/utils.py
+++ b/posthog/temporal/data_modeling/activities/utils.py
@@ -56,8 +56,9 @@ EXTERNALLY_ABORTED_MARKERS = (
     "Code: 202",  # TOO_MANY_SIMULTANEOUS_QUERIES
     "Cannot connect to host",
     "Connection refused",
-    "QueueEmpty",  # no root node to start from, so the graph was refused rather than the query
-    "Preempted: ",  # the trailing colon keeps a customer's column of that name out of the match
+    # the trailing colon is load-bearing: it keeps a customer column of the same name out of the match
+    "QueueEmpty: ",  # no root node to start from, so the graph was refused rather than the query
+    "Preempted: ",
     ABANDONED_ERROR,
 )
 

--- a/posthog/temporal/data_modeling/activities/utils.py
+++ b/posthog/temporal/data_modeling/activities/utils.py
@@ -6,7 +6,10 @@ from django.db import transaction
 
 from structlog.contextvars import bind_contextvars
 
+from posthog.models import Team
+from posthog.ph_client import feature_enabled_or_false
 from posthog.sync import database_sync_to_async_pool
+from posthog.temporal.common.logger import get_logger
 
 from products.data_modeling.backend.facade.api import (
     clear_node_suspension,
@@ -27,18 +30,62 @@ from products.data_modeling.backend.facade.models import (
 # API and DAG-sync paths that clear it. Re-exported so the activities keep importing from here.
 __all__ = [
     "CONSECUTIVE_FAILURES_TO_SUSPEND",
+    "INFRASTRUCTURE_ERROR_MARKERS",
+    "SUSPENSION_ENFORCEMENT_FLAG",
     "bind_data_modeling_log_context",
     "clear_node_suspension",
     "clear_node_suspension_for_engine",
+    "is_infrastructure_error",
     "is_node_suspended",
+    "is_suspension_enforced",
     "mark_node_suspended",
     "maybe_suspend_node_for_engine",
     "strip_hostname_from_error",
     "update_node_system_properties",
 ]
 
+LOGGER = get_logger(__name__)
+
 # Consecutive failed jobs (per engine) before a node is suspended from future DAG runs.
 CONSECUTIVE_FAILURES_TO_SUSPEND = 5
+
+SUSPENSION_ENFORCEMENT_FLAG = "data-modeling-suspend-failing-nodes"
+
+# Failures where the cluster was busy, restarting or unreachable. The customer's query is fine, so
+# there is nothing they could change to stop the streak.
+INFRASTRUCTURE_ERROR_MARKERS = (
+    "Code: 241",  # MEMORY_LIMIT_EXCEEDED
+    "Code: 202",  # TOO_MANY_SIMULTANEOUS_QUERIES
+    "MemoryLimitExceeded",
+    "TooManySimultaneousQueries",
+    "Too many simultaneous queries",
+    "QueueEmpty",
+    "Cannot connect to host",
+    "Connection refused",
+    "Workflow was cancelled",
+    "Preempted",
+)
+
+
+def is_suspension_enforced(team_id: int) -> bool:
+    try:
+        team = Team.objects.only("organization_id").get(id=team_id)
+        return feature_enabled_or_false(
+            SUSPENSION_ENFORCEMENT_FLAG,
+            str(team_id),
+            groups={"organization": str(team.organization_id), "project": str(team_id)},
+            group_properties={"organization": {"id": str(team.organization_id)}, "project": {"id": str(team_id)}},
+            only_evaluate_locally=True,
+            send_feature_flag_events=False,
+        )
+    except Exception:
+        LOGGER.warning("Failed to evaluate suspension enforcement flag; treating as disabled", team_id=team_id)
+        return False
+
+
+def is_infrastructure_error(error: str) -> bool:
+    """Whether the failure was ours - a busy or unreachable cluster - rather than the customer's query."""
+    return any(marker in error for marker in INFRASTRUCTURE_ERROR_MARKERS)
 
 
 def bind_data_modeling_log_context(team_id: int, saved_query_id: UUID | str) -> None:
@@ -111,10 +158,12 @@ def _count_leading_failures(saved_query_id: UUID, engine: str, *, since: str | N
         # Otherwise the failures that caused the suspension are still the most recent jobs, and one
         # new failure re-suspends the node we just resumed.
         jobs = jobs.filter(created_at__gt=dt.datetime.fromisoformat(since))
-    statuses = jobs.order_by("-created_at").values_list("status", flat=True)[:CONSECUTIVE_FAILURES_TO_SUSPEND]
+    rows = jobs.order_by("-created_at").values_list("status", "error")[:CONSECUTIVE_FAILURES_TO_SUSPEND]
     count = 0
-    for status in statuses:
-        if status != DataModelingJobStatus.FAILED:
+    for status, error in rows:
+        # An outage breaks the streak rather than extending it. Suspending on our own failures stops
+        # a model the customer cannot restart, because their query was never the problem.
+        if status != DataModelingJobStatus.FAILED or is_infrastructure_error(error or ""):
             break
         count += 1
     return count
@@ -144,7 +193,9 @@ def maybe_suspend_node_for_engine(
         )
         mark_node_suspended(node, engine=engine, reason=reason, job_id=job_id, fingerprint=fingerprint)
         node.save()
-    if str(engine) == DataModelingJobEngine.CLICKHOUSE.value:
+    # Without enforcement the node keeps materializing every tick, so telling the customer it stopped
+    # would be false.
+    if str(engine) == DataModelingJobEngine.CLICKHOUSE.value and is_suspension_enforced(team_id):
         job = DataModelingJob.objects.get(id=job_id)
         job.error = (
             f"This model has been suspended after {CONSECUTIVE_FAILURES_TO_SUSPEND} consecutive failed "

--- a/posthog/temporal/tests/data_modeling/test_execute_dag_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_execute_dag_workflow.py
@@ -152,7 +152,7 @@ class TestGetDagStructureActivity:
         await database_sync_to_async(suspended_node.save)()
 
         inputs = GetDAGStructureInputs(team_id=ateam.pk, dag_id=str(adag.id))
-        with unittest.mock.patch.object(gds, "_is_suspension_enforced", return_value=enforced):
+        with unittest.mock.patch.object(gds, "is_suspension_enforced", return_value=enforced):
             dag = await activity_environment.run(get_dag_structure_activity, inputs)
 
         assert dag.suspended_nodes["clickhouse"] == ([str(suspended_node.id)] if enforced else [])

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -462,7 +462,8 @@ class TestShouldPauseScheduleForTimeout:
 
 
 class TestNodeSuspension:
-    async def test_suspends_for_engine_after_consecutive_failures(self, ateam, anode, asaved_query, adag):
+    @pytest.mark.parametrize("enforced", [True, False])
+    async def test_suspends_for_engine_after_consecutive_failures(self, ateam, anode, asaved_query, adag, enforced):
         from posthog.temporal.data_modeling.activities.utils import (
             CONSECUTIVE_FAILURES_TO_SUSPEND,
             is_node_suspended,
@@ -477,7 +478,7 @@ class TestNodeSuspension:
         jobs.append(job)
 
         with unittest.mock.patch(
-            "posthog.temporal.data_modeling.activities.utils.is_suspension_enforced", return_value=True
+            "posthog.temporal.data_modeling.activities.utils.is_suspension_enforced", return_value=enforced
         ):
             suspended = await maybe_suspend_node_for_engine(
                 node_id=str(anode.id),
@@ -491,48 +492,11 @@ class TestNodeSuspension:
 
         assert suspended is True
         await database_sync_to_async(anode.refresh_from_db)()
+        # the marker is recorded either way, so widening the flag later still finds the node
         assert is_node_suspended(anode, DataModelingJobEngine.CLICKHOUSE) is True
         assert is_node_suspended(anode, DataModelingJobEngine.DUCKGRES) is False
         await database_sync_to_async(job.refresh_from_db)()
-        assert "has been suspended" in job.error
-
-        # DataModelingJob.team is SET_NULL, so it survives the ateam fixture's team teardown.
-        for j in jobs:
-            await database_sync_to_async(j.delete)()
-
-    async def test_does_not_claim_suspension_without_enforcement(self, ateam, anode, asaved_query, adag):
-        from posthog.temporal.data_modeling.activities.utils import (
-            CONSECUTIVE_FAILURES_TO_SUSPEND,
-            is_node_suspended,
-            maybe_suspend_node_for_engine,
-        )
-
-        jobs = [
-            await _make_job(ateam, asaved_query, DataModelingJob.Status.FAILED, error="boom")
-            for _ in range(CONSECUTIVE_FAILURES_TO_SUSPEND)
-        ]
-        job = await _make_job(ateam, asaved_query, DataModelingJob.Status.FAILED, error="boom")
-        jobs.append(job)
-
-        with unittest.mock.patch(
-            "posthog.temporal.data_modeling.activities.utils.is_suspension_enforced", return_value=False
-        ):
-            suspended = await maybe_suspend_node_for_engine(
-                node_id=str(anode.id),
-                team_id=ateam.pk,
-                dag_id=str(adag.id),
-                saved_query_id=asaved_query.id,
-                engine=DataModelingJobEngine.CLICKHOUSE,
-                reason="boom",
-                job_id=str(job.id),
-            )
-
-        assert suspended is True
-        await database_sync_to_async(anode.refresh_from_db)()
-        # the marker is still recorded, so widening the flag later still finds the node
-        assert is_node_suspended(anode, DataModelingJobEngine.CLICKHOUSE) is True
-        await database_sync_to_async(job.refresh_from_db)()
-        assert job.error == "boom"
+        assert ("has been suspended" in job.error) is enforced
 
         # DataModelingJob.team is SET_NULL, so it survives the ateam fixture's team teardown.
         for j in jobs:
@@ -542,8 +506,9 @@ class TestNodeSuspension:
         "infra_error",
         [
             "ClickHouseMemoryLimitExceededError: Code: 241. DB::Exception: Memory limit (total) exceeded",
-            "Code: 202. DB::Exception: Too many simultaneous queries for user datawarehouse",
+            "Code: 202. DB::Exception: Too many simultaneous queries",
             "Cannot connect to host ch-offline.example.com:8443",
+            "Abandoned: the materialization workflow is no longer running",
         ],
     )
     async def test_infrastructure_failures_do_not_suspend(self, ateam, anode, asaved_query, adag, infra_error):
@@ -571,6 +536,45 @@ class TestNodeSuspension:
         assert suspended is False
         await database_sync_to_async(anode.refresh_from_db)()
         assert is_node_suspended(anode, DataModelingJobEngine.CLICKHOUSE) is False
+
+        # DataModelingJob.team is SET_NULL, so it survives the ateam fixture's team teardown.
+        for job in jobs:
+            await database_sync_to_async(job.delete)()
+
+    @pytest.mark.parametrize(
+        "memory_error",
+        [
+            "ClickHouseMemoryLimitExceededError: Code: 241. DB::Exception: Memory limit (for query) exceeded",
+            "ClickHouseMemoryLimitExceededError: Code: 241. DB::Exception: Query memory limit exceeded",
+        ],
+    )
+    async def test_suspends_when_the_query_itself_blew_the_memory_limit(
+        self, ateam, anode, asaved_query, adag, memory_error
+    ):
+        from posthog.temporal.data_modeling.activities.utils import (
+            CONSECUTIVE_FAILURES_TO_SUSPEND,
+            is_node_suspended,
+            maybe_suspend_node_for_engine,
+        )
+
+        jobs = [
+            await _make_job(ateam, asaved_query, DataModelingJob.Status.FAILED, error=memory_error)
+            for _ in range(CONSECUTIVE_FAILURES_TO_SUSPEND)
+        ]
+
+        suspended = await maybe_suspend_node_for_engine(
+            node_id=str(anode.id),
+            team_id=ateam.pk,
+            dag_id=str(adag.id),
+            saved_query_id=asaved_query.id,
+            engine=DataModelingJobEngine.CLICKHOUSE,
+            reason=memory_error,
+            job_id=str(jobs[-1].id),
+        )
+
+        assert suspended is True
+        await database_sync_to_async(anode.refresh_from_db)()
+        assert is_node_suspended(anode, DataModelingJobEngine.CLICKHOUSE) is True
 
         # DataModelingJob.team is SET_NULL, so it survives the ateam fixture's team teardown.
         for job in jobs:

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -503,15 +503,14 @@ class TestNodeSuspension:
             await database_sync_to_async(j.delete)()
 
     @pytest.mark.parametrize(
-        "infra_error",
+        "aborted_error",
         [
-            "ClickHouseMemoryLimitExceededError: Code: 241. DB::Exception: Memory limit (total) exceeded",
             "Code: 202. DB::Exception: Too many simultaneous queries",
             "Cannot connect to host ch-offline.example.com:8443",
             "Abandoned: the materialization workflow is no longer running",
         ],
     )
-    async def test_infrastructure_failures_do_not_suspend(self, ateam, anode, asaved_query, adag, infra_error):
+    async def test_externally_aborted_failures_do_not_suspend(self, ateam, anode, asaved_query, adag, aborted_error):
         from posthog.temporal.data_modeling.activities.utils import (
             CONSECUTIVE_FAILURES_TO_SUSPEND,
             is_node_suspended,
@@ -519,7 +518,7 @@ class TestNodeSuspension:
         )
 
         jobs = [
-            await _make_job(ateam, asaved_query, DataModelingJob.Status.FAILED, error=infra_error)
+            await _make_job(ateam, asaved_query, DataModelingJob.Status.FAILED, error=aborted_error)
             for _ in range(CONSECUTIVE_FAILURES_TO_SUSPEND)
         ]
 
@@ -529,7 +528,7 @@ class TestNodeSuspension:
             dag_id=str(adag.id),
             saved_query_id=asaved_query.id,
             engine=DataModelingJobEngine.CLICKHOUSE,
-            reason=infra_error,
+            reason=aborted_error,
             job_id=str(jobs[-1].id),
         )
 
@@ -545,12 +544,11 @@ class TestNodeSuspension:
         "memory_error",
         [
             "ClickHouseMemoryLimitExceededError: Code: 241. DB::Exception: Memory limit (for query) exceeded",
+            "ClickHouseMemoryLimitExceededError: Code: 241. DB::Exception: Memory limit (total) exceeded",
             "ClickHouseMemoryLimitExceededError: Code: 241. DB::Exception: Query memory limit exceeded",
         ],
     )
-    async def test_suspends_when_the_query_itself_blew_the_memory_limit(
-        self, ateam, anode, asaved_query, adag, memory_error
-    ):
+    async def test_suspends_when_the_query_exhausts_memory(self, ateam, anode, asaved_query, adag, memory_error):
         from posthog.temporal.data_modeling.activities.utils import (
             CONSECUTIVE_FAILURES_TO_SUSPEND,
             is_node_suspended,
@@ -586,7 +584,7 @@ class TestNodeSuspension:
         jobs = [await _make_job(ateam, asaved_query, DataModelingJob.Status.FAILED, error="boom") for _ in range(4)]
         jobs.append(
             await _make_job(
-                ateam, asaved_query, DataModelingJob.Status.FAILED, error="Code: 241. Memory limit (total) exceeded"
+                ateam, asaved_query, DataModelingJob.Status.FAILED, error="Code: 202. Too many simultaneous queries"
             )
         )
         job = await _make_job(ateam, asaved_query, DataModelingJob.Status.FAILED, error="boom")

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -476,6 +476,118 @@ class TestNodeSuspension:
         job = await _make_job(ateam, asaved_query, DataModelingJob.Status.FAILED, error="boom")
         jobs.append(job)
 
+        with unittest.mock.patch(
+            "posthog.temporal.data_modeling.activities.utils.is_suspension_enforced", return_value=True
+        ):
+            suspended = await maybe_suspend_node_for_engine(
+                node_id=str(anode.id),
+                team_id=ateam.pk,
+                dag_id=str(adag.id),
+                saved_query_id=asaved_query.id,
+                engine=DataModelingJobEngine.CLICKHOUSE,
+                reason="boom",
+                job_id=str(job.id),
+            )
+
+        assert suspended is True
+        await database_sync_to_async(anode.refresh_from_db)()
+        assert is_node_suspended(anode, DataModelingJobEngine.CLICKHOUSE) is True
+        assert is_node_suspended(anode, DataModelingJobEngine.DUCKGRES) is False
+        await database_sync_to_async(job.refresh_from_db)()
+        assert "has been suspended" in job.error
+
+        # DataModelingJob.team is SET_NULL, so it survives the ateam fixture's team teardown.
+        for j in jobs:
+            await database_sync_to_async(j.delete)()
+
+    async def test_does_not_claim_suspension_without_enforcement(self, ateam, anode, asaved_query, adag):
+        from posthog.temporal.data_modeling.activities.utils import (
+            CONSECUTIVE_FAILURES_TO_SUSPEND,
+            is_node_suspended,
+            maybe_suspend_node_for_engine,
+        )
+
+        jobs = [
+            await _make_job(ateam, asaved_query, DataModelingJob.Status.FAILED, error="boom")
+            for _ in range(CONSECUTIVE_FAILURES_TO_SUSPEND)
+        ]
+        job = await _make_job(ateam, asaved_query, DataModelingJob.Status.FAILED, error="boom")
+        jobs.append(job)
+
+        with unittest.mock.patch(
+            "posthog.temporal.data_modeling.activities.utils.is_suspension_enforced", return_value=False
+        ):
+            suspended = await maybe_suspend_node_for_engine(
+                node_id=str(anode.id),
+                team_id=ateam.pk,
+                dag_id=str(adag.id),
+                saved_query_id=asaved_query.id,
+                engine=DataModelingJobEngine.CLICKHOUSE,
+                reason="boom",
+                job_id=str(job.id),
+            )
+
+        assert suspended is True
+        await database_sync_to_async(anode.refresh_from_db)()
+        # the marker is still recorded, so widening the flag later still finds the node
+        assert is_node_suspended(anode, DataModelingJobEngine.CLICKHOUSE) is True
+        await database_sync_to_async(job.refresh_from_db)()
+        assert job.error == "boom"
+
+        # DataModelingJob.team is SET_NULL, so it survives the ateam fixture's team teardown.
+        for j in jobs:
+            await database_sync_to_async(j.delete)()
+
+    @pytest.mark.parametrize(
+        "infra_error",
+        [
+            "ClickHouseMemoryLimitExceededError: Code: 241. DB::Exception: Memory limit (total) exceeded",
+            "Code: 202. DB::Exception: Too many simultaneous queries for user datawarehouse",
+            "Cannot connect to host ch-offline.example.com:8443",
+        ],
+    )
+    async def test_infrastructure_failures_do_not_suspend(self, ateam, anode, asaved_query, adag, infra_error):
+        from posthog.temporal.data_modeling.activities.utils import (
+            CONSECUTIVE_FAILURES_TO_SUSPEND,
+            is_node_suspended,
+            maybe_suspend_node_for_engine,
+        )
+
+        jobs = [
+            await _make_job(ateam, asaved_query, DataModelingJob.Status.FAILED, error=infra_error)
+            for _ in range(CONSECUTIVE_FAILURES_TO_SUSPEND)
+        ]
+
+        suspended = await maybe_suspend_node_for_engine(
+            node_id=str(anode.id),
+            team_id=ateam.pk,
+            dag_id=str(adag.id),
+            saved_query_id=asaved_query.id,
+            engine=DataModelingJobEngine.CLICKHOUSE,
+            reason=infra_error,
+            job_id=str(jobs[-1].id),
+        )
+
+        assert suspended is False
+        await database_sync_to_async(anode.refresh_from_db)()
+        assert is_node_suspended(anode, DataModelingJobEngine.CLICKHOUSE) is False
+
+        # DataModelingJob.team is SET_NULL, so it survives the ateam fixture's team teardown.
+        for job in jobs:
+            await database_sync_to_async(job.delete)()
+
+    async def test_infrastructure_failure_breaks_a_customer_streak(self, ateam, anode, asaved_query, adag):
+        from posthog.temporal.data_modeling.activities.utils import is_node_suspended, maybe_suspend_node_for_engine
+
+        jobs = [await _make_job(ateam, asaved_query, DataModelingJob.Status.FAILED, error="boom") for _ in range(4)]
+        jobs.append(
+            await _make_job(
+                ateam, asaved_query, DataModelingJob.Status.FAILED, error="Code: 241. Memory limit (total) exceeded"
+            )
+        )
+        job = await _make_job(ateam, asaved_query, DataModelingJob.Status.FAILED, error="boom")
+        jobs.append(job)
+
         suspended = await maybe_suspend_node_for_engine(
             node_id=str(anode.id),
             team_id=ateam.pk,
@@ -486,12 +598,9 @@ class TestNodeSuspension:
             job_id=str(job.id),
         )
 
-        assert suspended is True
+        assert suspended is False
         await database_sync_to_async(anode.refresh_from_db)()
-        assert is_node_suspended(anode, DataModelingJobEngine.CLICKHOUSE) is True
-        assert is_node_suspended(anode, DataModelingJobEngine.DUCKGRES) is False
-        await database_sync_to_async(job.refresh_from_db)()
-        assert "has been suspended" in job.error
+        assert is_node_suspended(anode, DataModelingJobEngine.CLICKHOUSE) is False
 
         # DataModelingJob.team is SET_NULL, so it survives the ateam fixture's team teardown.
         for j in jobs:

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -541,14 +541,17 @@ class TestNodeSuspension:
         for job in jobs:
             await database_sync_to_async(job.delete)()
 
-    async def test_suspends_when_a_customer_identifier_spells_an_abort_marker(self, ateam, anode, asaved_query, adag):
+    @pytest.mark.parametrize("identifier", ["Preempted", "QueueEmpty"])
+    async def test_suspends_when_a_customer_identifier_spells_an_abort_marker(
+        self, ateam, anode, asaved_query, adag, identifier
+    ):
         from posthog.temporal.data_modeling.activities.utils import (
             CONSECUTIVE_FAILURES_TO_SUSPEND,
             is_node_suspended,
             maybe_suspend_node_for_engine,
         )
 
-        error = "Code: 47. DB::Exception: Missing columns: 'Preempted' while processing query"
+        error = f"Code: 47. DB::Exception: Missing columns: '{identifier}' while processing query"
         jobs = [
             await _make_job(ateam, asaved_query, DataModelingJob.Status.FAILED, error=error)
             for _ in range(CONSECUTIVE_FAILURES_TO_SUSPEND)

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -508,6 +508,8 @@ class TestNodeSuspension:
             "Code: 202. DB::Exception: Too many simultaneous queries",
             "Cannot connect to host ch-offline.example.com:8443",
             "Abandoned: the materialization workflow is no longer running",
+            "QueueEmpty: Application error",
+            "Preempted: a new DAG run started before this job completed",
         ],
     )
     async def test_externally_aborted_failures_do_not_suspend(self, ateam, anode, asaved_query, adag, aborted_error):
@@ -540,11 +542,42 @@ class TestNodeSuspension:
         for job in jobs:
             await database_sync_to_async(job.delete)()
 
+    async def test_suspends_when_a_customer_identifier_spells_an_abort_marker(self, ateam, anode, asaved_query, adag):
+        from posthog.temporal.data_modeling.activities.utils import (
+            CONSECUTIVE_FAILURES_TO_SUSPEND,
+            is_node_suspended,
+            maybe_suspend_node_for_engine,
+        )
+
+        error = "Code: 47. DB::Exception: Missing columns: 'Preempted' while processing query"
+        jobs = [
+            await _make_job(ateam, asaved_query, DataModelingJob.Status.FAILED, error=error)
+            for _ in range(CONSECUTIVE_FAILURES_TO_SUSPEND)
+        ]
+
+        suspended = await maybe_suspend_node_for_engine(
+            node_id=str(anode.id),
+            team_id=ateam.pk,
+            dag_id=str(adag.id),
+            saved_query_id=asaved_query.id,
+            engine=DataModelingJobEngine.CLICKHOUSE,
+            reason=error,
+            job_id=str(jobs[-1].id),
+        )
+
+        assert suspended is True
+        await database_sync_to_async(anode.refresh_from_db)()
+        assert is_node_suspended(anode, DataModelingJobEngine.CLICKHOUSE) is True
+
+        # DataModelingJob.team is SET_NULL, so it survives the ateam fixture's team teardown.
+        for job in jobs:
+            await database_sync_to_async(job.delete)()
+
     @pytest.mark.parametrize(
         "memory_error",
         [
             "ClickHouseMemoryLimitExceededError: Code: 241. DB::Exception: Memory limit (for query) exceeded",
-            "ClickHouseMemoryLimitExceededError: Code: 241. DB::Exception: Memory limit (total) exceeded",
+            "ClickHouseMemoryLimitExceededError: Code: 241. DB::Exception: (total) memory limit exceeded",
             "ClickHouseMemoryLimitExceededError: Code: 241. DB::Exception: Query memory limit exceeded",
         ],
     )

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -492,7 +492,6 @@ class TestNodeSuspension:
 
         assert suspended is True
         await database_sync_to_async(anode.refresh_from_db)()
-        # the marker is recorded either way, so widening the flag later still finds the node
         assert is_node_suspended(anode, DataModelingJobEngine.CLICKHOUSE) is True
         assert is_node_suspended(anode, DataModelingJobEngine.DUCKGRES) is False
         await database_sync_to_async(job.refresh_from_db)()


### PR DESCRIPTION
## Problem

A model stops updating after five consecutive failed materializations, and only a successful run or an explicit resume brings it back. Two defects in that counter:

- Every failure counted as evidence against the query, including runs that never executed: a rate-limited admission, an unreachable cluster, or a run we preempted ourselves. A customer could lose a model over a busy afternoon and have nothing to fix.
- The job error gained the sentence "This model has been suspended after 5 consecutive failed materializations" whether or not suspension is enforced for that team. Without enforcement the model keeps materializing every tick, so the sentence was false for most teams that saw it.

## Changes

- A failure only counts when the query got to fail on its own merits. Refused admission (`Code: 202`), an unreachable cluster, a preempted or abandoned run, and a graph with no root node (`QueueEmpty`) break the streak instead of extending it.
- Running out of memory or wall-clock still counts, at any phrasing. Those are properties of the query, and a model that keeps exhausting the cluster is one we want stopped.
- `Preempted: ` matches with its colon, so a customer's column of that name cannot classify their own broken query as an abort.
- The suspension sentence is written only when enforcement is on for the team.
- `is_suspension_enforced` moves from `get_dag_structure.py` to `utils.py`, which both callers already import.

Detection is unchanged: the marker is still recorded either way, so widening the flag later still finds the node.

## How did you test this code?

`TestNodeSuspension`, 18 tests, 12 new. Each behavior is proven red-first: reverting one source change fails exactly its cases and nothing else.

Error strings in the fixtures are the ones production emits, including both ClickHouse wordings for a memory limit.

## 🤖 Agent context

Found while auditing whether the counter works at all before widening the enforcement flag. It does detect correctly; a minority of what it caught was our own infrastructure, which is what this fixes. Markers already recorded stay put, and are inert until the flag widens.

Reviewed adversarially by two independent agents. The first replaced the classifier's question, from "was this our fault" to "did the query get to fail on its own merits", which is answerable. The second caught the `QueueEmpty` removal and the bare-word `Preempted` collision.
