### PR TITLE
feat(tasks): add an idempotent task event emitter

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -6715,6 +6715,23 @@ def forward_thread_message(
 AGENT_THREAD_UPDATES_FLAG = "project-bluebird"
 
 
+# Matches TaskThreadMessage.event_key's column width. A key over it is hashed rather than
+# truncated: truncation could collide two different PRs onto one key.
+_EVENT_KEY_MAX_LENGTH = 255
+
+
+def _bounded_event_key(event_key: str) -> str:
+    """``event_key`` as it can be stored — a digest once it outgrows the column.
+
+    An overlong key would raise ``DataError`` inside a best-effort emitter, so the event
+    would vanish silently, and vanish again on every retry. A digest keeps the key stable,
+    which is all idempotency needs of it.
+    """
+    if len(event_key) <= _EVENT_KEY_MAX_LENGTH:
+        return event_key
+    return f"sha256:{hashlib.sha256(event_key.encode()).hexdigest()}"
+
+
 def emit_task_event(
     task: Task,
     *,
@@ -6740,6 +6757,7 @@ def emit_task_event(
     rows leave it off: a run starting is timeline material, not something to mark a
     task unread for.
     """
+    event_key = _bounded_event_key(event_key)
     # for_team: callers include non-request contexts (temporal relay) where the
     # fail-closed manager has no team scope.
     row = {

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -75,6 +75,7 @@ from products.tasks.backend.models import (
     SandboxSnapshot,
     Task,
     TaskActivity,
+    TaskActivityEvent,
     TaskAutomation,
     TaskClientProvenance,
     TaskCommentActivity,
@@ -6714,24 +6715,60 @@ def forward_thread_message(
 AGENT_THREAD_UPDATES_FLAG = "project-bluebird"
 
 
-def _create_agent_thread_message(task: Task, content: str, *, event: str, payload: dict | None = None) -> None:
-    """Write an agent-authored thread message and index its mentions.
+def emit_task_event(
+    task: Task,
+    *,
+    event: str,
+    content: str,
+    payload: dict | None = None,
+    event_key: str = "",
+    notify: bool = False,
+) -> TaskThreadMessage | None:
+    """Record one server-emitted task event, for the activity timeline.
 
     ``content`` is the rendered text (older clients show it as-is); ``event`` +
     ``payload`` are the structured record, mirroring ChannelFeedMessage, that
-    lets clients render agent rows natively and dedupe them against live views.
+    lets clients render the row natively and dedupe it against live views.
+
+    ``event_key`` names the real-world thing being announced (a run id, a PR url).
+    Supplying one makes the write idempotent against the partial unique index on
+    ``(task, event, event_key)``, so a redelivered webhook or a retried Temporal
+    activity is a no-op rather than a duplicate row. Returns ``None`` when the row
+    already existed.
+
+    ``notify`` opts a row into the notification feed and mention indexing. Lifecycle
+    rows leave it off: a run starting is timeline material, not something to mark a
+    task unread for.
     """
     # for_team: callers include non-request contexts (temporal relay) where the
     # fail-closed manager has no team scope.
-    message = TaskThreadMessage.objects.for_team(task.team_id).create(
-        team_id=task.team_id,
-        task_id=task.id,
-        author_id=None,
-        author_kind=TaskThreadMessage.AuthorKind.AGENT,
-        event=event,
-        payload=payload or {},
-        content=content,
-    )
+    row = {
+        "team_id": task.team_id,
+        "task_id": task.id,
+        "author_id": None,
+        "author_kind": TaskThreadMessage.AuthorKind.AGENT,
+        "event": event,
+        "event_key": event_key,
+        "payload": payload or {},
+        "content": content,
+    }
+    if event_key:
+        # get_or_create turns the unique index into the arbiter of the race between two
+        # paths observing the same thing (the agent's own output and the GitHub webhook
+        # backstop, say): the loser reads the winner's row instead of raising.
+        message, created = TaskThreadMessage.objects.for_team(task.team_id).get_or_create(
+            task_id=task.id,
+            event=event,
+            event_key=event_key,
+            defaults=row,
+        )
+        if not created:
+            return None
+    else:
+        message = TaskThreadMessage.objects.for_team(task.team_id).create(**row)
+
+    if not notify:
+        return message
     project_thread_message_activity(message)
     try:
         mentioned_user_ids = resolve_mentioned_user_ids(
@@ -6740,6 +6777,7 @@ def _create_agent_thread_message(task: Task, content: str, *, event: str, payloa
         _index_thread_message_mentions(message, mentioned_user_ids)
     except Exception:
         logger.exception("Failed to index thread message mentions", extra={"message_id": str(message.id)})
+    return message
 
 
 def _agent_thread_updates_enabled(creator: User | None) -> bool:
@@ -6783,11 +6821,12 @@ def post_canvas_created_thread_update(
         # Brackets and newlines in the name would break the [label](url) token.
         name = re.sub(r"[\[\]\n]", " ", canvas_name).strip() or "Canvas"
         content = f"[{name}]({canvas_url}) has been created" if canvas_url else f"{name} has been created"
-        _create_agent_thread_message(
+        emit_task_event(
             task,
-            content,
-            event="canvas_created",
+            event=TaskActivityEvent.CANVAS_CREATED,
+            content=content,
             payload={"canvas_name": name, "canvas_url": canvas_url},
+            notify=True,
         )
     except Exception:
         logger.exception("Failed to post canvas-created thread update", extra={"task_id": str(task_id)})
@@ -6826,14 +6865,27 @@ def _pr_display_label(pr_url: str) -> str:
     return pr_url
 
 
+def _pr_payload_identity(pr_url: str) -> dict[str, str | int]:
+    """``repository`` and ``pr_number`` parsed out of a GitHub PR url, so a client can
+    render "owner/repo#N" without a GitHub round trip. Empty for a non-GitHub url."""
+    parsed = urlparse(pr_url)
+    if parsed.hostname is None or parsed.hostname.lower() != "github.com":
+        return {}
+    match = _GITHUB_PR_PATH_PATTERN.fullmatch(parsed.path)
+    if not match:
+        return {}
+    owner, repo, number = match.groups()
+    return {"repository": f"{owner}/{repo}", "pr_number": int(number)}
+
+
 def post_pr_created_thread_update(run: TaskRun, pr_url: str) -> None:
     """Announce a run's freshly opened pull request in its task's thread.
 
     Posts "[owner/repo#N](url) has been opened" as an agent artifact message
     (``event="pr_created"``). Both the agent-output path and the GitHub webhook
-    backstop can observe the same PR, so the announcement dedupes on the task's
-    existing ``pr_created`` rows for this URL. Best-effort and never raises —
-    recording the PR must not fail because its announcement couldn't be written.
+    backstop can observe the same PR, so the announcement is keyed on the PR url and
+    the second observer's write is dropped. Best-effort and never raises — recording
+    the PR must not fail because its announcement couldn't be written.
     """
     try:
         if not _is_safe_pr_url(pr_url):
@@ -6850,22 +6902,14 @@ def post_pr_created_thread_update(run: TaskRun, pr_url: str) -> None:
                 extra={"task_id": str(task.id), "reason": "no_creator" if task.created_by is None else "flag_off"},
             )
             return
-        # The agent-output path and the webhook backstop can race on the same PR;
-        # locking the task row makes the dedupe check-and-create atomic across them.
-        with transaction.atomic():
-            Task.objects.select_for_update().filter(id=task.id).first()
-            if (
-                TaskThreadMessage.objects.for_team(task.team_id)
-                .filter(task_id=task.id, event="pr_created", payload__pr_url=pr_url)
-                .exists()
-            ):
-                return
-            label = _pr_display_label(pr_url)
-            _create_agent_thread_message(
-                task,
-                f"[{label}]({pr_url}) has been opened",
-                event="pr_created",
-                payload={"pr_url": pr_url},
-            )
+        label = _pr_display_label(pr_url)
+        emit_task_event(
+            task,
+            event=TaskActivityEvent.PR_CREATED,
+            content=f"[{label}]({pr_url}) has been opened",
+            payload={"pr_url": pr_url, **_pr_payload_identity(pr_url)},
+            event_key=pr_url,
+            notify=True,
+        )
     except Exception:
         logger.exception("Failed to post pr-created thread update", extra={"task_id": str(run.task_id)})

--- a/products/tasks/backend/migrations/0084_taskthreadmessage_event_key.py
+++ b/products/tasks/backend/migrations/0084_taskthreadmessage_event_key.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tasks", "0083_taskcommentactivity"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="taskthreadmessage",
+            name="event_key",
+            field=models.CharField(blank=True, db_default="", default="", max_length=255),
+        ),
+    ]

--- a/products/tasks/backend/migrations/0085_taskthreadmessage_event_key_unique.py
+++ b/products/tasks/backend/migrations/0085_taskthreadmessage_event_key_unique.py
@@ -1,0 +1,38 @@
+from django.db import migrations, models
+
+from posthog.migration_helpers.concurrent_index import CreateIndexConcurrently
+
+
+class Migration(migrations.Migration):
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction.
+    atomic = False
+
+    dependencies = [
+        ("tasks", "0084_taskthreadmessage_event_key"),
+    ]
+
+    operations = [
+        # The constraint exists in Django state only; the index behind it is built
+        # concurrently so writers to posthog_task_thread_message keep running.
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddConstraint(
+                    model_name="taskthreadmessage",
+                    constraint=models.UniqueConstraint(
+                        condition=models.Q(("event_key", ""), _negated=True),
+                        fields=("task", "event", "event_key"),
+                        name="task_thread_msg_event_key_uniq",
+                    ),
+                ),
+            ],
+            database_operations=[
+                CreateIndexConcurrently(
+                    index_name="task_thread_msg_event_key_uniq",
+                    table_name="posthog_task_thread_message",
+                    columns="(task_id, event, event_key)",
+                    unique=True,
+                    where="WHERE event_key <> ''",
+                ),
+            ],
+        ),
+    ]

--- a/products/tasks/backend/migrations/0086_backfill_pr_created_event_key.py
+++ b/products/tasks/backend/migrations/0086_backfill_pr_created_event_key.py
@@ -6,8 +6,10 @@ from django.db import migrations
 # only PRs already open at this deploy are affected.
 #
 # One statement, not batched: the filter is `event = 'pr_created'` on a per-task table, so
-# the row count is small and bounded by the number of PRs tasks have ever opened.
+# the row count is small and bounded by the number of PRs tasks have ever opened while the
+# announcement flag was on. The UPDATE joins on primary keys, so it takes row locks only.
 BACKFILL_SQL = """
+-- migration-analyzer: safe reason=Touches only pr_created rows in posthog_task_thread_message written before event_key existed - a few hundred at most - and updates them by primary key
 WITH ranked AS (
     SELECT
         id,

--- a/products/tasks/backend/migrations/0086_backfill_pr_created_event_key.py
+++ b/products/tasks/backend/migrations/0086_backfill_pr_created_event_key.py
@@ -1,0 +1,52 @@
+from django.db import migrations
+
+# Rows written before event_key existed carry an empty key, which the partial unique index
+# excludes — so a webhook re-observing one of those PRs after deploy would announce it a
+# second time. Backfilling the key from the payload closes that window, which is finite:
+# only PRs already open at this deploy are affected.
+#
+# One statement, not batched: the filter is `event = 'pr_created'` on a per-task table, so
+# the row count is small and bounded by the number of PRs tasks have ever opened.
+BACKFILL_SQL = """
+WITH ranked AS (
+    SELECT
+        id,
+        row_number() OVER (
+            PARTITION BY task_id, payload->>'pr_url' ORDER BY created_at, id
+        ) AS rank
+    FROM posthog_task_thread_message
+    WHERE event = 'pr_created'
+      AND event_key = ''
+      AND payload->>'pr_url' IS NOT NULL
+      AND payload->>'pr_url' <> ''
+      -- event_key is varchar(255); a longer url stays unkeyed rather than failing the update.
+      AND length(payload->>'pr_url') <= 255
+)
+UPDATE posthog_task_thread_message AS message
+   SET event_key = message.payload->>'pr_url'
+  FROM ranked
+ WHERE message.id = ranked.id
+   -- Only the first row of a duplicated pair takes the key; keying both would violate the
+   -- unique index this backfill runs behind.
+   AND ranked.rank = 1
+"""
+
+# Reversing re-empties only the keys this migration could have set, leaving rows written by
+# the emitter (which never writes an event_key that isn't in its payload) untouched.
+REVERSE_SQL = """
+UPDATE posthog_task_thread_message
+   SET event_key = ''
+ WHERE event = 'pr_created'
+   AND event_key <> ''
+   AND event_key = payload->>'pr_url'
+"""
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tasks", "0085_taskthreadmessage_event_key_unique"),
+    ]
+
+    operations = [
+        migrations.RunSQL(sql=BACKFILL_SQL, reverse_sql=REVERSE_SQL),
+    ]

--- a/products/tasks/backend/migrations/max_migration.txt
+++ b/products/tasks/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0083_taskcommentactivity
+0085_taskthreadmessage_event_key_unique

--- a/products/tasks/backend/migrations/max_migration.txt
+++ b/products/tasks/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0085_taskthreadmessage_event_key_unique
+0086_backfill_pr_created_event_key

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -995,6 +995,27 @@ class TaskSession(TeamScopedRootMixin, UUIDModel):
             )
 
 
+class TaskActivityEvent(models.TextChoices):
+    """The vocabulary of server-emitted task events rendered on the activity timeline.
+
+    Each value is a stable ``TaskThreadMessage.event`` key. Mirrored in
+    ``products/desktop/packages/core/src/canvas/activityEvents.ts``; a test asserts the two
+    lists match, and clients ignore keys they don't know, so the backend can emit a new
+    event before any client renders it.
+    """
+
+    RUN_STARTED = "run_started", "Run started"
+    RUN_FAILED = "run_failed", "Run failed"
+    AWAITING_INPUT = "awaiting_input", "Awaiting input"
+    ARTIFACT_CREATED = "artifact_created", "Artifact created"
+    ARTIFACT_REVISED = "artifact_revised", "Artifact revised"
+    CANVAS_CREATED = "canvas_created", "Canvas created"
+    PR_CREATED = "pr_created", "Pull request created"
+    PR_MERGED = "pr_merged", "Pull request merged"
+    PR_CLOSED = "pr_closed", "Pull request closed"
+    MESSAGE_FORWARDED = "message_forwarded", "Message forwarded to agent"
+
+
 class TaskThreadMessage(TeamScopedRootMixin):
     """One message in a task's thread — the side conversation channel members have
     around a task. Human messages never reach the agent unless the task author
@@ -1023,6 +1044,11 @@ class TaskThreadMessage(TeamScopedRootMixin):
     # Stable event key + structured payload for non-human rows (empty for human
     # messages); `content` stays the rendered text so older clients degrade cleanly.
     event = models.CharField(max_length=64, blank=True, default="")
+    # Identity of the real-world thing an event row announces (a run id, a PR url, a head
+    # SHA), empty for everything else. Paired with the partial unique index below, it is what
+    # makes emission idempotent: a redelivered webhook or a retried Temporal activity writes
+    # the same key and loses the race instead of duplicating the row.
+    event_key = models.CharField(max_length=255, blank=True, default="", db_default="")
     payload = models.JSONField(default=dict, blank=True)
     content = models.TextField()
     forwarded_to_agent_at = models.DateTimeField(null=True, blank=True)
@@ -1038,6 +1064,13 @@ class TaskThreadMessage(TeamScopedRootMixin):
         db_table = "posthog_task_thread_message"
         indexes = [
             models.Index(fields=["task", "created_at"], name="task_thread_msg_task_created"),
+        ]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["task", "event", "event_key"],
+                condition=~models.Q(event_key=""),
+                name="task_thread_msg_event_key_uniq",
+            )
         ]
 
     def __str__(self):

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -523,7 +523,7 @@ class TaskActivityAPITestCase(ChannelTaskAPITestCase):
         self.assertEqual(row["latest_author"]["id"], self.peer.id)
 
     def test_agent_message_is_unread_for_the_task_creator(self):
