### PR TITLE
fix(flags): BigInt serialization error on feature flag copy failure

### DIFF
--- a/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
@@ -16,6 +16,7 @@ import { dayjs } from 'lib/dayjs'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic as enabledFeaturesLogic } from 'lib/logic/featureFlagLogic'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { urls } from 'scenes/urls'
 
 import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
@@ -35,7 +36,10 @@ import {
 import { FeatureFlagFilters } from '~/types'
 
 import { TemplateKey } from 'products/feature_flags/frontend/featureFlagTemplateConstants'
-import type { CopyFlagsDependencyRequirementsResponseApi } from 'products/feature_flags/frontend/generated/api.schemas'
+import type {
+    CopyFlagsDependencyRequirementsResponseApi,
+    CopyFlagsResponseApi,
+} from 'products/feature_flags/frontend/generated/api.schemas'
 
 import * as defaultReleaseConditionsModule from './defaultReleaseConditionsLogic'
 import {
@@ -1882,6 +1886,9 @@ describe('featureFlagLogic', () => {
                     ],
                 },
             })
+            // The copy listener reports to eventUsageLogic, which nothing in this logic's
+            // connect() mounts — without this, the listener dies at that call.
+            eventUsageLogic.mount()
             logic.actions.setCopyDestinationProject(MOCK_TEAM_ID)
         })
 
@@ -1931,6 +1938,22 @@ describe('featureFlagLogic', () => {
             await expectLogic(logic).toFinishAllListeners()
 
             expect(lemonToast.error).toHaveBeenCalledWith('Error while copying feature flag: Project not found.')
+            expect(lemonToast.warning).not.toHaveBeenCalled()
+        })
+
+        it('serializes BigInt payload values in the error toast when a failure has no error_message', async () => {
+            // JSON transport can't carry a BigInt, so the HTTP mock layer can't produce this
+            // payload — dispatch the loader success action directly with the shape the
+            // stringifyWithBigInts fallback defends against.
+            logic.actions.copyFlagSuccess({
+                success: [],
+                failed: [{ project_id: MOCK_TEAM_ID, filter_value: BigInt(123) }],
+            } as unknown as CopyFlagsResponseApi)
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(lemonToast.error).toHaveBeenCalledWith(
+                `Error while copying feature flag: [{"project_id":${MOCK_TEAM_ID},"filter_value":"123"}]`
+            )
             expect(lemonToast.warning).not.toHaveBeenCalled()
         })
     })

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.test.ts
@@ -1886,8 +1886,8 @@ describe('featureFlagLogic', () => {
                     ],
                 },
             })
-            // The copy listener reports to eventUsageLogic, which nothing in this logic's
-            // connect() mounts — without this, the listener dies at that call.
+            // The copy listener reports to eventUsageLogic, but featureFlagLogic does not mount it via connect().
+            // Mount it here so the listener does not throw when it calls reportFeatureFlagCopyFailure().
             eventUsageLogic.mount()
             logic.actions.setCopyDestinationProject(MOCK_TEAM_ID)
         })

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -35,6 +35,7 @@ import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic as enabledFeaturesLogic } from 'lib/logic/featureFlagLogic'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { stringifyWithBigInts } from 'lib/utils/json'
 import { objectsEqual } from 'lib/utils/objects'
 import { slugify } from 'lib/utils/strings'
 import { experimentLogic } from 'scenes/experiments/experimentLogic'
@@ -3724,7 +3725,7 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
                     eventUsageLogic.actions.reportFeatureFlagCopyFailure(failure.error_message ?? 'Approval pending')
                 } else {
                     const errorMessage =
-                        failure?.error_message ?? JSON.stringify(featureFlagCopy?.failed ?? featureFlagCopy)
+                        failure?.error_message ?? stringifyWithBigInts(featureFlagCopy?.failed ?? featureFlagCopy)
                     lemonToast.error(`Error while copying feature flag: ${errorMessage}`)
                     eventUsageLogic.actions.reportFeatureFlagCopyFailure(errorMessage)
                 }


### PR DESCRIPTION
> [!NOTE]
> This re-lands #71842 by @smz202000, with their commit and authorship unchanged. That PR runs from a fork, and fork PRs run `Frontend typechecking` on a GitHub-hosted runner where `tsgo` no longer fits. It died three times in a row there. This branch is internal, so the job runs on a Depot runner.

## Problem

Copying a feature flag to another project shows no error when the copy fails and the flag holds a BigInt filter value. The person is left with a silent failure.

- The failure handler calls `JSON.stringify` on the failure payload.
- `JSON.stringify` throws "Do not know how to serialize a BigInt" on a BigInt property value.
- The throw happens before the error toast renders, so the reason never reaches the person.

Closes #19367

## Changes

- `featureFlagLogic` now builds the copy failure message with `stringifyWithBigInts` from `lib/utils/json`.
- That helper converts BigInt values to strings instead of throwing.
- `toParams` in `lib/utils/url.ts` already uses the same helper, so this follows an established pattern.
- A new test covers the BigInt payload.

The diff is two files and 26 lines. Nothing else changed in the re-land.

## How did you test this code?

- The new test dispatches `copyFlagSuccess` with a BigInt `filter_value` and asserts the toast text. The existing copy failure tests all use string payloads, so none of them reach the serializer that threw.
- The test dispatches the loader action directly rather than going through the HTTP mock. JSON transport cannot carry a BigInt, so the mock layer cannot produce this payload.
- I ran `featureFlagLogic.test.ts` locally against current master and it passed.
- Not checked: I did not exercise the copy flow in a browser.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing copy, API, or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Phil directed this work and I (Claude) carried it out, using Claude Code. Skills invoked: `/ci-monitor` and `/writing-pr-descriptions`.

The session began as CI triage on #71842. I fixed an import order violation there, which cleared three failing frontend checks. `Frontend typechecking` then failed three consecutive times on the fork runner. One run exceeded the 20 minute budget. Two died to a runner shutdown signal partway through `tsgo`. The fork runner split is documented and deliberate, so no change to this branch could clear it. Phil chose to re-land the commits internally.

I cherry-picked with `-x`, which preserved @smz202000 as author. The import order fix came out empty after conflict resolution, because merging against current master already produced the correct order, so this branch carries two commits rather than three.
