### PR TITLE
feat(slack_app): show personal GitHub connection on the home tab

### DIFF
--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -672,77 +672,76 @@ def _linked_accounts_section_blocks(
     account_state: AccountState | None,
     github_state: GitHubState | None,
 ) -> list[dict]:
-    """Render the linked-accounts card: PostHog and GitHub side by side.
+    """Render the linked-accounts card: one row per account.
 
-    Block Kit lays `section.fields` out in two columns, so each account gets
-    its own column with the buttons for both sharing one actions row below.
-    The PostHog column only appears when `is_slack_app_oauth_enabled` returned
-    True; the GitHub column is independent of that flag.
+    A row is a section carrying that account's status, with its button as the
+    right-aligned `accessory`. Block Kit allows at most one accessory per
+    section and renders `actions` blocks full width, so a row apiece is the
+    only layout that keeps each button next to the account it acts on.
+    The PostHog row only appears when `is_slack_app_oauth_enabled` returned
+    True; the GitHub row is independent of that flag.
     """
-    fields: list[dict] = []
-    actions: list[dict] = []
+    rows: list[dict] = []
 
     if account_state and account_state.enabled:
-        fields.append({"type": "mrkdwn", "text": _posthog_account_field(account_state)})
-        actions.extend(_posthog_account_actions(account_state))
+        rows.append(_account_row(_posthog_account_text(account_state), _posthog_account_button(account_state)))
 
     if github_state is not None:
-        fields.append({"type": "mrkdwn", "text": _github_account_field(github_state)})
-        actions.extend(_github_account_actions(github_state))
+        rows.append(_account_row(_github_account_text(github_state), _github_account_button(github_state)))
 
-    if not fields:
+    if not rows:
         return []
 
-    blocks: list[dict] = [
+    return [
         _section_title(
             "🔗 Linked accounts",
             "Who @PostHog acts as: your PostHog user, and the GitHub account it opens pull requests with.",
         ),
-        {"type": "section", "fields": fields},
+        *rows,
     ]
-    if actions:
-        blocks.append({"type": "actions", "elements": actions})
-    return blocks
 
 
-def _posthog_account_field(account_state: AccountState) -> str:
+def _account_row(text: str, button: dict | None) -> dict:
+    row: dict[str, Any] = {"type": "section", "text": {"type": "mrkdwn", "text": text}}
+    if button:
+        row["accessory"] = button
+    return row
+
+
+def _posthog_account_text(account_state: AccountState) -> str:
     if account_state.linked_email:
         return f"*PostHog*\n✅ Connected as {account_state.linked_email}"
     return "*PostHog*\nNot connected. Link your Slack identity so @PostHog knows it's you without matching on email."
 
 
-def _posthog_account_actions(account_state: AccountState) -> list[dict]:
+def _posthog_account_button(account_state: AccountState) -> dict | None:
     if account_state.linked_email:
-        return [
-            {
-                "type": "button",
-                "action_id": ACTION_UNLINK_ACCOUNT,
-                "style": "danger",
-                "text": {"type": "plain_text", "text": "Disconnect PostHog", "emoji": True},
-                "confirm": {
-                    "title": {"type": "plain_text", "text": "Disconnect your PostHog account?"},
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": "@PostHog will fall back to matching your Slack email against PostHog users until you link again.",
-                    },
-                    "confirm": {"type": "plain_text", "text": "Disconnect"},
-                    "deny": {"type": "plain_text", "text": "Cancel"},
-                },
-            }
-        ]
-    if not account_state.link_url:
-        return []
-    return [
-        {
+        return {
             "type": "button",
-            "url": account_state.link_url,
-            "text": {"type": "plain_text", "text": "Connect to PostHog", "emoji": True},
-            "style": "primary",
+            "action_id": ACTION_UNLINK_ACCOUNT,
+            "style": "danger",
+            "text": {"type": "plain_text", "text": "Disconnect", "emoji": True},
+            "confirm": {
+                "title": {"type": "plain_text", "text": "Disconnect your PostHog account?"},
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "@PostHog will fall back to matching your Slack email against PostHog users until you link again.",
+                },
+                "confirm": {"type": "plain_text", "text": "Disconnect"},
+                "deny": {"type": "plain_text", "text": "Cancel"},
+            },
         }
-    ]
+    if not account_state.link_url:
+        return None
+    return {
+        "type": "button",
+        "url": account_state.link_url,
+        "text": {"type": "plain_text", "text": "Connect to PostHog", "emoji": True},
+        "style": "primary",
+    }
 
 
-def _github_account_field(github_state: GitHubState) -> str:
+def _github_account_text(github_state: GitHubState) -> str:
     if not github_state.user_resolved:
         return "*GitHub*\nLink your PostHog account first, so we know whose GitHub to look up."
     if github_state.accounts:
@@ -751,9 +750,9 @@ def _github_account_field(github_state: GitHubState) -> str:
     return "*GitHub*\nNot connected. Connect it so @PostHog opens pull requests as you."
 
 
-def _github_account_actions(github_state: GitHubState) -> list[dict]:
+def _github_account_button(github_state: GitHubState) -> dict | None:
     if not github_state.user_resolved or not github_state.settings_url:
-        return []
+        return None
     connected = bool(github_state.accounts)
     button: dict[str, Any] = {
         "type": "button",
@@ -766,7 +765,7 @@ def _github_account_actions(github_state: GitHubState) -> list[dict]:
     }
     if not connected:
         button["style"] = "primary"
-    return [button]
+    return button
 
 
 def _personal_section_blocks(user_row: SlackSettings | None) -> list[dict]:

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -374,10 +374,15 @@ class GitHubState:
     ``user_resolved`` is False when we couldn't tell which PostHog user is
     behind this Slack identity — the card then asks them to link PostHog first
     instead of claiming they have no GitHub connection.
+
+    ``credentials_usable`` carries the same judgment the task flow gates on,
+    so a row whose tokens have gone stale reads as needing a reconnect rather
+    than as a working connection.
     """
 
     user_resolved: bool = False
     accounts: tuple[GitHubAccount, ...] = ()
