### PR TITLE
fix(azure-devops): name unexpected status in validation error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/azure_devops/azure_devops.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/azure_devops/azure_devops.py
@@ -106,7 +106,16 @@ _FORBIDDEN_MESSAGE = (
 )
 _ORGANIZATION_NOT_FOUND_MESSAGE = "Azure DevOps organization not found. Please check the organization name."
 _UNREACHABLE_MESSAGE = "Couldn't reach Azure DevOps to validate your credentials. Please try again in a few minutes."
-_GENERIC_INVALID_MESSAGE = "Invalid Azure DevOps credentials"
+
+
+def _unexpected_status_message(status_code: int) -> str:
+    # Any status the probe doesn't map explicitly (a 429, a 5xx, an unexpected redirect) lands here.
+    # Name the status and point at both inputs rather than asserting the credentials are invalid,
+    # which misdirects the user when the real cause is throttling or an Azure-side error.
+    return (
+        f"Azure DevOps returned an unexpected response (HTTP {status_code}). "
+        "Check your organization name and personal access token, then try again."
+    )
 
 
 def validate_credentials(organization: str, personal_access_token: str, api_version: str) -> tuple[bool, str | None]:
@@ -139,7 +148,7 @@ def validate_credentials(organization: str, personal_access_token: str, api_vers
         return False, _FORBIDDEN_MESSAGE
     if status_code == 404:
         return False, _ORGANIZATION_NOT_FOUND_MESSAGE
-    return False, _GENERIC_INVALID_MESSAGE
+    return False, _unexpected_status_message(status_code)
 
 
 def get_rows(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/azure_devops/tests/test_azure_devops.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/azure_devops/tests/test_azure_devops.py
@@ -113,6 +113,23 @@ class TestValidateCredentials:
 
         assert validate_credentials("myorg", "pat", AZURE_DEVOPS_VERSION_7_2) == expected
 
+    @pytest.mark.parametrize("status_code", [429, 500, 503])
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.azure_devops.azure_devops.make_tracked_session"
+    )
+    def test_validate_credentials_unexpected_status_names_the_status(self, mock_session, status_code):
+        # A throttled or Azure-side failure must not be reported as invalid credentials; the message
+        # names the status and stays actionable.
+        response = mock.MagicMock()
+        response.status_code = status_code
+        mock_session.return_value.get.return_value = response
+
+        is_valid, error = validate_credentials("myorg", "pat", AZURE_DEVOPS_VERSION_7_2)
+
+        assert is_valid is False
+        assert str(status_code) in (error or "")
+        assert "Invalid Azure DevOps credentials" not in (error or "")
+
     @mock.patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.azure_devops.azure_devops.make_tracked_session"
     )


### PR DESCRIPTION
## Problem

- Connecting an Azure DevOps source failed with "Invalid Azure DevOps credentials" even when the credentials were fine.
- The credential probe maps 200, 203, 401, 403, and 404. Every other status (a 429 rate limit, a 5xx, an unexpected redirect) fell through to that single message.
- The message misdirects the user: it asserts bad credentials when the real cause is throttling or an Azure-side error.

## Changes

- The fallback now names the HTTP status and points at both the organization name and the personal access token, so a non-credential failure stays actionable.
- The mapped statuses are unchanged.

## How did you test this code?

- Added a parameterized case to `TestValidateCredentials` covering 429, 500, and 503: the message names the status and no longer says "Invalid Azure DevOps credentials".
- The fallback path had no test before, so a regression to the misleading message went uncaught.
- Ran the `TestValidateCredentials` suite locally; not run: the full data-imports suite.

## Docs update

None

## 🤖 Agent context

**Autonomy:** Fully autonomous

- I (Claude) triaged data-warehouse source-creation failures and found the Azure DevOps probe reported unmapped statuses as invalid credentials.
- Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`.
- Only the fallback string and a test changed; no sync behavior or schema was touched.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
