### PR TITLE
feat(desktop): walk space creation through one dialog, and star new spaces

### DIFF
--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -2485,15 +2485,22 @@ export class PostHogAPIClient {
     return (await response.json()) as TaskChannel[];
   }
 
-  // Resolve-or-create a public channel by name (idempotent server-side).
-  async resolveTaskChannel(name: string): Promise<TaskChannel> {
+  // Resolve-or-create a public channel by name (idempotent server-side). `star`
+  // only applies when this call creates the channel; an existing one keeps the
+  // requester's star as it was.
+  async resolveTaskChannel(
+    name: string,
+    options: { star: boolean },
+  ): Promise<TaskChannel> {
     const teamId = await this.getTeamId();
     const urlPath = `/api/projects/${teamId}/task_channels/`;
     const response = await this.api.fetcher.fetch({
       method: "post",
       url: new URL(`${this.api.baseUrl}${urlPath}`),
       path: urlPath,
-      overrides: { body: JSON.stringify({ name }) },
+      overrides: {
+        body: JSON.stringify({ name, star: options.star }),
+      },
     });
     if (!response.ok) {
       throw new Error(`Failed to resolve task channel: ${response.statusText}`);

--- a/products/desktop/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
@@ -555,7 +555,16 @@ export function CreateChannelModal({
     <Dialog
       open={open}
       onOpenChange={(next) => {
-        if (!busy) onOpenChange(next);
+        if (busy || next) return;
+        // Escape and the backdrop walk the steps back, the way the buttons do.
+        // Closing outright from the last step would drop a filled-in draft,
+        // since reopening starts clean.
+        const previous = CREATE_STEPS[CREATE_STEPS.indexOf(step) - 1];
+        if (previous) {
+          goToStep(previous);
+          return;
+        }
+        onOpenChange(false);
       }}
     >
       <DialogContent showCloseButton={false} className="sm:max-w-lg">

--- a/products/desktop/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
@@ -14,7 +14,13 @@ import {
   FieldError,
   FieldLabel,
   Input,
-  Text,
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemTitle,
+  Label,
+  Switch,
   Textarea,
 } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
@@ -23,11 +29,12 @@ import { useChannelMutations } from "@posthog/ui/features/canvas/hooks/useChanne
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { useGenerateContext } from "@posthog/ui/features/canvas/hooks/useGenerateContext";
 import { useUpdateTaskChannelRepositories } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
+import { AnimatedHeight } from "@posthog/ui/primitives/AnimatedHeight";
 import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
 import { useNavigate } from "@tanstack/react-router";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
-import { type CSSProperties, useEffect, useId, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 
 // Matches Slack's "Create a channel" naming constraint.
 const MAX_CONTEXT_NAME_LENGTH = 80;
@@ -41,6 +48,19 @@ const DESCRIPTION_EXAMPLES = [
 ];
 
 const DESCRIPTION_ROTATION_INTERVAL_MS = 5000;
+
+const CREATE_STEPS = ["name", "describe", "repositories"] as const;
+type CreateStep = (typeof CREATE_STEPS)[number];
+
+// quill's dialog curves, so a step swap reads as part of the same surface. A
+// step enters and leaves (ease-out); the card's height morphs in place behind
+// it (ease-in-out), starting once the arriving step has been measured.
+const EASE_OUT: [number, number, number, number] = [0.215, 0.61, 0.355, 1];
+const EASE_IN_OUT: [number, number, number, number] = [0.645, 0.045, 0.355, 1];
+const STEP_DURATION = 0.2;
+// Enough travel to say which way the flow went without the text sliding far
+// enough to read as a page turn.
+const STEP_SHIFT = 12;
 
 function RotatingDescriptionPlaceholder({ visible }: { visible: boolean }) {
   const [exampleIndex, setExampleIndex] = useState(0);
@@ -84,12 +104,13 @@ interface CreateChannelModalProps {
 }
 
 // Two dialogs in one, split on `existingContext`:
-// - Create mode: two steps. Step one names the channel; "Next" advances to step
-//   two, which asks what it's about. Nothing is created until that second step
-//   resolves — "Create" makes the channel and launches the context.md plan
-//   session seeded by the description, "Skip" makes the channel alone. Either
-//   way the user lands in the channel's feed, whose intro card carries the
-//   onboarding (and offers context.md later if skipped).
+// - Create mode: three steps in one dialog, swapping its content as you go.
+//   Step one names the channel, step two asks what it's about, step three
+//   carries the settings. Nothing is created until that last step resolves —
+//   "Create" makes the channel, links the chosen repositories and launches the
+//   context.md plan session seeded by the description, "Skip" makes the channel
+//   alone. Either way the user lands in the channel's feed, whose intro card
+//   carries the onboarding (and offers context.md later if skipped).
 // - Describe mode: the "Create your context.md" dialog (opened from the intro
 //   card or the CONTEXT.md empty state). A single textarea whose text seeds
 //   a plan-mode session that builds the context's CONTEXT.md with the user.
@@ -110,11 +131,22 @@ export function CreateChannelModal({
   const [repositoryIntegration, setRepositoryIntegration] = useState<
     number | null
   >(null);
-  // Create mode's step. Describe mode has no name step, so it starts past it.
-  const [step, setStep] = useState<"name" | "describe" | "repositories">(
-    "name",
-  );
+  const [star, setStar] = useState(true);
+  // Create mode's step. Describe mode returns before this is read.
+  const [step, setStep] = useState<CreateStep>("name");
+  // Which way the last move went, so a step slides in from the side it came
+  // from. Derived from the step order, so no call site can disagree.
+  const [direction, setDirection] = useState(1);
   const descriptionHelperId = useId();
+  const reduceMotion = useReducedMotion();
+  const stepDuration = reduceMotion ? 0 : STEP_DURATION;
+
+  const goToStep = (next: CreateStep) => {
+    setDirection(
+      CREATE_STEPS.indexOf(next) > CREATE_STEPS.indexOf(step) ? 1 : -1,
+    );
+    setStep(next);
+  };
 
   // Reset the fields each time the modal opens so a previous draft never
   // lingers. Adjusted inline during render (prev-prop comparison) rather than in
@@ -127,6 +159,7 @@ export function CreateChannelModal({
       setDescription("");
       setRepositories([]);
       setRepositoryIntegration(null);
+      setStar(true);
       setStep("name");
     }
   }
@@ -158,7 +191,7 @@ export function CreateChannelModal({
   const submitCreate = async (linkSelectedRepositories: boolean) => {
     let contextId: string;
     try {
-      const channel = await createChannel(trimmedName);
+      const channel = await createChannel(trimmedName, { star });
       track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
         action_type: "create",
         surface: "sidebar",
@@ -245,22 +278,25 @@ export function CreateChannelModal({
       await submitDescribe();
       return;
     }
-    if (canDescribe) setStep("repositories");
+    if (canDescribe) goToStep("repositories");
   };
+
+  // Both surfaces ask the same thing — the create step in its header, describe
+  // mode on the field itself — so the copy is written once.
+  const aboutTitle = `What's this ${spacesLayout ? "space" : "channel"} about?`;
+  const aboutBlurb = `Tell PostHog about this ${
+    spacesLayout ? "space" : "channel"
+  }. We'll use it to create a CONTEXT.md file with relevant information for future tasks.`;
 
   const descriptionField = (
     <Field>
-      {/* In create mode the nested dialog's title asks the question, so the
-          label would just repeat it. */}
+      {/* In create mode the step's own header asks the question, so the label
+          would just repeat it. */}
       {isDescribeMode && (
         <>
-          <FieldLabel htmlFor="context-description">
-            What's this {spacesLayout ? "space" : "channel"} about?
-          </FieldLabel>
+          <FieldLabel htmlFor="context-description">{aboutTitle}</FieldLabel>
           <FieldDescription id={descriptionHelperId}>
-            Tell PostHog about this {spacesLayout ? "space" : "channel"}. We'll
-            use it to create a CONTEXT.md file with relevant information for
-            future tasks.
+            {aboutBlurb}
           </FieldDescription>
         </>
       )}
@@ -289,8 +325,8 @@ export function CreateChannelModal({
     </Field>
   );
 
-  // Describe mode is only ever the one dialog — the channel already exists, so
-  // there's no name step to nest under.
+  // Describe mode has no steps to walk — the channel already exists, so the
+  // dialog is only ever this one question.
   if (isDescribeMode) {
     return (
       <Dialog
@@ -328,100 +364,71 @@ export function CreateChannelModal({
     );
   }
 
-  return (
-    <Dialog
-      open={open}
-      onOpenChange={(next) => {
-        if (!busy) onOpenChange(next);
-      }}
-    >
-      {/* quill stacks a nested dialog by pushing the *parent* down, which would
-          leave step one peeking below step two. Invert it: pin this step at the
-          base gap and drop step two below it (see its content), so the stack
-          reads first-on-top. Inline style because these are CSS variables. */}
-      <DialogContent
-        showCloseButton={false}
-        className="sm:max-w-lg"
-        style={{ "--quill-dialog-top-gap": "max(1rem, 10vh)" } as CSSProperties}
-      >
-        <DialogHeader>
-          <DialogTitle>
-            Create a {spacesLayout ? "space" : "channel"}
-          </DialogTitle>
-        </DialogHeader>
-
-        <DialogBody className="flex flex-col gap-4">
-          <Field>
-            <FieldLabel htmlFor="context-name">Name</FieldLabel>
-            <Input
-              id="context-name"
-              autoFocus
-              value={name}
-              placeholder="e.g. mobile"
-              maxLength={MAX_CONTEXT_NAME_LENGTH}
-              disabled={busy}
-              onChange={(e) => setName(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  if (canAdvance) setStep("describe");
-                }
-              }}
-            />
-            {nameError ? (
-              <FieldError>{nameError}</FieldError>
-            ) : (
-              <span className="text-gray-9 text-xs tabular-nums">
-                {remaining} left
-              </span>
-            )}
-          </Field>
-        </DialogBody>
-
-        <DialogFooter>
-          <DialogClose
-            render={
-              <Button variant="outline" disabled={busy}>
-                Cancel
-              </Button>
-            }
-          />
-          <Button
-            variant="primary"
-            disabled={!canAdvance}
-            onClick={() => setStep("describe")}
-          >
-            Next
-          </Button>
-        </DialogFooter>
-
-        {/* The About dialog stays mounted behind the repository step so Quill
-            can preserve the visual stack and return path. */}
-        <Dialog
-          open={step === "describe" || step === "repositories"}
-          onOpenChange={(next) => {
-            if (!busy && !next) setStep("name");
-          }}
-        >
-          <DialogContent
-            showCloseButton={false}
-            className="sm:max-w-lg"
-            // Sits below the name step, whose scaled-down top edge stays visible
-            // above this one.
-            style={
-              {
-                "--quill-dialog-top-gap": "max(1rem, 10vh + 1.5rem)",
-              } as CSSProperties
-            }
-          >
+  // Only the live step is built — the others cost nothing until you reach them.
+  const renderStep = () => {
+    switch (step) {
+      case "name":
+        return (
+          <>
             <DialogHeader>
               <DialogTitle>
-                What's this {spacesLayout ? "space" : "channel"} about?
+                Create a {spacesLayout ? "space" : "channel"}
               </DialogTitle>
+            </DialogHeader>
+
+            <DialogBody className="flex max-h-[55vh] flex-col gap-4">
+              <Field>
+                <FieldLabel htmlFor="context-name">Name</FieldLabel>
+                <Input
+                  id="context-name"
+                  autoFocus
+                  value={name}
+                  placeholder="e.g. mobile"
+                  maxLength={MAX_CONTEXT_NAME_LENGTH}
+                  disabled={busy}
+                  onChange={(e) => setName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      if (canAdvance) goToStep("describe");
+                    }
+                  }}
+                />
+                {nameError ? (
+                  <FieldError>{nameError}</FieldError>
+                ) : (
+                  <span className="text-gray-9 text-xs tabular-nums">
+                    {remaining} left
+                  </span>
+                )}
+              </Field>
+            </DialogBody>
+
+            <DialogFooter>
+              <DialogClose
+                render={
+                  <Button variant="outline" disabled={busy}>
+                    Cancel
+                  </Button>
+                }
+              />
+              <Button
+                variant="primary"
+                disabled={!canAdvance}
+                onClick={() => goToStep("describe")}
+              >
+                Next
+              </Button>
+            </DialogFooter>
+          </>
+        );
+      case "describe":
+        return (
+          <>
+            <DialogHeader>
+              <DialogTitle>{aboutTitle}</DialogTitle>
               <DialogDescription id={descriptionHelperId}>
-                Tell PostHog about this {spacesLayout ? "space" : "channel"}.
-                We'll use it to create a CONTEXT.md file with relevant
-                information for future tasks.
+                {aboutBlurb}
               </DialogDescription>
             </DialogHeader>
 
@@ -432,8 +439,9 @@ export function CreateChannelModal({
             <DialogFooter>
               <Button
                 variant="outline"
+                className="sm:mr-auto"
                 disabled={busy}
-                onClick={() => setStep("name")}
+                onClick={() => goToStep("name")}
               >
                 Back
               </Button>
@@ -442,7 +450,7 @@ export function CreateChannelModal({
                 disabled={busy}
                 onClick={() => {
                   setDescription("");
-                  setStep("repositories");
+                  goToStep("repositories");
                 }}
               >
                 Skip
@@ -455,31 +463,25 @@ export function CreateChannelModal({
                 Next
               </Button>
             </DialogFooter>
+          </>
+        );
+      case "repositories":
+        return (
+          <>
+            <DialogHeader>
+              <DialogTitle>Settings</DialogTitle>
+            </DialogHeader>
 
-            <Dialog
-              open={step === "repositories"}
-              onOpenChange={(next) => {
-                if (!busy && !next) setStep("describe");
-              }}
-            >
-              <DialogContent
-                showCloseButton={false}
-                className="sm:max-w-lg"
-                style={
-                  {
-                    "--quill-dialog-top-gap": "max(1rem, 10vh + 3rem)",
-                  } as CSSProperties
-                }
-              >
-                <DialogHeader>
-                  <DialogTitle>Link repositories</DialogTitle>
-                </DialogHeader>
-
-                <DialogBody viewportClassName="flex flex-col gap-3">
-                  <Text size="sm" variant="muted">
+            <DialogBody viewportClassName="flex flex-col gap-3">
+              <Item variant="outline">
+                <ItemContent>
+                  <ItemTitle>Repositories</ItemTitle>
+                  <ItemDescription>
                     New tasks in this {spacesLayout ? "space" : "channel"} can
                     use these repositories. You can change them later.
-                  </Text>
+                  </ItemDescription>
+                </ItemContent>
+                <ItemActions>
                   <RepositoriesField
                     selected={repositories}
                     integrationId={repositoryIntegration}
@@ -489,36 +491,110 @@ export function CreateChannelModal({
                       setRepositoryIntegration(nextIntegration);
                     }}
                   />
-                </DialogBody>
+                </ItemActions>
+              </Item>
+              {/* Last stop before both create buttons, so the toggle is in view when
+              the space is actually made. */}
+              <Item variant="outline">
+                <ItemContent>
+                  <ItemTitle>
+                    <Label htmlFor="context-star">
+                      Star new {spacesLayout ? "space" : "channel"}
+                    </Label>
+                  </ItemTitle>
+                  <ItemDescription>
+                    Shows it in your starred list.
+                  </ItemDescription>
+                </ItemContent>
+                <ItemActions>
+                  <Switch
+                    id="context-star"
+                    checked={star}
+                    disabled={busy}
+                    onCheckedChange={setStar}
+                  />
+                </ItemActions>
+              </Item>
+            </DialogBody>
 
-                <DialogFooter>
-                  <Button
-                    variant="outline"
-                    disabled={busy}
-                    onClick={() => setStep("describe")}
-                  >
-                    Back
-                  </Button>
-                  <Button
-                    variant="default"
-                    disabled={busy}
-                    onClick={() => void submitOnce(() => submitCreate(false))}
-                  >
-                    Skip
-                  </Button>
-                  <Button
-                    variant="primary"
-                    disabled={busy || repositories.length === 0}
-                    loading={busy}
-                    onClick={() => void submitOnce(() => submitCreate(true))}
-                  >
-                    Create
-                  </Button>
-                </DialogFooter>
-              </DialogContent>
-            </Dialog>
-          </DialogContent>
-        </Dialog>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                className="sm:mr-auto"
+                disabled={busy}
+                onClick={() => goToStep("describe")}
+              >
+                Back
+              </Button>
+              <Button
+                variant="default"
+                disabled={busy}
+                onClick={() => void submitOnce(() => submitCreate(false))}
+              >
+                Skip
+              </Button>
+              <Button
+                variant="primary"
+                disabled={busy || repositories.length === 0}
+                loading={busy}
+                onClick={() => void submitOnce(() => submitCreate(true))}
+              >
+                Create
+              </Button>
+            </DialogFooter>
+          </>
+        );
+    }
+  };
+
+  // The exiting step is popped out of flow, so the card's height follows the
+  // arriving one. `relative` is what that pop positions against.
+  const stepDirection = reduceMotion ? 0 : direction;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!busy) onOpenChange(next);
+      }}
+    >
+      <DialogContent showCloseButton={false} className="sm:max-w-lg">
+        <AnimatedHeight
+          className="relative"
+          duration={stepDuration}
+          ease={EASE_IN_OUT}
+        >
+          <AnimatePresence
+            initial={false}
+            mode="popLayout"
+            custom={stepDirection}
+          >
+            <motion.div
+              key={step}
+              className="flex max-h-[70vh] flex-col"
+              custom={stepDirection}
+              transition={{ duration: stepDuration, ease: EASE_OUT }}
+              variants={{
+                enter: (d: number) => ({ opacity: 0, x: d * STEP_SHIFT }),
+                center: { opacity: 1, x: 0 },
+                exit: (d: number) => ({
+                  opacity: 0,
+                  x: -d * STEP_SHIFT,
+                  // Shorter than the entrance, so the arriving step leads.
+                  transition: {
+                    duration: stepDuration * 0.75,
+                    ease: EASE_OUT,
+                  },
+                }),
+              }}
+              initial="enter"
+              animate="center"
+              exit="exit"
+            >
+              {renderStep()}
+            </motion.div>
+          </AnimatePresence>
+        </AnimatedHeight>
       </DialogContent>
     </Dialog>
   );

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannels.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannels.test.tsx
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockClient = vi.hoisted(() => ({
   getTaskChannels: vi.fn(),
   resolveTaskChannel: vi.fn(),
+  starTaskChannel: vi.fn(),
 }));
 vi.mock("@posthog/ui/features/auth/authClient", () => ({
   useOptionalAuthenticatedClient: () => mockClient,
@@ -14,12 +15,12 @@ vi.mock("@posthog/ui/features/auth/authClient", () => ({
 
 import { useChannelMutations, useChannels } from "./useChannels";
 
-function taskChannel(id: string, name: string): TaskChannel {
+function taskChannel(id: string, name: string, starred = false): TaskChannel {
   return {
     id,
     name,
     channel_type: "public",
-    starred: false,
+    starred,
     created_at: "2026-01-01T00:00:00Z",
   };
 }
@@ -55,7 +56,7 @@ describe("useChannelMutations", () => {
 
     const mutations = renderHook(() => useChannelMutations(), { wrapper });
     await act(async () => {
-      await mutations.result.current.createChannel("beta");
+      await mutations.result.current.createChannel("beta", { star: false });
     });
 
     // The new channel is present from the optimistic cache write, sorted
@@ -85,10 +86,62 @@ describe("useChannelMutations", () => {
 
     const mutations = renderHook(() => useChannelMutations(), { wrapper });
     await act(async () => {
-      await mutations.result.current.createChannel("alpha");
+      await mutations.result.current.createChannel("alpha", { star: false });
     });
 
     // The duplicate-id guard keeps the list at one entry.
     expect(list.result.current.channels.map((c) => c.id)).toEqual(["1"]);
+  });
+
+  // A backend that ignores `star` on create is the case the follow-up call
+  // exists for; the other two rows keep it from firing when it would either be
+  // wasted or would star against the user's choice.
+  it.each([
+    ["a backend that ignored the create flag", true, false, true],
+    ["a backend that starred on create", true, true, false],
+    ["the toggle off", false, false, false],
+  ])(
+    "asks the star endpoint for the new channel only when needed: %s",
+    async (_case, star, starredOnCreate, expectStarCall) => {
+      mockClient.getTaskChannels.mockResolvedValue([]);
+      mockClient.resolveTaskChannel.mockResolvedValue(
+        taskChannel("1", "alpha", starredOnCreate),
+      );
+      mockClient.starTaskChannel.mockResolvedValue(undefined);
+
+      const mutations = renderHook(() => useChannelMutations(), { wrapper });
+      let channel: { starred: boolean } | undefined;
+      await act(async () => {
+        channel = await mutations.result.current.createChannel("alpha", {
+          star,
+        });
+      });
+
+      expect(mockClient.starTaskChannel).toHaveBeenCalledTimes(
+        expectStarCall ? 1 : 0,
+      );
+      if (expectStarCall) {
+        expect(mockClient.starTaskChannel).toHaveBeenCalledWith("1", true);
+      }
+      expect(channel?.starred).toBe(star);
+    },
+  );
+
+  it("leaves the star alone when the name resolves a space that already exists", async () => {
+    // The list the create form was filled against already holds the name, so
+    // this is a resolve, not a creation — the user's own star stands.
+    const existing = taskChannel("1", "alpha");
+    mockClient.getTaskChannels.mockResolvedValue([existing]);
+    mockClient.resolveTaskChannel.mockResolvedValue(existing);
+
+    const list = renderHook(() => useChannels(), { wrapper });
+    await waitFor(() => expect(list.result.current.isLoading).toBe(false));
+
+    const mutations = renderHook(() => useChannelMutations(), { wrapper });
+    await act(async () => {
+      await mutations.result.current.createChannel("alpha", { star: true });
+    });
+
+    expect(mockClient.starTaskChannel).not.toHaveBeenCalled();
   });
 });

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannels.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannels.test.tsx
@@ -14,6 +14,7 @@ vi.mock("@posthog/ui/features/auth/authClient", () => ({
 }));
 
 import { useChannelMutations, useChannels } from "./useChannels";
+import { TASK_CHANNELS_QUERY_KEY } from "./useTaskChannels";
 
 function taskChannel(id: string, name: string, starred = false): TaskChannel {
   return {
@@ -103,7 +104,8 @@ describe("useChannelMutations", () => {
   ])(
     "asks the star endpoint for the new channel only when needed: %s",
     async (_case, star, starredOnCreate, expectStarCall) => {
-      mockClient.getTaskChannels.mockResolvedValue([]);
+      // The sidebar has loaded and holds no spaces, so this name is new.
+      queryClient.setQueryData(TASK_CHANNELS_QUERY_KEY, []);
       mockClient.resolveTaskChannel.mockResolvedValue(
         taskChannel("1", "alpha", starredOnCreate),
       );
@@ -126,6 +128,20 @@ describe("useChannelMutations", () => {
       expect(channel?.starred).toBe(star);
     },
   );
+
+  it("leaves the star alone when the list it would check has not loaded", async () => {
+    // Nothing has fetched the list, so an existing unstarred space and a brand
+    // new one are indistinguishable here. Starring the wrong one is the costlier
+    // mistake, so the fallback stands down.
+    mockClient.resolveTaskChannel.mockResolvedValue(taskChannel("1", "alpha"));
+
+    const mutations = renderHook(() => useChannelMutations(), { wrapper });
+    await act(async () => {
+      await mutations.result.current.createChannel("alpha", { star: true });
+    });
+
+    expect(mockClient.starTaskChannel).not.toHaveBeenCalled();
+  });
 
   it("leaves the star alone when the name resolves a space that already exists", async () => {
     // The list the create form was filled against already holds the name, so

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannels.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannels.ts
@@ -61,11 +61,29 @@ export function useChannelMutations() {
   }, [queryClient]);
 
   const createMutation = useMutation({
-    mutationFn: async (name: string) => {
+    mutationFn: async ({ name, star }: { name: string; star: boolean }) => {
       if (!client) throw new Error("Not authenticated");
       // Resolve-or-create is idempotent server-side, so racing creators of the
       // same name converge on one channel.
-      return client.resolveTaskChannel(name);
+      // Names that reach here are already lowercase-dashed (the create form
+      // rejects anything else), so they match server-normalized names as typed.
+      const resolvedExisting = (
+        queryClient.getQueryData<TaskChannel[]>(TASK_CHANNELS_QUERY_KEY) ?? []
+      ).some((channel) => channel.name === name);
+      const created = await client.resolveTaskChannel(name, { star });
+      if (!star || created.starred || resolvedExisting) return created;
+      // TODO: delete once `star` on create is live on Cloud. A backend that
+      // predates it drops the flag and hands back an unstarred channel, so ask
+      // again through the star endpoint every version has. Resolving a channel
+      // that already existed is left alone either way — its star is the user's.
+      try {
+        await client.starTaskChannel(created.id, true);
+        return { ...created, starred: true };
+      } catch {
+        // The space exists either way, and the star is one click to fix, so a
+        // failure here isn't worth failing the create the user asked for.
+        return created;
+      }
     },
     onSuccess: (created) => {
       // Insert the created channel into the cache immediately so the sidebar
@@ -100,8 +118,8 @@ export function useChannelMutations() {
   });
 
   return {
-    createChannel: (name: string) =>
-      createMutation.mutateAsync(name).then(toChannel),
+    createChannel: (name: string, options: { star: boolean }) =>
+      createMutation.mutateAsync({ name, star: options.star }).then(toChannel),
     deleteChannel: (id: string) => deleteMutation.mutateAsync(id),
     renameChannel: (id: string, name: string) =>
       renameMutation.mutateAsync({ id, name }).then(toChannel),

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannels.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannels.ts
@@ -67,11 +67,14 @@ export function useChannelMutations() {
       // same name converge on one channel.
       // Names that reach here are already lowercase-dashed (the create form
       // rejects anything else), so they match server-normalized names as typed.
-      const resolvedExisting = (
-        queryClient.getQueryData<TaskChannel[]>(TASK_CHANNELS_QUERY_KEY) ?? []
-      ).some((channel) => channel.name === name);
+      // An unfetched list reads as undefined rather than "no such name", and
+      // starring a space the user had unstarred is worse than not starring a
+      // new one, so only a loaded list without the name earns the fallback.
+      const isNewToTheList = queryClient
+        .getQueryData<TaskChannel[]>(TASK_CHANNELS_QUERY_KEY)
+        ?.every((channel) => channel.name !== name);
       const created = await client.resolveTaskChannel(name, { star });
-      if (!star || created.starred || resolvedExisting) return created;
+      if (!star || created.starred || !isNewToTheList) return created;
       // TODO: delete once `star` on create is live on Cloud. A backend that
       // predates it drops the flag and hands back an unstarred channel, so ask
       // again through the star endpoint every version has. Resolving a channel

--- a/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
+++ b/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
@@ -299,7 +299,7 @@ export function GitHubRepoPicker({
           )}
         </ComboboxList>
         {hasMore ? (
-          <div className="shrink-0 border-t p-2">
+          <div className="shrink-0 border-t p-1">
             <Button
               variant="outline"
               size="sm"

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
@@ -42,8 +42,9 @@ import {
 } from "@posthog/ui/features/sessions/components/HarnessSubmenu";
 import { ModelRadioItem } from "@posthog/ui/features/sessions/components/ModelRadioItem";
 import type { AgentAdapter } from "@posthog/ui/features/settings/settingsStore";
+import { AnimatedHeight } from "@posthog/ui/primitives/AnimatedHeight";
 import { AnimatePresence, motion } from "framer-motion";
-import { Fragment, useLayoutEffect, useRef, useState } from "react";
+import { Fragment, useRef, useState } from "react";
 import { flattenSelectOptions } from "../sessionStore";
 import { useRetainedConfigOption } from "../useRetainedConfigOption";
 import {
@@ -70,33 +71,6 @@ interface ReasoningLevelSelectorProps {
   onConfigOptionChange?: (configId: string, value: string) => void;
   disabled?: boolean;
   isLoading?: boolean;
-}
-
-/** Tweens the menu's height between the slider and advanced views so the
- * popup morphs instead of snapping when the content swaps. */
-function AnimatedHeight({ children }: { children: React.ReactNode }) {
-  const contentRef = useRef<HTMLDivElement>(null);
-  const [height, setHeight] = useState<number | "auto">("auto");
-
-  useLayoutEffect(() => {
-    const node = contentRef.current;
-    if (!node || typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(() => setHeight(node.offsetHeight));
-    observer.observe(node);
-    setHeight(node.offsetHeight);
-    return () => observer.disconnect();
-  }, []);
-
-  return (
-    <motion.div
-      initial={false}
-      animate={{ height }}
-      transition={{ duration: 0.18, ease: [0.3, 0.9, 0.3, 1] }}
-      className="overflow-hidden"
-    >
-      <div ref={contentRef}>{children}</div>
-    </motion.div>
-  );
 }
 
 function toDropdownOptions(

--- a/products/desktop/packages/ui/src/primitives/AnimatedHeight.tsx
+++ b/products/desktop/packages/ui/src/primitives/AnimatedHeight.tsx
@@ -1,0 +1,48 @@
+import { cn } from "@posthog/quill";
+import { motion } from "framer-motion";
+import type { ReactElement, ReactNode } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
+
+type Bezier = [number, number, number, number];
+
+interface AnimatedHeightProps {
+  children: ReactNode;
+  /** Seconds. Pass 0 to cut the tween for reduced motion. */
+  duration?: number;
+  ease?: Bezier;
+  className?: string;
+}
+
+/** Tweens a container's height as its content changes, so a surface whose
+ * content swaps or grows morphs instead of snapping. Content sits in a
+ * measured inner wrapper, so children can mount and unmount freely — including
+ * an `AnimatePresence` whose exiting child is out of flow. */
+export function AnimatedHeight({
+  children,
+  duration = 0.18,
+  ease = [0.3, 0.9, 0.3, 1],
+  className,
+}: AnimatedHeightProps): ReactElement {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [height, setHeight] = useState<number | "auto">("auto");
+
+  useLayoutEffect(() => {
+    const node = contentRef.current;
+    if (!node || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => setHeight(node.offsetHeight));
+    observer.observe(node);
+    setHeight(node.offsetHeight);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <motion.div
+      initial={false}
+      animate={{ height }}
+      transition={{ duration, ease }}
+      className={cn("overflow-hidden", className)}
+    >
+      <div ref={contentRef}>{children}</div>
+    </motion.div>
+  );
+}


### PR DESCRIPTION
## Problem

- Someone creating a space in PostHog Code answers three questions, and each one arrives as its own dialog stacked on the last.
- The stack is built from nested dialogs, which cost the flow its focus trap: tabbing could leave the dialog that was in front.
- A new space is not starred, so the space you are about to work in does not appear in the starred list at the top of the sidebar until you star it by hand.

## Changes

- Creating a space now walks through one dialog. Its content slides between steps and its height follows the step it is showing.
- The dialog is a single Base UI dialog again, so it traps focus. Escape closes the flow from the first step, and Back walks the rest.
- The third step is a settings step. It holds the repositories picker and a new "Star new space" switch, on by default.
- The create call carries that switch. When the backend it is talking to predates the flag, the client stars through the star endpoint instead.
- Naming a space that already exists leaves that space's star alone. The client checks the list it was filled against before it compensates.
- The height tween moves to an `AnimatedHeight` primitive. The reasoning menu drops its own copy and uses it.

The server half is #80306, which adds the `star` field to the create endpoint. The two are safe to ship in either order: this client works against a backend without the field, and that backend defaults the field to true.

### Screenshots

| Step | |
| --- | --- |
| Name | ![shot-name](https://raw.githubusercontent.com/PostHog/pr-assets/5a2bb86e6ea7b68a65ef4bc455adf49bcf202875/2026/08/479c032f-9475-418c-9344-838a4bb0137e.png) |
| About | ![shot-about](https://raw.githubusercontent.com/PostHog/pr-assets/0e1125eece09795827a3694ae11b95c060c31dda/2026/08/0ddf1139-cc10-45c8-b2b7-100af7ae77ec.png) |
| Settings | ![shot-settings](https://raw.githubusercontent.com/PostHog/pr-assets/ee320942aab4d6afbfccccef75278a640ebde89f/2026/08/ffd8d115-d90a-4ddf-921a-a65f7e24b9ea.png) |

## How did you test this code?

- `useChannels.test.tsx` gains three parameterized cases covering when the client asks the star endpoint, and one covering a name that resolves an existing space.
- The last case catches the regression that matters: without it, creating against a name you already own would re-star a space you unstarred on purpose.
- I drove the running desktop app over CDP against production Cloud, which does not have #80306 yet. Creating a space with the switch on put it under "Starred", and its row menu offered "Unstar space". I deleted that space afterwards.
- I sampled the transition in the same session: the leaving step reaches -12px and opacity 0, the arriving step comes from +12px, and the card's height tweens between the two step heights.
- Focus stayed inside the dialog after every step change, and the name field kept its text across Back.
- Not checked: reduced motion, which the code handles by setting both the shift and the duration to zero. I did not run the app with the OS setting on.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude Opus 5, in Claude Code) wrote this under @adamleithp's direction.

The step stack went through two shapes before this one. It began as three nested dialogs, then as nested dialogs in reverse order so the steps still to come sat behind the current one. Both kept the focus-trap problem that nesting causes, which is why the third shape collapses them into one dialog.

The client-side star fallback carries a removal trigger in a comment. Once #80306 is live on Cloud, the create response comes back starred and the fallback is dead code.

Skills invoked: `/posthog-desktop` for the workspace rules, `/web-animation-design` for the easing and duration choices, `/simplify` for a four-agent cleanup pass that produced the `AnimatedHeight` extraction, `/writing-tests` for the test cases, `/test-electron-app` to drive the running app, `/writing-user-facing-copy` conventions for the switch copy, and `/writing-pr-descriptions` for this body.
