### PR TITLE
feat(spaces): make channel rename and delete optimistic

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannels.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannels.test.tsx
@@ -8,6 +8,8 @@ const mockClient = vi.hoisted(() => ({
   getTaskChannels: vi.fn(),
   resolveTaskChannel: vi.fn(),
   starTaskChannel: vi.fn(),
+  renameTaskChannel: vi.fn(),
+  deleteTaskChannel: vi.fn(),
 }));
 vi.mock("@posthog/ui/features/auth/authClient", () => ({
   useOptionalAuthenticatedClient: () => mockClient,
@@ -141,6 +143,112 @@ describe("useChannelMutations", () => {
     });
 
     expect(mockClient.starTaskChannel).not.toHaveBeenCalled();
+  });
+
+  it("applies a rename before the server round-trip resolves", async () => {
+    mockClient.getTaskChannels.mockResolvedValue([
+      taskChannel("1", "alpha"),
+      taskChannel("2", "beta"),
+    ]);
+    const list = renderHook(() => useChannels(), { wrapper });
+    await waitFor(() => expect(list.result.current.isLoading).toBe(false));
+    // Freeze both the rename call and any trailing refetch, so the rename can
+    // only show through the optimistic cache write.
+    let resolveRename: (channel: TaskChannel) => void = () => {};
+    mockClient.renameTaskChannel.mockReturnValue(
+      new Promise<TaskChannel>((resolve) => {
+        resolveRename = resolve;
+      }),
+    );
+    mockClient.getTaskChannels.mockReturnValue(new Promise(() => {}));
+
+    const mutations = renderHook(() => useChannelMutations(), { wrapper });
+    let pending: Promise<unknown> | undefined;
+    await act(async () => {
+      pending = mutations.result.current.renameChannel("2", "gamma");
+    });
+    // The server call is still in flight, so the rename can only be visible
+    // through the optimistic cache write.
+    await waitFor(() =>
+      expect(list.result.current.channels.map((c) => c.name)).toEqual([
+        "alpha",
+        "gamma",
+      ]),
+    );
+
+    await act(async () => {
+      resolveRename(taskChannel("2", "gamma"));
+      await pending;
+    });
+    expect(list.result.current.channels.map((c) => c.name)).toEqual([
+      "alpha",
+      "gamma",
+    ]);
+  });
+
+  it("restores the old name when a rename fails", async () => {
+    mockClient.getTaskChannels.mockResolvedValue([taskChannel("1", "alpha")]);
+    const list = renderHook(() => useChannels(), { wrapper });
+    await waitFor(() => expect(list.result.current.isLoading).toBe(false));
+    mockClient.renameTaskChannel.mockRejectedValue(new Error("nope"));
+    mockClient.getTaskChannels.mockReturnValue(new Promise(() => {}));
+
+    const mutations = renderHook(() => useChannelMutations(), { wrapper });
+    await act(async () => {
+      await expect(
+        mutations.result.current.renameChannel("1", "beta"),
+      ).rejects.toThrow("nope");
+    });
+    expect(list.result.current.channels.map((c) => c.name)).toEqual(["alpha"]);
+  });
+
+  it("removes a deleted space from the list before the round-trip resolves", async () => {
+    mockClient.getTaskChannels.mockResolvedValue([
+      taskChannel("1", "alpha"),
+      taskChannel("2", "beta"),
+    ]);
+    const list = renderHook(() => useChannels(), { wrapper });
+    await waitFor(() => expect(list.result.current.isLoading).toBe(false));
+    let resolveDelete: () => void = () => {};
+    mockClient.deleteTaskChannel.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveDelete = () => resolve(undefined);
+      }),
+    );
+    mockClient.getTaskChannels.mockReturnValue(new Promise(() => {}));
+
+    const mutations = renderHook(() => useChannelMutations(), { wrapper });
+    let pending: Promise<unknown> | undefined;
+    await act(async () => {
+      pending = mutations.result.current.deleteChannel("1");
+    });
+    // The server call is still in flight, so the removal can only be visible
+    // through the optimistic cache write.
+    await waitFor(() =>
+      expect(list.result.current.channels.map((c) => c.name)).toEqual(["beta"]),
+    );
+
+    await act(async () => {
+      resolveDelete();
+      await pending;
+    });
+    expect(list.result.current.channels.map((c) => c.name)).toEqual(["beta"]);
+  });
+
+  it("restores a deleted space when the delete fails", async () => {
+    mockClient.getTaskChannels.mockResolvedValue([taskChannel("1", "alpha")]);
+    const list = renderHook(() => useChannels(), { wrapper });
+    await waitFor(() => expect(list.result.current.isLoading).toBe(false));
+    mockClient.deleteTaskChannel.mockRejectedValue(new Error("nope"));
+    mockClient.getTaskChannels.mockReturnValue(new Promise(() => {}));
+
+    const mutations = renderHook(() => useChannelMutations(), { wrapper });
+    await act(async () => {
+      await expect(mutations.result.current.deleteChannel("1")).rejects.toThrow(
+        "nope",
+      );
+    });
+    expect(list.result.current.channels.map((c) => c.name)).toEqual(["alpha"]);
   });
 
   it("leaves the star alone when the name resolves a space that already exists", async () => {

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannels.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannels.ts
@@ -109,7 +109,24 @@ export function useChannelMutations() {
       if (!client) throw new Error("Not authenticated");
       return client.deleteTaskChannel(id);
     },
-    onSuccess: invalidate,
+    // Optimistic remove: the space leaves the sidebar the moment it's clicked,
+    // not after the delete round-trip + list refetch. Restore on failure.
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: TASK_CHANNELS_QUERY_KEY });
+      const previous = queryClient.getQueryData<TaskChannel[]>(
+        TASK_CHANNELS_QUERY_KEY,
+      );
+      queryClient.setQueryData<TaskChannel[]>(TASK_CHANNELS_QUERY_KEY, (old) =>
+        old?.filter((channel) => channel.id !== id),
+      );
+      return { previous };
+    },
+    onError: (_error, _id, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(TASK_CHANNELS_QUERY_KEY, context.previous);
+      }
+    },
+    onSettled: invalidate,
   });
 
   const renameMutation = useMutation({
@@ -117,7 +134,26 @@ export function useChannelMutations() {
       if (!client) throw new Error("Not authenticated");
       return client.renameTaskChannel(id, name);
     },
-    onSuccess: invalidate,
+    // Optimistic rename: the typed name already passed the same normalization
+    // rule the server applies, so it can land in the cache at submit time.
+    onMutate: async ({ id, name }) => {
+      await queryClient.cancelQueries({ queryKey: TASK_CHANNELS_QUERY_KEY });
+      const previous = queryClient.getQueryData<TaskChannel[]>(
+        TASK_CHANNELS_QUERY_KEY,
+      );
+      queryClient.setQueryData<TaskChannel[]>(TASK_CHANNELS_QUERY_KEY, (old) =>
+        old?.map((channel) =>
+          channel.id === id ? { ...channel, name } : channel,
+        ),
+      );
+      return { previous };
+    },
+    onError: (_error, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(TASK_CHANNELS_QUERY_KEY, context.previous);
+      }
+    },
+    onSettled: invalidate,
   });
 
   return {


### PR DESCRIPTION
## Problem

Someone renaming or deleting a space in the desktop app sidebar sees the old name, or the deleted space itself, stick around after the dialog closed. The mutation invalidated the channel list only on success, so the UI corrected itself one round-trip plus one refetch late.

## Changes

- Apply the optimistic-cache shape to the channel rename and delete mutations, the same one the channel star mutation already uses.
- `onMutate` cancels pending channel queries, snapshots the list, and writes the new name or removal into the cache.
- `onError` restores the snapshot, so a failed action reverts the sidebar to the true state and the existing error toast still fires.
- `onSettled` (previously `onSuccess`) invalidates the list, so failure paths reconverge with the server too.
- Create is untouched; it already seeds its row into the cache when the POST resolves.

No visible UI change, so no screenshots: the row and label look identical, they just update at click time instead of at refetch time.

## How did you test this code?

- Extended `useChannels.test.tsx` with four cases, each locking in a regression the create-only suite could not catch:
  - Rename is visible in the list while the server call is still in flight (hung promise proves no refetch dependency).
  - A failed rename restores the previous name.
  - A deletion is visible in the list while its server call is in flight.
  - A failed delete restores the removed space.
- Ran `npx vitest run useChannels.test.tsx` in `packages/ui`: all 11 tests pass.
- Ran Biome on both touched files: clean.
- Not run: the desktop app end to end. The workspace `@posthog/ui` typecheck fails on clean master inside an unrelated `workspace-server` package, before and after this change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: PostHog Code task agent, session driven by @puemos.
- Skills invoked: `/writing-pr-descriptions` (this body). `/writing-code-comments` and `/writing-tests` were checked retroactively against the diff.
- Direction shifted across the session: earlier candidates (thread messaging, file feed composer, git stage toggle, agent revision lifecycle, inbox actions) were ruled out by scope constraints; the driver steered toward task/space row actions, where channel rename and delete were the last non-optimistic mutations of that kind. Task rename, task delete, and task archive already handle their UX deliberately, so they are out of scope here.
