### PR TITLE
fix(conversations): prevent duplicate widget tickets

### DIFF
--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -14,7 +14,8 @@ from posthog.test.base import (
 )
 from unittest.mock import patch
 
-from django.db import transaction
+from django.db import connection, transaction
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
 from parameterized import parameterized
@@ -1505,6 +1506,23 @@ class TestTicketManager(BaseTest):
 
         self.assertEqual(ticket1.ticket_number, 1)
         self.assertEqual(ticket2.ticket_number, 2)
+
+    def test_create_with_number_takes_team_key_share_before_numbering_lock(self) -> None:
+        with CaptureQueriesContext(connection) as ctx:
+            Ticket.objects.create_with_number(
+                team=self.team,
+                channel_source=Channel.WIDGET,
+                widget_session_id="session-lock-check",
+                distinct_id="user-lock-check",
+            )
+
+        sqls = [query["sql"].lower() for query in ctx.captured_queries]
+        self.assertFalse(any("posthog_team" in sql and "for update" in sql for sql in sqls))
+        team_key_share_index = next(
+            index for index, sql in enumerate(sqls) if "posthog_team" in sql and "for key share" in sql
+        )
+        numbering_lock_index = next(index for index, sql in enumerate(sqls) if "pg_advisory_xact_lock" in sql)
+        self.assertLess(team_key_share_index, numbering_lock_index)
 
 
 @patch.object(transaction, "on_commit", side_effect=immediate_on_commit)

--- a/products/conversations/backend/api/tests/test_widget.py
+++ b/products/conversations/backend/api/tests/test_widget.py
@@ -1047,17 +1047,25 @@ class TestWidgetIdentityVerification(BaseTest):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    def test_ticketless_coalesce_ownership_mismatch_creates_ticket(self) -> None:
+    @parameterized.expand(
+        [
+            ("append", "Earlier question", "New question"),
+            ("replay", "Same question", "Same question"),
+        ]
+    )
+    def test_ticketless_coalesce_ownership_mismatch_creates_ticket(
+        self, _name: str, previous_content: str, new_content: str
+    ) -> None:
         derived_widget_session_id = str(uuid.UUID(self.identity_hash[:32]))
         previous_ticket = self._create_ticket(
             distinct_id="previous_distinct_id",
             widget_session_id=derived_widget_session_id,
         )
-        Comment.objects.create(
+        previous_comment = Comment.objects.create(
             team=self.team,
             scope="conversations_ticket",
             item_id=str(previous_ticket.id),
-            content="Earlier question",
+            content=previous_content,
             item_context={"author_type": "customer"},
         )
 
@@ -1070,7 +1078,7 @@ class TestWidgetIdentityVerification(BaseTest):
                 {
                     "identity_distinct_id": self.distinct_id,
                     "identity_hash": self.identity_hash,
-                    "message": "New question",
+                    "message": new_content,
                 },
                 **self._get_headers(),
             )
