### PR TITLE
feat(desktop): draw comments and lifecycle events on the task timeline

### DIFF
--- a/products/desktop/packages/agent/src/adapters/signed-commit-shared.ts
+++ b/products/desktop/packages/agent/src/adapters/signed-commit-shared.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
 import {
   reportCommitArtefacts,
   reportTaskRunBranch,
+  reportTaskRunCommits,
 } from "../signed-commit-artefacts";
 import { qualifiedLocalToolName } from "./local-tools/registry";
 
@@ -199,6 +200,14 @@ export function runSignedCommitTool(
       // try/catch-free success path — reportCommitArtefacts never throws, so a failed
       // artefact post can't fail a commit that already landed. git_signed_rewrite is
       // intentionally not hooked (it republishes existing history).
+      // The timeline's own record of the push: one row per call, carrying the SHAs and
+      // subjects it renders, so loading the timeline stays a read.
+      await reportTaskRunCommits({
+        taskId: ctx.taskId,
+        taskRunId: ctx.taskRunId,
+        result,
+        message: a.message,
+      });
       await reportCommitArtefacts({
         taskId: c.taskId,
         result,

--- a/products/desktop/packages/agent/src/posthog-api.ts
+++ b/products/desktop/packages/agent/src/posthog-api.ts
@@ -291,6 +291,27 @@ export class PostHogAPIClient {
     );
   }
 
+  /** Announce a push the signed-commit tool made, for the task's activity timeline. The
+   *  backend keys it on the head SHA, so a retried call records the push once. */
+  async recordTaskRunCommits(
+    taskId: string,
+    runId: string,
+    push: {
+      branch: string;
+      repository: string;
+      commits: { sha: string; subject: string; url: string }[];
+    },
+  ): Promise<void> {
+    const teamId = this.getTeamId();
+    await this.apiRequest<void>(
+      `/api/projects/${teamId}/tasks/${taskId}/runs/${runId}/commits/`,
+      {
+        method: "POST",
+        body: JSON.stringify(push),
+      },
+    );
+  }
+
   async setTaskRunOutput(
     taskId: string,
     runId: string,

--- a/products/desktop/packages/agent/src/signed-commit-artefacts.test.ts
+++ b/products/desktop/packages/agent/src/signed-commit-artefacts.test.ts
@@ -15,6 +15,7 @@ import {
   parseSandboxEnv,
   reportCommitArtefacts,
   reportTaskRunBranch,
+  reportTaskRunCommits,
   resolveSandboxPosthogApi,
 } from "./signed-commit-artefacts";
 
@@ -435,5 +436,105 @@ describe("reportTaskRunBranch", () => {
         },
       }),
     });
