### PR TITLE
fix(gladly): handle empty report windows without crashing the sync

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gladly/gladly.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gladly/gladly.py
@@ -5,9 +5,9 @@ import json
 import time
 import hashlib
 import dataclasses
-from collections.abc import Iterator
+from collections.abc import Buffer, Iterator
 from datetime import UTC, date, datetime, timedelta
-from typing import IO, Any, Optional, cast
+from typing import Any, Optional
 from urllib.parse import quote, urlencode
 
 import requests
@@ -28,6 +28,8 @@ REQUEST_TIMEOUT_SECONDS = 300
 MAX_RETRY_ATTEMPTS = 5
 # Yield JSONL rows in chunks so big files don't build one giant list.
 CHUNK_SIZE = 5000
+# Pull the report CSV off the wire in 64 KiB reads.
+REPORT_CHUNK_BYTES = 1 << 16
 # Gladly caps report CSVs (100k rows for most reports) and truncates silently,
 # so a window this full is likely missing rows.
 REPORT_ROW_WARNING_THRESHOLD = 90_000
@@ -45,6 +47,36 @@ DEFAULT_DOMAIN = "gladly.com"
 
 class GladlyRetryableError(Exception):
     pass
+
+
+class _ResponseByteStream(io.RawIOBase):
+    """Read a streaming response body through ``iter_content`` as a binary file.
+
+    Wrapping ``response.raw`` directly crashes on an empty report body: urllib3
+    closes the connection the moment it reads EOF, and a ``TextIOWrapper`` over
+    the now-closed raw stream raises ``ValueError: I/O operation on closed file``.
+    ``iter_content`` yields nothing for an empty body and turns a dropped
+    connection into a retryable ``requests`` error mid-stream.
+    """
+
+    def __init__(self, response: requests.Response, chunk_size: int) -> None:
+        self._chunks = response.iter_content(chunk_size=chunk_size)
+        self._buffer = b""
+
+    def readable(self) -> bool:
+        return True
+
+    def readinto(self, target: Buffer) -> int:
+        while not self._buffer:
+            try:
+                self._buffer = next(self._chunks)
+            except StopIteration:
+                return 0
+        view = memoryview(target).cast("B")
+        take = min(len(view), len(self._buffer))
+        view[:take] = self._buffer[:take]
+        self._buffer = self._buffer[take:]
+        return take
 
 
 @dataclasses.dataclass
@@ -371,10 +403,11 @@ def _report_rows(
             }
         )
 
-        response.raw.decode_content = True
-        # Wrap the raw stream rather than iterating lines: CSV values can contain
+        # Wrap the byte stream rather than iterating lines: CSV values can contain
         # newlines inside quoted fields, which line-splitting would tear apart.
-        text_stream = io.TextIOWrapper(cast(IO[bytes], response.raw), encoding="utf-8-sig", newline="")
+        text_stream = io.TextIOWrapper(
+            io.BufferedReader(_ResponseByteStream(response, REPORT_CHUNK_BYTES)), encoding="utf-8-sig", newline=""
+        )
         reader = csv.DictReader(text_stream)
         columns = {name: _normalize_report_column(name) for name in reader.fieldnames or []}
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gladly/tests/test_gladly.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gladly/tests/test_gladly.py
@@ -7,6 +7,7 @@ import pytest
 from freezegun import freeze_time
 from unittest import mock
 
+import urllib3
 import requests
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.gladly.gladly import (
@@ -54,16 +55,14 @@ def _job(job_id: str, updated_at: str, files: list[str] | None = None) -> dict[s
     return {"id": job_id, "updatedAt": updated_at, "files": files or ["customers.jsonl", "agents.jsonl"]}
 
 
-class _RawBytes(io.BytesIO):
-    """BytesIO subclass, so the transport can set decode_content on it."""
-
-
-def _csv_response(text: str) -> mock.MagicMock:
-    resp = mock.MagicMock()
-    resp.raw = _RawBytes(text.encode())
-    resp.status_code = 200
-    resp.ok = True
-    return resp
+def _csv_response(text: str) -> requests.Response:
+    # A real urllib3-backed response so iter_content streams the body and an empty
+    # body closes the connection on EOF exactly as it does in production.
+    raw = urllib3.HTTPResponse(body=io.BytesIO(text.encode()), preload_content=False)
+    response = requests.Response()
+    response.raw = raw
+    response.status_code = 200
+    return response
 
 
 def _error_response(status_code: int) -> mock.MagicMock:
@@ -498,6 +497,19 @@ class TestGetReportRows:
             "2024-03-14",
             "2024-03-15",
         ]
+
+    @freeze_time("2024-03-15T10:00:00Z")
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_empty_report_body_yields_no_rows_and_advances(self, mock_session):
+        # A window with no data returns an empty body; urllib3 closes the stream on
+        # EOF, which used to surface as "ValueError: I/O operation on closed file".
+        mock_session.return_value.post.side_effect = [_csv_response("")]
+
+        manager = _make_manager(GladlyResumeConfig(last_report_window_end="2024-03-15"))
+        batches = list(get_rows("myorg", "agent@x.com", "token", "conversation_timestamps", mock.MagicMock(), manager))
+
+        assert batches == []
+        assert manager.save_state.call_args.args[0].last_report_window_end == "2024-03-15"
 
     @freeze_time("2024-03-15T10:00:00Z")
     @mock.patch(f"{_MODULE}.make_tracked_session")


### PR DESCRIPTION
## Problem

- A team's Gladly report sync fails with `ValueError: I/O operation on closed file.` whenever a report window returns an empty body. Empty windows are routine during a multi-year backfill, so one stops the whole schema.
- The reports stream reads the CSV through `io.TextIOWrapper(response.raw)`. urllib3 closes the connection the moment it reads EOF, and the `csv` reader's next read hits the closed stream.
- Error tracking: https://us.posthog.com/project/2/error_tracking/019fec5e-ec1a-7123-937d-d0efef24e964

## Changes

- The report CSV now streams through `response.iter_content` instead of `response.raw`. An empty body yields no rows and the sync advances to the next window.
- A dropped connection mid-stream now surfaces as a retryable `requests` error, not a bare `ValueError`.
- Streaming and gzip decoding are unchanged: a small `io.RawIOBase` adapter feeds `iter_content` chunks to the same `TextIOWrapper`, so CSV values with quoted newlines stay intact.

## How did you test this code?

- Added `test_empty_report_body_yields_no_rows_and_advances`: it catches the regression where an empty report window crashes the sync instead of advancing. No existing test caught it.
- Reworked the `_csv_response` test helper to a real urllib3-backed response. A plain `BytesIO` never closes on EOF, so it hid the crash; the real response reproduces it, and the old read path raises on it.
- Ran ruff check and format, mypy scoped to the gladly package, and both gladly test modules. Not run: repo-wide mypy and the full CI matrix, left to this PR's CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- I (Claude, a PostHog Code session) triaged the error-tracking issue above and wrote this fix; no human drove the session.
- Skills invoked: /writing-tests, /writing-pr-descriptions.
- I reproduced the crash locally against a real urllib3 response and confirmed it fires only on a completely empty body (header-only bodies read fine). That ruled out a transient network error and pointed to the empty-window path, so this is a code fix rather than an addition to `NonRetryableErrors`.
- The related open PR #80010 adds a Gladly conversations table but does not touch this CSV read path, so it does not fix this crash. The two will need a trivial merge in `test_gladly.py`, which both edit.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
