### PR TITLE
fix(tasks): codify fixed VM memory requests

### DIFF
--- a/products/tasks/backend/logic/services/modal_sandbox.py
+++ b/products/tasks/backend/logic/services/modal_sandbox.py
@@ -224,17 +224,17 @@ def _resource_create_kwargs(config: SandboxConfig) -> dict[str, object]:
 
     The burstable request floors come from the config's ``effective_*_request`` properties — the
     same values the usage ledger records — so what Modal reserves and what pricing bills can't
-    diverge. VM memory can't burst, so it stays the flat scalar (request == limit).
+    diverge.
     """
     cpu_limit = float(config.cpu_cores)
     memory_limit_mb = int(config.memory_gb * 1024)
     if not config.burstable_resources:
         return {"cpu": cpu_limit, "memory": memory_limit_mb}
 
-    cpu_value = (config.effective_cpu_request_cores, cpu_limit)
-    if config.is_vm:
-        return {"cpu": cpu_value, "memory": memory_limit_mb}
-    return {"cpu": cpu_value, "memory": (config.effective_memory_request_mb, memory_limit_mb)}
+    return {
+        "cpu": (config.effective_cpu_request_cores, cpu_limit),
+        "memory": (config.effective_memory_request_mb, memory_limit_mb),
+    }
 
 
 LOCAL_MODAL_DOCKERFILES = {

--- a/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
@@ -1555,14 +1555,14 @@ class TestResourceCreateKwargs:
         # Reserve the explicitly requested floor, burst up to the configured limit.
         assert kwargs == {"cpu": (2.0, 8.0), "memory": (4096, 16384)}
 
-    def test_vm_runtime_pins_memory_but_keeps_cpu_elastic(self):
+    def test_vm_runtime_uses_equal_memory_request_and_limit(self):
         config = SandboxConfig(name="t", cpu_cores=4, memory_gb=16, burstable_resources=True, vm_runtime=True)
 
         kwargs = _resource_create_kwargs(config)
 
-        assert kwargs == {"cpu": (0.5, 4.0), "memory": 16384}
+        assert kwargs == {"cpu": (0.5, 4.0), "memory": (16384, 16384)}
 
-    def test_vm_template_pins_memory_but_keeps_cpu_elastic(self):
+    def test_vm_template_uses_equal_memory_request_and_limit(self):
         config = SandboxConfig(
             name="t",
             cpu_cores=4,
@@ -1573,7 +1573,7 @@ class TestResourceCreateKwargs:
 
         kwargs = _resource_create_kwargs(config)
 
-        assert kwargs == {"cpu": (0.5, 4.0), "memory": 16384}
+        assert kwargs == {"cpu": (0.5, 4.0), "memory": (16384, 16384)}
 
     def test_explicit_request_floor_is_clamped_to_limit(self):
         # A request floor above the configured limit is clamped down to the limit.


### PR DESCRIPTION
## Problem

VM sandbox memory requests used a scalar because memory cannot burst before GA. This hid the request-versus-limit policy from the shared resource path.

## Changes

- Burstable sandboxes always pass separate memory request and limit values to Modal.
- VM memory uses equal request and limit values until the effective request policy changes.
- The ledger and pricing continue to use that same effective request value.

## How did you test this code?

- `TestResourceCreateKwargs` covers equal VM memory request and limit values.
- The sandbox pricing unit suite passes.
- The database-backed ledger suite could not start because PostgreSQL is unavailable in this environment.
- `hogli ci:preflight --fix` passes without failures.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change. This codifies an internal provisioning policy without changing the configured resources.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this change with the `/writing-tests`, `/writing-code-comments`, and `/writing-pr-descriptions` skills. The design centralizes the temporary VM memory behavior in the effective request policy.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*