### PR TITLE
feat(logs): enable per-row retention in the hosted dev environment

### DIFF
--- a/nodejs/src/common/utils/env-utils.ts
+++ b/nodejs/src/common/utils/env-utils.ts
@@ -45,6 +45,11 @@ export const isProdEnv = (): boolean => determineNodeEnv() === NodeEnv.Productio
 export const isCloud = (): boolean =>
     ['EU', 'US', 'DEV', 'E2E'].includes((process.env.CLOUD_DEPLOYMENT ?? '').toUpperCase())
 
+// True only on the customer-facing production clouds (US / EU), excluding the hosted DEV/E2E
+// environments and local. Use to gate a feature on everywhere-but-prod while a per-team rollout
+// is pending, rather than `isProdEnv()` which also treats the hosted DEV deployment as prod.
+export const isProdCloud = (): boolean => ['EU', 'US'].includes((process.env.CLOUD_DEPLOYMENT ?? '').toUpperCase())
+
 export function isOverflowBatchByDistinctId(): boolean {
     const overflowBatchByDistinctId = process.env.INGESTION_OVERFLOW_BATCH_BY_DISTINCT_ID
     return stringToBoolean(overflowBatchByDistinctId)

--- a/nodejs/src/logs/config.ts
+++ b/nodejs/src/logs/config.ts
@@ -10,7 +10,7 @@ import {
     KAFKA_TRACES_INGESTION_DLQ,
     KAFKA_TRACES_INGESTION_OVERFLOW,
 } from '~/common/config/kafka-topics'
-import { isProdEnv } from '~/common/utils/env-utils'
+import { isProdCloud, isProdEnv } from '~/common/utils/env-utils'
 
 import { LogsProducerName, WARPSTREAM_INGESTION_PRODUCER, WARPSTREAM_LOGS_PRODUCER } from './outputs/producers'
 
@@ -113,8 +113,9 @@ export function getDefaultLogsIngestionConsumerConfig(): LogsIngestionConsumerCo
         LOGS_METRICS_RULES_ENABLED_TEAMS: isProdEnv() ? '' : '*',
         LOGS_METRICS_RULES_KILLSWITCH: false,
         LOGS_METRICS_RULES_EXPORT_URL: '',
-        // Off in prod until per-team rollout; on in dev for local end-to-end testing.
-        LOGS_RETENTION_ENABLED_TEAMS: isProdEnv() ? '' : '*',
+        // On everywhere except US/EU production (local, tests, and the hosted DEV environment),
+        // where it drives end-to-end testing. US/EU stay off until the per-team rollout.
+        LOGS_RETENTION_ENABLED_TEAMS: isProdCloud() ? '' : '*',
         LOGS_RETENTION_KILLSWITCH: false,
         LOGS_BILLING_PRORATE_ENABLED: false,
         LOGS_TRANSFORMATIONS_ENABLED_TEAMS: '',


### PR DESCRIPTION
## Problem

Per-row retention never applies in the hosted DEV environment. `LOGS_RETENTION_ENABLED_TEAMS` defaults to `isProdEnv() ? '' : '*'`, and `isProdEnv()` is true on DEV (it runs with `NODE_ENV=production`), so the enable-list is empty. A team can create an enabled retention rule with a valid tier and still see `retention_days` stamped `null` on every row — the stage is gated off. The env var isn't wired through `posthog/charts` yet, so there's no config surface to override it.

## Changes

Gate the default on `isProdCloud()` (US/EU only) instead of `isProdEnv()`:

```ts
LOGS_RETENTION_ENABLED_TEAMS: isProdCloud() ? '' : '*'
```

| Environment | `CLOUD_DEPLOYMENT` | Before | After |
|---|---|---|---|
| Local / tests | unset | `*` | `*` |
| Hosted DEV | `DEV` | `''` (off) | `*` (on) |
| US / EU prod | `US` / `EU` | `''` | `''` |

Adds `isProdCloud()` to `env-utils` — true only on the customer-facing US/EU clouds, excluding the hosted DEV/E2E environments that `isProdEnv()` treats as prod. Only the retention var changes; sampling/metrics/limiter keep their `isProdEnv()` gating.

## How did you test this code?

- `tsc`, `eslint`, `prettier --check` pass locally.
- No test added: this is a config default keyed off an env var — a test asserting the constant would be a change-detector. The three-way env table above is the reviewable contract.

Verified the mechanism, not a live rollout: I can't set env on the DEV deployment from here.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Came out of debugging why a valid, enabled retention rule stamped `null` in a hosted-DEV env — root cause was `isProdEnv()` gating the enable-list off there. Chose the code-default route because the env var isn't plumbed through `posthog/charts`/`posthog/secrets` yet (the open greptile P2 on #77338); this is the same default-gating pattern the sibling `LOGS_*` vars use, refined to separate hosted-DEV from US/EU prod. US/EU stay off pending the real per-team rollout.

Two related, still-open pieces this does **not** cover: ClickHouse enforcement of the stamped value (#73826, still open — the MV reads only the batch header until it lands), and the charts/secrets plumbing so US/EU can be rolled out per-team.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
