### PR TITLE
fix(oauth): accept private_key_jwt assertions addressed to the OAuth proxy

### DIFF
--- a/posthog/api/oauth/client_assertion.py
+++ b/posthog/api/oauth/client_assertion.py
@@ -129,9 +129,21 @@ def expected_assertion_audiences(*token_endpoint_paths: str) -> list[str]:
 
     RFC 7523 section 3 lets a client address either the issuer or the endpoint it is calling,
     so both are accepted. Callers pass the paths their own endpoint answers on.
+
+    A client mints ``aud`` from the issuer it discovered, which is not necessarily SITE_URL: on
+    Cloud the advertised authorization server is the OAuth proxy, and an assertion addressed to
+    it would fail here against SITE_URL alone. The extra issuers come from settings rather than
+    from the request, so the accepted set stays a fixed allowlist.
     """
-    site_url = settings.SITE_URL.rstrip("/")
-    return [site_url, *(f"{site_url}{path}" for path in token_endpoint_paths)]
+    issuers = [
+        settings.SITE_URL.rstrip("/"),
+        *(issuer.rstrip("/") for issuer in settings.OAUTH_CLIENT_ASSERTION_ALLOWED_AUDIENCES if issuer),
+    ]
+    audiences: list[str] = []
+    for issuer in dict.fromkeys(issuers):
+        audiences.append(issuer)
+        audiences.extend(f"{issuer}{path}" for path in token_endpoint_paths)
+    return audiences
 
 
 AGENTIC_TOKEN_ENDPOINT_PATH = "/api/agentic/oauth/token"

--- a/posthog/api/oauth/test_client_assertion.py
+++ b/posthog/api/oauth/test_client_assertion.py
@@ -20,6 +20,7 @@ from posthog.api.oauth.client_assertion import (
     CLIENT_ASSERTION_TYPE_JWT_BEARER,
     MAX_ASSERTION_LIFETIME_SECONDS,
     ClientAssertionError,
+    expected_assertion_audiences,
     extract_client_assertion,
     load_jwks,
     verify_client_assertion,
@@ -92,6 +93,21 @@ class TestClientAssertion(BaseTest):
     def _verify(self, assertion: str) -> None:
         with patch("posthog.api.oauth.client_assertion.fetch_client_json_document", return_value=(self.jwks, None)):
             verify_client_assertion(self.app, assertion)
+
+    @override_settings(
+        SITE_URL="https://us.posthog.com",
+        OAUTH_CLIENT_ASSERTION_ALLOWED_AUDIENCES=["https://oauth.posthog.com/"],
+    )
+    def test_advertised_issuers_are_accepted_audiences(self):
+        audiences = expected_assertion_audiences("/oauth/token/", "/oauth/token")
+        assert audiences == [
+            "https://us.posthog.com",
+            "https://us.posthog.com/oauth/token/",
+            "https://us.posthog.com/oauth/token",
+            "https://oauth.posthog.com",
+            "https://oauth.posthog.com/oauth/token/",
+            "https://oauth.posthog.com/oauth/token",
+        ]
 
     def test_valid_assertion_verifies(self):
         self._verify(self._assertion())

--- a/posthog/api/oauth/views.py
+++ b/posthog/api/oauth/views.py
@@ -204,6 +204,23 @@ def _token_error_code(response: HttpResponse) -> str:
     return f"http_{response.status_code}"
 
 
+def _presented_client_auth_method(request) -> str:
+    """Which client-authentication method the request actually carried.
+
+    The RFC 6749 error code cannot express this: `invalid_client` reads the same whether the
+    client sent a credential we refused or sent none at all. Those two need different fixes,
+    and telling them apart is otherwise only possible by reading the request body, which is
+    never logged because it holds the credential itself.
+    """
+    if request.META.get("HTTP_AUTHORIZATION", "").startswith("Basic "):
+        return "client_secret_basic"
+    if request.POST.get("client_assertion"):
+        return TokenEndpointAuthMethod.PRIVATE_KEY_JWT.value
+    if request.POST.get("client_secret"):
+        return TokenEndpointAuthMethod.CLIENT_SECRET_POST.value
+    return TokenEndpointAuthMethod.NONE.value
+
+
 def _scoped_organization_ids(
     user: User,
     access_level: str | None,
@@ -415,20 +432,55 @@ class OAuthValidator(OAuth2Validator):
         """
         if self._authenticate_client_assertion(request):
             return True
