### PR TITLE
fix(data-warehouse): coalesce Arrow tables in the batcher so chunk caps apply

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/batcher.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/batcher.py
@@ -64,6 +64,11 @@ def _split_table(table: pa.Table, *, offset_limit: int, bytes_limit: int) -> lis
 class Batcher:
     _buffer: list[Any]
     _buffer_size_bytes: int
+    _table_buffer: list[pa.Table]
+    _table_buffer_rows: int
+    _table_buffer_bytes: int
+    _table_buffer_schema: Optional[pa.Schema]
+    _coalesce_tables: bool
     _ready: deque[pa.Table]
     _logger: FilteringBoundLogger
     _chunk_size: int
@@ -84,6 +89,7 @@ class Batcher:
         source_type: Optional[str] = None,
         team_id: Optional[int] = None,
         schema_name: Optional[str] = None,
+        coalesce_tables: bool = False,
     ) -> None:
         self._logger = logger
 
@@ -97,9 +103,19 @@ class Batcher:
         self._source_type = source_type
         self._team_id = team_id
         self._schema_name = schema_name
+        # Off by default because coalescing delays when a yielded table becomes a durable batch:
+        # sources that checkpoint resume state or delete upstream staging right after yielding
+        # (ResumableSource implementations, the webhook S3 path) rely on yield => persisted and
+        # would lose data across a crash if their tables sat in this buffer. Only enable for
+        # sources with no such dependency.
+        self._coalesce_tables = coalesce_tables
 
         self._buffer = []
         self._buffer_size_bytes = 0
+        self._table_buffer = []
+        self._table_buffer_rows = 0
+        self._table_buffer_bytes = 0
+        self._table_buffer_schema = None
         self._ready = deque()
 
     def _set_ready(self, table: pa.Table) -> None:
@@ -117,7 +133,9 @@ class Batcher:
         report_buffer_bytes(payload_bytes)
         if self._source_type is not None:
             # The materialised table is the true in-memory peak (an unbounded source yields one giant
-            # list -> one giant table here, before the split into bounded chunks).
+            # list -> one giant table here, before the split into bounded chunks). With table
+            # coalescing this is the whole coalesced batch, not one source yield; the buffered input
+            # tables it was concatenated from share its buffers, so it still measures the real peak.
             record_table_stats(
                 source_type=self._source_type,
                 stage="batcher",
@@ -137,6 +155,89 @@ class Batcher:
             )
         self._ready = deque(chunks)
 
