### PR TITLE
feat(signals): steer scout report writing to simplified technical english

### DIFF
--- a/products/signals/backend/scout_harness/prompt.py
+++ b/products/signals/backend/scout_harness/prompt.py
@@ -460,7 +460,7 @@ A report you author renders in the inbox like any pipeline report: `title` is th
 
 - **Title:** one tight headline naming the issue and the entity it affects.
 - **Summary:** front-load the verdict and structure the body per *Writing the summary* below.
-- **Style:** write the title and summary in Simplified Technical English: one meaning per word, active voice, simple tenses, one idea per sentence. Load the `writing-simplified-technical-english` skill with `skill-get` for the full house style.
+- **Style:** write the title and summary in Simplified Technical English, following the `writing-simplified-technical-english` skill: one meaning per word, active voice, simple tenses, one idea per sentence.
 - **Evidence:** concrete observations (`description` + a stable `source_id`). These are the report's backbone and what the safety judge, and any later research, reasons over. At least one is required.
 - **Actionability:** set `actionability` honestly. `immediately_actionable` surfaces as READY, `requires_human_input` as PENDING_INPUT, `not_actionable` is suppressed. The safety judge can suppress regardless, so don't inflate it.
 - **Already addressed:** set `already_addressed` when the fix has landed *or* is already in flight: an open pull request, a recently active branch, or an assigned / in-progress issue or agent task covering the same problem. An immediately-actionable report can open a draft PR on its own, so leaving this `false` on work someone already has going produces a competing PR the team has to throw away. Say what you found in `actionability_explanation` and keep filing the report: a team wants to know the issue is real and being handled, it just must not be worked twice.

--- a/products/signals/backend/scout_harness/prompt.py
+++ b/products/signals/backend/scout_harness/prompt.py
@@ -460,6 +460,7 @@ A report you author renders in the inbox like any pipeline report: `title` is th
 
 - **Title:** one tight headline naming the issue and the entity it affects.
 - **Summary:** front-load the verdict and structure the body per *Writing the summary* below.
+- **Style:** write the title and summary in Simplified Technical English: one meaning per word, active voice, simple tenses, one idea per sentence. Load the `writing-simplified-technical-english` skill with `skill-get` for the full house style.
 - **Evidence:** concrete observations (`description` + a stable `source_id`). These are the report's backbone and what the safety judge, and any later research, reasons over. At least one is required.
 - **Actionability:** set `actionability` honestly. `immediately_actionable` surfaces as READY, `requires_human_input` as PENDING_INPUT, `not_actionable` is suppressed. The safety judge can suppress regardless, so don't inflate it.
 - **Already addressed:** set `already_addressed` when the fix has landed *or* is already in flight: an open pull request, a recently active branch, or an assigned / in-progress issue or agent task covering the same problem. An immediately-actionable report can open a draft PR on its own, so leaving this `false` on work someone already has going produces a competing PR the team has to throw away. Say what you found in `actionability_explanation` and keep filing the report: a team wants to know the issue is real and being handled, it just must not be worked twice.


### PR DESCRIPTION
## Problem

Signals scouts author inbox reports, but the scout report-authoring guidance (`_WRITING_REPORT`) said nothing about house writing style — so scouts never picked up the `writing-simplified-technical-english` skill when writing report titles and summaries. The pipeline research agent already references that skill in its preamble (`report_generation/research.py`), leaving the scout channel as the odd one out.

## Changes

- Add a `Style` bullet to the scout `_WRITING_REPORT` section steering scouts to write titles and summaries in Simplified Technical English and to load the `writing-simplified-technical-english` skill via `skill-get` for the full house style.
- Scope is intentionally minimal: one bullet, mirroring the wording already used on the pipeline path.

## How did you test this code?

Automated: none added — this is a prompt-string change. Verified the module still parses (`ast.parse`) and that the existing `_WRITING_REPORT` assertions in `products/signals/backend/test/test_scout_harness.py` are unaffected (the addition lives inside the section that the edit-only-scout test already asserts is dropped). Did not run the scouts end to end.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A PostHog engineer directed this from a Slack thread after we found scout report runs were not loading the shared writing-style skill; the pipeline research agent already did. I could not verify the requester's GitHub handle this session, so the PR is left unassigned — please assign the DRI on triage. No skills were invoked to produce the change beyond reading the repo. No agent-session material beyond public repo content is included.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1786145350779639)*
