### PR TITLE
fix(workflows): resolve templating autocomplete client-side

### DIFF
--- a/frontend/src/lib/monaco/CodeEditorImpl.tsx
+++ b/frontend/src/lib/monaco/CodeEditorImpl.tsx
@@ -24,6 +24,7 @@ import { initHogTemplateLanguage } from 'lib/monaco/languages/hogTemplate'
 import { initLiquidLanguage } from 'lib/monaco/languages/liquid'
 import { clearLogicReference, initModel } from 'lib/monaco/modelLogicReference'
 import { sharedMonacoOverflowRoot } from 'lib/monaco/sharedMonacoOverflowRoot'
+import { isTemplateLanguage, retriggerSuggestionsOnDeletion } from 'lib/monaco/templateAutocompleteProvider'
 import { inStorybookTestRunner } from 'lib/utils/dom'
 
 import { AnyDataNode, HogLanguage, HogQLMetadataResponse, NodeKind } from '~/queries/schema/schema-general'
@@ -454,6 +455,10 @@ export function CodeEditor({
         initEditor(monaco, editor, editorProps, options ?? {}, builtCodeEditorLogic)
         remeasureFontsWhenReady(monaco)
         monacoDisposables.current.push(trackFindWidgetVisibility(editor))
+
+        if (isTemplateLanguage(editorProps.language)) {
+            monacoDisposables.current.push(retriggerSuggestionsOnDeletion(editor, editorProps.language))
+        }
 
         // Override Monaco's suggestion widget styling to prevent truncation
         const styleId = 'monaco-suggestion-widget-fix'

--- a/frontend/src/lib/monaco/languages/hogTemplate.ts
+++ b/frontend/src/lib/monaco/languages/hogTemplate.ts
@@ -2,8 +2,8 @@
 import { Monaco } from '@monaco-editor/react'
 import { languages } from 'monaco-editor'
 
-import { hogQLAutocompleteProvider } from 'lib/monaco/hogQLAutocompleteProvider'
 import { hogQLMetadataProvider } from 'lib/monaco/hogQLMetadataProvider'
+import { templateAutocompleteProvider } from 'lib/monaco/templateAutocompleteProvider'
 
 import { HogLanguage } from '~/queries/schema/schema-general'
 
@@ -140,7 +140,7 @@ export function initHogTemplateLanguage(monaco: Monaco): void {
         monaco.languages.setMonarchTokensProvider('hogTemplate', language())
         monaco.languages.registerCompletionItemProvider(
             'hogTemplate',
-            hogQLAutocompleteProvider(HogLanguage.hogTemplate)
+            templateAutocompleteProvider(HogLanguage.hogTemplate)
         )
         monaco.languages.registerCodeActionProvider('hogTemplate', hogQLMetadataProvider())
     }

--- a/frontend/src/lib/monaco/languages/liquid.ts
+++ b/frontend/src/lib/monaco/languages/liquid.ts
@@ -1,7 +1,7 @@
 import { Monaco } from '@monaco-editor/react'
 
-import { hogQLAutocompleteProvider } from 'lib/monaco/hogQLAutocompleteProvider'
 import { hogQLMetadataProvider } from 'lib/monaco/hogQLMetadataProvider'
+import { templateAutocompleteProvider } from 'lib/monaco/templateAutocompleteProvider'
 
 import { HogLanguage } from '~/queries/schema/schema-general'
 
@@ -16,7 +16,7 @@ export function initLiquidLanguage(monaco: Monaco): void {
         monaco.languages.register({ id: 'hogLiquid' })
         // Liquid is a pre-registered language in Monaco, so we only need to register completion and code action providers.
 
-        monaco.languages.registerCompletionItemProvider('liquid', hogQLAutocompleteProvider(HogLanguage.liquid))
+        monaco.languages.registerCompletionItemProvider('liquid', templateAutocompleteProvider(HogLanguage.liquid))
 
         monaco.languages.registerCodeActionProvider('liquid', hogQLMetadataProvider())
     }

--- a/frontend/src/lib/monaco/templateAutocompleteProvider.test.ts
+++ b/frontend/src/lib/monaco/templateAutocompleteProvider.test.ts
@@ -1,0 +1,124 @@
+import { languages } from 'monaco-editor'
+
+import { TemplateLanguage, templateAutocompleteProvider } from 'lib/monaco/templateAutocompleteProvider'
+
+import { HogLanguage } from '~/queries/schema/schema-general'
+
+// Jest resolves monaco-editor to its type declarations, which leaves CompletionItemKind with no
+// runtime value. Restate the members the provider uses, keeping monaco's own numbering.
+jest.mock('monaco-editor', () => ({
+    languages: { CompletionItemKind: { Method: 0, Function: 1, Field: 3, Variable: 4 } },
+}))
+
+const GLOBALS: Record<string, unknown> = {
+    event: { event: '$pageview', properties: { $browser: 'Chrome' } },
+    person: { distinct_id: 'abc123', properties: { email: 'marius@example.com', name: 'Marius' } },
+}
+
+interface SuggestOptions {
+    language: TemplateLanguage
+    /** Text of the single-line editor up to the cursor. */
+    before: string
+    after?: string
+    globals?: Record<string, unknown>
+}
+
+function suggest(options: SuggestOptions): languages.CompletionItem[] {
+    const { language, before, after = '' } = options
+    const globals = 'globals' in options ? options.globals : GLOBALS
+    const cursorColumn = before.length + 1
+    const word = /[A-Za-z0-9_$]*$/.exec(before)![0]
+    const model = {
+        codeEditorLogic: { isMounted: () => true, props: { globals } },
+        getValue: () => before + after,
+        getOffsetAt: ({ column }: { column: number }) => column - 1,
+        getWordUntilPosition: () => ({
+            word,
+            startColumn: cursorColumn - word.length,
+            endColumn: cursorColumn,
+        }),
+    }
+    const result = templateAutocompleteProvider(language).provideCompletionItems?.(
+        model as any,
+        { lineNumber: 1, column: cursorColumn } as any,
+        {} as any,
+        {} as any
+    )
+    return (result as languages.CompletionList).suggestions
+}
+
+function labels(suggestions: languages.CompletionItem[]): string[] {
+    return suggestions.map((item) => (typeof item.label === 'string' ? item.label : item.label.label))
+}
+
+describe('templateAutocompleteProvider', () => {
+    test.each([
+        ['after a top-level global', '{person.', ['distinct_id', 'properties']],
+        ['after a nested global', '{person.properties.', ['email', 'name']],
+        ['while typing a member', '{person.properties.em', ['email', 'name']],
+        ['with the cursor in the middle of a chain', '{person.prop', ['distinct_id', 'properties']],
+        ['on a leaf that is not an object', '{person.properties.email.', []],
+        ['on a global that does not exist', '{unknown.', []],
+    ])('walks the chain into globals %s', (_name, before, expected) => {
+        const suggestions = suggest({ language: HogLanguage.hogTemplate, before, after: '}' })
+
+        expect(labels(suggestions)).toEqual(expected)
+        expect(suggestions.every((item) => item.kind === languages.CompletionItemKind.Field)).toBe(true)
+    })
+
+    test('suggests globals and Hog functions at the top level of a Hog template', () => {
+        const suggestions = suggest({ language: HogLanguage.hogTemplate, before: 'Hi {', after: '}' })
+
+        expect(suggestions).toContainEqual(
+            expect.objectContaining({
+                label: { label: 'person', detail: 'Object' },
+                kind: languages.CompletionItemKind.Variable,
+                sortText: '1-person',
+            })
+        )
+        expect(suggestions).toContainEqual(
+            expect.objectContaining({
+                label: 'concat',
+                insertText: 'concat()',
+                kind: languages.CompletionItemKind.Function,
+                command: { id: 'cursorLeft', title: 'Move cursor left' },
+            })
+        )
+    })
+
+    test('suggests Hog functions when no globals are set', () => {
+        const suggestions = suggest({ language: HogLanguage.hogTemplate, before: '{', globals: undefined })
+
+        expect(labels(suggestions)).toContain('concat')
+        expect(suggestions.every((item) => item.kind === languages.CompletionItemKind.Function)).toBe(true)
+    })
+
+    test.each<[TemplateLanguage, string]>([
+        [HogLanguage.hogTemplate, 'Hi there '],
+        [HogLanguage.hogTemplate, 'Hi {person.properties.name} '],
+        [HogLanguage.liquid, 'Hi there '],
+        [HogLanguage.liquid, 'Hi {{ person.properties.name }} '],
+    ])('suggests nothing outside a %s expression: %p', (language, before) => {
+        expect(suggest({ language, before })).toEqual([])
+    })
+
+    test.each([
+        ['output', '{{ '],
+        ['tag', '{% if '],
+    ])('suggests globals inside a Liquid %s expression', (_name, before) => {
+        const suggestions = suggest({ language: HogLanguage.liquid, before })
+
+        expect(labels(suggestions)).toEqual(['event', 'person'])
+    })
+
+    test.each([
+        ['right after the pipe', '{{ person.properties.email | '],
+        ['while typing the filter name', '{{ person.properties.email | up'],
+    ])('suggests Liquid filters %s', (_name, before) => {
+        const suggestions = suggest({ language: HogLanguage.liquid, before })
+
+        expect(labels(suggestions)).toContain('upcase')
+        // Hog's standard library is not available in Liquid, so it must never be offered there.
+        expect(labels(suggestions)).not.toContain('concat')
+    })
+})

--- a/frontend/src/lib/monaco/templateAutocompleteProvider.ts
+++ b/frontend/src/lib/monaco/templateAutocompleteProvider.ts
@@ -1,0 +1,242 @@
+import { BuiltLogic } from 'kea'
+import { languages } from 'monaco-editor'
+import type { IDisposable, editor } from 'monaco-editor'
+
+import { STL } from '@posthog/hogvm'
+
+import type { codeEditorLogicType } from 'lib/monaco/codeEditorLogic'
+
+import { HogLanguage } from '~/queries/schema/schema-general'
+
+/** Languages whose autocomplete is resolved from the globals the frontend already holds. */
+export type TemplateLanguage = HogLanguage.hogTemplate | HogLanguage.liquid
+
+interface LiquidFilter {
+    name: string
+    detail: string
+}
+
+const LIQUID_FILTERS: LiquidFilter[] = [
+    { name: 'date', detail: 'Format a date or timestamp' },
+    { name: 'default', detail: 'Use a fallback when the value is empty' },
+    { name: 'join', detail: 'Join a list into a string' },
+    { name: 'split', detail: 'Split a string into a list' },
+    { name: 'upcase', detail: 'Convert to uppercase' },
+    { name: 'downcase', detail: 'Convert to lowercase' },
+    { name: 'capitalize', detail: 'Capitalize the first letter' },
+    { name: 'replace', detail: 'Replace every match in a string' },
+    { name: 'truncate', detail: 'Shorten a string to a length' },
+    { name: 'plus', detail: 'Add a number' },
+    { name: 'minus', detail: 'Subtract a number' },
+]
+
+/** Identifier chain the cursor sits at the end of, e.g. `person.properties.em`. */
+const CHAIN_BEFORE_CURSOR = /([A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)*\.?)$/
+/** A `|` followed by at most the filter name being typed. */
+const AFTER_FILTER_PIPE = /\|\s*[A-Za-z0-9_]*$/
+const DETAIL_PREVIEW_MAX_LENGTH = 20
+
+export function isTemplateLanguage(language: string | undefined): language is TemplateLanguage {
+    return language === HogLanguage.hogTemplate || language === HogLanguage.liquid
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Offset at which the template expression containing the cursor starts, or null when the cursor sits
+ * in the literal text around it. Only text up to the cursor is considered, so an expression that the
+ * user has not closed yet still counts as open.
+ */
+function expressionStart(textBeforeCursor: string, language: TemplateLanguage): number | null {
+    if (language === HogLanguage.liquid) {
+        const open = Math.max(textBeforeCursor.lastIndexOf('{{'), textBeforeCursor.lastIndexOf('{%'))
+        if (open === -1) {
+            return null
+        }
+        const close = Math.max(textBeforeCursor.lastIndexOf('}}'), textBeforeCursor.lastIndexOf('%}'))
+        return close > open ? null : open + 2
+    }
+    const openOffsets: number[] = []
+    for (let index = 0; index < textBeforeCursor.length; index++) {
+        const character = textBeforeCursor[index]
+        if (character === '\\') {
+            index++
+        } else if (character === '{') {
+            openOffsets.push(index + 1)
+        } else if (character === '}') {
+            openOffsets.pop()
+        }
+    }
+    return openOffsets.length > 0 ? openOffsets[openOffsets.length - 1] : null
+}
+
+/**
+ * Keys of the chain that the completed word belongs to. The trailing segment is dropped either way:
+ * with a trailing dot it is empty, otherwise it is the partial word Monaco filters on.
+ */
+function parentChain(expressionTextBeforeCursor: string): string[] {
+    const match = CHAIN_BEFORE_CURSOR.exec(expressionTextBeforeCursor)
+    if (!match) {
+        return []
+    }
+    const parts = match[1].split('.')
+    parts.pop()
+    return parts
+}
+
+/** The object a chain resolves to within globals, or null when any step is missing or not an object. */
+function resolveChain(globals: Record<string, unknown> | undefined, chain: string[]): Record<string, unknown> | null {
+    let current: unknown = globals
+    for (const key of chain) {
+        if (!isPlainObject(current)) {
+            return null
+        }
+        current = current[key]
+    }
+    return isPlainObject(current) ? current : null
+}
+
+/** Type or truncated value shown next to a global, matching what the backend provider returned. */
+function globalDetail(value: unknown): string {
+    if (Array.isArray(value)) {
+        return 'Array'
+    }
+    if (isPlainObject(value)) {
+        return 'Object'
+    }
+    const serialized = JSON.stringify(value) ?? String(value)
+    return serialized.length > DETAIL_PREVIEW_MAX_LENGTH
+        ? `${serialized.slice(0, DETAIL_PREVIEW_MAX_LENGTH)}...`
+        : serialized
+}
+
+/** Mirrors the ordering the backend-backed provider applies, so both feel the same. */
+function sortText(kind: languages.CompletionItemKind, label: string): string {
+    if (kind === languages.CompletionItemKind.Variable) {
+        return `1-${label}`
+    }
+    if (kind === languages.CompletionItemKind.Function || kind === languages.CompletionItemKind.Method) {
+        return `2-${label}`
+    }
+    return `3-${label}`
+}
+
+function globalSuggestions(
+    members: Record<string, unknown>,
+    kind: languages.CompletionItemKind,
+    range: languages.CompletionItem['range']
+): languages.CompletionItem[] {
+    return Object.entries(members).map(([key, value]) => ({
+        label: { label: key, detail: globalDetail(value) },
+        insertText: key,
+        kind,
+        sortText: sortText(kind, key),
+        range,
+    }))
+}
+
+function hogFunctionSuggestions(range: languages.CompletionItem['range']): languages.CompletionItem[] {
+    return Object.entries(STL).map(([name, { description }]) => ({
+        label: name,
+        documentation: description,
+        insertText: `${name}()`,
+        kind: languages.CompletionItemKind.Function,
+        sortText: sortText(languages.CompletionItemKind.Function, name),
+        range,
+        // Park the cursor between the parentheses we just inserted.
+        command: { id: 'cursorLeft', title: 'Move cursor left' },
+    }))
+}
+
+function liquidFilterSuggestions(range: languages.CompletionItem['range']): languages.CompletionItem[] {
+    return LIQUID_FILTERS.map(({ name, detail }) => ({
+        label: { label: name, detail },
+        insertText: name,
+        kind: languages.CompletionItemKind.Function,
+        sortText: sortText(languages.CompletionItemKind.Function, name),
+        range,
+    }))
+}
+
+const emptyCompletionList = (): languages.CompletionList => ({ suggestions: [], incomplete: false })
+
+/**
+ * Autocomplete for Hog string templates and Liquid. Everything it offers is already in the browser:
+ * the globals the editor was handed, plus the Hog standard library. Resolving it here instead of
+ * posting a HogQLAutocomplete query keeps each keystroke off the network.
+ */
+export const templateAutocompleteProvider = (language: TemplateLanguage): languages.CompletionItemProvider => ({
+    triggerCharacters: [' ', ',', '.', '{', '|'],
+    provideCompletionItems: (model, position) => {
+        const logic: BuiltLogic<codeEditorLogicType> | undefined = (model as any).codeEditorLogic
+        if (!logic?.isMounted()) {
+            return emptyCompletionList()
+        }
+        const textBeforeCursor = model.getValue().slice(0, model.getOffsetAt(position))
+        const start = expressionStart(textBeforeCursor, language)
+        if (start === null) {
+            return emptyCompletionList()
+        }
+
+        const word = model.getWordUntilPosition(position)
+        const range: languages.CompletionItem['range'] = {
+            startLineNumber: position.lineNumber,
+            endLineNumber: position.lineNumber,
+            startColumn: word.startColumn,
+            endColumn: word.endColumn,
+        }
+        const expressionText = textBeforeCursor.slice(start)
+
+        if (language === HogLanguage.liquid && AFTER_FILTER_PIPE.test(expressionText)) {
+            return { suggestions: liquidFilterSuggestions(range), incomplete: false }
+        }
+
+        const globals: Record<string, unknown> | undefined = logic.props.globals
+        const chain = parentChain(expressionText)
+        const members = resolveChain(globals, chain)
+
+        if (chain.length > 0) {
+            return {
+                suggestions: members ? globalSuggestions(members, languages.CompletionItemKind.Field, range) : [],
+                incomplete: false,
+            }
+        }
+        return {
+            suggestions: [
+                ...(members ? globalSuggestions(members, languages.CompletionItemKind.Variable, range) : []),
+                ...(language === HogLanguage.hogTemplate ? hogFunctionSuggestions(range) : []),
+            ],
+            incomplete: false,
+        }
+    },
+})
+
+/**
+ * Monaco closes the suggest widget on backspace and does not reopen it, so a user who corrects a
+ * typo has to retype the trigger character. Reopen it ourselves while the cursor is still inside a
+ * template expression. Safe to do per keystroke only because these suggestions never hit the network.
+ */
+export function retriggerSuggestionsOnDeletion(
+    editorInstance: editor.IStandaloneCodeEditor,
+    language: TemplateLanguage
+): IDisposable {
+    return editorInstance.onDidChangeModelContent((event) => {
+        if (event.isFlush || !event.changes.some((change) => change.text === '' && change.rangeLength > 0)) {
+            return
+        }
+        if (!editorInstance.hasTextFocus()) {
+            return
+        }
+        const model = editorInstance.getModel()
+        const position = editorInstance.getPosition()
+        if (!model || !position) {
+            return
+        }
+        if (expressionStart(model.getValue().slice(0, model.getOffsetAt(position)), language) === null) {
+            return
+        }
+        editorInstance.trigger('deleteRetrigger', 'editor.action.triggerSuggest', {})
+    })
+}


### PR DESCRIPTION
## Problem

Autocomplete in templating inputs (workflow and destination fields) takes 1-2 seconds per suggestion, and deleting a character closes the suggestions without reopening them.
Every suggestion posts a `HogQLAutocomplete` query to the backend.
For Hog templates and Liquid the backend only walks the `globals` object the frontend itself sent, and appends the Hog standard library - data the browser already holds.

## Changes

- Hog template and Liquid editors now resolve suggestions in the browser, with no network request.
- A new provider finds the template expression around the cursor, walks the dot-chain into the editor's globals, and offers the members at that level.
- Hog templates also get the Hog standard library at the top level; Liquid gets a curated filter list after a `|`.
- Deleting a character now reopens the suggestions while the cursor stays inside an expression. This is wired only for the two template languages, so no other language can fire per-keystroke work.
- SQL, Hog, and JSON editors keep the backend provider unchanged, as does the backend validation (metadata) path for all languages.
- No visual change: the same suggest widget, now populated locally.

> [!NOTE]
> Two backend behaviors are dropped deliberately: suggestions for `{let ...}` variables declared inside the same template (needs the parse this PR removes), and the bytecode-only functions such as `arrayMap` (not exported by `@posthog/hogvm`; the suggestions popover already omits them).

Related: #81032 removes the schema build these requests paid for on the backend. The two PRs are independent; this one stops the requests entirely for template languages, that one speeds up the remaining callers.

## How did you test this code?

- New jest tests for the provider: chain walking into nested globals, top-level globals plus STL, Liquid output and tag delimiters, filter suggestions after `|`, no suggestions outside an expression, STL-only when globals are missing. No existing test covered any client-side completion path.
- The deletion re-trigger is untested; it needs a real editor instance.
- Not done: manual testing in a running app. The behavior claims above rest on the unit tests and code review only.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - no documented workflow changes; the same suggestions appear, faster.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by Michael (Silthus). External-contributor accounts cannot set assignees on this repo, so the DRI is named here instead.
Implemented by a Claude Opus 5 subagent in an isolated worktree; diff reviewed by Claude Fable 5 before push.
Skills invoked: /writing-tests, /writing-code-comments, /writing-user-facing-copy (Liquid filter details), /writing-pr-descriptions.
Session decisions: no guard against re-triggering while the widget is open (reaching Monaco's suggest controller needs private-state casts, and a local re-query is free); jest mocks `monaco-editor`'s `CompletionItemKind` with monaco's own numbering because jest resolves the package to type declarations.
