### PR TITLE
fix(tasks): report effective agent runtime in metrics

### DIFF
--- a/products/tasks/backend/metrics.py
+++ b/products/tasks/backend/metrics.py
@@ -22,12 +22,21 @@ StreamConnectionOutcome = Literal["completed", "stream_error", "unavailable", "c
 _ALLOWED_MODES = {"background", "interactive"}
 _ALLOWED_RUN_SOURCES = {"manual", "signal_report"}
 _ALLOWED_RUNTIME_ADAPTERS = {"claude", "codex"}
+_ALLOWED_TASK_RUNTIMES = {"acp", "pi"}
 
 
 TASK_RUN_CREATED_TOTAL = Counter(
     "posthog_tasks_task_run_created_total",
     "TaskRun rows created by the Tasks product",
-    labelnames=["origin_product", "run_environment", "mode", "run_source", "runtime_adapter", "prewarmed"],
+    labelnames=[
+        "origin_product",
+        "run_environment",
+        "mode",
+        "run_source",
+        "task_runtime",
+        "runtime_adapter",
+        "prewarmed",
+    ],
 )
 
 TASK_RUN_WORKFLOW_START_TOTAL = Counter(
@@ -38,6 +47,7 @@ TASK_RUN_WORKFLOW_START_TOTAL = Counter(
         "run_environment",
         "mode",
         "run_source",
+        "task_runtime",
         "runtime_adapter",
         "prewarmed",
         "outcome",
@@ -54,6 +64,7 @@ TASK_RUN_DISPATCH_CALLBACK_TOTAL = Counter(
         "run_environment",
         "mode",
         "run_source",
+        "task_runtime",
         "runtime_adapter",
         "prewarmed",
         "phase",
@@ -170,7 +181,7 @@ TASK_RUN_STREAM_RESUME_GAP_TOTAL = Counter(
 TASK_RUN_AGENT_FAILURE_TOTAL = Counter(
     "posthog_tasks_agent_turn_failed_total",
     "TaskRun transitions to FAILED via the API facade (agent-server turn failures)",
-    labelnames=["origin_product", "mode", "run_source", "runtime_adapter"],
+    labelnames=["origin_product", "mode", "run_source", "task_runtime", "runtime_adapter"],
 )
 
 TASK_RUN_FOLLOWUP_DELIVERY_FAILED_TOTAL = Counter(
@@ -244,6 +255,27 @@ def _failure_metric_label(value: object | None) -> str:
     return label[:100]
 
 
+def _task_runtime_label(task_run: "TaskRun | None") -> str:
+    if task_run is None:
+        return "unknown"
+    return _bounded_metric_label(getattr(task_run.task, "runtime", None), _ALLOWED_TASK_RUNTIMES)
+
+
+def _effective_runtime_adapter_label(task_run: "TaskRun | None", state: dict) -> str:
+    task_runtime = _task_runtime_label(task_run)
+    if task_runtime == "pi":
+        return "pi"
+
+    configured_adapter = state.get("runtime_adapter")
+    if configured_adapter is not None:
+        return _bounded_metric_label(configured_adapter, _ALLOWED_RUNTIME_ADAPTERS)
+
+    # ACP's default harness is Claude. A model-only override deliberately leaves
+    # runtime_adapter unset, so treating that valid configuration as unknown hides
+    # the runtime that actually handled the run.
+    return "claude" if task_runtime == "acp" else "unknown"
+
+
 def _task_run_labels(task_run: "TaskRun | None") -> dict[str, str]:
     if task_run is None:
         return {
@@ -251,6 +283,7 @@ def _task_run_labels(task_run: "TaskRun | None") -> dict[str, str]:
             "run_environment": "unknown",
             "mode": "unknown",
             "run_source": "unknown",
+            "task_runtime": "unknown",
             "runtime_adapter": "unknown",
             "prewarmed": "unknown",
         }
@@ -261,7 +294,8 @@ def _task_run_labels(task_run: "TaskRun | None") -> dict[str, str]:
         "run_environment": _metric_label(task_run.environment),
         "mode": _bounded_metric_label(state.get("mode"), _ALLOWED_MODES),
         "run_source": _bounded_metric_label(state.get("run_source"), _ALLOWED_RUN_SOURCES),
-        "runtime_adapter": _bounded_metric_label(state.get("runtime_adapter"), _ALLOWED_RUNTIME_ADAPTERS),
+        "task_runtime": _task_runtime_label(task_run),
+        "runtime_adapter": _effective_runtime_adapter_label(task_run, state),
         "prewarmed": "true" if state.get("prewarmed") else "false",
     }
 
@@ -358,6 +392,7 @@ def observe_agent_turn_failed(task_run: "TaskRun") -> None:
         origin_product=labels["origin_product"],
         mode=labels["mode"],
         run_source=labels["run_source"],
+        task_runtime=labels["task_runtime"],
         runtime_adapter=labels["runtime_adapter"],
     ).inc()
 

--- a/products/tasks/backend/tests/test_task_run_metrics.py
+++ b/products/tasks/backend/tests/test_task_run_metrics.py
@@ -54,6 +54,7 @@ class TestTaskRunMetrics(TestCase):
             "run_environment": "cloud",
             "mode": "background",
             "run_source": "manual",
+            "task_runtime": "acp",
             "runtime_adapter": "codex",
             "prewarmed": "false",
         }
@@ -72,6 +73,7 @@ class TestTaskRunMetrics(TestCase):
             "run_environment": "cloud",
             "mode": "other",
             "run_source": "other",
+            "task_runtime": "acp",
             "runtime_adapter": "other",
             "prewarmed": "false",
         }
@@ -91,7 +93,8 @@ class TestTaskRunMetrics(TestCase):
             "run_environment": "cloud",
             "mode": "interactive",
             "run_source": "unknown",
-            "runtime_adapter": "unknown",
+            "task_runtime": "acp",
+            "runtime_adapter": "claude",
             "prewarmed": "true",
         }
         before = _sample_value("posthog_tasks_task_run_created_total", labels)
@@ -171,7 +174,8 @@ class TestTaskRunMetrics(TestCase):
             "run_environment": "cloud",
             "mode": "background",
             "run_source": "unknown",
-            "runtime_adapter": "unknown",
+            "task_runtime": "acp",
+            "runtime_adapter": "claude",
             "prewarmed": "false",
         }
         labels_by_outcome = [
@@ -296,6 +300,7 @@ class TestTaskRunMetrics(TestCase):
             "origin_product": "user_created",
             "mode": "interactive",
             "run_source": "manual",
+            "task_runtime": "acp",
             "runtime_adapter": "codex",
         }
         before = _sample_value("posthog_tasks_agent_turn_failed_total", labels)
