### PR TITLE
fix(desktop): open tasks after unarchiving

### DIFF
--- a/products/desktop/packages/ui/src/features/archive/ArchivedTasksView.tsx
+++ b/products/desktop/packages/ui/src/features/archive/ArchivedTasksView.tsx
@@ -558,20 +558,18 @@ export function ArchivedTasksView() {
 
   const isLoading = isLoadingArchived || isLoadingTasks;
 
-  const applyRestoreOutcome = (taskId: string, outcome: RestoreOutcome) => {
+  const applyRestoreOutcome = async (
+    taskId: string,
+    outcome: RestoreOutcome,
+  ): Promise<void> => {
     if (outcome.kind === "restored") {
       const navigateToTaskId = outcome.navigateToTaskId;
-      toast.success("Task unarchived", {
-        action: navigateToTaskId
-          ? {
-              label: "View task",
-              onClick: () =>
-                void queryClient
-                  .fetchQuery(taskDetailQuery(navigateToTaskId))
-                  .then(openTask),
-            }
-          : undefined,
-      });
+      toast.success("Task unarchived");
+      if (navigateToTaskId) {
+        await queryClient
+          .fetchQuery(taskDetailQuery(navigateToTaskId))
+          .then(openTask);
+      }
     } else if (outcome.kind === "branch-not-found") {
       setBranchNotFound({ taskId, branchName: outcome.branchName });
     } else {
@@ -590,7 +588,7 @@ export function ArchivedTasksView() {
   const onUnarchive = async (taskId: string) => {
     const hasTask =
       items.find((i) => i.archived.taskId === taskId)?.task != null;
-    applyRestoreOutcome(taskId, await restore(taskId, hasTask));
+    await applyRestoreOutcome(taskId, await restore(taskId, hasTask));
   };
 
   const onDelete = async (taskId: string) => {
@@ -612,7 +610,7 @@ export function ArchivedTasksView() {
     if (outcome.kind === "menu-error") {
       toast.error(`Context menu error: ${outcome.message}`);
     } else if (outcome.kind === "restore") {
-      applyRestoreOutcome(item.archived.taskId, outcome.outcome);
+      await applyRestoreOutcome(item.archived.taskId, outcome.outcome);
     } else if (outcome.kind === "delete") {
       applyDeleteOutcome(outcome.outcome);
     }
@@ -624,7 +622,7 @@ export function ArchivedTasksView() {
     setBranchNotFound(null);
     const hasTask =
       items.find((i) => i.archived.taskId === taskId)?.task != null;
-    applyRestoreOutcome(
+    await applyRestoreOutcome(
       taskId,
       await restore(taskId, hasTask, { recreateBranch: true }),
     );


### PR DESCRIPTION
## Problem

- People stay in the archive after unarchiving a task.
- **Why:** Opening the task requires a second action before work can continue.

## Changes

```mermaid
flowchart LR
    A[Unarchive task] --> B[Success toast]
    B --> C[Click View task]
```

```mermaid
flowchart LR
    A[Unarchive task] --> B[Success toast]
    B --> C[Open restored task]
```

- Successful restores now load and open the restored task.
- The behavior applies to buttons, context menus, and branch recreation.
- No screenshot: the change affects navigation, not the rendered interface.

## How did you test this code?

- Checked the desktop production build, UI typecheck, and Biome validation.
- Checked repository preflight with zero failures.
- Verified the restore paths await navigation after a successful outcome.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No docs update. Existing documentation does not describe post-unarchive navigation.

## 🤖 Agent context

- **Autonomy:** Human-driven (agent-assisted)
- PostHog Code implemented and validated this change.
- Skills: `writing-user-facing-copy`, `writing-tests`, `running-ci-preflight`, and `writing-pr-descriptions`.
- No external or private source material entered the public diff.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*