### PR TITLE
feat(desktop): show per-task usage costs

### DIFF
--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -228,6 +228,12 @@ export interface TaskRunSessionLogsPage {
   matchingCount: number | null;
 }
 
+export interface TaskUsage {
+  token_cost_usd: number;
+  compute_cost_usd: number;
+  total_cost_usd: number;
+}
+
 export interface TaskListOptions {
   repository?: string;
   createdBy?: number;
@@ -2433,6 +2439,20 @@ export class PostHogAPIClient {
       path: { project_id: teamId.toString(), id: taskId },
     });
     return normalizeTaskResponse(data, { teamId });
+  }
+
+  async getTaskUsage(taskId: string): Promise<TaskUsage> {
+    const teamId = await this.getTeamId();
+    const urlPath = `/api/projects/${teamId}/tasks/${taskId}/usage/`;
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url: new URL(`${this.api.baseUrl}${urlPath}`),
+      path: urlPath,
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch task usage: ${response.statusText}`);
+    }
+    return (await response.json()) as TaskUsage;
   }
 
   async getPinnedTaskIds(): Promise<string[]> {

--- a/products/desktop/packages/shared/src/flags.ts
+++ b/products/desktop/packages/shared/src/flags.ts
@@ -39,6 +39,11 @@ export const MCP_GATEWAY_FLAG = "mcp-gateway";
 /** Per-task estimated cost readout in the context usage indicator. */
 export const TASK_COST_FLAG = "posthog-code-task-cost";
 /**
+ * Shows the task cost as text beside the context ring rather than only inside
+ * the popover. Requires TASK_COST_FLAG, which is what fetches the figure.
+ */
+export const TASK_COST_VISIBLE_FLAG = "posthog-code-task-cost-visible";
+/**
  * Remote in-app announcements. The flag's JSON payload carries the
  * announcements (schema: `announcements.ts`); rollout % arms the system.
  * All broad announcements go through this — do not add ad-hoc promo

--- a/products/desktop/packages/ui/src/features/sessions/components/ContextBreakdownPopover.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ContextBreakdownPopover.test.tsx
@@ -88,6 +88,27 @@ describe("ContextBreakdownPopover", () => {
     expect(screen.queryByText("Rules")).not.toBeInTheDocument();
   });
 
+  it("renders the authoritative task cost breakdown", () => {
+    render(
+      <Theme>
+        <ContextBreakdownPopover
+          usage={usageWith(null)}
+          taskUsage={{
+            token_cost_usd: 12.34,
+            compute_cost_usd: 0.56,
+            total_cost_usd: 12.9,
+          }}
+        />
+      </Theme>,
+    );
+    expect(screen.getByText("Estimated cost")).toBeInTheDocument();
+    expect(screen.getByText("Tokens")).toBeInTheDocument();
+    expect(screen.getByText("Cloud compute")).toBeInTheDocument();
+    expect(screen.getByText("$12.90")).toBeInTheDocument();
+    expect(screen.getByText("$12.34")).toBeInTheDocument();
+    expect(screen.getByText("$0.56")).toBeInTheDocument();
+  });
+
   it("scales segments to the context window, not the used tokens", () => {
     const { container } = render(
       <Theme>

--- a/products/desktop/packages/ui/src/features/sessions/components/ContextBreakdownPopover.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ContextBreakdownPopover.tsx
@@ -74,21 +74,48 @@ export function ContextBreakdownPopover({
       )}
 
       {taskUsage && (
-        <div className="flex flex-col gap-2 border-border border-t pt-2 text-[13px]">
-          <CostRow label="Estimated cost" value={taskUsage.total_cost_usd} />
-          <CostRow label="Tokens" value={taskUsage.token_cost_usd} />
-          <CostRow label="Cloud compute" value={taskUsage.compute_cost_usd} />
+        <div className="border-border border-t pt-3">
+          <div className="overflow-hidden rounded-lg border border-border bg-muted/30">
+            <div className="flex items-end justify-between gap-6 px-3 py-2.5">
+              <span className="pb-0.5 font-medium text-[12px] text-muted-foreground">
+                Estimated cost
+              </span>
+              <span className="font-semibold text-[20px] text-foreground tabular-nums leading-none tracking-tight">
+                {formatCostUsd(taskUsage.total_cost_usd)}
+              </span>
+            </div>
+            <div className="grid grid-cols-2 border-border border-t bg-background/60">
+              <CostDetail label="Tokens" value={taskUsage.token_cost_usd} />
+              <CostDetail
+                label="Cloud compute"
+                value={taskUsage.compute_cost_usd}
+                divided
+              />
+            </div>
+          </div>
         </div>
       )}
     </div>
   );
 }
 
-function CostRow({ label, value }: { label: string; value: number }) {
+function CostDetail({
+  label,
+  value,
+  divided = false,
+}: {
+  label: string;
+  value: number;
+  divided?: boolean;
+}) {
   return (
-    <div className="flex items-center justify-between gap-6">
-      <span className="text-muted-foreground">{label}</span>
-      <span className="font-medium text-foreground tabular-nums">
+    <div
+      className={`flex min-w-0 flex-col gap-0.5 px-3 py-2 ${divided ? "border-border border-l" : ""}`}
+    >
+      <span className="truncate text-[11px] text-muted-foreground">
+        {label}
+      </span>
+      <span className="font-medium text-[13px] text-foreground tabular-nums">
         {formatCostUsd(value)}
       </span>
     </div>

--- a/products/desktop/packages/ui/src/features/sessions/components/ContextBreakdownPopover.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ContextBreakdownPopover.tsx
@@ -1,3 +1,4 @@
+import type { TaskUsage } from "@posthog/api-client/posthog-client";
 import {
   CONTEXT_CATEGORIES,
   formatCostUsd,
@@ -8,14 +9,14 @@ import type { ContextUsage } from "@posthog/ui/features/sessions/hooks/useContex
 
 interface ContextBreakdownPopoverProps {
   usage: ContextUsage;
-  showCost?: boolean;
+  taskUsage?: TaskUsage;
 }
 
 export function ContextBreakdownPopover({
   usage,
-  showCost = false,
+  taskUsage,
 }: ContextBreakdownPopoverProps) {
-  const { used, size, percentage, cost, breakdown } = usage;
+  const { used, size, percentage, breakdown } = usage;
   const fillColor = getOverallUsageColor(percentage);
   // The context window can be unknown (size 0) — show just the token count
   // rather than a misleading "~X / 0 tokens · 0% full".
@@ -72,14 +73,24 @@ export function ContextBreakdownPopover({
         </span>
       )}
 
-      {showCost && cost && (
-        <div className="flex items-center justify-between border-border border-t pt-2 text-[13px]">
-          <span className="text-muted-foreground">Estimated cost</span>
-          <span className="font-medium text-foreground tabular-nums">
-            {formatCostUsd(cost.amount)}
-          </span>
+      {taskUsage && (
+        <div className="flex flex-col gap-2 border-border border-t pt-2 text-[13px]">
+          <CostRow label="Estimated cost" value={taskUsage.total_cost_usd} />
+          <CostRow label="Tokens" value={taskUsage.token_cost_usd} />
+          <CostRow label="Cloud compute" value={taskUsage.compute_cost_usd} />
         </div>
       )}
+    </div>
+  );
+}
+
+function CostRow({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="flex items-center justify-between gap-6">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-medium text-foreground tabular-nums">
+        {formatCostUsd(value)}
+      </span>
     </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/sessions/components/ContextBreakdownPopover.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ContextBreakdownPopover.tsx
@@ -74,17 +74,17 @@ export function ContextBreakdownPopover({
       )}
 
       {taskUsage && (
-        <div className="border-border border-t pt-3">
-          <div className="overflow-hidden rounded-lg border border-border bg-muted/30">
-            <div className="flex items-end justify-between gap-6 px-3 py-2.5">
-              <span className="pb-0.5 font-medium text-[12px] text-muted-foreground">
+        <div className="border-border border-t pt-2.5">
+          <div className="overflow-hidden rounded-md border border-border/70 bg-muted/20">
+            <div className="flex items-center justify-between gap-6 px-2.5 py-1.5">
+              <span className="font-medium text-[11px] text-muted-foreground">
                 Estimated cost
               </span>
-              <span className="font-semibold text-[20px] text-foreground tabular-nums leading-none tracking-tight">
+              <span className="font-semibold text-[15px] text-foreground tabular-nums leading-none">
                 {formatCostUsd(taskUsage.total_cost_usd)}
               </span>
             </div>
-            <div className="grid grid-cols-2 border-border border-t bg-background/60">
+            <div className="grid grid-cols-2 border-border/70 border-t bg-background/40">
               <CostDetail label="Tokens" value={taskUsage.token_cost_usd} />
               <CostDetail
                 label="Cloud compute"
@@ -110,12 +110,12 @@ function CostDetail({
 }) {
   return (
     <div
-      className={`flex min-w-0 flex-col gap-0.5 px-3 py-2 ${divided ? "border-border border-l" : ""}`}
+      className={`flex min-w-0 flex-col px-2.5 py-1.5 ${divided ? "border-border/70 border-l" : ""}`}
     >
-      <span className="truncate text-[11px] text-muted-foreground">
+      <span className="truncate text-[10px] text-muted-foreground">
         {label}
       </span>
-      <span className="font-medium text-[13px] text-foreground tabular-nums">
+      <span className="font-medium text-[12px] text-foreground tabular-nums">
         {formatCostUsd(value)}
       </span>
     </div>

--- a/products/desktop/packages/ui/src/features/sessions/components/ContextUsageIndicator.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ContextUsageIndicator.test.tsx
@@ -5,12 +5,25 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ContextUsageIndicator } from "./ContextUsageIndicator";
 
 const flagState = vi.hoisted(() => ({ enabled: false }));
+const taskUsageState = vi.hoisted(() => ({
+  data: undefined as
+    | {
+        token_cost_usd: number;
+        compute_cost_usd: number;
+        total_cost_usd: number;
+      }
+    | undefined,
+}));
 vi.mock("@posthog/ui/features/feature-flags/useFeatureFlag", () => ({
   useFeatureFlag: () => flagState.enabled,
+}));
+vi.mock("@posthog/ui/features/sessions/hooks/useTaskUsage", () => ({
+  useTaskUsage: () => taskUsageState,
 }));
 
 beforeEach(() => {
   flagState.enabled = false;
+  taskUsageState.data = undefined;
 });
 
 function usage(overrides?: Partial<ContextUsage>): ContextUsage {
@@ -45,18 +58,21 @@ describe("ContextUsageIndicator", () => {
       false,
       "Context usage: 50K tokens",
     ],
-    [
-      "cost enabled",
-      { cost: { amount: 0.42, currency: "USD" } },
-      true,
-      "Context usage: 25% · $0.42",
-    ],
+    ["cost enabled", {}, true, "Context usage: 25% · $0.42"],
   ])("names itself for %s", (_case, overrides, costEnabled, expected) => {
     flagState.enabled = costEnabled;
+    taskUsageState.data = costEnabled
+      ? {
+          token_cost_usd: 0.4,
+          compute_cost_usd: 0.02,
+          total_cost_usd: 0.42,
+        }
+      : undefined;
     const { container } = render(
       <Theme>
         <ContextUsageIndicator
           usage={usage(overrides as Partial<ContextUsage>)}
+          taskId="task-1"
         />
       </Theme>,
     );

--- a/products/desktop/packages/ui/src/features/sessions/components/ContextUsageIndicator.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ContextUsageIndicator.test.tsx
@@ -1,10 +1,11 @@
+import { TASK_COST_VISIBLE_FLAG } from "@posthog/shared";
 import type { ContextUsage } from "@posthog/ui/features/sessions/hooks/useContextUsage";
 import { Theme } from "@radix-ui/themes";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ContextUsageIndicator } from "./ContextUsageIndicator";
 
-const flagState = vi.hoisted(() => ({ enabled: false }));
+const flagState = vi.hoisted(() => ({ cost: false, costVisible: false }));
 const taskUsageState = vi.hoisted(() => ({
   data: undefined as
     | {
@@ -15,14 +16,26 @@ const taskUsageState = vi.hoisted(() => ({
     | undefined,
 }));
 vi.mock("@posthog/ui/features/feature-flags/useFeatureFlag", () => ({
-  useFeatureFlag: () => flagState.enabled,
+  useFeatureFlag: (key: string) =>
+    key === TASK_COST_VISIBLE_FLAG ? flagState.costVisible : flagState.cost,
 }));
 vi.mock("@posthog/ui/features/sessions/hooks/useTaskUsage", () => ({
   useTaskUsage: () => taskUsageState,
 }));
 
+function enableCost(costVisible = false) {
+  flagState.cost = true;
+  flagState.costVisible = costVisible;
+  taskUsageState.data = {
+    token_cost_usd: 0.4,
+    compute_cost_usd: 0.02,
+    total_cost_usd: 0.42,
+  };
+}
+
 beforeEach(() => {
-  flagState.enabled = false;
+  flagState.cost = false;
+  flagState.costVisible = false;
   taskUsageState.data = undefined;
 });
 
@@ -49,36 +62,54 @@ describe("ContextUsageIndicator", () => {
 
   // The ring carries no text, so the accessible name is the only way the
   // numbers reach a reader — including the "/0 · 0%" an unknown window must
-  // never claim, and the cost the flag is supposed to surface.
+  // never claim, and the cost while it has no text of its own.
   it.each([
-    ["a known window", {}, false, "Context usage: 25%"],
+    ["a known window", {}, false, false, "Context usage: 25%"],
     [
       "an unknown window (size 0)",
       { used: 50_000, size: 0, percentage: 0 },
       false,
+      false,
       "Context usage: 50K tokens",
     ],
-    ["cost enabled", {}, true, "Context usage: 25% · $0.42"],
-  ])("names itself for %s", (_case, overrides, costEnabled, expected) => {
-    flagState.enabled = costEnabled;
-    taskUsageState.data = costEnabled
-      ? {
-          token_cost_usd: 0.4,
-          compute_cost_usd: 0.02,
-          total_cost_usd: 0.42,
-        }
-      : undefined;
-    const { container } = render(
+    ["cost enabled", {}, true, false, "Context usage: 25% · $0.42"],
+    ["cost shown as text", {}, true, true, "Context usage: 25%"],
+  ])(
+    "names itself for %s",
+    (_case, overrides, costEnabled, costVisible, expected) => {
+      if (costEnabled) enableCost(costVisible);
+      const { container } = render(
+        <Theme>
+          <ContextUsageIndicator
+            usage={usage(overrides as Partial<ContextUsage>)}
+            taskId="task-1"
+          />
+        </Theme>,
+      );
+      expect(
+        container.querySelector("button")?.getAttribute("aria-label"),
+      ).toBe(expected);
+    },
+  );
+
+  it("shows the cost beside the ring once the visible flag is on", () => {
+    enableCost(true);
+    render(
       <Theme>
-        <ContextUsageIndicator
-          usage={usage(overrides as Partial<ContextUsage>)}
-          taskId="task-1"
-        />
+        <ContextUsageIndicator usage={usage()} taskId="task-1" />
       </Theme>,
     );
-    expect(container.querySelector("button")?.getAttribute("aria-label")).toBe(
-      expected,
+    expect(screen.getByText("$0.42")).toBeInTheDocument();
+  });
+
+  it("keeps the cost in the popover while the visible flag is off", () => {
+    enableCost();
+    render(
+      <Theme>
+        <ContextUsageIndicator usage={usage()} taskId="task-1" />
+      </Theme>,
     );
+    expect(screen.queryByText("$0.42")).not.toBeInTheDocument();
   });
 
   it("renders a finite stroke offset at 0% (no NaN/Infinity)", () => {

--- a/products/desktop/packages/ui/src/features/sessions/components/ContextUsageIndicator.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ContextUsageIndicator.tsx
@@ -3,8 +3,9 @@ import {
   Popover,
   PopoverContent,
   PopoverTrigger,
+  Text,
 } from "@posthog/quill";
-import { TASK_COST_FLAG } from "@posthog/shared";
+import { TASK_COST_FLAG, TASK_COST_VISIBLE_FLAG } from "@posthog/shared";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import {
   formatCostUsd,
@@ -32,6 +33,7 @@ export function ContextUsageIndicator({
   focused = true,
 }: ContextUsageIndicatorProps) {
   const costEnabled = useFeatureFlag(TASK_COST_FLAG) || import.meta.env.DEV;
+  const costVisible = useFeatureFlag(TASK_COST_VISIBLE_FLAG);
   const { data: taskUsage } = useTaskUsage(taskId, costEnabled && focused);
 
   if (!usage) return null;
@@ -43,67 +45,76 @@ export function ContextUsageIndicator({
   const strokeDashoffset = CIRCUMFERENCE - (percentage / 100) * CIRCUMFERENCE;
   const color = getOverallUsageColor(percentage);
   const showCost = costEnabled && taskUsage !== undefined;
+  const showCostText = showCost && costVisible;
+  // The ring carries no text, so the token figures reach a reader only through
+  // the accessible name. Cost joins them only while it has no text of its own,
+  // which would otherwise be announced twice.
+  const costSuffix =
+    showCost && !showCostText
+      ? ` · ${formatCostUsd(taskUsage.total_cost_usd)}`
+      : "";
   return (
-    <Popover>
-      <PopoverTrigger
-        render={
-          <Button
-            type="button"
-            variant="default"
-            size="icon-sm"
-            aria-label={
-              hasSize
-                ? `Context usage: ${percentage}%` +
-                  (showCost
-                    ? ` · ${formatCostUsd(taskUsage.total_cost_usd)}`
-                    : "")
-                : `Context usage: ${formatTokensCompact(used)} tokens` +
-                  (showCost
-                    ? ` · ${formatCostUsd(taskUsage.total_cost_usd)}`
-                    : "")
-            }
-          >
-            {/* viewBox, not width/height: quill sizes a button's svg down to
-                its icon slot, which would crop an unscaled drawing. */}
-            <svg
-              viewBox={`0 0 ${CIRCLE_SIZE} ${CIRCLE_SIZE}`}
-              className="-rotate-90 size-4 shrink-0"
-              role="img"
-              aria-hidden="true"
+    <div className="flex items-center gap-1">
+      <Popover>
+        <PopoverTrigger
+          render={
+            <Button
+              type="button"
+              variant="default"
+              size="icon-sm"
+              aria-label={
+                hasSize
+                  ? `Context usage: ${percentage}%${costSuffix}`
+                  : `Context usage: ${formatTokensCompact(used)} tokens${costSuffix}`
+              }
             >
-              <circle
-                cx={CIRCLE_SIZE / 2}
-                cy={CIRCLE_SIZE / 2}
-                r={RADIUS}
-                fill="none"
-                stroke="var(--border)"
-                strokeWidth={STROKE_WIDTH}
-              />
-              <circle
-                cx={CIRCLE_SIZE / 2}
-                cy={CIRCLE_SIZE / 2}
-                r={RADIUS}
-                fill="none"
-                stroke={color}
-                strokeWidth={STROKE_WIDTH}
-                strokeDasharray={CIRCUMFERENCE}
-                strokeDashoffset={strokeDashoffset}
-                strokeLinecap="round"
-              />
-            </svg>
-          </Button>
-        }
-      />
-      {/* quill's popup is a fixed 18rem; the token figures sit on their own
-          line and would spill out of it. */}
-      <PopoverContent
-        side="top"
-        align="end"
-        sideOffset={6}
-        className="w-auto min-w-[280px] gap-3"
-      >
-        <ContextBreakdownPopover usage={usage} taskUsage={taskUsage} />
-      </PopoverContent>
-    </Popover>
+              {/* viewBox, not width/height: quill sizes a button's svg down to
+                  its icon slot, which would crop an unscaled drawing. */}
+              <svg
+                viewBox={`0 0 ${CIRCLE_SIZE} ${CIRCLE_SIZE}`}
+                className="-rotate-90 size-4 shrink-0"
+                role="img"
+                aria-hidden="true"
+              >
+                <circle
+                  cx={CIRCLE_SIZE / 2}
+                  cy={CIRCLE_SIZE / 2}
+                  r={RADIUS}
+                  fill="none"
+                  stroke="var(--border)"
+                  strokeWidth={STROKE_WIDTH}
+                />
+                <circle
+                  cx={CIRCLE_SIZE / 2}
+                  cy={CIRCLE_SIZE / 2}
+                  r={RADIUS}
+                  fill="none"
+                  stroke={color}
+                  strokeWidth={STROKE_WIDTH}
+                  strokeDasharray={CIRCUMFERENCE}
+                  strokeDashoffset={strokeDashoffset}
+                  strokeLinecap="round"
+                />
+              </svg>
+            </Button>
+          }
+        />
+        {/* quill's popup is a fixed 18rem; the token figures sit on their own
+            line and would spill out of it. */}
+        <PopoverContent
+          side="top"
+          align="end"
+          sideOffset={6}
+          className="w-auto min-w-[280px] gap-3"
+        >
+          <ContextBreakdownPopover usage={usage} taskUsage={taskUsage} />
+        </PopoverContent>
+      </Popover>
+      {showCostText && (
+        <Text className="select-none font-medium text-[13px] text-gray-11 tabular-nums">
+          {formatCostUsd(taskUsage.total_cost_usd)}
+        </Text>
+      )}
+    </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/sessions/components/ContextUsageIndicator.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ContextUsageIndicator.tsx
@@ -12,6 +12,7 @@ import {
   getOverallUsageColor,
 } from "@posthog/ui/features/sessions/contextColors";
 import type { ContextUsage } from "@posthog/ui/features/sessions/hooks/useContextUsage";
+import { useTaskUsage } from "@posthog/ui/features/sessions/hooks/useTaskUsage";
 import { ContextBreakdownPopover } from "./ContextBreakdownPopover";
 
 const CIRCLE_SIZE = 20;
@@ -21,20 +22,27 @@ const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 
 interface ContextUsageIndicatorProps {
   usage: ContextUsage | null;
+  taskId?: string;
+  focused?: boolean;
 }
 
-export function ContextUsageIndicator({ usage }: ContextUsageIndicatorProps) {
+export function ContextUsageIndicator({
+  usage,
+  taskId,
+  focused = true,
+}: ContextUsageIndicatorProps) {
   const costEnabled = useFeatureFlag(TASK_COST_FLAG) || import.meta.env.DEV;
+  const { data: taskUsage } = useTaskUsage(taskId, costEnabled && focused);
 
   if (!usage) return null;
 
-  const { used, size, percentage, cost } = usage;
+  const { used, size, percentage } = usage;
   // The context window can be unknown (size 0) — show just the token count
   // rather than a misleading "X/0 · 0%".
   const hasSize = size > 0;
   const strokeDashoffset = CIRCUMFERENCE - (percentage / 100) * CIRCUMFERENCE;
   const color = getOverallUsageColor(percentage);
-  const showCost = costEnabled && cost !== null;
+  const showCost = costEnabled && taskUsage !== undefined;
   return (
     <Popover>
       <PopoverTrigger
@@ -46,9 +54,13 @@ export function ContextUsageIndicator({ usage }: ContextUsageIndicatorProps) {
             aria-label={
               hasSize
                 ? `Context usage: ${percentage}%` +
-                  (showCost ? ` · ${formatCostUsd(cost.amount)}` : "")
+                  (showCost
+                    ? ` · ${formatCostUsd(taskUsage.total_cost_usd)}`
+                    : "")
                 : `Context usage: ${formatTokensCompact(used)} tokens` +
-                  (showCost ? ` · ${formatCostUsd(cost.amount)}` : "")
+                  (showCost
+                    ? ` · ${formatCostUsd(taskUsage.total_cost_usd)}`
+                    : "")
             }
           >
             {/* viewBox, not width/height: quill sizes a button's svg down to
@@ -90,7 +102,7 @@ export function ContextUsageIndicator({ usage }: ContextUsageIndicatorProps) {
         sideOffset={6}
         className="w-auto min-w-[280px] gap-3"
       >
-        <ContextBreakdownPopover usage={usage} showCost={showCost} />
+        <ContextBreakdownPopover usage={usage} taskUsage={taskUsage} />
       </PopoverContent>
     </Popover>
   );

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -866,7 +866,11 @@ export function SessionView({
                             ) : undefined
                           }
                           toolbarEndSlot={
-                            <ContextUsageIndicator usage={contextUsage} />
+                            <ContextUsageIndicator
+                              usage={contextUsage}
+                              taskId={taskId}
+                              focused={isActiveSession !== false}
+                            />
                           }
                           onToggleMessagingMode={toggleMessagingMode}
                           onAttachmentsChange={handleAttachmentsChange}

--- a/products/desktop/packages/ui/src/features/sessions/hooks/useTaskUsage.ts
+++ b/products/desktop/packages/ui/src/features/sessions/hooks/useTaskUsage.ts
@@ -1,20 +1,24 @@
 import type { TaskUsage } from "@posthog/api-client/posthog-client";
-import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
-import { useQuery } from "@tanstack/react-query";
+import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
+import type { UseQueryResult } from "@tanstack/react-query";
 
 const TASK_USAGE_REFRESH_MS = 60_000;
 
-export function useTaskUsage(taskId: string | undefined, enabled: boolean) {
-  const client = useOptionalAuthenticatedClient();
-  return useQuery({
-    queryKey: ["task-usage", taskId],
-    queryFn: (): Promise<TaskUsage> => {
-      if (!client || !taskId) throw new Error("Task usage is unavailable");
+export function useTaskUsage(
+  taskId: string | undefined,
+  enabled: boolean,
+): UseQueryResult<TaskUsage> {
+  return useAuthenticatedQuery(
+    ["task-usage", taskId],
+    (client): Promise<TaskUsage> => {
+      if (!taskId) throw new Error("Task usage is unavailable");
       return client.getTaskUsage(taskId);
     },
-    enabled: enabled && client !== null && taskId !== undefined,
-    staleTime: TASK_USAGE_REFRESH_MS,
-    refetchInterval: TASK_USAGE_REFRESH_MS,
-    refetchOnMount: "always",
-  });
+    {
+      enabled: enabled && taskId !== undefined,
+      staleTime: TASK_USAGE_REFRESH_MS,
+      refetchInterval: TASK_USAGE_REFRESH_MS,
+      refetchOnMount: "always",
+    },
+  );
 }

--- a/products/desktop/packages/ui/src/features/sessions/hooks/useTaskUsage.ts
+++ b/products/desktop/packages/ui/src/features/sessions/hooks/useTaskUsage.ts
@@ -1,0 +1,20 @@
+import type { TaskUsage } from "@posthog/api-client/posthog-client";
+import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
+import { useQuery } from "@tanstack/react-query";
+
+const TASK_USAGE_REFRESH_MS = 60_000;
+
+export function useTaskUsage(taskId: string | undefined, enabled: boolean) {
+  const client = useOptionalAuthenticatedClient();
+  return useQuery({
+    queryKey: ["task-usage", taskId],
+    queryFn: (): Promise<TaskUsage> => {
+      if (!client || !taskId) throw new Error("Task usage is unavailable");
+      return client.getTaskUsage(taskId);
+    },
+    enabled: enabled && client !== null && taskId !== undefined,
+    staleTime: TASK_USAGE_REFRESH_MS,
+    refetchInterval: TASK_USAGE_REFRESH_MS,
+    refetchOnMount: "always",
+  });
+}


### PR DESCRIPTION
## Problem

Desktop shows an inflated Claude-only task estimate and provides no cloud compute breakdown. The figure it does show sits inside a popover, so nobody sees what a session costs without clicking.

## Changes

- Fetch task costs from the backend when the task is focused.
- Cache the result in-app and refresh it every minute while focused.
- Show total, token, and cloud compute costs in the context popover.
- Show the total beside the context ring as text, gated on `posthog-code-task-cost-visible`.
- Drop the cost from the button's `aria-label` while that text is on, so a reader does not hear it twice.

**Why:** People need a small, reliable task estimate without a new billing surface.

The visible readout is a second flag rather than part of the first. `posthog-code-task-cost` gates the fetch, so the readout still requires it, but the two roll out independently. A null cost renders nothing rather than `$0.00`, which would read as "this session is free" on a harness that reports no cost.

![Compact task cost breakdown in the Desktop context popover](https://raw.githubusercontent.com/PostHog/pr-assets/c7e9f2e534260b9a0089736bcbec4f1d21f03aec/2026/08/0b098230-37ee-4ed7-8f6c-2cca7ecd38ae.png)

The screenshot predates the visible readout. The popover is unchanged; the new text sits to the right of the ring in the composer toolbar.

## How did you test this code?

- Added component coverage for the authoritative total and cost breakdown.
- Added coverage that the cost renders as text only once the visible flag is on. The old suite asserted the `aria-label` alone, so deleting the visible figure would have gone unnoticed.
- Added coverage that the `aria-label` drops the cost in that same state.
- Not run: the desktop app itself for the visible readout, so its rendered position and spacing are unverified.

### Live E2E QA

**Verdict:** PASS across two consecutive runs with [the backend stack layer](https://github.com/PostHog/posthog/pull/81008). This covered the popover, before the visible readout existed.

- Drove the real Electron development app over CDP against the local backend stack.
- Confirmed the task indicator rendered `Context usage: 25% · $1.23`.
- Confirmed the popover rendered total `$1.23`, tokens `$1.23`, and cloud compute `$0.00`.
- Confirmed the API response included every cost field consumed by the component.
- Reloaded and repeated the interaction with the same result.

No Desktop UI defects remained after the backend fixes.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes. This adds a small detail to the existing context usage indicator.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code implemented this stack layer with `/stacking-prs`, `/improving-drf-endpoints`, `/writing-tests`, `/posthog-desktop`, `/writing-user-facing-copy`, and `/writing-pr-descriptions`. The live stack validation used `/qa-frontend` as a reference and drove Electron over CDP. The backend API is provided by the lower stack layer.

The visible readout started from [#83963](https://github.com/PostHog/posthog/pull/83963), which made the cost visible unconditionally on `master`. Two changes on the way in: it now reads the backend-sourced total this stack introduces rather than the client estimate, and it sits behind its own flag rather than the existing one. That PR used Radix `Flex` and `Text`, which are banned in this tree, so the wrapper is a `div` with Tailwind and the label is quill's `Text`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
