### PR TITLE
fix(lemon-ui): prevent number input from changing on scroll

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonInput/LemonInput.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInput/LemonInput.tsx
@@ -270,6 +270,12 @@ export const LemonInput = React.forwardRef<HTMLDivElement, LemonInputProps>(func
                         setFocused(false)
                         onBlur?.(event)
                     }}
+                    onWheel={(event) => {
+                        // Prevent native number inputs from changing value on scroll
+                        if (type === 'number') {
+                            event.currentTarget.blur()
+                        }
+                    }}
                     onKeyDown={(event) => {
                         if (stopPropagation) {
                             event.stopPropagation()


### PR DESCRIPTION
## Problem

Closes #72401

Number inputs in the LemonInput component respond to mouse wheel scroll events, which can accidentally change the value — especially problematic in forms where users scroll to view other fields.

For example, on the Postgres data source configuration page, scrolling to reach the next field can inadvertently change the port number.

## Fix

Added an `onWheel` handler that blurs the number input when the user scrolls over it, preventing the native browser behavior of incrementing/decrementing the value.

## Why blur instead of `preventDefault`?

Blurring is the standard approach used by many design systems (MUI, etc.) because it:
1. Prevents the value from changing
2. Gives the user a visual cue (focus lost) that they need to re-focus the input to type
3. Doesn't interfere with the page scrolling behavior