### PR TITLE
fix(dashboards): remove ineffective sharing details toggle

### DIFF
--- a/frontend/src/lib/components/Sharing/SharingModal.test.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.test.tsx
@@ -113,6 +113,8 @@ describe('SharingModal (dashboard)', () => {
 
         // Dashboard options smoke checks
         expect(screen.getByText(/Show PostHog branding/i)).toBeInTheDocument()
+        expect(screen.getByText('Theme')).toBeInTheDocument()
+        expect(screen.queryByText(/Show insight details/i)).toBeNull()
     })
 
     it('calls onSharingEnabledChange after the dashboard sharing switch update succeeds', async () => {

--- a/frontend/src/lib/components/Sharing/SharingModal.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.tsx
@@ -402,50 +402,29 @@ export function SharingModalContent({
                                                 )}
 
                                                 {dashboardId && (
-                                                    <>
-                                                        <LemonField name="hideExtraDetails">
-                                                            {({ value, onChange }) => (
-                                                                <LemonSwitch
-                                                                    fullWidth
-                                                                    bordered
-                                                                    label={
-                                                                        <div className="flex items-center">
-                                                                            <span>Show insight details</span>
-                                                                            <Tooltip title="When disabled, viewers won't see the extra insights details like the who created the insight and the applied filters.">
-                                                                                <IconInfo className="ml-1.5 text-secondary text-lg" />
-                                                                            </Tooltip>
-                                                                        </div>
-                                                                    }
-                                                                    onChange={() => onChange(!value)}
-                                                                    checked={!value}
+                                                    <LemonField
+                                                        name="theme"
+                                                        inline
+                                                        className="items-center justify-between col-span-2"
+                                                    >
+                                                        {({ value, onChange }) => (
+                                                            <>
+                                                                <LemonLabel htmlFor="sharing-theme-select">
+                                                                    Theme
+                                                                </LemonLabel>
+                                                                <LemonSelect
+                                                                    id="sharing-theme-select"
+                                                                    value={value ?? 'system'}
+                                                                    onSelect={(theme) => onChange(theme)}
+                                                                    options={[
+                                                                        { value: 'system', label: 'System' },
+                                                                        { value: 'light', label: 'Light' },
+                                                                        { value: 'dark', label: 'Dark' },
+                                                                    ]}
                                                                 />
-                                                            )}
-                                                        </LemonField>
-
-                                                        <LemonField
-                                                            name="theme"
-                                                            inline
-                                                            className="items-center justify-between col-span-2"
-                                                        >
-                                                            {({ value, onChange }) => (
-                                                                <>
-                                                                    <LemonLabel htmlFor="sharing-theme-select">
-                                                                        Theme
-                                                                    </LemonLabel>
-                                                                    <LemonSelect
-                                                                        id="sharing-theme-select"
-                                                                        value={value ?? 'system'}
-                                                                        onSelect={(theme) => onChange(theme)}
-                                                                        options={[
-                                                                            { value: 'system', label: 'System' },
-                                                                            { value: 'light', label: 'Light' },
-                                                                            { value: 'dark', label: 'Dark' },
-                                                                        ]}
-                                                                    />
-                                                                </>
-                                                            )}
-                                                        </LemonField>
-                                                    </>
+                                                            </>
+                                                        )}
+                                                    </LemonField>
                                                 )}
                                             </div>
 

--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -24,7 +24,7 @@ from rest_framework.request import Request
 
 from posthog.schema import SharingConfigurationSettings
 
-from posthog.api.data_color_theme import DataColorTheme, DataColorThemeSerializer
+from posthog.api.data_color_theme import DataColorTheme, PublicDataColorThemeSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.services.query import process_query_dict
 from posthog.api.shared import TeamPublicSerializer
@@ -265,13 +265,14 @@ def export_asset_for_opengraph(resource: SharingConfiguration) -> ExportedAsset 
 
 def get_themes_for_team(team: Team):
     global_and_team_themes = DataColorTheme.objects.filter(Q(team_id=team.pk) | Q(team_id=None))
-    themes = DataColorThemeSerializer(global_and_team_themes, many=True).data
+    # The shared payload is served to anonymous viewers, so use the serializer without `created_by`.
+    themes = PublicDataColorThemeSerializer(global_and_team_themes, many=True).data
     return themes
 
 
 def get_global_themes():
     global_themes = DataColorTheme.objects.filter(Q(team_id=None))
-    themes = DataColorThemeSerializer(global_themes, many=True).data
+    themes = PublicDataColorThemeSerializer(global_themes, many=True).data
     return themes
 
 

--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -1125,7 +1125,10 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSe
             record_dashboard_view(resource.dashboard, context["dashboard_access_method"])
 
             with task_chain_context():
-                dashboard_data = DashboardSerializer(resource.dashboard, context=context).data
+                # Viewers of a shared dashboard never get the tile details panel, so the people
+                # who created and last modified the dashboard and its tiles stay out of the payload
+                dashboard_context = {**context, "hide_extra_details": True}
+                dashboard_data = DashboardSerializer(resource.dashboard, context=dashboard_context).data
                 # We don't want the dashboard to be accidentally loaded via the shared endpoint
                 exported_data.update({"dashboard": dashboard_data})
             exported_data.update({"themes": get_themes_for_team(resource.team)})

--- a/posthog/api/test/test_sharing.py
+++ b/posthog/api/test/test_sharing.py
@@ -25,14 +25,16 @@ from posthog.api.sharing import (
 )
 from posthog.constants import AvailableFeature
 from posthog.models import ActivityLog, OrganizationMembership
+from posthog.models.data_color_theme import DataColorTheme
 from posthog.models.filters.filter import Filter
 from posthog.models.share_password import SharePassword
 from posthog.models.sharing_configuration import SharingConfiguration
 from posthog.models.user import User
 
+from products.alerts.backend.models.alert import AlertConfiguration
 from products.dashboards.backend.access import DashboardAccessMethod
 from products.dashboards.backend.models.dashboard import Dashboard
-from products.dashboards.backend.models.dashboard_tile import DashboardTile, Text
+from products.dashboards.backend.models.dashboard_tile import ButtonTile, DashboardTile, Text
 from products.dashboards.backend.models.dashboard_widget import DashboardWidget
 from products.data_modeling.backend.facade.models import DataWarehouseSavedQuery
 from products.exports.backend.models.exported_asset import ExportedAsset, get_render_access_token
@@ -1717,9 +1719,21 @@ class TestSharedCohortInlining(APIBaseTest):
             created_by=self.user,
             last_modified_by=self.user,
         )
+        AlertConfiguration.objects.create(
+            team=self.team, insight=insight, name="High pageviews", enabled=True, created_by=self.user
+        )
         DashboardTile.objects.create(dashboard=dashboard, team_id=self.team.id, insight=insight)
         text = Text.objects.create(team=self.team, body="Read me", created_by=self.user, last_modified_by=self.user)
         DashboardTile.objects.create(dashboard=dashboard, team_id=self.team.id, text=text)
+        button = ButtonTile.objects.create(
+            team=self.team,
+            url="https://example.com",
+            text="Open docs",
+            created_by=self.user,
+            last_modified_by=self.user,
+        )
+        DashboardTile.objects.create(dashboard=dashboard, team_id=self.team.id, button_tile=button)
+        DataColorTheme.objects.create(team=self.team, name="Brand", colors=["#000000"], created_by=self.user)
 
         config = SharingConfiguration.objects.create(team=self.team, dashboard=dashboard, enabled=True)
         response = self.client.get(f"/shared/{config.access_token}")
@@ -1728,13 +1742,18 @@ class TestSharedCohortInlining(APIBaseTest):
         body = response.content.decode()
         assert self.user.email not in body
 
-        exported_dashboard = self._parse_exported_data(body)["dashboard"]
+        exported = self._parse_exported_data(body)
+        exported_dashboard = exported["dashboard"]
         assert "created_by" not in exported_dashboard
         for tile in exported_dashboard["tiles"]:
-            for tile_content in (tile.get("insight"), tile.get("text")):
+            for tile_content in (tile.get("insight"), tile.get("text"), tile.get("button_tile")):
                 if tile_content is not None:
                     assert "created_by" not in tile_content
                     assert "last_modified_by" not in tile_content
+            if tile.get("insight") is not None:
+                assert tile["insight"]["alerts"] == []
+        for theme in exported["themes"]:
+            assert "created_by" not in theme
 
 
 class TestSharingResourceEditChecks(APIBaseTest):

--- a/posthog/api/test/test_sharing.py
+++ b/posthog/api/test/test_sharing.py
@@ -32,7 +32,7 @@ from posthog.models.user import User
 
 from products.dashboards.backend.access import DashboardAccessMethod
 from products.dashboards.backend.models.dashboard import Dashboard
-from products.dashboards.backend.models.dashboard_tile import DashboardTile
+from products.dashboards.backend.models.dashboard_tile import DashboardTile, Text
 from products.dashboards.backend.models.dashboard_widget import DashboardWidget
 from products.data_modeling.backend.facade.models import DataWarehouseSavedQuery
 from products.exports.backend.models.exported_asset import ExportedAsset, get_render_access_token
@@ -1706,6 +1706,35 @@ class TestSharedCohortInlining(APIBaseTest):
         assert widget_data["widget_type"] == "error_tracking_list"
         assert widget_data["config"]["limit"] == 10
         assert "created_by" not in widget_data
+
+    @mock_exporter_template
+    def test_shared_dashboard_omits_authorship_of_dashboard_and_tiles(self):
+        dashboard = Dashboard.objects.create(team=self.team, name="dash", created_by=self.user)
+        insight = Insight.objects.create(
+            team=self.team,
+            name="Pageviews",
+            query={"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "$pageview"}]},
+            created_by=self.user,
+            last_modified_by=self.user,
+        )
+        DashboardTile.objects.create(dashboard=dashboard, team_id=self.team.id, insight=insight)
+        text = Text.objects.create(team=self.team, body="Read me", created_by=self.user, last_modified_by=self.user)
+        DashboardTile.objects.create(dashboard=dashboard, team_id=self.team.id, text=text)
+
+        config = SharingConfiguration.objects.create(team=self.team, dashboard=dashboard, enabled=True)
+        response = self.client.get(f"/shared/{config.access_token}")
+        assert response.status_code == 200
+
+        body = response.content.decode()
+        assert self.user.email not in body
+
+        exported_dashboard = self._parse_exported_data(body)["dashboard"]
+        assert "created_by" not in exported_dashboard
+        for tile in exported_dashboard["tiles"]:
+            for tile_content in (tile.get("insight"), tile.get("text")):
+                if tile_content is not None:
+                    assert "created_by" not in tile_content
+                    assert "last_modified_by" not in tile_content
 
 
 class TestSharingResourceEditChecks(APIBaseTest):

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -910,6 +910,11 @@ class DashboardTileErrorSerializer(DashboardTileSerializer):
                     "user_access_level": user_access_level,
                 }
 
+        # InsightBasicSerializer ignores `hide_extra_details`, so strip authorship here too, otherwise
+        # a tile that errors on a shared dashboard leaks its insight's creator name and email.
+        if isinstance(representation.get("insight"), dict):
+            _hide_extra_details(self.context, representation["insight"])
+
         return representation
 
 

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -722,6 +722,15 @@ class CanEditDashboard(BasePermission):
         return view.user_permissions.dashboard(dashboard).can_edit
 
 
+def _hide_extra_details(context: dict[str, Any], representation: dict[str, Any]) -> None:
+    """Drop authorship details, which carry the name and email of a teammate, when the caller
+    can't see them anyway — a shared dashboard, or `hideExtraDetails` on the sharing config."""
+    if not context.get("hide_extra_details", False):
+        return
+    for field in ("created_by", "last_modified_by", "created_at", "last_modified_at"):
+        representation.pop(field, None)
+
+
 class TextSerializer(serializers.ModelSerializer):
     created_by = UserBasicSerializer(read_only=True)
     last_modified_by = UserBasicSerializer(read_only=True)
@@ -738,6 +747,11 @@ class TextSerializer(serializers.ModelSerializer):
         model = Text
         fields = "__all__"
         read_only_fields = ["id", "created_by", "last_modified_by", "last_modified_at"]
+
+    def to_representation(self, instance: Text) -> dict[str, Any]:
+        representation = super().to_representation(instance)
+        _hide_extra_details(self.context, representation)
+        return representation
 
 
 class ButtonTileSerializer(serializers.ModelSerializer):
@@ -758,6 +772,11 @@ class ButtonTileSerializer(serializers.ModelSerializer):
         model = ButtonTile
         fields = "__all__"
         read_only_fields = ["id", "created_by", "last_modified_by", "last_modified_at"]
+
+    def to_representation(self, instance: ButtonTile) -> dict[str, Any]:
+        representation = super().to_representation(instance)
+        _hide_extra_details(self.context, representation)
+        return representation
 
     def validate_url(self, value: str) -> str:
         if value.startswith("/"):
@@ -1106,6 +1125,7 @@ class DashboardMetadataSerializer(DashboardBasicSerializer):
         ret = super().to_representation(instance)
         if ret.get("quick_filter_ids") is None:
             ret["quick_filter_ids"] = []
+        _hide_extra_details(self.context, ret)
         return ret
 
     def _filter_out_non_existing_quick_filter_ids(self, quick_filter_ids: list[str], team_id: int) -> list[str]:

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -1135,6 +1135,11 @@ class InsightSerializer(InsightBasicSerializer):
         if insight.alertable_query_kind is None:
             return []
 
+        # Alert configs carry their creator's and subscribers' names and emails, which anonymous
+        # viewers of a shared dashboard must never receive, so omit them when hiding authorship.
+        if self.context.get("hide_extra_details", False):
+            return []
+
         # Use prefetched alerts data
         alerts = getattr(insight, "_prefetched_alerts", [])
         from products.alerts.backend.api.alert import AlertSerializer


### PR DESCRIPTION
## Problem

- Dashboard owners see a **Show insight details** switch that cannot change public dashboard behavior.
- [#79070](https://github.com/PostHog/posthog/pull/79070) makes authorship removal unconditional because public dashboards never show insight details.

## Changes

- Remove the ineffective switch from the dashboard sharing modal.
- Keep the theme selector unchanged.
- Preserve `hideExtraDetails` in the backend for old links and non-dashboard consumers.
- Screenshot not captured because this change only removes one switch from the existing modal.

## How did you test this code?

- Extended the dashboard modal test to verify the theme selector remains and the ineffective switch is absent.
- Checked the full frontend TypeScript project after formatting the change.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The removed switch no longer controls documented dashboard behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Code implemented this as a layer above [#79070](https://github.com/PostHog/posthog/pull/79070).
- Skills invoked: `/stacking-prs`, `/writing-user-facing-copy`, `/writing-tests`, and `/writing-pr-descriptions`.
- The backend setting remains for compatibility. This PR removes only the misleading dashboard control.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
