### PR TITLE
fix(code): preserve collapsed artifact files

### DIFF
--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -7576,7 +7576,9 @@ export class SessionService {
     runId: string,
   ): Promise<TaskRunArtifact[]> {
     const authStatus = await this.getAuthCredentialsStatus();
-    if (authStatus.kind !== "ready") return [];
+    if (authStatus.kind !== "ready") {
+      throw new Error("Not signed in to PostHog");
+    }
 
     return this.getCloudAttachmentManifest(
       authStatus.auth.client,

--- a/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.test.tsx
@@ -579,11 +579,11 @@ describe("CloudArtifactDownloads", () => {
     fireEvent.click(trigger);
   });
 
-  it("stays collapsed through an empty refresh when the session retains the files", () => {
+  it("treats a successful empty refresh as authoritative", () => {
     const { rerender } = renderDownloads();
 
     fireEvent.click(screen.getByRole("button", { name: "Files (1)" }));
-    session.cloudArtifacts = fetchedArtifacts;
+    const artifacts = fetchedArtifacts;
     fetchedArtifacts = [];
     rerender(
       <Theme>
@@ -591,9 +591,19 @@ describe("CloudArtifactDownloads", () => {
       </Theme>,
     );
 
-    const trigger = screen.getByRole("button", { name: "Files (1)" });
-    expect(trigger).toHaveAttribute("aria-expanded", "false");
-    fireEvent.click(trigger);
+    expect(screen.queryByRole("button", { name: "Files (1)" })).toBeNull();
+
+    fetchedArtifacts = artifacts;
+    rerender(
+      <Theme>
+        <CloudArtifactDownloads taskId="task-1" task={task} />
+      </Theme>,
+    );
+
+    expect(screen.getByRole("button", { name: "Files (1)" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
   });
 
   it("remembers collapse state per task", () => {

--- a/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.test.tsx
@@ -517,8 +517,6 @@ describe("CloudArtifactDownloads", () => {
     );
   });
 
-  // Collapse state lives in a module-scoped store that nothing here resets, so
-  // the case that leaves the box collapsed has to run last.
   it("starts expanded and collapses when the header is clicked", () => {
     renderDownloads();
 
@@ -537,6 +535,50 @@ describe("CloudArtifactDownloads", () => {
     expect(screen.getByText("report.pdf")).toBeVisible();
   });
 
+  it("expands when the visible file list changes", () => {
+    const { rerender } = renderDownloads();
+
+    fireEvent.click(screen.getByRole("button", { name: "Files (1)" }));
+    expect(screen.queryByText("report.pdf")).not.toBeInTheDocument();
+
+    fetchedArtifacts = [
+      ...(fetchedArtifacts ?? []),
+      {
+        id: "output-2",
+        name: "summary.txt",
+        type: "output",
+        storage_path: "tasks/run-1/summary.txt",
+      },
+    ];
+    rerender(
+      <Theme>
+        <CloudArtifactDownloads taskId="task-1" task={task} />
+      </Theme>,
+    );
+
+    expect(screen.getByRole("button", { name: "Files (2)" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+    expect(screen.getByText("summary.txt")).toBeVisible();
+  });
+
+  it("stays collapsed when a refetch returns the same files", () => {
+    const { rerender } = renderDownloads();
+
+    fireEvent.click(screen.getByRole("button", { name: "Files (1)" }));
+    fetchedArtifacts = [...(fetchedArtifacts ?? [])];
+    rerender(
+      <Theme>
+        <CloudArtifactDownloads taskId="task-1" task={task} />
+      </Theme>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Files (1)" });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(trigger);
+  });
+
   it("remembers collapse state per task", () => {
     const { unmount } = renderDownloads();
 
@@ -544,7 +586,15 @@ describe("CloudArtifactDownloads", () => {
     expect(screen.queryByText("report.pdf")).not.toBeInTheDocument();
     unmount();
 
-    renderDownloads();
+    const artifacts = fetchedArtifacts;
+    fetchedArtifacts = undefined;
+    const { rerender } = renderDownloads();
+    fetchedArtifacts = artifacts;
+    rerender(
+      <Theme>
+        <CloudArtifactDownloads taskId="task-1" task={task} />
+      </Theme>,
+    );
 
     expect(screen.getByRole("button", { name: "Files (1)" })).toHaveAttribute(
       "aria-expanded",

--- a/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.test.tsx
@@ -579,6 +579,23 @@ describe("CloudArtifactDownloads", () => {
     fireEvent.click(trigger);
   });
 
+  it("stays collapsed through an empty refresh when the session retains the files", () => {
+    const { rerender } = renderDownloads();
+
+    fireEvent.click(screen.getByRole("button", { name: "Files (1)" }));
+    session.cloudArtifacts = fetchedArtifacts;
+    fetchedArtifacts = [];
+    rerender(
+      <Theme>
+        <CloudArtifactDownloads taskId="task-1" task={task} />
+      </Theme>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Files (1)" });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(trigger);
+  });
+
   it("remembers collapse state per task", () => {
     const { unmount } = renderDownloads();
 

--- a/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.tsx
@@ -130,8 +130,14 @@ export function CloudArtifactDownloads({
     refetchInterval: isLive ? 120_000 : false,
   });
 
-  const artifactManifest =
-    fetchedArtifacts ?? sessionArtifacts ?? task?.latest_run?.artifacts;
+  const taskArtifacts = task?.latest_run?.artifacts;
+  const artifactManifest = fetchedArtifacts?.length
+    ? fetchedArtifacts
+    : sessionArtifacts?.length
+      ? sessionArtifacts
+      : taskArtifacts?.length
+        ? taskArtifacts
+        : (fetchedArtifacts ?? sessionArtifacts ?? taskArtifacts);
   const groups = useMemo(
     () =>
       groupRunArtifactVersions(

--- a/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.tsx
@@ -130,14 +130,8 @@ export function CloudArtifactDownloads({
     refetchInterval: isLive ? 120_000 : false,
   });
 
-  const taskArtifacts = task?.latest_run?.artifacts;
-  const artifactManifest = fetchedArtifacts?.length
-    ? fetchedArtifacts
-    : sessionArtifacts?.length
-      ? sessionArtifacts
-      : taskArtifacts?.length
-        ? taskArtifacts
-        : (fetchedArtifacts ?? sessionArtifacts ?? taskArtifacts);
+  const artifactManifest =
+    fetchedArtifacts ?? sessionArtifacts ?? task?.latest_run?.artifacts;
   const groups = useMemo(
     () =>
       groupRunArtifactVersions(

--- a/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.tsx
@@ -43,7 +43,7 @@ import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
 import { toast } from "@posthog/ui/primitives/toast";
 import { formatFileSize } from "@posthog/ui/utils/formatFileSize";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useCompletedArtifactUploads } from "./countArtifactUploads";
 
 type ArtifactGroup = RunArtifactVersions<TaskRunArtifact>;
@@ -95,8 +95,8 @@ export function CloudArtifactDownloads({
     taskId,
     (session) => session?.cloudStatus,
   );
-  const collapsed = useArtifactFilesCollapsed(taskId);
-  const { setArtifactFilesCollapsed } = useSessionViewActions();
+  const { setArtifactFilesCollapsed, syncArtifactFilesListKey } =
+    useSessionViewActions();
   const authIdentity = useAuthStateValue(getAuthIdentity);
   const { download, downloadingId } = useArtifactDownload();
   const { data: currentUser } = useMeQuery();
@@ -130,15 +130,12 @@ export function CloudArtifactDownloads({
     refetchInterval: isLive ? 120_000 : false,
   });
 
+  const artifactManifest =
+    fetchedArtifacts ?? sessionArtifacts ?? task?.latest_run?.artifacts;
   const groups = useMemo(
     () =>
       groupRunArtifactVersions(
-        (
-          fetchedArtifacts ??
-          sessionArtifacts ??
-          task?.latest_run?.artifacts ??
-          []
-        ).flatMap((artifact) => {
+        (artifactManifest ?? []).flatMap((artifact) => {
           if (artifact.type !== "output") return [];
           return [
             artifact.id && artifact.id in dismissalOverrides
@@ -147,15 +144,23 @@ export function CloudArtifactDownloads({
           ];
         }),
       ),
-    [
-      dismissalOverrides,
-      fetchedArtifacts,
-      sessionArtifacts,
-      task?.latest_run?.artifacts,
-    ],
+    [artifactManifest, dismissalOverrides],
   );
   const visibleGroups = groups.filter((group) => !group.dismissed);
   const dismissedGroups = groups.filter((group) => group.dismissed);
+  const fileListKey = artifactManifest
+    ? `${runId ?? ""}:${visibleGroups
+        .map((group) => group.name)
+        .sort()
+        .join("\u0000")}`
+    : undefined;
+  const collapsed = useArtifactFilesCollapsed(taskId, fileListKey);
+
+  useEffect(() => {
+    if (taskId && fileListKey !== undefined) {
+      syncArtifactFilesListKey(taskId, fileListKey);
+    }
+  }, [fileListKey, syncArtifactFilesListKey, taskId]);
 
   const dismissal = useMutation({
     mutationFn: ({
@@ -332,7 +337,9 @@ export function CloudArtifactDownloads({
     <Collapsible.Root
       open={!collapsed}
       onOpenChange={(open) => {
-        if (taskId) setArtifactFilesCollapsed(taskId, !open);
+        if (taskId && fileListKey !== undefined) {
+          setArtifactFilesCollapsed(taskId, !open, fileListKey);
+        }
       }}
       className="mb-3 rounded-lg border border-gray-4 bg-gray-2 p-3"
     >

--- a/products/desktop/packages/ui/src/features/sessions/sessionViewStore.ts
+++ b/products/desktop/packages/ui/src/features/sessions/sessionViewStore.ts
@@ -16,12 +16,10 @@ interface SessionViewState {
    * resets to expanded on app restart.
    */
   queueCollapsedByTaskId: Record<string, boolean>;
-  /**
-   * Ephemeral per-task collapse of the artifact "Files" box in the chat
-   * thread, keyed by taskId. `true` = collapsed; absent/`false` = expanded
-   * (the default — the box never collapses on its own). Not persisted.
-   */
-  artifactFilesCollapsedByTaskId: Record<string, boolean>;
+  artifactFilesCollapseByTaskId: Record<
+    string,
+    { collapsed: boolean; fileListKey: string }
+  >;
 }
 
 interface SessionViewActions {
@@ -31,7 +29,12 @@ interface SessionViewActions {
   setGroupOverride: (id: string, expanded: boolean) => void;
   clearGroupOverrides: () => void;
   setQueueCollapsed: (taskId: string, collapsed: boolean) => void;
-  setArtifactFilesCollapsed: (taskId: string, collapsed: boolean) => void;
+  setArtifactFilesCollapsed: (
+    taskId: string,
+    collapsed: boolean,
+    fileListKey: string,
+  ) => void;
+  syncArtifactFilesListKey: (taskId: string, fileListKey: string) => void;
 }
 
 type SessionViewStore = SessionViewState & { actions: SessionViewActions };
@@ -42,7 +45,7 @@ const useStore = create<SessionViewStore>((set) => ({
   showSearch: false,
   groupOverrides: {},
   queueCollapsedByTaskId: {},
-  artifactFilesCollapsedByTaskId: {},
+  artifactFilesCollapseByTaskId: {},
   actions: {
     setShowRawLogs: (show) => set({ showRawLogs: show }),
     setSearchQuery: (query) => set({ searchQuery: query }),
@@ -68,13 +71,24 @@ const useStore = create<SessionViewStore>((set) => ({
           [taskId]: collapsed,
         },
       })),
-    setArtifactFilesCollapsed: (taskId, collapsed) =>
+    setArtifactFilesCollapsed: (taskId, collapsed, fileListKey) =>
       set((state) => ({
-        artifactFilesCollapsedByTaskId: {
-          ...state.artifactFilesCollapsedByTaskId,
-          [taskId]: collapsed,
+        artifactFilesCollapseByTaskId: {
+          ...state.artifactFilesCollapseByTaskId,
+          [taskId]: { collapsed, fileListKey },
         },
       })),
+    syncArtifactFilesListKey: (taskId, fileListKey) =>
+      set((state) => {
+        const current = state.artifactFilesCollapseByTaskId[taskId];
+        if (!current || current.fileListKey === fileListKey) return state;
+        return {
+          artifactFilesCollapseByTaskId: {
+            ...state.artifactFilesCollapseByTaskId,
+            [taskId]: { collapsed: false, fileListKey },
+          },
+        };
+      }),
   },
 }));
 
@@ -84,10 +98,15 @@ export const useShowSearch = () => useStore((s) => s.showSearch);
 export const useGroupOverrides = () => useStore((s) => s.groupOverrides);
 export const useQueueCollapsed = (taskId: string) =>
   useStore((s) => s.queueCollapsedByTaskId[taskId] ?? false);
-export const useArtifactFilesCollapsed = (taskId: string | undefined) =>
+export const useArtifactFilesCollapsed = (
+  taskId: string | undefined,
+  fileListKey: string | undefined,
+) =>
   useStore((s) =>
     taskId === undefined
       ? false
-      : (s.artifactFilesCollapsedByTaskId[taskId] ?? false),
+      : (s.artifactFilesCollapseByTaskId[taskId]?.collapsed ?? false) &&
+        (fileListKey === undefined ||
+          s.artifactFilesCollapseByTaskId[taskId]?.fileListKey === fileListKey),
   );
 export const useSessionViewActions = () => useStore((s) => s.actions);


### PR DESCRIPTION
## Problem

People who collapse the Files card in a task chat see it expand after they navigate away and return.

## Changes

- The Files card keeps its collapsed state across remounts and temporary loading gaps.
- A new run or a changed set of visible filenames expands the card.
- Refetches with the same filenames do not expand the card.
- This behavior has no visual change, so there is no screenshot.

## How did you test this code?

- Added regressions for remounts, loading gaps, changed file lists, and equivalent refetches.
- Ran the focused CloudArtifactDownloads test suite.
- Ran the UI package typecheck and Biome checks.
- Ran the full desktop build.
- The repository preflight command was unavailable because this environment has no Python executable.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This fix does not change a documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and tested this fix. It used the repository writing-pr-descriptions skill to shape this description.

The file-list identity uses the run ID and sorted visible filenames. This avoids expanding on query object churn while detecting user-visible list changes.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*