### PR TITLE
feat(logs): add retention rule observability metrics

### DIFF
--- a/nodejs/src/logs/retention/retention-rules-cache.test.ts
+++ b/nodejs/src/logs/retention/retention-rules-cache.test.ts
@@ -1,6 +1,11 @@
 import { PostgresRouter } from '~/common/utils/db/postgres'
 
-import { RetentionRulesCache } from './retention-rules-cache'
+import { RetentionRulesCache, logsRetentionRulesDroppedCounter } from './retention-rules-cache'
+
+async function droppedCount(teamId: string): Promise<number> {
+    const metric = await logsRetentionRulesDroppedCounter.get()
+    return metric.values.find((v) => v.labels.team_id === teamId)?.value ?? 0
+}
 
 describe('RetentionRulesCache', () => {
     let query: jest.Mock
@@ -23,6 +28,16 @@ describe('RetentionRulesCache', () => {
         query.mockResolvedValueOnce(rows(30))
         const compiled = await cache.getCompiledRuleSet(1)
         expect(compiled.rules).toEqual([{ id: 'r1', filterGroup: null, retentionDays: 30 }])
+    })
+
+    it('surfaces rules discarded at compile via the dropped counter', async () => {
+        // 45 is not a valid retention tier, so compile discards the row: the rule is enabled and
+        // fetched but never stamped — the counter is the only signal of that silent drop.
+        query.mockResolvedValueOnce(rows(45))
+        const before = await droppedCount('7')
+        const compiled = await cache.getCompiledRuleSet(7)
+        expect(compiled.rules).toEqual([])
+        expect((await droppedCount('7')) - before).toBe(1)
     })
 
     it('fails open to no rules when the fetch throws and nothing is cached', async () => {

--- a/nodejs/src/logs/retention/retention-rules-cache.ts
+++ b/nodejs/src/logs/retention/retention-rules-cache.ts
@@ -1,4 +1,5 @@
 import { trace } from '@opentelemetry/api'
+import { Counter } from 'prom-client'
 
 import { instrumentFn } from '~/common/tracing/tracing-utils'
 import { PostgresRouter, PostgresUse } from '~/common/utils/db/postgres'
@@ -8,6 +9,18 @@ import { MAX_ENABLED_RETENTION_RULES, type RetentionRuleRow, compileRetentionRul
 import type { CompiledRetentionRuleSet } from './evaluate-retention'
 
 const REFRESH_MS = 30_000
+
+/**
+ * Enabled rules fetched from Postgres that `compileRetentionRuleSet` discarded — a `retention_days`
+ * outside the valid tiers or otherwise malformed config. A non-zero value for a team explains the
+ * "rule saved but ignored" symptom that is otherwise silent (the row exists and is enabled, yet no
+ * per-row retention is stamped).
+ */
+export const logsRetentionRulesDroppedCounter = new Counter({
+    name: 'logs_ingestion_retention_rules_dropped_total',
+    help: 'Enabled retention rules fetched but discarded at compile time (invalid retention_days tier or malformed config).',
+    labelNames: ['team_id'],
+})
 
 const retentionCacheInstrumentOpts = { measureTime: false, sendException: false } as const
 
@@ -60,6 +73,15 @@ export class RetentionRulesCache {
                     return existing?.compiled ?? compileRetentionRuleSet([])
                 }
                 const compiled = compileRetentionRuleSet(rows)
+                const droppedCount = rows.length - compiled.rules.length
+                if (droppedCount > 0) {
+                    logsRetentionRulesDroppedCounter.inc({ team_id: String(teamId) }, droppedCount)
+                    logger.warn('[logs-retention] enabled rules discarded at compile — check retention_days tier', {
+                        teamId,
+                        fetched: rows.length,
+                        dropped: droppedCount,
+                    })
+                }
                 const vw = rows.reduce((m, r) => Math.max(m, r.version ?? 0), 0)
                 this.cache.set(teamId, { compiled, versionWatermark: vw, fetchedAtMs: now })
                 trace.getActiveSpan()?.setAttributes({

--- a/nodejs/src/logs/retention/retention-stage.test.ts
+++ b/nodejs/src/logs/retention/retention-stage.test.ts
@@ -2,7 +2,12 @@ import type { LogRecord } from '~/logs/log-record-avro'
 import { runPipelineStages } from '~/logs/pipeline/log-processing-pipeline'
 
 import { compileRetentionRuleSet } from './compile-retention-rules'
-import { makeRetentionStage } from './retention-stage'
+import { logsRetentionRowsStampedCounter, makeRetentionStage } from './retention-stage'
+
+async function stampedCount(teamId: string, matched: 'true' | 'false'): Promise<number> {
+    const metric = await logsRetentionRowsStampedCounter.get()
+    return metric.values.find((v) => v.labels.team_id === teamId && v.labels.matched === matched)?.value ?? 0
+}
 
 describe('makeRetentionStage', () => {
     const record = (service: string): LogRecord => ({
@@ -44,9 +49,12 @@ describe('makeRetentionStage', () => {
         const ruleSet = compileRetentionRuleSet([serviceRule('a', 'api', 30)])
         const { kept } = await runPipelineStages(
             [record('api'), record('billing')],
-            [makeRetentionStage(ruleSet, 1, 14)]
+            [makeRetentionStage(ruleSet, 4242, 14)]
         )
         // 'api' matches the 30-day rule; 'billing' matches nothing so it takes the team default.
         expect(kept.map((r) => r.retention_days)).toEqual([30, 14])
+        // The counter split mirrors matching: one rule-matched row, one team-default row.
+        expect(await stampedCount('4242', 'true')).toBe(1)
+        expect(await stampedCount('4242', 'false')).toBe(1)
     })
 })

--- a/nodejs/src/logs/retention/retention-stage.ts
+++ b/nodejs/src/logs/retention/retention-stage.ts
@@ -1,6 +1,20 @@
+import { Counter } from 'prom-client'
+
 import type { PipelineStage } from '~/logs/pipeline/log-processing-pipeline'
 
 import { type CompiledRetentionRuleSet, safeEvaluateRetentionDays } from './evaluate-retention'
+
+/**
+ * Rows stamped with a per-row retention value, split by `matched`: `true` when a rule matched the
+ * row, `false` when no rule matched and the team default was applied. A team whose rules are working
+ * shows `matched="true"` traffic; a team seeing only `matched="false"` has rules that never match;
+ * no traffic at all means the stage never ran (rule disabled, not fetched, or gating off).
+ */
+export const logsRetentionRowsStampedCounter = new Counter({
+    name: 'logs_ingestion_retention_rows_stamped_total',
+    help: 'Log rows stamped with a per-row retention value, labelled by whether a rule matched (matched=true) or the team default was applied (matched=false).',
+    labelNames: ['team_id', 'matched'],
+})
 
 /**
  * Per-row retention `mutate` stage. Runs last in the pipeline (after sampling and hog transforms) so
@@ -17,8 +31,22 @@ export function makeRetentionStage(
         kind: 'mutate',
         name: 'retention',
         run: (records) => {
+            let matchedCount = 0
             for (const record of records) {
-                record.retention_days = safeEvaluateRetentionDays(ruleSet, record, teamId) ?? defaultRetentionDays
+                const ruleValue = safeEvaluateRetentionDays(ruleSet, record, teamId)
+                record.retention_days = ruleValue ?? defaultRetentionDays
+                if (ruleValue !== null) {
+                    matchedCount++
+                }
+            }
+            // One increment per batch (not per record) to keep the hot path cheap.
+            const teamLabel = String(teamId)
+            if (matchedCount > 0) {
+                logsRetentionRowsStampedCounter.inc({ team_id: teamLabel, matched: 'true' }, matchedCount)
+            }
+            const defaultCount = records.length - matchedCount
+            if (defaultCount > 0) {
+                logsRetentionRowsStampedCounter.inc({ team_id: teamLabel, matched: 'false' }, defaultCount)
             }
         },
     }


### PR DESCRIPTION
## Problem

When a retention rule is saved but no per-row retention gets stamped, ingestion is silent. The only retention counter (`logs_ingestion_retention_eval_error_total`) fires just on a *throw*, so a disabled rule, a rule that never matches, or a rule dropped at compile all read as "healthy 0". There's no metric to tell those apart.

## Changes

Two counters, both incremented once per batch (hot-path cheap):

| Metric | Labels | Answers |
|---|---|---|
| `logs_ingestion_retention_rows_stamped_total` | `team_id`, `matched` | Is the stage running, and are rules matching? Zero for a team → stage never ran (rule disabled / not fetched / gating off). `matched=false` only → rules never match. |
| `logs_ingestion_retention_rules_dropped_total` | `team_id` | Enabled rules fetched but discarded at compile (invalid `retention_days` tier or malformed config) — paired with a `warn` log. Surfaces the otherwise-invisible drop. |

No behavior change to stamping itself — only instrumentation.

## How did you test this code?

- Extended `retention-stage.test.ts`: asserts the `matched=true` / `matched=false` counter split mirrors actual rule matching — guards against inverting the label, which would mislead exactly when someone is debugging.
- Extended `retention-rules-cache.test.ts`: an enabled row with an invalid tier compiles to zero rules **and** increments the dropped counter — guards against the drop signal silently disappearing.
- `src/logs/retention` jest (11 tests), `tsc`, `eslint`, `prettier --check` all pass locally.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Written after a debugging session where a dev retention rule stamped nothing and no metric or log explained why — the existing instrumentation only covered throw/fetch-error paths, not the silent no-op modes (disabled rule, zero rules fetched, compile-time tier drop). Skills invoked: `/writing-tests` (gating the two assertions). Deliberately skipped an "enabled but zero rules" log: with `LOGS_RETENTION_ENABLED_TEAMS='*'` in dev that fires for every team with no rules, so it would be pure noise; the rows-stamped counter already shows non-activity as absence.

Note: I also spotted a latent inconsistency while here — Node accepts retention tiers `{14, 30, 90}` but the API only allows `{14, 30}`. Not fixed in this PR; worth a separate cleanup to share one source of truth.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
