### PR TITLE
feat(desktop): link the user to connect GitHub when a run needs code

### DIFF
--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -3613,6 +3613,32 @@ export class AgentServer {
 - If you created a local file but no upload or delivery tool is available, say that plainly and summarize the result in Slack instead.`;
   }
 
+  /**
+   * What to do when a cloud run has no way to reach the user's code.
+   *
+   * Repository access on a cloud run comes from the user's own GitHub connection in
+   * PostHog, so a run can legitimately start without one — nothing is checked out and
+   * there are no credentials to push with. The Slack mention path used to refuse those
+   * mentions outright, which walled off every question that only looked like it needed
+   * code; it now starts the run and leaves the judgement here, where the request itself
+   * is visible. The settings link is built from this run's own host and project so it
+   * lands the user in the right region rather than a hardcoded one.
+   *
+   * Appended to every cloud branch on purpose: a checkout is not proof of access. A
+   * public repository clones with no token at all, so a run can hold the code and still
+   * have no way to push it.
+   */
+  private buildSourceControlAccessInstructions(): string {
+    const settingsUrl = `${this.config.apiUrl.replace(/\/$/, "")}/project/${this.config.projectId}/settings/user-personal-integrations`;
+    return `
+## When you cannot reach the code
+You may have no repository checked out, or no credentials to push and open a pull request with.
+- Answer the part of the request that does not need the code first — questions about PostHog, their data, or their configuration are all still answerable.
+- If the request turns out not to need a code change at all, just answer it and say nothing about GitHub.
+- Only if it genuinely needs a code change, say so plainly and link them to ${settingsUrl} to connect GitHub, then ask them to come back to you.
+- Do not work around it: no guessing at file contents you cannot read, and no starting a change you have no way to deliver.`;
+  }
+
   private buildCloudSystemPrompt(
     prUrl?: string | null,
     slackThreadUrl?: string | null,
@@ -3714,7 +3740,7 @@ Optimize for the fewest shell round trips.
 When you create a non-code file the user should be able to download (such as a report, chart, image, archive, or data file), call the \`upload_artifact\` tool with its path before your final reply. In your final reply, link to the download URL returned by the tool—never link to the file's local workspace path. Files left in the workspace don't reach the user. Don't upload source code or repository changes—those belong in a commit or PR.`;
 
     // Closes out every branch below, so a new section is added once rather than five times.
-    const commonInstructions = `${signedCommitInstructions}${prLinkInstructions}${shellEfficiencyInstructions}${artifactInstructions}${this.buildSlackDeliveryInstructions()}`;
+    const commonInstructions = `${signedCommitInstructions}${prLinkInstructions}${shellEfficiencyInstructions}${artifactInstructions}${this.buildSlackDeliveryInstructions()}${this.buildSourceControlAccessInstructions()}`;
 
     const whyContextInstruction = `   - Add a brief **Why** to the body — one or two sentences capturing the reason the user asked for this change (the motivation, not a restatement of the diff). Keep it short.`;
     const publicRepoSafetyInstruction = `   - **Public-repo safety.** Treat the target repository as public-readable unless you have verified otherwise. The PR title, description, and commit messages must not contain private operational scale (exact event counts, internal row volumes, customer-usage percentages), customer names / emails / companies, references to internal tickets or incidents, the contents of Slack threads (do not quote or paraphrase what was said), or unreleased roadmap details. Linking to the originating Slack thread is fine and encouraged — Slack links are auth-gated and useful as context — as are channel references like "raised in #team-foo". Describe findings qualitatively ("present on nearly all X events, absent from Y") rather than with quantitative figures pulled from analytics queries — the reasoning that uses those numbers can stay in the thread; the PR copy cannot.`;


### PR DESCRIPTION
## Problem

A cloud run can start with no repository checked out and no credentials to push with. Nothing told the agent what to do in that state, so it could hedge, guess at files it couldn't read, or start a change it had no way to deliver.

Stacked on #80074, which stops the Slack mention path refusing those mentions up front.

## Changes

A `When you cannot reach the code` section in the cloud system prompt (`buildSourceControlAccessInstructions`), so Slack, inbox, and wizard runs all get it rather than only the Slack surface. It tells the agent to answer the part that doesn't need code, say nothing about GitHub when the ask never needed it, and otherwise link the user to personal integrations.

This is the point of the stack: the ask for GitHub now comes from the agent, at the moment it actually hits a wall, instead of from a gate guessing beforehand.

The settings link is built from the run's own `apiUrl` and `projectId`, so an EU customer gets an EU link. It lives in the cloud prompt because that's where those values are in scope, and because a local Desktop session uses the user's own checkout and credentials.

Appended to every cloud branch, not just the repo-less one: a checkout isn't proof of access, since a public repository clones with no token at all.

## How did you test this code?

- No test for the prompt text: it's a static string appended alongside five others that are likewise uncovered, and asserting its presence would only restate the concatenation.
- `packages/agent/src/server` — 160 passed in `agent-server.test.ts`. `tsc --noEmit` clean, biome clean.
- Not tested manually against a live Slack workspace or cloud run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code.
- Earlier drafts put this in the Slack task description, then in the static appended instructions. It belongs to the agent rather than the Slack surface, and in the cloud prompt so the link carries the real host and project.
- A review round suggested scoping the section to runs with no checkout. Rejected on the public-repo case, which is now a comment on the method so it isn't re-suggested.
- No customer data or Slack thread contents included.
