### PR TITLE
feat(tasks): record commits on the task timeline

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -241,6 +241,7 @@ __all__ = [
     "task_comment_mentions_allowed",
     "list_task_artifacts",
     "list_task_comments",
+    "record_task_run_commits",
     "retrieve_task_comment",
     "update_sandbox_environment",
     "update_task",
@@ -6450,6 +6451,23 @@ def retrieve_task_comment(
         raise ValueError("Invalid task comment cursor") from None
 
 
+def record_task_run_commits(
+    run_id: str | UUID,
+    task_id: str | UUID,
+    team_id: int,
+    *,
+    branch: str,
+    repository: str,
+    commits: Sequence[dict],
+) -> bool:
+    """Announce a push on the run's task. ``False`` when the run isn't visible to the caller."""
+    run = TaskRun.objects.filter(id=run_id, task_id=task_id, team_id=team_id).select_related("task").first()
+    if run is None:
+        return False
+    post_commits_pushed_event(run, branch=branch, repository=repository, commits=list(commits))
+    return True
+
+
 def list_mentions(
     team_id: int, user_id: int | None, *, since: datetime | None = None, limit: int = 100
 ) -> list[contracts.TaskMentionDTO]:
@@ -7108,6 +7126,67 @@ def post_artifact_event(artifact: TaskArtifact, *, revised: bool, run_id: str | 
         )
     except Exception:
         logger.exception("Failed to post artifact event", extra={"artifact_id": str(artifact.id)})
+
+
+# Commit subjects are agent-authored and land in a shared row; bound them, and bound how
+# many of one push the row lists.
+_COMMIT_SUBJECT_LIMIT = 120
+_COMMITS_PER_EVENT_LIMIT = 10
+
+
+def post_commits_pushed_event(
+    run: TaskRun,
+    *,
+    branch: str,
+    repository: str,
+    commits: Sequence[dict],
+) -> None:
+    """Record the commits one push put on a task's branch.
+
+    Reported by the signed-commit tool the agent uses, which is the only actor that knows a
+    push happened: the commits are created through GitHub's API from inside the sandbox, so
+    no webhook to this deployment observes them.
+
+    Keyed on the head SHA, so a retried tool call announces the push once. Best-effort and
+    never raises — an announcement must not fail the commit it announces.
+    """
+    try:
+        head_sha = str(commits[-1].get("sha") or "") if commits else ""
+        if not head_sha:
+            return
+        task = _emittable_task(run.task_id, run.team_id, event=TaskActivityEvent.COMMITS_PUSHED)
+        if task is None:
+            return
+        entries = [
+            {
+                "sha": str(commit.get("sha") or ""),
+                "subject": str(commit.get("subject") or "")[:_COMMIT_SUBJECT_LIMIT],
+                "url": str(commit.get("url") or ""),
+            }
+            for commit in commits[-_COMMITS_PER_EVENT_LIMIT:]
+            if commit.get("sha")
+        ]
+        if not entries:
+            return
+        count = len(commits)
+        emit_task_event(
+            task,
+            event=TaskActivityEvent.COMMITS_PUSHED,
+            content=f"{count} commit{'s' if count != 1 else ''} pushed to {branch}"
+            if branch
+            else f"{count} commits pushed",
+            payload={
+                "run_id": str(run.id),
+                "branch": branch,
+                "repository": repository,
+                "commits": entries,
+                # The row says "and N more" from this; entries are capped above.
+                "total": count,
+            },
+            event_key=head_sha,
+        )
+    except Exception:
+        logger.exception("Failed to post commits-pushed event", extra={"task_id": str(run.task_id)})
 
 
 def post_pr_closed_event(run: TaskRun, pr_url: str, *, merged: bool, actor: str | None = None) -> None:

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -1011,6 +1011,7 @@ class TaskActivityEvent(models.TextChoices):
     RUN_STARTED = "run_started", "Run started"
     RUN_FAILED = "run_failed", "Run failed"
     AWAITING_INPUT = "awaiting_input", "Awaiting input"
+    COMMITS_PUSHED = "commits_pushed", "Commits pushed"
     ARTIFACT_CREATED = "artifact_created", "Artifact created"
     ARTIFACT_REVISED = "artifact_revised", "Artifact revised"
     CANVAS_CREATED = "canvas_created", "Canvas created"

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -798,6 +798,24 @@ class TaskRunSetOutputRequestSerializer(serializers.Serializer):
     )
 
 
+class TaskRunCommitSerializer(serializers.Serializer):
+    sha = serializers.CharField(max_length=64, help_text="Commit SHA.")
+    subject = serializers.CharField(
+        required=False, allow_blank=True, help_text="Commit headline; truncated for display."
+    )
+    url = serializers.URLField(required=False, allow_blank=True, help_text="Commit URL on the host.")
+
+
+class TaskRunCommitsRequestSerializer(serializers.Serializer):
+    """A push the signed-commit tool made, oldest commit first."""
+
+    branch = serializers.CharField(max_length=255, help_text="Branch the commits landed on.")
+    repository = serializers.CharField(
+        max_length=255, allow_blank=True, required=False, help_text="Repository as owner/repo."
+    )
+    commits = TaskRunCommitSerializer(many=True, help_text="Commits in the push, oldest first.")
+
+
 class TaskRunErrorResponseSerializer(serializers.Serializer):
     detail = serializers.CharField(required=False, help_text="Human-readable validation error")
     error = serializers.CharField(required=False, help_text="Human-readable error message")

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -122,6 +122,7 @@ from products.tasks.backend.presentation.serializers import (
     TaskRunCancelRequestSerializer,
     TaskRunCommandRequestSerializer,
     TaskRunCommandResponseSerializer,
+    TaskRunCommitsRequestSerializer,
     TaskRunCreateRequestSchemaSerializer,
     TaskRunCreateRequestSerializer,
     TaskRunDetailSerializer,
@@ -1366,6 +1367,41 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         if run is None:
             raise NotFound()
         return Response(TaskRunDetailSerializer(run).data)
+
+    @validated_request(
+        request_serializer=TaskRunCommitsRequestSerializer,
+        responses={
+            204: OpenApiResponse(description="Push recorded"),
+            404: OpenApiResponse(description="Run not found"),
+        },
+        summary="Record a push",
+        description=(
+            "Announce the commits one push put on the run's branch. Called by the signed-commit "
+            "tool, which is the only actor that observes the push: the commits are created "
+            "through GitHub's API from inside the sandbox, so no webhook sees them. Keyed on the "
+            "head SHA, so a retried call records the push once."
+        ),
+        strict_request_validation=True,
+    )
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="commits",
+        required_scopes=["task:write"],
+    )
+    def commits(self, request, pk=None, **kwargs):
+        task_id = self._ensure_task_accessible()
+        recorded = tasks_facade.record_task_run_commits(
+            pk,
+            task_id,
+            self.team_id,
+            branch=request.validated_data["branch"],
+            repository=request.validated_data.get("repository") or "",
+            commits=request.validated_data["commits"],
+        )
+        if not recorded:
+            raise NotFound()
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
     @validated_request(
         request_serializer=TaskRunAppendLogRequestSerializer,

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -3250,6 +3250,36 @@ export interface TaskRunCommandResponseApi {
     error?: TaskRunCommandResponseApiError
 }
 
+export interface TaskRunCommitApi {
+    /**
+     * Commit SHA.
+     * @maxLength 64
+     */
+    sha: string
+    /** Commit headline; truncated for display. */
+    subject?: string
+    /** Commit URL on the host. */
+    url?: string
+}
+
+/**
+ * A push the signed-commit tool made, oldest commit first.
+ */
+export interface TaskRunCommitsRequestApi {
+    /**
+     * Branch the commits landed on.
+     * @maxLength 255
+     */
+    branch: string
+    /**
+     * Repository as owner/repo.
+     * @maxLength 255
+     */
+    repository?: string
+    /** Commits in the push, oldest first. */
+    commits: TaskRunCommitApi[]
+}
+
 /**
  * Response containing a JWT token for direct sandbox connection
  */

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -97,6 +97,7 @@ import type {
     TaskRunCancelRequestApi,
     TaskRunCommandRequestApi,
     TaskRunCommandResponseApi,
+    TaskRunCommitsRequestApi,
     TaskRunCreateRequestSchemaApi,
     TaskRunDetailDTOApi,
     TaskRunLivingArtifactChartRequestApi,
@@ -1882,6 +1883,29 @@ export const tasksRunsCommandCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(taskRunCommandRequestApi),
+    })
+}
+
+export const getTasksRunsCommitsCreateUrl = (projectId: string, taskId: string, id: string) => {
+    return `/api/projects/${projectId}/tasks/${taskId}/runs/${id}/commits/`
+}
+
+/**
+ * Announce the commits one push put on the run's branch. Called by the signed-commit tool, which is the only actor that observes the push: the commits are created through GitHub's API from inside the sandbox, so no webhook sees them. Keyed on the head SHA, so a retried call records the push once.
+ * @summary Record a push
+ */
+export const tasksRunsCommitsCreate = async (
+    projectId: string,
+    taskId: string,
+    id: string,
+    taskRunCommitsRequestApi: TaskRunCommitsRequestApi,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getTasksRunsCommitsCreateUrl(projectId, taskId, id), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(taskRunCommitsRequestApi),
     })
 }
 

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -2782,6 +2782,36 @@ export const TasksRunsCommandCreateBody = /* @__PURE__ */ zod
     .describe('JSON-RPC request to send a command to the agent server in the sandbox.')
 
 /**
+ * Announce the commits one push put on the run's branch. Called by the signed-commit tool, which is the only actor that observes the push: the commits are created through GitHub's API from inside the sandbox, so no webhook sees them. Keyed on the head SHA, so a retried call records the push once.
+ * @summary Record a push
+ */
+export const tasksRunsCommitsCreateBodyBranchMax = 255
+
+export const tasksRunsCommitsCreateBodyRepositoryMax = 255
+
+export const tasksRunsCommitsCreateBodyCommitsItemShaMax = 64
+
+export const TasksRunsCommitsCreateBody = /* @__PURE__ */ zod
+    .object({
+        branch: zod.string().max(tasksRunsCommitsCreateBodyBranchMax).describe('Branch the commits landed on.'),
+        repository: zod
+            .string()
+            .max(tasksRunsCommitsCreateBodyRepositoryMax)
+            .optional()
+            .describe('Repository as owner\/repo.'),
+        commits: zod
+            .array(
+                zod.object({
+                    sha: zod.string().max(tasksRunsCommitsCreateBodyCommitsItemShaMax).describe('Commit SHA.'),
+                    subject: zod.string().optional().describe('Commit headline; truncated for display.'),
+                    url: zod.url().optional().describe('Commit URL on the host.'),
+                })
+            )
+            .describe('Commits in the push, oldest first.'),
+    })
+    .describe('A push the signed-commit tool made, oldest commit first.')
+
+/**
  * Queue a Slack relay workflow to post a run message into the mapped Slack thread.
  * @summary Relay run message to Slack
  */

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -493,6 +493,9 @@ tools:
     tasks-runs-command-create:
         operation: tasks_runs_command_create
         enabled: false
