### PR TITLE
fix(error-tracking): highlight resolved source languages

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4686,10 +4686,10 @@ snapshots:
         hash: v1.k794b7964.ea754a4783f7653247f127337c407a8cdd4a9c6bc3f1b908d8d00dd1a090b966.KQ3yKnRzi4l3ZeYVThZdmo4L6mAbxtNa2uQh7y-kGWA
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--tile-filters-read-only--light:
         hash: v1.k794b7964.b2ca2efc52a9ccf56953159c66d3c8766acd1d3a17379d5faec45a4715ae24a9.fK76p7ZVcgvFJNcKJ5Ixy3YnBm_BcBSFnoytLS2jZdU
-    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark
-    :   hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
-    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light
-    :   hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
+    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark:
+        hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
+    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light:
+        hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--dark:
         hash: v1.k794b7964.b1e0f5f542426e34dec73826f3135902a392c0c13dade4fec14037c615186b13.kbxxijyDI1SdvgdKwkRnIRLLgmsine5AYvOcD79DYsY
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--light:
@@ -7085,7 +7085,7 @@ snapshots:
     scenes-app-settings-authentication-domains--one-unverified-domain--dark:
         hash: v1.k794b7964.d2354aea8e40abfcfeb18691d15e48abc24724460dbc0118185c750d3f8ce6d1.Gcj1tCTTgepeyP-Ep4JIhieodM8RlFeAjTQGNkP2UeQ
     scenes-app-settings-authentication-domains--one-unverified-domain--light:
-        hash: v1.k794b7964.4306d80a2262d721e1eda8709ea678a232283ec842763db7a5677ea107d9d43f.z_LMSeCZNSyfG7rnPAnjE7JxfQ2-Fc7g530wtdVapbs
+        hash: v1.k794b7964.826b954e1c03e3156d0c10598975c3fd43583672372c163fa08264506f929cd7.C22X_4g68JpmDtmjwe33M24AQZ4CTTIwW2cMZPL0JCo
     scenes-app-settings-environment--settings-environment-access-control--dark:
         hash: v1.k794b7964.cdbb2694b5d5524628e578f807f3282a0e458c45172c29b79e2b6e7c06eac09f.HqYn6cyhm9cm_fXbavd2nlYeqoTVNd7ODjvCMKlAsIc
     scenes-app-settings-environment--settings-environment-access-control--light:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4686,10 +4686,10 @@ snapshots:
         hash: v1.k794b7964.ea754a4783f7653247f127337c407a8cdd4a9c6bc3f1b908d8d00dd1a090b966.KQ3yKnRzi4l3ZeYVThZdmo4L6mAbxtNa2uQh7y-kGWA
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--tile-filters-read-only--light:
         hash: v1.k794b7964.b2ca2efc52a9ccf56953159c66d3c8766acd1d3a17379d5faec45a4715ae24a9.fK76p7ZVcgvFJNcKJ5Ixy3YnBm_BcBSFnoytLS2jZdU
-    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark:
-        hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
-    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light:
-        hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
+    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark
+    :   hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
+    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light
+    :   hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--dark:
         hash: v1.k794b7964.b1e0f5f542426e34dec73826f3135902a392c0c13dade4fec14037c615186b13.kbxxijyDI1SdvgdKwkRnIRLLgmsine5AYvOcD79DYsY
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--light:
@@ -7085,7 +7085,7 @@ snapshots:
     scenes-app-settings-authentication-domains--one-unverified-domain--dark:
         hash: v1.k794b7964.d2354aea8e40abfcfeb18691d15e48abc24724460dbc0118185c750d3f8ce6d1.Gcj1tCTTgepeyP-Ep4JIhieodM8RlFeAjTQGNkP2UeQ
     scenes-app-settings-authentication-domains--one-unverified-domain--light:
-        hash: v1.k794b7964.826b954e1c03e3156d0c10598975c3fd43583672372c163fa08264506f929cd7.C22X_4g68JpmDtmjwe33M24AQZ4CTTIwW2cMZPL0JCo
+        hash: v1.k794b7964.4306d80a2262d721e1eda8709ea678a232283ec842763db7a5677ea107d9d43f.z_LMSeCZNSyfG7rnPAnjE7JxfQ2-Fc7g530wtdVapbs
     scenes-app-settings-environment--settings-environment-access-control--dark:
         hash: v1.k794b7964.cdbb2694b5d5524628e578f807f3282a0e458c45172c29b79e2b6e7c06eac09f.HqYn6cyhm9cm_fXbavd2nlYeqoTVNd7ODjvCMKlAsIc
     scenes-app-settings-environment--settings-environment-access-control--light:

