### PR TITLE
fix(data-imports): point MotherDuck's DuckDB connection at a writable home directory

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/motherduck/motherduck.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/motherduck/motherduck.py
@@ -14,7 +14,9 @@ materializes at once (an Arrow record-batch reader rather than a full fetch).
 
 from __future__ import annotations
 
+import os
 import re
+import tempfile
 import collections
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -70,7 +72,14 @@ DEFAULT_MOTHERDUCK_FETCH_SIZE = 5_000
 
 # DuckDB otherwise sizes itself against the whole host (80% of RAM, one thread per core), which is
 # the wrong budget for a library sharing a worker with the rest of the import pipeline.
-DUCKDB_LOCAL_CONFIG: dict[str, Any] = {"memory_limit": "2GB", "threads": 2}
+#
+# `home_directory` overrides where DuckDB persists extensions/secrets, which otherwise defaults to
+# `~/.duckdb` — unwritable in a locked-down worker container regardless of who owns the process.
+DUCKDB_LOCAL_CONFIG: dict[str, Any] = {
+    "memory_limit": "2GB",
+    "threads": 2,
+    "home_directory": os.path.join(tempfile.gettempdir(), "posthog-duckdb-home"),
+}
 
 # The database name is interpolated into the `md:` connection string, so anything outside this
 # allowlist could smuggle extra connection parameters in alongside the token.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/motherduck/tests/test_motherduck.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/motherduck/tests/test_motherduck.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -128,6 +130,14 @@ class TestMotherDuck:
         assert mock_connect.call_args.args[0] == "md:my_db?motherduck_token=md-token"
         # DuckDB shares this process, so it must not size itself against the whole host.
         assert mock_connect.call_args.kwargs["config"] == DUCKDB_LOCAL_CONFIG
+
+    def test_connect_uses_a_writable_home_directory(self):
+        # Regression: DuckDB defaults extension/secrets storage to `~/.duckdb`, which raised
+        # `IOException: Failed to create directory "/root/.duckdb": Permission denied` in a
+        # worker container where the real home directory isn't writable.
+        home_directory = DUCKDB_LOCAL_CONFIG["home_directory"]
+        os.makedirs(home_directory, exist_ok=True)
+        assert os.access(home_directory, os.W_OK)
 
     def test_connect_closes_on_exit(self, impl):
         with patch(_CONNECT_PATH) as mock_connect:


### PR DESCRIPTION
## Problem

Setting up a MotherDuck data warehouse source can fail credential validation with an `IOException`, surfaced by [error tracking](https://us.posthog.com/project/2/error_tracking/019fed65-0f5a-7fa3-95fa-c0836bd3af99): `Failed to create directory "/root/.duckdb": Permission denied`.

DuckDB defaults its extension and secrets storage to `~/.duckdb`, resolved from the process's `$HOME`. `duckdb.connect()` needs to create that directory to load the bundled `motherduck` extension, and raises before running any query when the directory can't be created — which happens whenever the worker container's home directory isn't writable.

## Changes

- Set `home_directory` in `DUCKDB_LOCAL_CONFIG` to a directory under the process's temp dir, so the connection no longer depends on `$HOME` being writable.
- This is the only `duckdb.connect()` call site in the import pipeline, so the fix is scoped to `motherduck.py`.

## How did you test this code?

- Added `test_connect_uses_a_writable_home_directory`, which locks in that `DUCKDB_LOCAL_CONFIG["home_directory"]` resolves to a directory the process can actually create and write to — the case that raised the original `IOException`.
- Ran the full `test_motherduck.py` suite (70 tests) and `mypy` on the changed module locally; both pass.
- Not run: an end-to-end MotherDuck sync, since that needs live MotherDuck credentials.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal pipeline configuration, no user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error-tracking MCP tools (issue `019fed65-0f5a-7fa3-95fa-c0836bd3af99`), then read the pipeline code with a research subagent to trace the stack (`source.py:validate_credentials` → `common/sql/base.py:get_schemas` → `motherduck.py:connect`). Searched open PRs for a duplicate fix; found only an unrelated in-flight MotherDuck feature PR ([#78917](https://github.com/PostHog/posthog/pull/78917)) that touches the same file but doesn't configure `home_directory`.