### PR TITLE
fix(data-warehouse): give superseded v3 batches their own terminal state

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
@@ -190,9 +190,10 @@ class DeltaBatchConsumerAdapter:
         batch_created_at: datetime | None = None,
         expected_state_changed_at: datetime | None | _Unset = _UNSET,
     ) -> None:
-        # 'failed' is absorbing: fail_run can retire a claimed batch mid-flight, and a
-        # newer write would supersede it — un-failing a cancelled run. Takeover-sentinel
-        # failures stay supersedable (see _is_job_dead's matching exemption).
+        # 'failed' and 'superseded' are absorbing: fail_run or the supersede sweep can
+        # retire a claimed batch mid-flight, and a newer write would supersede it —
+        # un-retiring a cancelled or replaced run. Takeover-sentinel failures stay
+        # supersedable (see _is_job_dead's matching exemption).
         # expected_state_changed_at additionally fences the recovery re-queue against a
         # live owner that completed the batch after the stale scan (see the sweep).
         inserted = await BatchQueue.update_status_unless_failed(

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
@@ -190,12 +190,12 @@ def build_status_dual_write_unless_failed_sql(
     *, with_batch_created_at: bool, with_expected_state_changed_at: bool = False
 ) -> str:
     """Guarded twin of :func:`build_status_dual_write_sql`: inserts nothing over a
-    terminal 'failed', so a consumer's newer executing/succeeded rows can't
-    un-retire a batch fail_run already failed. A 'failed' carrying
-    ``%(supersedable_failed_error)s`` (the lock-takeover sentinel) stays writable —
-    takeover deliberately lets an in-flight batch finish. Returns the INSERT count
-    (0 = refused); the column UPDATE is a designed no-op for heartbeat re-inserts,
-    so its rowcount can't be the signal.
+    terminal 'failed' or 'superseded', so a consumer's newer executing/succeeded
+    rows can't un-retire a batch fail_run or supersede_other_runs already retired.
+    A 'failed' carrying ``%(supersedable_failed_error)s`` (the lock-takeover
+    sentinel) stays writable — takeover deliberately lets an in-flight batch
+    finish. Returns the INSERT count (0 = refused); the column UPDATE is a
+    designed no-op for heartbeat re-inserts, so its rowcount can't be the signal.
 
     ``with_expected_state_changed_at`` arms a compare-and-swap on the caller's
     observed ``state_changed_at`` — the recovery sweep's fence against a live owner
@@ -222,7 +222,7 @@ def build_status_dual_write_unless_failed_sql(
             WHERE b.id = %(batch_id)s
               AND {created_at_predicate}
               AND (
-                  b.latest_state IS DISTINCT FROM 'failed'
+                  b.latest_state NOT IN ('failed', 'superseded')
                   OR s.error_response->>'error' = %(supersedable_failed_error)s
               ){cas_predicate}
             FOR UPDATE OF b
@@ -248,13 +248,17 @@ def build_status_dual_write_unless_failed_sql(
     """
 
 
-def _bulk_fail_dual_write_sql(where_sql: str) -> str:
-    """Bulk 'failed' status inserts plus the denormalized-state UPDATE, one statement.
+def _bulk_fail_dual_write_sql(where_sql: str, *, terminal_state: str = "failed") -> str:
+    """Bulk terminal-status inserts plus the denormalized-state UPDATE, one statement.
 
-    ``targets`` carries ``(id, created_at)`` so the UPDATE join prunes partitions
-    exactly; rowcount reports updated batches (== inserted statuses, minus any a
-    concurrent newer write already superseded via the monotonic guard).
+    ``terminal_state`` is 'failed' or 'superseded': both retire the run for the
+    claim path, but only 'failed' feeds the reconcile sweep. ``targets`` carries
+    ``(id, created_at)`` so the UPDATE join prunes partitions exactly; rowcount
+    reports updated batches (== inserted statuses, minus any a concurrent newer
+    write already superseded via the monotonic guard).
     """
+    if terminal_state not in ("failed", "superseded"):
+        raise ValueError(f"unsupported terminal state: {terminal_state!r}")
     return f"""
         WITH targets AS (
             SELECT b.id, b.created_at
@@ -267,12 +271,12 @@ def _bulk_fail_dual_write_sql(where_sql: str) -> str:
         ),
         ins AS (
             INSERT INTO {STATUS_TABLE} (batch_id, job_state, attempt, exec_time, error_response, created_at)
-            SELECT t.id, 'failed', 0, now(), %(error_response)s, now()
+            SELECT t.id, '{terminal_state}', 0, now(), %(error_response)s, now()
             FROM targets t
             RETURNING batch_id, created_at
         )
         UPDATE {BATCH_TABLE} b
-        SET latest_state = 'failed', latest_attempt = 0, state_changed_at = ins.created_at
+        SET latest_state = '{terminal_state}', latest_attempt = 0, state_changed_at = ins.created_at
         FROM ins
         JOIN targets t ON t.id = ins.batch_id
         WHERE b.id = t.id
@@ -297,7 +301,7 @@ def _state_claim_candidates_sql(sync_type_scope: str = "") -> str:
     """Claimable-batch candidates read from the denormalized state columns.
 
     The claimable scan and every NOT EXISTS gate are answered by the partial
-    indexes (sb_claimable_idx, sb_run_gate_idx, sb_schema_busy_idx), so the
+    indexes (sb_claimable_idx, sb_run_gate2_idx, sb_schema_busy_idx), so the
     work tracks the claimable set instead of everything retained. 'pending'
     means no status row yet; 'waiting' is deliberately not claimable.
 
@@ -350,12 +354,16 @@ def _state_claim_candidates_sql(sync_type_scope: str = "") -> str:
                         )
                     )
             )
+            -- Run-failed gate: 'superseded' must stay in this set. A superseded
+            -- run can still receive straggler inserts from its in-flight
+            -- producer; if superseded rows stopped matching here, those
+            -- stragglers would become claimable and revive the retired run.
             AND NOT EXISTS (
                 SELECT 1
                 FROM {BATCH_TABLE} b2
                 WHERE b2.run_uuid = b.run_uuid
                     AND b2.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
-                    AND b2.latest_state = 'failed'
+                    AND b2.latest_state IN ('failed', 'superseded')
             )
             AND NOT EXISTS (
                 SELECT 1
@@ -1050,9 +1058,20 @@ class BatchQueue:
         job_id: str,
         current_run_uuid: str,
     ) -> int:
-        """Mark non-terminal batches from older runs of the same job as superseded."""
+        """Mark non-terminal batches from older runs of the same job as superseded.
+
+        'superseded' is its own terminal state, not a flavor of 'failed': it retires
+        the run for the claim path exactly like 'failed' does, but the reconcile
+        sweep never scans it, because superseded rows are routine (every retried job
+        produces them) and there is no ExternalDataJob left to fail. The redundant
+        ``superseded`` flag in ``error_response`` is kept so rows written by either
+        code version read the same during a rollout.
+        """
         cursor = conn.execute(
-            _bulk_fail_dual_write_sql("b.job_id = %(job_id)s AND b.run_uuid != %(current_run_uuid)s"),
+            _bulk_fail_dual_write_sql(
+                "b.job_id = %(job_id)s AND b.run_uuid != %(current_run_uuid)s",
+                terminal_state="superseded",
+            ),
             {
                 "job_id": job_id,
                 "current_run_uuid": current_run_uuid,
@@ -1106,6 +1125,12 @@ class BatchQueue:
                         AND s.job_state = 'failed'
                         AND s.created_at <= now() - make_interval(secs => %(grace)s)
                         AND s.created_at >= now() - make_interval(secs => %(lookback)s)
+                        -- Superseded batches carry latest_state='superseded' and so
+                        -- never enter this scan; they were the bulk of the 'failed'
+                        -- set when a failure storm made this sort spill to disk.
+                        -- This flag filter only covers rows written before the
+                        -- distinct state existed, until they age out of the
+                        -- pruning window.
                         AND COALESCE((s.error_response->>'superseded')::boolean, false) = false
                     ORDER BY b.run_uuid, s.created_at DESC
                 ) failed_runs
@@ -1147,7 +1172,8 @@ class BatchQueue:
         deliberately do not reset the clock, mirroring ``get_run_activity_summary``, so a live producer
         streaming into a dead loader still reads as stale. A live group lease means a pod is actively
         working the group (making progress, or the recovery sweep reclaims it on lease expiry), so those
-        are excluded. Runs with a ``failed`` batch are excluded — ``get_failed_runs`` owns those.
+        are excluded. Runs with a ``failed`` batch are excluded — ``get_failed_runs`` owns those. So are
+        runs with a ``superseded`` batch, whose job now belongs to the run that superseded them.
 
         Seeded from the cheap denormalized-state index (oldest-batch-first, so the bounded candidate
         window always holds the longest-stranded runs rather than an arbitrary set), then the full-run
@@ -1168,11 +1194,14 @@ class BatchQueue:
                           WHERE l.team_id = b.team_id AND l.schema_id = b.schema_id
                             AND l.expires_at > now()
                       )
+                      -- 'superseded' must keep excluding here: sweeping a superseded
+                      -- run would fail its ExternalDataJob, which is the same job its
+                      -- live replacement run is still working on.
                       AND NOT EXISTS (
                           SELECT 1 FROM {BATCH_TABLE} bf
                           WHERE bf.run_uuid = b.run_uuid
                             AND bf.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
-                            AND bf.latest_state = 'failed'
+                            AND bf.latest_state IN ('failed', 'superseded')
                       )
                     -- Oldest-batch-first, so the window can't be starved by an arbitrary set of
                     -- not-yet-stale runs the outer HAVING later rejects: the longest-stranded runs
@@ -1250,13 +1279,13 @@ class BatchQueue:
 
         Non-terminal means unclaimed ('pending', 'waiting') or claimed but unfinished
         ('executing', 'waiting_retry'), read from the denormalized state columns.
-        Runs containing a 'failed' batch are excluded, mirroring the loader's claim
-        gate: their remaining batches can never be claimed (a batch enqueued into a
-        run after ``fail_run`` swept it stays 'pending' forever — seen in production),
-        so counting them would hold the backpressure guard down for the whole pruning
-        window. Sync because its caller is the CDC producer's backpressure guard,
-        which runs in synchronous activity code. Bounded to the pruning window —
-        older batches are gone anyway.
+        Runs containing a 'failed' or 'superseded' batch are excluded, mirroring the
+        loader's claim gate: their remaining batches can never be claimed (a batch
+        enqueued into a run after ``fail_run`` or the supersede sweep retired it
+        stays 'pending' forever — seen in production), so counting them would hold
+        the backpressure guard down for the whole pruning window. Sync because its
+        caller is the CDC producer's backpressure guard, which runs in synchronous
+        activity code. Bounded to the pruning window — older batches are gone anyway.
         """
         with conn.cursor() as cur:
             cur.execute(
@@ -1274,7 +1303,7 @@ class BatchQueue:
                           AND b_failed.team_id = b.team_id
                           AND b_failed.schema_id = b.schema_id
                           AND b_failed.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
-                          AND b_failed.latest_state = 'failed'
+                          AND b_failed.latest_state IN ('failed', 'superseded')
                   )
                 """,
                 {"team_id": team_id, "schema_ids": schema_ids},
@@ -1349,7 +1378,7 @@ class BatchQueue:
                     COUNT(*) AS batch_count,
                     COUNT(*) FILTER (
                         WHERE s.batch_id IS NULL
-                            OR s.job_state NOT IN ('succeeded', 'failed')
+                            OR s.job_state NOT IN ('succeeded', 'failed', 'superseded')
                     ) AS non_terminal_count,
                     MAX(s.created_at) AS last_status_write_at,
                     MIN(b.created_at) FILTER (WHERE s.batch_id IS NULL) AS oldest_unclaimed_at

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
@@ -88,9 +88,10 @@ def _ensure_tables(conn: psycopg.Connection[Any]) -> None:
         CREATE INDEX IF NOT EXISTS sb_claimable_idx ON {BATCH_TABLE} (team_id, created_at, batch_index)
             WHERE latest_state IN ('pending', 'waiting_retry')
     """)
