### PR TITLE
chore(ci): filter the playwright and storybook suites on the pushed commits

### DIFF
--- a/.github/actions/paths-filter/README.md
+++ b/.github/actions/paths-filter/README.md
@@ -65,6 +65,50 @@ changed:
   - added|modified: ['src/**', '!src/vendor/**']
 ```
 
+## `since-last-push`: filtering on the pushed commits only
+
+By default a `pull_request` run filters on everything the pull request changes,
+so a follow-up push that touches only docs still re-runs every suite the earlier commits matched.
+`since-last-push: true` narrows detection to the commits the triggering push added:
+
+```yaml
+- uses: ./.github/actions/paths-filter
+  with:
+    token: ${{ steps.app-token.outputs.token || github.token }}
+    # Trunk's merge queue is the merge gate, so its runs always see the full diff.
+    since-last-push: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
+    filters: |
+      frontend:
+        - 'frontend/**'
+```
+
+It reads `before`/`after` off the `synchronize` payload and asks the compare API for `before...after`.
+Three dots means the comparison starts from `merge-base(before, after)`,
+so an appended push reports exactly its own commits,
+while a force-push or rebase widens to the whole branch delta instead of reporting a wrong one.
+
+The full pull request diff is used instead whenever the push delta isn't available or isn't trustworthy:
+any event other than `synchronize` (including `opened` and `ready_for_review`),
+a missing or null `before`/`after`,
+no `token`,
+an API error,
+or a comparison at the API's 300-file cap, where the file list may be truncated.
+Every fallback reports more changes than the push delta would, never fewer.
+
+**Know the trade-off before enabling this.**
+Pull request runs cancel in progress on a new push.
+If push A touches Rust and push B touches only docs,
+A's Rust job can be cancelled while B's run filters it out,
+so nothing tests A on this pull request.
+What makes that survivable here is that Trunk's merge queue re-runs CI on a fresh `trunk-merge/**` pull request,
+whose full diff against master is the actual merge gate.
+The cost is that the breakage surfaces in the queue rather than on the pull request.
+Enable this on suites where that trade is worth the runner time, and keep the merge queue on the full diff.
+
+Detection is per invocation,
+so a workflow can gate cheap jobs on the push delta
+while a second step keeps the whole-pull-request `*_files` lists that test selection and lint scoping need.
+
 ## Rebuilding after source changes
 
 The action runs the committed `dist/index.js` bundle. After editing anything under `src/`,

--- a/.github/actions/paths-filter/__tests__/push-delta.test.ts
+++ b/.github/actions/paths-filter/__tests__/push-delta.test.ts
@@ -1,0 +1,38 @@
+import {COMPARE_FILE_LIMIT, getPushDeltaRange, isComparisonTruncated, PushDeltaPayload} from '../src/push-delta'
+
+const BEFORE = '1111111111111111111111111111111111111111'
+const AFTER = '2222222222222222222222222222222222222222'
+const NULL_SHA = '0000000000000000000000000000000000000000'
+
+describe('detecting changes from the last push only', () => {
+  test('uses the pushed range on a synchronize event', () => {
+    const range = getPushDeltaRange('pull_request', {action: 'synchronize', before: BEFORE, after: AFTER})
+    expect(range).toEqual({usable: true, before: BEFORE, after: AFTER})
+  })
+
+  test.each<[string, string, PushDeltaPayload]>([
+    ['a push to a branch', 'push', {before: BEFORE, after: AFTER}],
+    ['a newly opened pull request', 'pull_request', {action: 'opened'}],
+    ['a pull request leaving draft', 'pull_request', {action: 'ready_for_review'}],
+    ['a payload without before', 'pull_request', {action: 'synchronize', after: AFTER}],
+    ['a payload without after', 'pull_request', {action: 'synchronize', before: BEFORE}],
+    ['a branch created at the null SHA', 'pull_request', {action: 'synchronize', before: NULL_SHA, after: AFTER}],
+    ['a branch deleted to the null SHA', 'pull_request', {action: 'synchronize', before: BEFORE, after: NULL_SHA}],
+    ['a push that did not move the head', 'pull_request', {action: 'synchronize', before: BEFORE, after: BEFORE}]
+  ])('falls back to the full diff for %s', (_description, eventName, payload) => {
+    expect(getPushDeltaRange(eventName, payload).usable).toBe(false)
+  })
+
+  test.each([
+    ['an empty comparison', 0, false],
+    ['a comparison below the cap', COMPARE_FILE_LIMIT - 1, false],
+    ['a comparison at the cap', COMPARE_FILE_LIMIT, true],
+    ['a comparison past the cap', COMPARE_FILE_LIMIT + 1, true]
+  ])('decides whether %s is truncated', (_description, count, expected) => {
+    expect(isComparisonTruncated(new Array(count).fill({}))).toBe(expected)
+  })
+
+  test('treats a comparison with no file list as truncated', () => {
+    expect(isComparisonTruncated(undefined)).toBe(true)
+  })
+})

--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -20,6 +20,17 @@ inputs:
             If it references same branch it was pushed to, changes are detected against the most recent commit before the push.
             This option is ignored if action is triggered by pull_request event.
         required: false
+    since-last-push:
+        description: |
+            Detect changes from the commits of the triggering push only, instead of from the
+            whole pull request. Takes effect on `pull_request` `synchronize` events when `token`
+            is set, and silently falls back to the full pull request diff everywhere else, so a
+            filter can only ever report more changes than it would have, never fewer.
+            The full diff is also used when the push cannot be compared reliably: a force-push or
+            rebase, a comparison at the API's 300-file cap, or an API error.
+            Read the trade-off in README.md before enabling this on a workflow.
+        required: false
+        default: 'false'
     filters:
         description: 'Path to the configuration file or YAML string with filters definition'
         required: true

--- a/.github/actions/paths-filter/dist/index.js
+++ b/.github/actions/paths-filter/dist/index.js
@@ -42687,6 +42687,7 @@ const github = __importStar(__nccwpck_require__(3228));
 const filter_1 = __nccwpck_require__(9037);
 const file_1 = __nccwpck_require__(3765);
 const git = __importStar(__nccwpck_require__(1243));
+const push_delta_1 = __nccwpck_require__(5616);
 const shell_escape_1 = __nccwpck_require__(6880);
 const csv_escape_1 = __nccwpck_require__(6146);
 async function run() {
@@ -42702,12 +42703,16 @@ async function run() {
         const filtersYaml = isPathInput(filtersInput) ? getConfigFileContent(filtersInput) : filtersInput;
         const listFiles = core.getInput('list-files', { required: false }).toLowerCase() || 'none';
         const initialFetchDepth = parseInt(core.getInput('initial-fetch-depth', { required: false })) || 10;
+        // Parsed leniently rather than with getBooleanInput: an unexpected value degrades
+        // to the full diff, which over-reports changes, instead of failing the job that
+        // every other job in the workflow waits on.
+        const sinceLastPush = core.getInput('since-last-push', { required: false }).toLowerCase() === 'true';
         if (!isExportFormat(listFiles)) {
             core.setFailed(`Input parameter 'list-files' is set to invalid value '${listFiles}'`);
             return;
         }
         const filter = new filter_1.Filter(filtersYaml);
-        const files = await getChangedFiles(token, base, ref, initialFetchDepth);
+        const files = await getChangedFiles(token, base, ref, initialFetchDepth, sinceLastPush);
         core.info(`Detected ${files.length} changed files`);
         const results = filter.match(files);
         exportResults(results, listFiles);
@@ -42728,7 +42733,7 @@ function getConfigFileContent(configPath) {
     }
     return fs.readFileSync(configPath, { encoding: 'utf8' });
 }
-async function getChangedFiles(token, base, ref, initialFetchDepth) {
+async function getChangedFiles(token, base, ref, initialFetchDepth, sinceLastPush) {
     var _a, _b;
     // if base is 'HEAD' only local uncommitted changes will be detected
     // This is the simplest case as we don't need to fetch more commits or evaluate current/before refs
@@ -42753,7 +42758,16 @@ async function getChangedFiles(token, base, ref, initialFetchDepth) {
             }
             const pr = github.context.payload.pull_request;
             if (token) {
+                if (sinceLastPush) {
+                    const pushed = await getPushDeltaFromApi(token);
+                    if (pushed) {
+                        return pushed;
+                    }
+                }
                 return await getChangedFilesFromApi(token, pr);
+            }
+            if (sinceLastPush) {
+                core.warning(`'token' input parameter is required by 'since-last-push' - the full pull request diff will be used`);
             }
             if (github.context.eventName === 'pull_request_target') {
                 // pull_request_target is executed in context of base branch and GITHUB_SHA points to last commit in base branch
@@ -42835,37 +42849,79 @@ async function getChangedFilesFromApi(token, pullRequest) {
                 throw new Error(`Fetching list of changed files from GitHub API failed with error code ${response.status}`);
             }
             core.info(`Received ${response.data.length} items`);
-            for (const row of response.data) {
-                core.info(`[${row.status}] ${row.filename}`);
-                // There's no obvious use-case for detection of renames
-                // Therefore we treat it as if rename detection in git diff was turned off.
-                // Rename is replaced by delete of original filename and add of new filename
-                if (row.status === file_1.ChangeStatus.Renamed) {
-                    files.push({
-                        filename: row.filename,
-                        status: file_1.ChangeStatus.Added
-                    });
-                    files.push({
-                        // 'previous_filename' for some unknown reason isn't in the type definition or documentation
-                        filename: row.previous_filename,
-                        status: file_1.ChangeStatus.Deleted
-                    });
-                }
-                else {
-                    // Github status and git status variants are same except for deleted files
-                    const status = row.status === 'removed' ? file_1.ChangeStatus.Deleted : row.status;
-                    files.push({
-                        filename: row.filename,
-                        status
-                    });
-                }
-            }
+            files.push(...apiFilesToChanges(response.data));
         }
         return files;
     }
     finally {
         core.endGroup();
     }
+}
+// Lists the files a single push added to the pull request, rather than everything
+// the pull request changes. Returns null whenever that comparison can't be trusted,
+// which leaves the caller on the full pull request diff.
+async function getPushDeltaFromApi(token) {
+    var _a, _b, _c;
+    const range = (0, push_delta_1.getPushDeltaRange)(github.context.eventName, github.context.payload);
+    if (!range.usable) {
+        core.info(`Changes since last push are not available (${range.reason}) - using the full pull request diff`);
+        return null;
+    }
+    const basehead = `${range.before}...${range.after}`;
+    core.startGroup(`Fetching list of files changed by the push ${basehead} from Github API`);
+    try {
+        const client = github.getOctokit(token);
+        // Three dots so the comparison starts from merge-base(before, after): for an
+        // appended push that is exactly the pushed commits, while a force-push or a
+        // rebase widens it to the whole branch delta rather than reporting a bogus one.
+        const response = await client.rest.repos.compareCommitsWithBasehead({
+            owner: github.context.repo.owner,
+            repo: github.context.repo.repo,
+            basehead
+        });
+        if ((0, push_delta_1.isComparisonTruncated)(response.data.files)) {
+            core.warning(`Comparison of ${basehead} reports ${(_b = (_a = response.data.files) === null || _a === void 0 ? void 0 : _a.length) !== null && _b !== void 0 ? _b : 0} files and is capped at ` +
+                `${push_delta_1.COMPARE_FILE_LIMIT} - using the full pull request diff instead of a possibly truncated list`);
+            return null;
+        }
+        return apiFilesToChanges((_c = response.data.files) !== null && _c !== void 0 ? _c : []);
+    }
+    catch (error) {
+        core.warning(`Failed to compare ${basehead} (${getErrorMessage(error)}) - using the full pull request diff instead`);
+        return null;
+    }
+    finally {
+        core.endGroup();
+    }
+}
+function apiFilesToChanges(rows) {
+    const files = [];
+    for (const row of rows) {
+        core.info(`[${row.status}] ${row.filename}`);
+        // There's no obvious use-case for detection of renames
+        // Therefore we treat it as if rename detection in git diff was turned off.
+        // Rename is replaced by delete of original filename and add of new filename
+        if (row.status === file_1.ChangeStatus.Renamed) {
+            files.push({
+                filename: row.filename,
+                status: file_1.ChangeStatus.Added
+            });
+            files.push({
+                // 'previous_filename' for some unknown reason isn't in the type definition or documentation
+                filename: row.previous_filename,
+                status: file_1.ChangeStatus.Deleted
+            });
+        }
+        else {
+            // Github status and git status variants are same except for deleted files
+            const status = row.status === 'removed' ? file_1.ChangeStatus.Deleted : row.status;
+            files.push({
+                filename: row.filename,
+                status
+            });
+        }
+    }
+    return files;
 }
 function exportResults(results, format) {
     core.info('Results:');
@@ -42924,6 +42980,50 @@ function getErrorMessage(error) {
     return String(error);
 }
 run();
+
+
+/***/ }),
+
+/***/ 5616:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.COMPARE_FILE_LIMIT = void 0;
+exports.getPushDeltaRange = getPushDeltaRange;
+exports.isComparisonTruncated = isComparisonTruncated;
+// The compare API caps its file list at 300 entries and does not paginate them,
+// so a list at the cap may be truncated. Under-reporting changed files would let
+// a workflow skip jobs it should have run, so the caller falls back to the full
+// pull request diff instead.
+exports.COMPARE_FILE_LIMIT = 300;
+const NULL_SHA = '0000000000000000000000000000000000000000';
+function getPushDeltaRange(eventName, payload) {
+    // Only a synchronize payload carries before/after. Every other pull request
+    // action (opened, reopened, ready_for_review) has no previous head to compare
+    // against, and those are exactly the events where the whole diff is wanted.
+    if (eventName !== 'pull_request') {
+        return { usable: false, reason: `event is ${eventName}, not pull_request` };
+    }
+    if (payload.action !== 'synchronize') {
+        return { usable: false, reason: `pull request action is ${payload.action}, not synchronize` };
+    }
+    const { before, after } = payload;
+    if (!before || !after) {
+        return { usable: false, reason: 'payload is missing before or after' };
+    }
+    if (before === NULL_SHA || after === NULL_SHA) {
+        return { usable: false, reason: 'before or after is the null SHA' };
+    }
+    if (before === after) {
+        return { usable: false, reason: 'before and after are the same commit' };
+    }
+    return { usable: true, before, after };
+}
+function isComparisonTruncated(files) {
+    return files === undefined || files.length >= exports.COMPARE_FILE_LIMIT;
+}
 
 
 /***/ }),

