### PR TITLE
fix(data-warehouse): tunnel Framer WebSocket through the egress proxy

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/framer/framer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/framer/framer.py
@@ -11,13 +11,17 @@ sent as the `sdkVersion` query parameter, exactly like the SDK release it mirror
 import re
 import json
 import time
+import socket
+import http.client
 from collections.abc import Callable, Iterator
 from typing import Any, Optional, Protocol
 from urllib.parse import unquote, urlencode, urljoin, urlsplit
 
 from structlog.types import FilteringBoundLogger
 from websockets.exceptions import ConnectionClosed, InvalidStatus
+from websockets.headers import build_authorization_basic
 from websockets.sync.client import connect as websocket_connect
+from websockets.uri import Proxy, get_proxy, parse_proxy, parse_uri
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.framer import devalue
@@ -63,6 +67,39 @@ class WebSocketLike(Protocol):
     def recv(self, timeout: Optional[float] = None) -> Any: ...
 
     def close(self) -> None: ...
+
+
+def _tunnel_through_proxy(proxy: Proxy, host: str, port: int) -> socket.socket:
+    """Open a CONNECT tunnel to ``host:port`` through an HTTP(S) proxy and return the socket.
+
+    websockets' own proxy support requires an HTTP/1.1 status line on the CONNECT
+    response (until v17), but goproxy-based egress proxies such as Smokescreen answer a
+    successful CONNECT with ``HTTP/1.0 200 OK``, which websockets rejects as
+    "did not receive a valid HTTP response from proxy". ``http.client`` accepts HTTP/1.0,
+    so we establish the tunnel ourselves and hand the socket to websockets. This helper
+    can be dropped once the pinned websockets version is >= 17.
+    """
+    connection_class = http.client.HTTPSConnection if proxy.scheme == "https" else http.client.HTTPConnection
+    connection = connection_class(proxy.host, proxy.port, timeout=CONNECT_TIMEOUT_SECONDS)
+    headers: dict[str, str] = {}
+    if proxy.username is not None:
+        headers["Proxy-Authorization"] = build_authorization_basic(proxy.username, proxy.password or "")
+    connection.set_tunnel(host, port, headers)
+    try:
+        connection.connect()
+    except OSError as e:
+        connection.close()
+        raise FramerAPIError(
+            f"Could not reach Framer through the network proxy ({e}). Try again, and contact support if it keeps failing.",
+            code="PROXY",
+            retryable=True,
+        ) from e
+    sock = connection.sock
+    # Detach before the connection object goes out of scope, so its close() can't
+    # tear down the tunnel we're handing to websockets.
+    connection.sock = None
+    assert sock is not None  # connect() either sets the socket or raises
+    return sock
 
 
 def parse_project_id(project: str) -> Optional[str]:
@@ -120,12 +157,26 @@ class FramerClient:
 
     def connect(self) -> None:
         query = urlencode({"projectId": self._project_id, "sdkVersion": self._protocol_version})
+        url = f"{self._url}?{query}"
+        connect_kwargs: dict[str, Any] = {}
+        ws_uri = parse_uri(url)
+        proxy = get_proxy(ws_uri)
+        if proxy is not None:
+            proxy_parsed = parse_proxy(proxy)
+            if proxy_parsed.scheme in ("http", "https"):
+                # Tunnel the CONNECT ourselves because websockets < 17 rejects the
+                # HTTP/1.0 success line Smokescreen sends (see _tunnel_through_proxy).
+                # Passing a socket makes websockets skip its own proxy handling while
+                # still doing TLS against the Framer host. SOCKS proxies fall through
+                # to websockets' built-in support.
+                connect_kwargs["sock"] = _tunnel_through_proxy(proxy_parsed, ws_uri.host, ws_uri.port)
         try:
             self._ws = self._connect_fn(
-                f"{self._url}?{query}",
+                url,
                 additional_headers={"Authorization": f"Token {self._api_key}"},
                 open_timeout=CONNECT_TIMEOUT_SECONDS,
                 max_size=MAX_MESSAGE_BYTES,
+                **connect_kwargs,
             )
         except InvalidStatus as e:
             status = e.response.status_code

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/framer/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/framer/source.py
@@ -54,12 +54,14 @@ class FramerSource(SimpleSource[FramerSourceConfig]):
 
     def get_retryable_errors(self) -> set[str]:
         # Transient channel conditions the next Temporal attempt recovers from: a busy
