### PR TITLE
feat(replay-vision): add lite/standard/pro tier-naming arm

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4686,10 +4686,10 @@ snapshots:
         hash: v1.k794b7964.ea754a4783f7653247f127337c407a8cdd4a9c6bc3f1b908d8d00dd1a090b966.KQ3yKnRzi4l3ZeYVThZdmo4L6mAbxtNa2uQh7y-kGWA
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--tile-filters-read-only--light:
         hash: v1.k794b7964.b2ca2efc52a9ccf56953159c66d3c8766acd1d3a17379d5faec45a4715ae24a9.fK76p7ZVcgvFJNcKJ5Ixy3YnBm_BcBSFnoytLS2jZdU
-    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark
-    :   hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
-    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light
-    :   hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
+    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark:
+        hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
+    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light:
+        hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--dark:
         hash: v1.k794b7964.b1e0f5f542426e34dec73826f3135902a392c0c13dade4fec14037c615186b13.kbxxijyDI1SdvgdKwkRnIRLLgmsine5AYvOcD79DYsY
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--light:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4686,10 +4686,10 @@ snapshots:
         hash: v1.k794b7964.ea754a4783f7653247f127337c407a8cdd4a9c6bc3f1b908d8d00dd1a090b966.KQ3yKnRzi4l3ZeYVThZdmo4L6mAbxtNa2uQh7y-kGWA
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--tile-filters-read-only--light:
         hash: v1.k794b7964.b2ca2efc52a9ccf56953159c66d3c8766acd1d3a17379d5faec45a4715ae24a9.fK76p7ZVcgvFJNcKJ5Ixy3YnBm_BcBSFnoytLS2jZdU
-    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark:
-        hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
-    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light:
-        hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
+    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark
+    :   hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
+    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light
+    :   hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--dark:
         hash: v1.k794b7964.b1e0f5f542426e34dec73826f3135902a392c0c13dade4fec14037c615186b13.kbxxijyDI1SdvgdKwkRnIRLLgmsine5AYvOcD79DYsY
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--light:
@@ -7018,6 +7018,10 @@ snapshots:
         hash: v1.k794b7964.743d310929077c6f9536dfc962dce2f27df811003c65cc516fd17d8f0b5eeecd.aW0-0vZESyFTHDpkkwh-h9qMuBPV_vSckCJPimIcCw0
     scenes-app-replay-vision--scanner-configuration--light:
         hash: v1.k794b7964.1206162998fff84813f6229193f0b899b1dd6070278daacf44aecc05221a93e7.ojPoX16jVxawSkCy296WSxvBu8RtOPQBH5RcaNX13hw
+    scenes-app-replay-vision--scanner-configuration-lite-standard-pro--dark:
+        hash: v1.k794b7964.c0a3d4914a3a70419b2d3017c92fd25687719eb9c4053d28943fcb038c2fec26.916jH-LwqzgTY_vnhAfCNmYbOv8PS0Q3RTgXR9SFLXU
+    scenes-app-replay-vision--scanner-configuration-lite-standard-pro--light:
+        hash: v1.k794b7964.ae618eb4ae8f691e6ec7d1c0c479c4de7277dfc83d98339f999b1817be2da27e.lqAjIF_c2t5HcvPhVXKxo-81pzVUa48y1rr4qZgvh6E
     scenes-app-replay-vision--scanner-configuration-tier-names--dark:
         hash: v1.k794b7964.b8ac97b2eeb1809548ba38f22f3b9bcf959e05dae7c7b6ab25f0a2a9b8897cbd.zWWTm0YR8k5zyzy1jofPE4GEJrgjqxzirG5jV1PZS1I
     scenes-app-replay-vision--scanner-configuration-tier-names--light:
@@ -7030,6 +7034,10 @@ snapshots:
         hash: v1.k794b7964.329c7556ad85d746580d8662dad3a6a0c125926a21aa0cd1cd857ef60559b57c.gRO-AooWlKqPdgRt2ESC64X8njkXNgN3AHc-tz0QIqQ
     scenes-app-replay-vision--scanner-editor-configure--light:
         hash: v1.k794b7964.a5a08cc989e7c33b8e809d85faf68e5944f8e419d4b56fc200b8758005237933.xcQ7tgZqUe4NJeN-RmXX2rGfxbTvVkILJjka4SL1nzs
