### PR TITLE
feat(desktop): draw comments and lifecycle events on the task timeline

### DIFF
--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -102,6 +102,7 @@ import type {
   TaskActivityPage,
   TaskActivityReadMarker,
   TaskChannel,
+  TaskCommentThreadSummary,
   TaskMention,
   TaskRun,
   TaskRunArtefact,
@@ -2795,6 +2796,30 @@ export class PostHogAPIClient {
       );
     }
     return (await response.json()) as TaskThreadMessage[];
+  }
+
+  /** Every comment thread on the task, collapsed one row per thread — the activity
+   *  timeline's comment feed. One request for the whole task, so the panel never fans out
+   *  per artifact the way the Comments tab has to. */
+  async getTaskCommentActivity(
+    taskId: string,
+  ): Promise<TaskCommentThreadSummary[]> {
+    const teamId = await this.getTeamId();
+    const urlPath = `/api/projects/${teamId}/tasks/${taskId}/thread_messages/comment_activity/`;
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url: new URL(`${this.api.baseUrl}${urlPath}`),
+      path: urlPath,
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch comment activity: ${response.statusText}`,
+      );
+    }
+    const body = (await response.json()) as {
+      comments?: TaskCommentThreadSummary[];
+    };
+    return body.comments ?? [];
   }
 
   async createTaskThreadMessage(

--- a/products/desktop/packages/core/src/canvas/activityEvents.ts
+++ b/products/desktop/packages/core/src/canvas/activityEvents.ts
@@ -27,7 +27,6 @@ export interface RunStartedPayload {
   runId: string;
   environment: string;
   branch: string;
-  runNumber: number;
 }
 
 export interface RunFailedPayload {
@@ -128,7 +127,6 @@ export function parseActivityEvent(message: {
           runId: str(payload.run_id),
           environment: str(payload.environment),
           branch: str(payload.branch),
-          runNumber: num(payload.run_number, 1),
         },
       };
     case "run_failed":

--- a/products/desktop/packages/core/src/canvas/activityEvents.ts
+++ b/products/desktop/packages/core/src/canvas/activityEvents.ts
@@ -1,0 +1,179 @@
+/**
+ * The vocabulary of server-emitted task events the activity timeline renders.
+ *
+ * Mirrors `TaskActivityEvent` in `products/tasks/backend/models.py`; a test asserts the
+ * two lists match. `parseActivityEvent` returns `null` for anything it doesn't know, which
+ * is what lets the backend emit a new event before this client can draw it.
+ */
+
+export const ACTIVITY_EVENTS = [
+  "run_started",
+  "run_failed",
+  "awaiting_input",
+  "artifact_created",
+  "artifact_revised",
+  "canvas_created",
+  "pr_created",
+  "pr_merged",
+  "pr_closed",
+  "message_forwarded",
+] as const;
+
+export type ActivityEventKind = (typeof ACTIVITY_EVENTS)[number];
+
+const ACTIVITY_EVENT_SET: ReadonlySet<string> = new Set(ACTIVITY_EVENTS);
+
+export interface RunStartedPayload {
+  runId: string;
+  environment: string;
+  branch: string;
+  runNumber: number;
+}
+
+export interface RunFailedPayload {
+  runId: string;
+  errorSummary: string;
+}
+
+export interface AwaitingInputPayload {
+  runId: string;
+}
+
+export interface ArtifactPayload {
+  artifactId: string;
+  name: string;
+  artifactType: string;
+  version: number;
+}
+
+export interface CanvasCreatedPayload {
+  name: string;
+  url: string | null;
+}
+
+export interface PrPayload {
+  prUrl: string;
+  repository: string | null;
+  prNumber: number | null;
+  actor: string | null;
+}
+
+export interface MessageForwardedPayload {
+  messageId: string;
+  runId: string;
+}
+
+export type ActivityEvent =
+  | { kind: "run_started"; payload: RunStartedPayload }
+  | { kind: "run_failed"; payload: RunFailedPayload }
+  | { kind: "awaiting_input"; payload: AwaitingInputPayload }
+  | { kind: "artifact_created"; payload: ArtifactPayload }
+  | { kind: "artifact_revised"; payload: ArtifactPayload }
+  | { kind: "canvas_created"; payload: CanvasCreatedPayload }
+  | { kind: "pr_created"; payload: PrPayload }
+  | { kind: "pr_merged"; payload: PrPayload }
+  | { kind: "pr_closed"; payload: PrPayload }
+  | { kind: "message_forwarded"; payload: MessageForwardedPayload };
+
+function str(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function num(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function optionalStr(value: unknown): string | null {
+  return typeof value === "string" && value ? value : null;
+}
+
+function prPayload(payload: Record<string, unknown>): PrPayload {
+  return {
+    prUrl: str(payload.pr_url),
+    repository: optionalStr(payload.repository),
+    prNumber: typeof payload.pr_number === "number" ? payload.pr_number : null,
+    actor: optionalStr(payload.actor),
+  };
+}
+
+function artifactPayload(payload: Record<string, unknown>): ArtifactPayload {
+  return {
+    artifactId: str(payload.artifact_id),
+    name: str(payload.name, "Artifact"),
+    artifactType: str(payload.artifact_type),
+    version: num(payload.version, 1),
+  };
+}
+
+export function isActivityEventKind(event: string): event is ActivityEventKind {
+  return ACTIVITY_EVENT_SET.has(event);
+}
+
+/**
+ * The typed event a thread message carries, or `null` when the message isn't one this
+ * client renders — a human message, an older event, or one added after this release.
+ */
+export function parseActivityEvent(message: {
+  event?: string;
+  payload?: Record<string, unknown>;
+}): ActivityEvent | null {
+  const event = message.event ?? "";
+  if (!isActivityEventKind(event)) return null;
+  const payload = message.payload ?? {};
+  switch (event) {
+    case "run_started":
+      return {
+        kind: event,
+        payload: {
+          runId: str(payload.run_id),
+          environment: str(payload.environment),
+          branch: str(payload.branch),
+          runNumber: num(payload.run_number, 1),
+        },
+      };
+    case "run_failed":
+      return {
+        kind: event,
+        payload: {
+          runId: str(payload.run_id),
+          errorSummary: str(payload.error_summary),
+        },
+      };
+    case "awaiting_input":
+      return { kind: event, payload: { runId: str(payload.run_id) } };
+    case "artifact_created":
+    case "artifact_revised":
+      return { kind: event, payload: artifactPayload(payload) };
+    case "canvas_created":
+      return {
+        kind: event,
+        payload: {
+          name: str(payload.canvas_name, "Canvas"),
+          url: optionalStr(payload.canvas_url),
+        },
+      };
+    case "pr_created":
+    case "pr_merged":
+    case "pr_closed": {
+      const parsed = prPayload(payload);
+      // A PR row with no url can't be labelled or opened, so it isn't a row.
+      return parsed.prUrl ? { kind: event, payload: parsed } : null;
+    }
+    case "message_forwarded":
+      return {
+        kind: event,
+        payload: {
+          messageId: str(payload.message_id),
+          runId: str(payload.run_id),
+        },
+      };
+  }
+}
+
+/** "owner/repo#12" when the event knows both, else the bare url. */
+export function prLabel(payload: PrPayload): string {
+  if (payload.repository && payload.prNumber !== null) {
+    return `${payload.repository}#${payload.prNumber}`;
+  }
+  return payload.prUrl;
+}

