### PR TITLE
fix(mcp-analytics): add thousands separators to activity headline counts

### DIFF
--- a/products/mcp_analytics/frontend/earlyData/activitySummary.ts
+++ b/products/mcp_analytics/frontend/earlyData/activitySummary.ts
@@ -1,4 +1,4 @@
-import { humanFriendlyLargeNumber } from 'lib/utils/numbers'
+import { humanFriendlyLargeNumber, humanFriendlyNumber } from 'lib/utils/numbers'
 
 export interface ActivitySummaryInput {
     totalCalls: number
@@ -28,14 +28,15 @@ export function buildActivitySummary(input: ActivitySummaryInput): string {
 
     const parts = [`${humanFriendlyLargeNumber(totalCalls)} tool calls`]
     if (distinctClients > 0) {
-        parts.push(`from ${distinctClients} client${distinctClients === 1 ? '' : 's'}`)
+        parts.push(`from ${humanFriendlyNumber(distinctClients)} client${distinctClients === 1 ? '' : 's'}`)
     }
     let summary = `${parts.join(' ')} so far`
     if (topTool) {
         summary += ` — ${topTool} is the favorite`
     }
     if (errorCalls > 0) {
-        summary += `${topTool ? ',' : ' —'} ${errorCalls} failure${errorCalls === 1 ? '' : 's'} worth a look`
+        const failures = `${humanFriendlyNumber(errorCalls)} failure${errorCalls === 1 ? '' : 's'}`
+        summary += `${topTool ? ',' : ' —'} ${failures} worth a look`
     }
     return summary
 }

--- a/products/mcp_analytics/frontend/earlyData/earlyData.test.ts
+++ b/products/mcp_analytics/frontend/earlyData/earlyData.test.ts
@@ -22,6 +22,11 @@ describe('early data derivations', () => {
             { totalCalls: 42, distinctClients: 3, errorCalls: 4, topTool: 'search_docs' },
             /^42 tool calls from 3 clients so far — search_docs is the favorite, 4 failures worth a look$/,
         ],
+        // Big client and failure counts get thousands separators, unlike the abbreviated call count.
+        [
+            { totalCalls: 21_700_000, distinctClients: 1051, errorCalls: 533_638, topTool: 'execute-sql' },
+            /^21\.7M tool calls from 1,051 clients so far — execute-sql is the favorite, 533,638 failures worth a look$/,
+        ],
         // Failures read grammatically even without a favorite tool.
         [
             { totalCalls: 42, distinctClients: 0, errorCalls: 1, topTool: null },


### PR DESCRIPTION
## Problem

The MCP analytics Activity headline printed raw counts, so a busy project read "21.7M tool calls from 1051 clients so far — execute-sql is the favorite, 533638 failures worth a look". Six-digit numbers without separators are hard to read at a glance, which is the whole job of that sentence.

## Changes

- Format the client and failure counts with `humanFriendlyNumber`, giving "from 1,051 clients ... 533,638 failures".
- The tool call total keeps its abbreviated `21.7M` form — that one already reads fine.

## How did you test this code?

Added a case to the existing parameterized `buildActivitySummary` test covering counts large enough to need separators; the previous cases all used two-digit numbers, so nothing caught unformatted output. Ran `jest earlyData.test` locally — 11 passed. No manual run of the app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from a Slack thread with a screenshot of the headline. Written by the PostHog Slack app (Claude Code harness); no repo skills were needed beyond the frontend conventions in AGENTS.md. Extracted the pluralized failure phrase into a local so the template literal stays on one line after formatting.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B3E1Y576X/p1786367316054979)*
