### PR TITLE
feat(replay-vision): move scanner enable toggle into the scene header

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
@@ -26,6 +26,7 @@ import { ScannerBackfillsTab } from './components/ScannerBackfillsTab'
 import { ScannerCalibrationTab } from './components/ScannerCalibrationTab'
 import { ScannerConfigReadonly } from './components/ScannerConfigReadonly'
 import { ScannerDigestCard } from './components/ScannerDigestCard'
+import { ScannerEnabledSwitch } from './components/ScannerEnabledSwitch'
 import { ScannerObservationsTable } from './components/ScannerObservationsTable'
 import { ScannerOverview } from './components/ScannerOverview'
 import { ScannerRunTab } from './components/ScannerRunTab'
@@ -75,6 +76,7 @@ export function ReplayScannerSceneComponent(): JSX.Element {
                 resourceType={{ type: 'replay_vision' }}
                 actions={
                     <>
+                        <ScannerEnabledSwitch scanner={scanner} />
                         {activeTab !== ReplayScannerTab.Calibration && (
                             <LemonButton
                                 type="secondary"

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerConfigReadonly.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerConfigReadonly.tsx
@@ -1,4 +1,4 @@
-import { useActions, useValues } from 'kea'
+import { useValues } from 'kea'
 
 import {
     IconBolt,
@@ -10,7 +10,7 @@ import {
     IconThumbsDownFilled,
     IconThumbsUpFilled,
 } from '@posthog/icons'
-import { LemonCard, LemonSwitch, LemonTag } from '@posthog/lemon-ui'
+import { LemonCard, LemonTag } from '@posthog/lemon-ui'
 
 import { PropertyFilterButton } from 'lib/components/PropertyFilters/components/PropertyFilterButton'
 import { TZLabel } from 'lib/components/TZLabel'
@@ -34,7 +34,6 @@ import { CardHeader } from '../../components/CardHeader'
 import { LabeledRow } from '../../components/LabeledRow'
 import { ScannerTypeBadge } from '../../components/ScannerTypeBadge'
 import { visionQuotaLogic } from '../../logics/visionQuotaLogic'
-import { getReplayVisionEditDisabledReason } from '../../utils/accessControl'
 import { formatCreditsMaybeUsd } from '../../utils/credits'
 import { promptUnchangedSince } from '../../utils/labelStats'
 import { replayScannerLogic } from '../replayScannerLogic'
@@ -265,9 +264,8 @@ function PromptVersionHistory({ scanner }: { scanner: ReplayScanner }): JSX.Elem
 }
 
 export function ScannerConfigReadonly({ scanner }: { scanner: ReplayScanner }): JSX.Element {
-    const { observationStats, togglingEnabled } = useValues(replayScannerLogic({ id: scanner.id }))
+    const { observationStats } = useValues(replayScannerLogic({ id: scanner.id }))
     const { showUsd } = useValues(visionQuotaLogic)
-    const { toggleEnabled } = useActions(replayScannerLogic({ id: scanner.id }))
     const showTierNames = useFeatureFlag('REPLAY_VISION_MODEL_TIER_NAMING_EXPERIMENT', 'test')
     const samplingPercent = Math.round((scanner.sampling_rate ?? 0) * 1000) / 10
     // Read every filter dimension (events, actions, properties, console logs, …), not just top-level properties.
@@ -300,16 +298,11 @@ export function ScannerConfigReadonly({ scanner }: { scanner: ReplayScanner }): 
                             <OptionTags options={getModelOptions(showTierNames)} selected={scanner.model} />
                         </LabeledRow>
                         <LabeledRow label="Status">
+                            {/* Read-only here — the switch in the scene header is the one control, on every tab. */}
                             <div className="flex items-center gap-2">
-                                <LemonSwitch
-                                    checked={scanner.enabled}
-                                    onChange={() => toggleEnabled()}
-                                    loading={togglingEnabled}
-                                    disabledReason={getReplayVisionEditDisabledReason(scanner.user_access_level)}
-                                    data-attr="vision-scanner-toggle-enabled"
-                                    data-ph-capture-attribute-scanner-type={scanner.scanner_type}
-                                    data-ph-capture-attribute-will-be-enabled={!scanner.enabled}
-                                />
+                                <span className={scanner.enabled ? 'text-success' : 'text-muted'}>
+                                    {scanner.enabled ? 'Enabled' : 'Disabled'}
+                                </span>
                                 <span className="text-muted text-xs">
                                     {scanner.enabled ? 'Runs automatically on a schedule' : 'Runs on-demand only'}
                                 </span>

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerEnabledSwitch.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerEnabledSwitch.tsx
@@ -1,0 +1,29 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonSwitch } from '@posthog/lemon-ui'
+
+import { getReplayVisionEditDisabledReason } from '../../utils/accessControl'
+import { replayScannerLogic } from '../replayScannerLogic'
+import { ReplayScanner } from '../types'
+
+/** The single enable/disable control for a scanner, shared by every surface that shows a scanner. */
+export function ScannerEnabledSwitch({ scanner }: { scanner: ReplayScanner }): JSX.Element {
+    const { togglingEnabled } = useValues(replayScannerLogic({ id: scanner.id }))
+    const { toggleEnabled } = useActions(replayScannerLogic({ id: scanner.id }))
+
+    return (
+        <LemonSwitch
+            checked={scanner.enabled}
+            onChange={() => toggleEnabled()}
+            loading={togglingEnabled}
+            bordered
+            size="small"
+            label={scanner.enabled ? 'Enabled' : 'Disabled'}
+            tooltip={scanner.enabled ? 'Runs automatically on a schedule' : 'Runs on-demand only'}
+            disabledReason={getReplayVisionEditDisabledReason(scanner.user_access_level)}
+            data-attr="vision-scanner-toggle-enabled"
+            data-ph-capture-attribute-scanner-type={scanner.scanner_type}
+            data-ph-capture-attribute-will-be-enabled={!scanner.enabled}
+        />
+    )
+}


### PR DESCRIPTION
## Problem

A person looking at a Replay Vision scanner could only enable or disable it from the scanners list or from the Configuration tab. On the Overview tab — the tab you land on — the header offered "Edit scanner" but no way to turn the scanner on or off, so the control appeared and disappeared depending on which tab you were on.

## Changes

- The enable/disable switch now lives in the scanner page header, next to "Edit scanner", so it is present on every tab.
- The switch is labeled "Enabled"/"Disabled" and keeps the existing tooltip wording ("Runs automatically on a schedule" / "Runs on-demand only").
- The Configuration tab's Status row is now read-only text. Two identical switches on the same page would be redundant and would double up the toggle's capture attributes.
- Extracted the switch into `ScannerEnabledSwitch` so any future surface reuses one control and one set of analytics attributes.

No backend, API, or permission change: the switch calls the same `toggleEnabled` action, still gated by `getReplayVisionEditDisabledReason`.

Screenshots are not attached because `hogli pr:upload-image` was not runnable in this environment. Both surfaces were rendered locally in Storybook.

## How did you test this code?

- Rendered the existing `Scenes-App/Replay Vision` stories (`SummarizerOverview`, `ScannerConfiguration`) in a local Storybook and checked the header switch and the read-only Status row.
- Ran `pnpm --filter=@posthog/frontend typescript:check` and `pnpm --filter=@posthog/frontend fix`. The typecheck reports pre-existing errors elsewhere from unbuilt quill workspaces; none in the changed files.
- No new tests. This is a placement change over an already-tested action, and the existing stories cover both surfaces.
- Not checked: the running app, and the disabled-scanner label variant.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) from a Slack request about the toggle being hard to find on the scanner Overview tab.

One decision worth flagging: whether to keep the Configuration tab's switch alongside the new header one. Keeping both would put two live controls sharing one `data-attr` on the same page, so the tab row became read-only instead. If reviewers would rather keep it interactive there, that is a small revert.

The request also mentioned the standalone observation detail page. That is not included here — a scanner-level kill switch on a single observation's page seemed like a separate call, and `ScannerEnabledSwitch` makes it a one-line addition if wanted.

Public artifact: nothing in this PR carries material from the agent session that is not already public.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C03PB072FMJ/p1786400160861949)*
