### PR TITLE
fix(data-warehouse): flag non-https self-managed bucket URLs before submit

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/selfManagedSourceLogic.test.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/selfManagedSourceLogic.test.ts
@@ -32,4 +32,17 @@ describe('selfManagedTableFormErrors', () => {
         expect(errors.format).toBeFalsy()
         expect(errors.credential).toEqual({ access_key: false, access_secret: false })
     })
+
+    // The backend rejects any non-https url pattern; these should surface a frontend error instead
+    // of falling through to the generic server-side message.
+    it.each([
+        ['s3://your-org/invoices/*.pqt'],
+        ['http://your-org.s3.amazonaws.com/invoices/*.pqt'],
+        ['s3a://your-org/invoices/*.pqt'],
+        ['your-org.s3.amazonaws.com/invoices/*.pqt'],
+    ])('rejects non-https url pattern %s', (url_pattern) => {
+        const errors = selfManagedTableFormErrors({ ...validTable, url_pattern })
+
+        expect(errors.url_pattern).toBeTruthy()
+    })
 })

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/selfManagedSourceLogic.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/selfManagedSourceLogic.tsx
@@ -63,6 +63,15 @@ export function selfManagedTableFormErrors({
         }
     }
 
+    // The backend only accepts https bucket URLs and rejects anything else (a bare path, http://,
+    // s3a://, gs://) with a generic error, so catch those here with the same guidance as s3://.
+    if (url_pattern && !url_pattern.startsWith('https://')) {
+        return {
+            url_pattern:
+                'Please use the https URL for your bucket, e.g. https://your-org.s3.amazonaws.com/airbyte/stripe/invoices/*.pqt',
+        }
+    }
+
     return {
         name: !name && 'Please enter a name.',
         url_pattern: !url_pattern && 'Please enter a url pattern.',


### PR DESCRIPTION
## Problem

- Users adding a self-managed bucket source (S3, GCS, Azure, R2) hit repeated validation failures when their URL was not `https://`, and got no guidance on how to fix it until the server rejected the submit.
- The form only caught a literal `s3://` prefix on the client. Other non-https inputs (a bare `bucket/path`, `http://`, `s3a://`, `gs://`) passed the client check.
- Those inputs failed server-side with the generic "URL pattern must use https." message, which does not tell the user what a valid URL looks like.

## Changes

- The self-managed source form now flags any non-https `url_pattern` before submit, with the same example URL already shown for the `s3://` case.
- This mirrors the backend rule, which accepts only `https://` bucket URLs, so the client can no longer pass an input the server will reject.
- No change to sync behavior, schemas, or the backend validator.

## How did you test this code?

- Added 4 cases to `selfManagedSourceLogic.test.ts` covering `s3://`, `http://`, `s3a://`, and a scheme-less path. They catch a regression where dropping the non-https guard lets those inputs fall through to the generic server error. Existing tests still cover a valid `https://` URL passing.
- Ran the updated Jest file locally; all 6 cases pass.
- Not run: the full frontend typecheck suite (unchanged function signature, pure string check).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored by Claude (via PostHog Code) while reviewing data-warehouse onboarding session summaries for recurring friction. This addresses the theme of users repeatedly failing S3 path validation and only learning the https requirement from a generic server error.
- Skills invoked: `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.
- The frontend already had an `s3://`-specific message; the change generalizes it to the full non-https case rather than adding another per-scheme branch.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
