### PR TITLE
fix(tasks): require comment:read for comment activity

### DIFF
--- a/products/tasks/backend/presentation/views/channels_api.py
+++ b/products/tasks/backend/presentation/views/channels_api.py
@@ -527,7 +527,7 @@ class TaskThreadMessageViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     )
     # Without required_scopes the scope check has no read action to match, and every personal
     # API key, OAuth token and MCP caller gets a 403 while session auth sails through.
-    @action(detail=False, methods=["get"], url_path="comment_activity", required_scopes=["task:read"])
+    @action(detail=False, methods=["get"], url_path="comment_activity", required_scopes=["comment:read"])
     def comment_activity(self, request, *args, **kwargs):
         page = tasks_facade.list_task_comment_activity(self._task_id(), self.team_id, self._user_id())
         if page is None:


### PR DESCRIPTION
## Problem

A personal API key or OAuth token granted `task:read` but deliberately denied `comment:read` could read comment bodies and participant names through `/thread_messages/comment_activity/`. The sibling task comment endpoints already require `comment:read`.

Raised in review on #80764.

## Changes

- The `comment_activity` action declares `required_scopes=["comment:read"]`.

Lands as its own PR into #80764 rather than in the desktop layer above it: that PR cannot carry a backend change past the desktop backend coupling gate.

## How did you test this code?

Ran `test_channels_api` locally, which covers the endpoint through session auth. The scope path itself is covered by the shared `APIScopePermission` machinery, not by a new test.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

One line, from review feedback. Skills invoked: `/writing-pr-descriptions`.