### PR TITLE
feat(inbox): capture scout creations that came from a template link

### DIFF
--- a/products/signals/frontend/inbox/inboxAnalytics.ts
+++ b/products/signals/frontend/inbox/inboxAnalytics.ts
@@ -34,6 +34,7 @@ export const INBOX_EVENTS = {
     SCOUT_CONFIG_CHANGED: 'Scout config changed',
     SCOUT_ACTION: 'Scout action',
     SCOUT_CHAT_STARTED: 'Scout chat started',
+    SCOUT_CREATED_FROM_TEMPLATE: 'Scout created from template',
     RUN_OPENED: 'Inbox run opened',
     ONBOARDING_DECIDED: 'Inbox onboarding decided',
 } as const
@@ -577,6 +578,24 @@ export function captureInboxOnboardingDecided(params: {
     captureInboxEvent(INBOX_EVENTS.ONBOARDING_DECIDED, {
         mode: params.mode,
         suppression_reason: params.reason,
+    })
+}
+
+/**
+ * A scout was created from a prefilled `#createScout=` link — the conversion end of a
+ * posthog.com pocket-guide "Add this scout" click (`pocket_guide_interaction`, kind
+ * `add_scout_click`, in the website's project). Fires only once the create request succeeds;
+ * `already_existed` marks the idempotent case where the name was taken and settings were updated.
+ */
+export function captureScoutCreatedFromTemplate(params: {
+    skillName: string
+    templateSource: string
+    alreadyExisted: boolean
+}): void {
+    captureInboxEvent(INBOX_EVENTS.SCOUT_CREATED_FROM_TEMPLATE, {
+        skill_name: params.skillName,
+        template_source: params.templateSource,
+        already_existed: params.alreadyExisted,
     })
 }
 

--- a/products/signals/frontend/inbox/logics/scoutCreateModalLogic.test.ts
+++ b/products/signals/frontend/inbox/logics/scoutCreateModalLogic.test.ts
@@ -1,6 +1,7 @@
 import { MOCK_TEAM_ID } from 'lib/api.mock'
 
 import { expectLogic } from 'kea-test-utils'
+import posthog from 'posthog-js'
 
 import { ApiError } from 'lib/api-error'
 
@@ -207,6 +208,39 @@ describe('scoutCreateModalLogic', () => {
         expect(mockSignalsScoutCreate).not.toHaveBeenCalled()
         expect(onCreated).not.toHaveBeenCalled()
         expect(onClose).not.toHaveBeenCalled()
+    })
+
+    it('captures the template conversion on success, with source kept out of the form and the API call', async () => {
+        const capture = jest.spyOn(posthog, 'capture').mockImplementation(jest.fn())
+        mockSignalsScoutCreate.mockResolvedValue(CREATED_SCOUT)
+        logic = scoutCreateModalLogic({
+            logicKey: 'pocket-guide-scout',
+            initialValues: {
+                name: 'signals-scout-checkout-failures',
+                description: 'Investigates recurring checkout failures.',
+                body: 'Inspect checkout failure signals and report meaningful regressions.',
+                source: 'pocket_guide',
+            },
+            onClose,
+            onCreated,
+        })
+        logic.mount()
+
+        expect(logic.values.scoutCreateForm).not.toHaveProperty('source')
+
+        await expectLogic(logic, () => logic.actions.submitScoutCreateForm()).toFinishAllListeners()
+
+        expect(mockSignalsScoutCreate).toHaveBeenCalledWith(
+            String(MOCK_TEAM_ID),
+            expect.not.objectContaining({ source: expect.anything() })
+        )
+        expect(capture).toHaveBeenCalledWith('Scout created from template', {
+            inbox_client: 'cloud',
+            skill_name: 'signals-scout-checkout-failures',
+            template_source: 'pocket_guide',
+            already_existed: false,
+        })
+        capture.mockRestore()
     })
 
     it('keeps the form open and surfaces a conflicting scout name', async () => {

--- a/products/signals/frontend/inbox/logics/scoutCreateModalLogic.ts
+++ b/products/signals/frontend/inbox/logics/scoutCreateModalLogic.ts
@@ -15,6 +15,7 @@ import type {
 } from 'products/signals/frontend/generated/api.schemas'
 import { SKILL_DESCRIPTION_MAX_LENGTH, validateSkillName } from 'products/skills/frontend/skillConstants'
 
+import { captureScoutCreatedFromTemplate } from '../inboxAnalytics'
 import {
     dailyCronToTime,
     DEFAULT_SCOUT_DAILY_TIME,
@@ -24,6 +25,7 @@ import {
     timeToDailyCron,
 } from '../utils/scoutRunsWindow'
 import { MAX_SCOUT_TAG_LENGTH, MAX_SCOUT_TAGS, normalizeScoutTag } from '../utils/scoutTags'
+import type { ScoutTemplateSource } from '../utils/scoutTemplateDeepLink'
 
 type ScoutCreateConfigFormValues = Required<
     Pick<SignalScoutConfigOptionsApi, 'enabled' | 'emit' | 'run_interval_minutes' | 'run_cron_schedule' | 'tags'>
@@ -37,6 +39,8 @@ export type ScoutCreateFormValues = Pick<SignalScoutCreateApi, 'name' | 'descrip
 
 export type ScoutCreateInitialValues = Partial<Pick<SignalScoutCreateApi, 'name' | 'description' | 'body'>> & {
     config?: Partial<ScoutCreateConfigFormValues>
+    /** Where a prefilled template came from. Analytics-only: stripped from the form, never persisted. */
+    source?: ScoutTemplateSource
 }
 
 export interface ScoutCreateModalLogicProps {
@@ -61,13 +65,14 @@ export const DEFAULT_SCOUT_CREATE_FORM_VALUES: ScoutCreateFormValues = {
 }
 
 export function getScoutCreateFormValues(initialValues?: ScoutCreateInitialValues): ScoutCreateFormValues {
+    const { source: _source, ...prefill } = initialValues ?? {}
     const config = {
         ...DEFAULT_SCOUT_CREATE_FORM_VALUES.config,
-        ...initialValues?.config,
+        ...prefill.config,
     }
     return {
         ...DEFAULT_SCOUT_CREATE_FORM_VALUES,
-        ...initialValues,
+        ...prefill,
         config,
         dailyTime: dailyCronToTime(config.run_cron_schedule) ?? DEFAULT_SCOUT_DAILY_TIME,
     }
@@ -227,6 +232,15 @@ export const scoutCreateModalLogic: LogicWrapper<scoutCreateModalLogicType> = ke
                         body: formValues.body.trim(),
                         config: formValues.config,
                     })
+
+                    // The conversion event for prefilled links: fires only once the scout exists.
+                    if (logicProps.initialValues?.source) {
+                        captureScoutCreatedFromTemplate({
+                            skillName: formValues.name.trim(),
+                            templateSource: logicProps.initialValues.source,
+                            alreadyExisted: !scout.created,
+                        })
+                    }
 
                     actions.resetScoutCreateForm()
                     lemonToast.success(

--- a/products/signals/frontend/inbox/utils/scoutTemplateDeepLink.test.ts
+++ b/products/signals/frontend/inbox/utils/scoutTemplateDeepLink.test.ts
@@ -48,6 +48,16 @@ describe('scoutTemplateDeepLink', () => {
         expect(decodeScoutCreateTemplate(encoded)).toEqual({ description: 'd' })
     })
 
+    it('passes a known source through for attribution', () => {
+        const encoded = encodeScoutCreateTemplate({ description: 'd', source: 'pocket_guide' })
+        expect(decodeScoutCreateTemplate(encoded)).toEqual({ description: 'd', source: 'pocket_guide' })
+    })
+
+    it('drops an unknown source', () => {
+        const encoded = encodeScoutCreateTemplate({ description: 'd', source: 'evil_site' })
+        expect(decodeScoutCreateTemplate(encoded)).toEqual({ description: 'd' })
+    })
+
     it.each([
         ['undefined', undefined],
         ['empty string', ''],

--- a/products/signals/frontend/inbox/utils/scoutTemplateDeepLink.ts
+++ b/products/signals/frontend/inbox/utils/scoutTemplateDeepLink.ts
@@ -13,7 +13,13 @@ export interface ScoutTemplatePayload {
     name?: string
     description?: string
     body?: string
+    /** Where the link came from, for conversion analytics. Allowlisted on decode. */
+    source?: string
 }
+
+/** Link origins we attribute scout creations to. Anything else decodes as if absent. */
+const TEMPLATE_SOURCES = ['pocket_guide'] as const
+export type ScoutTemplateSource = (typeof TEMPLATE_SOURCES)[number]
 
 /** Whole-payload cap, before decoding. Far above any real template, far below abuse territory. */
 const MAX_ENCODED_LENGTH = 16384
@@ -44,7 +50,8 @@ export function decodeScoutCreateTemplate(raw: unknown): ScoutCreateInitialValue
         return null
     }
 
-    const { name, description, body } = parsed as Record<string, unknown>
+    const { name, description, body, source } = parsed as Record<string, unknown>
+    const cleanSource = TEMPLATE_SOURCES.find((known) => known === source)
     const cleanDescription =
         typeof description === 'string' ? description.trim().slice(0, SKILL_DESCRIPTION_MAX_LENGTH) : ''
     const cleanBody = typeof body === 'string' ? body.trim().slice(0, MAX_BODY_LENGTH) : ''
@@ -67,5 +74,6 @@ export function decodeScoutCreateTemplate(raw: unknown): ScoutCreateInitialValue
         ...(cleanName ? { name: cleanName } : {}),
         ...(cleanDescription ? { description: cleanDescription } : {}),
         ...(cleanBody ? { body: cleanBody } : {}),
+        ...(cleanSource ? { source: cleanSource } : {}),
     }
 }


### PR DESCRIPTION
posthog.com's pocket guides stamp their `#createScout=` deep-link payloads with `source: 'pocket_guide'` ([posthog.com side](https://github.com/PostHog/posthog.com/tree/pocket-guide-scout-attribution)). This PR is the receiving end: decode the field and fire the conversion event when the scout is actually created.

## Changes

- `scoutTemplateDeepLink.ts`: `source` decodes through an allowlist (`pocket_guide` only – anything else is dropped, so the field can't be abused as a free-text channel).
- `scoutCreateModalLogic.ts`: `source` is stripped from the form values and never reaches the create API – it's analytics-only. On a successful create it fires **`Scout created from template`** (`skill_name`, `template_source`, `already_existed`) via the existing `inboxAnalytics` module, so it carries `inbox_client` like every other inbox event.
- Fires only once the create request succeeds – not on modal open, not on failed submits. A manually-opened modal has no `source`, so it never fires there.

## Blast radius

Prefill links without `source` (all existing ones) behave exactly as before – the decoder treats the field as optional and every prior test still passes. No API or persistence changes.

## Tests

- Decoder: known source passes through, unknown source dropped, absent source unchanged (15/15 pass).
- Modal logic: new test asserts the capture fires on success with the right props, and that `source` stays out of both the form and the API payload (5/5 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)