### PR TITLE
fix(marketing-analytics): follow-ups from reviewing #80556

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -5179,14 +5179,6 @@
             "enum": ["bing", "microsoft", "msads", "bing_video"],
             "type": "string"
         },
-        "BingAdsTableExclusions": {
-            "enum": ["performance"],
-            "type": "string"
-        },
-        "BingAdsTableKeywords": {
-            "enum": ["campaigns"],
-            "type": "string"
-        },
         "BoxPlotDatum": {
             "additionalProperties": false,
             "properties": {
@@ -26417,14 +26409,6 @@
             ],
             "type": "string"
         },
-        "GoogleAdsTableExclusions": {
-            "enum": ["stats"],
-            "type": "string"
-        },
-        "GoogleAdsTableKeywords": {
-            "enum": ["campaign"],
-            "type": "string"
-        },
         "GroupMathType": {
             "const": "unique_group",
             "type": "string"
@@ -29135,14 +29119,6 @@
         },
         "LinkedinAdsDefaultSources": {
             "enum": ["linkedin", "li"],
-            "type": "string"
-        },
-        "LinkedinAdsTableExclusions": {
-            "enum": ["stats"],
-            "type": "string"
-        },
-        "LinkedinAdsTableKeywords": {
-            "enum": ["campaign_groups"],
             "type": "string"
         },
         "LoadingBlock": {
@@ -32903,24 +32879,6 @@
                         "statsTableName": {
                             "const": "campaign_overview_stats",
                             "type": "string"
-                        },
-                        "tableExclusions": {
-                            "items": {
-                                "const": "stats",
-                                "type": "string"
-                            },
-                            "maxItems": 1,
-                            "minItems": 1,
-                            "type": "array"
-                        },
-                        "tableKeywords": {
-                            "items": {
-                                "const": "campaign",
-                                "type": "string"
-                            },
-                            "maxItems": 1,
-                            "minItems": 1,
-                            "type": "array"
                         }
                     },
                     "required": [
@@ -32929,8 +32887,6 @@
                         "idField",
                         "campaignTableName",
                         "statsTableName",
-                        "tableKeywords",
-                        "tableExclusions",
                         "defaultSources",
                         "primarySource",
                         "adsetTableName",
@@ -32997,24 +32953,6 @@
                         "statsTableName": {
                             "const": "campaign_group_stats",
                             "type": "string"
-                        },
-                        "tableExclusions": {
-                            "items": {
-                                "const": "stats",
-                                "type": "string"
-                            },
-                            "maxItems": 1,
-                            "minItems": 1,
-                            "type": "array"
-                        },
-                        "tableKeywords": {
-                            "items": {
-                                "const": "campaign_groups",
-                                "type": "string"
-                            },
-                            "maxItems": 1,
-                            "minItems": 1,
-                            "type": "array"
                         }
                     },
                     "required": [
@@ -33023,8 +32961,6 @@
                         "idField",
                         "campaignTableName",
                         "statsTableName",
-                        "tableKeywords",
-                        "tableExclusions",
                         "defaultSources",
                         "primarySource",
                         "adsetTableName",
@@ -33223,24 +33159,6 @@
                         "statsTableName": {
                             "const": "campaign_stats",
                             "type": "string"
-                        },
-                        "tableExclusions": {
-                            "items": {
-                                "const": "stats",
-                                "type": "string"
-                            },
-                            "maxItems": 1,
-                            "minItems": 1,
-                            "type": "array"
-                        },
-                        "tableKeywords": {
-                            "items": {
-                                "const": "campaigns",
-                                "type": "string"
-                            },
-                            "maxItems": 1,
-                            "minItems": 1,
-                            "type": "array"
                         }
                     },
                     "required": [
@@ -33249,8 +33167,6 @@
                         "idField",
                         "campaignTableName",
                         "statsTableName",
-                        "tableKeywords",
-                        "tableExclusions",
                         "defaultSources",
                         "primarySource",
                         "adsetTableName",
@@ -33312,24 +33228,6 @@
                         "statsTableName": {
                             "const": "campaign_report",
                             "type": "string"
-                        },
-                        "tableExclusions": {
-                            "items": {
-                                "const": "report",
-                                "type": "string"
-                            },
-                            "maxItems": 1,
-                            "minItems": 1,
-                            "type": "array"
-                        },
-                        "tableKeywords": {
-                            "items": {
-                                "const": "campaigns",
-                                "type": "string"
-                            },
-                            "maxItems": 1,
-                            "minItems": 1,
-                            "type": "array"
                         }
                     },
                     "required": [
@@ -33338,8 +33236,6 @@
                         "idField",
                         "campaignTableName",
                         "statsTableName",
-                        "tableKeywords",
-                        "tableExclusions",
                         "defaultSources",
                         "primarySource",
                         "adsetTableName",
@@ -33400,24 +33296,6 @@
                         "statsTableName": {
                             "const": "campaign_report",
                             "type": "string"
-                        },
-                        "tableExclusions": {
-                            "items": {
-                                "const": "report",
-                                "type": "string"
-                            },
-                            "maxItems": 1,
-                            "minItems": 1,
-                            "type": "array"
-                        },
-                        "tableKeywords": {
-                            "items": {
-                                "const": "campaigns",
-                                "type": "string"
-                            },
-                            "maxItems": 1,
-                            "minItems": 1,
-                            "type": "array"
                         }
                     },
                     "required": [
@@ -33426,8 +33304,6 @@
                         "idField",
                         "campaignTableName",
                         "statsTableName",
-                        "tableKeywords",
-                        "tableExclusions",
                         "defaultSources",
                         "primarySource",
                         "adsetTableName",
@@ -33502,24 +33378,6 @@
                         "statsTableName": {
                             "const": "campaign_performance_report",
                             "type": "string"
-                        },
-                        "tableExclusions": {
-                            "items": {
-                                "const": "performance",
-                                "type": "string"
-                            },
-                            "maxItems": 1,
-                            "minItems": 1,
-                            "type": "array"
-                        },
-                        "tableKeywords": {
-                            "items": {
-                                "const": "campaigns",
-                                "type": "string"
-                            },
-                            "maxItems": 1,
-                            "minItems": 1,
-                            "type": "array"
                         }
                     },
                     "required": [
@@ -33528,8 +33386,6 @@
                         "idField",
                         "campaignTableName",
                         "statsTableName",
-                        "tableKeywords",
-                        "tableExclusions",
                         "defaultSources",
                         "primarySource",
                         "adsetTableName",
@@ -33628,24 +33484,6 @@
                         "statsTableName": {
                             "const": "campaign_stats_daily",
                             "type": "string"
-                        },
-                        "tableExclusions": {
-                            "items": {
-                                "const": "stats_daily",
-                                "type": "string"
-                            },
-                            "maxItems": 1,
-                            "minItems": 1,
-                            "type": "array"
-                        },
-                        "tableKeywords": {
-                            "items": {
-                                "const": "campaigns",
-                                "type": "string"
-                            },
-                            "maxItems": 1,
-                            "minItems": 1,
-                            "type": "array"
                         }
                     },
                     "required": [
@@ -33654,8 +33492,6 @@
                         "idField",
                         "campaignTableName",
                         "statsTableName",
-                        "tableKeywords",
-                        "tableExclusions",
                         "defaultSources",
                         "primarySource",
                         "adsetTableName",
@@ -33718,24 +33554,6 @@
                         "statsTableName": {
                             "const": "campaign_analytics",
                             "type": "string"
-                        },
-                        "tableExclusions": {
-                            "items": {
-                                "const": "analytics",
-                                "type": "string"
-                            },
-                            "maxItems": 1,
-                            "minItems": 1,
-                            "type": "array"
-                        },
-                        "tableKeywords": {
-                            "items": {
-                                "const": "campaigns",
-                                "type": "string"
-                            },
-                            "maxItems": 1,
-                            "minItems": 1,
-                            "type": "array"
                         }
                     },
                     "required": [
@@ -33744,8 +33562,6 @@
                         "idField",
                         "campaignTableName",
                         "statsTableName",
-                        "tableKeywords",
-                        "tableExclusions",
                         "defaultSources",
                         "primarySource",
                         "adsetTableName",
@@ -33783,18 +33599,6 @@
                 },
                 "statsTableName": {
                     "type": "string"
-                },
-                "tableExclusions": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "tableKeywords": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
                 }
             },
             "required": [
@@ -33803,8 +33607,6 @@
                 "idField",
                 "campaignTableName",
                 "statsTableName",
-                "tableKeywords",
-                "tableExclusions",
                 "defaultSources",
                 "primarySource"
             ],
