### PR TITLE
fix(billing): align billing proxy access rules

### DIFF
--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -20,6 +20,7 @@ from posthog.event_usage import groups
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Organization, OrganizationIntegration, Team, User
 from posthog.models.organization import OrganizationMembership
+from posthog.permissions import posthog_feature_flag_enabled
 from posthog.utils import get_trusted_client_ip, relative_date_parse
 
 from ee.billing.billing_manager import BillingManager
@@ -37,14 +38,10 @@ def _owner_only_billing_enabled(user: User, organization: Organization) -> bool:
         return False
 
     try:
-        return bool(
-            posthoganalytics.feature_enabled(
-                OWNER_ONLY_BILLING_FLAG,
-                user.distinct_id,
-                groups=groups(organization=organization),
-                group_properties={"organization": {"id": str(organization.id)}},
-                send_feature_flag_events=False,
-            )
+        return posthog_feature_flag_enabled(
+            OWNER_ONLY_BILLING_FLAG,
+            str(user.distinct_id),
+            organization_id=organization.id,
         )
     except Exception as e:
         capture_exception(e, {"organization_id": organization.id, "flag": OWNER_ONLY_BILLING_FLAG})

--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -1,7 +1,6 @@
 from typing import Any, Optional
 from zoneinfo import ZoneInfo
 
-from django.contrib.auth.models import AbstractUser
 from django.http import HttpResponse
 from django.shortcuts import redirect
 
@@ -19,7 +18,7 @@ from posthog.api.utils import action
 from posthog.cloud_utils import get_cached_instance_license
 from posthog.event_usage import groups
 from posthog.exceptions_capture import capture_exception
-from posthog.models import Organization, OrganizationIntegration, Team
+from posthog.models import Organization, OrganizationIntegration, Team, User
 from posthog.models.organization import OrganizationMembership
 from posthog.utils import get_trusted_client_ip, relative_date_parse
 
@@ -30,21 +29,59 @@ from ee.settings import BILLING_SERVICE_URL
 logger = structlog.get_logger(__name__)
 
 BILLING_SERVICE_JWT_AUD = "posthog:license-key"
+OWNER_ONLY_BILLING_FLAG = "owner-only-billing"
 
 
-class IsOrganizationAdmin(permissions.BasePermission):
+def _owner_only_billing_enabled(user: User, organization: Organization) -> bool:
+    if not user.distinct_id:
+        return False
+
+    try:
+        return bool(
+            posthoganalytics.feature_enabled(
+                OWNER_ONLY_BILLING_FLAG,
+                user.distinct_id,
+                groups=groups(organization=organization),
+                group_properties={"organization": {"id": str(organization.id)}},
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception as e:
+        capture_exception(e, {"organization_id": organization.id, "flag": OWNER_ONLY_BILLING_FLAG})
+        return False
+
+
+def user_has_billing_access(user: User, organization: Organization) -> bool:
+    membership = OrganizationMembership.objects.filter(user=user, organization=organization).only("level").first()
+    if not membership:
+        return False
+
+    if membership.level >= OrganizationMembership.Level.OWNER:
+        return True
+
+    if membership.level < OrganizationMembership.Level.ADMIN:
+        return False
+
+    return not _owner_only_billing_enabled(user, organization)
+
+
+class HasBillingAccess(permissions.BasePermission):
     """
-    Permission to allow only organization admins (level >= ADMIN) to access billing endpoints.
+    Permission to allow users with Billing access to access Billing endpoints.
     """
 
-    def has_permission(self, request, view):
+    message = "You do not have access to Billing for this organization."
+
+    def has_permission(self, request: Request, view: Any) -> bool:
         try:
             org = view._get_org_required()
         except Exception:
             return False
-        return OrganizationMembership.objects.filter(
-            user=request.user, organization=org, level__gte=OrganizationMembership.Level.ADMIN
-        ).exists()
+
+        if not isinstance(request.user, User):
+            return False
+
+        return user_has_billing_access(request.user, org)
 
 
 class BillingSerializer(serializers.Serializer):
@@ -111,9 +148,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
     def get_billing_manager(self) -> BillingManager:
         license = get_cached_instance_license()
-        user = (
-            self.request.user if isinstance(self.request.user, AbstractUser) and self.request.user.distinct_id else None
-        )
+        user = self.request.user if isinstance(self.request.user, User) and self.request.user.distinct_id else None
         return BillingManager(license, user, ip_address=get_trusted_client_ip(self.request))
 
     def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
@@ -172,7 +207,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         methods=["PATCH"],
         detail=False,
         url_path="/",
-        permission_classes=[permissions.IsAuthenticated, IsOrganizationAdmin],
+        permission_classes=[permissions.IsAuthenticated, HasBillingAccess],
     )
     def patch(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         distinct_id = None if self.request.user.is_anonymous else self.request.user.distinct_id
@@ -227,7 +262,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     @action(
         methods=["POST"],
         detail=False,
-        permission_classes=[permissions.IsAuthenticated, IsOrganizationAdmin],
+        permission_classes=[permissions.IsAuthenticated, HasBillingAccess],
     )
     def activate(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         organization = self._get_org_required()
@@ -241,7 +276,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     @action(
         methods=["POST"],
         detail=False,
-        permission_classes=[permissions.IsAuthenticated, IsOrganizationAdmin],
+        permission_classes=[permissions.IsAuthenticated, HasBillingAccess],
     )
     def deactivate(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         organization = self._get_org_required()
@@ -275,7 +310,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         methods=["POST"],
         detail=False,
         url_path="subscription/switch-plan",
-        permission_classes=[permissions.IsAuthenticated, IsOrganizationAdmin],
+        permission_classes=[permissions.IsAuthenticated, HasBillingAccess],
     )
     def subscription_switch_plan(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         organization = self._get_org_required()
@@ -286,7 +321,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     @action(
         methods=["GET"],
         detail=False,
-        permission_classes=[permissions.IsAuthenticated, IsOrganizationAdmin],
+        permission_classes=[permissions.IsAuthenticated, HasBillingAccess],
     )
     def portal(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         license = get_cached_instance_license()
@@ -361,7 +396,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         methods=["POST"],
         detail=False,
         url_path="credits/purchase",
-        permission_classes=[permissions.IsAuthenticated, IsOrganizationAdmin],
+        permission_classes=[permissions.IsAuthenticated, HasBillingAccess],
     )
     def purchase_credits(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         license = get_cached_instance_license()
@@ -381,7 +416,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         methods=["POST"],
         detail=False,
         url_path="trials/activate",
-        permission_classes=[permissions.IsAuthenticated, IsOrganizationAdmin],
+        permission_classes=[permissions.IsAuthenticated, HasBillingAccess],
     )
     def activate_trial(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         organization = self._get_org_required()
@@ -393,7 +428,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         methods=["POST"],
         detail=False,
         url_path="trials/cancel",
-        permission_classes=[permissions.IsAuthenticated, IsOrganizationAdmin],
+        permission_classes=[permissions.IsAuthenticated, HasBillingAccess],
     )
     def cancel_trial(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         organization = self._get_org_required()
@@ -432,7 +467,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     @action(
         methods=["PATCH"],
         detail=False,
-        permission_classes=[permissions.IsAuthenticated, IsOrganizationAdmin],
+        permission_classes=[permissions.IsAuthenticated, HasBillingAccess],
     )
     def license(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         license = get_cached_instance_license()
@@ -473,7 +508,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     )
     def apply_startup_program(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         user = self.request.user
-        if not isinstance(user, AbstractUser):
+        if not isinstance(user, User):
             raise PermissionDenied("You must be logged in to apply for the startup program")
 
         organization_id = request.data.get("organization_id")
@@ -484,10 +519,8 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         if not organization:
             raise ValidationError({"organization_id": "Organization not found."})
 
-        if not OrganizationMembership.objects.filter(
-            user=user, organization=organization, level__gte=OrganizationMembership.Level.ADMIN
-        ).exists():
-            raise PermissionDenied("You need to be an organization admin or owner to apply for the startup program")
+        if not user_has_billing_access(user, organization):
+            raise PermissionDenied("You need Billing access to apply for the startup program")
 
         billing_manager = self.get_billing_manager()
 
@@ -524,7 +557,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         methods=["POST"],
         detail=False,
         url_path="coupons/claim",
-        permission_classes=[permissions.IsAuthenticated, IsOrganizationAdmin],
+        permission_classes=[permissions.IsAuthenticated, HasBillingAccess],
     )
     def claim_coupon(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         organization = self._get_org_required()
@@ -569,7 +602,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         methods=["GET"],
         detail=False,
         url_path="usage",
-        permission_classes=[permissions.IsAuthenticated, IsOrganizationAdmin],
+        permission_classes=[permissions.IsAuthenticated, HasBillingAccess],
     )
     def usage(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         organization = self._get_org_required()
@@ -605,7 +638,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         methods=["GET"],
         detail=False,
         url_path="spend",
-        permission_classes=[permissions.IsAuthenticated, IsOrganizationAdmin],
+        permission_classes=[permissions.IsAuthenticated, HasBillingAccess],
     )
     def spend(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         """Endpoint to fetch spend data (proxy to billing service)."""

--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -33,9 +33,9 @@ BILLING_SERVICE_JWT_AUD = "posthog:license-key"
 OWNER_ONLY_BILLING_FLAG = "owner-only-billing"
 
 
-def _owner_only_billing_enabled(user: User, organization: Organization) -> bool:
+def _owner_only_billing_enabled(user: User, organization: Organization) -> Optional[bool]:
     if not user.distinct_id:
-        return False
+        return None
 
     try:
         return posthog_feature_flag_enabled(
@@ -45,7 +45,7 @@ def _owner_only_billing_enabled(user: User, organization: Organization) -> bool:
         )
     except Exception as e:
         capture_exception(e, {"organization_id": organization.id, "flag": OWNER_ONLY_BILLING_FLAG})
-        return False
+        return None
 
 
 def user_has_billing_access(user: User, organization: Organization) -> bool:
@@ -59,7 +59,8 @@ def user_has_billing_access(user: User, organization: Organization) -> bool:
     if membership.level < OrganizationMembership.Level.ADMIN:
         return False
 
-    return not _owner_only_billing_enabled(user, organization)
+    # Only a confirmed disabled flag lets admins through. Unknown flag state fails closed to owners.
+    return _owner_only_billing_enabled(user, organization) is False
 
 
 class HasBillingAccess(permissions.BasePermission):

--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -606,6 +606,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     )
     def usage(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         organization = self._get_org_required()
+
         billing_manager = self.get_billing_manager()
 
         serializer = BillingUsageRequestSerializer(data=request.GET)
@@ -643,6 +644,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     def spend(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         """Endpoint to fetch spend data (proxy to billing service)."""
         organization = self._get_org_required()
+
         billing_manager = self.get_billing_manager()
 
         serializer = BillingUsageRequestSerializer(data=request.GET)

--- a/ee/api/test/test_billing.py
+++ b/ee/api/test/test_billing.py
@@ -1196,6 +1196,18 @@ class TestBillingUsageAndSpendAPI(APILicensedTest):
         mock_get_usage_data.assert_not_called()
 
     @patch("ee.billing.billing_manager.BillingManager.get_usage_data")
+    @patch("ee.api.billing.posthog_feature_flag_enabled", return_value=False)
+    def test_admin_usage_access_allowed_when_owner_only_billing_is_off(self, mock_feature_enabled, mock_get_usage_data):
+        mock_get_usage_data.return_value = self.MOCK_USAGE_DATA
+
+        response = self.client.get("/api/billing/usage/", {"start_date": "2025-01-01"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_get_usage_data.assert_called_once()
+        mock_feature_enabled.assert_called_once()
+        self.assertEqual(mock_feature_enabled.call_args.args[0], "owner-only-billing")
+
+    @patch("ee.billing.billing_manager.BillingManager.get_usage_data")
     @patch("ee.api.billing.posthog_feature_flag_enabled", return_value=True)
     def test_owner_only_billing_allows_owner_usage_access(self, _mock_feature_enabled, mock_get_usage_data):
         self.organization_membership.level = OrganizationMembership.Level.OWNER

--- a/ee/api/test/test_billing.py
+++ b/ee/api/test/test_billing.py
@@ -1185,6 +1185,40 @@ class TestBillingUsageAndSpendAPI(APILicensedTest):
         self.assertEqual(passed_params["team_ids"], f"[{str(self.team.pk)}]")
         self.assertEqual(passed_params["teams_map"], {self.team.pk: self.team.name})
 
+    @patch("ee.billing.billing_manager.BillingManager.get_usage_data")
+    @patch("ee.api.billing.posthoganalytics.feature_enabled", return_value=True)
+    def test_owner_only_billing_rejects_admin_usage_access(self, _mock_feature_enabled, mock_get_usage_data):
+        mock_get_usage_data.return_value = self.MOCK_USAGE_DATA
+
+        response = self.client.get("/api/billing/usage/", {"start_date": "2025-01-01"})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        mock_get_usage_data.assert_not_called()
+
+    @patch("ee.billing.billing_manager.BillingManager.get_usage_data")
+    @patch("ee.api.billing.posthoganalytics.feature_enabled", return_value=True)
+    def test_owner_only_billing_allows_owner_usage_access(self, _mock_feature_enabled, mock_get_usage_data):
+        self.organization_membership.level = OrganizationMembership.Level.OWNER
+        self.organization_membership.save()
+        mock_get_usage_data.return_value = self.MOCK_USAGE_DATA
+
+        response = self.client.get("/api/billing/usage/", {"start_date": "2025-01-01"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_get_usage_data.assert_called_once()
+
+    @patch("ee.billing.billing_manager.BillingManager.update_billing")
+    @patch("ee.api.billing.posthoganalytics.feature_enabled", return_value=True)
+    def test_owner_only_billing_rejects_admin_limit_update(self, _mock_feature_enabled, mock_update_billing):
+        response = self.client.patch(
+            "/api/billing//",
+            data={"custom_limits_usd": {"events": 10}},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        mock_update_billing.assert_not_called()
+
     def test_get_usage_permission_denied_for_member(self):
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()

--- a/ee/api/test/test_billing.py
+++ b/ee/api/test/test_billing.py
@@ -1208,6 +1208,42 @@ class TestBillingUsageAndSpendAPI(APILicensedTest):
         self.assertEqual(mock_feature_enabled.call_args.args[0], "owner-only-billing")
 
     @patch("ee.billing.billing_manager.BillingManager.get_usage_data")
+    @patch("ee.api.billing.posthog_feature_flag_enabled", return_value=None)
+    def test_owner_only_billing_rejects_admin_usage_access_when_flag_is_unknown(
+        self, _mock_feature_enabled, mock_get_usage_data
+    ):
+        response = self.client.get("/api/billing/usage/", {"start_date": "2025-01-01"})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        mock_get_usage_data.assert_not_called()
+
+    @patch("ee.api.billing.capture_exception")
+    @patch("ee.billing.billing_manager.BillingManager.get_usage_data")
+    @patch("ee.api.billing.posthog_feature_flag_enabled", side_effect=Exception("flag lookup failed"))
+    def test_owner_only_billing_rejects_admin_usage_access_when_flag_check_raises(
+        self, _mock_feature_enabled, mock_get_usage_data, mock_capture_exception
+    ):
+        response = self.client.get("/api/billing/usage/", {"start_date": "2025-01-01"})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        mock_get_usage_data.assert_not_called()
+        mock_capture_exception.assert_called_once()
+
+    @patch("ee.billing.billing_manager.BillingManager.get_usage_data")
+    @patch("ee.api.billing.posthog_feature_flag_enabled")
+    def test_owner_only_billing_rejects_admin_usage_access_without_distinct_id(
+        self, mock_feature_enabled, mock_get_usage_data
+    ):
+        self.user.distinct_id = ""
+        self.user.save()
+
+        response = self.client.get("/api/billing/usage/", {"start_date": "2025-01-01"})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        mock_get_usage_data.assert_not_called()
+        mock_feature_enabled.assert_not_called()
+
+    @patch("ee.billing.billing_manager.BillingManager.get_usage_data")
     @patch("ee.api.billing.posthog_feature_flag_enabled", return_value=True)
     def test_owner_only_billing_allows_owner_usage_access(self, _mock_feature_enabled, mock_get_usage_data):
         self.organization_membership.level = OrganizationMembership.Level.OWNER

--- a/ee/api/test/test_billing.py
+++ b/ee/api/test/test_billing.py
@@ -1186,7 +1186,7 @@ class TestBillingUsageAndSpendAPI(APILicensedTest):
         self.assertEqual(passed_params["teams_map"], {self.team.pk: self.team.name})
 
     @patch("ee.billing.billing_manager.BillingManager.get_usage_data")
-    @patch("ee.api.billing.posthoganalytics.feature_enabled", return_value=True)
+    @patch("ee.api.billing.posthog_feature_flag_enabled", return_value=True)
     def test_owner_only_billing_rejects_admin_usage_access(self, _mock_feature_enabled, mock_get_usage_data):
         mock_get_usage_data.return_value = self.MOCK_USAGE_DATA
 
@@ -1196,7 +1196,7 @@ class TestBillingUsageAndSpendAPI(APILicensedTest):
         mock_get_usage_data.assert_not_called()
 
     @patch("ee.billing.billing_manager.BillingManager.get_usage_data")
-    @patch("ee.api.billing.posthoganalytics.feature_enabled", return_value=True)
+    @patch("ee.api.billing.posthog_feature_flag_enabled", return_value=True)
     def test_owner_only_billing_allows_owner_usage_access(self, _mock_feature_enabled, mock_get_usage_data):
         self.organization_membership.level = OrganizationMembership.Level.OWNER
         self.organization_membership.save()
@@ -1208,7 +1208,7 @@ class TestBillingUsageAndSpendAPI(APILicensedTest):
         mock_get_usage_data.assert_called_once()
 
     @patch("ee.billing.billing_manager.BillingManager.update_billing")
-    @patch("ee.api.billing.posthoganalytics.feature_enabled", return_value=True)
+    @patch("ee.api.billing.posthog_feature_flag_enabled", return_value=True)
     def test_owner_only_billing_rejects_admin_limit_update(self, _mock_feature_enabled, mock_update_billing):
         response = self.client.patch(
             "/api/billing//",


### PR DESCRIPTION
## Stack context

This is the first PR in the `billing` MCP stack. It fixes the existing PostHog proxy access rule before any MCP `billing` surface is exposed.

- #80734 - billing proxy access rules
- #79047 - billing API scope and MCP scaffold
- #79048 - read-only billing MCP tools
- #79049 - billing usage investigation skill

## Problem

`billing` access is not just a plain organization admin check. Owners always have access. Admins have access by default. Some organizations use `owner-only-billing`, which restricts billing access to owners.

The billing UI already follows that rule, and the `billing` service checks access downstream. The PostHog proxy was the gap: several actions checked only `admin+` before forwarding the request.

Flag failures need the same treatment on both sides. PostHog/billing#2169 makes the `billing` service fail closed when `owner-only-billing` cannot be evaluated, and this PR mirrors that in the PostHog proxy.

## Changes

- Adds a shared `HasBillingAccess` permission for billing proxy actions.
- Uses the existing server-side `user_has_billing_access` helper so the PostHog proxy follows the same owner/admin rule as the `billing` service.
- Applies that rule to existing billing proxy actions for usage, spend, limits, product activation, trials, credits, portal, license, coupons, and startup program checks.
- Fails closed to owners when `owner-only-billing` returns `None`, raises, or cannot be evaluated because the user has no distinct ID.
- Adds tests for owners, admins, members, owner-only behavior, and the fail-closed cases above.

## How did you test this code?

- Focused billing API tests pass for usage/spend access and member-denied proxy actions.
- Ruff passes for the touched Python files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.