### PR TITLE
refactor(notebooks): drop NOTEBOOKS_FRAME_STORE_ENABLED for the flag alone

### DIFF
--- a/posthog/settings/object_storage.py
+++ b/posthog/settings/object_storage.py
@@ -36,11 +36,6 @@ OBJECT_STORAGE_TASKS_FOLDER = os.getenv("OBJECT_STORAGE_TASKS_FOLDER", "tasks")
 OBJECT_STORAGE_LEGAL_DOCUMENTS_FOLDER = os.getenv("OBJECT_STORAGE_LEGAL_DOCUMENTS_FOLDER", "legal_documents")
 OBJECT_STORAGE_EXTERNAL_WEB_ANALYTICS_BUCKET = os.getenv("OBJECT_STORAGE_EXTERNAL_WEB_ANALYTICS_BUCKET", "posthog")
 
-# Notebooks SQLV2 frame store (products/notebooks/backend/sql_v2_frame_store.md): stream
-# python-node frame materializations to object storage instead of the Redis JSON transport.
-# Default off — rollout is env-gated per deployment on top of the product feature flag.
-NOTEBOOKS_FRAME_STORE_ENABLED = get_from_env("NOTEBOOKS_FRAME_STORE_ENABLED", False, type_cast=str_to_bool)
-
 # Query cache specific bucket - falls back to general object storage bucket if not set
 QUERY_CACHE_S3_BUCKET = os.getenv("QUERY_CACHE_S3_BUCKET") or OBJECT_STORAGE_BUCKET
 

--- a/products/notebooks/backend/frame_store.py
+++ b/products/notebooks/backend/frame_store.py
@@ -28,8 +28,14 @@ class FrameStoreError(Exception):
 
 
 def is_enabled() -> bool:
-    """The frame store is env-gated (rollout) and needs object storage to be configured."""
-    return bool(settings.NOTEBOOKS_FRAME_STORE_ENABLED and settings.OBJECT_STORAGE_ENABLED)
+    """Whether this deployment can serve frames from object storage at all.
+
+    Rollout is the `notebooks-frame-store` flag's job, not this function's. What stays here
+    is the configuration guard: without object storage the client is a silent no-op, so a
+    materialization would "succeed", fail its post-write HEAD, and burn the activity's whole
+    retry budget re-running the query. Failing this check serves the frame inline instead.
+    """
+    return bool(settings.OBJECT_STORAGE_ENABLED)
 
 
 def team_prefix(team_id: int) -> str:

--- a/products/notebooks/backend/sql_v2_data_plane.py
+++ b/products/notebooks/backend/sql_v2_data_plane.py
@@ -145,13 +145,12 @@ def notebook_sql_v2_data_plane(request: HttpRequest) -> HttpResponse:
     bounded = apply_page_bounds(data["query"], limit=data["limit"], offset=data["offset"])
 
     if data["delivery"] == "object":
-        # Two independent gates. The deployment gate says the environment can serve objects
-        # at all; the per-user flag says this user is in the rollout. Failing either one
+        # The `notebooks-frame-store` flag carries the rollout on its own; the only other
+        # condition is that the deployment has object storage to write to. Failing either
         # falls through to the inline transport below, which is correct for any user but
         # clamped at the async row ceiling. DEBUG stands in for the flag, the way the SQLV2
-        # endpoints already treat `revamped-py-notebooks`, so local dev reaches the object
-        # path by setting NOTEBOOKS_FRAME_STORE_ENABLED alone. Without it, local testing
-        # would need a real flag on whichever project this instance sends analytics to.
+        # endpoints already treat `revamped-py-notebooks`, so local dev takes the object
+        # path without a flag on whichever project this instance sends analytics to.
         frame_store_configured = frame_store.is_enabled()
         if frame_store_configured and (settings.DEBUG or is_frame_store_enabled(user)):
             # Whole-frame materialization: stream the result to object storage via a
@@ -182,13 +181,13 @@ def notebook_sql_v2_data_plane(request: HttpRequest) -> HttpResponse:
             FRAME_STORE_FALLBACK_COUNTER.labels(reason="not_in_rollout").inc()
         else:
             # Degraded mode: the cell still runs over the inline (Redis) transport, clamped
-            # at the async row ceiling, instead of hard-failing. Loud on purpose.
+            # at the async row ceiling, instead of hard-failing. Loud on purpose, because a
+            # deployment with the flag on and no object storage cannot serve a frame at all.
             FRAME_STORE_FALLBACK_COUNTER.labels(reason="not_configured").inc()
             logger.warning(
                 "notebook_frame_store_fallback_inline",
                 notebook_short_id=notebook_short_id,
                 team_id=team_id,
-                frame_store_enabled=settings.NOTEBOOKS_FRAME_STORE_ENABLED,
                 object_storage_enabled=settings.OBJECT_STORAGE_ENABLED,
             )
 

