### PR TITLE
feat(experiments): show Replay vision promo on the Recordings tab

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentReplayTab.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentReplayTab.tsx
@@ -217,7 +217,7 @@ export function ExperimentReplayTab({ experiment }: { experiment: Experiment }):
 
     return (
         <div data-attr="experiment-recordings-tab">
-            <ReplayVisionPromoBanner source="experiment-recordings-tab" className="mb-2" />
+            <ReplayVisionPromoBanner source="experiment-recordings-tab" className="mb-4" />
             {usingExposureFallback && (
                 <LemonBanner type="info" className="mb-2">
                     {EXPOSURE_FALLBACK_NOTICE}

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentReplayTab.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentReplayTab.tsx
@@ -18,6 +18,7 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { pluralize } from 'lib/utils/strings'
 import { SessionRecordingsPlaylist } from 'scenes/session-recordings/playlist/SessionRecordingsPlaylist'
+import { ReplayVisionPromoBanner } from 'scenes/session-recordings/ReplayVisionPromoBanner'
 
 import { Experiment } from '~/types'
 
@@ -216,6 +217,7 @@ export function ExperimentReplayTab({ experiment }: { experiment: Experiment }):
 
     return (
         <div data-attr="experiment-recordings-tab">
+            <ReplayVisionPromoBanner source="experiment-recordings-tab" className="mb-2" />
             {usingExposureFallback && (
                 <LemonBanner type="info" className="mb-2">
                     {EXPOSURE_FALLBACK_NOTICE}

--- a/frontend/src/scenes/session-recordings/ReplayVisionPromoBanner.tsx
+++ b/frontend/src/scenes/session-recordings/ReplayVisionPromoBanner.tsx
@@ -1,0 +1,46 @@
+import { useValues } from 'kea'
+
+import { PostHogCaptureOnViewed } from '@posthog/react'
+
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
+import { lemonBannerLogic } from 'lib/lemon-ui/LemonBanner/lemonBannerLogic'
+import { urls } from 'scenes/urls'
+
+const REPLAY_VISION_PROMO_DISMISS_KEY = 'replay-vision-launch-promo'
+
+export function ReplayVisionPromoBanner({
+    source,
+    className,
+}: {
+    /** Which surface rendered the banner, sent on the impression event so surfaces can be compared. */
+    source: string
+    className?: string
+}): JSX.Element | null {
+    const { isDismissed } = useValues(lemonBannerLogic({ dismissKey: REPLAY_VISION_PROMO_DISMISS_KEY }))
+    const hasReplayVision = useFeatureFlag('REPLAY_VISION')
+
+    // Without the flag the CTA would land on a 404, so don't advertise the feature at all.
+    // A dismissed LemonBanner renders null but the viewed tracker would still fire, skewing impressions
+    if (!hasReplayVision || isDismissed) {
+        return null
+    }
+
+    return (
+        <PostHogCaptureOnViewed name="replay-vision-launch-banner-shown" properties={{ source }}>
+            <LemonBanner
+                type="ai"
+                className={className}
+                dismissKey={REPLAY_VISION_PROMO_DISMISS_KEY}
+                action={{
+                    children: 'Try Replay vision',
+                    to: urls.replayVision(),
+                    center: true,
+                    'data-attr': 'replay-vision-launch-banner-cta',
+                }}
+            >
+                Replay vision is here. Scanners watch your recordings for you and surface what matters.
+            </LemonBanner>
+        </PostHogCaptureOnViewed>
+    )
+}

--- a/frontend/src/scenes/session-recordings/SessionRecordings.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordings.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react'
 
 import { IconDocument, IconGear, IconHeadset, IconOpenSidebar } from '@posthog/icons'
 import { LemonBadge, LemonButton, Link } from '@posthog/lemon-ui'
-import { PostHogCaptureOnViewed } from '@posthog/react'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { WarningHog } from 'lib/components/hedgehogs'
@@ -13,7 +12,6 @@ import { Shortcut } from 'lib/components/Shortcuts/Shortcut'
 import { keyBinds } from 'lib/components/Shortcuts/shortcuts'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
-import { lemonBannerLogic } from 'lib/lemon-ui/LemonBanner/lemonBannerLogic'
 import { LemonTab, LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
@@ -37,6 +35,7 @@ import {
     SessionRecordingPlaylistLogicProps,
     sessionRecordingsPlaylistLogic,
 } from './playlist/sessionRecordingsPlaylistLogic'
+import { ReplayVisionPromoBanner } from './ReplayVisionPromoBanner'
 import { sessionRecordingEventUsageLogic } from './sessionRecordingEventUsageLogic'
 import { sessionReplaySceneLogic } from './sessionReplaySceneLogic'
 import SessionRecordingTemplates from './templates/SessionRecordingTemplates'
@@ -121,36 +120,6 @@ function Header(): JSX.Element {
                 Settings
             </LemonButton>
         </div>
-    )
-}
-
-const REPLAY_VISION_PROMO_DISMISS_KEY = 'replay-vision-launch-promo'
-
-function ReplayVisionPromoBanner(): JSX.Element | null {
-    const { isDismissed } = useValues(lemonBannerLogic({ dismissKey: REPLAY_VISION_PROMO_DISMISS_KEY }))
-    const hasReplayVision = useFeatureFlag('REPLAY_VISION')
-
-    // Without the flag the CTA would land on a 404, so don't advertise the feature at all.
-    // A dismissed LemonBanner renders null but the viewed tracker would still fire, skewing impressions
-    if (!hasReplayVision || isDismissed) {
-        return null
-    }
-
-    return (
-        <PostHogCaptureOnViewed name="replay-vision-launch-banner-shown">
-            <LemonBanner
-                type="ai"
-                dismissKey={REPLAY_VISION_PROMO_DISMISS_KEY}
-                action={{
-                    children: 'Try Replay vision',
-                    to: urls.replayVision(),
-                    center: true,
-                    'data-attr': 'replay-vision-launch-banner-cta',
-                }}
-            >
-                Replay vision is here. Scanners watch your recordings for you and surface what matters.
-            </LemonBanner>
-        </PostHogCaptureOnViewed>
     )
 }
 
@@ -243,7 +212,7 @@ function MainPanel(): JSX.Element {
 
     return (
         <div className={cn('flex flex-col gap-y-4', ReplayTabs.Home === tab && 'grow')}>
-            <ReplayVisionPromoBanner />
+            <ReplayVisionPromoBanner source="replay-home" />
             <Warnings />
 
             {!tab ? (


### PR DESCRIPTION
## Problem

We recently released replay vision, but have no banner in our experiment > recordings tab. Adding it here to as a way to drive traffic into replay vision. 

## Changes

- The experiment Recordings tab now shows the same "Replay vision is here" banner, with a "Try Replay vision" button that opens the Replay Vision page.
- The banner component moved out of `SessionRecordings.tsx` into a shared `ReplayVisionPromoBanner.tsx`, unchanged: same copy, same `REPLAY_VISION` flag gate, same dismiss behavior.
- The dismiss key is shared, so dismissing the banner on either surface hides it on both.
- The impression event (`replay-vision-launch-banner-shown`) gains a `source` property (`replay-home` / `experiment-recordings-tab`) so the two surfaces can be compared.

![experiment-recordings-banner](https://raw.githubusercontent.com/PostHog/pr-assets/106472ea2ca2da6d3f3ee348671f1f897b6fc646/2026/08/11a1108f-30cb-4f7d-bf32-1d5f58e465b8.png)

## How did you test this code?

Ruby:
- Tested locally and ensured link takes user to replay vision.

- Drove the change in the local app with a Playwright script against a fresh test workspace, with the `replay-vision` and `experiment-recordings-tab` flags forced on:
  - The banner renders on a launched experiment's Recordings tab, and the button navigates to `/replay-vision`.
  - Dismissing it on the experiment tab also hides it on the Session Replay scene, and vice versa.
  - The Session Replay scene banner still renders as before the extraction.
- No new automated tests: the diff is a component extraction plus one render site, and the flag/dismiss gating logic is unchanged.
- Not run: Jest and Playwright CI suites locally; frontend typecheck passes on the changed files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude).
Skills invoked: /writing-user-facing-copy, /writing-code-comments, /run-posthog, /writing-pr-descriptions.
The session extracted the existing banner rather than duplicating it, and verified both surfaces end to end in a local dev stack before pushing.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