-        # headless pool, a concurrent-session collision, or a dropped connection.
+        # headless pool, a concurrent-session collision, a dropped connection, or an
+        # egress-proxy hiccup.
         return {
             "Framer API error POOL_EXHAUSTED",
             "Framer API error TOKEN_SESSION_LIMIT",
             "Framer API error TIMEOUT",
             "Framer API error CONNECTION_CLOSED",
+            "Framer API error PROXY",
         }
 
     def get_canonical_descriptions(self) -> CanonicalDescriptions:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/framer/tests/test_framer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/framer/tests/test_framer.py
@@ -1,5 +1,8 @@
+import os
 import json
 import math
+import socket
+import threading
 from collections import deque
 from collections.abc import Iterable
 from datetime import UTC, datetime
@@ -72,6 +75,51 @@ class FakeFramerServer:
 
     def close(self) -> None:
         self.closed = True
+
+
+class FakeConnectProxy:
+    """In-memory CONNECT proxy with a configurable status line, so tests can speak the
+    `HTTP/1.0 200 OK` that goproxy-based egress proxies (Smokescreen) answer with."""
+
+    def __init__(self, status_line: str) -> None:
+        self.status_line = status_line
+        self.connect_request = ""
+        self.tunneled = b""
+        self._server = socket.socket()
+        self._server.settimeout(10)
+        self._server.bind(("127.0.0.1", 0))
+        self._server.listen(1)
+        self.port = self._server.getsockname()[1]
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def _serve(self) -> None:
+        connection, _ = self._server.accept()
+        connection.settimeout(10)
+        try:
+            request = b""
+            while b"\r\n\r\n" not in request:
+                request += connection.recv(4096)
+            self.connect_request = request.decode()
+            connection.sendall(f"{self.status_line}\r\n\r\n".encode())
+            while data := connection.recv(4096):
+                self.tunneled += data
+        except OSError:
+            pass
+        finally:
+            connection.close()
+
+    def join(self) -> None:
+        self._thread.join(timeout=10)
+        self._server.close()
+
+
+@pytest.fixture(autouse=True)
+def no_ambient_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The client resolves proxies from process env, so an ambient HTTP(S)_PROXY on the
+    # host would reroute every connect in this file through a real proxy.
+    for name in [key for key in os.environ if key.lower().endswith("_proxy")]:
+        monkeypatch.delenv(name)
 
 
 def make_client(server: FakeFramerServer) -> FramerClient:
@@ -255,6 +303,45 @@ class TestFramer:
         server.enqueue_raw(json.dumps({"$chunk": 1, "id": "c1", "seq": 0, "data": full[:middle]}))
         server.enqueue_raw(json.dumps({"$chunk": 1, "id": "c1", "seq": -1, "data": full[middle:]}))
         assert client.call("getCollections") == [{"id": "big"}]
