### PR TITLE
feat(hogli): read metabase cookies from arc

### DIFF
--- a/tools/hogli-commands/hogli_commands/metabase.py
+++ b/tools/hogli-commands/hogli_commands/metabase.py
@@ -40,6 +40,7 @@ _CHROMIUM_PROFILE_ROOTS: dict[str, list[Path]] = {
     "chrome": [_HOME / "Library/Application Support/Google/Chrome"],
     "chromium": [_HOME / "Library/Application Support/Chromium"],
     "brave": [_HOME / "Library/Application Support/BraveSoftware/Brave-Browser"],
+    "arc": [_HOME / "Library/Application Support/Arc/User Data"],
     "dia": [_HOME / "Library/Application Support/Dia/User Data"],
 }
 
@@ -54,7 +55,7 @@ REQUIRED_COOKIES: tuple[str, ...] = (
     "ph_int_auth-0",
     "ph_int_auth-1",
 )
-SUPPORTED_BROWSERS: tuple[str, ...] = ("chrome", "chromium", "brave", "dia", "firefox", "safari")
+SUPPORTED_BROWSERS: tuple[str, ...] = ("chrome", "chromium", "brave", "arc", "dia", "firefox", "safari")
 CACHE_DIR: Path = Path.home() / ".config" / "posthog" / "metabase"
 
 
@@ -69,7 +70,7 @@ def _format_cookie_header(cookies: dict[str, str]) -> str:
 def _enumerate_cookie_files(browser: str | None) -> list[tuple[str, Path]]:
     """Return (loader_name, cookie_file_path) pairs for every browser profile to try.
 
-    Chromium-family browsers (Chrome, Brave, Chromium, Dia) keep a `Cookies`
+    Chromium-family browsers (Chrome, Brave, Chromium, Arc, Dia) keep a `Cookies`
     SQLite db per profile (`Default`, `Profile 1`, ...). We glob each profile
     directory so users with multiple profiles (work + personal) don't have to
     care which one they logged in with.


### PR DESCRIPTION
## Problem

`hogli metabase:login` fails for anyone who browses in Arc, even with a live Metabase SSO session open in a tab.
The cookie scan covered chrome, chromium, brave, dia, firefox and safari, so Arc profiles were never read.
The failure shows up as a stale-cookie error that names no browser, so the cause is not obvious from the message.

## Changes

- `metabase.py` registers Arc's profile root at `~/Library/Application Support/Arc/User Data`, and adds `arc` to `SUPPORTED_BROWSERS`.
- Arc needs no custom loader. `browser_cookie3` ships an `arc` loader, so the existing `getattr(browser_cookie3, loader_name, None)` path resolves it, unlike Dia which still needs its local `ChromiumBased` shim.
- `browser-cookie3~=0.20` is already a dev dependency, so this adds no dependency.
- The `_enumerate_cookie_files` docstring lists Arc with the other Chromium-family browsers.

## How did you test this code?

I ran `hogli metabase:login --region us --browser arc --no-open`, which captured a working session cookie from Arc.
Follow-up `hogli metabase:databases` and `hogli metabase:query` calls succeeded with that cookie.

Claude re-checked the cheap parts: `--help` now lists `arc` in `--browser`, and profile discovery resolves `Default/Cookies` under the Arc root.
Claude could not exercise the Keychain decryption, which fails from an agent shell.

No test added. An Arc case would assert the same loader-resolution path as the existing chrome case in `test_load_cookies_filters_to_required_names`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing docs cover the `--browser` list.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I wrote the three-line change, then had Claude Code verify it, commit it, and open this PR.
Skills invoked: `/writing-pr-descriptions`.

We considered a test asserting the Arc loader resolves, and dropped it as a duplicate of the existing chrome coverage.
Nothing from the session reached this PR: no cookie values, tokens, or query results appear in the diff or this description.