-        return super().authenticate_client(request, *args, **kwargs)
+
+        authenticated = super().authenticate_client(request, *args, **kwargs)
+        if not authenticated:
+            # oauthlib turns every failure here into a bare `invalid_client`, which tells an
+            # operator nothing about which credential the client actually presented. Recording
+            # the shape of the attempt is what makes a client stuck on the wrong auth method
+            # distinguishable from one whose credential we rejected. Only presence is recorded
+            # because the assertion and the secret are themselves credentials.
+            logger.warning(
+                "oauth_client_authentication_failed",
+                client_id=getattr(request, "client_id", None) or "",
+                client_assertion_type=getattr(request, "client_assertion_type", None) or "",
+                has_client_assertion=bool(getattr(request, "client_assertion", None)),
+                has_client_secret=bool(getattr(request, "client_secret", None)),
+            )
+        return authenticated
 
     def _authenticate_client_assertion(self, request) -> bool:
+        assertion_type = getattr(request, "client_assertion_type", None) or ""
+        presented_client_id = getattr(request, "client_id", None) or ""
         assertion = resolve_client_assertion(
             getattr(request, "client_assertion", None) or "",
-            getattr(request, "client_assertion_type", None) or "",
-            getattr(request, "client_id", None) or "",
+            assertion_type,
+            presented_client_id,
         )
         if assertion is None:
+            # A request carrying neither field is the ordinary secret-based client, which the
+            # caller logs if it goes on to fail. A request carrying one of them meant to use
+            # this method, so the half-formed attempt is worth naming on its own.
+            if assertion_type or getattr(request, "client_assertion", None):
+                logger.warning(
+                    "oauth_client_assertion_unusable",
+                    client_id=presented_client_id,
+                    client_assertion_type=assertion_type,
+                    has_client_assertion=bool(getattr(request, "client_assertion", None)),
+                )
             return False
 
         assertion_value, client_id = assertion
         app = self._load_application(client_id, request)
-        if app is None or not app.uses_private_key_jwt_auth:
+        if app is None:
+            logger.warning("oauth_client_assertion_client_not_found", client_id=client_id)
+            return False
+        if not app.uses_private_key_jwt_auth:
+            logger.warning(
+                "oauth_client_assertion_method_mismatch",
+                client_id=client_id,
+                registered_method=app.token_endpoint_auth_method.value,
+            )
             return False
 
         if app.is_cimd_client and app.cimd_metadata_url:
@@ -1522,7 +1574,9 @@ class OAuthTokenView(TokenView):
         )
 
     @staticmethod
