### PR TITLE
feat(tasks): expose sandbox compute pricing API

### DIFF
--- a/products/tasks/backend/facade/pricing.py
+++ b/products/tasks/backend/facade/pricing.py
@@ -1,0 +1,3 @@
+from products.tasks.backend.logic.services.sandbox_pricing import ComputeRateCardCatalog, get_compute_rate_card_catalog
+
+__all__ = ["ComputeRateCardCatalog", "get_compute_rate_card_catalog"]

--- a/products/tasks/backend/logic/services/sandbox_pricing.py
+++ b/products/tasks/backend/logic/services/sandbox_pricing.py
@@ -52,6 +52,33 @@ class SandboxComputeCost:
 COMPUTE_RATE_CARDS: tuple[ComputeRateCard, ...] = ()
 
 
+@dataclass(frozen=True)
+class ComputeRateCardCatalog:
+    current: ComputeRateCard | None
+    history: tuple[ComputeRateCard, ...]
+
+
+def get_compute_rate_card_catalog(
+    *, at: datetime | None = None, rate_cards: Sequence[ComputeRateCard] | None = None
+) -> ComputeRateCardCatalog:
+    cards = tuple(COMPUTE_RATE_CARDS if rate_cards is None else rate_cards)
+    if not cards:
+        return ComputeRateCardCatalog(current=None, history=())
+
+    cards = validate_compute_rate_cards(cards)
+    effective_at = at or timezone.now()
+    if timezone.is_naive(effective_at):
+        raise ValueError("rate card lookup timestamp must be timezone-aware")
+
+    published_cards = tuple(card for card in cards if card.effective_at <= effective_at)
+    current = next(
+        (card for card in reversed(published_cards) if card.expires_at is None or effective_at < card.expires_at),
+        None,
+    )
+    history = tuple(card for card in reversed(published_cards) if card != current)
+    return ComputeRateCardCatalog(current=current, history=history)
+
+
 def validate_reporting_window(reporting_start: datetime, reporting_end: datetime) -> None:
     if timezone.is_naive(reporting_start) or timezone.is_naive(reporting_end):
         raise ValueError("reporting timestamps must be timezone-aware")

--- a/products/tasks/backend/presentation/views/sandbox_pricing_api.py
+++ b/products/tasks/backend/presentation/views/sandbox_pricing_api.py
@@ -34,7 +34,6 @@ class SandboxComputePricingSerializer(serializers.Serializer):
     )
 
 
-@extend_schema(tags=["sandbox-compute-pricing"])
 class SandboxComputePricingViewSet(viewsets.ViewSet):
     authentication_classes: list[type] = []
     permission_classes = [AllowAny]

--- a/products/tasks/backend/presentation/views/sandbox_pricing_api.py
+++ b/products/tasks/backend/presentation/views/sandbox_pricing_api.py
@@ -1,0 +1,58 @@
+from dataclasses import asdict
+
+from drf_spectacular.utils import extend_schema
+from rest_framework import serializers, viewsets
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
+from posthog.permissions import APIScopePermission
+
+from products.tasks.backend.logic.services.sandbox_pricing import get_compute_rate_card_catalog
+
+
+class ComputeRateCardSerializer(serializers.Serializer):
+    version = serializers.CharField(help_text="Stable identifier for this rate card.")
+    effective_at = serializers.DateTimeField(help_text="Time when this rate card became effective.")
+    expires_at = serializers.DateTimeField(
+        allow_null=True,
+        help_text="Time when this rate card stopped applying, or null while it remains current.",
+    )
+    cpu_core_second_usd = serializers.CharField(help_text="USD charged per CPU core-second as an exact decimal string.")
+    memory_gib_second_usd = serializers.CharField(
+        help_text="USD charged per GiB-second of memory as an exact decimal string."
+    )
+
+
+class SandboxComputePricingSerializer(serializers.Serializer):
+    current = ComputeRateCardSerializer(
+        allow_null=True,
+        help_text="Currently effective sandbox compute rate card, or null before pricing is published.",
+    )
+    history = ComputeRateCardSerializer(
+        many=True,
+        help_text="Expired sandbox compute rate cards, newest first.",
+    )
+
+
+@extend_schema(tags=["sandbox-compute-pricing"])
+class SandboxComputePricingViewSet(viewsets.ViewSet):
+    authentication_classes = [SessionAuthentication, PersonalAPIKeyAuthentication, OAuthAccessTokenAuthentication]
+    permission_classes = [IsAuthenticated, APIScopePermission]
+    scope_object = "task"
+    http_method_names = ["get", "head", "options"]
+
+    @extend_schema(
+        responses={200: SandboxComputePricingSerializer},
+        summary="Get sandbox compute pricing",
+        description="Get the current sandbox compute rate card and expired rate-card history.",
+    )
+    def list(self, request: Request) -> Response:
+        catalog = get_compute_rate_card_catalog()
+        payload = {
+            "current": asdict(catalog.current) if catalog.current is not None else None,
+            "history": [asdict(card) for card in catalog.history],
+        }
+        return Response(SandboxComputePricingSerializer(payload).data)