@@ -309,6 +314,44 @@ class TestTaskRunMetrics(TestCase):
             )
 
         assert _sample_value("posthog_tasks_agent_turn_failed_total", labels) == before + expected_delta
+
+    @parameterized.expand(
+        [
+            ("acp_default", Task.Runtime.ACP, {"model": "claude-opus-5"}, "acp", "claude"),
+            ("pi", Task.Runtime.PI, {}, "pi", "pi"),
+        ]
+    )
+    def test_agent_turn_failure_counter_uses_effective_runtime(
+        self,
+        _name: str,
+        runtime: str,
+        extra_state: dict,
+        expected_task_runtime: str,
+        expected_runtime_adapter: str,
+    ) -> None:
+        from products.tasks.backend.facade import api as facade
+
+        self.task.runtime = runtime
+        self.task.save(update_fields=["runtime"])
+        run = self.task.create_run(environment=TaskRun.Environment.CLOUD, extra_state=extra_state)
+        labels = {
+            "origin_product": "user_created",
+            "mode": "background" if runtime == Task.Runtime.ACP else "unknown",
+            "run_source": "unknown",
+            "task_runtime": expected_task_runtime,
+            "runtime_adapter": expected_runtime_adapter,
+        }
+        before = _sample_value("posthog_tasks_agent_turn_failed_total", labels)
+
+        with patch.object(facade, "signal_workflow_completion"):
+            facade.update_task_run(
+                run.id,
+                self.task.id,
+                self.team.id,
+                validated_data={"status": "failed", "error_message": "boom"},
+            )
+
+        assert _sample_value("posthog_tasks_agent_turn_failed_total", labels) == before + 1
 
     @parameterized.expand(
         [

--- a/products/tasks/backend/tests/test_task_run_metrics.py
+++ b/products/tasks/backend/tests/test_task_run_metrics.py
@@ -324,7 +324,7 @@ class TestTaskRunMetrics(TestCase):
     def test_agent_turn_failure_counter_uses_effective_runtime(
         self,
         _name: str,
-        runtime: str,
+        runtime: Task.Runtime,
         extra_state: dict,
         expected_task_runtime: str,
         expected_runtime_adapter: str,


### PR DESCRIPTION
## Problem

Agent failure metrics label valid model-only ACP runs as `unknown`, which obscures the runtime responsible for failures.

**Why:** Operators need runtime attribution that reflects the harness actually executing each task.

## Changes

- Resolve the effective adapter as `pi`, an explicit ACP adapter, or ACP’s default `claude`.
- Add a bounded `task_runtime` label and regression coverage for model-only ACP and Pi runs.