-    def _capture_token_rejected(grant_type: str, client_id: str, error: str) -> None:
+    def _capture_token_rejected(
+        grant_type: str, client_id: str, error: str, presented_auth_method: str | None = None
+    ) -> None:
         """The token exchange has no authenticated user, so this keys on the client id —
         enough to tell "the client never came back for a token" apart from "it came back
         and we refused", which the authorization events alone cannot distinguish.
@@ -1536,6 +1590,7 @@ class OAuthTokenView(TokenView):
             "client_id": client_id,
             # Personless: the client id is not a user, and one person per client would be noise.
             "$process_person_profile": False,
+            **({"presented_auth_method": presented_auth_method} if presented_auth_method else {}),
             **(get_region_info() or {}),
         }
         try:
@@ -1628,11 +1683,13 @@ class OAuthTokenView(TokenView):
         client_id = request.POST.get("client_id", "")
         client_id_prefix = client_id[:8] if client_id else "unknown"
         redirect_uri = request.POST.get("redirect_uri", "")
+        presented_auth_method = _presented_client_auth_method(request)
         logger.info(
             "oauth_token_request",
             grant_type=grant_type,
             client_id_prefix=client_id_prefix,
             redirect_uri=redirect_uri,
+            presented_auth_method=presented_auth_method,
         )
 
         try:
@@ -1647,7 +1704,7 @@ class OAuthTokenView(TokenView):
                 client_id_prefix=client_id_prefix,
                 redirect_uri=redirect_uri,
             )
-            self._capture_token_rejected(grant_type, client_id, "invalid_grant")
+            self._capture_token_rejected(grant_type, client_id, "invalid_grant", presented_auth_method)
             return JsonResponse(
                 {
                     "error": "invalid_grant",
@@ -1668,7 +1725,7 @@ class OAuthTokenView(TokenView):
                 redirect_uri=redirect_uri,
                 error=str(e),
             )
-            self._capture_token_rejected(grant_type, client_id, "temporarily_unavailable")
+            self._capture_token_rejected(grant_type, client_id, "temporarily_unavailable", presented_auth_method)
             return _temporarily_unavailable_response()
         except RedisError as e:
             # Client authentication reads Redis on the private_key_jwt path (JWKS cache, jti
@@ -1743,7 +1800,7 @@ class OAuthTokenView(TokenView):
                 response["Content-Type"] = "application/json"
 
         if response.status_code != 200:
-            self._capture_token_rejected(grant_type, client_id, _token_error_code(response))
+            self._capture_token_rejected(grant_type, client_id, _token_error_code(response), presented_auth_method)
 
         return response
 

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -1202,6 +1202,14 @@ ID_JAG_ALLOWED_AUDIENCES: list[str] = get_list(get_from_env("ID_JAG_ALLOWED_AUDI
 # e.g. "https://mcp.posthog.com,https://mcp.us.posthog.com" on Cloud. SITE_URL is always accepted.
 ID_JAG_ALLOWED_RESOURCES: list[str] = get_list(get_from_env("ID_JAG_ALLOWED_RESOURCES", ""))
 
+# Extra accepted `aud` values for private_key_jwt client assertions. A client addresses its
+# assertion to the issuer it discovered, which on Cloud is the OAuth proxy rather than SITE_URL,
+# so without this every proxied assertion fails audience validation. Defaults to
+# ID_JAG_ALLOWED_AUDIENCES because both name the same set of advertised issuers.
+OAUTH_CLIENT_ASSERTION_ALLOWED_AUDIENCES: list[str] = get_list(
+    get_from_env("OAUTH_CLIENT_ASSERTION_ALLOWED_AUDIENCES", get_from_env("ID_JAG_ALLOWED_AUDIENCES", ""))
+)
+
 TOOLBAR_OAUTH_STATE_TTL_SECONDS = 60 * 5
 TOOLBAR_OAUTH_EXCHANGE_TIMEOUT_SECONDS = 10
 TOOLBAR_OAUTH_APPLICATION_NAME = "PostHog Toolbar"


### PR DESCRIPTION
## Problem

ChatGPT and Codex users cannot connect the PostHog MCP connector. They complete the consent screen, then the install rolls back.

- The token exchange returns `invalid_client`. Every attempt fails; no exchange for this client has succeeded since 6 August.
- ChatGPT's client metadata document started declaring `private_key_jwt` that day. Our CIMD refresh re-derives `client_type` from that document, so the app was promoted from public to confidential.
- Before the promotion it was a public client using `none` plus PKCE, and it worked.
- After it, PostHog required client authentication that the token endpoint could not accept.
- A client signs its assertion for the issuer it discovered. On Cloud that issuer is `https://oauth.posthog.com`, not `SITE_URL`.
- `expected_assertion_audiences` built its allowlist from `SITE_URL` alone, so a proxied assertion could never validate.
- Existing installs still work on unexpired access tokens. Refresh grants use the same path, so they fail as those tokens expire.
- No log recorded which credential a request carried, so `invalid_client` read the same whether a client sent the wrong credential or none at all.

## Changes

- `expected_assertion_audiences` accepts each advertised issuer plus its token endpoint paths.
- New `OAUTH_CLIENT_ASSERTION_ALLOWED_AUDIENCES` setting, defaulting to `ID_JAG_ALLOWED_AUDIENCES` because both name the same advertised issuers.
- `presented_auth_method` rides the `oauth_token_request` log and the `oauth_token_rejected` event.
- It records only which credential was present, derived from the Basic header, `client_assertion`, or `client_secret`. Never the value, because the request body holds the credential.
- Each previously silent exit in `_authenticate_client_assertion` now logs its reason.

> [!WARNING]
> This is inert unless `ID_JAG_ALLOWED_AUDIENCES` (or the new setting) names the OAuth proxy on Cloud. An empty allowlist reproduces the old behavior exactly.

This removes one of two blockers. The client must also present an assertion, which it does not do today. `presented_auth_method` is how we will see that change.

I reused `ID_JAG_ALLOWED_AUDIENCES` as the default rather than adding an independent variable, because a second unset variable is how this bug reaches production a second time.

## How did you test this code?

- Added one case to `test_client_assertion.py`: a configured extra issuer appears in the accepted audiences. It catches a revert to `SITE_URL`-only, which is the exact defect this PR fixes and which no existing test covered.
- I (Claude) ran `posthog/api/oauth/` locally, plus the agentic `private_key_jwt` and ID-JAG suites, since they share the audience helper.
- Not verified: the fix against the real client. That needs a deploy, because the failure only reproduces against ChatGPT's live metadata document and signing key.
- Not verified: whether Cloud sets `ID_JAG_ALLOWED_AUDIENCES`. I cannot read production configuration.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) did this work in Claude Code, driven by @skoob13. Skills invoked: `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.

The session started as an investigation into production 401s, not as a code change. Reading ingress logs and the app row ruled out the CIMD registration, the proxy body forwarding, and the oauthlib request parsing in turn. The audience mismatch is what survived, and it is provable from the metadata documents alone.

The diagnostic half exists because that investigation cost a full deploy cycle and returned nothing: every failure mode landed on a branch that returned `False` without logging.

Follow-ups this PR does not cover: the OAuth proxy serves the authorization server metadata with `Cache-Control: public, max-age=3600`, which delays every auth-method correction by up to an hour; and whether to accept `none` from CIMD clients that advertise it, which would restore the pre-6-August behavior but weakens authentication for a client we hold a key for.

