### PR TITLE
fix(tiktok_ads): keep known-transient TikTok errors out of error tracking

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/source.py
@@ -84,6 +84,15 @@ class TikTokAdsSource(ResumableSource[TikTokAdsSourceConfig, TikTokAdsResumeConf
             "Integration not found": "The linked TikTok Ads integration no longer exists. Please reconnect your TikTok Ads integration.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        return {
+            # The paginator's `update_state` raises this exact prefix for every TikTok API code
+            # it already classifies as transient (rate limits, "System error", maintenance) — see
+            # `TikTokAdsPaginator.update_state`'s `retryable_codes`. Temporal retries the whole
+            # activity regardless, so this shouldn't page us as a bug.
+            "TikTok API error:",
+        }
+
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_source.py
@@ -120,6 +120,45 @@ class TestTikTokAdsSource:
 
     @parameterized.expand(
         [
+            ("system_error", 50000, "System error"),
+            ("rate_limited", 40100, "Requests made too frequently"),
+            ("maintenance", 60001, "The system is in maintenance"),
+        ]
+    )
+    def test_retryable_paginator_error_matches_get_retryable_errors(self, name, api_code, message):
+        """A mid-pagination TikTok error the paginator already classifies as transient must
+        match get_retryable_errors, otherwise Temporal's outer retry reports it as a bug on
+        every attempt instead of logging a warning."""
+        paginator = TikTokAdsPaginator()
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"code": api_code, "message": message, "data": {}}
+
+        with pytest.raises(TikTokAdsAPIError) as exc_info:
+            paginator.update_state(mock_response)
+
+        error_message = str(exc_info.value)
+        patterns = self.source.get_retryable_errors()
+        assert any(pattern in error_message for pattern in patterns), (
+            f"TikTok retryable error '{error_message}' does not match any retryable pattern"
+        )
+
+    def test_non_retryable_paginator_error_does_not_match_get_retryable_errors(self):
+        """A non-retryable paginator error must not be swallowed as a benign retryable one."""
+        paginator = TikTokAdsPaginator()
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"code": 40001, "message": "The advertiser doesn't exist", "data": {}}
+
+        with pytest.raises(ValueError) as exc_info:
+            paginator.update_state(mock_response)
+
+        error_message = str(exc_info.value)
+        patterns = self.source.get_retryable_errors()
+        assert not any(pattern in error_message for pattern in patterns)
+
+    @parameterized.expand(
+        [
             ("connection_reset", RequestsConnectionError("Connection reset by peer")),
             ("timeout", Timeout("Read timed out")),
             ("base_request_exception", RequestException("DNS lookup failed")),


### PR DESCRIPTION
## Problem

TikTok Ads imports report a bug to error tracking every time TikTok returns a transient error (rate limits, "System error" code 50000, maintenance code 60001, and other codes the paginator already knows are safe to retry). See [issue 019ff03b-b99e-79c1-9445-0919f6570763](https://us.posthog.com/project/2/error_tracking/019ff03b-b99e-79c1-9445-0919f6570763), raised from `TikTokAdsPaginator.update_state` in `tiktok_ads/utils.py`.

`_handle_import_error` checks `source_cls.get_retryable_errors()` and logs a warning instead of tracking an exception on a match. `TikTokAdsSource` only overrode `get_non_retryable_errors()`, so nothing matched and these self-recovering blips fell through to `logger.aexception`, becoming noise in error tracking.

## Changes

- Add `TikTokAdsSource.get_retryable_errors()`, matching the paginator's stable `"TikTok API error:"` prefix. This is the same prefix used only by the retryable branch of `update_state`, so it can't collide with the non-retryable (`"TikTok API client error (non-retryable):"`) or advertiser-listing error messages.
- Mirrors the pattern already used by `MetaAdsSource.get_retryable_errors` and other sources for the same class of problem.
- Behavior is unchanged for retries: Temporal still retries the whole activity either way. This only stops a known-transient failure from paging as a bug.

## How did you test this code?

- Added `test_retryable_paginator_error_matches_get_retryable_errors`, parameterized over three of the paginator's retryable codes (50000, 40100, 60001) — catches the regression this issue hit, where the paginator's message and `get_retryable_errors()` drift out of sync.
- Added `test_non_retryable_paginator_error_does_not_match_get_retryable_errors` — guards against widening the pattern to swallow a real non-retryable failure (code 40001).
- Ran the full `tiktok_ads` source test suite locally: all cases pass.
- Ran `mypy` scoped to the `tiktok_ads` source package: clean.
- Not run: a live TikTok sync, since this sandbox has no TikTok credentials.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing or API behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by an agent triaging error tracking issue `019ff03b-b99e-79c1-9445-0919f6570763`. Read the stack trace and confirmed the exception originates in `tiktok_ads/utils.py`'s paginator, traced the classification path (`_handle_import_error` → `get_retryable_errors`/`get_non_retryable_errors`), and compared against `MetaAdsSource`'s existing `get_retryable_errors` override for the same pattern. Invoked `/writing-tests` before adding tests and `/writing-pr-descriptions` before writing this body.

Before opening this PR, found an earlier bot-authored PR on the same fix: [#75247](https://github.com/PostHog/posthog/pull/75247) (unassigned, unreviewed). It implements the same `get_retryable_errors()` override plus an additional change to strip TikTok's raw response body out of the exception message for fingerprint stability. That second part is a separate improvement not needed to resolve this specific issue, so this PR stays scoped to the `get_retryable_errors()` fix. The two should be reconciled at review time.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*