+  });
+});
+
+describe("reportTaskRunCommits", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  const push = {
+    branch: "posthog-code/fix-foo",
+    repository: "PostHog/PostHog",
+    commits: [
+      {
+        sha: "a41c9e2",
+        url: "https://github.com/PostHog/PostHog/commit/a41c9e2",
+      },
+      {
+        sha: "7d0be55",
+        url: "https://github.com/PostHog/PostHog/commit/7d0be55",
+      },
+    ],
+  };
+
+  it("reports the push, because nothing else observes it", () => {
+    // The commits are created through GitHub's API from inside the sandbox, so no webhook
+    // on the PostHog side sees them.
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+
+    return reportTaskRunCommits({
+      taskId: "task-1",
+      taskRunId: "run-1",
+      result: push,
+      message: "feat: one",
+      env: ENV,
+      envFilePath: NO_ENV_FILE,
+      oauthEnvFilePath: TEST_OAUTH_ENV_FILE,
+    }).then(() => {
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(String(url)).toBe(
+        "https://us.posthog.com/api/projects/7/tasks/task-1/runs/run-1/commits/",
+      );
+      expect(JSON.parse(String((init as RequestInit).body))).toEqual({
+        branch: push.branch,
+        repository: push.repository,
+        commits: push.commits.map((commit) => ({
+          sha: commit.sha,
+          subject: "feat: one",
+          url: commit.url,
+        })),
+      });
+    });
+  });
+
+  it("stays quiet when the push carried nothing, or the run is unknown", async () => {
+    await reportTaskRunCommits({
+      taskId: "task-1",
+      taskRunId: "run-1",
+      result: { ...push, commits: [] },
+      message: "feat: one",
+      env: ENV,
+      envFilePath: NO_ENV_FILE,
+      oauthEnvFilePath: TEST_OAUTH_ENV_FILE,
+    });
+    await reportTaskRunCommits({
+      taskId: undefined,
+      taskRunId: undefined,
+      result: push,
+      message: "feat: one",
+      env: ENV,
+      envFilePath: NO_ENV_FILE,
+      oauthEnvFilePath: TEST_OAUTH_ENV_FILE,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("never throws, so a commit that landed is not undone by a failed report", async () => {
+    fetchMock.mockRejectedValue(new Error("network down"));
+
+    await expect(
+      reportTaskRunCommits({
+        taskId: "task-1",
+        taskRunId: "run-1",
+        result: push,
+        message: "feat: one",
+        env: ENV,
+        envFilePath: NO_ENV_FILE,
+        oauthEnvFilePath: TEST_OAUTH_ENV_FILE,
+      }),
+    ).resolves.toBeUndefined();
   });
 });

--- a/products/desktop/packages/agent/src/signed-commit-artefacts.ts
+++ b/products/desktop/packages/agent/src/signed-commit-artefacts.ts
@@ -138,6 +138,52 @@ export async function reportCommitArtefacts(opts: {
   }
 }
 
+/**
+ * Announce a push on the task's timeline.
+ *
+ * The signed-commit tool is the only actor that sees this push: the commits are created
+ * through GitHub's API from inside the sandbox, so no webhook on the PostHog side observes
+ * them. The backend keys the event on the head SHA, so a retried tool call records it once.
+ *
+ * Best-effort like the reporters beside it — a commit that landed must not fail because its
+ * announcement didn't.
+ */
+export async function reportTaskRunCommits(opts: {
+  taskId: string | undefined;
+  taskRunId: string | undefined;
+  result: SignedCommitResult;
+  /** Commit headline — the same for every chunk of a split payload. */
+  message: string;
+  env?: Record<string, string | undefined>;
+  envFilePath?: string;
+  oauthEnvFilePath?: string;
+}): Promise<void> {
+  if (!opts.taskId || !opts.taskRunId || opts.result.commits.length === 0) {
+    return;
+  }
+  try {
+    const client = createSandboxPosthogClient(
+      opts.env,
+      opts.envFilePath,
+      opts.oauthEnvFilePath,
+    );
+    if (!client) {
+      return;
+    }
+    await client.recordTaskRunCommits(opts.taskId, opts.taskRunId, {
+      branch: opts.result.branch,
+      repository: opts.result.repository,
+      commits: opts.result.commits.map((commit) => ({
+        sha: commit.sha,
+        subject: opts.message,
+        url: commit.url,
+      })),
+    });
+  } catch (err) {
+    warn(`failed to record push on ${opts.result.branch}: ${err}`);
+  }
+}
+
 export async function reportTaskRunBranch(opts: {
   taskId: string | undefined;
   taskRunId: string | undefined;

--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -102,6 +102,7 @@ import type {
   TaskActivityPage,
   TaskActivityReadMarker,
   TaskChannel,
+  TaskCommentThreadSummary,
   TaskMention,
   TaskRun,
   TaskRunArtefact,
@@ -2795,6 +2796,30 @@ export class PostHogAPIClient {
       );
     }
     return (await response.json()) as TaskThreadMessage[];
+  }
+
+  /** Every comment thread on the task, collapsed one row per thread — the activity
+   *  timeline's comment feed. One request for the whole task, so the panel never fans out
+   *  per artifact the way the Comments tab has to. */
+  async getTaskCommentActivity(
+    taskId: string,
+  ): Promise<TaskCommentThreadSummary[]> {
+    const teamId = await this.getTeamId();
+    const urlPath = `/api/projects/${teamId}/tasks/${taskId}/thread_messages/comment_activity/`;
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url: new URL(`${this.api.baseUrl}${urlPath}`),
+      path: urlPath,
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch comment activity: ${response.statusText}`,
+      );
+    }
+    const body = (await response.json()) as {
+      comments?: TaskCommentThreadSummary[];
+    };
+    return body.comments ?? [];
   }
 
   async createTaskThreadMessage(

--- a/products/desktop/packages/core/src/canvas/activityEvents.ts
+++ b/products/desktop/packages/core/src/canvas/activityEvents.ts
@@ -9,6 +9,7 @@
 export const ACTIVITY_EVENTS = [
   "run_started",
   "run_failed",
+  "commits_pushed",
   "awaiting_input",
   "artifact_created",
   "artifact_revised",
@@ -32,6 +33,15 @@ export interface RunStartedPayload {
 export interface RunFailedPayload {
   runId: string;
   errorSummary: string;
+}
+
+export interface CommitsPushedPayload {
+  runId: string;
+  branch: string;
+  repository: string | null;
+  commits: { sha: string; subject: string; url: string | null }[];
+  /** How many the push carried; `commits` is capped, so this can be larger. */
+  total: number;
 }
 
 export interface AwaitingInputPayload {
@@ -65,6 +75,7 @@ export interface MessageForwardedPayload {
 export type ActivityEvent =
   | { kind: "run_started"; payload: RunStartedPayload }
   | { kind: "run_failed"; payload: RunFailedPayload }
+  | { kind: "commits_pushed"; payload: CommitsPushedPayload }
   | { kind: "awaiting_input"; payload: AwaitingInputPayload }
   | { kind: "artifact_created"; payload: ArtifactPayload }
   | { kind: "artifact_revised"; payload: ArtifactPayload }
@@ -137,6 +148,36 @@ export function parseActivityEvent(message: {
           errorSummary: str(payload.error_summary),
         },
       };
+    case "commits_pushed": {
+      const raw = Array.isArray(payload.commits) ? payload.commits : [];
+      const commits = raw.flatMap((entry) => {
+        if (typeof entry !== "object" || entry === null) return [];
+        const commit = entry as Record<string, unknown>;
+        const sha = str(commit.sha);
+        return sha
+          ? [
+              {
+                sha,
+                subject: str(commit.subject),
+                url: optionalStr(commit.url),
+              },
+            ]
+          : [];
+      });
+      // A push with no readable commit can't be drawn, so it isn't a row.
+      return commits.length
+        ? {
+            kind: event,
+            payload: {
+              runId: str(payload.run_id),
+              branch: str(payload.branch),
+              repository: optionalStr(payload.repository),
+              commits,
+              total: num(payload.total, commits.length),
+            },
+          }
+        : null;
+    }
     case "awaiting_input":
       return { kind: event, payload: { runId: str(payload.run_id) } };
     case "artifact_created":

--- a/products/desktop/packages/core/src/canvas/activityEvents.ts
+++ b/products/desktop/packages/core/src/canvas/activityEvents.ts
@@ -1,0 +1,177 @@
+/**
+ * The vocabulary of server-emitted task events the activity timeline renders.
+ *
+ * Mirrors `TaskActivityEvent` in `products/tasks/backend/models.py`; a test asserts the
+ * two lists match. `parseActivityEvent` returns `null` for anything it doesn't know, which
+ * is what lets the backend emit a new event before this client can draw it.
+ */
+
+export const ACTIVITY_EVENTS = [
+  "run_started",
+  "run_failed",
+  "awaiting_input",
+  "artifact_created",
+  "artifact_revised",
+  "canvas_created",
+  "pr_created",
+  "pr_merged",
+  "pr_closed",
+  "message_forwarded",
+] as const;
+
+export type ActivityEventKind = (typeof ACTIVITY_EVENTS)[number];
+
+const ACTIVITY_EVENT_SET: ReadonlySet<string> = new Set(ACTIVITY_EVENTS);
+
+export interface RunStartedPayload {
+  runId: string;
+  environment: string;
+  branch: string;
+}
+
+export interface RunFailedPayload {
+  runId: string;
+  errorSummary: string;
+}
+
+export interface AwaitingInputPayload {
+  runId: string;
+}
+
+export interface ArtifactPayload {
+  artifactId: string;
+  name: string;
+  artifactType: string;
+  version: number;
+}
+
+export interface CanvasCreatedPayload {
+  name: string;
+  url: string | null;
+}
+
+export interface PrPayload {
+  prUrl: string;
+  repository: string | null;
+  prNumber: number | null;
+  actor: string | null;
+}
+
+export interface MessageForwardedPayload {
+  messageId: string;
+  runId: string;
+}
+
+export type ActivityEvent =
+  | { kind: "run_started"; payload: RunStartedPayload }
+  | { kind: "run_failed"; payload: RunFailedPayload }
+  | { kind: "awaiting_input"; payload: AwaitingInputPayload }
+  | { kind: "artifact_created"; payload: ArtifactPayload }
+  | { kind: "artifact_revised"; payload: ArtifactPayload }
+  | { kind: "canvas_created"; payload: CanvasCreatedPayload }
+  | { kind: "pr_created"; payload: PrPayload }
+  | { kind: "pr_merged"; payload: PrPayload }
+  | { kind: "pr_closed"; payload: PrPayload }
+  | { kind: "message_forwarded"; payload: MessageForwardedPayload };
+
+function str(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function num(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function optionalStr(value: unknown): string | null {
+  return typeof value === "string" && value ? value : null;
+}
+
+function prPayload(payload: Record<string, unknown>): PrPayload {
+  return {
+    prUrl: str(payload.pr_url),
+    repository: optionalStr(payload.repository),
+    prNumber: typeof payload.pr_number === "number" ? payload.pr_number : null,
+    actor: optionalStr(payload.actor),
+  };
+}
+
+function artifactPayload(payload: Record<string, unknown>): ArtifactPayload {
+  return {
+    artifactId: str(payload.artifact_id),
+    name: str(payload.name, "Artifact"),
+    artifactType: str(payload.artifact_type),
+    version: num(payload.version, 1),
+  };
+}
+
+export function isActivityEventKind(event: string): event is ActivityEventKind {
+  return ACTIVITY_EVENT_SET.has(event);
+}
+
+/**
+ * The typed event a thread message carries, or `null` when the message isn't one this
+ * client renders — a human message, an older event, or one added after this release.
+ */
+export function parseActivityEvent(message: {
+  event?: string;
+  payload?: Record<string, unknown>;
+}): ActivityEvent | null {
+  const event = message.event ?? "";
+  if (!isActivityEventKind(event)) return null;
+  const payload = message.payload ?? {};
+  switch (event) {
+    case "run_started":
+      return {
+        kind: event,
+        payload: {
+          runId: str(payload.run_id),
+          environment: str(payload.environment),
+          branch: str(payload.branch),
+        },
+      };
+    case "run_failed":
+      return {
+        kind: event,
+        payload: {
+          runId: str(payload.run_id),
+          errorSummary: str(payload.error_summary),
+        },
+      };
+    case "awaiting_input":
+      return { kind: event, payload: { runId: str(payload.run_id) } };
+    case "artifact_created":
+    case "artifact_revised":
+      return { kind: event, payload: artifactPayload(payload) };
+    case "canvas_created":
+      return {
+        kind: event,
+        payload: {
+          name: str(payload.canvas_name, "Canvas"),
+          url: optionalStr(payload.canvas_url),
+        },
+      };
+    case "pr_created":
+    case "pr_merged":
+    case "pr_closed": {
+      const parsed = prPayload(payload);
+      // A PR row with no url can't be labelled or opened, so it isn't a row.
+      return parsed.prUrl ? { kind: event, payload: parsed } : null;
+    }
+    case "message_forwarded":
+      return {
+        kind: event,
+        payload: {
+          messageId: str(payload.message_id),
+          runId: str(payload.run_id),
+        },
+      };
+  }
+}
+
+/** "owner/repo#12" when the event knows both, else the bare url. */
+export function prLabel(payload: PrPayload): string {
+  if (payload.repository && payload.prNumber !== null) {
+    return `${payload.repository}#${payload.prNumber}`;
+  }
+  return payload.prUrl;
+}

--- a/products/desktop/packages/core/src/canvas/activityTimeline.test.ts
+++ b/products/desktop/packages/core/src/canvas/activityTimeline.test.ts
@@ -269,6 +269,9 @@ describe("activity events", () => {
 
   it("matches the backend vocabulary", async () => {
     // The two lists are one contract: adding an event on one side only is a silent gap.
+    // `commits_pushed` is emitted by the layer below this one (#81070), so it is expected
+    // ahead of the enum until that layer is in this branch.
+    const pendingBackendEvents = new Set(["commits_pushed"]);
     const { readFile } = await import("node:fs/promises");
     const models = await readFile(
       new URL("../../../../../tasks/backend/models.py", import.meta.url)
@@ -284,6 +287,70 @@ describe("activity events", () => {
         .matchAll(/^\s{4}[A-Z_]+ = "([a-z_]+)"/gm),
     ].map((match) => match[1]);
 
-    expect([...ACTIVITY_EVENTS].sort()).toEqual(backendEvents.sort());
+    expect(
+      [...ACTIVITY_EVENTS]
+        .filter((event) => !pendingBackendEvents.has(event))
+        .sort(),
+    ).toEqual(backendEvents.sort());
+  });
+});
+
+describe("commits pushed", () => {
+  it("reads a push into a row with its commits", () => {
+    expect(
+      parseActivityEvent({
+        event: "commits_pushed",
+        payload: {
+          run_id: "run-1",
+          branch: "shy/x",
+          repository: "PostHog/posthog",
+          total: 3,
+          commits: [
+            { sha: "a41c9e2", subject: "feat: one", url: "https://x/1" },
+            { sha: "7d0be55", subject: "feat: two", url: null },
+          ],
+        },
+      }),
+    ).toEqual({
+      kind: "commits_pushed",
+      payload: {
+        runId: "run-1",
+        branch: "shy/x",
+        repository: "PostHog/posthog",
+        total: 3,
+        commits: [
+          { sha: "a41c9e2", subject: "feat: one", url: "https://x/1" },
+          { sha: "7d0be55", subject: "feat: two", url: null },
+        ],
+      },
+    });
+  });
+
+  it("drops a push with no readable commit, which cannot be drawn", () => {
+    expect(
+      parseActivityEvent({
+        event: "commits_pushed",
+        payload: { run_id: "run-1", commits: [{ subject: "no sha" }] },
+      }),
+    ).toBeNull();
+  });
+
+  it("keys a push on its head SHA, so a retried report is one row", () => {
+    const push = (id: string) =>
+      eventMessage(
+        id,
+        "commits_pushed",
+        {
+          run_id: "run-1",
+          branch: "shy/x",
+          total: 1,
+          commits: [{ sha: "head1", subject: "feat: one" }],
+        },
+        "2026-08-01T10:30:00Z",
+      );
+
+    const rows = build({ messages: [push("m1"), push("m2")] });
+
+    expect(rows.filter((row) => row.kind === "event")).toHaveLength(1);
   });
 });

--- a/products/desktop/packages/core/src/canvas/activityTimeline.test.ts
+++ b/products/desktop/packages/core/src/canvas/activityTimeline.test.ts
@@ -1,0 +1,289 @@
+import {
+  ACTIVITY_EVENTS,
+  parseActivityEvent,
+} from "@posthog/core/canvas/activityEvents";
+import {
+  type ActivityTaskLike,
+  buildActivityTimeline,
+  type CommentThreadLike,
+} from "@posthog/core/canvas/activityTimeline";
+import type { ThreadMessageLike } from "@posthog/core/canvas/threadTimeline";
+import { describe, expect, it } from "vitest";
+
+const task: ActivityTaskLike = {
+  id: "task-1",
+  createdAt: "2026-08-01T10:00:00Z",
+  updatedAt: "2026-08-01T12:00:00Z",
+};
+
+function eventMessage(
+  id: string,
+  event: string,
+  payload: Record<string, unknown>,
+  createdAt: string,
+): ThreadMessageLike {
+  return {
+    id,
+    content: "",
+    created_at: createdAt,
+    author_kind: "agent",
+    event,
+    payload,
+  };
+}
+
+function thread(overrides: Partial<CommentThreadLike> = {}): CommentThreadLike {
+  return {
+    id: "thread-1",
+    lastActivityAt: "2026-08-01T11:00:00Z",
+    mentionedUserIds: [],
+    resolved: false,
+    stateEvent: null,
+    ...overrides,
+  };
+}
+
+function build(input: {
+  messages?: ThreadMessageLike[];
+  commentThreads?: CommentThreadLike[];
+  commentsEnabled?: boolean;
+  taskOverrides?: Partial<ActivityTaskLike>;
+}) {
+  return buildActivityTimeline({
+    task: { ...task, ...input.taskOverrides },
+    messages: input.messages ?? [],
+    commentThreads: input.commentThreads ?? [],
+    commentsEnabled: input.commentsEnabled,
+  });
+}
+
+describe("activity timeline", () => {
+  it("leads with the task's creation", () => {
+    const rows = build({});
+
+    expect(rows.map((row) => row.kind)).toEqual(["task_created"]);
+  });
+
+  it("orders every source by time", () => {
+    const rows = build({
+      messages: [
+        eventMessage(
+          "m2",
+          "run_started",
+          { run_id: "run-1" },
+          "2026-08-01T10:30:00Z",
+        ),
+        {
+          id: "m1",
+          content: "what about mobile?",
+          created_at: "2026-08-01T10:15:00Z",
+        },
+      ],
+      commentThreads: [thread()],
+    });
+
+    expect(rows.map((row) => row.key)).toEqual([
+      "task-created",
+      "message-m1",
+      "event-m2",
+      "comment-thread-1",
+    ]);
+  });
+
+  it("places a comment thread at its newest activity, not its start", () => {
+    // A thread that keeps getting replies has to stay one row that moves, or a five-reply
+    // exchange pushes everything else off the panel.
+    const rows = build({
+      messages: [
+        eventMessage(
+          "m1",
+          "run_started",
+          { run_id: "run-1" },
+          "2026-08-01T13:00:00Z",
+        ),
+      ],
+      commentThreads: [thread({ lastActivityAt: "2026-08-01T14:00:00Z" })],
+    });
+
+    expect(rows.map((row) => row.kind)).toEqual([
+      "task_created",
+      "event",
+      "comment",
+    ]);
+  });
+
+  it("gives resolve its own row after the thread", () => {
+    const rows = build({
+      commentThreads: [
+        thread({
+          resolved: true,
+          stateEvent: { state: "resolved", createdAt: "2026-08-01T11:30:00Z" },
+        }),
+      ],
+    });
+
+    expect(rows.map((row) => row.kind)).toEqual([
+      "task_created",
+      "comment",
+      "comment_state",
+    ]);
+  });
+
+  it("drops the comment feed when comments are off", () => {
+    const rows = build({
+      commentThreads: [
+        thread({
+          stateEvent: { state: "resolved", createdAt: "2026-08-01T11:30:00Z" },
+        }),
+      ],
+      commentsEnabled: false,
+    });
+
+    expect(rows.map((row) => row.kind)).toEqual(["task_created"]);
+  });
+
+  it("keeps one row when two paths announced the same pull request", () => {
+    // The agent's own output and the GitHub webhook backstop can both observe a PR.
+    const rows = build({
+      messages: [
+        eventMessage(
+          "m1",
+          "pr_created",
+          { pr_url: "https://github.com/posthog/posthog/pull/1" },
+          "2026-08-01T10:30:00Z",
+        ),
+        eventMessage(
+          "m2",
+          "pr_created",
+          { pr_url: "https://github.com/posthog/posthog/pull/1" },
+          "2026-08-01T10:31:00Z",
+        ),
+      ],
+    });
+
+    expect(rows.filter((row) => row.kind === "event")).toHaveLength(1);
+  });
+
+  it("ignores events it doesn't know, so the backend can ship first", () => {
+    const rows = build({
+      messages: [
+        eventMessage("m1", "checks_failed_someday", {}, "2026-08-01T10:30:00Z"),
+      ],
+    });
+
+    expect(rows.map((row) => row.kind)).toEqual(["task_created"]);
+  });
+
+  it("numbers runs over the feed, since the backend cannot number them", () => {
+    // Counting runs server-side races two concurrent creations onto one number; the ordered
+    // feed can only be read one way.
+    const rows = build({
+      messages: [
+        eventMessage(
+          "m1",
+          "run_started",
+          { run_id: "run-1" },
+          "2026-08-01T10:30:00Z",
+        ),
+        eventMessage(
+          "m2",
+          "run_started",
+          { run_id: "run-2" },
+          "2026-08-01T11:30:00Z",
+        ),
+      ],
+    });
+
+    expect(
+      rows.flatMap((row) => (row.kind === "event" ? [row.runOrdinal] : [])),
+    ).toEqual([1, 2]);
+  });
+
+  it("derives an ending for tasks with no failure event", () => {
+    const rows = build({
+      taskOverrides: { latestRunStatus: "completed", latestRunId: "run-1" },
+    });
+
+    expect(rows.at(-1)).toMatchObject({
+      kind: "run_status",
+      status: "completed",
+    });
+  });
+
+  it("prefers the failure event over the derived ending", () => {
+    // The event carries the reason, which is the whole point of having it.
+    const rows = build({
+      messages: [
+        eventMessage(
+          "m1",
+          "run_failed",
+          { run_id: "run-1", error_summary: "pnpm build failed" },
+          "2026-08-01T11:00:00Z",
+        ),
+      ],
+      taskOverrides: { latestRunStatus: "failed", latestRunId: "run-1" },
+    });
+
+    expect(rows.filter((row) => row.kind === "run_status")).toHaveLength(0);
+    expect(rows.at(-1)).toMatchObject({ kind: "event" });
+  });
+});
+
+describe("activity events", () => {
+  it("reads a run_started payload", () => {
+    expect(
+      parseActivityEvent({
+        event: "run_started",
+        payload: { run_id: "run-1", environment: "cloud", branch: "casey/x" },
+      }),
+    ).toEqual({
+      kind: "run_started",
+      payload: { runId: "run-1", environment: "cloud", branch: "casey/x" },
+    });
+  });
+
+  it("falls back rather than rendering a partial payload", () => {
+    expect(
+      parseActivityEvent({ event: "artifact_created", payload: {} }),
+    ).toEqual({
+      kind: "artifact_created",
+      payload: {
+        artifactId: "",
+        name: "Artifact",
+        artifactType: "",
+        version: 1,
+      },
+    });
+  });
+
+  it("drops a pull request event with no url, since it can't be opened", () => {
+    expect(parseActivityEvent({ event: "pr_merged", payload: {} })).toBeNull();
+  });
+
+  it.each(["", "turn_complete", "something_new"])(
+    "returns null for %s",
+    (event) => {
+      expect(parseActivityEvent({ event, payload: {} })).toBeNull();
+    },
+  );
+
+  it("matches the backend vocabulary", async () => {
+    // The two lists are one contract: adding an event on one side only is a silent gap.
+    const { readFile } = await import("node:fs/promises");
+    const models = await readFile(
+      new URL("../../../../../tasks/backend/models.py", import.meta.url)
+        .pathname,
+      "utf8",
+    );
+    const block = models.slice(
+      models.indexOf("class TaskActivityEvent(models.TextChoices):"),
+    );
+    const backendEvents = [
+      ...block
+        .slice(0, block.indexOf("class TaskThreadMessage("))
+        .matchAll(/^\s{4}[A-Z_]+ = "([a-z_]+)"/gm),
+    ].map((match) => match[1]);
+
+    expect([...ACTIVITY_EVENTS].sort()).toEqual(backendEvents.sort());
+  });
+});

--- a/products/desktop/packages/core/src/canvas/activityTimeline.ts
+++ b/products/desktop/packages/core/src/canvas/activityTimeline.ts
@@ -209,6 +209,9 @@ function eventIdentity(event: ActivityEvent): string {
     case "run_failed":
     case "awaiting_input":
       return event.payload.runId;
+    case "commits_pushed":
+      // The head SHA identifies the push, the way the backend keys it.
+      return event.payload.commits.at(-1)?.sha ?? event.payload.runId;
     case "artifact_created":
     case "artifact_revised":
       return `${event.payload.artifactId}:${event.payload.version}`;

--- a/products/desktop/packages/core/src/canvas/activityTimeline.ts
+++ b/products/desktop/packages/core/src/canvas/activityTimeline.ts
@@ -1,0 +1,224 @@
+/**
+ * Merging the task activity timeline's three sources into one ordered list of rows.
+ *
+ * Kept out of the renderer so the ordering, collapsing and dedupe rules can be tested
+ * without mounting anything — the same split `threadTimeline.ts` uses.
+ *
+ * The sources:
+ *  - the task itself (created, and a terminal status for tasks with no event rows),
+ *  - its thread messages: human messages plus the server-emitted event rows,
+ *  - its comment threads, already collapsed one row per thread by the backend.
+ */
+
+import {
+  type ActivityEvent,
+  parseActivityEvent,
+} from "@posthog/core/canvas/activityEvents";
+import type { ThreadMessageLike } from "@posthog/core/canvas/threadTimeline";
+
+export interface CommentThreadLike {
+  id: string;
+  lastActivityAt: string;
+  mentionedUserIds: number[];
+  resolved: boolean;
+  stateEvent: { state: string; createdAt: string } | null;
+}
+
+export interface ActivityTaskLike {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  latestRunId?: string | null;
+  latestRunStatus?: string | null;
+}
+
+/** A prompt the task's author sent the agent, from the live session's own event stream.
+ *  Only the fields the row needs, so core stays independent of the UI's item type. */
+export interface UserMessageLike {
+  id: string;
+  content: string;
+  timestamp: number;
+}
+
+export type ActivityRow<
+  TMessage extends ThreadMessageLike = ThreadMessageLike,
+  TComment extends CommentThreadLike = CommentThreadLike,
+> =
+  | { kind: "task_created"; key: string; ts: number }
+  | {
+      kind: "event";
+      key: string;
+      ts: number;
+      event: ActivityEvent;
+      message: TMessage;
+      /** Which run of the task a `run_started` row is, counted over the feed. The backend
+       *  cannot number these without racing two concurrent creations onto one number. */
+      runOrdinal?: number;
+    }
+  | { kind: "human_message"; key: string; ts: number; message: TMessage }
+  | { kind: "user_message"; key: string; ts: number; item: UserMessageLike }
+  | { kind: "comment"; key: string; ts: number; thread: TComment }
+  | {
+      kind: "comment_state";
+      key: string;
+      ts: number;
+      thread: TComment;
+      state: string;
+    }
+  | { kind: "run_status"; key: string; ts: number; status: string };
+
+/** Rows in the same second still need a stable order, so each kind carries a rank.
+ *  Ordering by rank rather than nudging timestamps (the old `updatedTs + 1`) keeps two
+ *  events that genuinely share a timestamp from fighting over the same slot. */
+const KIND_RANK: Record<ActivityRow["kind"], number> = {
+  task_created: 0,
+  event: 1,
+  human_message: 1,
+  user_message: 1,
+  comment: 1,
+  comment_state: 2,
+  run_status: 3,
+};
+
+function timestamp(value: string | undefined): number {
+  const parsed = Date.parse(value ?? "");
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function buildActivityTimeline<
+  TMessage extends ThreadMessageLike,
+  TComment extends CommentThreadLike,
+>({
+  task,
+  messages,
+  commentThreads,
+  userMessages = [],
+  commentsEnabled = true,
+}: {
+  task: ActivityTaskLike;
+  messages: TMessage[];
+  commentThreads: TComment[];
+  userMessages?: UserMessageLike[];
+  /** False drops the comment feed entirely, rather than leaving the renderer to hide
+   *  rows it was handed. */
+  commentsEnabled?: boolean;
+}): ActivityRow<TMessage, TComment>[] {
+  const rows: ActivityRow<TMessage, TComment>[] = [
+    {
+      kind: "task_created",
+      key: "task-created",
+      ts: timestamp(task.createdAt),
+    },
+  ];
+
+  // Two paths can observe the same thing (the agent's own output and the GitHub webhook
+  // backstop), and the backend keys writes to stop that. A client-side guard on the same
+  // identity covers rows written before the key existed.
+  const seenEvents = new Set<string>();
+  let hasTerminalEvent = false;
+  let runStartedSeen = 0;
+
+  for (const message of messages) {
+    const event = parseActivityEvent(message);
+    if (!event) {
+      if ((message.author_kind ?? "human") === "human") {
+        rows.push({
+          kind: "human_message",
+          key: `message-${message.id}`,
+          ts: timestamp(message.created_at),
+          message,
+        });
+      }
+      continue;
+    }
+    const identity = `${event.kind}:${eventIdentity(event)}`;
+    if (seenEvents.has(identity)) continue;
+    seenEvents.add(identity);
+    if (event.kind === "run_failed") hasTerminalEvent = true;
+    if (event.kind === "run_started") runStartedSeen += 1;
+    rows.push({
+      kind: "event",
+      key: `event-${message.id}`,
+      ts: timestamp(message.created_at),
+      event,
+      message,
+      ...(event.kind === "run_started" ? { runOrdinal: runStartedSeen } : {}),
+    });
+  }
+
+  for (const item of userMessages) {
+    rows.push({
+      kind: "user_message",
+      key: `user-message-${item.id}`,
+      ts: item.timestamp,
+      item,
+    });
+  }
+
+  if (commentsEnabled) {
+    for (const thread of commentThreads) {
+      rows.push({
+        kind: "comment",
+        key: `comment-${thread.id}`,
+        ts: timestamp(thread.lastActivityAt),
+        thread,
+      });
+      // Resolve and reopen are state changes with an author and a time, so they get their
+      // own row rather than folding into the thread they close.
+      if (thread.stateEvent) {
+        rows.push({
+          kind: "comment_state",
+          key: `comment-state-${thread.id}`,
+          ts: timestamp(thread.stateEvent.createdAt),
+          thread,
+          state: thread.stateEvent.state,
+        });
+      }
+    }
+  }
+
+  // Fallback for tasks whose runs predate the event rows: derive the ending from the task.
+  const status = task.latestRunStatus ?? null;
+  if (status && isTerminalRunStatus(status) && !hasTerminalEvent) {
+    rows.push({
+      kind: "run_status",
+      key: `run-status-${task.latestRunId ?? "latest"}`,
+      ts: timestamp(task.updatedAt) || timestamp(task.createdAt),
+      status,
+    });
+  }
+
+  return rows.sort(
+    (left, right) =>
+      left.ts - right.ts ||
+      KIND_RANK[left.kind] - KIND_RANK[right.kind] ||
+      left.key.localeCompare(right.key),
+  );
+}
+
+function isTerminalRunStatus(status: string): boolean {
+  return (
+    status === "completed" || status === "failed" || status === "cancelled"
+  );
+}
+
+/** What makes an event unique in the world, for the dedupe guard above. */
+function eventIdentity(event: ActivityEvent): string {
+  switch (event.kind) {
+    case "run_started":
+    case "run_failed":
+    case "awaiting_input":
+      return event.payload.runId;
+    case "artifact_created":
+    case "artifact_revised":
+      return `${event.payload.artifactId}:${event.payload.version}`;
+    case "canvas_created":
+      return event.payload.name;
+    case "pr_created":
+    case "pr_merged":
+    case "pr_closed":
+      return event.payload.prUrl;
+    case "message_forwarded":
+      return event.payload.messageId;
+  }
+}

--- a/products/desktop/packages/shared/src/domain-types.ts
+++ b/products/desktop/packages/shared/src/domain-types.ts
@@ -148,6 +148,40 @@ export interface TaskThreadMessage {
   author?: UserBasic | null;
   forwarded_to_agent_at?: string | null;
   forwarded_by?: UserBasic | null;
+  /** Users mentioned in the row, indexed at write time. Absent on older backends. */
+  mentioned_user_ids?: number[];
+}
+
+/** The latest resolve or reopen on a comment thread. */
+export interface TaskCommentStateEvent {
+  state: string;
+  author?: UserBasic | null;
+  created_at: string;
+}
+
+/**
+ * One comment thread on a task, collapsed the way the activity timeline shows it
+ * (`/thread_messages/comment_activity/`). Mirrors `TaskCommentActivityDTO`.
+ */
+export interface TaskCommentThreadSummary {
+  id: string;
+  target: { id: string; type: string; name: string };
+  content: string;
+  content_truncated: boolean;
+  selected_text: string | null;
+  author?: UserBasic | null;
+  created_at: string;
+  last_activity_at: string;
+  reply_count: number;
+  participants: UserBasic[];
+  mentioned_user_ids: number[];
+  resolved: boolean;
+  state_event: TaskCommentStateEvent | null;
+  latest_reply: {
+    author?: UserBasic | null;
+    content: string;
+    created_at: string;
+  } | null;
 }
 
 /**

--- a/products/desktop/packages/shared/src/domain-types.ts
+++ b/products/desktop/packages/shared/src/domain-types.ts
@@ -154,7 +154,7 @@ export interface TaskThreadMessage {
 
 /** The latest resolve or reopen on a comment thread. */
 export interface TaskCommentStateEvent {
-  state: string;
+  state: "resolved" | "open";
   author?: UserBasic | null;
   created_at: string;
 }
@@ -180,6 +180,8 @@ export interface TaskCommentThreadSummary {
   latest_reply: {
     author?: UserBasic | null;
     content: string;
+    /** The excerpt is bounded, so a long reply comes back cut. */
+    content_truncated: boolean;
     created_at: string;
   } | null;
 }

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.test.tsx
@@ -30,6 +30,12 @@ vi.mock("@posthog/ui/features/canvas/hooks/useThreadConversation", () => ({
     onMentionInsert: vi.fn(),
   }),
 }));
+vi.mock("@posthog/ui/features/canvas/hooks/useTaskCommentActivity", () => ({
+  useTaskCommentActivity: () => ({ threads: [], isLoading: false }),
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useTaskRuns", () => ({
+  useTaskRuns: () => ({ runs: [], isLoading: false, refreshRuns: vi.fn() }),
+}));
 vi.mock("@posthog/ui/features/canvas/components/ActivityTimeline", () => ({
   ActivityTimeline: () => <div>timeline body</div>,
 }));

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.test.tsx
@@ -10,9 +10,14 @@ import {
   vi,
 } from "vitest";
 
+// Mutable so a test can render the panel mid-load. Hoisted for the same reason the
+// comments flag below is: a plain `let` is initialized after the hoisted mock factories.
+const loaded = vi.hoisted(() => ({ thread: true, comments: true }));
+
 vi.mock("@posthog/ui/features/canvas/hooks/useThreadConversation", () => ({
   useThreadConversation: () => ({
     timeline: [],
+    hasLoadedThread: loaded.thread,
     agentStatus: null,
     events: [],
     isPromptPending: false,
@@ -31,7 +36,11 @@ vi.mock("@posthog/ui/features/canvas/hooks/useThreadConversation", () => ({
   }),
 }));
 vi.mock("@posthog/ui/features/canvas/hooks/useTaskCommentActivity", () => ({
-  useTaskCommentActivity: () => ({ threads: [], isLoading: false }),
+  useTaskCommentActivity: () => ({
+    threads: [],
+    isLoading: false,
+    hasLoaded: loaded.comments,
+  }),
 }));
 vi.mock("@posthog/ui/features/canvas/hooks/useTaskRuns", () => ({
   useTaskRuns: () => ({ runs: [], isLoading: false, refreshRuns: vi.fn() }),
@@ -87,6 +96,8 @@ describe("ActivityPanel", () => {
   let scrollTo: MockInstance;
 
   beforeEach(() => {
+    loaded.thread = true;
+    loaded.comments = true;
     commentsFlag.enabled = true;
     scrollTo = vi.spyOn(Element.prototype, "scrollTo");
     useCommentNavigationStore.setState({
@@ -210,5 +221,38 @@ describe("ActivityPanel", () => {
     fireEvent.click(screen.getByRole("tab", { name: "Comments" }));
 
     expect(scrollTo.mock.calls.length).toBe(timelineScrolls);
+  });
+
+  it("waits for both sources, then never takes the timeline away again", () => {
+    // The panel used to draw rows, blink a loader while the live session connected, and
+    // draw them again. The loader belongs to the first paint only.
+    loaded.thread = false;
+    loaded.comments = false;
+    // A fresh element each time: React bails out of `rerender` when handed the identical one.
+    const panel = () => (
+      <ActivityPanel
+        taskId="task-1"
+        channelId="channel-1"
+        task={task}
+        showTaskSummary={false}
+      />
+    );
+    const view = render(panel());
+    expect(screen.getByText("Loading timeline")).toBeInTheDocument();
+
+    loaded.thread = true;
+    view.rerender(panel());
+    // Comments haven't answered yet, so drawing now would show a partial timeline.
+    expect(screen.getByText("Loading timeline")).toBeInTheDocument();
+
+    loaded.comments = true;
+    view.rerender(panel());
+    expect(screen.getByText("timeline body")).toBeInTheDocument();
+
+    // A refetch flips a query back to loading; the rows must stay put.
+    loaded.thread = false;
+    view.rerender(panel());
+    expect(screen.getByText("timeline body")).toBeInTheDocument();
+    expect(screen.queryByText("Loading timeline")).toBeNull();
   });
 });

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.test.tsx
@@ -238,12 +238,12 @@ describe("ActivityPanel", () => {
       />
     );
     const view = render(panel());
-    expect(screen.getByText("Loading timeline")).toBeInTheDocument();
+    expect(screen.getByLabelText("Loading timeline")).toBeInTheDocument();
 
     loaded.thread = true;
     view.rerender(panel());
     // Comments haven't answered yet, so drawing now would show a partial timeline.
-    expect(screen.getByText("Loading timeline")).toBeInTheDocument();
+    expect(screen.getByLabelText("Loading timeline")).toBeInTheDocument();
 
     loaded.comments = true;
     view.rerender(panel());
@@ -253,6 +253,6 @@ describe("ActivityPanel", () => {
     loaded.thread = false;
     view.rerender(panel());
     expect(screen.getByText("timeline body")).toBeInTheDocument();
-    expect(screen.queryByText("Loading timeline")).toBeNull();
+    expect(screen.queryByLabelText("Loading timeline")).toBeNull();
   });
 });

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.tsx
@@ -15,6 +15,8 @@ import {
   ThreadLoadingState,
   ThreadReplyComposer,
 } from "@posthog/ui/features/canvas/components/ThreadPanel";
+import { useTaskCommentActivity } from "@posthog/ui/features/canvas/hooks/useTaskCommentActivity";
+import { useTaskRuns } from "@posthog/ui/features/canvas/hooks/useTaskRuns";
 import { useThreadConversation } from "@posthog/ui/features/canvas/hooks/useThreadConversation";
 import { useCommentNavigationStore } from "@posthog/ui/features/sessions/commentNavigationStore";
 import { buildConversationItems } from "@posthog/ui/features/sessions/components/buildConversationItems";
@@ -162,6 +164,12 @@ function ActivityConversation({
     [taskId],
   );
 
+  // The comment feed is its own request, and only for the tab that draws it.
+  const { threads: commentThreads } = useTaskCommentActivity(taskId, {
+    enabled: commentsEnabled && tab === "timeline",
+  });
+  const { runs } = useTaskRuns(taskId);
+
   const conversationItems = useMemo(
     () =>
       tab === "timeline"
@@ -237,6 +245,10 @@ function ActivityConversation({
         task={task}
         timeline={timeline}
         conversationItems={conversationItems}
+        commentThreads={commentThreads}
+        commentsEnabled={commentsEnabled}
+        runCount={runs.length}
+        currentUserId={currentUser?.id}
         currentUserUuid={currentUser?.uuid}
         currentUserEmail={currentUser?.email}
         isTaskAuthor={isTaskAuthor}

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.tsx
@@ -7,6 +7,7 @@ import { Button, Tabs, TabsList, TabsTrigger } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/domain-types";
 import { ActivityTimeline } from "@posthog/ui/features/canvas/components/ActivityTimeline";
+import { ActivityLoadingState } from "@posthog/ui/features/canvas/components/activityRows";
 import { TaskCard } from "@posthog/ui/features/canvas/components/ChannelFeedView";
 import { TaskArtifactsList } from "@posthog/ui/features/canvas/components/TaskArtifactsList";
 import { TaskCommentsList } from "@posthog/ui/features/canvas/components/TaskCommentsList";
@@ -136,7 +137,7 @@ function ActivityConversation({
     agentStatus,
     events,
     isPromptPending,
-    isReady,
+    hasLoadedThread,
     members,
     currentUser,
     isTaskAuthor,
@@ -165,9 +166,17 @@ function ActivityConversation({
   );
 
   // The comment feed is its own request, and only for the tab that draws it.
-  const { threads: commentThreads } = useTaskCommentActivity(taskId, {
-    enabled: commentsEnabled && tab === "timeline",
-  });
+  const { threads: commentThreads, hasLoaded: hasLoadedComments } =
+    useTaskCommentActivity(taskId, {
+      enabled: commentsEnabled && tab === "timeline",
+    });
+  // Draw the timeline once both of its durable sources have answered, and never take it
+  // away again. Gating on the live session instead (`isReady`) is what made the panel show
+  // rows, blink a loader while the session connected, then show the rows again.
+  const hasDrawnTimeline = useRef(false);
+  const timelineReady =
+    hasDrawnTimeline.current || (hasLoadedThread && hasLoadedComments);
+  if (timelineReady) hasDrawnTimeline.current = true;
   const { runs } = useTaskRuns(taskId);
 
   const conversationItems = useMemo(
@@ -239,7 +248,7 @@ function ActivityConversation({
         />
       );
     }
-    if (!isReady) return <ThreadLoadingState />;
+    if (!timelineReady) return <ActivityLoadingState />;
     return (
       <ActivityTimeline
         task={task}
@@ -278,7 +287,7 @@ function ActivityConversation({
       )}
       <div
         ref={scrollRef}
-        aria-busy={!isReady}
+        aria-busy={!timelineReady}
         className="flex-1 overflow-y-auto"
       >
         {body()}

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.tsx
@@ -15,7 +15,6 @@ import { TaskCommentsList } from "@posthog/ui/features/canvas/components/TaskCom
 import {
   AgentStatusLine,
   ThreadLoadingState,
-  ThreadReplyComposer,
 } from "@posthog/ui/features/canvas/components/ThreadPanel";
 import { useTaskCommentActivity } from "@posthog/ui/features/canvas/hooks/useTaskCommentActivity";
 import { useTaskRuns } from "@posthog/ui/features/canvas/hooks/useTaskRuns";
@@ -139,17 +138,7 @@ function ActivityConversation({
     events,
     isPromptPending,
     hasLoadedThread,
-    members,
     currentUser,
-    isTaskAuthor,
-    canForward,
-    draft,
-    setDraft,
-    isSubmitDisabled,
-    submit,
-    sendMessageToAgent,
-    deleteMessage,
-    onMentionInsert,
   } = useThreadConversation(task, { surface: "activity_panel" });
 
   const [tab, setTab] = useState<ActivityTab>("timeline");
@@ -265,8 +254,6 @@ function ActivityConversation({
     setHasNewerBelow(true);
   }, [timeline, events.length, agentStatus?.phase, tab]);
 
-  const showComposer = tab === "timeline";
-
   const body = () => {
     if (tab === "comments") {
       return <TaskCommentsList task={task} timeline={timeline} />;
@@ -290,13 +277,7 @@ function ActivityConversation({
         commentsEnabled={commentsEnabled}
         runCount={runs.length}
         currentUserId={currentUser?.id}
-        currentUserUuid={currentUser?.uuid}
-        currentUserEmail={currentUser?.email}
-        isTaskAuthor={isTaskAuthor}
-        canForward={canForward}
         canOpenInPlace={canOpenInPlace}
-        onSendToAgent={sendMessageToAgent}
-        onDelete={deleteMessage}
       />
     );
   };
@@ -339,18 +320,8 @@ function ActivityConversation({
         )}
       </div>
 
-      {showComposer && agentStatus && <AgentStatusLine status={agentStatus} />}
-
-      {showComposer && (
-        <ThreadReplyComposer
-          draft={draft}
-          onDraftChange={setDraft}
-          onSubmit={submit}
-          members={members}
-          allowAgentMention={isTaskAuthor && canForward}
-          onMentionInsert={onMentionInsert}
-          disabled={isSubmitDisabled}
-        />
+      {tab === "timeline" && agentStatus && (
+        <AgentStatusLine status={agentStatus} />
       )}
     </div>
   );

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.tsx
@@ -1,4 +1,5 @@
 import {
+  ArrowDownIcon,
   ArrowSquareOutIcon,
   CaretRightIcon,
   XIcon,
@@ -226,11 +227,42 @@ function ActivityConversation({
   }, [acknowledgeCommentsTabOpen, commentFocus, tab, taskId]);
 
   const scrollRef = useRef<HTMLDivElement>(null);
-  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll when rendered thread content changes
+  // Within this much of the bottom still counts as "watching the end", so a row arriving
+  // mid-poll keeps following. Wide enough to survive a partially scrolled last row.
+  const AT_BOTTOM_SLACK_PX = 48;
+  const [hasNewerBelow, setHasNewerBelow] = useState(false);
+  const scrollToLatest = useCallback(() => {
+    const node = scrollRef.current;
+    if (!node) return;
+    node.scrollTo({ top: node.scrollHeight });
+    setHasNewerBelow(false);
+  }, []);
+  const onScroll = useCallback(() => {
+    const node = scrollRef.current;
+    if (!node) return;
+    const atBottom =
+      node.scrollHeight - node.scrollTop - node.clientHeight <=
+      AT_BOTTOM_SLACK_PX;
+    if (atBottom) setHasNewerBelow(false);
+  }, []);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: follow the end when rendered content changes
   useEffect(() => {
     // Only the timeline reads bottom-up; the other tabs put what matters on top.
     if (tab !== "timeline") return;
-    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+    const node = scrollRef.current;
+    if (!node) return;
+    // Poll after poll, this ran on every refetch and yanked the panel to the bottom while
+    // someone was reading further up. Follow the end only for a reader already at it, and
+    // offer the jump to everyone else.
+    const atBottom =
+      node.scrollHeight - node.scrollTop - node.clientHeight <=
+      AT_BOTTOM_SLACK_PX;
+    if (atBottom) {
+      node.scrollTo({ top: node.scrollHeight });
+      setHasNewerBelow(false);
+      return;
+    }
+    setHasNewerBelow(true);
   }, [timeline, events.length, agentStatus?.phase, tab]);
 
   const showComposer = tab === "timeline";
@@ -285,12 +317,26 @@ function ActivityConversation({
           <TaskCard task={task} channelId={channelId} inThread />
         </div>
       )}
-      <div
-        ref={scrollRef}
-        aria-busy={!timelineReady}
-        className="flex-1 overflow-y-auto"
-      >
-        {body()}
+      <div className="relative flex min-h-0 flex-1 flex-col">
+        <div
+          ref={scrollRef}
+          onScroll={onScroll}
+          aria-busy={!timelineReady}
+          className="flex-1 overflow-y-auto"
+        >
+          {body()}
+        </div>
+        {tab === "timeline" && hasNewerBelow && (
+          <Button
+            variant="default"
+            size="sm"
+            className="-translate-x-1/2 absolute bottom-2 left-1/2 z-20 shadow-md"
+            onClick={scrollToLatest}
+          >
+            <ArrowDownIcon size={12} />
+            New activity
+          </Button>
+        )}
       </div>
 
       {showComposer && agentStatus && <AgentStatusLine status={agentStatus} />}

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.stories.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.stories.tsx
@@ -1,0 +1,197 @@
+import type { ThreadTimelineRow } from "@posthog/core/canvas/threadTimeline";
+import type {
+  Task,
+  TaskCommentThreadSummary,
+  TaskThreadMessage,
+} from "@posthog/shared/domain-types";
+import { ActivityTimeline } from "@posthog/ui/features/canvas/components/ActivityTimeline";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const shy = {
+  id: 9,
+  uuid: "u-shy",
+  first_name: "Shy",
+  last_name: "Alter",
+  email: "shy@example.com",
+};
+const ben = {
+  id: 7,
+  uuid: "u-ben",
+  first_name: "Ben",
+  last_name: "White",
+  email: "ben@example.com",
+};
+
+const task = {
+  id: "task-1",
+  created_at: "2026-08-04T09:00:00Z",
+  updated_at: "2026-08-05T16:00:00Z",
+  created_by: shy,
+  latest_run: { id: "run-1", status: "completed" },
+} as unknown as Task;
+
+function event(
+  id: string,
+  event: string,
+  payload: Record<string, unknown>,
+  createdAt: string,
+): ThreadTimelineRow<TaskThreadMessage> {
+  return {
+    kind: "human",
+    timestamp: Date.parse(createdAt),
+    message: {
+      id,
+      task: task.id,
+      content: "",
+      created_at: createdAt,
+      author_kind: "agent",
+      event,
+      payload,
+    } as TaskThreadMessage,
+  };
+}
+
+const timeline: ThreadTimelineRow<TaskThreadMessage>[] = [
+  event(
+    "e1",
+    "run_started",
+    { run_id: "run-1", environment: "cloud", branch: "shy/activity-events" },
+    "2026-08-04T09:02:00Z",
+  ),
+  event("e2", "awaiting_input", { run_id: "run-1" }, "2026-08-04T09:40:00Z"),
+  event(
+    "e3",
+    "artifact_created",
+    {
+      artifact_id: "artifact-1",
+      name: "activity-events.html",
+      artifact_type: "document",
+      version: 1,
+    },
+    "2026-08-04T10:10:00Z",
+  ),
+  event(
+    "e4",
+    "message_forwarded",
+    { message_id: "m-1", run_id: "run-1" },
+    "2026-08-05T09:30:00Z",
+  ),
+  event(
+    "e5",
+    "artifact_revised",
+    {
+      artifact_id: "artifact-1",
+      name: "activity-events.html",
+      artifact_type: "document",
+      version: 2,
+    },
+    "2026-08-05T10:00:00Z",
+  ),
+  event(
+    "e6",
+    "pr_merged",
+    {
+      pr_url: "https://github.com/PostHog/posthog/pull/80060",
+      repository: "PostHog/posthog",
+      pr_number: 80060,
+      actor: "benjackwhite",
+    },
+    "2026-08-05T15:30:00Z",
+  ),
+];
+
+const commentThreads: TaskCommentThreadSummary[] = [
+  {
+    id: "thread-1",
+    target: {
+      id: "artifact-1",
+      type: "artifact",
+      name: "activity-events.html",
+    },
+    content:
+      "Missing the awaiting-input case — that's the one that costs us time.",
+    content_truncated: false,
+    selected_text: "every event should also go to the activity panel",
+    author: shy,
+    created_at: "2026-08-05T08:00:00Z",
+    last_activity_at: "2026-08-05T08:45:00Z",
+    reply_count: 3,
+    participants: [shy, ben],
+    mentioned_user_ids: [],
+    resolved: false,
+    state_event: null,
+    latest_reply: {
+      author: ben,
+      content: "collapse looks right, keep resolve separate",
+      created_at: "2026-08-05T08:45:00Z",
+    },
+  },
+  {
+    id: "thread-2",
+    target: { id: "canvas-1", type: "canvas", name: "Activity mockup" },
+    content: "@ben can you sanity check the collapse rule before this ships?",
+    content_truncated: false,
+    selected_text: null,
+    author: shy,
+    created_at: "2026-08-05T09:00:00Z",
+    last_activity_at: "2026-08-05T09:00:00Z",
+    reply_count: 0,
+    participants: [shy],
+    mentioned_user_ids: [ben.id],
+    resolved: true,
+    state_event: {
+      state: "resolved",
+      author: ben,
+      created_at: "2026-08-05T11:00:00Z",
+    },
+    latest_reply: null,
+  },
+];
+
+const meta: Meta<typeof ActivityTimeline> = {
+  title: "Canvas/ActivityTimeline",
+  component: ActivityTimeline,
+  parameters: { layout: "centered" },
+  decorators: [
+    (Story) => (
+      <div className="w-[468px] border border-border bg-gray-1">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ActivityTimeline>;
+
+/** Every row the timeline can draw, in the order a real task produces them. */
+export const FullTimeline: Story = {
+  args: {
+    task,
+    timeline,
+    conversationItems: [
+      {
+        type: "user_message",
+        id: "turn-1",
+        content: "Add the events that belong on the activity panel.",
+        timestamp: Date.parse("2026-08-04T09:05:00Z"),
+      },
+      // biome-ignore lint/suspicious/noExplicitAny: story fixture for the row under test
+    ] as any,
+    commentThreads,
+    commentsEnabled: true,
+    currentUserId: ben.id,
+    currentUserUuid: ben.uuid,
+    isTaskAuthor: false,
+    canForward: false,
+    runCount: 1,
+    onSendToAgent: () => {},
+    onDelete: () => {},
+  },
+};
+
+/** What a reader without the comments flag sees: lifecycle rows only. */
+export const WithoutComments: Story = {
+  args: { ...FullTimeline.args, commentsEnabled: false } as Story["args"],
+};

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.stories.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.stories.tsx
@@ -129,7 +129,8 @@ const commentThreads: TaskCommentThreadSummary[] = [
   {
     id: "thread-2",
     target: { id: "canvas-1", type: "canvas", name: "Activity mockup" },
-    content: "@ben can you sanity check the collapse rule before this ships?",
+    content:
+      "@[Ben White](ben@example.com) can you sanity check the collapse rule before this ships?",
     content_truncated: false,
     selected_text: null,
     author: shy,

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
@@ -330,3 +330,25 @@ describe("ActivityTimeline events and comments", () => {
     expect(screen.queryByText("commented on")).toBeNull();
   });
 });
+
+describe("ActivityTimeline connectors", () => {
+  it("connects every row but the last", () => {
+    // The line is drawn inside each row, under its own bead: behind the rows it was covered
+    // by the hover fill, and it ran through the beads instead of between them.
+    const { container } = renderTimeline(true);
+
+    const rows = container.querySelectorAll(".group");
+    const connectors = container.querySelectorAll("[aria-hidden].w-px");
+    expect(rows.length).toBeGreaterThan(1);
+    expect(connectors).toHaveLength(rows.length - 1);
+  });
+
+  it("always opens a message to its full text", () => {
+    // A truncated one-line preview used to open onto nothing but the action.
+    renderTimeline(true);
+
+    fireEvent.click(screen.getByRole("button", { name: /second thing/ }));
+
+    expect(screen.getAllByText(/second thing/).length).toBeGreaterThan(1);
+  });
+});

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
@@ -303,15 +303,19 @@ describe("ActivityTimeline events and comments", () => {
 });
 
 describe("ActivityTimeline connectors", () => {
-  it("connects every row but the last", () => {
-    // The line is drawn inside each row, under its own bead: behind the rows it was covered
-    // by the hover fill, and it ran through the beads instead of between them.
+  it("runs the line between every pair of beads, and no further", () => {
+    // Each row draws the half above and the half below its own bead, so consecutive rows
+    // meet: the first row has no upper half and the last has no lower one.
     const { container } = renderTimeline(true);
 
-    const rows = container.querySelectorAll(".group");
-    const connectors = container.querySelectorAll("[aria-hidden].w-px");
-    expect(rows.length).toBeGreaterThan(1);
-    expect(connectors).toHaveLength(rows.length - 1);
+    const rows = [...container.querySelectorAll(".group")];
+    const halves = rows.map(
+      (row) => row.querySelectorAll("[aria-hidden].w-px").length,
+    );
+    expect(rows.length).toBeGreaterThan(2);
+    expect(halves.at(0)).toBe(1);
+    expect(halves.at(-1)).toBe(1);
+    expect(halves.slice(1, -1).every((count) => count === 2)).toBe(true);
   });
 
   it("always opens a message to its full text", () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
@@ -74,23 +74,27 @@ describe("ActivityTimeline", () => {
     expect(screen.queryByRole("button", { name: /SA/ })).toBeNull();
   });
 
-  it("asks the transcript to scroll to the clicked message", () => {
+  it("asks the transcript to scroll to the message, once its row is open", () => {
     renderTimeline(true);
 
-    fireEvent.click(screen.getAllByRole("button")[1]);
+    // The row opens; jumping to the transcript is the button inside it.
+    fireEvent.click(screen.getByRole("button", { name: /second thing/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Show in transcript" }));
 
     expect(useThreadNavigationStore.getState().scrollRequests["task-1"]).toBe(
       "turn-2-2-user",
     );
   });
 
-  it("leaves rows inert with no transcript alongside to drive", () => {
+  it("offers no transcript jump when there is nothing alongside to drive", () => {
     renderTimeline();
 
-    expect(screen.queryAllByRole("button")).toHaveLength(0);
-    const body = screen.getByText(/first thing/).closest("[data-slot]");
-    expect(body).toHaveClass("whitespace-pre-wrap", "break-words");
-    expect(body).not.toHaveClass("line-clamp-1");
+    fireEvent.click(screen.getByRole("button", { name: /first thing/ }));
+
+    expect(screen.getByText(/and more detail/)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Show in transcript" }),
+    ).toBeNull();
   });
 
   it("renders structured references natively in conversation previews", () => {
@@ -104,6 +108,7 @@ describe("ActivityTimeline", () => {
       },
     ]);
 
+    // The whole message fits on the row, so the preview is the content — rendered, not raw.
     expect(screen.getByText("#73874 - Loading…")).toBeInTheDocument();
     expect(screen.queryByText(/<github_pr/)).toBeNull();
   });
@@ -122,6 +127,8 @@ describe("ActivityTimeline", () => {
     expect(screen.getByText("Review this")).toBeInTheDocument();
     expect(screen.queryByText(/<channel_context/)).toBeNull();
     expect(screen.queryByText("Saved workspace context")).toBeNull();
+    // The context lives inside the row, so open it before reaching for the fold.
+    fireEvent.click(screen.getByRole("button", { name: /Review this/ }));
 
     fireEvent.click(screen.getByRole("button", { name: "#code CONTEXT.md" }));
 

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
@@ -219,7 +219,8 @@ describe("ActivityTimeline events and comments", () => {
     );
   }
 
-  it("writes the reason on a failed run, so nobody has to open the transcript", () => {
+  it("keeps the failure reason one click away, not on the row", () => {
+    // Rows are collapsed so the panel reads as a timeline; the detail is what opening is for.
     renderRows({
       timeline: [
         threadMessage("m1", "run_failed", {
@@ -228,6 +229,9 @@ describe("ActivityTimeline events and comments", () => {
         }),
       ],
     });
+
+    expect(screen.queryByText(/Command failed: pnpm build/)).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /Run failed/ }));
 
     expect(screen.getByText(/Command failed: pnpm build/)).toBeInTheDocument();
   });
@@ -248,8 +252,13 @@ describe("ActivityTimeline events and comments", () => {
     expect(screen.getByText(/Agent started run 2/)).toBeInTheDocument();
   });
 
-  it("keeps the anchor with the comment it points at", () => {
+  it("keeps the anchor with the comment it points at, once opened", () => {
     renderRows({ commentThreads: [commentThread()], commentsEnabled: true });
+
+    expect(
+      screen.queryByText(/every event should also go to the activity panel/),
+    ).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /commented on/ }));
 
     expect(
       screen.getByText(/every event should also go to the activity panel/),

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
@@ -43,21 +43,13 @@ function renderTimeline(canOpenInPlace?: boolean, items = conversationItems) {
       timeline={[]}
       // biome-ignore lint/suspicious/noExplicitAny: narrow fixture for the rows under test
       conversationItems={items as any}
-      isTaskAuthor
-      canForward={false}
       canOpenInPlace={canOpenInPlace}
-      onSendToAgent={() => {}}
-      onDelete={() => {}}
     />,
   );
 }
 
 beforeEach(() => {
-  // A transcript registers itself when mounted; the jump is only offered when one has.
-  useThreadNavigationStore.setState({
-    scrollRequests: {},
-    listeners: { "task-1": 1 },
-  });
+  useThreadNavigationStore.setState({ scrollRequests: {}, listeners: {} });
 });
 
 describe("ActivityTimeline", () => {
@@ -78,29 +70,12 @@ describe("ActivityTimeline", () => {
     expect(screen.queryByRole("button", { name: /SA/ })).toBeNull();
   });
 
-  it("asks the transcript to scroll to the message, once its row is open", () => {
-    renderTimeline(true);
-
-    // The row opens; jumping to the transcript is the button inside it.
-    fireEvent.click(screen.getByRole("button", { name: /second thing/ }));
-    fireEvent.click(screen.getByRole("button", { name: "Show in transcript" }));
-
-    expect(useThreadNavigationStore.getState().scrollRequests["task-1"]).toBe(
-      "turn-2-2-user",
-    );
-  });
-
-  it("offers no transcript jump when no transcript is listening", () => {
-    // Without this the button rendered in panes with no transcript and did nothing.
-    useThreadNavigationStore.setState({ listeners: {} });
+  it("opens a message to its full text", () => {
     renderTimeline(true);
 
     fireEvent.click(screen.getByRole("button", { name: /first thing/ }));
 
     expect(screen.getByText(/and more detail/)).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "Show in transcript" }),
-    ).toBeNull();
   });
 
   it("renders structured references natively in conversation previews", () => {
@@ -222,10 +197,6 @@ describe("ActivityTimeline events and comments", () => {
         task={task}
         timeline={[]}
         conversationItems={[]}
-        isTaskAuthor
-        canForward={false}
-        onSendToAgent={() => {}}
-        onDelete={() => {}}
         // biome-ignore lint/suspicious/noExplicitAny: narrow fixture for the rows under test
         {...(props as any)}
       />,
@@ -350,5 +321,41 @@ describe("ActivityTimeline connectors", () => {
     fireEvent.click(screen.getByRole("button", { name: /second thing/ }));
 
     expect(screen.getAllByText(/second thing/).length).toBeGreaterThan(1);
+  });
+});
+
+describe("ActivityTimeline thread replies", () => {
+  const reply = {
+    kind: "human" as const,
+    timestamp: Date.parse("2026-07-17T09:30:00Z"),
+    message: {
+      id: "reply-1",
+      task: "task-1",
+      author: { id: 7, uuid: "u2", first_name: "Ben", last_name: "White" },
+      author_kind: "human" as const,
+      content: "@[Shy Alter](shy@example.com) you seeing this?\nsecond line",
+      created_at: "2026-07-17T09:30:00Z",
+    },
+  };
+
+  it("collapses a legacy thread reply like every other row", () => {
+    // These predate comments and used to render as full message blocks, which is what made
+    // the panel read as a chat log rather than a timeline.
+    render(
+      <ActivityTimeline
+        task={task}
+        // biome-ignore lint/suspicious/noExplicitAny: narrow fixture for the row under test
+        timeline={[reply] as any}
+        conversationItems={[]}
+      />,
+    );
+
+    expect(screen.queryByText(/second line/)).toBeNull();
+    // The mention renders as a chip in the preview, not as its markup.
+    expect(screen.queryByText(/@\[/)).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /you seeing this/ }));
+
+    expect(screen.getByText(/second line/)).toBeInTheDocument();
   });
 });

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
@@ -162,3 +162,149 @@ describe("ActivityTimeline", () => {
     expect(screen.getByText(/be terse/)).toBeInTheDocument();
   });
 });
+
+describe("ActivityTimeline events and comments", () => {
+  const threadMessage = (
+    id: string,
+    event: string,
+    payload: Record<string, unknown>,
+  ) => ({
+    kind: "human" as const,
+    timestamp: Date.parse("2026-07-17T09:20:00Z"),
+    message: {
+      id,
+      task: "task-1",
+      content: "",
+      created_at: "2026-07-17T09:20:00Z",
+      author_kind: "agent" as const,
+      event,
+      payload,
+    },
+  });
+
+  const commentThread = (overrides = {}) => ({
+    id: "thread-1",
+    target: { id: "artifact-1", type: "artifact", name: "report.md" },
+    content: "this needs a guard",
+    content_truncated: false,
+    selected_text: "every event should also go to the activity panel",
+    author: { id: 7, uuid: "u2", first_name: "Ben", last_name: "White" },
+    created_at: "2026-07-17T09:30:00Z",
+    last_activity_at: "2026-07-17T09:35:00Z",
+    reply_count: 2,
+    participants: [
+      { id: 7, uuid: "u2", first_name: "Ben", last_name: "White" },
+      { id: 9, uuid: "u3", first_name: "Shy", last_name: "Alter" },
+    ],
+    mentioned_user_ids: [],
+    resolved: false,
+    state_event: null,
+    latest_reply: null,
+    ...overrides,
+  });
+
+  function renderRows(props: Record<string, unknown>) {
+    return render(
+      <ActivityTimeline
+        task={task}
+        timeline={[]}
+        conversationItems={[]}
+        isTaskAuthor
+        canForward={false}
+        onSendToAgent={() => {}}
+        onDelete={() => {}}
+        // biome-ignore lint/suspicious/noExplicitAny: narrow fixture for the rows under test
+        {...(props as any)}
+      />,
+    );
+  }
+
+  it("writes the reason on a failed run, so nobody has to open the transcript", () => {
+    renderRows({
+      timeline: [
+        threadMessage("m1", "run_failed", {
+          run_id: "run-1",
+          error_summary: "Command failed: pnpm build",
+        }),
+      ],
+    });
+
+    expect(screen.getByText(/Command failed: pnpm build/)).toBeInTheDocument();
+  });
+
+  it("labels the run only once a task has run more than once", () => {
+    const first = threadMessage("m1", "run_started", {
+      run_id: "run-1",
+      environment: "cloud",
+      branch: "shy/activity",
+    });
+    const second = threadMessage("m2", "run_started", { run_id: "run-2" });
+
+    const single = renderRows({ timeline: [first], runCount: 1 });
+    expect(screen.getByText(/Agent started work/)).toBeInTheDocument();
+    single.unmount();
+
+    renderRows({ timeline: [first, second], runCount: 2 });
+    expect(screen.getByText(/Agent started run 2/)).toBeInTheDocument();
+  });
+
+  it("keeps the anchor with the comment it points at", () => {
+    renderRows({ commentThreads: [commentThread()], commentsEnabled: true });
+
+    expect(
+      screen.getByText(/every event should also go to the activity panel/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("2 replies · Ben White, Shy Alter"),
+    ).toBeInTheDocument();
+  });
+
+  it("reads as a mention when the mention is of you", () => {
+    renderRows({
+      commentThreads: [commentThread({ mentioned_user_ids: [42] })],
+      commentsEnabled: true,
+      currentUserId: 42,
+    });
+
+    expect(screen.getByText("mentioned you on")).toBeInTheDocument();
+  });
+
+  it("reads as an ordinary comment when someone else was mentioned", () => {
+    renderRows({
+      commentThreads: [commentThread({ mentioned_user_ids: [7] })],
+      commentsEnabled: true,
+      currentUserId: 42,
+    });
+
+    expect(screen.getByText("commented on")).toBeInTheDocument();
+  });
+
+  it("gives resolve its own row, with who resolved it", () => {
+    renderRows({
+      commentThreads: [
+        commentThread({
+          resolved: true,
+          state_event: {
+            state: "resolved",
+            created_at: "2026-07-17T09:40:00Z",
+            author: {
+              id: 9,
+              uuid: "u3",
+              first_name: "Shy",
+              last_name: "Alter",
+            },
+          },
+        }),
+      ],
+      commentsEnabled: true,
+    });
+
+    expect(screen.getByText("resolved a thread on")).toBeInTheDocument();
+  });
+
+  it("shows no comment rows when comments are off", () => {
+    renderRows({ commentThreads: [commentThread()], commentsEnabled: false });
+
+    expect(screen.queryByText("commented on")).toBeNull();
+  });
+});

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
@@ -53,7 +53,11 @@ function renderTimeline(canOpenInPlace?: boolean, items = conversationItems) {
 }
 
 beforeEach(() => {
-  useThreadNavigationStore.setState({ scrollRequests: {} });
+  // A transcript registers itself when mounted; the jump is only offered when one has.
+  useThreadNavigationStore.setState({
+    scrollRequests: {},
+    listeners: { "task-1": 1 },
+  });
 });
 
 describe("ActivityTimeline", () => {
@@ -86,8 +90,10 @@ describe("ActivityTimeline", () => {
     );
   });
 
-  it("offers no transcript jump when there is nothing alongside to drive", () => {
-    renderTimeline();
+  it("offers no transcript jump when no transcript is listening", () => {
+    // Without this the button rendered in panes with no transcript and did nothing.
+    useThreadNavigationStore.setState({ listeners: {} });
+    renderTimeline(true);
 
     fireEvent.click(screen.getByRole("button", { name: /first thing/ }));
 

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
@@ -23,6 +23,7 @@ import {
   ActivityEventRow,
   CommentRow,
   CommentStateRow,
+  DetailAction,
   DetailBlock,
   RunStatusRow,
   TimelineRow,
@@ -37,7 +38,10 @@ import { useCommentNavigationStore } from "@posthog/ui/features/sessions/comment
 import type { buildConversationItems } from "@posthog/ui/features/sessions/components/buildConversationItems";
 import { extractChannelContext } from "@posthog/ui/features/sessions/components/session-update/channelContext";
 import { extractCustomInstructions } from "@posthog/ui/features/sessions/components/session-update/customInstructions";
-import { useThreadNavigationStore } from "@posthog/ui/features/sessions/threadNavigationStore";
+import {
+  useHasTranscriptListener,
+  useThreadNavigationStore,
+} from "@posthog/ui/features/sessions/threadNavigationStore";
 import { Fragment, useMemo } from "react";
 
 type ConversationItem = ReturnType<
@@ -81,7 +85,7 @@ function UserMessageRow({
         // initials out of the row's accessible name.
         <div
           aria-hidden
-          className="relative z-10 flex size-5 items-center justify-center overflow-hidden rounded-full ring-4 ring-gray-1"
+          className="relative z-10 flex size-5 items-center justify-center overflow-hidden rounded-full border border-gray-7 ring-4 ring-gray-1"
         >
           <UserAvatar user={author} size="sm" className="size-5" />
         </div>
@@ -113,9 +117,7 @@ function UserMessageRow({
             </Collapsible>
           )}
           {onSelect && (
-            <Button variant="default" size="sm" onClick={onSelect}>
-              Show in transcript
-            </Button>
+            <DetailAction onClick={onSelect}>Show in transcript</DetailAction>
           )}
         </div>
       }
@@ -174,6 +176,9 @@ export function ActivityTimeline({
   const requestScrollToMessage = useThreadNavigationStore(
     (state) => state.requestScrollToMessage,
   );
+  // The jump only lands if a transcript is mounted for this task. Without this the button
+  // renders in panes that have no transcript beside them and does nothing when clicked.
+  const hasTranscript = useHasTranscriptListener(task.id);
   const requestCommentFocus = useCommentNavigationStore(
     (state) => state.requestCommentFocus,
   );
@@ -265,12 +270,8 @@ export function ActivityTimeline({
         return (
           <TimelineRow
             gutter={
-              <span className="relative z-10 flex size-6 items-center justify-center rounded-full bg-gray-3 ring-4 ring-gray-1">
-                <PlusCircleIcon
-                  size={14}
-                  weight="fill"
-                  className="text-gray-11"
-                />
+              <span className="relative z-10 flex size-5 items-center justify-center rounded-full border border-gray-7 bg-gray-5 text-gray-12 ring-4 ring-gray-1">
+                <PlusCircleIcon size={11} weight="fill" />
               </span>
             }
             timestamp={task.created_at}
@@ -285,7 +286,7 @@ export function ActivityTimeline({
             content={row.item.content}
             timestamp={new Date(row.item.timestamp).toISOString()}
             onSelect={
-              canOpenInPlace
+              canOpenInPlace && hasTranscript
                 ? () => requestScrollToMessage(task.id, row.item.id)
                 : undefined
             }
@@ -359,7 +360,7 @@ export function ActivityTimeline({
           as spanning them rather than running past. */}
       <div
         aria-hidden
-        className="pointer-events-none absolute top-6 bottom-6 left-8 w-px bg-border"
+        className="pointer-events-none absolute top-5 bottom-5 left-8 w-px bg-gray-8"
       />
       <div className="relative z-10">
         <ThreadItemGroup>

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
@@ -1,9 +1,9 @@
+import { FileTextIcon, PlusCircleIcon } from "@phosphor-icons/react";
 import {
-  CheckCircleIcon,
-  FileTextIcon,
-  PlusCircleIcon,
-  XCircleIcon,
-} from "@phosphor-icons/react";
+  type ActivityRow,
+  buildActivityTimeline,
+  type UserMessageLike,
+} from "@posthog/core/canvas/activityTimeline";
 import type { ThreadTimelineRow } from "@posthog/core/canvas/threadTimeline";
 import {
   Collapsible,
@@ -20,11 +20,18 @@ import {
 } from "@posthog/quill";
 import type {
   Task,
+  TaskCommentThreadSummary,
   TaskThreadMessage,
   UserBasic,
 } from "@posthog/shared/domain-types";
-import { isTerminalStatus } from "@posthog/shared/domain-types";
 import { UserAvatar } from "@posthog/ui/features/auth/UserAvatar";
+import {
+  ActivityEventRow,
+  CommentRow,
+  CommentStateRow,
+  RunStatusRow,
+  TimelineRow,
+} from "@posthog/ui/features/canvas/components/activityRows";
 import { MentionText } from "@posthog/ui/features/canvas/components/MentionText";
 import {
   ThreadArtifactRow,
@@ -32,40 +39,16 @@ import {
 } from "@posthog/ui/features/canvas/components/ThreadPanel";
 import { ThreadTimestamp } from "@posthog/ui/features/canvas/components/ThreadTimestamp";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
+import { useCommentNavigationStore } from "@posthog/ui/features/sessions/commentNavigationStore";
 import type { buildConversationItems } from "@posthog/ui/features/sessions/components/buildConversationItems";
 import { extractChannelContext } from "@posthog/ui/features/sessions/components/session-update/channelContext";
 import { extractCustomInstructions } from "@posthog/ui/features/sessions/components/session-update/customInstructions";
 import { useThreadNavigationStore } from "@posthog/ui/features/sessions/threadNavigationStore";
-import { Fragment, type KeyboardEvent, type ReactNode, useMemo } from "react";
+import { Fragment, type KeyboardEvent, useMemo } from "react";
 
 type ConversationItem = ReturnType<
   typeof buildConversationItems
 >["items"][number];
-
-/** A lifecycle marker (task created, run finished): an icon bubble and a single
- *  line, in the same size and colour as every other row's copy. Only the icon
- *  distinguishes it, so the pane reads as one typographic system. */
-function ActivityEventRow({
-  icon,
-  label,
-  timestamp,
-}: {
-  icon: ReactNode;
-  label: string;
-  timestamp: string;
-}) {
-  return (
-    <div className="flex items-center gap-2 py-1.5 pr-2 pl-2">
-      <div className="flex w-10 shrink-0 justify-center">
-        <span className="relative z-10 flex size-6 items-center justify-center rounded-full bg-gray-3">
-          {icon}
-        </span>
-      </div>
-      <span className="min-w-0 truncate text-[13px]">{label}</span>
-      <ThreadTimestamp dateTime={timestamp} />
-    </div>
-  );
-}
 
 function UserMessageRow({
   author,
@@ -153,21 +136,34 @@ function UserMessageRow({
   );
 }
 
+/** Stable identity: an inline `= []` default is a new array on every render, which would
+ *  rebuild the timeline on every render through the memo's dependency list. */
+const NO_COMMENT_THREADS: TaskCommentThreadSummary[] = [];
+
 export function ActivityTimeline({
   task,
   timeline,
   conversationItems,
+  commentThreads = NO_COMMENT_THREADS,
+  commentsEnabled = false,
+  currentUserId,
   currentUserUuid,
   currentUserEmail,
   isTaskAuthor,
   canForward,
   canOpenInPlace,
+  runCount = 1,
   onSendToAgent,
   onDelete,
 }: {
   task: Task;
   timeline: ThreadTimelineRow<TaskThreadMessage>[];
   conversationItems: ConversationItem[];
+  /** The task's comment threads, already collapsed one row per thread by the backend. */
+  commentThreads?: TaskCommentThreadSummary[];
+  commentsEnabled?: boolean;
+  /** Needed to tell a mention of you from a mention of someone else. */
+  currentUserId?: number;
   currentUserUuid?: string;
   currentUserEmail?: string | null;
   isTaskAuthor: boolean;
@@ -176,139 +172,196 @@ export function ActivityTimeline({
    *  pane. False in the channel-home sidebar, where there is nothing to drive —
    *  rows there stay inert and PRs open externally instead of dead-clicking. */
   canOpenInPlace?: boolean;
+  /** How many runs the task has; a single-run task shouldn't label its run. */
+  runCount?: number;
   onSendToAgent: (messageId: string) => void;
   onDelete: (messageId: string) => void;
 }) {
   const requestScrollToMessage = useThreadNavigationStore(
     (state) => state.requestScrollToMessage,
   );
+  const requestCommentFocus = useCommentNavigationStore(
+    (state) => state.requestCommentFocus,
+  );
 
-  const nodes = useMemo(() => {
-    const entries: { key: string; ts: number; node: ReactNode }[] = [];
-    const createdTs = Date.parse(task.created_at) || 0;
-    entries.push({
-      key: "task-created",
-      ts: createdTs,
-      node: (
-        <ActivityEventRow
-          icon={
-            <PlusCircleIcon size={14} weight="fill" className="text-gray-11" />
-          }
-          label={`${task.created_by ? userDisplayName(task.created_by) : "Someone"} created this task`}
-          timestamp={task.created_at}
-        />
-      ),
-    });
+  // Thread messages arrive as `timeline` rows (human messages and the artifact
+  // announcements it already understands) plus the raw messages behind them, which carry
+  // the event rows. Rebuilding the message list from `timeline` keeps this component's
+  // props unchanged while the merge itself moves into core.
+  const messages = useMemo(
+    () => timeline.map((row) => row.message),
+    [timeline],
+  );
+  const messageRows = useMemo(() => {
+    const byId = new Map<string, ThreadTimelineRow<TaskThreadMessage>>();
+    for (const row of timeline) byId.set(row.message.id, row);
+    return byId;
+  }, [timeline]);
 
-    for (const item of conversationItems) {
-      if (item.type !== "user_message") continue;
-      entries.push({
-        key: `user-message-${item.id}`,
-        ts: item.timestamp,
-        node: (
+  const rows = useMemo(
+    () =>
+      buildActivityTimeline({
+        task: {
+          id: task.id,
+          createdAt: task.created_at,
+          updatedAt: task.updated_at,
+          latestRunId: task.latest_run?.id ?? null,
+          latestRunStatus: task.latest_run?.status ?? null,
+        },
+        messages,
+        commentThreads: commentThreads.map((thread) => ({
+          id: thread.id,
+          lastActivityAt: thread.last_activity_at,
+          mentionedUserIds: thread.mentioned_user_ids ?? [],
+          resolved: thread.resolved,
+          stateEvent: thread.state_event
+            ? {
+                state: thread.state_event.state,
+                createdAt: thread.state_event.created_at,
+              }
+            : null,
+        })),
+        userMessages: conversationItems.reduce<UserMessageLike[]>(
+          (items, item) => {
+            if (item.type === "user_message") {
+              items.push({
+                id: item.id,
+                content: item.content,
+                timestamp: item.timestamp,
+              });
+            }
+            return items;
+          },
+          [],
+        ),
+        commentsEnabled,
+      }),
+    [task, messages, commentThreads, conversationItems, commentsEnabled],
+  );
+
+  const threadsById = useMemo(() => {
+    const byId = new Map<string, TaskCommentThreadSummary>();
+    for (const thread of commentThreads) byId.set(thread.id, thread);
+    return byId;
+  }, [commentThreads]);
+
+  const focusThread = (thread: TaskCommentThreadSummary) => {
+    if (!canOpenInPlace) return undefined;
+    return () =>
+      requestCommentFocus(
+        task.id,
+        // The target is the scope/itemId pair the comment stores; `task` scope points at
+        // the task itself.
+        thread.target.type === "task"
+          ? { scope: "task", itemId: task.id }
+          : {
+              scope:
+                thread.target.type === "canvas"
+                  ? "desktop_canvas"
+                  : "task_artifact",
+              itemId: thread.target.id,
+            },
+        thread.id,
+      );
+  };
+
+  const renderRow = (row: ActivityRow<TaskThreadMessage>) => {
+    switch (row.kind) {
+      case "task_created":
+        return (
+          <TimelineRow
+            gutter={
+              <span className="relative z-10 flex size-6 items-center justify-center rounded-full bg-gray-3">
+                <PlusCircleIcon
+                  size={14}
+                  weight="fill"
+                  className="text-gray-11"
+                />
+              </span>
+            }
+            timestamp={task.created_at}
+          >
+            {`${task.created_by ? userDisplayName(task.created_by) : "Someone"} created this task`}
+          </TimelineRow>
+        );
+      case "user_message":
+        return (
           <UserMessageRow
             author={task.created_by}
-            content={item.content}
-            timestamp={new Date(item.timestamp).toISOString()}
+            content={row.item.content}
+            timestamp={new Date(row.item.timestamp).toISOString()}
             onSelect={
               canOpenInPlace
-                ? () => requestScrollToMessage(task.id, item.id)
+                ? () => requestScrollToMessage(task.id, row.item.id)
                 : undefined
             }
           />
-        ),
-      });
-    }
-
-    let hasPrArtifact = false;
-    for (const row of timeline) {
-      if (row.kind === "artifact" && row.artifact.kind === "pr") {
-        hasPrArtifact = true;
-      }
-      entries.push({
-        key: `thread-${row.message.id}`,
-        ts: row.timestamp,
-        node:
-          row.kind === "human" ? (
-            <ThreadMessageRow
-              message={row.message}
-              isTaskAuthor={isTaskAuthor}
-              isOwnMessage={
-                !!currentUserUuid &&
-                currentUserUuid === row.message.author?.uuid
-              }
-              currentUserEmail={currentUserEmail}
-              canForward={canForward}
-              preview
-              onSendToAgent={() => onSendToAgent(row.message.id)}
-              onDelete={() => onDelete(row.message.id)}
-            />
-          ) : (
+        );
+      case "human_message":
+        return (
+          <ThreadMessageRow
+            message={row.message}
+            isTaskAuthor={isTaskAuthor}
+            isOwnMessage={
+              !!currentUserUuid && currentUserUuid === row.message.author?.uuid
+            }
+            currentUserEmail={currentUserEmail}
+            canForward={canForward}
+            preview
+            onSendToAgent={() => onSendToAgent(row.message.id)}
+            onDelete={() => onDelete(row.message.id)}
+          />
+        );
+      case "event": {
+        // Canvases and pull requests already have a card row; the rest read as one line.
+        const artifactRow = messageRows.get(row.message.id);
+        if (artifactRow?.kind === "artifact") {
+          return (
             <ThreadArtifactRow
-              artifact={row.artifact}
+              artifact={artifactRow.artifact}
               createdAt={row.message.created_at}
               openInPlaceTaskId={canOpenInPlace ? task.id : undefined}
             />
-          ),
-      });
-    }
-
-    const updatedTs = Date.parse(task.updated_at) || createdTs;
-    const outputPr = task.latest_run?.output?.pr_url;
-    if (typeof outputPr === "string" && outputPr && !hasPrArtifact) {
-      entries.push({
-        key: "output-pr",
-        ts: updatedTs,
-        node: (
-          <ThreadArtifactRow
-            artifact={{ kind: "pr", url: outputPr }}
-            createdAt={task.updated_at}
-            openInPlaceTaskId={canOpenInPlace ? task.id : undefined}
-          />
-        ),
-      });
-    }
-
-    const runStatus = task.latest_run?.status;
-    if (runStatus && isTerminalStatus(runStatus)) {
-      const succeeded = runStatus === "completed";
-      entries.push({
-        key: "run-status",
-        ts: updatedTs + 1,
-        node: (
+          );
+        }
+        return (
           <ActivityEventRow
-            icon={
-              succeeded ? (
-                <CheckCircleIcon
-                  size={14}
-                  weight="fill"
-                  className="text-green-9"
-                />
-              ) : (
-                <XCircleIcon size={14} weight="fill" className="text-red-9" />
-              )
-            }
-            label={`Task ${runStatus.replace(/_/g, " ")}`}
-            timestamp={task.updated_at}
+            event={row.event}
+            timestamp={row.message.created_at}
+            runCount={runCount}
+            runOrdinal={row.runOrdinal}
           />
-        ),
-      });
+        );
+      }
+      case "comment": {
+        const thread = threadsById.get(row.thread.id);
+        if (!thread) return null;
+        return (
+          <CommentRow
+            thread={thread}
+            isMentioned={
+              !!currentUserId &&
+              (thread.mentioned_user_ids ?? []).includes(currentUserId)
+            }
+            onSelect={focusThread(thread)}
+          />
+        );
+      }
+      case "comment_state": {
+        const thread = threadsById.get(row.thread.id);
+        if (!thread) return null;
+        return (
+          <CommentStateRow
+            thread={thread}
+            state={row.state}
+            onSelect={focusThread(thread)}
+          />
+        );
+      }
+      case "run_status":
+        return <RunStatusRow status={row.status} timestamp={task.updated_at} />;
     }
-
-    return entries.sort((a, b) => a.ts - b.ts);
-  }, [
-    conversationItems,
-    timeline,
-    task,
-    isTaskAuthor,
-    canForward,
-    currentUserUuid,
-    currentUserEmail,
-    onSendToAgent,
-    onDelete,
-    canOpenInPlace,
-    requestScrollToMessage,
-  ]);
+  };
 
   return (
     <div className="relative">
@@ -320,8 +373,8 @@ export function ActivityTimeline({
       />
       <div className="relative z-10">
         <ThreadItemGroup>
-          {nodes.map((entry) => (
-            <Fragment key={entry.key}>{entry.node}</Fragment>
+          {rows.map((row) => (
+            <Fragment key={row.key}>{renderRow(row)}</Fragment>
           ))}
         </ThreadItemGroup>
       </div>

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
@@ -6,17 +6,11 @@ import {
 } from "@posthog/core/canvas/activityTimeline";
 import type { ThreadTimelineRow } from "@posthog/core/canvas/threadTimeline";
 import {
+  Button,
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
-  cn,
-  ThreadItem,
-  ThreadItemAuthor,
-  ThreadItemBody,
-  ThreadItemContent,
   ThreadItemGroup,
-  ThreadItemGutter,
-  ThreadItemHeader,
 } from "@posthog/quill";
 import type {
   Task,
@@ -29,6 +23,7 @@ import {
   ActivityEventRow,
   CommentRow,
   CommentStateRow,
+  DetailBlock,
   RunStatusRow,
   TimelineRow,
 } from "@posthog/ui/features/canvas/components/activityRows";
@@ -37,19 +32,20 @@ import {
   ThreadArtifactCard,
   ThreadMessageRow,
 } from "@posthog/ui/features/canvas/components/ThreadPanel";
-import { ThreadTimestamp } from "@posthog/ui/features/canvas/components/ThreadTimestamp";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
 import { useCommentNavigationStore } from "@posthog/ui/features/sessions/commentNavigationStore";
 import type { buildConversationItems } from "@posthog/ui/features/sessions/components/buildConversationItems";
 import { extractChannelContext } from "@posthog/ui/features/sessions/components/session-update/channelContext";
 import { extractCustomInstructions } from "@posthog/ui/features/sessions/components/session-update/customInstructions";
 import { useThreadNavigationStore } from "@posthog/ui/features/sessions/threadNavigationStore";
-import { Fragment, type KeyboardEvent, useMemo } from "react";
+import { Fragment, useMemo } from "react";
 
 type ConversationItem = ReturnType<
   typeof buildConversationItems
 >["items"][number];
 
+/** A prompt the task's author sent the agent. Collapsed like every other row: the first
+ *  line on the row, the message and its context when opened. */
 function UserMessageRow({
   author,
   content,
@@ -73,50 +69,36 @@ function UserMessageRow({
     [afterChannelContext],
   );
   const displayContent = customInstructions?.stripped ?? afterChannelContext;
-  // The row itself is the hit target. `ThreadItem` renders an <article>, which a
-  // <button> may not wrap and which can't become one (quill's primitive takes no
-  // `render`), so it carries the button role and its own key handling.
-  //
-  // Deliberately no `aria-label`: the button takes its name from its contents, so
-  // it announces the author, time and preview a sighted user sees. A label would
-  // replace all three — and since every row here is authored by the task creator,
-  // one built from the name alone would be identical on every row.
-  const activation = onSelect
-    ? ({
-        role: "button",
-        tabIndex: 0,
-        onClick: onSelect,
-        onKeyDown: (event: KeyboardEvent<HTMLElement>) => {
-          if (event.key !== "Enter" && event.key !== " ") return;
-          event.preventDefault();
-          onSelect();
-        },
-      } as const)
-    : {};
+  const trimmed = displayContent.trim();
+  const firstLine = trimmed.split("\n", 1)[0] ?? "";
+  // A one-line message is already fully shown on the row; repeating it below the fold is
+  // noise. Longer ones keep the full text as their detail.
+  const hasMoreThanPreview = trimmed !== firstLine;
   return (
-    <ThreadItem
-      className={cn("rounded-none", onSelect && "cursor-pointer")}
-      {...activation}
-    >
-      {/* Decorative: the author's name is written beside it, so keep the avatar's
-          initials out of the row's accessible name. */}
-      <ThreadItemGutter className="justify-center" aria-hidden>
-        <UserAvatar user={author} size="sm" className="sticky top-2" />
-      </ThreadItemGutter>
-      <ThreadItemContent>
-        <ThreadItemHeader>
-          <ThreadItemAuthor className="text-[13px]">{name}</ThreadItemAuthor>
-          <ThreadTimestamp dateTime={timestamp} />
-        </ThreadItemHeader>
-        <ThreadItemBody className="mt-1.5 whitespace-pre-wrap break-words text-[13px]">
-          <MentionText content={displayContent} />
+    <TimelineRow
+      gutter={
+        // Decorative: the author's name is written beside it, so keep the avatar's
+        // initials out of the row's accessible name.
+        <div
+          aria-hidden
+          className="relative z-10 flex size-5 items-center justify-center overflow-hidden rounded-full ring-4 ring-gray-1"
+        >
+          <UserAvatar user={author} size="sm" className="size-5" />
+        </div>
+      }
+      timestamp={timestamp}
+      detail={
+        <div className="space-y-1.5">
+          {hasMoreThanPreview && (
+            <DetailBlock>
+              <div className="whitespace-pre-wrap break-words">
+                <MentionText content={displayContent} />
+              </div>
+            </DetailBlock>
+          )}
           {channelContext && (
-            <Collapsible className="mt-2 min-w-0 bg-transparent hover:bg-transparent data-open:bg-transparent">
-              <CollapsibleTrigger
-                className="min-h-0 w-full bg-transparent px-0 py-1 text-left hover:bg-transparent aria-expanded:bg-transparent"
-                onClick={(event) => event.stopPropagation()}
-                onKeyDown={(event) => event.stopPropagation()}
-              >
+            <Collapsible className="min-w-0 bg-transparent hover:bg-transparent data-open:bg-transparent">
+              <CollapsibleTrigger className="min-h-0 w-full bg-transparent px-0 py-1 text-left hover:bg-transparent aria-expanded:bg-transparent">
                 <FileTextIcon size={12} />
                 <span className="truncate text-xs">
                   {channelContext.mention.name
@@ -130,9 +112,21 @@ function UserMessageRow({
               </CollapsibleContent>
             </Collapsible>
           )}
-        </ThreadItemBody>
-      </ThreadItemContent>
-    </ThreadItem>
+          {onSelect && (
+            <Button variant="default" size="sm" onClick={onSelect}>
+              Show in transcript
+            </Button>
+          )}
+        </div>
+      }
+    >
+      <span className="font-medium">{name}</span>{" "}
+      {/* Through MentionText like the body: a preview that prints raw mention or chip
+          markup is the same bug as a body that does. */}
+      <span className="text-muted-foreground">
+        <MentionText content={firstLine} />
+      </span>
+    </TimelineRow>
   );
 }
 

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
@@ -6,7 +6,6 @@ import {
 } from "@posthog/core/canvas/activityTimeline";
 import type { ThreadTimelineRow } from "@posthog/core/canvas/threadTimeline";
 import {
-  Button,
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
@@ -54,11 +53,13 @@ function UserMessageRow({
   author,
   content,
   timestamp,
+  connected,
   onSelect,
 }: {
   author?: UserBasic | null;
   content: string;
   timestamp: string;
+  connected: boolean;
   /** Jumps the transcript to this message. Absent once the run is unavailable. */
   onSelect?: () => void;
 }) {
@@ -75,11 +76,9 @@ function UserMessageRow({
   const displayContent = customInstructions?.stripped ?? afterChannelContext;
   const trimmed = displayContent.trim();
   const firstLine = trimmed.split("\n", 1)[0] ?? "";
-  // A one-line message is already fully shown on the row; repeating it below the fold is
-  // noise. Longer ones keep the full text as their detail.
-  const hasMoreThanPreview = trimmed !== firstLine;
   return (
     <TimelineRow
+      connected={connected}
       gutter={
         // Decorative: the author's name is written beside it, so keep the avatar's
         // initials out of the row's accessible name.
@@ -93,13 +92,11 @@ function UserMessageRow({
       timestamp={timestamp}
       detail={
         <div className="space-y-1.5">
-          {hasMoreThanPreview && (
-            <DetailBlock>
-              <div className="whitespace-pre-wrap break-words">
-                <MentionText content={displayContent} />
-              </div>
-            </DetailBlock>
-          )}
+          <DetailBlock>
+            <div className="whitespace-pre-wrap break-words">
+              <MentionText content={displayContent} />
+            </div>
+          </DetailBlock>
           {channelContext && (
             <Collapsible className="min-w-0 bg-transparent hover:bg-transparent data-open:bg-transparent">
               <CollapsibleTrigger className="min-h-0 w-full bg-transparent px-0 py-1 text-left hover:bg-transparent aria-expanded:bg-transparent">
@@ -264,11 +261,15 @@ export function ActivityTimeline({
       );
   };
 
-  const renderRow = (row: ActivityRow<TaskThreadMessage>) => {
+  const renderRow = (
+    row: ActivityRow<TaskThreadMessage>,
+    connected: boolean,
+  ) => {
     switch (row.kind) {
       case "task_created":
         return (
           <TimelineRow
+            connected={connected}
             gutter={
               <span className="relative z-10 flex size-5 items-center justify-center rounded-full border border-gray-7 bg-gray-5 text-gray-12 ring-4 ring-gray-1">
                 <PlusCircleIcon size={11} weight="fill" />
@@ -282,6 +283,7 @@ export function ActivityTimeline({
       case "user_message":
         return (
           <UserMessageRow
+            connected={connected}
             author={task.created_by}
             content={row.item.content}
             timestamp={new Date(row.item.timestamp).toISOString()}
@@ -313,6 +315,7 @@ export function ActivityTimeline({
         const artifactRow = messageRows.get(row.message.id);
         return (
           <ActivityEventRow
+            connected={connected}
             event={row.event}
             timestamp={row.message.created_at}
             runCount={runCount}
@@ -333,6 +336,7 @@ export function ActivityTimeline({
         if (!thread) return null;
         return (
           <CommentRow
+            connected={connected}
             thread={thread}
             isMentioned={
               !!currentUserId &&
@@ -345,30 +349,34 @@ export function ActivityTimeline({
       case "comment_state": {
         const thread = threadsById.get(row.thread.id);
         if (!thread) return null;
-        return <CommentStateRow thread={thread} state={row.state} />;
+        return (
+          <CommentStateRow
+            thread={thread}
+            state={row.state}
+            connected={connected}
+          />
+        );
       }
       case "run_status":
-        return <RunStatusRow status={row.status} timestamp={task.updated_at} />;
+        return (
+          <RunStatusRow
+            status={row.status}
+            timestamp={task.updated_at}
+            connected={connected}
+          />
+        );
     }
   };
 
   return (
-    <div className="relative px-1 py-2">
-      {/* Each row centers its node in a 2.5rem gutter, inset by this container's 0.25rem
-          padding and the row's own 0.5rem, so the line runs through
-          0.25 + 0.5 + 2.5/2 = 2rem. It stops short of the first and last node, so it reads
-          as spanning them rather than running past. */}
-      <div
-        aria-hidden
-        className="pointer-events-none absolute top-5 bottom-5 left-8 w-px bg-gray-8"
-      />
-      <div className="relative z-10">
-        <ThreadItemGroup>
-          {rows.map((row) => (
-            <Fragment key={row.key}>{renderRow(row)}</Fragment>
-          ))}
-        </ThreadItemGroup>
-      </div>
+    <div className="px-1 py-2">
+      <ThreadItemGroup>
+        {rows.map((row, index) => (
+          <Fragment key={row.key}>
+            {renderRow(row, index < rows.length - 1)}
+          </Fragment>
+        ))}
+      </ThreadItemGroup>
     </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
@@ -46,12 +46,14 @@ function UserMessageRow({
   author,
   content,
   timestamp,
-  connected,
+  connectedAbove,
+  connectedBelow,
 }: {
   author?: UserBasic | null;
   content: string;
   timestamp: string;
-  connected: boolean;
+  connectedAbove: boolean;
+  connectedBelow: boolean;
 }) {
   const name = author ? userDisplayName(author) : "You";
   const channelContext = useMemo(
@@ -68,13 +70,14 @@ function UserMessageRow({
   const firstLine = trimmed.split("\n", 1)[0] ?? "";
   return (
     <TimelineRow
-      connected={connected}
+      connectedAbove={connectedAbove}
+      connectedBelow={connectedBelow}
       gutter={
         // Decorative: the author's name is written beside it, so keep the avatar's
         // initials out of the row's accessible name.
         <div
           aria-hidden
-          className="relative z-10 flex size-5 items-center justify-center overflow-hidden rounded-full border border-gray-7 ring-4 ring-gray-1"
+          className="relative z-10 flex size-5 items-center justify-center overflow-hidden rounded-full border border-gray-7"
         >
           <UserAvatar user={author} size="sm" className="size-5" />
         </div>
@@ -232,15 +235,17 @@ export function ActivityTimeline({
 
   const renderRow = (
     row: ActivityRow<TaskThreadMessage>,
-    connected: boolean,
+    connectedAbove: boolean,
+    connectedBelow: boolean,
   ) => {
     switch (row.kind) {
       case "task_created":
         return (
           <TimelineRow
-            connected={connected}
+            connectedAbove={connectedAbove}
+            connectedBelow={connectedBelow}
             gutter={
-              <span className="relative z-10 flex size-5 items-center justify-center rounded-full border border-gray-7 bg-gray-5 text-gray-12 ring-4 ring-gray-1">
+              <span className="relative z-10 flex size-5 items-center justify-center rounded-full border border-gray-7 bg-gray-5 text-gray-12">
                 <PlusCircleIcon size={11} weight="fill" />
               </span>
             }
@@ -252,7 +257,8 @@ export function ActivityTimeline({
       case "user_message":
         return (
           <UserMessageRow
-            connected={connected}
+            connectedAbove={connectedAbove}
+            connectedBelow={connectedBelow}
             author={task.created_by}
             content={row.item.content}
             timestamp={new Date(row.item.timestamp).toISOString()}
@@ -261,7 +267,8 @@ export function ActivityTimeline({
       case "human_message":
         return (
           <ThreadReplyRow
-            connected={connected}
+            connectedAbove={connectedAbove}
+            connectedBelow={connectedBelow}
             author={row.message.author}
             content={row.message.content}
             timestamp={row.message.created_at}
@@ -273,7 +280,8 @@ export function ActivityTimeline({
         const artifactRow = messageRows.get(row.message.id);
         return (
           <ActivityEventRow
-            connected={connected}
+            connectedAbove={connectedAbove}
+            connectedBelow={connectedBelow}
             event={row.event}
             timestamp={row.message.created_at}
             runCount={runCount}
@@ -294,7 +302,8 @@ export function ActivityTimeline({
         if (!thread) return null;
         return (
           <CommentRow
-            connected={connected}
+            connectedAbove={connectedAbove}
+            connectedBelow={connectedBelow}
             thread={thread}
             isMentioned={
               !!currentUserId &&
@@ -311,7 +320,8 @@ export function ActivityTimeline({
           <CommentStateRow
             thread={thread}
             state={row.state}
-            connected={connected}
+            connectedAbove={connectedAbove}
+            connectedBelow={connectedBelow}
           />
         );
       }
@@ -320,7 +330,8 @@ export function ActivityTimeline({
           <RunStatusRow
             status={row.status}
             timestamp={task.updated_at}
-            connected={connected}
+            connectedAbove={connectedAbove}
+            connectedBelow={connectedBelow}
           />
         );
     }
@@ -331,7 +342,7 @@ export function ActivityTimeline({
       <ThreadItemGroup>
         {rows.map((row, index) => (
           <Fragment key={row.key}>
-            {renderRow(row, index < rows.length - 1)}
+            {renderRow(row, index > 0, index < rows.length - 1)}
           </Fragment>
         ))}
       </ThreadItemGroup>

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
@@ -271,7 +271,7 @@ export function ActivityTimeline({
         return (
           <TimelineRow
             gutter={
-              <span className="relative z-10 flex size-6 items-center justify-center rounded-full bg-gray-3">
+              <span className="relative z-10 flex size-6 items-center justify-center rounded-full bg-gray-3 ring-4 ring-gray-1">
                 <PlusCircleIcon
                   size={14}
                   weight="fill"
@@ -364,12 +364,14 @@ export function ActivityTimeline({
   };
 
   return (
-    <div className="relative">
-      {/* Every row centers its node in a 2.5rem gutter inset by the row's
-          0.5rem padding, so the line runs through 0.5 + 2.5/2 = 1.75rem. */}
+    <div className="relative px-1 py-2">
+      {/* Each row centers its node in a 2.5rem gutter, inset by this container's 0.25rem
+          padding and the row's own 0.5rem, so the line runs through
+          0.25 + 0.5 + 2.5/2 = 2rem. It stops short of the first and last node, so it reads
+          as spanning them rather than running past. */}
       <div
         aria-hidden
-        className="pointer-events-none absolute top-4 bottom-4 left-[1.75rem] w-px bg-border"
+        className="pointer-events-none absolute top-6 bottom-6 left-8 w-px bg-border"
       />
       <div className="relative z-10">
         <ThreadItemGroup>

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
@@ -22,25 +22,18 @@ import {
   ActivityEventRow,
   CommentRow,
   CommentStateRow,
-  DetailAction,
   DetailBlock,
   RunStatusRow,
+  ThreadReplyRow,
   TimelineRow,
 } from "@posthog/ui/features/canvas/components/activityRows";
 import { MentionText } from "@posthog/ui/features/canvas/components/MentionText";
-import {
-  ThreadArtifactCard,
-  ThreadMessageRow,
-} from "@posthog/ui/features/canvas/components/ThreadPanel";
+import { ThreadArtifactCard } from "@posthog/ui/features/canvas/components/ThreadPanel";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
 import { useCommentNavigationStore } from "@posthog/ui/features/sessions/commentNavigationStore";
 import type { buildConversationItems } from "@posthog/ui/features/sessions/components/buildConversationItems";
 import { extractChannelContext } from "@posthog/ui/features/sessions/components/session-update/channelContext";
 import { extractCustomInstructions } from "@posthog/ui/features/sessions/components/session-update/customInstructions";
-import {
-  useHasTranscriptListener,
-  useThreadNavigationStore,
-} from "@posthog/ui/features/sessions/threadNavigationStore";
 import { Fragment, useMemo } from "react";
 
 type ConversationItem = ReturnType<
@@ -54,14 +47,11 @@ function UserMessageRow({
   content,
   timestamp,
   connected,
-  onSelect,
 }: {
   author?: UserBasic | null;
   content: string;
   timestamp: string;
   connected: boolean;
-  /** Jumps the transcript to this message. Absent once the run is unavailable. */
-  onSelect?: () => void;
 }) {
   const name = author ? userDisplayName(author) : "You";
   const channelContext = useMemo(
@@ -113,9 +103,6 @@ function UserMessageRow({
               </CollapsibleContent>
             </Collapsible>
           )}
-          {onSelect && (
-            <DetailAction onClick={onSelect}>Show in transcript</DetailAction>
-          )}
         </div>
       }
     >
@@ -140,14 +127,8 @@ export function ActivityTimeline({
   commentThreads = NO_COMMENT_THREADS,
   commentsEnabled = false,
   currentUserId,
-  currentUserUuid,
-  currentUserEmail,
-  isTaskAuthor,
-  canForward,
   canOpenInPlace,
   runCount = 1,
-  onSendToAgent,
-  onDelete,
 }: {
   task: Task;
   timeline: ThreadTimelineRow<TaskThreadMessage>[];
@@ -157,25 +138,13 @@ export function ActivityTimeline({
   commentsEnabled?: boolean;
   /** Needed to tell a mention of you from a mention of someone else. */
   currentUserId?: number;
-  currentUserUuid?: string;
-  currentUserEmail?: string | null;
-  isTaskAuthor: boolean;
-  canForward: boolean;
   /** True when the task's transcript and review pane are mounted beside this
    *  pane. False in the channel-home sidebar, where there is nothing to drive —
    *  rows there stay inert and PRs open externally instead of dead-clicking. */
   canOpenInPlace?: boolean;
   /** How many runs the task has; a single-run task shouldn't label its run. */
   runCount?: number;
-  onSendToAgent: (messageId: string) => void;
-  onDelete: (messageId: string) => void;
 }) {
-  const requestScrollToMessage = useThreadNavigationStore(
-    (state) => state.requestScrollToMessage,
-  );
-  // The jump only lands if a transcript is mounted for this task. Without this the button
-  // renders in panes that have no transcript beside them and does nothing when clicked.
-  const hasTranscript = useHasTranscriptListener(task.id);
   const requestCommentFocus = useCommentNavigationStore(
     (state) => state.requestCommentFocus,
   );
@@ -287,26 +256,15 @@ export function ActivityTimeline({
             author={task.created_by}
             content={row.item.content}
             timestamp={new Date(row.item.timestamp).toISOString()}
-            onSelect={
-              canOpenInPlace && hasTranscript
-                ? () => requestScrollToMessage(task.id, row.item.id)
-                : undefined
-            }
           />
         );
       case "human_message":
         return (
-          <ThreadMessageRow
-            message={row.message}
-            isTaskAuthor={isTaskAuthor}
-            isOwnMessage={
-              !!currentUserUuid && currentUserUuid === row.message.author?.uuid
-            }
-            currentUserEmail={currentUserEmail}
-            canForward={canForward}
-            preview
-            onSendToAgent={() => onSendToAgent(row.message.id)}
-            onDelete={() => onDelete(row.message.id)}
+          <ThreadReplyRow
+            connected={connected}
+            author={row.message.author}
+            content={row.message.content}
+            timestamp={row.message.created_at}
           />
         );
       case "event": {

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
@@ -34,7 +34,7 @@ import {
 } from "@posthog/ui/features/canvas/components/activityRows";
 import { MentionText } from "@posthog/ui/features/canvas/components/MentionText";
 import {
-  ThreadArtifactRow,
+  ThreadArtifactCard,
   ThreadMessageRow,
 } from "@posthog/ui/features/canvas/components/ThreadPanel";
 import { ThreadTimestamp } from "@posthog/ui/features/canvas/components/ThreadTimestamp";
@@ -313,23 +313,23 @@ export function ActivityTimeline({
           />
         );
       case "event": {
-        // Canvases and pull requests already have a card row; the rest read as one line.
+        // A canvas or pull request announcement keeps its card, but as the row's detail:
+        // every row in the panel opens the same way.
         const artifactRow = messageRows.get(row.message.id);
-        if (artifactRow?.kind === "artifact") {
-          return (
-            <ThreadArtifactRow
-              artifact={artifactRow.artifact}
-              createdAt={row.message.created_at}
-              openInPlaceTaskId={canOpenInPlace ? task.id : undefined}
-            />
-          );
-        }
         return (
           <ActivityEventRow
             event={row.event}
             timestamp={row.message.created_at}
             runCount={runCount}
             runOrdinal={row.runOrdinal}
+            detail={
+              artifactRow?.kind === "artifact" ? (
+                <ThreadArtifactCard
+                  artifact={artifactRow.artifact}
+                  openInPlaceTaskId={canOpenInPlace ? task.id : undefined}
+                />
+              ) : undefined
+            }
           />
         );
       }
@@ -350,13 +350,7 @@ export function ActivityTimeline({
       case "comment_state": {
         const thread = threadsById.get(row.thread.id);
         if (!thread) return null;
-        return (
-          <CommentStateRow
-            thread={thread}
-            state={row.state}
-            onSelect={focusThread(thread)}
-          />
-        );
+        return <CommentStateRow thread={thread} state={row.state} />;
       }
       case "run_status":
         return <RunStatusRow status={row.status} timestamp={task.updated_at} />;

--- a/products/desktop/packages/ui/src/features/canvas/components/ThreadPanel.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ThreadPanel.tsx
@@ -311,6 +311,23 @@ export function ThreadArtifactRow({
   );
 }
 
+/** Just the card an artifact announcement carries, without the thread row around it, for
+ *  surfaces that supply their own row (the activity timeline opens it as a row's detail). */
+export function ThreadArtifactCard({
+  artifact,
+  openInPlaceTaskId,
+}: {
+  artifact: ThreadArtifact;
+  /** Task whose review pane is mounted alongside; absent means open externally. */
+  openInPlaceTaskId?: string;
+}) {
+  return artifact.kind === "canvas" ? (
+    <CanvasArtifactCard name={artifact.name} url={artifact.url} />
+  ) : (
+    <PrArtifactCard url={artifact.url} openInPlaceTaskId={openInPlaceTaskId} />
+  );
+}
+
 export function ThreadLoadingState() {
   return (
     <Empty className="h-full border-0">

--- a/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
@@ -44,6 +44,7 @@ export function TimelineRow({
   timestamp,
   detail,
   defaultOpen = false,
+  connected = true,
   ariaLabel,
 }: {
   gutter: ReactNode;
@@ -52,6 +53,9 @@ export function TimelineRow({
   /** Shown when the row is opened. Absent means there is nothing more to say. */
   detail?: ReactNode;
   defaultOpen?: boolean;
+  /** Draw the line down to the next row. False on the last row, which has nothing to
+   *  connect to. */
+  connected?: boolean;
   ariaLabel?: string;
 }) {
   const [open, setOpen] = useState(defaultOpen);
@@ -75,12 +79,25 @@ export function TimelineRow({
   return (
     <div
       className={cn(
-        "group flex items-start gap-2 rounded-md py-1.5 pr-2 pl-2 transition-colors",
+        "group flex items-stretch gap-2 rounded-md py-1.5 pr-2 pl-2 transition-colors",
         hasDetail &&
           "cursor-pointer focus-within:bg-gray-2 hover:bg-gray-2 has-[:focus-visible]:bg-gray-2",
       )}
     >
-      <div className="flex w-10 shrink-0 justify-center">{gutter}</div>
+      {/* The connector sits inside the row, so the hover fill paints behind it rather than
+          over it. It runs from just under this row's bead to the row's bottom edge; the next
+          row's top padding leaves the gap before its bead. Positioned rather than flexed:
+          on a single-line row the bead fills the content box and a flex child gets no
+          height at all. */}
+      <div className="relative flex w-10 shrink-0 justify-center self-stretch">
+        {gutter}
+        {connected && (
+          <span
+            aria-hidden
+            className="-translate-x-1/2 -bottom-1.5 absolute top-6 left-1/2 w-px bg-gray-8"
+          />
+        )}
+      </div>
       <div className="min-w-0 flex-1">
         {hasDetail ? (
           <>
@@ -269,7 +286,8 @@ function eventDetail(event: ActivityEvent): ReactNode {
   }
 }
 
-/** A quiet inline action under an opened row — reads as a link, not a form control. */
+/** The action under an opened row: a small outline button, so it reads as something to
+ *  press rather than as more copy. */
 export function DetailAction({
   children,
   onClick,
@@ -278,14 +296,9 @@ export function DetailAction({
   onClick: () => void;
 }) {
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="inline-flex items-center gap-1 rounded px-0.5 text-[12px] text-muted-foreground underline-offset-2 transition-colors hover:text-gray-12 hover:underline"
-    >
+    <Button variant="outline" size="xs" onClick={onClick}>
       {children}
-      <CaretRightIcon size={10} />
-    </button>
+    </Button>
   );
 }
 
@@ -304,7 +317,9 @@ export function ActivityEventRow({
   runCount,
   runOrdinal = 1,
   detail,
+  connected = true,
 }: {
+  connected?: boolean;
   event: ActivityEvent;
   timestamp: string;
   /** How many runs the task has, so a single-run task doesn't say "run 1". */
@@ -317,6 +332,7 @@ export function ActivityEventRow({
 }) {
   return (
     <TimelineRow
+      connected={connected}
       gutter={
         <IconBubble tone={EVENT_TONES[event.kind]}>
           {EVENT_ICONS[event.kind]}
@@ -335,13 +351,16 @@ export function ActivityEventRow({
 export function RunStatusRow({
   status,
   timestamp,
+  connected = true,
 }: {
   status: string;
   timestamp: string;
+  connected?: boolean;
 }) {
   const succeeded = status === "completed";
   return (
     <TimelineRow
+      connected={connected}
       gutter={
         <IconBubble tone={succeeded ? "green" : "red"}>
           {succeeded ? (
@@ -371,7 +390,9 @@ export function CommentRow({
   thread,
   isMentioned,
   onSelect,
+  connected = true,
 }: {
+  connected?: boolean;
   thread: TaskCommentThreadSummary;
   /** The current user was mentioned somewhere in the thread. */
   isMentioned: boolean;
@@ -382,6 +403,7 @@ export function CommentRow({
   const verb = isMentioned ? "mentioned you on" : "commented on";
   return (
     <TimelineRow
+      connected={connected}
       gutter={
         // Decorative: the author's name is written beside it.
         <div
@@ -430,14 +452,17 @@ export function CommentRow({
 export function CommentStateRow({
   thread,
   state,
+  connected = true,
 }: {
   thread: TaskCommentThreadSummary;
   state: string;
+  connected?: boolean;
 }) {
   const author = thread.state_event?.author ?? null;
   const resolved = state === "resolved";
   return (
     <TimelineRow
+      connected={connected}
       gutter={
         <IconBubble tone={resolved ? "green" : "amber"}>
           {resolved ? (
@@ -467,11 +492,7 @@ export function ActivityLoadingState() {
   return (
     // <output> is the semantic element for role=status; the label names the wait.
     <output className="relative block px-1 py-2" aria-label="Loading timeline">
-      <div
-        aria-hidden
-        className="pointer-events-none absolute top-5 bottom-5 left-8 w-px bg-gray-8"
-      />
-      <div className="relative z-10">
+      <div>
         {/* Widths vary so the block reads as copy rather than a progress bar. */}
         {[36, 52, 44, 60, 40].map((width) => (
           <div key={width} className="flex items-start gap-2 py-1 pr-2 pl-2">

--- a/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
@@ -28,6 +28,7 @@ import type {
   UserBasic,
 } from "@posthog/shared/domain-types";
 import { UserAvatar } from "@posthog/ui/features/auth/UserAvatar";
+import { MentionText } from "@posthog/ui/features/canvas/components/MentionText";
 import { ThreadTimestamp } from "@posthog/ui/features/canvas/components/ThreadTimestamp";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
 import { type ReactNode, useState } from "react";
@@ -56,7 +57,7 @@ export function TimelineRow({
   const [open, setOpen] = useState(defaultOpen);
   const hasDetail = detail !== undefined && detail !== null;
   const header = (
-    <div className="flex min-w-0 items-baseline gap-1.5 text-[13px] leading-5">
+    <div className="flex min-w-0 items-center gap-1.5 text-[12.5px] leading-[22px]">
       <span className="min-w-0 truncate">{children}</span>
       <ThreadTimestamp dateTime={timestamp} />
       {hasDetail && (
@@ -64,8 +65,8 @@ export function TimelineRow({
           size={11}
           aria-hidden
           className={cn(
-            "ml-auto shrink-0 self-center text-muted-foreground opacity-0 transition-all group-hover:opacity-100",
-            open && "rotate-90 opacity-100",
+            "ml-auto shrink-0 text-muted-foreground opacity-0 transition-transform group-hover:opacity-60",
+            open && "rotate-90 opacity-60",
           )}
         />
       )}
@@ -74,13 +75,13 @@ export function TimelineRow({
   return (
     <div
       className={cn(
-        "group flex items-start gap-2 rounded-md py-2 pr-2 pl-2 transition-colors",
+        "group flex items-start gap-2 rounded-md py-1 pr-2 pl-2 transition-colors",
         hasDetail &&
-          "cursor-pointer focus-within:bg-gray-3 hover:bg-gray-3 has-[:focus-visible]:bg-gray-3",
+          "cursor-pointer focus-within:bg-gray-2 hover:bg-gray-2 has-[:focus-visible]:bg-gray-2",
       )}
     >
       <div className="flex w-10 shrink-0 justify-center">{gutter}</div>
-      <div className="min-w-0 flex-1 pt-0.5">
+      <div className="min-w-0 flex-1">
         {hasDetail ? (
           <>
             <button
@@ -104,27 +105,27 @@ export function TimelineRow({
 
 function IconBubble({ children }: { children: ReactNode }) {
   return (
-    <span className="relative z-10 flex size-6 items-center justify-center rounded-full bg-gray-3 ring-4 ring-gray-1">
+    <span className="relative z-10 flex size-5 items-center justify-center rounded-full bg-gray-3 ring-4 ring-gray-1">
       {children}
     </span>
   );
 }
 
 const EVENT_ICONS: Record<ActivityEvent["kind"], ReactNode> = {
-  run_started: <PlayIcon size={12} weight="fill" className="text-blue-11" />,
-  run_failed: <XCircleIcon size={14} weight="fill" className="text-red-11" />,
+  run_started: <PlayIcon size={10} weight="fill" className="text-blue-11" />,
+  run_failed: <XCircleIcon size={12} weight="fill" className="text-red-11" />,
   awaiting_input: (
-    <WarningIcon size={13} weight="fill" className="text-amber-11" />
+    <WarningIcon size={11} weight="fill" className="text-amber-11" />
   ),
-  artifact_created: <FileTextIcon size={13} className="text-violet-11" />,
+  artifact_created: <FileTextIcon size={11} className="text-violet-11" />,
   artifact_revised: (
     <ArrowsClockwiseIcon size={12} className="text-violet-11" />
   ),
-  canvas_created: <FileTextIcon size={13} className="text-violet-11" />,
-  pr_created: <GitPullRequestIcon size={13} className="text-gray-12" />,
-  pr_merged: <GitPullRequestIcon size={13} className="text-violet-11" />,
-  pr_closed: <GitPullRequestIcon size={13} className="text-red-11" />,
-  message_forwarded: <ArrowRightIcon size={12} className="text-blue-11" />,
+  canvas_created: <FileTextIcon size={11} className="text-violet-11" />,
+  pr_created: <GitPullRequestIcon size={11} className="text-gray-12" />,
+  pr_merged: <GitPullRequestIcon size={11} className="text-violet-11" />,
+  pr_closed: <GitPullRequestIcon size={11} className="text-red-11" />,
+  message_forwarded: <ArrowRightIcon size={11} className="text-blue-11" />,
 };
 
 /** The sentence an event reads as. Written so a person skimming the panel learns what
@@ -287,12 +288,12 @@ export function RunStatusRow({
         <IconBubble>
           {succeeded ? (
             <CheckCircleIcon
-              size={14}
+              size={12}
               weight="fill"
               className="text-green-11"
             />
           ) : (
-            <XCircleIcon size={14} weight="fill" className="text-red-11" />
+            <XCircleIcon size={12} weight="fill" className="text-red-11" />
           )}
         </IconBubble>
       }
@@ -346,7 +347,7 @@ export function CommentRow({
               </div>
             )}
             <div className="whitespace-pre-wrap break-words">
-              {thread.content}
+              <MentionText content={thread.content} />
             </div>
           </DetailBlock>
           {thread.reply_count > 0 && (
@@ -389,13 +390,13 @@ export function CommentStateRow({
         <IconBubble>
           {resolved ? (
             <CheckCircleIcon
-              size={14}
+              size={12}
               weight="fill"
               className="text-green-11"
             />
           ) : (
             <WarningCircleIcon
-              size={14}
+              size={12}
               weight="fill"
               className="text-amber-11"
             />
@@ -420,28 +421,20 @@ export function CommentStateRow({
  *  a loader over rows already on screen reads as the content disappearing. */
 export function ActivityLoadingState() {
   return (
-    // role=status so a screen reader hears the wait; a bare div can't carry the label.
-    <div
-      className="relative px-1 py-2"
-      role="status"
-      aria-label="Loading timeline"
-    >
+    // <output> is the semantic element for role=status; the label names the wait.
+    <output className="relative block px-1 py-2" aria-label="Loading timeline">
       <div
         aria-hidden
-        className="pointer-events-none absolute top-6 bottom-6 left-8 w-px bg-border"
+        className="pointer-events-none absolute top-5 bottom-5 left-8 w-px bg-border"
       />
       <div className="relative z-10">
         {/* Widths vary so the block reads as copy rather than a progress bar. */}
-        {[36, 52, 44, 60, 40].map((width, index) => (
-          <div
-            // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length decorative placeholder
-            key={index}
-            className="flex items-start gap-2 py-2 pr-2 pl-2"
-          >
+        {[36, 52, 44, 60, 40].map((width) => (
+          <div key={width} className="flex items-start gap-2 py-1 pr-2 pl-2">
             <div className="flex w-10 shrink-0 justify-center">
-              <Skeleton className="size-6 rounded-full ring-4 ring-gray-1" />
+              <Skeleton className="size-5 rounded-full ring-4 ring-gray-1" />
             </div>
-            <div className="min-w-0 flex-1 pt-1">
+            <div className="min-w-0 flex-1 py-1">
               <Skeleton
                 className="h-3 rounded"
                 style={{ width: `${width}%` }}
@@ -450,6 +443,6 @@ export function ActivityLoadingState() {
           </div>
         ))}
       </div>
-    </div>
+    </output>
   );
 }

--- a/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
@@ -9,6 +9,7 @@
 import {
   ArrowRightIcon,
   ArrowsClockwiseIcon,
+  CaretRightIcon,
   CheckCircleIcon,
   FileTextIcon,
   GitPullRequestIcon,
@@ -21,14 +22,7 @@ import {
   type ActivityEvent,
   prLabel,
 } from "@posthog/core/canvas/activityEvents";
-import {
-  cn,
-  Empty,
-  EmptyHeader,
-  EmptyMedia,
-  EmptyTitle,
-  Spinner,
-} from "@posthog/quill";
+import { Button, cn, Skeleton } from "@posthog/quill";
 import type {
   TaskCommentThreadSummary,
   UserBasic,
@@ -36,51 +30,73 @@ import type {
 import { UserAvatar } from "@posthog/ui/features/auth/UserAvatar";
 import { ThreadTimestamp } from "@posthog/ui/features/canvas/components/ThreadTimestamp";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
-import type { ReactNode } from "react";
+import { type ReactNode, useState } from "react";
 
-/** A gutter node, a line of copy and a timestamp, at the same size as every other row's
- *  copy: only the icon distinguishes a lifecycle row from its neighbours. */
+/** One row: a gutter node, a line of copy, a timestamp, and optionally a detail block the
+ *  row hides until it is opened.
+ *
+ *  Collapsed by default so the panel reads as a timeline rather than a wall of content.
+ *  A row with no detail is inert — no chevron, no hover target, nothing to click. */
 export function TimelineRow({
   gutter,
   children,
   timestamp,
-  onSelect,
+  detail,
+  defaultOpen = false,
   ariaLabel,
 }: {
   gutter: ReactNode;
   children: ReactNode;
   timestamp: string;
-  onSelect?: () => void;
+  /** Shown when the row is opened. Absent means there is nothing more to say. */
+  detail?: ReactNode;
+  defaultOpen?: boolean;
   ariaLabel?: string;
 }) {
-  const activation = onSelect
-    ? {
-        role: "button" as const,
-        tabIndex: 0,
-        "aria-label": ariaLabel,
-        onClick: onSelect,
-        onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => {
-          if (event.key !== "Enter" && event.key !== " ") return;
-          event.preventDefault();
-          onSelect();
-        },
-      }
-    : {};
+  const [open, setOpen] = useState(defaultOpen);
+  const hasDetail = detail !== undefined && detail !== null;
+  const header = (
+    <div className="flex min-w-0 items-baseline gap-1.5 text-[13px] leading-5">
+      <span className="min-w-0 truncate">{children}</span>
+      <ThreadTimestamp dateTime={timestamp} />
+      {hasDetail && (
+        <CaretRightIcon
+          size={11}
+          aria-hidden
+          className={cn(
+            "ml-auto shrink-0 self-center text-muted-foreground opacity-0 transition-all group-hover:opacity-100",
+            open && "rotate-90 opacity-100",
+          )}
+        />
+      )}
+    </div>
+  );
   return (
     <div
       className={cn(
         "group flex items-start gap-2 rounded-md py-2 pr-2 pl-2 transition-colors",
-        onSelect &&
-          "cursor-pointer hover:bg-gray-3 focus-visible:bg-gray-3 focus-visible:outline-none",
+        hasDetail &&
+          "cursor-pointer focus-within:bg-gray-3 hover:bg-gray-3 has-[:focus-visible]:bg-gray-3",
       )}
-      {...activation}
     >
       <div className="flex w-10 shrink-0 justify-center">{gutter}</div>
       <div className="min-w-0 flex-1 pt-0.5">
-        <div className="flex min-w-0 items-baseline gap-1.5 text-[13px] leading-5">
-          <span className="min-w-0 truncate">{children}</span>
-          <ThreadTimestamp dateTime={timestamp} />
-        </div>
+        {hasDetail ? (
+          <>
+            <button
+              type="button"
+              aria-expanded={open}
+              aria-label={ariaLabel}
+              className="w-full text-left focus-visible:outline-none"
+              onClick={() => setOpen((current) => !current)}
+            >
+              {header}
+            </button>
+            {open && <div className="mt-1.5">{detail}</div>}
+          </>
+        ) : (
+          header
+        )}
       </div>
     </div>
   );
@@ -95,18 +111,20 @@ function IconBubble({ children }: { children: ReactNode }) {
 }
 
 const EVENT_ICONS: Record<ActivityEvent["kind"], ReactNode> = {
-  run_started: <PlayIcon size={12} weight="fill" className="text-blue-9" />,
-  run_failed: <XCircleIcon size={14} weight="fill" className="text-red-9" />,
+  run_started: <PlayIcon size={12} weight="fill" className="text-blue-11" />,
+  run_failed: <XCircleIcon size={14} weight="fill" className="text-red-11" />,
   awaiting_input: (
-    <WarningIcon size={13} weight="fill" className="text-warning" />
+    <WarningIcon size={13} weight="fill" className="text-amber-11" />
   ),
-  artifact_created: <FileTextIcon size={13} className="text-violet-9" />,
-  artifact_revised: <ArrowsClockwiseIcon size={12} className="text-violet-9" />,
-  canvas_created: <FileTextIcon size={13} className="text-violet-9" />,
-  pr_created: <GitPullRequestIcon size={13} className="text-gray-11" />,
-  pr_merged: <GitPullRequestIcon size={13} className="text-violet-9" />,
-  pr_closed: <GitPullRequestIcon size={13} className="text-red-9" />,
-  message_forwarded: <ArrowRightIcon size={12} className="text-blue-9" />,
+  artifact_created: <FileTextIcon size={13} className="text-violet-11" />,
+  artifact_revised: (
+    <ArrowsClockwiseIcon size={12} className="text-violet-11" />
+  ),
+  canvas_created: <FileTextIcon size={13} className="text-violet-11" />,
+  pr_created: <GitPullRequestIcon size={13} className="text-gray-12" />,
+  pr_merged: <GitPullRequestIcon size={13} className="text-violet-11" />,
+  pr_closed: <GitPullRequestIcon size={13} className="text-red-11" />,
+  message_forwarded: <ArrowRightIcon size={12} className="text-blue-11" />,
 };
 
 /** The sentence an event reads as. Written so a person skimming the panel learns what
@@ -117,38 +135,13 @@ function eventLabel(
   runOrdinal: number,
 ): ReactNode {
   switch (event.kind) {
-    case "run_started": {
-      const details = [
-        event.payload.environment,
-        event.payload.branch || null,
-      ].filter(Boolean);
-      return (
-        <>
-          {/* A run number only helps once a task has run more than once. */}
-          {runCount > 1
-            ? `Agent started run ${runOrdinal}`
-            : "Agent started work"}
-          {details.length > 0 && (
-            <span className="text-muted-foreground">
-              {" "}
-              · {details.join(" · ")}
-            </span>
-          )}
-        </>
-      );
-    }
+    case "run_started":
+      // A run number only helps once a task has run more than once.
+      return runCount > 1
+        ? `Agent started run ${runOrdinal}`
+        : "Agent started work";
     case "run_failed":
-      return event.payload.errorSummary ? (
-        <>
-          Run failed
-          <span className="text-muted-foreground">
-            {" "}
-            · {event.payload.errorSummary}
-          </span>
-        </>
-      ) : (
-        "Run failed"
-      );
+      return "Run failed";
     case "awaiting_input":
       return "Agent needs input";
     case "artifact_created":
@@ -205,12 +198,57 @@ function eventLabel(
   }
 }
 
+/** What an event has to say beyond its headline, or nothing. */
+function eventDetail(event: ActivityEvent): ReactNode {
+  switch (event.kind) {
+    case "run_failed":
+      return event.payload.errorSummary ? (
+        <DetailBlock>{event.payload.errorSummary}</DetailBlock>
+      ) : null;
+    case "run_started": {
+      const details = [
+        event.payload.environment,
+        event.payload.branch || null,
+      ].filter(Boolean);
+      return details.length > 0 ? (
+        <DetailBlock>{details.join(" · ")}</DetailBlock>
+      ) : null;
+    }
+    case "artifact_created":
+    case "artifact_revised":
+      return (
+        <DetailBlock>
+          {event.payload.name}
+          <span className="text-muted-foreground">
+            {" "}
+            · v{event.payload.version}
+          </span>
+        </DetailBlock>
+      );
+    case "pr_created":
+    case "pr_merged":
+    case "pr_closed":
+      return <DetailBlock>{event.payload.prUrl}</DetailBlock>;
+    default:
+      return null;
+  }
+}
+
+/** The shared shape of an opened row's content: one quoted block, indented to the copy. */
+export function DetailBlock({ children }: { children: ReactNode }) {
+  return (
+    <div className="break-words rounded-md border-border border-l-2 bg-gray-2 px-2.5 py-1.5 text-[12.5px]">
+      {children}
+    </div>
+  );
+}
+
 export function ActivityEventRow({
   event,
   timestamp,
   runCount,
   runOrdinal = 1,
-  onSelect,
+  detail,
 }: {
   event: ActivityEvent;
   timestamp: string;
@@ -218,13 +256,15 @@ export function ActivityEventRow({
   runCount: number;
   /** Which run this row starts, counted over the feed rather than stamped by the backend. */
   runOrdinal?: number;
-  onSelect?: () => void;
+  /** Supplied by the caller for events that carry a card (a canvas, a pull request);
+   *  otherwise the row derives its own from the payload. */
+  detail?: ReactNode;
 }) {
   return (
     <TimelineRow
       gutter={<IconBubble>{EVENT_ICONS[event.kind]}</IconBubble>}
       timestamp={timestamp}
-      onSelect={onSelect}
+      detail={detail ?? eventDetail(event)}
     >
       {eventLabel(event, runCount, runOrdinal)}
     </TimelineRow>
@@ -246,9 +286,13 @@ export function RunStatusRow({
       gutter={
         <IconBubble>
           {succeeded ? (
-            <CheckCircleIcon size={14} weight="fill" className="text-green-9" />
+            <CheckCircleIcon
+              size={14}
+              weight="fill"
+              className="text-green-11"
+            />
           ) : (
-            <XCircleIcon size={14} weight="fill" className="text-red-9" />
+            <XCircleIcon size={14} weight="fill" className="text-red-11" />
           )}
         </IconBubble>
       }
@@ -264,8 +308,9 @@ function participantNames(participants: UserBasic[]): string {
 }
 
 /**
- * One comment thread. The anchor's quoted selection travels with the row, because a
- * comment without the text it points at is just a notification.
+ * One comment thread, collapsed to who commented on what. Opening it shows the anchor's
+ * quoted selection and the comment itself, because a comment without the text it points at
+ * is just a notification — and a button to open the thread where it lives.
  */
 export function CommentRow({
   thread,
@@ -281,60 +326,49 @@ export function CommentRow({
   const name = userDisplayName(author);
   const verb = isMentioned ? "mentioned you on" : "commented on";
   return (
-    <div
-      className={cn(
-        "group flex items-start gap-2 rounded-md py-2 pr-2 pl-2 transition-colors",
-        onSelect &&
-          "cursor-pointer hover:bg-gray-3 focus-visible:bg-gray-3 focus-visible:outline-none",
-      )}
-      {...(onSelect
-        ? {
-            role: "button" as const,
-            tabIndex: 0,
-            onClick: onSelect,
-            onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => {
-              if (event.key !== "Enter" && event.key !== " ") return;
-              event.preventDefault();
-              onSelect();
-            },
-          }
-        : {})}
-    >
-      <div className="flex w-10 shrink-0 justify-center">
-        {/* Decorative: the author's name is written beside it. */}
-        <div aria-hidden>
-          <UserAvatar user={author} size="sm" className="sticky top-2" />
+    <TimelineRow
+      gutter={
+        // Decorative: the author's name is written beside it.
+        <div
+          aria-hidden
+          className="relative z-10 rounded-full ring-4 ring-gray-1"
+        >
+          <UserAvatar user={author} size="sm" />
         </div>
-      </div>
-      <div className="min-w-0 flex-1">
-        <div className="flex min-w-0 items-baseline gap-1.5 text-[13px] leading-5">
-          <span className="min-w-0 truncate">
-            <span className="font-medium">{name}</span>{" "}
-            <span className="text-muted-foreground">{verb}</span>{" "}
-            <span className="font-medium">{thread.target.name}</span>
-          </span>
-          <ThreadTimestamp dateTime={thread.last_activity_at} />
-        </div>
-        <div className="mt-1.5 space-y-1 rounded-md border-border border-l-2 bg-gray-2 px-2.5 py-1.5">
-          {thread.selected_text && (
-            <div className="truncate text-[12.5px] text-muted-foreground italic">
-              “{thread.selected_text}”
+      }
+      timestamp={thread.last_activity_at}
+      detail={
+        <div className="space-y-1.5">
+          <DetailBlock>
+            {thread.selected_text && (
+              <div className="mb-1 truncate text-muted-foreground italic">
+                “{thread.selected_text}”
+              </div>
+            )}
+            <div className="whitespace-pre-wrap break-words">
+              {thread.content}
+            </div>
+          </DetailBlock>
+          {thread.reply_count > 0 && (
+            <div className="truncate text-[12.5px] text-muted-foreground">
+              {thread.reply_count}{" "}
+              {thread.reply_count === 1 ? "reply" : "replies"}
+              {thread.participants.length > 0 &&
+                ` · ${participantNames(thread.participants)}`}
             </div>
           )}
-          <div className="line-clamp-2 whitespace-pre-wrap break-words text-[12.5px]">
-            {thread.content}
-          </div>
+          {onSelect && (
+            <Button variant="default" size="sm" onClick={onSelect}>
+              Open thread
+            </Button>
+          )}
         </div>
-        {thread.reply_count > 0 && (
-          <div className="mt-1 truncate text-[12.5px] text-muted-foreground">
-            {thread.reply_count}{" "}
-            {thread.reply_count === 1 ? "reply" : "replies"}
-            {thread.participants.length > 0 &&
-              ` · ${participantNames(thread.participants)}`}
-          </div>
-        )}
-      </div>
-    </div>
+      }
+    >
+      <span className="font-medium">{name}</span>{" "}
+      <span className="text-muted-foreground">{verb}</span>{" "}
+      <span className="font-medium">{thread.target.name}</span>
+    </TimelineRow>
   );
 }
 
@@ -343,11 +377,9 @@ export function CommentRow({
 export function CommentStateRow({
   thread,
   state,
-  onSelect,
 }: {
   thread: TaskCommentThreadSummary;
   state: string;
-  onSelect?: () => void;
 }) {
   const author = thread.state_event?.author ?? null;
   const resolved = state === "resolved";
@@ -356,18 +388,21 @@ export function CommentStateRow({
       gutter={
         <IconBubble>
           {resolved ? (
-            <CheckCircleIcon size={14} weight="fill" className="text-green-9" />
+            <CheckCircleIcon
+              size={14}
+              weight="fill"
+              className="text-green-11"
+            />
           ) : (
             <WarningCircleIcon
               size={14}
               weight="fill"
-              className="text-warning"
+              className="text-amber-11"
             />
           )}
         </IconBubble>
       }
       timestamp={thread.state_event?.created_at ?? thread.last_activity_at}
-      onSelect={onSelect}
     >
       {author ? (
         <span className="font-medium">{userDisplayName(author)}</span>
@@ -380,17 +415,41 @@ export function CommentStateRow({
   );
 }
 
-/** Shown once, on the panel's first draw. The timeline never returns to it: a loader over
- *  rows that are already on screen reads as the content disappearing. */
+/** Shown once, on the panel's first draw: the timeline's own shape rather than a spinner,
+ *  so the panel doesn't change size or layout when the rows arrive. It never returns —
+ *  a loader over rows already on screen reads as the content disappearing. */
 export function ActivityLoadingState() {
   return (
-    <Empty className="h-full border-0">
-      <EmptyHeader>
-        <EmptyMedia variant="icon">
-          <Spinner />
-        </EmptyMedia>
-        <EmptyTitle>Loading timeline</EmptyTitle>
-      </EmptyHeader>
-    </Empty>
+    // role=status so a screen reader hears the wait; a bare div can't carry the label.
+    <div
+      className="relative px-1 py-2"
+      role="status"
+      aria-label="Loading timeline"
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute top-6 bottom-6 left-8 w-px bg-border"
+      />
+      <div className="relative z-10">
+        {/* Widths vary so the block reads as copy rather than a progress bar. */}
+        {[36, 52, 44, 60, 40].map((width, index) => (
+          <div
+            // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length decorative placeholder
+            key={index}
+            className="flex items-start gap-2 py-2 pr-2 pl-2"
+          >
+            <div className="flex w-10 shrink-0 justify-center">
+              <Skeleton className="size-6 rounded-full ring-4 ring-gray-1" />
+            </div>
+            <div className="min-w-0 flex-1 pt-1">
+              <Skeleton
+                className="h-3 rounded"
+                style={{ width: `${width}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
@@ -12,6 +12,7 @@ import {
   CaretRightIcon,
   CheckCircleIcon,
   FileTextIcon,
+  GitCommitIcon,
   GitPullRequestIcon,
   PlayIcon,
   WarningCircleIcon,
@@ -168,6 +169,7 @@ function IconBubble({
 const EVENT_TONES: Record<ActivityEvent["kind"], BeadTone> = {
   run_started: "blue",
   run_failed: "red",
+  commits_pushed: "neutral",
   awaiting_input: "amber",
   artifact_created: "violet",
   artifact_revised: "violet",
@@ -181,6 +183,7 @@ const EVENT_TONES: Record<ActivityEvent["kind"], BeadTone> = {
 const EVENT_ICONS: Record<ActivityEvent["kind"], ReactNode> = {
   run_started: <PlayIcon size={10} weight="fill" />,
   run_failed: <XCircleIcon size={12} weight="fill" />,
+  commits_pushed: <GitCommitIcon size={11} />,
   awaiting_input: <WarningIcon size={11} weight="fill" />,
   artifact_created: <FileTextIcon size={11} />,
   artifact_revised: <ArrowsClockwiseIcon size={12} />,
@@ -206,6 +209,17 @@ function eventLabel(
         : "Agent started work";
     case "run_failed":
       return "Run failed";
+    case "commits_pushed": {
+      const { total, branch } = event.payload;
+      const count = `${total} commit${total === 1 ? "" : "s"} pushed`;
+      return branch ? (
+        <>
+          {count} <span className="text-muted-foreground">to {branch}</span>
+        </>
+      ) : (
+        count
+      );
+    }
     case "awaiting_input":
       return "Agent needs input";
     case "artifact_created":
@@ -289,6 +303,31 @@ function eventDetail(event: ActivityEvent): ReactNode {
           </span>
         </DetailBlock>
       );
+    case "commits_pushed": {
+      const { commits, total } = event.payload;
+      return (
+        <DetailBlock>
+          <div className="space-y-1">
+            {commits.map((commit) => (
+              <div
+                key={commit.sha}
+                className="flex min-w-0 items-baseline gap-2"
+              >
+                <span className="shrink-0 font-mono text-[11.5px] text-muted-foreground">
+                  {commit.sha.slice(0, 7)}
+                </span>
+                <span className="min-w-0 truncate">{commit.subject}</span>
+              </div>
+            ))}
+            {total > commits.length && (
+              <div className="text-muted-foreground">
+                and {total - commits.length} more
+              </div>
+            )}
+          </div>
+        </DetailBlock>
+      );
+    }
     case "pr_created":
     case "pr_merged":
     case "pr_closed":

--- a/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
@@ -61,7 +61,7 @@ export function TimelineRow({
   const [open, setOpen] = useState(defaultOpen);
   const hasDetail = detail !== undefined && detail !== null;
   const header = (
-    <div className="flex min-w-0 items-center gap-1.5 text-[12.5px] leading-[22px]">
+    <div className="flex min-w-0 flex-1 items-center gap-1.5 text-[12.5px] leading-[22px]">
       <span className="min-w-0 truncate">{children}</span>
       <ThreadTimestamp dateTime={timestamp} />
       {hasDetail && (
@@ -90,7 +90,9 @@ export function TimelineRow({
           on a single-line row the bead fills the content box and a flex child gets no
           height at all. */}
       <div className="relative flex w-10 shrink-0 justify-center self-stretch">
-        {gutter}
+        {/* h-[22px] is the copy's line height, so the bead centres on the first line
+            whatever the row grows to. */}
+        <div className="flex h-[22px] items-center">{gutter}</div>
         {connected && (
           <span
             aria-hidden
@@ -101,11 +103,13 @@ export function TimelineRow({
       <div className="min-w-0 flex-1">
         {hasDetail ? (
           <>
+            {/* flex, not block: an inline-level button contributes its own inherited
+                line-height as a strut, which pushed the copy 3px below the bead. */}
             <button
               type="button"
               aria-expanded={open}
               aria-label={ariaLabel}
-              className="w-full text-left focus-visible:outline-none"
+              className="flex w-full text-left focus-visible:outline-none"
               onClick={() => setOpen((current) => !current)}
             >
               {header}
@@ -509,5 +513,47 @@ export function ActivityLoadingState() {
         ))}
       </div>
     </output>
+  );
+}
+
+/** A human reply in the task's thread — the surface comments replaced. Collapsed like
+ *  everything else: author and first line on the row, the message when opened. */
+export function ThreadReplyRow({
+  author,
+  content,
+  timestamp,
+  connected = true,
+}: {
+  author?: UserBasic | null;
+  content: string;
+  timestamp: string;
+  connected?: boolean;
+}) {
+  const firstLine = content.trim().split("\n", 1)[0] ?? "";
+  return (
+    <TimelineRow
+      connected={connected}
+      gutter={
+        <div
+          aria-hidden
+          className="relative z-10 flex size-5 items-center justify-center overflow-hidden rounded-full border border-gray-7 ring-4 ring-gray-1"
+        >
+          <UserAvatar user={author} size="sm" className="size-5" />
+        </div>
+      }
+      timestamp={timestamp}
+      detail={
+        <DetailBlock>
+          <div className="whitespace-pre-wrap break-words">
+            <MentionText content={content} />
+          </div>
+        </DetailBlock>
+      }
+    >
+      <span className="font-medium">{userDisplayName(author)}</span>{" "}
+      <span className="text-muted-foreground">
+        <MentionText content={firstLine} />
+      </span>
+    </TimelineRow>
   );
 }

--- a/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
@@ -21,7 +21,14 @@ import {
   type ActivityEvent,
   prLabel,
 } from "@posthog/core/canvas/activityEvents";
-import { cn } from "@posthog/quill";
+import {
+  cn,
+  Empty,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+  Spinner,
+} from "@posthog/quill";
 import type {
   TaskCommentThreadSummary,
   UserBasic,
@@ -62,14 +69,15 @@ export function TimelineRow({
   return (
     <div
       className={cn(
-        "flex items-start gap-2 py-1.5 pr-2 pl-2",
-        onSelect && "cursor-pointer",
+        "group flex items-start gap-2 rounded-md py-2 pr-2 pl-2 transition-colors",
+        onSelect &&
+          "cursor-pointer hover:bg-gray-3 focus-visible:bg-gray-3 focus-visible:outline-none",
       )}
       {...activation}
     >
       <div className="flex w-10 shrink-0 justify-center">{gutter}</div>
-      <div className="min-w-0 flex-1">
-        <div className="flex min-w-0 items-center gap-1 text-[13px]">
+      <div className="min-w-0 flex-1 pt-0.5">
+        <div className="flex min-w-0 items-baseline gap-1.5 text-[13px] leading-5">
           <span className="min-w-0 truncate">{children}</span>
           <ThreadTimestamp dateTime={timestamp} />
         </div>
@@ -80,7 +88,7 @@ export function TimelineRow({
 
 function IconBubble({ children }: { children: ReactNode }) {
   return (
-    <span className="relative z-10 flex size-6 items-center justify-center rounded-full bg-gray-3">
+    <span className="relative z-10 flex size-6 items-center justify-center rounded-full bg-gray-3 ring-4 ring-gray-1">
       {children}
     </span>
   );
@@ -275,8 +283,9 @@ export function CommentRow({
   return (
     <div
       className={cn(
-        "flex items-start gap-2 py-1.5 pr-2 pl-2",
-        onSelect && "cursor-pointer",
+        "group flex items-start gap-2 rounded-md py-2 pr-2 pl-2 transition-colors",
+        onSelect &&
+          "cursor-pointer hover:bg-gray-3 focus-visible:bg-gray-3 focus-visible:outline-none",
       )}
       {...(onSelect
         ? {
@@ -298,7 +307,7 @@ export function CommentRow({
         </div>
       </div>
       <div className="min-w-0 flex-1">
-        <div className="flex min-w-0 items-center gap-1 text-[13px]">
+        <div className="flex min-w-0 items-baseline gap-1.5 text-[13px] leading-5">
           <span className="min-w-0 truncate">
             <span className="font-medium">{name}</span>{" "}
             <span className="text-muted-foreground">{verb}</span>{" "}
@@ -306,7 +315,7 @@ export function CommentRow({
           </span>
           <ThreadTimestamp dateTime={thread.last_activity_at} />
         </div>
-        <div className="mt-1 border-border border-l-2 pl-2">
+        <div className="mt-1.5 space-y-1 rounded-md border-border border-l-2 bg-gray-2 px-2.5 py-1.5">
           {thread.selected_text && (
             <div className="truncate text-[12.5px] text-muted-foreground italic">
               “{thread.selected_text}”
@@ -368,5 +377,20 @@ export function CommentStateRow({
       {resolved ? "resolved a thread on" : "reopened a thread on"}{" "}
       <span className="font-medium">{thread.target.name}</span>
     </TimelineRow>
+  );
+}
+
+/** Shown once, on the panel's first draw. The timeline never returns to it: a loader over
+ *  rows that are already on screen reads as the content disappearing. */
+export function ActivityLoadingState() {
+  return (
+    <Empty className="h-full border-0">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <Spinner />
+        </EmptyMedia>
+        <EmptyTitle>Loading timeline</EmptyTitle>
+      </EmptyHeader>
+    </Empty>
   );
 }

--- a/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
@@ -1,0 +1,372 @@
+/**
+ * The rows the activity timeline draws for one server-emitted event, and for one comment
+ * thread.
+ *
+ * Split out of `ActivityTimeline` so that component stays the merge plus the rail, and a
+ * new event is an entry in `EVENT_ICONS` plus a line of copy here.
+ */
+
+import {
+  ArrowRightIcon,
+  ArrowsClockwiseIcon,
+  CheckCircleIcon,
+  FileTextIcon,
+  GitPullRequestIcon,
+  PlayIcon,
+  WarningCircleIcon,
+  WarningIcon,
+  XCircleIcon,
+} from "@phosphor-icons/react";
+import {
+  type ActivityEvent,
+  prLabel,
+} from "@posthog/core/canvas/activityEvents";
+import { cn } from "@posthog/quill";
+import type {
+  TaskCommentThreadSummary,
+  UserBasic,
+} from "@posthog/shared/domain-types";
+import { UserAvatar } from "@posthog/ui/features/auth/UserAvatar";
+import { ThreadTimestamp } from "@posthog/ui/features/canvas/components/ThreadTimestamp";
+import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
+import type { ReactNode } from "react";
+
+/** A gutter node, a line of copy and a timestamp, at the same size as every other row's
+ *  copy: only the icon distinguishes a lifecycle row from its neighbours. */
+export function TimelineRow({
+  gutter,
+  children,
+  timestamp,
+  onSelect,
+  ariaLabel,
+}: {
+  gutter: ReactNode;
+  children: ReactNode;
+  timestamp: string;
+  onSelect?: () => void;
+  ariaLabel?: string;
+}) {
+  const activation = onSelect
+    ? {
+        role: "button" as const,
+        tabIndex: 0,
+        "aria-label": ariaLabel,
+        onClick: onSelect,
+        onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => {
+          if (event.key !== "Enter" && event.key !== " ") return;
+          event.preventDefault();
+          onSelect();
+        },
+      }
+    : {};
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-2 py-1.5 pr-2 pl-2",
+        onSelect && "cursor-pointer",
+      )}
+      {...activation}
+    >
+      <div className="flex w-10 shrink-0 justify-center">{gutter}</div>
+      <div className="min-w-0 flex-1">
+        <div className="flex min-w-0 items-center gap-1 text-[13px]">
+          <span className="min-w-0 truncate">{children}</span>
+          <ThreadTimestamp dateTime={timestamp} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function IconBubble({ children }: { children: ReactNode }) {
+  return (
+    <span className="relative z-10 flex size-6 items-center justify-center rounded-full bg-gray-3">
+      {children}
+    </span>
+  );
+}
+
+const EVENT_ICONS: Record<ActivityEvent["kind"], ReactNode> = {
+  run_started: <PlayIcon size={12} weight="fill" className="text-blue-9" />,
+  run_failed: <XCircleIcon size={14} weight="fill" className="text-red-9" />,
+  awaiting_input: (
+    <WarningIcon size={13} weight="fill" className="text-warning" />
+  ),
+  artifact_created: <FileTextIcon size={13} className="text-violet-9" />,
+  artifact_revised: <ArrowsClockwiseIcon size={12} className="text-violet-9" />,
+  canvas_created: <FileTextIcon size={13} className="text-violet-9" />,
+  pr_created: <GitPullRequestIcon size={13} className="text-gray-11" />,
+  pr_merged: <GitPullRequestIcon size={13} className="text-violet-9" />,
+  pr_closed: <GitPullRequestIcon size={13} className="text-red-9" />,
+  message_forwarded: <ArrowRightIcon size={12} className="text-blue-9" />,
+};
+
+/** The sentence an event reads as. Written so a person skimming the panel learns what
+ *  happened without opening anything. */
+function eventLabel(
+  event: ActivityEvent,
+  runCount: number,
+  runOrdinal: number,
+): ReactNode {
+  switch (event.kind) {
+    case "run_started": {
+      const details = [
+        event.payload.environment,
+        event.payload.branch || null,
+      ].filter(Boolean);
+      return (
+        <>
+          {/* A run number only helps once a task has run more than once. */}
+          {runCount > 1
+            ? `Agent started run ${runOrdinal}`
+            : "Agent started work"}
+          {details.length > 0 && (
+            <span className="text-muted-foreground">
+              {" "}
+              · {details.join(" · ")}
+            </span>
+          )}
+        </>
+      );
+    }
+    case "run_failed":
+      return event.payload.errorSummary ? (
+        <>
+          Run failed
+          <span className="text-muted-foreground">
+            {" "}
+            · {event.payload.errorSummary}
+          </span>
+        </>
+      ) : (
+        "Run failed"
+      );
+    case "awaiting_input":
+      return "Agent needs input";
+    case "artifact_created":
+      return (
+        <>
+          Agent created{" "}
+          <span className="font-medium">{event.payload.name}</span>
+        </>
+      );
+    case "artifact_revised":
+      return (
+        <>
+          Agent revised{" "}
+          <span className="font-medium">{event.payload.name}</span>
+          <span className="text-muted-foreground">
+            {" "}
+            · v{event.payload.version}
+          </span>
+        </>
+      );
+    case "canvas_created":
+      return (
+        <>
+          Agent created{" "}
+          <span className="font-medium">{event.payload.name}</span>
+        </>
+      );
+    case "pr_created":
+      return (
+        <>
+          Pull request opened
+          <span className="text-muted-foreground">
+            {" "}
+            · {prLabel(event.payload)}
+          </span>
+        </>
+      );
+    case "pr_merged":
+    case "pr_closed": {
+      const verb = event.kind === "pr_merged" ? "merged" : "closed";
+      return (
+        <>
+          {event.payload.actor
+            ? `${event.payload.actor} ${verb} `
+            : `Pull request ${verb} `}
+          <span className="text-muted-foreground">
+            {prLabel(event.payload)}
+          </span>
+        </>
+      );
+    }
+    case "message_forwarded":
+      return "Message sent to the agent";
+  }
+}
+
+export function ActivityEventRow({
+  event,
+  timestamp,
+  runCount,
+  runOrdinal = 1,
+  onSelect,
+}: {
+  event: ActivityEvent;
+  timestamp: string;
+  /** How many runs the task has, so a single-run task doesn't say "run 1". */
+  runCount: number;
+  /** Which run this row starts, counted over the feed rather than stamped by the backend. */
+  runOrdinal?: number;
+  onSelect?: () => void;
+}) {
+  return (
+    <TimelineRow
+      gutter={<IconBubble>{EVENT_ICONS[event.kind]}</IconBubble>}
+      timestamp={timestamp}
+      onSelect={onSelect}
+    >
+      {eventLabel(event, runCount, runOrdinal)}
+    </TimelineRow>
+  );
+}
+
+/** A lifecycle marker derived from the task rather than an event row — the ending of a run
+ *  that predates the event rows. */
+export function RunStatusRow({
+  status,
+  timestamp,
+}: {
+  status: string;
+  timestamp: string;
+}) {
+  const succeeded = status === "completed";
+  return (
+    <TimelineRow
+      gutter={
+        <IconBubble>
+          {succeeded ? (
+            <CheckCircleIcon size={14} weight="fill" className="text-green-9" />
+          ) : (
+            <XCircleIcon size={14} weight="fill" className="text-red-9" />
+          )}
+        </IconBubble>
+      }
+      timestamp={timestamp}
+    >
+      {`Task ${status.replace(/_/g, " ")}`}
+    </TimelineRow>
+  );
+}
+
+function participantNames(participants: UserBasic[]): string {
+  return participants.map((person) => userDisplayName(person)).join(", ");
+}
+
+/**
+ * One comment thread. The anchor's quoted selection travels with the row, because a
+ * comment without the text it points at is just a notification.
+ */
+export function CommentRow({
+  thread,
+  isMentioned,
+  onSelect,
+}: {
+  thread: TaskCommentThreadSummary;
+  /** The current user was mentioned somewhere in the thread. */
+  isMentioned: boolean;
+  onSelect?: () => void;
+}) {
+  const author = thread.author ?? null;
+  const name = userDisplayName(author);
+  const verb = isMentioned ? "mentioned you on" : "commented on";
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-2 py-1.5 pr-2 pl-2",
+        onSelect && "cursor-pointer",
+      )}
+      {...(onSelect
+        ? {
+            role: "button" as const,
+            tabIndex: 0,
+            onClick: onSelect,
+            onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => {
+              if (event.key !== "Enter" && event.key !== " ") return;
+              event.preventDefault();
+              onSelect();
+            },
+          }
+        : {})}
+    >
+      <div className="flex w-10 shrink-0 justify-center">
+        {/* Decorative: the author's name is written beside it. */}
+        <div aria-hidden>
+          <UserAvatar user={author} size="sm" className="sticky top-2" />
+        </div>
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex min-w-0 items-center gap-1 text-[13px]">
+          <span className="min-w-0 truncate">
+            <span className="font-medium">{name}</span>{" "}
+            <span className="text-muted-foreground">{verb}</span>{" "}
+            <span className="font-medium">{thread.target.name}</span>
+          </span>
+          <ThreadTimestamp dateTime={thread.last_activity_at} />
+        </div>
+        <div className="mt-1 border-border border-l-2 pl-2">
+          {thread.selected_text && (
+            <div className="truncate text-[12.5px] text-muted-foreground italic">
+              “{thread.selected_text}”
+            </div>
+          )}
+          <div className="line-clamp-2 whitespace-pre-wrap break-words text-[12.5px]">
+            {thread.content}
+          </div>
+        </div>
+        {thread.reply_count > 0 && (
+          <div className="mt-1 truncate text-[12.5px] text-muted-foreground">
+            {thread.reply_count}{" "}
+            {thread.reply_count === 1 ? "reply" : "replies"}
+            {thread.participants.length > 0 &&
+              ` · ${participantNames(thread.participants)}`}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Resolve and reopen: state changes with an author and a time, so they read as their own
+ *  rows rather than a property of the thread above. */
+export function CommentStateRow({
+  thread,
+  state,
+  onSelect,
+}: {
+  thread: TaskCommentThreadSummary;
+  state: string;
+  onSelect?: () => void;
+}) {
+  const author = thread.state_event?.author ?? null;
+  const resolved = state === "resolved";
+  return (
+    <TimelineRow
+      gutter={
+        <IconBubble>
+          {resolved ? (
+            <CheckCircleIcon size={14} weight="fill" className="text-green-9" />
+          ) : (
+            <WarningCircleIcon
+              size={14}
+              weight="fill"
+              className="text-warning"
+            />
+          )}
+        </IconBubble>
+      }
+      timestamp={thread.state_event?.created_at ?? thread.last_activity_at}
+      onSelect={onSelect}
+    >
+      {author ? (
+        <span className="font-medium">{userDisplayName(author)}</span>
+      ) : (
+        "Someone"
+      )}{" "}
+      {resolved ? "resolved a thread on" : "reopened a thread on"}{" "}
+      <span className="font-medium">{thread.target.name}</span>
+    </TimelineRow>
+  );
+}

--- a/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
@@ -44,7 +44,8 @@ export function TimelineRow({
   timestamp,
   detail,
   defaultOpen = false,
-  connected = true,
+  connectedAbove = true,
+  connectedBelow = true,
   ariaLabel,
 }: {
   gutter: ReactNode;
@@ -55,7 +56,8 @@ export function TimelineRow({
   defaultOpen?: boolean;
   /** Draw the line down to the next row. False on the last row, which has nothing to
    *  connect to. */
-  connected?: boolean;
+  connectedAbove?: boolean;
+  connectedBelow?: boolean;
   ariaLabel?: string;
 }) {
   const [open, setOpen] = useState(defaultOpen);
@@ -84,21 +86,27 @@ export function TimelineRow({
           "cursor-pointer focus-within:bg-gray-2 hover:bg-gray-2 has-[:focus-visible]:bg-gray-2",
       )}
     >
-      {/* The connector sits inside the row, so the hover fill paints behind it rather than
-          over it. It runs from just under this row's bead to the row's bottom edge; the next
-          row's top padding leaves the gap before its bead. Positioned rather than flexed:
-          on a single-line row the bead fills the content box and a flex child gets no
-          height at all. */}
+      {/* The connector lives inside the row, so the hover fill paints behind it rather than
+          over it, and consecutive rows' segments meet to form one line. It runs through the
+          bead's centre; the bead is opaque and sits above it, so the line reads as touching
+          it on both sides. The halves are separate so the first and last rows stop at their
+          own bead instead of running past it. */}
       <div className="relative flex w-10 shrink-0 justify-center self-stretch">
-        {/* h-[22px] is the copy's line height, so the bead centres on the first line
-            whatever the row grows to. */}
-        <div className="flex h-[22px] items-center">{gutter}</div>
-        {connected && (
+        {connectedAbove && (
           <span
             aria-hidden
-            className="-translate-x-1/2 -bottom-1.5 absolute top-6 left-1/2 w-px bg-gray-8"
+            className="-translate-x-1/2 absolute top-0 left-1/2 h-[11px] w-px bg-gray-8"
           />
         )}
+        {connectedBelow && (
+          <span
+            aria-hidden
+            className="-translate-x-1/2 absolute top-[11px] bottom-0 left-1/2 w-px bg-gray-8"
+          />
+        )}
+        {/* h-[22px] is the copy's line height, so the bead centres on the first line
+            whatever the row grows to. */}
+        <div className="relative z-10 flex h-[22px] items-center">{gutter}</div>
       </div>
       <div className="min-w-0 flex-1">
         {hasDetail ? (
@@ -148,7 +156,7 @@ function IconBubble({
   return (
     <span
       className={cn(
-        "relative z-10 flex size-5 items-center justify-center rounded-full border ring-4 ring-gray-1",
+        "relative z-10 flex size-5 items-center justify-center rounded-full border",
         BEAD_TONES[tone],
       )}
     >
@@ -321,9 +329,11 @@ export function ActivityEventRow({
   runCount,
   runOrdinal = 1,
   detail,
-  connected = true,
+  connectedAbove = true,
+  connectedBelow = true,
 }: {
-  connected?: boolean;
+  connectedAbove?: boolean;
+  connectedBelow?: boolean;
   event: ActivityEvent;
   timestamp: string;
   /** How many runs the task has, so a single-run task doesn't say "run 1". */
@@ -336,7 +346,8 @@ export function ActivityEventRow({
 }) {
   return (
     <TimelineRow
-      connected={connected}
+      connectedAbove={connectedAbove}
+      connectedBelow={connectedBelow}
       gutter={
         <IconBubble tone={EVENT_TONES[event.kind]}>
           {EVENT_ICONS[event.kind]}
@@ -355,16 +366,19 @@ export function ActivityEventRow({
 export function RunStatusRow({
   status,
   timestamp,
-  connected = true,
+  connectedAbove = true,
+  connectedBelow = true,
 }: {
   status: string;
   timestamp: string;
-  connected?: boolean;
+  connectedAbove?: boolean;
+  connectedBelow?: boolean;
 }) {
   const succeeded = status === "completed";
   return (
     <TimelineRow
-      connected={connected}
+      connectedAbove={connectedAbove}
+      connectedBelow={connectedBelow}
       gutter={
         <IconBubble tone={succeeded ? "green" : "red"}>
           {succeeded ? (
@@ -394,9 +408,11 @@ export function CommentRow({
   thread,
   isMentioned,
   onSelect,
-  connected = true,
+  connectedAbove = true,
+  connectedBelow = true,
 }: {
-  connected?: boolean;
+  connectedAbove?: boolean;
+  connectedBelow?: boolean;
   thread: TaskCommentThreadSummary;
   /** The current user was mentioned somewhere in the thread. */
   isMentioned: boolean;
@@ -407,13 +423,11 @@ export function CommentRow({
   const verb = isMentioned ? "mentioned you on" : "commented on";
   return (
     <TimelineRow
-      connected={connected}
+      connectedAbove={connectedAbove}
+      connectedBelow={connectedBelow}
       gutter={
         // Decorative: the author's name is written beside it.
-        <div
-          aria-hidden
-          className="relative z-10 rounded-full ring-4 ring-gray-1"
-        >
+        <div aria-hidden className="relative z-10 rounded-full">
           <UserAvatar user={author} size="sm" />
         </div>
       }
@@ -456,17 +470,20 @@ export function CommentRow({
 export function CommentStateRow({
   thread,
   state,
-  connected = true,
+  connectedAbove = true,
+  connectedBelow = true,
 }: {
   thread: TaskCommentThreadSummary;
   state: string;
-  connected?: boolean;
+  connectedAbove?: boolean;
+  connectedBelow?: boolean;
 }) {
   const author = thread.state_event?.author ?? null;
   const resolved = state === "resolved";
   return (
     <TimelineRow
-      connected={connected}
+      connectedAbove={connectedAbove}
+      connectedBelow={connectedBelow}
       gutter={
         <IconBubble tone={resolved ? "green" : "amber"}>
           {resolved ? (
@@ -501,7 +518,7 @@ export function ActivityLoadingState() {
         {[36, 52, 44, 60, 40].map((width) => (
           <div key={width} className="flex items-start gap-2 py-1 pr-2 pl-2">
             <div className="flex w-10 shrink-0 justify-center">
-              <Skeleton className="size-5 rounded-full ring-4 ring-gray-1" />
+              <Skeleton className="size-5 rounded-full" />
             </div>
             <div className="min-w-0 flex-1 py-1">
               <Skeleton
@@ -522,21 +539,24 @@ export function ThreadReplyRow({
   author,
   content,
   timestamp,
-  connected = true,
+  connectedAbove = true,
+  connectedBelow = true,
 }: {
   author?: UserBasic | null;
   content: string;
   timestamp: string;
-  connected?: boolean;
+  connectedAbove?: boolean;
+  connectedBelow?: boolean;
 }) {
   const firstLine = content.trim().split("\n", 1)[0] ?? "";
   return (
     <TimelineRow
-      connected={connected}
+      connectedAbove={connectedAbove}
+      connectedBelow={connectedBelow}
       gutter={
         <div
           aria-hidden
-          className="relative z-10 flex size-5 items-center justify-center overflow-hidden rounded-full border border-gray-7 ring-4 ring-gray-1"
+          className="relative z-10 flex size-5 items-center justify-center overflow-hidden rounded-full border border-gray-7"
         >
           <UserAvatar user={author} size="sm" className="size-5" />
         </div>

--- a/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/activityRows.tsx
@@ -75,7 +75,7 @@ export function TimelineRow({
   return (
     <div
       className={cn(
-        "group flex items-start gap-2 rounded-md py-1 pr-2 pl-2 transition-colors",
+        "group flex items-start gap-2 rounded-md py-1.5 pr-2 pl-2 transition-colors",
         hasDetail &&
           "cursor-pointer focus-within:bg-gray-2 hover:bg-gray-2 has-[:focus-visible]:bg-gray-2",
       )}
@@ -103,29 +103,63 @@ export function TimelineRow({
   );
 }
 
-function IconBubble({ children }: { children: ReactNode }) {
+/** Each bead is tinted to its event's hue: a wash for the fill, a step up for the edge, and
+ *  the high-contrast step for the glyph. Neutral rows keep the gray bead, so colour means
+ *  something rather than decorating every row. */
+const BEAD_TONES = {
+  neutral: "border-gray-7 bg-gray-5 text-gray-12",
+  blue: "border-blue-7 bg-blue-4 text-blue-11",
+  green: "border-green-7 bg-green-4 text-green-11",
+  amber: "border-amber-7 bg-amber-4 text-amber-11",
+  violet: "border-violet-7 bg-violet-4 text-violet-11",
+  red: "border-red-7 bg-red-4 text-red-11",
+} as const;
+
+type BeadTone = keyof typeof BEAD_TONES;
+
+function IconBubble({
+  children,
+  tone = "neutral",
+}: {
+  children: ReactNode;
+  tone?: BeadTone;
+}) {
   return (
-    <span className="relative z-10 flex size-5 items-center justify-center rounded-full bg-gray-3 ring-4 ring-gray-1">
+    <span
+      className={cn(
+        "relative z-10 flex size-5 items-center justify-center rounded-full border ring-4 ring-gray-1",
+        BEAD_TONES[tone],
+      )}
+    >
       {children}
     </span>
   );
 }
 
+const EVENT_TONES: Record<ActivityEvent["kind"], BeadTone> = {
+  run_started: "blue",
+  run_failed: "red",
+  awaiting_input: "amber",
+  artifact_created: "violet",
+  artifact_revised: "violet",
+  canvas_created: "violet",
+  pr_created: "neutral",
+  pr_merged: "violet",
+  pr_closed: "red",
+  message_forwarded: "blue",
+};
+
 const EVENT_ICONS: Record<ActivityEvent["kind"], ReactNode> = {
-  run_started: <PlayIcon size={10} weight="fill" className="text-blue-11" />,
-  run_failed: <XCircleIcon size={12} weight="fill" className="text-red-11" />,
-  awaiting_input: (
-    <WarningIcon size={11} weight="fill" className="text-amber-11" />
-  ),
-  artifact_created: <FileTextIcon size={11} className="text-violet-11" />,
-  artifact_revised: (
-    <ArrowsClockwiseIcon size={12} className="text-violet-11" />
-  ),
-  canvas_created: <FileTextIcon size={11} className="text-violet-11" />,
-  pr_created: <GitPullRequestIcon size={11} className="text-gray-12" />,
-  pr_merged: <GitPullRequestIcon size={11} className="text-violet-11" />,
-  pr_closed: <GitPullRequestIcon size={11} className="text-red-11" />,
-  message_forwarded: <ArrowRightIcon size={11} className="text-blue-11" />,
+  run_started: <PlayIcon size={10} weight="fill" />,
+  run_failed: <XCircleIcon size={12} weight="fill" />,
+  awaiting_input: <WarningIcon size={11} weight="fill" />,
+  artifact_created: <FileTextIcon size={11} />,
+  artifact_revised: <ArrowsClockwiseIcon size={12} />,
+  canvas_created: <FileTextIcon size={11} />,
+  pr_created: <GitPullRequestIcon size={11} />,
+  pr_merged: <GitPullRequestIcon size={11} />,
+  pr_closed: <GitPullRequestIcon size={11} />,
+  message_forwarded: <ArrowRightIcon size={11} />,
 };
 
 /** The sentence an event reads as. Written so a person skimming the panel learns what
@@ -235,6 +269,26 @@ function eventDetail(event: ActivityEvent): ReactNode {
   }
 }
 
+/** A quiet inline action under an opened row — reads as a link, not a form control. */
+export function DetailAction({
+  children,
+  onClick,
+}: {
+  children: ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline-flex items-center gap-1 rounded px-0.5 text-[12px] text-muted-foreground underline-offset-2 transition-colors hover:text-gray-12 hover:underline"
+    >
+      {children}
+      <CaretRightIcon size={10} />
+    </button>
+  );
+}
+
 /** The shared shape of an opened row's content: one quoted block, indented to the copy. */
 export function DetailBlock({ children }: { children: ReactNode }) {
   return (
@@ -263,7 +317,11 @@ export function ActivityEventRow({
 }) {
   return (
     <TimelineRow
-      gutter={<IconBubble>{EVENT_ICONS[event.kind]}</IconBubble>}
+      gutter={
+        <IconBubble tone={EVENT_TONES[event.kind]}>
+          {EVENT_ICONS[event.kind]}
+        </IconBubble>
+      }
       timestamp={timestamp}
       detail={detail ?? eventDetail(event)}
     >
@@ -285,15 +343,11 @@ export function RunStatusRow({
   return (
     <TimelineRow
       gutter={
-        <IconBubble>
+        <IconBubble tone={succeeded ? "green" : "red"}>
           {succeeded ? (
-            <CheckCircleIcon
-              size={12}
-              weight="fill"
-              className="text-green-11"
-            />
+            <CheckCircleIcon size={12} weight="fill" />
           ) : (
-            <XCircleIcon size={12} weight="fill" className="text-red-11" />
+            <XCircleIcon size={12} weight="fill" />
           )}
         </IconBubble>
       }
@@ -359,9 +413,7 @@ export function CommentRow({
             </div>
           )}
           {onSelect && (
-            <Button variant="default" size="sm" onClick={onSelect}>
-              Open thread
-            </Button>
+            <DetailAction onClick={onSelect}>Open thread</DetailAction>
           )}
         </div>
       }
@@ -387,19 +439,11 @@ export function CommentStateRow({
   return (
     <TimelineRow
       gutter={
-        <IconBubble>
+        <IconBubble tone={resolved ? "green" : "amber"}>
           {resolved ? (
-            <CheckCircleIcon
-              size={12}
-              weight="fill"
-              className="text-green-11"
-            />
+            <CheckCircleIcon size={12} weight="fill" />
           ) : (
-            <WarningCircleIcon
-              size={12}
-              weight="fill"
-              className="text-amber-11"
-            />
+            <WarningCircleIcon size={12} weight="fill" />
           )}
         </IconBubble>
       }
@@ -425,7 +469,7 @@ export function ActivityLoadingState() {
     <output className="relative block px-1 py-2" aria-label="Loading timeline">
       <div
         aria-hidden
-        className="pointer-events-none absolute top-5 bottom-5 left-8 w-px bg-border"
+        className="pointer-events-none absolute top-5 bottom-5 left-8 w-px bg-gray-8"
       />
       <div className="relative z-10">
         {/* Widths vary so the block reads as copy rather than a progress bar. */}

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useTaskCommentActivity.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useTaskCommentActivity.ts
@@ -1,0 +1,30 @@
+import type { TaskCommentThreadSummary } from "@posthog/shared/domain-types";
+import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
+
+/** Comments move at human pace, so this polls slower than the 5s thread poll. The
+ *  Comments tab keeps its own faster poll for the surface people type into. */
+const POLL_INTERVAL_MS = 15_000;
+
+/**
+ * The task's comment threads for the activity timeline.
+ *
+ * Deliberately not patched by the optimistic comment writes in `useComments`: a comment
+ * you just left shows up within one poll, and cross-patching two differently shaped caches
+ * is how they drift apart.
+ */
+export function useTaskCommentActivity(
+  taskId: string | undefined,
+  options: { enabled?: boolean } = {},
+): { threads: TaskCommentThreadSummary[]; isLoading: boolean } {
+  const enabled = options.enabled !== false && !!taskId;
+  const query = useAuthenticatedQuery<TaskCommentThreadSummary[]>(
+    ["task-comment-activity", taskId ?? "none"],
+    (client) => client.getTaskCommentActivity(taskId as string),
+    {
+      enabled,
+      refetchInterval: POLL_INTERVAL_MS,
+      staleTime: POLL_INTERVAL_MS,
+    },
+  );
+  return { threads: query.data ?? [], isLoading: query.isLoading };
+}

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useTaskCommentActivity.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useTaskCommentActivity.ts
@@ -15,7 +15,13 @@ const POLL_INTERVAL_MS = 15_000;
 export function useTaskCommentActivity(
   taskId: string | undefined,
   options: { enabled?: boolean } = {},
-): { threads: TaskCommentThreadSummary[]; isLoading: boolean } {
+): {
+  threads: TaskCommentThreadSummary[];
+  isLoading: boolean;
+  /** The first fetch has finished (or was never asked for). The timeline waits on this so
+   *  it draws once, complete, instead of drawing thread rows and then adding comments. */
+  hasLoaded: boolean;
+} {
   const enabled = options.enabled !== false && !!taskId;
   const query = useAuthenticatedQuery<TaskCommentThreadSummary[]>(
     ["task-comment-activity", taskId ?? "none"],
@@ -26,5 +32,9 @@ export function useTaskCommentActivity(
       staleTime: POLL_INTERVAL_MS,
     },
   );
-  return { threads: query.data ?? [], isLoading: query.isLoading };
+  return {
+    threads: query.data ?? [],
+    isLoading: query.isLoading,
+    hasLoaded: !enabled || query.isSuccess || query.isError,
+  };
 }

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useTaskThread.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useTaskThread.ts
@@ -26,6 +26,9 @@ export function useTaskThread(
 ): {
   messages: TaskThreadMessage[];
   isLoading: boolean;
+  /** The thread has come back at least once. Distinct from `!isLoading`, which flips back
+   *  on a refetch and would blink a loader over content already on screen. */
+  hasLoaded: boolean;
 } {
   const pollIntervalMs = options?.pollIntervalMs ?? THREAD_POLL_INTERVAL_MS;
   const enabled = options?.enabled ?? true;
@@ -60,7 +63,11 @@ export function useTaskThread(
     opening,
     query.dataUpdatedAt,
   ]);
-  return { messages: query.data ?? [], isLoading: query.isLoading };
+  return {
+    messages: query.data ?? [],
+    isLoading: query.isLoading,
+    hasLoaded: query.isSuccess || query.isError,
+  };
 }
 
 export function usePostTaskThreadMessage(taskId: string | undefined) {

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useThreadConversation.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useThreadConversation.ts
@@ -41,7 +41,7 @@ export interface ThreadConversation {
   isPromptPending: boolean;
   isReady: boolean;
   members: UserBasic[];
-  currentUser: { uuid?: string; email?: string } | undefined;
+  currentUser: { id?: number; uuid?: string; email?: string } | undefined;
   isTaskAuthor: boolean;
   canForward: boolean;
   draft: string;

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useThreadConversation.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useThreadConversation.ts
@@ -40,6 +40,9 @@ export interface ThreadConversation {
   events: SessionEvents;
   isPromptPending: boolean;
   isReady: boolean;
+  /** The thread's own durable content has arrived. The timeline draws on this rather than
+   *  on `isReady`, which also waits for the live session to connect. */
+  hasLoadedThread: boolean;
   members: UserBasic[];
   currentUser: { id?: number; uuid?: string; email?: string } | undefined;
   isTaskAuthor: boolean;
@@ -61,7 +64,11 @@ export function useThreadConversation(
   const client = useOptionalAuthenticatedClient();
   const { data: currentUser } = useCurrentUser({ client });
 
-  const { messages, isLoading } = useTaskThread(taskId);
+  const {
+    messages,
+    isLoading,
+    hasLoaded: hasLoadedThread,
+  } = useTaskThread(taskId);
   const { postMessage, isPosting } = usePostTaskThreadMessage(taskId);
   const { postMessageToAgent, isPostingToAgent } =
     usePostTaskThreadMessageToAgent(taskId);
@@ -198,6 +205,7 @@ export function useThreadConversation(
     events,
     isPromptPending,
     isReady: !isInitializing && !isLoading,
+    hasLoadedThread,
     members,
     currentUser,
     isTaskAuthor,

--- a/products/desktop/packages/ui/src/features/sessions/threadNavigationStore.ts
+++ b/products/desktop/packages/ui/src/features/sessions/threadNavigationStore.ts
@@ -4,11 +4,16 @@ import { create } from "zustand";
 interface ThreadNavigationStoreState {
   /** taskId → conversation item id the transcript should scroll to, if any. */
   scrollRequests: Record<string, string | null>;
+  /** taskId → how many transcripts are mounted and listening. A request with no
+   *  listener goes nowhere, so callers offer the jump only when this is non-zero. */
+  listeners: Record<string, number>;
 }
 
 interface ThreadNavigationStoreActions {
   requestScrollToMessage: (taskId: string, messageId: string) => void;
   clearScrollRequest: (taskId: string) => void;
+  registerTranscript: (taskId: string) => void;
+  unregisterTranscript: (taskId: string) => void;
 }
 
 type ThreadNavigationStore = ThreadNavigationStoreState &
@@ -24,6 +29,7 @@ type ThreadNavigationStore = ThreadNavigationStoreState &
 export const useThreadNavigationStore = create<ThreadNavigationStore>()(
   (set) => ({
     scrollRequests: {},
+    listeners: {},
 
     requestScrollToMessage: (taskId, messageId) =>
       set((state) => ({
@@ -34,6 +40,23 @@ export const useThreadNavigationStore = create<ThreadNavigationStore>()(
       set((state) => ({
         scrollRequests: { ...state.scrollRequests, [taskId]: null },
       })),
+
+    registerTranscript: (taskId) =>
+      set((state) => ({
+        listeners: {
+          ...state.listeners,
+          [taskId]: (state.listeners[taskId] ?? 0) + 1,
+        },
+      })),
+
+    unregisterTranscript: (taskId) =>
+      set((state) => {
+        const next = (state.listeners[taskId] ?? 0) - 1;
+        const listeners = { ...state.listeners };
+        if (next > 0) listeners[taskId] = next;
+        else delete listeners[taskId];
+        return { listeners };
+      }),
   }),
 );
 
@@ -50,10 +73,27 @@ export function useThreadScrollRequest(
     taskId ? state.scrollRequests[taskId] : null,
   );
 
+  // Announce that this transcript can answer a jump, so a pane that offers one can hide
+  // the affordance when nothing is listening — a dead button is worse than no button.
+  useEffect(() => {
+    if (!taskId) return;
+    const { registerTranscript, unregisterTranscript } =
+      useThreadNavigationStore.getState();
+    registerTranscript(taskId);
+    return () => unregisterTranscript(taskId);
+  }, [taskId]);
+
   useEffect(() => {
     if (!taskId || !requestedMessageId) return;
     jumpToMessage(requestedMessageId);
     // Clear via getState so the action isn't an effect dependency.
     useThreadNavigationStore.getState().clearScrollRequest(taskId);
   }, [taskId, requestedMessageId, jumpToMessage]);
+}
+
+/** Whether a transcript for this task is mounted to answer a scroll request. */
+export function useHasTranscriptListener(taskId: string | undefined): boolean {
+  return useThreadNavigationStore((state) =>
+    taskId ? (state.listeners[taskId] ?? 0) > 0 : false,
+  );
 }


### PR DESCRIPTION
## Problem

A person opening a task's Timeline tab sees three rows: the task was created, a pull request appeared, the task finished.
Everything they actually want is somewhere else — the agent sat blocked for 34 minutes, an artifact reached version 2, someone left a comment on a canvas, a mention pulled a second person in.
Now that comments and mentions exist, the timeline is where someone should catch up on a task without opening four tabs.

Top layer of a four-PR stack. The three below add the events and the comment read surface; this one draws them.

Replaces #80661, respun onto today's master.

## Changes

![Timeline with every row type](https://raw.githubusercontent.com/PostHog/pr-assets/62e646ddfb8dbe206a7263382ae448bd7779e168/2026/08/f1f81973-a9f5-4eb7-bdc6-3fc46564e15a.png)

New rows: agent started work, agent needs input, run failed with the first line of its error, artifact created and revised with its version, message sent to the agent, pull request merged or closed, comments with the text they point at, and resolve or reopen.

- A comment thread is one row, positioned at its newest reply, carrying the reply count and everyone who spoke. One row per reply would push the rest of the task off the panel.
- A comment row shows the anchor's quoted selection. A comment without the text it points at is just a notification.
- Clicking a comment focuses it on its anchor through `commentNavigationStore`, the same path the Activity feed's notification rows already take, so tab switching and canvas versions come for free.
- Resolve and reopen are their own rows, with who did it.
- A row reads "mentioned you" only when the mention is of the reader; otherwise it names who was mentioned.
- A run is numbered only once a task has run more than once. "Run 1" on a single-run task is noise. The number comes from counting `run_started` rows over the feed, because the backend cannot number them without racing concurrent run creations.

The merge moves into `buildActivityTimeline` in `packages/core`, so ordering, dedupe and collapsing are testable without rendering anything — the same split `threadTimeline.ts` uses. Rows sort by time, then by a per-kind rank. The old code nudged a timestamp by a millisecond to force the status row last, which breaks the moment two events share a timestamp.

Unknown events render nothing, which is what lets the backend layers deploy ahead of a desktop release. A test asserts the TypeScript vocabulary matches `TaskActivityEvent` in the backend, so adding an event on one side only fails CI.

Comment rows are gated by `posthog-code-comments`; `buildActivityTimeline` drops the comment feed when it is off rather than leaving the renderer to hide rows it was handed. The comment feed is one request for the whole task, polled at 15s, and deliberately not patched by the optimistic comment writes in `useComments` — cross-patching two differently shaped caches is how they drift.

## How did you test this code?

The screenshot above is the new `Canvas/ActivityTimeline` Storybook story, rendered headless from a Storybook build. Row order, copy and gutter alignment were checked against the DOM: every gutter node centers on the rail (`145px` in that render) and nothing overflows the 468px panel.

New tests, each naming a regression:

- Core: a comment thread sorts by newest activity, not creation; resolve gets its own row; the comment feed disappears when comments are off; two announcements of one PR collapse to a single row; an unknown event renders nothing; a `run_failed` event suppresses the derived status row so the reason is not replaced by "Task failed".
- UI: a failed run writes its reason on the row; a run is labeled only when the task has several; the anchor renders with its comment; a mention of you reads differently from a mention of someone else; resolve names who resolved it.

Ran locally: `@posthog/core` and `@posthog/ui` canvas suites, and `tsc --noEmit` for core, ui and api-client.

Not checked: no run against a live backend. Every fixture is local, so the payload shapes are only as right as the serializers in the layer below.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by PostHog Code (claude-opus-5). Skills invoked: `/writing-pr-descriptions`, `/writing-tests`, `/writing-user-facing-copy` for the row copy.

The session began with a proposal for which events belong on the panel, reviewed through comments on the artifact, then a technical plan; the four-PR split follows that plan's phases. Two rounds of review feedback shaped what shipped: git and CI events were considered and deliberately left out of this stack (commits need the GitHub `push` webhook, failing checks need a `check_suite` subscription), and a filter bar was dropped in favor of one list.

`ActivityTimeline` keeps its existing props and rebuilds the message list from the `timeline` rows it is already handed, so `ActivityPanel` and the channel sidebar need no restructuring in this PR.

Public artifact: no material from the session that isn't already public. Every fixture, including the story behind the screenshot, is invented.