+    def _batch_table(self, table: pa.Table) -> None:
+        """Buffer `table` and flush the accumulated buffer once `_chunk_size` / `_chunk_size_bytes`
+        is reached, so a source's per-yield fetch size doesn't dictate batch granularity (a driver
+        fetching 10k rows per Arrow table would otherwise emit one queue batch per fetch).
+
+        Bytes are counted as each table arrives, and a table that would push the buffer past
+        `_chunk_size_bytes` flushes the buffer *before* joining it, so buffered payload never
+        exceeds the byte cap unless a single table does on its own. With the default caps
+        (200 MiB chunk vs 256 MiB max table) the flushed batch stays under `_max_table_bytes`,
+        so `_split_table` doesn't undo the coalescing, and accumulation memory stays bounded on
+        pods where memory is the constraint.
+        """
+        table_bytes = table_payload_bytes(table)
+
+        if not self._table_buffer:
+            self._start_table_buffer(table, table_bytes)
+            self._flush_table_buffer_if_full()
+            return
+
+        unified_schema = self._unify_schema_or_none(table.schema)
+        would_overflow = (
+            self._table_buffer_rows + table.num_rows > self._chunk_size
+            or self._table_buffer_bytes + table_bytes > self._chunk_size_bytes
+        )
+        if unified_schema is None or would_overflow:
+            if unified_schema is None:
+                self._logger.info(
+                    "batcher_flush_on_schema_drift",
+                    buffered_rows=self._table_buffer_rows,
+                    incoming_rows=table.num_rows,
+                )
+            # `_set_ready` replaces `_ready` wholesale, so only one flush can happen per
+            # `batch()` call; the incoming table waits in a fresh buffer until the next
+            # call (or `get_table` at end of stream) flushes it.
+            self._flush_table_buffer()
+            self._start_table_buffer(table, table_bytes)
+            return
+
+        self._table_buffer.append(table)
+        self._table_buffer_rows += table.num_rows
+        self._table_buffer_bytes += table_bytes
+        self._table_buffer_schema = unified_schema
+        self._flush_table_buffer_if_full()
+
+    def _unify_schema_or_none(self, schema: pa.Schema) -> Optional[pa.Schema]:
+        """Permissively unify `schema` with the buffered schema, or None if they can't be merged.
+
+        Permissive promotion (nullability, new columns, numeric widening) matches how
+        `S3BatchWriter.write_batch` already unifies schemas across batches, so coalescing doesn't
+        reject drift the writer would have accepted. Non-promotable drift (e.g. int64 vs string)
+        returns None and the caller flushes, yielding the same per-table failure surface the
+        writer had.
+        """
+        assert self._table_buffer_schema is not None
+        try:
+            return pa.unify_schemas([self._table_buffer_schema, schema], promote_options="permissive")
+        except (pa.ArrowInvalid, pa.ArrowTypeError):
+            return None
+
+    def _start_table_buffer(self, table: pa.Table, table_bytes: int) -> None:
+        self._table_buffer = [table]
+        self._table_buffer_rows = table.num_rows
+        self._table_buffer_bytes = table_bytes
+        self._table_buffer_schema = table.schema
+
+    def _flush_table_buffer_if_full(self) -> None:
+        if self._table_buffer_rows >= self._chunk_size or self._table_buffer_bytes >= self._chunk_size_bytes:
+            self._flush_table_buffer()
+
+    def _flush_table_buffer(self) -> None:
+        if len(self._table_buffer) == 1:
+            table = self._table_buffer[0]
+        else:
+            # Zero-copy for matching schemas (the output table references the buffered chunks);
+            # only columns needing promotion are cast, so the flush doesn't double peak memory
+            # in the common no-drift case.
+            table = pa.concat_tables(self._table_buffer, promote_options="permissive")
+        self._table_buffer = []
+        self._table_buffer_rows = 0
+        self._table_buffer_bytes = 0
+        self._table_buffer_schema = None
+        self._set_ready(table)
+
     def _estimate_size(self, obj: Any) -> int:
         if isinstance(obj, dict):
             return sys.getsizeof(obj) + sum(self._estimate_size(k) + self._estimate_size(v) for k, v in obj.items())
@@ -148,6 +249,11 @@ class Batcher:
     def batch(self, item: list[Any] | dict | pa.Table) -> None:
         if self._ready:
             raise Exception("Batcher already has a table ready to yield. Call get_table() before batching more items.")
+
+        # Mirror of the pa.Table guard below: buffered tables and buffered rows can't be merged
+        # into one batch, so mixing them would silently reorder or drop data on flush.
+        if self._table_buffer and not isinstance(item, pa.Table):
+            raise Exception("Cannot batch list/dict rows while pa.Tables are buffered; call get_table() first")
 
         if isinstance(item, list):
             if len(self._buffer) > 0:
@@ -176,12 +282,15 @@ class Batcher:
             self._logger.debug(f"Processing buffer (dict). Length of buffer = {len(self._buffer)}")
             self._set_ready(table_from_py_list(self._buffer))
         elif isinstance(item, pa.Table):
-            # A pa.Table is self-contained and bypasses the buffer. Clearing the buffer
+            # A pa.Table never joins the list/dict buffer. Clearing the buffer
             # below would silently drop any rows accumulated from earlier list/dict
             # items, so treat a non-empty buffer here as a programming error rather than
             # losing data. (In practice sources emit only one item type, never a mix.)
             if self._buffer:
                 raise Exception("Cannot batch a pa.Table while list/dict rows are buffered; call get_table() first")
+            if self._coalesce_tables:
+                self._batch_table(item)
+                return
             self._set_ready(item)
         else:
             raise Exception(f"Unhandled item type: {item.__class__.__name__}")
@@ -194,7 +303,7 @@ class Batcher:
 
     def should_yield(self, include_incomplete_chunk: bool = False) -> bool:
         if include_incomplete_chunk:
-            return len(self._ready) > 0 or len(self._buffer) > 0
+            return len(self._ready) > 0 or len(self._buffer) > 0 or len(self._table_buffer) > 0
 
         return len(self._ready) > 0
 
