### PR TITLE
chore(ci): resolve proto merge-queue lanes per tree

### DIFF
--- a/.github/scripts/trunk-impacted-targets.js
+++ b/.github/scripts/trunk-impacted-targets.js
@@ -1312,10 +1312,10 @@ const PROTO_TREES = new Map([
     ['personhog', { crates: ['personhog-proto'], domains: [PYTHON, NODE] }],
 ])
 
-// A file sitting directly at proto/ configures every tree at once (buf's lint
-// and breaking-change settings), so it takes the union. A subdirectory the
-// table does not name has unknown consumers and widens, which is what makes
-// adding a tree without declaring it here safe rather than silent.
+// A file directly under proto/ is treated as impacting all trees, since it's not
+// scoped to a single proto subdirectory. A subdirectory the table does not name
+// has unknown consumers and widens, which is what makes adding a tree without
+// declaring it here safe rather than silent.
 function addProtoLanes(targets, context, file) {
     const segments = file.split('/')
     const trees =

--- a/.github/scripts/trunk-impacted-targets.js
+++ b/.github/scripts/trunk-impacted-targets.js
@@ -127,10 +127,10 @@ const RUST = 'rust'
 // those files can reach.
 const PRODUCT_SURFACE = 'product-surface'
 
-// The three proto trees, named for their consumers for the same reason. Every
-// consumer generates stubs from them, so the set is enumerable: tonic builds
-// the rust ones on `cargo build`, and the personhog stubs are checked in for
-// both python and nodejs.
+// The proto trees, named for their consumers for the same reason. Every
+// consumer generates stubs, so the set is enumerable: tonic builds the rust
+// ones on `cargo build`, and the personhog stubs are checked in for both python
+// and nodejs. Resolved per tree rather than per file, against PROTO_TREES.
 const PROTO = 'proto'
 
 // Resolved per file from the rule's own `languages:` declaration rather than
@@ -1288,18 +1288,61 @@ function addNodeLanes(targets) {
     return true
 }
 
-// proto/README.md's consumer table is the source for this set, and the stubs
-// themselves are the check on it: every consumer commits generated code, so a
-// tree that reads a proto without one would be reading nothing. The nodejs half
-// takes the node domain rather than the javascript one because the stubs land
-// only in nodejs/src/common/generated; no frontend or services package imports
-// them.
-function addProtoLanes(targets, context) {
-    if (!addRustLanes(targets, context)) {
+// Each proto tree and the consumers that generate from it. proto/README.md's
+// consumer table is the source, and the generated code is the check on it: a
+// consumer that read a proto without committing stubs would be reading nothing.
+// A test re-derives both halves from the tree — the crate from the build.rs
+// that compiles the tree, the stub directories from disk — so a renamed crate
+// or a fourth consumer fails there rather than going unclaimed here.
+//
+// The rust half names the crate that compiles the tree rather than every crate.
+// tonic turns the tree into that crate's generated module and nothing else, so
+// the crates a proto change can break are the ones that depend on it, which is
+// the reverse closure computeTargets already runs over every rust:crate: target
+// it holds. That is the same treatment a file inside the crate would get.
+//
+// The nodejs half takes the node domain rather than the javascript one because
+// the stubs land only in nodejs/src/common/generated; no frontend or services
+// package imports them. The python half cannot narrow below every python lane:
+// the stubs are checked into posthog/, which is py:core, and py:core covers
+// every product lane by construction.
+const PROTO_TREES = new Map([
+    ['cymbal', { crates: ['cymbal-proto'], domains: [] }],
+    ['kafka_assigner', { crates: ['kafka-assigner-proto'], domains: [] }],
+    ['personhog', { crates: ['personhog-proto'], domains: [PYTHON, NODE] }],
+])
+
+// A file sitting directly at proto/ configures every tree at once (buf's lint
+// and breaking-change settings), so it takes the union. A subdirectory the
+// table does not name has unknown consumers and widens, which is what makes
+// adding a tree without declaring it here safe rather than silent.
+function addProtoLanes(targets, context, file) {
+    const segments = file.split('/')
+    const trees =
+        segments.length === 2 ? [...PROTO_TREES.keys()] : [segments[1]].filter((tree) => PROTO_TREES.has(tree))
+    if (trees.length === 0 || !context.rustGraph) {
         return false
     }
-    addPythonLanes(targets, context)
-    return addNodeLanes(targets)
+    for (const tree of trees) {
+        const { crates, domains } = PROTO_TREES.get(tree)
+        // A crate renamed out from under the table would drop the rust half
+        // silently, which is the under-reporting direction.
+        if (crates.some((crate) => !context.rustGraph.dependsOn.has(crate))) {
+            console.error(
+                `No crate named for proto tree ${tree}; widening to every target until PROTO_TREES is updated`
+            )
+            return false
+        }
+        for (const crate of crates) {
+            targets.add(rustCrate(crate))
+        }
+        for (const domain of domains) {
+            if (!DOMAIN_LANES.get(domain)(targets, context)) {
+                return false
+            }
+        }
+    }
+    return true
 }
 
 const DOMAIN_LANES = new Map([
@@ -1316,7 +1359,7 @@ const DOMAIN_LANES = new Map([
 function applyTripwireDomain(domain, file, targets, context) {
     const resolved = domain === SEMGREP ? (context.semgrepDomains || new Map()).get(file) || UNIVERSAL : domain
     const addLanes = DOMAIN_LANES.get(resolved)
-    return addLanes ? addLanes(targets, context) : false
+    return addLanes ? addLanes(targets, context, file) : false
 }
 
 // Paths under rust/ that belong to no crate, and the domains that read them. A
@@ -1750,6 +1793,8 @@ module.exports = {
     ALL,
     JAVASCRIPT,
     NATIVE_BINDING_CONSUMER_LANES,
+    NODE,
+    PROTO_TREES,
     PYTHON,
     REPO_ROOT,
     RUNTIME_SPAWN_EDGES,

--- a/.github/scripts/trunk-impacted-targets.test.js
+++ b/.github/scripts/trunk-impacted-targets.test.js
@@ -21,6 +21,7 @@ const {
     isProductDirectory,
     isTripwire,
     parseCrateDependencies,
+    parseCrateName,
     parsePytestIgnores,
     parseSemgrepLanguages,
     parseWorkspacePackageGlobs,
@@ -30,6 +31,8 @@ const {
     ALL,
     JAVASCRIPT,
     NATIVE_BINDING_CONSUMER_LANES,
+    NODE,
+    PROTO_TREES,
     PYTHON,
     REPO_ROOT,
     RUNTIME_SPAWN_EDGES,
@@ -94,6 +97,32 @@ layer = "modules"
         tachDependents,
     },
 }
+
+// PROTO_TREES names the crates that compile each tree, so the crate half of
+// this graph has to carry their real names. The dependent and the bystander are
+// synthetic, which is what keeps the closure assertions off the real crate
+// graph.
+const PROTO_CONTEXT = {
+    ...CONTEXT,
+    rustGraph: {
+        dependsOn: new Map([
+            ['cymbal-proto', []],
+            ['kafka-assigner-proto', []],
+            ['personhog-proto', []],
+            ['personhog-consumer', ['personhog-proto']],
+            ['unrelated', []],
+        ]),
+        byDir: [
+            { dir: 'cymbal-proto', name: 'cymbal-proto' },
+            { dir: 'kafka-assigner-proto', name: 'kafka-assigner-proto' },
+            { dir: 'personhog-proto', name: 'personhog-proto' },
+            { dir: 'personhog-consumer', name: 'personhog-consumer' },
+            { dir: 'unrelated', name: 'unrelated' },
+        ],
+    },
+}
+
+const PROTO_EVERYTHING = allKnownTargets(PROTO_CONTEXT)
 
 // gamma vendors its own pnpm workspace; alpha and beta keep the conventional
 // backend/ + frontend/ layout, so the cases above stay on the old behavior.
@@ -169,16 +198,23 @@ test('a lockfile claims its own toolchain rather than every lane', () => {
 })
 
 // Every consumer of a proto commits the stubs generated from it, so the set is
-// enumerable rather than open-ended: tonic for the crates, and checked-in
-// personhog stubs for python and nodejs. The frontend and services lanes are
-// the ones this buys, and a new consumer tree has to fail here.
-test('a proto claims its three consumer toolchains rather than every lane', () => {
-    const targets = computeTargets(['proto/personhog/types/v1/person.proto'], CONTEXT)
-    for (const target of ['py:core', 'py:product:alpha', 'rust:crate:shared', 'node:ingestion']) {
+// enumerable rather than open-ended: tonic for the crate, and checked-in
+// personhog stubs for python and nodejs. The rust half is the crate that
+// compiles the tree plus the dependents the closure adds, not every crate.
+test('a proto claims the consumers that generate from it rather than every lane', () => {
+    const targets = computeTargets(['proto/personhog/types/v1/person.proto'], PROTO_CONTEXT)
+    for (const target of [
+        'py:core',
+        'py:product:alpha',
+        'node:ingestion',
+        'rust:crate:personhog-proto',
+        'rust:crate:personhog-consumer',
+    ]) {
         assert.equal(targets.includes(target), true, target)
     }
-    assert.equal(targets.includes('fe:core'), false)
-    assert.equal(targets.includes('svc:mcp'), false)
+    for (const target of ['fe:core', 'svc:mcp', 'rust:crate:cymbal-proto', 'rust:crate:unrelated']) {
+        assert.equal(targets.includes(target), false, target)
+    }
 
     const generatedDirs = [
         'posthog/personhog_client/proto/generated',
@@ -187,6 +223,125 @@ test('a proto claims its three consumer toolchains rather than every lane', () =
     ]
     for (const dir of generatedDirs) {
         assert.equal(fs.existsSync(path.join(REPO_ROOT, dir)), true, `${dir} is the stub tree its lane stands for`)
+    }
+})
+
+// The narrowing the per-tree table buys: a tree nothing outside rust/ generates
+// from used to serialize against every python lane in the repo.
+test('a proto tree with no stubs outside rust claims neither python nor nodejs', () => {
+    assert.deepEqual(computeTargets(['proto/cymbal/resolution/v1/resolution.proto'], PROTO_CONTEXT), [
+        'rust:crate:cymbal-proto',
+    ])
+    assert.deepEqual(computeTargets(['proto/kafka_assigner/v1/service.proto'], PROTO_CONTEXT), [
+        'rust:crate:kafka-assigner-proto',
+    ])
+})
+
+// buf's lint and breaking-change settings sit at the root and govern every
+// tree, so a file there can break any consumer of any of them.
+test('proto configuration at the root claims every tree', () => {
+    const union = new Set()
+    for (const file of [
+        'proto/personhog/types/v1/person.proto',
+        'proto/cymbal/resolution/v1/resolution.proto',
+        'proto/kafka_assigner/v1/service.proto',
+    ]) {
+        for (const target of computeTargets([file], PROTO_CONTEXT)) {
+            union.add(target)
+        }
+    }
+    assert.deepEqual(computeTargets(['proto/buf.yaml'], PROTO_CONTEXT), [...union].sort())
+})
+
+// The two ways the table can go stale. Both are the under-reporting direction —
+// a tree whose consumers are unknown, and a crate the table can no longer
+// find — so both widen rather than claiming the lanes they can still name.
+test('an undeclared proto tree or a renamed proto crate widens', () => {
+    assert.deepEqual(computeTargets(['proto/newthing/v1/service.proto'], PROTO_CONTEXT), PROTO_EVERYTHING)
+
+    const renamed = {
+        ...PROTO_CONTEXT,
+        rustGraph: {
+            ...PROTO_CONTEXT.rustGraph,
+            dependsOn: new Map([...PROTO_CONTEXT.rustGraph.dependsOn].filter(([crate]) => crate !== 'personhog-proto')),
+        },
+    }
+    assert.deepEqual(computeTargets(['proto/personhog/types/v1/person.proto'], renamed), allKnownTargets(renamed))
+})
+
+// The table is declared rather than derived, so the tree it describes has to
+// fail here when it moves. Reads the real repo for that reason: the crate half
+// comes from the build.rs that compiles each tree, which is the same file tonic
+// reads, so a tree compiled by a second crate or by a renamed one shows up.
+test('every proto tree is declared, with the crate that compiles it', () => {
+    const trees = fs
+        .readdirSync(path.join(REPO_ROOT, 'proto'), { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name)
+    assert.deepEqual(trees.sort(), [...PROTO_TREES.keys()].sort())
+
+    const compiledBy = new Map()
+    const walk = (dir, depth) => {
+        if (depth > 3) {
+            return
+        }
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+            const full = path.join(dir, entry.name)
+            if (entry.isDirectory() && entry.name !== 'target' && !entry.name.startsWith('.')) {
+                walk(full, depth + 1)
+                continue
+            }
+            if (entry.name !== 'build.rs') {
+                continue
+            }
+            const text = fs.readFileSync(full, 'utf8')
+            const referenced = [...text.matchAll(/\{proto_root\}\/([A-Za-z0-9_]+)\//g)].map((match) => match[1])
+            if (referenced.length === 0) {
+                // The three build scripts share the {proto_root}/<tree>/ idiom
+                // the regex above keys on. One that compiles protos some other
+                // way would read as compiling none, so it fails here rather
+                // than leaving its tree looking unclaimed by any crate.
+                assert.equal(
+                    text.includes('compile_protos'),
+                    false,
+                    `${full} compiles protos the derivation cannot see`
+                )
+                continue
+            }
+            const crate = parseCrateName(fs.readFileSync(path.join(dir, 'Cargo.toml'), 'utf8'))
+            for (const tree of referenced) {
+                compiledBy.set(tree, [...new Set([...(compiledBy.get(tree) || []), crate])].sort())
+            }
+        }
+    }
+    walk(path.join(REPO_ROOT, 'rust'), 0)
+
+    for (const [tree, { crates }] of PROTO_TREES) {
+        assert.deepEqual(compiledBy.get(tree), [...crates].sort(), `crates compiling proto/${tree}`)
+    }
+})
+
+// The other half of the same guard. It reads the two roots the checked-in stubs
+// land in today, so a tree that starts generating into one of them without
+// declaring the domain fails here. A consumer that generates into a root
+// neither of these names is still only caught by review.
+test('every proto tree declaring a stub consumer has stubs there, and no other tree does', () => {
+    const stubRoots = [
+        ['posthog/personhog_client/proto/generated', PYTHON],
+        ['nodejs/src/common/generated', NODE],
+    ]
+    for (const [root, domain] of stubRoots) {
+        const generated = fs
+            .readdirSync(path.join(REPO_ROOT, root), { withFileTypes: true })
+            .filter((entry) => entry.isDirectory())
+            .map((entry) => entry.name)
+        for (const [tree, { domains }] of PROTO_TREES) {
+            assert.equal(
+                generated.includes(tree),
+                domains.includes(domain),
+                `proto/${tree} stubs in ${root} must match its declared ${domain} consumer`
+            )
+        }
     }
 })
 


### PR DESCRIPTION
## Problem

A PR that touches any file under `proto/` waits behind every backend PR in the merge queue, even when nothing outside `rust/` reads that proto.

- Trunk runs two PRs in parallel only when their target sets are disjoint, so a PR claiming every python lane serializes against all backend work.
- `.github/scripts/trunk-impacted-targets.js` maps all of `proto/**` to one domain, which claims every rust crate, every python lane, and the nodejs lane.
- The three trees do not share consumers. Only `personhog` commits stubs for python and nodejs; `cymbal` and `kafka_assigner` are read by one crate each.
- [PR #80701](https://github.com/PostHog/posthog/pull/80701) claimed 162 targets, 85 of them `py:*`, for a diff of one proto file and nine rust files.

## Changes

- `PROTO_TREES` declares each tree with the crates that compile it and the consumer domains it reaches.
- The rust half names the compiling crate. The reverse closure `computeTargets` already runs adds that crate's dependents, which is the treatment a file inside the crate gets.
- A file directly at `proto/` takes the union of every tree, because buf's lint and breaking-change settings govern all of them.
- An undeclared tree, or a crate the table can no longer find, widens to every target. This mirrors `RUST_NON_CRATE_RULES` and `RUNTIME_SPAWN_EDGES`.
- The python half of `personhog` does not narrow. Its stubs live under `posthog/`, which is `py:core`, and `py:core` covers every product lane by construction.

Targets claimed, computed by running the script over each path:

| Change | Before | After |
| --- | ---: | ---: |
| PR #80701 (`proto/personhog` plus rust files) | 162 | 104 (rust 74 → 11) |
| `proto/cymbal/resolution/v1/resolution.proto` | 162 | 2 |
| `proto/kafka_assigner/v1/service.proto` | 162 | 3 |
| `proto/buf.yaml` | 162 | 108 |

> [!NOTE]
> Reporting too few targets lets conflicting PRs merge side by side, so each narrowing here rests on a check. The rust one rests on tonic compiling a tree into exactly one crate, which the three `build.rs` files show. The python and nodejs ones rest on the checked-in stubs, which two tests re-derive from disk.

## How did you test this code?

`node --test .github/scripts/trunk-impacted-targets.test.js`, plus the neighboring `trunk-lane-telemetry` and `turbo-discover-cascade` suites, which CI also runs.

New tests, and the regression each catches:

- A tree with no stubs outside rust claims no python or nodejs lane. This is the narrowing itself, so nothing else fails if the table stops being read.
- An undeclared tree, and a renamed crate, both widen. Either one silently dropping half a claim is the failure mode that breaks master.
- Root configuration claims the union of the trees, asserted against the three per-tree results rather than a hardcoded list.
- Two guards read the real repo: every directory under `proto/` is declared, its crate is re-derived from the `build.rs` that compiles it, and a tree has stubs in a generated root only when it declares that consumer.

I did not observe lane assignment in Trunk itself. The evidence above is the script's output for those paths, not queue behavior.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. `proto/README.md`'s consumer table is the source for the new table and is already accurate.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude Opus 5, via Claude Code) wrote this after tracing why a personhog proto PR expanded to all `py:*` lanes. Skills invoked: `/writing-pr-descriptions`.

The first shape I considered fed each tree's generated-artifact paths back through the script's own path rules, so the radius would be derived rather than declared. I dropped it: the table is three entries, and recursion through `computeTargets` would have to answer what a nested widening or a `prose` result means. Declaring the table and making two tests re-derive it from `build.rs` and the stub directories gives the same drift protection with less machinery.

The branch sits behind master, which changed no file this PR touches.
