### PR TITLE
fix(signals): stop repeating toast when inbox PR checks can't be fetched

### DIFF
--- a/frontend/src/initKea.ts
+++ b/frontend/src/initKea.ts
@@ -48,6 +48,8 @@ const ERROR_FILTER_ALLOW_LIST = [
     'loadDatasetItemVersions', // Dataset item modals render their own retry state
     'exportDataset', // Dataset scenes render their own retry state
     'loadToolDataEvents',
+    'loadPrChecks', // Polled in the Inbox report detail; the CI checks section renders its own error state
+    'loadPrComments', // The Inbox report detail's PR comments section renders its own error state
 ]
 
 /*

--- a/products/signals/frontend/inbox/components/detail/PrChecksSection.tsx
+++ b/products/signals/frontend/inbox/components/detail/PrChecksSection.tsx
@@ -105,8 +105,8 @@ function CheckSummary({ variant, count }: { variant: CheckVariant; count: number
 /**
  * "CI checks" section for a report's implementation PR: the GitHub Actions check runs and legacy
  * commit statuses of the PR's head commit, polled every 15s by `inboxReportDetailLogic` while the
- * detail is open (the poll gives up after repeated failures and the inline error stays put).
- * Read-only — each row links out to the check on GitHub.
+ * detail is open (after repeated failures the poll backs off to a slow retry and the inline error
+ * stays put until one succeeds). Read-only — each row links out to the check on GitHub.
  */
 export function PrChecksSection({ report }: { report: SignalReport }): JSX.Element | null {
     const { prChecks, prChecksLoading, prChecksError } = useValues(

--- a/products/signals/frontend/inbox/components/detail/PrChecksSection.tsx
+++ b/products/signals/frontend/inbox/components/detail/PrChecksSection.tsx
@@ -105,7 +105,8 @@ function CheckSummary({ variant, count }: { variant: CheckVariant; count: number
 /**
  * "CI checks" section for a report's implementation PR: the GitHub Actions check runs and legacy
  * commit statuses of the PR's head commit, polled every 15s by `inboxReportDetailLogic` while the
- * detail is open. Read-only — each row links out to the check on GitHub.
+ * detail is open (the poll gives up after repeated failures and the inline error stays put).
+ * Read-only — each row links out to the check on GitHub.
  */
 export function PrChecksSection({ report }: { report: SignalReport }): JSX.Element | null {
     const { prChecks, prChecksLoading, prChecksError } = useValues(

--- a/products/signals/frontend/inbox/logics/inboxReportDetailLogic.test.ts
+++ b/products/signals/frontend/inbox/logics/inboxReportDetailLogic.test.ts
@@ -1,5 +1,6 @@
 import { expectLogic } from 'kea-test-utils'
 
+import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
@@ -8,59 +9,120 @@ import { inboxReportDetailLogic } from './inboxReportDetailLogic'
 
 const REPORT = { id: 'report-1', status: 'ready', title: 'Checkout errors spiked' } as unknown as SignalReport
 
-describe('inboxReportDetailLogic feedback note submission', () => {
-    let logic: ReturnType<typeof inboxReportDetailLogic.build>
-    let notePosts: number
-    let bareRatingPosts: number
+describe('inboxReportDetailLogic', () => {
+    describe('feedback note submission', () => {
+        let logic: ReturnType<typeof inboxReportDetailLogic.build>
+        let notePosts: number
+        let bareRatingPosts: number
 
-    beforeEach(() => {
-        notePosts = 0
-        bareRatingPosts = 0
-        useMocks({
-            get: {
-                '/api/projects/:team_id/signals/reports/:id/artefacts/': { results: [] },
-                '/api/projects/:team_id/signals/reports/:id/signals/': [],
-                '/api/projects/:team_id/signals/reports/available_reviewers/': [],
-            },
-            post: {
-                '/api/projects/:team_id/signals/reports/:id/feedback/': async ({ request }) => {
-                    const body = (await request.json()) as { note?: string }
-                    if (body.note) {
-                        notePosts += 1
-                    } else {
-                        bareRatingPosts += 1
-                    }
-                    return [200, { forwarded: Boolean(body.note) }]
+        beforeEach(() => {
+            notePosts = 0
+            bareRatingPosts = 0
+            useMocks({
+                get: {
+                    '/api/projects/:team_id/signals/reports/:id/artefacts/': { results: [] },
+                    '/api/projects/:team_id/signals/reports/:id/signals/': [],
+                    '/api/projects/:team_id/signals/reports/available_reviewers/': [],
                 },
-            },
+                post: {
+                    '/api/projects/:team_id/signals/reports/:id/feedback/': async ({ request }) => {
+                        const body = (await request.json()) as { note?: string }
+                        if (body.note) {
+                            notePosts += 1
+                        } else {
+                            bareRatingPosts += 1
+                        }
+                        return [200, { forwarded: Boolean(body.note) }]
+                    },
+                },
+            })
+            initKeaTests()
+            logic = inboxReportDetailLogic({ reportId: REPORT.id, report: REPORT })
+            logic.mount()
         })
-        initKeaTests()
-        logic = inboxReportDetailLogic({ reportId: REPORT.id, report: REPORT })
-        logic.mount()
+
+        afterEach(() => {
+            logic.unmount()
+        })
+
+        it('posts once on a double-click and lets a revised note through after re-rating', async () => {
+            logic.actions.rateReport('positive')
+            // A double-click dispatches submit twice before the first request settles.
+            logic.actions.submitFeedbackNote('the repro steps were right')
+            logic.actions.submitFeedbackNote('the repro steps were right')
+            await expectLogic(logic).toFinishAllListeners()
+
+            // The rating itself posts once (consumption evidence), the note once despite the double-click.
+            expect(bareRatingPosts).toBe(1)
+            expect(notePosts).toBe(1)
+            expect(logic.values.feedbackNoteSubmitting).toBe(false)
+
+            // Re-rating reopens the note flow; the guard must have reset or this submit is silently dropped.
+            logic.actions.rateReport('negative')
+            logic.actions.submitFeedbackNote('actually this was stale')
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(bareRatingPosts).toBe(2)
+            expect(notePosts).toBe(2)
+        })
     })
 
-    afterEach(() => {
-        logic.unmount()
-    })
+    describe('PR checks fetching', () => {
+        const PR_REPORT = {
+            id: 'report-2',
+            status: 'ready',
+            title: 'Checkout errors spiked',
+            implementation_pr_url: 'https://github.com/example/repo/pull/1',
+        } as unknown as SignalReport
 
-    it('posts once on a double-click and lets a revised note through after re-rating', async () => {
-        logic.actions.rateReport('positive')
-        // A double-click dispatches submit twice before the first request settles.
-        logic.actions.submitFeedbackNote('the repro steps were right')
-        logic.actions.submitFeedbackNote('the repro steps were right')
-        await expectLogic(logic).toFinishAllListeners()
+        let logic: ReturnType<typeof inboxReportDetailLogic.build>
+        let prChecksRequests: number
 
-        // The rating itself posts once (consumption evidence), the note once despite the double-click.
-        expect(bareRatingPosts).toBe(1)
-        expect(notePosts).toBe(1)
-        expect(logic.values.feedbackNoteSubmitting).toBe(false)
+        beforeEach(() => {
+            prChecksRequests = 0
+            useMocks({
+                get: {
+                    '/api/projects/:team_id/signals/reports/:id/artefacts/': { results: [] },
+                    '/api/projects/:team_id/signals/reports/:id/signals/': [],
+                    '/api/projects/:team_id/signals/reports/available_reviewers/': [],
+                    '/api/projects/:team_id/signals/reports/:id/pr_checks/': () => {
+                        prChecksRequests += 1
+                        return [502, { error: 'GitHub could not return the checks for this pull request.' }]
+                    },
+                    '/api/projects/:team_id/signals/reports/:id/pr_comments/': { comments: [] },
+                },
+            })
+            initKeaTests()
+            silenceKeaLoadersErrors()
+            logic = inboxReportDetailLogic({ reportId: PR_REPORT.id, report: PR_REPORT })
+            logic.mount()
+        })
 
-        // Re-rating reopens the note flow; the guard must have reset or this submit is silently dropped.
-        logic.actions.rateReport('negative')
-        logic.actions.submitFeedbackNote('actually this was stale')
-        await expectLogic(logic).toFinishAllListeners()
+        afterEach(() => {
+            logic.unmount()
+            resumeKeaLoadersErrors()
+        })
 
-        expect(bareRatingPosts).toBe(2)
-        expect(notePosts).toBe(2)
+        it('does not endlessly retry a failing checks fetch', async () => {
+            await expectLogic(logic).toFinishAllListeners()
+            expect(prChecksRequests).toBe(1)
+            expect(logic.values.prChecksError).toBeTruthy()
+
+            // The shell refreshes the report prop on its list poll; a failed load must not re-fire then.
+            logic.actions.setReport(PR_REPORT)
+            await expectLogic(logic).toFinishAllListeners()
+            expect(prChecksRequests).toBe(1)
+
+            // Two more failures (as the 15s poll would produce) reach the cap and stop the poll's gate.
+            logic.actions.loadPrChecks()
+            await expectLogic(logic).toFinishAllListeners()
+            expect(logic.values.prChecksAutoFetchEnabled).toBe(true)
+            logic.actions.loadPrChecks()
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(prChecksRequests).toBe(3)
+            expect(logic.values.prChecksAutoFetchEnabled).toBe(false)
+            expect(logic.values.prChecksError).toBeTruthy()
+        })
     })
 })

--- a/products/signals/frontend/inbox/logics/inboxReportDetailLogic.test.ts
+++ b/products/signals/frontend/inbox/logics/inboxReportDetailLogic.test.ts
@@ -113,15 +113,15 @@ describe('inboxReportDetailLogic', () => {
             await expectLogic(logic).toFinishAllListeners()
             expect(prChecksRequests).toBe(1)
 
-            // Two more failures (as the 15s poll would produce) reach the cap and stop the poll's gate.
+            // Two more failures (as the 15s poll would produce) reach the cap and back the poll off.
             logic.actions.loadPrChecks()
             await expectLogic(logic).toFinishAllListeners()
-            expect(logic.values.prChecksAutoFetchEnabled).toBe(true)
+            expect(logic.values.prChecksBackedOff).toBe(false)
             logic.actions.loadPrChecks()
             await expectLogic(logic).toFinishAllListeners()
 
             expect(prChecksRequests).toBe(3)
-            expect(logic.values.prChecksAutoFetchEnabled).toBe(false)
+            expect(logic.values.prChecksBackedOff).toBe(true)
             expect(logic.values.prChecksError).toBeTruthy()
         })
     })

--- a/products/signals/frontend/inbox/logics/inboxReportDetailLogic.ts
+++ b/products/signals/frontend/inbox/logics/inboxReportDetailLogic.ts
@@ -106,6 +106,11 @@ const REPORT_TASKS_POLL_INTERVAL_MS = 5000
 // without hammering GitHub. Mirrors the desktop PR-review view's 15s poll.
 const PR_CHECKS_POLL_INTERVAL_MS = 15000
 
+// Give up auto-fetching checks after this many consecutive failures: a PR GitHub can't return
+// checks for (deleted branch, lost integration access) won't start succeeding mid-session, and
+// each retry flashes the section's inline error back to a loading skeleton.
+const PR_CHECKS_MAX_CONSECUTIVE_FAILURES = 3
+
 /** Extract the PR url from a task's latest run output, if present. Mirrors desktop `getTaskPrUrl`. */
 export function getTaskPrUrl(task: Task): string | null {
     const prUrl = task.latest_run?.output?.pr_url
@@ -212,6 +217,8 @@ export interface inboxReportDetailLogicValues {
     optimisticReviewers: EnrichedReviewer[] | null
     postingThreadKey: string | null
     prChecks: readonly PullRequestCheckApi[] | null
+    prChecksAutoFetchEnabled: boolean
+    prChecksConsecutiveFailures: number
     prChecksError: string | null
     prChecksLoading: boolean
     prComments: readonly PullRequestCommentApi[] | null
@@ -458,6 +465,7 @@ export interface inboxReportDetailLogicMeta {
         reportReviewers: (reportArtefacts: SignalReportArtefact[] | null) => EnrichedReviewer[] | null
         isReportActive: (report: SignalReport | null) => boolean
         hasImplementationPr: (report: SignalReport | null) => boolean
+        prChecksAutoFetchEnabled: (prChecksConsecutiveFailures: number) => boolean
         hasPersonalGithub: (personalIntegrations: PersonalGitHubIntegration[]) => boolean
         currentUserGithubLogin: (personalIntegrations: PersonalGitHubIntegration[]) => string | null
         inlineThreadsByFile: (prComments: readonly PullRequestCommentApi[] | null) => Record<string, ReviewThread[]>
@@ -803,6 +811,14 @@ export const inboxReportDetailLogic = kea<inboxReportDetailLogicType>([
                 loadPrChecksFailure: () => "Couldn't load the PR checks from GitHub.",
             },
         ],
+        // Consecutive failed checks fetches — feeds `prChecksAutoFetchEnabled`.
+        prChecksConsecutiveFailures: [
+            0,
+            {
+                loadPrChecksSuccess: () => 0,
+                loadPrChecksFailure: (state: number) => state + 1,
+            },
+        ],
         prCommentsError: [
             null as string | null,
             {
@@ -866,6 +882,13 @@ export const inboxReportDetailLogic = kea<inboxReportDetailLogicType>([
         hasImplementationPr: [
             (s) => [s.report],
             (report: SignalReport | null): boolean => !!report?.implementation_pr_url,
+        ],
+        // Gate for the 15s checks poll: once GitHub keeps failing, retrying stops until the detail is
+        // reopened — the section's inline error stays put instead of flashing back to a skeleton.
+        prChecksAutoFetchEnabled: [
+            (s) => [s.prChecksConsecutiveFailures],
+            (prChecksConsecutiveFailures: number): boolean =>
+                prChecksConsecutiveFailures < PR_CHECKS_MAX_CONSECUTIVE_FAILURES,
         ],
         // Whether the current user has a personal GitHub connection — required to post review comments
         // (they're attributed to the user's own GitHub identity, not the app's).
@@ -1339,11 +1362,13 @@ export const inboxReportDetailLogic = kea<inboxReportDetailLogicType>([
             // Load the PR checks/comments once the report has a shipped PR. The recurring checks poll
             // is registered once in `afterMount` (not here) so it isn't torn down and restarted every
             // time the shell hands us a fresh `report` prop — which would starve the 15s cadence.
+            // A failed load leaves the value null, so gate on the error too: without it every prop
+            // churn from the shell's list poll would re-fetch (and re-fail) a PR GitHub can't serve.
             if (values.hasImplementationPr) {
-                if (values.prChecks === null && !values.prChecksLoading) {
+                if (values.prChecks === null && !values.prChecksLoading && values.prChecksError === null) {
                     actions.loadPrChecks()
                 }
-                if (values.prComments === null && !values.prCommentsLoading) {
+                if (values.prComments === null && !values.prCommentsLoading && values.prCommentsError === null) {
                     actions.loadPrComments()
                 }
             }
@@ -1365,12 +1390,12 @@ export const inboxReportDetailLogic = kea<inboxReportDetailLogicType>([
         // Seed the report from props so polling is gated on its status from the first tick.
         actions.setReport(props.report ?? null)
         // Register the PR-checks poll once for the lifetime of the mount — the tick re-checks whether
-        // the report has a PR, so it stays correct as the report prop churns without the interval ever
-        // being torn down and restarted (which would keep resetting the 15s cadence). Auto-disposed on
-        // unmount / hidden tab.
+        // the report has a PR (and whether GitHub keeps failing), so it stays correct as the report
+        // prop churns without the interval ever being torn down and restarted (which would keep
+        // resetting the 15s cadence). Auto-disposed on unmount / hidden tab.
         cache.disposables.add(() => {
             const interval = setInterval(() => {
-                if (values.hasImplementationPr) {
+                if (values.hasImplementationPr && values.prChecksAutoFetchEnabled) {
                     actions.loadPrChecks()
                 }
             }, PR_CHECKS_POLL_INTERVAL_MS)

--- a/products/signals/frontend/inbox/logics/inboxReportDetailLogic.ts
+++ b/products/signals/frontend/inbox/logics/inboxReportDetailLogic.ts
@@ -106,10 +106,13 @@ const REPORT_TASKS_POLL_INTERVAL_MS = 5000
 // without hammering GitHub. Mirrors the desktop PR-review view's 15s poll.
 const PR_CHECKS_POLL_INTERVAL_MS = 15000
 
-// Give up auto-fetching checks after this many consecutive failures: a PR GitHub can't return
-// checks for (deleted branch, lost integration access) won't start succeeding mid-session, and
-// each retry flashes the section's inline error back to a loading skeleton.
+// Back off the checks poll after this many consecutive failures: a PR GitHub can't return
+// checks for (deleted branch, lost integration access) re-fails on every 15s tick for nothing.
 const PR_CHECKS_MAX_CONSECUTIVE_FAILURES = 3
+
+// While backed off, still retry every Nth tick (20 × 15s = 5 min) so a transient GitHub outage
+// heals the section without the report having to be closed and reopened.
+const PR_CHECKS_FAILURE_BACKOFF_TICKS = 20
 
 /** Extract the PR url from a task's latest run output, if present. Mirrors desktop `getTaskPrUrl`. */
 export function getTaskPrUrl(task: Task): string | null {
@@ -217,7 +220,7 @@ export interface inboxReportDetailLogicValues {
     optimisticReviewers: EnrichedReviewer[] | null
     postingThreadKey: string | null
     prChecks: readonly PullRequestCheckApi[] | null
-    prChecksAutoFetchEnabled: boolean
+    prChecksBackedOff: boolean
     prChecksConsecutiveFailures: number
     prChecksError: string | null
     prChecksLoading: boolean
@@ -465,7 +468,7 @@ export interface inboxReportDetailLogicMeta {
         reportReviewers: (reportArtefacts: SignalReportArtefact[] | null) => EnrichedReviewer[] | null
         isReportActive: (report: SignalReport | null) => boolean
         hasImplementationPr: (report: SignalReport | null) => boolean
-        prChecksAutoFetchEnabled: (prChecksConsecutiveFailures: number) => boolean
+        prChecksBackedOff: (prChecksConsecutiveFailures: number) => boolean
         hasPersonalGithub: (personalIntegrations: PersonalGitHubIntegration[]) => boolean
         currentUserGithubLogin: (personalIntegrations: PersonalGitHubIntegration[]) => string | null
         inlineThreadsByFile: (prComments: readonly PullRequestCommentApi[] | null) => Record<string, ReviewThread[]>
@@ -803,15 +806,16 @@ export const inboxReportDetailLogic = kea<inboxReportDetailLogicType>([
         ],
         // Human-readable PR checks/comments load failures (kea-loaders only exposes a boolean flag).
         // A failure usually means the branch/PR was deleted or the GitHub integration lost access.
+        // Cleared only on success (not on load start), so the section keeps showing the error while
+        // a backed-off retry is in flight instead of flashing back to the loading skeleton.
         prChecksError: [
             null as string | null,
             {
-                loadPrChecks: () => null,
                 loadPrChecksSuccess: () => null,
                 loadPrChecksFailure: () => "Couldn't load the PR checks from GitHub.",
             },
         ],
-        // Consecutive failed checks fetches — feeds `prChecksAutoFetchEnabled`.
+        // Consecutive failed checks fetches — feeds `prChecksBackedOff`.
         prChecksConsecutiveFailures: [
             0,
             {
@@ -883,12 +887,12 @@ export const inboxReportDetailLogic = kea<inboxReportDetailLogicType>([
             (s) => [s.report],
             (report: SignalReport | null): boolean => !!report?.implementation_pr_url,
         ],
-        // Gate for the 15s checks poll: once GitHub keeps failing, retrying stops until the detail is
-        // reopened — the section's inline error stays put instead of flashing back to a skeleton.
-        prChecksAutoFetchEnabled: [
+        // True once GitHub has failed enough consecutive times that the 15s cadence stops being worth
+        // it — the poll tick then drops to a slow retry (see PR_CHECKS_FAILURE_BACKOFF_TICKS).
+        prChecksBackedOff: [
             (s) => [s.prChecksConsecutiveFailures],
             (prChecksConsecutiveFailures: number): boolean =>
-                prChecksConsecutiveFailures < PR_CHECKS_MAX_CONSECUTIVE_FAILURES,
+                prChecksConsecutiveFailures >= PR_CHECKS_MAX_CONSECUTIVE_FAILURES,
         ],
         // Whether the current user has a personal GitHub connection — required to post review comments
         // (they're attributed to the user's own GitHub identity, not the app's).
@@ -1394,10 +1398,18 @@ export const inboxReportDetailLogic = kea<inboxReportDetailLogicType>([
         // prop churns without the interval ever being torn down and restarted (which would keep
         // resetting the 15s cadence). Auto-disposed on unmount / hidden tab.
         cache.disposables.add(() => {
+            let tick = 0
             const interval = setInterval(() => {
-                if (values.hasImplementationPr && values.prChecksAutoFetchEnabled) {
-                    actions.loadPrChecks()
+                tick += 1
+                if (!values.hasImplementationPr) {
+                    return
                 }
+                // While backed off, only every Nth tick retries — enough for a transient GitHub
+                // outage to heal the section without hammering a permanently broken PR.
+                if (values.prChecksBackedOff && tick % PR_CHECKS_FAILURE_BACKOFF_TICKS !== 0) {
+                    return
+                }
+                actions.loadPrChecks()
             }, PR_CHECKS_POLL_INTERVAL_MS)
             return () => clearInterval(interval)
         }, 'prChecksPoll')


### PR DESCRIPTION
## Problem

Opening an Inbox report whose implementation PR's CI checks can't be fetched from GitHub fires a "Load pr checks failed" toast roughly every 15 seconds, for as long as the detail stays open.

- The detail logic polls the checks endpoint every 15s, and every failure also hits the global kea-loaders failure toast — duplicating the inline error the CI checks section already renders.
- A failed load leaves the loader value `null`, so the shell's report prop refresh kept re-firing the initial fetch on top of the poll (same for PR comments).
- The backend returns 404/502 when the PR, branch, or integration access is gone — a state that rarely recovers quickly, so retrying every 15s just repeats the failure.

## Changes

- Inbox PR checks/comments load failures no longer toast; the sections' inline error states are the only surface (`loadPrChecks`/`loadPrComments` added to the kea-loaders `ERROR_FILTER_ALLOW_LIST`).
- After 3 consecutive failures the 15s checks poll backs off to a retry every 5 minutes, so a transient GitHub outage still heals the section without reopening the report.
- The checks error is kept until a retry succeeds, so the section shows a steady inline error instead of flashing back to a loading skeleton on every retry.
- The `setReport` auto-load is gated on no prior error, so report prop churn stops re-firing a failed fetch.
- No new UI; the sections' existing inline error states are unchanged, so no screenshot.

## How did you test this code?

- Added a jest logic test: a failing checks fetch fires once on mount, is not re-fired by report prop churn, and the poll backs off after 3 consecutive failures. It catches the regression where a failing fetch was retried (and toasted) unboundedly, which no existing test covered.
- Ran the file's jest suite, `pnpm --filter=@posthog/frontend fix`, and kea typegen (type block up to date). Full `typescript:check` reports only pre-existing errors in unrelated files (unbuilt workspace packages, `cyclotronJobTemplateSuggestionsLogic`).
- Not verified manually in a running app against a real failing GitHub integration.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by PostHog Code (Claude Code) from a user report of the repeating toast on PRs without loadable CI checks. Traced the toast to the global kea-loaders failure handler plus the unguarded 15s poll and prop-churn reload. Initially stopped the poll permanently after 3 failures; changed to a 5-minute backoff after Greptile flagged that transient failures would leave the section stale for the session. Repo skills consulted: /writing-code-comments, /using-kea-disposables, /writing-tests, /writing-pr-descriptions.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*