-        tasks_facade._create_agent_thread_message(self.task, "Hello!", event="agent_message")
+        tasks_facade.emit_task_event(self.task, event="agent_message", content="Hello!", notify=True)
 
         row = self._row_for(self.author_client, self.task)
         self.assertEqual(row["activity_kind"], "message")

--- a/products/tasks/backend/tests/test_thread_updates.py
+++ b/products/tasks/backend/tests/test_thread_updates.py
@@ -387,3 +387,25 @@ class TestEmitTaskEvent(TestCase):
         activity = TaskActivity.objects.for_team(self.team.id).filter(task=self.task, user=self.user).first()
         assert activity is not None
         self.assertEqual(activity.kind, TaskActivity.Kind.MESSAGE)
+
+    def test_an_overlong_key_is_hashed_rather_than_dropped(self) -> None:
+        # event_key is varchar(255) and PR urls are validated up to 2048, so an overlong key
+        # would raise inside a best-effort emitter and lose the row silently — every retry.
+        long_key = "https://example.com/pull/" + "x" * 300
+
+        first = emit_task_event(self.task, event="pr_created", content="opened", event_key=long_key)
+        second = emit_task_event(self.task, event="pr_created", content="opened again", event_key=long_key)
+
+        events = self._events()
+        self.assertEqual(len(events), 1)
+        self.assertIsNotNone(first)
+        self.assertIsNone(second)
+        self.assertTrue(events[0].event_key.startswith("sha256:"))
+        self.assertLessEqual(len(events[0].event_key), 255)
+
+    def test_overlong_keys_that_differ_do_not_collide(self) -> None:
+        prefix = "https://example.com/pull/" + "x" * 300
+        emit_task_event(self.task, event="pr_created", content="one", event_key=f"{prefix}/1")
+        emit_task_event(self.task, event="pr_created", content="two", event_key=f"{prefix}/2")
+
+        self.assertEqual(len(self._events()), 2)

