### PR TITLE
fix(desktop): stop refreshing the PostHog token on a connected server's auth error

### DIFF
--- a/products/desktop/packages/workspace-server/src/services/agent/auth-adapter.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/auth-adapter.test.ts
@@ -169,6 +169,8 @@ describe("AgentAuthAdapter", () => {
     expect(deps.mcpProxy.register).toHaveBeenCalledWith(
       "installation-inst-2",
       "https://proxy.posthog.com/inst-2/",
+      // An auth failure here is about the vendor's credential, not the user's PostHog token.
+      { credentialOwner: "installation" },
     );
     expect(servers).toEqual(
       expect.arrayContaining([

--- a/products/desktop/packages/workspace-server/src/services/agent/auth-adapter.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/auth-adapter.ts
@@ -153,6 +153,7 @@ export class AgentAuthAdapter {
       const proxiedUrl = this.mcpProxy.register(
         `installation-${installation.id}`,
         installation.proxy_url,
+        { credentialOwner: "installation" },
       );
       const server: McpServerConnection = {
         name,

--- a/products/desktop/packages/workspace-server/src/services/mcp-proxy/mcp-proxy.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/mcp-proxy/mcp-proxy.test.ts
@@ -256,6 +256,31 @@ describe("McpProxyService", () => {
       expect(authServiceMock.authenticatedFetch).toHaveBeenCalledTimes(2);
     });
 
+    it("passes an installation credential failure through without refreshing", async () => {
+      // The failing credential belongs to the connected vendor, not to PostHog, so a
+      // PostHog token refresh cannot fix it and the retry only hides the real error.
+      authServiceMock.authenticatedFetch.mockResolvedValue(
+        new Response(JSON.stringify({ error: "Authentication failed" }), {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      await service.start();
+      const proxyUrl = service.register(
+        "installation-abc",
+        "https://app.posthog.com/api/environments/1/mcp_server_installations/abc/proxy/",
+        { credentialOwner: "installation" },
+      );
+
+      const res = await fetch(proxyUrl, { method: "POST", body: "payload" });
+
+      expect(res.status).toBe(401);
+      expect(await res.text()).toBe('{"error":"Authentication failed"}');
+      expect(authServiceMock.refreshAccessToken).not.toHaveBeenCalled();
+      expect(authServiceMock.authenticatedFetch).toHaveBeenCalledTimes(1);
+    });
+
     it("does not retry when the body looks healthy", async () => {
       authServiceMock.authenticatedFetch.mockResolvedValue(
         new Response('{"ok":true}', {

--- a/products/desktop/packages/workspace-server/src/services/mcp-proxy/mcp-proxy.ts
+++ b/products/desktop/packages/workspace-server/src/services/mcp-proxy/mcp-proxy.ts
@@ -30,12 +30,27 @@ function truncateRequestBody(body: RequestInit["body"]): string | undefined {
  * before forwarding, but any local process can still use it to issue requests
  * on the user's behalf — acceptable for a single-user desktop app.
  */
+/**
+ * Whose credential an auth failure from a target is about.
+ *
+ * `posthog` targets answer for the user's PostHog token, so a stale one is worth
+ * refreshing and retrying. An `installation` target proxies a connected third-party
+ * server, and its auth failures are about that vendor's token — refreshing the PostHog
+ * token cannot fix one, and retrying buries the real reason.
+ */
+export type McpProxyCredentialOwner = "posthog" | "installation";
+
+interface McpProxyTarget {
+  url: string;
+  credentialOwner: McpProxyCredentialOwner;
+}
+
 @injectable()
 export class McpProxyService {
   private server: http.Server | null = null;
   private port: number | null = null;
   private startPromise: Promise<void> | null = null;
-  private targets = new Map<string, string>();
+  private targets = new Map<string, McpProxyTarget>();
 
   private readonly log: ScopedLogger;
 
@@ -88,11 +103,18 @@ export class McpProxyService {
    * should be passed to the MCP transport. Subsequent registrations with the
    * same ID overwrite the target.
    */
-  register(id: string, targetUrl: string): string {
+  register(
+    id: string,
+    targetUrl: string,
+    options: { credentialOwner?: McpProxyCredentialOwner } = {},
+  ): string {
     if (!this.port) {
       throw new Error("MCP proxy not started");
     }
-    this.targets.set(id, targetUrl);
+    this.targets.set(id, {
+      url: targetUrl,
+      credentialOwner: options.credentialOwner ?? "posthog",
+    });
     return `http://127.0.0.1:${this.port}/${encodeURIComponent(id)}`;
   }
 
@@ -136,7 +158,7 @@ export class McpProxyService {
     }
 
     const suffix = rest.join("/");
-    const targetBase = target.replace(/\/+$/, "");
+    const targetBase = target.url.replace(/\/+$/, "");
     const targetUrl =
       (suffix ? `${targetBase}/${suffix}` : targetBase) + incoming.search;
 
@@ -181,10 +203,10 @@ export class McpProxyService {
       req.on("data", (chunk: Buffer) => chunks.push(chunk));
       req.on("end", () => {
         fetchOptions.body = Buffer.concat(chunks);
-        this.forwardRequest(id, targetUrl, fetchOptions, res);
+        this.forwardRequest(id, targetUrl, fetchOptions, res, target);
       });
     } else {
-      this.forwardRequest(id, targetUrl, fetchOptions, res);
+      this.forwardRequest(id, targetUrl, fetchOptions, res, target);
     }
   }
 
@@ -193,6 +215,7 @@ export class McpProxyService {
     url: string,
     options: RequestInit,
     res: http.ServerResponse,
+    target: McpProxyTarget,
   ): Promise<void> {
     this.log.debug("MCP proxy forwarding request", {
       id,
@@ -214,6 +237,19 @@ export class McpProxyService {
         const bodyText = buf.toString("utf8");
 
         if (this.isAuthErrorBody(bodyText, response.status)) {
+          if (target.credentialOwner === "installation") {
+            this.log.warn(
+              "Connected MCP server rejected the request; its stored credential needs reconnecting in PostHog",
+              {
+                id,
+                url,
+                status: response.status,
+                body: bodyText.slice(0, 2000),
+              },
+            );
+            this.writeBufferedResponse(response, buf, res);
+            return;
+          }
           this.log.warn("MCP auth failure — refreshing token and retrying", {
             id,
             url,


### PR DESCRIPTION
## Problem

A connected MCP server stops working in a local desktop run, and the logs point at the wrong thing.
The user sees a server with no tools, and the log line blames the PostHog token.

- The local MCP proxy matches the string "Authentication failed" in a response body and concludes the user's PostHog token is stale.
- The store proxy uses that wording for a failure of the *connected vendor's* credential.
- So the proxy refreshes the PostHog token, retries once, and hits the identical failure.
- The log reads "MCP auth failure — refreshing token and retrying", which names a credential that was never the problem.

## Changes

- A connected server's auth failure now passes straight through to the agent, and the log says the connection needs reconnecting in PostHog.
- `McpProxyService.register` takes a `credentialOwner`, so each target declares whose credential its auth errors are about.
- The PostHog MCP keeps the refresh-and-retry: a stale PostHog token is exactly what it reports, and it answers 200 with the error inside the JSON-RPC body, which `authenticatedFetch` cannot see.
- The default stays `posthog`, so any future caller keeps today's behavior until it opts out.

The discriminator is the registration, not the response. The proxy already knows which target it forwards to, so this needs no agreement with the backend and cannot be thrown off by wording that changes on either side.

> [!NOTE]
> No UI change. The reconnect prompt comes from the `needs_reauth` flag in [#80615](https://github.com/PostHog/posthog/pull/80615), which is a separate PR because desktop and backend cannot ship together.

## How did you test this code?

- Added a test first: an installation target that answers `401 {"error": "Authentication failed"}` returns that response unchanged and never calls `refreshAccessToken`. It fails on master.
- The existing test that the PostHog target still refreshes and retries on `authentication_failed` covers the other side, unchanged.
- Ran the workspace-server suites and the typecheck locally.
- Not run: the desktop app against a real revoked connection.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I am an agent (pi, in a PostHog Code cloud task). @k11kirky asked why MCP servers connected in desktop were unusable from task agents in the pi, claude, and codex harnesses.

- This is one of three findings from that investigation. Discovery is [#80364](https://github.com/PostHog/posthog/pull/80364), the backend reconnect flag is [#80615](https://github.com/PostHog/posthog/pull/80615), and this is the local proxy misreading whose credential failed.
- I first drafted a response header from the backend to mark the error kind, then dropped it: the proxy already knows the target it registered, so the registration is a stronger signal and needs no deploy ordering.
- Skills invoked: `/writing-pr-descriptions`, `/writing-code-comments`, `/writing-tests`.
- Nothing here comes from outside this repository, and no customer data.