+    credentials_usable: bool = False
     settings_url: str | None = None
 
 
@@ -744,27 +749,31 @@ def _posthog_account_button(account_state: AccountState) -> dict | None:
 def _github_account_text(github_state: GitHubState) -> str:
     if not github_state.user_resolved:
         return "*GitHub*\nLink your PostHog account first, so we know whose GitHub to look up."
-    if github_state.accounts:
-        listed = "\n".join(f"✅ {account.label}" for account in github_state.accounts)
+    if not github_state.accounts:
+        return "*GitHub*\nNot connected. Connect it so @PostHog opens pull requests as you."
+    marker = "✅" if github_state.credentials_usable else "⚠️"
+    listed = "\n".join(f"{marker} {account.label}" for account in github_state.accounts)
+    if github_state.credentials_usable:
         return f"*GitHub*\n{listed}"
-    return "*GitHub*\nNot connected. Connect it so @PostHog opens pull requests as you."
+    return f"*GitHub*\n{listed}\nYour access has expired. Reconnect it, or @PostHog can't open pull requests as you."
 
 
 def _github_account_button(github_state: GitHubState) -> dict | None:
     if not github_state.user_resolved or not github_state.settings_url:
         return None
-    connected = bool(github_state.accounts)
+    if not github_state.accounts:
+        label, style = "Connect GitHub", "primary"
+    elif not github_state.credentials_usable:
+        label, style = "Reconnect GitHub", "primary"
+    else:
+        label, style = "Manage GitHub", ""
     button: dict[str, Any] = {
         "type": "button",
         "url": github_state.settings_url,
-        "text": {
-            "type": "plain_text",
-            "text": "Manage GitHub" if connected else "Connect GitHub",
-            "emoji": True,
-        },
+        "text": {"type": "plain_text", "text": label, "emoji": True},
     }
-    if not connected:
-        button["style"] = "primary"
+    if style:
+        button["style"] = style
     return button
 
 
@@ -2037,7 +2046,9 @@ def _resolve_home_user(integration: Integration, slack_user_id: str) -> User | N
 
     Mirrors the event-path cascade in `resolve_posthog_user_from_event`: the
     OAuth link wins, otherwise we match the cached Slack profile email against
-    members of the organizations connected to this workspace. Reading the
+    members of the organizations connected to this workspace. Deactivated
+    users count as no match on both paths, so an offboarded account can't be
+    reached through a Slack identity that still maps to it. Reading the
     profile cache instead of calling `users.info` keeps the Home render free
     of a Slack API roundtrip.
     """
@@ -2053,13 +2064,17 @@ def _resolve_home_user(integration: Integration, slack_user_id: str) -> User | N
             candidate_org_ids=candidate_org_ids,
         )
         if linked_user is not None:
-            return linked_user
+            return linked_user if linked_user.is_active else None
 
     profile = SlackUserProfileCache.objects.filter(integration_id=integration.id, slack_user_id=slack_user_id).first()
     if profile is None or not profile.email:
         return None
     membership = (
-        OrganizationMembership.objects.filter(organization_id__in=candidate_org_ids, user__email__iexact=profile.email)
+        OrganizationMembership.objects.filter(
+            organization_id__in=candidate_org_ids,
+            user__email__iexact=profile.email,
+            user__is_active=True,
+        )
         .select_related("user")
         .first()
     )
@@ -2069,10 +2084,16 @@ def _resolve_home_user(integration: Integration, slack_user_id: str) -> User | N
 def _resolve_github_state(integration: Integration, slack_user_id: str) -> GitHubState:
     """List the personal GitHub installations of the user opening the Home tab.
 
