### PR TITLE
fix(personhog): heal condemned fences on condemnation

### DIFF
--- a/rust/personhog-coordination/src/pod.rs
+++ b/rust/personhog-coordination/src/pod.rs
@@ -10,7 +10,7 @@ use etcd_client::{EventType, WatchStream};
 use futures::future::BoxFuture;
 use futures::stream::{FuturesUnordered, StreamExt};
 use metrics::{counter, gauge, histogram};
-use tokio::sync::{mpsc, Mutex, Notify, Semaphore, SemaphorePermit};
+use tokio::sync::{Mutex, Notify, Semaphore, SemaphorePermit};
 use tokio::task::JoinError;
 use tokio_util::sync::CancellationToken;
 
@@ -273,13 +273,11 @@ pub struct PodHandle {
     authority: Arc<AuthorityClock>,
     /// Optional K8s awareness for departure classification during shutdown.
     k8s_awareness: Option<Arc<K8sAwareness>>,
-    /// Data-plane repair requests: partitions whose serving state broke
-    /// in a way only a convergence can mend (the leader sends one when a
-    /// changelog producer is condemned). Consumed by the watch loop as an
-    /// extra convergence trigger, so repair happens now rather than on
-    /// the next reconcile tick. Behind a mutex only because the loop
-    /// needs `&mut` through `&self`; the loop runs once at a time.
-    repair_rx: Option<tokio::sync::Mutex<mpsc::UnboundedReceiver<u32>>>,
+    /// Nudged when serving state broke in a way only a convergence can
+    /// mend (the leader nudges when a changelog producer is condemned).
+    /// The watch loop answers with an early reconcile pass, so repair
+    /// happens now rather than on the next tick.
+    repair_nudge: Option<Arc<Notify>>,
 }
 
 impl PodHandle {
@@ -313,17 +311,17 @@ impl PodHandle {
             fence_poisoned: AtomicBool::new(false),
             authority,
             k8s_awareness,
-            repair_rx: None,
+            repair_nudge: None,
         }
     }
 