--- a/products/tasks/backend/tests/test_thread_updates.py
+++ b/products/tasks/backend/tests/test_thread_updates.py
@@ -9,6 +9,7 @@ from posthog.models import Organization, OrganizationMembership, Team, User
 from posthog.models.scoping import team_scope
 
 from products.tasks.backend.facade.api import (
+    emit_task_event,
     list_mentions,
     list_thread_messages,
     post_canvas_created_thread_update,
@@ -16,7 +17,14 @@ from products.tasks.backend.facade.api import (
     set_task_run_output,
     update_task_run,
 )
-from products.tasks.backend.models import Channel, Task, TaskRun, TaskThreadMessage, TaskThreadMessageMention
+from products.tasks.backend.models import (
+    Channel,
+    Task,
+    TaskActivity,
+    TaskRun,
+    TaskThreadMessage,
+    TaskThreadMessageMention,
+)
 
 _FLAG_TARGET = "products.tasks.backend.facade.api.posthoganalytics.feature_enabled"
 
@@ -56,7 +64,15 @@ class TestAgentThreadUpdates(TestCase):
         self.assertIsNone(messages[0].author_id)
         self.assertEqual(messages[0].author_kind, TaskThreadMessage.AuthorKind.AGENT)
         self.assertEqual(messages[0].event, "pr_created")
-        self.assertEqual(messages[0].payload, {"pr_url": "https://github.com/posthog/posthog/pull/123"})
+        self.assertEqual(
+            messages[0].payload,
+            {
+                "pr_url": "https://github.com/posthog/posthog/pull/123",
+                "repository": "posthog/posthog",
+                "pr_number": 123,
+            },
+        )
+        self.assertEqual(messages[0].event_key, "https://github.com/posthog/posthog/pull/123")
         self.assertEqual(
             messages[0].content,
             "[posthog/posthog#123](https://github.com/posthog/posthog/pull/123) has been opened",
@@ -149,7 +165,14 @@ class TestAgentThreadUpdates(TestCase):
 
         messages = self._messages(self.task)
         self.assertEqual([message.event for message in messages], ["pr_created"])
-        self.assertEqual(messages[0].payload, {"pr_url": "https://github.com/posthog/posthog/pull/321"})
+        self.assertEqual(
+            messages[0].payload,
+            {
+                "pr_url": "https://github.com/posthog/posthog/pull/321",
+                "repository": "posthog/posthog",
+                "pr_number": 321,
+            },
+        )
 
     @patch(_FLAG_TARGET, return_value=True)
     def test_pr_created_posts_when_set_output_records_pr_url(self, _flag) -> None:
@@ -294,3 +317,73 @@ class TestAgentThreadUpdates(TestCase):
             mentions = list_mentions(self.team.id, self.user.id)
 
         self.assertEqual([mention.message_id for mention in mentions], [human_message.id])
+
+
+class TestEmitTaskEvent(TestCase):
+    def setUp(self) -> None:
+        self.organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=self.organization, name="Test Team")
+        self.user = User.objects.create_user(
+            email="creator@example.com", first_name="Casey", last_name="Creator", password="password"
+        )
+        OrganizationMembership.objects.create(user=self.user, organization=self.organization)
+        self.task = Task.objects.create(
+            team=self.team,
+            title="Ship activity events",
+            description="",
+            origin_product=Task.OriginProduct.USER_CREATED,
+            created_by=self.user,
+        )
+
+    def _events(self) -> list[TaskThreadMessage]:
+        return list(TaskThreadMessage.objects.for_team(self.team.id).filter(task=self.task).order_by("created_at"))
+
+    def test_keyed_event_is_written_once(self) -> None:
+        first = emit_task_event(
+            self.task, event="run_started", content="Run started", payload={"a": 1}, event_key="run-1"
+        )
+        second = emit_task_event(
+            self.task, event="run_started", content="Run started again", payload={"a": 2}, event_key="run-1"
+        )
+
+        self.assertIsNotNone(first)
+        self.assertIsNone(second)
+        events = self._events()
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].payload, {"a": 1})
+
+    @parameterized.expand(
+        [
+            ("different_key", "run_started", "run-2"),
+            ("different_event", "run_failed", "run-1"),
+        ]
+    )
+    def test_distinct_identities_each_get_a_row(self, _name, event, event_key) -> None:
+        emit_task_event(self.task, event="run_started", content="Run started", event_key="run-1")
+        emit_task_event(self.task, event=event, content="Another", event_key=event_key)
+
+        self.assertEqual(len(self._events()), 2)
+
+    def test_unkeyed_events_are_never_collapsed(self) -> None:
+        # Repeatable events (a push, an artifact write) carry no key when the caller has
+        # no identity to key on, and must not silently swallow the second occurrence.
+        emit_task_event(self.task, event="artifact_created", content="One")
+        emit_task_event(self.task, event="artifact_created", content="Two")
+
+        self.assertEqual([event.content for event in self._events()], ["One", "Two"])
+
+    def test_lifecycle_events_stay_out_of_the_notification_feed(self) -> None:
+        # A run starting is timeline material; marking the task unread for it would
+        # bury the events a person actually needs to answer.
+        emit_task_event(self.task, event="run_started", content="Run started", event_key="run-1")
+
+        self.assertFalse(
+            TaskActivity.objects.for_team(self.team.id).filter(task=self.task, kind=TaskActivity.Kind.MESSAGE).exists()
+        )
+
+    def test_notify_projects_the_row_onto_the_feed(self) -> None:
+        emit_task_event(self.task, event="pr_created", content="PR opened", event_key="url", notify=True)
+
+        activity = TaskActivity.objects.for_team(self.team.id).filter(task=self.task, user=self.user).first()
+        assert activity is not None
+        self.assertEqual(activity.kind, TaskActivity.Kind.MESSAGE)


