### PR TITLE
fix(data-imports): classify ClickHouse deltaLake S3 blips as transient

### DIFF
--- a/products/warehouse_sources/backend/models/table.py
+++ b/products/warehouse_sources/backend/models/table.py
@@ -52,6 +52,10 @@ from products.warehouse_sources.backend.models.util import (
     remove_named_tuples,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.consts import PARTITION_KEY
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.errors import (
+    TRANSIENT_OBJECT_STORE_ERRORS,
+    TransientObjectStoreError,
+)
 
 from .credential import DataWarehouseCredential
 from .external_table_definitions import external_tables, get_hogql_column_name_mapping
@@ -943,6 +947,14 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
                 "Reading the files from your storage bucket took too long and the query was cancelled. "
                 "This is usually temporary - try again, or narrow the URL pattern if the dataset is very large."
             )
+
+        # ClickHouse's own deltaLake() S3 table function hits the same transient object-store
+        # blips as delta-rs (see TRANSIENT_OBJECT_STORE_ERRORS), just wrapped in a ClickHouse
+        # exception instead of an OSError/DeltaError. Recognize it here too, before the generic
+        # bucket-misconfiguration fallback below, so it's classified as retryable instead of
+        # blamed on the customer's credentials or URL pattern.
+        if any(needle in raw_message for needle in TRANSIENT_OBJECT_STORE_ERRORS):
+            raise TransientObjectStoreError(raw_message)
 
         for key, value in ExtractErrors.items():
             if key in raw_message:

--- a/products/warehouse_sources/backend/models/table.py
+++ b/products/warehouse_sources/backend/models/table.py
@@ -52,10 +52,6 @@ from products.warehouse_sources.backend.models.util import (
     remove_named_tuples,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.consts import PARTITION_KEY
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.errors import (
-    TRANSIENT_OBJECT_STORE_ERRORS,
-    TransientObjectStoreError,
-)
 
 from .credential import DataWarehouseCredential
 from .external_table_definitions import external_tables, get_hogql_column_name_mapping
@@ -953,6 +949,13 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
         # exception instead of an OSError/DeltaError. Recognize it here too, before the generic
         # bucket-misconfiguration fallback below, so it's classified as retryable instead of
         # blamed on the customer's credentials or URL pattern.
+        # Deferred: pipelines.core.delta.errors pulls in posthog.temporal.common.errors ->
+        # temporalio, which must stay off django.setup(), where this model loads in every process.
+        from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.errors import (  # noqa: PLC0415
+            TRANSIENT_OBJECT_STORE_ERRORS,
+            TransientObjectStoreError,
+        )
+
         if any(needle in raw_message for needle in TRANSIENT_OBJECT_STORE_ERRORS):
             raise TransientObjectStoreError(raw_message)
 

--- a/products/warehouse_sources/backend/tests/test_table.py
+++ b/products/warehouse_sources/backend/tests/test_table.py
@@ -22,6 +22,9 @@ from products.warehouse_sources.backend.models.table import (
     get_hogql_field_for_column,
     run_chdb_query,
 )
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.errors import (
+    TransientObjectStoreError,
+)
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 
@@ -160,6 +163,23 @@ class TestSafeExposeChError:
         )
 
         with pytest.raises(Exception, match="Access was denied when reading the provided file"):
+            DataWarehouseTable()._safe_expose_ch_error(delta_kernel_error)
+
+    def test_delta_kernel_object_store_blip_is_retried_not_blamed_on_the_bucket(self) -> None:
+        # ClickHouse's own deltaLake() S3 table function hits the same transient object-store
+        # blips as delta-rs (e.g. a dropped connection to our own data-warehouse bucket), just
+        # wrapped in a ClickHouse exception. Without this check it fell through to the generic
+        # "check your credentials" message, which downstream code can no longer recognise as a
+        # retryable infra blip (see is_transient_object_store_error) once it's a bare Exception.
+        delta_kernel_error = ServerException(
+            "DB::Exception: Received DeltaLake kernel error ObjectStoreError: Error interacting with "
+            "object store: Generic S3 error: Error performing GET "
+            "http://objectstorage:19000/data-warehouse/team_2_postgres_x/dw_table/_delta_log/_last_checkpoint "
+            "in 6.1s, after 10 retries, max_retries: 10, retry_timeout: 180s - HTTP error: error sending request",
+            code=742,  # DELTA_KERNEL_ERROR
+        )
+
+        with pytest.raises(TransientObjectStoreError):
             DataWarehouseTable()._safe_expose_ch_error(delta_kernel_error)
 
 


