### PR TITLE
fix(alerts): avoid recording failed evaluation delivery

### DIFF
--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -244,33 +244,8 @@ def send_test_alert_email(alert: AlertConfiguration, recipients: Collection[str]
     )
 
 
-def send_notifications_for_errors(alert: AlertConfiguration, error: dict) -> list[str]:
-    logger.info("Sending alert error notifications", alert_id=alert.id, error=error)
-    email_targets = alert.get_subscribed_users_emails()
-
-    # TODO: uncomment this after checking errors sent
-    # if email_targets:
-    #     subject = f"PostHog alert {alert.name} check failed to evaluate"
-    #     campaign_key = f"alert-firing-notification-{alert.id}-{timezone.now().timestamp()}"
-    #     insight_url = f"/project/{alert.team.pk}/insights/{alert.insight.short_id}"
-    #     alert_url = f"{insight_url}?alert_id={alert.id}"
-    #     message = EmailMessage(
-    #         campaign_key=campaign_key,
-    #         subject=subject,
-    #         template_name="alert_check_failed_to_evaluate",
-    #         template_context={
-    #             "alert_error": error,
-    #             "insight_url": insight_url,
-    #             "insight_name": alert.insight.name,
-    #             "alert_url": alert_url,
-    #             "alert_name": alert.name,
-    #         },
-    #     )
-    #     for target in email_targets:
-    #         message.add_recipient(email=target)
-    #     message.send()
-
-    return email_targets
+def send_notifications_for_errors(alert: AlertConfiguration, error: dict) -> None:
+    logger.info("Alert evaluation errored; no notification configured", alert_id=alert.id, error=error)
 
 
 def dispatch_alert_notification(
@@ -282,7 +257,7 @@ def dispatch_alert_notification(
     """Route an AlertCheck to the correct notification sender.
 
     Returns the list of recipients the delivery targeted, or None if nothing was sent
-    (NOT_FIRING, or ERRORED with a non-dict error payload). Callers pass the returned
+    (NOT_FIRING or ERRORED). Callers pass the returned
     list to record_alert_delivery so the `targets_notified` sentinel reflects reality
     — never claiming delivery for a state that didn't actually send.
 
@@ -320,7 +295,8 @@ def dispatch_alert_notification(
                         alert_check_id=alert_check.id,
                     )
                     return None
-                return send_notifications_for_errors(alert, alert_check.error)
+                send_notifications_for_errors(alert, alert_check.error)
+                return None
             case AlertState.FIRING:
                 if not breaches:
                     raise ValueError(

--- a/posthog/temporal/tests/test_alerts_activities.py
+++ b/posthog/temporal/tests/test_alerts_activities.py
@@ -489,6 +489,25 @@ class TestNotifyAlert:
         mock_breaches.assert_not_called()
         mock_errors.assert_not_called()
 
+    async def test_error_does_not_record_notification_delivery(self, alert_with_user) -> None:
+        check = await _create_alert_check(
+            alert_with_user,
+            state=AlertState.ERRORED,
+            error={"message": "query failed"},
+        )
+
+        env = ActivityEnvironment()
+        await env.run(
+            notify_alert,
+            NotifyAlertActivityInputs(alert_id=str(alert_with_user.id), alert_check_id=str(check.id)),
+        )
+
+        refreshed_check = await sync_to_async(AlertCheck.objects.get)(pk=check.id)
+        assert refreshed_check.targets_notified == {}
+
+        refreshed_alert = await sync_to_async(AlertConfiguration.objects.get)(pk=alert_with_user.pk)
+        assert refreshed_alert.last_notified_at is None
+
     async def test_sends_breach_notifications_when_firing(self, alert_with_user) -> None:
         check = await _create_alert_check(alert_with_user, state=AlertState.FIRING)
 


### PR DESCRIPTION
## Problem

- Alert owners can see a recent notification time after an evaluation error, even though PostHog sent no notification.

## Changes

**Before**

```mermaid
flowchart LR
    Error[Evaluation error] --> NoSend[No notification sent]
    NoSend --> Recorded[Delivery recorded]
```

**After**

```mermaid
flowchart LR
    Error[Evaluation error] --> NoSend[No notification sent]
    NoSend --> Unchanged[Delivery state unchanged]
```

- Errored checks now return no delivery targets.
- Internal evaluation errors remain hidden from users.

## How did you test this code?

- Added an activity regression test that protects `last_notified_at` and `targets_notified` after an errored check.
- Checked the full Python type graph because this change narrows a return type.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. This corrects internal delivery bookkeeping without changing a documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Code implemented the fix with `/writing-tests` and `/writing-pr-descriptions`.
- The investigation used private support context. The committed test data is invented and contains no customer material.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*