+    conn.execute("DROP INDEX IF EXISTS sb_run_gate_idx")
     conn.execute(f"""
-        CREATE INDEX IF NOT EXISTS sb_run_gate_idx ON {BATCH_TABLE} (run_uuid, latest_state, batch_index)
-            WHERE latest_state IN ('executing', 'waiting_retry', 'failed')
+        CREATE INDEX IF NOT EXISTS sb_run_gate2_idx ON {BATCH_TABLE} (run_uuid, latest_state, batch_index)
+            WHERE latest_state IN ('executing', 'waiting_retry', 'failed', 'superseded')
     """)
     conn.execute(f"""
         CREATE INDEX IF NOT EXISTS sb_schema_busy_idx ON {BATCH_TABLE} (team_id, schema_id)
@@ -270,6 +271,21 @@ class TestBatchQueueGetUnprocessed:
         batches = await _claim(conn)
 
         assert len(batches) == 0
+
+    @pytest.mark.asyncio
+    async def test_skips_straggler_in_superseded_run(self, conn, sync_conn):
+        # Revival guard: a straggler the producer enqueues into a run after the
+        # supersede sweep retired it must stay unclaimable — claiming it would
+        # load the retired run's stale data over the replacement run's.
+        await _insert_batch(conn, batch_index=0, run_uuid="run-old", job_id="job-j")
+        await _insert_batch(conn, batch_index=0, run_uuid="run-new", job_id="job-j")
+        BatchQueue.supersede_other_runs(sync_conn, job_id="job-j", current_run_uuid="run-new")
+        await _insert_batch(conn, batch_index=1, run_uuid="run-old", job_id="job-j")
+
+        batches = await _claim(conn)
+
+        assert [b.run_uuid for b in batches] == ["run-new"]
+        await _release(conn, batches=batches)
 
     @pytest.mark.asyncio
     async def test_respects_limit(self, conn):
@@ -637,6 +653,7 @@ class TestOldestNonTerminalBatchAge:
             ("waiting_retry", True),
             ("succeeded", False),
             ("failed", False),
+            ("superseded", False),
         ],
     )
     @pytest.mark.asyncio
@@ -670,13 +687,15 @@ class TestOldestNonTerminalBatchAge:
             is not None
         )
 
+    @pytest.mark.parametrize("terminal_state", ["failed", "superseded"])
     @pytest.mark.asyncio
-    async def test_dead_run_remnants_do_not_count(self, conn, sync_conn):
-        # A batch enqueued into a run after fail_run swept it stays 'pending' but can
-        # never be claimed; counting it would hold the CDC backpressure guard down for
-        # the whole pruning window (a full extraction stop for the source).
-        failed = await _insert_batch(conn, run_uuid="dead-run", batch_index=0)
-        await BatchQueue.update_status(conn, batch_id=failed, job_state="failed", attempt=1)
+    async def test_dead_run_remnants_do_not_count(self, conn, sync_conn, terminal_state):
+        # A batch enqueued into a run after fail_run or the supersede sweep retired it
+        # stays 'pending' but can never be claimed; counting it would hold the CDC
+        # backpressure guard down for the whole pruning window (a full extraction
+        # stop for the source).
+        retired = await _insert_batch(conn, run_uuid="dead-run", batch_index=0)
+        await BatchQueue.update_status(conn, batch_id=retired, job_state=terminal_state, attempt=1)
         await _insert_batch(conn, run_uuid="dead-run", batch_index=1)
 
         assert (
@@ -891,13 +910,14 @@ class TestGetRunActivitySummary:
         assert summary.has_non_terminal is True
         assert summary.is_stale is False
 
+    @pytest.mark.parametrize("terminal_state", ["succeeded", "failed", "superseded"])
     @pytest.mark.asyncio
-    async def test_all_terminal_batches_report_no_non_terminal(self, conn, sync_conn):
+    async def test_all_terminal_batches_report_no_non_terminal(self, conn, sync_conn, terminal_state):
         # Every batch terminal but the job still RUNNING (final batch never
         # enqueued) is genuinely abandoned and must remain stealable.
         for i in range(2):
             bid = await _insert_batch(conn, batch_index=i, metadata={"workflow_run_id": self.WF_RUN_ID})
-            await BatchQueue.update_status(conn, batch_id=bid, job_state="succeeded", attempt=1)
+            await BatchQueue.update_status(conn, batch_id=bid, job_state=terminal_state, attempt=1)
 
         summary = self._summary(sync_conn)
 
@@ -964,6 +984,34 @@ class TestGetRunActivitySummary:
 
 
 @pytest.mark.django_db(transaction=True)
+class TestGetFailedRuns:
+    @pytest.mark.asyncio
+    async def test_only_genuinely_failed_runs_enter_the_scan(self, conn, sync_conn):
+        # Superseded batches are routine (every retried job produces them) and have no
+        # job left to reconcile; if they re-entered this scan they would dominate it —
+        # in production they were the bulk of the 'failed' set during a failure storm,
+        # spilling the sort to disk on every pod at once. Legacy rows written as
+        # 'failed' with the superseded flag must stay excluded too until they age out.
+        await _insert_batch(conn, run_uuid="run-f", job_id="job-f", schema_id="s-f")
+        await BatchQueue.fail_run(conn, run_uuid="run-f", team_id=1, schema_id="s-f", reason="boom")
+        await _insert_batch(conn, run_uuid="run-old", job_id="job-x", schema_id="s-x", batch_index=0)
+        await _insert_batch(conn, run_uuid="run-new", job_id="job-x", schema_id="s-x", batch_index=0)
+        BatchQueue.supersede_other_runs(sync_conn, job_id="job-x", current_run_uuid="run-new")
+        legacy = await _insert_batch(conn, run_uuid="run-legacy", job_id="job-l", schema_id="s-l")
+        await BatchQueue.update_status(
+            conn,
+            batch_id=legacy,
+            job_state="failed",
+            attempt=1,
+            error_response={"error": "superseded by newer attempt", "superseded": True},
+        )
+
+        refs = await BatchQueue.get_failed_runs(conn, grace_seconds=0, lookback_seconds=3600, limit=10)
+
+        assert [(r.run_uuid, r.job_id, r.reason) for r in refs] == [("run-f", "job-f", "boom")]
+
+
+@pytest.mark.django_db(transaction=True)
 class TestGetStaleStrandedRuns:
     """The abandoned-run query: non-terminal batches, no live lease, no loader progress past the threshold."""
 
@@ -1012,11 +1060,14 @@ class TestGetStaleStrandedRuns:
 
         assert await self._run(conn) == []
 
+    @pytest.mark.parametrize("terminal_state", ["failed", "superseded"])
     @pytest.mark.asyncio
-    async def test_excludes_run_with_failed_batch(self, conn):
+    async def test_excludes_run_with_failed_or_superseded_batch(self, conn, terminal_state):
         # A failed batch is the failed-run reconcile's job; this sweep must not double-handle it.
-        failed = await self._stale_pending(conn, batch_index=0, run_uuid="had-failure")
-        await BatchQueue.update_status(conn, batch_id=failed, job_state="failed", attempt=1)
+        # A superseded batch means the job now belongs to the replacement run — sweeping it
+        # would fail the very job that run is still working on.
+        retired = await self._stale_pending(conn, batch_index=0, run_uuid="had-failure")
+        await BatchQueue.update_status(conn, batch_id=retired, job_state=terminal_state, attempt=1)
         await self._stale_pending(conn, batch_index=1, run_uuid="had-failure")
 
         assert await self._run(conn) == []
@@ -1190,15 +1241,21 @@ class TestStateDualWrite:
         assert (await _batch_state(conn, done))[0] == "succeeded"
 
     @pytest.mark.asyncio
-    async def test_supersede_fails_columns_of_older_runs(self, conn, sync_conn):
+    async def test_supersede_marks_columns_and_status_log_superseded(self, conn, sync_conn):
         old = await _insert_batch(conn, run_uuid="run-old", job_id="job-dw")
         current = await _insert_batch(conn, run_uuid="run-new", job_id="job-dw")
 
         superseded = BatchQueue.supersede_other_runs(sync_conn, job_id="job-dw", current_run_uuid="run-new")
 
         assert superseded == 1
-        assert (await _batch_state(conn, old))[0] == "failed"
+        assert (await _batch_state(conn, old))[0] == "superseded"
         assert (await _batch_state(conn, current))[0] == "pending"
+        # The status log must agree: it is the source of truth the backfill
+        # command repairs the columns from, so a 'failed' log row would flip
+        # the column back into the reconcile sweep's scan.
+        cur = await conn.execute(f"SELECT job_state FROM {STATUS_TABLE} WHERE batch_id = %s", (old,))
+        row = await cur.fetchone()
+        assert row is not None and row[0] == "superseded"
 
     @pytest.mark.asyncio
     async def test_fail_batches_for_job_fails_columns_across_runs(self, conn, sync_conn):
@@ -1238,6 +1295,25 @@ class TestUpdateStatusUnlessFailed:
         cur = await conn.execute(f"SELECT count(*) FROM {STATUS_TABLE} WHERE batch_id = %s", (bid,))
         row = await cur.fetchone()
         assert row is not None and row[0] == 1  # only fail_run's row; nothing appended over it
+
+    @pytest.mark.asyncio
+    async def test_refuses_lifecycle_writes_over_superseded(self, conn, sync_conn):
+        # A consumer that claimed a batch before the supersede sweep retired it
+        # must not be able to un-retire it with a later succeeded/executing row.
+        bid = await _insert_batch(conn, batch_index=0, run_uuid="run-old", job_id="job-g")
+        await _insert_batch(conn, batch_index=0, run_uuid="run-new", job_id="job-g")
+        BatchQueue.supersede_other_runs(sync_conn, job_id="job-g", current_run_uuid="run-new")
+
+        written = await BatchQueue.update_status_unless_failed(
+            conn,
+            batch_id=bid,
+            job_state="succeeded",
+            attempt=1,
+            supersedable_failed_error=LOCK_TAKEOVER_LATEST_ERROR,
+        )
+
+        assert written is False
+        assert (await _batch_state(conn, bid))[0] == "superseded"
 
     @pytest.mark.asyncio
     async def test_normal_lifecycle_writes_pass_and_dual_write(self, conn):

--- a/products/warehouse_sources_queue/backend/migrations/0008_sourcebatch_superseded_state.py
+++ b/products/warehouse_sources_queue/backend/migrations/0008_sourcebatch_superseded_state.py
@@ -1,0 +1,108 @@
+from django.db import migrations, models
+
+# Guarded with to_regclass so the migration no-ops on DBs without the sourcebatch
+# table, following 0006. The run-gate partial index gains 'superseded' in its
+# predicate; a predicate can't be altered in place, so the successor index is
+# created first (under a new name) and the old one dropped after, so the claim
+# gates never lose index coverage. Plain (non-concurrent) creation follows this
+# app's 0002/0006 precedent; lock_timeout keeps a blocked attempt from queueing
+# behind long claim queries (bin/migrate retries). The choices change on
+# latest_state/job_state is state-only — both are plain varchars.
+_FORWARD_SQL = """
+DO $$
+BEGIN
+    IF to_regclass('public.sourcebatch') IS NOT NULL THEN
+        SET LOCAL lock_timeout = '5s';
+        CREATE INDEX IF NOT EXISTS sb_run_gate2_idx
+            ON sourcebatch (run_uuid, latest_state, batch_index)
+            WHERE latest_state IN ('executing', 'waiting_retry', 'failed', 'superseded');
+        DROP INDEX IF EXISTS sb_run_gate_idx;
+    END IF;
+END
+$$;
+"""
+
+_REVERSE_SQL = """
+DO $$
+BEGIN
+    IF to_regclass('public.sourcebatch') IS NOT NULL THEN
+        SET LOCAL lock_timeout = '5s';
+        CREATE INDEX IF NOT EXISTS sb_run_gate_idx
+            ON sourcebatch (run_uuid, latest_state, batch_index)
+            WHERE latest_state IN ('executing', 'waiting_retry', 'failed');
+        DROP INDEX IF EXISTS sb_run_gate2_idx;
+    END IF;
+END
+$$;
+"""
+
+
+def _forward(apps, schema_editor):
+    schema_editor.execute(_FORWARD_SQL)
+
+
+def _reverse(apps, schema_editor):
+    schema_editor.execute(_REVERSE_SQL)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("warehouse_sources_queue", "0007_remove_duckgres_batch_sink_models"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AlterField(
+                    model_name="sourcebatch",
+                    name="latest_state",
+                    field=models.CharField(
+                        choices=[
+                            ("pending", "pending"),
+                            ("waiting", "waiting"),
+                            ("executing", "executing"),
+                            ("succeeded", "succeeded"),
+                            ("waiting_retry", "waiting_retry"),
+                            ("failed", "failed"),
+                            ("superseded", "superseded"),
+                        ],
+                        db_default="pending",
+                        default="pending",
+                        max_length=32,
+                    ),
+                ),
+                migrations.AlterField(
+                    model_name="sourcebatchstatus",
+                    name="job_state",
+                    field=models.CharField(
+                        choices=[
+                            ("waiting", "waiting"),
+                            ("executing", "executing"),
+                            ("succeeded", "succeeded"),
+                            ("waiting_retry", "waiting_retry"),
+                            ("failed", "failed"),
+                            ("superseded", "superseded"),
+                        ],
+                        max_length=32,
+                    ),
+                ),
+                migrations.RemoveIndex(
+                    model_name="sourcebatch",
+                    name="sb_run_gate_idx",
+                ),
+                migrations.AddIndex(
+                    model_name="sourcebatch",
+                    index=models.Index(
+                        condition=models.Q(
+                            ("latest_state__in", ["executing", "waiting_retry", "failed", "superseded"])
+                        ),
+                        fields=["run_uuid", "latest_state", "batch_index"],
+                        name="sb_run_gate2_idx",
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunPython(_forward, _reverse),
+            ],
+        ),
+    ]

--- a/products/warehouse_sources_queue/backend/migrations/max_migration.txt
+++ b/products/warehouse_sources_queue/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0007_remove_duckgres_batch_sink_models
+0008_sourcebatch_superseded_state

--- a/products/warehouse_sources_queue/backend/models.py
+++ b/products/warehouse_sources_queue/backend/models.py
@@ -19,6 +19,11 @@ class SourceBatch(UUIDModel):
         SUCCEEDED = "succeeded", "succeeded"
         WAITING_RETRY = "waiting_retry", "waiting_retry"
         FAILED = "failed", "failed"
+        # Terminal like 'failed', but retired by a newer run of the same job rather
+        # than by an error. Distinct so the reconcile sweep never scans these rows
+        # (they dominated the 'failed' set in production), while the claim path's
+        # run gate still treats them as run-blocking.
+        SUPERSEDED = "superseded", "superseded"
 
     team_id = models.BigIntegerField()
     schema_id = models.CharField(max_length=200)
@@ -71,10 +76,14 @@ class SourceBatch(UUIDModel):
                 name="sb_claimable_idx",
                 condition=models.Q(latest_state__in=["pending", "waiting_retry"]),
             ),
+            # Successor of sb_run_gate_idx: same shape, predicate extended with
+            # 'superseded'. Renamed because a partial-index predicate can't be
+            # altered in place, and the replacement is built before the old one
+            # is dropped so the claim gates never lose index coverage.
             models.Index(
                 fields=["run_uuid", "latest_state", "batch_index"],
-                name="sb_run_gate_idx",
-                condition=models.Q(latest_state__in=["executing", "waiting_retry", "failed"]),
+                name="sb_run_gate2_idx",
+                condition=models.Q(latest_state__in=["executing", "waiting_retry", "failed", "superseded"]),
             ),
             models.Index(
                 fields=["team_id", "schema_id"],
@@ -91,6 +100,7 @@ class SourceBatchStatus(UUIDModel):
         SUCCEEDED = "succeeded", "succeeded"
         WAITING_RETRY = "waiting_retry", "waiting_retry"
         FAILED = "failed", "failed"
+        SUPERSEDED = "superseded", "superseded"
 
     # No DB-level FK constraint: sourcebatch is range-partitioned on
     # created_at, making its PK composite (id, created_at). A real FK


### PR DESCRIPTION
## Problem

- A warehouse V3 loader can stall fleet-wide when failed batches pile up: on 2026-08-09 the reconcile sweep's `get_failed_runs` scan spilled to disk on every pod at once and starved the claim path.
- Most of the rows in that scan were superseded batches, which the sweep was always going to discard: they are written as `latest_state='failed'` with a `superseded` flag, and the flag filter runs after the expensive lateral join and sort.
- Superseded batches are routine (every retried job produces them), so they dominate the `failed` set exactly when a failure storm makes the sweep expensive.

Follow-up to #80257, which single-flighted the sweep and bounded its sort input; this removes the superseded rows from the scan entirely.

## Changes

- `supersede_other_runs` now writes a distinct terminal state, `superseded`, into both the status log and the denormalized `latest_state` column, instead of `failed` plus a JSON flag.
- `get_failed_runs` keeps filtering on `latest_state='failed'`, so superseded rows never enter its scan. The flag filter stays only for rows written before this change, until they age out of the pruning window.
- The `sb_run_gate_idx` partial index is replaced by `sb_run_gate2_idx` with `superseded` added to its predicate (migration 0008). The new index is created before the old one is dropped, so the claim gates never lose coverage. A partial index predicate cannot be altered in place, hence the rename.

> [!WARNING]
> A superseded run must stay excluded from claiming. Every consumer of `latest_state='failed'` was traced; the ones below now match `('failed', 'superseded')` so superseded runs keep their current behavior everywhere except the reconcile scan.

Consumers of `latest_state='failed'` / `job_state='failed'` and what happened to each:

| Consumer | Change |
| --- | --- |
| Claim path run-failed gate (`_state_claim_candidates_sql`, the `b2` NOT EXISTS) | Matches `('failed', 'superseded')`. Critical: stragglers enqueued into a superseded run must never become claimable and revive it. |
| Absorbing-state guard (`build_status_dual_write_unless_failed_sql`) | Refuses writes over `superseded` too, so an in-flight consumer cannot un-retire a superseded batch. |
| Reconcile scan (`get_failed_runs`) | Unchanged filter; superseded rows now fall out of the scan by state. |
| Stranded-run sweep (`get_stale_stranded_runs`) | Excludes runs with a `superseded` batch. Sweeping one would fail the job its replacement run is still working on. |
| CDC backpressure probe (`get_oldest_non_terminal_batch_age_seconds`) | Excludes runs with a `superseded` batch, same as failed runs. |
| Lock-takeover summary (`get_run_activity_summary`) | Counts `superseded` as terminal. |
| Bulk fail writers (`fail_run`, `fail_run_sync`, `fail_batches_for_job_sync`) | Still write `failed`; only `supersede_other_runs` writes `superseded`. |

Verified unchanged because they never keyed on `failed`: the retention sweep's stranded-run terminalizer (non-terminal states only), the state backfill command (derives from the status log), the ops state summary and active-run listing, and `pending_batch_predicate`.

Rollout: migrations run before code, and the new index predicate still serves the old code's `= 'failed'` gate. During the deploy itself an old-code consumer does not treat `superseded` as run-blocking; the exposure is limited to stragglers enqueued into a run superseded during that window.

## How did you test this code?

- New DB-level test for `get_failed_runs` catches superseded or legacy-flagged runs re-entering the reconcile scan, which had no direct test before.
- New claim test catches the revival regression: a straggler in a superseded run becoming claimable.
- New absorbing-state test catches a consumer overwriting `superseded` with `succeeded`.
- Extended parameterized tests cover the stranded sweep, backpressure probe, and takeover summary treating `superseded` like `failed`.
- Ran the full `postgres_queue` suites (`test_jobs_db`, `test_consumer`, `test_producer`) and the backfill command tests locally against Postgres; all pass.
- Validated the migration's forward and reverse SQL on a scratch range-partitioned copy of `sourcebatch`: idempotent under retries, index propagates to partitions.
- `uv run mypy --cache-fine-grained .` is clean; `makemigrations --check` reports no drift.
- Not run: the pipeline e2e suites, which need the full dev stack.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None; internal queue mechanics only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code from a written incident brief; no customer material appears in code, tests, or this description.
- Skills invoked: /django-migrations, /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- Considered a partial index excluding superseded rows instead of a new state, and rejected it: the run-failed gate and the reconcile scan need opposite views of superseded rows, which only a distinct state value gives both cheaply.
