### PR TITLE
feat(tasks): expose comment activity for the task timeline

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -59,6 +59,7 @@ from products.tasks.backend.logic.services.image_builder import (
     is_custom_images_enabled,
     read_spec_from_builder_sandbox,
 )
+from products.tasks.backend.logic.services.user_display import hedgehog_config, user_basic_info
 from products.tasks.backend.mentions import resolve_mentioned_user_ids
 from products.tasks.backend.models import (
     Channel,
@@ -240,6 +241,7 @@ __all__ = [
     "task_comment_mentions_allowed",
     "list_task_artifacts",
     "list_task_comments",
+    "list_task_comment_activity",
     "retrieve_task_comment",
     "update_sandbox_environment",
     "update_task",
@@ -308,42 +310,10 @@ def _task_run_to_dto(run: TaskRun, *, task: Task | None = None) -> contracts.Tas
     )
 
 
-def _hedgehog_config(user: "User") -> dict | None:
-    """Mirror core ``UserBasicSerializer.get_hedgehog_config`` so ``created_by`` output is identical."""
-    config = user.hedgehog_config
-    if not config:
-        return None
-    if config.get("version") == 2:
-        actor_options = config.get("actor_options", {})
-        return {
-            "use_as_profile": config.get("use_as_profile"),
-            "color": actor_options.get("color"),
-            "accessories": actor_options.get("accessories"),
-            "skin": actor_options.get("skin"),
-        }
-    return {
-        "use_as_profile": config.get("use_as_profile"),
-        "color": config.get("color"),
-        "accessories": config.get("accessories"),
-        "skin": config.get("skin"),
-    }
-
-
-def _user_basic_info(user: "User | None") -> contracts.TaskUserBasicInfo | None:
-    """Map a core ``User`` to the display DTO (matches ``UserBasicSerializer`` fields)."""
-    if user is None:
-        return None
-    return contracts.TaskUserBasicInfo(
-        id=user.id,
-        uuid=user.uuid,
-        distinct_id=str(user.distinct_id),
-        first_name=user.first_name,
-        last_name=user.last_name,
-        email=user.email,
-        is_email_verified=user.is_email_verified,
-        hedgehog_config=_hedgehog_config(user),
-        role_at_organization=user.role_at_organization,
-    )
+# Re-exported from the shared display mapper: the module-level names stay so the many call
+# sites below read unchanged, and one implementation feeds every surface.
+_hedgehog_config = hedgehog_config
+_user_basic_info = user_basic_info
 
 
 # Presigned log URLs are cached just under their 1-hour S3 expiry to avoid regeneration.
@@ -6226,7 +6196,9 @@ def star_channel(channel_id: str | UUID, team_id: int, user_id: int, *, starred:
     return True
 
 
-def _thread_message_to_dto(message: TaskThreadMessage) -> contracts.TaskThreadMessageDTO:
+def _thread_message_to_dto(
+    message: TaskThreadMessage, *, mentioned_user_ids: Sequence[int] = ()
+) -> contracts.TaskThreadMessageDTO:
     return contracts.TaskThreadMessageDTO(
         id=message.id,
         task=message.task_id,
@@ -6238,6 +6210,7 @@ def _thread_message_to_dto(message: TaskThreadMessage) -> contracts.TaskThreadMe
         author=_user_basic_info(message.author if message.author_id else None),
         forwarded_to_agent_at=message.forwarded_to_agent_at,
         forwarded_by=_user_basic_info(message.forwarded_by if message.forwarded_by_id else None),
+        mentioned_user_ids=list(mentioned_user_ids),
     )
 
 
@@ -6259,7 +6232,18 @@ def list_thread_messages(
         .select_related("author", "forwarded_by")
         .order_by("created_at", "id")
     )
-    return [_thread_message_to_dto(message) for message in messages]
+    messages = list(messages)
+    # One query for the whole thread's mentions rather than one per message: clients need
+    # them to tell "mentioned you" rows from ordinary ones without re-parsing content.
+    mentions_by_message: dict[UUID, list[int]] = {}
+    for message_id, mentioned_user_id in TaskThreadMessageMention.objects.filter(
+        team_id=team_id, message_id__in=[message.id for message in messages]
+    ).values_list("message_id", "mentioned_user_id"):
+        mentions_by_message.setdefault(message_id, []).append(mentioned_user_id)
+    return [
+        _thread_message_to_dto(message, mentioned_user_ids=sorted(mentions_by_message.get(message.id, [])))
+        for message in messages
+    ]
 
 
 def create_thread_message(
@@ -6435,6 +6419,23 @@ def retrieve_task_comment(
         )
     except InvalidTaskCommentCursor:
         raise ValueError("Invalid task comment cursor") from None
+
+
+def list_task_comment_activity(
+    task_id: str | UUID, team_id: int, user_id: int | None
+) -> contracts.TaskCommentActivityPageDTO | None:
+    """Every comment thread on the task, collapsed for the activity timeline.
+
+    ``None`` when the task isn't visible to the user — the same gate the thread listing uses.
+    """
+    from products.tasks.backend.logic.services.task_comments import (  # noqa: PLC0415 — mirrors the sibling comment facades
+        list_comment_activity,
+    )
+
+    task = _visible_task(task_id, team_id, user_id)
+    if task is None:
+        return None
+    return list_comment_activity(team_id=team_id, task_id=task.id)
 
 
 def list_mentions(

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -6224,7 +6224,7 @@ def list_thread_messages(
     """A task's thread, ascending. ``None`` when the task isn't visible to the user."""
     if _visible_task(task_id, team_id, user_id) is None:
         return None
-    messages = (
+    messages = list(
         TaskThreadMessage.objects.filter(task_id=task_id, team_id=team_id)
         # The thread is human-to-human plus artifact announcements; rows written
         # back when the agent finished a turn (a since-removed behavior) stay out.
@@ -6232,7 +6232,6 @@ def list_thread_messages(
         .select_related("author", "forwarded_by")
         .order_by("created_at", "id")
     )
-    messages = list(messages)
     # One query for the whole thread's mentions rather than one per message: clients need
     # them to tell "mentioned you" rows from ordinary ones without re-parsing content.
     mentions_by_message: dict[UUID, list[int]] = {}

--- a/products/tasks/backend/facade/contracts.py
+++ b/products/tasks/backend/facade/contracts.py
@@ -231,6 +231,9 @@ class TaskThreadMessageDTO:
     author: "TaskUserBasicInfo | None" = None
     forwarded_to_agent_at: datetime | None = None
     forwarded_by: "TaskUserBasicInfo | None" = None
+    # Indexed at write time, so a client renders "mentioned you" without parsing content —
+    # and both surfaces agree on who was mentioned.
+    mentioned_user_ids: list[int] = Field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -324,6 +327,54 @@ class TaskCommentSummaryDTO:
 @dataclass(frozen=True)
 class TaskCommentPageDTO:
     comments: list[TaskCommentSummaryDTO]
+    next: str | None
+
+
+@dataclass(frozen=True)
+class TaskCommentStateEventDTO:
+    """The latest resolve or reopen on a thread. Its own row on the timeline: a boolean says
+    what a thread's state is, but only an event says who changed it and when."""
+
+    state: str
+    author: "TaskUserBasicInfo | None"
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class TaskCommentReplyPreviewDTO:
+    """The newest reply in a thread, for the collapsed row's second line."""
+
+    author: "TaskUserBasicInfo | None"
+    content: str
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class TaskCommentActivityDTO:
+    """One comment thread as the activity timeline renders it: the root, collapsed with its
+    replies rather than one row per reply."""
+
+    id: UUID
+    target: TaskCommentTargetDTO
+    content: str
+    content_truncated: bool
+    selected_text: str | None
+    author: "TaskUserBasicInfo | None"
+    created_at: datetime
+    # The thread's position on the timeline: a thread moves to its newest reply, so an
+    # exchange stays one row instead of scattering across the feed.
+    last_activity_at: datetime
+    reply_count: int
+    participants: list["TaskUserBasicInfo"]
+    mentioned_user_ids: list[int]
+    resolved: bool
+    state_event: TaskCommentStateEventDTO | None
+    latest_reply: TaskCommentReplyPreviewDTO | None
+
+
+@dataclass(frozen=True)
+class TaskCommentActivityPageDTO:
+    comments: list[TaskCommentActivityDTO]
     next: str | None
 
 

--- a/products/tasks/backend/logic/services/task_comments.py
+++ b/products/tasks/backend/logic/services/task_comments.py
@@ -8,7 +8,8 @@ from django.db.models import Count, Q, QuerySet
 from posthog.models import Comment
 
 from products.tasks.backend.facade import contracts
-from products.tasks.backend.models import TaskArtifact, TaskRun, TaskThreadMessage
+from products.tasks.backend.logic.services.user_display import user_basic_info
+from products.tasks.backend.models import TaskArtifact, TaskCommentActivity, TaskRun, TaskThreadMessage
 
 COMMENT_STATES = frozenset({"open", "resolved"})
 LEGACY_TASK_RUN_LIMIT = 100
@@ -392,3 +393,136 @@ def retrieve_comment(
         comments=comments,
         next=next_cursor,
     )
+
+
+# The activity timeline shows every thread on the task in one request rather than fanning
+# out per artifact, so it is bounded here instead of paginated by the caller.
+ACTIVITY_THREAD_LIMIT = 100
+ACTIVITY_CONTENT_BYTES = 512
+
+
+def list_comment_activity(*, team_id: int, task_id: UUID) -> contracts.TaskCommentActivityPageDTO:
+    """Every comment thread on the task, collapsed one row per thread, newest activity first.
+
+    One query set for the whole task: the Comments tab fans out per artifact and per PR,
+    which the timeline must not inherit — it would turn one panel into N requests.
+
+    Mentions come from the notification rows the comment API already projects rather than
+    from re-parsing comment bodies, so the timeline and the Activity feed can't disagree
+    about who was mentioned.
+    """
+    roots = list(
+        _comments(team_id, task_id)
+        .filter(source_comment_id__isnull=True)
+        .select_related("created_by")
+        .order_by("-created_at", "-id")[:ACTIVITY_THREAD_LIMIT]
+    )
+    if not roots:
+        return contracts.TaskCommentActivityPageDTO(comments=[], next=None)
+
+    root_ids = [root.id for root in roots]
+    replies = list(
+        _comments(team_id, task_id)
+        .filter(source_comment_id__in=root_ids)
+        .select_related("created_by")
+        .order_by("created_at", "id")
+    )
+    target_names = _target_names_for_roots(team_id=team_id, task_id=task_id, roots=roots)
+    mentioned_by_root = _mentioned_user_ids_by_root(team_id=team_id, roots=roots, replies=replies)
+
+    conversational: dict[UUID, list[Comment]] = {root_id: [] for root_id in root_ids}
+    state_events: dict[UUID, Comment] = {}
+    for reply in replies:
+        if reply.source_comment_id is None:
+            continue
+        if _is_state_event(reply):
+            # Ordered ascending, so the last one wins.
+            state_events[reply.source_comment_id] = reply
+        else:
+            conversational.setdefault(reply.source_comment_id, []).append(reply)
+
+    rows: list[contracts.TaskCommentActivityDTO] = []
+    for root in roots:
+        thread_replies = conversational.get(root.id, [])
+        state_event = state_events.get(root.id)
+        latest_state = _item_context(state_event).get("threadState") if state_event else None
+        content, content_next_offset = _content_chunk(root.content or "", limit=ACTIVITY_CONTENT_BYTES)
+        anchor = _item_context(root).get("anchor")
+        selected_text = anchor.get("quote") if isinstance(anchor, dict) else None
+        if isinstance(selected_text, str):
+            selected_text = _content_chunk(selected_text, limit=SELECTED_TEXT_BYTES)[0]
+        else:
+            selected_text = None
+        latest_reply = thread_replies[-1] if thread_replies else None
+        candidates = [reply.created_at for reply in thread_replies]
+        if state_event is not None:
+            candidates.append(state_event.created_at)
+        rows.append(
+            contracts.TaskCommentActivityDTO(
+                id=root.id,
+                target=_target(root, target_names),
+                content=content,
+                content_truncated=content_next_offset is not None,
+                selected_text=selected_text,
+                author=user_basic_info(root.created_by),
+                created_at=root.created_at,
+                last_activity_at=max([root.created_at, *candidates]),
+                reply_count=len(thread_replies),
+                participants=_participants(root, thread_replies),
+                mentioned_user_ids=mentioned_by_root.get(root.id, []),
+                resolved=_resolved(root, latest_state),
+                state_event=(
+                    contracts.TaskCommentStateEventDTO(
+                        state=str(latest_state),
+                        author=user_basic_info(state_event.created_by),
+                        created_at=state_event.created_at,
+                    )
+                    if state_event is not None and latest_state is not None
+                    else None
+                ),
+                latest_reply=(
+                    contracts.TaskCommentReplyPreviewDTO(
+                        author=user_basic_info(latest_reply.created_by),
+                        content=_content_chunk(latest_reply.content or "", limit=ACTIVITY_CONTENT_BYTES)[0],
+                        created_at=latest_reply.created_at,
+                    )
+                    if latest_reply is not None
+                    else None
+                ),
+            )
+        )
+
+    rows.sort(key=lambda row: (row.last_activity_at, row.id), reverse=True)
+    return contracts.TaskCommentActivityPageDTO(comments=rows, next=None)
+
+
+def _participants(root: Comment, replies: Sequence[Comment]) -> list[contracts.TaskUserBasicInfo]:
+    """Everyone who spoke in the thread, root author first, deduplicated in speaking order."""
+    seen: set[int] = set()
+    participants: list[contracts.TaskUserBasicInfo] = []
+    for comment in [root, *replies]:
+        user = comment.created_by
+        if user is None or user.id in seen:
+            continue
+        seen.add(user.id)
+        info = user_basic_info(user)
+        if info is not None:
+            participants.append(info)
+    return participants
+
+
+def _mentioned_user_ids_by_root(
+    *, team_id: int, roots: Sequence[Comment], replies: Sequence[Comment]
+) -> dict[UUID, list[int]]:
+    comment_ids = [comment.id for comment in [*roots, *replies]]
+    if not comment_ids:
+        return {}
+    mentioned: dict[UUID, set[int]] = {}
+    rows = (
+        TaskCommentActivity.objects.for_team(team_id)
+        .filter(comment_id__in=comment_ids, kind=TaskCommentActivity.Kind.MENTION)
+        .values_list("root_comment_id", "user_id")
+    )
+    for root_comment_id, user_id in rows:
+        mentioned.setdefault(root_comment_id, set()).add(user_id)
+    return {root_comment_id: sorted(user_ids) for root_comment_id, user_ids in mentioned.items()}

--- a/products/tasks/backend/logic/services/user_display.py
+++ b/products/tasks/backend/logic/services/user_display.py
@@ -1,0 +1,48 @@
+"""Mapping a core ``User`` onto the display DTO task responses expose.
+
+Its own module so the facade and the services that build their own DTOs share one
+implementation: two copies drift, and the drift shows up as an avatar that renders in one
+surface and not the other.
+"""
+
+from posthog.models.user import User
+
+from products.tasks.backend.facade import contracts
+
+
+def hedgehog_config(user: User) -> dict | None:
+    """Mirror core ``UserBasicSerializer.get_hedgehog_config`` so ``created_by`` output is identical."""
+    config = user.hedgehog_config
+    if not config:
+        return None
+    if config.get("version") == 2:
+        actor_options = config.get("actor_options", {})
+        return {
+            "use_as_profile": config.get("use_as_profile"),
+            "color": actor_options.get("color"),
+            "accessories": actor_options.get("accessories"),
+            "skin": actor_options.get("skin"),
+        }
+    return {
+        "use_as_profile": config.get("use_as_profile"),
+        "color": config.get("color"),
+        "accessories": config.get("accessories"),
+        "skin": config.get("skin"),
+    }
+
+
+def user_basic_info(user: User | None) -> contracts.TaskUserBasicInfo | None:
+    """Map a core ``User`` to the display DTO (matches ``UserBasicSerializer`` fields)."""
+    if user is None:
+        return None
+    return contracts.TaskUserBasicInfo(
+        id=user.id,
+        uuid=user.uuid,
+        distinct_id=str(user.distinct_id),
+        first_name=user.first_name,
+        last_name=user.last_name,
+        email=user.email,
+        is_email_verified=user.is_email_verified,
+        hedgehog_config=hedgehog_config(user),
+        role_at_organization=user.role_at_organization,
+    )

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -1650,6 +1650,7 @@ class TaskThreadMessageSerializer(DataclassSerializer):
             "author",
             "forwarded_to_agent_at",
             "forwarded_by",
+            "mentioned_user_ids",
         ]
 
 
@@ -3535,3 +3536,41 @@ class AgentProxyCallbackResponseSerializer(serializers.Serializer):
     dispatched = serializers.BooleanField(
         help_text="True when the requested side effect was dispatched; false when skipped (e.g. run not found)."
     )
+
+
+class TaskCommentStateEventSerializer(serializers.Serializer):
+    state = serializers.CharField(help_text="Thread state the event set: 'resolved' or 'open'.")
+    author = TaskUserBasicInfoSerializer(allow_null=True, help_text="Who changed the thread's state.")
+    created_at = serializers.DateTimeField(help_text="When the state changed.")
+
+
+class TaskCommentReplyPreviewSerializer(serializers.Serializer):
+    author = TaskUserBasicInfoSerializer(allow_null=True, help_text="Who wrote the newest reply.")
+    content = serializers.CharField(help_text="Bounded excerpt of the newest reply.")
+    created_at = serializers.DateTimeField(help_text="When the newest reply was written.")
+
+
+class TaskCommentActivitySerializer(serializers.Serializer):
+    """One comment thread as the activity timeline renders it."""
+
+    id = serializers.UUIDField(help_text="Root comment id.")
+    target = TaskCommentTargetSerializer(help_text="Task, artifact, or canvas receiving the comment.")
+    content = serializers.CharField(help_text="Bounded excerpt of the root comment body.")
+    content_truncated = serializers.BooleanField(help_text="Whether the root comment body has more content.")
+    selected_text = serializers.CharField(allow_null=True, help_text="Text selected when the comment was created.")
+    author = TaskUserBasicInfoSerializer(allow_null=True, help_text="Who started the thread.")
+    created_at = serializers.DateTimeField(help_text="When the thread started.")
+    last_activity_at = serializers.DateTimeField(help_text="Newest activity in the thread; its timeline position.")
+    reply_count = serializers.IntegerField(help_text="Number of human replies, excluding resolve and reopen events.")
+    participants = TaskUserBasicInfoSerializer(many=True, help_text="Everyone who spoke, in speaking order.")
+    mentioned_user_ids = serializers.ListField(
+        child=serializers.IntegerField(), help_text="Users mentioned anywhere in the thread."
+    )
+    resolved = serializers.BooleanField(help_text="Whether the thread is resolved.")
+    state_event = TaskCommentStateEventSerializer(allow_null=True, help_text="Latest resolve or reopen, if any.")
+    latest_reply = TaskCommentReplyPreviewSerializer(allow_null=True, help_text="Newest reply, if any.")
+
+
+class TaskCommentActivityResponseSerializer(serializers.Serializer):
+    comments = TaskCommentActivitySerializer(many=True, help_text="Comment threads, newest activity first.")
+    next = serializers.CharField(allow_null=True, help_text="Reserved for pagination; always null today.")

--- a/products/tasks/backend/presentation/views/channels_api.py
+++ b/products/tasks/backend/presentation/views/channels_api.py
@@ -32,6 +32,7 @@ from products.tasks.backend.presentation.serializers import (
     TaskActivityPageSerializer,
     TaskActivityQuerySerializer,
     TaskActivitySerializer,
+    TaskCommentActivityResponseSerializer,
     TaskMentionQuerySerializer,
     TaskMentionSerializer,
     TaskThreadMessageSerializer,
@@ -514,6 +515,22 @@ class TaskThreadMessageViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         if messages is None:
             raise NotFound("Task not found")
         return Response(TaskThreadMessageSerializer(messages, many=True).data)
+
+    @extend_schema(
+        responses={200: TaskCommentActivityResponseSerializer},
+        summary="List comment activity",
+        description=(
+            "Every comment thread on the task, collapsed one row per thread and ordered by newest "
+            "activity — what the activity timeline renders. One request for the whole task rather "
+            "than one per artifact."
+        ),
+    )
+    @action(detail=False, methods=["get"], url_path="comment_activity")
+    def comment_activity(self, request, *args, **kwargs):
+        page = tasks_facade.list_task_comment_activity(self._task_id(), self.team_id, self._user_id())
+        if page is None:
+            raise NotFound("Task not found")
+        return Response(TaskCommentActivityResponseSerializer(page).data)
 
     @extend_schema(
         request=TaskThreadMessageWriteSerializer,

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -9,7 +9,7 @@ from parameterized import parameterized
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from posthog.models import Integration, Organization, OrganizationMembership, Team, User
+from posthog.models import Comment, Integration, Organization, OrganizationMembership, Team, User
 
 from products.tasks.backend.facade import api as tasks_facade
 from products.tasks.backend.models import Channel, ChannelFeedMessage, Task, TaskActivity, TaskRun, TaskThreadMessage
@@ -272,6 +272,32 @@ class ThreadMessagesAPITestCase(ChannelTaskAPITestCase):
 
         listed = self.author_client.get(self._thread_url()).json()
         self.assertEqual([m["content"] for m in listed], ["What about mobile?"])
+
+    def test_comment_activity_lists_threads_for_the_task(self):
+        Comment.objects.create(
+            team=self.team,
+            scope="task",
+            item_id=str(self.task.id),
+            item_context={"taskId": str(self.task.id)},
+            content="worth a second look",
+            created_by=self.peer,
+        )
+
+        response = self.author_client.get(f"{self._thread_url()}comment_activity/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        body = response.json()
+        self.assertEqual([row["content"] for row in body["comments"]], ["worth a second look"])
+        self.assertEqual(body["comments"][0]["target"]["type"], "task")
+        self.assertEqual(body["comments"][0]["author"]["id"], self.peer.id)
+
+    def test_comment_activity_404s_for_a_task_outside_the_team(self):
+        other_team = Team.objects.create(organization=self.organization, name="Other Team")
+        response = self.author_client.get(
+            f"/api/projects/{other_team.id}/tasks/{self.task.id}/thread_messages/comment_activity/"
+        )
+
+        self.assertIn(response.status_code, (status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND))
 
     def test_delete_is_author_only(self):
         message_id = self.peer_client.post(self._thread_url(), {"content": "mine"}).json()["id"]

--- a/products/tasks/backend/tests/test_comment_activity.py
+++ b/products/tasks/backend/tests/test_comment_activity.py
@@ -276,3 +276,110 @@ class TestCommentActivity(CommentActivityTestCase):
         assert first_activity.read_at is not None
         assert TaskCommentActivity.objects.get(comment=second, user=self.author).read_at is None
         assert TaskActivity.objects.get(team=self.team, user=self.author, task=self.task).read_at is None
+
+
+class TestCommentActivityTimeline(CommentActivityTestCase):
+    """The collapsed comment rows the activity timeline renders."""
+
+    def _rows(self):
+        page = tasks_facade.list_task_comment_activity(self.task.id, self.team.id, self.author.id)
+        assert page is not None
+        return page.comments
+
+    def test_a_thread_is_one_row_positioned_at_its_newest_reply(self):
+        # One row per reply would push every other event off the panel, so replies fold into
+        # the root and the root moves to the newest reply's time.
+        root = self._comment(content="this needs a guard")
+        older = self._comment(content="unrelated thread")
+        reply = self._comment(content="agreed, on it", source_comment=root, created_by=self.author)
+
+        rows = self._rows()
+
+        self.assertEqual([row.id for row in rows], [root.id, older.id])
+        self.assertEqual(rows[0].reply_count, 1)
+        self.assertEqual(rows[0].last_activity_at, reply.created_at)
+        self.assertEqual(rows[0].latest_reply.content, "agreed, on it")
+
+    def test_resolve_events_are_not_replies(self):
+        # The Comments tab excludes thread-state events from its count; a second definition
+        # here is how the two surfaces start disagreeing.
+        root = self._comment()
+        self._comment(content="agreed", source_comment=root, created_by=self.author)
+        self._comment(
+            content="Resolved this thread",
+            source_comment=root,
+            created_by=self.author,
+            item_context={"taskId": str(self.task.id), "threadState": "resolved"},
+        )
+
+        row = self._rows()[0]
+
+        self.assertEqual(row.reply_count, 1)
+        self.assertTrue(row.resolved)
+        assert row.state_event is not None
+        self.assertEqual(row.state_event.state, "resolved")
+        self.assertEqual(row.state_event.author.id, self.author.id)
+
+    def test_reopening_supersedes_an_earlier_resolve(self):
+        root = self._comment()
+        for state in ("resolved", "open"):
+            self._comment(
+                content=f"{state} this thread",
+                source_comment=root,
+                created_by=self.author,
+                item_context={"taskId": str(self.task.id), "threadState": state},
+            )
+
+        row = self._rows()[0]
+
+        self.assertFalse(row.resolved)
+        assert row.state_event is not None
+        self.assertEqual(row.state_event.state, "open")
+
+    def test_participants_are_listed_in_speaking_order(self):
+        root = self._comment(created_by=self.peer)
+        self._comment(content="looking", source_comment=root, created_by=self.author)
+        self._comment(content="still looking", source_comment=root, created_by=self.author)
+
+        row = self._rows()[0]
+
+        self.assertEqual([person.id for person in row.participants], [self.peer.id, self.author.id])
+
+    def test_mentions_come_from_the_projected_notification_rows(self):
+        root = self._comment()
+        self._record_activity(root, [self.author.id])
+
+        self.assertEqual(self._rows()[0].mentioned_user_ids, [self.author.id])
+
+    def test_the_anchor_travels_with_the_row(self):
+        # A comment without its quoted selection is just a notification.
+        self._comment(
+            item_context={
+                "taskId": str(self.task.id),
+                "anchor": {"kind": "text", "quote": "every event should also go to the activity panel"},
+            }
+        )
+
+        self.assertEqual(self._rows()[0].selected_text, "every event should also go to the activity panel")
+
+    def test_threads_from_every_target_arrive_in_one_call(self):
+        canvas = Canvas.objects.create(
+            team=self.team,
+            channel=self.channel,
+            name="Activity mockup",
+            created_by=self.author,
+            generation_task_id=self.task.id,
+        )
+        self._comment(scope="task", item_id=str(self.task.id), item_context={"taskId": str(self.task.id)})
+        self._comment(scope="desktop_canvas", item_id=str(canvas.id))
+        self._comment()
+
+        self.assertEqual({row.target.type for row in self._rows()}, {"task", "canvas", "artifact"})
+
+    def test_a_task_the_user_cannot_see_returns_nothing(self):
+        # A task in another team is invisible here, so the endpoint must not answer for it.
+        other_team = Team.objects.create(organization=self.organization, name="Other Team")
+        with team_scope(other_team.id, canonical=True):
+            stranger_task = Task.objects.create(team=other_team, title="Not yours", created_by=self.peer)
+
+        self.assertIsNone(tasks_facade.list_task_comment_activity(stranger_task.id, self.team.id, self.author.id))

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -3631,6 +3631,7 @@ export interface TaskThreadMessageDTOApi {
     /** @nullable */
     forwarded_to_agent_at?: string | null
     forwarded_by?: TaskUserBasicInfoApi | null
+    mentioned_user_ids?: number[]
 }
 
 export interface PaginatedTaskThreadMessageDTOListApi {
@@ -3648,6 +3649,71 @@ export interface PaginatedTaskThreadMessageDTOListApi {
 export interface TaskThreadMessageWriteApi {
     /** Message text. */
     content: string
+}
+
+export interface TaskCommentStateEventApi {
+    /** Thread state the event set: 'resolved' or 'open'. */
+    state: string
+    /** Who changed the thread's state. */
+    author: TaskUserBasicInfoApi | null
+    /** When the state changed. */
+    created_at: string
+}
+
+export interface TaskCommentReplyPreviewApi {
+    /** Who wrote the newest reply. */
+    author: TaskUserBasicInfoApi | null
+    /** Bounded excerpt of the newest reply. */
+    content: string
+    /** When the newest reply was written. */
+    created_at: string
+}
+
+/**
+ * One comment thread as the activity timeline renders it.
+ */
+export interface TaskCommentActivityApi {
+    /** Root comment id. */
+    id: string
+    /** Task, artifact, or canvas receiving the comment. */
+    target: TaskCommentTargetApi
+    /** Bounded excerpt of the root comment body. */
+    content: string
+    /** Whether the root comment body has more content. */
+    content_truncated: boolean
+    /**
+     * Text selected when the comment was created.
+     * @nullable
+     */
+    selected_text: string | null
+    /** Who started the thread. */
+    author: TaskUserBasicInfoApi | null
+    /** When the thread started. */
+    created_at: string
+    /** Newest activity in the thread; its timeline position. */
+    last_activity_at: string
+    /** Number of human replies, excluding resolve and reopen events. */
+    reply_count: number
+    /** Everyone who spoke, in speaking order. */
+    participants: TaskUserBasicInfoApi[]
+    /** Users mentioned anywhere in the thread. */
+    mentioned_user_ids: number[]
+    /** Whether the thread is resolved. */
+    resolved: boolean
+    /** Latest resolve or reopen, if any. */
+    state_event: TaskCommentStateEventApi | null
+    /** Newest reply, if any. */
+    latest_reply: TaskCommentReplyPreviewApi | null
+}
+
+export interface TaskCommentActivityResponseApi {
+    /** Comment threads, newest activity first. */
+    comments: TaskCommentActivityApi[]
+    /**
+     * Reserved for pagination; always null today.
+     * @nullable
+     */
+    next: string | null
 }
 
 /**

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -73,6 +73,7 @@ import type {
     TaskAutomationsListParams,
     TaskChannelsFeedListParams,
     TaskChannelsListParams,
+    TaskCommentActivityResponseApi,
     TaskCommentDetailApi,
     TaskCommentsResponseApi,
     TaskCreateApi,
@@ -2365,6 +2366,28 @@ export const tasksThreadMessagesSendToAgentCreate = async (
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(taskThreadMessageDTOApi),
     })
+}
+
+export const getTasksThreadMessagesCommentActivityRetrieveUrl = (projectId: string, taskId: string) => {
+    return `/api/projects/${projectId}/tasks/${taskId}/thread_messages/comment_activity/`
+}
+
+/**
+ * Every comment thread on the task, collapsed one row per thread and ordered by newest activity — what the activity timeline renders. One request for the whole task rather than one per artifact.
+ * @summary List comment activity
+ */
+export const tasksThreadMessagesCommentActivityRetrieve = async (
+    projectId: string,
+    taskId: string,
+    options?: RequestInit
+): Promise<TaskCommentActivityResponseApi> => {
+    return apiMutator<TaskCommentActivityResponseApi>(
+        getTasksThreadMessagesCommentActivityRetrieveUrl(projectId, taskId),
+        {
+            ...options,
+            method: 'GET',
+        }
+    )
 }
 
 export const getTasksActiveWizardRunRetrieveUrl = (projectId: string) => {

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -3039,6 +3039,7 @@ export const TasksThreadMessagesSendToAgentCreateBody = /* @__PURE__ */ zod
                 zod.null(),
             ])
             .optional(),
+        mentioned_user_ids: zod.array(zod.number()).optional(),
     })
     .describe("Response shape for one message in a task's thread.")
 

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -617,6 +617,9 @@ tools:
     tasks-summaries-create:
         operation: tasks_summaries_create
         enabled: false
+    tasks-thread-messages-comment-activity-retrieve:
+        operation: tasks_thread_messages_comment_activity_retrieve
+        enabled: false
     tasks-thread-messages-create:
         operation: tasks_thread_messages_create
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -50551,6 +50551,7 @@ export namespace Schemas {
       /** @nullable */
       forwarded_to_agent_at?: string | null;
       forwarded_by?: TaskUserBasicInfo | null;
+      mentioned_user_ids?: number[];
     }
 
     export interface PaginatedTaskThreadMessageDTOList {
@@ -74066,6 +74067,80 @@ export namespace Schemas {
       enabled?: boolean;
     }
 
+    export interface TaskCommentTarget {
+      /** Stable target id. */
+      id: string;
+      /** Target type: task, artifact, or canvas. */
+      type: string;
+      /** Display name of the comment target. */
+      name: string;
+    }
+
+    export interface TaskCommentStateEvent {
+      /** Thread state the event set: 'resolved' or 'open'. */
+      state: string;
+      /** Who changed the thread's state. */
+      author: TaskUserBasicInfo | null;
+      /** When the state changed. */
+      created_at: string;
+    }
+
+    export interface TaskCommentReplyPreview {
+      /** Who wrote the newest reply. */
+      author: TaskUserBasicInfo | null;
+      /** Bounded excerpt of the newest reply. */
+      content: string;
+      /** When the newest reply was written. */
+      created_at: string;
+    }
+
+    /**
+     * One comment thread as the activity timeline renders it.
+     */
+    export interface TaskCommentActivity {
+      /** Root comment id. */
+      id: string;
+      /** Task, artifact, or canvas receiving the comment. */
+      target: TaskCommentTarget;
+      /** Bounded excerpt of the root comment body. */
+      content: string;
+      /** Whether the root comment body has more content. */
+      content_truncated: boolean;
+      /**
+         * Text selected when the comment was created.
+         * @nullable
+         */
+      selected_text: string | null;
+      /** Who started the thread. */
+      author: TaskUserBasicInfo | null;
+      /** When the thread started. */
+      created_at: string;
+      /** Newest activity in the thread; its timeline position. */
+      last_activity_at: string;
+      /** Number of human replies, excluding resolve and reopen events. */
+      reply_count: number;
+      /** Everyone who spoke, in speaking order. */
+      participants: TaskUserBasicInfo[];
+      /** Users mentioned anywhere in the thread. */
+      mentioned_user_ids: number[];
+      /** Whether the thread is resolved. */
+      resolved: boolean;
+      /** Latest resolve or reopen, if any. */
+      state_event: TaskCommentStateEvent | null;
+      /** Newest reply, if any. */
+      latest_reply: TaskCommentReplyPreview | null;
+    }
+
+    export interface TaskCommentActivityResponse {
+      /** Comment threads, newest activity first. */
+      comments: TaskCommentActivity[];
+      /**
+         * Reserved for pagination; always null today.
+         * @nullable
+         */
+      next: string | null;
+    }
+
     export interface TaskCommentAnchor {
       /** Anchor kind. */
       kind?: string;
@@ -74109,15 +74184,6 @@ export namespace Schemas {
          * @maximum 1
          */
       height?: number;
-    }
-
-    export interface TaskCommentTarget {
-      /** Stable target id. */
-      id: string;
-      /** Target type: task, artifact, or canvas. */
-      type: string;
-      /** Display name of the comment target. */
-      name: string;
     }
 
     export interface TaskCommentEntry {


### PR DESCRIPTION
## Problem

Comments and mentions exist on tasks, artifacts and canvases, but the task timeline has no way to read them.
The Comments tab loads them by fanning out across every artifact and every PR on the task — up to 20 targets plus three GitHub queries per PR — which the timeline must not inherit. That would turn one panel into N requests.

Layer 3 of 4. The two layers below emit lifecycle events; this one adds the read surface for comments. Still no visible change.

## Changes

`GET /api/projects/:team/tasks/:task/thread_messages/comment_activity/` returns every comment thread on a task in one request: root plus target, the anchor's quoted selection, reply count, participants in speaking order, the latest reply, the latest resolve or reopen, and who was mentioned. Threads come back collapsed one row per thread, ordered by newest activity.

- One task-scoped query set, so the panel makes one request no matter how much output the task produced.
- Reply counts exclude resolve and reopen events, reusing the rule `list_comments` already applies. A second definition of "reply" is how two surfaces start disagreeing about the same thread.
- Resolve and reopen come back as an event with an author and a time. A boolean says what state a thread is in, but only an event says who changed it — which is what a timeline row needs.
- `last_activity_at` is the thread's timeline position, so an exchange stays one row that moves rather than scattering across the feed.
- Mentions come from the notification rows the comment API already projects, not from re-parsing comment bodies. The timeline and the Activity feed therefore cannot disagree about who was mentioned.
- Thread messages now carry `mentioned_user_ids`, read from the mention rows indexed at write time, in one query for the whole thread.
- The user-display mapping moves to `logic/services/user_display.py`, so the facade and this service cannot drift on avatar config. Two copies would show an avatar in one surface and not the other.

Generated API types are refreshed by `hogli build:openapi`; the diff is additive.

The service function lives beside `list_comments` in `task_comments.py`, which the MCP comment tools already use. `TaskCommentSummaryDTO` is untouched, so those tools' output shape does not move.

## How did you test this code?

New service tests, each naming a case nothing covered:

- A thread with replies is one row, positioned at its newest reply.
- A resolve event is not counted as a reply, and surfaces as a state event with its author.
- A reopen supersedes an earlier resolve.
- Participants come back in speaking order.
- The anchor's quoted selection travels with the row.
- Threads on the task, an artifact and a canvas all arrive in one call.
- A task outside the requester's visibility returns nothing.

Plus two API tests: the endpoint lists a task's threads with author and target, and refuses a task from another team.

Ran locally: `test_comment_activity`, `test_channels_api`, `test_thread_updates`, `test_facade`.

Not checked: no load testing of the single-query path against a task with hundreds of threads. The listing is bounded to the 100 newest threads.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by PostHog Code (claude-opus-5). Skills invoked: `/improving-drf-endpoints`, `/adopting-generated-api-types`, `/writing-pr-descriptions`.

Comments deliberately stay out of the `TaskThreadMessage` event stream the layers below use. They mutate after creation — resolve, reopen, replies, re-anchoring — so an immutable event row would disagree with the comment the moment a thread is resolved.

Reading mentions from `TaskCommentActivity` rather than parsing content is the one non-obvious data choice: it couples the timeline to the notification projection, which is exactly what keeps the two surfaces consistent.

Public artifact: no material from the session that isn't already public. Test data is invented.
