### PR TITLE
chore(skills): drop the nonexistent NodeRole.COORDINATOR from the CH migration skill

### DIFF
--- a/.agents/skills/clickhouse-migrations/SKILL.md
+++ b/.agents/skills/clickhouse-migrations/SKILL.md
@@ -24,9 +24,15 @@ operations = [
 
 ### Node roles (choose based on table type)
 
-- `[NodeRole.DATA]`: Sharded tables (data nodes only)
-- `[NodeRole.DATA, NodeRole.COORDINATOR]`: Non-sharded data tables, distributed read tables, replicated tables, views, dictionaries
-- `[NodeRole.INGESTION_SMALL]`: Writable tables, Kafka tables, materialized views on ingestion layer
+Only the members of `NodeRole` in `posthog/clickhouse/client/connection.py` are valid: `ALL`, `DATA`,
+`INGESTION_EVENTS`, `INGESTION_SMALL`, `INGESTION_MEDIUM`, `ENDPOINTS`, `LOGS`, `AI_EVENTS`, `AUX`,
+`OPS`, `SESSIONS`. A name that is not in that enum fails at import, which aborts migration discovery
+and takes every job that runs migrations down with it.
+
+- `[NodeRole.DATA]`: sharded tables, non-sharded replicated tables, distributed read tables, views,
+  dictionaries — the default, and correct for almost everything on the main cluster
+- `[NodeRole.INGESTION_SMALL]`: writable tables, Kafka tables, materialized views on ingestion layer
+- `[NodeRole.ALL]`: rarely used
 
 ### Table engines quick reference
 
@@ -91,6 +97,26 @@ If you create a new table inside such a guard, you must also add its SQL functio
 The only exception is tables whose definition intentionally differs per environment and is not tracked in the repo (e.g. the no-go zone `events_json_ws_mv` table).
 
 **Dictionary credentials:** when a dictionary uses a `SOURCE(CLICKHOUSE(...))`, resolve the source user/password via `get_clickhouse_creds(ClickHouseUser.DICT_READER)` and interpolate them into the `USER`/`PASSWORD` clause — do not hardcode `default`/`CLICKHOUSE_USER` or omit credentials. This keeps dictionary auth on the dedicated low-privilege `dict_reader` user, decoupled from `default`; it falls back to `default` creds when the env vars are unset. See `posthog/models/exchange_rate/sql.py` for the pattern.
+
+### Declarative schema (HCL) must agree
+
+Some roles are also declared in `posthog/clickhouse/hcl/`, and the multinode migration smoke re-introspects
+the migrated cluster and fails on any drift between the live schema and the committed golden. A table added
+by a migration on a managed role therefore needs the HCL updated in the same PR, or CI fails at
+`check_live_hcl` with a `DRIFT:` block naming your new objects.
+
+The `data` role is managed for the `local-multi` composition, so a new table on `NodeRole.DATA` counts.
+After writing the migration:
+
+```sh
+HCL=posthog/clickhouse/hcl
+# add the table to the layer that composes it, e.g. $HCL/roles/data/local/tables.hcl
+bash $HCL/gen-golden.sh && bash $HCL/gen-sql.sh   # refresh generated artifacts
+bash $HCL/check.sh                                # must exit 0
+```
+
+Read `posthog/clickhouse/hcl/README.md` before editing a layer — it covers which layer to pick, abstract
+column lists, and the codegen path that writes the migration for you.
 
 ### Testing
 

--- a/.agents/skills/clickhouse-migrations/SKILL.md
+++ b/.agents/skills/clickhouse-migrations/SKILL.md
@@ -22,16 +22,22 @@ operations = [
 ]
 ```
 
-### Node roles (choose based on table type)
+### Node roles (choose by the cluster that owns the object)
 
 Only the members of `NodeRole` in `posthog/clickhouse/client/connection.py` are valid: `ALL`, `DATA`,
 `INGESTION_EVENTS`, `INGESTION_SMALL`, `INGESTION_MEDIUM`, `ENDPOINTS`, `LOGS`, `AI_EVENTS`, `AUX`,
 `OPS`, `SESSIONS`. A name that is not in that enum fails at import, which aborts migration discovery
 and takes every job that runs migrations down with it.
 
-- `[NodeRole.DATA]`: sharded tables, non-sharded replicated tables, distributed read tables, views,
-  dictionaries — the default, and correct for almost everything on the main cluster
-- `[NodeRole.INGESTION_SMALL]`: writable tables, Kafka tables, materialized views on ingestion layer
+Pick the role by **which cluster owns the object**, not by its type alone:
+
+- `[NodeRole.DATA]`: anything on the main cluster — sharded tables, non-sharded replicated tables,
+  distributed read tables, views, dictionaries. The default, and right for most migrations.
+- `[NodeRole.INGESTION_SMALL]`: writable tables, Kafka tables, materialized views on the ingestion layer
+- `[NodeRole.OPS]`, `[NodeRole.LOGS]`, `[NodeRole.AUX]`, `[NodeRole.AI_EVENTS]`, `[NodeRole.SESSIONS]`:
+  objects that live on a satellite cluster. A table for one of those on `DATA` lands on the wrong
+  nodes and leaves the intended cluster without it, so check where the object is read and written
+  before defaulting to `DATA`.
 - `[NodeRole.ALL]`: rarely used
 
 ### Table engines quick reference


### PR DESCRIPTION
## Problem

Anyone who writes a ClickHouse migration by following this skill produces a migration that cannot be imported, and the failure takes down every CI job that runs migrations. The skill's node-role table told them to use `[NodeRole.DATA, NodeRole.COORDINATOR]` for non-sharded tables. `COORDINATOR` is not a member of `NodeRole`, so the module-level `operations` list raises `AttributeError` during migration discovery.

I hit this on a real stack: one migration written from this line turned every backend, Dagster, and code-quality job red across four PRs, and the only failure that named a cause was a single mypy line.

The checked-in [`posthog/clickhouse/migrations/AGENTS.md`](https://github.com/PostHog/posthog/blob/master/posthog/clickhouse/migrations/AGENTS.md) already says `[NodeRole.DATA]`, and every migration in the repo uses it. The skill was the only source of the phantom role.

## Changes

- The node-role section lists the real enum members and says what an invented one costs.
- `[NodeRole.DATA]` now covers non-sharded replicated tables, which is what the enum supports and what migration `0118` does for the closest analogue.
- New section: a table on a managed role needs `posthog/clickhouse/hcl/` updated in the same PR, with the commands to regenerate the golden artifacts. Migrations that skip this fail the multinode smoke at `check_live_hcl` after the migration itself succeeds, which is a confusing place to land.

## How did you test this code?

`hogli lint:skills` passes (143 skills). The three advisory warnings it prints are pre-existing and in other products.

I verified both claims against the repo rather than trusting the doc:

- `NodeRole` in `posthog/clickhouse/client/connection.py` has no `COORDINATOR` member, and `grep -rn COORDINATOR` over `.agents/`, `docs/`, and `posthog/` returns this skill line and unrelated Temporal constants.
- The HCL gate is real: a four-table migration on `NodeRole.DATA` failed the multinode smoke with a `DRIFT: local-multi/data` block until I added the tables to `roles/data/local/tables.hcl` and reran `gen-golden.sh` / `gen-sql.sh`.

No behavior change to test — this PR edits one markdown file.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude Opus 5) found this while getting a stalled ClickHouse cleanup PR series green. The `NodeRole.COORDINATOR` line was the root cause of the red, so fixing the source seemed worth more than fixing the one migration.

Skills invoked: `/clickhouse-migrations` (which is how I read the bad line in the first place), `/writing-skills`, `/writing-pr-descriptions`, `/writing-code-comments`.

The HCL section is second-hand experience rather than a guess: the gate caught my migration one CI round-trip after the migration itself started passing, and nothing in the skill pointed at it.
