### PR TITLE
fix(logs): stop live-tail poller crashing on unmount

### DIFF
--- a/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.test.ts
@@ -164,6 +164,32 @@ describe('logsViewerDataLogic', () => {
 
             expect(logic.values.newLogUuids.size).toBe(0)
         })
+
+        it('unmounting mid-poll does not throw ([KEA] Can not find path ...)', async () => {
+            // beforeUnmount aborts the in-flight live-tail request. pollForNewLogs' finally
+            // block used to run unconditionally after that abort, dispatching actions against
+            // a logic that had already been torn down and crashing with a Kea "path not found"
+            // error. Guarding the finally block on signal.aborted (mirroring the existing catch
+            // block) fixes it.
+            let resolveQuery: (() => void) | undefined
+            useMocks({
+                post: {
+                    '/api/environments/:team_id/logs/query/': () =>
+                        new Promise((resolve) => {
+                            resolveQuery = () => resolve([200, { results: [], maxExportableLogs: 5000 }])
+                        }),
+                },
+            })
+
+            logic.actions.setLiveTailRunning(true)
+            await expectLogic(logic).toDispatchActions(['setLiveTailAbortController'])
+
+            expect(() => logic.unmount()).not.toThrow()
+
+            // Let the aborted request's rejection propagate through pollForNewLogs' catch/finally.
+            resolveQuery?.()
+            await new Promise((resolve) => setTimeout(resolve, 0))
+        })
     })
 
     describe('sparklineData selector', () => {

--- a/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.ts
@@ -994,7 +994,7 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
         },
     })),
 
-    listeners(({ actions, values, cache }) => ({
+    listeners(({ actions, values, cache, props }) => ({
         handleQueryChange: ({ filterType, extraProps }) => {
             if (values.hasRunQuery) {
                 posthog.capture('logs filter changed', { filter_type: filterType, ...extraProps })
@@ -1201,7 +1201,7 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
                     actions.setNewLogUuids([])
                 }
             } catch (error) {
-                if (signal.aborted) {
+                if (signal.aborted || !logsViewerDataLogic.isMounted(props.id)) {
                     return
                 }
                 console.error('Live tail polling error:', error)
@@ -1214,17 +1214,25 @@ export const logsViewerDataLogic = kea<logsViewerDataLogicType>([
                 })
                 actions.setLiveTailRunning(false)
             } finally {
-                actions.setLiveTailAbortController(null)
-                if (values.liveTailRunning) {
-                    cache.disposables.add(() => {
-                        const timerId = setTimeout(
-                            () => {
-                                actions.pollForNewLogs()
-                            },
-                            Math.max(duration, values.liveTailPollInterval)
-                        )
-                        return () => clearTimeout(timerId)
-                    }, 'liveTailTimer')
+                // beforeUnmount aborts the in-flight controller and marks liveTailRunning false,
+                // but those are plain dispatches during teardown, not guaranteed to run their
+                // listeners before the logic's keyed path is torn down. So an unmount that lands
+                // while this request is in flight can resolve normally afterwards. Re-check both
+                // signals before touching actions/values, or this can dispatch against an
+                // already-unmounted keyed logic instance and throw "[KEA] Can not find path ...".
+                if (!signal.aborted && logsViewerDataLogic.isMounted(props.id)) {
+                    actions.setLiveTailAbortController(null)
+                    if (values.liveTailRunning) {
+                        cache.disposables.add(() => {
+                            const timerId = setTimeout(
+                                () => {
+                                    actions.pollForNewLogs()
+                                },
+                                Math.max(duration, values.liveTailPollInterval)
+                            )
+                            return () => clearTimeout(timerId)
+                        }, 'liveTailTimer')
+                    }
                 }
             }
         },


### PR DESCRIPTION
## Problem

The Logs page can crash for a user who navigates away while live tail is
polling, with an unhandled `[KEA] Can not find path ... in the store` error.

## Changes

- `pollForNewLogs` already guards its `catch` block with
  `if (signal.aborted) return`, added for the case where a newer request
  supersedes an in-flight one.
- On unmount, `beforeUnmount` dispatches `cancelInProgressLiveTail` and
  `setLiveTailRunning(false)` as plain actions. Dispatching an action during
  teardown does not reliably run its listener before the logic's keyed path
  is removed, so the abort that is supposed to cancel the in-flight request
  often does not happen.
- The pending request then resolves normally after unmount, and the listener
  keeps running: it reads `values.logs` in the `try` block, then
  `values.liveTailAbortController` and `values.liveTailRunning` in `finally`,
  each of which was completely unguarded and throws when the logic is gone.
- Guard both `catch` and the previously unguarded `finally` block on
  `logsViewerDataLogic.isMounted(props.id)`, alongside the existing
  `signal.aborted` check.

Found via a scheduled bug-check loop that flagged this error tracking issue:
recurring since 2026-04-29, still firing as of this PR, unhandled.

## How did you test this code?

Added a test to `logsViewerDataLogic.test.ts` that starts live tail with a
pending mock response, unmounts the logic mid-request, then resolves the
response. It reproduces the exact production crash against the prior code and
passes with this fix — verified both ways in this sandbox with:

```
frontend/node_modules/.bin/jest --config frontend/jest.config.ts \
  products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic.test.ts
```

All 55 tests in the file pass, and the full `products/logs/frontend` suite
(31 files, 551 tests) passes with no regressions.

Not run: `pnpm typecheck` reports pre-existing errors elsewhere in the repo
from an unbuilt `@posthog/quill-primitives` workspace package, unrelated to
this change; none are in the changed file.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Found via a scheduled daily bug-check loop that queries PostHog's own error
tracking MCP tools for issues with stack frames resolving into
`products/logs/`. `/using-kea-disposables` and `/writing-tests` were invoked
while diagnosing and fixing this. An initial attempt guarded only on
`signal.aborted`; running the new test against it reproduced the crash
anyway, which is what surfaced that `beforeUnmount`'s dispatches don't
reliably abort the request, and led to the `isMounted` check instead.