+    Usability comes from the tasks facade, the same judgment
+    `should_block_task_for_missing_user_github` gates on, so the card and the
+    task flow never disagree about whether a connection works.
+
     Connecting GitHub needs an authenticated PostHog session, so the button
     deep-links to Personal integrations settings — the same target the
     in-thread "Connect GitHub" prompt uses.
     """
+    from products.tasks.backend.facade import api as tasks_facade
+
     settings_url = f"{settings.SITE_URL.rstrip('/')}/project/{integration.team_id}/settings/user-personal-integrations"
     try:
         user = _resolve_home_user(integration, slack_user_id)
@@ -2083,6 +2104,7 @@ def _resolve_github_state(integration: Integration, slack_user_id: str) -> GitHu
             kind=UserIntegration.IntegrationKind.GITHUB,
         ).order_by("created_at")
         accounts = tuple(_github_account_from_row(row) for row in rows)
+        credentials_usable = bool(accounts) and tasks_facade.user_has_usable_personal_github(user.id)
     except Exception:
         logger.exception(
             "slack_app_home_resolve_github_state_failed",
@@ -2090,7 +2112,12 @@ def _resolve_github_state(integration: Integration, slack_user_id: str) -> GitHu
             integration_id=integration.id,
         )
         return GitHubState(user_resolved=False, settings_url=settings_url)
-    return GitHubState(user_resolved=True, accounts=accounts, settings_url=settings_url)
+    return GitHubState(
+        user_resolved=True,
+        accounts=accounts,
+        credentials_usable=credentials_usable,
+        settings_url=settings_url,
+    )
 
 
 def _github_account_from_row(row: UserIntegration) -> GitHubAccount:

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -28,6 +28,7 @@ import structlog
 
 from posthog.models.integration import SLACK_INTEGRATION_KINDS, Integration, SlackIntegration
 from posthog.models.organization import OrganizationMembership
+from posthog.models.user import User
 from posthog.models.user_integration import UserIntegration
 from posthog.user_permissions import UserPermissions
 
@@ -349,12 +350,44 @@ class AccountState:
     link_url: str | None = None
 
 
+@dataclass(frozen=True)
+class GitHubAccount:
+    """One personal GitHub App installation the user has connected."""
+
+    installation_id: str
+    login: str | None = None
+    account_name: str | None = None
+
+    @property
+    def label(self) -> str:
+        """`login` is the GitHub user who authorized; `account_name` is the org
+        or user the App is installed on. Show both when they differ."""
+        if self.login and self.account_name and self.login != self.account_name:
+            return f"`{self.login}` on *{self.account_name}*"
+        return f"`{self.login or self.account_name or self.installation_id}`"
+
+
+@dataclass(frozen=True)
+class GitHubState:
+    """Inputs the renderer needs to draw the GitHub half of the accounts card.
+
+    ``user_resolved`` is False when we couldn't tell which PostHog user is
+    behind this Slack identity — the card then asks them to link PostHog first
+    instead of claiming they have no GitHub connection.
+    """
+
+    user_resolved: bool = False
+    accounts: tuple[GitHubAccount, ...] = ()
+    settings_url: str | None = None
+
+
 def render_home_view(
     *,
     effective: AIPreferences,
     user_row: SlackSettings | None,
     is_admin: bool,
     account_state: AccountState | None = None,
+    github_state: GitHubState | None = None,
     project_state: ProjectState | None = None,
     tasks_state: TasksState | None = None,
     stats_state: StatsState | None = None,
@@ -396,11 +429,12 @@ def render_home_view(
     blocks.extend(_active_model_blocks(effective, source))
     blocks.extend(_personal_section_blocks(user_row))
 
-    # Section 4 — account linking: shown before Tasks so the connect
-    # prompt is visible while the Tasks list is still empty. Flag-gated.
-    if account_state and account_state.enabled:
+    # Section 4 — linked accounts: PostHog and GitHub side by side, shown
+    # before Tasks so the connect prompts are visible while the Tasks list
+    # is still empty. The PostHog half is flag-gated.
+    if (account_state and account_state.enabled) or github_state is not None:
         blocks.append({"type": "divider"})
-        blocks.extend(_account_section_blocks(account_state))
+        blocks.extend(_linked_accounts_section_blocks(account_state, github_state))
 
     # Section 5 — your tasks: a quiet list of tasks the calling user
     # started via @PostHog mentions, so they can see status without
@@ -634,65 +668,105 @@ def _project_section_blocks(state: ProjectState, *, is_admin: bool) -> list[dict
     return blocks
 
 
-def _account_section_blocks(account_state: AccountState) -> list[dict]:
-    """Render the Sign-in-with-Slack account card.
+def _linked_accounts_section_blocks(
+    account_state: AccountState | None,
+    github_state: GitHubState | None,
+) -> list[dict]:
+    """Render the linked-accounts card: PostHog and GitHub side by side.
 
-    Visible only when `is_slack_app_oauth_enabled` returned True. Linked
-    state mirrors the Claude home pattern: ✅ + email, with a danger-styled
-    Disconnect button at the bottom.
+    Block Kit lays `section.fields` out in two columns, so each account gets
+    its own column with the buttons for both sharing one actions row below.
+    The PostHog column only appears when `is_slack_app_oauth_enabled` returned
+    True; the GitHub column is independent of that flag.
     """
-    if account_state.linked_email:
-        return [
-            _section_title("🔗 Linked PostHog account"),
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": f"✅ Connected as *{account_state.linked_email}*",
-                },
-            },
-            {
-                "type": "actions",
-                "elements": [
-                    {
-                        "type": "button",
-                        "action_id": ACTION_UNLINK_ACCOUNT,
-                        "style": "danger",
-                        "text": {"type": "plain_text", "text": "Disconnect", "emoji": True},
-                        "confirm": {
-                            "title": {"type": "plain_text", "text": "Disconnect your PostHog account?"},
-                            "text": {
-                                "type": "mrkdwn",
-                                "text": "@PostHog will fall back to matching your Slack email against PostHog users until you link again.",
-                            },
-                            "confirm": {"type": "plain_text", "text": "Disconnect"},
-                            "deny": {"type": "plain_text", "text": "Cancel"},
-                        },
-                    }
-                ],
-            },
-        ]
+    fields: list[dict] = []
+    actions: list[dict] = []
+
+    if account_state and account_state.enabled:
+        fields.append({"type": "mrkdwn", "text": _posthog_account_field(account_state)})
+        actions.extend(_posthog_account_actions(account_state))
+
+    if github_state is not None:
+        fields.append({"type": "mrkdwn", "text": _github_account_field(github_state)})
+        actions.extend(_github_account_actions(github_state))
+
+    if not fields:
+        return []
+
     blocks: list[dict] = [
         _section_title(
-            "🔗 Connect your PostHog account",
-            "Link your Slack identity to a PostHog user so @PostHog knows it's you without falling back to email matching.",
+            "🔗 Linked accounts",
+            "Who @PostHog acts as: your PostHog user, and the GitHub account it opens pull requests with.",
         ),
+        {"type": "section", "fields": fields},
     ]