@@ -1078,12 +1086,49 @@ class TestWidgetIdentityVerification(BaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         get_person_distinct_ids_mock.assert_called_once_with(self.team.id, self.distinct_id)
         self.assertNotEqual(response.json()["ticket_id"], str(previous_ticket.id))
+        self.assertNotEqual(response.json()["message_id"], str(previous_comment.id))
         self.assertEqual(
             Ticket.objects.filter(team=self.team, widget_session_id=derived_widget_session_id).count(),
             2,
         )
+        previous_ticket.refresh_from_db()
+        self.assertEqual(previous_ticket.unread_team_count, 0)
         created_ticket = Ticket.objects.get(id=response.json()["ticket_id"])
         self.assertEqual(created_ticket.distinct_id, self.distinct_id)
+
+    def test_ticketless_replay_with_owned_identity_returns_existing_message(self) -> None:
+        derived_widget_session_id = str(uuid.UUID(self.identity_hash[:32]))
+        ticket = self._create_ticket(widget_session_id=derived_widget_session_id)
+        comment = Comment.objects.create(
+            team=self.team,
+            scope="conversations_ticket",
+            item_id=str(ticket.id),
+            content="Same question",
+            item_context={"author_type": "customer"},
+        )
+
+        with patch(
+            "products.conversations.backend.api.widget.get_person_distinct_ids",
+            return_value=[self.distinct_id],
+        ) as get_person_distinct_ids_mock:
+            response = self.client.post(
+                "/api/conversations/v1/widget/message",
+                {
+                    "identity_distinct_id": self.distinct_id,
+                    "identity_hash": self.identity_hash,
+                    "message": "Same question",
+                },
+                **self._get_headers(),
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        get_person_distinct_ids_mock.assert_called_once_with(self.team.id, self.distinct_id)
+        self.assertEqual(response.json()["ticket_id"], str(ticket.id))
+        self.assertEqual(response.json()["message_id"], str(comment.id))
+        self.assertEqual(
+            Ticket.objects.filter(team=self.team, widget_session_id=derived_widget_session_id).count(),
+            1,
+        )
 
     def test_send_message_invalid_hash_no_session_returns_forbidden(self):
         response = self.client.post(

--- a/products/conversations/backend/api/tests/test_widget.py
+++ b/products/conversations/backend/api/tests/test_widget.py
@@ -1,9 +1,12 @@
 import uuid
+from datetime import timedelta
 
+from freezegun import freeze_time
 from posthog.test.base import BaseTest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase
+from django.utils import timezone
 
 from parameterized import parameterized
 from rest_framework import status
@@ -84,6 +87,141 @@ class TestWidgetAPI(BaseTest):
         self.assertEqual(ticket.distinct_id, self.distinct_id)
         self.assertEqual(ticket.status, "new")
         self.assertEqual(ticket.unread_team_count, 1)
+
+    def test_ticketless_retry_appends_to_recent_ticket(self) -> None:
+        with self.captureOnCommitCallbacks(execute=True):
+            first = self.client.post(
+                "/api/conversations/v1/widget/message",
+                {
+                    "message": "First wording of the question",
+                    "widget_session_id": self.widget_session_id,
+                    "distinct_id": self.distinct_id,
+                },
+                **self._get_headers(),
+            )
+        self.assertEqual(first.status_code, status.HTTP_200_OK)
+        ticket_id = first.json()["ticket_id"]
+
+        with self.captureOnCommitCallbacks(execute=True):
+            second = self.client.post(
+                "/api/conversations/v1/widget/message",
+                {
+                    "message": "Retyped wording of the same question",
+                    "widget_session_id": self.widget_session_id,
+                    "distinct_id": self.distinct_id,
+                },
+                **self._get_headers(),
+            )
+        self.assertEqual(second.status_code, status.HTTP_200_OK)
+        self.assertEqual(second.json()["ticket_id"], ticket_id)
+        self.assertNotEqual(second.json()["message_id"], first.json()["message_id"])
+
+        self.assertEqual(Ticket.objects.filter(team=self.team, widget_session_id=self.widget_session_id).count(), 1)
+        ticket = Ticket.objects.get(id=ticket_id)
+        self.assertEqual(
+            Comment.objects.filter(
+                team=self.team, scope="conversations_ticket", item_id=ticket_id, deleted=False
+            ).count(),
+            2,
+        )
+        self.assertEqual(ticket.unread_team_count, 2)
+        self.assertEqual(ticket.message_count, 2)
+
+    def test_identical_ticketless_resend_replays_message(self) -> None:
+        with self.captureOnCommitCallbacks(execute=True):
+            first = self.client.post(
+                "/api/conversations/v1/widget/message",
+                {
+                    "message": "Identical body",
+                    "widget_session_id": self.widget_session_id,
+                    "distinct_id": self.distinct_id,
+                },
+                **self._get_headers(),
+            )
+        self.assertEqual(first.status_code, status.HTTP_200_OK)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            second = self.client.post(
+                "/api/conversations/v1/widget/message",
+                {
+                    "message": "Identical body",
+                    "widget_session_id": self.widget_session_id,
+                    "distinct_id": self.distinct_id,
+                },
+                **self._get_headers(),
+            )
+        self.assertEqual(second.status_code, status.HTTP_200_OK)
+        self.assertEqual(second.json()["ticket_id"], first.json()["ticket_id"])
+        self.assertEqual(second.json()["message_id"], first.json()["message_id"])
+
+        ticket = Ticket.objects.get(id=first.json()["ticket_id"])
+        self.assertEqual(
+            Comment.objects.filter(
+                team=self.team, scope="conversations_ticket", item_id=str(ticket.id), deleted=False
+            ).count(),
+            1,
+        )
+        self.assertEqual(ticket.unread_team_count, 1)
+        self.assertEqual(ticket.message_count, 1)
+
+    def test_identical_ticketless_resend_outside_replay_window_appends(self) -> None:
+        now = timezone.now()
+        with freeze_time(now - timedelta(seconds=31)), self.captureOnCommitCallbacks(execute=True):
+            first = self.client.post(
+                "/api/conversations/v1/widget/message",
+                {
+                    "message": "Identical body",
+                    "widget_session_id": self.widget_session_id,
+                    "distinct_id": self.distinct_id,
+                },
+                **self._get_headers(),
+            )
+        self.assertEqual(first.status_code, status.HTTP_200_OK)
+
+        with freeze_time(now), self.captureOnCommitCallbacks(execute=True):
+            second = self.client.post(
+                "/api/conversations/v1/widget/message",
+                {
+                    "message": "Identical body",
+                    "widget_session_id": self.widget_session_id,
+                    "distinct_id": self.distinct_id,
+                },
+                **self._get_headers(),
+            )
+
+        self.assertEqual(second.status_code, status.HTTP_200_OK)
+        self.assertEqual(second.json()["ticket_id"], first.json()["ticket_id"])
+        self.assertNotEqual(second.json()["message_id"], first.json()["message_id"])
+        ticket = Ticket.objects.get(id=first.json()["ticket_id"])
+        self.assertEqual(ticket.message_count, 2)
+        self.assertEqual(ticket.unread_team_count, 2)
+
+    @patch("products.conversations.backend.api.widget.invalidate_unread_count_cache")
+    @patch("products.conversations.backend.api.widget.report_team_action")
+    @patch("products.conversations.backend.api.widget.try_lock_widget_session", return_value=False)
+    def test_session_lock_miss_fails_without_writing(
+        self,
+        _try_lock: MagicMock,
+        report_team_action_mock: MagicMock,
+        invalidate_unread_count_cache_mock: MagicMock,
+    ) -> None:
+        response = self.client.post(
+            "/api/conversations/v1/widget/message",
+            {
+                "message": "Do not store this",
+                "widget_session_id": self.widget_session_id,
+                "distinct_id": self.distinct_id,
+            },
+            **self._get_headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        self.assertEqual(response["Retry-After"], "1")
+        self.assertEqual(response.json(), {"message": "Another message is still sending. Try again shortly."})
+        self.assertFalse(Ticket.objects.filter(team=self.team, widget_session_id=self.widget_session_id).exists())
+        self.assertFalse(Comment.objects.filter(team=self.team, scope="conversations_ticket").exists())
+        report_team_action_mock.assert_not_called()
+        invalidate_unread_count_cache_mock.assert_not_called()
 
     def test_create_ticket_channel_detail_widget_enabled(self):
         self.team.conversations_settings = {**self.team.conversations_settings, "widget_enabled": True}
@@ -908,6 +1046,44 @@ class TestWidgetIdentityVerification(BaseTest):
             **self._get_headers(),
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_ticketless_coalesce_ownership_mismatch_creates_ticket(self) -> None:
+        derived_widget_session_id = str(uuid.UUID(self.identity_hash[:32]))
+        previous_ticket = self._create_ticket(
+            distinct_id="previous_distinct_id",
+            widget_session_id=derived_widget_session_id,
+        )
+        Comment.objects.create(
+            team=self.team,
+            scope="conversations_ticket",
+            item_id=str(previous_ticket.id),
+            content="Earlier question",
+            item_context={"author_type": "customer"},
+        )
+
+        with patch(
+            "products.conversations.backend.api.widget.get_person_distinct_ids",
+            return_value=[self.distinct_id],
+        ) as get_person_distinct_ids_mock:
+            response = self.client.post(
+                "/api/conversations/v1/widget/message",
+                {
+                    "identity_distinct_id": self.distinct_id,
+                    "identity_hash": self.identity_hash,
+                    "message": "New question",
+                },
+                **self._get_headers(),
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        get_person_distinct_ids_mock.assert_called_once_with(self.team.id, self.distinct_id)
+        self.assertNotEqual(response.json()["ticket_id"], str(previous_ticket.id))
+        self.assertEqual(
+            Ticket.objects.filter(team=self.team, widget_session_id=derived_widget_session_id).count(),
+            2,
+        )
+        created_ticket = Ticket.objects.get(id=response.json()["ticket_id"])
+        self.assertEqual(created_ticket.distinct_id, self.distinct_id)
 
     def test_send_message_invalid_hash_no_session_returns_forbidden(self):
         response = self.client.post(

--- a/products/conversations/backend/api/widget.py
+++ b/products/conversations/backend/api/widget.py
@@ -13,8 +13,11 @@ Anonymous users are controlled by widget_session_id. Verified users are controll
 
 import uuid
 import logging
+from typing import Literal
 
+from django.db import transaction
 from django.db.models import F, Q
+from django.utils import timezone
 
 from prometheus_client import Counter
 from rest_framework import serializers, status
@@ -31,6 +34,7 @@ from posthog.models import Team
 from posthog.models.comment import Comment
 from posthog.rate_limit import WidgetTeamThrottle, WidgetUserBurstThrottle
 
+from products.conversations.backend import ticket_coalesce
 from products.conversations.backend.api.serializers import (
     WIDGET_TICKETS_DEFAULT_LIMIT,
     WidgetMarkReadSerializer,
@@ -48,6 +52,7 @@ from products.conversations.backend.cache import (
     set_cached_messages,
     set_cached_tickets,
 )
+from products.conversations.backend.locks import try_lock_widget_session
 from products.conversations.backend.models import SigningSecret, Ticket
 from products.conversations.backend.models.constants import ChannelDetail
 from products.conversations.backend.services.identity import verify_identity_hash
@@ -235,97 +240,166 @@ class WidgetMessageView(APIView):
             except ValidationError:
                 return Response({"error": "Invalid ticket_id format"}, status=status.HTTP_400_BAD_REQUEST)
 
-        # Find or create ticket
-        if ticket_id:
-            # Adding to existing ticket
-            try:
-                ticket = Ticket.objects.get(id=ticket_id, team=team)
+        coalesce_reason: Literal["replayed", "appended"] | None = None
+        created_ticket = False
+        session_busy = False
+        ticket: Ticket | None = None
+        comment: Comment | None = None
 
-                if verified_distinct_id is not None:
-                    allowed_ids = get_person_distinct_ids(team.id, verified_distinct_id)
-                    if ticket.distinct_id not in allowed_ids:
-                        return Response({"error": "Forbidden"}, status=status.HTTP_403_FORBIDDEN)
+        # ATOMIC_REQUESTS is off: ticket + first message must commit together so a
+        # concurrent coalesce lookup sees both or neither. Side effects run after.
+        with transaction.atomic():
+            if not ticket_id:
+                if not try_lock_widget_session(team.id, widget_session_id):
+                    session_busy = True
                 else:
-                    # CRITICAL: Verify ticket belongs to this widget_session_id (NOT distinct_id)
-                    if ticket.widget_session_id != widget_session_id:
-                        return Response({"error": "Forbidden"}, status=status.HTTP_403_FORBIDDEN)
+                    target = ticket_coalesce.resolve(
+                        team_id=team.id,
+                        widget_session_id=widget_session_id,
+                        content=message_content,
+                        now=timezone.now(),
+                    )
+                    if isinstance(target, ticket_coalesce.ReplayTarget):
+                        ticket = target.ticket
+                        comment = target.comment
+                        coalesce_reason = "replayed"
+                    elif isinstance(target, ticket_coalesce.AppendTarget):
+                        ticket_id = str(target.ticket.id)
+                        coalesce_reason = "appended"
 
-                # Only HMAC-verified requests may (re)bind a ticket's distinct_id.
-                # Anonymous → identified continuity is still handled by person merging.
-                if verified_distinct_id is not None and ticket.distinct_id != distinct_id:
-                    ticket.distinct_id = distinct_id
+            if not session_busy and comment is None:
+                if ticket_id:
+                    try:
+                        # A coalesced append is serialized by the session advisory lock. Keep this
+                        # read unlocked because an ownership mismatch can proceed to ticket creation.
+                        ticket = Ticket.objects.get(id=ticket_id, team=team)
 
-                # Update traits if provided
-                if traits:
-                    ticket.anonymous_traits.update(traits)
+                        owned = True
+                        if verified_distinct_id is not None:
+                            allowed_ids = get_person_distinct_ids(team.id, verified_distinct_id)
+                            if ticket.distinct_id not in allowed_ids:
+                                owned = False
+                        elif ticket.widget_session_id != widget_session_id:
+                            # CRITICAL: anonymous access is by widget_session_id, not distinct_id
+                            owned = False
 
-                # Update session data if provided
-                if session_id:
-                    ticket.session_id = session_id
-                if session_context:
-                    ticket.session_context.update(session_context)
+                        if not owned:
+                            # Coalesced append must not 403 a send that used to create a ticket.
+                            # Explicit ticket_id keeps the old Forbidden/Not-found behaviour.
+                            if coalesce_reason == "appended":
+                                ticket_id = None
+                                ticket = None
+                                coalesce_reason = None
+                            else:
+                                return Response({"error": "Forbidden"}, status=status.HTTP_403_FORBIDDEN)
 
-                # HMAC-verified requests are server-attested — mark the identity trusted.
-                if verified_distinct_id is not None:
-                    ticket.identity_verified = True
+                        if ticket is not None:
+                            # Only HMAC-verified requests may (re)bind a ticket's distinct_id.
+                            # Anonymous → identified continuity is still handled by person merging.
+                            if verified_distinct_id is not None and ticket.distinct_id != distinct_id:
+                                ticket.distinct_id = distinct_id
 
-                # Increment unread count for team (customer sent a message)
-                ticket.unread_team_count = F("unread_team_count") + 1
-                ticket.save(
-                    update_fields=[
-                        "distinct_id",
-                        "anonymous_traits",
-                        "session_id",
-                        "session_context",
-                        "unread_team_count",
-                        "identity_verified",
-                        "updated_at",
-                    ]
+                            # Update traits if provided
+                            if traits:
+                                ticket.anonymous_traits.update(traits)
+
+                            # Update session data if provided
+                            if session_id:
+                                ticket.session_id = session_id
+                            if session_context:
+                                ticket.session_context.update(session_context)
+
+                            # HMAC-verified requests are server-attested — mark the identity trusted.
+                            if verified_distinct_id is not None:
+                                ticket.identity_verified = True
+
+                            # Increment unread count for team (customer sent a message)
+                            ticket.unread_team_count = F("unread_team_count") + 1
+                            ticket.save(
+                                update_fields=[
+                                    "distinct_id",
+                                    "anonymous_traits",
+                                    "session_id",
+                                    "session_context",
+                                    "unread_team_count",
+                                    "identity_verified",
+                                    "updated_at",
+                                ]
+                            )
+                            ticket.refresh_from_db()
+
+                    except Ticket.DoesNotExist:
+                        if coalesce_reason == "appended":
+                            ticket_id = None
+                            coalesce_reason = None
+                        else:
+                            return Response({"error": "Ticket not found"}, status=status.HTTP_404_NOT_FOUND)
+
+                if ticket is None:
+                    # No ticket_id and nothing to coalesce onto — create a new ticket
+                    conversations_settings = team.conversations_settings or {}
+                    widget_channel_detail = (
+                        ChannelDetail.WIDGET_EMBEDDED
+                        if conversations_settings.get("widget_enabled")
+                        else ChannelDetail.WIDGET_API
+                    )
+                    ticket = Ticket.objects.create_with_number(
+                        team=team,
+                        widget_session_id=widget_session_id,
+                        distinct_id=distinct_id,
+                        channel_source="widget",
+                        channel_detail=widget_channel_detail,
+                        status="new",
+                        anonymous_traits=traits,
+                        unread_team_count=1,
+                        session_id=session_id,
+                        session_context=session_context,
+                        identity_verified=verified_distinct_id is not None,
+                    )
+                    created_ticket = True
+
+                if ticket is None:
+                    raise RuntimeError("Widget message transaction has no ticket")
+
+                comment = Comment.objects.create(
+                    team=team,
+                    scope="conversations_ticket",
+                    item_id=str(ticket.id),
+                    content=message_content,
+                    item_context={"author_type": "customer", "distinct_id": distinct_id, "is_private": False},
                 )
-                ticket.refresh_from_db()
 
-            except Ticket.DoesNotExist:
-                return Response({"error": "Ticket not found"}, status=status.HTTP_404_NOT_FOUND)
-        else:
-            # No ticket_id provided - always create a new ticket
-            conversations_settings = team.conversations_settings or {}
-            widget_channel_detail = (
-                ChannelDetail.WIDGET_EMBEDDED
-                if conversations_settings.get("widget_enabled")
-                else ChannelDetail.WIDGET_API
-            )
-            ticket = Ticket.objects.create_with_number(
-                team=team,
-                widget_session_id=widget_session_id,
-                distinct_id=distinct_id,
-                channel_source="widget",
-                channel_detail=widget_channel_detail,
-                status="new",
-                anonymous_traits=traits,
-                unread_team_count=1,
-                session_id=session_id,
-                session_context=session_context,
-                identity_verified=verified_distinct_id is not None,
+        if session_busy:
+            return Response(
+                # posthog-js surfaces `message`; an `error` field falls back to generic copy.
+                {"message": "Another message is still sending. Try again shortly."},
+                status=status.HTTP_409_CONFLICT,
+                headers={"Retry-After": "1"},
             )
 
+        if ticket is None or comment is None:
+            raise RuntimeError("Widget message transaction completed without an outcome")
+
+        if created_ticket:
             try:
                 report_team_action(team, "support ticket created", {"channel_source": ticket.channel_source})
             except Exception as e:
                 capture_exception(e, {"ticket_id": str(ticket.id)})
-
-        # Create message
-        comment = Comment.objects.create(
-            team=team,
-            scope="conversations_ticket",
-            item_id=str(ticket.id),
-            content=message_content,
-            item_context={"author_type": "customer", "distinct_id": distinct_id, "is_private": False},
-        )
+        elif coalesce_reason is not None:
+            try:
+                report_team_action(
+                    team,
+                    "support ticket coalesced",
+                    {"channel_source": ticket.channel_source, "reason": coalesce_reason},
+                )
+            except Exception as e:
+                capture_exception(e, {"ticket_id": str(ticket.id)})
 
         # tickets + messages caches are invalidated by the post_save signal
         # via transaction.on_commit (see signals.py). Only unread_count needs
         # explicit invalidation here since the signal doesn't cover it.
-        invalidate_unread_count_cache(team.id)
+        if coalesce_reason != "replayed":
+            invalidate_unread_count_cache(team.id)
 
         return Response(
             {

--- a/products/conversations/backend/api/widget.py
+++ b/products/conversations/backend/api/widget.py
@@ -148,6 +148,18 @@ def _verify_identity(data: dict, team: Team) -> str | None:
     raise IdentityVerificationFailed("Invalid identity hash")
 
 
+def _request_owns_ticket(
+    *,
+    ticket: Ticket,
+    team_id: int,
+    verified_distinct_id: str | None,
+    widget_session_id: str,
+) -> bool:
+    if verified_distinct_id is not None:
+        return ticket.distinct_id in get_person_distinct_ids(team_id, verified_distinct_id)
+    return ticket.widget_session_id == widget_session_id
+
+
 class WidgetMessageView(APIView):
     """
     POST /api/conversations/v1/widget/message
@@ -260,9 +272,15 @@ class WidgetMessageView(APIView):
                         now=timezone.now(),
                     )
                     if isinstance(target, ticket_coalesce.ReplayTarget):
-                        ticket = target.ticket
-                        comment = target.comment
-                        coalesce_reason = "replayed"
+                        if _request_owns_ticket(
+                            ticket=target.ticket,
+                            team_id=team.id,
+                            verified_distinct_id=verified_distinct_id,
+                            widget_session_id=widget_session_id,
+                        ):
+                            ticket = target.ticket
+                            comment = target.comment
+                            coalesce_reason = "replayed"
                     elif isinstance(target, ticket_coalesce.AppendTarget):
                         ticket_id = str(target.ticket.id)
                         coalesce_reason = "appended"
@@ -274,16 +292,12 @@ class WidgetMessageView(APIView):
                         # read unlocked because an ownership mismatch can proceed to ticket creation.
                         ticket = Ticket.objects.get(id=ticket_id, team=team)
 
-                        owned = True
-                        if verified_distinct_id is not None:
-                            allowed_ids = get_person_distinct_ids(team.id, verified_distinct_id)
-                            if ticket.distinct_id not in allowed_ids:
-                                owned = False
-                        elif ticket.widget_session_id != widget_session_id:
-                            # CRITICAL: anonymous access is by widget_session_id, not distinct_id
-                            owned = False
-
-                        if not owned:
+                        if not _request_owns_ticket(
+                            ticket=ticket,
+                            team_id=team.id,
+                            verified_distinct_id=verified_distinct_id,
+                            widget_session_id=widget_session_id,
+                        ):
                             # Coalesced append must not 403 a send that used to create a ticket.
                             # Explicit ticket_id keeps the old Forbidden/Not-found behaviour.
                             if coalesce_reason == "appended":

--- a/products/conversations/backend/locks.py
+++ b/products/conversations/backend/locks.py
@@ -1,0 +1,53 @@
+import time
+import hashlib
+
+from django.db import connection
+
+# Ticket numbering has no IntegrityError retry, so this lock must block until allocation is safe.
+_TICKET_NUMBER_NAMESPACE = 0x0C0F_5E71
+
+# Keep the idle-in-transaction window bounded on this public endpoint.
+_SESSION_LOCK_ATTEMPTS = 5
+_SESSION_LOCK_BACKOFF_SECONDS = 0.1
+
+
+def _ensure_in_transaction() -> None:
+    if not connection.in_atomic_block:
+        raise RuntimeError("Conversation advisory locks require transaction.atomic()")
+
+
+def lock_ticket_numbering(team_id: int) -> None:
+    """Serialize ticket_number allocation for a team. Call inside transaction.atomic()."""
+    _ensure_in_transaction()
+    with connection.cursor() as cursor:
+        # Ticket inserts take this lock for their team foreign key. Taking it before the
+        # advisory lock prevents inversion with Team FOR UPDATE callers that create tickets.
+        # Callers must not upgrade the Team row to FOR UPDATE later in this transaction,
+        # because an earlier FOR UPDATE waiter can deadlock with that lock upgrade.
+        cursor.execute("SELECT id FROM posthog_team WHERE id = %s FOR KEY SHARE", [team_id])
+        cursor.execute("SELECT pg_advisory_xact_lock(%s, %s)", [_TICKET_NUMBER_NAMESPACE, team_id])
+
+
+def try_lock_widget_session(team_id: int, widget_session_id: str) -> bool:
+    """
+    Try to take the per-widget-session create lock, with a short retry.
+
+    Callers must fail without writing when this returns False. Using lock_timeout
+    would abort the transaction with 55P03 instead of allowing a controlled response.
+
+    The single-bigint key space is separate from the two-int numbering lock above.
+    Call inside transaction.atomic(); the lock releases on commit/rollback.
+    """
+    _ensure_in_transaction()
+    key = f"conversations-widget-session:{team_id}:{widget_session_id}"
+    lock_id = int.from_bytes(hashlib.sha256(key.encode()).digest()[:8], byteorder="big", signed=True)
+
+    for attempt in range(_SESSION_LOCK_ATTEMPTS):
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT pg_try_advisory_xact_lock(%s)", [lock_id])
+            row = cursor.fetchone()
+        if row is not None and row[0]:
+            return True
+        if attempt < _SESSION_LOCK_ATTEMPTS - 1:
+            time.sleep(_SESSION_LOCK_BACKOFF_SECONDS)
+    return False

--- a/products/conversations/backend/models/ticket.py
+++ b/products/conversations/backend/models/ticket.py
@@ -4,6 +4,8 @@ from django.db import models, transaction
 
 from posthog.models.utils import UUIDTModel
 
+from products.conversations.backend.locks import lock_ticket_numbering
+
 from .constants import Channel, ChannelDetail, Priority, Status
 
 if TYPE_CHECKING:
@@ -14,17 +16,19 @@ class TicketManager(models.Manager):
     def create_with_number(self, **kwargs):
         """
         Create a ticket with an auto-incrementing ticket_number.
-        Uses SELECT FOR UPDATE on Team row to serialize ticket creation per team.
-        """
-        from posthog.models import Team
 
+        Serializes per team via a Postgres advisory lock so concurrent creates
+        cannot allocate the same number. An advisory lock is used instead of
+        SELECT FOR UPDATE on the Team row. An explicit foreign-key key-share lock
+        establishes deadlock-safe ordering and stays compatible with ordinary
+        updates to the team.
+        """
         team = kwargs.get("team")
         if not team:
             raise ValueError("team is required")
 
         with transaction.atomic():
-            # Lock team row to serialize ticket creation for this team
-            Team.objects.select_for_update().get(id=team.id)
+            lock_ticket_numbering(team.id)
 
             max_num = self.filter(team=team).aggregate(models.Max("ticket_number"))["ticket_number__max"] or 0
             kwargs["ticket_number"] = max_num + 1

--- a/products/conversations/backend/temporal/zendesk_import/activities.py
+++ b/products/conversations/backend/temporal/zendesk_import/activities.py
@@ -28,6 +28,7 @@ with workflow.unsafe.imports_passed_through():
     from posthog.sync import database_sync_to_async
     from posthog.temporal.common.heartbeat import Heartbeater
 
+    from products.conversations.backend.locks import lock_ticket_numbering
     from products.conversations.backend.models import EmailChannel, Ticket, ZendeskImportJob
     from products.conversations.backend.models.constants import Status
     from products.conversations.backend.services.attachments import (
@@ -439,8 +440,8 @@ def _import_ticket_batch_sync(input: ImportBatchInput) -> ImportBatchOutput:
     tags_by_name = {name: Tag.objects.get_or_create(name=name, team_id=team.id)[0] for name in all_tag_names}
 
     # Phase 3: Persist tickets + comments in a single transaction (no network I/O).
-    # Ticket numbers are assigned under the same lock that guards bulk_create, so
-    # concurrent batch activities can't collide on unique_ticket_number_per_team.
+    # Ticket numbers are assigned under the same advisory lock as create_with_number, so
+    # concurrent widget creates and batch activities can't collide on unique_ticket_number_per_team.
     #
     # IMPORTANT: persist historical rows with bulk_create/bulk_update ONLY. These bypass the
     # post_save/pre_save receivers in products/conversations/backend/signals.py, which is what
@@ -450,7 +451,7 @@ def _import_ticket_batch_sync(input: ImportBatchInput) -> ImportBatchOutput:
     # Comment.objects.create(), or .save() would fire those signals for every imported row —
     # triggering workflows and re-sending replies to real customers for years-old tickets. Don't.
     with transaction.atomic():
-        Team.objects.select_for_update().get(id=team.id)
+        lock_ticket_numbering(team.id)
         max_num = Ticket.objects.filter(team_id=team.id).aggregate(Max("ticket_number"))["ticket_number__max"] or 0
         for offset, ticket_to_number in enumerate(tickets_to_create):
             ticket_to_number.ticket_number = max_num + 1 + offset

--- a/products/conversations/backend/temporal/zendesk_import/tests/test_activities.py
+++ b/products/conversations/backend/temporal/zendesk_import/tests/test_activities.py
@@ -5,6 +5,9 @@ from typing import Any
 from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
 from parameterized import parameterized
 
 from posthog.models import Tag
@@ -484,12 +487,13 @@ class TestZendeskImportBatchActivity(BaseTest):
         # without colliding on unique_ticket_number_per_team.
         Ticket.objects.create(team=self.team, ticket_number=5, widget_session_id="s", distinct_id="d")
 
-        self._run_batch(
-            [301, 302, 303],
-            tickets=[_zd_ticket(301, 10), _zd_ticket(302, 10), _zd_ticket(303, 10)],
-            users={10: _zd_user(10, "requester@x.com")},
-            comments_by_ticket={},
-        )
+        with CaptureQueriesContext(connection) as query_context:
+            self._run_batch(
+                [301, 302, 303],
+                tickets=[_zd_ticket(301, 10), _zd_ticket(302, 10), _zd_ticket(303, 10)],
+                users={10: _zd_user(10, "requester@x.com")},
+                comments_by_ticket={},
+            )
 
         numbers = sorted(
             Ticket.objects.filter(team=self.team, zendesk_ticket_id__in=[301, 302, 303]).values_list(
@@ -497,6 +501,13 @@ class TestZendeskImportBatchActivity(BaseTest):
             )
         )
         self.assertEqual(numbers, [6, 7, 8])
+        sql_statements = [query["sql"].lower() for query in query_context.captured_queries]
+        self.assertFalse(any("posthog_team" in sql and "for update" in sql for sql in sql_statements))
+        team_key_share_index = next(
+            index for index, sql in enumerate(sql_statements) if "posthog_team" in sql and "for key share" in sql
+        )
+        numbering_lock_index = next(index for index, sql in enumerate(sql_statements) if "pg_advisory_xact_lock" in sql)
+        self.assertLess(team_key_share_index, numbering_lock_index)
 
     def test_image_attachment_embedded_in_rich_content(self) -> None:
         comment = _zd_comment(

--- a/products/conversations/backend/tests/test_ticket_coalesce.py
+++ b/products/conversations/backend/tests/test_ticket_coalesce.py
@@ -1,0 +1,192 @@
+from datetime import timedelta
+
+from freezegun import freeze_time
+from posthog.test.base import BaseTest
+
+from django.utils import timezone
+
+from parameterized import parameterized
+
+from posthog.models.comment import Comment
+
+from products.conversations.backend.models import Ticket
+from products.conversations.backend.models.constants import Status
+from products.conversations.backend.ticket_coalesce import (
+    APPEND_WINDOW_SECONDS,
+    IDENTICAL_REPLAY_WINDOW_SECONDS,
+    AppendTarget,
+    ReplayTarget,
+    resolve,
+)
+
+
+class TestTicketCoalesceResolve(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.widget_session_id = "11111111-1111-4111-8111-111111111111"
+        self.now = timezone.now()
+
+    def _ticket(self, **overrides: object) -> Ticket:
+        fields: dict[str, object] = {
+            "team": self.team,
+            "widget_session_id": self.widget_session_id,
+            "distinct_id": "customer-1",
+            "channel_source": "widget",
+            "status": "new",
+        }
+        fields.update(overrides)
+        return Ticket.objects.create_with_number(**fields)
+
+    def _customer_comment(self, ticket: Ticket, content: str, **overrides: object) -> Comment:
+        fields: dict[str, object] = {
+            "team": self.team,
+            "scope": "conversations_ticket",
+            "item_id": str(ticket.id),
+            "content": content,
+            "item_context": {"author_type": "customer", "distinct_id": "customer-1", "is_private": False},
+        }
+        fields.update(overrides)
+        return Comment.objects.create(**fields)
+
+    def test_appends_recent_unanswered_ticket_with_different_text(self) -> None:
+        ticket = self._ticket()
+        self._customer_comment(ticket, "First attempt")
+
+        target = resolve(
+            team_id=self.team.id,
+            widget_session_id=self.widget_session_id,
+            content="Retyped with different wording",
+            now=self.now,
+        )
+
+        self.assertEqual(target, AppendTarget(ticket=ticket))
+
+    def test_replays_identical_text_inside_replay_window(self) -> None:
+        ticket = self._ticket()
+        comment = self._customer_comment(ticket, "Same body twice")
+
+        target = resolve(
+            team_id=self.team.id,
+            widget_session_id=self.widget_session_id,
+            content="Same body twice",
+            now=self.now,
+        )
+
+        self.assertEqual(target, ReplayTarget(ticket=ticket, comment=comment))
+
+    def test_replays_older_identical_body_over_newer_different_candidate(self) -> None:
+        with freeze_time(self.now - timedelta(seconds=20)):
+            older = self._ticket()
+            older_comment = self._customer_comment(older, "Original wording")
+        with freeze_time(self.now - timedelta(seconds=10)):
+            newer = self._ticket()
+            self._customer_comment(newer, "Different follow-up wording")
+
+        target = resolve(
+            team_id=self.team.id,
+            widget_session_id=self.widget_session_id,
+            content="Original wording",
+            now=self.now,
+        )
+
+        self.assertEqual(target, ReplayTarget(ticket=older, comment=older_comment))
+
+    @parameterized.expand(
+        [
+            ("support_reply", {"author_type": "support", "is_private": False}),
+            ("ai_reply", {"author_type": "AI", "is_private": False}),
+            ("team_reply", {"author_type": "team", "is_private": False}),
+            ("unknown_reply", {"author_type": "other", "is_private": False}),
+            ("missing_author_type", {"is_private": False}),
+        ]
+    )
+    def test_creates_when_candidate_has_non_customer_comment(self, _name: str, item_context: dict[str, object]) -> None:
+        ticket = self._ticket()
+        self._customer_comment(ticket, "Customer opener")
+        Comment.objects.create(
+            team=self.team,
+            scope="conversations_ticket",
+            item_id=str(ticket.id),
+            content="We looked into it",
+            item_context=item_context,
+        )
+
+        target = resolve(
+            team_id=self.team.id,
+            widget_session_id=self.widget_session_id,
+            content="Follow-up that should be a new ticket",
+            now=self.now,
+        )
+
+        self.assertIsNone(target)
+
+    def test_creates_when_candidate_is_resolved(self) -> None:
+        ticket = self._ticket(status=Status.RESOLVED)
+        self._customer_comment(ticket, "Already closed out")
+
+        target = resolve(
+            team_id=self.team.id,
+            widget_session_id=self.widget_session_id,
+            content="New question after resolve",
+            now=self.now,
+        )
+
+        self.assertIsNone(target)
+
+    def test_creates_when_widget_session_differs(self) -> None:
+        ticket = self._ticket()
+        self._customer_comment(ticket, "Hello")
+
+        target = resolve(
+            team_id=self.team.id,
+            widget_session_id="22222222-2222-4222-8222-222222222222",
+            content="Hello",
+            now=self.now,
+        )
+
+        self.assertIsNone(target)
+
+    def test_creates_when_candidate_older_than_both_windows(self) -> None:
+        with freeze_time(self.now - timedelta(seconds=APPEND_WINDOW_SECONDS + 1)):
+            ticket = self._ticket()
+            self._customer_comment(ticket, "Stale opener")
+
+        target = resolve(
+            team_id=self.team.id,
+            widget_session_id=self.widget_session_id,
+            content="New question after the windows",
+            now=self.now,
+        )
+
+        self.assertIsNone(target)
+
+    def test_appends_identical_text_outside_replay_window(self) -> None:
+        age = IDENTICAL_REPLAY_WINDOW_SECONDS + 1
+        assert age < APPEND_WINDOW_SECONDS
+        with freeze_time(self.now - timedelta(seconds=age)):
+            ticket = self._ticket()
+            self._customer_comment(ticket, "Exact same body")
+
+        target = resolve(
+            team_id=self.team.id,
+            widget_session_id=self.widget_session_id,
+            content="Exact same body",
+            now=self.now,
+        )
+
+        self.assertEqual(target, AppendTarget(ticket=ticket))
+
+    def test_appends_when_recent_comment_has_not_updated_last_message_at_yet(self) -> None:
+        with freeze_time(self.now - timedelta(seconds=APPEND_WINDOW_SECONDS + 1)):
+            ticket = self._ticket()
+        with freeze_time(self.now - timedelta(seconds=5)):
+            self._customer_comment(ticket, "Recent message on an older ticket")
+
+        target = resolve(
+            team_id=self.team.id,
+            widget_session_id=self.widget_session_id,
+            content="Retried message",
+            now=self.now,
+        )
+
+        self.assertEqual(target, AppendTarget(ticket=ticket))

--- a/products/conversations/backend/tests/test_ticket_coalesce.py
+++ b/products/conversations/backend/tests/test_ticket_coalesce.py
@@ -74,10 +74,10 @@ class TestTicketCoalesceResolve(BaseTest):
 
         self.assertEqual(target, ReplayTarget(ticket=ticket, comment=comment))
 
-    def test_replays_older_identical_body_over_newer_different_candidate(self) -> None:
+    def test_appends_to_newest_ticket_instead_of_replaying_older_candidate(self) -> None:
         with freeze_time(self.now - timedelta(seconds=20)):
             older = self._ticket()
-            older_comment = self._customer_comment(older, "Original wording")
+            self._customer_comment(older, "Original wording")
         with freeze_time(self.now - timedelta(seconds=10)):
             newer = self._ticket()
             self._customer_comment(newer, "Different follow-up wording")
@@ -89,7 +89,39 @@ class TestTicketCoalesceResolve(BaseTest):
             now=self.now,
         )
 
-        self.assertEqual(target, ReplayTarget(ticket=older, comment=older_comment))
+        self.assertEqual(target, AppendTarget(ticket=newer))
+
+    def test_appends_repeated_text_when_a_different_message_intervened(self) -> None:
+        ticket = self._ticket()
+        with freeze_time(self.now - timedelta(seconds=20)):
+            self._customer_comment(ticket, "Repeated wording")
+        with freeze_time(self.now - timedelta(seconds=10)):
+            self._customer_comment(ticket, "Intervening message")
+
+        target = resolve(
+            team_id=self.team.id,
+            widget_session_id=self.widget_session_id,
+            content="Repeated wording",
+            now=self.now,
+        )
+
+        self.assertEqual(target, AppendTarget(ticket=ticket))
+
+    def test_replays_when_identical_text_is_the_latest_of_multiple_messages(self) -> None:
+        ticket = self._ticket()
+        with freeze_time(self.now - timedelta(seconds=20)):
+            self._customer_comment(ticket, "Earlier message")
+        with freeze_time(self.now - timedelta(seconds=10)):
+            latest_comment = self._customer_comment(ticket, "Repeated wording")
+
+        target = resolve(
+            team_id=self.team.id,
+            widget_session_id=self.widget_session_id,
+            content="Repeated wording",
+            now=self.now,
+        )
+
+        self.assertEqual(target, ReplayTarget(ticket=ticket, comment=latest_comment))
 
     @parameterized.expand(
         [

--- a/products/conversations/backend/ticket_coalesce.py
+++ b/products/conversations/backend/ticket_coalesce.py
@@ -54,7 +54,8 @@ def resolve(*, team_id: int, widget_session_id: str, content: str, now: datetime
     The latest comment participates in recency because last_message_at is updated
     on commit and can briefly lag behind release of the advisory lock.
 
-    Replay is checked across all unanswered candidates before append.
+    Replay only applies to the latest customer message on the newest unanswered ticket.
+    A matching message on any older ticket appends to the newest ticket instead.
     """
     replay_cutoff = now - timedelta(seconds=IDENTICAL_REPLAY_WINDOW_SECONDS)
     append_cutoff = now - timedelta(seconds=APPEND_WINDOW_SECONDS)
@@ -84,34 +85,34 @@ def resolve(*, team_id: int, widget_session_id: str, content: str, now: datetime
             )
         )
         .filter(last_activity__gte=append_cutoff)
-        .order_by("-last_activity")[:_CANDIDATE_LIMIT]
+        .order_by("-last_activity", "-created_at", "-id")[:_CANDIDATE_LIMIT]
     )
 
-    ticket_by_id = {str(ticket.id): ticket for ticket in candidates}
     answered_ticket_ids = _ticket_ids_with_non_customer_replies(
         team_id=team_id, ticket_ids=[ticket.id for ticket in candidates]
     )
     unanswered = [ticket for ticket in candidates if str(ticket.id) not in answered_ticket_ids]
 
-    identical = (
+    if not unanswered:
+        return None
+
+    ticket = unanswered[0]
+    latest_customer_comment = (
         Comment.objects.filter(
             team_id=team_id,
             scope="conversations_ticket",
-            item_id__in=[str(ticket.id) for ticket in unanswered],
+            item_id=str(ticket.id),
             deleted=False,
-            content=content,
-            created_at__gte=replay_cutoff,
             item_context__author_type="customer",
         )
         .order_by("-created_at")
         .first()
     )
-    if identical is not None and identical.item_id is not None:
-        ticket = ticket_by_id.get(identical.item_id)
-        if ticket is not None:
-            return ReplayTarget(ticket=ticket, comment=identical)
+    if (
+        latest_customer_comment is not None
+        and latest_customer_comment.created_at >= replay_cutoff
+        and latest_customer_comment.content == content
+    ):
+        return ReplayTarget(ticket=ticket, comment=latest_customer_comment)
 
-    if unanswered:
-        return AppendTarget(ticket=unanswered[0])
-
-    return None
+    return AppendTarget(ticket=ticket)

--- a/products/conversations/backend/ticket_coalesce.py
+++ b/products/conversations/backend/ticket_coalesce.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from uuid import UUID
+
+from django.db.models import CharField, OuterRef, Q, Subquery
+from django.db.models.functions import Cast, Coalesce, Greatest
+
+from posthog.models.comment import Comment
+
+from products.conversations.backend.models import Ticket
+from products.conversations.backend.models.constants import Status
+
+IDENTICAL_REPLAY_WINDOW_SECONDS = 30
+APPEND_WINDOW_SECONDS = 180
+
+_CANDIDATE_LIMIT = 5
+_APPENDABLE_STATUSES = (Status.NEW, Status.OPEN, Status.PENDING, Status.ON_HOLD)
+
+
+@dataclass(frozen=True, kw_only=True)
+class AppendTarget:
+    ticket: Ticket
+
+
+@dataclass(frozen=True, kw_only=True)
+class ReplayTarget:
+    ticket: Ticket
+    comment: Comment
+
+
+def _ticket_ids_with_non_customer_replies(*, team_id: int, ticket_ids: list[UUID]) -> set[str]:
+    return set(
+        Comment.objects.filter(
+            team_id=team_id,
+            scope="conversations_ticket",
+            item_id__in=[str(ticket_id) for ticket_id in ticket_ids],
+            deleted=False,
+        )
+        .filter(~Q(item_context__author_type="customer") | Q(item_context__author_type__isnull=True))
+        .values_list("item_id", flat=True)
+    )
+
+
+def resolve(*, team_id: int, widget_session_id: str, content: str, now: datetime) -> AppendTarget | ReplayTarget | None:
+    """
+    Decide whether a ticket-less widget send should create, append, or replay.
+
+    Caller must hold the widget-session advisory lock so concurrent creates see
+    each other's commits. Keys on widget_session_id (not distinct_id) so the
+    returned ticket stays readable by the anonymous widget messages endpoint.
+
+    The latest comment participates in recency because last_message_at is updated
+    on commit and can briefly lag behind release of the advisory lock.
+
+    Replay is checked across all unanswered candidates before append.
+    """
+    replay_cutoff = now - timedelta(seconds=IDENTICAL_REPLAY_WINDOW_SECONDS)
+    append_cutoff = now - timedelta(seconds=APPEND_WINDOW_SECONDS)
+    latest_comment = (
+        Comment.objects.filter(
+            team_id=team_id,
+            scope="conversations_ticket",
+            item_id=Cast(OuterRef("id"), output_field=CharField()),
+            deleted=False,
+        )
+        .order_by("-created_at")
+        .values("created_at")[:1]
+    )
+
+    candidates = list(
+        Ticket.objects.filter(
+            team_id=team_id,
+            widget_session_id=widget_session_id,
+            channel_source="widget",
+            status__in=_APPENDABLE_STATUSES,
+        )
+        .annotate(latest_comment_at=Subquery(latest_comment))
+        .annotate(
+            last_activity=Greatest(
+                Coalesce("last_message_at", "created_at"),
+                Coalesce("latest_comment_at", "created_at"),
+            )
+        )
+        .filter(last_activity__gte=append_cutoff)
+        .order_by("-last_activity")[:_CANDIDATE_LIMIT]
+    )
+
+    ticket_by_id = {str(ticket.id): ticket for ticket in candidates}
+    answered_ticket_ids = _ticket_ids_with_non_customer_replies(
+        team_id=team_id, ticket_ids=[ticket.id for ticket in candidates]
+    )
+    unanswered = [ticket for ticket in candidates if str(ticket.id) not in answered_ticket_ids]
+
+    identical = (
+        Comment.objects.filter(
+            team_id=team_id,
+            scope="conversations_ticket",
+            item_id__in=[str(ticket.id) for ticket in unanswered],
+            deleted=False,
+            content=content,
+            created_at__gte=replay_cutoff,
+            item_context__author_type="customer",
+        )
+        .order_by("-created_at")
+        .first()
+    )
+    if identical is not None and identical.item_id is not None:
+        ticket = ticket_by_id.get(identical.item_id)
+        if ticket is not None:
+            return ReplayTarget(ticket=ticket, comment=identical)
+
+    if unanswered:
+        return AppendTarget(ticket=unanswered[0])
+
+    return None


### PR DESCRIPTION
## Problem

Support widget customers can create duplicate tickets when a successful request loses its response and they retry.

Ticket numbering also waits on unrelated `Team` updates, increasing request latency and the chance of a lost response.

## Changes

- Ticketless retries now serialize by widget session and reuse recent unanswered tickets.

Before:

```mermaid
flowchart LR
    Send[Ticketless send] --> Create[Create ticket]
    Retry[Retry] --> Duplicate[Create duplicate ticket]
```

After:

```mermaid
flowchart LR
    Send[Ticketless send] --> Lock[Lock widget session]
    Lock --> Recent{Recent unanswered ticket?}
    Recent -->|Yes| Reuse[Replay or append]
    Recent -->|No| Create[Create ticket]
    Lock -->|Busy| Reject[Return 409 without writing]
```

- Identical retries replay for 30 seconds. Different retries append for 180 seconds.
- Ticket creation and its first message now commit atomically.
- Ticket numbering uses deadlock-safe key-share and advisory lock ordering.
- Zendesk imports use the same numbering lock.
- Client-supplied ticket IDs retain the existing ownership checks and 403 response.

