### PR TITLE
fix(desktop): restore Discord release notes

### DIFF
--- a/.github/workflows/desktop-discord-release.yml
+++ b/.github/workflows/desktop-discord-release.yml
@@ -4,7 +4,6 @@ on:
     release:
         types: [published]
 
-# No GITHUB_TOKEN permissions needed -- this workflow only calls an external webhook.
 permissions: {}
 
 jobs:

--- a/.github/workflows/desktop-discord-release.yml
+++ b/.github/workflows/desktop-discord-release.yml
@@ -1,0 +1,19 @@
+name: Desktop Release to Discord
+
+on:
+    release:
+        types: [published]
+
+# No GITHUB_TOKEN permissions needed -- this workflow only calls an external webhook.
+permissions: {}
+
+jobs:
+    notify:
+        if: startsWith(github.event.release.tag_name, 'desktop-v')
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            - name: Publish release notes to Discord
+              uses: SethCohen/github-releases-to-discord@37afa88c8c9302a9307244b5a0d4e782d528a4b5 # v1.15.1
+              with:
+                  webhook_url: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}


### PR DESCRIPTION
## Problem

Desktop release notes stopped reaching the Discord release channel after the app moved into the monorepo.

**Why:** Release announcements keep desktop users informed when a new version is available.

## Changes

- Restore the release-published Discord notification workflow omitted during the repository migration.
- Limit notifications to desktop-v tags so other monorepo releases do not reach the desktop channel.