-    if account_state.link_url:
-        blocks.append(
-            {
-                "type": "actions",
-                "elements": [
-                    {
-                        "type": "button",
-                        "url": account_state.link_url,
-                        "text": {"type": "plain_text", "text": "Connect to PostHog", "emoji": True},
-                        "style": "primary",
-                    }
-                ],
-            }
-        )
+    if actions:
+        blocks.append({"type": "actions", "elements": actions})
     return blocks
+
+
+def _posthog_account_field(account_state: AccountState) -> str:
+    if account_state.linked_email:
+        return f"*PostHog*\n✅ Connected as {account_state.linked_email}"
+    return "*PostHog*\nNot connected. Link your Slack identity so @PostHog knows it's you without matching on email."
+
+
+def _posthog_account_actions(account_state: AccountState) -> list[dict]:
+    if account_state.linked_email:
+        return [
+            {
+                "type": "button",
+                "action_id": ACTION_UNLINK_ACCOUNT,
+                "style": "danger",
+                "text": {"type": "plain_text", "text": "Disconnect PostHog", "emoji": True},
+                "confirm": {
+                    "title": {"type": "plain_text", "text": "Disconnect your PostHog account?"},
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "@PostHog will fall back to matching your Slack email against PostHog users until you link again.",
+                    },
+                    "confirm": {"type": "plain_text", "text": "Disconnect"},
+                    "deny": {"type": "plain_text", "text": "Cancel"},
+                },
+            }
+        ]
+    if not account_state.link_url:
+        return []
+    return [
+        {
+            "type": "button",
+            "url": account_state.link_url,
+            "text": {"type": "plain_text", "text": "Connect to PostHog", "emoji": True},
+            "style": "primary",
+        }
+    ]
+
+
+def _github_account_field(github_state: GitHubState) -> str:
+    if not github_state.user_resolved:
+        return "*GitHub*\nLink your PostHog account first, so we know whose GitHub to look up."
+    if github_state.accounts:
+        listed = "\n".join(f"✅ {account.label}" for account in github_state.accounts)
+        return f"*GitHub*\n{listed}"
+    return "*GitHub*\nNot connected. Connect it so @PostHog opens pull requests as you."
+
+
+def _github_account_actions(github_state: GitHubState) -> list[dict]:
+    if not github_state.user_resolved or not github_state.settings_url:
+        return []
+    connected = bool(github_state.accounts)
+    button: dict[str, Any] = {
+        "type": "button",
+        "url": github_state.settings_url,
+        "text": {
+            "type": "plain_text",
+            "text": "Manage GitHub" if connected else "Connect GitHub",
+            "emoji": True,
+        },
+    }
+    if not connected:
+        button["style"] = "primary"
+    return [button]
 
 
 def _personal_section_blocks(user_row: SlackSettings | None) -> list[dict]:
