### PR TITLE
fix(warehouse): drop business_management-gated fields from Meta Ads ad_account

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/schemas.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/schemas.py
@@ -423,16 +423,14 @@ RESOURCE_SCHEMAS: dict[MetaAdsResource, dict[str, Any]] = {
             "created_time",
             "business_country_code",
             "business_name",
-            # No `business`: reading it needs the `business_management` scope, which the Meta
-            # OAuth consent doesn't request (`ads_read` only) — see `AD_ACCOUNT_FIELDS` in
-            # meta_ads.py, which excludes it from the account-listing request for the same reason.
-            # Meta 400s the whole request when it's asked for, failing this table's sync outright.
-            "funding_source_details",
             "disable_reason",
-            "is_prepay_account",
-            "tos_accepted",
             "capabilities",
-            "owner",
+            # No `business`, `owner`, `funding_source_details`, `is_prepay_account`, or
+            # `tos_accepted`: each needs the `business_management` scope, which the Meta OAuth
+            # consent doesn't request (`ads_read` only) — see `AD_ACCOUNT_FIELDS` in meta_ads.py,
+            # which excludes `business` from the account-listing request for the same reason.
+            # Meta rejects the whole field set when any one of them is asked for without that
+            # scope, so a single one of these sneaking back in fails this table's sync outright.
         ],
         "single_object": True,
     },

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/source.py
@@ -131,6 +131,17 @@ class MetaAdsSource(ResumableSource[MetaAdsSourceConfig, MetaAdsResumeConfig], O
                 "required to read your ads data. Please reconnect the Meta Ads integration and grant "
                 "all requested permissions."
             ),
+            # Graph API code 200: "Requires business_management permission to manage the object."
+            # Distinct from the generic re-authorize message above — re-authorizing can never grant
+            # this scope, since the Meta OAuth consent only requests `ads_read` (see
+            # `AD_ACCOUNT_FIELDS` in meta_ads.py). Only the account owner granting
+            # `business_management`, or PostHog dropping the field that needs it, fixes this.
+            "Requires business_management permission": (
+                "Meta rejected part of this request because it needs the business_management "
+                "permission, which this integration does not request and cannot request without "
+                "widening OAuth consent for every customer. Re-authorizing will not fix this — "
+                "contact PostHog support if this table keeps failing."
+            ),
             # Meta returns this 500 when the requested query is too large for their backend to
             # service. Both pagination paths adapt to it (stats chunks shrink 30 → 7 → 1 day, and
             # both paths shrink the per-page limit 500 → 100 → 50); if it still escapes after those

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/test_meta_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/test_meta_ads.py
@@ -1266,6 +1266,8 @@ class TestNonRetryableErrors:
             'Meta API request failed: 400 - {"error":{"message":"(#200) Ad account owner has NOT granted ads_management or ads_read permission.","type":"OAuthException","code":200}}',
             # 400 when a specific endpoint cannot be accessed with the granted permissions.
             'Meta API request failed: 400 - {"error":{"message":"(#100) This endpoint cannot be loaded due to missing permissions."}}',
+            # 400 when a business_management-gated field is requested without that scope.
+            'Meta API request failed: 400 - {"error":{"message":"(#200) Requires business_management permission to manage the object.","type":"OAuthException","code":200}}',
             # 500 when Meta's backend refuses to service the query even after adaptive
             # chunking has shrunk the window to its smallest size.
             'Meta API request failed: 500 - {"error":{"code":1,"message":"Please reduce the amount of data you\'re asking for, then retry your request"}}',
@@ -1874,6 +1876,15 @@ class TestSingleObjectEndpoint:
         field_names = get_meta_ads_schemas()[MetaAdsResource.AdAccount].field_names
         assert "business" not in field_names
         assert {"business_name", "business_country_code"} <= set(field_names)
+
+    def test_field_list_omits_fields_gated_behind_business_management(self) -> None:
+        # These four live in the same business_management-gated family as `business` above, but
+        # each was pruned only from `AD_ACCOUNT_FIELDS` in meta_ads.py, not from this list — Meta
+        # rejects the whole field set when any one field needs a scope beyond `ads_read`, so any
+        # one of them sneaking back in fails every sync of this table, not just that field.
+        gated_fields = {"owner", "funding_source_details", "is_prepay_account", "tos_accepted"}
+        field_names = get_meta_ads_schemas()[MetaAdsResource.AdAccount].field_names
+        assert gated_fields.isdisjoint(field_names)
 
 
 class TestApiVersionDispatch:


### PR DESCRIPTION
## Problem

- The Meta Ads source's `ad_account` table fails on every sync with a Graph API 403, and the error the customer sees tells them to do something that cannot fix it.
- `schemas.py`'s `AdAccount` field list still requested `owner`, `funding_source_details`, `is_prepay_account`, and `tos_accepted`, all gated behind the `business_management` scope. The Meta OAuth consent only requests `ads_read` (`AD_ACCOUNT_FIELDS` in `meta_ads.py` already excludes `business` for the same reason, but `schemas.py`'s separate field list was never pruned to match).
- Meta rejects the whole field set when any one field needs a missing scope, so the single-object read for the account node fails outright and the table never syncs.
- Separately, `_is_permanent_auth_error` maps this to `META_AUTH_ERROR_MESSAGE` ("Please re-authorize the integration"). Re-authorizing can never grant `business_management` — the consent screen does not request that scope — so the customer loops through OAuth repeatedly and lands on the same 403.

## Changes

- Drop the four `business_management`-gated fields from the `AdAccount` field list in `schemas.py`, and fold the explanation into one comment naming all five excluded fields (including `business`, already absent).
- Add a scope-specific entry to `MetaAdsSource.get_non_retryable_errors`, matched on Meta's `"Requires business_management permission"` text, so this class of failure no longer tells the customer to re-authorize.
- Add a regression test asserting the `AdAccount` field list contains none of the four gated fields, alongside the existing test for `business`.
- Add a parametrized case to `test_errors_match_pattern` covering the real Graph API error text for this failure.

## How did you test this code?

- `uv run --no-sync pytest products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/test_meta_ads.py -q` — 207 passed, including the 2 new cases.
- `uv run --no-sync ty check` and `uv run --no-sync ruff check` on the 3 changed files — clean.
- Verified the new field-list test fails against the pre-fix field list (reintroducing any of the 4 fields breaks it) and passes against the fix.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal source behavior, no documented table or config change.

Fixes #80771