--- a/products/tasks/backend/presentation/views/sandbox_pricing_api.py
+++ b/products/tasks/backend/presentation/views/sandbox_pricing_api.py
@@ -1,12 +1,12 @@
 from dataclasses import asdict
 
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import extend_schema, extend_schema_serializer
 from rest_framework import serializers, viewsets
 from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from products.tasks.backend.logic.services.sandbox_pricing import get_compute_rate_card_catalog
+from products.tasks.backend.facade.pricing import get_compute_rate_card_catalog
 
 
 class ComputeRateCardSerializer(serializers.Serializer):
@@ -22,6 +22,7 @@ class ComputeRateCardSerializer(serializers.Serializer):
     )
 
 
+@extend_schema_serializer(many=False)
 class SandboxComputePricingSerializer(serializers.Serializer):
     current = ComputeRateCardSerializer(
         allow_null=True,
@@ -38,6 +39,7 @@ class SandboxComputePricingViewSet(viewsets.ViewSet):
     authentication_classes: list[type] = []
     permission_classes = [AllowAny]
     throttle_classes: list[type] = []
+    scope_object = None
     http_method_names = ["get", "head", "options"]
 
     @extend_schema(

--- a/products/tasks/backend/presentation/views/sandbox_pricing_api.py
+++ b/products/tasks/backend/presentation/views/sandbox_pricing_api.py
@@ -2,13 +2,9 @@ from dataclasses import asdict
 
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, viewsets
-from rest_framework.authentication import SessionAuthentication
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
 from rest_framework.response import Response
-
-from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
-from posthog.permissions import APIScopePermission
 
 from products.tasks.backend.logic.services.sandbox_pricing import get_compute_rate_card_catalog
 
@@ -39,9 +35,9 @@ class SandboxComputePricingSerializer(serializers.Serializer):
 
 @extend_schema(tags=["sandbox-compute-pricing"])
 class SandboxComputePricingViewSet(viewsets.ViewSet):
-    authentication_classes = [SessionAuthentication, PersonalAPIKeyAuthentication, OAuthAccessTokenAuthentication]
-    permission_classes = [IsAuthenticated, APIScopePermission]
-    scope_object = "task"
+    authentication_classes: list[type] = []
+    permission_classes = [AllowAny]
+    throttle_classes: list[type] = []
     http_method_names = ["get", "head", "options"]
 
     @extend_schema(

--- a/products/tasks/backend/routes.py
+++ b/products/tasks/backend/routes.py
@@ -4,6 +4,7 @@ import products.tasks.backend.presentation.views.api as tasks
 import products.tasks.backend.presentation.views.loops as loops
 import products.tasks.backend.presentation.views.seat_api as seats
 import products.tasks.backend.presentation.views.channels_api as channels
+import products.tasks.backend.presentation.views.sandbox_pricing_api as sandbox_pricing
 
 
 def register_routes(routers: RouterRegistry) -> None:
@@ -40,4 +41,7 @@ def register_routes(routers: RouterRegistry) -> None:
         r"sandbox_custom_images", tasks.SandboxCustomImageViewSet, "project_sandbox_custom_images", ["team_id"]
     )
     routers.root.register(r"code/invites", tasks.CodeInviteViewSet, "code_invites")
+    routers.root.register(
+        r"code/sandbox-pricing", sandbox_pricing.SandboxComputePricingViewSet, "sandbox_compute_pricing"
+    )
     routers.root.register(r"seats", seats.SeatViewSet, "seats")

--- a/products/tasks/backend/tests/test_sandbox_pricing_api.py
+++ b/products/tasks/backend/tests/test_sandbox_pricing_api.py
@@ -3,24 +3,18 @@ from decimal import Decimal
 
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.test import SimpleTestCase
 
 from rest_framework.test import APIClient
-
-from posthog.models import Organization, User
 
 from products.tasks.backend.logic.services.sandbox_pricing import ComputeRateCard
 
 
-class TestSandboxComputePricingAPI(TestCase):
+class TestSandboxComputePricingAPI(SimpleTestCase):
     def setUp(self) -> None:
-        organization = Organization.objects.create(name="Test organization")
-        user = User.objects.create_user(email="test@example.com", password="password")
-        organization.members.add(user)
         self.client = APIClient()
-        self.client.force_authenticate(user)
 
-    def test_returns_current_and_expired_rates_without_scheduled_rates(self) -> None:
+    def test_anonymous_request_returns_current_and_expired_rates_without_scheduled_rates(self) -> None:
         cards = (
             self._rate_card("v1", datetime(2026, 1, 1, tzinfo=UTC), datetime(2026, 2, 1, tzinfo=UTC)),
             self._rate_card("v2", datetime(2026, 2, 1, tzinfo=UTC), datetime(2026, 3, 1, tzinfo=UTC)),

--- a/products/tasks/backend/tests/test_sandbox_pricing_api.py
+++ b/products/tasks/backend/tests/test_sandbox_pricing_api.py
@@ -1,0 +1,67 @@
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from rest_framework.test import APIClient
+
+from posthog.models import Organization, User
+
+from products.tasks.backend.logic.services.sandbox_pricing import ComputeRateCard
+
+
+class TestSandboxComputePricingAPI(TestCase):
+    def setUp(self) -> None:
+        organization = Organization.objects.create(name="Test organization")
+        user = User.objects.create_user(email="test@example.com", password="password")
+        organization.members.add(user)
+        self.client = APIClient()
+        self.client.force_authenticate(user)
+
+    def test_returns_current_and_expired_rates_without_scheduled_rates(self) -> None:
+        cards = (
+            self._rate_card("v1", datetime(2026, 1, 1, tzinfo=UTC), datetime(2026, 2, 1, tzinfo=UTC)),
+            self._rate_card("v2", datetime(2026, 2, 1, tzinfo=UTC), datetime(2026, 3, 1, tzinfo=UTC)),
+            self._rate_card("v3", datetime(2026, 3, 1, tzinfo=UTC), None),
+        )
+
+        with (
+            patch("products.tasks.backend.logic.services.sandbox_pricing.COMPUTE_RATE_CARDS", cards),
+            patch(
+                "products.tasks.backend.logic.services.sandbox_pricing.timezone.now",
+                return_value=datetime(2026, 2, 15, tzinfo=UTC),
+            ),
+        ):
+            response = self.client.get("/api/code/sandbox-pricing/")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "current": {
+                "version": "v2",
+                "effective_at": "2026-02-01T00:00:00Z",
+                "expires_at": "2026-03-01T00:00:00Z",
+                "cpu_core_second_usd": "0.000011",
+                "memory_gib_second_usd": "0.0000021",
+            },
+            "history": [
+                {
+                    "version": "v1",
+                    "effective_at": "2026-01-01T00:00:00Z",
+                    "expires_at": "2026-02-01T00:00:00Z",
+                    "cpu_core_second_usd": "0.000011",
+                    "memory_gib_second_usd": "0.0000021",
+                }
+            ],
+        }
+
+    @staticmethod
+    def _rate_card(version: str, effective_at: datetime, expires_at: datetime | None) -> ComputeRateCard:
+        return ComputeRateCard(
+            version=version,
+            effective_at=effective_at,
+            expires_at=expires_at,
+            cpu_core_second_usd=Decimal("0.000011"),
+            memory_gib_second_usd=Decimal("0.0000021"),
+        )

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -47,6 +47,29 @@ export interface TaskRunErrorResponseApi {
     is_pro?: boolean
 }
 
+export interface ComputeRateCardApi {
+    /** Stable identifier for this rate card. */
+    version: string
+    /** Time when this rate card became effective. */
+    effective_at: string
+    /**
+     * Time when this rate card stopped applying, or null while it remains current.
+     * @nullable
+     */
+    expires_at: string | null
+    /** USD charged per CPU core-second as an exact decimal string. */
+    cpu_core_second_usd: string
+    /** USD charged per GiB-second of memory as an exact decimal string. */
+    memory_gib_second_usd: string
+}
+
+export interface SandboxComputePricingApi {
+    /** Currently effective sandbox compute rate card, or null before pricing is published. */
+    current: ComputeRateCardApi | null
+    /** Expired sandbox compute rate cards, newest first. */
+    history: ComputeRateCardApi[]
+}
+
 export interface LoopRepositoryEntryDTOApi {
     github_integration_id: number
     full_name: string

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -54,6 +54,7 @@ import type {
     PatchedTaskWriteApi,
     PinnedTaskIdsResponseApi,
     RepositoryReadinessResponseApi,
+    SandboxComputePricingApi,
     SandboxCustomImageBuildApi,
     SandboxCustomImageDTOApi,
     SandboxCustomImageWriteApi,
@@ -166,6 +167,21 @@ export const codeInvitesRedeemCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(codeInviteRedeemRequestApi),
+    })
+}
+
+export const getCodeSandboxPricingListUrl = () => {
+    return `/api/code/sandbox-pricing/`
+}
+
+/**
+ * Get the current sandbox compute rate card and expired rate-card history.
+ * @summary Get sandbox compute pricing
+ */
+export const codeSandboxPricingList = async (options?: RequestInit): Promise<SandboxComputePricingApi> => {
+    return apiMutator<SandboxComputePricingApi>(getCodeSandboxPricingListUrl(), {
+        ...options,
+        method: 'GET',
     })
 }
 

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -99,6 +99,9 @@ tools:
     code-invites-redeem-create:
         operation: code_invites_redeem_create
         enabled: false
+    code-sandbox-pricing-list:
+        operation: code_sandbox_pricing_list
+        enabled: false
     loops-create:
         operation: loops_create
         enabled: true

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -16202,6 +16202,22 @@ export namespace Schemas {
       ticket_number: number;
     }
 
+    export interface ComputeRateCard {
+      /** Stable identifier for this rate card. */
+      version: string;
+      /** Time when this rate card became effective. */
+      effective_at: string;
+      /**
+         * Time when this rate card stopped applying, or null while it remains current.
+         * @nullable
+         */
+      expires_at: string | null;
+      /** USD charged per CPU core-second as an exact decimal string. */
+      cpu_core_second_usd: string;
+      /** USD charged per GiB-second of memory as an exact decimal string. */
+      memory_gib_second_usd: string;
+    }
+
     /**
      * * `won` - won
      * * `lost` - lost
@@ -67623,6 +67639,13 @@ export namespace Schemas {
       name?: string;
       /** Free-text content. Only for `text` attachments. */
       value?: string;
+    }
+
+    export interface SandboxComputePricing {
+      /** Currently effective sandbox compute rate card, or null before pricing is published. */
+      current: ComputeRateCard | null;
+      /** Expired sandbox compute rate cards, newest first. */
+      history: ComputeRateCard[];
     }
 
     /**


### PR DESCRIPTION
## Problem

The posthog.com website cannot show current sandbox compute prices or explain which prices applied to earlier usage.

**Why:** The website needs a stable public pricing contract before it can display cloud-compute cost details.

## Changes

- Add a public read-only API for the current rate card and expired history.
- Preserve exact decimal rates and exclude scheduled cards until their effective time.
- Return an empty catalog until production pricing is published.

## How did you test this code?

- The pricing unit suite guards effective dates, boundaries, and cost calculations.
- The anonymous HTTP test guards public access, route wiring, history ordering, and future-card exclusion.
- Ruff lint and formatting checks pass.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The generated API schema documents the public response fields. No pricing guide changes are needed before rates are published.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code implemented this change with the `improving-drf-endpoints`, `writing-tests`, `writing-user-facing-copy`, and `writing-pr-descriptions` skills.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*