@@ -204,6 +313,12 @@ class Batcher:
             self._set_ready(table_from_py_list(self._buffer))
             self._buffer = []
             self._buffer_size_bytes = 0
+
+        # End-of-stream flush of a partial Arrow buffer, matching the list/dict path above;
+        # dropping it would lose every row batched since the last full chunk.
+        if not self._ready and len(self._table_buffer) > 0:
+            self._logger.debug(f"Processing leftover table buffer. Buffered tables = {len(self._table_buffer)}")
+            self._flush_table_buffer()
 
         if self._ready:
             return self._ready.popleft()

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_batcher.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_batcher.py
@@ -316,6 +316,122 @@ def test_batcher_does_not_split_small_table_under_byte_cap():
     assert drained[0].equals(table)
 
 
+def test_coalescing_pa_tables_accumulates_to_row_cap():
+    batcher = Batcher(logger=mock.MagicMock(), chunk_size=10, coalesce_tables=True)
+
+    tables = [pa.table({"id": [i * 2, i * 2 + 1]}) for i in range(6)]
+    yielded = []
+    for table in tables:
+        batcher.batch(table)
+        while batcher.should_yield():
+            yielded.append(batcher.get_table())
+
+    # 5 x 2-row tables buffer silently; the 5th reaches the 10-row cap and flushes as one batch.
+    assert len(yielded) == 1
+    assert yielded[0].num_rows == 10
+    while batcher.should_yield(include_incomplete_chunk=True):
+        yielded.append(batcher.get_table())
+    combined = pa.concat_tables(yielded)
+    assert combined.column("id").to_pylist() == list(range(12))
+
+
+def test_coalescing_disabled_by_default_keeps_one_yield_one_batch():
+    batcher = Batcher(logger=mock.MagicMock(), chunk_size=1_000)
+    table = pa.table({"id": [1, 2]})
+
+    batcher.batch(table)
+
+    assert batcher.should_yield() is True
+    assert batcher.get_table().equals(table)
+
+
+def test_coalescing_flushes_buffer_before_byte_cap_is_exceeded():
+    table = pa.table({"id": [1, 2], "val": ["aa", "bb"]})
+    per_table = table_payload_bytes(table)
+    # Cap fits 2 tables but not 3, so the 3rd must flush the buffer *without* joining it.
+    cap = per_table * 2 + per_table // 2
+    batcher = Batcher(logger=mock.MagicMock(), chunk_size_bytes=cap, coalesce_tables=True)
+
+    batcher.batch(table)
+    batcher.batch(table)
+    assert batcher.should_yield() is False
+
+    # The flushed batch stays within chunk_size_bytes (which keeps it under max_table_bytes,
+    # so _split_table doesn't undo the coalescing) and the 3rd table starts the next buffer.
+    batcher.batch(table)
+    assert batcher.should_yield() is True
+    flushed = batcher.get_table()
+    assert flushed.num_rows == 4
+    assert table_payload_bytes(flushed) <= cap
+
+    assert batcher.should_yield(include_incomplete_chunk=True) is True
+    assert batcher.get_table().equals(table)
+
+
+def test_coalescing_oversized_single_table_flushes_alone_without_waiting():
+    table = pa.table({"id": [1, 2], "val": ["aa", "bb"]})
+    batcher = Batcher(logger=mock.MagicMock(), chunk_size_bytes=1, coalesce_tables=True)
+
+    batcher.batch(table)
+
+    assert batcher.should_yield() is True
+    assert batcher.get_table().equals(table)
+
+
+def test_coalescing_promotes_compatible_schema_drift():
+    batcher = Batcher(logger=mock.MagicMock(), chunk_size=4, coalesce_tables=True)
+
+    batcher.batch(pa.table({"a": pa.array([1, 2], pa.int64()), "b": ["x", "y"]}))
+    batcher.batch(pa.table({"a": pa.array([1.5, 2.5], pa.float64())}))
+
+    assert batcher.should_yield() is True
+    flushed = batcher.get_table()
+    assert flushed.num_rows == 4
+    assert flushed.schema.field("a").type == pa.float64()
+    assert flushed.column("b").to_pylist() == ["x", "y", None, None]
+
+
+def test_coalescing_flushes_on_non_promotable_schema_drift():
+    batcher = Batcher(logger=mock.MagicMock(), chunk_size=1_000, coalesce_tables=True)
+    int_table = pa.table({"a": pa.array([1, 2], pa.int64())})
+    str_table = pa.table({"a": pa.array(["x", "y"], pa.string())})
+
+    batcher.batch(int_table)
+    assert batcher.should_yield() is False
+
+    # int64 -> string can't be promoted, so the buffered table flushes as-is and the
+    # incompatible one starts a new buffer instead of crashing pa.concat_tables.
+    batcher.batch(str_table)
+    assert batcher.should_yield() is True
+    assert batcher.get_table().equals(int_table)
+
+    assert batcher.should_yield(include_incomplete_chunk=True) is True
+    assert batcher.get_table().equals(str_table)
+
+
+def test_coalescing_partial_buffer_flushes_at_end_of_stream():
+    batcher = Batcher(logger=mock.MagicMock(), chunk_size=1_000, coalesce_tables=True)
+
+    batcher.batch(pa.table({"id": [1, 2]}))
+    batcher.batch(pa.table({"id": [3]}))
+
+    # Below the caps nothing is ready, but the end-of-stream drain must still see and
+    # flush the buffered tables; dropping them would silently lose the sync's tail.
+    assert batcher.should_yield() is False
+    assert batcher.should_yield(include_incomplete_chunk=True) is True
+    assert batcher.get_table().column("id").to_pylist() == [1, 2, 3]
+    assert batcher.should_yield(include_incomplete_chunk=True) is False
+
+
+def test_batching_list_while_tables_buffered_raises():
+    batcher = Batcher(logger=mock.MagicMock(), chunk_size=1_000, coalesce_tables=True)
+
+    batcher.batch(pa.table({"id": [1]}))
+
+    with pytest.raises(Exception, match="Cannot batch list/dict rows while pa.Tables are buffered"):
+        batcher.batch([{"id": 2}])
+
+
 def test_batching_should_not_yield_when_buffer_not_full():
     batcher = Batcher(logger=mock.MagicMock(), chunk_size=5, chunk_size_bytes=1000)
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
@@ -212,6 +212,11 @@ class PipelineV3(Generic[ResumableData]):
         self._resumable_source_manager = resumable_source_manager
         # A source can shrink the batcher chunk (e.g. document sources with large rows) so the
         # source->Arrow conversion doesn't materialise an oversized table; None falls back to defaults.