@@ -34838,14 +34640,6 @@
                 "facebook_marketplace",
                 "threads"
             ],
-            "type": "string"
-        },
-        "MetaAdsTableExclusions": {
-            "enum": ["stats"],
-            "type": "string"
-        },
-        "MetaAdsTableKeywords": {
-            "enum": ["campaigns"],
             "type": "string"
         },
         "MetricPropertyFilter": {
@@ -36865,14 +36659,6 @@
         },
         "PinterestAdsDefaultSources": {
             "enum": ["pinterest"],
-            "type": "string"
-        },
-        "PinterestAdsTableExclusions": {
-            "enum": ["analytics"],
-            "type": "string"
-        },
-        "PinterestAdsTableKeywords": {
-            "enum": ["campaigns"],
             "type": "string"
         },
         "PlanningMessage": {
@@ -45983,14 +45769,6 @@
             "enum": ["reddit"],
             "type": "string"
         },
-        "RedditAdsTableExclusions": {
-            "enum": ["report"],
-            "type": "string"
-        },
-        "RedditAdsTableKeywords": {
-            "enum": ["campaigns"],
-            "type": "string"
-        },
         "RefreshType": {
             "enum": [
                 "async",
@@ -48140,14 +47918,6 @@
             "enum": ["snapchat"],
             "type": "string"
         },
-        "SnapchatAdsTableExclusions": {
-            "enum": ["stats_daily"],
-            "type": "string"
-        },
-        "SnapchatAdsTableKeywords": {
-            "enum": ["campaigns"],
-            "type": "string"
-        },
         "SourceConfig": {
             "additionalProperties": false,
             "properties": {
@@ -50116,14 +49886,6 @@
         },
         "TikTokAdsDefaultSources": {
             "enum": ["tiktok"],
-            "type": "string"
-        },
-        "TikTokAdsTableExclusions": {
-            "enum": ["report"],
-            "type": "string"
-        },
-        "TikTokAdsTableKeywords": {
-            "enum": ["campaigns"],
             "type": "string"
         },
         "TileFilters": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -8952,16 +8952,6 @@ export const MARKETING_INTEGRATION_FIELD_MAP = Object.fromEntries(
     ])
 ) as unknown as Record<NativeMarketingSource, { nameField: string; idField: string }>
 