### PR DESCRIPTION
## Problem

The task Timeline tab shows three things: the task was created, a pull request appeared, the task finished.
Everything else — the agent waiting on a human, an artifact reaching version 3, a comment on a canvas — is invisible unless you go looking in another tab.
This is the first of four PRs that put those events on the timeline. It ships the plumbing and emits nothing new.

`TaskThreadMessage` is already an event stream: agent-authored rows with a stable `event` key and a JSON `payload`, two of them live today (`canvas_created`, `pr_created`).
Writing more of them needs two things this PR adds — one vocabulary, and one writer that cannot double-write.

## Changes

- `TaskActivityEvent` names the events the timeline will render. Clients ignore keys they don't know, so the backend can emit before any client draws them.
- `TaskThreadMessage.event_key` names the thing a row announces: a run id, a PR url, a head SHA.
- A partial unique index on `(task, event, event_key)` makes emission idempotent. A redelivered webhook or a retried Temporal activity now loses the race instead of duplicating a row.
- `emit_task_event` replaces `_create_agent_thread_message`. It keeps rows out of the notification feed unless a caller opts in, so a run starting can never mark a task unread.
- The PR announcement drops its bespoke `select_for_update` dedupe for the new key, and carries `repository` and `pr_number` so a client labels it `owner/repo#N` without calling GitHub.

