### PR TITLE
feat(sidebar): use slack logo for slack task origin badge

### DIFF
--- a/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.test.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.test.ts
@@ -1,11 +1,12 @@
-import { ArrowSquareIn, type Icon, SlackLogo } from "@phosphor-icons/react";
+import { ArrowSquareIn, type Icon } from "@phosphor-icons/react";
+import { SlackMark } from "@posthog/ui/primitives/SlackMark";
 import { describe, expect, it } from "vitest";
 
 import { taskBadges } from "./taskStatusVocabulary";
 
 describe("taskBadges", () => {
   it.each([
-    ["slack", SlackLogo],
+    ["slack", SlackMark],
     ["signals_scout", ArrowSquareIn],
     ["error_tracking", ArrowSquareIn],
   ])("marks a %s row with its source glyph", (originProduct, expected) => {

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.test.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.test.ts
@@ -1,0 +1,18 @@
+import { ArrowSquareIn, type Icon, SlackLogo } from "@phosphor-icons/react";
+import { describe, expect, it } from "vitest";
+
+import { taskBadges } from "./taskStatusVocabulary";
+
+describe("taskBadges", () => {
+  it.each([
+    ["slack", SlackLogo],
+    ["signals_scout", ArrowSquareIn],
+    ["error_tracking", ArrowSquareIn],
+  ])("marks a %s row with its source glyph", (originProduct, expected) => {
+    const origin = taskBadges({ originProduct }).find(
+      (badge) => badge.key === "origin",
+    );
+
+    expect(origin?.Icon).toBe(expected as Icon);
+  });
+});

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.ts
@@ -5,12 +5,12 @@ import {
   GitPullRequest,
   type Icon,
   Laptop,
-  SlackLogo,
 } from "@phosphor-icons/react";
 import {
   getOriginProductMeta,
   type TaskIconProps,
 } from "@posthog/ui/features/sidebar/components/items/TaskIcon";
+import { SlackMark } from "@posthog/ui/primitives/SlackMark";
 
 /**
  * The task state a status dot / badge stack is drawn from: what the shipped
@@ -242,7 +242,7 @@ export function taskBadges(props: TaskStatusInput): TaskBadge[] {
   if (origin) {
     badges.push({
       key: "origin",
-      Icon: props.originProduct === "slack" ? SlackLogo : ArrowSquareIn,
+      Icon: props.originProduct === "slack" ? SlackMark : ArrowSquareIn,
       label: `Source: ${origin.label}`,
     });
   }

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.ts
@@ -5,6 +5,7 @@ import {
   GitPullRequest,
   type Icon,
   Laptop,
+  SlackLogo,
 } from "@phosphor-icons/react";
 import {
   getOriginProductMeta,
@@ -224,10 +225,12 @@ export interface TaskBadge {
  * nothing else to say carries no badges at all, which is the honest shape:
  * nothing has happened to it yet.
  *
- * Origins deliberately share ONE glyph. Eight product marks at avatar size is a
- * vocabulary nobody learns — and the badge's job in a nav row is "this didn't
- * come from you", which is the same fact whether Slack or error tracking filed
- * it. The tooltip names the actual product for anyone who needs it.
+ * Origins share ONE glyph, with Slack as the exception. Eight product marks at
+ * avatar size is a vocabulary nobody learns — and the badge's job in a nav row
+ * is "this didn't come from you", which is the same fact whether Slack or error
+ * tracking filed it. The tooltip names the actual product for anyone who needs
+ * it. Slack keeps its own mark because it's the one origin where the row came
+ * from a person in a thread, and readers already know that logo on sight.
  *
  * The PR badge is the exception that gets colour: merged / ready / closed is the
  * outcome people actually scan a task list for, and it's a three-value
@@ -239,7 +242,7 @@ export function taskBadges(props: TaskStatusInput): TaskBadge[] {
   if (origin) {
     badges.push({
       key: "origin",
-      Icon: ArrowSquareIn,
+      Icon: props.originProduct === "slack" ? SlackLogo : ArrowSquareIn,
       label: `Source: ${origin.label}`,
     });
   }

--- a/products/desktop/packages/ui/src/primitives/SlackMark.tsx
+++ b/products/desktop/packages/ui/src/primitives/SlackMark.tsx
@@ -1,0 +1,46 @@
+import type { IconProps } from "@phosphor-icons/react";
+import { forwardRef } from "react";
+
+// Slack's four-colour mark, inlined so the brand colours survive. It takes the
+// Phosphor `IconProps` shape to drop into an `Icon` slot, but `weight` and
+// `color` are deliberately ignored: honouring `color` would flatten the mark to
+// one fill, which is the thing this component exists not to do.
+export const SlackMark = forwardRef<SVGSVGElement, IconProps>(
+  function SlackMark(
+    // `weight`, `color`, `mirrored` and `alt` are Phosphor's, not the DOM's —
+    // pulled out here so they can't land on the `svg` as invalid attributes.
+    { size = 20, className, weight, color, mirrored, alt, ...props },
+    ref,
+  ) {
+    return (
+      <svg
+        {...props}
+        ref={ref}
+        width={size}
+        height={size}
+        className={className}
+        viewBox="0 0 127 127"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <path
+          d="M27.2 80c0 7.3-5.9 13.2-13.2 13.2C6.7 93.2.8 87.3.8 80c0-7.3 5.9-13.2 13.2-13.2h13.2V80zm6.6 0c0-7.3 5.9-13.2 13.2-13.2 7.3 0 13.2 5.9 13.2 13.2v33c0 7.3-5.9 13.2-13.2 13.2-7.3 0-13.2-5.9-13.2-13.2V80z"
+          fill="#E01E5A"
+        />
+        <path
+          d="M47 27c-7.3 0-13.2-5.9-13.2-13.2C33.8 6.5 39.7.6 47 .6c7.3 0 13.2 5.9 13.2 13.2V27H47zm0 6.7c7.3 0 13.2 5.9 13.2 13.2 0 7.3-5.9 13.2-13.2 13.2H13.9C6.6 60.1.7 54.2.7 46.9c0-7.3 5.9-13.2 13.2-13.2H47z"
+          fill="#36C5F0"
+        />
+        <path
+          d="M99.9 46.9c0-7.3 5.9-13.2 13.2-13.2 7.3 0 13.2 5.9 13.2 13.2 0 7.3-5.9 13.2-13.2 13.2H99.9V46.9zm-6.6 0c0 7.3-5.9 13.2-13.2 13.2-7.3 0-13.2-5.9-13.2-13.2V13.8C66.9 6.5 72.8.6 80.1.6c7.3 0 13.2 5.9 13.2 13.2v33.1z"
+          fill="#2EB67D"
+        />
+        <path
+          d="M80.1 99.8c7.3 0 13.2 5.9 13.2 13.2 0 7.3-5.9 13.2-13.2 13.2-7.3 0-13.2-5.9-13.2-13.2V99.8h13.2zm0-6.6c-7.3 0-13.2-5.9-13.2-13.2 0-7.3 5.9-13.2 13.2-13.2h33.1c7.3 0 13.2 5.9 13.2 13.2 0 7.3-5.9 13.2-13.2 13.2H80.1z"
+          fill="#ECB22E"
+        />
+      </svg>
+    );
+  },
+);


### PR DESCRIPTION
## Problem

Task origin badges currently use a generic arrow icon for all external sources (Slack, error tracking, etc.). Slack is unique among origins because tasks from Slack come from people in threads—a context readers already recognize by the Slack logo. Using Slack's distinctive mark for Slack-sourced tasks improves visual recognition and makes the origin clearer at a glance.

<img width="768" height="552" alt="2026-08-10 23 14 49" src="https://github.com/user-attachments/assets/72e85550-d066-4d39-af55-bcb636570e91" />

<img width="768" height="552" alt="2026-08-10 23 15 32" src="https://github.com/user-attachments/assets/4b4d0ad2-9c50-40b0-8462-efecdd161a28" />


## Changes

- Modified `taskBadges()` to conditionally render `SlackLogo` for Slack origins instead of the generic `ArrowSquareIn` icon
- Updated the vocabulary comment to document that Slack is the exception to the shared-glyph pattern
- Added unit tests covering the icon selection for each origin type (Slack, signals_scout, error_tracking)

## How did you test this code?

Added parametrized unit tests in `taskStatusVocabulary.test.ts` that verify the correct icon is assigned to the origin badge for each origin product type. Tests pass.

https://claude.ai/code/session_01T7Y8tqthNWREVfCjxSq47f