### PR TITLE
fix(desktop): gate cloud compute billing details

### DIFF
--- a/products/desktop/packages/shared/src/flags.ts
+++ b/products/desktop/packages/shared/src/flags.ts
@@ -1,4 +1,6 @@
 export const BILLING_FLAG = "posthog-code-billing";
+export const CLOUD_COMPUTE_BILLING_FLAG =
+  "posthog-desktop-cloud-compute-billing";
 export const SPEND_ANALYSIS_FLAG = "posthog-code-spend-analysis";
 export const EXPERIMENT_SUGGESTIONS_FLAG =
   "posthog-code-experiment-suggestions";

--- a/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.stories.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.stories.tsx
@@ -44,6 +44,7 @@ const meta: Meta<typeof PlanUsageContent> = {
   ],
   args: {
     billingEnabled: true,
+    cloudComputeEnabled: true,
     spendAnalysisEnabled: true,
     billingUrl: "https://app.posthog.com/organization/billing",
     usage,
@@ -55,6 +56,13 @@ export default meta;
 type Story = StoryObj<typeof PlanUsageContent>;
 
 export const WithComponentBreakdown: Story = {};
+
+export const CloudComputeDisabled: Story = {
+  args: {
+    cloudComputeEnabled: false,
+    spendAnalysisEnabled: false,
+  },
+};
 
 export const BreakdownAwaitingData: Story = {
   args: {

--- a/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
@@ -21,7 +21,7 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@posthog/quill";
-import { BILLING_FLAG } from "@posthog/shared";
+import { BILLING_FLAG, CLOUD_COMPUTE_BILLING_FLAG } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { UsageMeter } from "@posthog/ui/features/billing/UsageMeter";
@@ -38,6 +38,7 @@ import { type ReactNode, useEffect, useState } from "react";
 
 export function PlanUsageSettings() {
   const billingEnabled = useFeatureFlag(BILLING_FLAG);
+  const cloudComputeEnabled = useFeatureFlag(CLOUD_COMPUTE_BILLING_FLAG);
   const spendAnalysisEnabled = useSpendAnalysisEnabled();
   const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
   const billingUrl = getBillingUrl(cloudRegion);
@@ -64,6 +65,7 @@ export function PlanUsageSettings() {
   return (
     <PlanUsageContent
       billingEnabled={billingEnabled}
+      cloudComputeEnabled={cloudComputeEnabled}
       spendAnalysisEnabled={spendAnalysisEnabled}
       billingUrl={billingUrl}
       usage={usage}
@@ -75,6 +77,7 @@ export function PlanUsageSettings() {
 
 interface PlanUsageContentProps {
   billingEnabled: boolean;
+  cloudComputeEnabled: boolean;
   spendAnalysisEnabled: boolean;
   billingUrl: string | null | undefined;
   usage: UsageOutput | null | undefined;
@@ -84,6 +87,7 @@ interface PlanUsageContentProps {
 
 export function PlanUsageContent({
   billingEnabled,
+  cloudComputeEnabled,
   spendAnalysisEnabled,
   billingUrl,
   usage,
@@ -227,7 +231,9 @@ export function PlanUsageContent({
           )}
           {!usageLoading && (
             <Flex direction="column" gap="3">
-              {hasUsageMix && <UsageMix components={components} />}
+              {cloudComputeEnabled && hasUsageMix && (
+                <UsageMix components={components} />
+              )}
               <Text className="text-[12px] text-gray-10">
                 Usage reporting may be delayed by 15–20 minutes.
               </Text>


### PR DESCRIPTION
## Problem

Desktop users see a token-versus-compute split before cloud compute pricing is ready.

**Why:** An explicit zero currently looks like real compute billing data, which makes the usage mix misleading during rollout.

## Changes

- Hide the usage mix unless the new cloud compute billing flag is enabled.
- Add the client-side `posthog-desktop-cloud-compute-billing` flag at 0% rollout in [project 2](https://us.posthog.com/project/2/feature_flags/810624).
- Keep the combined organization usage meter visible and unchanged.
- No screenshot: the flag defaults off, so the current billing surface only loses the premature usage split.

## How did you test this code?

- Ran focused Biome checks and typechecks for `@posthog/shared` and `@posthog/ui`.
- Ran the full Desktop typecheck and lint successfully.
- Full `pnpm test` is not clean because two existing `@posthog/git` tests fail under this root-run environment.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes. This is a temporary rollout gate for an existing billing detail.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code implemented the requested rollout gate using `/posthog-desktop`, `/instrument-feature-flags`, `/writing-tests`, and `/writing-pr-descriptions`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*