### PR TITLE
fix(ingestion): configure ai blob offload on the combined consumer

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -575,6 +575,17 @@ services:
             COOKIELESS_REDIS_PORT: 6379
             CDP_REDIS_HOST: redis7
             ENCRYPTION_SALT_KEYS: '00beef0000beef0000beef0000beef00'
+            # Combined mode runs the AI consumer on events_plugin_ingestion_ai, which is where
+            # capture diverts $ai_* events, so it needs the same blob offload config as the
+            # dedicated ingestion-ai service. Without a bucket, buildAiBlobStore returns null and
+            # multimodal payloads are stored inline instead of as phaiblob:// pointers.
+            AI_BLOB_S3_BUCKET: ai-blobs
+            AI_BLOB_S3_PREFIX: 'aio/'
+            AI_BLOB_S3_ENDPOINT: 'http://objectstorage:19000'
+            AI_BLOB_S3_REGION: us-east-1
+            AI_BLOB_S3_ACCESS_KEY_ID: object_storage_root_user
+            AI_BLOB_S3_SECRET_ACCESS_KEY: object_storage_root_password
+            AI_BLOB_OFFLOAD_TEAMS: '*'
 
     ingestion-ai:
         command: node nodejs/dist/index.js

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -238,6 +238,10 @@ services:
                 condition: service_healthy
             db:
                 condition: service_healthy
+            objectstorage:
+                # SeaweedFS creates the ai-blobs bucket asynchronously, and the AI blob store
+                # healthchecks the bucket at startup, so wait for the bootstrap sentinel.
+                condition: service_healthy
             personhog-router:
                 condition: service_started
         healthcheck:


### PR DESCRIPTION
## Problem

Every full Playwright run fails on master and on every open branch. The failing test is `products/ai_observability/frontend/e2e/multimodal-trace.spec.ts`, which sends a screenshot through ingestion and expects a `phaiblob://` pointer in `ai_events.input`.

- [#78260](https://github.com/PostHog/posthog/pull/78260) made `CaptureMode::Events` divert `$ai_*` events to the AI topic. The dev stack's `capture-ai` service runs that mode, so its events now land on `events_plugin_ingestion_ai` instead of its own main topic `ai_events_ingestion`.
- `ingestion-general` (combined mode) consumes `events_plugin_ingestion_ai`, but it had none of the `AI_BLOB_*` settings that `ingestion-ai` has.
- `buildAiBlobStore` returns `null` when `AI_BLOB_S3_BUCKET` is empty, which disables the offload step silently. The image stays inline as a `data:image/png;base64,...` string.
- The break reaches branches regardless of merge base, because the E2E job pulls `capture:master` when the branch has no image of its own. Example failing run: [job 93551491728](https://github.com/PostHog/posthog/actions/runs/31417786772/job/93551491728).
- Anyone running the local dev stack loses the offload the same way.

## Changes

```diff
 ingestion-general:
     environment:
+        AI_BLOB_S3_BUCKET: ai-blobs
+        AI_BLOB_S3_PREFIX: 'aio/'
+        AI_BLOB_S3_ENDPOINT: 'http://objectstorage:19000'
+        AI_BLOB_S3_REGION: us-east-1
+        AI_BLOB_S3_ACCESS_KEY_ID: object_storage_root_user
+        AI_BLOB_S3_SECRET_ACCESS_KEY: object_storage_root_password
+        AI_BLOB_OFFLOAD_TEAMS: '*'
```

- `ingestion-general` gets the blob offload config that `ingestion-ai` already carries, so the consumer that now receives the traffic can offload it.
- `ingestion-general` waits for the `objectstorage` health sentinel in the dev stack. The blob store healthchecks its bucket at startup, and SeaweedFS creates `ai-blobs` asynchronously, so without the gate the service fails to start.
- I configured the consumer rather than changing `capture-ai` back to a non-diverting mode. Combined mode consuming the AI topic is the intent of [#79506](https://github.com/PostHog/posthog/pull/79506), and the main `capture` service diverts to the same topic, so the config gap would remain either way.

> [!NOTE]
> `ingestion-ai` still consumes `ai_events_ingestion`, which nothing produces to in the dev stack now. I left it in place because removing it is a separate decision about the dev topology.

## How did you test this code?

- I (actually Claude) verified the merged compose config resolves: `ingestion-general` shows `AI_BLOB_S3_BUCKET: ai-blobs` and `objectstorage: service_healthy`.
- I did not run the dev stack or the Playwright suite locally. This PR's own E2E run is the check, because it exercises the exact path that fails today.
- No new tests. The regression already has coverage in the multimodal trace spec, which fails now and should pass here.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Dev and CI stack config only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code in the PostHog Slack app. Skills invoked: `/stacking-prs`, `/writing-code-comments`, `/writing-pr-descriptions`.
- I first read the failure as a flake. The Playwright artifacts settled it: the container logs show `capture-ai` producing to `events_plugin_ingestion_ai` while `ingestion-ai` subscribes to `ai_events_ingestion`, and the error context shows the raw base64 payload that ingestion stored.
- Public artifact: nothing in this PR carries material from the agent session that is not already public.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09ADEV3AJD/p1786384635392089)*
