### PR TITLE
fix(signoz): classify exhausted read-timeouts as retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/signoz/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/signoz/source.py
@@ -98,6 +98,22 @@ Create the API key in SigNoz under **Settings > Service Accounts**: create a ser
             HOST_NOT_ALLOWED_ERROR: "The configured SigNoz host is not allowed. Check the host and try again.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # `get_rows`'s tenacity retry already retries a 429/5xx (the "SigNoz API error
+        # (retryable)" sentinel), a dropped connection, and a read timeout up to MAX_RETRIES.
+        # The query_range telemetry fetch is a POST, which the tracked session's own urllib3
+        # retry skips (it only covers GET/HEAD/OPTIONS), so an exhausted read timeout there
+        # surfaces as the raw "Read timed out" message; a GET config fetch or a failed connect
+        # instead exhausts that adapter-level retry first and surfaces wrapped as "Max retries
+        # exceeded with url". Either way, Temporal retries the whole activity once tenacity's
+        # budget is exhausted, so the failure is self-recovering. The host is
+        # customer-controlled, so match only the stable, host-independent parts of the message.
+        return {
+            "SigNoz API error (retryable)",
+            "Read timed out",
+            "Max retries exceeded with url",
+        }
+
     def get_canonical_descriptions(self) -> CanonicalDescriptions:
         from products.warehouse_sources.backend.temporal.data_imports.sources.signoz.canonical_descriptions import (
             CANONICAL_DESCRIPTIONS,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/signoz/tests/test_signoz_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/signoz/tests/test_signoz_source.py
@@ -73,6 +73,13 @@ class TestSigNozSource:
     def test_non_retryable_errors(self, expected_key: str) -> None:
         assert expected_key in self.source.get_non_retryable_errors()
 
+    @pytest.mark.parametrize(
+        "expected_pattern",
+        ["SigNoz API error (retryable)", "Read timed out", "Max retries exceeded with url"],
+    )
+    def test_retryable_errors(self, expected_pattern: str) -> None:
+        assert expected_pattern in self.source.get_retryable_errors()
+
     def test_get_schemas_returns_all_endpoints(self) -> None:
         schemas = self.source.get_schemas(self.config, self.team_id)
         assert {s.name for s in schemas} == set(ENDPOINTS)


### PR DESCRIPTION
## Problem

A SigNoz import sync that hits a slow or unresponsive customer host logs a tracked exception on every occurrence, even though the sync already retries and recovers on its own.

[Error tracking issue](https://us.posthog.com/project/2/error_tracking/019fed58-cf11-7920-8a9c-a093b1372b24): a `ReadTimeout` raised from `signoz.py`'s `fetch()`, after its own tenacity retry loop exhausted `MAX_RETRIES` attempts against the customer's collector.

## Changes

- Add `SigNozSource.get_retryable_errors()`, matching the pattern already used by sibling sources (Notion, Google Sheets, Vercel, ClickHouse) for exhausted-retry conditions.
- Match three host-independent substrings: the source's own `"SigNoz API error (retryable)"` sentinel (429/5xx), `"Read timed out"` (a raw timeout on the POST-only telemetry fetch, which skips the session's own urllib3-level retry), and `"Max retries exceeded with url"` (a dropped connection, or a GET config fetch exhausting that urllib3-level retry).
- The host is customer-controlled, so none of the matched substrings include it - only the stable, vendor-independent parts of the message.
- This does not change retry behavior. Temporal still retries the whole sync activity either way; this only stops a self-recovering failure from being logged as a tracked exception.

## How did you test this code?

- Added `test_retryable_errors`, parametrized over the three new patterns, next to the existing `test_non_retryable_errors`.
- Ran the full `signoz` test suite locally: 22 passed.
- `ruff check` and `ruff format --check` on both changed files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - no user-facing behavior or config changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for the `signoz` data warehouse import source. I confirmed the stack trace originates in `signoz.py`, compared retry/timeout handling against ~10 sibling sources to check whether 60s/5-retries was an outlier (it isn't), and found the actual gap: `SigNozSource` was missing a `get_retryable_errors()` override that every comparable self-hosted/variable-host source already has. No skills were invoked; this followed the repo's existing `get_retryable_errors()` convention documented in `products/warehouse_sources/backend/temporal/data_imports/sources/README.md`.
