### PR TITLE
feat(onboarding): offer GitHub connect on the self-driving install step

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -411,6 +411,7 @@ export const FEATURE_FLAGS = {
     ONBOARDING_NAVBAR: 'onboarding-navbar', // owner: @fercgomes #team-growth, hides the navbar during onboarding to reduce distractions multivariate=true
     ONBOARDING_PLATFORM_PACKAGES: 'onboarding-platform-packages', // owner: @mjwarren3 #team-growth multivariate=control,test — surfaces platform packages with a free trial on the plans step after subscribing
     ONBOARDING_PRODUCT_SELECTION_HEADING: 'onboarding-product-selection-heading', // owner: @fercgomes #team-growth, payload overrides the heading copy on the first onboarding page
+    ONBOARDING_SELF_DRIVING_GITHUB_PROMPT: 'onboarding-self-driving-github-prompt', // owner: #team-growth multivariate=control,test — offers GitHub connect on the self-driving install step, ahead of the setup agent asking for it
     ONBOARDING_SESSION_REPLAY_MEDIA: 'onboarding-session-replay-media', // owner: @fercgomes #team-growth multivariate=control,screenshot,demo
     ONBOARDING_SOCIAL_PROOF_INFO: 'onboarding-social-proof-info', // owner: @fercgomes #team-growth, payload overrides social proof strings per product
     ONBOARDING_WIZARD_CLOUD_RUN: 'onboarding-wizard-cloud-run', // owner: @fercgomes #team-growth multivariate=control,test — gates the "open a PR for me" cloud wizard option on the install step

--- a/frontend/src/scenes/onboarding/onboardingEventUsageLogic.ts
+++ b/frontend/src/scenes/onboarding/onboardingEventUsageLogic.ts
@@ -86,6 +86,12 @@ export interface onboardingEventUsageLogicActions {
     reportSelfDrivingOnboardingCompleted: (productKey: string) => {
         productKey: string
     }
+    reportSelfDrivingOnboardingGitHubAccessRequested: () => {
+        value: true
+    }
+    reportSelfDrivingOnboardingGitHubConnectClicked: () => {
+        value: true
+    }
     reportSelfDrivingOnboardingInstallModeSelected: (mode: 'cloud' | 'local') => {
         mode: 'cloud' | 'local'
     }
@@ -177,6 +183,12 @@ export const onboardingEventUsageLogic = kea<onboardingEventUsageLogicType>([
         reportSelfDrivingOnboardingCompleted: (productKey: string) => ({ productKey }),
         reportSelfDrivingOnboardingInstallModeSelected: (mode: 'cloud' | 'local') => ({ mode }),
         reportSelfDrivingOnboardingPlanSelected: (plan: 'free' | 'pay_as_you_go') => ({ plan }),
+        // GitHub prompt on the install step. Exposure rides on the flag read (`$feature_flag_called`),
+        // so these two only need to cover what the user does with the prompt. The connect click leaves
+        // the app for GitHub, so its outcome is the server-side `integration created` event, not a
+        // follow-up here.
+        reportSelfDrivingOnboardingGitHubConnectClicked: true,
+        reportSelfDrivingOnboardingGitHubAccessRequested: true,
         // Cloud-run funnel events mirror the backend `task_run_created` / `task_run_completed`
         // lifecycle events (products/tasks/backend/models.py) and reuse their property names.
         reportSelfDrivingOnboardingCloudRunQueued: (props: { taskId: string; runId: string; repository: string }) =>
@@ -258,6 +270,18 @@ export const onboardingEventUsageLogic = kea<onboardingEventUsageLogicType>([
         reportSelfDrivingOnboardingPlanSelected: ({ plan }) => {
             posthog.capture('onboarding plan selected', {
                 plan,
+                ...SELF_DRIVING_ONBOARDING_EVENT_PROPS,
+            })
+        },
+        reportSelfDrivingOnboardingGitHubConnectClicked: () => {
+            posthog.capture('onboarding github connect clicked', {
+                ...SELF_DRIVING_ONBOARDING_EVENT_PROPS,
+            })
+        },
+        // No reason text: it is free-form and often names people or internal systems, and the
+        // backend already carries its length on `integration access requested`.
+        reportSelfDrivingOnboardingGitHubAccessRequested: () => {
+            posthog.capture('onboarding github access requested', {
                 ...SELF_DRIVING_ONBOARDING_EVENT_PROPS,
             })
         },

--- a/frontend/src/scenes/onboarding/self-driving/components/SelfDrivingGitHubConnect.tsx
+++ b/frontend/src/scenes/onboarding/self-driving/components/SelfDrivingGitHubConnect.tsx
@@ -1,0 +1,127 @@
+import { useActions, useValues } from 'kea'
+import { combineUrl, router } from 'kea-router'
+
+import { IconCheckCircle, IconGithub } from '@posthog/icons'
+import { LemonBanner, LemonButton, LemonTextArea } from '@posthog/lemon-ui'
+
+import api from 'lib/api'
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
+import { TeamMembershipLevel } from 'lib/constants'
+import { integrationsLogic } from 'lib/integrations/integrationsLogic'
+import { onboardingEventUsageLogic } from 'scenes/onboarding/onboardingEventUsageLogic'
+
+/**
+ * Offers GitHub on the install step, ahead of the setup agent asking for it.
+ *
+ * Installing the GitHub App on an organization the user does not own needs a GitHub owner to
+ * approve it, which can take days. The agent only reaches that question partway through its run, so
+ * today the wait starts whenever someone sits down to run the command. Asking at the top of the step
+ * starts the same approval earlier, against the same integration the agent picks up.
+ */
+export function SelfDrivingGitHubConnect(): JSX.Element | null {
+    const { githubIntegrations, integrationsLoading } = useValues(integrationsLogic)
+    const { reportSelfDrivingOnboardingGitHubConnectClicked } = useActions(onboardingEventUsageLogic)
+
+    // Connecting an integration needs project membership (the backend enforces it again). Anyone
+    // below that gets the request-access path instead of a button that would fail.
+    const restrictionReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Member,
+    })
+
+    // Hold the space until we know: showing "Connect GitHub" to someone already connected reads as
+    // a step they still owe us.
+    if (integrationsLoading && githubIntegrations.length === 0) {
+        return null
+    }
+
+    if (githubIntegrations.length > 0) {
+        return (
+            <LemonBanner type="success" className="w-full">
+                <div className="flex items-center gap-2">
+                    <IconCheckCircle className="text-success shrink-0" />
+                    <span className="text-sm">
+                        GitHub is connected. The setup agent picks it up when you run the command below.
+                    </span>
+                </div>
+            </LemonBanner>
+        )
+    }
+
+    if (restrictionReason) {
+        return <RequestGitHubAccess />
+    }
+
+    // Full-page redirect out to GitHub and back to this step. integrationsLogic's OAuth callback
+    // creates the integration and reloads the list, so the connected state above renders on return.
+    const next = combineUrl(router.values.location.pathname, {
+        ...router.values.searchParams,
+        step: 'install',
+    }).url
+
+    return (
+        <div className="flex flex-col gap-2 items-center">
+            <p className="text-sm text-muted text-center m-0">
+                Connect GitHub so agents can open pull requests. If you are not an owner of your GitHub organization, an
+                owner has to approve the install, so starting now means the approval is under way before you run the
+                setup agent.
+            </p>
+            <LemonButton
+                type="secondary"
+                icon={<IconGithub />}
+                to={api.integrations.authorizeUrl({ kind: 'github', next })}
+                disableClientSideRouting
+                data-attr="self-driving-connect-github"
+                onClick={() => reportSelfDrivingOnboardingGitHubConnectClicked()}
+            >
+                Connect GitHub
+            </LemonButton>
+        </div>
+    )
+}
+
+/** For users without project access: the same request that Settings sends, from here. */
+function RequestGitHubAccess(): JSX.Element {
+    const { accessRequestReason, accessRequestLoading, requestedAccessKinds } = useValues(integrationsLogic)
+    const { setAccessRequestReason, requestIntegrationAccess } = useActions(integrationsLogic)
+    const { reportSelfDrivingOnboardingGitHubAccessRequested } = useActions(onboardingEventUsageLogic)
+
+    if (requestedAccessKinds.includes('github')) {
+        return (
+            <LemonBanner type="success" className="w-full">
+                Request sent. Your project admins have been notified and can connect GitHub.
+            </LemonBanner>
+        )
+    }
+
+    return (
+        <div className="flex flex-col gap-2 w-full">
+            <LemonBanner type="info" className="w-full">
+                You need more project access to connect GitHub. Tell your project admins why you need it and we will
+                email them.
+            </LemonBanner>
+            <LemonTextArea
+                value={accessRequestReason}
+                onChange={setAccessRequestReason}
+                placeholder="Why does your team need GitHub?"
+                minRows={2}
+                maxLength={2000}
+            />
+            <LemonButton
+                type="secondary"
+                icon={<IconGithub />}
+                fullWidth
+                center
+                loading={accessRequestLoading}
+                disabledReason={!accessRequestReason.trim() ? 'Add a short note for your admins' : undefined}
+                data-attr="self-driving-request-github-access"
+                onClick={() => {
+                    reportSelfDrivingOnboardingGitHubAccessRequested()
+                    requestIntegrationAccess({ kind: 'github' })
+                }}
+            >
+                Request GitHub
+            </LemonButton>
+        </div>
+    )
+}

--- a/frontend/src/scenes/onboarding/self-driving/components/SelfDrivingGitHubConnect.tsx
+++ b/frontend/src/scenes/onboarding/self-driving/components/SelfDrivingGitHubConnect.tsx
@@ -19,7 +19,7 @@ import { onboardingEventUsageLogic } from 'scenes/onboarding/onboardingEventUsag
  * starts the same approval earlier, against the same integration the agent picks up.
  */
 export function SelfDrivingGitHubConnect(): JSX.Element | null {
-    const { githubIntegrations, integrationsLoading } = useValues(integrationsLogic)
+    const { integrations, githubIntegrations } = useValues(integrationsLogic)
     const { reportSelfDrivingOnboardingGitHubConnectClicked } = useActions(onboardingEventUsageLogic)
 
     // Connecting an integration needs project membership (the backend enforces it again). Anyone
@@ -29,9 +29,10 @@ export function SelfDrivingGitHubConnect(): JSX.Element | null {
         minimumAccessLevel: TeamMembershipLevel.Member,
     })
 
-    // Hold the space until we know: showing "Connect GitHub" to someone already connected reads as
-    // a step they still owe us.
-    if (integrationsLoading && githubIntegrations.length === 0) {
+    // `integrations` stays null until the first load resolves. Keying off `integrationsLoading`
+    // instead would flash "Connect GitHub" at someone already connected, because the loader has not
+    // set it yet on the render that follows mount.
+    if (integrations === null) {
         return null
     }
 

--- a/frontend/src/scenes/onboarding/self-driving/components/SelfDrivingInstallOptions.tsx
+++ b/frontend/src/scenes/onboarding/self-driving/components/SelfDrivingInstallOptions.tsx
@@ -3,15 +3,20 @@ import { useActions } from 'kea'
 import { IconCheckCircle } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { onboardingEventUsageLogic } from 'scenes/onboarding/onboardingEventUsageLogic'
 import { CheckList } from 'scenes/onboarding/shared/components/CheckList'
 import { useWizardCommand } from 'scenes/onboarding/shared/useWizardCommand'
 import { WizardCommandBlock } from 'scenes/onboarding/shared/wizard-sync/WizardCommandBlock'
 import { WizardInstallOptions } from 'scenes/onboarding/shared/wizard-sync/WizardInstallOptions'
 
+import { SelfDrivingGitHubConnect } from './SelfDrivingGitHubConnect'
+
+const CONNECTS_GITHUB = 'Connects your GitHub, so agents can open pull requests'
+
 /** What the self-driving run wires up, so the command isn't a leap of faith. */
 const WIZARD_SETS_UP = [
-    'Connects your GitHub, so agents can open pull requests',
+    CONNECTS_GITHUB,
     'Picks the signal sources and scouts worth watching',
     'Sends findings to your inbox as they land',
 ]
@@ -23,6 +28,8 @@ const WIZARD_SETS_UP = [
 export function SelfDrivingInstallOptions({ onContinue }: { onContinue: () => void }): JSX.Element {
     const { isCloudOrDev } = useWizardCommand()
     const { reportSelfDrivingOnboardingInstallModeSelected } = useActions(onboardingEventUsageLogic)
+    // Read on both arms so the flag call itself is the experiment's exposure.
+    const gitHubPromptEnabled = useFeatureFlag('ONBOARDING_SELF_DRIVING_GITHUB_PROMPT', 'test')
 
     // Self-hosted: the wizard CLI only targets cloud + dev, so the command block renders nothing.
     // Show a real, actionable fallback instead of an empty step.
@@ -45,6 +52,7 @@ export function SelfDrivingInstallOptions({ onContinue }: { onContinue: () => vo
             <p className="text-sm text-muted text-center m-0">
                 Run this in your project. It sets everything up and hands back an inbox that's already working.
             </p>
+            {gitHubPromptEnabled && <SelfDrivingGitHubConnect />}
             <WizardInstallOptions
                 hideHog
                 offerCloudRun={false}
@@ -60,10 +68,13 @@ export function SelfDrivingInstallOptions({ onContinue }: { onContinue: () => vo
             />
             <CheckList
                 size="xs"
-                items={WIZARD_SETS_UP.map((line) => ({
-                    icon: <IconCheckCircle />,
-                    content: <span className="text-muted">{line}</span>,
-                }))}
+                // The prompt above already covers GitHub, so listing it again reads as a second ask.
+                items={WIZARD_SETS_UP.filter((line) => !gitHubPromptEnabled || line !== CONNECTS_GITHUB).map(
+                    (line) => ({
+                        icon: <IconCheckCircle />,
+                        content: <span className="text-muted">{line}</span>,
+                    })
+                )}
             />
         </div>
     )

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -89,6 +89,7 @@ from posthog.models.integration import (
     StripeIntegration,
     TwilioIntegration,
     defer_repository_cache_fields,
+    github_account_type as _github_account_type,
 )
 from posthog.models.user_integration import UserIntegration
 from posthog.permissions import (
@@ -135,15 +136,6 @@ def _reraise_slack_api_error(error: SlackApiError) -> NoReturn:
     if error_code in SLACK_AUTH_FAILURE_CODES:
         raise SlackIntegrationInactiveError() from error
     raise error
-
-
-def _github_account_type(owner_type: str | None) -> str | None:
-    """Normalize GitHub's account ``type`` ("Organization" / "User") to org vs personal."""
-    if owner_type == "Organization":
-        return "organization"
-    if owner_type == "User":
-        return "personal"
-    return None
 
 
 def validate_github_repository_name(repo: str) -> str:

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -39,6 +39,7 @@ from posthog.models.integration import (
     PRIVATE_CHANNEL_WITHOUT_ACCESS,
     SLACK_INTEGRATION_KINDS,
     EmailIntegration,
+    GitHubInstallationAccess,
     GitHubIntegration,
     GitHubIntegrationError,
     GitHubUserAuthorization,
@@ -2077,6 +2078,45 @@ class TestGithubAccountTypeHelper:
         from posthog.api.integration import _github_account_type
 
         assert _github_account_type(owner_type) == expected
+
+
+class TestGitHubIntegrationCreatedReporting:
+    @pytest.fixture(autouse=True)
+    def setup_environment(self, db):
+        self.organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=self.organization, name="Test Team")
+        self.user = User.objects.create_and_join(
+            self.organization, "reporting@posthog.com", "test", level=OrganizationMembership.Level.ADMIN
+        )
+
+    @patch("posthog.event_usage.report_user_action")
+    @patch("posthog.models.integration.GitHubIntegration.fetch_installation_access")
+    def test_reports_integration_created_once_per_installation(self, mock_fetch, mock_report):
+        mock_fetch.return_value = GitHubInstallationAccess(
+            installation_id="12345",
+            installation_info={"account": {"type": "Organization", "login": "acme"}},
+            access_token="ghs_token",
+            token_expires_at=(timezone.now() + timedelta(hours=1)).isoformat(),
+            repository_selection="selected",
+        )
+
+        GitHubIntegration.integration_from_installation_id("12345", self.team.id, self.user)
+
+        assert mock_report.call_count == 1
+        args, kwargs = mock_report.call_args
+        assert args[1] == "integration created"
+        assert args[2] == {
+            "integration_kind": "github",
+            "is_overwrite": False,
+            "repo_owner_type": "Organization",
+            "account_type": "organization",
+        }
+        assert kwargs["team"] == self.team
+
+        # Token refreshes and repeat installs re-run this, and must not read as new connections.
+        GitHubIntegration.integration_from_installation_id("12345", self.team.id, self.user)
+
+        assert mock_report.call_count == 1
 
 
 class TestGitHubIntegrationStateValidation:

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -3365,6 +3365,15 @@ def invalidate_github_repository_caches_for_installation(installation_id: str | 
     ).update(repository_cache_updated_at=None)
 
 
+def github_account_type(owner_type: str | None) -> str | None:
+    """Normalize GitHub's account ``type`` ("Organization" / "User") to org vs personal."""
+    if owner_type == "Organization":
+        return "organization"
+    if owner_type == "User":
+        return "personal"
+    return None
+
+
 class GitHubIntegration(GitHubIntegrationBase):
     integration: Integration
 
@@ -3430,6 +3439,27 @@ class GitHubIntegration(GitHubIntegrationBase):
         if integration.errors:
             integration.errors = ""
             integration.save()
+
+        # Every other integration reports this from the API serializer's create(). GitHub is linked
+        # through its own App installation callback instead, which skips that path, so report it here
+        # to keep the kind comparable with the rest.
+        if created and created_by is not None:
+            from posthog.event_usage import (
+                report_user_action,  # noqa: PLC0415 — posthog.event_usage imports posthog.models
+            )
+
+            owner_type = config["account"]["type"]
+            report_user_action(
+                created_by,
+                "integration created",
+                {
+                    "integration_kind": "github",
+                    "is_overwrite": False,
+                    "repo_owner_type": owner_type,
+                    "account_type": github_account_type(owner_type),
+                },
+                team=integration.team,
+            )
 
         invalidate_github_repository_caches_for_installation(installation_id)
 

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -3408,13 +3408,14 @@ class GitHubIntegration(GitHubIntegrationBase):
         now = int(time.time())
         expires_in = int(datetime.fromisoformat(installation_access.token_expires_at).timestamp() - now)
 
+        owner_type: str | None = dot_get(installation_access.installation_info, "account.type", None)
         config = {
             "installation_id": installation_id,
             "expires_in": expires_in,
             "refreshed_at": now,
             "repository_selection": installation_access.repository_selection,
             "account": {
-                "type": dot_get(installation_access.installation_info, "account.type", None),
+                "type": owner_type,
                 "name": dot_get(installation_access.installation_info, "account.login", installation_id),
             },
         }
@@ -3448,7 +3449,6 @@ class GitHubIntegration(GitHubIntegrationBase):
                 report_user_action,  # noqa: PLC0415 — posthog.event_usage imports posthog.models
             )
 
-            owner_type = config["account"]["type"]
             report_user_action(
                 created_by,
                 "integration created",


### PR DESCRIPTION
## Problem

- A team going through self-driving onboarding cannot get a single pull request opened until GitHub is connected, and that wait often starts late.
- The install step shows only the wizard command. The setup agent asks for GitHub partway through its run.
- Installing the GitHub App on an organization the user does not own needs a GitHub owner to approve it. That approval can take days.
- So the approval clock only starts once someone sits down and runs the command, not while they finish onboarding.
- GitHub is also the one integration kind that never reports `integration created`, so none of this is measurable today.

## Changes

- The self-driving install step now offers **Connect GitHub** above the wizard command, behind the `onboarding-self-driving-github-prompt` flag (`control` / `test`).
- Users without project access get the existing request-access box, which emails their project admins. Nobody hits a button that would fail.
- GitHub App installs report `integration created` with `integration_kind: github`, matching every other integration kind.
- Two new events cover the prompt: `onboarding github connect clicked` and `onboarding github access requested`.
- The checklist drops its "Connects your GitHub" line in the test arm, so the step does not ask twice.

The reporting call sits in `GitHubIntegration.integration_from_installation_id`, the one choke point every GitHub link path already goes through, rather than in the six callback call sites. It fires only when the row is newly created, so token refreshes and repeat installs do not read as new connections.

The prompt does not take over GitHub configuration. The setup agent still owns that, against the same integration this connects, so the two never disagree.

Experiment: [Self-driving onboarding: GitHub connect prompt on install step](https://us.posthog.com/project/2/experiments/411304). Primary metric is GitHub connected; onboarding completion and install step completion are guardrails.

> [!NOTE]
> The primary metric has no history, because `integration created` never fired for GitHub before this PR. Leave the experiment in draft until this ships and the event is confirmed in the data.

No screenshot: I could not run the app in this sandbox, so the new prompt is unverified visually. A reviewer should check it before this leaves draft.

## How did you test this code?

- Added `TestGitHubIntegrationCreatedReporting`. It catches a GitHub link that stops reporting `integration created`, which is the exact gap this PR closes, and it pins the once-per-installation behavior. No existing test covered this: every other GitHub test patches `integration_from_installation_id` out.
- Ran that test locally against a rebuilt test database. It passed.
- Ran `mypy --cache-fine-grained .` repo-wide, the same command CI runs. Clean.
- Ran oxlint, oxfmt and ruff over the changed files.
- Not run: the repo-wide `typescript:check`. `tsgo` was OOM-killed in this sandbox on every attempt, so CI is the first full typecheck.
- Not done: any manual click-through of the GitHub App install flow, and any check of how the prompt renders.

> [!NOTE]
> The draft jest run times out at its 20 minute budget on this branch. Selective mode is unsharded, and adding a flag to `lib/constants.tsx` makes `--findRelatedTests` reach most of the suite. Every test that ran passed before the cancellation. I added the `run-ci-frontend` label, which falls back to the sharded matrix; it takes effect on the next push or when this PR is marked ready for review.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually the PostHog Slack app, running Claude) built this from a Slack thread asking for an experiment that prompts for GitHub on this screen.

Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`, `/creating-experiments`, `/configuring-experiment-analytics`.

Two decisions worth flagging. First, I started out planning a frontend-only change, then found that `integration created` has no GitHub rows at all. Tracing it showed GitHub links run through `posthog/api/github_callback/`, which skips the serializer that reports the event for every other kind. Without fixing that the experiment has no readable primary metric, so the backend change came in scope.

Second, the request-access fallback reuses the existing `requestIntegrationAccess` flow rather than adding a second one. The backend, email task and dedup key are already generic over `kind` and needed no changes.

Still open, and not in this PR: notifying whoever started onboarding once an admin connects GitHub, so they know to come back and run the setup agent. That needs a new backend notification keyed off integration creation.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1786376257495339)*