-    /// Converge a partition whenever `rx` names it, in addition to the
-    /// event and reconcile triggers. The sending end announces breakage
-    /// the protocol has no event for — the leader's condemned changelog
-    /// producer — and this is what turns its repair latency from one
-    /// reconcile interval into one convergence.
-    pub fn with_repair_requests(mut self, rx: mpsc::UnboundedReceiver<u32>) -> Self {
-        self.repair_rx = Some(tokio::sync::Mutex::new(rx));
+    /// Run a reconcile pass whenever `nudge` fires, in addition to the
+    /// periodic tick. The nudging end announces breakage the protocol
+    /// has no event for — the leader's condemned changelog producer —
+    /// and this is what turns its repair latency from one reconcile
+    /// interval into one convergence.
+    pub fn with_repair_nudge(mut self, nudge: Arc<Notify>) -> Self {
+        self.repair_nudge = Some(nudge);
         self
     }
 
@@ -1261,33 +1259,20 @@ impl PodHandle {
         let mut in_flight: HashSet<u32> = HashSet::new();
         let mut pending: HashMap<u32, Trigger> = HashMap::new();
 
-        // Held for the loop's lifetime; a supervisor restart re-locks
-        // after this future is dropped. Repairs sent while no loop runs
-        // wait in the channel and are drained by the next attempt.
-        let mut repair_rx = match &self.repair_rx {
-            Some(m) => Some(m.lock().await),
-            None => None,
-        };
-        // One repair-triggered convergence per partition per reconcile
-        // interval. A partition whose producer condemns again right
-        // after every heal would otherwise cycle at broker speed — and
-        // each successful heal counts as applied work, resetting the
-        // budgets that exist to catch exactly that wedge. Suppressed
-        // requests fall back to the reconcile tick, so a flapping
-        // partition degrades to tick-rate healing, the pre-repair shape.
-        let mut repair_dispatched_at: HashMap<u32, tokio::time::Instant> = HashMap::new();
+        // One nudge-driven pass per reconcile interval at most. A
+        // producer that condemns again right after every heal would
+        // otherwise drive passes at broker speed — and each successful
+        // heal counts as applied work, resetting the budgets that exist
+        // to catch exactly that wedge. A suppressed nudge falls back to
+        // the tick, so a flap degrades to tick-rate healing, the
+        // pre-nudge shape.
+        let mut last_repair_pass: Option<tokio::time::Instant> = None;
 
-        /// Resolves to the next repair request, or never: an absent or
-        /// closed channel must leave the other arms in charge rather
-        /// than spin this one.
-        async fn next_repair(
-            rx: &mut Option<tokio::sync::MutexGuard<'_, mpsc::UnboundedReceiver<u32>>>,
-        ) -> u32 {
-            match rx {
-                Some(rx) => match rx.recv().await {
-                    Some(partition) => partition,
-                    None => std::future::pending().await,
-                },
+        /// Resolves when the repair nudge fires, or never when none is
+        /// wired, leaving the other arms in charge.
+        async fn nudged(nudge: &Option<Arc<Notify>>) {
+            match nudge {
+                Some(nudge) => nudge.notified().await,
                 None => std::future::pending().await,
             }
         }
@@ -1411,47 +1396,54 @@ impl PodHandle {
                         }
                     }
                 }
-                partition = next_repair(&mut repair_rx) => {
+                _ = nudged(&self.repair_nudge) => {
                     let now = tokio::time::Instant::now();
-                    let cooling = repair_dispatched_at.get(&partition).is_some_and(|last| {
-                        now.duration_since(*last) < self.config.reconcile_interval
+                    let cooling = last_repair_pass.is_some_and(|last| {
+                        now.duration_since(last) < self.config.reconcile_interval
                     });
                     if cooling {
-                        counter!(
-                            "personhog_coordination_repair_requests_suppressed_total",
-                            "partition" => partition.to_string()
-                        )
-                        .increment(1);
+                        counter!("personhog_coordination_repair_passes_total", "outcome" => "suppressed")
+                            .increment(1);
                         tracing::warn!(
                             pod = %self.config.pod_name,
-                            partition,
-                            "repair requested again inside the cooldown; leaving it to the reconcile tick"
+                            "repair nudged again inside the cooldown; leaving it to the reconcile tick"
                         );
                     } else {
-                        repair_dispatched_at.insert(partition, now);
-                        counter!(
-                            "personhog_coordination_repair_requests_total",
-                            "partition" => partition.to_string()
-                        )
-                        .increment(1);
+                        last_repair_pass = Some(now);
+                        counter!("personhog_coordination_repair_passes_total", "outcome" => "run")
+                            .increment(1);
                         tracing::info!(
                             pod = %self.config.pod_name,
-                            partition,
-                            "data-plane repair requested; converging"
+                            "data-plane repair nudge; converging involved partitions"
                         );
-                        // Reconcile severity: the convergence re-derives
-                        // the truth, and a repair that cannot be applied
-                        // is the reconcile budget's business —
-                        // `verify_serving` already declines to make a
-                        // failed heal fatal.
-                        dispatch(
-                            self,
-                            partition,
-                            Trigger::Reconcile,
-                            &mut in_flight,
-                            &mut pending,
-                            &mut lanes,
-                        );
+                        // The same derivation the tick runs: the nudge
+                        // carries no payload, and `verify_serving`
+                        // repairs exactly the partitions that need it
+                        // while the rest converge as no-ops. Reconcile
+                        // severity throughout; a failed snapshot leaves
+                        // repair to the tick, whose budget owns
+                        // sustained failure.
+                        match self.involved_partitions().await {
+                            Ok((partitions, _)) => {
+                                for partition in partitions {
+                                    dispatch(
+                                        self,
+                                        partition,
+                                        Trigger::Reconcile,
+                                        &mut in_flight,
+                                        &mut pending,
+                                        &mut lanes,
+                                    );
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    pod = %self.config.pod_name,
+                                    error = %e,
+                                    "repair-pass snapshot failed; leaving repair to the reconcile tick"
+                                );
+                            }
+                        }
                     }
                 }
                 msg = stream.message() => {

--- a/rust/personhog-coordination/src/pod.rs
+++ b/rust/personhog-coordination/src/pod.rs
@@ -10,7 +10,7 @@ use etcd_client::{EventType, WatchStream};
 use futures::future::BoxFuture;
 use futures::stream::{FuturesUnordered, StreamExt};
 use metrics::{counter, gauge, histogram};
-use tokio::sync::{Mutex, Notify, Semaphore, SemaphorePermit};
+use tokio::sync::{mpsc, Mutex, Notify, Semaphore, SemaphorePermit};
 use tokio::task::JoinError;
 use tokio_util::sync::CancellationToken;
 
@@ -273,6 +273,13 @@ pub struct PodHandle {
     authority: Arc<AuthorityClock>,
     /// Optional K8s awareness for departure classification during shutdown.
     k8s_awareness: Option<Arc<K8sAwareness>>,
+    /// Data-plane repair requests: partitions whose serving state broke
+    /// in a way only a convergence can mend (the leader sends one when a
+    /// changelog producer is condemned). Consumed by the watch loop as an
+    /// extra convergence trigger, so repair happens now rather than on
+    /// the next reconcile tick. Behind a mutex only because the loop
+    /// needs `&mut` through `&self`; the loop runs once at a time.
+    repair_rx: Option<tokio::sync::Mutex<mpsc::UnboundedReceiver<u32>>>,
 }
 
 impl PodHandle {
@@ -306,7 +313,18 @@ impl PodHandle {
             fence_poisoned: AtomicBool::new(false),
             authority,
             k8s_awareness,
+            repair_rx: None,
         }
+    }
+
+    /// Converge a partition whenever `rx` names it, in addition to the
+    /// event and reconcile triggers. The sending end announces breakage
+    /// the protocol has no event for — the leader's condemned changelog
+    /// producer — and this is what turns its repair latency from one
+    /// reconcile interval into one convergence.
+    pub fn with_repair_requests(mut self, rx: mpsc::UnboundedReceiver<u32>) -> Self {
+        self.repair_rx = Some(tokio::sync::Mutex::new(rx));
+        self
     }
 
     /// This pod's claim to serve, for the data plane to consult on the
@@ -1243,6 +1261,37 @@ impl PodHandle {
         let mut in_flight: HashSet<u32> = HashSet::new();
         let mut pending: HashMap<u32, Trigger> = HashMap::new();
 
+        // Held for the loop's lifetime; a supervisor restart re-locks
+        // after this future is dropped. Repairs sent while no loop runs
+        // wait in the channel and are drained by the next attempt.
+        let mut repair_rx = match &self.repair_rx {
+            Some(m) => Some(m.lock().await),
+            None => None,
+        };
+        // One repair-triggered convergence per partition per reconcile
+        // interval. A partition whose producer condemns again right
+        // after every heal would otherwise cycle at broker speed — and
+        // each successful heal counts as applied work, resetting the
+        // budgets that exist to catch exactly that wedge. Suppressed
+        // requests fall back to the reconcile tick, so a flapping
+        // partition degrades to tick-rate healing, the pre-repair shape.
+        let mut repair_dispatched_at: HashMap<u32, tokio::time::Instant> = HashMap::new();
+
+        /// Resolves to the next repair request, or never: an absent or
+        /// closed channel must leave the other arms in charge rather
+        /// than spin this one.
+        async fn next_repair(
+            rx: &mut Option<tokio::sync::MutexGuard<'_, mpsc::UnboundedReceiver<u32>>>,
+        ) -> u32 {
+            match rx {
+                Some(rx) => match rx.recv().await {
+                    Some(partition) => partition,
+                    None => std::future::pending().await,
+                },
+                None => std::future::pending().await,
+            }
+        }
+
         fn dispatch<'s>(
             handle: &'s PodHandle,
             partition: u32,
@@ -1360,6 +1409,49 @@ impl PodHandle {
                         if consecutive_reconcile_failures >= self.config.reconcile_failure_budget {
                             return Err(e);
                         }
+                    }
+                }
+                partition = next_repair(&mut repair_rx) => {
+                    let now = tokio::time::Instant::now();
+                    let cooling = repair_dispatched_at.get(&partition).is_some_and(|last| {
+                        now.duration_since(*last) < self.config.reconcile_interval
+                    });
+                    if cooling {
+                        counter!(
+                            "personhog_coordination_repair_requests_suppressed_total",
+                            "partition" => partition.to_string()
+                        )
+                        .increment(1);
+                        tracing::warn!(
+                            pod = %self.config.pod_name,
+                            partition,
+                            "repair requested again inside the cooldown; leaving it to the reconcile tick"
+                        );
+                    } else {
+                        repair_dispatched_at.insert(partition, now);
+                        counter!(
+                            "personhog_coordination_repair_requests_total",
+                            "partition" => partition.to_string()
+                        )
+                        .increment(1);
+                        tracing::info!(
+                            pod = %self.config.pod_name,
+                            partition,
+                            "data-plane repair requested; converging"
+                        );
+                        // Reconcile severity: the convergence re-derives
+                        // the truth, and a repair that cannot be applied
+                        // is the reconcile budget's business —
+                        // `verify_serving` already declines to make a
+                        // failed heal fatal.
+                        dispatch(
+                            self,
+                            partition,
+                            Trigger::Reconcile,
+                            &mut in_flight,
+                            &mut pending,
+                            &mut lanes,
+                        );
                     }
                 }
                 msg = stream.message() => {

--- a/rust/personhog-coordination/tests/protocol_hardening.rs
+++ b/rust/personhog-coordination/tests/protocol_hardening.rs
@@ -16,7 +16,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{Mutex, Notify, RwLock};
 use tokio_util::sync::CancellationToken;
 
 use assignment_coordination::store::parse_watch_value;
@@ -4162,7 +4162,7 @@ async fn a_repair_nudge_converges_without_waiting_for_reconcile() {
         events: Arc::clone(&events),
         verified: Arc::clone(&verified),
     };
-    let nudge = Arc::new(tokio::sync::Notify::new());
+    let nudge = Arc::new(Notify::new());
     let pod = personhog_coordination::pod::PodHandle::new(
         Arc::clone(&store),
         personhog_coordination::pod::PodConfig {

--- a/rust/personhog-coordination/tests/protocol_hardening.rs
+++ b/rust/personhog-coordination/tests/protocol_hardening.rs
@@ -4134,15 +4134,15 @@ impl personhog_coordination::pod::HandoffHandler for RepairProbeHandler {
     }
 }
 
-/// A data-plane repair request must converge the partition immediately.
-/// The condemned-producer incident this pins: every write on the
-/// partition bounces until `verify_serving` re-takes the fence, and with
-/// the reconcile tick as the only trigger that wait is a whole interval.
+/// A data-plane repair nudge must converge immediately. The
+/// condemned-producer incident this pins: every write on the partition
+/// bounces until `verify_serving` re-takes the fence, and with the
+/// reconcile tick as the only trigger that wait is a whole interval.
 /// Here reconcile is parked at a day and no etcd event fires, so the
-/// only thing that can drive the second `verify_serving` is the repair
+/// only thing that can drive the second `verify_serving` is the nudge
 /// arm itself.
 #[tokio::test]
-async fn a_repair_request_converges_the_partition_without_waiting_for_reconcile() {
+async fn a_repair_nudge_converges_without_waiting_for_reconcile() {
     let store = test_store("repair-request-converges").await;
     let cancel = CancellationToken::new();
 
@@ -4162,7 +4162,7 @@ async fn a_repair_request_converges_the_partition_without_waiting_for_reconcile(
         events: Arc::clone(&events),
         verified: Arc::clone(&verified),
     };
-    let (repair_tx, repair_rx) = tokio::sync::mpsc::unbounded_channel();
+    let nudge = Arc::new(tokio::sync::Notify::new());
     let pod = personhog_coordination::pod::PodHandle::new(
         Arc::clone(&store),
         personhog_coordination::pod::PodConfig {
@@ -4179,7 +4179,7 @@ async fn a_repair_request_converges_the_partition_without_waiting_for_reconcile(
         None,
         Arc::new(AuthorityClock::unclaimed()),
     )
-    .with_repair_requests(repair_rx);
+    .with_repair_nudge(Arc::clone(&nudge));
     let token = cancel.child_token();
     tokio::spawn(async move { pod.run(token).await });
 
@@ -4192,12 +4192,12 @@ async fn a_repair_request_converges_the_partition_without_waiting_for_reconcile(
     .await;
     let baseline = verified.load(Ordering::SeqCst);
 
-    repair_tx.send(0).expect("repair channel open");
+    nudge.notify_one();
 
     wait_for_condition_named(
         WAIT_TIMEOUT,
         POLL_INTERVAL,
-        "repair request drives a convergence",
+        "repair nudge drives a convergence",
         || {
             let verified = Arc::clone(&verified);
             async move { verified.load(Ordering::SeqCst) > baseline }
@@ -4205,18 +4205,18 @@ async fn a_repair_request_converges_the_partition_without_waiting_for_reconcile(
     )
     .await;
 
-    // A second request inside the cooldown must not converge again: the
-    // condemn-heal-condemn flap would otherwise cycle at broker speed,
-    // resetting the budgets that exist to catch it. The cooldown is the
-    // reconcile interval, parked at a day here, so nothing but the
-    // suppression can be holding the counter still.
+    // A second nudge inside the cooldown must not run another pass: the
+    // condemn-heal-condemn flap would otherwise drive passes at broker
+    // speed, resetting the budgets that exist to catch it. The cooldown
+    // is the reconcile interval, parked at a day here, so nothing but
+    // the suppression can be holding the counter still.
     let after_first = verified.load(Ordering::SeqCst);
-    repair_tx.send(0).expect("repair channel open");
+    nudge.notify_one();
     tokio::time::sleep(Duration::from_millis(1_500)).await;
     assert_eq!(
         verified.load(Ordering::SeqCst),
         after_first,
-        "a repair request inside the cooldown must fall to the reconcile tick"
+        "a nudge inside the cooldown must fall to the reconcile tick"
     );
 
     cancel.cancel();

--- a/rust/personhog-coordination/tests/protocol_hardening.rs
+++ b/rust/personhog-coordination/tests/protocol_hardening.rs
@@ -4086,3 +4086,138 @@ async fn phase_advance_refuses_a_handoff_that_was_replaced() {
         "a replaced handoff must not be advanced by its predecessor's quorum"
     );
 }
+
+/// Records `verify_serving` calls — the repair a data-plane repair
+/// request exists to trigger.
+struct RepairProbeHandler {
+    events: Arc<Mutex<Vec<HandoffEvent>>>,
+    verified: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl personhog_coordination::pod::HandoffHandler for RepairProbeHandler {
+    async fn drain_partition_inflight(&self, partition: u32) -> Result<()> {
+        self.events
+            .lock()
+            .await
+            .push(HandoffEvent::Drained(partition));
+        Ok(())
+    }
+
+    async fn warm_partition(&self, partition: u32) -> Result<()> {
+        self.events
+            .lock()
+            .await
+            .push(HandoffEvent::Warmed(partition));
+        Ok(())
+    }
+
+    async fn verify_serving(&self, _partition: u32) -> Result<bool> {
+        self.verified.fetch_add(1, Ordering::SeqCst);
+        Ok(false)
+    }
+
+    async fn release_partition(&self, partition: u32) -> Result<()> {
+        self.events
+            .lock()
+            .await
+            .push(HandoffEvent::Released(partition));
+        Ok(())
+    }
+
+    async fn resume_partition(&self, partition: u32) -> Result<()> {
+        self.events
+            .lock()
+            .await
+            .push(HandoffEvent::Resumed(partition));
+        Ok(())
+    }
+}
+
+/// A data-plane repair request must converge the partition immediately.
+/// The condemned-producer incident this pins: every write on the
+/// partition bounces until `verify_serving` re-takes the fence, and with
+/// the reconcile tick as the only trigger that wait is a whole interval.
+/// Here reconcile is parked at a day and no etcd event fires, so the
+/// only thing that can drive the second `verify_serving` is the repair
+/// arm itself.
+#[tokio::test]
+async fn a_repair_request_converges_the_partition_without_waiting_for_reconcile() {
+    let store = test_store("repair-request-converges").await;
+    let cancel = CancellationToken::new();
+
+    store
+        .put_assignments(&[PartitionAssignment {
+            partition: 0,
+            owner: "repair-pod".to_string(),
+            status: AssignmentStatus::Active,
+            advertise_address: None,
+        }])
+        .await
+        .expect("write assignment");
+
+    let events: Arc<Mutex<Vec<HandoffEvent>>> = Arc::new(Mutex::new(Vec::new()));
+    let verified = Arc::new(AtomicUsize::new(0));
+    let handler = RepairProbeHandler {
+        events: Arc::clone(&events),
+        verified: Arc::clone(&verified),
+    };
+    let (repair_tx, repair_rx) = tokio::sync::mpsc::unbounded_channel();
+    let pod = personhog_coordination::pod::PodHandle::new(
+        Arc::clone(&store),
+        personhog_coordination::pod::PodConfig {
+            pod_name: "repair-pod".to_string(),
+            // A session restart re-runs the seed convergence, which also
+            // bumps `verified`; a 30s lease keeps restarts out of this
+            // test's window so only the repair arm can move the counter.
+            lease_ttl: 30,
+            heartbeat_interval: Duration::from_secs(10),
+            reconcile_interval: Duration::from_secs(86_400),
+            ..Default::default()
+        },
+        Arc::new(handler),
+        None,
+        Arc::new(AuthorityClock::unclaimed()),
+    )
+    .with_repair_requests(repair_rx);
+    let token = cancel.child_token();
+    tokio::spawn(async move { pod.run(token).await });
+
+    // The seed convergence serves the partition and runs the first
+    // verification on its way.
+    wait_for_condition(WAIT_TIMEOUT, POLL_INTERVAL, || {
+        let verified = Arc::clone(&verified);
+        async move { verified.load(Ordering::SeqCst) >= 1 }
+    })
+    .await;
+    let baseline = verified.load(Ordering::SeqCst);
+
+    repair_tx.send(0).expect("repair channel open");
+
+    wait_for_condition_named(
+        WAIT_TIMEOUT,
+        POLL_INTERVAL,
+        "repair request drives a convergence",
+        || {
+            let verified = Arc::clone(&verified);
+            async move { verified.load(Ordering::SeqCst) > baseline }
+        },
+    )
+    .await;
+
+    // A second request inside the cooldown must not converge again: the
+    // condemn-heal-condemn flap would otherwise cycle at broker speed,
+    // resetting the budgets that exist to catch it. The cooldown is the
+    // reconcile interval, parked at a day here, so nothing but the
+    // suppression can be holding the counter still.
+    let after_first = verified.load(Ordering::SeqCst);
+    repair_tx.send(0).expect("repair channel open");
+    tokio::time::sleep(Duration::from_millis(1_500)).await;
+    assert_eq!(
+        verified.load(Ordering::SeqCst),
+        after_first,
+        "a repair request inside the cooldown must fall to the reconcile tick"
+    );
+
+    cancel.cancel();
+}

--- a/rust/personhog-leader/src/fencing.rs
+++ b/rust/personhog-leader/src/fencing.rs
@@ -36,7 +36,7 @@ use prost::Message as ProtoMessage;
 use rdkafka::client::ClientContext;
 use rdkafka::error::{KafkaError, RDKafkaErrorCode};
 use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
-use tokio::sync::{mpsc, oneshot, Notify};
+use tokio::sync::{oneshot, Notify};
 use tokio::task::spawn_blocking;
 use tokio::time::{sleep, timeout};
 use tracing::{debug, error, warn};
@@ -166,9 +166,9 @@ struct PartitionFence {
     /// epoch once the pod's claim is confirmed.
     unusable: AtomicBool,
     commit_timeout: Duration,
-    /// Clone of the map's repair sender; a condemnation must be able to
+    /// Clone of the map's repair nudge; a condemnation must be able to
     /// announce itself from wherever the commit task discovers it.
-    repair_tx: Option<mpsc::UnboundedSender<u32>>,
+    repair_nudge: Option<Arc<Notify>>,
 }
 
 impl PartitionFence {
@@ -187,12 +187,12 @@ impl PartitionFence {
             );
             // The only way back is a heal on a convergence to Serving, and
             // the reconcile tick that would otherwise carry it is seconds
-            // away — writes bounce for that whole gap. Announcing the
-            // condemnation lets the coordination loop converge now. Best
-            // effort: a closed channel means coordination is gone, where
-            // the tick (or the shutdown) owns the outcome anyway.
-            if let Some(tx) = &self.repair_tx {
-                let _ = tx.send(partition);
+            // away — writes bounce for that whole gap. The nudge lets the
+            // coordination loop run its repair pass now; Notify stores
+            // the permit, so a nudge landing before the loop listens is
+            // not lost.
+            if let Some(nudge) = &self.repair_nudge {
+                nudge.notify_one();
             }
         }
     }
@@ -428,10 +428,11 @@ pub struct FencedChangelogProducers {
     /// and report a failed drain.
     settle_budget: Duration,
     partitions: DashMap<u32, Arc<PartitionFence>>,
-    /// Where a condemnation announces itself, so the coordination loop
-    /// can converge the partition now instead of on its next reconcile
-    /// tick. `None` leaves repair to the tick alone.
-    repair_tx: Option<mpsc::UnboundedSender<u32>>,
+    /// Nudged on condemnation, so the coordination loop can run a
+    /// repair pass now instead of on its next reconcile tick. Carries no
+    /// payload: the pass re-derives what needs converging, the same way
+    /// the tick does. `None` leaves repair to the tick alone.
+    repair_nudge: Option<Arc<Notify>>,
     /// Outcomes a test stages for the next produce on a partition.
     ///
     /// The uncertain outcomes need a broker fault landing inside a
@@ -477,18 +478,18 @@ impl FencedChangelogProducers {
             window,
             settle_budget,
             partitions: DashMap::new(),
-            repair_tx: None,
+            repair_nudge: None,
             #[cfg(any(test, feature = "test-support"))]
             staged_failures: DashMap::new(),
         }
     }
 
-    /// Announce condemnations on `tx`, so the coordination loop can
-    /// converge the partition immediately instead of on its next
-    /// reconcile tick. The receiving end is [`PodHandle::
-    /// with_repair_requests`](personhog_coordination::pod::PodHandle).
-    pub fn with_repair_requests(mut self, tx: mpsc::UnboundedSender<u32>) -> Self {
-        self.repair_tx = Some(tx);
+    /// Announce condemnations on `nudge`, so the coordination loop can
+    /// run a repair pass immediately instead of on its next reconcile
+    /// tick. The listening end is [`PodHandle::
+    /// with_repair_nudge`](personhog_coordination::pod::PodHandle).
+    pub fn with_repair_nudge(mut self, nudge: Arc<Notify>) -> Self {
+        self.repair_nudge = Some(nudge);
         self
     }
 
@@ -528,7 +529,7 @@ impl FencedChangelogProducers {
             panic_next_commit: AtomicBool::new(false),
             unusable: AtomicBool::new(false),
             commit_timeout: self.commit_timeout,
-            repair_tx: self.repair_tx.clone(),
+            repair_nudge: self.repair_nudge.clone(),
         });
         if let Some(replaced) = self.partitions.insert(partition, Arc::clone(&installed)) {
             // The heal path installs over a still-present condemned
@@ -1384,6 +1385,12 @@ pub fn preregister_fencing_metrics(partitions: u32) {
         counter!("personhog_leader_fence_condemned_total", "reason" => reason).increment(0);
     }
     counter!("personhog_leader_fence_commit_retries_total").increment(0);
+    // The coordination loop's repair-pass counter fires exclusively
+    // mid-incident, exactly when a first-increment series would be
+    // swallowed between scrapes.
+    for outcome in ["run", "suppressed"] {
+        counter!("personhog_coordination_repair_passes_total", "outcome" => outcome).increment(0);
+    }
     counter!("personhog_leader_kafka_produce_errors_total").increment(0);
     for partition in 0..partitions {
         let p = partition.to_string();
@@ -1398,20 +1405,7 @@ pub fn preregister_fencing_metrics(partitions: u32) {
             "partition" => p.clone()
         )
         .increment(0);
-        // The coordination loop's repair counters, preregistered here
-        // because this is where the partition count is known. They fire
-        // exclusively mid-incident, exactly when a first-increment
-        // series would be swallowed between scrapes.
-        counter!(
-            "personhog_coordination_repair_requests_total",
-            "partition" => p.clone()
-        )
-        .increment(0);
-        counter!(
-            "personhog_coordination_repair_requests_suppressed_total",
-            "partition" => p.clone()
-        )
-        .increment(0);
+
         counter!(
             "personhog_leader_fence_commit_indeterminate_total",
             "partition" => p.clone()

--- a/rust/personhog-leader/src/fencing.rs
+++ b/rust/personhog-leader/src/fencing.rs
@@ -36,7 +36,7 @@ use prost::Message as ProtoMessage;
 use rdkafka::client::ClientContext;
 use rdkafka::error::{KafkaError, RDKafkaErrorCode};
 use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
-use tokio::sync::{oneshot, Notify};
+use tokio::sync::{mpsc, oneshot, Notify};
 use tokio::task::spawn_blocking;
 use tokio::time::{sleep, timeout};
 use tracing::{debug, error, warn};
@@ -166,6 +166,9 @@ struct PartitionFence {
     /// epoch once the pod's claim is confirmed.
     unusable: AtomicBool,
     commit_timeout: Duration,
+    /// Clone of the map's repair sender; a condemnation must be able to
+    /// announce itself from wherever the commit task discovers it.
+    repair_tx: Option<mpsc::UnboundedSender<u32>>,
 }
 
 impl PartitionFence {
@@ -182,6 +185,15 @@ impl PartitionFence {
                 partition,
                 reason, "changelog producer left unusable; awaiting re-acquisition"
             );
+            // The only way back is a heal on a convergence to Serving, and
+            // the reconcile tick that would otherwise carry it is seconds
+            // away — writes bounce for that whole gap. Announcing the
+            // condemnation lets the coordination loop converge now. Best
+            // effort: a closed channel means coordination is gone, where
+            // the tick (or the shutdown) owns the outcome anyway.
+            if let Some(tx) = &self.repair_tx {
+                let _ = tx.send(partition);
+            }
         }
     }
 
@@ -416,6 +428,10 @@ pub struct FencedChangelogProducers {
     /// and report a failed drain.
     settle_budget: Duration,
     partitions: DashMap<u32, Arc<PartitionFence>>,
+    /// Where a condemnation announces itself, so the coordination loop
+    /// can converge the partition now instead of on its next reconcile
+    /// tick. `None` leaves repair to the tick alone.
+    repair_tx: Option<mpsc::UnboundedSender<u32>>,
     /// Outcomes a test stages for the next produce on a partition.
     ///
     /// The uncertain outcomes need a broker fault landing inside a
@@ -461,9 +477,19 @@ impl FencedChangelogProducers {
             window,
             settle_budget,
             partitions: DashMap::new(),
+            repair_tx: None,
             #[cfg(any(test, feature = "test-support"))]
             staged_failures: DashMap::new(),
         }
+    }
+
+    /// Announce condemnations on `tx`, so the coordination loop can
+    /// converge the partition immediately instead of on its next
+    /// reconcile tick. The receiving end is [`PodHandle::
+    /// with_repair_requests`](personhog_coordination::pod::PodHandle).
+    pub fn with_repair_requests(mut self, tx: mpsc::UnboundedSender<u32>) -> Self {
+        self.repair_tx = Some(tx);
+        self
     }
 
     /// Take the partition's fence: create the transactional producer and
@@ -502,8 +528,16 @@ impl FencedChangelogProducers {
             panic_next_commit: AtomicBool::new(false),
             unusable: AtomicBool::new(false),
             commit_timeout: self.commit_timeout,
+            repair_tx: self.repair_tx.clone(),
         });
-        self.partitions.insert(partition, Arc::clone(&installed));
+        if let Some(replaced) = self.partitions.insert(partition, Arc::clone(&installed)) {
+            // The heal path installs over a still-present condemned
+            // fence, and by then the commit task has usually dropped its
+            // clones — making this insert the last reference and its
+            // drop a blocking librdkafka destroy. Send it to the
+            // blocking pool like every other eviction site.
+            drop_fence_off_worker(replaced);
+        }
         Ok(installed)
     }
 
@@ -1014,16 +1048,42 @@ enum WindowVerdict {
 /// record at the same number behind one that may be committed. Reporting
 /// it as merely indeterminate throws away the ownership answer the router
 /// bounces on. `FencedUncertain` is both.
+/// Every reason production code passes to `condemn`, in one place so the
+/// preregistration below cannot drift from the call sites: a reason
+/// missing here first appears as a brand-new series mid-incident instead
+/// of rising from zero.
+const CONDEMN_REASONS: [&str; 6] = [
+    "abort_fenced",
+    "abort_failed",
+    "commit_fenced",
+    "commit_indeterminate",
+    "commit_task_lost",
+    "committer_unwound",
+];
+
 /// Why a window's outcome leaves the producer unusable, if it does.
 ///
 /// Extracted so the arrow *into* the condemned state is reachable: the
 /// tests could reach the aftermath through a staging hook, but the branch
 /// that decides it could be deleted outright with the suite still green,
 /// and it is the only path in production that ever sets the flag.
-fn condemn_reason(outcome: CommitOutcome) -> Option<&'static str> {
+///
+/// A dead producer carries two very different stories, split by
+/// `fenced`: a producer fenced by a newer owner's init lost the epoch (a
+/// handoff, a heal, a zombie being cut off — coordination working), while
+/// an abort that failed on a producer nobody fenced means the broker
+/// could not be reached in time (an infrastructure excursion). The panel
+/// reading this label has to tell those apart without the logs.
+fn condemn_reason(outcome: CommitOutcome, fenced: bool) -> Option<&'static str> {
     match outcome {
         CommitOutcome::Aborted => None,
+        CommitOutcome::AbortedProducerDead if fenced => Some("abort_fenced"),
         CommitOutcome::AbortedProducerDead => Some("abort_failed"),
+        // A commit killed by a newer owner's init reports librdkafka's
+        // fatal class and lands here, not in AbortedProducerDead — the
+        // fenced split must cover this arm or every deploy-shaped
+        // condemnation reads as a broker excursion.
+        CommitOutcome::Unknown if fenced => Some("commit_fenced"),
         CommitOutcome::Unknown => Some("commit_indeterminate"),
     }
 }
@@ -1213,10 +1273,10 @@ async fn commit_window_after(
         Ok(Err((e, outcome))) => {
             histogram!("personhog_leader_fence_commit_ms", "outcome" => "failed")
                 .record(commit_start.elapsed().as_secs_f64() * 1000.0);
-            if let Some(reason) = condemn_reason(outcome) {
+            let fenced_now = is_fenced(&e) || producer_fenced(fence.producer.inner());
+            if let Some(reason) = condemn_reason(outcome, fenced_now) {
                 fence.condemn(partition, reason);
             }
-            let fenced_now = is_fenced(&e) || producer_fenced(fence.producer.inner());
             let verdict = window_verdict(outcome, fenced_now);
             if verdict == WindowVerdict::FencedUncertain {
                 counter!(
@@ -1320,7 +1380,7 @@ pub fn preregister_fencing_metrics(partitions: u32) {
     // can swallow the first burst between scrapes.
     counter!("personhog_leader_fence_healed_total").increment(0);
     counter!("personhog_leader_fence_heal_abandoned_total").increment(0);
-    for reason in ["abort_failed", "commit_indeterminate", "commit_task_lost"] {
+    for reason in CONDEMN_REASONS {
         counter!("personhog_leader_fence_condemned_total", "reason" => reason).increment(0);
     }
     counter!("personhog_leader_fence_commit_retries_total").increment(0);
@@ -1335,6 +1395,20 @@ pub fn preregister_fencing_metrics(partitions: u32) {
         .increment(0);
         counter!(
             "personhog_leader_fence_heal_failures_total",
+            "partition" => p.clone()
+        )
+        .increment(0);
+        // The coordination loop's repair counters, preregistered here
+        // because this is where the partition count is known. They fire
+        // exclusively mid-incident, exactly when a first-increment
+        // series would be swallowed between scrapes.
+        counter!(
+            "personhog_coordination_repair_requests_total",
+            "partition" => p.clone()
+        )
+        .increment(0);
+        counter!(
+            "personhog_coordination_repair_requests_suppressed_total",
             "partition" => p.clone()
         )
         .increment(0);
@@ -1484,15 +1558,55 @@ mod tests {
     /// that cannot serve one, for the life of the process.
     #[test]
     fn a_producer_that_cannot_begin_another_window_is_condemned() {
-        assert_eq!(condemn_reason(CommitOutcome::Aborted), None);
+        for fenced in [false, true] {
+            assert_eq!(condemn_reason(CommitOutcome::Aborted, fenced), None);
+        }
         assert_eq!(
-            condemn_reason(CommitOutcome::AbortedProducerDead),
-            Some("abort_failed")
+            condemn_reason(CommitOutcome::Unknown, true),
+            Some("commit_fenced")
         );
         assert_eq!(
-            condemn_reason(CommitOutcome::Unknown),
+            condemn_reason(CommitOutcome::Unknown, false),
             Some("commit_indeterminate")
         );
+        // The same dead producer, split by what killed it: an epoch lost
+        // to a newer owner is coordination working, an abort nobody
+        // fenced failing is the broker unreachable — the operator's first
+        // question, answered from the series alone.
+        assert_eq!(
+            condemn_reason(CommitOutcome::AbortedProducerDead, true),
+            Some("abort_fenced")
+        );
+        assert_eq!(
+            condemn_reason(CommitOutcome::AbortedProducerDead, false),
+            Some("abort_failed")
+        );
+    }
+
+    /// A condemn reason absent from the preregistration list first
+    /// appears as a new series mid-incident instead of rising from zero.
+    #[test]
+    fn every_condemn_reason_is_preregistered() {
+        for outcome in [
+            CommitOutcome::Aborted,
+            CommitOutcome::AbortedProducerDead,
+            CommitOutcome::Unknown,
+        ] {
+            for fenced in [false, true] {
+                if let Some(reason) = condemn_reason(outcome, fenced) {
+                    assert!(
+                        CONDEMN_REASONS.contains(&reason),
+                        "condemn_reason produced {reason:?}, missing from CONDEMN_REASONS"
+                    );
+                }
+            }
+        }
+        for direct in ["commit_task_lost", "committer_unwound"] {
+            assert!(
+                CONDEMN_REASONS.contains(&direct),
+                "direct condemn call site uses {direct:?}, missing from CONDEMN_REASONS"
+            );
+        }
     }
 
     #[test]

--- a/rust/personhog-leader/src/main.rs
+++ b/rust/personhog-leader/src/main.rs
@@ -17,6 +17,7 @@ use personhog_coordination::authority::AuthorityClock;
 use personhog_coordination::pod::{PodConfig, PodHandle};
 use personhog_coordination::store::PersonhogStore;
 use personhog_proto::personhog::leader::v1::person_hog_leader_server::PersonHogLeaderServer;
+use tokio::sync::Notify;
 use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
 use tonic::codec::CompressionEncoding;
@@ -322,7 +323,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.ingestion_warnings_topic.clone(),
     );
     let fence_scan_pool = fallback.as_ref().map(|f| f.pool.clone());
-    let mut fence_repair_nudge: Option<std::sync::Arc<tokio::sync::Notify>> = None;
+    let mut fence_repair_nudge: Option<Arc<Notify>> = None;
     let fenced = if config.kafka_transactional_fencing {
         // Every one of these is derived from LEASE_TTL rather than set
         // directly, so an operator debugging a fenced-write timeout has
@@ -340,8 +341,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // A condemned producer's repair otherwise waits for the next
         // reconcile tick; this nudge lets the condemnation itself
         // trigger the repair pass that heals it.
-        let repair_nudge = std::sync::Arc::new(tokio::sync::Notify::new());
-        fence_repair_nudge = Some(std::sync::Arc::clone(&repair_nudge));
+        let repair_nudge = Arc::new(Notify::new());
+        fence_repair_nudge = Some(Arc::clone(&repair_nudge));
         // The fenced producer runs on a tighter message timeout than the
         // shared one: its writes must resolve inside the lease runway.
         let fencing_kafka = common_kafka::config::KafkaConfig {

--- a/rust/personhog-leader/src/main.rs
+++ b/rust/personhog-leader/src/main.rs
@@ -322,7 +322,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.ingestion_warnings_topic.clone(),
     );
     let fence_scan_pool = fallback.as_ref().map(|f| f.pool.clone());
-    let mut fence_repair_rx = None;
+    let mut fence_repair_nudge: Option<std::sync::Arc<tokio::sync::Notify>> = None;
     let fenced = if config.kafka_transactional_fencing {
         // Every one of these is derived from LEASE_TTL rather than set
         // directly, so an operator debugging a fenced-write timeout has
@@ -338,10 +338,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
         preregister_fencing_metrics(num_partitions);
         // A condemned producer's repair otherwise waits for the next
-        // reconcile tick; this channel lets the condemnation itself
-        // trigger the convergence that heals it.
-        let (repair_tx, repair_rx) = tokio::sync::mpsc::unbounded_channel();
-        fence_repair_rx = Some(repair_rx);
+        // reconcile tick; this nudge lets the condemnation itself
+        // trigger the repair pass that heals it.
+        let repair_nudge = std::sync::Arc::new(tokio::sync::Notify::new());
+        fence_repair_nudge = Some(std::sync::Arc::clone(&repair_nudge));
         // The fenced producer runs on a tighter message timeout than the
         // shared one: its writes must resolve inside the lease runway.
         let fencing_kafka = common_kafka::config::KafkaConfig {
@@ -363,7 +363,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 window: Duration::from_millis(config.fencing_window_ms),
                 settle_budget: config.fencing_settle_budget(),
             })
-            .with_repair_requests(repair_tx),
+            .with_repair_nudge(repair_nudge),
         ))
     } else {
         None
@@ -578,8 +578,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         k8s_awareness,
         Arc::clone(&authority),
     );
-    if let Some(rx) = fence_repair_rx.take() {
-        pod = pod.with_repair_requests(rx);
+    if let Some(nudge) = fence_repair_nudge.take() {
+        pod = pod.with_repair_nudge(nudge);
     }
 
     tokio::spawn(async move {

--- a/rust/personhog-leader/src/main.rs
+++ b/rust/personhog-leader/src/main.rs
@@ -322,6 +322,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.ingestion_warnings_topic.clone(),
     );
     let fence_scan_pool = fallback.as_ref().map(|f| f.pool.clone());
+    let mut fence_repair_rx = None;
     let fenced = if config.kafka_transactional_fencing {
         // Every one of these is derived from LEASE_TTL rather than set
         // directly, so an operator debugging a fenced-write timeout has
@@ -336,6 +337,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "broker-enforced epoch fencing enabled for the changelog"
         );
         preregister_fencing_metrics(num_partitions);
+        // A condemned producer's repair otherwise waits for the next
+        // reconcile tick; this channel lets the condemnation itself
+        // trigger the convergence that heals it.
+        let (repair_tx, repair_rx) = tokio::sync::mpsc::unbounded_channel();
+        fence_repair_rx = Some(repair_rx);
         // The fenced producer runs on a tighter message timeout than the
         // shared one: its writes must resolve inside the lease runway.
         let fencing_kafka = common_kafka::config::KafkaConfig {
@@ -347,8 +353,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             kafka_producer_queue_messages: config.fencing_queue_messages(num_partitions),
             ..config.kafka.clone()
         };
-        Some(Arc::new(FencedChangelogProducers::new(
-            FencedProducerConfig {
+        Some(Arc::new(
+            FencedChangelogProducers::new(FencedProducerConfig {
                 kafka: fencing_kafka,
                 topic: config.kafka_person_state_topic.clone(),
                 init_timeout: config.fencing_init_timeout(),
@@ -356,8 +362,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 broker_txn_timeout: config.fencing_broker_txn_timeout(),
                 window: Duration::from_millis(config.fencing_window_ms),
                 settle_budget: config.fencing_settle_budget(),
-            },
-        )))
+            })
+            .with_repair_requests(repair_tx),
+        ))
     } else {
         None
     };
@@ -564,13 +571,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    let pod = PodHandle::new(
+    let mut pod = PodHandle::new(
         store,
         pod_config,
         Arc::new(handler),
         k8s_awareness,
         Arc::clone(&authority),
     );
+    if let Some(rx) = fence_repair_rx.take() {
+        pod = pod.with_repair_requests(rx);
+    }
 
     tokio::spawn(async move {
         let _guard = coordination_handle.process_scope();

--- a/rust/personhog-leader/tests/fencing_integration.rs
+++ b/rust/personhog-leader/tests/fencing_integration.rs
@@ -18,6 +18,7 @@ use personhog_leader::fencing::{
 };
 use personhog_leader::inflight::InflightTracker;
 use personhog_proto::personhog::types::v1::Person;
+use tokio::sync::Notify;
 use tokio::time::sleep;
 
 use common::{test_kafka_config, KAFKA_BOOTSTRAP};
@@ -382,7 +383,7 @@ async fn a_completed_warm_keeps_its_fence() {
 #[tokio::test]
 async fn a_condemnation_nudges_repair_once() {
     let topic = format!("fence_repair_{}", uuid::Uuid::new_v4().simple());
-    let nudge = Arc::new(tokio::sync::Notify::new());
+    let nudge = Arc::new(Notify::new());
     let producers = fenced_producers(&topic).with_repair_nudge(Arc::clone(&nudge));
     producers.acquire(3).await.expect("acquire the fence");
 

--- a/rust/personhog-leader/tests/fencing_integration.rs
+++ b/rust/personhog-leader/tests/fencing_integration.rs
@@ -374,28 +374,31 @@ async fn a_completed_warm_keeps_its_fence() {
         .expect("a completed warm keeps a usable fence");
 }
 
-/// A condemnation must request its own repair: the fix for a condemned
-/// producer is a convergence-driven heal, and without the announcement
-/// that convergence waits for the next reconcile tick while every write
-/// on the partition bounces. Exactly once per producer: the unusable
-/// swap, not the channel, bounds the announcements.
+/// A condemnation must nudge its own repair: the fix for a condemned
+/// producer is a convergence-driven heal, and without the nudge that
+/// convergence waits for the next reconcile tick while every write on
+/// the partition bounces. Once per producer: the unusable swap, not the
+/// notify, bounds the nudges.
 #[tokio::test]
-async fn a_condemnation_requests_repair_once() {
+async fn a_condemnation_nudges_repair_once() {
     let topic = format!("fence_repair_{}", uuid::Uuid::new_v4().simple());
-    let (repair_tx, mut repair_rx) = tokio::sync::mpsc::unbounded_channel();
-    let producers = fenced_producers(&topic).with_repair_requests(repair_tx);
+    let nudge = Arc::new(tokio::sync::Notify::new());
+    let producers = fenced_producers(&topic).with_repair_nudge(Arc::clone(&nudge));
     producers.acquire(3).await.expect("acquire the fence");
 
     producers.condemn_for_test(3);
-    producers.condemn_for_test(3);
-
-    let announced = tokio::time::timeout(Duration::from_secs(5), repair_rx.recv())
+    tokio::time::timeout(Duration::from_secs(5), nudge.notified())
         .await
-        .expect("a condemnation must announce the partition for repair");
-    assert_eq!(announced, Some(3));
+        .expect("a condemnation must nudge the repair pass");
+
+    // The permit was consumed above; a second condemnation of the same
+    // producer takes the unusable-swap early exit and stores no new one.
+    producers.condemn_for_test(3);
     assert!(
-        repair_rx.try_recv().is_err(),
-        "a second condemnation of the same producer must not announce again"
+        tokio::time::timeout(Duration::from_millis(250), nudge.notified())
+            .await
+            .is_err(),
+        "a second condemnation of the same producer must not nudge again"
     );
 }
 

--- a/rust/personhog-leader/tests/fencing_integration.rs
+++ b/rust/personhog-leader/tests/fencing_integration.rs
@@ -374,6 +374,31 @@ async fn a_completed_warm_keeps_its_fence() {
         .expect("a completed warm keeps a usable fence");
 }
 
+/// A condemnation must request its own repair: the fix for a condemned
+/// producer is a convergence-driven heal, and without the announcement
+/// that convergence waits for the next reconcile tick while every write
+/// on the partition bounces. Exactly once per producer: the unusable
+/// swap, not the channel, bounds the announcements.
+#[tokio::test]
+async fn a_condemnation_requests_repair_once() {
+    let topic = format!("fence_repair_{}", uuid::Uuid::new_v4().simple());
+    let (repair_tx, mut repair_rx) = tokio::sync::mpsc::unbounded_channel();
+    let producers = fenced_producers(&topic).with_repair_requests(repair_tx);
+    producers.acquire(3).await.expect("acquire the fence");
+
+    producers.condemn_for_test(3);
+    producers.condemn_for_test(3);
+
+    let announced = tokio::time::timeout(Duration::from_secs(5), repair_rx.recv())
+        .await
+        .expect("a condemnation must announce the partition for repair");
+    assert_eq!(announced, Some(3));
+    assert!(
+        repair_rx.try_recv().is_err(),
+        "a second condemnation of the same producer must not announce again"
+    );
+}
+
 /// A producer whose abort exhausted its retries, or whose commit outcome
 /// stayed unknown, is left in a transaction state it cannot begin another
 /// window from. It is still installed, so nothing that checks for the

--- a/rust/personhog-router/src/backend/leader.rs
+++ b/rust/personhog-router/src/backend/leader.rs
@@ -26,68 +26,17 @@ pub type AddressResolver = Arc<dyn Fn(&str) -> Option<String> + Send + Sync>;
 const LEADER_PREFIX: &str = "/personhog.leader.v1.PersonHogLeader/";
 
 /// How long to wait after a bounced forward attempt before the next one.
-/// Most bounce conditions clear on their own — a fence in
+/// Both bounce conditions clear on their own — a fence in
 /// watch-propagation time, a transport failure as the target pod comes
-/// up — so the first wait only needs to outpace the caller's latency
-/// bound, not be aggressive. The drain's wave loop uses it flat: its
-/// requests are parked and invisible to clients, so yielding the lane to
-/// the reconcile pass after a few cheap waves is the better escalation.
-/// The direct path doubles it instead — see [`direct_bounce_backoff`].
+/// up — so the cadence only needs to outpace the caller's latency bound,
+/// not be aggressive. Shared by the direct path's re-entrant retry loop
+/// and the drain's wave loop so the two paths settle at the same rate.
 pub(crate) const BOUNCE_BACKOFF: Duration = Duration::from_millis(150);
 
-/// Bounced waves after which the drain yields its lane to the reconcile
-/// pass rather than keep re-forwarding.
+/// Consecutive bounces after which a retry loop gives up — the direct path
+/// returns a definitive `UNAVAILABLE` (the client's own retry may reach
+/// a healthier router), the drain yields its lane to the reconcile pass.
 pub(crate) const MAX_CONSECUTIVE_BOUNCES: u32 = 4;
-
-/// Fenced bounces after which the direct path stops holding the request
-/// and returns a definitive `UNAVAILABLE` (the client's own retry may
-/// reach a healthier router).
-///
-/// Together with [`fenced_bounce_backoff`] this is the fenced-bounce
-/// patience, sized against the slowest condition it deliberately
-/// covers: the *first* heal of a condemned changelog fence, which
-/// answers `FailedPrecondition` until a repair convergence re-takes the
-/// epoch — two timeout-bounded broker calls (a metadata ping, then
-/// `init_transactions`), up to twice the leader's
-/// `fencing_init_timeout`, 4s at the default `LEASE_TTL=30`. Patience
-/// below that bound exhausts against a repair that was always going to
-/// land, which is exactly what turned a fleet-wide fence condemnation
-/// into client-visible failures. Fenced responses return in a round
-/// trip, so this whole hold is sleep, not backend timeouts.
-///
-/// Not covered, deliberately: a fence eviction with no condemnation,
-/// and a re-condemnation inside the leader's repair cooldown — both
-/// heal on the leader's reconcile tick (5s), and waiting out a tick
-/// would hold every fenced request for seconds. Those exhaust as
-/// retryable `UNAVAILABLE`, the pre-repair behavior.
-///
-/// The 4s bound is the leader's derivation at `LEASE_TTL=30` and
-/// nothing enforces the relation across the two services: a deployment
-/// that raises the leader's `LEASE_TTL` (which scales
-/// `fencing_init_timeout`) must revisit this budget. The default-config
-/// relation is pinned by `fenced_bounce_patience_outlasts_a_fence_repair`.
-const MAX_FENCED_BOUNCES: u32 = 8;
-
-/// Transport and unrouted bounces after which the direct path gives up.
-/// Each such attempt can burn a full backend timeout before bouncing,
-/// so this stays small to keep the worst-case hold inside typical
-/// client gRPC deadlines.
-const MAX_TRANSPORT_BOUNCES: u32 = 4;
-
-/// Ceiling on the fenced-bounce doubling backoff, so patience grows at
-/// the tail without the early retries losing the handoff races they
-/// usually win in one wave.
-const FENCED_BOUNCE_BACKOFF_CAP: Duration = Duration::from_millis(800);
-
-/// The wait after the `n`th consecutive fenced bounce: `BOUNCE_BACKOFF`
-/// doubling per bounce, capped. Fast first (most fence bounces are
-/// routing races that clear in watch-propagation time), patient at the
-/// tail (the rest are waiting on a leader-side repair).
-fn fenced_bounce_backoff(fenced_bounces: u32) -> Duration {
-    BOUNCE_BACKOFF
-        .saturating_mul(1u32 << fenced_bounces.saturating_sub(1).min(4))
-        .min(FENCED_BOUNCE_BACKOFF_CAP)
-}
 
 /// Why a forward attempt produced no outcome, and what that implies for
 /// the request's delivery state. All reasons share retry mechanics; they
@@ -422,8 +371,7 @@ impl LeaderBackend {
     /// (the re-resolve targets the new owner), or nothing changed yet
     /// (re-send, possibly bounce again). Each re-attempt is counted by
     /// `personhog_router_forward_retries_total` under the reason that
-    /// caused it. After `MAX_FENCED_BOUNCES` fenced bounces, or
-    /// `MAX_TRANSPORT_BOUNCES` transport/unrouted ones, the request fails with
+    /// caused it. After `MAX_CONSECUTIVE_BOUNCES` the request fails with
     /// a definitive `UNAVAILABLE`, counted by
     /// `personhog_router_forward_retries_exhausted_total`, so a router
     /// whose view never updates (a dead watch) can't hold requests
@@ -442,8 +390,7 @@ impl LeaderBackend {
         headers: HeaderMap,
         frame: Bytes,
     ) -> (http::Response<BoxBody>, Option<f64>) {
-        let mut fenced_bounces = 0u32;
-        let mut transport_bounces = 0u32;
+        let mut consecutive_bounces = 0u32;
         let mut possibly_applied = false;
         loop {
             // The stash module emits its own enqueued/rejected counters
@@ -487,13 +434,8 @@ impl LeaderBackend {
                     if counts_as_possibly_applied(reason) {
                         possibly_applied = true;
                     }
-                    match reason {
-                        BounceReason::Fenced => fenced_bounces += 1,
-                        BounceReason::Transport | BounceReason::Unrouted => transport_bounces += 1,
-                    }
-                    if fenced_bounces >= MAX_FENCED_BOUNCES
-                        || transport_bounces >= MAX_TRANSPORT_BOUNCES
-                    {
+                    consecutive_bounces += 1;
+                    if consecutive_bounces >= MAX_CONSECUTIVE_BOUNCES {
                         counter!("personhog_router_forward_retries_exhausted_total").increment(1);
                         return (
                             grpc_error_response(
@@ -509,11 +451,7 @@ impl LeaderBackend {
                         "reason" => reason.label()
                     )
                     .increment(1);
-                    let backoff = match reason {
-                        BounceReason::Fenced => fenced_bounce_backoff(fenced_bounces),
-                        BounceReason::Transport | BounceReason::Unrouted => BOUNCE_BACKOFF,
-                    };
-                    tokio::time::sleep(backoff).await;
+                    tokio::time::sleep(BOUNCE_BACKOFF).await;
                 }
             }
         }
@@ -702,26 +640,5 @@ mod tests {
             "rejection must surface as UNAVAILABLE so callers retry"
         );
         assert!(call_ms.is_none(), "no forward happened, so no call time");
-    }
-
-    /// The fenced-bounce patience must outlast the slowest thing such a
-    /// bounce can be waiting on: the leader re-taking a condemned
-    /// changelog fence, two timeout-bounded broker calls (metadata ping
-    /// plus `init_transactions`) of `fencing_init_timeout` each — 4s
-    /// total at the default `LEASE_TTL`. Patience below that bound
-    /// exhausts against a repair that was always going to land, failing
-    /// clients during a window the system heals on its own.
-    #[test]
-    fn fenced_bounce_patience_outlasts_a_fence_repair() {
-        let patience: Duration = (1..MAX_FENCED_BOUNCES).map(fenced_bounce_backoff).sum();
-        assert!(
-            patience >= Duration::from_secs(4),
-            "fenced bounce patience ({patience:?}) must cover the leader's \
-             fence repair (2 x fencing_init_timeout, 4s at the default LEASE_TTL)"
-        );
-        // The schedule buys that patience at the tail: the first retry
-        // stays at the base cadence, because most bounces are routing
-        // races that clear in watch-propagation time.
-        assert_eq!(fenced_bounce_backoff(1), BOUNCE_BACKOFF);
     }
 }

--- a/rust/personhog-router/src/backend/leader.rs
+++ b/rust/personhog-router/src/backend/leader.rs
@@ -26,17 +26,68 @@ pub type AddressResolver = Arc<dyn Fn(&str) -> Option<String> + Send + Sync>;
 const LEADER_PREFIX: &str = "/personhog.leader.v1.PersonHogLeader/";
 
 /// How long to wait after a bounced forward attempt before the next one.
-/// Both bounce conditions clear on their own — a fence in
+/// Most bounce conditions clear on their own — a fence in
 /// watch-propagation time, a transport failure as the target pod comes
-/// up — so the cadence only needs to outpace the caller's latency bound,
-/// not be aggressive. Shared by the direct path's re-entrant retry loop
-/// and the drain's wave loop so the two paths settle at the same rate.
+/// up — so the first wait only needs to outpace the caller's latency
+/// bound, not be aggressive. The drain's wave loop uses it flat: its
+/// requests are parked and invisible to clients, so yielding the lane to
+/// the reconcile pass after a few cheap waves is the better escalation.
+/// The direct path doubles it instead — see [`direct_bounce_backoff`].
 pub(crate) const BOUNCE_BACKOFF: Duration = Duration::from_millis(150);
 
-/// Consecutive bounces after which a retry loop gives up — the direct path
-/// returns a definitive `UNAVAILABLE` (the client's own retry may reach
-/// a healthier router), the drain yields its lane to the reconcile pass.
+/// Bounced waves after which the drain yields its lane to the reconcile
+/// pass rather than keep re-forwarding.
 pub(crate) const MAX_CONSECUTIVE_BOUNCES: u32 = 4;
+
+/// Fenced bounces after which the direct path stops holding the request
+/// and returns a definitive `UNAVAILABLE` (the client's own retry may
+/// reach a healthier router).
+///
+/// Together with [`fenced_bounce_backoff`] this is the fenced-bounce
+/// patience, sized against the slowest condition it deliberately
+/// covers: the *first* heal of a condemned changelog fence, which
+/// answers `FailedPrecondition` until a repair convergence re-takes the
+/// epoch — two timeout-bounded broker calls (a metadata ping, then
+/// `init_transactions`), up to twice the leader's
+/// `fencing_init_timeout`, 4s at the default `LEASE_TTL=30`. Patience
+/// below that bound exhausts against a repair that was always going to
+/// land, which is exactly what turned a fleet-wide fence condemnation
+/// into client-visible failures. Fenced responses return in a round
+/// trip, so this whole hold is sleep, not backend timeouts.
+///
+/// Not covered, deliberately: a fence eviction with no condemnation,
+/// and a re-condemnation inside the leader's repair cooldown — both
+/// heal on the leader's reconcile tick (5s), and waiting out a tick
+/// would hold every fenced request for seconds. Those exhaust as
+/// retryable `UNAVAILABLE`, the pre-repair behavior.
+///
+/// The 4s bound is the leader's derivation at `LEASE_TTL=30` and
+/// nothing enforces the relation across the two services: a deployment
+/// that raises the leader's `LEASE_TTL` (which scales
+/// `fencing_init_timeout`) must revisit this budget. The default-config
+/// relation is pinned by `fenced_bounce_patience_outlasts_a_fence_repair`.
+const MAX_FENCED_BOUNCES: u32 = 8;
+
+/// Transport and unrouted bounces after which the direct path gives up.
+/// Each such attempt can burn a full backend timeout before bouncing,
+/// so this stays small to keep the worst-case hold inside typical
+/// client gRPC deadlines.
+const MAX_TRANSPORT_BOUNCES: u32 = 4;
+
+/// Ceiling on the fenced-bounce doubling backoff, so patience grows at
+/// the tail without the early retries losing the handoff races they
+/// usually win in one wave.
+const FENCED_BOUNCE_BACKOFF_CAP: Duration = Duration::from_millis(800);
+
+/// The wait after the `n`th consecutive fenced bounce: `BOUNCE_BACKOFF`
+/// doubling per bounce, capped. Fast first (most fence bounces are
+/// routing races that clear in watch-propagation time), patient at the
+/// tail (the rest are waiting on a leader-side repair).
+fn fenced_bounce_backoff(fenced_bounces: u32) -> Duration {
+    BOUNCE_BACKOFF
+        .saturating_mul(1u32 << fenced_bounces.saturating_sub(1).min(4))
+        .min(FENCED_BOUNCE_BACKOFF_CAP)
+}
 
 /// Why a forward attempt produced no outcome, and what that implies for
 /// the request's delivery state. All reasons share retry mechanics; they
@@ -371,7 +422,8 @@ impl LeaderBackend {
     /// (the re-resolve targets the new owner), or nothing changed yet
     /// (re-send, possibly bounce again). Each re-attempt is counted by
     /// `personhog_router_forward_retries_total` under the reason that
-    /// caused it. After `MAX_CONSECUTIVE_BOUNCES` the request fails with
+    /// caused it. After `MAX_FENCED_BOUNCES` fenced bounces, or
+    /// `MAX_TRANSPORT_BOUNCES` transport/unrouted ones, the request fails with
     /// a definitive `UNAVAILABLE`, counted by
     /// `personhog_router_forward_retries_exhausted_total`, so a router
     /// whose view never updates (a dead watch) can't hold requests
@@ -390,7 +442,8 @@ impl LeaderBackend {
         headers: HeaderMap,
         frame: Bytes,
     ) -> (http::Response<BoxBody>, Option<f64>) {
-        let mut consecutive_bounces = 0u32;
+        let mut fenced_bounces = 0u32;
+        let mut transport_bounces = 0u32;
         let mut possibly_applied = false;
         loop {
             // The stash module emits its own enqueued/rejected counters
@@ -434,8 +487,13 @@ impl LeaderBackend {
                     if counts_as_possibly_applied(reason) {
                         possibly_applied = true;
                     }
-                    consecutive_bounces += 1;
-                    if consecutive_bounces >= MAX_CONSECUTIVE_BOUNCES {
+                    match reason {
+                        BounceReason::Fenced => fenced_bounces += 1,
+                        BounceReason::Transport | BounceReason::Unrouted => transport_bounces += 1,
+                    }
+                    if fenced_bounces >= MAX_FENCED_BOUNCES
+                        || transport_bounces >= MAX_TRANSPORT_BOUNCES
+                    {
                         counter!("personhog_router_forward_retries_exhausted_total").increment(1);
                         return (
                             grpc_error_response(
@@ -451,7 +509,11 @@ impl LeaderBackend {
                         "reason" => reason.label()
                     )
                     .increment(1);
-                    tokio::time::sleep(BOUNCE_BACKOFF).await;
+                    let backoff = match reason {
+                        BounceReason::Fenced => fenced_bounce_backoff(fenced_bounces),
+                        BounceReason::Transport | BounceReason::Unrouted => BOUNCE_BACKOFF,
+                    };
+                    tokio::time::sleep(backoff).await;
                 }
             }
         }
@@ -640,5 +702,26 @@ mod tests {
             "rejection must surface as UNAVAILABLE so callers retry"
         );
         assert!(call_ms.is_none(), "no forward happened, so no call time");
+    }
+
+    /// The fenced-bounce patience must outlast the slowest thing such a
+    /// bounce can be waiting on: the leader re-taking a condemned
+    /// changelog fence, two timeout-bounded broker calls (metadata ping
+    /// plus `init_transactions`) of `fencing_init_timeout` each — 4s
+    /// total at the default `LEASE_TTL`. Patience below that bound
+    /// exhausts against a repair that was always going to land, failing
+    /// clients during a window the system heals on its own.
+    #[test]
+    fn fenced_bounce_patience_outlasts_a_fence_repair() {
+        let patience: Duration = (1..MAX_FENCED_BOUNCES).map(fenced_bounce_backoff).sum();
+        assert!(
+            patience >= Duration::from_secs(4),
+            "fenced bounce patience ({patience:?}) must cover the leader's \
+             fence repair (2 x fencing_init_timeout, 4s at the default LEASE_TTL)"
+        );
+        // The schedule buys that patience at the tail: the first retry
+        // stays at the base cadence, because most bounces are routing
+        // races that clear in watch-propagation time.
+        assert_eq!(fenced_bounce_backoff(1), BOUNCE_BACKOFF);
     }
 }


### PR DESCRIPTION
## Problem
  
  - A write hitting a condemned changelog producer fails to the client as UNAVAILABLE, even though the leader heals the fence on its own moments later.
  - A condemned producer answers every write as unowned until a convergence re-takes the broker epoch. The only trigger was the reconcile tick, up to 5 seconds away.
  - During a broker latency excursion on the dev traffic bed, that window turned a self-healing fault into sustained client-visible failures and retry churn.

## Changes

  - A condemnation now nudges a shared Notify, and the coordination loop answers with an early reconcile pass. The heal runs one init round trip after the fault instead of waiting for the tick.
  - The nudge carries no payload on purpose: the reconcile pass already re-derives what needs converging, and `verify_serving` repairs exactly the partitions missing their fence while the rest converge as no-ops.
  - One nudge-driven pass per reconcile interval at most, behind a single min-gap. A condemn-heal flap (a broker that accepts init but fails every window) degrades to tick-rate healing instead of driving passes at broker speed while successful heals reset the wedge budgets.
  - Condemnation reasons split by whether the producer was fenced (`abort_fenced`, `commit_fenced`), so a deploy-shaped condemnation reads differently on the dashboard from a broker excursion. All reasons live in one preregistered list, pinned by test.
  - The heal path drops a replaced producer on the blocking pool; librdkafka teardown blocks for hundreds of milliseconds.
  - The router's bounce patience is deliberately unchanged. A per-class budget split was built and then backed out in favor of watching how far the nudge alone closes the gap; the repair counters this PR adds are the evidence for that call.

## How did you test this code?
  
  - New regression pins, each red-checked (fix disabled, test fails for the predicted reason): a condemnation nudges the repair pass, and a second condemnation of the same producer does not; the nudge converges with reconcile parked at a day; a nudge inside the min-gap falls to the tick; every condemn reason is preregistered.
  - Ran the leader, coordination, and router suites locally, including the fencing integration tests against a real broker and the protocol tests against a real etcd.
  - Two independent cold-context adversarial review passes examined the original channel-based mechanism; the notify simplification kept its invariants and every regression pin, and was re-red-checked after the rework.
  - Not run: the e2e harness gate scenarios. The dev traffic bed validates post-deploy: repair-pass counters moving, the `abort_fenced` split, and client-visible failure rate during the next excursion.

## 🤖 Agent context

  **Autonomy:** Human-driven (agent-assisted)

  - Authored in a Claude Code session that started as an incident investigation on the dev traffic bed: fence condemnations during a broker latency excursion healed correctly but surfaced client failures, and the metric/log trace of that window drove the design.
  - Skills invoked: /reviewing-personhog-protocol (two adversarial subagent passes with author verification of every finding), /writing-pr-descriptions, /writing-code-comments.
  - Decisions across the session: retrying the abort was rejected (re-acquisition already aborts broker-side and the budget has no room); the repair cooldown and the per-class router budgets came out of review passes that found the first repair arm unbounded and the first patience budget sized to half the real repair cost.