### PR TITLE
feat(tasks): help agents find related space tasks

### DIFF
--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -397,12 +397,12 @@ tools:
             idempotent: true
         enrich_url: '{id}'
         list: true
-        title: List tasks
+        title: Search and list tasks
         description: >
-            List agent tasks in the current project. Supports filtering by `origin_product`, `stage`, `organization`,
-            `repository`, `created_by`, and `internal`. Returns lightweight task metadata only — call tasks-retrieve for
-            the full task including its latest run, or tasks-runs-list for run history. Requires the calling token's
-            organization to have Tasks access enabled.
+            Search agent tasks before starting related work. Use `search` to match task titles and descriptions, and
+            `channel` to limit results to the current space. The results identify who created each task and whether its
+            latest run is active. Supports additional filtering by status, repository, creator, origin product, and
+            archived or internal state. Requires the calling token's organization to have Tasks access enabled.
         feature_flag: tasks
         response:
             include:
@@ -413,6 +413,11 @@ tools:
                 - origin_product
                 - repository
                 - internal
+                - channel
+                - created_by.first_name
+                - created_by.last_name
+                - latest_run.id
+                - latest_run.status
                 - created_at
                 - updated_at
     tasks-partial-update:

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -9692,7 +9692,7 @@
         "description": "Search agent tasks before starting related work. Use `search` to match task titles and descriptions, and `channel` to limit results to the current space. The results identify who created each task and whether its latest run is active. Supports additional filtering by status, repository, creator, origin product, and archived or internal state. Requires the calling token's organization to have Tasks access enabled.",
         "category": "Tasks",
         "feature": "tasks",
-        "summary": "List tasks",
+        "summary": "Search and list tasks",
         "title": "Search and list tasks",
         "required_scopes": ["task:read"],
         "annotations": {

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -9689,11 +9689,11 @@
         "feature_flag": "tasks"
     },
     "tasks-list": {
-        "description": "List agent tasks in the current project. Supports filtering by `origin_product`, `stage`, `organization`, `repository`, `created_by`, and `internal`. Returns lightweight task metadata only — call tasks-retrieve for the full task including its latest run, or tasks-runs-list for run history. Requires the calling token's organization to have Tasks access enabled.",
+        "description": "Search agent tasks before starting related work. Use `search` to match task titles and descriptions, and `channel` to limit results to the current space. The results identify who created each task and whether its latest run is active. Supports additional filtering by status, repository, creator, origin product, and archived or internal state. Requires the calling token's organization to have Tasks access enabled.",
         "category": "Tasks",
         "feature": "tasks",
         "summary": "List tasks",
-        "title": "List tasks",
+        "title": "Search and list tasks",
         "required_scopes": ["task:read"],
         "annotations": {
             "destructiveHint": false,

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -10294,7 +10294,7 @@
         "description": "Search agent tasks before starting related work. Use `search` to match task titles and descriptions, and `channel` to limit results to the current space. The results identify who created each task and whether its latest run is active. Supports additional filtering by status, repository, creator, origin product, and archived or internal state. Requires the calling token's organization to have Tasks access enabled.",
         "category": "Tasks",
         "feature": "tasks",
-        "summary": "List tasks",
+        "summary": "Search and list tasks",
         "title": "Search and list tasks",
         "required_scopes": ["task:read"],
         "annotations": {

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -10291,11 +10291,11 @@
         "feature_flag": "tasks"
     },
     "tasks-list": {
-        "description": "List agent tasks in the current project. Supports filtering by `origin_product`, `stage`, `organization`, `repository`, `created_by`, and `internal`. Returns lightweight task metadata only — call tasks-retrieve for the full task including its latest run, or tasks-runs-list for run history. Requires the calling token's organization to have Tasks access enabled.",
+        "description": "Search agent tasks before starting related work. Use `search` to match task titles and descriptions, and `channel` to limit results to the current space. The results identify who created each task and whether its latest run is active. Supports additional filtering by status, repository, creator, origin product, and archived or internal state. Requires the calling token's organization to have Tasks access enabled.",
         "category": "Tasks",
         "feature": "tasks",
         "summary": "List tasks",
-        "title": "List tasks",
+        "title": "Search and list tasks",
         "required_scopes": ["task:read"],
         "annotations": {
             "destructiveHint": false,

--- a/services/mcp/src/tools/generated/tasks.ts
+++ b/services/mcp/src/tools/generated/tasks.ts
@@ -551,6 +551,11 @@ const tasksList = (): ToolBase<typeof TasksListSchema, WithPostHogUrl<Schemas.Pa
                     'origin_product',
                     'repository',
                     'internal',
+                    'channel',
+                    'created_by.first_name',
+                    'created_by.last_name',
+                    'latest_run.id',
+                    'latest_run.status',
                     'created_at',
                     'updated_at',
                 ])


### PR DESCRIPTION
## Problem

Agents cannot tell from the Tasks tool when another person is already working on related work in the same space.

## Changes

- The Tasks tool now tells agents to search titles and descriptions before starting related work.
- Space, creator, and latest run details show whether a matching task is active and who started it.

## How did you test this code?

The MCP type check, formatting check, tool-name validation, and complete automated test suite passed.

The full OpenAPI generator could not run because this environment had no local Postgres service. The MCP artifacts were synchronized directly.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation update is needed. The tool description documents the behavior for agents.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex made this change using the `posthog-desktop`, `implementing-mcp-tools`, `improving-drf-endpoints`, `writing-tests`, `writing-user-facing-copy`, and `writing-pr-descriptions` skills.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
