### PR TITLE
feat(flags): measure requests whose geoip values differ from lookup

### DIFF
--- a/docs/internal/feature-flags/rust-service-overview.md
+++ b/docs/internal/feature-flags/rust-service-overview.md
@@ -184,7 +184,7 @@ Before changing that, the affected population is being measured:
 - The canonical log line carries the same fact as `geoip_properties_differ_from_lookup`. The counter has no labels, so query the log line in Loki to attribute a spike to a team or SDK.
 
 Both only measure. Nothing about evaluation changes until the precedence flip ships, and both are removable once it has settled.
-A JSON null in the request counts as absent for this purpose, since callers clear a property with `$unset` and a null would be filled rather than kept.
+A JSON null in the request counts as absent for this purpose, since it carries no value to compare against the lookup.
 
 ### `FlagsResponse` (v2 response)
 

--- a/docs/internal/feature-flags/rust-service-overview.md
+++ b/docs/internal/feature-flags/rust-service-overview.md
@@ -170,6 +170,22 @@ pub struct FlagRequest {
 }
 ```
 
+#### GeoIP enrichment of `person_properties`
+
+Unless `geoip_disable: true` is set in the body, `handler::properties::get_person_property_overrides` looks up the request IP in MaxMind and merges the resulting `$geoip_*` properties into `person_properties` before evaluation.
+The lookup wins: a `$geoip_*` value in the request body is overwritten.
+
+That precedence is likely wrong for server-side evaluation, because the IP we geolocate is whoever the request appears to come from.
+A backend that doesn't forward the end user's IP resolves its own server's location, so a caller that resolved geo itself (from `CF-IPCountry`, `X-Forwarded-For`, or similar) loses values it is better placed to know.
+
+Before changing that, the affected population is being measured:
+
+- `flags_geoip_properties_differ_from_lookup_total` counts requests that supplied a `$geoip_*` value disagreeing with the lookup.
+- The canonical log line carries the same fact as `geoip_properties_differ_from_lookup`. The counter has no labels, so query the log line in Loki to attribute a spike to a team or SDK.
+
+Both only measure. Nothing about evaluation changes until the precedence flip ships, and both are removable once it has settled.
+A JSON null in the request counts as absent for this purpose, since callers clear a property with `$unset` and a null would be filled rather than kept.
+
 ### `FlagsResponse` (v2 response)
 
 ```rust

