### PR TITLE
feat(code): add Codex multitask mode

### DIFF
--- a/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
@@ -1840,7 +1840,7 @@ describe("CodexAppServerAgent", () => {
     ]);
     expect(
       opts.find((o) => o.category === "mode").options.map((x: any) => x.value),
-    ).toEqual(["plan", "read-only", "auto", "full-access"]);
+    ).toEqual(["plan", "read-only", "auto", "multitask", "full-access"]);
     expect(
       opts
         .find((o) => o.category === "thought_level")

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/session-config.test.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/session-config.test.ts
@@ -19,6 +19,7 @@ describe("modeApprovalPolicy", () => {
   it.each([
     ["read-only", "untrusted"],
     ["auto", "on-request"],
+    ["multitask", "on-request"],
     ["full-access", "never"],
   ])("maps mode %s to approval policy %s", (mode, policy) => {
     expect(modeApprovalPolicy(mode)).toBe(policy);
@@ -48,7 +49,7 @@ describe("sandboxPolicyFor", () => {
     });
   });
 
-  it("restores an editable sandbox for auto + full-access (turn overrides are sticky)", () => {
+  it("restores an editable sandbox for editable modes (turn overrides are sticky)", () => {
     expect(sandboxPolicyFor("full-access")).toEqual({
       type: "dangerFullAccess",
     });
@@ -57,6 +58,7 @@ describe("sandboxPolicyFor", () => {
         ? { type: "workspaceWrite", networkAccess: false }
         : { type: "dangerFullAccess" },
     );
+    expect(sandboxPolicyFor("multitask")).toEqual(sandboxPolicyFor("auto"));
   });
 
   it("returns undefined for unknown ids", () => {
@@ -69,7 +71,7 @@ describe("buildCodexModes", () => {
   const sandboxFor = (platform: string, id: string) =>
     buildCodexModes(platform).find((m) => m.id === id)?.sandboxPolicy;
 
-  it("gives auto the platform's editable sandbox (Seatbelt workspace-write on macOS, danger elsewhere)", () => {
+  it("gives editable modes the platform's editable sandbox (Seatbelt workspace-write on macOS, danger elsewhere)", () => {
     // Network stays restricted: egress still goes through codex's escalation prompt.
     expect(sandboxFor("darwin", "auto")).toEqual({
       type: "workspaceWrite",
@@ -77,6 +79,13 @@ describe("buildCodexModes", () => {
     });
     expect(sandboxFor("linux", "auto")).toEqual({ type: "dangerFullAccess" });
     expect(sandboxFor("win32", "auto")).toEqual({ type: "dangerFullAccess" });
+    expect(sandboxFor("darwin", "multitask")).toEqual({
+      type: "workspaceWrite",
+      networkAccess: false,
+    });
+    expect(sandboxFor("linux", "multitask")).toEqual({
+      type: "dangerFullAccess",
+    });
   });
 
   it.each(["darwin", "linux", "win32"])(
@@ -107,6 +116,7 @@ describe("collaborationModeFor", () => {
     expect(collaborationModeFor("plan")).toBe("plan");
     expect(collaborationModeFor("read-only")).toBe("default");
     expect(collaborationModeFor("auto")).toBe("default");
+    expect(collaborationModeFor("multitask")).toBe("default");
     expect(collaborationModeFor("full-access")).toBe("default");
     expect(collaborationModeFor(undefined)).toBe("default");
   });
@@ -116,6 +126,7 @@ describe("resolveCodexMode", () => {
   it.each([
     ["read-only", "read-only"],
     ["auto", "auto"],
+    ["multitask", "multitask"],
     ["full-access", "full-access"],
     ["bypassPermissions", "full-access"],
     ["default", "auto"],
@@ -126,6 +137,31 @@ describe("resolveCodexMode", () => {
 });
 
 describe("SessionConfigState", () => {
+  it("adds orchestrator instructions only in multitask mode", () => {
+    const config = new SessionConfigState("gpt-5.5");
+
+    config.setOption("mode", "multitask");
+
+    expect(config.collaborationModeForTurn()).toEqual({
+      mode: "default",
+      settings: {
+        model: "gpt-5.5",
+        developerInstructions: expect.stringContaining(
+          "Delegate each independent user task to its own subagent",
+        ),
+      },
+    });
+    expect(config.approvalPolicy()).toBe("on-request");
+    expect(config.sandboxPolicy()).toEqual(sandboxPolicyFor("auto"));
+
+    config.setOption("mode", "auto");
+
+    expect(config.collaborationModeForTurn()).toEqual({
+      mode: "default",
+      settings: { model: "gpt-5.5" },
+    });
+  });
+
   it("canonicalizes bypassPermissions during a live mode update", () => {
     const config = new SessionConfigState("gpt-5.5");
 
@@ -253,6 +289,7 @@ describe("buildConfigOptions", () => {
       "plan",
       "read-only",
       "auto",
+      "multitask",
       "full-access",
     ]);
   });

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/session-config.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/session-config.ts
@@ -56,6 +56,15 @@ export interface CodexMode {
   collaborationMode?: "plan" | "default";
 }
 
+const MULTITASK_DEVELOPER_INSTRUCTIONS = [
+  "You are the root orchestrator in multitask mode.",
+  "Delegate each independent user task to its own subagent as soon as possible.",
+  "Continue useful coordination and integration work while subagents run.",
+  "Use available subagent slots for independent work instead of queueing or steering it into the active task.",
+  "Keep tightly coupled work with one owner to avoid conflicting edits.",
+  "Wait for required subagents, integrate their results, and report one coherent outcome to the user.",
+].join("\n");
+
 /**
  * The editable sandbox for a platform, mirroring spawn.ts's `sandbox_mode`:
  * macOS Seatbelt supports workspace-write; linux/windows have no sandbox
@@ -90,6 +99,10 @@ function modePolicies(
       sandboxPolicy: { type: "readOnly", networkAccess: true },
     },
     auto: {
+      approvalPolicy: "on-request",
+      sandboxPolicy: editableSandboxPolicy(platform),
+    },
+    multitask: {
       approvalPolicy: "on-request",
       sandboxPolicy: editableSandboxPolicy(platform),
     },
@@ -368,7 +381,12 @@ export class SessionConfigState {
   collaborationModeForTurn(): unknown {
     return {
       mode: collaborationModeFor(this._mode),
-      settings: { model: this._model },
+      settings: {
+        model: this._model,
+        ...(this._mode === "multitask"
+          ? { developerInstructions: MULTITASK_DEVELOPER_INSTRUCTIONS }
+          : {}),
+      },
     };
   }
 

--- a/products/desktop/packages/agent/src/execution-mode.test.ts
+++ b/products/desktop/packages/agent/src/execution-mode.test.ts
@@ -17,6 +17,7 @@ describe("execution modes", () => {
       "plan",
       "read-only",
       "auto",
+      "multitask",
       "full-access",
     ]);
   });

--- a/products/desktop/packages/core/src/sessions/executionModes.test.ts
+++ b/products/desktop/packages/core/src/sessions/executionModes.test.ts
@@ -7,7 +7,7 @@ import {
 describe("getAvailableModesForAdapter", () => {
   it.each([
     ["claude", ["default", "acceptEdits", "plan", "bypassPermissions", "auto"]],
-    ["codex", ["plan", "read-only", "auto", "full-access"]],
+    ["codex", ["plan", "read-only", "auto", "multitask", "full-access"]],
   ] as const)("returns %s execution modes", (adapter, expected) => {
     expect(getAvailableModesForAdapter(adapter).map((mode) => mode.id)).toEqual(
       expected,

--- a/products/desktop/packages/shared/src/exec-types.ts
+++ b/products/desktop/packages/shared/src/exec-types.ts
@@ -4,5 +4,6 @@ export type ExecutionMode =
   | "plan"
   | "bypassPermissions"
   | "auto"
+  | "multitask"
   | "read-only"
   | "full-access";

--- a/products/desktop/packages/shared/src/execution-modes.ts
+++ b/products/desktop/packages/shared/src/execution-modes.ts
@@ -2,7 +2,7 @@ import type { Adapter } from "./adapter";
 import type { ExecutionMode } from "./exec-types";
 
 export interface CodexModePreset {
-  id: "plan" | "read-only" | "auto" | "full-access";
+  id: "plan" | "read-only" | "auto" | "multitask" | "full-access";
   name: string;
   description: string;
 }
@@ -30,6 +30,11 @@ export const CODEX_MODE_PRESETS: readonly CodexModePreset[] = [
     description: "Edits the workspace; asks before risky operations",
   },
   {
+    id: "multitask",
+    name: "Multitask",
+    description: "Delegates tasks to subagents and coordinates their work",
+  },
+  {
     id: "full-access",
     name: "Full access",
     description: "Auto-approves all operations",
@@ -47,6 +52,7 @@ const CLAUDE_CLOUD_PERMISSION_MODES = [
 const CODEX_CLOUD_PERMISSION_MODES = [
   "plan",
   "auto",
+  "multitask",
   "read-only",
   "full-access",
 ] as const;
@@ -81,6 +87,7 @@ const CLAUDE_CLOUD_MODE_FALLBACKS: Record<
   ClaudeCloudPermissionMode
 > = {
   "read-only": "plan",
+  multitask: "auto",
   "full-access": "bypassPermissions",
 };
 

--- a/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -1207,6 +1207,7 @@ describe("SessionService", () => {
                 expect.objectContaining({ value: "plan" }),
                 expect.objectContaining({ value: "read-only" }),
                 expect.objectContaining({ value: "auto" }),
+                expect.objectContaining({ value: "multitask" }),
                 expect.objectContaining({ value: "full-access" }),
               ],
             }),


### PR DESCRIPTION
## Problem

Codex users cannot choose a mode that delegates independent tasks while the root agent continues coordination and integration.

**Why**

Parallel delegation avoids forcing unrelated work through one active turn and gives the root agent an explicit orchestration role.

## Changes

- The new Codex-only Multitask mode uses Auto permissions and adds per-turn orchestration instructions.
- Switching away from Multitask removes its instructions on the next turn.

```mermaid
flowchart LR
    U[User task] --> R{{Root agent}}
    R --> W[All work in active turn]
```

```mermaid
flowchart LR
    U[User task] --> R{{Root orchestrator}}
    R --> A{{Subagent A}}
    R --> B{{Subagent B}}
    R --> I[Coordination and integration]
    A --> I
    B --> I
```

## How did you test this code?

- Added coverage that catches Multitask losing its orchestration instructions or retaining them after a mode switch.
- Checked that Multitask keeps Auto permission and sandbox behavior across supported platforms.
- Checked that Claude maps an imported Multitask selection to its safe Auto fallback.
- Not manually tested against a live Codex app-server.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No docs update. The prototype adds a self-described picker option without changing a documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Code implemented and verified the prototype.
- Skills used: `/implementing-agent-modes`, `/writing-user-facing-copy`, `/writing-tests`, and `/writing-pr-descriptions`.
- The prototype targets Codex only. Pi behavior remains unchanged.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*