### PR TITLE
fix(llm-gateway): log unhandled exceptions and their 500 status

### DIFF
--- a/services/llm-gateway/src/llm_gateway/main.py
+++ b/services/llm-gateway/src/llm_gateway/main.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import os
 import time
+import traceback
 import uuid
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -78,26 +79,47 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         structlog.contextvars.bind_contextvars(request_id=request_id)
 
         start_time = time.monotonic()
+        # Stays None when neither branch below runs, which happens when the client disconnects and
+        # the request task is cancelled. Those requests get no status code, so logging one would
+        # invent a response the client never received.
+        status_code: int | None = None
 
-        response = await call_next(request)
-        response.headers["x-request-id"] = request_id
-
-        duration_ms = (time.monotonic() - start_time) * 1000
-
-        if request.url.path not in ("/_liveness", "/_readiness", "/metrics"):
-            logger.info(
-                "request",
+        try:
+            response = await call_next(request)
+            status_code = response.status_code
+            response.headers["x-request-id"] = request_id
+            if hasattr(request.app.state, "db_pool"):
+                update_db_pool_metrics(request.app.state.db_pool)
+            return response
+        except Exception as exc:
+            # Starlette's ServerErrorMiddleware sits above this middleware, so an exception escaping
+            # call_next is the 500 the client gets. Without logging it here the request would leave
+            # no line at all, and a status-code aggregation would read the failure as no traffic.
+            status_code = 500
+            logger.error(
+                "unhandled_exception",
                 method=request.method,
                 path=request.url.path,
-                status_code=response.status_code,
-                duration_ms=round(duration_ms, 2),
+                error_type=type(exc).__name__,
+                # The configured processor chain has no format_exc_info, so exc_info would render as
+                # a repr of the tuple instead of a traceback. Pass the formatted text explicitly,
+                # under the key structlog's own exception renderer would use.
+                exception=traceback.format_exc(),
             )
+            raise
+        finally:
+            duration_ms = (time.monotonic() - start_time) * 1000
 
-        if hasattr(request.app.state, "db_pool"):
-            update_db_pool_metrics(request.app.state.db_pool)
+            if status_code is not None and request.url.path not in ("/_liveness", "/_readiness", "/metrics"):
+                logger.info(
+                    "request",
+                    method=request.method,
+                    path=request.url.path,
+                    status_code=status_code,
+                    duration_ms=round(duration_ms, 2),
+                )
 
-        structlog.contextvars.unbind_contextvars("request_id")
-        return response
+            structlog.contextvars.unbind_contextvars("request_id")
 
 
 async def init_redis(url: str | None) -> Redis[bytes] | None:

--- a/services/llm-gateway/src/llm_gateway/main.py
+++ b/services/llm-gateway/src/llm_gateway/main.py
@@ -79,9 +79,9 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         structlog.contextvars.bind_contextvars(request_id=request_id)
 
         start_time = time.monotonic()
-        # Stays None when neither branch below runs, which happens when the client disconnects and
-        # the request task is cancelled. Those requests get no status code, so logging one would
-        # invent a response the client never received.
+        # CancelledError is a BaseException, so it escapes the except below and leaves this None.
+        # A request cancelled that way never produced a status code, so logging one would invent a
+        # response the client never received.
         status_code: int | None = None
 
         try:

--- a/services/llm-gateway/src/llm_gateway/main.py
+++ b/services/llm-gateway/src/llm_gateway/main.py
@@ -17,6 +17,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from redis.asyncio import Redis
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import ClientDisconnect
 from starlette.responses import Response
 from starlette.types import ASGIApp
 
@@ -79,9 +80,9 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         structlog.contextvars.bind_contextvars(request_id=request_id)
 
         start_time = time.monotonic()
-        # CancelledError is a BaseException, so it escapes the except below and leaves this None.
-        # A request cancelled that way never produced a status code, so logging one would invent a
-        # response the client never received.
+        # Stays None for a client that went away: CancelledError is a BaseException and escapes the
+        # except clauses below, and ClientDisconnect is re-raised untouched. Neither produced a
+        # status code, so logging one would invent a response the client never received.
         status_code: int | None = None
 
         try:
@@ -91,6 +92,11 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
             if hasattr(request.app.state, "db_pool"):
                 update_db_pool_metrics(request.app.state.db_pool)
             return response
+        except ClientDisconnect:
+            # A plain Exception, so without this it would take the clause below and report a 500 the
+            # aborting client never saw. The rest of the service treats a disconnect as ordinary
+            # traffic too (see the disconnect counters in api/handler.py and api/anthropic.py).
+            raise
         except Exception as exc:
             # Starlette's ServerErrorMiddleware sits above this middleware, so an exception escaping
             # call_next is the 500 the client gets. Without logging it here the request would leave

--- a/services/llm-gateway/tests/test_main.py
+++ b/services/llm-gateway/tests/test_main.py
@@ -4,6 +4,7 @@ import pytest
 import structlog
 from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
+from starlette.requests import ClientDisconnect
 from structlog.testing import capture_logs
 
 from llm_gateway.config import Settings, get_settings
@@ -172,6 +173,13 @@ def _middleware_test_client() -> TestClient:
     def raises() -> dict[str, bool]:
         return {"ok": True}
 
+    def abandon_request() -> None:
+        raise ClientDisconnect
+
+    @app.get("/disconnects", dependencies=[Depends(abandon_request)])
+    def disconnects() -> dict[str, bool]:
+        return {"ok": True}
+
     return TestClient(app, raise_server_exceptions=False)
 
 
@@ -206,3 +214,14 @@ class TestRequestLoggingMiddleware:
 
         request_lines = [log for log in logs if log["event"] == "request"]
         assert errors[0]["request_id"] == request_lines[0]["request_id"]
+
+    def test_client_disconnect_logs_neither_an_error_nor_a_status(self) -> None:
+        # ClientDisconnect is a plain Exception, so a client aborting mid-body would otherwise be
+        # reported as a 500 it never saw, and every abort would raise an error-level event.
+        client = _middleware_test_client()
+
+        with capture_logs() as logs:
+            client.get("/disconnects")
+
+        assert [log for log in logs if log["event"] == "unhandled_exception"] == []
+        assert [log for log in logs if log["event"] == "request"] == []

--- a/services/llm-gateway/tests/test_main.py
+++ b/services/llm-gateway/tests/test_main.py
@@ -1,9 +1,13 @@
 import os
 
 import pytest
+import structlog
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+from structlog.testing import capture_logs
 
 from llm_gateway.config import Settings, get_settings
-from llm_gateway.main import export_provider_credentials
+from llm_gateway.main import RequestLoggingMiddleware, export_provider_credentials
 
 _EXPORTED_ENV_VARS = (
     "ANTHROPIC_API_KEY",
@@ -151,3 +155,54 @@ class TestExportProviderCredentials:
 
         export_provider_credentials(settings)
         assert os.environ["OPENAI_BASE_URL"] == "https://eu.api.openai.com/v1"
+
+
+def _middleware_test_client() -> TestClient:
+    app = FastAPI()
+    app.add_middleware(RequestLoggingMiddleware)
+
+    def refuse_to_read_postgres() -> None:
+        raise RuntimeError("permission denied for table posthog_team")
+
+    @app.get("/ok")
+    def ok() -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.get("/raises", dependencies=[Depends(refuse_to_read_postgres)])
+    def raises() -> dict[str, bool]:
+        return {"ok": True}
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestRequestLoggingMiddleware:
+    def test_every_request_gets_one_request_line_with_the_status_the_client_saw(self) -> None:
+        # Guards the regression where a raising dependency leaves no request line, which makes a
+        # status-code aggregation over these logs read a total outage as zero traffic.
+        client = _middleware_test_client()
+
+        with capture_logs() as logs:
+            assert client.get("/ok").status_code == 200
+            assert client.get("/raises").status_code == 500
+
+        assert [(log["path"], log["status_code"]) for log in logs if log["event"] == "request"] == [
+            ("/ok", 200),
+            ("/raises", 500),
+        ]
+
+    def test_unhandled_exception_is_logged_at_error_level_with_its_traceback(self) -> None:
+        client = _middleware_test_client()
+
+        with capture_logs(processors=[structlog.contextvars.merge_contextvars]) as logs:
+            client.get("/raises")
+
+        errors = [log for log in logs if log["event"] == "unhandled_exception"]
+        assert len(errors) == 1
+        assert errors[0]["log_level"] == "error"
+        assert errors[0]["method"] == "GET"
+        assert errors[0]["path"] == "/raises"
+        assert errors[0]["error_type"] == "RuntimeError"
+        assert "permission denied for table posthog_team" in errors[0]["exception"]
+
+        request_lines = [log for log in logs if log["event"] == "request"]
+        assert errors[0]["request_id"] == request_lines[0]["request_id"]


### PR DESCRIPTION
Human tl;dr: AI description below pretty solid - origin boils down to `#inc-2026-08-11-ai-tasks-elevated-errors`. We had no logging on this class of LLM gateway errors, which prolonged debugging via logs. Let's ensure coverage.

## Problem

On 2026-08-11 the LLM gateway returned 500 to one class of requests for six and a half hours. Monitoring did not show the failure.

- The auth dependency raised an exception on each request that carried an `x-posthog-project-id` header and an OAuth token. Those requests were all cloud AI task runs.
- Other callers did not fail. Desktop local runs continued to work.
- The exception escaped `call_next` inside the request-logging middleware.
- The middleware writes its `request` event after `call_next` returns. A request that raises an exception writes no line at all.
- The logs held about 14 lines with `status_code: 500` in 14 hours. The true rate was about 13,500 per hour.
- A status-code dashboard therefore showed the failed traffic as absent, not as failed.
- The traceback went to the uvicorn stdlib logger instead of structlog. It arrives with `severity_text: info`.
- An alert on error severity cannot find an unhandled exception.
- Both faults are on master now. They are independent of the change that caused the outage (#80720, reverted in #81030, re-landed in #81035). This PR changes neither that code nor auth.

## Changes

- Each request now writes one `request` log line. That line holds the status the client received, including the 500 from a dependency that raises an exception.
- A new error-level `unhandled_exception` event holds the traceback, the exception type, the path, the method and the request ID.
- `RequestLoggingMiddleware` puts `call_next` inside a `try`/`except`/`finally` block. The `request` line moves into the `finally` block.
- The middleware raises the exception again, so `ServerErrorMiddleware` builds the same 500 response. This PR changes no contract. It does not change the request shape, the response shape, auth, routing, or attribution.
- The traceback goes into an explicit `exception` field. The configured structlog processors do not include `format_exc_info`, so `exc_info` shows a repr of the tuple instead of a traceback. `api/anthropic.py` records the same constraint.
- A request that the client disconnects writes no line and no error event. Neither disconnect gives a status code. A 500 in the log would make the aggregation wrong.
- `CancelledError` is a `BaseException`. It escapes the `except` clauses without help.
- `ClientDisconnect` is an `Exception`. It needs its own clause above the general clause. `Request.stream()` raises it when a client disconnects during a POST body. This is normal traffic for a gateway that streams.
- Without that clause, each disconnect writes an error-level event with a traceback. That volume makes `unhandled_exception` useless for an alert.
- Other parts of the service also count a disconnect as normal traffic. See the disconnect counters in `api/handler.py` and `api/anthropic.py`.

I rejected a Starlette exception handler for `Exception`. Starlette runs that handler inside `ServerErrorMiddleware`. That middleware sits above this middleware, and it raises the exception again afterwards. The handler therefore cannot restore the missing `request` line, and it cannot stop the uvicorn traceback.

### Why this change lands on the frozen Python gateway

`services/llm-gateway/PARITY.md` permits a reliability fix for a caller that still needs the Python gateway. First-party products and cloud agents are such callers. An incident caused this change, and it is an observability fix on their request path. It changes no contract in the parity map. PARITY.md therefore needs no update, and I did not run `/auditing-llm-gateway-parity`.

### Prometheus recorded these responses

`prometheus-fastapi-instrumentator` writes `http_requests_total` from a `finally` block, and its default status is 500. It therefore counted these responses. I confirmed this on a local route with a dependency that raises an exception. The metrics path showed the outage. Only the log path did not. This PR does not change the instrumentation.

## How did you test this code?

- I reproduced both faults on master. I used a local FastAPI app with this middleware and a dependency that raises an exception. The app wrote no `request` line and no error-level event, and `http_requests_total{status="500"}` was 1.
- I added three tests to `services/llm-gateway/tests/test_main.py`.
- Test 1 catches the fault that shipped. A dependency that raises an exception writes no `request` line, so no line holds the 500.
- Test 2 catches an unhandled exception that writes below error level, loses its traceback, or loses its request ID.
- Test 3 catches a client disconnect that writes an error event or a false 500.
- I ran each test against the code without its fix, and each test failed. I then ran each test against the fix, and each test passed.
- Test 3 fails with `error_type: ClientDisconnect` at `log_level: error`. That is the noise the test prevents.
- `pytest tests` in `services/llm-gateway` gives 20 passed for this module. The full suite gives 1466 passed, 50 skipped and 52 xpassed.
- I did not test against a deployed gateway, so I did not see the new line in PostHog logs. The local test uses the real processor chain, and the JSON holds `"level": "error"`.