--- a/rust/feature-flags/src/handler/canonical_log.rs
+++ b/rust/feature-flags/src/handler/canonical_log.rs
@@ -199,6 +199,10 @@ pub struct FlagsCanonicalLogLine {
     pub flags_experience_continuity: usize,
     pub flags_disabled: bool,
     pub quota_limited: bool,
+    /// Set when the request supplied a `$geoip_*` value disagreeing with the MaxMind lookup.
+    /// Attributable counterpart to `flags_geoip_properties_differ_from_lookup_total`, which has
+    /// no labels.
+    pub geoip_properties_differ_from_lookup: bool,
     /// Flag keys that were overridden with custom definitions (for testing/historical evaluation)
     pub flags_overridden: Option<Vec<String>>,
     /// Source of the flags data: "Redis", "S3", or "Fallback" (PostgreSQL).
@@ -329,6 +333,7 @@ impl Default for FlagsCanonicalLogLine {
             flags_experience_continuity: 0,
             flags_disabled: false,
             quota_limited: false,
+            geoip_properties_differ_from_lookup: false,
             flags_overridden: None,
             flags_cache_source: None,
             eval: EvalCounters::default(),
@@ -398,6 +403,7 @@ impl FlagsCanonicalLogLine {
             flags_device_id_bucketing = self.eval.flags_device_id_bucketing,
             flags_disabled = self.flags_disabled,
             quota_limited = self.quota_limited,
+            geoip_properties_differ_from_lookup = self.geoip_properties_differ_from_lookup,
             flags_overridden = ?self.flags_overridden,
             flags_cache_source = self.flags_cache_source,
             db_property_fetches = self.db_property_fetches,

--- a/rust/feature-flags/src/handler/properties.rs
+++ b/rust/feature-flags/src/handler/properties.rs
@@ -50,8 +50,8 @@ pub fn prepare_overrides(
 /// wins. The lookup still overwrites them.
 ///
 /// Sizes the population that letting request values win would affect, so that change can be
-/// measured before it ships rather than after. A JSON null counts as absent: callers clear a
-/// property with `$unset`, so a null is a missing value that would be filled either way.
+/// measured before it ships rather than after. A JSON null counts as absent: it carries no
+/// value to compare against the lookup, so it can't be a divergence.
 fn record_geoip_divergence(
     person_properties: &HashMap<String, Value>,
     geoip_props: &HashMap<String, String>,

--- a/rust/feature-flags/src/handler/properties.rs
+++ b/rust/feature-flags/src/handler/properties.rs
@@ -1,8 +1,13 @@
-use crate::{api::errors::FlagError, flags::flag_request::FlagRequest};
+use crate::{
+    api::errors::FlagError, flags::flag_request::FlagRequest,
+    metrics::consts::GEOIP_PROPERTIES_DIFFER_FROM_LOOKUP_COUNTER,
+};
 use common_geoip::GeoIpClient;
+use common_metrics::inc;
 use serde_json::Value;
 use std::{collections::HashMap, net::IpAddr};
 
+use super::canonical_log::with_canonical_log;
 use super::types::{RequestContext, RequestPropertyOverrides};
 
 pub fn prepare_overrides(
@@ -41,6 +46,27 @@ pub fn prepare_overrides(
     })
 }
 
+/// Flags requests whose own `$geoip_*` values disagree with the lookup, without changing what
+/// wins. The lookup still overwrites them.
+///
+/// Sizes the population that letting request values win would affect, so that change can be
+/// measured before it ships rather than after. A JSON null counts as absent: callers clear a
+/// property with `$unset`, so a null is a missing value that would be filled either way.
+fn record_geoip_divergence(
+    person_properties: &HashMap<String, Value>,
+    geoip_props: &HashMap<String, String>,
+) {
+    let diverged = geoip_props.iter().any(|(key, resolved)| {
+        person_properties.get(key).is_some_and(|supplied| {
+            !supplied.is_null() && supplied.as_str() != Some(resolved.as_str())
+        })
+    });
+    if diverged {
+        inc(GEOIP_PROPERTIES_DIFFER_FROM_LOOKUP_COUNTER, &[], 1);
+        with_canonical_log(|log| log.geoip_properties_differ_from_lookup = true);
+    }
+}
+
 pub fn get_person_property_overrides(
     geoip_disabled: bool,
     person_properties: Option<HashMap<String, Value>>,
@@ -50,6 +76,7 @@ pub fn get_person_property_overrides(
     match (!geoip_disabled, person_properties) {
         (true, Some(mut props)) => {
             if let Some(geoip_props) = geoip_service.get_geoip_properties(&ip.to_string()) {
+                record_geoip_divergence(&props, &geoip_props);
                 props.extend(geoip_props.into_iter().map(|(k, v)| (k, Value::String(v))));
             }
             Some(props)

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -24,8 +24,12 @@ use crate::{
         flag_service::FlagService,
     },
     handler::{
-        apply_minimal_flag_called_events, decoding, evaluation::evaluate_feature_flags,
-        flags::fetch_and_filter, properties, FeatureFlagEvaluationContext,
+        apply_minimal_flag_called_events,
+        canonical_log::{run_with_canonical_log, FlagsCanonicalLogLine},
+        decoding,
+        evaluation::evaluate_feature_flags,
+        flags::fetch_and_filter,
+        properties, FeatureFlagEvaluationContext,
     },
     mock,
     properties::property_models::PropertyType,
@@ -174,6 +178,65 @@ fn test_geoip_person_property_overrides(
             assert!(result.contains_key("$geoip_country_name"));
         }
         GeoipExpected::None => assert!(result.is_none()),
+    }
+}
+
+/// `supplied` is the value the request sends for `$geoip_country_code`, or `None` to send no
+/// person properties at all.
+#[rstest]
+#[case::differs(false, Some(Value::String("DE".to_string())), true)]
+#[case::matches_lookup(false, Some(Value::String("US".to_string())), false)]
+#[case::null_counts_as_absent(false, Some(Value::Null), false)]
+#[case::unrelated_key_only(false, None, false)]
+#[case::geoip_disabled(true, Some(Value::String("DE".to_string())), false)]
+#[tokio::test]
+async fn test_canonical_log_records_geoip_divergence(
+    #[case] geoip_disabled: bool,
+    #[case] supplied: Option<Value>,
+    #[case] expected: bool,
+) {
+    let geoip_service = create_test_geoip_service();
+    let ip = IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8));
+
+    // The `matches_lookup` case is only meaningful if the lookup really resolves this value.
+    assert_eq!(
+        geoip_service
+            .get_geoip_properties(&ip.to_string())
+            .unwrap_or_default()
+            .get("$geoip_country_code")
+            .map(String::as_str),
+        Some("US")
+    );
+
+    let person_properties = supplied
+        .map(|value| HashMap::from([("$geoip_country_code".to_string(), value)]))
+        .or_else(|| {
+            Some(HashMap::from([(
+                "name".to_string(),
+                Value::String("John".to_string()),
+            )]))
+        });
+
+    let log = FlagsCanonicalLogLine::new(Uuid::new_v4(), ip.to_string());
+    let (result, final_log) = run_with_canonical_log(log, async {
+        properties::get_person_property_overrides(
+            geoip_disabled,
+            person_properties,
+            &ip,
+            &geoip_service,
+        )
+    })
+    .await;
+
+    assert_eq!(final_log.geoip_properties_differ_from_lookup, expected);
+
+    // Measuring only: the lookup still overwrites whatever the request sent.
+    if !geoip_disabled {
+        let result = result.expect("expected property overrides");
+        assert_eq!(
+            result.get("$geoip_country_code"),
+            Some(&Value::String("US".to_string()))
+        );
     }
 }
 

--- a/rust/feature-flags/src/handler/tests.rs
+++ b/rust/feature-flags/src/handler/tests.rs
@@ -181,8 +181,8 @@ fn test_geoip_person_property_overrides(
     }
 }
 
-/// `supplied` is the value the request sends for `$geoip_country_code`, or `None` to send no
-/// person properties at all.
+/// `supplied` is the value the request sends for `$geoip_country_code`, or `None` for a request
+/// that sends person properties without that key at all (the `unrelated_key_only` case).
 #[rstest]
 #[case::differs(false, Some(Value::String("DE".to_string())), true)]
 #[case::matches_lookup(false, Some(Value::String("US".to_string())), false)]

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -74,6 +74,12 @@ pub const DB_PERSON_AND_GROUP_PROPERTIES_READS_COUNTER: &str =
     "flags_db_person_and_group_properties_reads_total";
 pub const FLAG_REQUESTS_COUNTER: &str = "flags_requests_total";
 pub const FLAG_REQUESTS_LATENCY: &str = "flags_requests_duration_ms";
+// Incremented once per request that supplied a `$geoip_*` value disagreeing with the MaxMind
+// lookup. The lookup currently wins, so this only sizes the population that a pending change to
+// let request values win would affect. Removable once that change has shipped and settled.
+// Per-team and per-SDK attribution lives in the canonical log line via Loki.
+pub const GEOIP_PROPERTIES_DIFFER_FROM_LOOKUP_COUNTER: &str =
+    "flags_geoip_properties_differ_from_lookup_total";
 
 // Internal batch flag evaluation endpoint (static cohort generation). Dedicated
 // `flags_batch_eval_*` names keep batch traffic separable from live `/flags` metrics.


### PR DESCRIPTION
## Problem

The flags service merges MaxMind GeoIP results over whatever `person_properties` a request sent, so a resolved `$geoip_*` key wins over a caller-supplied one.
For server-side evaluation that is probably backwards. The IP we geolocate is whoever the request appears to come from, so a backend that does not forward the end user's IP resolves its own server's location and overwrites geo the caller had already resolved correctly.

I want to flip that precedence. Flipping it changes flag evaluation for anyone currently sending their own `$geoip_*`, and right now we have no way to know who that is. This PR measures the affected population first so the flip can be sized before it ships instead of after.

## Changes

Two signals. Evaluation is untouched and the lookup still wins.

- `flags_geoip_properties_differ_from_lookup_total` counts requests that supplied a `$geoip_*` value disagreeing with the lookup.
- The canonical log line carries the same fact as `geoip_properties_differ_from_lookup`. The counter has no labels, so the log line is the attribution path for team and SDK in Loki.

It counts divergence rather than collision. A caller echoing back the same country code the lookup would resolve does not count, because that request's evaluation input would not change under the flip. A JSON null also counts as absent, since callers clear a person property with `$unset`, so a null would be filled either way.

Both signals are removable once the flip has shipped and settled, and the const comment says so.

> [!NOTE]
> No behavior change. `get_person_property_overrides` keeps its existing shape and its `props.extend(...)` line. The measurement is one helper plus one call site.

The precedence flip itself is #74397, which I will rebase onto this once it lands.

## How did you test this code?

Automated tests only. I have not run this against a live service or real traffic.

- `cargo test -p feature-flags --lib -- geoip`: 10 pass, 5 pre-existing and 5 new.
- `cargo clippy -p feature-flags --all-targets` and `cargo fmt --check`: clean.

The new `test_canonical_log_records_geoip_divergence` is 5 rstest cases. The regression they catch that nothing else did is the counter firing on the wrong population. Mutating the helper to count key collisions instead of value divergences fails exactly `matches_lookup` and `null_counts_as_absent`, which is why those two cases exist. `differs` pins the true positive, `geoip_disabled` pins that a disabled lookup never counts, and `unrelated_key_only` pins that an ordinary person property does not.

Each case also asserts the returned override still holds the lookup's value, so if someone later flips precedence inside this PR by accident the test fails.

The 5 pre-existing `test_geoip_person_property_overrides` cases pass unchanged, which is the evidence that behavior is untouched.

One caveat for local runs: the geoip tests need `share/GeoLite2-City.mmdb`, which is gitignored. CI fetches it via `bin/download-mmdb`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

Neither applies. This is an internal metric with no user-visible effect.

## Docs update

Added a "GeoIP enrichment of `person_properties`" section to `docs/internal/feature-flags/rust-service-overview.md` covering the current precedence, why it is suspect for server-side evaluation, and both signals.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (PostHog Code) wrote this one under my direction. It started as a single PR that both flipped the precedence and added a counter. A multi-agent review pass I ran flagged that the counter only fires inside the new code path, so shipping them together means the first data point lands after customers are already on the new precedence. Splitting the measurement out ahead of the flip was the fix, and this is the first half.

Decisions worth knowing about:

- Naming. Earlier drafts called it `not_applied`, then `overridden_by_request`. Both describe the post-flip world and would be plainly false during the observe phase, so it became `differ_from_lookup`, which reads correctly on either side of the flip and keeps the series comparable across it.
- Null handling. Claude checked how PostHog actually clears a person property and found `$unset` in `PostHog/posthog-js` `packages/types/src/capture.ts`, handled locally in `nodejs/src/ingestion/common/persons/person-update.ts`. No SDK writes a `$geoip_*` person property at all. So a null is an absent value rather than an assertion, and it should not count.
- Skills invoked: none of the repo skills under `.agents/skills/` ran for this PR. The work went through my own review and simplify passes, plus the seven specialized reviewer agents.

> [!WARNING]
> This branch is based on an older master commit, not current master. I could not compile against current master in this worktree because reaching crates.io failed TLS verification, so Claude based the branch where the dependency cache was already warm and verified there. Everything above was run on that base. Worth a rebase onto master before this is marked ready.