@@ -1359,6 +1433,7 @@ def handle_app_home_opened(event: dict, slack_team_id: str, *, integration: Inte
     is_admin = _is_admin(slack, integration, slack_user_id)
     accessible = _accessible_integrations(integration, slack_user_id)
     account_state = _resolve_account_state(integration, slack_user_id)
+    github_state = _resolve_github_state(integration, slack_user_id)
     project_state = _resolve_project_state(integration, slack_user_id, accessible=accessible)
     tasks_state = _resolve_tasks_state(integration, slack_user_id, accessible=accessible)
     stats_state = _resolve_stats_state(integration, accessible=accessible, is_admin=is_admin)
@@ -1368,6 +1443,7 @@ def handle_app_home_opened(event: dict, slack_team_id: str, *, integration: Inte
         user_row=user_row,
         is_admin=is_admin,
         account_state=account_state,
+        github_state=github_state,
         project_state=project_state,
         tasks_state=tasks_state,
         stats_state=stats_state,
@@ -1722,6 +1798,7 @@ def _republish_home(
     is_admin = _is_admin(slack, integration, slack_user_id)
     accessible = _accessible_integrations(integration, slack_user_id)
     account_state = _resolve_account_state(integration, slack_user_id)
+    github_state = _resolve_github_state(integration, slack_user_id)
     project_state = _resolve_project_state(integration, slack_user_id, accessible=accessible)
     tasks_state = _resolve_tasks_state(
         integration,
@@ -1743,6 +1820,7 @@ def _republish_home(
         user_row=user_row,
         is_admin=is_admin,
         account_state=account_state,
+        github_state=github_state,
         project_state=project_state,
         tasks_state=tasks_state,
         stats_state=stats_state,
@@ -1953,6 +2031,78 @@ def _resolve_account_state(integration: Integration, slack_user_id: str) -> Acco
         )
         link_url = None
     return AccountState(enabled=True, linked_email=None, link_url=link_url)
+
+
+def _resolve_home_user(integration: Integration, slack_user_id: str) -> User | None:
+    """Identify the PostHog user behind this Slack identity.
+
+    Mirrors the event-path cascade in `resolve_posthog_user_from_event`: the
+    OAuth link wins, otherwise we match the cached Slack profile email against
+    members of the organizations connected to this workspace. Reading the
+    profile cache instead of calling `users.info` keeps the Home render free
+    of a Slack API roundtrip.
+    """
+    slack_team_id = integration.integration_id
+    candidate_org_ids = _workspace_org_ids(slack_team_id)
+    if not candidate_org_ids:
+        return None
+
+    if is_slack_app_oauth_enabled(integration, slack_team_id):
+        linked_user = find_linked_posthog_user(
+            slack_user_id=slack_user_id,
+            slack_team_id=slack_team_id,
+            candidate_org_ids=candidate_org_ids,
+        )
+        if linked_user is not None:
+            return linked_user
+
+    profile = SlackUserProfileCache.objects.filter(integration_id=integration.id, slack_user_id=slack_user_id).first()
+    if profile is None or not profile.email:
+        return None
+    membership = (
+        OrganizationMembership.objects.filter(organization_id__in=candidate_org_ids, user__email__iexact=profile.email)
+        .select_related("user")
+        .first()
+    )
+    return membership.user if membership else None
+
+
+def _resolve_github_state(integration: Integration, slack_user_id: str) -> GitHubState:
+    """List the personal GitHub installations of the user opening the Home tab.
+
+    Connecting GitHub needs an authenticated PostHog session, so the button
+    deep-links to Personal integrations settings — the same target the
+    in-thread "Connect GitHub" prompt uses.
+    """
+    settings_url = f"{settings.SITE_URL.rstrip('/')}/project/{integration.team_id}/settings/user-personal-integrations"
+    try:
+        user = _resolve_home_user(integration, slack_user_id)
+        if user is None:
+            return GitHubState(user_resolved=False, settings_url=settings_url)
+        rows = UserIntegration.objects.filter(
+            user=user,
+            kind=UserIntegration.IntegrationKind.GITHUB,
+        ).order_by("created_at")
+        accounts = tuple(_github_account_from_row(row) for row in rows)
+    except Exception:
+        logger.exception(
+            "slack_app_home_resolve_github_state_failed",
+            slack_user_id=slack_user_id,
+            integration_id=integration.id,
+        )
+        return GitHubState(user_resolved=False, settings_url=settings_url)
+    return GitHubState(user_resolved=True, accounts=accounts, settings_url=settings_url)
+
+
+def _github_account_from_row(row: UserIntegration) -> GitHubAccount:
+    config = row.config or {}
+    github_user = config.get("github_user")
+    account = config.get("account")
+    return GitHubAccount(
+        installation_id=row.integration_id,
+        login=github_user.get("login") if isinstance(github_user, dict) else None,
+        account_name=account.get("name") if isinstance(account, dict) else None,
+    )
 
 
 def _workspace_integrations(slack_team_id: str) -> list[Integration]:

--- a/products/slack_app/backend/tests/services/test_slack_app_home.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home.py
@@ -24,8 +24,10 @@ from django.core.exceptions import ValidationError
 from posthog.models.integration import Integration
 from posthog.models.organization import Organization
 from posthog.models.team.team import Team
+from posthog.models.user import User
+from posthog.models.user_integration import UserIntegration
 
-from products.slack_app.backend.models import SlackSettings, SlackThreadTaskMapping
+from products.slack_app.backend.models import SlackSettings, SlackThreadTaskMapping, SlackUserProfileCache
 from products.slack_app.backend.services import slack_app_home
 from products.slack_app.backend.services.slack_app_home import (
     ACTION_EDIT_PERSONAL,
@@ -45,6 +47,8 @@ from products.slack_app.backend.services.slack_app_home import (
     MODAL_BLOCK_REASONING_EFFORT,
     MODAL_BLOCK_RUNTIME_ADAPTER,
     AccountState,
+    GitHubAccount,
+    GitHubState,
     PreferenceSource,
     ProjectChoice,
     ProjectState,
@@ -472,6 +476,95 @@ class TestRenderHomeView:
         assert (
             resolve_source(_make_row(runtime_adapter="claude", model="claude-opus-4-7")) == PreferenceSource.personal()
         )
+
+
+class TestLinkedAccountsCard:
+    def _view(self, *, account_state=None, github_state=None) -> dict:
+        return render_home_view(
+            effective=AIPreferences(),
+            user_row=None,
+            is_admin=False,
+            account_state=account_state,
+            github_state=github_state,
+        )
+
+    def _fields(self, view: dict) -> list[str]:
+        for block in view["blocks"]:
+            if block.get("type") == "section" and block.get("fields"):
+                return [field["text"] for field in block["fields"]]
+        return []
+
+    def _url_buttons(self, view: dict) -> list[dict]:
+        return [
+            element for block in view["blocks"] for element in block.get("elements", []) or [] if element.get("url")
+        ]
+
+    @pytest.mark.parametrize(
+        "user_resolved,accounts,expected_button",
+        [
+            (
+                True,
+                (GitHubAccount(installation_id="1", login="octocat", account_name="octocat"),),
+                "Manage GitHub",
+            ),
+            (True, (), "Connect GitHub"),
+            (False, (), None),
+        ],
+    )
+    def test_github_button_matches_connection_state(self, user_resolved, accounts, expected_button):
+        view = self._view(
+            github_state=GitHubState(
+                user_resolved=user_resolved,
+                accounts=accounts,
+                settings_url="https://app/project/1/settings/user-personal-integrations",
+            )
+        )
+        buttons = self._url_buttons(view)
+        if expected_button is None:
+            # Without a resolved PostHog user we can't say anything about their
+            # GitHub, so the card points at account linking instead.
+            assert buttons == []
+            assert "Link your PostHog account first" in _all_text(view)
+        else:
+            assert [b["text"]["text"] for b in buttons] == [expected_button]
+            assert buttons[0]["url"] == "https://app/project/1/settings/user-personal-integrations"
+            assert buttons[0].get("style") == (None if accounts else "primary")
+
+    def test_every_connected_installation_is_listed(self):
+        view = self._view(
+            github_state=GitHubState(
+                user_resolved=True,
+                accounts=(
+                    GitHubAccount(installation_id="1", login="octocat", account_name="octocat"),
+                    GitHubAccount(installation_id="2", login="octocat", account_name="PostHog"),
+                ),
+                settings_url="https://app/settings",
+            )
+        )
+        github_field = next(field for field in self._fields(view) if field.startswith("*GitHub*"))
+        assert "`octocat`" in github_field
+        # Installation on an org the login differs from names both sides.
+        assert "`octocat` on *PostHog*" in github_field
+
+    def test_posthog_and_github_render_as_two_columns(self):
+        view = self._view(
+            account_state=AccountState(enabled=True, linked_email="user@posthog.com"),
+            github_state=GitHubState(user_resolved=True, settings_url="https://app/settings"),
+        )
+        fields = self._fields(view)
+        assert len(fields) == 2
+        assert fields[0].startswith("*PostHog*")
+        assert fields[1].startswith("*GitHub*")
+
+    def test_github_column_stands_alone_when_account_linking_is_off(self):
+        view = self._view(
+            account_state=AccountState(enabled=False),
+            github_state=GitHubState(user_resolved=True, settings_url="https://app/settings"),
+        )
+        fields = self._fields(view)
+        assert len(fields) == 1
+        assert fields[0].startswith("*GitHub*")
+        assert ACTION_UNLINK_ACCOUNT not in _action_ids(view)
 
 
 _TASK_TITLES = ("Fix flaky retention test", "Refactor mention dispatcher")
@@ -951,6 +1044,31 @@ class TestHandleAppHomeOpened:
     def test_noop_when_user_missing(self, slack_integration, mock_slack_client, flag_on):
         handle_app_home_opened({}, SLACK_WORKSPACE_ID, integration=slack_integration)
         assert not mock_slack_client.views_publish.called
+
+    def test_github_card_lists_only_the_opening_users_installations(
+        self, slack_integration, mock_slack_client, flag_on, admin_user
+    ):
+        organization = slack_integration.team.organization
+        opener = User.objects.create_and_join(organization, "opener@posthog.com", None)
+        colleague = User.objects.create_and_join(organization, "colleague@posthog.com", None)
+        for user, login in ((opener, "opener-gh"), (colleague, "colleague-gh")):
+            UserIntegration.objects.create(
+                user=user,
+                kind=UserIntegration.IntegrationKind.GITHUB,
+                integration_id=f"install-{login}",
+                config={"github_user": {"login": login}, "account": {"name": login}},
+            )
+        SlackUserProfileCache.objects.create(
+            integration=slack_integration,
+            slack_user_id="U001",
+            email=opener.email,
+        )
+
+        handle_app_home_opened({"user": "U001"}, SLACK_WORKSPACE_ID, integration=slack_integration)
+
+        text = _all_text(mock_slack_client.views_publish.call_args.kwargs["view"])
+        assert "opener-gh" in text
+        assert "colleague-gh" not in text
 
 
 # ---------------------------------------------------------------------------

--- a/products/slack_app/backend/tests/services/test_slack_app_home.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home.py
@@ -488,16 +488,16 @@ class TestLinkedAccountsCard:
             github_state=github_state,
         )
 
-    def _fields(self, view: dict) -> list[str]:
-        for block in view["blocks"]:
-            if block.get("type") == "section" and block.get("fields"):
-                return [field["text"] for field in block["fields"]]
-        return []
-
-    def _url_buttons(self, view: dict) -> list[dict]:
+    def _rows(self, view: dict) -> list[tuple[str, dict | None]]:
+        """The (text, accessory) pair of each account row on the card."""
         return [
-            element for block in view["blocks"] for element in block.get("elements", []) or [] if element.get("url")
+            (block["text"]["text"], block.get("accessory"))
+            for block in view["blocks"]
+            if block.get("type") == "section" and block["text"]["text"].startswith(("*PostHog*", "*GitHub*"))
         ]
+
+    def _row(self, view: dict, prefix: str) -> tuple[str, dict | None]:
+        return next(row for row in self._rows(view) if row[0].startswith(prefix))
 
     @pytest.mark.parametrize(
         "user_resolved,accounts,expected_button",
@@ -519,16 +519,17 @@ class TestLinkedAccountsCard:
                 settings_url="https://app/project/1/settings/user-personal-integrations",
             )
         )
-        buttons = self._url_buttons(view)
+        _text, button = self._row(view, "*GitHub*")
         if expected_button is None:
             # Without a resolved PostHog user we can't say anything about their
-            # GitHub, so the card points at account linking instead.
-            assert buttons == []
+            # GitHub, so the row points at account linking instead.
+            assert button is None
             assert "Link your PostHog account first" in _all_text(view)
         else:
-            assert [b["text"]["text"] for b in buttons] == [expected_button]
-            assert buttons[0]["url"] == "https://app/project/1/settings/user-personal-integrations"
-            assert buttons[0].get("style") == (None if accounts else "primary")
+            assert button is not None
+            assert button["text"]["text"] == expected_button
+            assert button["url"] == "https://app/project/1/settings/user-personal-integrations"
+            assert button.get("style") == (None if accounts else "primary")
 
     def test_every_connected_installation_is_listed(self):
         view = self._view(
@@ -541,30 +542,31 @@ class TestLinkedAccountsCard:
                 settings_url="https://app/settings",
             )
         )
-        github_field = next(field for field in self._fields(view) if field.startswith("*GitHub*"))
-        assert "`octocat`" in github_field
+        text, _button = self._row(view, "*GitHub*")
+        assert "`octocat`" in text
         # Installation on an org the login differs from names both sides.
-        assert "`octocat` on *PostHog*" in github_field
+        assert "`octocat` on *PostHog*" in text
 
-    def test_posthog_and_github_render_as_two_columns(self):
+    def test_each_account_carries_its_own_button(self):
         view = self._view(
             account_state=AccountState(enabled=True, linked_email="user@posthog.com"),
             github_state=GitHubState(user_resolved=True, settings_url="https://app/settings"),
         )
-        fields = self._fields(view)
-        assert len(fields) == 2
-        assert fields[0].startswith("*PostHog*")
-        assert fields[1].startswith("*GitHub*")
+        rows = self._rows(view)
+        assert [text.split("\n")[0] for text, _ in rows] == ["*PostHog*", "*GitHub*"]
+        # Disconnect belongs to the PostHog row, Connect GitHub to its own.
+        assert rows[0][1] is not None and rows[0][1]["action_id"] == ACTION_UNLINK_ACCOUNT
+        assert rows[1][1] is not None and rows[1][1]["text"]["text"] == "Connect GitHub"
 
-    def test_github_column_stands_alone_when_account_linking_is_off(self):
+    def test_github_row_stands_alone_when_account_linking_is_off(self):
         view = self._view(
             account_state=AccountState(enabled=False),
             github_state=GitHubState(user_resolved=True, settings_url="https://app/settings"),
         )
-        fields = self._fields(view)
-        assert len(fields) == 1
-        assert fields[0].startswith("*GitHub*")
-        assert ACTION_UNLINK_ACCOUNT not in _action_ids(view)
+        rows = self._rows(view)
+        assert len(rows) == 1
+        assert rows[0][0].startswith("*GitHub*")
+        assert ACTION_UNLINK_ACCOUNT not in _all_text(view)
 
 
 _TASK_TITLES = ("Fix flaky retention test", "Refactor mention dispatcher")

--- a/products/slack_app/backend/tests/services/test_slack_app_home.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home.py
@@ -489,7 +489,6 @@ class TestLinkedAccountsCard:
         )
 
     def _rows(self, view: dict) -> list[tuple[str, dict | None]]:
-        """The (text, accessory) pair of each account row on the card."""
         return [
             (block["text"]["text"], block.get("accessory"))
             for block in view["blocks"]
@@ -500,36 +499,41 @@ class TestLinkedAccountsCard:
         return next(row for row in self._rows(view) if row[0].startswith(prefix))
 
     @pytest.mark.parametrize(
-        "user_resolved,accounts,expected_button",
+        "user_resolved,connected,credentials_usable,expected_button,expected_style",
         [
-            (
-                True,
-                (GitHubAccount(installation_id="1", login="octocat", account_name="octocat"),),
-                "Manage GitHub",
-            ),
-            (True, (), "Connect GitHub"),
-            (False, (), None),
+            (True, True, True, "Manage GitHub", None),
+            # A row whose tokens went stale is what the task flow refuses to run on,
+            # so the card has to ask for a reconnect rather than read as connected.
+            (True, True, False, "Reconnect GitHub", "primary"),
+            (True, False, False, "Connect GitHub", "primary"),
+            (False, False, False, None, None),
         ],
     )
-    def test_github_button_matches_connection_state(self, user_resolved, accounts, expected_button):
+    def test_github_button_matches_connection_state(
+        self, user_resolved, connected, credentials_usable, expected_button, expected_style
+    ):
+        accounts = (GitHubAccount(installation_id="1", login="octocat", account_name="octocat"),) if connected else ()
         view = self._view(
             github_state=GitHubState(
                 user_resolved=user_resolved,
                 accounts=accounts,
+                credentials_usable=credentials_usable,
                 settings_url="https://app/project/1/settings/user-personal-integrations",
             )
         )
-        _text, button = self._row(view, "*GitHub*")
+        text, button = self._row(view, "*GitHub*")
         if expected_button is None:
             # Without a resolved PostHog user we can't say anything about their
             # GitHub, so the row points at account linking instead.
             assert button is None
             assert "Link your PostHog account first" in _all_text(view)
-        else:
-            assert button is not None
-            assert button["text"]["text"] == expected_button
-            assert button["url"] == "https://app/project/1/settings/user-personal-integrations"
-            assert button.get("style") == (None if accounts else "primary")
+            return
+        assert button is not None
+        assert button["text"]["text"] == expected_button
+        assert button["url"] == "https://app/project/1/settings/user-personal-integrations"
+        assert button.get("style") == expected_style
+        if connected:
+            assert ("✅" in text) is credentials_usable
 
     def test_every_connected_installation_is_listed(self):
         view = self._view(
@@ -539,6 +543,7 @@ class TestLinkedAccountsCard:
                     GitHubAccount(installation_id="1", login="octocat", account_name="octocat"),
                     GitHubAccount(installation_id="2", login="octocat", account_name="PostHog"),
                 ),
+                credentials_usable=True,
                 settings_url="https://app/settings",
             )
         )
@@ -1047,19 +1052,23 @@ class TestHandleAppHomeOpened:
         handle_app_home_opened({}, SLACK_WORKSPACE_ID, integration=slack_integration)
         assert not mock_slack_client.views_publish.called
 
+    def _github_row(self, user: User, login: str) -> UserIntegration:
+        return UserIntegration.objects.create(
+            user=user,
+            kind=UserIntegration.IntegrationKind.GITHUB,
+            integration_id=f"install-{login}",
+            config={"github_user": {"login": login}, "account": {"name": login}},
+            sensitive_config={"user_access_token": "gho_x", "user_refresh_token": "ghr_x"},
+        )
+
     def test_github_card_lists_only_the_opening_users_installations(
         self, slack_integration, mock_slack_client, flag_on, admin_user
     ):
         organization = slack_integration.team.organization
         opener = User.objects.create_and_join(organization, "opener@posthog.com", None)
         colleague = User.objects.create_and_join(organization, "colleague@posthog.com", None)
-        for user, login in ((opener, "opener-gh"), (colleague, "colleague-gh")):
-            UserIntegration.objects.create(
-                user=user,
-                kind=UserIntegration.IntegrationKind.GITHUB,
-                integration_id=f"install-{login}",
-                config={"github_user": {"login": login}, "account": {"name": login}},
-            )
+        self._github_row(opener, "opener-gh")
+        self._github_row(colleague, "colleague-gh")
         SlackUserProfileCache.objects.create(
             integration=slack_integration,
             slack_user_id="U001",
@@ -1071,6 +1080,26 @@ class TestHandleAppHomeOpened:
         text = _all_text(mock_slack_client.views_publish.call_args.kwargs["view"])
         assert "opener-gh" in text
         assert "colleague-gh" not in text
+
+    def test_deactivated_user_is_not_resolved_from_their_slack_identity(
+        self, slack_integration, mock_slack_client, flag_on, admin_user
+    ):
+        organization = slack_integration.team.organization
+        offboarded = User.objects.create_and_join(organization, "offboarded@posthog.com", None)
+        self._github_row(offboarded, "offboarded-gh")
+        SlackUserProfileCache.objects.create(
+            integration=slack_integration,
+            slack_user_id="U001",
+            email=offboarded.email,
+        )
+        offboarded.is_active = False
+        offboarded.save(update_fields=["is_active"])
+
+        handle_app_home_opened({"user": "U001"}, SLACK_WORKSPACE_ID, integration=slack_integration)
+
+        text = _all_text(mock_slack_client.views_publish.call_args.kwargs["view"])
+        assert "offboarded-gh" not in text
+        assert "Link your PostHog account first" in text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A user whose Slack task needs a personal GitHub connection only finds out after mentioning @PostHog, when the bot replies that it cannot open the PR as them. The Home tab is where they manage the integration, and it said nothing about GitHub.

## Changes

- The Home tab lists the connected personal GitHub installations of the user viewing it.
- With no connection, the card offers a "Connect GitHub" button that deep-links to Personal integrations settings. Connecting needs an authenticated PostHog session, so Slack cannot do it in place.
- GitHub sits next to the PostHog account in one "Linked accounts" card, as a two-column `section.fields` layout.
- Resolving the viewer reuses the event-path cascade: the OAuth link first, then the cached Slack profile email. Reading the cache keeps the render free of a `users.info` call.
- The GitHub column does not depend on the `slack-app-oauth` flag, so a workspace without account linking still sees its GitHub state.

<img width="1227" height="389" alt="Screenshot 2026-08-11 at 12 55 14" src="https://github.com/user-attachments/assets/550a4e19-c9d8-4262-b2de-5436f4e66fc2" />
<img width="1258" height="385" alt="Screenshot 2026-08-11 at 12 54 44" src="https://github.com/user-attachments/assets/6f9e8f19-7b4b-4812-94b8-e4f232755dda" />


## How did you test this code?

- Renderer tests cover the three states of the column: connected, not connected, and viewer unresolved. They catch a card that offers "Connect" to an already-connected user, and one that drops the second installation.
- One Django test publishes the Home tab for a user with a colleague in the same org, and asserts the view carries only the viewer's GitHub login. It catches the resolver returning the wrong user.
- I ran the `products/slack_app/backend/tests/services/` suite locally. Not run: anything outside that directory.
- Slack's `blocks.validate` accepted the rendered view.
- manual check in a real Slack workspace.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: `/writing-tests`, `slack:block-kit` (to validate the payload against `blocks.validate`), `/writing-pr-descriptions`.

The card started as a GitHub-only section below the existing account card. It became one two-column card on request, which is why the account renderer was rewritten rather than extended.