--- a/frontend/src/lib/components/CodeSnippet/CodeSnippet.tsx
+++ b/frontend/src/lib/components/CodeSnippet/CodeSnippet.tsx
@@ -46,6 +46,8 @@ export enum Language {
     Kotlin = 'kotlin',
     Groovy = 'groovy',
     CSharp = 'csharp',
+    Lua = 'lua',
+    VBNet = 'vbnet',
     TypeScript = 'typescript',
     HCL = 'terraform',
     Rust = 'rust',
@@ -101,6 +103,14 @@ export const getLanguage = (lang: string): Language => {
             return Language.Kotlin
         case 'groovy':
             return Language.Groovy
+        case 'lua':
+        case 'luau':
+            return Language.Lua
+        case 'vb':
+        case 'vbnet':
+            return Language.VBNet
+        case 'objectivecpp':
+            return Language.ObjectiveC
         case 'hcl':
             return Language.HCL
         case 'rust':

--- a/frontend/src/lib/components/Errors/Frame/CollapsibleFrameContent.tsx
+++ b/frontend/src/lib/components/Errors/Frame/CollapsibleFrameContent.tsx
@@ -1,9 +1,9 @@
-import { getLanguage } from 'lib/components/CodeSnippet/CodeSnippet'
 import { Collapsible } from 'lib/ui/Collapsible/Collapsible'
 
 import { ErrorTrackingStackFrame, ErrorTrackingStackFrameContext, ErrorTrackingStackFrameRecord } from '../types'
 import { CodeVariablesInlineBanner } from './CodeVariablesInlineBanner'
 import { FrameContext } from './FrameContext'
+import { getFrameLanguage } from './frameLanguage'
 import { FrameVariables } from './FrameVariables'
 
 export interface CollapsibleFrameContentProps {
@@ -18,7 +18,7 @@ export function CollapsibleFrameContent({
     record,
     onFrameContextClick,
 }: CollapsibleFrameContentProps): JSX.Element | null {
-    const { lang, code_variables } = frame
+    const { code_variables } = frame
     const hasCodeVariables = code_variables && Object.keys(code_variables).length > 0
     if (!record || !record.context) {
         return null
@@ -26,7 +26,7 @@ export function CollapsibleFrameContent({
     return (
         <Collapsible.Panel>
             <div onClick={(e) => onFrameContextClick?.(record.context!, e)}>
-                <FrameContext context={record.context} language={getLanguage(lang)} />
+                <FrameContext context={record.context} language={getFrameLanguage(frame)} />
                 {hasCodeVariables ? <FrameVariables variables={code_variables!} /> : <CodeVariablesInlineBanner />}
             </div>
         </Collapsible.Panel>

--- a/frontend/src/lib/components/Errors/Frame/frameLanguage.test.ts
+++ b/frontend/src/lib/components/Errors/Frame/frameLanguage.test.ts
@@ -1,0 +1,25 @@
+import { Language } from 'lib/components/CodeSnippet'
+
+import { getFrameLanguage } from './frameLanguage'
+
+describe('getFrameLanguage', () => {
+    it.each([
+        ['TypeScript', 'javascript', 'src/lib/api.ts', Language.TypeScript],
+        ['TSX', 'javascript', 'src/components/App.tsx', Language.TypeScript],
+        ['ES module TypeScript', 'javascript', 'src/server.mts', Language.TypeScript],
+        ['CommonJS TypeScript', 'javascript', 'src/server.cts', Language.TypeScript],
+        ['Dart compiled for web', 'javascript', 'src/main.dart', Language.Dart],
+        ['Kotlin on the JVM', 'java', 'Checkout.kt', Language.Kotlin],
+        ['Groovy on the JVM', 'java', 'Checkout.groovy', Language.Groovy],
+        ['C# on .NET', 'dotnet', 'Checkout.cs', Language.CSharp],
+        ['Visual Basic on .NET', 'dotnet', 'Checkout.vb', Language.VBNet],
+        ['Objective-C++', 'objectivecpp', 'Checkout.mm', Language.ObjectiveC],
+        ['Luau', 'luau', 'ServerScriptService.Checkout', Language.Lua],
+    ])('uses %s highlighting for source context', (_label, lang, source, expected) => {
+        expect(getFrameLanguage({ lang, source })).toBe(expected)
+    })
+
+    it('keeps JavaScript highlighting for JavaScript sources', () => {
+        expect(getFrameLanguage({ lang: 'javascript', source: 'src/lib/api.js' })).toBe(Language.JavaScript)
+    })
+})

--- a/frontend/src/lib/components/Errors/Frame/frameLanguage.ts
+++ b/frontend/src/lib/components/Errors/Frame/frameLanguage.ts
@@ -1,0 +1,21 @@
+import { Language, getLanguage } from 'lib/components/CodeSnippet'
+
+import type { ErrorTrackingStackFrame } from '../types'
+
+const SOURCE_LANGUAGE_OVERRIDES: Record<string, Language> = {
+    cs: Language.CSharp,
+    cts: Language.TypeScript,
+    dart: Language.Dart,
+    groovy: Language.Groovy,
+    kt: Language.Kotlin,
+    kts: Language.Kotlin,
+    mts: Language.TypeScript,
+    ts: Language.TypeScript,
+    tsx: Language.TypeScript,
+    vb: Language.VBNet,
+}
+
+export function getFrameLanguage({ lang, source }: Pick<ErrorTrackingStackFrame, 'lang' | 'source'>): Language {
+    const sourceExtension = source?.match(/\.([^./?#]+)(?:[?#].*)?$/)?.[1]?.toLowerCase()
+    return (sourceExtension && SOURCE_LANGUAGE_OVERRIDES[sourceExtension]) || getLanguage(lang)
+}


### PR DESCRIPTION
## Problem

Error tracking users see resolved source context highlighted as the runtime language, leaving source-language keywords such as TypeScript's `public` unhighlighted.

Cymbal identifies several frames by runtime, including JavaScript, JVM, and .NET frames, after resolution returns another source language.

## Changes

- Select highlighting from resolved source extensions for TypeScript, Dart, Kotlin, Groovy, C#, and Visual Basic.
- Recognize Luau and Objective-C++ frame identifiers while retaining the runtime-language fallback.
- Keep Cymbal frame metadata unchanged to avoid changing fingerprints or regrouping issues.
- Screenshot not included because I did not render the issue scene locally.

## How did you test this code?

- Focused Jest tests cover each runtime-to-source mismatch and the JavaScript fallback.
- `hogli ci:preflight --fix` found no deterministic CI failures in the diff.
- Not tested: browser rendering of an Error tracking issue.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update. This corrects existing syntax-highlighting behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented this change with repository file, shell, and Jujutsu tools. It invoked `/error-tracking`, `/writing-tests`, `/react-doctor`, `/running-ci-preflight`, `/writing-pr-descriptions`, and `/pr`.
