### PR TITLE
fix(logs): reject non-object query payloads in LogsViewSet

### DIFF
--- a/products/logs/backend/presentation/views/api.py
+++ b/products/logs/backend/presentation/views/api.py
@@ -1149,6 +1149,12 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
             return filter_group
         return {"type": "AND", "values": []}
 
+    @staticmethod
+    def _require_dict_query(query_data: object) -> None:
+        """Guard against a non-object `query` field crashing on the first `.get()` call below."""
+        if not isinstance(query_data, dict):
+            raise ParseError("query must be an object")
+
     def _filtered_logs_query(self, query_data: dict) -> LogsQuery:
         """The shared date-range + filters subset of LogsQuery used by aggregation actions."""
         date_range_data = query_data.get("dateRange")
@@ -1169,6 +1175,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
         query_data = request.data.get("query", None)
         if query_data is None:
             return Response({"error": "No query provided"}, status=status.HTTP_400_BAD_REQUEST)
+        self._require_dict_query(query_data)
 
         live_logs_checkpoint = query_data.get("liveLogsCheckpoint", None)
         after_cursor = query_data.get("after", None)
@@ -1299,6 +1306,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
     def sparkline(self, request: Request, *args, **kwargs) -> Response:
         tag_queries(product=Product.LOGS, feature=Feature.QUERY)
         query_data = request.data.get("query", {})
+        self._require_dict_query(query_data)
 
         date_range_data = query_data.get("dateRange")
         date_range = self.get_model(date_range_data, DateRange) if date_range_data else DateRange(date_from="-1h")
@@ -1343,6 +1351,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
     def facet_values(self, request: Request, *args, **kwargs) -> Response:
         tag_queries(product=Product.LOGS, feature=Feature.QUERY)
         query_data = request.data.get("query", {})
+        self._require_dict_query(query_data)
 
         facet_field = query_data.get("facetField")
         facet_resource_attribute = query_data.get("facetResourceAttribute")
@@ -1384,6 +1393,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
     def count(self, request: Request, *args, **kwargs) -> Response:
         tag_queries(product=Product.LOGS, feature=Feature.QUERY)
         query_data = request.data.get("query", {})
+        self._require_dict_query(query_data)
 
         date_range_data = query_data.get("dateRange")
         date_range = self.get_model(date_range_data, DateRange) if date_range_data else DateRange(date_from="-1h")
@@ -1426,6 +1436,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
     def count_ranges(self, request: Request, *args, **kwargs) -> Response:
         tag_queries(product=Product.LOGS, feature=Feature.QUERY)
         query_data = request.data.get("query", {})
+        self._require_dict_query(query_data)
 
         date_range_data = query_data.get("dateRange")
         date_range = self.get_model(date_range_data, DateRange) if date_range_data else DateRange(date_from="-1h")
@@ -1468,6 +1479,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
     def services(self, request: Request, *args, **kwargs) -> Response:
         tag_queries(product=Product.LOGS, feature=Feature.QUERY)
         query_data = request.data.get("query", {})