### PR DESCRIPTION
## Problem

A data-warehouse sync that hits a transient hiccup reading its own Delta table's S3 storage reports a tracked exception and tells the customer to check their bucket credentials, even though the same class of blip is already treated as retryable and non-reported when it surfaces through delta-rs.

- [Error tracking issue](https://us.posthog.com/project/2/error_tracking/019fede7-b37e-7ae3-8df1-33dcf398fd95): schema introspection (`get_columns`) hits a DeltaLake kernel `ObjectStoreError` ("Generic S3 error") while reading `_delta_log/_last_checkpoint`, and `_safe_expose_ch_error` turns it into a generic "Could not read the files from your storage bucket" `Exception`.
- `TRANSIENT_OBJECT_STORE_ERRORS` (`pipelines/core/delta/errors.py`) already recognizes this exact text as a self-recovering blip against our own storage, not a customer config problem – but only for `OSError`/`DeltaError`, the shapes delta-rs raises it as.
- ClickHouse's own `deltaLake()` S3 table function hits the identical blip, wrapped in a `ClickHouseServerException` instead. `_safe_expose_ch_error` doesn't check for it, so it falls through to the generic message before the retry-classification code in `import_data_sync.py` ever sees the original text or type.

## Changes

- `_safe_expose_ch_error` now checks the raw ClickHouse message against `TRANSIENT_OBJECT_STORE_ERRORS` before falling back to the generic bucket-misconfiguration message, and raises `TransientObjectStoreError` when it matches.
- `TransientObjectStoreError` is already a `NonReportableError` subclass and is already recognized by type in `is_transient_object_store_error`, so this reuses the existing retry/reporting path rather than adding a new one.

## How did you test this code?

- Added `test_delta_kernel_object_store_blip_is_retried_not_blamed_on_the_bucket` to `TestSafeExposeChError`, reproducing the reported DeltaLake kernel error text and asserting it raises `TransientObjectStoreError` instead of the generic message. Catches the case where a transient blip loses its type and text before reaching the retry classifier.
- Ran `products/warehouse_sources/backend/tests/test_table.py` (18 tests): all non-DB-backed tests pass, including the new one; the DB-backed ones in that file error with `connection refused` in this sandbox (no Postgres available), same as on master.
- Ran `ruff check`/`ruff format --check` on both changed files and a repo-wide `mypy` pass: clean.
- Not run: `hogli ci:preflight` (hogli isn't installed in this environment); no end-to-end sync exercised.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None – internal error classification, no user-facing behavior or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook. I read the full stack trace and traced the call path from the Postgres CDC companion-table registration (`register_cdc_companion_table`) through `get_columns`'s ClickHouse fallback into `_safe_expose_ch_error`, then found the existing `is_transient_object_store_error`/`TRANSIENT_OBJECT_STORE_ERRORS` classification in `pipelines/core/delta/errors.py` that this code path bypasses. No skills were invoked for the fix itself; `/writing-tests` and `/writing-pr-descriptions` were invoked for the test and this body.

Checked for duplicates: none of the human-authored open PRs matched. Two open bot (`app/posthog`) PRs touch the same function/file for unrelated error types – [#74001](https://github.com/PostHog/posthog/pull/74001) (schema-drift format handling) and [#73719](https://github.com/PostHog/posthog/pull/73719) (OOM classification in the same `_safe_expose_ch_error`) – neither addresses this transient object-store case.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*