### PR TITLE
fix(error-tracking): filter Firefox iOS bridge errors

### DIFF
--- a/frontend/src/loadPostHogJS.test.tsx
+++ b/frontend/src/loadPostHogJS.test.tsx
@@ -1,0 +1,31 @@
+import { type CaptureResult } from 'posthog-js'
+
+import { filterFirefoxInjectedExceptions } from './loadPostHogJS'
+
+describe('filterFirefoxInjectedExceptions', () => {
+    const makeEvent = (event: string, exceptionValues: unknown): CaptureResult =>
+        ({
+            uuid: 'test-uuid',
+            event,
+            properties: { $exception_values: exceptionValues },
+        }) as CaptureResult
+
+    it.each([
+        "undefined is not an object (evaluating 'window.__firefox__.reader')",
+        "undefined is not an object (evaluating 'window.__firefox__.playlistLongPressed_123')",
+    ])('drops Firefox for iOS injected exceptions: %s', (message) => {
+        expect(filterFirefoxInjectedExceptions(makeEvent('$exception', [message]))).toBeNull()
+    })
+
+    it('preserves application exceptions', () => {
+        const event = makeEvent('$exception', ['undefined is not an object'])
+
+        expect(filterFirefoxInjectedExceptions(event)).toBe(event)
+    })
+
+    it('preserves non-exception events containing the Firefox bridge name', () => {
+        const event = makeEvent('custom event', ['window.__firefox__.reader'])
+
+        expect(filterFirefoxInjectedExceptions(event)).toBe(event)
+    })
+})

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -10,6 +10,20 @@ import { startFramerateTracking } from './framerateTracker'
 
 export const SDK_DEFAULTS_DATE = '2026-05-30'
 
+export const filterFirefoxInjectedExceptions: BeforeSendFn = (event) => {
+    const exceptionValues = event?.properties?.$exception_values
+
+    if (
+        event?.event === '$exception' &&
+        Array.isArray(exceptionValues) &&
+        exceptionValues.some((value) => typeof value === 'string' && value.includes('window.__firefox__.'))
+    ) {
+        return null
+    }
+
+    return event
+}
+
 const shouldDefer = (): boolean => {
     const sessionId = posthog.get_session_id()
     return sampleOnProperty(sessionId, 0.5)
@@ -38,6 +52,13 @@ export interface LoadPostHogJSOptions {
 
 export function loadPostHogJS(options: LoadPostHogJSOptions = {}): void {
     if (window.JS_POSTHOG_API_KEY) {
+        const beforeSend = options.beforeSend
+            ? [
+                  filterFirefoxInjectedExceptions,
+                  ...(Array.isArray(options.beforeSend) ? options.beforeSend : [options.beforeSend]),
+              ]
+            : filterFirefoxInjectedExceptions
+
         posthog.init(window.JS_POSTHOG_API_KEY, {
             opt_out_useragent_filter: window.location.hostname === 'localhost', // we ARE a bot when running in localhost, so we need to enable this opt-out
             api_host: window.JS_POSTHOG_HOST,
@@ -57,7 +78,7 @@ export function loadPostHogJS(options: LoadPostHogJSOptions = {}): void {
             error_tracking: {
                 __capturePostHogExceptions: true,
             },
-            before_send: options.beforeSend,
+            before_send: beforeSend,
             loaded: (loadedInstance) => {
                 if (loadedInstance.sessionRecording) {
                     loadedInstance.sessionRecording._forceAllowLocalhostNetworkCapture = true


### PR DESCRIPTION
## Problem

Firefox for iOS users can generate false application errors while browsing PostHog.

Firefox injects native bridge calls that WebKit attributes to the current page instead of an extension frame.

## Changes

- Drop exception events whose messages identify the injected `window.__firefox__` bridge.
- Preserve application exceptions, non-exception events, and caller-provided `before_send` hooks.
- No visible UI change.

## How did you test this code?

- Added focused Jest coverage for known Firefox bridge messages and unaffected events.
- Ran `jest --runInBand src/loadPostHogJS.test.tsx`.
- Ran `oxfmt` on both changed files.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code investigated the error data and repository. It used the `investigating-error-issue` and `writing-pr-descriptions` skills.

The filter stays application-side because Firefox supplies the failing bridge code and does not expose a repairable application call site.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*