+        self._require_dict_query(query_data)
 
         query = LogsQuery(
             dateRange=self.get_model(query_data.get("dateRange"), DateRange),
@@ -1506,6 +1518,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
     def patterns(self, request: Request, *args, **kwargs) -> Response:
         tag_queries(product=Product.LOGS, feature=Feature.QUERY)
         query_data = request.data.get("query", {})
+        self._require_dict_query(query_data)
 
         query = self._filtered_logs_query(query_data)
 
@@ -1539,6 +1552,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
     def patterns_diff(self, request: Request, *args, **kwargs) -> Response:
         tag_queries(product=Product.LOGS, feature=Feature.QUERY)
         query_data = request.data.get("query", {})
+        self._require_dict_query(query_data)
 
         query = self._filtered_logs_query(query_data)
         baseline_date_range = (
@@ -1571,6 +1585,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
     def group_by(self, request: Request, *args, **kwargs) -> Response:
         tag_queries(product=Product.LOGS, feature=Feature.QUERY)
         query_data = request.data.get("query", {})
+        self._require_dict_query(query_data)
 
         query = self._filtered_logs_query(query_data)
 
@@ -1779,6 +1794,7 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
         query_data = request.data.get("query", None)
         if query_data is None:
             return Response({"error": "No query provided"}, status=status.HTTP_400_BAD_REQUEST)
+        self._require_dict_query(query_data)
 
         custom_columns = query_data.get("customColumns") or []
         if len(custom_columns) > MAX_CUSTOM_COLUMNS:

--- a/products/logs/backend/test/test_count_api.py
+++ b/products/logs/backend/test/test_count_api.py
@@ -84,6 +84,12 @@ class TestCountApi(ClickhouseTestMixin, APIBaseTest):
         response = self._count({})
         self.assertEqual(response["count"], 0)
 
+    def test_count_rejects_non_object_query(self):
+        # A non-object `query` (e.g. a bare string) used to crash with an unhandled
+        # AttributeError on the first `.get()` call instead of a clean 400.
+        response = self.client.post(f"/api/projects/{self.team.id}/logs/count", data={"query": "not-an-object"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     @parameterized.expand(
         [
             # Multi-day window — exercises full WHERE clause

--- a/products/logs/backend/test/test_logs_export.py
+++ b/products/logs/backend/test/test_logs_export.py
@@ -102,3 +102,13 @@ class TestLogsExportEndpoint(APIBaseTest):
             format="json",
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_export_rejects_non_object_query(self):
+        # A non-object `query` (e.g. a bare string) used to crash with an unhandled
+        # AttributeError on the first `.get()` call instead of a clean 400.
+        response = self.client.post(
+            f"/api/projects/{self.team.pk}/logs/export/",
+            data={"query": "not-an-object"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
## Problem

Sending a malformed `query` field (a bare string instead of an object) to any
`/logs/*` endpoint crashes the request with an unhandled 500 instead of a
clean 400.

## Changes

- Every `LogsViewSet` action reads `query_data = request.data.get("query", ...)`
  and calls `.get(...)` on it without checking the type, so a non-object value
  throws `AttributeError: 'str' object has no attribute 'get'`.
- Add `LogsViewSet._require_dict_query`, a static helper that raises
  `ParseError` (the same pattern already used in `facet_values` in this file)
  when `query` is present but not an object. DRF turns `ParseError` into a 400
  automatically.
- Call it at all 10 affected actions: `query`, `sparkline`, `facet_values`,
  `count`, `count_ranges`, `services`, `patterns`, `patterns_diff`,
  `group_by`, `export`.
- Well-formed requests are unaffected; only a non-object `query` changes
  behavior, from a 500 to a 400.

Error tracking shows this crash recurring on the `query` action for months,
and a same-shaped 500 on `count` reported separately by an MCP client hitting
the same endpoint family.

## How did you test this code?

Added `test_export_rejects_non_object_query` to `test_logs_export.py` and
`test_count_rejects_non_object_query` to `test_count_api.py`, each posting a
string `query` and asserting a 400. These are the two actions error tracking
showed actually crashing in production.

Ran manually in this sandbox:
- `ruff check --fix` and `ruff format` on the changed files: clean.
- `mypy` on the changed file: no issues.
- Direct invocation of `LogsViewSet._require_dict_query` with dict and
  non-dict input: raises only for non-dict, as expected.

Not run: the new tests themselves, and the rest of the `products/logs/backend`
suite. This sandbox has no Postgres or ClickHouse server (`hogli`, `docker`,
and `bootstrap-dev-stack` are all unavailable here), so no Django test can
execute. CI will run the full suite on this PR.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Found via a scheduled daily bug-check loop that queries PostHog's own error
tracking MCP tools for issues with stack frames resolving into
`products/logs/`. `/improving-drf-endpoints` and `/writing-tests` were invoked
before writing the fix and tests.

A full migration of these actions to `@validated_request` (so drf-spectacular's
declared request schema is actually enforced, not just documented) would be a
more thorough fix but is a larger, riskier change across 10 actions' control
flow. Left as a follow-up for a human to scope separately.