+    scenes-app-replay-vision--scanner-editor-configure-lite-standard-pro--dark:
+        hash: v1.k794b7964.e8fbe797e1b0858c45e803cf6a4a043b6b3b5aa0a2ce3011b12de9c2160b94fd.bkKxe-QjoehlnyX94StQ2u-5Q10vwQt5kgdUdywAnM0
+    scenes-app-replay-vision--scanner-editor-configure-lite-standard-pro--light:
+        hash: v1.k794b7964.6e0d79b5a63fd70d1d5fa61c1b9c7d36a165127c22352d7ed834693ea4290d8b.U0wnfDrrV2AMlFyTkS6P_SOHDZdcbp5fpKEwLKsU7aw
     scenes-app-replay-vision--scanner-editor-configure-tier-names--dark:
         hash: v1.k794b7964.54a591d5a9c4e7ee136a0ae16f3aba2854890630c1b99fabfd73fe809ea116f3.u6BUDK3AL8hBaHZ__KDmQYLLhvGEuP6qjoW3xKrKCGI
     scenes-app-replay-vision--scanner-editor-configure-tier-names--light:

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -474,7 +474,7 @@ export const FEATURE_FLAGS = {
     REPLAY_VIDEO_BASED_SUMMARIZATION: 'replay-video-based-summarization', // owner: #team-replay
     REPLAY_VISION: 'replay-vision', // owner: #team-replay
     REPLAY_VISION_ACTIONS: 'replay-vision-actions', // owner: #team-replay
-    REPLAY_VISION_MODEL_TIER_NAMING_EXPERIMENT: 'replay-vision-model-tier-naming-experiment', // owner: #team-replay multivariate=control,test
+    REPLAY_VISION_MODEL_TIER_NAMING_EXPERIMENT: 'replay-vision-model-tier-naming-experiment', // owner: #team-replay multivariate=control,test,lite-standard-pro
     REVAMPED_PY_NOTEBOOKS: 'revamped-py-notebooks', // owner: #team-data-tools
     REVENUE_FIELDS_IN_POWER_USERS_TABLE: 'revenue-fields-in-power-users-table', // owner: @arthurdedeus #team-customer-analytics
     REVIEW_HOG: 'review-hog', // owner: #team-devex, gates the Code review menu entry

--- a/products/replay_vision/frontend/observations/ReplayObservation.tsx
+++ b/products/replay_vision/frontend/observations/ReplayObservation.tsx
@@ -20,7 +20,6 @@ import { NotFound } from 'lib/components/NotFound'
 import { TZLabel } from 'lib/components/TZLabel'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
@@ -62,6 +61,7 @@ import {
     failureKindDescription,
     ineligibleKindDescription,
     modelLabel,
+    modelNamingVariant,
     parseFailureReason,
     parseIneligibleReason,
     OBSERVATION_TRIGGER_TAG,
@@ -116,7 +116,7 @@ export function ReplayObservationSceneComponent(): JSX.Element {
     const { searchParams } = useValues(router)
     const { featureFlags, receivedFeatureFlags } = useValues(featureFlagLogic)
     const { featureFlagsTimedOut } = useValues(appLogic)
-    const showTierNames = useFeatureFlag('REPLAY_VISION_MODEL_TIER_NAMING_EXPERIMENT', 'test')
+    const namingVariant = modelNamingVariant(featureFlags[FEATURE_FLAGS.REPLAY_VISION_MODEL_TIER_NAMING_EXPERIMENT])
     const [recordingExpanded, setRecordingExpanded] = useState(false)
     const [pendingSeek, setPendingSeek] = useState<{ ms: number; trigger: number } | null>(null)
 
@@ -545,7 +545,7 @@ export function ReplayObservationSceneComponent(): JSX.Element {
                     <div className="flex flex-col gap-3 text-sm">
                         {snapshot?.model && (
                             <LabeledRow label="Model">
-                                <span>{modelLabel(snapshot.model, showTierNames)}</span>
+                                <span>{modelLabel(snapshot.model, namingVariant)}</span>
                             </LabeledRow>
                         )}
                         {summarizerLength && (

--- a/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.stories.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.stories.tsx
@@ -510,14 +510,24 @@ export const ScannerConfiguration: StoryObj = {
     parameters: { pageUrl: `${urls.replayVision(summarizerScanner.id)}?tab=configuration` },
 }
 
-// Test arm of the model tier-naming experiment: models labeled Basic/Pro/Ultra instead of provider
-// names. A per-story featureFlags replaces the meta's, so REPLAY_VISION must be re-listed.
+// Test arms of the model tier-naming experiment: models labeled by capability tier instead of
+// provider names. A per-story featureFlags replaces the meta's, so REPLAY_VISION must be re-listed.
 export const ScannerConfigurationTierNames: StoryObj = {
     parameters: {
         pageUrl: `${urls.replayVision(summarizerScanner.id)}?tab=configuration`,
         featureFlags: {
             [FEATURE_FLAGS.REPLAY_VISION]: true,
             [FEATURE_FLAGS.REPLAY_VISION_MODEL_TIER_NAMING_EXPERIMENT]: 'test',
+        },
+    },
+}
+
+export const ScannerConfigurationLiteStandardPro: StoryObj = {
+    parameters: {
+        pageUrl: `${urls.replayVision(summarizerScanner.id)}?tab=configuration`,
+        featureFlags: {
+            [FEATURE_FLAGS.REPLAY_VISION]: true,
+            [FEATURE_FLAGS.REPLAY_VISION_MODEL_TIER_NAMING_EXPERIMENT]: 'lite-standard-pro',
         },
     },
 }
@@ -548,6 +558,16 @@ export const ScannerEditorConfigureTierNames: StoryObj = {
         featureFlags: {
             [FEATURE_FLAGS.REPLAY_VISION]: true,
             [FEATURE_FLAGS.REPLAY_VISION_MODEL_TIER_NAMING_EXPERIMENT]: 'test',
+        },
+    },
+}
+
+export const ScannerEditorConfigureLiteStandardPro: StoryObj = {
+    parameters: {
+        pageUrl: urls.replayVisionScannerConfigure(summarizerScanner.id),
+        featureFlags: {
+            [FEATURE_FLAGS.REPLAY_VISION]: true,
+            [FEATURE_FLAGS.REPLAY_VISION_MODEL_TIER_NAMING_EXPERIMENT]: 'lite-standard-pro',
         },
     },
 }

--- a/products/replay_vision/frontend/replay_scanners/ScannerEditorScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ScannerEditorScene.tsx
@@ -20,7 +20,6 @@ import {
 import { pngHoggie } from 'lib/brand/hoggies'
 import { NotFound } from 'lib/components/NotFound'
 import { FEATURE_FLAGS } from 'lib/constants'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -46,7 +45,7 @@ import {
     scannerStepUrl,
 } from './scannerEditorSceneLogic'
 import { ScannerEditorStepper, STEP_LABELS } from './ScannerEditorStepper'
-import { SCANNER_TYPE_OPTIONS, getModelOptions } from './types'
+import { SCANNER_TYPE_OPTIONS, getModelOptions, modelNamingVariant } from './types'
 
 const HedgehogConstruction2 = pngHoggie(construction2Png)
 const HedgehogImTheDriver = pngHoggie(imTheDriverPng)
@@ -224,7 +223,8 @@ function ConfigureStep(): JSX.Element {
     const { scanner, isNew } = useValues(replayScannerLogic({ id: scannerId }))
     const { setScannerType } = useActions(replayScannerLogic({ id: scannerId }))
     const { searchParams } = useValues(router)
-    const showTierNames = useFeatureFlag('REPLAY_VISION_MODEL_TIER_NAMING_EXPERIMENT', 'test')
+    const { featureFlags } = useValues(featureFlagLogic)
+    const namingVariant = modelNamingVariant(featureFlags[FEATURE_FLAGS.REPLAY_VISION_MODEL_TIER_NAMING_EXPERIMENT])
     const isTypeSelectable = isNew && !searchParams.template
 
     if (!scanner) {
@@ -306,11 +306,11 @@ function ConfigureStep(): JSX.Element {
                     <LemonSelect
                         className="max-w-full"
                         value={scanner.model}
-                        options={getModelOptions(showTierNames)}
+                        options={getModelOptions(namingVariant)}
                     />
                 </LemonField>
                 <div className="text-xs text-muted">
-                    {showTierNames
+                    {namingVariant
                         ? 'Higher tiers tend to produce higher-quality observations, but cost more per observation.'
                         : 'Newer models tend to produce higher-quality observations, but cost more per observation.'}
                 </div>

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerConfigReadonly.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerConfigReadonly.tsx
@@ -16,9 +16,10 @@ import { PropertyFilterButton } from 'lib/components/PropertyFilters/components/
 import { TZLabel } from 'lib/components/TZLabel'
 import { UniversalFilterButton } from 'lib/components/UniversalFilters/UniversalFilterButton'
 import { isEntityFilter } from 'lib/components/UniversalFilters/utils'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { humanFriendlyDurationFilter } from 'scenes/session-recordings/filters/DurationFilter'
 import {
     deriveOperand,
@@ -38,7 +39,7 @@ import { getReplayVisionEditDisabledReason } from '../../utils/accessControl'
 import { formatCreditsMaybeUsd } from '../../utils/credits'
 import { promptUnchangedSince } from '../../utils/labelStats'
 import { replayScannerLogic } from '../replayScannerLogic'
-import { ReplayScanner, SAMPLING_MODE_OPTIONS, ScannerType, getModelOptions } from '../types'
+import { ReplayScanner, SAMPLING_MODE_OPTIONS, ScannerType, getModelOptions, modelNamingVariant } from '../types'
 
 const SUMMARY_LENGTHS = [
     { value: 'short', label: 'Short' },
@@ -268,7 +269,8 @@ export function ScannerConfigReadonly({ scanner }: { scanner: ReplayScanner }): 
     const { observationStats, togglingEnabled } = useValues(replayScannerLogic({ id: scanner.id }))
     const { showUsd } = useValues(visionQuotaLogic)
     const { toggleEnabled } = useActions(replayScannerLogic({ id: scanner.id }))
-    const showTierNames = useFeatureFlag('REPLAY_VISION_MODEL_TIER_NAMING_EXPERIMENT', 'test')
+    const { featureFlags } = useValues(featureFlagLogic)
+    const namingVariant = modelNamingVariant(featureFlags[FEATURE_FLAGS.REPLAY_VISION_MODEL_TIER_NAMING_EXPERIMENT])
     const samplingPercent = Math.round((scanner.sampling_rate ?? 0) * 1000) / 10
     // Read every filter dimension (events, actions, properties, console logs, …), not just top-level properties.
     const universal = recordingsQueryToUniversalFilters((scanner.query ?? null) as RecordingsQuery | null)
@@ -297,7 +299,7 @@ export function ScannerConfigReadonly({ scanner }: { scanner: ReplayScanner }): 
                             <Multiline value={scanner.description} />
                         </LabeledRow>
                         <LabeledRow label="Model">
-                            <OptionTags options={getModelOptions(showTierNames)} selected={scanner.model} />
+                            <OptionTags options={getModelOptions(namingVariant)} selected={scanner.model} />
                         </LabeledRow>
                         <LabeledRow label="Status">
                             <div className="flex items-center gap-2">

--- a/products/replay_vision/frontend/replay_scanners/components/VisionUsageTab.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionUsageTab.tsx
@@ -3,9 +3,10 @@ import { useMemo } from 'react'
 
 import { LemonSegmentedButton, LemonTable, LemonTag, Link, Spinner, Tooltip } from '@posthog/lemon-ui'
 
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
 import { LemonTableColumns } from 'lib/lemon-ui/LemonTable'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { urls } from 'scenes/urls'
 
 import { InsightVizNode, NodeKind, ProductKey } from '~/queries/schema/schema-general'
@@ -15,7 +16,7 @@ import { visionQuotaLogic } from '../../logics/visionQuotaLogic'
 import { creditsToUsd, formatCreditCount, formatCreditsMaybeUsd, formatCreditsRange } from '../../utils/credits'
 import { exhaustionForecast, hasCreditLimit, projectQuota } from '../../utils/quotaProjection'
 import { STARTUP_CAP_EXPLANATION } from '../../utils/startupCap'
-import { OBSERVATION_CREDITS_BY_MODEL, ReplayScanner, modelName } from '../types'
+import { OBSERVATION_CREDITS_BY_MODEL, ReplayScanner, modelName, modelNamingVariant } from '../types'
 import { SpendChartInterval, visionUsageLogic } from '../visionUsageLogic'
 import { QuotaMeterBar } from './QuotaMeterBar'
 import { VisionInsightChart } from './VisionInsightChart'
@@ -63,7 +64,8 @@ export function VisionUsageTab(): JSX.Element {
         billedLimitCredits,
         showStartupCap,
     } = useValues(visionQuotaLogic)
-    const showTierNames = useFeatureFlag('REPLAY_VISION_MODEL_TIER_NAMING_EXPERIMENT', 'test')
+    const { featureFlags } = useValues(featureFlagLogic)
+    const namingVariant = modelNamingVariant(featureFlags[FEATURE_FLAGS.REPLAY_VISION_MODEL_TIER_NAMING_EXPERIMENT])
 
     const projection = projectQuota(quota)
     const hasCap = hasCreditLimit(quota)
@@ -154,7 +156,7 @@ export function VisionUsageTab(): JSX.Element {
                     <span className="tabular-nums">
                         {scanner.credits_per_observation} credit{scanner.credits_per_observation === 1 ? '' : 's'}
                     </span>
-                    <span className="text-muted"> · {modelName(scanner.model, showTierNames)}</span>
+                    <span className="text-muted"> · {modelName(scanner.model, namingVariant)}</span>
                 </span>
             ),
         },

--- a/products/replay_vision/frontend/replay_scanners/types.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/types.test.ts
@@ -1,4 +1,12 @@
-import { type FailureKind, failureRetryGuidance, getModelOptions, modelLabel, observationRetryOffer } from './types'
+import {
+    type FailureKind,
+    type ModelNamingVariant,
+    failureRetryGuidance,
+    getModelOptions,
+    modelLabel,
+    modelNamingVariant,
+    observationRetryOffer,
+} from './types'
 
 describe('scanner type helpers', () => {
     describe('failureRetryGuidance', () => {
@@ -62,24 +70,47 @@ describe('scanner type helpers', () => {
     })
 
     describe('model naming', () => {
-        // Both maps satisfy the types, so wiring the wrong one into a variant (a Gemini name leaking
-        // into tier labels, or vice versa) would silently contaminate the naming experiment's arms.
-        it('labels models by tier in the experiment variant and by model name by default', () => {
-            expect(getModelOptions(false).map((o) => o.label)).toEqual([
-                'Gemini 3.5 Flash Lite · 2 credits/observation',
-                'Gemini 3 Flash · 5 credits/observation',
-                'Gemini 3.6 Flash · 15 credits/observation',
-            ])
-            expect(getModelOptions(true).map((o) => o.label)).toEqual([
-                'Basic · 2 credits/observation',
-                'Pro · 5 credits/observation',
-                'Ultra · 15 credits/observation',
-            ])
+        // Every tier map satisfies the same type, so wiring the wrong map into an arm (a Gemini name
+        // leaking into tier labels, or one scheme's labels into the other) would silently contaminate
+        // the naming experiment's arms.
+        it.each<[ModelNamingVariant | null, string[]]>([
+            [
+                null,
+                [
+                    'Gemini 3.5 Flash Lite · 2 credits/observation',
+                    'Gemini 3 Flash · 5 credits/observation',
+                    'Gemini 3.6 Flash · 15 credits/observation',
+                ],
+            ],
+            [
+                'test',
+                ['Basic · 2 credits/observation', 'Pro · 5 credits/observation', 'Ultra · 15 credits/observation'],
+            ],
+            [
+                'lite-standard-pro',
+                ['Lite · 2 credits/observation', 'Standard · 5 credits/observation', 'Pro · 15 credits/observation'],
+            ],
+        ])('labels models for naming variant %s', (variant, labels) => {
+            expect(getModelOptions(variant).map((o) => o.label)).toEqual(labels)
+        })
+
+        // The flag can serve values this build doesn't know (a new arm added before the frontend
+        // deploys, control, or a plain boolean); all of them must degrade to provider names, never
+        // to a tier scheme, or the control arm gets contaminated.
+        it.each<[unknown, ModelNamingVariant | null]>([
+            ['test', 'test'],
+            ['lite-standard-pro', 'lite-standard-pro'],
+            ['control', null],
+            ['some-future-arm', null],
+            [true, null],
+            [undefined, null],
+        ])('narrows flag value %p to naming variant %p', (flagValue, expected) => {
+            expect(modelNamingVariant(flagValue)).toBe(expected)
         })
 
         it('falls back to the raw id for retired models frozen in old observation snapshots', () => {
-            expect(modelLabel('gemini-1.5-retired', true)).toBe('gemini-1.5-retired')
-            expect(modelLabel('gemini-1.5-retired', false)).toBe('gemini-1.5-retired')
+            expect(modelLabel('gemini-1.5-retired', 'test')).toBe('gemini-1.5-retired')
+            expect(modelLabel('gemini-1.5-retired', null)).toBe('gemini-1.5-retired')
         })
     })
 })

--- a/products/replay_vision/frontend/replay_scanners/types.ts
+++ b/products/replay_vision/frontend/replay_scanners/types.ts
@@ -243,36 +243,54 @@ const MODEL_NAMES: Record<ScannerModelEnumApi, string> = {
     [ScannerModelEnumApi.Gemini36Flash]: 'Gemini 3.6 Flash',
 }
 
-// Test variant of the replay-vision-model-tier-naming-experiment flag: capability tiers instead of
-// provider model names. Every surface that shows a model must pass the same variant so a user never
-// sees both naming schemes for one scanner.
-const MODEL_TIER_NAMES: Record<ScannerModelEnumApi, string> = {
-    [ScannerModelEnumApi.Gemini35FlashLite]: 'Basic',
-    [ScannerModelEnumApi.Gemini3FlashPreview]: 'Pro',
-    [ScannerModelEnumApi.Gemini36Flash]: 'Ultra',
+// Tier-name arms of the replay-vision-model-tier-naming-experiment flag: capability tiers instead
+// of provider model names, keyed by the flag's variant key. Every surface that shows a model must
+// resolve the variant the same way so a user never sees mixed naming schemes for one scanner.
+export type ModelNamingVariant = 'test' | 'lite-standard-pro'
+
+const MODEL_TIER_NAMES: Record<ModelNamingVariant, Record<ScannerModelEnumApi, string>> = {
+    test: {
+        [ScannerModelEnumApi.Gemini35FlashLite]: 'Basic',
+        [ScannerModelEnumApi.Gemini3FlashPreview]: 'Pro',
+        [ScannerModelEnumApi.Gemini36Flash]: 'Ultra',
+    },
+    'lite-standard-pro': {
+        [ScannerModelEnumApi.Gemini35FlashLite]: 'Lite',
+        [ScannerModelEnumApi.Gemini3FlashPreview]: 'Standard',
+        [ScannerModelEnumApi.Gemini36Flash]: 'Pro',
+    },
 }
 
-export function getModelOptions(showTierNames: boolean): { value: ScannerModelEnumApi; label: string }[] {
+// Narrows a raw flag value to a naming variant. Control, booleans, and variant keys this build
+// doesn't know yet all resolve to null (provider model names), so a flag/frontend version skew
+// degrades to the control experience instead of mislabeling an arm.
+export function modelNamingVariant(flagValue: unknown): ModelNamingVariant | null {
+    return typeof flagValue === 'string' && flagValue in MODEL_TIER_NAMES ? (flagValue as ModelNamingVariant) : null
+}
+
+export function getModelOptions(
+    namingVariant: ModelNamingVariant | null
+): { value: ScannerModelEnumApi; label: string }[] {
     return Object.values(ScannerModelEnumApi).map((value) => ({
         value,
-        label: `${modelName(value, showTierNames)} · ${formatCreditCount(OBSERVATION_CREDITS_BY_MODEL[value])}/observation`,
+        label: `${modelName(value, namingVariant)} · ${formatCreditCount(OBSERVATION_CREDITS_BY_MODEL[value])}/observation`,
     }))
 }
 
 // Falls back to the raw id for retired models frozen in old observation snapshots.
-export function modelLabel(model: string | null | undefined, showTierNames: boolean = false): string {
+export function modelLabel(model: string | null | undefined, namingVariant: ModelNamingVariant | null = null): string {
     if (!model) {
         return '—'
     }
-    return getModelOptions(showTierNames).find((opt) => opt.value === model)?.label ?? model
+    return getModelOptions(namingVariant).find((opt) => opt.value === model)?.label ?? model
 }
 
 /** Plain model name without the price suffix, for surfaces that show the price separately. */
-export function modelName(model: string | null | undefined, showTierNames: boolean = false): string {
+export function modelName(model: string | null | undefined, namingVariant: ModelNamingVariant | null = null): string {
     if (!model) {
         return '—'
     }
-    const names = showTierNames ? MODEL_TIER_NAMES : MODEL_NAMES
+    const names = namingVariant ? MODEL_TIER_NAMES[namingVariant] : MODEL_NAMES
     return names[model as ScannerModelEnumApi] ?? model
 }
 


### PR DESCRIPTION
## Problem

- The tier-naming experiment's test arm labels models Basic / Pro / Ultra, and the upper two names read as more than a person needs: "Pro" asks for an identity, "Ultra" sounds like overkill.
- That framing can push people back to the cheapest model, the opposite of what the experiment is trying to move.
- We want a second scheme in the test where the middle tier sounds like the normal choice, with the old scheme kept at a reduced share.

## Changes

- Adds a second test arm to the naming flag: `lite-standard-pro` labels the models Lite / Standard / Pro at 2 / 5 / 15 credits. Prices stay visible in every arm.
- The four gated surfaces now read the flag's raw variant key instead of a boolean match, so all surfaces follow the same arm and new arms need no plumbing changes.
- Unknown flag values (control, booleans, arm keys newer than the running build) narrow to provider names, so version skew degrades to the control experience instead of a mislabeled picker.
- Two new Storybook stories pin the new arm's editor and configuration views in visual regression.
- This PR does not touch the running experiment. The flag's new variant and the 45/10/45 split land in PostHog after this deploys (reset to draft, add the arm, relaunch).

| Surface | Control | Basic / Pro / Ultra (existing arm) | Lite / Standard / Pro (new arm) |
| --- | --- | --- | --- |
| Editor model picker | ![editor picker, control](https://raw.githubusercontent.com/PostHog/pr-assets/34da7988bccc440682f79be6258dd763c384f152/2026/08/0cbd278d-1b6f-4171-a302-1e75acf27569.png) | ![editor picker, basic pro ultra](https://raw.githubusercontent.com/PostHog/pr-assets/34da7988bccc440682f79be6258dd763c384f152/2026/08/95fc977b-e0e9-4069-9b39-8f8fdf865497.png) | ![editor picker, lite standard pro](https://raw.githubusercontent.com/PostHog/pr-assets/34da7988bccc440682f79be6258dd763c384f152/2026/08/8c886b19-bee9-4337-a97c-351da5bb7fd1.png) |
| Configuration tab | ![configuration, control](https://raw.githubusercontent.com/PostHog/pr-assets/34da7988bccc440682f79be6258dd763c384f152/2026/08/423dc1c1-dea8-4447-9f52-c5f62e0deb84.png) | ![configuration, basic pro ultra](https://raw.githubusercontent.com/PostHog/pr-assets/34da7988bccc440682f79be6258dd763c384f152/2026/08/a49b04bf-9742-40c1-bdd7-4fd51d8fc27d.png) | ![configuration, lite standard pro](https://raw.githubusercontent.com/PostHog/pr-assets/34da7988bccc440682f79be6258dd763c384f152/2026/08/3737bfe9-0416-407e-bc12-334f2a9b4def.png) |

## How did you test this code?

- The Jest naming cases pin all three label sets per variant, so wiring the wrong map into an arm fails the suite.
- New narrowing cases guard the control arm: a flag value of `control`, `true`, or an unknown arm key must never activate a tier scheme.
- The screenshots above are the stories rendered in a local Storybook via Playwright, all three arms from the same mock scanner.
- Ran locally: the types Jest suite, the full frontend typecheck, and `hogli ci:preflight --fix`, all clean.
- Not run: backend suites, because the diff has no backend change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Docs don't enumerate the scanner model names.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Driven by Cory Slater (assigned).

- Authored with Claude Code as a PostHog Code cloud task, continuing the session that shipped the original experiment ([#79866](https://github.com/PostHog/posthog/pull/79866)).
- The tier names and the plan to keep the old arm at a reduced share come from the task request; the variant plumbing, tests, and stories were written fresh.
- Skills invoked: `/configuring-experiment-rollout`, `/managing-experiment-lifecycle`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`, `/setting-feature-flags-in-storybook`, `/writing-pr-descriptions`.
- The live-experiment side (reset, split change, relaunch) is planned over MCP for after this deploys; nothing in the PostHog project was changed yet.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