--- a/products/notebooks/backend/sql_v2_frame_store.md
+++ b/products/notebooks/backend/sql_v2_frame_store.md
@@ -1,7 +1,7 @@
 # SQLV2 frame materialization via object storage
 
 Design notes for moving python-node frame materialization off the Redis JSON transport and onto an object-storage handoff.
-Status: **phase 1 shipped** (env-gated by `NOTEBOOKS_FRAME_STORE_ENABLED`, default off, **and** per-user by the `notebooks-frame-store` feature flag) — object delivery at a 500k row tier-1 ceiling (`MAX_SELECT_NOTEBOOK_MATERIALIZE_LIMIT`); the inline path remains as the degraded fallback, still clamped at 50k. Phases 2+ not started.
+Status: **phase 1 shipped**, gated per user by the `notebooks-frame-store` feature flag (off by default) — object delivery at a 500k row tier-1 ceiling (`MAX_SELECT_NOTEBOOK_MATERIALIZE_LIMIT`); the inline path remains as the degraded fallback, still clamped at 50k. Phases 2+ not started.
 
 ## Problem
 
@@ -168,7 +168,7 @@ query-log exports make its CH footprint analyzable, so the knobs can be tightene
 Fine for the current flag-gated audience and frames up to low hundreds of thousands of rows.
 Since phase 1 this path survives only as the degraded fallback (frame store disabled or unconfigured).
 
-**Phase 1 — swap the payload path, minimal moving parts. (Shipped, env-gated by `NOTEBOOKS_FRAME_STORE_ENABLED`.)**
+**Phase 1 — swap the payload path, minimal moving parts. (Shipped, gated by the `notebooks-frame-store` flag.)**
 The kernel opts in per request with `delivery: "object"` (pages and envelope fetches stay `"inline"`).
 The data plane registers a `notebook-frame:{team}:{query_hash}` dedup mapping and dispatches a Temporal
 materialize workflow (`temporal/frame_materialize.py`, general-purpose queue, Redis-Lua concurrency slots
@@ -196,20 +196,25 @@ ClickHouse error from `system.query_log` — a confirmed query-side exception is
 re-scans), an unconfirmed failure stays retryable.
 The Redis path stays as fallback when the frame store is disabled or unconfigured (dev parity, degraded mode).
 
-_Two gates, both required (`sql_v2_data_plane.py`):_ `NOTEBOOKS_FRAME_STORE_ENABLED` says the deployment can
-serve objects at all, and the `notebooks-frame-store` feature flag says a given user is in the rollout.
-Failing either one degrades that request to the inline transport and its 50k clamp, so the environment
-setting can be enabled estate-wide while the flag stays targeted at a handful of users. The flag is checked
-in the web process at delivery-decision time, which is the only place a materialization is ever enqueued —
-nothing downstream re-checks it. `DEBUG` stands in for the flag, so local dev only needs
-`NOTEBOOKS_FRAME_STORE_ENABLED=1` on the web and worker processes to exercise the object path.
-The `reason` label on `posthog_notebooks_frame_store_fallback_inline`
-separates the two: `not_in_rollout` is the expected state during a ramp, `not_configured` means the
-deployment cannot serve objects and should be near zero once provisioned.
+_Gating (`sql_v2_data_plane.py`):_ the `notebooks-frame-store` feature flag carries the rollout by itself.
+There is deliberately no environment switch beside it — one gate means one place to look, and a flag
+retargets instantly where an env var needs a deploy. The only other condition is `OBJECT_STORAGE_ENABLED`,
+which is a configuration guard rather than a rollout control: without it the storage client is a silent
+no-op, so a materialization would "succeed", fail its post-write HEAD, and burn the activity's retry budget
+re-running the query. Failing either condition degrades that request to the inline transport and its 50k
+clamp. The flag is checked in the web process at delivery-decision time, which is the only place a
+materialization is ever enqueued — nothing downstream re-checks it. `DEBUG` stands in for the flag, so local
+dev takes the object path with no flag to evaluate. The `reason` label on
+`posthog_notebooks_frame_store_fallback_inline` separates the two: `not_in_rollout` is the expected state
+during a ramp, `not_configured` means the deployment has no object storage and should never appear in cloud.
+
+Consequence worth knowing: a self-hosted instance evaluates this flag against PostHog's own cloud project
+(`posthog/apps.py`), so it stays on the inline transport unless that flag targets it. That matches how
+`revamped-py-notebooks` already gates the whole revamped-notebooks surface.
 
 _Rollout prerequisites (per environment, before flipping the flag on):_
 
