### PR TITLE
feat(cdp): add a separately tunable timeout for third-party requests

### DIFF
--- a/nodejs/src/cdp/services/hog-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.test.ts
@@ -1397,9 +1397,11 @@ describe('Hog Executor', () => {
 
         it('handles timeouts', async () => {
             mockRequest.mockImplementation((_req: any, res: any) => {
-                // Never send response
+                // Never respond within the request's budget. The delay has to clear
+                // EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS, or the server answers first and there is
+                // no timeout to assert — and the socket it leaves open trips the next test.
                 clearTimeout(timeoutHandle)
-                timeoutHandle = setTimeout(() => res.end(), 10000)
+                timeoutHandle = setTimeout(() => res.end(), 30000)
             })
 
             const invocation = await createFetchInvocation({
@@ -1416,7 +1418,8 @@ describe('Hog Executor', () => {
                   "HTTP fetch failed on attempt 1 with status code (none). Error: The operation was aborted due to timeout. Retrying in 1500ms.",
                 ]
             `)
-        })
+            // The abort now waits out the third-party budget rather than the internal one.
+        }, 20000)
 
         it('handles ResponseContentLengthMismatchError', async () => {
             jest.mocked(fetch).mockImplementationOnce(() => {

--- a/nodejs/src/cdp/services/hog-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.test.ts
@@ -1397,11 +1397,9 @@ describe('Hog Executor', () => {
 
         it('handles timeouts', async () => {
             mockRequest.mockImplementation((_req: any, res: any) => {
-                // Never respond within the request's budget. The delay has to clear
-                // EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS, or the server answers first and there is
-                // no timeout to assert — and the socket it leaves open trips the next test.
+                // Never send response
                 clearTimeout(timeoutHandle)
-                timeoutHandle = setTimeout(() => res.end(), 30000)
+                timeoutHandle = setTimeout(() => res.end(), 10000)
             })
 
             const invocation = await createFetchInvocation({
@@ -1418,8 +1416,7 @@ describe('Hog Executor', () => {
                   "HTTP fetch failed on attempt 1 with status code (none). Error: The operation was aborted due to timeout. Retrying in 1500ms.",
                 ]
             `)
-            // The abort now waits out the third-party budget rather than the internal one.
-        }, 20000)
+        })
 
         it('handles ResponseContentLengthMismatchError', async () => {
             jest.mocked(fetch).mockImplementationOnce(() => {

--- a/nodejs/src/common/config.ts
+++ b/nodejs/src/common/config.ts
@@ -8,6 +8,19 @@ export const DEFAULT_HTTP_SERVER_PORT = 6738
 // (mirrors LOCAL_DEV_INTERNAL_API_SECRET on the Django side).
 export const LOCAL_DEV_INTERNAL_API_SECRET = 'posthog123'
 
+/**
+ * Response budget for a request to a host we don't run, used by `fetch`/`legacyFetch` in
+ * common/utils/request.ts. Kept well above EXTERNAL_REQUEST_TIMEOUT_MS, which is sized for calls
+ * between our own services on the same network.
+ *
+ * A CDP destination points at whatever API the customer configured, which is routinely in another
+ * region and under no latency obligation to us. At the internal-service budget, an API that
+ * answers in a few seconds is cut off on every attempt, so every retry fails the same way and the
+ * event is lost for good, which penalizes the destination for the third party being slow rather
+ * than for being broken.
+ */
+export const DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS = 10000
+
 export enum KafkaSaslMechanism {
     Plain = 'plain',
     ScramSha256 = 'scram-sha-256',
@@ -177,6 +190,7 @@ export type CommonConfig = BaseServerConfig & {
     HOGFLOW_SCHEDULER_MAX_POLL_INTERVAL_MS: number
     HOGFLOW_SCHEDULER_HEALTH_TIMEOUT_MS: number
     EXTERNAL_REQUEST_TIMEOUT_MS: number
+    EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS: number
     EXTERNAL_REQUEST_CONNECT_TIMEOUT_MS: number
     EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS: number
     EXTERNAL_REQUEST_CONNECTIONS: number
@@ -203,6 +217,7 @@ export type CommonConfig = BaseServerConfig & {
 export type ExternalRequestConfig = Pick<
     CommonConfig,
     | 'EXTERNAL_REQUEST_TIMEOUT_MS'
+    | 'EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS'
     | 'EXTERNAL_REQUEST_CONNECT_TIMEOUT_MS'
     | 'EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS'
     | 'EXTERNAL_REQUEST_CONNECTIONS'
@@ -211,6 +226,9 @@ export type ExternalRequestConfig = Pick<
 export function getExternalRequestConfig(): ExternalRequestConfig {
     return {
         EXTERNAL_REQUEST_TIMEOUT_MS: Number(process.env.EXTERNAL_REQUEST_TIMEOUT_MS ?? 3000),
+        EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS: Number(
+            process.env.EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS ?? DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS
+        ),
         EXTERNAL_REQUEST_CONNECT_TIMEOUT_MS: Number(process.env.EXTERNAL_REQUEST_CONNECT_TIMEOUT_MS ?? 3000),
         EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS: Number(process.env.EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS ?? 10000),
         EXTERNAL_REQUEST_CONNECTIONS: Number(process.env.EXTERNAL_REQUEST_CONNECTIONS ?? 500),
@@ -354,6 +372,7 @@ export function getDefaultCommonConfig(): CommonConfig {
         HOGFLOW_SCHEDULER_MAX_POLL_INTERVAL_MS: 5 * 60_000,
         HOGFLOW_SCHEDULER_HEALTH_TIMEOUT_MS: 10 * 60_000,
         EXTERNAL_REQUEST_TIMEOUT_MS: 3000,
+        EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS: DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS,
         EXTERNAL_REQUEST_CONNECT_TIMEOUT_MS: 3000,
         EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS: 10000,
         EXTERNAL_REQUEST_CONNECTIONS: 500,

--- a/nodejs/src/common/config.ts
+++ b/nodejs/src/common/config.ts
@@ -189,6 +189,8 @@ export type CommonConfig = BaseServerConfig & {
     HOGFLOW_SCHEDULER_POLL_INTERVAL_MS: number
     HOGFLOW_SCHEDULER_MAX_POLL_INTERVAL_MS: number
     HOGFLOW_SCHEDULER_HEALTH_TIMEOUT_MS: number
+    // Despite the EXTERNAL_REQUEST_ prefix this one only reaches `internalFetch`, so it is the
+    // budget for calls to our own services. Third-party hosts use the sibling below.
     EXTERNAL_REQUEST_TIMEOUT_MS: number
     EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS: number
     EXTERNAL_REQUEST_CONNECT_TIMEOUT_MS: number

--- a/nodejs/src/common/config.ts
+++ b/nodejs/src/common/config.ts
@@ -10,16 +10,17 @@ export const LOCAL_DEV_INTERNAL_API_SECRET = 'posthog123'
 
 /**
  * Response budget for a request to a host we don't run, used by `fetch`/`legacyFetch` in
- * common/utils/request.ts. Kept well above EXTERNAL_REQUEST_TIMEOUT_MS, which is sized for calls
- * between our own services on the same network.
+ * common/utils/request.ts. A CDP destination points at whatever API the customer configured, which
+ * is routinely in another region and under no latency obligation to us, so it has different needs
+ * from EXTERNAL_REQUEST_TIMEOUT_MS, which is sized for calls between our own services on the same
+ * network.
  *
- * A CDP destination points at whatever API the customer configured, which is routinely in another
- * region and under no latency obligation to us. At the internal-service budget, an API that
- * answers in a few seconds is cut off on every attempt, so every retry fails the same way and the
- * event is lost for good, which penalizes the destination for the third party being slow rather
- * than for being broken.
+ * Starts equal to the internal budget so the split changes no behavior on its own. Raise it with
+ * EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS to buy slower third-party APIs more headroom; an
+ * unanswered request holds its worker slot for the whole budget, so the cost lands on
+ * cdp_http_inflight_requests.
  */
-export const DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS = 10000
+export const DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS = 3000
 
 export enum KafkaSaslMechanism {
     Plain = 'plain',

--- a/nodejs/src/common/utils/request.test.ts
+++ b/nodejs/src/common/utils/request.test.ts
@@ -3,8 +3,17 @@ import { range } from 'lodash'
 import http from 'node:http'
 import { AddressInfo } from 'node:net'
 
+import { DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS } from '~/common/config'
+
 import { parseJSON } from './json-parse'
-import { SecureRequestError, fetch, internalFetch, legacyFetch, raiseIfUserProvidedUrlUnsafe } from './request'
+import {
+    FetchOptions,
+    SecureRequestError,
+    fetch,
+    internalFetch,
+    legacyFetch,
+    raiseIfUserProvidedUrlUnsafe,
+} from './request'
 
 const realDnsLookup = jest.requireActual('dns/promises').lookup
 jest.mock('dns/promises', () => ({
@@ -114,6 +123,37 @@ describe('fetch', () => {
             try {
                 const response = await fetch(baseUrl)
                 expect(response.status).toBe(200)
+            } finally {
+                process.env.NODE_ENV = originalNodeEnv
+            }
+        })
+
+        // A CDP destination calls whatever API the customer configured, so it needs the
+        // third-party budget rather than the tighter one sized for our own services. Routing it
+        // back through the internal budget fails silently, because the only symptom is slower
+        // cross-region APIs being cut off on every retry until the event is dropped.
+        it.each([
+            ['fetch', fetch, DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS],
+            ['internalFetch', internalFetch, 3000],
+        ])('%s defaults the request timeout to %sms', async (_name, doFetch, expectedTimeoutMs) => {
+            const originalNodeEnv = process.env.NODE_ENV
+            process.env.NODE_ENV = 'test'
+            try {
+                const options: FetchOptions = {}
+                await doFetch(baseUrl, options)
+                expect(options.timeoutMs).toBe(expectedTimeoutMs)
+            } finally {
+                process.env.NODE_ENV = originalNodeEnv
+            }
+        })
+
+        it('keeps a timeout the caller set explicitly', async () => {
+            const originalNodeEnv = process.env.NODE_ENV
+            process.env.NODE_ENV = 'test'
+            try {
+                const options: FetchOptions = { timeoutMs: 1234 }
+                await fetch(baseUrl, options)
+                expect(options.timeoutMs).toBe(1234)
             } finally {
                 process.env.NODE_ENV = originalNodeEnv
             }

--- a/nodejs/src/common/utils/request.test.ts
+++ b/nodejs/src/common/utils/request.test.ts
@@ -3,7 +3,7 @@ import { range } from 'lodash'
 import http from 'node:http'
 import { AddressInfo } from 'node:net'
 
-import { DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS } from '~/common/config'
+import { DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS, getExternalRequestConfig } from '~/common/config'
 
 import { parseJSON } from './json-parse'
 import {
@@ -128,14 +128,13 @@ describe('fetch', () => {
             }
         })
 
-        // A CDP destination calls whatever API the customer configured, so it needs the
-        // third-party budget rather than the tighter one sized for our own services. Routing it
-        // back through the internal budget fails silently, because the only symptom is slower
-        // cross-region APIs being cut off on every retry until the event is dropped.
+        // Each entry point has to resolve to its own budget. Sending third-party traffic through
+        // the internal one fails silently: the only symptom is slower cross-region APIs getting
+        // cut off on every retry until the invocation is dropped.
         it.each([
-            ['fetch', fetch, DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS],
-            ['internalFetch', internalFetch, 3000],
-        ])('%s defaults the request timeout to %sms', async (_name, doFetch, expectedTimeoutMs) => {
+            ['fetch', DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS, fetch],
+            ['internalFetch', getExternalRequestConfig().EXTERNAL_REQUEST_TIMEOUT_MS, internalFetch],
+        ])('%s defaults the request timeout to %sms', async (_name, expectedTimeoutMs, doFetch) => {
             const originalNodeEnv = process.env.NODE_ENV
             process.env.NODE_ENV = 'test'
             try {

--- a/nodejs/src/common/utils/request.test.ts
+++ b/nodejs/src/common/utils/request.test.ts
@@ -3,7 +3,7 @@ import { range } from 'lodash'
 import http from 'node:http'
 import { AddressInfo } from 'node:net'
 
-import { DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS, getExternalRequestConfig } from '~/common/config'
+import { getExternalRequestConfig } from '~/common/config'
 
 import { parseJSON } from './json-parse'
 import {
@@ -128,23 +128,32 @@ describe('fetch', () => {
             }
         })
 
-        // Each entry point has to resolve to its own budget. Sending third-party traffic through
-        // the internal one fails silently: the only symptom is slower cross-region APIs getting
-        // cut off on every retry until the invocation is dropped.
-        it.each([
-            ['fetch', DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS, fetch],
-            ['internalFetch', getExternalRequestConfig().EXTERNAL_REQUEST_TIMEOUT_MS, internalFetch],
-        ])('%s defaults the request timeout to %sms', async (_name, expectedTimeoutMs, doFetch) => {
+        // The split is only worth anything if `fetch` reads the third-party setting and
+        // `internalFetch` does not. Wiring either one to the other's budget fails silently: raising
+        // the third-party timeout would then do nothing, or internal calls would quietly inherit it.
+        it('resolves each entry point against its own timeout setting', async () => {
             const originalNodeEnv = process.env.NODE_ENV
             process.env.NODE_ENV = 'test'
+            process.env.EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS = '7654'
             try {
-                const options: FetchOptions = {}
-                await doFetch(baseUrl, options)
-                expect(options.timeoutMs).toBe(expectedTimeoutMs)
+                await jest.isolateModulesAsync(async () => {
+                    // Re-import against the isolated registry: request.ts reads the config once, at
+                    // module load, so the override only lands on a fresh copy.
+                    const fresh = require('./request')
+                    const thirdPartyOptions: FetchOptions = {}
+                    const internalOptions: FetchOptions = {}
+
+                    await fresh.fetch(baseUrl, thirdPartyOptions)
+                    await fresh.internalFetch(baseUrl, internalOptions)
+
+                    expect(thirdPartyOptions.timeoutMs).toBe(7654)
+                    expect(internalOptions.timeoutMs).toBe(getExternalRequestConfig().EXTERNAL_REQUEST_TIMEOUT_MS)
+                })
             } finally {
+                delete process.env.EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS
                 process.env.NODE_ENV = originalNodeEnv
             }
-        })
+        }, 10000)
 
         it('keeps a timeout the caller set explicitly', async () => {
             const originalNodeEnv = process.env.NODE_ENV

--- a/nodejs/src/common/utils/request.ts
+++ b/nodejs/src/common/utils/request.ts
@@ -332,7 +332,12 @@ async function readAndDestroyBody(body: Dispatcher.ResponseData['body']): Promis
     return text
 }
 
-export async function _fetch(url: string, options: FetchOptions = {}, dispatcher: Dispatcher): Promise<FetchResponse> {
+export async function _fetch(
+    url: string,
+    options: FetchOptions = {},
+    dispatcher: Dispatcher,
+    defaultTimeoutMs: number = requestConfig.EXTERNAL_REQUEST_TIMEOUT_MS
+): Promise<FetchResponse> {
     let parsed: URL
     try {
         parsed = new URL(url)
@@ -344,7 +349,7 @@ export async function _fetch(url: string, options: FetchOptions = {}, dispatcher
         throw new Error('URL must have HTTP or HTTPS protocol and a valid hostname')
     }
 
-    options.timeoutMs = options.timeoutMs ?? requestConfig.EXTERNAL_REQUEST_TIMEOUT_MS
+    options.timeoutMs = options.timeoutMs ?? defaultTimeoutMs
 
     const result = await request(parsed.toString(), {
         method: options.method ?? 'GET',
@@ -399,13 +404,18 @@ export async function internalFetch(url: string, options: FetchOptions = {}): Pr
     return await _fetch(url, options, sharedInsecureAgent)
 }
 
+/**
+ * Requests to a host we don't run, meaning CDP destinations and anything else pointed at a
+ * customer-supplied URL. These get the third-party response budget rather than the internal-service
+ * one that `internalFetch` keeps; see DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS for why they differ.
+ */
 export async function fetch(url: string, options: FetchOptions = {}): Promise<FetchResponse> {
     const parsed = new URL(url)
     validateHostnameIPLiteral(parsed.hostname, !isProdEnv())
     inflightExternalRequests.inc()
     try {
         const dispatcher = options.allowH2 ? sharedSecureH2Agent : sharedSecureAgent
-        return await _fetch(url, options, dispatcher)
+        return await _fetch(url, options, dispatcher, requestConfig.EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS)
     } finally {
         inflightExternalRequests.dec()
     }
@@ -428,7 +438,7 @@ export function legacyFetch(input: RequestInfo, options?: RequestInit): Promise<
 
     const requestOptions = options ?? {}
     requestOptions.dispatcher = sharedSecureAgent
-    requestOptions.signal = AbortSignal.timeout(requestConfig.EXTERNAL_REQUEST_TIMEOUT_MS)
+    requestOptions.signal = AbortSignal.timeout(requestConfig.EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS)
 
     return undiciFetch(parsed.toString(), requestOptions)
 }

--- a/nodejs/src/common/utils/request.ts
+++ b/nodejs/src/common/utils/request.ts
@@ -406,8 +406,9 @@ export async function internalFetch(url: string, options: FetchOptions = {}): Pr
 
 /**
  * Requests to a host we don't run, meaning CDP destinations and anything else pointed at a
- * customer-supplied URL. These get the third-party response budget rather than the internal-service
- * one that `internalFetch` keeps; see DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS for why they differ.
+ * customer-supplied URL. These take the third-party response budget, which is tunable separately
+ * from the internal-service one that `internalFetch` keeps; see
+ * DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS.
  */
 export async function fetch(url: string, options: FetchOptions = {}): Promise<FetchResponse> {
     const parsed = new URL(url)


### PR DESCRIPTION
## Problem

- A destination pointed at a slow third-party API fails permanently rather than late. All 3 attempts hit the same 3 second wall, so the event is lost.
- That wall is `EXTERNAL_REQUEST_TIMEOUT_MS`, sized for calls between our own services on the same network.
- A destination calls whatever API the customer configured, often in another region, so it has no reason to share that budget.
- Nobody can say how much headroom those APIs need. Every third-party request has been cut off at 3 seconds for as long as the setting has existed, so we have no observation of a slower one.

## Changes

Third-party requests now read their own timeout setting, which starts at the 3 seconds they already get.

- `fetch` and `legacyFetch` read `EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS`. `internalFetch` keeps `EXTERNAL_REQUEST_TIMEOUT_MS`.
- The new setting defaults to the same 3000, so merging this changes no behavior.
- A `timeoutMs` set by the caller still wins, so push notifications and the replay rasterizer keep the value they pass.

```diff
  EXTERNAL_REQUEST_TIMEOUT_MS: 3000,
+ EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS: 3000,
```

It lands as a setting rather than a raised constant because I want to try the value in production. I will set it to 5 seconds and watch what happens. Reverting is then an env var, not a deploy.

Setting it needs `EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS` passed to the CDP worker pods in posthog/charts, which is a separate repo. Until that lands the workers keep the 3000 default, which is what they run today.

- The split sits at the fetch layer rather than in `cdpTrackedFetch`, so every CDP egress path picks it up: Hog templates, native, Segment and legacy plugin destinations.
- A new call site therefore cannot inherit the internal budget by accident.
- Every caller of the secure `fetch` reaches a third-party or customer-supplied host: the CDP executors, SNS signing certs in `ses.ts`, a maildev dev helper, and the replay rasterizer. `legacyFetch` has no production callers.

> [!NOTE]
> Raising the value costs worker capacity. An unanswered request holds its slot for the whole budget, and a batch finishes when its slowest member does. The cdp-cyclotron-worker HPA scales on `cdp_http_inflight_requests`, which measures exactly that, so watch it when the value goes up.

### Why not the retry window

Segment runs a 5 second timeout and retries across 4 hours. We retry 3 times inside 13 seconds, so spreading our retries looks like the better fix.

It is not available. Destinations run on the Kafka job queue, which never reads `queueScheduledAt`. The backoff is computed, reported to the customer as &#34;Retrying in Xms&#34;, then discarded, and we are not going to teach Kafka to respect scheduling. Hog flows are unaffected: they run on `postgresV2Queue`, which dequeues with `scheduled <= NOW()`.

That leaves the timeout as the only lever, and all 3 attempts share it, so a slow API needs the single-attempt budget raised.

## How did you test this code?

Automated, all run by me (Claude):

- `pnpm exec jest src/common/utils/request.test.ts`. The 2 new cases pin that `fetch` and `internalFetch` resolve against different settings, and that a caller-supplied `timeoutMs` still wins.
- Nothing else asserted a timeout budget on either path. Pointing `fetch` back at the internal setting would pass CI silently and surface only as a timeout change that does nothing.
- I confirmed the first case fails under exactly that mutation. With both defaults at 3000, asserting the resolved value alone would prove nothing.
- `pnpm exec tsc --noEmit` over the nodejs workspace reports nothing in the changed files.

Not done in this sandbox:

- No manual or end-to-end verification against a real destination.
- `hogli ci:preflight` did not run. Its venv needs a Python interpreter this environment cannot fetch.
- The rest of `request.test.ts` needs real outbound DNS, which this sandbox blocks. 36 failures on master, 36 with this change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No doc under `docs/` covers any `EXTERNAL_REQUEST_*` setting, and the sibling CDP settings (`CDP_FETCH_RETRIES`, `CDP_FETCH_BACKOFF_BASE_MS`, `CDP_FETCH_BACKOFF_MAX_MS`) are undocumented too. There is no matching doc to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via Claude Code) wrote this after Daniel asked me to investigate destination invocations failing on timeouts. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.

The PR first raised the budget to 10 seconds outright. Daniel asked for the knob at parity instead, so the value can be tried in production and walked back without a deploy. The 10 second version also needed a longer delay in the hog executor timeout test; at parity that test goes back to its master version.

It replaces #78001, which carried the same diff under reasoning that no longer holds. An earlier attempt threaded a `CDP_FETCH_TIMEOUT_MS` through `HogExecutorConfig` and applied it inside `cdpTrackedFetch`. I dropped it: it moved 48 inline snapshots across 11 CDP test files, and it missed legacy plugin destinations and legacy webhooks.

Worth knowing for review: the 3 second value is itself an artifact. [#36384](https://github.com/PostHog/posthog/pull/36384) standardised two settings into one, deleting `CDP_FETCH_TIMEOUT_MS` (3000) and lowering `EXTERNAL_REQUEST_TIMEOUT_MS` from 10000 to 3000 so CDP kept its behavior. This PR is closer to restoring that split than to inventing one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjAwGCorRz6qs3YiLMqRKL)_