-export const MARKETING_CAMPAIGN_TABLE_PATTERNS = Object.fromEntries(
-    VALID_NATIVE_MARKETING_SOURCES.map((source) => [
-        source,
-        {
-            keywords: [...MARKETING_INTEGRATION_CONFIGS[source].tableKeywords],
-            exclusions: [...MARKETING_INTEGRATION_CONFIGS[source].tableExclusions],
-        },
-    ])
-) as unknown as Record<NativeMarketingSource, { keywords: string[]; exclusions: string[] }>
-
 export const MARKETING_DEFAULT_SOURCE_MAPPINGS = Object.fromEntries(
     VALID_NATIVE_MARKETING_SOURCES.map((source) => [source, [...MARKETING_INTEGRATION_CONFIGS[source].defaultSources]])
 ) as unknown as Record<NativeMarketingSource, string[]>

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -8718,8 +8718,6 @@ export const MARKETING_INTEGRATION_CONFIGS = {
         idField: 'campaign_id',
         campaignTableName: 'campaign',
         statsTableName: 'campaign_overview_stats',
-        tableKeywords: ['campaign'] as const,
-        tableExclusions: ['stats'] as const,
         defaultSources: [
             'google',
             'adwords',
@@ -8747,8 +8745,6 @@ export const MARKETING_INTEGRATION_CONFIGS = {
         idField: 'id',
         campaignTableName: 'campaign_groups',
         statsTableName: 'campaign_group_stats',
-        tableKeywords: ['campaign_groups'] as const,
-        tableExclusions: ['stats'] as const,
         defaultSources: ['linkedin', 'li'] as const,
         primarySource: 'linkedin',
         // LinkedIn API hierarchy: Account → CampaignGroup → Campaign → Creative.
@@ -8766,8 +8762,6 @@ export const MARKETING_INTEGRATION_CONFIGS = {
         idField: 'id',
         campaignTableName: 'campaigns',
         statsTableName: 'campaign_stats',
-        tableKeywords: ['campaigns'] as const,
-        tableExclusions: ['stats'] as const,
         defaultSources: [
             'meta',
             'facebook',
@@ -8812,8 +8806,6 @@ export const MARKETING_INTEGRATION_CONFIGS = {
         idField: 'campaign_id',
         campaignTableName: 'campaigns',
         statsTableName: 'campaign_report',
-        tableKeywords: ['campaigns'] as const,
-        tableExclusions: ['report'] as const,
         defaultSources: ['tiktok'] as const,
         primarySource: 'tiktok',
         adsetTableName: 'ad_groups' as const,
@@ -8827,8 +8819,6 @@ export const MARKETING_INTEGRATION_CONFIGS = {
         idField: 'id',
         campaignTableName: 'campaigns',
         statsTableName: 'campaign_report',
-        tableKeywords: ['campaigns'] as const,
-        tableExclusions: ['report'] as const,
         defaultSources: ['reddit'] as const,
         primarySource: 'reddit',
         adsetTableName: 'ad_groups' as const,
@@ -8842,8 +8832,6 @@ export const MARKETING_INTEGRATION_CONFIGS = {
         idField: 'id',
         campaignTableName: 'campaigns',
         statsTableName: 'campaign_performance_report',
-        tableKeywords: ['campaigns'] as const,
-        tableExclusions: ['performance'] as const,
         defaultSources: ['bing', 'microsoft', 'msads', 'bing_video'] as const,
         primarySource: 'bing',
         // At ad-group / ad level Bing's data import only ships performance *reports* —
@@ -8863,8 +8851,6 @@ export const MARKETING_INTEGRATION_CONFIGS = {
         idField: 'id',
         campaignTableName: 'campaigns',
         statsTableName: 'campaign_stats_daily',
-        tableKeywords: ['campaigns'] as const,
-        tableExclusions: ['stats_daily'] as const,
         defaultSources: ['snapchat'] as const,
         primarySource: 'snapchat',
         adsetTableName: 'ad_squads' as const,
@@ -8884,8 +8870,6 @@ export const MARKETING_INTEGRATION_CONFIGS = {
         idField: 'id',
         campaignTableName: 'campaigns',
         statsTableName: 'campaign_analytics',
-        tableKeywords: ['campaigns'] as const,
-        tableExclusions: ['analytics'] as const,
         defaultSources: ['pinterest'] as const,
         primarySource: 'pinterest',
         adsetTableName: 'ad_groups' as const,
@@ -8906,27 +8890,6 @@ export type BingAdsDefaultSources = (typeof MARKETING_INTEGRATION_CONFIGS)['Bing
 export type SnapchatAdsDefaultSources = (typeof MARKETING_INTEGRATION_CONFIGS)['SnapchatAds']['defaultSources'][number]
 export type PinterestAdsDefaultSources =
     (typeof MARKETING_INTEGRATION_CONFIGS)['PinterestAds']['defaultSources'][number]
-
-export type GoogleAdsTableKeywords = (typeof MARKETING_INTEGRATION_CONFIGS)['GoogleAds']['tableKeywords'][number]
-export type LinkedinAdsTableKeywords = (typeof MARKETING_INTEGRATION_CONFIGS)['LinkedinAds']['tableKeywords'][number]
-export type MetaAdsTableKeywords = (typeof MARKETING_INTEGRATION_CONFIGS)['MetaAds']['tableKeywords'][number]
-export type TikTokAdsTableKeywords = (typeof MARKETING_INTEGRATION_CONFIGS)['TikTokAds']['tableKeywords'][number]
-export type RedditAdsTableKeywords = (typeof MARKETING_INTEGRATION_CONFIGS)['RedditAds']['tableKeywords'][number]
-export type BingAdsTableKeywords = (typeof MARKETING_INTEGRATION_CONFIGS)['BingAds']['tableKeywords'][number]
-export type SnapchatAdsTableKeywords = (typeof MARKETING_INTEGRATION_CONFIGS)['SnapchatAds']['tableKeywords'][number]
-export type PinterestAdsTableKeywords = (typeof MARKETING_INTEGRATION_CONFIGS)['PinterestAds']['tableKeywords'][number]
-
-export type GoogleAdsTableExclusions = (typeof MARKETING_INTEGRATION_CONFIGS)['GoogleAds']['tableExclusions'][number]
-export type LinkedinAdsTableExclusions =
-    (typeof MARKETING_INTEGRATION_CONFIGS)['LinkedinAds']['tableExclusions'][number]
-export type MetaAdsTableExclusions = (typeof MARKETING_INTEGRATION_CONFIGS)['MetaAds']['tableExclusions'][number]
-export type TikTokAdsTableExclusions = (typeof MARKETING_INTEGRATION_CONFIGS)['TikTokAds']['tableExclusions'][number]
-export type RedditAdsTableExclusions = (typeof MARKETING_INTEGRATION_CONFIGS)['RedditAds']['tableExclusions'][number]
-export type BingAdsTableExclusions = (typeof MARKETING_INTEGRATION_CONFIGS)['BingAds']['tableExclusions'][number]
-export type SnapchatAdsTableExclusions =
-    (typeof MARKETING_INTEGRATION_CONFIGS)['SnapchatAds']['tableExclusions'][number]
-export type PinterestAdsTableExclusions =
-    (typeof MARKETING_INTEGRATION_CONFIGS)['PinterestAds']['tableExclusions'][number]
 
 // Conversion fields for Snapchat Ads - extracted as types so they generate as StrEnum in Python
 export type SnapchatAdsConversionFields =
@@ -8962,8 +8925,6 @@ export interface MarketingIntegrationConfigType {
     idField: string
     campaignTableName: string
     statsTableName: string
-    tableKeywords: string[]
-    tableExclusions: string[]
     defaultSources: string[]
     primarySource: string
 }

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsSettingsLogic.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsSettingsLogic.ts
@@ -10,7 +10,7 @@ import {
     ConversionGoalFilter,
     DatabaseSchemaDataWarehouseTable,
     HogQLQueryResponse,
-    MARKETING_CAMPAIGN_TABLE_PATTERNS,
+    MARKETING_INTEGRATION_CONFIGS,
     MARKETING_INTEGRATION_FIELD_MAP,
     MarketingAnalyticsColumnsSchemaNames,
     MarketingAnalyticsConfig,
@@ -29,7 +29,7 @@ import type { PaginatedResponse } from '../../../../../../lib/api'
 import type { ProductIntentProperties } from '../../../../../../lib/utils/product-intents'
 import type { TeamPublicType, TeamType } from '../../../../../../types'
 import { IntegrationSettingsTab } from '../components/settings/IntegrationSettingsModal'
-import { DEFAULT_ATTRIBUTION_WINDOW_DAYS, generateUniqueName } from './utils'
+import { DEFAULT_ATTRIBUTION_WINDOW_DAYS, extractSchemaName, generateUniqueName } from './utils'
 
 export interface IntegrationSettingsModalState {
     isOpen: boolean
@@ -496,8 +496,8 @@ export const marketingAnalyticsSettingsLogic = kea<marketingAnalyticsSettingsLog
                     if (!isNativeMarketingSource(sourceType)) {
                         continue
                     }
-                    const patterns = MARKETING_CAMPAIGN_TABLE_PATTERNS[sourceType]
-                    if (!patterns) {
+                    const campaignTableName = MARKETING_INTEGRATION_CONFIGS[sourceType]?.campaignTableName
+                    if (!campaignTableName) {
                         continue
                     }
 
@@ -506,14 +506,12 @@ export const marketingAnalyticsSettingsLogic = kea<marketingAnalyticsSettingsLog
                         (table) => table.source?.source_type === sourceType
                     )
 
-                    // Find the campaign table using the same pattern matching as the backend
+                    // Match the declared schema name exactly, like the backend factory does.
+                    // Keyword matching also claimed unrelated schemas that merely contain the
+                    // keyword — Google Ads `campaign_budget` — and then every query against
+                    // the resolved table failed on the missing campaign columns.
                     for (const table of sourceTables) {
-                        const tableSuffix = table.name.split('.').pop()?.toLowerCase() || ''
-
-                        const matchesKeyword = patterns.keywords.some((kw: string) => tableSuffix.includes(kw))
-                        const matchesExclusion = patterns.exclusions.some((ex: string) => tableSuffix.includes(ex))
-
-                        if (matchesKeyword && !matchesExclusion) {
+                        if (extractSchemaName(table.name, sourceType) === campaignTableName) {
                             result[sourceType] = table.name
                             break
                         }

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/utils.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/utils.ts
@@ -107,6 +107,16 @@ export const NATIVE_SOURCE_HIERARCHY_SCHEMA_NAMES: Partial<
     }).filter((entry): entry is [NativeMarketingSource, NativeSourceHierarchySchemaNames] => entry !== null)
 )
 
+/** Mirrors the backend `_extract_schema_name` (factory.py). Warehouse tables are named
+ * `{user_prefix}{source_type}_{schema_name}`, and the prefix is free text, so it can
+ * repeat the marker — take the last occurrence, which is always the real boundary. */
+export function extractSchemaName(tableName: string, sourceType: string): string {
+    const suffix = tableName.split('.').pop()?.toLowerCase() || ''
+    const marker = `${sourceType.toLowerCase()}_`
+    const index = suffix.lastIndexOf(marker)
+    return index === -1 ? suffix : suffix.slice(index + marker.length)
+}
+
 // Old syncs may still use a stats table's pre-rename name — mirrors the backend
 // fallback in factory.py.
 const LEGACY_TABLE_NAME_FALLBACKS: Partial<Record<NativeMarketingSource, Record<string, string[]>>> = {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -48,8 +48,6 @@ from posthog.schema_enums import (
     BillingSpendResponseBreakdownType as BillingSpendResponseBreakdownType,
     BillingUsageResponseBreakdownType as BillingUsageResponseBreakdownType,
     BingAdsDefaultSources as BingAdsDefaultSources,
-    BingAdsTableExclusions as BingAdsTableExclusions,
-    BingAdsTableKeywords as BingAdsTableKeywords,
     BounceRatePageViewMode as BounceRatePageViewMode,
     BreakdownAttributionType as BreakdownAttributionType,
     BreakdownType as BreakdownType,
@@ -119,8 +117,6 @@ from posthog.schema_enums import (
     FunnelVizType as FunnelVizType,
     Goal as Goal,
     GoogleAdsDefaultSources as GoogleAdsDefaultSources,
-    GoogleAdsTableExclusions as GoogleAdsTableExclusions,
-    GoogleAdsTableKeywords as GoogleAdsTableKeywords,
     GradientScaleMode as GradientScaleMode,
     HeatmapSortOrder as HeatmapSortOrder,
     HedgehogActorAccessoryOption as HedgehogActorAccessoryOption,
@@ -147,8 +143,6 @@ from posthog.schema_enums import (
     LifecycleToggle as LifecycleToggle,
     LimitContext as LimitContext,
     LinkedinAdsDefaultSources as LinkedinAdsDefaultSources,
-    LinkedinAdsTableExclusions as LinkedinAdsTableExclusions,
-    LinkedinAdsTableKeywords as LinkedinAdsTableKeywords,
     LogPropertyFilterType as LogPropertyFilterType,
     LogSeverityLevel as LogSeverityLevel,
     LogsOrderBy as LogsOrderBy,
@@ -175,8 +169,6 @@ from posthog.schema_enums import (
     MetaAdsConversionOmniActionTypes as MetaAdsConversionOmniActionTypes,
     MetaAdsConversionSpecificActionTypes as MetaAdsConversionSpecificActionTypes,
     MetaAdsDefaultSources as MetaAdsDefaultSources,
-    MetaAdsTableExclusions as MetaAdsTableExclusions,
-    MetaAdsTableKeywords as MetaAdsTableKeywords,
     Method as Method,
     Metric as Metric,
     MetricsAggregation as MetricsAggregation,
@@ -205,8 +197,6 @@ from posthog.schema_enums import (
     PersonsJoinMode as PersonsJoinMode,
     PersonsOnEventsMode as PersonsOnEventsMode,
     PinterestAdsDefaultSources as PinterestAdsDefaultSources,
-    PinterestAdsTableExclusions as PinterestAdsTableExclusions,
-    PinterestAdsTableKeywords as PinterestAdsTableKeywords,
     PlanningStepStatus as PlanningStepStatus,
     Position as Position,
     PrecomputationMode as PrecomputationMode,
@@ -224,8 +214,6 @@ from posthog.schema_enums import (
     RecordingOrder as RecordingOrder,
     RecordingOrderDirection as RecordingOrderDirection,
     RedditAdsDefaultSources as RedditAdsDefaultSources,
-    RedditAdsTableExclusions as RedditAdsTableExclusions,
-    RedditAdsTableKeywords as RedditAdsTableKeywords,
     RefreshType as RefreshType,
     ReleaseStatus as ReleaseStatus,
     ResultCustomizationBy as ResultCustomizationBy,
@@ -245,8 +233,6 @@ from posthog.schema_enums import (
     SnapchatAdsConversionFields as SnapchatAdsConversionFields,
     SnapchatAdsConversionValueFields as SnapchatAdsConversionValueFields,
     SnapchatAdsDefaultSources as SnapchatAdsDefaultSources,
-    SnapchatAdsTableExclusions as SnapchatAdsTableExclusions,
-    SnapchatAdsTableKeywords as SnapchatAdsTableKeywords,
     SnapshotSource as SnapshotSource,
     SourceFieldInputConfigType as SourceFieldInputConfigType,
     SourceFieldSelectConfigConverter as SourceFieldSelectConfigConverter,
@@ -273,8 +259,6 @@ from posthog.schema_enums import (
     TextMatching as TextMatching,
     Theme as Theme,
     TikTokAdsDefaultSources as TikTokAdsDefaultSources,
-    TikTokAdsTableExclusions as TikTokAdsTableExclusions,
-    TikTokAdsTableKeywords as TikTokAdsTableKeywords,
     TimeWindowMode as TimeWindowMode,
     TraceOrderColumn as TraceOrderColumn,
     TraceSpanBreakdownOrderBy as TraceSpanBreakdownOrderBy,
@@ -1705,8 +1689,6 @@ class MarketingIntegrationConfig1(BaseModel):
     primarySource: Literal["google"] = "google"
     sourceType: Literal["GoogleAds"] = "GoogleAds"
     statsTableName: Literal["campaign_overview_stats"] = "campaign_overview_stats"
-    tableExclusions: list[str] = Field(..., max_length=1, min_length=1)
-    tableKeywords: list[str] = Field(..., max_length=1, min_length=1)
 
 
 class MarketingIntegrationConfig2(BaseModel):
@@ -1724,8 +1706,6 @@ class MarketingIntegrationConfig2(BaseModel):
     primarySource: Literal["linkedin"] = "linkedin"
     sourceType: Literal["LinkedinAds"] = "LinkedinAds"
     statsTableName: Literal["campaign_group_stats"] = "campaign_group_stats"
-    tableExclusions: list[str] = Field(..., max_length=1, min_length=1)
-    tableKeywords: list[str] = Field(..., max_length=1, min_length=1)
 
 
 class ConversionActionTypes(BaseModel):
@@ -1753,8 +1733,6 @@ class MarketingIntegrationConfig3(BaseModel):
     primarySource: Literal["meta"] = "meta"
     sourceType: Literal["MetaAds"] = "MetaAds"
     statsTableName: Literal["campaign_stats"] = "campaign_stats"
-    tableExclusions: list[str] = Field(..., max_length=1, min_length=1)
-    tableKeywords: list[str] = Field(..., max_length=1, min_length=1)
 
 
 class MarketingIntegrationConfig4(BaseModel):
@@ -1772,8 +1750,6 @@ class MarketingIntegrationConfig4(BaseModel):
     primarySource: Literal["tiktok"] = "tiktok"
     sourceType: Literal["TikTokAds"] = "TikTokAds"
     statsTableName: Literal["campaign_report"] = "campaign_report"
-    tableExclusions: list[str] = Field(..., max_length=1, min_length=1)
-    tableKeywords: list[str] = Field(..., max_length=1, min_length=1)
 
 
 class MarketingIntegrationConfig5(BaseModel):
@@ -1791,8 +1767,6 @@ class MarketingIntegrationConfig5(BaseModel):
     primarySource: Literal["reddit"] = "reddit"
     sourceType: Literal["RedditAds"] = "RedditAds"
     statsTableName: Literal["campaign_report"] = "campaign_report"
-    tableExclusions: list[str] = Field(..., max_length=1, min_length=1)
-    tableKeywords: list[str] = Field(..., max_length=1, min_length=1)
 
 
 class MarketingIntegrationConfig6(BaseModel):
@@ -1810,8 +1784,6 @@ class MarketingIntegrationConfig6(BaseModel):
     primarySource: Literal["bing"] = "bing"
     sourceType: Literal["BingAds"] = "BingAds"
     statsTableName: Literal["campaign_performance_report"] = "campaign_performance_report"
-    tableExclusions: list[str] = Field(..., max_length=1, min_length=1)
-    tableKeywords: list[str] = Field(..., max_length=1, min_length=1)
 
 
 class MarketingIntegrationConfig7(BaseModel):
@@ -1831,8 +1803,6 @@ class MarketingIntegrationConfig7(BaseModel):
     primarySource: Literal["snapchat"] = "snapchat"
     sourceType: Literal["SnapchatAds"] = "SnapchatAds"
     statsTableName: Literal["campaign_stats_daily"] = "campaign_stats_daily"
-    tableExclusions: list[str] = Field(..., max_length=1, min_length=1)
-    tableKeywords: list[str] = Field(..., max_length=1, min_length=1)
 
 
 class MarketingIntegrationConfig8(BaseModel):
@@ -1850,8 +1820,6 @@ class MarketingIntegrationConfig8(BaseModel):
     primarySource: Literal["pinterest"] = "pinterest"
     sourceType: Literal["PinterestAds"] = "PinterestAds"
     statsTableName: Literal["campaign_analytics"] = "campaign_analytics"
-    tableExclusions: list[str] = Field(..., max_length=1, min_length=1)
-    tableKeywords: list[str] = Field(..., max_length=1, min_length=1)
 
 
 class MarketingIntegrationConfig(
@@ -5638,8 +5606,6 @@ class MarketingIntegrationConfigType(BaseModel):
     primarySource: str
     sourceType: NativeMarketingSource
     statsTableName: str
-    tableExclusions: list[str]
-    tableKeywords: list[str]
 
 
 class MatchedRecording(BaseModel):

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -546,14 +546,6 @@ class BingAdsDefaultSources(StrEnum):
     BING_VIDEO = "bing_video"
 
 
-class BingAdsTableExclusions(StrEnum):
-    PERFORMANCE = "performance"
-
-
-class BingAdsTableKeywords(StrEnum):
-    CAMPAIGNS = "campaigns"
-
-
 class BreakdownAttributionType(StrEnum):
     FIRST_TOUCH = "first_touch"
     LAST_TOUCH = "last_touch"
@@ -2667,14 +2659,6 @@ class GoogleAdsDefaultSources(StrEnum):
     WAZE = "waze"
 
 
-class GoogleAdsTableExclusions(StrEnum):
-    STATS = "stats"
-
-
-class GoogleAdsTableKeywords(StrEnum):
-    CAMPAIGN = "campaign"
-
-
 class GradientScaleMode(StrEnum):
     ABSOLUTE = "absolute"
     RELATIVE = "relative"
@@ -2923,14 +2907,6 @@ class LinkedinAdsDefaultSources(StrEnum):
     LI = "li"
 
 
-class LinkedinAdsTableExclusions(StrEnum):
-    STATS = "stats"
-
-
-class LinkedinAdsTableKeywords(StrEnum):
-    CAMPAIGN_GROUPS = "campaign_groups"
-
-
 class MatchedOn(StrEnum):
     KEY = "key"
     VALUE = "value"
@@ -3111,14 +3087,6 @@ class MetaAdsDefaultSources(StrEnum):
     AUDIENCE_NETWORK = "audience_network"
     FACEBOOK_MARKETPLACE = "facebook_marketplace"
     THREADS = "threads"
-
-
-class MetaAdsTableExclusions(StrEnum):
-    STATS = "stats"
-
-
-class MetaAdsTableKeywords(StrEnum):
-    CAMPAIGNS = "campaigns"
 
 
 class MetricsAggregation(StrEnum):
@@ -3339,14 +3307,6 @@ class ValueDisplay(StrEnum):
 
 class PinterestAdsDefaultSources(StrEnum):
     PINTEREST = "pinterest"
-
-
-class PinterestAdsTableExclusions(StrEnum):
-    ANALYTICS = "analytics"
-
-
-class PinterestAdsTableKeywords(StrEnum):
-    CAMPAIGNS = "campaigns"
 
 
 class PlanningStepStatus(StrEnum):
@@ -3676,14 +3636,6 @@ class RedditAdsDefaultSources(StrEnum):
     REDDIT = "reddit"
 
 
-class RedditAdsTableExclusions(StrEnum):
-    REPORT = "report"
-
-
-class RedditAdsTableKeywords(StrEnum):
-    CAMPAIGNS = "campaigns"
-
-
 class RefreshType(StrEnum):
     ASYNC_ = "async"
     ASYNC_EXCEPT_ON_CACHE_MISS = "async_except_on_cache_miss"
@@ -3798,14 +3750,6 @@ class SnapchatAdsConversionValueFields(StrEnum):
 
 class SnapchatAdsDefaultSources(StrEnum):
     SNAPCHAT = "snapchat"
-
-
-class SnapchatAdsTableExclusions(StrEnum):
-    STATS_DAILY = "stats_daily"
-
-
-class SnapchatAdsTableKeywords(StrEnum):
-    CAMPAIGNS = "campaigns"
 
 
 class ReleaseStatus(StrEnum):
@@ -4004,14 +3948,6 @@ class TaxonomicFilterGroupType(StrEnum):
 
 class TikTokAdsDefaultSources(StrEnum):
     TIKTOK = "tiktok"
-
-
-class TikTokAdsTableExclusions(StrEnum):
-    REPORT = "report"
-
-
-class TikTokAdsTableKeywords(StrEnum):
-    CAMPAIGNS = "campaigns"
 
 
 class TraceOrderColumn(StrEnum):

--- a/products/marketing_analytics/backend/hogql_queries/adapters/factory.py
+++ b/products/marketing_analytics/backend/hogql_queries/adapters/factory.py
@@ -57,10 +57,14 @@ def _extract_schema_name(table_suffix: str, source_type: str) -> str:
     Table names follow the format: {user_prefix}{source_type}_{schema_name}
     Exclusions should only match against the schema part, not user prefixes.
     For example: 'analytics_pinterestads_campaigns' -> 'campaigns'
+
+    The user prefix is free text, so it can contain the marker itself
+    ('googleads_googleads_campaign'). Take the last occurrence: no schema name
+    contains the marker, so the last one is always the real boundary.
     """
     source_type_lower = source_type.lower()
     marker = f"{source_type_lower}_"
-    idx = table_suffix.find(marker)
+    idx = table_suffix.rfind(marker)
     if idx != -1:
         return table_suffix[idx + len(marker) :]
     return table_suffix

--- a/products/marketing_analytics/backend/hogql_queries/adapters/test_factory.py
+++ b/products/marketing_analytics/backend/hogql_queries/adapters/test_factory.py
@@ -11,7 +11,7 @@ from parameterized import parameterized
 from posthog.schema import DateRange, MarketingAnalyticsDrillDownLevel, NativeMarketingSource
 
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
-from posthog.models.team.team import DEFAULT_CURRENCY
+from posthog.models.team.team import DEFAULT_CURRENCY, Team
 
 from products.marketing_analytics.backend.hogql_queries.adapters.base import (
     BingAdsConfig,
@@ -30,15 +30,18 @@ from products.marketing_analytics.backend.hogql_queries.adapters.meta_ads import
 from products.warehouse_sources.backend.facade.models import DataWarehouseTable
 
 
-def _make_factory(team) -> MarketingSourceFactory:
-    date_range = QueryDateRange(
-        date_range=DateRange(date_from="2024-01-01", date_to="2024-01-31"),
-        team=team,
-        interval=None,
-        now=datetime.now(),
-    )
-    context = QueryContext(date_range=date_range, team=team, base_currency=DEFAULT_CURRENCY)
-    return MarketingSourceFactory(context=context)
+class FactoryTestMixin:
+    team: Team
+
+    def _make_factory(self) -> MarketingSourceFactory:
+        date_range = QueryDateRange(
+            date_range=DateRange(date_from="2024-01-01", date_to="2024-01-31"),
+            team=self.team,
+            interval=None,
+            now=datetime.now(),
+        )
+        context = QueryContext(date_range=date_range, team=self.team, base_currency=DEFAULT_CURRENCY)
+        return MarketingSourceFactory(context=context)
 
 
 class TestMarketingSourceFactoryCustomSourceMappings(BaseTest):
@@ -172,7 +175,7 @@ class TestMarketingSourceFactoryCustomSourceMappings(BaseTest):
         assert "custom_source" not in str(mappings)
 
 
-class TestMetaAdsConfigDiscovery(BaseTest):
+class TestMetaAdsConfigDiscovery(FactoryTestMixin, BaseTest):
     """Test suite for native config discovery of optional ad-group / ad tables.
 
     The factory must correctly populate `adset_table` / `adset_stats_table` /
@@ -212,7 +215,7 @@ class TestMetaAdsConfigDiscovery(BaseTest):
     def test_meta_only_campaign_tables_yields_config_with_no_optional_tables(self):
         """Bare-minimum sync (campaigns + campaign_stats) → adapter loads but
         cannot serve AD_GROUP / AD."""
-        factory = _make_factory(self.team)
+        factory = self._make_factory()
         tables = [self._make_table("campaigns"), self._make_table("campaign_stats")]
 
         config = self._create_meta_config(factory, tables)
@@ -228,7 +231,7 @@ class TestMetaAdsConfigDiscovery(BaseTest):
     def test_meta_with_full_hierarchy_yields_all_six_tables(self):
         """All Meta resources synced → all six slots populated → adapter supports
         every drill-down level."""
-        factory = _make_factory(self.team)
+        factory = self._make_factory()
         tables = [
             self._make_table("campaigns"),
             self._make_table("campaign_stats"),
@@ -248,7 +251,7 @@ class TestMetaAdsConfigDiscovery(BaseTest):
 
     def test_meta_with_only_adset_tables_supports_ad_group_but_not_ad(self):
         """Partial hierarchy (adsets but no ads) → AD_GROUP works, AD doesn't."""
-        factory = _make_factory(self.team)
+        factory = self._make_factory()
         tables = [
             self._make_table("campaigns"),
             self._make_table("campaign_stats"),
@@ -266,7 +269,7 @@ class TestMetaAdsConfigDiscovery(BaseTest):
 
     def test_meta_without_required_campaign_tables_returns_none(self):
         """Missing campaigns or campaign_stats → adapter can't load at all."""
-        factory = _make_factory(self.team)
+        factory = self._make_factory()
         tables_no_stats = [self._make_table("campaigns")]
         assert self._create_meta_config(factory, tables_no_stats) is None
 
@@ -274,7 +277,7 @@ class TestMetaAdsConfigDiscovery(BaseTest):
         assert self._create_meta_config(factory, tables_no_campaign) is None
 
 
-class TestNativeHierarchicalConfigDiscovery(BaseTest):
+class TestNativeHierarchicalConfigDiscovery(FactoryTestMixin, BaseTest):
     """Verifies `_create_native_config` populates adset/ad slots for every native source
     that has a hierarchy entry. Without this, a working sync looks dead in the UI: the
     factory loads a campaign-only config and `supports_level(AD_GROUP/AD)` returns False.
@@ -430,7 +433,7 @@ class TestNativeHierarchicalConfigDiscovery(BaseTest):
         just non-None, so a regression that broke the `if adset_unified: ...` wiring
         would surface here.
         """
-        factory = _make_factory(self.team)
+        factory = self._make_factory()
         # Deduplicate by schema: in production each schema is one DataWarehouseTable,
         # and unified-mode sources reuse the same table for both entity and stats slots.
         unique_schemas = list(
@@ -464,7 +467,7 @@ class TestNativeHierarchicalConfigDiscovery(BaseTest):
         prefix: str,
         schemas: dict[str, str],
     ):
-        factory = _make_factory(self.team)
+        factory = self._make_factory()
         unique_schemas = list(dict.fromkeys(schemas[k] for k in ("campaign", "stats", "adset", "adset_stats")))
         tables = [self._make_table(prefix, schema) for schema in unique_schemas]
 
@@ -481,7 +484,7 @@ class TestNativeHierarchicalConfigDiscovery(BaseTest):
             )
 
 
-class TestNativeCampaignTableResolution(BaseTest):
+class TestNativeCampaignTableResolution(FactoryTestMixin, BaseTest):
     def _make_source(self, prefix: str = "") -> Mock:
         source = Mock()
         source.id = "googleads_source_id"
@@ -499,7 +502,7 @@ class TestNativeCampaignTableResolution(BaseTest):
     def _create_config(self, tables: list[DataWarehouseTable]) -> GoogleAdsConfig | None:
         return cast(
             GoogleAdsConfig | None,
-            _make_factory(self.team)._create_native_config(
+            self._make_factory()._create_native_config(
                 self._make_source(), tables, NativeMarketingSource.GOOGLE_ADS, GoogleAdsConfig
             ),
         )

--- a/products/marketing_analytics/backend/hogql_queries/adapters/test_factory.py
+++ b/products/marketing_analytics/backend/hogql_queries/adapters/test_factory.py
@@ -28,6 +28,7 @@ from products.marketing_analytics.backend.hogql_queries.adapters.base import (
 from products.marketing_analytics.backend.hogql_queries.adapters.factory import MarketingSourceFactory
 from products.marketing_analytics.backend.hogql_queries.adapters.meta_ads import MetaAdsAdapter
 from products.warehouse_sources.backend.facade.models import DataWarehouseTable
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.helpers import build_table_name
 
 
 def _make_factory(team) -> MarketingSourceFactory:
@@ -482,22 +483,23 @@ class TestNativeHierarchicalConfigDiscovery(BaseTest):
 
 
 class TestNativeCampaignTableResolution(BaseTest):
-    def _make_table(self, schema_name: str, prefix: str = "") -> DataWarehouseTable:
-        """Build a DataWarehouseTable mock named the way `build_table_name` names them:
-        `{user_prefix}{source_type}_{schema_name}`, lowercased.
-        """
-        table = Mock()
-        table.name = f"{prefix}googleads_{schema_name}"
-        return cast(DataWarehouseTable, table)
-
-    def _create_config(self, tables: list[DataWarehouseTable]) -> GoogleAdsConfig | None:
+    def _make_source(self, prefix: str = "") -> Mock:
         source = Mock()
         source.id = "googleads_source_id"
         source.source_type = "GoogleAds"
+        source.prefix = prefix
+        return source
+
+    def _make_table(self, schema_name: str, prefix: str = "") -> DataWarehouseTable:
+        table = Mock()
+        table.name = build_table_name(self._make_source(prefix), schema_name)
+        return cast(DataWarehouseTable, table)
+
+    def _create_config(self, tables: list[DataWarehouseTable]) -> GoogleAdsConfig | None:
         return cast(
             GoogleAdsConfig | None,
             _make_factory(self.team)._create_native_config(
-                source, tables, NativeMarketingSource.GOOGLE_ADS, GoogleAdsConfig
+                self._make_source(), tables, NativeMarketingSource.GOOGLE_ADS, GoogleAdsConfig
             ),
         )
 

--- a/products/marketing_analytics/backend/hogql_queries/adapters/test_factory.py
+++ b/products/marketing_analytics/backend/hogql_queries/adapters/test_factory.py
@@ -28,7 +28,6 @@ from products.marketing_analytics.backend.hogql_queries.adapters.base import (
 from products.marketing_analytics.backend.hogql_queries.adapters.factory import MarketingSourceFactory
 from products.marketing_analytics.backend.hogql_queries.adapters.meta_ads import MetaAdsAdapter
 from products.warehouse_sources.backend.facade.models import DataWarehouseTable
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.helpers import build_table_name
 
 
 def _make_factory(team) -> MarketingSourceFactory:
@@ -492,7 +491,9 @@ class TestNativeCampaignTableResolution(BaseTest):
 
     def _make_table(self, schema_name: str, prefix: str = "") -> DataWarehouseTable:
         table = Mock()
-        table.name = build_table_name(self._make_source(prefix), schema_name)
+        # Duplicates `build_table_name`, which warehouse_sources keeps out of its public
+        # interface — this format is what the factory parses back apart, so it has to match.
+        table.name = f"{prefix}googleads_{schema_name}".lower()
         return cast(DataWarehouseTable, table)
 
     def _create_config(self, tables: list[DataWarehouseTable]) -> GoogleAdsConfig | None:

--- a/products/marketing_analytics/backend/hogql_queries/adapters/test_factory.py
+++ b/products/marketing_analytics/backend/hogql_queries/adapters/test_factory.py
@@ -30,6 +30,17 @@ from products.marketing_analytics.backend.hogql_queries.adapters.meta_ads import
 from products.warehouse_sources.backend.facade.models import DataWarehouseTable
 
 
+def _make_factory(team) -> MarketingSourceFactory:
+    date_range = QueryDateRange(
+        date_range=DateRange(date_from="2024-01-01", date_to="2024-01-31"),
+        team=team,
+        interval=None,
+        now=datetime.now(),
+    )
+    context = QueryContext(date_range=date_range, team=team, base_currency=DEFAULT_CURRENCY)
+    return MarketingSourceFactory(context=context)
+
+
 class TestMarketingSourceFactoryCustomSourceMappings(BaseTest):
     """Test suite for MarketingSourceFactory custom source mapping functionality"""
 
@@ -179,16 +190,6 @@ class TestMetaAdsConfigDiscovery(BaseTest):
         table.name = f"metaads_{schema_name}"
         return cast(DataWarehouseTable, table)
 
-    def _make_factory(self) -> MarketingSourceFactory:
-        date_range = QueryDateRange(
-            date_range=DateRange(date_from="2024-01-01", date_to="2024-01-31"),
-            team=self.team,
-            interval=None,
-            now=datetime.now(),
-        )
-        context = QueryContext(date_range=date_range, team=self.team, base_currency=DEFAULT_CURRENCY)
-        return MarketingSourceFactory(context=context)
-
     def _make_source(self) -> Mock:
         source = Mock()
         source.id = "meta_source_id"
@@ -211,7 +212,7 @@ class TestMetaAdsConfigDiscovery(BaseTest):
     def test_meta_only_campaign_tables_yields_config_with_no_optional_tables(self):
         """Bare-minimum sync (campaigns + campaign_stats) → adapter loads but
         cannot serve AD_GROUP / AD."""
-        factory = self._make_factory()
+        factory = _make_factory(self.team)
         tables = [self._make_table("campaigns"), self._make_table("campaign_stats")]
 
         config = self._create_meta_config(factory, tables)
@@ -227,7 +228,7 @@ class TestMetaAdsConfigDiscovery(BaseTest):
     def test_meta_with_full_hierarchy_yields_all_six_tables(self):
         """All Meta resources synced → all six slots populated → adapter supports
         every drill-down level."""
-        factory = self._make_factory()
+        factory = _make_factory(self.team)
         tables = [
             self._make_table("campaigns"),
             self._make_table("campaign_stats"),
@@ -247,7 +248,7 @@ class TestMetaAdsConfigDiscovery(BaseTest):
 
     def test_meta_with_only_adset_tables_supports_ad_group_but_not_ad(self):
         """Partial hierarchy (adsets but no ads) → AD_GROUP works, AD doesn't."""
-        factory = self._make_factory()
+        factory = _make_factory(self.team)
         tables = [
             self._make_table("campaigns"),
             self._make_table("campaign_stats"),
@@ -265,7 +266,7 @@ class TestMetaAdsConfigDiscovery(BaseTest):
 
     def test_meta_without_required_campaign_tables_returns_none(self):
         """Missing campaigns or campaign_stats → adapter can't load at all."""
-        factory = self._make_factory()
+        factory = _make_factory(self.team)
         tables_no_stats = [self._make_table("campaigns")]
         assert self._create_meta_config(factory, tables_no_stats) is None
 
@@ -404,16 +405,6 @@ class TestNativeHierarchicalConfigDiscovery(BaseTest):
         table.name = f"{prefix}_{schema_name}"
         return cast(DataWarehouseTable, table)
 
-    def _make_factory(self) -> MarketingSourceFactory:
-        date_range = QueryDateRange(
-            date_range=DateRange(date_from="2024-01-01", date_to="2024-01-31"),
-            team=self.team,
-            interval=None,
-            now=datetime.now(),
-        )
-        context = QueryContext(date_range=date_range, team=self.team, base_currency=DEFAULT_CURRENCY)
-        return MarketingSourceFactory(context=context)
-
     def _make_source(self, source_type: str) -> Mock:
         source = Mock()
         source.id = f"{source_type}_source_id"
@@ -439,7 +430,7 @@ class TestNativeHierarchicalConfigDiscovery(BaseTest):
         just non-None, so a regression that broke the `if adset_unified: ...` wiring
         would surface here.
         """
-        factory = self._make_factory()
+        factory = _make_factory(self.team)
         # Deduplicate by schema: in production each schema is one DataWarehouseTable,
         # and unified-mode sources reuse the same table for both entity and stats slots.
         unique_schemas = list(
@@ -473,7 +464,7 @@ class TestNativeHierarchicalConfigDiscovery(BaseTest):
         prefix: str,
         schemas: dict[str, str],
     ):
-        factory = self._make_factory()
+        factory = _make_factory(self.team)
         unique_schemas = list(dict.fromkeys(schemas[k] for k in ("campaign", "stats", "adset", "adset_stats")))
         tables = [self._make_table(prefix, schema) for schema in unique_schemas]
 
@@ -491,20 +482,24 @@ class TestNativeHierarchicalConfigDiscovery(BaseTest):
 
 
 class TestNativeCampaignTableResolution(BaseTest):
-    def _make_table(self, schema_name: str) -> DataWarehouseTable:
+    def _make_table(self, schema_name: str, prefix: str = "") -> DataWarehouseTable:
+        """Build a DataWarehouseTable mock named the way `build_table_name` names them:
+        `{user_prefix}{source_type}_{schema_name}`, lowercased.
+        """
         table = Mock()
-        table.name = f"googleads.{schema_name}"
+        table.name = f"{prefix}googleads_{schema_name}"
         return cast(DataWarehouseTable, table)
 
-    def _make_factory(self) -> MarketingSourceFactory:
-        date_range = QueryDateRange(
-            date_range=DateRange(date_from="2024-01-01", date_to="2024-01-31"),
-            team=self.team,
-            interval=None,
-            now=datetime.now(),
+    def _create_config(self, tables: list[DataWarehouseTable]) -> GoogleAdsConfig | None:
+        source = Mock()
+        source.id = "googleads_source_id"
+        source.source_type = "GoogleAds"
+        return cast(
+            GoogleAdsConfig | None,
+            _make_factory(self.team)._create_native_config(
+                source, tables, NativeMarketingSource.GOOGLE_ADS, GoogleAdsConfig
+            ),
         )
-        context = QueryContext(date_range=date_range, team=self.team, base_currency=DEFAULT_CURRENCY)
-        return MarketingSourceFactory(context=context)
 
     @parameterized.expand([("budget_last", False), ("budget_first", True)])
     def test_campaign_budget_never_wins_the_campaign_slot(self, _name: str, reverse: bool):
@@ -518,15 +513,30 @@ class TestNativeCampaignTableResolution(BaseTest):
         budget = self._make_table("campaign_budget")
         tables = [campaign, stats, budget]
 
-        source = Mock()
-        source.id = "googleads_source_id"
-        source.source_type = "GoogleAds"
-        config = self._make_factory()._create_native_config(
-            source,
-            list(reversed(tables)) if reverse else tables,
-            NativeMarketingSource.GOOGLE_ADS,
-            GoogleAdsConfig,
-        )
+        config = self._create_config(list(reversed(tables)) if reverse else tables)
+
+        assert config is not None
+        assert config.campaign_table is campaign
+        assert config.stats_table is stats
+
+    def test_campaign_budget_without_campaign_yields_no_config(self):
+        """The state already-affected projects are in: `campaign_budget` synced, `campaign`
+        not. Nothing can serve the campaign slot, so the source must be dropped rather
+        than wired up to a table that will fail to resolve at query time.
+        """
+        tables = [self._make_table("campaign_budget"), self._make_table("campaign_overview_stats")]
+
+        assert self._create_config(tables) is None
+
+    @parameterized.expand([("plain", "analytics_"), ("prefix_repeats_source_type", "googleads_")])
+    def test_user_prefix_is_stripped_before_matching(self, _name: str, prefix: str):
+        """The source prefix is free text, so it can repeat the source type. Exact matching
+        only works if the schema name survives prefix stripping in both cases.
+        """
+        campaign = self._make_table("campaign", prefix=prefix)
+        stats = self._make_table("campaign_overview_stats", prefix=prefix)
+
+        config = self._create_config([campaign, stats])
 
         assert config is not None
         assert config.campaign_table is campaign

--- a/products/marketing_analytics/backend/hogql_queries/constants.py
+++ b/products/marketing_analytics/backend/hogql_queries/constants.py
@@ -7,16 +7,10 @@ from pydantic import BaseModel
 
 from posthog.schema import (
     BingAdsDefaultSources,
-    BingAdsTableExclusions,
-    BingAdsTableKeywords,
     DefaultChannelTypes,
     GoogleAdsDefaultSources,
-    GoogleAdsTableExclusions,
-    GoogleAdsTableKeywords,
     InfinityValue,
     LinkedinAdsDefaultSources,
-    LinkedinAdsTableExclusions,
-    LinkedinAdsTableKeywords,
     MarketingAnalyticsBaseColumns,
     MarketingAnalyticsColumnsSchemaNames,
     MarketingAnalyticsConstants,
@@ -34,24 +28,14 @@ from posthog.schema import (
     MetaAdsConversionOmniActionTypes,
     MetaAdsConversionSpecificActionTypes,
     MetaAdsDefaultSources,
-    MetaAdsTableExclusions,
-    MetaAdsTableKeywords,
     NativeMarketingSource,
     NodeKind,
     PinterestAdsDefaultSources,
-    PinterestAdsTableExclusions,
-    PinterestAdsTableKeywords,
     RedditAdsDefaultSources,
-    RedditAdsTableExclusions,
-    RedditAdsTableKeywords,
     SnapchatAdsConversionFields,
     SnapchatAdsConversionValueFields,
     SnapchatAdsDefaultSources,
-    SnapchatAdsTableExclusions,
-    SnapchatAdsTableKeywords,
     TikTokAdsDefaultSources,
-    TikTokAdsTableExclusions,
-    TikTokAdsTableKeywords,
     WebAnalyticsItemKind,
 )
 
@@ -539,28 +523,6 @@ _DEFAULT_SOURCES_ENUMS = {
     NativeMarketingSource.PINTEREST_ADS: PinterestAdsDefaultSources,
 }
 
-_TABLE_KEYWORDS_ENUMS = {
-    NativeMarketingSource.GOOGLE_ADS: GoogleAdsTableKeywords,
-    NativeMarketingSource.LINKEDIN_ADS: LinkedinAdsTableKeywords,
-    NativeMarketingSource.META_ADS: MetaAdsTableKeywords,
-    NativeMarketingSource.TIK_TOK_ADS: TikTokAdsTableKeywords,
-    NativeMarketingSource.REDDIT_ADS: RedditAdsTableKeywords,
-    NativeMarketingSource.BING_ADS: BingAdsTableKeywords,
-    NativeMarketingSource.SNAPCHAT_ADS: SnapchatAdsTableKeywords,
-    NativeMarketingSource.PINTEREST_ADS: PinterestAdsTableKeywords,
-}
-
-_TABLE_EXCLUSIONS_ENUMS = {
-    NativeMarketingSource.GOOGLE_ADS: GoogleAdsTableExclusions,
-    NativeMarketingSource.LINKEDIN_ADS: LinkedinAdsTableExclusions,
-    NativeMarketingSource.META_ADS: MetaAdsTableExclusions,
-    NativeMarketingSource.TIK_TOK_ADS: TikTokAdsTableExclusions,
-    NativeMarketingSource.REDDIT_ADS: RedditAdsTableExclusions,
-    NativeMarketingSource.BING_ADS: BingAdsTableExclusions,
-    NativeMarketingSource.SNAPCHAT_ADS: SnapchatAdsTableExclusions,
-    NativeMarketingSource.PINTEREST_ADS: PinterestAdsTableExclusions,
-}
-
 # Derived constants from generated types
 NEEDED_FIELDS_FOR_NATIVE_MARKETING_ANALYTICS = {
     source: [
@@ -572,8 +534,6 @@ NEEDED_FIELDS_FOR_NATIVE_MARKETING_ANALYTICS = {
 
 TABLE_PATTERNS = {
     source: {
-        "campaign_table_keywords": _get_enum_values(_TABLE_KEYWORDS_ENUMS[source]),
-        "campaign_table_exclusions": _get_enum_values(_TABLE_EXCLUSIONS_ENUMS[source]),
         "stats_table_keywords": [_get_field_default(config, "statsTableName")],
         "campaign_table_name": _get_field_default(config, "campaignTableName"),
     }

--- a/products/marketing_analytics/backend/hogql_queries/test_constants.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_constants.py
@@ -5,8 +5,6 @@ from posthog.schema import NativeMarketingSource
 from .constants import (
     _CONFIG_MODELS,
     _DEFAULT_SOURCES_ENUMS,
-    _TABLE_EXCLUSIONS_ENUMS,
-    _TABLE_KEYWORDS_ENUMS,
     INTEGRATION_DEFAULT_SOURCES,
     INTEGRATION_FIELD_NAMES,
     INTEGRATION_PRIMARY_SOURCE,
@@ -27,18 +25,6 @@ class TestMarketingAnalyticsConstantsCoverage:
         covered_sources = set(_DEFAULT_SOURCES_ENUMS.keys())
         missing = all_sources - covered_sources
         assert covered_sources == all_sources, f"Missing sources in _DEFAULT_SOURCES_ENUMS: {missing}"
-
-    def test_table_keywords_enums_covers_all_sources(self):
-        all_sources = set(NativeMarketingSource)
-        covered_sources = set(_TABLE_KEYWORDS_ENUMS.keys())
-        missing = all_sources - covered_sources
-        assert covered_sources == all_sources, f"Missing sources in _TABLE_KEYWORDS_ENUMS: {missing}"
-
-    def test_table_exclusions_enums_covers_all_sources(self):
-        all_sources = set(NativeMarketingSource)
-        covered_sources = set(_TABLE_EXCLUSIONS_ENUMS.keys())
-        missing = all_sources - covered_sources
-        assert covered_sources == all_sources, f"Missing sources in _TABLE_EXCLUSIONS_ENUMS: {missing}"
 
     def test_integration_default_sources_covers_all_sources(self):
         all_sources = set(NativeMarketingSource)
@@ -109,11 +95,13 @@ class TestMarketingAnalyticsConstantsStructure:
     @parameterized.expand([(source,) for source in NativeMarketingSource])
     def test_table_patterns_has_required_keys(self, source):
         patterns = TABLE_PATTERNS[source]
-        required_keys = ["campaign_table_keywords", "campaign_table_exclusions", "stats_table_keywords"]
-        for key in required_keys:
-            assert key in patterns, f"{source}: missing '{key}'"
-            assert isinstance(patterns[key], list), f"{source}: '{key}' should be a list"
-            assert len(patterns[key]) > 0, f"{source}: '{key}' is empty"
+        stats_keywords = patterns["stats_table_keywords"]
+        assert isinstance(stats_keywords, list), f"{source}: 'stats_table_keywords' should be a list"
+        assert len(stats_keywords) > 0, f"{source}: 'stats_table_keywords' is empty"
+
+        campaign_table_name = patterns["campaign_table_name"]
+        assert isinstance(campaign_table_name, str), f"{source}: 'campaign_table_name' should be a string"
+        assert campaign_table_name, f"{source}: 'campaign_table_name' is empty"
 
 
 class TestMarketingAnalyticsConstantsConsistency:


### PR DESCRIPTION
## Problem

Stacked on top of #80556, which is the actual fix: the campaign slot now matches `campaignTableName` exactly instead of by keyword-with-exclusions, so Google Ads `campaign_budget` can no longer claim it.

I reviewed that PR and it holds up. The claim worth restating, because it is what makes the change safe: exact matching is *strictly narrower* than the old predicate. For all eight native sources `campaignTableName` contains its keyword and does not contain its exclusion, so anything the new check binds, the old one bound too. The change cannot introduce a new wrong binding — it can only fail to bind. That is what the four commits here are about: the ways it can now fail to bind, and the places that did not get the same treatment.

## Changes

Four independent commits, ordered so the least contentious come first. Each one stands alone — drop any of them.

**1. `_extract_schema_name` takes the wrong occurrence of the marker.** It used `find()`, i.e. the *first* `{source_type}_`. The source prefix is user-supplied free text (`ExternalDataSource.prefix`, unvalidated), so it can contain the marker: a `googleads_` prefix produces `googleads_googleads_campaign` and `find()` leaves `googleads_campaign`. The keyword match tolerated that — `campaign` is still a substring. Exact matching does not, so the campaign slot stays empty, `_create_native_config` returns `None`, and the whole source vanishes from the dashboard with no error to point at. `rfind` fixes it; no schema name contains the marker, so the last occurrence is always the real boundary.

**2. The new test did not exercise prefix stripping.** `_make_table` named its mocks `googleads.<schema>`, but `build_table_name` emits `{prefix}{source_type}_{schema}` and replaces dots with `__`. With a dotted name `_extract_schema_name` never finds its marker and returns the suffix untouched — so the test passed while skipping the exact part the fix depends on. Renamed to match the warehouse, plus two cases: `campaign_budget` synced *without* `campaign` (the state already-affected projects are in) must yield no config rather than a config that fails at query time; and a prefix that repeats the source type, covering commit 1. Also collapses the three identical `_make_factory` copies.

**3. The keyword patterns are dead code in the backend now.** Nothing reads `campaign_table_keywords` / `campaign_table_exclusions` after the fix — the only thing keeping them alive was a test asserting they exist, which is circular reasoning. Dropped both keys, the enum maps behind them, and their imports; the assertion now pins what the factory actually consumes.

**4. The frontend still matches by keyword.** `integrationCampaignTables` in `marketingAnalyticsSettingsLogic.ts` resolves the campaign table with the old keyword/exclusion logic — with a comment claiming it mirrors the backend — and takes the first match in `dataWarehouseTables` order. On a Google Ads project with `campaign_budget` synced it can return `googleads_campaign_budget`, which goes straight into `SELECT DISTINCT name, id FROM ${tableName}` for the campaign picker in NonIntegratedConversions, where the `catch` swallows the failure and the picker silently comes up empty. Now matches `campaignTableName` exactly, via a frontend `extractSchemaName` in `utils.ts` next to the other backend mirrors. `MARKETING_CAMPAIGN_TABLE_PATTERNS` had no callers left, so it goes.

**5. The schema fields themselves.** After commit 4 nothing reads `tableKeywords` / `tableExclusions` anywhere — eight pairs of literals generating sixteen StrEnums that describe a rule the code no longer applies. Removed from `schema-general.ts` and regenerated; `schema.json`, `schema.py` and `schema_enums.py` are generated output, deletions only.

There is also a sixth commit walking back part of commit 2: naming the mocks by calling `build_table_name` failed the tach module-boundary check, since `products.warehouse_sources` deliberately keeps its pipelines internals out of its public interface. The format stays duplicated in the test, with one line saying that the duplication is the constraint.

## How did you test this code?

- `pytest products/marketing_analytics/backend/hogql_queries/` — 619 passed, 72 snapshots unchanged (618 on the base branch; +3 new tests, -2 deleted).
- Confirmed each new test fails without its fix: the repeated-prefix case fails on `find()`, and the budget-only case is what asserts the source gets dropped.
- `tsc --noEmit`: no errors in the three touched frontend files.
- One flaky run of `test_marketing_costs_precompute::test_native_read_dedups_when_label_changes_across_jobs` (`450.0 == 300.0`, leftover ClickHouse rows). Does not reproduce in isolation or on a rerun of the full suite, and does not touch this code path.

Not run: Playwright, and verification against a real affected project.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing config or API changed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude) was asked to review #80556, and these are the four things that came out of it. The review itself checked the PR's central table independently — parsing every native source's schema catalog for `campaign` substrings — which is where the strictly-narrower property and the "Google Ads is the only collision" claim both got confirmed rather than taken on faith.

Findings 1 and 4 are the ones I would not have found from the diff alone: both are places where the surrounding code was relying on the keyword match being loose. Finding 4 in particular means the reported symptom is only half fixed by #80556 — the dashboard queries recover, the campaign picker does not.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