-- Enable `NOTEBOOKS_FRAME_STORE_ENABLED` only **after** both the web and general-purpose Temporal worker
+- Target the `notebooks-frame-store` flag only **after** both the web and general-purpose Temporal worker
   fleets are on the new image. Temporal accepts a `start_workflow` for a workflow type no worker has
   registered yet — so flipping the flag early produces a bounded window of hung polls that the enqueue
   rollback (which only catches a dispatch _exception_) cannot recover.

--- a/products/notebooks/backend/test/test_sql_v2.py
+++ b/products/notebooks/backend/test/test_sql_v2.py
@@ -1675,7 +1675,7 @@ class TestSQLV2DataPlaneEndpoint(APIBaseTest):
         from products.notebooks.backend import frame_store
 
         frame_uuid = "018e0e7a-1111-2222-3333-444444444444"
-        with self.settings(NOTEBOOKS_FRAME_STORE_ENABLED=True, OBJECT_STORAGE_ENABLED=True):
+        with self.settings(OBJECT_STORAGE_ENABLED=True):
             self.addCleanup(self._delete_team_frames)
             response = self._run_to_completion(
                 {
@@ -1698,11 +1698,11 @@ class TestSQLV2DataPlaneEndpoint(APIBaseTest):
 
     @parameterized.expand(
         [
-            ("frame_store_disabled", False, True),
+            ("object_storage_unconfigured", False, True),
             ("user_not_in_rollout", True, False),
         ]
     )
-    def test_object_delivery_falls_back_to_inline(self, _name, frame_store_enabled, in_rollout):
+    def test_object_delivery_falls_back_to_inline(self, _name, object_storage_enabled, in_rollout):
         # Either gate failing must degrade to the inline (Redis) path rather than hard-fail
         # the cell, and must write no object. The rollout case is the one that matters for
         # the flag: dropping that check would put every user's frames on object storage.
@@ -1710,7 +1710,7 @@ class TestSQLV2DataPlaneEndpoint(APIBaseTest):
 
         from products.notebooks.backend import frame_store
 
-        with self.settings(NOTEBOOKS_FRAME_STORE_ENABLED=frame_store_enabled, OBJECT_STORAGE_ENABLED=True):
+        with self.settings(OBJECT_STORAGE_ENABLED=object_storage_enabled):
             with patch(
                 "products.notebooks.backend.sql_v2_data_plane.is_frame_store_enabled",
                 return_value=in_rollout,
@@ -1719,6 +1719,9 @@ class TestSQLV2DataPlaneEndpoint(APIBaseTest):
             self.assertEqual(response.status_code, 200, response.content)
             _columns, rows, _types = decode_arrow_stream(response.content)
             self.assertEqual(len(rows), 3)
+        # Checked with storage back on: the unconfigured client returns None for any prefix,
+        # so asserting inside the block above would pass even if a frame had been written.
+        with self.settings(OBJECT_STORAGE_ENABLED=True):
             self.assertIsNone(object_storage.list_objects(frame_store.team_prefix(self.team.id)))
 
     def test_object_delivery_failure_surfaces_error_and_stores_no_object(self):
@@ -1729,7 +1732,7 @@ class TestSQLV2DataPlaneEndpoint(APIBaseTest):
         from products.notebooks.backend import frame_store
         from products.notebooks.backend.temporal import frame_materialize
 
-        with self.settings(NOTEBOOKS_FRAME_STORE_ENABLED=True, OBJECT_STORAGE_ENABLED=True):
+        with self.settings(OBJECT_STORAGE_ENABLED=True):
             with patch.object(frame_materialize.frame_store, "write_stream", side_effect=Exception("upload torn")):
                 response = self._run_to_completion({"query": "select number from numbers(3)", "delivery": "object"})
             self.assertEqual(response.status_code, 400, response.content)
@@ -1741,7 +1744,7 @@ class TestSQLV2DataPlaneEndpoint(APIBaseTest):
         # job instead of stacking a second ClickHouse execution.
         from products.notebooks.backend.temporal import frame_materialize
 
-        with self.settings(NOTEBOOKS_FRAME_STORE_ENABLED=True, OBJECT_STORAGE_ENABLED=True):
+        with self.settings(OBJECT_STORAGE_ENABLED=True):
             # Leave the job "running": the materialize body never executes, so the status
             # stays incomplete and the cache-key mapping stays registered.
             with patch.object(frame_materialize, "materialize_frame"):

--- a/products/notebooks/backend/test/test_sql_v2.py
+++ b/products/notebooks/backend/test/test_sql_v2.py
@@ -1597,6 +1597,23 @@ class TestSQLV2DataPlaneToken(SimpleTestCase):
             verify_data_plane_token(make_token())
 
 
+class TestFrameStoreFlagResolution(SimpleTestCase):
+    @parameterized.expand([("enabled", True), ("disabled", False)])
+    def test_frame_store_flag_is_its_own_flag(self, _name, flag_value):
+        # Every other frame-store test patches is_frame_store_enabled, so this is the only
+        # place the flag key is checked. It shares _flag_enabled_for with is_sql_v2_enabled,
+        # and a refactor that collapsed the two would put every revamped-notebooks user on
+        # object storage — in production only, with the rest of the suite still green.
+        from products.notebooks.backend.sql_v2 import NOTEBOOKS_FRAME_STORE_FLAG, is_frame_store_enabled
+
+        user = SimpleNamespace(distinct_id="user-distinct-id", organization=None)
+        with patch("products.notebooks.backend.sql_v2.posthoganalytics.feature_enabled") as feature_enabled:
+            feature_enabled.return_value = flag_value
+            self.assertEqual(is_frame_store_enabled(user), flag_value)
+        self.assertEqual(feature_enabled.call_args.args[0], NOTEBOOKS_FRAME_STORE_FLAG)
+        self.assertEqual(NOTEBOOKS_FRAME_STORE_FLAG, "notebooks-frame-store")
+
+
 class TestSQLV2DataPlaneEndpoint(APIBaseTest):
     URL = "/internal/notebooks/data_plane/query/"
 

--- a/products/notebooks/backend/test/test_sql_v2.py
+++ b/products/notebooks/backend/test/test_sql_v2.py
@@ -1606,7 +1606,9 @@ class TestFrameStoreFlagResolution(SimpleTestCase):
         # object storage — in production only, with the rest of the suite still green.
         from products.notebooks.backend.sql_v2 import NOTEBOOKS_FRAME_STORE_FLAG, is_frame_store_enabled
 
-        user = SimpleNamespace(distinct_id="user-distinct-id", organization=None)
+        # A structural stub, not a User row: the helper only reads distinct_id and
+        # organization, so this keeps the case off the database.
+        user: Any = SimpleNamespace(distinct_id="user-distinct-id", organization=None)
         with patch("products.notebooks.backend.sql_v2.posthoganalytics.feature_enabled") as feature_enabled:
             feature_enabled.return_value = flag_value
             self.assertEqual(is_frame_store_enabled(user), flag_value)


### PR DESCRIPTION
## Problem

Turning the notebooks frame store on for someone takes two switches in two systems: the `notebooks-frame-store` flag (#80333) and the `NOTEBOOKS_FRAME_STORE_ENABLED` environment variable, which needs a charts PR and a deploy per environment. The flag alone is finer-grained, retargets instantly, and is off by default, so the environment variable adds a step without adding safety.

## Changes

- Removes `NOTEBOOKS_FRAME_STORE_ENABLED`. The flag is now the only rollout control, so enabling the frame store for a user is one change in one place and needs no deploy.
- Keeps `OBJECT_STORAGE_ENABLED` as a **configuration guard, not a rollout control**. Without object storage the client is a silent no-op, so a materialization would "succeed", fail its post-write HEAD, and spend the activity's entire retry budget re-running the query. `frame_store.is_enabled()` now means exactly "this deployment has somewhere to write".
- `not_configured` on `posthog_notebooks_frame_store_fallback_inline` now has one cause, so the warning names one setting.

Nothing changes for any user: the flag is off by default and no environment sets the removed variable today.

> [!NOTE]
> Two consequences worth knowing. Local dev now takes the object path by default, because `OBJECT_STORAGE_ENABLED` defaults true under DEBUG and DEBUG stands in for the flag — there is no longer an opt-in. And a self-hosted instance evaluates this flag against PostHog's cloud project (`posthog/apps.py`), so it stays on the inline transport unless the flag targets it, which is how `revamped-py-notebooks` already gates the whole revamped-notebooks surface.

## How did you test this code?

I am an agent. I ran the notebooks data-plane, frame-store and frame-materialize suites locally against real ClickHouse and object storage, plus repo-wide mypy. I did not exercise the flag against a live PostHog project.

The fallback test's first case was `frame_store_disabled` and is now `object_storage_unconfigured`. I also moved its "no object was written" assertion outside the settings block: with object storage disabled the client returns `None` for any prefix, so asserting inside would have passed even if a frame had been written. The rollout case is unchanged and still catches a change that drops the per-user check.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`products/notebooks/backend/sql_v2_frame_store.md`: the status line, the phase-1 heading and the gating section now describe one gate, the prerequisite says target the flag rather than enable the variable, and the self-hosted consequence is written down.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Sinan proposed collapsing to the flag. Skills invoked: `writing-code-comments`, `writing-tests`, `writing-pr-descriptions`.

Follow-up to #80333, which landed while this was being written. PostHog/charts#14117 would have set the removed variable in dev and both prods; I closed it, since this makes it unnecessary.