+    tasks-runs-commits-create:
+        operation: tasks_runs_commits_create
+        enabled: false
     tasks-runs-connection-token-retrieve:
         operation: tasks_runs_connection_token_retrieve
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -75110,6 +75110,36 @@ export namespace Schemas {
       error?: TaskRunCommandResponseError;
     }
 
+    export interface TaskRunCommit {
+      /**
+         * Commit SHA.
+         * @maxLength 64
+         */
+      sha: string;
+      /** Commit headline; truncated for display. */
+      subject?: string;
+      /** Commit URL on the host. */
+      url?: string;
+    }
+
+    /**
+     * A push the signed-commit tool made, oldest commit first.
+     */
+    export interface TaskRunCommitsRequest {
+      /**
+         * Branch the commits landed on.
+         * @maxLength 255
+         */
+      branch: string;
+      /**
+         * Repository as owner/repo.
+         * @maxLength 255
+         */
+      repository?: string;
+      /** Commits in the push, oldest first. */
+      commits: TaskRunCommit[];
+    }
+
     export interface TaskRunResumeRequestSchema {
       /** Execution mode: 'interactive' for user-connected runs, 'background' for autonomous runs
        *


### PR DESCRIPTION
## Problem

A person watching a task sees no commits. The agent's commits are created through GitHub's API from inside the sandbox by the signed-commit tool, so no webhook on this deployment observes them — which is why the timeline shows a PR appearing with nothing before it.

The tool is the only actor that knows a push happened, so it reports it.

## Changes

`POST /tasks/:task/runs/:run/commits/` takes the branch, repository and the push's commits, and emits a `commits_pushed` event carrying the SHAs and subjects the row renders. Loading the timeline stays a read — no call out to GitHub.

- Keyed on the head SHA, so a retried tool call records the push once.
- The payload caps at the 10 most recent commits and carries a `total`, so a large push renders as a list plus "and N more" rather than an unbounded row.
- Subjects are truncated. They are agent-authored text landing in a row other people read.
- Best-effort like the sibling emitters: a commit that landed must not fail because its announcement did not.

The reporting call and the row are the desktop half, on #80765. It sits above this layer, so this one lands first.

## How did you test this code?

Not run against a live sandbox from here — the emit path is covered the same way the sibling lifecycle events are, and the endpoint is thin over the facade.

Automated: the emitter goes through `emit_task_event`, whose idempotency is already covered in `test_thread_updates`. The client-side parse and dedupe of `commits_pushed` are tested in `@posthog/core` on #80765.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Commits were scoped out of the original stack on the assumption they would arrive by GitHub `push` webhook. They cannot: the signed-commit tool pushes through the API from inside the sandbox. Reporting from the tool is both simpler and the only thing that observes the event, and it reuses the shape `attachPrToTaskRun` already uses for pull requests.

Skills invoked: `/improving-drf-endpoints`, `/writing-pr-descriptions`.