### PR TITLE
fix(slack_app): stop asking who authors the PR before starting a task

### DIFF
--- a/posthog/temporal/ai/slack_app/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/slack_app/posthog_code_slack_mention.py
@@ -294,13 +294,6 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
                             )
                             return
                         repository = self._selected_repo
-            if repository:
-                # A resolved repository is the one place a GitHub requirement is not a
-                # guess, so authorship is still settled before the sandbox starts: without
-                # a usable install the run would fail partway through the clone.
-                workflow.deprecate_patch("posthog-code-authorship-confirm-2026-06")
-                if await self._resolve_authorship(inputs, channel, thread_ts, slack_user_id, user_id, repository):
-                    return
             # Read a per-task model choice ("use fable for this one") out of the
             # mention. Runs here, past every gate that can still abandon the
             # mention, so the reply announcing the model only ever describes a task

--- a/posthog/temporal/tests/ai/slack_app/test_slack_app_mention_workflow.py
+++ b/posthog/temporal/tests/ai/slack_app/test_slack_app_mention_workflow.py
@@ -64,6 +64,8 @@ class _Recorder:
         self.cascade_modes: dict[str, Literal["auto", "no_repo", "agent_needed", "needs_user_github"]] = {}
         # ts per personal-GitHub gate call, in execution order.
         self.github_gate_calls: list[str] = []
+        # repository per authorship-gate call, in execution order.
+        self.authorship_calls: list[str] = []
         # event text per needs-repo classifier call, in execution order.
         self.needs_repo_calls: list[str] = []
         # ts -> gate the create-task fake blocks on, to hold a message mid-processing.
@@ -159,7 +161,10 @@ def _fake_activities(rec: _Recorder) -> list:
         workflow_id: str,
         repository: str,
     ) -> str:
-        return "proceed"
+        rec.authorship_calls.append(repository)
+        # Blocks whenever it is reached, so a test that expects a task can only pass
+        # by not reaching it.
+        return "blocked"
 
     @activity.defn(name="block_posthog_code_task_if_no_personal_github_activity")
     async def block_github(
@@ -403,6 +408,18 @@ async def test_mention_resolving_no_repo_creates_a_task_without_the_github_gate(
     assert rec.created == [("1.1", None)]
     assert rec.github_gate_calls == []
     assert rec.needs_repo_calls == []
+
+
+@pytest.mark.asyncio
+async def test_mention_resolving_a_repo_creates_a_task_without_the_authorship_gate():
+    rec = _Recorder()
+
+    async with _Harness(rec) as h:
+        handle = await _signal_with_start(h.env, h.task_queue, f"wf-{uuid.uuid4()}", _message("1.1"))
+        await asyncio.wait_for(handle.result(), timeout=30)
+
+    assert rec.created == [("1.1", "org/auto-repo")]
+    assert rec.authorship_calls == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

A Slack user mentions `@PostHog` on a repository their personal GitHub cannot author in, and the task stops to ask them to click "Continue as PostHog" before anything starts. The click decides nothing — task creation had already resolved who authors the PR.

Stacked on #80074, which stops the same mention path refusing repo-less asks.

## Changes

Removes the authorship gate from the mention workflow. `create_task_and_run_state` already resolves authorship on its own: `get_pr_authorship_mode` returns `USER` for Slack-origin tasks without consulting the team install, the mentioner's personal integration is used whenever it is present and usable, and the team install is the fallback. `_resolve_cloud_pr_authorship_mode` does the same at run time. The gate re-derived that decision one step earlier and interrupted for a confirmation.

The confirmation carried nothing: `authorship_confirmed` is a bare signal that releases a `wait_condition`, with no payload and no state written. Clicking it never influenced which credentials the run used.

What changes for a person:

- A repo the personal install can author: unchanged, still authored by them.
- A repo only the team install can author: the task starts immediately instead of waiting on a click, and the PR is authored by the PostHog bot — the same outcome the click produced.
- A stale or revoked personal install: proceeds under the team install rather than being refused.

No patch guard. The only durable wait after the activity was recorded was the confirmation itself, which requires the bot-PRs flag; without it an execution that reached the gate is seconds from completing, so there is no in-flight history to protect.

Follow-up, not in this PR: `resolve_posthog_code_authorship_activity` and `post_posthog_code_authorship_timeout_activity` are now unreachable from the mention path, along with `_handle_continue_as_bot` and its routing in `products/slack_app/backend/api.py`. That sweep is mechanical and touches its own tests, so it is kept separate.

## How did you test this code?

- The authorship fake in `test_slack_app_mention_workflow.py` now records its calls and blocks whenever it is reached, so any test expecting a task can only pass by not reaching it — nothing previously pinned this, because the fake returned `proceed` unconditionally.
- New test `test_mention_resolving_a_repo_creates_a_task_without_the_authorship_gate` states the rule directly for the repo-resolved path.
- Ran `posthog/temporal/tests/ai/slack_app/test_slack_app_mention_workflow.py` — 11 passed.
- Not tested manually against a live Slack workspace.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code.
- Started as a question about whether the gate could go entirely, given the personal-then-team fallback already exists downstream. Verified the precedence in `models.py`, `process_task/utils.py`, and `facade/api.py` before removing anything.
- A patch guard was drafted first and dropped: the gate's only durable wait is behind a flag that is not on, so the replay window it would protect does not exist.
- No customer data or Slack thread contents included.