The index is built `CONCURRENTLY` in migration 0085 rather than by `AddConstraint`, which would take an `ACCESS EXCLUSIVE` lock on `posthog_task_thread_message` while it builds. The constraint exists in Django state only; `SeparateDatabaseAndState` keeps the two in agreement.

`db_default=""` alongside `default=""` on the new column, so the generated SQL is a plain `ADD COLUMN ... DEFAULT '' NOT NULL` with no `DROP DEFAULT` follow-up, and the model-built test schema in `setup_test_environment` gets the same default.

## How did you test this code?

Added tests for the emitter's contract, which nothing covered before:

- A keyed event written twice produces one row, and the first payload survives.
- A different key or a different event each gets its own row.
- An unkeyed event is never collapsed — a repeatable event with no identity to key on must not swallow its second occurrence.
- A lifecycle event writes no `MESSAGE` activity row, and `notify=True` still does.

Ran the tasks suites that touch this path locally (`test_thread_updates`, `test_channels_api`, `test_models`, `test_webhooks`, `test_facade`, `test_api`), plus `makemigrations --dry-run` for state drift and `sqlmigrate` on both migrations.

Not checked: nothing was exercised against a real GitHub webhook delivery or a live Temporal retry — the idempotency claim rests on the unique index and the tests above.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by PostHog Code (claude-opus-5). Skills invoked: `/django-migrations` for the two-phase index, `/writing-pr-descriptions` for this body.

Bottom layer of a four-PR stack. The session started from a written proposal and a technical plan for the whole timeline; this layer is the part of that plan with no user-visible effect, split out so the emitters above it are small to review.

Two decisions worth flagging for review. Idempotency is structural (a unique index) rather than per-caller, because the existing `pr_created` path had already hand-rolled it once and the same race recurs for every webhook-fed event. And `notify` defaults to off: projecting every lifecycle row onto the notification feed would mark a task unread for its own agent starting work.

Public artifact: no material from the session that isn't already public. Test data is invented.
