### PR TITLE
feat(review-hog): allow reviews on posthog.com

### DIFF
--- a/.github/workflows/review-hog.yml
+++ b/.github/workflows/review-hog.yml
@@ -9,9 +9,6 @@
 # checkout, no app token, no Anthropic key here — the only secret is the shared trigger token.
 # Publishing happens server-side via the PostHog GitHub App installation token.
 #
-# PostHog/posthog.com carries a copy of this file; keep the two in sync. The repos ReviewHog accepts
-# are allowlisted server-side in products/review_hog/backend/api/trigger.py.
-#
 # Safety: `pull_request_target` always runs the base branch's version of this file, so a PR cannot
 # edit its own trigger, and it fires even when the PR has merge conflicts. It does expose secrets to
 # fork PRs, so the `if:` hard-gates forks — safe because this job never checks out or runs PR code.

--- a/.github/workflows/review-hog.yml
+++ b/.github/workflows/review-hog.yml
@@ -9,6 +9,9 @@
 # checkout, no app token, no Anthropic key here — the only secret is the shared trigger token.
 # Publishing happens server-side via the PostHog GitHub App installation token.
 #
+# PostHog/posthog.com carries a copy of this file; keep the two in sync. The repos ReviewHog accepts
+# are allowlisted server-side in products/review_hog/backend/api/trigger.py.
+#
 # Safety: `pull_request_target` always runs the base branch's version of this file, so a PR cannot
 # edit its own trigger, and it fires even when the PR has merge conflicts. It does expose secrets to
 # fork PRs, so the `if:` hard-gates forks — safe because this job never checks out or runs PR code.

--- a/products/review_hog/backend/api/trigger.py
+++ b/products/review_hog/backend/api/trigger.py
@@ -18,8 +18,8 @@ from products.review_hog.backend.temporal.types import TRIGGER_LABEL
 
 logger = logging.getLogger(__name__)
 
-# v1 scope: ReviewHog only runs against the main PostHog monorepo. Matched case-insensitively.
-ALLOWED_REPOS = {"posthog/posthog"}
+# ReviewHog runs against the main PostHog monorepo and the website/docs repo. Matched case-insensitively.
+ALLOWED_REPOS = {"posthog/posthog", "posthog/posthog.com"}
 
 
 class ReviewHogTriggerRequestSerializer(serializers.Serializer):

--- a/products/review_hog/backend/tests/test_trigger_api.py
+++ b/products/review_hog/backend/tests/test_trigger_api.py
@@ -92,16 +92,23 @@ class TestReviewHogTriggerApi(APIBaseTest):
         self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
         mock_start.assert_not_called()
 
+    @parameterized.expand(
+        [
+            ("monorepo_lowercase", "posthog/posthog"),
+            ("website", "PostHog/posthog.com"),
+            ("website_lowercase", "posthog/posthog.com"),
+        ]
+    )
     @patch(_START, return_value="wf-1")
-    def test_allowlist_is_case_insensitive(self, mock_start):
+    def test_allowed_repos_accepted(self, _name, repo, mock_start):
         resp = self.client.post(
             TRIGGER_URL,
-            {"repo": "posthog/posthog", "pr_number": 7},
+            {"repo": repo, "pr_number": 7},
             format="json",
             HTTP_AUTHORIZATION="Bearer secret-token",
         )
         self.assertEqual(resp.status_code, status.HTTP_202_ACCEPTED, resp.content)
-        mock_start.assert_called_once()
+        self.assertEqual(mock_start.call_args.kwargs["pr_url"], f"https://github.com/{repo}/pull/7")
 
     @override_settings(REVIEWHOG_TEAM_ID=None)
     @patch(_START, return_value="wf-1")


### PR DESCRIPTION
## Problem

Anyone reviewing a PostHog/posthog.com pull request can add the `reviewhog` label, and nothing happens. The label exists on that repo, so the request looks accepted and then no review ever arrives.

ReviewHog checks the repository against a server-side allowlist that held one entry, the monorepo. A trigger from posthog.com gets a 403.

## Changes

- The trigger endpoint now admits `posthog/posthog.com` alongside `posthog/posthog`.

The label also needs a workflow in the target repository to send the trigger. [PostHog/posthog.com#19362](https://github.com/PostHog/posthog.com/pull/19362) adds it. The two pull requests are independent and can merge in either order. The label starts working once both land.

Two setup steps sit outside both diffs:

- Actions in posthog.com need to read the `REVIEWHOG_TRIGGER_TOKEN` secret. The workflow fails with a clear error if they cannot.
- The PostHog GitHub App installation for the ReviewHog team needs access to posthog.com. Without it the review runs and then fails to publish.

## How did you test this code?

I (actually the PostHog Slack app) extended `test_allowlist_is_case_insensitive` into `test_allowed_repos_accepted`, a parameterized test over both allowed repositories. It catches a later narrowing of `ALLOWED_REPOS` that would silently stop reviews on posthog.com, which no existing test covered.

Not checked: the end-to-end label path. That needs the companion workflow merged and the production secret, neither reachable from this sandbox.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The repository scope is not documented outside the code.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A PostHog engineer asked in Slack why the `reviewhog` label works on the monorepo but not on posthog.com. The diagnosis found two gates: this allowlist, and the missing workflow in the other repository. This pull request handles the first.

An earlier revision also added a note to the `review-hog.yml` header telling readers to keep it in sync with the posthog.com copy. Review asked for it to go, since divergence is acceptable. This branch no longer touches the workflow.

Skills invoked: `/writing-tests` and `/writing-pr-descriptions`.

I left the assignee unset because I cannot verify the requester's GitHub handle from a Slack display name. The person who asked should assign themselves.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BH6R0RDFX/p1786382921016259)*
