### PR TITLE
fix(google-ads): clarify MCC customer-not-accessible error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/source.py
@@ -417,7 +417,9 @@ class GoogleAdsSource(
             if "CUSTOMER_NOT_FOUND" in error_message or "USER_PERMISSION_DENIED" in error_message:
                 return (
                     False,
-                    f"Customer ID {config.customer_id} is not accessible. Please verify your customer ID and manager account settings.",
+                    f"Customer ID {config.customer_id} isn't accessible through the connected manager "
+                    "(MCC) account. Check that the customer ID is correct, that the manager customer ID "
+                    "you entered is right, and that this account is linked under that manager, then try again.",
                 )
             raise
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -492,27 +492,6 @@ class TestValidateCredentials:
         assert "172.217.112.4" not in (message or "")
         assert "StatusCode" not in (message or "")
 
-    @pytest.mark.parametrize("error_text", ["USER_PERMISSION_DENIED", "CUSTOMER_NOT_FOUND"])
-    def test_mcc_customer_not_accessible_returns_actionable_message(self, error_text):
-        # When the account is validated through a manager (MCC) login and the client account can't be
-        # reached, point the user at the manager linkage rather than a bare "not accessible".
-        config = GoogleAdsSourceConfig(
-            customer_id="1234567890",
-            google_ads_integration_id=1,
-            is_mcc_account=GoogleAdsIsMccAccountConfig(mcc_client_id="9876543210", enabled=True),
-        )
-        client = mock.Mock()
-        client.get_service.return_value.search.side_effect = Exception(error_text)
-        with mock.patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.google_ads.google_ads.google_ads_client",
-            return_value=client,
-        ):
-            ok, message = GoogleAdsSource().validate_credentials(config, team_id=1)
-
-        assert ok is False
-        assert "manager" in (message or "")
-        assert "try again" in (message or "")
-
 
 def _google_ads_exception(request_error: int) -> GoogleAdsException:
     failure = GoogleAdsFailure(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -492,6 +492,27 @@ class TestValidateCredentials:
         assert "172.217.112.4" not in (message or "")
         assert "StatusCode" not in (message or "")
 
+    @pytest.mark.parametrize("error_text", ["USER_PERMISSION_DENIED", "CUSTOMER_NOT_FOUND"])
+    def test_mcc_customer_not_accessible_returns_actionable_message(self, error_text):
+        # When the account is validated through a manager (MCC) login and the client account can't be
+        # reached, point the user at the manager linkage rather than a bare "not accessible".
+        config = GoogleAdsSourceConfig(
+            customer_id="1234567890",
+            google_ads_integration_id=1,
+            is_mcc_account=GoogleAdsIsMccAccountConfig(mcc_client_id="9876543210", enabled=True),
+        )
+        client = mock.Mock()
+        client.get_service.return_value.search.side_effect = Exception(error_text)
+        with mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.google_ads.google_ads.google_ads_client",
+            return_value=client,
+        ):
+            ok, message = GoogleAdsSource().validate_credentials(config, team_id=1)
+
+        assert ok is False
+        assert "manager" in (message or "")
+        assert "try again" in (message or "")
+
 
 def _google_ads_exception(request_error: int) -> GoogleAdsException:
     failure = GoogleAdsFailure(

--- a/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/test_google_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/test_google_ads_source.py
@@ -543,7 +543,7 @@ class TestGoogleAdsSourceValidation:
 
         assert is_valid is False
         assert error is not None
-        assert "is not accessible" in error
+        assert "linked under that manager" in error
 
     @mock.patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.google_ads.google_ads.google_ads_client"
@@ -563,7 +563,7 @@ class TestGoogleAdsSourceValidation:
 
         assert is_valid is False
         assert error is not None
-        assert "is not accessible" in error
+        assert "linked under that manager" in error
 
 
 class TestGoogleAdsClientStaleConnection:


### PR DESCRIPTION
## Problem

- Connecting a Google Ads account through a manager (MCC) login showed a vaguer error than the direct-account path when the client account could not be reached.
- The MCC validation path returned a generic "verify your customer ID and manager account settings" message that does not name the linkage that has to hold.
- The direct-account path already explains the fix in detail, so the two paths were inconsistent for the same failure.

## Changes

- The MCC path now names the fix: check the customer ID, check the manager customer ID, and confirm the account is linked under that manager.
- The phrasing mirrors the direct-account path's existing message.

## How did you test this code?

- Added a parameterized case to `TestValidateCredentials` asserting the MCC not-accessible message names the manager and stays actionable, for both `USER_PERMISSION_DENIED` and `CUSTOMER_NOT_FOUND`.
- This catches a regression to a bare or leaked message on the MCC probe path, which no existing test covered.
- Ran the `TestValidateCredentials` suite locally; not run: the full data-imports suite.

## Docs update

None

## 🤖 Agent context

**Autonomy:** Fully autonomous

- I (Claude) triaged data-warehouse source-creation failures and found the MCC path's error was thinner than its direct-account sibling for the same failure.
- Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`.
- Only the error string and a test changed; no sync behavior or schema was touched.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