--- a/.github/actions/paths-filter/src/main.ts
+++ b/.github/actions/paths-filter/src/main.ts
@@ -7,6 +7,7 @@ import {PullRequest, PushEvent} from '@octokit/webhooks-types'
 import {Filter, FilterResults} from './filter'
 import {File, ChangeStatus} from './file'
 import * as git from './git'
+import {COMPARE_FILE_LIMIT, getPushDeltaRange, isComparisonTruncated} from './push-delta'
 import {backslashEscape, shellEscape} from './list-format/shell-escape'
 import {csvEscape} from './list-format/csv-escape'
 
@@ -26,6 +27,10 @@ async function run(): Promise<void> {
     const filtersYaml = isPathInput(filtersInput) ? getConfigFileContent(filtersInput) : filtersInput
     const listFiles = core.getInput('list-files', {required: false}).toLowerCase() || 'none'
     const initialFetchDepth = parseInt(core.getInput('initial-fetch-depth', {required: false})) || 10
+    // Parsed leniently rather than with getBooleanInput: an unexpected value degrades
+    // to the full diff, which over-reports changes, instead of failing the job that
+    // every other job in the workflow waits on.
+    const sinceLastPush = core.getInput('since-last-push', {required: false}).toLowerCase() === 'true'
 
     if (!isExportFormat(listFiles)) {
       core.setFailed(`Input parameter 'list-files' is set to invalid value '${listFiles}'`)
@@ -33,7 +38,7 @@ async function run(): Promise<void> {
     }
 
     const filter = new Filter(filtersYaml)
-    const files = await getChangedFiles(token, base, ref, initialFetchDepth)
+    const files = await getChangedFiles(token, base, ref, initialFetchDepth, sinceLastPush)
     core.info(`Detected ${files.length} changed files`)
     const results = filter.match(files)
     exportResults(results, listFiles)
@@ -58,7 +63,13 @@ function getConfigFileContent(configPath: string): string {
   return fs.readFileSync(configPath, {encoding: 'utf8'})
 }
 
-async function getChangedFiles(token: string, base: string, ref: string, initialFetchDepth: number): Promise<File[]> {
+async function getChangedFiles(
+  token: string,
+  base: string,
+  ref: string,
+  initialFetchDepth: number,
+  sinceLastPush: boolean
+): Promise<File[]> {
   // if base is 'HEAD' only local uncommitted changes will be detected
   // This is the simplest case as we don't need to fetch more commits or evaluate current/before refs
   if (base === git.HEAD) {
@@ -83,7 +94,18 @@ async function getChangedFiles(token: string, base: string, ref: string, initial
       }
       const pr = github.context.payload.pull_request as PullRequest
       if (token) {
+        if (sinceLastPush) {
+          const pushed = await getPushDeltaFromApi(token)
+          if (pushed) {
+            return pushed
+          }
+        }
         return await getChangedFilesFromApi(token, pr)
+      }
+      if (sinceLastPush) {
+        core.warning(
+          `'token' input parameter is required by 'since-last-push' - the full pull request diff will be used`
+        )
       }
       if (github.context.eventName === 'pull_request_target') {
         // pull_request_target is executed in context of base branch and GITHUB_SHA points to last commit in base branch
@@ -186,36 +208,84 @@ async function getChangedFilesFromApi(token: string, pullRequest: PullRequest): 
       }
       core.info(`Received ${response.data.length} items`)
 
-      for (const row of response.data as GetResponseDataTypeFromEndpointMethod<typeof client.rest.pulls.listFiles>) {
-        core.info(`[${row.status}] ${row.filename}`)
-        // There's no obvious use-case for detection of renames
-        // Therefore we treat it as if rename detection in git diff was turned off.
-        // Rename is replaced by delete of original filename and add of new filename
-        if (row.status === ChangeStatus.Renamed) {
-          files.push({
-            filename: row.filename,
-            status: ChangeStatus.Added
-          })
-          files.push({
-            // 'previous_filename' for some unknown reason isn't in the type definition or documentation
-            filename: (<any>row).previous_filename as string,
-            status: ChangeStatus.Deleted
-          })
-        } else {
-          // Github status and git status variants are same except for deleted files
-          const status = row.status === 'removed' ? ChangeStatus.Deleted : (row.status as ChangeStatus)
-          files.push({
-            filename: row.filename,
-            status
-          })
-        }
-      }
+      files.push(
+        ...apiFilesToChanges(response.data as GetResponseDataTypeFromEndpointMethod<typeof client.rest.pulls.listFiles>)
+      )
     }
 
     return files
   } finally {
     core.endGroup()
   }
+}
+
+// Lists the files a single push added to the pull request, rather than everything
+// the pull request changes. Returns null whenever that comparison can't be trusted,
+// which leaves the caller on the full pull request diff.
+async function getPushDeltaFromApi(token: string): Promise<File[] | null> {
+  const range = getPushDeltaRange(github.context.eventName, github.context.payload)
+  if (!range.usable) {
+    core.info(`Changes since last push are not available (${range.reason}) - using the full pull request diff`)
+    return null
+  }
+
+  const basehead = `${range.before}...${range.after}`
+  core.startGroup(`Fetching list of files changed by the push ${basehead} from Github API`)
+  try {
+    const client = github.getOctokit(token)
+    // Three dots so the comparison starts from merge-base(before, after): for an
+    // appended push that is exactly the pushed commits, while a force-push or a
+    // rebase widens it to the whole branch delta rather than reporting a bogus one.
+    const response = await client.rest.repos.compareCommitsWithBasehead({
+      owner: github.context.repo.owner,
+      repo: github.context.repo.repo,
+      basehead
+    })
+
+    if (isComparisonTruncated(response.data.files)) {
+      core.warning(
+        `Comparison of ${basehead} reports ${response.data.files?.length ?? 0} files and is capped at ` +
+          `${COMPARE_FILE_LIMIT} - using the full pull request diff instead of a possibly truncated list`
+      )
+      return null
+    }
+
+    return apiFilesToChanges(response.data.files ?? [])
+  } catch (error) {
+    core.warning(`Failed to compare ${basehead} (${getErrorMessage(error)}) - using the full pull request diff instead`)
+    return null
+  } finally {
+    core.endGroup()
+  }
+}
+
+function apiFilesToChanges(rows: {filename: string; status: string}[]): File[] {
+  const files: File[] = []
+  for (const row of rows) {
+    core.info(`[${row.status}] ${row.filename}`)
+    // There's no obvious use-case for detection of renames
+    // Therefore we treat it as if rename detection in git diff was turned off.
+    // Rename is replaced by delete of original filename and add of new filename
+    if (row.status === ChangeStatus.Renamed) {
+      files.push({
+        filename: row.filename,
+        status: ChangeStatus.Added
+      })
+      files.push({
+        // 'previous_filename' for some unknown reason isn't in the type definition or documentation
+        filename: (<any>row).previous_filename as string,
+        status: ChangeStatus.Deleted
+      })
+    } else {
+      // Github status and git status variants are same except for deleted files
+      const status = row.status === 'removed' ? ChangeStatus.Deleted : (row.status as ChangeStatus)
+      files.push({
+        filename: row.filename,
+        status
+      })
+    }
+  }
+  return files
 }
 
 function exportResults(results: FilterResults, format: ExportFormat): void {

--- a/.github/actions/paths-filter/src/push-delta.ts
+++ b/.github/actions/paths-filter/src/push-delta.ts
@@ -1,0 +1,44 @@
+// The compare API caps its file list at 300 entries and does not paginate them,
+// so a list at the cap may be truncated. Under-reporting changed files would let
+// a workflow skip jobs it should have run, so the caller falls back to the full
+// pull request diff instead.
+export const COMPARE_FILE_LIMIT = 300
+
+const NULL_SHA = '0000000000000000000000000000000000000000'
+
+export interface PushDeltaPayload {
+  action?: string
+  before?: string
+  after?: string
+}
+
+export type PushDeltaRange = {usable: true; before: string; after: string} | {usable: false; reason: string}
+
+export function getPushDeltaRange(eventName: string, payload: PushDeltaPayload): PushDeltaRange {
+  // Only a synchronize payload carries before/after. Every other pull request
+  // action (opened, reopened, ready_for_review) has no previous head to compare
+  // against, and those are exactly the events where the whole diff is wanted.
+  if (eventName !== 'pull_request') {
+    return {usable: false, reason: `event is ${eventName}, not pull_request`}
+  }
+  if (payload.action !== 'synchronize') {
+    return {usable: false, reason: `pull request action is ${payload.action}, not synchronize`}
+  }
+
+  const {before, after} = payload
+  if (!before || !after) {
+    return {usable: false, reason: 'payload is missing before or after'}
+  }
+  if (before === NULL_SHA || after === NULL_SHA) {
+    return {usable: false, reason: 'before or after is the null SHA'}
+  }
+  if (before === after) {
+    return {usable: false, reason: 'before and after are the same commit'}
+  }
+
+  return {usable: true, before, after}
+}
+
+export function isComparisonTruncated(files: unknown[] | undefined): boolean {
+  return files === undefined || files.length >= COMPARE_FILE_LIMIT
+}

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -127,6 +127,15 @@ jobs:
               if: github.event_name == 'pull_request'
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
+                  # Filter on the pushed commits rather than the whole PR, so a follow-up
+                  # push touching nothing this suite exercises doesn't boot the stack again.
+                  # The cost: PR runs cancel in progress, so an earlier push's E2E run can be
+                  # cancelled while this one filters itself out, leaving the suite unrun on
+                  # this PR. Trunk's merge queue opens a fresh trunk-merge/** PR whose full
+                  # diff against master is the merge gate, which is what still catches that,
+                  # so the queue's own runs must keep filtering on the full diff.
+                  # See .github/actions/paths-filter/README.md.
+                  since-last-push: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
                   filters: |
                       shouldRun:
                         # Any change that could affect E2E behavior triggers a run.
@@ -171,9 +180,11 @@ jobs:
 
             # Visual Review auto-commits a snapshot baseline after human review and CI
             # approval. Re-running the full E2E stack for that bot push is pure waste;
-            # the `playwright_tests` aggregator treats the resulting skip as success. Key
-            # off the push delta (this push's commits), not the whole-PR diff the filter reports,
-            # so it fires even when the PR also carries real code changes.
+            # the `playwright_tests` aggregator treats the resulting skip as success.
+            # The filter above can't express this on its own: snapshots.yml sits under
+            # frontend/, so the push delta it reports still matches the `frontend/**/*`
+            # include. This step vetoes the run by looking at who pushed and at nothing
+            # but the baseline file being in the delta.
             - name: Detect Visual Review baseline-only push
               id: baseline_push
               if: github.event_name == 'pull_request' && github.event.action == 'synchronize'

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -46,9 +46,11 @@ jobs:
             #
             # Additionally skip when a bot's push adds only snapshot baselines —
             # Visual Review auto-commits frontend/snapshots.yml after human review
-            # and CI approval, so re-running the suite is pure waste. The detect
-            # step keys off the push delta (this push's commits), not the whole-PR
-            # diff the filter reports, so it fires even when the PR also has code changes.
+            # and CI approval, so re-running the suite is pure waste. The filter
+            # can't express this on its own: snapshots.yml sits under frontend/, so
+            # the push delta it reports still matches the 'frontend/**' include. The
+            # detect step vetoes the run by looking at who pushed and at nothing but
+            # the baseline file being in the delta.
             frontend: >-
                 ${{
                     github.event_name == 'push'
@@ -87,6 +89,15 @@ jobs:
               if: github.event_name != 'push' # Run all tests on master push
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
+                  # Filter on the pushed commits rather than the whole PR, so a follow-up
+                  # push touching no story input doesn't re-run the chromium matrix.
+                  # The cost: PR runs cancel in progress, so an earlier push's matrix can be
+                  # cancelled while this one filters itself out, leaving the visual suite
+                  # unrun on this PR. Trunk's merge queue opens a fresh trunk-merge/** PR
+                  # whose full diff against master is the merge gate, which is what still
+                  # catches that, so the queue's own runs must keep the full diff.
+                  # See .github/actions/paths-filter/README.md.
+                  since-last-push: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
                   filters: |
                       frontend:
                         - 'frontend/**'
@@ -157,6 +168,10 @@ jobs:
               if: github.event_name != 'push'
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
+                  # Same basis as the filter above: the two outputs are AND-ed into
+                  # `frontend`, so comparing a push delta against a whole-PR exclusion
+                  # would keep the matrix running for files this push never touched.
+                  since-last-push: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
                   filters: ${{ runner.temp }}/frontend-exclude.yml
 
             # Build the visual-regression matrix.


### PR DESCRIPTION
## Problem

A follow-up push that touches nothing a suite exercises still re-runs that suite in full, so a docs-only commit on an open PR boots the whole Playwright stack and the Storybook chromium matrix again.

- Change detection compares against the whole pull request on every push, not against what the push added.
- The vendored paths-filter cannot express this: on `pull_request` events it drops the `base` and `ref` inputs and diffs the whole PR.
- Both workflows already compute a push delta in shell for their Visual Review baseline check, so only that one step benefits from it.

## Changes

- The vendored paths-filter takes a `since-last-push` input that detects changes from the pushed commits.
- `ci-e2e-playwright` and `ci-storybook` opt in. Every other consumer keeps the current behavior.
- The action reads `before` and `after` off the `synchronize` payload, then asks the compare API for `before...after`. Three dots start the comparison at the merge base, so an appended push reports its own commits and a force-push widens to the whole branch delta.
- Trunk merge queue runs pass `since-last-push: false` through `!startsWith(github.head_ref, 'trunk-merge/')`.
- I kept this as an opt-in input rather than a new default, because `*_files` outputs feed snob test selection and lint scoping in `ci-backend`. Narrowing those would under-select tests instead of skipping jobs.

The action falls back to the full pull request diff whenever the push delta is unavailable or untrustworthy. Every fallback reports more changes, never fewer.

| Situation | Basis used |
| --- | --- |
| `synchronize` with a usable `before` and `after` | The pushed commits |
| `opened`, `reopened`, `ready_for_review` | Full pull request diff |
| A `trunk-merge/**` head | Full pull request diff |
| Missing or null `before` or `after` | Full pull request diff |
| No `token` input | Full pull request diff |
| Comparison at the API's 300-file cap | Full pull request diff |
| Compare API error | Full pull request diff |

> [!WARNING]
> Pull request runs cancel in progress on a new push. If push A touches Rust and push B touches only docs, A's job can be cancelled while B's run filters it out, so nothing tests A on the pull request. Trunk's merge queue re-runs CI on a fresh `trunk-merge/**` pull request, whose full diff against master is the merge gate that still catches this. The cost is that the breakage surfaces in the queue rather than on the pull request.

## How did you test this code?

- `__tests__/push-delta.test.ts` covers the fallback matrix and the 300-file boundary. Both guard the same regression: a change that drops a guard makes the action trust a bogus comparison and skip suites that should run.
- `ci-paths-filter.yml` already runs the typecheck, the unit tests, and the `dist/index.js` drift check on this diff.
- Not verified: the `synchronize` path itself. It only runs on a second push to a real pull request, so the first evidence is this PR's next push.

<details>
<summary>Local checks</summary>

`hogli ci:preflight`, `bin/hogli lint:workflows`, and `actionlint` under CI's `SHELLCHECK_OPTS=--severity=error` all pass.

</details>

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. `.github/actions/paths-filter/README.md` documents the input and the trade-off.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude Opus 5, in Claude Code) wrote this. @gantoine asked whether commit-based path filtering was possible and chose the scope: the action plus one or two expensive workflows, rather than all 25 consumers.

The ask started as filtering on the last commit. I moved it to the push delta, because a push often lands several commits and the pull request checkout is a merge ref, so `HEAD^` there is the base branch rather than the previous commit.

Skills invoked: `/authoring-ci-workflows`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

Everything in this diff comes from this repository. No session material reached the code, the tests, or this description.
