### PR TITLE
fix(desktop): drop "Merging" from agent thinking activities

### DIFF
--- a/products/desktop/packages/core/src/sessions/thinkingActivities.ts
+++ b/products/desktop/packages/core/src/sessions/thinkingActivities.ts
@@ -42,7 +42,6 @@ export const THINKING_ACTIVITIES = [
   "Clustering",
   "Teasing",
   "Cranking",
-  "Merging",
   "Snooping",
   "Rewiring",
   "Bundling",


### PR DESCRIPTION
## Problem

While the desktop agent is thinking, it shows a random activity verb. One of them is "Merging...", which reads as if the agent is running a git merge on your branch. It's confusing and alarming when nothing is actually happening to your code.

## Changes

- Removed `"Merging"` from `THINKING_ACTIVITIES` in `products/desktop/packages/core/src/sessions/thinkingActivities.ts`.

The list is purely decorative, so dropping the entry is enough — nothing indexes into it by position.

## How did you test this code?

No tests were run by the agent. The change deletes one string from a literal array; the existing `thinkingActivities.test.ts` cases assert the first and last entries and neighbour ordering from `"Booping"`, all unaffected.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by PostHog Code (Claude). A person reported the "Merging..." status text as scary; the fix was tracing the string to the shared thinking-activity list and removing that entry. No repo skills were invoked. Other verbs in the list that hint at repo mutation (for example "Rewiring", "Trimming", "Stacking") were left alone since none of them name a real git operation.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
