### PR TITLE
fix(data-modeling): stop running nodes whose query was deleted

### DIFF
--- a/posthog/temporal/data_modeling/activities/get_dag_structure.py
+++ b/posthog/temporal/data_modeling/activities/get_dag_structure.py
@@ -64,7 +64,11 @@ class DAG:
 def _get_dag_structure_async(team_id: int, dag_id: str) -> DAG:
     """Retrieve all nodes and edges for a DAG from the database."""
     nodes = Node.objects.filter(team_id=team_id, dag_id=dag_id)
-    executable_nodes = nodes.filter(type__in=[NodeType.VIEW, NodeType.MAT_VIEW, NodeType.ENDPOINT])
+    # a node outlives the query it points at, because deleting one is best-effort while soft-deleting
+    # the query is not. running it can only fail, so it must not reach the materialization activity.
+    executable_nodes = nodes.filter(type__in=[NodeType.VIEW, NodeType.MAT_VIEW, NodeType.ENDPOINT]).exclude(
+        saved_query__deleted=True
+    )
     ephemeral_nodes = executable_nodes.filter(type=NodeType.VIEW)
     edges = (
         Edge.objects.prefetch_related("source", "target")

--- a/posthog/temporal/tests/data_modeling/test_execute_dag_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_execute_dag_workflow.py
@@ -140,6 +140,32 @@ class TestGetDagStructureActivity:
         source_node = dag_nodes[0]
         assert str(source_node.id) not in dag.executable_nodes
 
+    async def test_excludes_nodes_whose_saved_query_was_deleted(
+        self, activity_environment, ateam, saved_queries, dag_nodes, adag
+    ):
+        ghost_query, ghost_node = saved_queries[0], dag_nodes[1]
+        ghost_query.deleted = True
+        await database_sync_to_async(ghost_query.save)()
+
+        inputs = GetDAGStructureInputs(team_id=ateam.pk, dag_id=str(adag.id))
+        dag = await activity_environment.run(get_dag_structure_activity, inputs)
+
+        assert str(ghost_node.id) not in dag.executable_nodes
+        assert len(dag.executable_nodes) == 2
+
+    async def test_keeps_nodes_whose_saved_query_has_no_deleted_flag(
+        self, activity_environment, ateam, saved_queries, dag_nodes, adag
+    ):
+        # deleted is nullable and null on most rows, a case an exclude() can silently take with it
+        for query in saved_queries:
+            query.deleted = None
+            await database_sync_to_async(query.save)()
+
+        inputs = GetDAGStructureInputs(team_id=ateam.pk, dag_id=str(adag.id))
+        dag = await activity_environment.run(get_dag_structure_activity, inputs)
+
+        assert len(dag.executable_nodes) == 3
+
     @pytest.mark.parametrize("enforced", [True, False])
     async def test_reports_suspended_nodes_only_when_enforced(
         self, activity_environment, ateam, dag_nodes, adag, enforced


### PR DESCRIPTION
## Problem

A deleted saved query keeps being materialized. Its DAG node outlives it, so every tier tick starts a run that fails immediately with `DoesNotExist`, forever.

- Soft-deleting the query always happens; deleting its node is best-effort, and several delete paths either skip it or swallow its failure.
- The DAG's executable set (`get_dag_structure`) never filtered those nodes out, so the node keeps being scheduled.
- Tier membership already filters them (`schedulable_nodes` excludes `saved_query__deleted=True`). The two sets disagreed, and `execute_dag` runs their intersection, so a legacy schedule with no `node_ids` runs the unfiltered one.

The failures are invisible to the customer, who deleted the query on purpose. They burn a run per tick and pollute the failure history the suspension counter reads.

## Changes

- `executable_nodes` now excludes nodes whose saved query is soft-deleted, matching the filter tier membership applies.
- Fixing the executable set rather than the four raise sites downstream: it covers all of them at once, and the query that raises is also the one that decides whether a node is a ghost, so a guard there cannot tell "deleted" from "wrong team".
- Dependents are unaffected. The level sort counts only dependencies that are themselves in the executable set, so removing a node does not strand its children.

This stops new burn. It does not delete the leftover nodes, and it does not close the delete paths that create them — both are follow-ups.

## How did you test this code?

- Two new tests in `TestGetDagStructureActivity`: a node whose query is soft-deleted is absent from the executable set, and nodes with `deleted = NULL` still appear (the field is nullable, and `exclude(deleted=True)` is the correct spelling for that).
- Red-first: with the tests kept and the source reverted, the first fails and the rest pass.
- No manual testing. I did not run this against a real DAG.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Written after tracing why `DoesNotExist` failures were accumulating: two independent read-only subagents traced the code path, and their findings agreed on the asymmetry between the executable and schedulable sets.

Two alternatives were dropped. Deleting the node when the activity cannot find its query self-heals, but the lookup filters on team and deletion at once, so it would delete live nodes on an unrelated miss. Filtering at each raise site needs four edits and still runs the workflow.

The `DoesNotExist` string is ambiguous — `Node`, `Team` and `DataModelingJob` lookups in the same function stringify identically, so anyone measuring this has to match on the message tail.