--- a/products/desktop/packages/core/src/canvas/activityTimeline.test.ts
+++ b/products/desktop/packages/core/src/canvas/activityTimeline.test.ts
@@ -1,0 +1,274 @@
+import {
+  ACTIVITY_EVENTS,
+  parseActivityEvent,
+} from "@posthog/core/canvas/activityEvents";
+import {
+  type ActivityTaskLike,
+  buildActivityTimeline,
+  type CommentThreadLike,
+} from "@posthog/core/canvas/activityTimeline";
+import type { ThreadMessageLike } from "@posthog/core/canvas/threadTimeline";
+import { describe, expect, it } from "vitest";
+
+const task: ActivityTaskLike = {
+  id: "task-1",
+  createdAt: "2026-08-01T10:00:00Z",
+  updatedAt: "2026-08-01T12:00:00Z",
+};
+
+function eventMessage(
+  id: string,
+  event: string,
+  payload: Record<string, unknown>,
+  createdAt: string,
+): ThreadMessageLike {
+  return {
+    id,
+    content: "",
+    created_at: createdAt,
+    author_kind: "agent",
+    event,
+    payload,
+  };
+}
+
+function thread(overrides: Partial<CommentThreadLike> = {}): CommentThreadLike {
+  return {
+    id: "thread-1",
+    lastActivityAt: "2026-08-01T11:00:00Z",
+    mentionedUserIds: [],
+    resolved: false,
+    stateEvent: null,
+    ...overrides,
+  };
+}
+
+function build(input: {
+  messages?: ThreadMessageLike[];
+  commentThreads?: CommentThreadLike[];
+  commentsEnabled?: boolean;
+  taskOverrides?: Partial<ActivityTaskLike>;
+}) {
+  return buildActivityTimeline({
+    task: { ...task, ...input.taskOverrides },
+    messages: input.messages ?? [],
+    commentThreads: input.commentThreads ?? [],
+    commentsEnabled: input.commentsEnabled,
+  });
+}
+
+describe("activity timeline", () => {
+  it("leads with the task's creation", () => {
+    const rows = build({});
+
+    expect(rows.map((row) => row.kind)).toEqual(["task_created"]);
+  });
+
+  it("orders every source by time", () => {
+    const rows = build({
+      messages: [
+        eventMessage(
+          "m2",
+          "run_started",
+          { run_id: "run-1" },
+          "2026-08-01T10:30:00Z",
+        ),
+        {
+          id: "m1",
+          content: "what about mobile?",
+          created_at: "2026-08-01T10:15:00Z",
+        },
+      ],
+      commentThreads: [thread()],
+    });
+
+    expect(rows.map((row) => row.key)).toEqual([
+      "task-created",
+      "message-m1",
+      "event-m2",
+      "comment-thread-1",
+    ]);
+  });
+
+  it("places a comment thread at its newest activity, not its start", () => {
+    // A thread that keeps getting replies has to stay one row that moves, or a five-reply
+    // exchange pushes everything else off the panel.
+    const rows = build({
+      messages: [
+        eventMessage(
+          "m1",
+          "run_started",
+          { run_id: "run-1" },
+          "2026-08-01T13:00:00Z",
+        ),
+      ],
+      commentThreads: [thread({ lastActivityAt: "2026-08-01T14:00:00Z" })],
+    });
+
+    expect(rows.map((row) => row.kind)).toEqual([
+      "task_created",
+      "event",
+      "comment",
+    ]);
+  });
+
+  it("gives resolve its own row after the thread", () => {
+    const rows = build({
+      commentThreads: [
+        thread({
+          resolved: true,
+          stateEvent: { state: "resolved", createdAt: "2026-08-01T11:30:00Z" },
+        }),
+      ],
+    });
+
+    expect(rows.map((row) => row.kind)).toEqual([
+      "task_created",
+      "comment",
+      "comment_state",
+    ]);
+  });
+
+  it("drops the comment feed when comments are off", () => {
+    const rows = build({
+      commentThreads: [
+        thread({
+          stateEvent: { state: "resolved", createdAt: "2026-08-01T11:30:00Z" },
+        }),
+      ],
+      commentsEnabled: false,
+    });
+
+    expect(rows.map((row) => row.kind)).toEqual(["task_created"]);
+  });
+
+  it("keeps one row when two paths announced the same pull request", () => {
+    // The agent's own output and the GitHub webhook backstop can both observe a PR.
+    const rows = build({
+      messages: [
+        eventMessage(
+          "m1",
+          "pr_created",
+          { pr_url: "https://github.com/posthog/posthog/pull/1" },
+          "2026-08-01T10:30:00Z",
+        ),
+        eventMessage(
+          "m2",
+          "pr_created",
+          { pr_url: "https://github.com/posthog/posthog/pull/1" },
+          "2026-08-01T10:31:00Z",
+        ),
+      ],
+    });
+
+    expect(rows.filter((row) => row.kind === "event")).toHaveLength(1);
+  });
+
+  it("ignores events it doesn't know, so the backend can ship first", () => {
+    const rows = build({
+      messages: [
+        eventMessage("m1", "checks_failed_someday", {}, "2026-08-01T10:30:00Z"),
+      ],
+    });
+
+    expect(rows.map((row) => row.kind)).toEqual(["task_created"]);
+  });
+
+  it("derives an ending for tasks with no failure event", () => {
+    const rows = build({
+      taskOverrides: { latestRunStatus: "completed", latestRunId: "run-1" },
+    });
+
+    expect(rows.at(-1)).toMatchObject({
+      kind: "run_status",
+      status: "completed",
+    });
+  });
+
+  it("prefers the failure event over the derived ending", () => {
+    // The event carries the reason, which is the whole point of having it.
+    const rows = build({
+      messages: [
+        eventMessage(
+          "m1",
+          "run_failed",
+          { run_id: "run-1", error_summary: "pnpm build failed" },
+          "2026-08-01T11:00:00Z",
+        ),
+      ],
+      taskOverrides: { latestRunStatus: "failed", latestRunId: "run-1" },
+    });
+
+    expect(rows.filter((row) => row.kind === "run_status")).toHaveLength(0);
+    expect(rows.at(-1)).toMatchObject({ kind: "event" });
+  });
+});
+
+describe("activity events", () => {
+  it("reads a run_started payload", () => {
+    expect(
+      parseActivityEvent({
+        event: "run_started",
+        payload: {
+          run_id: "run-1",
+          environment: "cloud",
+          branch: "casey/x",
+          run_number: 2,
+        },
+      }),
+    ).toEqual({
+      kind: "run_started",
+      payload: {
+        runId: "run-1",
+        environment: "cloud",
+        branch: "casey/x",
+        runNumber: 2,
+      },
+    });
+  });
+
+  it("falls back rather than rendering a partial payload", () => {
+    expect(
+      parseActivityEvent({ event: "artifact_created", payload: {} }),
+    ).toEqual({
+      kind: "artifact_created",
+      payload: {
+        artifactId: "",
+        name: "Artifact",
+        artifactType: "",
+        version: 1,
+      },
+    });
+  });
+
+  it("drops a pull request event with no url, since it can't be opened", () => {
+    expect(parseActivityEvent({ event: "pr_merged", payload: {} })).toBeNull();
+  });
+
+  it.each(["", "turn_complete", "something_new"])(
+    "returns null for %s",
+    (event) => {
+      expect(parseActivityEvent({ event, payload: {} })).toBeNull();
+    },
+  );
+
+  it("matches the backend vocabulary", async () => {
+    // The two lists are one contract: adding an event on one side only is a silent gap.
+    const { readFile } = await import("node:fs/promises");
+    const models = await readFile(
+      new URL("../../../../../tasks/backend/models.py", import.meta.url)
+        .pathname,
+      "utf8",
+    );
+    const block = models.slice(
+      models.indexOf("class TaskActivityEvent(models.TextChoices):"),
+    );
+    const backendEvents = [
+      ...block
+        .slice(0, block.indexOf("class TaskThreadMessage("))
+        .matchAll(/^\s{4}[A-Z_]+ = "([a-z_]+)"/gm),
+    ].map((match) => match[1]);
+
+    expect([...ACTIVITY_EVENTS].sort()).toEqual(backendEvents.sort());
+  });
+});

--- a/products/desktop/packages/core/src/canvas/activityTimeline.test.ts
+++ b/products/desktop/packages/core/src/canvas/activityTimeline.test.ts
@@ -174,6 +174,31 @@ describe("activity timeline", () => {
     expect(rows.map((row) => row.kind)).toEqual(["task_created"]);
   });
 