+
+    @parameterized.expand(
+        [
+            ("HTTP/1.0 200 OK",),  # goproxy/Smokescreen success line, rejected by websockets < 17
+            ("HTTP/1.1 200 Connection established",),
+        ]
+    )
+    def test_client_tunnels_through_env_configured_proxy(self, status_line: str) -> None:
+        proxy = FakeConnectProxy(status_line)
+        server = FakeFramerServer()
+        with pytest.MonkeyPatch.context() as patcher:
+            patcher.setenv("HTTPS_PROXY", f"http://pod:x@127.0.0.1:{proxy.port}")
+            client = FramerClient(PROJECT_ID, "test-key", protocol_version="0.1.29", connect_fn=server)
+            client.connect()
+        client.close()
+        assert proxy.connect_request.startswith("CONNECT api.framer.com:443 ")
+        assert "Proxy-Authorization: Basic" in proxy.connect_request
+        sock = server.connect_kwargs["sock"]
+        sock.sendall(b"tunneled")
+        sock.close()
+        proxy.join()
+        assert proxy.tunneled == b"tunneled"
+
+    def test_client_wraps_proxy_denial_as_retryable(self) -> None:
+        proxy = FakeConnectProxy("HTTP/1.0 407 Request rejected by proxy")
+        server = FakeFramerServer()
+        with pytest.MonkeyPatch.context() as patcher:
+            patcher.setenv("HTTPS_PROXY", f"http://127.0.0.1:{proxy.port}")
+            client = FramerClient(PROJECT_ID, "test-key", protocol_version="0.1.29", connect_fn=server)
+            with pytest.raises(FramerAPIError) as exc_info:
+                client.connect()
+        proxy.join()
+        assert exc_info.value.code == "PROXY"
+        assert exc_info.value.retryable
+
+    def test_client_connects_directly_without_proxy(self) -> None:
+        server = FakeFramerServer()
+        make_client(server)
+        assert "sock" not in server.connect_kwargs
 
     def test_validate_credentials_success(self) -> None:
         server = FakeFramerServer(methods={"getProjectInfo2": {"id": PROJECT_ID, "name": "Site"}})


### PR DESCRIPTION
## Problem

- Connecting a Framer source in production fails for every user with "Could not connect to Framer: did not receive a valid HTTP response from proxy". No Framer source has connected since the source shipped in #79776.
- Production routes outbound HTTP through the Smokescreen egress proxy. Its goproxy core answers a successful CONNECT with `HTTP/1.0 200 OK`.
- websockets 15 rejects any CONNECT response that is not HTTP/1.1 and aborts the handshake.
- requests/urllib3 accept HTTP/1.0, which is why every other API source works through the same proxy.

## Changes

- `FramerClient.connect` now opens the CONNECT tunnel itself with stdlib `http.client`, which accepts HTTP/1.0, and hands the tunneled socket to websockets.
- Proxy resolution reuses websockets' `get_proxy`, so `HTTPS_PROXY` and `NO_PROXY` behave exactly as before. Without a proxy in the environment the client connects directly, as today.
- Tunnel failures surface as a retryable `FramerAPIError` with a readable message instead of a raw `OSError`.
- The upstream parser fix ships in websockets 17, two major versions past our pin. Upgrading a shared transitive dependency (uvicorn, elevenlabs) was too risky here; the tunnel can be dropped after that upgrade.

## How did you test this code?

- New test: connect through a fake CONNECT proxy speaking goproxy's exact `HTTP/1.0 200 OK` line. Catches any regression back to today's production failure.
- New test: a 407 proxy denial maps to a retryable `FramerAPIError`. Catches raw `OSError`s leaking to users and Temporal.
- New test: without proxy env vars the client connects directly. Catches spurious tunneling in self-hosted setups.
- Verified end-to-end in the sandbox: `validate_credentials` through a local goproxy-style proxy against the live Framer channel completes the tunnel, TLS, and handshake, and returns the in-band auth error. Before this change the identical setup reproduces the production error verbatim.
- Not run: a sync against a real Framer project, because this environment has no Framer API key.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: user-visible connection behavior is unchanged, and no docs describe the egress path.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude via PostHog Code, directed by Jake Sciotto, from a production failure report.
- Root cause pinned by reproducing the handshake locally: goproxy replies `HTTP/1.0 200 OK\r\n\r\n` to CONNECT, and websockets 15.0.1's response parser rejects anything but HTTP/1.1, wrapping it as `InvalidProxyMessage`.
- Skills invoked: /writing-tests, /writing-user-facing-copy, /writing-code-comments, /writing-pr-descriptions.
- Public artifact: all test data is invented; no customer identifiers appear in this PR.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
