### PR TITLE
chore(signals): remove subscription routing from the scout skills

### DIFF
--- a/products/signals/skills/authoring-scouts/SKILL.md
+++ b/products/signals/skills/authoring-scouts/SKILL.md
@@ -33,10 +33,6 @@ A scout is just an `LLMSkill` whose name starts with `signals-scout-`.
 The harness discovers scouts by globbing `signals-scout-*` over the project's skills, loads the body **verbatim** as the agent's system prompt, and progressively reads any bundled reference files on demand.
 **The `signals-scout-` name prefix is load-bearing: a skill named anything else will never run as a scout.**
 
-> **Not everything phrased as a scout is a scout.**
-> If the ask is to deliver the key numbers from an **existing dashboard or insight** to a channel on a fixed schedule ("set up a scout to post the top-line from this dashboard in #launch once a day"), a **dashboard (or insight) subscription with the AI summary enabled** is usually the better fit — scouts are for open-ended watching that decides what's worth surfacing, not scheduled delivery of a fixed, user-specified metric set.
-> Respect a user who's certain they want a scout; when it's ambiguous, suggest the subscription and confirm first ("A dashboard subscription is a better fit for a recurring message — want me to set that up?"), and route to `managing-subscriptions`.
-
 ## The job before the writing
 
 Don't write a scout in the abstract.

--- a/products/signals/skills/working-with-scouts/SKILL.md
+++ b/products/signals/skills/working-with-scouts/SKILL.md
@@ -31,10 +31,6 @@ Three sibling skills carry the mechanics — reach for them when a workflow belo
 | `exploring-scouts`  | Read-only observability: the fleet roster, run history, scratchpad memory, health assessment        |
 | `inbox-exploration` | The inbox itself: triaging, drilling into, acting on, and resolving / dismissing / snoozing reports |
 
-> **Before delegating: is this actually a scout job?**
-> If the user wants the key numbers from an **existing dashboard or insight** posted to a channel on a fixed schedule ("have a scout post the top-line from this dashboard in #launch once a day"), a **dashboard (or insight) subscription with the AI summary enabled** is usually the better fit — scouts are for open-ended watching that decides what's worth surfacing, not scheduled delivery of a fixed, user-specified metric set.
-> Respect a user who's certain they want a scout; when it's ambiguous, suggest the subscription and confirm first ("A dashboard subscription is a better fit for a recurring message — want me to set that up?"), and route to `managing-subscriptions`.
-
 ## First: is the fleet running?
 
 Don't delegate to a fleet that isn't there.


### PR DESCRIPTION
## Problem

A user who asks for a scout should get a scout. After #80066, `authoring-scouts` and `working-with-scouts` open with a bolded "Not everything phrased as a scout is a scout" blockquote that steers scout requests toward dashboard subscriptions, with a confirm gate.

- The blockquote guards a path that never failed: in the originating session ([Slack](https://posthog.slack.com/archives/C0B7TE4R8GH/p1786139989724859), [discussion](https://posthog.slack.com/archives/C09SK2PAGKF/p1786178401046319)) no scout was built. The failures were a loop and a prompt subscription, which #80066's subscription-skill fixes cover.
- Bolded blockquote framing over-applies. A scout that reads dashboards is still a scout when the user wants judgment, memory, and steering on top.
- Scout creation is already confirm-gated at the tool level (`scout-create-prepare` → user confirms → `scout-create-execute`), so no prose is needed to prevent a silent build.

## Changes

- Removes the routing blockquote from `authoring-scouts` and from `working-with-scouts`, restoring their pre-#80066 openings. Deletions only.
- The subscription skills (`managing-subscriptions`, `creating-ai-subscription`) are deliberately untouched; how they route is their owners' call.

> [!NOTE]
> Open PR #80122 adds an eval whose ambiguous case uses scout wording and expects the agent to withhold and offer a choice. This PR doesn't conflict with it file-wise, but the direction question (is the word "scout" ambiguous?) is shared and worth settling together.

## How did you test this code?

Prose-only deletions. `hogli lint:skills` passes (143 skills) and `hogli build:skills` builds cleanly. Not run: the repo test suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by Andrew Maguire (assignee) in Claude Code, following the Slack discussion linked above about #80066's routing guidance. The session reviewed #80066, the originating Slack session, and open PR #80122 before deciding scope; a first draft also reworded the two subscription skills, then Andrew narrowed the PR to the scout skills only. Skills invoked: `/writing-skills`, `/writing-pr-descriptions`. Nothing here carries private session material; the Slack links sit behind PostHog auth and are origin context only.
