### PR TITLE
ci(clickhouse): gate hcl PRs on the cloud-infra compose check

### DIFF
--- a/.github/workflows/ci-clickhouse-hcl-schema.yml
+++ b/.github/workflows/ci-clickhouse-hcl-schema.yml
@@ -55,3 +55,95 @@ jobs:
 
             - name: HCL schema guard (validate + drift)
               run: bash posthog/clickhouse/hcl/check.sh
+
+    # Cross-repo compose gate: posthog-cloud-infra composes vendored base layers
+    # from this repo (roles/shared, roles/data/shared, growing per role). This
+    # job asks cloud-infra to compose against the PR head and fails if a patch
+    # no longer resolves there. It cannot catch golden movement — a legitimate
+    # shared-layer change shifts cloud goldens at the next base-ref bump, and
+    # that bump PR owns the regen.
+    cloud-compose-gate:
+        name: Cloud compose gate
+        runs-on: ubuntu-24.04
+        timeout-minutes: 25
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+            # secrets is unavailable in step `if:` — surface presence through env.
+            HAS_GATE_CREDS: ${{ secrets.GH_APP_HCL_COMPOSE_GATE_APP_ID != '' }}
+        steps:
+            - name: Mint cloud-infra token
+              id: app-token
+              # Secrets are absent on forks (already excluded above) and until the
+              # App is provisioned — in both cases the gate reports skipped, not red.
+              if: env.HAS_GATE_CREDS == 'true'
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_HCL_COMPOSE_GATE_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_HCL_COMPOSE_GATE_PRIVATE_KEY }}
+                  owner: PostHog
+                  repositories: posthog-cloud-infra
+
+            - name: Dispatch and poll the cloud compose check
+              if: steps.app-token.outcome == 'success'
+              env:
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
+                  POSTHOG_REF: ${{ github.event.pull_request.head.sha }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+              run: |
+                  set -euo pipefail
+                  repo="PostHog/posthog-cloud-infra"
+                  workflow="ci-clickhouse-hcl-compose-gate.yaml"
+                  correlation_id="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+                  gh api "repos/$repo/dispatches" \
+                    -f event_type=posthog-hcl-compose-check \
+                    -f "client_payload[posthog_ref]=$POSTHOG_REF" \
+                    -f "client_payload[correlation_id]=$correlation_id" \
+                    -f "client_payload[pr]=$PR_NUMBER"
+                  echo "dispatched posthog-hcl-compose-check ref=$POSTHOG_REF correlation=$correlation_id"
+
+                  # The run-name echoes the correlation id; find our run, then wait it out.
+                  run_id=""
+                  for _ in $(seq 1 24); do  # up to ~2 min for the run to appear
+                    sleep 5
+                    run_id="$(gh api "repos/$repo/actions/workflows/$workflow/runs?event=repository_dispatch&per_page=30" \
+                      --jq ".workflow_runs[] | select(.name | contains(\"$correlation_id\")) | .id" | head -1)"
+                    if [ -n "$run_id" ]; then break; fi
+                  done
+                  if [ -z "$run_id" ]; then
+                    echo "::error::compose-gate run never appeared in $repo (correlation $correlation_id)"
+                    exit 1
+                  fi
+                  run_url="https://github.com/$repo/actions/runs/$run_id"
+                  echo "watching $run_url"
+
+                  conclusion=""
+                  for _ in $(seq 1 60); do  # up to ~20 min; the gate job's own budget is 15
+                    sleep 20
+                    read -r status conclusion < <(gh api "repos/$repo/actions/runs/$run_id" \
+                      --jq '.status + " " + (.conclusion // "")') || true
+                    if [ "$status" = "completed" ]; then break; fi
+                  done
+
+                  {
+                    echo "## Cloud compose gate"
+                    echo
+                    echo "[cloud-infra run]($run_url) — conclusion: \`${conclusion:-timed out}\`"
+                    echo
+                    echo "Failure details (which object failed to resolve) are in that run's summary."
+                  } >> "$GITHUB_STEP_SUMMARY"
+
+                  if [ "$conclusion" != "success" ]; then
+                    echo "::error::cloud composition failed for $POSTHOG_REF — see $run_url"
+                    exit 1
+                  fi
+
+            - name: Gate skipped (no credentials)
+              if: steps.app-token.outcome == 'skipped'
+              run: |
+                  {
+                    echo "## Cloud compose gate"
+                    echo
+                    echo "Skipped: the GH_APP_HCL_COMPOSE_GATE_* secrets are not provisioned."
+                    echo "The cloud composition is NOT verified for this PR."
+                  } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-clickhouse-hcl-schema.yml
+++ b/.github/workflows/ci-clickhouse-hcl-schema.yml
@@ -62,19 +62,30 @@ jobs:
     # no longer resolves there. It cannot catch golden movement — a legitimate
     # shared-layer change shifts cloud goldens at the next base-ref bump, and
     # that bump PR owns the regen.
+    #
+    # Credential blast radius: any same-repo branch can edit this workflow and
+    # run it with repo secrets, so the App key must be worth as little as
+    # possible. The gate therefore triggers cloud-infra via workflow_dispatch —
+    # which needs only the Actions permission — and the App is provisioned with
+    # Actions: read & write on posthog-cloud-infra ONLY, no contents access. A
+    # stolen key can start or cancel that repo's workflow runs; it cannot read
+    # or write its code.
     cloud-compose-gate:
         name: Cloud compose gate
         runs-on: ubuntu-24.04
         timeout-minutes: 25
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name == 'pull_request'
         env:
             # secrets is unavailable in step `if:` — surface presence through env.
-            HAS_GATE_CREDS: ${{ secrets.GH_APP_HCL_COMPOSE_GATE_APP_ID != '' }}
+            # Both halves checked: a provisioned App ID with a missing key must
+            # read as "not provisioned" (skip), not as a red minting step.
+            HAS_GATE_CREDS: ${{ secrets.GH_APP_HCL_COMPOSE_GATE_APP_ID != '' && secrets.GH_APP_HCL_COMPOSE_GATE_PRIVATE_KEY != '' }}
+            IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
         steps:
             - name: Mint cloud-infra token
               id: app-token
-              # Secrets are absent on forks (already excluded above) and until the
-              # App is provisioned — in both cases the gate reports skipped, not red.
+              # Secrets are empty on fork PRs and until the App is provisioned —
+              # in both cases the gate reports skipped (with a summary), not red.
               if: env.HAS_GATE_CREDS == 'true'
               uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
               with:
@@ -95,18 +106,22 @@ jobs:
                   workflow="ci-clickhouse-hcl-compose-gate.yaml"
                   correlation_id="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
 
-                  gh api "repos/$repo/dispatches" \
-                    -f event_type=posthog-hcl-compose-check \
-                    -f "client_payload[posthog_ref]=$POSTHOG_REF" \
-                    -f "client_payload[correlation_id]=$correlation_id" \
-                    -f "client_payload[pr]=$PR_NUMBER"
-                  echo "dispatched posthog-hcl-compose-check ref=$POSTHOG_REF correlation=$correlation_id"
+                  # workflow_dispatch, not repository_dispatch: the latter needs a
+                  # token with contents write; this needs only actions write (see
+                  # the job comment). ref=main pins the gate to cloud-infra main's
+                  # workflow definition and overrides.
+                  gh api "repos/$repo/actions/workflows/$workflow/dispatches" \
+                    -f ref=main \
+                    -f "inputs[posthog_ref]=$POSTHOG_REF" \
+                    -f "inputs[correlation_id]=$correlation_id" \
+                    -f "inputs[pr]=$PR_NUMBER"
+                  echo "dispatched $workflow ref=$POSTHOG_REF correlation=$correlation_id"
 
                   # The run-name echoes the correlation id; find our run, then wait it out.
                   run_id=""
                   for _ in $(seq 1 24); do  # up to ~2 min for the run to appear
                     sleep 5
-                    run_id="$(gh api "repos/$repo/actions/workflows/$workflow/runs?event=repository_dispatch&per_page=30" \
+                    run_id="$(gh api "repos/$repo/actions/workflows/$workflow/runs?event=workflow_dispatch&per_page=30" \
                       --jq ".workflow_runs[] | select(.name | contains(\"$correlation_id\")) | .id" | head -1)"
                     if [ -n "$run_id" ]; then break; fi
                   done
@@ -144,6 +159,10 @@ jobs:
                   {
                     echo "## Cloud compose gate"
                     echo
-                    echo "Skipped: the GH_APP_HCL_COMPOSE_GATE_* secrets are not provisioned."
+                    if [ "$IS_FORK" = "true" ]; then
+                      echo "Skipped: fork PRs have no repository secrets, so the gate cannot dispatch."
+                    else
+                      echo "Skipped: the GH_APP_HCL_COMPOSE_GATE_* secrets are not provisioned."
+                    fi
                     echo "The cloud composition is NOT verified for this PR."
                   } >> "$GITHUB_STEP_SUMMARY"

--- a/posthog/clickhouse/hcl/README.md
+++ b/posthog/clickhouse/hcl/README.md
@@ -90,6 +90,18 @@ skipped. `system.*` remotes are always resolvable. The `posthog` data cluster is
 for `local`, `@absent` elsewhere. A tiny `known_drift_skip` covers real proxy/storage drift pending
 a fix.
 
+## The cloud seam: vendored layers and the compose gate
+
+posthog-cloud-infra composes its cloud envs (dev, prod-us, prod-eu) from base layers vendored out of this directory at a pinned `base-ref` — today `roles/shared/` and `roles/data/shared/`, growing as roles migrate.
+Editing a vendored layer therefore changes compositions in another repo.
+Two consequences:
+
+- The **Cloud compose gate** job (in `ci-clickhouse-hcl-schema.yml`) dispatches to posthog-cloud-infra and composes the cloud envs against your PR head; it fails when a change breaks composition there (a patch that no longer resolves, a redeclaration, a validation error).
+- A change that composes cleanly may still legitimately _shift_ cloud goldens (say, a new column on `_event_base`) — that regen happens in cloud-infra's next `base-ref` bump PR, not here, and is expected.
+
+The events family is the canonical example: `roles/data/shared/` declares `_event_base` + `sharded_events` + `events` once; cloud env deltas (mat\_ columns, env specs) live as patches in cloud-infra's `overrides/`.
+Schema changes to those tables belong in `roles/data/shared/`, never re-declared per env.
+
 ## Making a change (edit HCL → migration)
 
 Run from the repo root. All the scripts below call `hclexp` through `bin/hclexp`,


### PR DESCRIPTION
## Problem

posthog-cloud-infra composes vendored base layers from this repo (`roles/shared`, `roles/data/shared`). A PR editing them can break the cloud composition, and nothing notices until the next `base-ref` bump — after merge. Phase A of `docs/plans/2026-07-14-hcl-recreate.md`; the cloud half is [posthog-cloud-infra#9905](https://github.com/PostHog/posthog-cloud-infra/pull/9905).

## Changes

- Adds a `cloud-compose-gate` job to `ci-clickhouse-hcl-schema.yml` (same paths trigger, no new dispatch).
- The job sends `posthog-hcl-compose-check` to posthog-cloud-infra with the PR head sha and a correlation id, finds the run via `run-name`, polls its conclusion, and links it in the summary.
- Failure means composition breakage in cloud-infra (unresolvable patch, redeclaration, validation error).
- Legit shared-layer changes pass; cloud golden movement is handled by the `base-ref` bump PR.
- Only posthog holds a credential: a GitHub App token scoped to posthog-cloud-infra. Nothing writes back.
- Fork PRs and unprovisioned secrets skip with an explicit summary note instead of failing.
- Documents the vendored-layer seam in `posthog/clickhouse/hcl/README.md`.

> [!NOTE]
> Dormant until the `GH_APP_HCL_COMPOSE_GATE_*` secrets exist (App with `contents:write` + `actions:read` on posthog-cloud-infra). Until then the job reports skipped.

## How did you test this code?

- `actionlint` and `bin/hogli lint:workflows` pass.
- End-to-end needs the App secrets and posthog-cloud-infra#9905 merged; verify by pushing a trivial hcl change and watching the gate link a green cloud run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`posthog/clickhouse/hcl/README.md` gains the seam section.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5). Skills: /authoring-ci-workflows, /writing-pr-descriptions. Built against the interface of posthog-cloud-infra#9905 as under review (dispatch type, payload, run-name correlation). Folded into the existing hcl workflow per the dispatch-budget rule rather than a new workflow file.