### PR TITLE
fix(conversations): warn when a resend is deduplicated

### DIFF
--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.test.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.test.ts
@@ -98,7 +98,6 @@ function makeSupportComment(overrides: Partial<CommentType> = {}): CommentType {
     } as unknown as CommentType
 }
 
-/** The comments endpoint answers 201 for a new message, and 200 with the original when it dedupes. */
 function commentResponse(comment: CommentType, status: number = 201): Response {
     return { status, json: () => Promise.resolve(comment) } as unknown as Response
 }
@@ -489,8 +488,6 @@ describe('supportTicketSceneLogic send outcome handling', () => {
         expect(logic.values.messageSending).toBe(false)
     })
 
-    // A 200 means the server matched an identical recent send and wrote nothing. Treating that as a
-    // send would clear the composer and leave the operator no sign that the reply never went out.
     it('flags a resend the server deduplicated instead of reporting it as sent', async () => {
         createResponseMock.mockResolvedValue(commentResponse(makeSupportComment(), 200))
         const onSuccess = jest.fn()

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.test.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.test.ts
@@ -31,9 +31,9 @@ jest.mock('~/lib/api', () => {
         __esModule: true,
         default: {
             ...actual.default,
+            createResponse: jest.fn(),
             comments: {
                 ...actual.default?.comments,
-                create: jest.fn().mockResolvedValue(undefined),
                 list: jest.fn().mockResolvedValue({ results: [] }),
             },
             persons: {
@@ -96,6 +96,11 @@ function makeSupportComment(overrides: Partial<CommentType> = {}): CommentType {
         created_by: MOCK_DEFAULT_USER,
         ...overrides,
     } as unknown as CommentType
+}
+
+/** The comments endpoint answers 201 for a new message, and 200 with the original when it dedupes. */
+function commentResponse(comment: CommentType, status: number = 201): Response {
+    return { status, json: () => Promise.resolve(comment) } as unknown as Response
 }
 
 function makeTicket(): Ticket {
@@ -336,7 +341,7 @@ describe('supportTicketSceneLogic replyRecipientDescription', () => {
 describe('supportTicketSceneLogic sendMessage with statusAfterSend', () => {
     let logic: ReturnType<typeof supportTicketSceneLogic.build>
 
-    const commentsCreateMock = api.comments.create as jest.Mock
+    const createResponseMock = api.createResponse as jest.Mock
     const ticketGetMock = api.conversationsTickets.get as jest.Mock
     const ticketUpdateMock = api.conversationsTickets.update as jest.Mock
 
@@ -346,7 +351,7 @@ describe('supportTicketSceneLogic sendMessage with statusAfterSend', () => {
 
     beforeEach(async () => {
         initKeaTests()
-        commentsCreateMock.mockReset().mockResolvedValue(makeSupportComment())
+        createResponseMock.mockReset().mockResolvedValue(commentResponse(makeSupportComment()))
         ticketGetMock.mockReset().mockResolvedValue(loadedTicket())
         ticketUpdateMock.mockReset()
         // A non-'new', dash-free id: sendMessage early-returns on 'new' and loadTicket
@@ -385,7 +390,7 @@ describe('supportTicketSceneLogic sendMessage with statusAfterSend', () => {
     })
 
     it('does not update the ticket when the send fails', async () => {
-        commentsCreateMock.mockRejectedValue(new Error('request failed'))
+        createResponseMock.mockRejectedValue(new Error('request failed'))
 
         await expectLogic(logic, () => {
             logic.actions.sendMessage('hello', null, false, undefined, 'resolved')
@@ -441,7 +446,7 @@ describe('supportTicketSceneLogic sendMessage with statusAfterSend', () => {
 describe('supportTicketSceneLogic send outcome handling', () => {
     let logic: ReturnType<typeof supportTicketSceneLogic.build>
 
-    const commentsCreateMock = api.comments.create as jest.Mock
+    const createResponseMock = api.createResponse as jest.Mock
     const commentsListMock = api.comments.list as jest.Mock
     const ticketGetMock = api.conversationsTickets.get as jest.Mock
     const captureMock = posthog.capture as jest.Mock
@@ -449,12 +454,12 @@ describe('supportTicketSceneLogic send outcome handling', () => {
     const loadedTicket = (): Ticket => ({ ...makeTicket(), priority: 'medium', assignee: null }) as Ticket
 
     const rejectWith = (status?: number): void => {
-        commentsCreateMock.mockRejectedValue(Object.assign(new Error('send failed'), { status }))
+        createResponseMock.mockRejectedValue(Object.assign(new Error('send failed'), { status }))
     }
 
     beforeEach(async () => {
         initKeaTests()
-        commentsCreateMock.mockReset().mockResolvedValue(makeSupportComment())
+        createResponseMock.mockReset().mockResolvedValue(commentResponse(makeSupportComment()))
         commentsListMock.mockReset().mockResolvedValue({ results: [] })
         ticketGetMock.mockReset().mockResolvedValue(loadedTicket())
         captureMock.mockClear()
@@ -469,7 +474,7 @@ describe('supportTicketSceneLogic send outcome handling', () => {
         // These cases point the shared mock at failures and pending promises, which would break
         // every later suite's initial message load.
         commentsListMock.mockReset().mockResolvedValue({ results: [] })
-        commentsCreateMock.mockReset().mockResolvedValue(makeSupportComment())
+        createResponseMock.mockReset().mockResolvedValue(commentResponse(makeSupportComment()))
     })
 
     it('shows the sent message without waiting for the next poll', async () => {
@@ -481,6 +486,22 @@ describe('supportTicketSceneLogic send outcome handling', () => {
 
         expect(logic.values.messages.map((message) => message.id)).toEqual(['msg-sent-1'])
         expect(onSuccess).toHaveBeenCalledTimes(1)
+        expect(logic.values.messageSending).toBe(false)
+    })
+
+    // A 200 means the server matched an identical recent send and wrote nothing. Treating that as a
+    // send would clear the composer and leave the operator no sign that the reply never went out.
+    it('flags a resend the server deduplicated instead of reporting it as sent', async () => {
+        createResponseMock.mockResolvedValue(commentResponse(makeSupportComment(), 200))
+        const onSuccess = jest.fn()
+
+        await expectLogic(logic, () => {
+            logic.actions.sendMessage('hello', null, false, onSuccess)
+        }).toFinishAllListeners()
+
+        expect(logic.values.messages.map((message) => message.id)).toEqual(['msg-sent-1'])
+        expect(onSuccess).not.toHaveBeenCalled()
+        expect(captureMock).toHaveBeenCalledWith('support reply send deduplicated', { is_private: false })
         expect(logic.values.messageSending).toBe(false)
     })
 
@@ -545,7 +566,7 @@ describe('supportTicketSceneLogic send outcome handling', () => {
 
         expect(logic.values.messages.map((message) => message.id)).toEqual(['msg-landed-1'])
         expect(onSuccess).toHaveBeenCalledTimes(1)
-        expect(commentsCreateMock).toHaveBeenCalledTimes(1)
+        expect(createResponseMock).toHaveBeenCalledTimes(1)
         expect(captureMock).not.toHaveBeenCalledWith('support reply send unconfirmed', expect.anything())
     })
 
@@ -711,7 +732,7 @@ describe('supportTicketSceneLogic private note editing', () => {
 
     const ticketGetMock = api.conversationsTickets.get as jest.Mock
     const noteUpdateMock = conversationsTicketsNotesPartialUpdate as jest.Mock
-    const commentsCreateMock = api.comments.create as jest.Mock
+    const createResponseMock = api.createResponse as jest.Mock
 
     const loadedTicket = (): Ticket => ({ ...makeTicket(), priority: 'medium', assignee: null }) as Ticket
 
@@ -719,7 +740,7 @@ describe('supportTicketSceneLogic private note editing', () => {
         localStorage.clear()
         initKeaTests()
         noteUpdateMock.mockReset().mockResolvedValue(undefined)
-        commentsCreateMock.mockReset().mockResolvedValue(makeSupportComment())
+        createResponseMock.mockReset().mockResolvedValue(commentResponse(makeSupportComment()))
         ticketGetMock.mockReset().mockResolvedValue(loadedTicket())
         logic = supportTicketSceneLogic({ id: 42 })
         logic.mount()
@@ -838,7 +859,7 @@ describe('supportTicketSceneLogic private note editing', () => {
             message: 'updated',
             rich_content: updatedRich,
         })
-        expect(commentsCreateMock).not.toHaveBeenCalled()
+        expect(createResponseMock).not.toHaveBeenCalled()
         expect(onSuccess).not.toHaveBeenCalled()
         expect(logic.values.editingMessageId).toBeNull()
         expect(logic.values.draftContent).toEqual(draft)

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
@@ -1330,9 +1330,6 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
             let alreadySent = false
 
             try {
-                // The raw response carries the only signal that separates a send from a no-op:
-                // 201 means this request wrote the message, 200 means the server's dedupe guard
-                // matched an identical recent send and handed back that one instead.
                 const response = await api.createResponse(getCommentsCreateUrl(String(getCurrentTeamId())), {
                     content,
                     rich_content: richContent,
@@ -1390,9 +1387,6 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
             }
 
             if (alreadySent) {
-                // Nothing was written, so appending only backfills a message the thread may not
-                // have polled yet. The draft stays put: the operator asked for a second copy and
-                // did not get one, so they decide whether to reword it or drop it.
                 posthog.capture('support reply send deduplicated', { is_private: isPrivate })
                 cache.messageRevision += 1
                 actions.appendMessage(sent)

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
@@ -51,6 +51,7 @@ import {
     conversationsTicketsNotesDestroy,
     conversationsTicketsNotesPartialUpdate,
 } from 'products/conversations/frontend/generated/api'
+import { getCommentsCreateUrl } from 'products/platform_features/frontend/generated/api'
 import { signalsReportsList } from 'products/signals/frontend/generated/api'
 import type { SignalReportApi } from 'products/signals/frontend/generated/api.schemas'
 
@@ -1326,21 +1327,24 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
             const attemptStartedAt = dayjs()
             let sent: CommentType | null = null
             let unconfirmedReason: UnconfirmedSendReason = null
+            let alreadySent = false
 
             try {
-                sent = await api.comments.create(
-                    {
-                        content,
-                        rich_content: richContent,
-                        scope: 'conversations_ticket',
-                        item_id: ticketId,
-                        item_context: {
-                            author_type: 'support',
-                            is_private: isPrivate,
-                        },
+                // The raw response carries the only signal that separates a send from a no-op:
+                // 201 means this request wrote the message, 200 means the server's dedupe guard
+                // matched an identical recent send and handed back that one instead.
+                const response = await api.createResponse(getCommentsCreateUrl(String(getCurrentTeamId())), {
+                    content,
+                    rich_content: richContent,
+                    scope: 'conversations_ticket',
+                    item_id: ticketId,
+                    item_context: {
+                        author_type: 'support',
+                        is_private: isPrivate,
                     },
-                    {}
-                )
+                })
+                alreadySent = response.status === 200
+                sent = (await response.json()) as CommentType
             } catch (error: any) {
                 unconfirmedReason = classifySendFailure(error)
                 if (unconfirmedReason === null) {
@@ -1380,6 +1384,22 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
                 })
                 lemonToast.error(
                     "We couldn't confirm that your message was added. Check the thread before sending it again."
+                )
+                actions.setMessageSending(false)
+                return
+            }
+
+            if (alreadySent) {
+                // Nothing was written, so appending only backfills a message the thread may not
+                // have polled yet. The draft stays put: the operator asked for a second copy and
+                // did not get one, so they decide whether to reword it or drop it.
+                posthog.capture('support reply send deduplicated', { is_private: isPrivate })
+                cache.messageRevision += 1
+                actions.appendMessage(sent)
+                lemonToast.warning(
+                    isPrivate
+                        ? "You just added this note, so we didn't add it again. Edit your draft to add something different."
+                        : "You just sent this reply, so we didn't send it again. Edit your draft to send something different."
                 )
                 actions.setMessageSending(false)
                 return


### PR DESCRIPTION
## Problem

A support operator who sends the same reply twice within two minutes sees "Reply added", loses their draft, and gets no second message in the thread. Nothing tells them the reply never went out again.

- The comments endpoint deduplicates support messages. It answers 200 with the message an identical recent send already created, and 201 when the send writes a new one.
- The composer read only the response body, so both answers looked the same.
- `appendMessage` ignores a message id already in the thread, so the 200 case appended nothing.

Follows [#78936](https://github.com/PostHog/posthog/pull/78936), which added the guard and handled the 409 and network cases but not this one.

## Changes

- A deduplicated resend now shows "You just sent this reply, so we didn't send it again. Edit your draft to send something different."
- The composer keeps the draft on that outcome, so the operator can reword or drop the message.
- The send reads the raw response and treats a 200 as a no-op, a 201 as a send.
- A ticket status change requested through "send and set status" no longer applies when nothing was sent.
- The send posts through `getCommentsCreateUrl` plus `api.createResponse`, because neither `api.comments.create` nor the generated `commentsCreate` exposes the status code.
- The recovery path after a 409, a 5xx, or a network error is unchanged.

No layout changes. The only new visible strings are the two toast messages above, and I did not render them in a browser.

## How did you test this code?

- I ran the Jest suite for `supportTicketSceneLogic` locally. I did no manual or browser testing.
- One new test covers the 200 path: the thread keeps a single copy of the message, the composer callback does not fire, and the send is reported as deduplicated. No existing test exercised a 200 response, because the old mocks resolved a comment with no status attached.
- The existing send tests moved to the new mock shape and still pass unchanged in intent.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually the PostHog Slack app, running Claude) wrote this from a Slack request that suspected the duplicate check failed silently. I confirmed it before changing anything: the guard returns the original comment with a 200, and the composer's success path swallowed it.

I first considered detecting the replay by checking whether the returned message id was already in local state. I dropped that because it misreads a message the poller had not yet fetched. The status code is the server's own signal and needs no heuristic.

Skills invoked: `/adopting-generated-api-types` (which is why the call uses the generated URL helper rather than new surface in `lib/api.ts`), `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`.

Nothing in this PR carries material from the originating thread.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08S2L0S5MZ/p1786367183183359)*
