### PR TITLE
fix(canvas): keep the side panel open when switching to Chat

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/freeform/CanvasSidePanel.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/CanvasSidePanel.test.tsx
@@ -60,4 +60,26 @@ describe("CanvasSidePanel", () => {
       "task-1:canvas-1",
     );
   });
+
+  it("shows the run that built the canvas on the chat tab while viewing", () => {
+    useCanvasChatPanelStore.setState({ tab: "comments", collapsed: false });
+    render(
+      <CanvasSidePanel
+        effectiveTaskId={null}
+        commentTaskId="task-1"
+        interactive={false}
+        onMinimize={vi.fn()}
+        dashboardId="canvas-1"
+        channelId="channel-1"
+        channelName="General"
+        name="Launch canvas"
+        displayedVersionId="version-2"
+        commentVersionLabel={(versionId) => versionId}
+        onCommentOpen={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Chat"));
+    expect(screen.getByTestId("task-chat")).toBeInTheDocument();
+  });
 });

--- a/products/desktop/packages/ui/src/features/canvas/freeform/CanvasSidePanel.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/CanvasSidePanel.tsx
@@ -28,6 +28,7 @@ import { type Ref, useEffect, useRef } from "react";
 export function CanvasSidePanel({
   effectiveTaskId,
   commentTaskId,
+  interactive,
   onMinimize,
   dashboardId,
   channelId,
@@ -43,6 +44,9 @@ export function CanvasSidePanel({
 }: {
   effectiveTaskId: string | null;
   commentTaskId: string | null;
+  /** Whether the canvas is being edited. The composer is an edit affordance, so
+   * view mode falls back to the conversation that last built the canvas. */
+  interactive?: boolean;
   onMinimize: () => void;
   dashboardId: string;
   channelId: string;
@@ -62,6 +66,9 @@ export function CanvasSidePanel({
   const tab = useCanvasChatPanelStore((state) => state.tab);
   const setTab = useCanvasChatPanelStore((state) => state.setTab);
   const previousTaskId = useRef(effectiveTaskId);
+  // With no run in flight, edit mode gets the composer for the next change,
+  // while view mode gets the chat of the run that produced this canvas.
+  const chatTaskId = effectiveTaskId ?? (interactive ? null : commentTaskId);
 
   useEffect(() => {
     if (effectiveTaskId && effectiveTaskId !== previousTaskId.current) {
@@ -117,8 +124,8 @@ export function CanvasSidePanel({
             commentVersionLabel={commentVersionLabel}
             onCommentOpen={onCommentOpen}
           />
-        ) : effectiveTaskId ? (
-          <CanvasChatLoader taskId={effectiveTaskId} />
+        ) : chatTaskId ? (
+          <CanvasChatLoader taskId={chatTaskId} />
         ) : (
           <div className="flex h-full min-h-0 flex-col gap-3 p-3">
             <FreeformGenerateBar

--- a/products/desktop/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
@@ -82,6 +82,7 @@ import { CanvasPermissionDialog } from "./CanvasPermissionDialog";
 import { CanvasSelectionCommentAction } from "./CanvasSelectionCommentAction";
 import { CanvasSidePanel } from "./CanvasSidePanel";
 import { canvasCommentTaskId } from "./canvasCommentTask";
+import { canvasSidePanelVisibility } from "./canvasSidePanelVisibility";
 import {
   canvasVersionNavigation,
   shouldClearCanvasBrowse,
@@ -131,7 +132,7 @@ export function FreeformCanvasView({
     setClearTextSelectionKey((key) => key + 1);
   }, []);
   const collapsed = useCanvasChatPanelStore((s) => s.collapsed);
-  const panelTab = useCanvasChatPanelStore((s) => s.tab);
+  const panelViewOpen = useCanvasChatPanelStore((s) => s.viewOpen);
   const setCollapsed = useCanvasChatPanelStore((s) => s.setCollapsed);
   const panelWidth = useCanvasChatPanelStore((s) => s.width);
   const setPanelWidth = useCanvasChatPanelStore((s) => s.setWidth);
@@ -529,11 +530,18 @@ export function FreeformCanvasView({
     !headCode &&
     !generatingPanelDismissed;
   // The side panel exists once there's a canvas or an active run (edit mode),
-  // or while the generating default holds (any mode).
-  const showPanel =
-    (interactive && (hasContent || !!effectiveTaskId)) || generatingPanelOpen;
-  const showCommentsPanel =
-    panelTab === "comments" && !collapsed && !!commentTaskId;
+  // while the generating default holds (any mode), or once it was opened from
+  // view mode — a tested pure helper.
+  const panelVisibility = canvasSidePanelVisibility({
+    interactive,
+    hasContent,
+    hasActiveTask: !!effectiveTaskId,
+    generatingPanelOpen,
+    viewOpen: panelViewOpen,
+    collapsed,
+    hasCommentTask: !!commentTaskId,
+  });
+  const showPanel = panelVisibility.editing;
   // Build failures/progress surface in view mode too — the toolbar renders
   // there only while it has something to say.
   const hasBuildSignal =
@@ -852,7 +860,7 @@ export function FreeformCanvasView({
         </Box>
       </Flex>
 
-      {(showPanel || showCommentsPanel) && (
+      {(panelVisibility.editing || panelVisibility.viewing) && (
         <ResizableSidebar
           open={(!collapsed || generatingPanelOpen) && !waitingForHeroExit}
           width={panelWidth}
@@ -867,6 +875,7 @@ export function FreeformCanvasView({
           <CanvasSidePanel
             effectiveTaskId={effectiveTaskId}
             commentTaskId={commentTaskId}
+            interactive={interactive}
             onMinimize={() => {
               setCollapsed(true);
               setGeneratingPanelDismissed(true);

--- a/products/desktop/packages/ui/src/features/canvas/freeform/canvasSidePanelVisibility.test.ts
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/canvasSidePanelVisibility.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { canvasSidePanelVisibility } from "./canvasSidePanelVisibility";
+
+const base = {
+  interactive: false,
+  hasContent: true,
+  hasActiveTask: false,
+  generatingPanelOpen: false,
+  viewOpen: false,
+  collapsed: false,
+  hasCommentTask: true,
+};
+
+describe("canvasSidePanelVisibility", () => {
+  it.each([
+    ["editing a canvas with content", { interactive: true }, true, false],
+    [
+      "editing an empty canvas with a run in flight",
+      { interactive: true, hasContent: false, hasActiveTask: true },
+      true,
+      false,
+    ],
+    [
+      "generating in view mode",
+      { hasActiveTask: true, generatingPanelOpen: true },
+      true,
+      false,
+    ],
+    ["viewing, dock never opened", {}, false, false],
+    [
+      "viewing, dock opened from the breadcrumb",
+      { viewOpen: true },
+      false,
+      true,
+    ],
+    [
+      "viewing, dock opened but minimized",
+      { viewOpen: true, collapsed: true },
+      false,
+      false,
+    ],
+    [
+      "viewing a canvas no task backs",
+      { viewOpen: true, hasCommentTask: false },
+      false,
+      false,
+    ],
+  ])("%s", (_name, overrides, editing, viewing) => {
+    expect(canvasSidePanelVisibility({ ...base, ...overrides })).toEqual({
+      editing,
+      viewing,
+    });
+  });
+});

--- a/products/desktop/packages/ui/src/features/canvas/freeform/canvasSidePanelVisibility.ts
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/canvasSidePanelVisibility.ts
@@ -1,0 +1,37 @@
+// Whether the canvas's right-hand dock is mounted, and why. Two independent
+// reasons, because the dock serves two modes: editing a canvas, and reading the
+// comments/agent chat of one you're only viewing.
+
+export interface CanvasSidePanelVisibility {
+  /** The edit-mode dock: there's a canvas to change, or a run to watch. */
+  editing: boolean;
+  /** The on-demand dock in view mode, opened from the breadcrumb's Comments
+   * button. Held open by its own state rather than by which tab is showing, so
+   * switching tabs inside it can't tear it down. */
+  viewing: boolean;
+}
+
+export function canvasSidePanelVisibility(args: {
+  /** Whether the canvas is being edited. */
+  interactive: boolean;
+  /** Whether the canvas has any published source or artifact. */
+  hasContent: boolean;
+  /** Whether a generation/edit run is in flight or just submitted. */
+  hasActiveTask: boolean;
+  /** The generating-canvas default: the run's chat is the only content there
+   * is, so the dock opens in view mode too. */
+  generatingPanelOpen: boolean;
+  /** Whether the dock was opened while viewing the canvas. */
+  viewOpen: boolean;
+  /** Whether the dock is minimized to the rail. */
+  collapsed: boolean;
+  /** Whether a task backs this canvas's comments and agent chat. */
+  hasCommentTask: boolean;
+}): CanvasSidePanelVisibility {
+  return {
+    editing:
+      (args.interactive && (args.hasContent || args.hasActiveTask)) ||
+      args.generatingPanelOpen,
+    viewing: args.viewOpen && !args.collapsed && args.hasCommentTask,
+  };
+}

--- a/products/desktop/packages/ui/src/features/canvas/stores/canvasChatPanelStore.ts
+++ b/products/desktop/packages/ui/src/features/canvas/stores/canvasChatPanelStore.ts
@@ -13,6 +13,10 @@ interface CanvasChatPanelState {
   collapsed: boolean;
   width: number;
   tab: CanvasPanelTab;
+  /** Whether the dock was opened while viewing (rather than editing) a canvas.
+   * View mode has no other reason to keep it mounted, so this — not the active
+   * tab — is what holds it open there, and a tab switch leaves it alone. */
+  viewOpen: boolean;
   setCollapsed: (collapsed: boolean) => void;
   setWidth: (width: number) => void;
   setTab: (tab: CanvasPanelTab) => void;
@@ -25,10 +29,15 @@ export const useCanvasChatPanelStore = create<CanvasChatPanelState>()(
       collapsed: false,
       width: DEFAULT_PANEL_WIDTH,
       tab: "chat",
-      setCollapsed: (collapsed) => set({ collapsed }),
+      viewOpen: false,
+      // Minimizing in view mode dismisses the dock entirely: there's no rail
+      // button there, so the way back is the breadcrumb's Comments button.
+      setCollapsed: (collapsed) =>
+        set(collapsed ? { collapsed, viewOpen: false } : { collapsed }),
       setWidth: (width) => set({ width }),
       setTab: (tab) => set({ tab }),
-      openComments: () => set({ collapsed: false, tab: "comments" }),
+      openComments: () =>
+        set({ collapsed: false, tab: "comments", viewOpen: true }),
     }),
     {
       name: "canvas-chat-panel-storage",


### PR DESCRIPTION
## Problem

- Clicking Chat in a canvas's side panel closes the whole panel, so the agent conversation is unreachable while viewing a canvas.
- The panel is mounted in view mode only while the Comments tab is active, so selecting Chat drops its last reason to render.
- The Chat tab had nothing to show there anyway: without a run in flight it falls through to the edit composer.

## Changes

- The dock now tracks whether it was opened from view mode, so switching tabs inside it leaves it open.
- The Chat tab shows the run that built the canvas when a person is viewing rather than editing.
- Minimizing in view mode still dismisses the dock; the breadcrumb's Comments button reopens it.
- Panel visibility moved into `canvasSidePanelVisibility`, a pure helper, so the tab can no longer take part in the decision.

No screenshot: the visible result is the panel staying where it already was.

## How did you test this code?

- Added `canvasSidePanelVisibility.test.ts`. It catches a return to visibility keyed on the active tab, which is what closed the dock.
- Added a `CanvasSidePanel` case for the chat tab in view mode. It catches the composer rendering where the canvas's own chat belongs.
- Ran both files with vitest in `packages/ui`.
- Not run: the app itself. I did not build or launch the Electron host, so the fix is unverified by hand.
- One unrelated file in `src/features/canvas` fails to collect in this sandbox because `@posthog/agent` subpath types are not built.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually the PostHog Slack app, running Claude) traced the report from the Slack thread to the canvas dock. The first candidate was the main app's side panel, which turned out to be unrelated.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

The narrower fix was to disable the Chat tab in view mode. I rejected it: the question raised was whether Chat is meant to be the agent chat, and in view mode the canvas does have a conversation worth showing.

The PR is unassigned because I could not verify the requester's GitHub handle from the thread.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1786373377193299?thread_ts=1786373377.193299&cid=C09G8Q32R6F)*
