### PR TITLE
feat(desktop): sync agent instructions from the home root too

### DIFF
--- a/products/desktop/packages/ui/src/features/settings/sections/PersonalizationSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/PersonalizationSettings.tsx
@@ -54,9 +54,9 @@ export function PersonalizationSettingsView({
         {syncFromFile && !synced && (
           <Callout.Root size="1" color="amber" mb="2">
             <Callout.Text>
-              No AGENTS.md or CLAUDE.md found in ~/.agents, ~/.codex or
-              ~/.claude. Nothing is synced — add one of those files, or turn
-              sync off to use the instructions below.
+              No AGENTS.md or CLAUDE.md found in your home directory or in
+              ~/.agents, ~/.codex or ~/.claude. Nothing is synced — add one of
+              those files, or turn sync off to use the instructions below.
             </Callout.Text>
           </Callout.Root>
         )}

--- a/products/desktop/packages/workspace-server/src/services/os/os.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/os/os.test.ts
@@ -179,6 +179,8 @@ describe("OsService.getUserAgentInstructions", () => {
   const agentsPath = path.join(home, ".agents", "AGENTS.md");
   const codexPath = path.join(home, ".codex", "AGENTS.md");
   const claudePath = path.join(home, ".claude", "CLAUDE.md");
+  const rootAgentsPath = path.join(home, "AGENTS.md");
+  const rootClaudePath = path.join(home, "CLAUDE.md");
 
   function givenFiles(files: Record<string, string>) {
     mockReadFile.mockImplementation(async (filePath: string) => {
@@ -215,6 +217,61 @@ describe("OsService.getUserAgentInstructions", () => {
     {
       label: "falls back to the user CLAUDE.md when no AGENTS.md exists",
       files: { [claudePath]: "claude instructions" },
+      winner: {
+        path: claudePath,
+        displayPath: "~/.claude/CLAUDE.md",
+        content: "claude instructions",
+      },
+    },
+    {
+      label: "reads ~/AGENTS.md at the home root",
+      files: { [rootAgentsPath]: "root agents instructions" },
+      winner: {
+        path: rootAgentsPath,
+        displayPath: "~/AGENTS.md",
+        content: "root agents instructions",
+      },
+    },
+    {
+      label: "reads ~/CLAUDE.md at the home root",
+      files: { [rootClaudePath]: "root claude instructions" },
+      winner: {
+        path: rootClaudePath,
+        displayPath: "~/CLAUDE.md",
+        content: "root claude instructions",
+      },
+    },
+    {
+      label: "prefers ~/.agents/AGENTS.md over the home-root AGENTS.md",
+      files: {
+        [agentsPath]: "agents instructions",
+        [rootAgentsPath]: "root agents instructions",
+      },
+      winner: {
+        path: agentsPath,
+        displayPath: "~/.agents/AGENTS.md",
+        content: "agents instructions",
+      },
+    },
+    {
+      label: "prefers the home-root AGENTS.md over any CLAUDE.md",
+      files: {
+        [rootAgentsPath]: "root agents instructions",
+        [claudePath]: "claude instructions",
+        [rootClaudePath]: "root claude instructions",
+      },
+      winner: {
+        path: rootAgentsPath,
+        displayPath: "~/AGENTS.md",
+        content: "root agents instructions",
+      },
+    },
+    {
+      label: "prefers ~/.claude/CLAUDE.md over the home-root CLAUDE.md",
+      files: {
+        [claudePath]: "claude instructions",
+        [rootClaudePath]: "root claude instructions",
+      },
       winner: {
         path: claudePath,
         displayPath: "~/.claude/CLAUDE.md",

--- a/products/desktop/packages/workspace-server/src/services/os/os.ts
+++ b/products/desktop/packages/workspace-server/src/services/os/os.ts
@@ -49,14 +49,18 @@ const MAX_FILE_SIZE = 50 * 1024 * 1024;
 const CLIPBOARD_TEMP_DIR = path.join(os.tmpdir(), "posthog-code-clipboard");
 const claudeSettingsPath = path.join(os.homedir(), ".claude", "settings.json");
 
-// User-level agent instruction files, most-preferred first: AGENTS.md (the
-// cross-agent convention) from any of its conventional homes wins over Claude
-// Code's CLAUDE.md.
-const USER_AGENT_INSTRUCTIONS_CANDIDATES: ReadonlyArray<[string, string]> = [
+// User-level agent instruction files as path segments under the home
+// directory, most-preferred first: AGENTS.md (the cross-agent convention) from
+// any of its conventional homes wins over Claude Code's CLAUDE.md, and a
+// tool-specific home wins over the bare home root. Only the first match is
+// read, so pointing several of these at one file still syncs it once.
+const USER_AGENT_INSTRUCTIONS_CANDIDATES: ReadonlyArray<readonly string[]> = [
   [".agents", "AGENTS.md"],
   [".codex", "AGENTS.md"],
   [".claude", "AGENTS.md"],
+  ["AGENTS.md"],
   [".claude", "CLAUDE.md"],
+  ["CLAUDE.md"],
 ];
 
 // Claude Code follows `@path` imports up to four hops deep; we match that so a
@@ -113,8 +117,8 @@ export class OsService {
    * user's CLAUDE.md. Null when none exists.
    */
   async getUserAgentInstructions(): Promise<UserAgentInstructions | null> {
-    for (const [dir, file] of USER_AGENT_INSTRUCTIONS_CANDIDATES) {
-      const filePath = path.join(os.homedir(), dir, file);
+    for (const segments of USER_AGENT_INSTRUCTIONS_CANDIDATES) {
+      const filePath = path.join(os.homedir(), ...segments);
       let content: string;
       try {
         content = await fsPromises.readFile(filePath, "utf-8");
@@ -133,7 +137,7 @@ export class OsService {
       const truncated = expanded.length > USER_AGENT_INSTRUCTIONS_MAX_LENGTH;
       return {
         path: filePath,
-        displayPath: `~/${dir}/${file}`,
+        displayPath: `~/${segments.join("/")}`,
         content: truncated
           ? expanded.slice(0, USER_AGENT_INSTRUCTIONS_MAX_LENGTH)
           : expanded,


### PR DESCRIPTION
## Problem

Personalization sync looks for user-level agent instructions in `~/.agents`, `~/.codex` and `~/.claude` only. A plain `~/AGENTS.md` — the location Claude Code itself reads — isn't a candidate, so sync finds nothing and the settings pane shows:

> No AGENTS.md or CLAUDE.md found in ~/.agents, ~/.codex or ~/.claude.

...even though the user has the file the agent is actually reading.

## Change

Add `~/AGENTS.md` and `~/CLAUDE.md` to `USER_AGENT_INSTRUCTIONS_CANDIDATES`, preserving the existing ordering principle: every `AGENTS.md` outranks `CLAUDE.md`, and a tool-specific home outranks the bare home root.

```
.agents/AGENTS.md
.codex/AGENTS.md
.claude/AGENTS.md
AGENTS.md          <- new
.claude/CLAUDE.md
CLAUDE.md          <- new
```

Resolution already returns on the first non-empty match, so nothing is read twice: someone who symlinks both `~/AGENTS.md` and `~/.agents/AGENTS.md` at one file still syncs it once.

Candidates are now path segments rather than `[dir, file]` pairs, so a root-level file doesn't need an empty directory segment special-cased; `displayPath` joins the same segments.

## Behaviour change to be aware of

One existing case resolves differently: with **both** `~/AGENTS.md` and `~/.claude/CLAUDE.md` present, sync now picks `~/AGENTS.md`.

That's the intent rather than a side effect — such a user was syncing `CLAUDE.md` while their agent read `AGENTS.md`. It's covered by a test. Say the word if you'd rather the root sort strictly last so the change is purely additive.

## Tests

Six cases added to the existing `it.each` block in `os.test.ts`, covering both new locations, both new precedence pairs, and the changed case above. Confirmed red for the three that needed the feature before implementing.

`pnpm vitest run src/services/os/os.test.ts` — 53/53 pass. `biome check` clean on all changed files.

Note: `tsc --noEmit` reports errors in this package locally, but the identical set appears on a clean `master` in the same environment (unbuilt sibling packages), and none are in `os.ts`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