+  it("numbers runs over the feed, since the backend cannot number them", () => {
+    // Counting runs server-side races two concurrent creations onto one number; the ordered
+    // feed can only be read one way.
+    const rows = build({
+      messages: [
+        eventMessage(
+          "m1",
+          "run_started",
+          { run_id: "run-1" },
+          "2026-08-01T10:30:00Z",
+        ),
+        eventMessage(
+          "m2",
+          "run_started",
+          { run_id: "run-2" },
+          "2026-08-01T11:30:00Z",
+        ),
+      ],
+    });
+
+    expect(
+      rows.flatMap((row) => (row.kind === "event" ? [row.runOrdinal] : [])),
+    ).toEqual([1, 2]);
+  });
+
   it("derives an ending for tasks with no failure event", () => {
     const rows = build({
       taskOverrides: { latestRunStatus: "completed", latestRunId: "run-1" },
@@ -209,21 +234,11 @@ describe("activity events", () => {
     expect(
       parseActivityEvent({
         event: "run_started",
-        payload: {
-          run_id: "run-1",
-          environment: "cloud",
-          branch: "casey/x",
-          run_number: 2,
-        },
+        payload: { run_id: "run-1", environment: "cloud", branch: "casey/x" },
       }),
     ).toEqual({
       kind: "run_started",
-      payload: {
-        runId: "run-1",
-        environment: "cloud",
-        branch: "casey/x",
-        runNumber: 2,
-      },
+      payload: { runId: "run-1", environment: "cloud", branch: "casey/x" },
     });
   });
 

--- a/products/desktop/packages/core/src/canvas/activityTimeline.ts
+++ b/products/desktop/packages/core/src/canvas/activityTimeline.ts
@@ -51,6 +51,9 @@ export type ActivityRow<
       ts: number;
       event: ActivityEvent;
       message: TMessage;
+      /** Which run of the task a `run_started` row is, counted over the feed. The backend
+       *  cannot number these without racing two concurrent creations onto one number. */
+      runOrdinal?: number;
     }
   | { kind: "human_message"; key: string; ts: number; message: TMessage }
   | { kind: "user_message"; key: string; ts: number; item: UserMessageLike }
@@ -113,6 +116,7 @@ export function buildActivityTimeline<
   // identity covers rows written before the key existed.
   const seenEvents = new Set<string>();
   let hasTerminalEvent = false;
+  let runStartedSeen = 0;
 
   for (const message of messages) {
     const event = parseActivityEvent(message);
@@ -131,12 +135,14 @@ export function buildActivityTimeline<
     if (seenEvents.has(identity)) continue;
     seenEvents.add(identity);
     if (event.kind === "run_failed") hasTerminalEvent = true;
+    if (event.kind === "run_started") runStartedSeen += 1;
     rows.push({
       kind: "event",
       key: `event-${message.id}`,
       ts: timestamp(message.created_at),
       event,
       message,
+      ...(event.kind === "run_started" ? { runOrdinal: runStartedSeen } : {}),
     });
   }
 

--- a/products/desktop/packages/core/src/canvas/activityTimeline.ts
+++ b/products/desktop/packages/core/src/canvas/activityTimeline.ts
@@ -1,0 +1,218 @@
+/**
+ * Merging the task activity timeline's three sources into one ordered list of rows.
+ *
+ * Kept out of the renderer so the ordering, collapsing and dedupe rules can be tested
+ * without mounting anything — the same split `threadTimeline.ts` uses.
+ *
+ * The sources:
+ *  - the task itself (created, and a terminal status for tasks with no event rows),
+ *  - its thread messages: human messages plus the server-emitted event rows,
+ *  - its comment threads, already collapsed one row per thread by the backend.
+ */
+
+import {
+  type ActivityEvent,
+  parseActivityEvent,
+} from "@posthog/core/canvas/activityEvents";
+import type { ThreadMessageLike } from "@posthog/core/canvas/threadTimeline";
+
+export interface CommentThreadLike {
+  id: string;
+  lastActivityAt: string;
+  mentionedUserIds: number[];
+  resolved: boolean;
+  stateEvent: { state: string; createdAt: string } | null;
+}
+
+export interface ActivityTaskLike {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  latestRunId?: string | null;
+  latestRunStatus?: string | null;
+}
+
+/** A prompt the task's author sent the agent, from the live session's own event stream.
+ *  Only the fields the row needs, so core stays independent of the UI's item type. */
+export interface UserMessageLike {
+  id: string;
+  content: string;
+  timestamp: number;
+}
+
+export type ActivityRow<
+  TMessage extends ThreadMessageLike = ThreadMessageLike,
+  TComment extends CommentThreadLike = CommentThreadLike,
+> =
+  | { kind: "task_created"; key: string; ts: number }
+  | {
+      kind: "event";
+      key: string;
+      ts: number;
+      event: ActivityEvent;
+      message: TMessage;
+    }
+  | { kind: "human_message"; key: string; ts: number; message: TMessage }
+  | { kind: "user_message"; key: string; ts: number; item: UserMessageLike }
+  | { kind: "comment"; key: string; ts: number; thread: TComment }
+  | {
+      kind: "comment_state";
+      key: string;
+      ts: number;
+      thread: TComment;
+      state: string;
+    }
+  | { kind: "run_status"; key: string; ts: number; status: string };
+
+/** Rows in the same second still need a stable order, so each kind carries a rank.
+ *  Ordering by rank rather than nudging timestamps (the old `updatedTs + 1`) keeps two
+ *  events that genuinely share a timestamp from fighting over the same slot. */
+const KIND_RANK: Record<ActivityRow["kind"], number> = {
+  task_created: 0,
+  event: 1,
+  human_message: 1,
+  user_message: 1,
+  comment: 1,
+  comment_state: 2,
+  run_status: 3,
+};
+
+function timestamp(value: string | undefined): number {
+  const parsed = Date.parse(value ?? "");
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function buildActivityTimeline<
+  TMessage extends ThreadMessageLike,
+  TComment extends CommentThreadLike,
+>({
+  task,
+  messages,
+  commentThreads,
+  userMessages = [],
+  commentsEnabled = true,
+}: {
+  task: ActivityTaskLike;
+  messages: TMessage[];
+  commentThreads: TComment[];
+  userMessages?: UserMessageLike[];
+  /** False drops the comment feed entirely, rather than leaving the renderer to hide
+   *  rows it was handed. */
+  commentsEnabled?: boolean;
+}): ActivityRow<TMessage, TComment>[] {
+  const rows: ActivityRow<TMessage, TComment>[] = [
+    {
+      kind: "task_created",
+      key: "task-created",
+      ts: timestamp(task.createdAt),
+    },
+  ];
+
+  // Two paths can observe the same thing (the agent's own output and the GitHub webhook
+  // backstop), and the backend keys writes to stop that. A client-side guard on the same
+  // identity covers rows written before the key existed.
+  const seenEvents = new Set<string>();
+  let hasTerminalEvent = false;
+
+  for (const message of messages) {
+    const event = parseActivityEvent(message);
+    if (!event) {
+      if ((message.author_kind ?? "human") === "human") {
+        rows.push({
+          kind: "human_message",
+          key: `message-${message.id}`,
+          ts: timestamp(message.created_at),
+          message,
+        });
+      }
+      continue;
+    }
+    const identity = `${event.kind}:${eventIdentity(event)}`;
+    if (seenEvents.has(identity)) continue;
+    seenEvents.add(identity);
+    if (event.kind === "run_failed") hasTerminalEvent = true;
+    rows.push({
+      kind: "event",
+      key: `event-${message.id}`,
+      ts: timestamp(message.created_at),
+      event,
+      message,
+    });
+  }
+
+  for (const item of userMessages) {
+    rows.push({
+      kind: "user_message",
+      key: `user-message-${item.id}`,
+      ts: item.timestamp,
+      item,
+    });
+  }
+
+  if (commentsEnabled) {
+    for (const thread of commentThreads) {
+      rows.push({
+        kind: "comment",
+        key: `comment-${thread.id}`,
+        ts: timestamp(thread.lastActivityAt),
+        thread,
+      });
+      // Resolve and reopen are state changes with an author and a time, so they get their
+      // own row rather than folding into the thread they close.
+      if (thread.stateEvent) {
+        rows.push({
+          kind: "comment_state",
+          key: `comment-state-${thread.id}`,
+          ts: timestamp(thread.stateEvent.createdAt),
+          thread,
+          state: thread.stateEvent.state,
+        });
+      }
+    }
+  }
+
+  // Fallback for tasks whose runs predate the event rows: derive the ending from the task.
+  const status = task.latestRunStatus ?? null;
+  if (status && isTerminalRunStatus(status) && !hasTerminalEvent) {
+    rows.push({
+      kind: "run_status",
+      key: `run-status-${task.latestRunId ?? "latest"}`,
+      ts: timestamp(task.updatedAt) || timestamp(task.createdAt),
+      status,
+    });
+  }
+
+  return rows.sort(
+    (left, right) =>
+      left.ts - right.ts ||
+      KIND_RANK[left.kind] - KIND_RANK[right.kind] ||
+      left.key.localeCompare(right.key),
+  );
+}
+
+function isTerminalRunStatus(status: string): boolean {
+  return (
+    status === "completed" || status === "failed" || status === "cancelled"
+  );
+}
+
+/** What makes an event unique in the world, for the dedupe guard above. */
+function eventIdentity(event: ActivityEvent): string {
+  switch (event.kind) {
+    case "run_started":
+    case "run_failed":
+    case "awaiting_input":
+      return event.payload.runId;
+    case "artifact_created":
+    case "artifact_revised":
+      return `${event.payload.artifactId}:${event.payload.version}`;
+    case "canvas_created":
+      return event.payload.name;
+    case "pr_created":
+    case "pr_merged":
+    case "pr_closed":
+      return event.payload.prUrl;
+    case "message_forwarded":
+      return event.payload.messageId;
+  }
+}

--- a/products/desktop/packages/shared/src/domain-types.ts
+++ b/products/desktop/packages/shared/src/domain-types.ts
@@ -148,6 +148,40 @@ export interface TaskThreadMessage {
   author?: UserBasic | null;
   forwarded_to_agent_at?: string | null;
   forwarded_by?: UserBasic | null;
+  /** Users mentioned in the row, indexed at write time. Absent on older backends. */
+  mentioned_user_ids?: number[];
+}
+
+/** The latest resolve or reopen on a comment thread. */
+export interface TaskCommentStateEvent {
+  state: string;
+  author?: UserBasic | null;
+  created_at: string;
+}
+
+/**
+ * One comment thread on a task, collapsed the way the activity timeline shows it
+ * (`/thread_messages/comment_activity/`). Mirrors `TaskCommentActivityDTO`.
+ */
+export interface TaskCommentThreadSummary {
+  id: string;
+  target: { id: string; type: string; name: string };
+  content: string;
+  content_truncated: boolean;
+  selected_text: string | null;
+  author?: UserBasic | null;
+  created_at: string;
+  last_activity_at: string;
+  reply_count: number;
+  participants: UserBasic[];
+  mentioned_user_ids: number[];
+  resolved: boolean;
+  state_event: TaskCommentStateEvent | null;
+  latest_reply: {
+    author?: UserBasic | null;
+    content: string;
+    created_at: string;
+  } | null;
 }
 
 /**

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.test.tsx
@@ -30,6 +30,12 @@ vi.mock("@posthog/ui/features/canvas/hooks/useThreadConversation", () => ({
     onMentionInsert: vi.fn(),
   }),
 }));
+vi.mock("@posthog/ui/features/canvas/hooks/useTaskCommentActivity", () => ({
+  useTaskCommentActivity: () => ({ threads: [], isLoading: false }),
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useTaskRuns", () => ({
+  useTaskRuns: () => ({ runs: [], isLoading: false, refreshRuns: vi.fn() }),
+}));
 vi.mock("@posthog/ui/features/canvas/components/ActivityTimeline", () => ({
   ActivityTimeline: () => <div>timeline body</div>,
 }));

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.tsx
@@ -15,6 +15,8 @@ import {
   ThreadLoadingState,
   ThreadReplyComposer,
 } from "@posthog/ui/features/canvas/components/ThreadPanel";
+import { useTaskCommentActivity } from "@posthog/ui/features/canvas/hooks/useTaskCommentActivity";
+import { useTaskRuns } from "@posthog/ui/features/canvas/hooks/useTaskRuns";
 import { useThreadConversation } from "@posthog/ui/features/canvas/hooks/useThreadConversation";
 import { useCommentNavigationStore } from "@posthog/ui/features/sessions/commentNavigationStore";
 import { buildConversationItems } from "@posthog/ui/features/sessions/components/buildConversationItems";
@@ -162,6 +164,12 @@ function ActivityConversation({
     [taskId],
   );
 
+  // The comment feed is its own request, and only for the tab that draws it.
+  const { threads: commentThreads } = useTaskCommentActivity(taskId, {
+    enabled: commentsEnabled && tab === "timeline",
+  });
+  const { runs } = useTaskRuns(taskId);
+
   const conversationItems = useMemo(
     () =>
       tab === "timeline"
@@ -237,6 +245,10 @@ function ActivityConversation({
         task={task}
         timeline={timeline}
         conversationItems={conversationItems}
+        commentThreads={commentThreads}
+        commentsEnabled={commentsEnabled}
+        runCount={runs.length}
+        currentUserId={currentUser?.id}
         currentUserUuid={currentUser?.uuid}
         currentUserEmail={currentUser?.email}
         isTaskAuthor={isTaskAuthor}

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.stories.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.stories.tsx
@@ -1,0 +1,202 @@
+import type { ThreadTimelineRow } from "@posthog/core/canvas/threadTimeline";
+import type {
+  Task,
+  TaskCommentThreadSummary,
+  TaskThreadMessage,
+} from "@posthog/shared/domain-types";
+import { ActivityTimeline } from "@posthog/ui/features/canvas/components/ActivityTimeline";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const shy = {
+  id: 9,
+  uuid: "u-shy",
+  first_name: "Shy",
+  last_name: "Alter",
+  email: "shy@example.com",
+};
+const ben = {
+  id: 7,
+  uuid: "u-ben",
+  first_name: "Ben",
+  last_name: "White",
+  email: "ben@example.com",
+};
+
+const task = {
+  id: "task-1",
+  created_at: "2026-08-04T09:00:00Z",
+  updated_at: "2026-08-05T16:00:00Z",
+  created_by: shy,
+  latest_run: { id: "run-1", status: "completed" },
+} as unknown as Task;
+
+function event(
+  id: string,
+  event: string,
+  payload: Record<string, unknown>,
+  createdAt: string,
+): ThreadTimelineRow<TaskThreadMessage> {
+  return {
+    kind: "human",
+    timestamp: Date.parse(createdAt),
+    message: {
+      id,
+      task: task.id,
+      content: "",
+      created_at: createdAt,
+      author_kind: "agent",
+      event,
+      payload,
+    } as TaskThreadMessage,
+  };
+}
+
+const timeline: ThreadTimelineRow<TaskThreadMessage>[] = [
+  event(
+    "e1",
+    "run_started",
+    {
+      run_id: "run-1",
+      environment: "cloud",
+      branch: "shy/activity-events",
+      run_number: 1,
+    },
+    "2026-08-04T09:02:00Z",
+  ),
+  event("e2", "awaiting_input", { run_id: "run-1" }, "2026-08-04T09:40:00Z"),
+  event(
+    "e3",
+    "artifact_created",
+    {
+      artifact_id: "artifact-1",
+      name: "activity-events.html",
+      artifact_type: "document",
+      version: 1,
+    },
+    "2026-08-04T10:10:00Z",
+  ),
+  event(
+    "e4",
+    "message_forwarded",
+    { message_id: "m-1", run_id: "run-1" },
+    "2026-08-05T09:30:00Z",
+  ),
+  event(
+    "e5",
+    "artifact_revised",
+    {
+      artifact_id: "artifact-1",
+      name: "activity-events.html",
+      artifact_type: "document",
+      version: 2,
+    },
+    "2026-08-05T10:00:00Z",
+  ),
+  event(
+    "e6",
+    "pr_merged",
+    {
+      pr_url: "https://github.com/PostHog/posthog/pull/80060",
+      repository: "PostHog/posthog",
+      pr_number: 80060,
+      actor: "benjackwhite",
+    },
+    "2026-08-05T15:30:00Z",
+  ),
+];
+
+const commentThreads: TaskCommentThreadSummary[] = [
+  {
+    id: "thread-1",
+    target: {
+      id: "artifact-1",
+      type: "artifact",
+      name: "activity-events.html",
+    },
+    content:
+      "Missing the awaiting-input case — that's the one that costs us time.",
+    content_truncated: false,
+    selected_text: "every event should also go to the activity panel",
+    author: shy,
+    created_at: "2026-08-05T08:00:00Z",
+    last_activity_at: "2026-08-05T08:45:00Z",
+    reply_count: 3,
+    participants: [shy, ben],
+    mentioned_user_ids: [],
+    resolved: false,
+    state_event: null,
+    latest_reply: {
+      author: ben,
+      content: "collapse looks right, keep resolve separate",
+      created_at: "2026-08-05T08:45:00Z",
+    },
+  },
+  {
+    id: "thread-2",
+    target: { id: "canvas-1", type: "canvas", name: "Activity mockup" },
+    content: "@ben can you sanity check the collapse rule before this ships?",
+    content_truncated: false,
+    selected_text: null,
+    author: shy,
+    created_at: "2026-08-05T09:00:00Z",
+    last_activity_at: "2026-08-05T09:00:00Z",
+    reply_count: 0,
+    participants: [shy],
+    mentioned_user_ids: [ben.id],
+    resolved: true,
+    state_event: {
+      state: "resolved",
+      author: ben,
+      created_at: "2026-08-05T11:00:00Z",
+    },
+    latest_reply: null,
+  },
+];
+
+const meta: Meta<typeof ActivityTimeline> = {
+  title: "Canvas/ActivityTimeline",
+  component: ActivityTimeline,
+  parameters: { layout: "centered" },
+  decorators: [
+    (Story) => (
+      <div className="w-[468px] border border-border bg-gray-1">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ActivityTimeline>;
+
+/** Every row the timeline can draw, in the order a real task produces them. */
+export const FullTimeline: Story = {
+  args: {
+    task,
+    timeline,
+    conversationItems: [
+      {
+        type: "user_message",
+        id: "turn-1",
+        content: "Add the events that belong on the activity panel.",
+        timestamp: Date.parse("2026-08-04T09:05:00Z"),
+      },
+      // biome-ignore lint/suspicious/noExplicitAny: story fixture for the row under test
+    ] as any,
+    commentThreads,
+    commentsEnabled: true,
+    currentUserId: ben.id,
+    currentUserUuid: ben.uuid,
+    isTaskAuthor: false,
+    canForward: false,
+    runCount: 1,
+    onSendToAgent: () => {},
+    onDelete: () => {},
+  },
+};
+
+/** What a reader without the comments flag sees: lifecycle rows only. */
+export const WithoutComments: Story = {
+  args: { ...FullTimeline.args, commentsEnabled: false } as Story["args"],
+};

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.stories.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.stories.tsx
@@ -55,12 +55,7 @@ const timeline: ThreadTimelineRow<TaskThreadMessage>[] = [
   event(
     "e1",
     "run_started",
-    {
-      run_id: "run-1",
-      environment: "cloud",
-      branch: "shy/activity-events",
-      run_number: 1,
-    },
+    { run_id: "run-1", environment: "cloud", branch: "shy/activity-events" },
     "2026-08-04T09:02:00Z",
   ),
   event("e2", "awaiting_input", { run_id: "run-1" }, "2026-08-04T09:40:00Z"),

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
@@ -233,18 +233,18 @@ describe("ActivityTimeline events and comments", () => {
   });
 
   it("labels the run only once a task has run more than once", () => {
-    const message = threadMessage("m1", "run_started", {
+    const first = threadMessage("m1", "run_started", {
       run_id: "run-1",
       environment: "cloud",
       branch: "shy/activity",
-      run_number: 2,
     });
+    const second = threadMessage("m2", "run_started", { run_id: "run-2" });
 
-    const single = renderRows({ timeline: [message], runCount: 1 });
+    const single = renderRows({ timeline: [first], runCount: 1 });
     expect(screen.getByText(/Agent started work/)).toBeInTheDocument();
     single.unmount();
 
-    renderRows({ timeline: [message], runCount: 2 });
+    renderRows({ timeline: [first, second], runCount: 2 });
     expect(screen.getByText(/Agent started run 2/)).toBeInTheDocument();
   });
 

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
@@ -162,3 +162,149 @@ describe("ActivityTimeline", () => {
     expect(screen.getByText(/be terse/)).toBeInTheDocument();
   });
 });
+
+describe("ActivityTimeline events and comments", () => {
+  const threadMessage = (
+    id: string,
+    event: string,
+    payload: Record<string, unknown>,
+  ) => ({
+    kind: "human" as const,
+    timestamp: Date.parse("2026-07-17T09:20:00Z"),
+    message: {
+      id,
+      task: "task-1",
+      content: "",
+      created_at: "2026-07-17T09:20:00Z",
+      author_kind: "agent" as const,
+      event,
+      payload,
+    },
+  });
+
+  const commentThread = (overrides = {}) => ({
+    id: "thread-1",
+    target: { id: "artifact-1", type: "artifact", name: "report.md" },
+    content: "this needs a guard",
+    content_truncated: false,
+    selected_text: "every event should also go to the activity panel",
+    author: { id: 7, uuid: "u2", first_name: "Ben", last_name: "White" },
+    created_at: "2026-07-17T09:30:00Z",
+    last_activity_at: "2026-07-17T09:35:00Z",
+    reply_count: 2,
+    participants: [
+      { id: 7, uuid: "u2", first_name: "Ben", last_name: "White" },
+      { id: 9, uuid: "u3", first_name: "Shy", last_name: "Alter" },
+    ],
+    mentioned_user_ids: [],
+    resolved: false,
+    state_event: null,
+    latest_reply: null,
+    ...overrides,
+  });
+
+  function renderRows(props: Record<string, unknown>) {
+    return render(
+      <ActivityTimeline
+        task={task}
+        timeline={[]}
+        conversationItems={[]}
+        isTaskAuthor
+        canForward={false}
+        onSendToAgent={() => {}}
+        onDelete={() => {}}
+        // biome-ignore lint/suspicious/noExplicitAny: narrow fixture for the rows under test
+        {...(props as any)}
+      />,
+    );
+  }
+
+  it("writes the reason on a failed run, so nobody has to open the transcript", () => {
+    renderRows({
+      timeline: [
+        threadMessage("m1", "run_failed", {
+          run_id: "run-1",
+          error_summary: "Command failed: pnpm build",
+        }),
+      ],
+    });
+
+    expect(screen.getByText(/Command failed: pnpm build/)).toBeInTheDocument();
+  });
+
+  it("labels the run only once a task has run more than once", () => {
+    const message = threadMessage("m1", "run_started", {
+      run_id: "run-1",
+      environment: "cloud",
+      branch: "shy/activity",
+      run_number: 2,
+    });
+
+    const single = renderRows({ timeline: [message], runCount: 1 });
+    expect(screen.getByText(/Agent started work/)).toBeInTheDocument();
+    single.unmount();
+
+    renderRows({ timeline: [message], runCount: 2 });
+    expect(screen.getByText(/Agent started run 2/)).toBeInTheDocument();
+  });
+
+  it("keeps the anchor with the comment it points at", () => {
+    renderRows({ commentThreads: [commentThread()], commentsEnabled: true });
+
+    expect(
+      screen.getByText(/every event should also go to the activity panel/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("2 replies · Ben White, Shy Alter"),
+    ).toBeInTheDocument();
+  });
+
+  it("reads as a mention when the mention is of you", () => {
+    renderRows({
+      commentThreads: [commentThread({ mentioned_user_ids: [42] })],
+      commentsEnabled: true,
+      currentUserId: 42,
+    });
+
+    expect(screen.getByText("mentioned you on")).toBeInTheDocument();
+  });
+
+  it("reads as an ordinary comment when someone else was mentioned", () => {
+    renderRows({
+      commentThreads: [commentThread({ mentioned_user_ids: [7] })],
+      commentsEnabled: true,
+      currentUserId: 42,
+    });
+
+    expect(screen.getByText("commented on")).toBeInTheDocument();
+  });
+
+  it("gives resolve its own row, with who resolved it", () => {
+    renderRows({
+      commentThreads: [
+        commentThread({
+          resolved: true,
+          state_event: {
+            state: "resolved",
+            created_at: "2026-07-17T09:40:00Z",
+            author: {
+              id: 9,
+              uuid: "u3",
+              first_name: "Shy",
+              last_name: "Alter",
+            },
+          },
+        }),
+      ],
+      commentsEnabled: true,
+    });
+
+    expect(screen.getByText("resolved a thread on")).toBeInTheDocument();
+  });
+
+  it("shows no comment rows when comments are off", () => {
+    renderRows({ commentThreads: [commentThread()], commentsEnabled: false });
+
+    expect(screen.queryByText("commented on")).toBeNull();
+  });
+});

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
@@ -2,6 +2,7 @@ import { FileTextIcon, PlusCircleIcon } from "@phosphor-icons/react";
 import {
   type ActivityRow,
   buildActivityTimeline,
+  type UserMessageLike,
 } from "@posthog/core/canvas/activityTimeline";
 import type { ThreadTimelineRow } from "@posthog/core/canvas/threadTimeline";
 import {
@@ -135,11 +136,15 @@ function UserMessageRow({
   );
 }
 
+/** Stable identity: an inline `= []` default is a new array on every render, which would
+ *  rebuild the timeline on every render through the memo's dependency list. */
+const NO_COMMENT_THREADS: TaskCommentThreadSummary[] = [];
+
 export function ActivityTimeline({
   task,
   timeline,
   conversationItems,
-  commentThreads = [],
+  commentThreads = NO_COMMENT_THREADS,
   commentsEnabled = false,
   currentUserId,
   currentUserUuid,
@@ -216,13 +221,19 @@ export function ActivityTimeline({
               }
             : null,
         })),
-        userMessages: conversationItems
-          .filter((item) => item.type === "user_message")
-          .map((item) => ({
-            id: item.id,
-            content: item.content,
-            timestamp: item.timestamp,
-          })),
+        userMessages: conversationItems.reduce<UserMessageLike[]>(
+          (items, item) => {
+            if (item.type === "user_message") {
+              items.push({
+                id: item.id,
+                content: item.content,
+                timestamp: item.timestamp,
+              });
+            }
+            return items;
+          },
+          [],
+        ),
         commentsEnabled,
       }),
     [task, messages, commentThreads, conversationItems, commentsEnabled],
@@ -318,6 +329,7 @@ export function ActivityTimeline({
             event={row.event}
             timestamp={row.message.created_at}
             runCount={runCount}
+            runOrdinal={row.runOrdinal}
           />
         );
       }

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
@@ -1,9 +1,8 @@
+import { FileTextIcon, PlusCircleIcon } from "@phosphor-icons/react";
 import {
-  CheckCircleIcon,
-  FileTextIcon,
-  PlusCircleIcon,
-  XCircleIcon,
-} from "@phosphor-icons/react";
+  type ActivityRow,
+  buildActivityTimeline,
+} from "@posthog/core/canvas/activityTimeline";
 import type { ThreadTimelineRow } from "@posthog/core/canvas/threadTimeline";
 import {
   Collapsible,
@@ -20,11 +19,18 @@ import {
 } from "@posthog/quill";
 import type {
   Task,
+  TaskCommentThreadSummary,
   TaskThreadMessage,
   UserBasic,
 } from "@posthog/shared/domain-types";
-import { isTerminalStatus } from "@posthog/shared/domain-types";
 import { UserAvatar } from "@posthog/ui/features/auth/UserAvatar";
+import {
+  ActivityEventRow,
+  CommentRow,
+  CommentStateRow,
+  RunStatusRow,
+  TimelineRow,
+} from "@posthog/ui/features/canvas/components/activityRows";
 import { MentionText } from "@posthog/ui/features/canvas/components/MentionText";
 import {
   ThreadArtifactRow,
@@ -32,40 +38,16 @@ import {
 } from "@posthog/ui/features/canvas/components/ThreadPanel";
 import { ThreadTimestamp } from "@posthog/ui/features/canvas/components/ThreadTimestamp";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
+import { useCommentNavigationStore } from "@posthog/ui/features/sessions/commentNavigationStore";
 import type { buildConversationItems } from "@posthog/ui/features/sessions/components/buildConversationItems";
 import { extractChannelContext } from "@posthog/ui/features/sessions/components/session-update/channelContext";
 import { extractCustomInstructions } from "@posthog/ui/features/sessions/components/session-update/customInstructions";
 import { useThreadNavigationStore } from "@posthog/ui/features/sessions/threadNavigationStore";
-import { Fragment, type KeyboardEvent, type ReactNode, useMemo } from "react";
+import { Fragment, type KeyboardEvent, useMemo } from "react";
 
 type ConversationItem = ReturnType<
   typeof buildConversationItems
 >["items"][number];
-
-/** A lifecycle marker (task created, run finished): an icon bubble and a single
- *  line, in the same size and colour as every other row's copy. Only the icon
- *  distinguishes it, so the pane reads as one typographic system. */
-function ActivityEventRow({
-  icon,
-  label,
-  timestamp,
-}: {
-  icon: ReactNode;
-  label: string;
-  timestamp: string;
-}) {
-  return (
-    <div className="flex items-center gap-2 py-1.5 pr-2 pl-2">
-      <div className="flex w-10 shrink-0 justify-center">
-        <span className="relative z-10 flex size-6 items-center justify-center rounded-full bg-gray-3">
-          {icon}
-        </span>
-      </div>
-      <span className="min-w-0 truncate text-[13px]">{label}</span>
-      <ThreadTimestamp dateTime={timestamp} />
-    </div>
-  );
-}
 
 function UserMessageRow({
   author,
@@ -157,17 +139,26 @@ export function ActivityTimeline({
   task,
   timeline,
   conversationItems,
+  commentThreads = [],
+  commentsEnabled = false,
+  currentUserId,
   currentUserUuid,
   currentUserEmail,
   isTaskAuthor,
   canForward,
   canOpenInPlace,
+  runCount = 1,
   onSendToAgent,
   onDelete,
 }: {
   task: Task;
   timeline: ThreadTimelineRow<TaskThreadMessage>[];
   conversationItems: ConversationItem[];
+  /** The task's comment threads, already collapsed one row per thread by the backend. */
+  commentThreads?: TaskCommentThreadSummary[];
+  commentsEnabled?: boolean;
+  /** Needed to tell a mention of you from a mention of someone else. */
+  currentUserId?: number;
   currentUserUuid?: string;
   currentUserEmail?: string | null;
   isTaskAuthor: boolean;
@@ -176,139 +167,189 @@ export function ActivityTimeline({
    *  pane. False in the channel-home sidebar, where there is nothing to drive —
    *  rows there stay inert and PRs open externally instead of dead-clicking. */
   canOpenInPlace?: boolean;
+  /** How many runs the task has; a single-run task shouldn't label its run. */
+  runCount?: number;
   onSendToAgent: (messageId: string) => void;
   onDelete: (messageId: string) => void;
 }) {
   const requestScrollToMessage = useThreadNavigationStore(
     (state) => state.requestScrollToMessage,
   );
+  const requestCommentFocus = useCommentNavigationStore(
+    (state) => state.requestCommentFocus,
+  );
 
-  const nodes = useMemo(() => {
-    const entries: { key: string; ts: number; node: ReactNode }[] = [];
-    const createdTs = Date.parse(task.created_at) || 0;
-    entries.push({
-      key: "task-created",
-      ts: createdTs,
-      node: (
-        <ActivityEventRow
-          icon={
-            <PlusCircleIcon size={14} weight="fill" className="text-gray-11" />
-          }
-          label={`${task.created_by ? userDisplayName(task.created_by) : "Someone"} created this task`}
-          timestamp={task.created_at}
-        />
-      ),
-    });
+  // Thread messages arrive as `timeline` rows (human messages and the artifact
+  // announcements it already understands) plus the raw messages behind them, which carry
+  // the event rows. Rebuilding the message list from `timeline` keeps this component's
+  // props unchanged while the merge itself moves into core.
+  const messages = useMemo(
+    () => timeline.map((row) => row.message),
+    [timeline],
+  );
+  const messageRows = useMemo(() => {
+    const byId = new Map<string, ThreadTimelineRow<TaskThreadMessage>>();
+    for (const row of timeline) byId.set(row.message.id, row);
+    return byId;
+  }, [timeline]);
 
-    for (const item of conversationItems) {
-      if (item.type !== "user_message") continue;
-      entries.push({
-        key: `user-message-${item.id}`,
-        ts: item.timestamp,
-        node: (
+  const rows = useMemo(
+    () =>
+      buildActivityTimeline({
+        task: {
+          id: task.id,
+          createdAt: task.created_at,
+          updatedAt: task.updated_at,
+          latestRunId: task.latest_run?.id ?? null,
+          latestRunStatus: task.latest_run?.status ?? null,
+        },
+        messages,
+        commentThreads: commentThreads.map((thread) => ({
+          id: thread.id,
+          lastActivityAt: thread.last_activity_at,
+          mentionedUserIds: thread.mentioned_user_ids ?? [],
+          resolved: thread.resolved,
+          stateEvent: thread.state_event
+            ? {
+                state: thread.state_event.state,
+                createdAt: thread.state_event.created_at,
+              }
+            : null,
+        })),
+        userMessages: conversationItems
+          .filter((item) => item.type === "user_message")
+          .map((item) => ({
+            id: item.id,
+            content: item.content,
+            timestamp: item.timestamp,
+          })),
+        commentsEnabled,
+      }),
+    [task, messages, commentThreads, conversationItems, commentsEnabled],
+  );
+
+  const threadsById = useMemo(() => {
+    const byId = new Map<string, TaskCommentThreadSummary>();
+    for (const thread of commentThreads) byId.set(thread.id, thread);
+    return byId;
+  }, [commentThreads]);
+
+  const focusThread = (thread: TaskCommentThreadSummary) => {
+    if (!canOpenInPlace) return undefined;
+    return () =>
+      requestCommentFocus(
+        task.id,
+        // The target is the scope/itemId pair the comment stores; `task` scope points at
+        // the task itself.
+        thread.target.type === "task"
+          ? { scope: "task", itemId: task.id }
+          : {
+              scope:
+                thread.target.type === "canvas"
+                  ? "desktop_canvas"
+                  : "task_artifact",
+              itemId: thread.target.id,
+            },
+        thread.id,
+      );
+  };
+
+  const renderRow = (row: ActivityRow<TaskThreadMessage>) => {
+    switch (row.kind) {
+      case "task_created":
+        return (
+          <TimelineRow
+            gutter={
+              <span className="relative z-10 flex size-6 items-center justify-center rounded-full bg-gray-3">
+                <PlusCircleIcon
+                  size={14}
+                  weight="fill"
+                  className="text-gray-11"
+                />
+              </span>
+            }
+            timestamp={task.created_at}
+          >
+            {`${task.created_by ? userDisplayName(task.created_by) : "Someone"} created this task`}
+          </TimelineRow>
+        );
+      case "user_message":
+        return (
           <UserMessageRow
             author={task.created_by}
-            content={item.content}
-            timestamp={new Date(item.timestamp).toISOString()}
+            content={row.item.content}
+            timestamp={new Date(row.item.timestamp).toISOString()}
             onSelect={
               canOpenInPlace
-                ? () => requestScrollToMessage(task.id, item.id)
+                ? () => requestScrollToMessage(task.id, row.item.id)
                 : undefined
             }
           />
-        ),
-      });
-    }
-
-    let hasPrArtifact = false;
-    for (const row of timeline) {
-      if (row.kind === "artifact" && row.artifact.kind === "pr") {
-        hasPrArtifact = true;
-      }
-      entries.push({
-        key: `thread-${row.message.id}`,
-        ts: row.timestamp,
-        node:
-          row.kind === "human" ? (
-            <ThreadMessageRow
-              message={row.message}
-              isTaskAuthor={isTaskAuthor}
-              isOwnMessage={
-                !!currentUserUuid &&
-                currentUserUuid === row.message.author?.uuid
-              }
-              currentUserEmail={currentUserEmail}
-              canForward={canForward}
-              preview
-              onSendToAgent={() => onSendToAgent(row.message.id)}
-              onDelete={() => onDelete(row.message.id)}
-            />
-          ) : (
+        );
+      case "human_message":
+        return (
+          <ThreadMessageRow
+            message={row.message}
+            isTaskAuthor={isTaskAuthor}
+            isOwnMessage={
+              !!currentUserUuid && currentUserUuid === row.message.author?.uuid
+            }
+            currentUserEmail={currentUserEmail}
+            canForward={canForward}
+            preview
+            onSendToAgent={() => onSendToAgent(row.message.id)}
+            onDelete={() => onDelete(row.message.id)}
+          />
+        );
+      case "event": {
+        // Canvases and pull requests already have a card row; the rest read as one line.
+        const artifactRow = messageRows.get(row.message.id);
+        if (artifactRow?.kind === "artifact") {
+          return (
             <ThreadArtifactRow
-              artifact={row.artifact}
+              artifact={artifactRow.artifact}
               createdAt={row.message.created_at}
               openInPlaceTaskId={canOpenInPlace ? task.id : undefined}
             />
-          ),
-      });
-    }
-
-    const updatedTs = Date.parse(task.updated_at) || createdTs;
-    const outputPr = task.latest_run?.output?.pr_url;
-    if (typeof outputPr === "string" && outputPr && !hasPrArtifact) {
-      entries.push({
-        key: "output-pr",
-        ts: updatedTs,
-        node: (
-          <ThreadArtifactRow
-            artifact={{ kind: "pr", url: outputPr }}
-            createdAt={task.updated_at}
-            openInPlaceTaskId={canOpenInPlace ? task.id : undefined}
-          />
-        ),
-      });
-    }
-
-    const runStatus = task.latest_run?.status;
-    if (runStatus && isTerminalStatus(runStatus)) {
-      const succeeded = runStatus === "completed";
-      entries.push({
-        key: "run-status",
-        ts: updatedTs + 1,
-        node: (
+          );
+        }
+        return (
           <ActivityEventRow
-            icon={
-              succeeded ? (
-                <CheckCircleIcon
-                  size={14}
-                  weight="fill"
-                  className="text-green-9"
-                />
-              ) : (
-                <XCircleIcon size={14} weight="fill" className="text-red-9" />
-              )
-            }
-            label={`Task ${runStatus.replace(/_/g, " ")}`}
-            timestamp={task.updated_at}
+            event={row.event}
+            timestamp={row.message.created_at}
+            runCount={runCount}
           />
-        ),
-      });
+        );
+      }
+      case "comment": {
+        const thread = threadsById.get(row.thread.id);
+        if (!thread) return null;
+        return (
+          <CommentRow
+            thread={thread}
+            isMentioned={
+              !!currentUserId &&
+              (thread.mentioned_user_ids ?? []).includes(currentUserId)
+            }
+            onSelect={focusThread(thread)}
+          />
+        );
+      }
+      case "comment_state": {
+        const thread = threadsById.get(row.thread.id);
+        if (!thread) return null;
+        return (
+          <CommentStateRow
+            thread={thread}
+            state={row.state}
+            onSelect={focusThread(thread)}
+          />
+        );
+      }
+      case "run_status":
+        return <RunStatusRow status={row.status} timestamp={task.updated_at} />;
     }
-
-    return entries.sort((a, b) => a.ts - b.ts);
-  }, [
-    conversationItems,
-    timeline,
-    task,
-    isTaskAuthor,
-    canForward,
-    currentUserUuid,
-    currentUserEmail,
-    onSendToAgent,
-    onDelete,
-    canOpenInPlace,
-    requestScrollToMessage,
-  ]);
+  };
 
   return (
     <div className="relative">
@@ -320,8 +361,8 @@ export function ActivityTimeline({
       />
       <div className="relative z-10">
         <ThreadItemGroup>
-          {nodes.map((entry) => (
-            <Fragment key={entry.key}>{entry.node}</Fragment>
+          {rows.map((row) => (
+            <Fragment key={row.key}>{renderRow(row)}</Fragment>
           ))}
         </ThreadItemGroup>
       </div>

--- a/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
@@ -103,7 +103,11 @@ const EVENT_ICONS: Record<ActivityEvent["kind"], ReactNode> = {
 
 /** The sentence an event reads as. Written so a person skimming the panel learns what
  *  happened without opening anything. */
-function eventLabel(event: ActivityEvent, runCount: number): ReactNode {
+function eventLabel(
+  event: ActivityEvent,
+  runCount: number,
+  runOrdinal: number,
+): ReactNode {
   switch (event.kind) {
     case "run_started": {
       const details = [
@@ -114,7 +118,7 @@ function eventLabel(event: ActivityEvent, runCount: number): ReactNode {
         <>
           {/* A run number only helps once a task has run more than once. */}
           {runCount > 1
-            ? `Agent started run ${event.payload.runNumber}`
+            ? `Agent started run ${runOrdinal}`
             : "Agent started work"}
           {details.length > 0 && (
             <span className="text-muted-foreground">
@@ -197,12 +201,15 @@ export function ActivityEventRow({
   event,
   timestamp,
   runCount,
+  runOrdinal = 1,
   onSelect,
 }: {
   event: ActivityEvent;
   timestamp: string;
   /** How many runs the task has, so a single-run task doesn't say "run 1". */
   runCount: number;
+  /** Which run this row starts, counted over the feed rather than stamped by the backend. */
+  runOrdinal?: number;
   onSelect?: () => void;
 }) {
   return (
@@ -211,7 +218,7 @@ export function ActivityEventRow({
       timestamp={timestamp}
       onSelect={onSelect}
     >
-      {eventLabel(event, runCount)}
+      {eventLabel(event, runCount, runOrdinal)}
     </TimelineRow>
   );
 }

--- a/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
@@ -1,0 +1,365 @@
+/**
+ * The rows the activity timeline draws for one server-emitted event, and for one comment
+ * thread.
+ *
+ * Split out of `ActivityTimeline` so that component stays the merge plus the rail, and a
+ * new event is an entry in `EVENT_ICONS` plus a line of copy here.
+ */
+
+import {
+  ArrowRightIcon,
+  ArrowsClockwiseIcon,
+  CheckCircleIcon,
+  FileTextIcon,
+  GitPullRequestIcon,
+  PlayIcon,
+  WarningCircleIcon,
+  WarningIcon,
+  XCircleIcon,
+} from "@phosphor-icons/react";
+import {
+  type ActivityEvent,
+  prLabel,
+} from "@posthog/core/canvas/activityEvents";
+import { cn } from "@posthog/quill";
+import type {
+  TaskCommentThreadSummary,
+  UserBasic,
+} from "@posthog/shared/domain-types";
+import { UserAvatar } from "@posthog/ui/features/auth/UserAvatar";
+import { ThreadTimestamp } from "@posthog/ui/features/canvas/components/ThreadTimestamp";
+import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
+import type { ReactNode } from "react";
+
+/** A gutter node, a line of copy and a timestamp, at the same size as every other row's
+ *  copy: only the icon distinguishes a lifecycle row from its neighbours. */
+export function TimelineRow({
+  gutter,
+  children,
+  timestamp,
+  onSelect,
+  ariaLabel,
+}: {
+  gutter: ReactNode;
+  children: ReactNode;
+  timestamp: string;
+  onSelect?: () => void;
+  ariaLabel?: string;
+}) {
+  const activation = onSelect
+    ? {
+        role: "button" as const,
+        tabIndex: 0,
+        "aria-label": ariaLabel,
+        onClick: onSelect,
+        onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => {
+          if (event.key !== "Enter" && event.key !== " ") return;
+          event.preventDefault();
+          onSelect();
+        },
+      }
+    : {};
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-2 py-1.5 pr-2 pl-2",
+        onSelect && "cursor-pointer",
+      )}
+      {...activation}
+    >
+      <div className="flex w-10 shrink-0 justify-center">{gutter}</div>
+      <div className="min-w-0 flex-1">
+        <div className="flex min-w-0 items-center gap-1 text-[13px]">
+          <span className="min-w-0 truncate">{children}</span>
+          <ThreadTimestamp dateTime={timestamp} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function IconBubble({ children }: { children: ReactNode }) {
+  return (
+    <span className="relative z-10 flex size-6 items-center justify-center rounded-full bg-gray-3">
+      {children}
+    </span>
+  );
+}
+
+const EVENT_ICONS: Record<ActivityEvent["kind"], ReactNode> = {
+  run_started: <PlayIcon size={12} weight="fill" className="text-blue-9" />,
+  run_failed: <XCircleIcon size={14} weight="fill" className="text-red-9" />,
+  awaiting_input: (
+    <WarningIcon size={13} weight="fill" className="text-warning" />
+  ),
+  artifact_created: <FileTextIcon size={13} className="text-violet-9" />,
+  artifact_revised: <ArrowsClockwiseIcon size={12} className="text-violet-9" />,
+  canvas_created: <FileTextIcon size={13} className="text-violet-9" />,
+  pr_created: <GitPullRequestIcon size={13} className="text-gray-11" />,
+  pr_merged: <GitPullRequestIcon size={13} className="text-violet-9" />,
+  pr_closed: <GitPullRequestIcon size={13} className="text-red-9" />,
+  message_forwarded: <ArrowRightIcon size={12} className="text-blue-9" />,
+};
+
+/** The sentence an event reads as. Written so a person skimming the panel learns what
+ *  happened without opening anything. */
+function eventLabel(event: ActivityEvent, runCount: number): ReactNode {
+  switch (event.kind) {
+    case "run_started": {
+      const details = [
+        event.payload.environment,
+        event.payload.branch || null,
+      ].filter(Boolean);
+      return (
+        <>
+          {/* A run number only helps once a task has run more than once. */}
+          {runCount > 1
+            ? `Agent started run ${event.payload.runNumber}`
+            : "Agent started work"}
+          {details.length > 0 && (
+            <span className="text-muted-foreground">
+              {" "}
+              · {details.join(" · ")}
+            </span>
+          )}
+        </>
+      );
+    }
+    case "run_failed":
+      return event.payload.errorSummary ? (
+        <>
+          Run failed
+          <span className="text-muted-foreground">
+            {" "}
+            · {event.payload.errorSummary}
+          </span>
+        </>
+      ) : (
+        "Run failed"
+      );
+    case "awaiting_input":
+      return "Agent needs input";
+    case "artifact_created":
+      return (
+        <>
+          Agent created{" "}
+          <span className="font-medium">{event.payload.name}</span>
+        </>
+      );
+    case "artifact_revised":
+      return (
+        <>
+          Agent revised{" "}
+          <span className="font-medium">{event.payload.name}</span>
+          <span className="text-muted-foreground">
+            {" "}
+            · v{event.payload.version}
+          </span>
+        </>
+      );
+    case "canvas_created":
+      return (
+        <>
+          Agent created{" "}
+          <span className="font-medium">{event.payload.name}</span>
+        </>
+      );
+    case "pr_created":
+      return (
+        <>
+          Pull request opened
+          <span className="text-muted-foreground">
+            {" "}
+            · {prLabel(event.payload)}
+          </span>
+        </>
+      );
+    case "pr_merged":
+    case "pr_closed": {
+      const verb = event.kind === "pr_merged" ? "merged" : "closed";
+      return (
+        <>
+          {event.payload.actor
+            ? `${event.payload.actor} ${verb} `
+            : `Pull request ${verb} `}
+          <span className="text-muted-foreground">
+            {prLabel(event.payload)}
+          </span>
+        </>
+      );
+    }
+    case "message_forwarded":
+      return "Message sent to the agent";
+  }
+}
+
+export function ActivityEventRow({
+  event,
+  timestamp,
+  runCount,
+  onSelect,
+}: {
+  event: ActivityEvent;
+  timestamp: string;
+  /** How many runs the task has, so a single-run task doesn't say "run 1". */
+  runCount: number;
+  onSelect?: () => void;
+}) {
+  return (
+    <TimelineRow
+      gutter={<IconBubble>{EVENT_ICONS[event.kind]}</IconBubble>}
+      timestamp={timestamp}
+      onSelect={onSelect}
+    >
+      {eventLabel(event, runCount)}
+    </TimelineRow>
+  );
+}
+
+/** A lifecycle marker derived from the task rather than an event row — the ending of a run
+ *  that predates the event rows. */
+export function RunStatusRow({
+  status,
+  timestamp,
+}: {
+  status: string;
+  timestamp: string;
+}) {
+  const succeeded = status === "completed";
+  return (
+    <TimelineRow
+      gutter={
+        <IconBubble>
+          {succeeded ? (
+            <CheckCircleIcon size={14} weight="fill" className="text-green-9" />
+          ) : (
+            <XCircleIcon size={14} weight="fill" className="text-red-9" />
+          )}
+        </IconBubble>
+      }
+      timestamp={timestamp}
+    >
+      {`Task ${status.replace(/_/g, " ")}`}
+    </TimelineRow>
+  );
+}
+
+function participantNames(participants: UserBasic[]): string {
+  return participants.map((person) => userDisplayName(person)).join(", ");
+}
+
+/**
+ * One comment thread. The anchor's quoted selection travels with the row, because a
+ * comment without the text it points at is just a notification.
+ */
+export function CommentRow({
+  thread,
+  isMentioned,
+  onSelect,
+}: {
+  thread: TaskCommentThreadSummary;
+  /** The current user was mentioned somewhere in the thread. */
+  isMentioned: boolean;
+  onSelect?: () => void;
+}) {
+  const author = thread.author ?? null;
+  const name = userDisplayName(author);
+  const verb = isMentioned ? "mentioned you on" : "commented on";
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-2 py-1.5 pr-2 pl-2",
+        onSelect && "cursor-pointer",
+      )}
+      {...(onSelect
+        ? {
+            role: "button" as const,
+            tabIndex: 0,
+            onClick: onSelect,
+            onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => {
+              if (event.key !== "Enter" && event.key !== " ") return;
+              event.preventDefault();
+              onSelect();
+            },
+          }
+        : {})}
+    >
+      <div className="flex w-10 shrink-0 justify-center">
+        {/* Decorative: the author's name is written beside it. */}
+        <div aria-hidden>
+          <UserAvatar user={author} size="sm" className="sticky top-2" />
+        </div>
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex min-w-0 items-center gap-1 text-[13px]">
+          <span className="min-w-0 truncate">
+            <span className="font-medium">{name}</span>{" "}
+            <span className="text-muted-foreground">{verb}</span>{" "}
+            <span className="font-medium">{thread.target.name}</span>
+          </span>
+          <ThreadTimestamp dateTime={thread.last_activity_at} />
+        </div>
+        <div className="mt-1 border-border border-l-2 pl-2">
+          {thread.selected_text && (
+            <div className="truncate text-[12.5px] text-muted-foreground italic">
+              “{thread.selected_text}”
+            </div>
+          )}
+          <div className="line-clamp-2 whitespace-pre-wrap break-words text-[12.5px]">
+            {thread.content}
+          </div>
+        </div>
+        {thread.reply_count > 0 && (
+          <div className="mt-1 truncate text-[12.5px] text-muted-foreground">
+            {thread.reply_count}{" "}
+            {thread.reply_count === 1 ? "reply" : "replies"}
+            {thread.participants.length > 0 &&
+              ` · ${participantNames(thread.participants)}`}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Resolve and reopen: state changes with an author and a time, so they read as their own
+ *  rows rather than a property of the thread above. */
+export function CommentStateRow({
+  thread,
+  state,
+  onSelect,
+}: {
+  thread: TaskCommentThreadSummary;
+  state: string;
+  onSelect?: () => void;
+}) {
+  const author = thread.state_event?.author ?? null;
+  const resolved = state === "resolved";
+  return (
+    <TimelineRow
+      gutter={
+        <IconBubble>
+          {resolved ? (
+            <CheckCircleIcon size={14} weight="fill" className="text-green-9" />
+          ) : (
+            <WarningCircleIcon
+              size={14}
+              weight="fill"
+              className="text-warning"
+            />
+          )}
+        </IconBubble>
+      }
+      timestamp={thread.state_event?.created_at ?? thread.last_activity_at}
+      onSelect={onSelect}
+    >
+      {author ? (
+        <span className="font-medium">{userDisplayName(author)}</span>
+      ) : (
+        "Someone"
+      )}{" "}
+      {resolved ? "resolved a thread on" : "reopened a thread on"}{" "}
+      <span className="font-medium">{thread.target.name}</span>
+    </TimelineRow>
+  );
+}

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useTaskCommentActivity.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useTaskCommentActivity.ts
@@ -1,0 +1,30 @@
+import type { TaskCommentThreadSummary } from "@posthog/shared/domain-types";
+import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
+
+/** Comments move at human pace, so this polls slower than the 5s thread poll. The
+ *  Comments tab keeps its own faster poll for the surface people type into. */
+const POLL_INTERVAL_MS = 15_000;
+
+/**
+ * The task's comment threads for the activity timeline.
+ *
+ * Deliberately not patched by the optimistic comment writes in `useComments`: a comment
+ * you just left shows up within one poll, and cross-patching two differently shaped caches
+ * is how they drift apart.
+ */
+export function useTaskCommentActivity(
+  taskId: string | undefined,
+  options: { enabled?: boolean } = {},
+): { threads: TaskCommentThreadSummary[]; isLoading: boolean } {
+  const enabled = options.enabled !== false && !!taskId;
+  const query = useAuthenticatedQuery<TaskCommentThreadSummary[]>(
+    ["task-comment-activity", taskId ?? "none"],
+    (client) => client.getTaskCommentActivity(taskId as string),
+    {
+      enabled,
+      refetchInterval: POLL_INTERVAL_MS,
+      staleTime: POLL_INTERVAL_MS,
+    },
+  );
+  return { threads: query.data ?? [], isLoading: query.isLoading };
+}

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useThreadConversation.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useThreadConversation.ts
@@ -41,7 +41,7 @@ export interface ThreadConversation {
   isPromptPending: boolean;
   isReady: boolean;
   members: UserBasic[];
-  currentUser: { uuid?: string; email?: string } | undefined;
+  currentUser: { id?: number; uuid?: string; email?: string } | undefined;
   isTaskAuthor: boolean;
   canForward: boolean;
   draft: string;


### PR DESCRIPTION
## Problem

A person opening a task's Timeline tab sees three rows: the task was created, a pull request appeared, the task finished.
Everything they actually want is somewhere else — the agent sat blocked for 34 minutes, an artifact reached version 2, someone left a comment on a canvas, a mention pulled a second person in.
Now that comments and mentions exist, the timeline is where someone should catch up on a task without opening four tabs.

Top layer of a four-PR stack. The three below add the events and the comment read surface; this one draws them.

## Changes

![Timeline with every row type](https://raw.githubusercontent.com/PostHog/pr-assets/62e646ddfb8dbe206a7263382ae448bd7779e168/2026/08/f1f81973-a9f5-4eb7-bdc6-3fc46564e15a.png)

New rows: agent started work, agent needs input, run failed with the first line of its error, artifact created and revised with its version, message sent to the agent, pull request merged or closed, comments with the text they point at, and resolve or reopen.

- A comment thread is one row, positioned at its newest reply, carrying the reply count and everyone who spoke. One row per reply would push the rest of the task off the panel.
- A comment row shows the anchor's quoted selection. A comment without the text it points at is just a notification.
- Clicking a comment focuses it on its anchor through `commentNavigationStore`, the same path the Activity feed's notification rows already take, so tab switching and canvas versions come for free.
- Resolve and reopen are their own rows, with who did it.
- A row reads "mentioned you" only when the mention is of the reader; otherwise it names who was mentioned.
- A run is numbered only once a task has run more than once. "Run 1" on a single-run task is noise.

The merge moves into `buildActivityTimeline` in `packages/core`, so ordering, dedupe and collapsing are testable without rendering anything — the same split `threadTimeline.ts` uses. Rows sort by time, then by a per-kind rank. The old code nudged a timestamp by a millisecond to force the status row last, which breaks the moment two events share a timestamp.

Unknown events render nothing, which is what lets the backend layers deploy ahead of a desktop release. A test asserts the TypeScript vocabulary matches `TaskActivityEvent` in the backend, so adding an event on one side only fails CI.

Comment rows are gated by `posthog-code-comments`; `buildActivityTimeline` drops the comment feed when it is off rather than leaving the renderer to hide rows it was handed. The comment feed is one request for the whole task, polled at 15s, and deliberately not patched by the optimistic comment writes in `useComments` — cross-patching two differently shaped caches is how they drift.

## How did you test this code?

The screenshot above is the new `Canvas/ActivityTimeline` Storybook story, rendered headless from a Storybook build. Row order, copy and gutter alignment were checked against the DOM: every gutter node centers on the rail (`145px` in that render) and nothing overflows the 468px panel.

New tests, each naming a regression:

- Core: a comment thread sorts by newest activity, not creation; resolve gets its own row; the comment feed disappears when comments are off; two announcements of one PR collapse to a single row; an unknown event renders nothing; a `run_failed` event suppresses the derived status row so the reason is not replaced by "Task failed".
- UI: a failed run writes its reason on the row; a run is labeled only when the task has several; the anchor renders with its comment; a mention of you reads differently from a mention of someone else; resolve names who resolved it.

Ran locally: `@posthog/core` and `@posthog/ui` canvas suites, and `tsc --noEmit` for core, ui and api-client.

Not checked: no run against a live backend. Every fixture is local, so the payload shapes are only as right as the serializers in the layer below.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by PostHog Code (claude-opus-5). Skills invoked: `/writing-pr-descriptions`, `/writing-tests`, `/writing-user-facing-copy` for the row copy.

The session began with a proposal for which events belong on the panel, reviewed through comments on the artifact, then a technical plan; the four-PR split follows that plan's phases. Two rounds of review feedback shaped what shipped: git and CI events were considered and deliberately left out of this stack (commits need the GitHub `push` webhook, failing checks need a `check_suite` subscription), and a filter bar was dropped in favor of one list.

`ActivityTimeline` keeps its existing props and rebuilds the message list from the `timeline` rows it is already handed, so `ActivityPanel` and the channel sidebar need no restructuring in this PR.

Public artifact: no material from the session that isn't already public. Every fixture, including the story behind the screenshot, is invented.
