### PR TITLE
fix(tasks): report effective runtime in task metrics

### DIFF
--- a/products/tasks/backend/tests/test_task_run_metrics.py
+++ b/products/tasks/backend/tests/test_task_run_metrics.py
@@ -87,6 +87,37 @@ class TestTaskRunMetrics(TestCase):
 
         assert _sample_value("posthog_tasks_task_run_created_total", labels) == before + 1
 
+    @parameterized.expand(
+        [
+            ("default_acp", Task.Runtime.ACP, "background", "acp", "claude"),
+            ("pi", Task.Runtime.PI, "unknown", "pi", "pi"),
+        ]
+    )
+    def test_create_run_labels_effective_runtime(
+        self,
+        _name: str,
+        task_runtime: Task.Runtime,
+        expected_mode: str,
+        expected_task_runtime: str,
+        expected_runtime_adapter: str,
+    ) -> None:
+        self.task.runtime = task_runtime
+        self.task.save(update_fields=["runtime"])
+        labels = {
+            "origin_product": "user_created",
+            "run_environment": "cloud",
+            "mode": expected_mode,
+            "run_source": "unknown",
+            "task_runtime": expected_task_runtime,
+            "runtime_adapter": expected_runtime_adapter,
+            "prewarmed": "false",
+        }
+        before = _sample_value("posthog_tasks_task_run_created_total", labels)
+
+        self.task.create_run(environment=TaskRun.Environment.CLOUD)
+
+        assert _sample_value("posthog_tasks_task_run_created_total", labels) == before + 1
+
     def test_prewarmed_run_created_carries_prewarmed_true_label(self) -> None:
         labels = {
             "origin_product": "user_created",


### PR DESCRIPTION
## Problem

Task metrics read `runtime_adapter` directly from run state. ACP runs can omit this field to use the default Claude harness. Pi runs do not use an ACP adapter. Both cases appeared as `unknown` in Grafana.

## Changes

- Report `claude` for ACP runs that use the default harness.
- Report `pi` for Pi task runs.
- Keep explicit `claude` and `codex` values unchanged.
- Keep the existing `runtime_adapter` label name so current dashboards continue to work.
- Add coverage for default ACP and Pi runs.