### PR TITLE
fix(desktop): improve task timeline message previews

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.test.tsx
@@ -10,6 +10,22 @@ import {
   vi,
 } from "vitest";
 
+const activityMocks = vi.hoisted(() => ({
+  rawItems: [] as Array<{
+    type: "user_message";
+    id: string;
+    content: string;
+    timestamp: number;
+  }>,
+  optimisticItems: [] as Array<{
+    type: "user_message";
+    id: string;
+    content: string;
+    timestamp: number;
+  }>,
+  receivedItemIds: [] as string[],
+}));
+
 vi.mock("@posthog/ui/features/canvas/hooks/useThreadConversation", () => ({
   useThreadConversation: () => ({
     timeline: [],
@@ -31,7 +47,26 @@ vi.mock("@posthog/ui/features/canvas/hooks/useThreadConversation", () => ({
   }),
 }));
 vi.mock("@posthog/ui/features/canvas/components/ActivityTimeline", () => ({
-  ActivityTimeline: () => <div>timeline body</div>,
+  ActivityTimeline: ({
+    conversationItems,
+  }: {
+    conversationItems: Array<{ id: string }>;
+  }) => {
+    activityMocks.receivedItemIds = conversationItems.map((item) => item.id);
+    return <div>timeline body</div>;
+  },
+}));
+vi.mock(
+  "@posthog/ui/features/sessions/components/buildConversationItems",
+  () => ({
+    buildConversationItems: () => ({ items: activityMocks.rawItems }),
+  }),
+);
+vi.mock("@posthog/ui/features/sessions/sessionStore", () => ({
+  useOptimisticItemsForTask: () => activityMocks.optimisticItems,
+}));
+vi.mock("@posthog/ui/features/sessions/useSession", () => ({
+  useSessionIsCloud: () => true,
 }));
 vi.mock("@posthog/ui/features/canvas/components/TaskArtifactsList", () => ({
   TaskArtifactsList: () => <div>artifacts body</div>,
@@ -82,6 +117,9 @@ describe("ActivityPanel", () => {
 
   beforeEach(() => {
     commentsFlag.enabled = true;
+    activityMocks.rawItems = [];
+    activityMocks.optimisticItems = [];
+    activityMocks.receivedItemIds = [];
     scrollTo = vi.spyOn(Element.prototype, "scrollTo");
     useCommentNavigationStore.setState({
       focusByTask: {},
@@ -91,6 +129,29 @@ describe("ActivityPanel", () => {
 
   afterEach(() => {
     scrollTo.mockRestore();
+  });
+
+  it("uses the visible prompt id for timeline navigation", () => {
+    activityMocks.rawItems = [
+      {
+        type: "user_message",
+        id: "echoed-prompt",
+        content: "Original prompt",
+        timestamp: 1,
+      },
+    ];
+    activityMocks.optimisticItems = [
+      {
+        type: "user_message",
+        id: "visible-prompt",
+        content: "Original prompt",
+        timestamp: 1,
+      },
+    ];
+
+    renderPanel();
+
+    expect(activityMocks.receivedItemIds).toEqual(["visible-prompt"]);
   });
 
   it("offers comments as a third tab beside the timeline and artifacts", () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.tsx
@@ -18,7 +18,10 @@ import {
 import { useThreadConversation } from "@posthog/ui/features/canvas/hooks/useThreadConversation";
 import { useCommentNavigationStore } from "@posthog/ui/features/sessions/commentNavigationStore";
 import { buildConversationItems } from "@posthog/ui/features/sessions/components/buildConversationItems";
+import { mergeConversationItems } from "@posthog/ui/features/sessions/components/mergeConversationItems";
+import { useOptimisticItemsForTask } from "@posthog/ui/features/sessions/sessionStore";
 import { useCommentsEnabled } from "@posthog/ui/features/sessions/useCommentsEnabled";
+import { useSessionIsCloud } from "@posthog/ui/features/sessions/useSession";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { track } from "@posthog/ui/shell/analytics";
 import { useQuery } from "@tanstack/react-query";
@@ -162,13 +165,16 @@ function ActivityConversation({
     [taskId],
   );
 
-  const conversationItems = useMemo(
-    () =>
-      tab === "timeline"
-        ? buildConversationItems(events, isPromptPending).items
-        : [],
-    [tab, events, isPromptPending],
-  );
+  const optimisticItems = useOptimisticItemsForTask(taskId);
+  const isCloud = useSessionIsCloud(taskId);
+  const conversationItems = useMemo(() => {
+    if (tab !== "timeline") return [];
+    return mergeConversationItems({
+      conversationItems: buildConversationItems(events, isPromptPending).items,
+      optimisticItems,
+      isCloud,
+    });
+  }, [tab, events, isPromptPending, optimisticItems, isCloud]);
 
   // A thread picked on the artifact itself lives in the Comments tab, so the
   // pick has to bring the tab with it. Only a fresh request switches tabs: a

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
@@ -19,8 +19,6 @@ const task = {
   latest_run: null,
 } as unknown as Task;
 
-// Every conversation row is attributed to the task's creator, which is exactly why
-// an author-derived accessible name would be identical on all of them.
 const conversationItems = [
   {
     type: "user_message" as const,
@@ -57,40 +55,45 @@ beforeEach(() => {
 });
 
 describe("ActivityTimeline", () => {
-  it("names each message row by its own content, not a shared template", () => {
+  it("renders each message preview with a chat navigation action", () => {
     renderTimeline(true);
 
-    expect(screen.getAllByRole("button")).toHaveLength(2);
-    // `name` here is the computed accessible name, so this is what a screen reader
-    // announces: each row carries the content a sighted user sees, which is what
-    // makes the two distinguishable — the author is the same on every row.
+    expect(screen.getByText(/first thing/)).toBeInTheDocument();
+    expect(screen.getByText(/second thing/)).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /Shy Alter.*first thing/ }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /Shy Alter.*second thing/ }),
-    ).toBeInTheDocument();
-    // The avatar is decorative, so its initials stay out of the name.
-    expect(screen.queryByRole("button", { name: /SA/ })).toBeNull();
+      screen.getAllByRole("button", { name: "View in chat" }),
+    ).toHaveLength(2);
   });
 
-  it("asks the transcript to scroll to the clicked message", () => {
+  it("truncates long message previews to 100 characters", () => {
+    const content = `${"a".repeat(100)}overflow`;
+    renderTimeline(true, [
+      {
+        type: "user_message",
+        id: "long-message",
+        content,
+        timestamp: Date.parse("2026-07-17T09:05:00Z"),
+      },
+    ]);
+
+    expect(screen.getByText(`${"a".repeat(100)}…`)).toBeInTheDocument();
+    expect(screen.queryByText(content)).toBeNull();
+  });
+
+  it("asks the transcript to scroll to the selected message", () => {
     renderTimeline(true);
 
-    fireEvent.click(screen.getAllByRole("button")[1]);
+    fireEvent.click(screen.getAllByRole("button", { name: "View in chat" })[1]);
 
     expect(useThreadNavigationStore.getState().scrollRequests["task-1"]).toBe(
       "turn-2-2-user",
     );
   });
 
-  it("leaves rows inert with no transcript alongside to drive", () => {
+  it("hides chat navigation when no transcript is alongside", () => {
     renderTimeline();
 
-    expect(screen.queryAllByRole("button")).toHaveLength(0);
-    const body = screen.getByText(/first thing/).closest("[data-slot]");
-    expect(body).toHaveClass("whitespace-pre-wrap", "break-words");
-    expect(body).not.toHaveClass("line-clamp-1");
+    expect(screen.queryByRole("button", { name: "View in chat" })).toBeNull();
   });
 
   it("renders structured references natively in conversation previews", () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
@@ -60,9 +60,12 @@ describe("ActivityTimeline", () => {
 
     expect(screen.getByText(/first thing/)).toBeInTheDocument();
     expect(screen.getByText(/second thing/)).toBeInTheDocument();
-    expect(
-      screen.getAllByRole("button", { name: "View in chat" }),
-    ).toHaveLength(2);
+    const actions = screen.getAllByRole("button", { name: "View in chat" });
+    expect(actions).toHaveLength(2);
+    for (const action of actions) {
+      expect(action).toHaveAttribute("data-size", "icon-xs");
+      expect(action.closest('[role="toolbar"]')).toBeNull();
+    }
   });
 
   it("truncates long message previews to 100 characters", () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
@@ -96,19 +96,19 @@ describe("ActivityTimeline", () => {
     expect(screen.queryByRole("button", { name: "View in chat" })).toBeNull();
   });
 
-  it("renders structured references natively in conversation previews", () => {
+  it("keeps long structured references intact in conversation previews", () => {
     renderTimeline(false, [
       {
         type: "user_message",
         id: "pr-message",
-        content:
-          '<github_pr number="73874" title="Loading…" url="https://github.com/PostHog/posthog/pull/73874" />',
+        content: `<github_pr number="73874" title="Loading…" url="https://github.com/PostHog/posthog/pull/73874/files?diff=split&long=${"a".repeat(80)}" /> ${"b".repeat(100)}`,
         timestamp: Date.parse("2026-07-17T09:05:00Z"),
       },
     ]);
 
     expect(screen.getByText("#73874 - Loading…")).toBeInTheDocument();
     expect(screen.queryByText(/<github_pr/)).toBeNull();
+    expect(screen.getByText(/^b+…$/)).toBeInTheDocument();
   });
 
   it("folds injected channel context by default", () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
@@ -64,6 +64,7 @@ describe("ActivityTimeline", () => {
     expect(actions).toHaveLength(2);
     for (const action of actions) {
       expect(action).toHaveAttribute("data-size", "icon-xs");
+      expect(action).toHaveClass("hover:bg-gray-3");
       expect(action.closest('[role="toolbar"]')).toBeNull();
     }
   });

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
@@ -1,4 +1,5 @@
 import {
+  ArrowRightIcon,
   CheckCircleIcon,
   FileTextIcon,
   PlusCircleIcon,
@@ -9,8 +10,9 @@ import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
-  cn,
   ThreadItem,
+  ThreadItemAction,
+  ThreadItemActions,
   ThreadItemAuthor,
   ThreadItemBody,
   ThreadItemContent,
@@ -31,12 +33,13 @@ import {
   ThreadMessageRow,
 } from "@posthog/ui/features/canvas/components/ThreadPanel";
 import { ThreadTimestamp } from "@posthog/ui/features/canvas/components/ThreadTimestamp";
+import { timelineMessagePreview } from "@posthog/ui/features/canvas/components/timelineMessagePreview";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
 import type { buildConversationItems } from "@posthog/ui/features/sessions/components/buildConversationItems";
 import { extractChannelContext } from "@posthog/ui/features/sessions/components/session-update/channelContext";
 import { extractCustomInstructions } from "@posthog/ui/features/sessions/components/session-update/customInstructions";
 import { useThreadNavigationStore } from "@posthog/ui/features/sessions/threadNavigationStore";
-import { Fragment, type KeyboardEvent, type ReactNode, useMemo } from "react";
+import { Fragment, type ReactNode, useMemo } from "react";
 
 type ConversationItem = ReturnType<
   typeof buildConversationItems
@@ -89,32 +92,11 @@ function UserMessageRow({
     () => extractCustomInstructions(afterChannelContext),
     [afterChannelContext],
   );
-  const displayContent = customInstructions?.stripped ?? afterChannelContext;
-  // The row itself is the hit target. `ThreadItem` renders an <article>, which a
-  // <button> may not wrap and which can't become one (quill's primitive takes no
-  // `render`), so it carries the button role and its own key handling.
-  //
-  // Deliberately no `aria-label`: the button takes its name from its contents, so
-  // it announces the author, time and preview a sighted user sees. A label would
-  // replace all three — and since every row here is authored by the task creator,
-  // one built from the name alone would be identical on every row.
-  const activation = onSelect
-    ? ({
-        role: "button",
-        tabIndex: 0,
-        onClick: onSelect,
-        onKeyDown: (event: KeyboardEvent<HTMLElement>) => {
-          if (event.key !== "Enter" && event.key !== " ") return;
-          event.preventDefault();
-          onSelect();
-        },
-      } as const)
-    : {};
+  const displayContent = timelineMessagePreview(
+    customInstructions?.stripped ?? afterChannelContext,
+  );
   return (
-    <ThreadItem
-      className={cn("rounded-none", onSelect && "cursor-pointer")}
-      {...activation}
-    >
+    <ThreadItem className="rounded-none">
       {/* Decorative: the author's name is written beside it, so keep the avatar's
           initials out of the row's accessible name. */}
       <ThreadItemGutter className="justify-center" aria-hidden>
@@ -149,6 +131,13 @@ function UserMessageRow({
           )}
         </ThreadItemBody>
       </ThreadItemContent>
+      {onSelect && (
+        <ThreadItemActions aria-label="Timeline actions">
+          <ThreadItemAction label="View in chat" onClick={onSelect}>
+            <ArrowRightIcon size={14} />
+          </ThreadItemAction>
+        </ThreadItemActions>
+      )}
     </ThreadItem>
   );
 }

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
@@ -33,7 +33,7 @@ import {
   ThreadMessageRow,
 } from "@posthog/ui/features/canvas/components/ThreadPanel";
 import { ThreadTimestamp } from "@posthog/ui/features/canvas/components/ThreadTimestamp";
-import { timelineMessagePreview } from "@posthog/ui/features/canvas/components/timelineMessagePreview";
+import { TIMELINE_MESSAGE_PREVIEW_LENGTH } from "@posthog/ui/features/canvas/components/timelineMessagePreview";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
 import type { buildConversationItems } from "@posthog/ui/features/sessions/components/buildConversationItems";
 import { extractChannelContext } from "@posthog/ui/features/sessions/components/session-update/channelContext";
@@ -92,9 +92,7 @@ function UserMessageRow({
     () => extractCustomInstructions(afterChannelContext),
     [afterChannelContext],
   );
-  const displayContent = timelineMessagePreview(
-    customInstructions?.stripped ?? afterChannelContext,
-  );
+  const displayContent = customInstructions?.stripped ?? afterChannelContext;
   return (
     <ThreadItem className="rounded-none">
       {/* Decorative: the author's name is written beside it, so keep the avatar's
@@ -108,7 +106,10 @@ function UserMessageRow({
           <ThreadTimestamp dateTime={timestamp} />
         </ThreadItemHeader>
         <ThreadItemBody className="mt-1.5 whitespace-pre-wrap break-words text-[13px]">
-          <MentionText content={displayContent} />
+          <MentionText
+            content={displayContent}
+            maxLength={TIMELINE_MESSAGE_PREVIEW_LENGTH}
+          />
           {channelContext && (
             <Collapsible className="mt-2 min-w-0 bg-transparent hover:bg-transparent data-open:bg-transparent">
               <CollapsibleTrigger

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
@@ -110,7 +110,7 @@ function UserMessageRow({
                 label="View in chat"
                 variant="link-muted"
                 size="icon-xs"
-                className="ml-auto self-center opacity-0 transition-opacity group-focus-within/timeline-message:opacity-100 group-hover/timeline-message:opacity-100"
+                className="ml-auto self-center opacity-0 transition-[background-color,color,opacity] hover:bg-gray-3 hover:text-foreground focus-visible:bg-gray-3 group-focus-within/timeline-message:opacity-100 group-hover/timeline-message:opacity-100"
                 onClick={onSelect}
               >
                 <ArrowRightIcon size={12} />

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
@@ -12,13 +12,13 @@ import {
   CollapsibleTrigger,
   ThreadItem,
   ThreadItemAction,
-  ThreadItemActions,
   ThreadItemAuthor,
   ThreadItemBody,
   ThreadItemContent,
   ThreadItemGroup,
   ThreadItemGutter,
   ThreadItemHeader,
+  TooltipProvider,
 } from "@posthog/quill";
 import type {
   Task,
@@ -94,7 +94,7 @@ function UserMessageRow({
   );
   const displayContent = customInstructions?.stripped ?? afterChannelContext;
   return (
-    <ThreadItem className="rounded-none">
+    <ThreadItem className="group/timeline-message rounded-none">
       {/* Decorative: the author's name is written beside it, so keep the avatar's
           initials out of the row's accessible name. */}
       <ThreadItemGutter className="justify-center" aria-hidden>
@@ -104,6 +104,19 @@ function UserMessageRow({
         <ThreadItemHeader>
           <ThreadItemAuthor className="text-[13px]">{name}</ThreadItemAuthor>
           <ThreadTimestamp dateTime={timestamp} />
+          {onSelect && (
+            <TooltipProvider>
+              <ThreadItemAction
+                label="View in chat"
+                variant="link-muted"
+                size="icon-xs"
+                className="ml-auto self-center opacity-0 transition-opacity group-focus-within/timeline-message:opacity-100 group-hover/timeline-message:opacity-100"
+                onClick={onSelect}
+              >
+                <ArrowRightIcon size={12} />
+              </ThreadItemAction>
+            </TooltipProvider>
+          )}
         </ThreadItemHeader>
         <ThreadItemBody className="mt-1.5 whitespace-pre-wrap break-words text-[13px]">
           <MentionText
@@ -132,13 +145,6 @@ function UserMessageRow({
           )}
         </ThreadItemBody>
       </ThreadItemContent>
-      {onSelect && (
-        <ThreadItemActions aria-label="Timeline actions">
-          <ThreadItemAction label="View in chat" onClick={onSelect}>
-            <ArrowRightIcon size={14} />
-          </ThreadItemAction>
-        </ThreadItemActions>
-      )}
     </ThreadItem>
   );
 }

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelFeedView.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelFeedView.test.tsx
@@ -1,4 +1,4 @@
-import type { Task } from "@posthog/shared/domain-types";
+import type { Task, TaskThreadMessage } from "@posthog/shared/domain-types";
 import { Theme } from "@radix-ui/themes";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -26,6 +26,14 @@ vi.mock("@tanstack/react-router", () => ({
 vi.mock("@posthog/ui/features/canvas/hooks/useChannelTaskData", () => ({
   useChannelTaskData: () => undefined,
 }));
+
+const threadMocks = vi.hoisted(() => ({
+  messages: [] as TaskThreadMessage[],
+}));
+
+vi.mock("@posthog/ui/features/canvas/hooks/useTaskThread", () => ({
+  useTaskThread: () => ({ messages: threadMocks.messages }),
+}));
 vi.mock("@posthog/ui/features/sidebar/useTaskPrStatus", () => ({
   useTaskPrStatus: () => ({ prState: null }),
 }));
@@ -33,7 +41,7 @@ vi.mock("@posthog/ui/features/browser-tabs/TaskTabIcon", () => ({
   TaskTabIcon: () => <span />,
 }));
 
-import { TaskCard, TaskFeedRow } from "./ChannelFeedView";
+import { ReplyFooter, TaskCard, TaskFeedRow } from "./ChannelFeedView";
 
 const task = {
   id: "task-1",
@@ -55,6 +63,7 @@ const task = {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  threadMocks.messages = [];
 });
 
 // ExpandablePrompt measures how the prompt wraps to decide where to cut and
@@ -132,5 +141,28 @@ describe("TaskFeedRow", () => {
     );
 
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("uses the agent symbol for agent replies", () => {
+    threadMocks.messages = [
+      {
+        id: "agent-reply",
+        task: task.id,
+        author_kind: "agent",
+        content: "Finished the task",
+        created_at: "2026-07-17T12:05:00.000Z",
+        author: null,
+      },
+    ];
+
+    const { container } = render(
+      <ReplyFooter taskId={task.id} inView onOpenThread={() => undefined} />,
+    );
+
+    expect(screen.getByText("1 reply")).toBeInTheDocument();
+    expect(screen.queryByText("U")).toBeNull();
+    expect(
+      container.querySelector('[data-slot="avatar-fallback"] svg'),
+    ).not.toBeNull();
   });
 });

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -26,6 +26,7 @@ import {
   ChatMessageScrollerViewport,
   cn,
   Spinner,
+  Text,
   ThreadItem,
   ThreadItemAction,
   ThreadItemActions,
@@ -60,7 +61,6 @@ import {
   useTaskPrStatus,
 } from "@posthog/ui/features/sidebar/useTaskPrStatus";
 import { useInView } from "@posthog/ui/primitives/hooks/useInView";
-import { Text } from "@radix-ui/themes";
 import { Link } from "@tanstack/react-router";
 import {
   memo,
@@ -279,7 +279,12 @@ export function TaskCard({
                 </span>
               )}
               {stage && (
-                <Text size="1" className="truncate text-muted-foreground">
+                <Text
+                  size="xs"
+                  variant="muted"
+                  render={<span />}
+                  className="truncate"
+                >
                   {stage}
                 </Text>
               )}
@@ -306,7 +311,7 @@ export function TaskCard({
 //
 // The fetch/poll only runs for near-viewport rows (`inView`); off-screen rows
 // render the static affordance and idle, so a long feed isn't polling per row.
-function ReplyFooter({
+export function ReplyFooter({
   taskId,
   inView,
   onOpenThread,
@@ -321,10 +326,14 @@ function ReplyFooter({
     markActivityRead: false,
   });
   const authors = useMemo(() => {
-    const seen = new Map<string, (typeof messages)[number]["author"]>();
+    const seen = new Map<string, (typeof messages)[number]>();
     for (const message of messages) {
-      const key = message.author?.uuid ?? "unknown";
-      if (!seen.has(key)) seen.set(key, message.author);
+      const authorKind = message.author_kind ?? "human";
+      const key =
+        authorKind === "human"
+          ? `human:${message.author?.uuid ?? "unknown"}`
+          : authorKind;
+      if (!seen.has(key)) seen.set(key, message);
     }
     return [...seen.values()].slice(0, 4);
   }, [messages]);
@@ -350,9 +359,21 @@ function ReplyFooter({
   return (
     <ThreadItemReplies onClick={onOpenThread} className="mt-1">
       <AvatarGroup size="xs">
-        {authors.map((author, index) => (
-          <UserAvatar key={author?.uuid ?? index} user={author} size="xs" />
-        ))}
+        {authors.map((message, index) =>
+          message.author_kind === "agent" ? (
+            <Avatar key="agent" size="xs">
+              <AvatarFallback>
+                <RobotIcon size={12} />
+              </AvatarFallback>
+            </Avatar>
+          ) : (
+            <UserAvatar
+              key={message.author?.uuid ?? index}
+              user={message.author}
+              size="xs"
+            />
+          ),
+        )}
       </AvatarGroup>
       <ThreadItemRepliesLabel>
         {messages.length} {messages.length === 1 ? "reply" : "replies"}

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -335,7 +335,7 @@ export function ReplyFooter({
           : authorKind;
       if (!seen.has(key)) seen.set(key, message);
     }
-    return [...seen.values()].slice(0, 4);
+    return [...seen.entries()].slice(0, 4);
   }, [messages]);
 
   if (messages.length === 0) {
@@ -359,19 +359,15 @@ export function ReplyFooter({
   return (
     <ThreadItemReplies onClick={onOpenThread} className="mt-1">
       <AvatarGroup size="xs">
-        {authors.map((message, index) =>
+        {authors.map(([key, message]) =>
           message.author_kind === "agent" ? (
-            <Avatar key="agent" size="xs">
+            <Avatar key={key} size="xs">
               <AvatarFallback>
                 <RobotIcon size={12} />
               </AvatarFallback>
             </Avatar>
           ) : (
-            <UserAvatar
-              key={message.author?.uuid ?? index}
-              user={message.author}
-              size="xs"
-            />
+            <UserAvatar key={key} user={message.author} size="xs" />
           ),
         )}
       </AvatarGroup>

--- a/products/desktop/packages/ui/src/features/canvas/components/MentionText.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/MentionText.test.tsx
@@ -102,6 +102,21 @@ describe("MentionText", () => {
     );
   });
 
+  it("truncates rendered text without exposing structured token syntax", () => {
+    const structuredReference =
+      '<github_pr number="73874" title="Loading…" url="https://github.com/PostHog/posthog/pull/73874" />';
+    const { container } = render(
+      <MentionText
+        content={`${structuredReference} ${"a".repeat(100)}`}
+        maxLength={100}
+      />,
+    );
+
+    expect(screen.getByText("#73874 - Loading…")).toBeInTheDocument();
+    expect(container).not.toHaveTextContent("<github_pr");
+    expect(container.textContent?.endsWith("…")).toBe(true);
+  });
+
   it("leaves malformed and unsafe structured references as readable text", () => {
     render(
       <MentionText

--- a/products/desktop/packages/ui/src/features/canvas/components/MentionText.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/MentionText.tsx
@@ -25,6 +25,65 @@ type RenderSegment =
   | { type: "mention"; name: string; email: string }
   | { type: "chip"; chip: MentionChip };
 
+type RenderEntry = { segment: RenderSegment; key: string };
+
+function segmentDisplayText(segment: RenderSegment): string {
+  if (
+    segment.type === "text" ||
+    segment.type === "link" ||
+    segment.type === "agent"
+  ) {
+    return segment.text;
+  }
+  if (segment.type === "mention") return `@${segment.name}`;
+  if (
+    segment.chip.type === "github_issue" ||
+    segment.chip.type === "github_pr"
+  ) {
+    return segment.chip.label;
+  }
+  const prefix = segment.chip.type === "command" ? "/" : "@";
+  return `${prefix}${segment.chip.label}`;
+}
+
+function truncateRenderEntries(
+  entries: RenderEntry[],
+  maxLength: number | undefined,
+): RenderEntry[] {
+  if (maxLength === undefined) return entries;
+
+  const truncated: RenderEntry[] = [];
+  let usedLength = 0;
+  for (const entry of entries) {
+    const displayCharacters = Array.from(segmentDisplayText(entry.segment));
+    if (usedLength + displayCharacters.length <= maxLength) {
+      truncated.push(entry);
+      usedLength += displayCharacters.length;
+      continue;
+    }
+
+    const remainingLength = Math.max(0, maxLength - usedLength);
+    if (
+      remainingLength > 0 &&
+      (entry.segment.type === "text" || entry.segment.type === "link")
+    ) {
+      truncated.push({
+        ...entry,
+        segment: {
+          ...entry.segment,
+          text: displayCharacters.slice(0, remainingLength).join(""),
+        },
+      });
+    }
+    truncated.push({
+      segment: { type: "text", text: "…" },
+      key: `${entry.key}-ellipsis`,
+    });
+    return truncated;
+  }
+  return truncated;
+}
+
 const chipIcons = {
   file: FileTextIcon,
   folder: FolderIcon,
@@ -77,15 +136,17 @@ export function MentionText({
   content,
   currentUserEmail,
   className,
+  maxLength,
 }: {
   content: string;
   currentUserEmail?: string | null;
   className?: string;
+  maxLength?: number;
 }) {
   // Key each segment by its character offset — stable for a given content.
   const segments = useMemo(() => {
     let offset = 0;
-    const entries: Array<{ segment: RenderSegment; key: string }> = [];
+    const entries: RenderEntry[] = [];
     const push = (segment: RenderSegment, length: number) => {
       entries.push({ segment, key: `${offset}` });
       offset += length;
@@ -132,8 +193,8 @@ export function MentionText({
         }
       }
     }
-    return entries;
-  }, [content]);
+    return truncateRenderEntries(entries, maxLength);
+  }, [content, maxLength]);
   const selfEmail = currentUserEmail?.toLowerCase();
   return (
     <span className={className}>

--- a/products/desktop/packages/ui/src/features/canvas/components/ThreadPanel.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ThreadPanel.test.tsx
@@ -97,13 +97,14 @@ describe("ThreadMessageRow", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows the full message in timeline previews", () => {
+  it("truncates timeline previews to 100 characters", () => {
+    const content = `${"a".repeat(100)}overflow`;
     render(
       <ThreadMessageRow
         message={{
           id: "m1",
           task: "task",
-          content: multiline,
+          content,
           created_at: "2026-07-17T00:00:00Z",
           author: null,
         }}
@@ -116,9 +117,8 @@ describe("ThreadMessageRow", () => {
       />,
     );
 
-    const body = screen.getByText(/Second line with more detail/).parentElement;
-    expect(body).toHaveClass("whitespace-pre-wrap", "break-words");
-    expect(body).not.toHaveClass("line-clamp-1");
+    expect(screen.getByText(`${"a".repeat(100)}…`)).toBeInTheDocument();
+    expect(screen.queryByText(content)).toBeNull();
   });
 });
 

--- a/products/desktop/packages/ui/src/features/canvas/components/ThreadPanel.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ThreadPanel.test.tsx
@@ -120,6 +120,31 @@ describe("ThreadMessageRow", () => {
     expect(screen.getByText(`${"a".repeat(100)}…`)).toBeInTheDocument();
     expect(screen.queryByText(content)).toBeNull();
   });
+
+  it("keeps long structured references intact in timeline previews", () => {
+    const content = `<github_pr number="73874" title="Loading…" url="https://github.com/PostHog/posthog/pull/73874/files?diff=split&long=${"a".repeat(80)}" /> ${"b".repeat(100)}`;
+    render(
+      <ThreadMessageRow
+        message={{
+          id: "m1",
+          task: "task",
+          content,
+          created_at: "2026-07-17T00:00:00Z",
+          author: null,
+        }}
+        isTaskAuthor
+        isOwnMessage={false}
+        canForward
+        preview
+        onSendToAgent={() => {}}
+        onDelete={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("#73874 - Loading…")).toBeInTheDocument();
+    expect(screen.queryByText(/<github_pr/)).toBeNull();
+    expect(screen.getByText(/^b+…$/)).toBeInTheDocument();
+  });
 });
 
 describe("ThreadArtifactRow", () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ThreadPanel.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ThreadPanel.tsx
@@ -51,6 +51,7 @@ import { iconForTemplate } from "@posthog/ui/features/canvas/components/canvasTe
 import { MentionComposer } from "@posthog/ui/features/canvas/components/MentionComposer";
 import { MentionText } from "@posthog/ui/features/canvas/components/MentionText";
 import { ThreadTimestamp } from "@posthog/ui/features/canvas/components/ThreadTimestamp";
+import { timelineMessagePreview } from "@posthog/ui/features/canvas/components/timelineMessagePreview";
 import { useThreadConversation } from "@posthog/ui/features/canvas/hooks/useThreadConversation";
 import { canvasArtifactOpenHandler } from "@posthog/ui/features/canvas/utils/canvasArtifactNavigation";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
@@ -76,7 +77,6 @@ export function ThreadMessageRow({
   isOwnMessage: boolean;
   currentUserEmail?: string | null;
   canForward: boolean;
-  /** Timeline rows preserve authored whitespace while showing the full message. */
   preview?: boolean;
   onSendToAgent: () => void;
   onDelete: () => void;
@@ -103,7 +103,11 @@ export function ThreadMessageRow({
           )}
         >
           <MentionText
-            content={message.content}
+            content={
+              preview
+                ? timelineMessagePreview(message.content)
+                : message.content
+            }
             currentUserEmail={currentUserEmail}
           />
         </ThreadItemBody>

--- a/products/desktop/packages/ui/src/features/canvas/components/ThreadPanel.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ThreadPanel.tsx
@@ -51,7 +51,7 @@ import { iconForTemplate } from "@posthog/ui/features/canvas/components/canvasTe
 import { MentionComposer } from "@posthog/ui/features/canvas/components/MentionComposer";
 import { MentionText } from "@posthog/ui/features/canvas/components/MentionText";
 import { ThreadTimestamp } from "@posthog/ui/features/canvas/components/ThreadTimestamp";
-import { timelineMessagePreview } from "@posthog/ui/features/canvas/components/timelineMessagePreview";
+import { TIMELINE_MESSAGE_PREVIEW_LENGTH } from "@posthog/ui/features/canvas/components/timelineMessagePreview";
 import { useThreadConversation } from "@posthog/ui/features/canvas/hooks/useThreadConversation";
 import { canvasArtifactOpenHandler } from "@posthog/ui/features/canvas/utils/canvasArtifactNavigation";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
@@ -103,12 +103,9 @@ export function ThreadMessageRow({
           )}
         >
           <MentionText
-            content={
-              preview
-                ? timelineMessagePreview(message.content)
-                : message.content
-            }
+            content={message.content}
             currentUserEmail={currentUserEmail}
+            maxLength={preview ? TIMELINE_MESSAGE_PREVIEW_LENGTH : undefined}
           />
         </ThreadItemBody>
         {forwarded && (

--- a/products/desktop/packages/ui/src/features/canvas/components/timelineMessagePreview.ts
+++ b/products/desktop/packages/ui/src/features/canvas/components/timelineMessagePreview.ts
@@ -1,7 +1,1 @@
-const TIMELINE_MESSAGE_PREVIEW_LENGTH = 100;
-
-export function timelineMessagePreview(content: string): string {
-  const characters = Array.from(content);
-  if (characters.length <= TIMELINE_MESSAGE_PREVIEW_LENGTH) return content;
-  return `${characters.slice(0, TIMELINE_MESSAGE_PREVIEW_LENGTH).join("")}…`;
-}
+export const TIMELINE_MESSAGE_PREVIEW_LENGTH = 100;

--- a/products/desktop/packages/ui/src/features/canvas/components/timelineMessagePreview.ts
+++ b/products/desktop/packages/ui/src/features/canvas/components/timelineMessagePreview.ts
@@ -1,0 +1,7 @@
+const TIMELINE_MESSAGE_PREVIEW_LENGTH = 100;
+
+export function timelineMessagePreview(content: string): string {
+  const characters = Array.from(content);
+  if (characters.length <= TIMELINE_MESSAGE_PREVIEW_LENGTH) return content;
+  return `${characters.slice(0, TIMELINE_MESSAGE_PREVIEW_LENGTH).join("")}…`;
+}

--- a/products/desktop/packages/ui/src/features/sessions/components/ConversationView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ConversationView.tsx
@@ -62,7 +62,10 @@ import {
   useGroupOverrides,
   useSessionViewActions,
 } from "@posthog/ui/features/sessions/sessionViewStore";
-import { useThreadScrollRequest } from "@posthog/ui/features/sessions/threadNavigationStore";
+import {
+  THREAD_SCROLL_SETTLE_FRAMES,
+  useThreadScrollRequest,
+} from "@posthog/ui/features/sessions/threadNavigationStore";
 import { SessionTaskIdProvider } from "@posthog/ui/features/sessions/useSessionTaskId";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { SkillButtonActionMessage } from "@posthog/ui/features/skill-buttons/components/SkillButtonActionMessage";
@@ -335,7 +338,9 @@ export function ConversationView({
 
   // The Activity timeline lives in a sibling pane, so it asks for the jump
   // through the store rather than reaching in here.
-  useThreadScrollRequest(taskId, handleJumpToMessage);
+  useThreadScrollRequest(taskId, handleJumpToMessage, {
+    settleFrames: THREAD_SCROLL_SETTLE_FRAMES,
+  });
 
   const handleScrollStateChange = useCallback((isAtBottom: boolean) => {
     isAtBottomRef.current = isAtBottom;

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -114,7 +114,10 @@ import {
   useSessionViewActions,
   useShowRawLogs,
 } from "@posthog/ui/features/sessions/sessionViewStore";
-import { useThreadScrollRequest } from "@posthog/ui/features/sessions/threadNavigationStore";
+import {
+  THREAD_SCROLL_SETTLE_FRAMES,
+  useThreadScrollRequest,
+} from "@posthog/ui/features/sessions/threadNavigationStore";
 import type { UserMessageAttachment } from "@posthog/ui/features/sessions/userMessageTypes";
 import {
   SessionTaskIdProvider,
@@ -1157,7 +1160,9 @@ function ThreadScrollRequestBridge({
   jumpToMessage?: (id: string) => void;
 }) {
   const { scrollToMessage } = useChatMessageScroller();
-  useThreadScrollRequest(taskId, jumpToMessage ?? scrollToMessage);
+  useThreadScrollRequest(taskId, jumpToMessage ?? scrollToMessage, {
+    settleFrames: jumpToMessage ? 0 : THREAD_SCROLL_SETTLE_FRAMES,
+  });
   return null;
 }
 

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -986,6 +986,7 @@ function ThreadScrollBody({
   keyboardFocusedMessageId,
   onUserInteract,
   resumeStateRef,
+  followRef,
 }: {
   items: ConversationItem[];
   rows: TurnRow[];
@@ -997,6 +998,7 @@ function ThreadScrollBody({
   onUserInteract?: () => void;
   /** Continuously updated so the virtualized body can take over mid-session (see {@link ThreadScrollResume}). */
   resumeStateRef: RefObject<ThreadScrollResume>;
+  followRef: RefObject<ThreadFollowState>;
 }) {
   const keyedRows = useMemo(() => {
     let userTurn = 0;
@@ -1005,8 +1007,6 @@ function ThreadScrollBody({
       key: item.type === "user_message" ? `user-turn-${userTurn++}` : item.id,
     }));
   }, [rows]);
-
-  const autoFollowRef = useRef<ThreadFollowState>(FOLLOWING_END);
 
   // `group/thread` so the footer's hover-reveal (opacity-50 → 100 on group-hover) tracks the thread,
   // mirroring the legacy ConversationView container. `@container/thread` makes the thread's own
@@ -1018,7 +1018,7 @@ function ThreadScrollBody({
       onPointerDownCapture={onUserInteract}
     >
       <MessageMinimap items={items} />
-      <ThreadAutoFollow items={items} followRef={autoFollowRef} />
+      <ThreadAutoFollow items={items} followRef={followRef} />
       <ThreadScrollStateRecorder stateRef={resumeStateRef} />
       <ChatMessageScrollerViewport>
         <ChatMessageScrollerContent
@@ -1047,7 +1047,7 @@ function ThreadScrollBody({
       {/* Re-arms the pin as well as scrolling: the button is the reader saying "follow again". */}
       <ChatMessageScrollerButton
         onClick={() => {
-          autoFollowRef.current = FOLLOWING_END;
+          followRef.current = FOLLOWING_END;
         }}
       />
     </ChatMessageScroller>
@@ -1155,13 +1155,16 @@ export interface ChatThreadProps extends SharedChatThreadProps {
 function ThreadScrollRequestBridge({
   taskId,
   jumpToMessage,
+  prepareForJump,
 }: {
   taskId?: string;
   jumpToMessage?: (id: string) => void;
+  prepareForJump?: () => void;
 }) {
   const { scrollToMessage } = useChatMessageScroller();
   useThreadScrollRequest(taskId, jumpToMessage ?? scrollToMessage, {
     settleFrames: jumpToMessage ? 0 : THREAD_SCROLL_SETTLE_FRAMES,
+    prepareForJump,
   });
   return null;
 }
@@ -1263,6 +1266,10 @@ function ChatThreadRenderer({
     atBottom: true,
     anchorId: null,
   });
+  const nonVirtualFollowRef = useRef<ThreadFollowState>(FOLLOWING_END);
+  const prepareForNonVirtualJump = useCallback(() => {
+    nonVirtualFollowRef.current = { following: false, leftEnd: true };
+  }, []);
 
   const [jumpPickerOpen, setJumpPickerOpen] = useState(false);
   const [keyboardFocusedMessageId, setKeyboardFocusedMessageId] = useState<
@@ -1377,6 +1384,7 @@ function ChatThreadRenderer({
       <ThreadScrollRequestBridge
         taskId={taskId}
         jumpToMessage={jumpToMessage}
+        prepareForJump={jumpToMessage ? undefined : prepareForNonVirtualJump}
       />
     </>
   );
@@ -1421,6 +1429,7 @@ function ChatThreadRenderer({
                   onUserInteract={clearKeyboardFocus}
                   footer={footer}
                   resumeStateRef={threadResumeRef}
+                  followRef={nonVirtualFollowRef}
                 />
                 {renderNav()}
               </>

--- a/products/desktop/packages/ui/src/features/sessions/threadNavigationStore.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/threadNavigationStore.test.ts
@@ -48,11 +48,15 @@ describe("useThreadScrollRequest", () => {
     expect(jump).toHaveBeenCalledTimes(2);
   });
 
-  it("retries jumps while older rows settle", () => {
+  it("retries prepared jumps while older rows settle", () => {
     vi.useFakeTimers();
+    const prepareForJump = vi.fn();
     const jump = vi.fn();
     renderHook(() =>
-      useThreadScrollRequest("task-1", jump, { settleFrames: 2 }),
+      useThreadScrollRequest("task-1", jump, {
+        settleFrames: 2,
+        prepareForJump,
+      }),
     );
 
     act(() => {
@@ -65,5 +69,9 @@ describe("useThreadScrollRequest", () => {
     act(() => vi.runAllTimers());
 
     expect(jump).toHaveBeenCalledTimes(3);
+    expect(prepareForJump).toHaveBeenCalledTimes(3);
+    expect(prepareForJump.mock.invocationCallOrder[0]).toBeLessThan(
+      jump.mock.invocationCallOrder[0],
+    );
   });
 });

--- a/products/desktop/packages/ui/src/features/sessions/threadNavigationStore.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/threadNavigationStore.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   useThreadNavigationStore,
   useThreadScrollRequest,
@@ -7,6 +7,10 @@ import {
 
 beforeEach(() => {
   useThreadNavigationStore.setState({ scrollRequests: {} });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("useThreadScrollRequest", () => {
@@ -42,5 +46,24 @@ describe("useThreadScrollRequest", () => {
     request();
 
     expect(jump).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries jumps while older rows settle", () => {
+    vi.useFakeTimers();
+    const jump = vi.fn();
+    renderHook(() =>
+      useThreadScrollRequest("task-1", jump, { settleFrames: 2 }),
+    );
+
+    act(() => {
+      useThreadNavigationStore
+        .getState()
+        .requestScrollToMessage("task-1", "turn-1-1-user");
+    });
+    expect(jump).toHaveBeenCalledTimes(1);
+
+    act(() => vi.runAllTimers());
+
+    expect(jump).toHaveBeenCalledTimes(3);
   });
 });

--- a/products/desktop/packages/ui/src/features/sessions/threadNavigationStore.ts
+++ b/products/desktop/packages/ui/src/features/sessions/threadNavigationStore.ts
@@ -1,5 +1,7 @@
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { create } from "zustand";
+
+export const THREAD_SCROLL_SETTLE_FRAMES = 8;
 
 interface ThreadNavigationStoreState {
   /** taskId → conversation item id the transcript should scroll to, if any. */
@@ -45,15 +47,38 @@ export const useThreadNavigationStore = create<ThreadNavigationStore>()(
 export function useThreadScrollRequest(
   taskId: string | undefined,
   jumpToMessage: (messageId: string) => void,
+  { settleFrames = 0 }: { settleFrames?: number } = {},
 ): void {
   const requestedMessageId = useThreadNavigationStore((state) =>
     taskId ? state.scrollRequests[taskId] : null,
   );
+  const jumpRef = useRef(jumpToMessage);
+  jumpRef.current = jumpToMessage;
+  const frameRef = useRef<number | null>(null);
+  const cancelSettle = useCallback(() => {
+    if (frameRef.current === null) return;
+    cancelAnimationFrame(frameRef.current);
+    frameRef.current = null;
+  }, []);
+
+  useEffect(() => cancelSettle, [cancelSettle]);
 
   useEffect(() => {
     if (!taskId || !requestedMessageId) return;
-    jumpToMessage(requestedMessageId);
-    // Clear via getState so the action isn't an effect dependency.
+    cancelSettle();
+    let framesRemaining = settleFrames;
+    const jump = () => {
+      jumpRef.current(requestedMessageId);
+      if (framesRemaining <= 0) {
+        frameRef.current = null;
+        return;
+      }
+      framesRemaining--;
+      frameRef.current = requestAnimationFrame(jump);
+    };
+    jump();
+    // Clear via getState so the action isn't an effect dependency. Scheduled
+    // retries continue after the request clears while older rows remeasure.
     useThreadNavigationStore.getState().clearScrollRequest(taskId);
-  }, [taskId, requestedMessageId, jumpToMessage]);
+  }, [taskId, requestedMessageId, settleFrames, cancelSettle]);
 }

--- a/products/desktop/packages/ui/src/features/sessions/threadNavigationStore.ts
+++ b/products/desktop/packages/ui/src/features/sessions/threadNavigationStore.ts
@@ -47,13 +47,18 @@ export const useThreadNavigationStore = create<ThreadNavigationStore>()(
 export function useThreadScrollRequest(
   taskId: string | undefined,
   jumpToMessage: (messageId: string) => void,
-  { settleFrames = 0 }: { settleFrames?: number } = {},
+  {
+    settleFrames = 0,
+    prepareForJump,
+  }: { settleFrames?: number; prepareForJump?: () => void } = {},
 ): void {
   const requestedMessageId = useThreadNavigationStore((state) =>
     taskId ? state.scrollRequests[taskId] : null,
   );
   const jumpRef = useRef(jumpToMessage);
   jumpRef.current = jumpToMessage;
+  const prepareForJumpRef = useRef(prepareForJump);
+  prepareForJumpRef.current = prepareForJump;
   const frameRef = useRef<number | null>(null);
   const cancelSettle = useCallback(() => {
     if (frameRef.current === null) return;
@@ -68,6 +73,7 @@ export function useThreadScrollRequest(
     cancelSettle();
     let framesRemaining = settleFrames;
     const jump = () => {
+      prepareForJumpRef.current?.();
       jumpRef.current(requestedMessageId);
       if (framesRemaining <= 0) {
         frameRef.current = null;


### PR DESCRIPTION
## Problem

People scanning a task timeline see full-length messages, agent replies use an unknown avatar, and jumps to earlier chat messages can miss their target.

## Changes

- Task timelines now show 100-character previews with a subtle hover icon that opens the matching chat message.
- Chat jumps retry while older rows remeasure, so navigation works upward and downward.
- Jumping pauses automatic bottom-following so the selected message stays in view during streamed updates.
- The timeline uses the same merged prompt IDs as the visible chat, including the original prompt.
- Preview truncation preserves parsed references, mentions, and links instead of exposing partial syntax.
- Task feed summaries now use the agent symbol for agent-authored replies.

![Task timeline with the View in chat hover treatment and tooltip](https://raw.githubusercontent.com/PostHog/pr-assets/ecef45f8f8ce5788b0689803c1e7ed687ccd4c68/2026/08/de2206cb-5390-4609-9692-6376319bf485.png)

## How did you test this code?

- Added UI regression coverage for prompt ID alignment, prepared jump settling, agent identity, structured previews, and compact chat navigation.
- Ran the targeted Vitest suites, the UI typecheck, Biome, preflight, and the host-boundary check.
- Rendered the timeline in Storybook and verified the hover treatment and tooltip with headless Chromium.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I used OpenAI's coding agent in pi with repository file, shell, browser, and signed-commit tools.

Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, and `/working-with-task-comments`.
