### PR TITLE
fix(cdp): skip the Attio upsert when the person has no email

### DIFF
--- a/posthog/cdp/templates/attio/template_attio.py
+++ b/posthog/cdp/templates/attio/template_attio.py
@@ -11,6 +11,11 @@ template: HogFunctionTemplateDC = HogFunctionTemplateDC(
     category=["Advertisement"],
     code_language="hog",
     code="""
+if (empty(inputs.email)) {
+    print('No email set. Skipping...')
+    return
+}
+
 let body := {
     'data': {
         'values': {

--- a/posthog/cdp/templates/attio/test_template_attio.py
+++ b/posthog/cdp/templates/attio/test_template_attio.py
@@ -39,6 +39,12 @@ class TestTemplateAttio(BaseHogFunctionTemplateTest):
             },
         )
 
+    def test_function_requires_email(self):
+        self.run_function(inputs=create_inputs(email=""))
+
+        assert not self.get_mock_fetch_calls()
+        assert self.get_mock_print_calls() == [("No email set. Skipping...",)]
+
     def test_ignores_empty_values(self):
         self.mock_fetch_response = lambda *args: {"status": 200, "body": {"ok": True}}  # type: ignore
         self.run_function(inputs=create_inputs(personAttributes={"name": "Max", "job_title": ""}))


### PR DESCRIPTION
## Problem

Customers using the Attio destination see failed invocations for every person without an email, and the failure is ours.

The template builds the body with no guard:

```hog
'email_addresses': [ { 'email_address': inputs.email } ]
```

A person without an email sends `null`, and Attio rejects the record:

```
An invalid value was passed to attribute with slug "email_addresses"
{"code": "invalid_type", "path": ["email_address"], "expected": "string", "received": "null"}
```

`required: True` on the input only means the config field must be filled in. It says nothing about the resolved value at runtime. The field description tells people to use filters to handle it, which puts our omission on them.

I found this in production data. It affects several teams, and this rejection is the most common Attio validation failure across the fleet.

## Changes

Guard and return early, matching what every comparable template already does:

```hog
if (empty(inputs.email)) {
    print('No email set. Skipping...')
    return
}
```

Intercom, HubSpot, SendGrid, Mailchimp, Klaviyo and Knock all do this. Attio is the outlier. The message and the test are copied from Intercom's so the behavior reads identically across templates.

## How did you test this code?
Manual, end to end, run by me (Claude) on a local stack:

- I synced the templates so the changed Hog reached the database, created an Attio destination, and invoked it twice through the real invocations endpoint.
- A person with no email logs `No email set. Skipping...` and makes no fetch.
- A person with an email still sends the `PUT` to `api.attio.com/v2/objects/people/records`, so the skip does not affect the normal path.

The new test catches the regression this PR exists to prevent: remove the guard and the template resumes sending `email_address: null`. Neither existing test covers the empty-email path, both pass a valid address.

I could not run it. Being straight about how far I got, because it was further than usual and still short:

- The repo pins Python 3.13.13 and this environment cannot fetch that interpreter. I installed a compatible uv from PyPI and synced against the system 3.13.12.
- Docker images are blocked by egress policy, so I installed Postgres 16 via apt instead.
- The test database took 28 minutes to migrate, then setup failed shelling out to a `sqlx` binary that is not installed.

So this is unverified. The Hog is four lines copied verbatim from six sibling templates and the test is copied from Intercom's, which is why I am comfortable opening it, but CI is the first real check.

`hogli ci:preflight` did not run either, same interpreter problem.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The input description still tells people to use filters for unwanted emails, which remains correct for its actual purpose of excluding internal users.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via Claude Code) found this while investigating an unrelated destination timeout report, by grouping production destination failures by error kind. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

I checked the sibling templates before writing anything, which is where the guard shape, the log message and the test came from. Consistency across templates mattered more here than picking my own wording.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NjAwGCorRz6qs3YiLMqRKL)_
