### PR TITLE
fix(cd): emit the ecr-repository job output from a step

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -37,7 +37,7 @@ jobs:
         outputs:
             image-digest: ${{ steps.image.outputs.digest }}
             ecr-registry: ${{ steps.docker-meta.outputs.ecr-registry }}
-            ecr-repository: ${{ env.ECR_REPOSITORY }}
+            ecr-repository: ${{ steps.ecr-repository.outputs.name }}
         # Production build/deploy runs only from the canonical deploy repo (CD_DEPLOY_ENABLED).
         if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true'
         runs-on: depot-ubuntu-24.04
@@ -61,6 +61,12 @@ jobs:
 
             - name: Set up Depot CLI
               uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
+
+            - name: Expose ECR repository
+              id: ecr-repository
+              shell: bash
+              run: |
+                  echo "name=${ECR_REPOSITORY:?ECR_REPOSITORY is unset}" >> "$GITHUB_OUTPUT"
 
             - name: Docker meta and registry login
               id: docker-meta


### PR DESCRIPTION
## Problem

Every master build since #80240 merged publishes no ordered release alias and stamps the run with an "Ordered image alias read-back unavailable" error annotation.

- The [first run of the alias job](https://github.com/PostHog/posthog/actions/runs/31403144357/job/93507382148) received an empty repository name: `imagetools create` failed with `invalid reference format`, and the ECR read-back failed parameter validation.
- `posthog_build` declares `ecr-repository: ${{ env.ECR_REPOSITORY }}` as a job output, and the `env` context resolves empty in job-level outputs.
- Deploys are unaffected; the alias path fails soft by design.

## Changes

- `posthog_build` emits the repository name from a new step through `GITHUB_OUTPUT`, and the `ecr-repository` job output references that step.
- The step body uses `${ECR_REPOSITORY:?}`, so removing or renaming the env entry fails that step loudly instead of publishing an empty value downstream.

## How did you test this code?

I (actually Claude) did not run the workflow live.

- The extracted step body ran under the runner's exact interpreter invocation (`bash --noprofile --norc -eo pipefail`): with the variable set it writes `name=posthog-cloud` and exits 0; unset, it exits 1 with the `:?` message and writes nothing.
- A repo grep shows exactly one `ecr-repository:` job-output line, referencing the new step, and no `outputs:` block reading `env.ECR_REPOSITORY`.
- Not run: the workflow itself. The first master build after merge verifies the alias publishes and resolves at the expected digest.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code coordinated the change; a Codex CLI worker authored the diff, and a two-model review gate (GPT and Claude reviewers) passed the frozen diff before commit.
- Skills invoked: /writing-pr-descriptions.
- Decision across the session: pre-dispatch review added the `:?` fail-loud expansion so the producing step cannot silently emit an empty value, the same defect class this PR fixes at the consuming end.
