### PR TITLE
fix(data-warehouse): fix broken grammar in new-source required-field errors

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
@@ -3922,7 +3922,7 @@ export const getErrorsForFields = (
 
             if (!hasOptionFields) {
                 if (field.required && !valueObj[field.name]) {
-                    errorsObj[field.name] = `Please select a ${field.label.toLowerCase()}`
+                    errorsObj[field.name] = `${field.label} is required`
                 }
             } else {
                 errorsObj[field.name] = {}
@@ -3950,7 +3950,7 @@ export const getErrorsForFields = (
         if ('required' in field && field.required && valueMissing) {
             errorsObj[field.name] = Array.isArray(fieldValue)
                 ? `Please enter at least one of your ${field.label.toLowerCase()}`
-                : `Please enter a ${field.label.toLowerCase()}`
+                : `${field.label} is required`
         }
     }
 

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardValidation.test.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardValidation.test.ts
@@ -19,7 +19,7 @@ describe('source wizard multi-value fields', () => {
         // with zero repositories selected.
         it.each([
             [[], 'Please enter at least one of your repositories'],
-            [undefined, 'Please enter a repositories'],
+            [undefined, 'Repositories is required'],
             [['posthog/posthog'], undefined],
         ])('required multi field with value %p yields error %p', (value, expectedError) => {
             const errors = getErrorsForFields([REPOSITORIES_FIELD], {

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceWizardLogic.test.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceWizardLogic.test.ts
@@ -651,7 +651,7 @@ describe('sourceWizardLogic', () => {
                 { prefix: 'src', payload: { host: '' }, access_method: 'direct' },
                 { allowBlankSensitiveFields: true }
             )
-            expect(res.payload.host).toBe('Please enter a host')
+            expect(res.payload.host).toBe('Host is required')
         })
     })
 


### PR DESCRIPTION
## Problem

A user filling in a new data warehouse source saw broken grammar when they left a required field empty. The wizard built the error from the field label, so a missing "API key" read as "Please enter a api key", and "Access token", "App ID", and "Email" all got the wrong article too. Every connector was affected because the message is generated once for all of them.

- The generator was `Please enter a ${field.label.toLowerCase()}` (and `Please select a ...` for dropdowns).
- The article is wrong before every vowel-initial label, and `toLowerCase()` mangled acronyms into "api key", "customer id", "url".
- An existing test even asserted the broken output "Please enter a repositories".

## Changes

- Required-field errors now read `${field.label} is required`, for example "API key is required" and "Customer ID is required".
- This drops the article entirely, so there is no a/an bug, and keeps the label's own casing so acronyms stay uppercase.
- Updated the two tests that pinned the old strings.
- The multi-select message ("Please enter at least one of your ...") is unchanged; it was already correct.

## How did you test this code?

- Ran the two affected Jest suites locally; both pass.
- No manual browser testing.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (actually Claude) found this while reviewing new-source onboarding friction. The wizard's shared validation helper `getErrorsForFields` interpolated the field label into `Please enter a ...`, which breaks for vowel-initial and acronym labels across all connectors. I chose `${label} is required` over a/an detection because vowel-sound rules are unreliable ("an SSH key", "a URL") and this phrasing sidesteps them while preserving acronym casing.

Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