+        # Arrow coalescing keeps a driver's fetch size (e.g. a SQL cursor's 10k-row Arrow tables)
+        # from becoming the queue's batch granularity, but it delays when a yielded table is
+        # persisted, so it must stay off for sources that treat yield as durable: resumable
+        # sources checkpoint resume state right after yielding, and the webhook path deletes its
+        # staged S3 files right after yielding.
         self._batcher = Batcher(
             self._logger,
             chunk_size=source_response.chunk_size,
@@ -219,6 +224,7 @@ class PipelineV3(Generic[ResumableData]):
             source_type=self._source.source_type if self._source else None,
             team_id=self._job.team_id,
             schema_name=self._schema.name,
+            coalesce_tables=resumable_source_manager is None and not self._schema.is_webhook,
         )
         self._internal_schema = HogQLSchema()
         self._sinks = build_pipeline_sinks(

--- a/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/test_end_to_end.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/test_end_to_end.py
@@ -1722,6 +1722,11 @@ async def test_delta_no_merging_on_first_sync(team, postgres_config, postgres_co
         mock.patch(
             "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres._get_table_chunk_size"
         ) as mock_chunk_size,
+        # The pipeline batcher coalesces the source's 1-row Arrow tables back into one batch
+        # unless its own row cap is pinned to 1; this test needs two batches to reach the loader.
+        mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.pipelines.core.batcher.DEFAULT_CHUNK_SIZE", 1
+        ),
         mock.patch.object(DeltaTable, "merge") as mock_merge,
         mock.patch.object(deltalake, "write_deltalake") as mock_write,
         mock.patch.object(PipelineNonDLT, "_post_run_operations") as mock_post_run_operations,
@@ -1915,6 +1920,11 @@ async def test_delta_no_merging_on_first_sync_after_reset(team, postgres_config,
         mock.patch(
             "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres._get_table_chunk_size"
         ) as mock_chunk_size,
+        # The pipeline batcher coalesces the source's 1-row Arrow tables back into one batch
+        # unless its own row cap is pinned to 1; this test needs two batches to reach the loader.
+        mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.pipelines.core.batcher.DEFAULT_CHUNK_SIZE", 1
+        ),
         mock.patch.object(DeltaTable, "merge") as mock_merge,
         mock.patch.object(deltalake, "write_deltalake") as mock_write,
         mock.patch.object(PipelineNonDLT, "_post_run_operations") as mock_post_run_operations,


### PR DESCRIPTION
## Problem

A first sync of a large table from an Arrow-yielding source can produce tens of thousands of tiny v3 queue batches, and the queue drains them slowly enough to back up the whole loader.

- Each batch costs a queue row, a claim, an S3 read, and a Delta commit, and batches within a (team, schema) group load serially.
- The `Batcher` has row and byte caps (`chunk_size`, `chunk_size_bytes`), but the `pa.Table` branch bypasses them: one yielded table becomes one queue batch.
- The driver's fetch size therefore sets batch granularity. Databricks fetches 10k rows per Arrow table, so a 500M-row sync becomes 50,000 batches; MotherDuck fetches 5k, MySQL and MSSQL cap at 20k.

## Changes

- The batcher now buffers consecutive `pa.Table` inputs and concatenates them once the row cap (500k rows) or byte cap (200 MiB) is reached, so the existing caps apply to Arrow sources. For Databricks-sized yields that is up to 50x fewer batches.
- Byte accounting runs during accumulation with `table_payload_bytes`. A table that would push the buffer past the byte cap flushes the buffer before joining it, so buffered payload never exceeds the cap unless a single table does on its own, and the flushed batch stays under the 256 MiB `_max_table_bytes` split limit instead of being re-split.
- Schema drift between consecutive tables unifies with `promote_options="permissive"`, matching how `S3BatchWriter.write_batch` already unifies batch schemas. Non-promotable drift (int vs string) flushes the buffer and starts a new one instead of crashing `pa.concat_tables`.
- `should_yield(include_incomplete_chunk=True)` reports the Arrow buffer and `get_table()` flushes a partial buffer at end of stream, so the drain protocol both pipelines use loses no tail rows.

> [!WARNING]
> Coalescing is opt-in (`coalesce_tables=False` by default) and only the v3 pipeline enables it, and only when the source is neither resumable nor webhook-fed. Resumable sources checkpoint resume state right after yielding, and the webhook path deletes its staged S3 files right after yielding. Both treat yield as durable, so buffering their tables would lose data if the worker crashed before the flush. All SQL-family sources (Databricks, Snowflake, MotherDuck, Postgres, MySQL, MSSQL, Redshift, BigQuery, ClickHouse) are non-resumable `SimpleSource`s and get coalescing.

- The v2 pipeline and source-internal batchers keep the old bypass behavior via the default.
- Memory: `pa.concat_tables` is zero-copy when schemas match (the output references the buffered chunks), so the flush does not double peak memory in the no-drift case. The `stage="batcher"` telemetry now measures the coalesced batch, which is still the true in-memory peak.

## How did you test this code?

- New batcher tests cover: coalescing to the row cap (catches the caps going dead again for Arrow input), flushing before the byte cap is exceeded (catches unbounded accumulation and split-undo), permissive promotion and flush-on-incompatible-drift (catches a concat crash on drifting schemas), partial-buffer flush at end of stream (catches tail-row loss), and the new list-while-tables-buffered guard.
- `coalesce_tables` defaults off, and an existing test now pins that the default keeps one yield = one batch.
- Ran the full `pipelines/` pytest suite and repo-wide `uv run mypy --cache-fine-grained .` locally; both clean. 61 suite errors in one full run were shared-dev-DB fixture contention and pass standalone.
- Not run: an end-to-end sync against a live SQL source; the batch-count reduction is verified at the batcher level only.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal pipeline behavior, no user-facing or documented workflow change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code from a written task brief. Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions. Before changing the contract, an exploration pass enumerated every Arrow-yielding source and whether it depends on a 1:1 yield-to-batch mapping; that audit produced the resumable/webhook gate above, since ~30 resumable sources and all webhook-fed sources checkpoint or delete upstream state right after yielding. No customer data or internal metrics are included; sizing numbers are derived from constants in the code.
