### PR TITLE
feat(cli): experimental release injection

### DIFF
--- a/cli/.sampo/changesets/cli-experimental-release-injection.md
+++ b/cli/.sampo/changesets/cli-experimental-release-injection.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: minor
+---
+
+Add experimental `--no-release-bind` (env `POSTHOG_NO_RELEASE_BIND`) to `inject`/`upload`/`process`: derive content-addressed chunk ids that stay stable across rebuilds, and inject the release id into each JS chunk as `_posthogReleaseId` so the SDK reports it per event, instead of stamping it onto the uploaded symbol sets. The release is still created — it just isn't bound to any chunk. Off by default; the existing paths are unchanged.

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2815,6 +2815,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3583,6 +3589,7 @@ dependencies = [
  "getrandom 0.3.4",
  "js-sys",
  "serde",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -50,7 +50,7 @@ serde_yaml = "0.9"
 colored = "3.0"
 regex = "1.12"
 tracing = "0.1.41"
-uuid = { version = "1.16.0", features = ["v7"] }
+uuid = { version = "1.16.0", features = ["v5", "v7"] }
 thiserror = "2.0.12"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 posthog-rs = { version = "0.15.0", default-features = false, features = ["error-tracking"] }

--- a/cli/src/api/symbol_sets.rs
+++ b/cli/src/api/symbol_sets.rs
@@ -38,6 +38,11 @@ pub struct SymbolSetUpload {
     pub release_id: Option<String>,
 
     pub data: Vec<u8>,
+
+    /// Precomputed hash for the server's skip-identical-content check; `None` hashes `data`
+    /// as-is. Set this when `data` contains bytes that vary between builds of identical code
+    /// (e.g. an injected release id), so unchanged chunks still skip re-upload.
+    pub content_hash: Option<String>,
 }
 
 /// Per-run tally of what an upload actually did. Without it a run that skipped
@@ -183,6 +188,7 @@ pub fn upload_with_retry_and_concurrency(
                     chunk_id: s.chunk_id.clone(),
                     release_id: None,
                     data: s.data,
+                    content_hash: s.content_hash,
                 })
                 .collect();
             let res = upload_inner(
@@ -247,8 +253,16 @@ fn upload_inner(
         info!("Starting upload of batch {i}, {} symbol sets", batch.len());
         // Hash each payload once, across the pool — the same hash is sent in the
         // start request and used to confirm the upload when finishing.
-        let content_hashes: Vec<String> =
-            thread_pool.install(|| batch.par_iter().map(|u| content_hash([&u.data])).collect());
+        let content_hashes: Vec<String> = thread_pool.install(|| {
+            batch
+                .par_iter()
+                .map(|u| {
+                    u.content_hash
+                        .clone()
+                        .unwrap_or_else(|| content_hash([&u.data]))
+                })
+                .collect()
+        });
         let start_response = start_upload(batch, &content_hashes, force, skip_on_conflict)?;
 
         let id_map: HashMap<_, _> = batch
@@ -460,6 +474,7 @@ impl SymbolSetUpload {
             chunk_id: self.chunk_id.clone(),
             release_id: self.release_id.clone(),
             data: vec![],
+            content_hash: self.content_hash.clone(),
         }
     }
 }

--- a/cli/src/debug_symbols/mod.rs
+++ b/cli/src/debug_symbols/mod.rs
@@ -121,6 +121,7 @@ impl DebugSymbolFile {
             chunk_id: self.debug_id,
             release_id,
             data: wrapped,
+            content_hash: None,
         })
     }
 }

--- a/cli/src/debug_symbols/upload.rs
+++ b/cli/src/debug_symbols/upload.rs
@@ -165,6 +165,7 @@ mod tests {
             chunk_id: chunk_id.to_string(),
             release_id: None,
             data: data.to_vec(),
+            content_hash: None,
         };
 
         let uploads = merge_uploads_prefer_dsym(
@@ -184,6 +185,7 @@ mod tests {
             chunk_id: uuid.to_string(),
             release_id: None,
             data: data.to_vec(),
+            content_hash: None,
         };
 
         let uploads =

--- a/cli/src/dsym/mod.rs
+++ b/cli/src/dsym/mod.rs
@@ -83,6 +83,7 @@ impl DsymFile {
                 chunk_id: entry.uuid,
                 release_id: self.release_id.clone(),
                 data: entry.data,
+                content_hash: None,
             })
             .collect()
     }

--- a/cli/src/proguard/mod.rs
+++ b/cli/src/proguard/mod.rs
@@ -53,6 +53,7 @@ impl TryInto<SymbolSetUpload> for ProguardFile {
             chunk_id: self.map_id,
             release_id: self.release_id,
             data,
+            content_hash: None,
         })
     }
 }

--- a/cli/src/sourcemaps/constant.rs
+++ b/cli/src/sourcemaps/constant.rs
@@ -1,3 +1,18 @@
+// Chunk-id-only injection. `e._posthogChunkIds[stack] = chunkId` on the global.
 pub const CODE_SNIPPET_TEMPLATE: &str = r#"!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof globalThis?globalThis:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._posthogChunkIds=e._posthogChunkIds||{},e._posthogChunkIds[n]="__POSTHOG_CHUNK_ID__")}catch(e){}}();"#;
+
+// Chunk-id + release injection. Sets `e._posthogReleaseId` to the release row's id
+// (first-wins, so the first loaded chunk pins the release) alongside the chunk-id map.
+// The SDK only reads it when it is a non-empty string, so the placeholder is filled with
+// a JSON-encoded string literal that carries its own quotes.
+pub const CODE_SNIPPET_WITH_RELEASE_TEMPLATE: &str = r#"!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof globalThis?globalThis:"undefined"!=typeof self?self:{};e._posthogReleaseId=e._posthogReleaseId||__POSTHOG_RELEASE_ID__;var n=(new e.Error).stack;n&&(e._posthogChunkIds=e._posthogChunkIds||{},e._posthogChunkIds[n]="__POSTHOG_CHUNK_ID__")}catch(e){}}();"#;
+
 pub const CHUNKID_COMMENT_PREFIX: &str = "\n//# chunkId=__POSTHOG_CHUNK_ID__";
 pub const CHUNKID_PLACEHOLDER: &str = "__POSTHOG_CHUNK_ID__";
+pub const RELEASE_ID_PLACEHOLDER: &str = "__POSTHOG_RELEASE_ID__";
+
+// Fixed namespace for deriving deterministic (content-addressed) chunk ids via UUIDv5.
+// Same minified bytes in, same chunk id out — across machines and rebuilds — so re-uploads
+// dedupe and symbol sets stay stable without a per-build random id.
+pub const CHUNK_ID_NAMESPACE: uuid::Uuid =
+    uuid::Uuid::from_u128(0x0e9b3c7a5d1f42a8b6c4e2d0f8a17593);

--- a/cli/src/sourcemaps/content.rs
+++ b/cli/src/sourcemaps/content.rs
@@ -27,11 +27,15 @@ fn build_code_snippet(chunk_id: &str, release_id: Option<&str>) -> Result<String
         .replace(RELEASE_ID_PLACEHOLDER, &serde_json::to_string(release_id)?))
 }
 
-/// When `source` carries the release-variant snippet, return it with the snippet removed.
-/// The injected release id changes on every release even when the chunk's code didn't, so
-/// content hashes must be computed over the stripped bytes or the server would never skip
-/// an unchanged chunk. Returns `None` for sources without a release-variant snippet.
-pub fn strip_release_snippet(source: &str, chunk_id: &str) -> Option<String> {
+struct ReleaseSnippetSpan {
+    start: usize,
+    end: usize,
+    release_id_start: usize,
+    release_id_end: usize,
+}
+
+/// Locate the release-variant snippet for `chunk_id` in `source`, if present.
+fn find_release_snippet(source: &str, chunk_id: &str) -> Option<ReleaseSnippetSpan> {
     let (prefix, suffix) = CODE_SNIPPET_WITH_RELEASE_TEMPLATE
         .split_once(RELEASE_ID_PLACEHOLDER)
         .expect("release template has a release id placeholder");
@@ -45,12 +49,32 @@ pub fn strip_release_snippet(source: &str, chunk_id: &str) -> Option<String> {
     if release_id_len > 256 {
         return None;
     }
+    let release_id_end = release_id_start + release_id_len;
 
-    let end = release_id_start + release_id_len + suffix.len();
-    let mut stripped = String::with_capacity(source.len() - (end - start));
-    stripped.push_str(&source[..start]);
-    stripped.push_str(&source[end..]);
+    Some(ReleaseSnippetSpan {
+        start,
+        end: release_id_end + suffix.len(),
+        release_id_start,
+        release_id_end,
+    })
+}
+
+/// When `source` carries the release-variant snippet, return it with the snippet removed.
+/// The injected release id changes on every release even when the chunk's code didn't, so
+/// content hashes must be computed over the stripped bytes or the server would never skip
+/// an unchanged chunk. Returns `None` for sources without a release-variant snippet.
+pub fn strip_release_snippet(source: &str, chunk_id: &str) -> Option<String> {
+    let span = find_release_snippet(source, chunk_id)?;
+    let mut stripped = String::with_capacity(source.len() - (span.end - span.start));
+    stripped.push_str(&source[..span.start]);
+    stripped.push_str(&source[span.end..]);
     Some(stripped)
+}
+
+/// Read the release id embedded in the source's release-variant snippet, if any.
+pub fn get_injected_release_id(source: &str, chunk_id: &str) -> Option<String> {
+    let span = find_release_snippet(source, chunk_id)?;
+    serde_json::from_str(&source[span.release_id_start..span.release_id_end]).ok()
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -353,6 +377,10 @@ impl MinifiedSourceFile {
                 let code_snippet_end = code_snippet_start as i64 + code_snippet.len() as i64;
                 magic_source
                     .remove(code_snippet_start as i64, code_snippet_end)
+                    .map_err(|err| anyhow!("Failed to remove code snippet {err}"))?;
+            } else if let Some(span) = find_release_snippet(source_content, &chunk_id) {
+                magic_source
+                    .remove(span.start as i64, span.end as i64)
                     .map_err(|err| anyhow!("Failed to remove code snippet {err}"))?;
             }
 

--- a/cli/src/sourcemaps/content.rs
+++ b/cli/src/sourcemaps/content.rs
@@ -8,9 +8,24 @@ use std::{collections::BTreeMap, path::PathBuf};
 
 use crate::{
     api::symbol_sets::SymbolSetUpload,
-    sourcemaps::constant::{CHUNKID_COMMENT_PREFIX, CHUNKID_PLACEHOLDER, CODE_SNIPPET_TEMPLATE},
+    sourcemaps::constant::{
+        CHUNKID_COMMENT_PREFIX, CHUNKID_PLACEHOLDER, CODE_SNIPPET_TEMPLATE,
+        CODE_SNIPPET_WITH_RELEASE_TEMPLATE, RELEASE_ID_PLACEHOLDER,
+    },
     utils::files::SourceFile,
 };
+
+/// Build the injected IIFE for a chunk. When a release id is present we use the release-carrying
+/// template and fill its placeholder with a JSON-encoded string literal, so quotes/backslashes in
+/// the value can't break out of the snippet.
+fn build_code_snippet(chunk_id: &str, release_id: Option<&str>) -> Result<String> {
+    let Some(release_id) = release_id else {
+        return Ok(CODE_SNIPPET_TEMPLATE.replace(CHUNKID_PLACEHOLDER, chunk_id));
+    };
+    Ok(CODE_SNIPPET_WITH_RELEASE_TEMPLATE
+        .replace(CHUNKID_PLACEHOLDER, chunk_id)
+        .replace(RELEASE_ID_PLACEHOLDER, &serde_json::to_string(release_id)?))
+}
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SourceMapContent {
@@ -176,12 +191,12 @@ impl MinifiedSourceFile {
         self.get_comment_value(&patterns)
     }
 
-    pub fn set_chunk_id(&mut self, chunk_id: &str) -> Result<SourceMap> {
+    pub fn set_chunk_id(&mut self, chunk_id: &str, release_id: Option<&str>) -> Result<SourceMap> {
         let (new_source_content, source_adjustment) = {
             // Update source content with chunk ID
             let source_content = &self.inner.content;
             let mut magic_source = MagicString::new(source_content);
-            let code_snippet = CODE_SNIPPET_TEMPLATE.replace(CHUNKID_PLACEHOLDER, chunk_id);
+            let code_snippet = build_code_snippet(chunk_id, release_id)?;
             magic_source
                 .prepend(&code_snippet)
                 .map_err(|err| anyhow!("Failed to prepend code snippet: {err}"))?;

--- a/cli/src/sourcemaps/content.rs
+++ b/cli/src/sourcemaps/content.rs
@@ -27,6 +27,32 @@ fn build_code_snippet(chunk_id: &str, release_id: Option<&str>) -> Result<String
         .replace(RELEASE_ID_PLACEHOLDER, &serde_json::to_string(release_id)?))
 }
 
+/// When `source` carries the release-variant snippet, return it with the snippet removed.
+/// The injected release id changes on every release even when the chunk's code didn't, so
+/// content hashes must be computed over the stripped bytes or the server would never skip
+/// an unchanged chunk. Returns `None` for sources without a release-variant snippet.
+pub fn strip_release_snippet(source: &str, chunk_id: &str) -> Option<String> {
+    let (prefix, suffix) = CODE_SNIPPET_WITH_RELEASE_TEMPLATE
+        .split_once(RELEASE_ID_PLACEHOLDER)
+        .expect("release template has a release id placeholder");
+    let suffix = suffix.replace(CHUNKID_PLACEHOLDER, chunk_id);
+
+    let start = source.find(prefix)?;
+    let release_id_start = start + prefix.len();
+    let release_id_len = source[release_id_start..].find(&suffix)?;
+    // The span between prefix and suffix must be the injected release id — a short JSON
+    // string literal. A distant suffix match means user code, not our snippet.
+    if release_id_len > 256 {
+        return None;
+    }
+
+    let end = release_id_start + release_id_len + suffix.len();
+    let mut stripped = String::with_capacity(source.len() - (end - start));
+    stripped.push_str(&source[..start]);
+    stripped.push_str(&source[end..]);
+    Some(stripped)
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SourceMapContent {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -401,6 +427,7 @@ impl TryInto<SymbolSetUpload> for SourceMapFile {
             chunk_id,
             release_id,
             data,
+            content_hash: None,
         })
     }
 }
@@ -418,6 +445,39 @@ mod tests {
         MinifiedSourceFile {
             inner: SourceFile::new(PathBuf::from("chunk.js"), content.to_string()),
         }
+    }
+
+    #[test]
+    fn strip_release_snippet_yields_identical_output_across_releases() {
+        let chunk_id = "e0b0778e-ecb0-5900-9b2e-05642a44e6a9";
+        let original = r#"console.log("hi");
+//# sourceMappingURL=index.js.map"#;
+
+        let stripped: Vec<_> = [
+            "11111111-2222-4333-8444-555555555555",
+            "99999999-8888-4777-8666-000000000000",
+        ]
+        .iter()
+        .map(|release_id| {
+            let snippet = build_code_snippet(chunk_id, Some(release_id)).unwrap();
+            strip_release_snippet(&format!("{snippet}{original}"), chunk_id)
+        })
+        .collect();
+
+        assert_eq!(stripped[0].as_deref(), Some(original));
+        assert_eq!(stripped[0], stripped[1]);
+    }
+
+    #[test]
+    fn strip_release_snippet_ignores_sources_without_release_snippet() {
+        let chunk_id = "e0b0778e-ecb0-5900-9b2e-05642a44e6a9";
+        let plain_snippet = build_code_snippet(chunk_id, None).unwrap();
+
+        assert_eq!(
+            strip_release_snippet(&format!("{plain_snippet}code();"), chunk_id),
+            None
+        );
+        assert_eq!(strip_release_snippet("code();", chunk_id), None);
     }
 
     #[test]

--- a/cli/src/sourcemaps/hermes/inject.rs
+++ b/cli/src/sourcemaps/hermes/inject.rs
@@ -2,7 +2,7 @@
 // It's intended as an escape hatch for people rolling their own build pipeline - we expect most users to be
 // using the metro plugin for injecting, and then calling clone
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use walkdir::DirEntry;
 
 use crate::{
@@ -13,6 +13,13 @@ use crate::{
 pub fn inject(args: &InjectArgs) -> Result<()> {
     context().capture_command_invoked("hermes_inject");
     args.validate()?;
+    // The rest of the Hermes pipeline (clone, upload, the RN SDK) has no release-unbinding
+    // support, so accepting the flag would inject a global nothing reads while upload
+    // re-binds the release anyway. Rejecting also catches a POSTHOG_NO_RELEASE_BIND env var
+    // set for a web build leaking into a React Native build in the same environment.
+    if args.no_release_bind {
+        bail!("--no-release-bind is not supported for Hermes bundles. Remove the flag (or unset POSTHOG_NO_RELEASE_BIND) and inject again.");
+    }
     inject_impl(args, is_metro_bundle, None)
 }
 

--- a/cli/src/sourcemaps/inject.rs
+++ b/cli/src/sourcemaps/inject.rs
@@ -114,13 +114,26 @@ pub fn inject_pairs(
     release_id: Option<&str>,
 ) -> Result<Vec<SourcePair>> {
     for pair in &mut pairs {
-        // Chunk ids are content-addressed and stable, so a chunk that already carries one is
-        // already injected — leave it untouched (idempotent re-injection).
-        if pair.get_chunk_id().is_none() {
+        let Some(chunk_id) = pair.get_chunk_id() else {
             let sourcemap_json = serde_json::to_string(&pair.sourcemap.inner.content)?;
             let chunk_id = stable_chunk_id(&pair.source.inner.content, &sourcemap_json);
             pair.add_chunk_id(chunk_id, release_id)?;
+            continue;
+        };
+
+        // Already injected: the chunk id is content-addressed and the content didn't change,
+        // so keep it — but refresh the embedded release id when a different release resolved,
+        // or a re-run over an existing dist would keep reporting the old release on every
+        // event. When no release resolves, leave the pair untouched: failing to resolve is
+        // missing information (e.g. no git context), not evidence the embedded id is stale.
+        let Some(release_id) = release_id else {
+            continue;
+        };
+        if pair.get_injected_release_id().as_deref() == Some(release_id) {
+            continue;
         }
+        pair.remove_chunk_id(chunk_id.clone())?;
+        pair.add_chunk_id(chunk_id, Some(release_id))?;
     }
 
     Ok(pairs)

--- a/cli/src/sourcemaps/inject.rs
+++ b/cli/src/sourcemaps/inject.rs
@@ -7,6 +7,7 @@ use crate::{
     api::releases::{Release, ReleaseBuilder},
     sourcemaps::{
         args::{FileSelectionArgs, ReleaseArgs},
+        constant::CHUNK_ID_NAMESPACE,
         content::SourceMapFile,
         source_pairs::{read_pairs, SourcePair},
     },
@@ -26,6 +27,23 @@ pub struct InjectArgs {
 
     #[clap(flatten)]
     pub release: ReleaseArgs,
+
+    /// EXPERIMENTAL: don't bind the injected chunks to a server-side release. The release is still
+    /// created, but instead of stamping its id into the sourcemap (which binds the uploaded symbol
+    /// set to it), this injects the id into each chunk as `_posthogReleaseId` so the SDK emits it
+    /// on every exception, and derives content-addressed chunk ids that are stable across rebuilds.
+    /// When unset (the default), inject behaves exactly as before. Also settable via
+    /// `POSTHOG_NO_RELEASE_BIND`.
+    #[arg(
+        long,
+        env = "POSTHOG_NO_RELEASE_BIND",
+        value_parser = clap::builder::BoolishValueParser::new(),
+        num_args = 0..=1,
+        require_equals = true,
+        default_value = "false",
+        default_missing_value = "true",
+    )]
+    pub no_release_bind: bool,
 }
 
 impl InjectArgs {
@@ -43,6 +61,7 @@ pub fn inject_impl(
         file_selection,
         public_path_prefix,
         release,
+        no_release_bind,
     } = args;
 
     info!("injecting selection: {}", file_selection);
@@ -57,16 +76,28 @@ pub fn inject_impl(
         bail!("no source files found");
     }
 
-    let created_release_id = if let Some(r) = existing_release {
-        Some(r.id.to_string())
+    if *no_release_bind {
+        // The release id travels inside each chunk for the SDK to emit, rather than being stamped
+        // into the sourcemap — so the release exists, but nothing binds a symbol set to it.
+        let release_id = resolve_release_id(release.clone(), existing_release)?;
+        if release_id.is_none() {
+            warn!(
+                "no release could be resolved, injecting chunk ids only — events will carry no release"
+            );
+        }
+        pairs = inject_pairs(pairs, release_id.as_deref())?;
     } else {
-        let cwd = std::env::current_dir()?;
-        get_release_for_maps(&cwd, release.clone(), pairs.iter().map(|p| &p.sourcemap))?
-            .as_ref()
-            .map(|r| r.id.to_string())
-    };
-
-    pairs = inject_pairs(pairs, created_release_id)?;
+        // Legacy path: fetch or create a release over the API and stamp its id into the sourcemap.
+        let created_release_id = if let Some(r) = existing_release {
+            Some(r.id.to_string())
+        } else {
+            let cwd = std::env::current_dir()?;
+            get_release_for_maps(&cwd, release.clone(), pairs.iter().map(|p| &p.sourcemap))?
+                .as_ref()
+                .map(|r| r.id.to_string())
+        };
+        pairs = inject_pairs_legacy(pairs, created_release_id)?;
+    }
 
     // Write the source and sourcemaps back to disk
     for pair in &pairs {
@@ -76,7 +107,27 @@ pub fn inject_impl(
     Ok(())
 }
 
+/// Experimental injection: content-addressed chunk ids plus an optional `_posthogReleaseId`
+/// payload.
 pub fn inject_pairs(
+    mut pairs: Vec<SourcePair>,
+    release_id: Option<&str>,
+) -> Result<Vec<SourcePair>> {
+    for pair in &mut pairs {
+        // Chunk ids are content-addressed and stable, so a chunk that already carries one is
+        // already injected — leave it untouched (idempotent re-injection).
+        if pair.get_chunk_id().is_none() {
+            let chunk_id = stable_chunk_id(&pair.source.inner.content);
+            pair.add_chunk_id(chunk_id, release_id)?;
+        }
+    }
+
+    Ok(pairs)
+}
+
+/// Legacy injection: a random per-build chunk id and the created release id stamped into the
+/// sourcemap. Regenerates the chunk id whenever the release id changes or is missing.
+pub fn inject_pairs_legacy(
     mut pairs: Vec<SourcePair>,
     created_release_id: Option<String>,
 ) -> Result<Vec<SourcePair>> {
@@ -90,12 +141,42 @@ pub fn inject_pairs(
             if let Some(previous_chunk_id) = pair.get_chunk_id() {
                 pair.update_chunk_id(previous_chunk_id, chunk_id)?;
             } else {
-                pair.add_chunk_id(chunk_id)?;
+                pair.add_chunk_id(chunk_id, None)?;
             }
         }
     }
 
     Ok(pairs)
+}
+
+/// Deterministically derive a chunk id from the minified source bytes (UUIDv5). Identical
+/// source produces an identical id on every machine and rebuild, so uploads dedupe and symbol
+/// sets stay stable — no per-build random id.
+fn stable_chunk_id(source_content: &str) -> String {
+    uuid::Uuid::new_v5(&CHUNK_ID_NAMESPACE, source_content.as_bytes()).to_string()
+}
+
+/// Resolve the release row whose id gets injected into the chunks. Reuses the release already
+/// fetched upstream (the `process` command) when there is one; otherwise resolves name/version
+/// from flags and git/CI metadata and fetches or creates the row. Returns `None` only when there
+/// isn't enough information to identify a release at all.
+fn resolve_release_id(
+    release: ReleaseArgs,
+    existing_release: Option<&Release>,
+) -> Result<Option<String>> {
+    if let Some(r) = existing_release {
+        return Ok(Some(r.id.to_string()));
+    }
+
+    let cwd = std::env::current_dir()?;
+    let release_args_were_provided =
+        release.name.is_some() || release.version.is_some() || release.build.is_some();
+    let mut builder: ReleaseBuilder = release.into();
+    add_git_info_to_release_builder(&cwd, &mut builder, release_args_were_provided)?;
+    if !builder.can_create() {
+        return Ok(None);
+    }
+    Ok(Some(builder.fetch_or_create()?.id.to_string()))
 }
 
 pub fn get_release_for_maps<'a>(

--- a/cli/src/sourcemaps/inject.rs
+++ b/cli/src/sourcemaps/inject.rs
@@ -117,7 +117,8 @@ pub fn inject_pairs(
         // Chunk ids are content-addressed and stable, so a chunk that already carries one is
         // already injected — leave it untouched (idempotent re-injection).
         if pair.get_chunk_id().is_none() {
-            let chunk_id = stable_chunk_id(&pair.source.inner.content);
+            let sourcemap_json = serde_json::to_string(&pair.sourcemap.inner.content)?;
+            let chunk_id = stable_chunk_id(&pair.source.inner.content, &sourcemap_json);
             pair.add_chunk_id(chunk_id, release_id)?;
         }
     }
@@ -149,11 +150,18 @@ pub fn inject_pairs_legacy(
     Ok(pairs)
 }
 
-/// Deterministically derive a chunk id from the minified source bytes (UUIDv5). Identical
-/// source produces an identical id on every machine and rebuild, so uploads dedupe and symbol
-/// sets stay stable — no per-build random id.
-fn stable_chunk_id(source_content: &str) -> String {
-    uuid::Uuid::new_v5(&CHUNK_ID_NAMESPACE, source_content.as_bytes()).to_string()
+/// Deterministically derive a chunk id from the pristine minified source and its sourcemap
+/// (UUIDv5). Identical builds produce identical ids on every machine and rebuild, so uploads
+/// dedupe — no per-build random id. The sourcemap is part of the identity on purpose: a
+/// map-only change (e.g. enabling `sourcesContent`) mints a new chunk instead of conflicting
+/// with the symbol set already stored under the old id.
+fn stable_chunk_id(source_content: &str, sourcemap_content: &str) -> String {
+    let mut name = Vec::with_capacity(source_content.len() + sourcemap_content.len() + 1);
+    name.extend_from_slice(source_content.as_bytes());
+    // JSON serialization never contains a raw NUL, so it unambiguously separates the parts.
+    name.push(0);
+    name.extend_from_slice(sourcemap_content.as_bytes());
+    uuid::Uuid::new_v5(&CHUNK_ID_NAMESPACE, &name).to_string()
 }
 
 /// Resolve the release row whose id gets injected into the chunks. Reuses the release already
@@ -321,6 +329,15 @@ mod tests {
         fs::write(git_dir.join("HEAD"), "ref: refs/heads/main\n").expect("failed to write HEAD");
 
         temp_root
+    }
+
+    #[test]
+    fn stable_chunk_id_covers_source_and_sourcemap() {
+        let id = stable_chunk_id("code();", r#"{"mappings":"AAAA"}"#);
+
+        assert_eq!(id, stable_chunk_id("code();", r#"{"mappings":"AAAA"}"#));
+        assert_ne!(id, stable_chunk_id("code();", r#"{"mappings":"BBBB"}"#));
+        assert_ne!(id, stable_chunk_id("other();", r#"{"mappings":"AAAA"}"#));
     }
 
     #[test]

--- a/cli/src/sourcemaps/plain/mod.rs
+++ b/cli/src/sourcemaps/plain/mod.rs
@@ -47,6 +47,22 @@ pub struct ProcessArgs {
 
     #[clap(flatten)]
     pub upload_concurrency: UploadConcurrencyArgs,
+
+    /// EXPERIMENTAL: don't bind the chunks to a server-side release. The release is still created,
+    /// but its id is injected into each chunk as `_posthogReleaseId` (alongside content-addressed
+    /// chunk ids) rather than stamped onto the uploaded symbol sets, so the SDK reports the release
+    /// per event. When unset (the default), process behaves exactly as before.
+    /// Also settable via `POSTHOG_NO_RELEASE_BIND`.
+    #[arg(
+        long,
+        env = "POSTHOG_NO_RELEASE_BIND",
+        value_parser = clap::builder::BoolishValueParser::new(),
+        num_args = 0..=1,
+        require_equals = true,
+        default_value = "false",
+        default_missing_value = "true",
+    )]
+    pub no_release_bind: bool,
 }
 
 impl ProcessArgs {
@@ -63,6 +79,7 @@ impl From<ProcessArgs> for (InjectArgs, upload::Args) {
             file_selection: args.file_selection.clone(),
             release: args.release.clone(),
             public_path_prefix: args.public_path_prefix.clone(),
+            no_release_bind: args.no_release_bind,
         };
         let upload_args = upload::Args {
             file_selection: args.file_selection,
@@ -73,6 +90,7 @@ impl From<ProcessArgs> for (InjectArgs, upload::Args) {
             release: args.release,
             conflict: args.conflict,
             upload_concurrency: args.upload_concurrency,
+            no_release_bind: args.no_release_bind,
         };
 
         (inject_args, upload_args)

--- a/cli/src/sourcemaps/plain/upload.rs
+++ b/cli/src/sourcemaps/plain/upload.rs
@@ -60,6 +60,21 @@ pub struct Args {
     /// DEPRECATED - this flag is a no-op. Use top-level `--skip-ssl-verification` instead.
     #[arg(long)]
     pub skip_ssl_verification: bool,
+
+    /// EXPERIMENTAL: don't bind the uploaded symbol sets to a release. The chunks carry the release
+    /// id in their injected snippet instead, so the release is resolved per event rather than per
+    /// symbol set. When unset (the default), upload behaves exactly as before. Also settable via
+    /// `POSTHOG_NO_RELEASE_BIND`.
+    #[arg(
+        long,
+        env = "POSTHOG_NO_RELEASE_BIND",
+        value_parser = clap::builder::BoolishValueParser::new(),
+        num_args = 0..=1,
+        require_equals = true,
+        default_value = "false",
+        default_missing_value = "true",
+    )]
+    pub no_release_bind: bool,
 }
 
 pub fn upload_cmd(args: &Args) -> Result<()> {
@@ -86,8 +101,13 @@ pub fn upload(args: &Args, existing_release: Option<&Release>) -> Result<()> {
         .collect::<Vec<_>>();
     info!("Found {} chunks to upload", pairs.len());
 
-    // Reuse the pre-resolved release if available, otherwise fetch or create one
-    let created_release_id = if let Some(r) = existing_release {
+    // Reuse the pre-resolved release if available, otherwise fetch or create one. Skipped entirely
+    // under `--no-release-bind`: inject already put the release id inside the chunks, and resolving
+    // one here would only serve to stamp it onto the symbol sets, which is the binding we're
+    // avoiding.
+    let created_release_id = if args.no_release_bind {
+        None
+    } else if let Some(r) = existing_release {
         Some(r.id.to_string())
     } else {
         let cwd = std::env::current_dir()?;

--- a/cli/src/sourcemaps/source_pairs.rs
+++ b/cli/src/sourcemaps/source_pairs.rs
@@ -1,6 +1,8 @@
 use crate::{
     api::symbol_sets::SymbolSetUpload,
-    sourcemaps::content::{strip_release_snippet, MinifiedSourceFile, SourceMapFile},
+    sourcemaps::content::{
+        get_injected_release_id, strip_release_snippet, MinifiedSourceFile, SourceMapFile,
+    },
     utils::files::content_hash,
 };
 use anyhow::{anyhow, Context, Result};
@@ -32,6 +34,13 @@ impl SourcePair {
 
     pub fn get_release_id(&self) -> Option<String> {
         self.sourcemap.get_release_id()
+    }
+
+    /// The release id embedded in the source's injected snippet (no-release-bind mode),
+    /// as opposed to `get_release_id`, which reads the one stamped into the sourcemap.
+    pub fn get_injected_release_id(&self) -> Option<String> {
+        let chunk_id = self.get_chunk_id()?;
+        get_injected_release_id(&self.source.inner.content, &chunk_id)
     }
 
     pub fn remove_chunk_id(&mut self, chunk_id: String) -> Result<()> {

--- a/cli/src/sourcemaps/source_pairs.rs
+++ b/cli/src/sourcemaps/source_pairs.rs
@@ -49,16 +49,16 @@ impl SourcePair {
         new_chunk_id: String,
     ) -> Result<()> {
         self.remove_chunk_id(previous_chunk_id)?;
-        self.add_chunk_id(new_chunk_id)?;
+        self.add_chunk_id(new_chunk_id, None)?;
         Ok(())
     }
 
-    pub fn add_chunk_id(&mut self, chunk_id: String) -> Result<()> {
+    pub fn add_chunk_id(&mut self, chunk_id: String, release_id: Option<&str>) -> Result<()> {
         if self.has_chunk_id() {
             return Err(anyhow!("Chunk ID already set"));
         }
 
-        let adjustment = self.source.set_chunk_id(&chunk_id)?;
+        let adjustment = self.source.set_chunk_id(&chunk_id, release_id)?;
         // In cases where sourcemaps are shared across multiple chunks,
         // we should only apply the adjustment if the sourcemap doesn't
         // have a chunk ID set (since otherwise, it's already been adjusted)

--- a/cli/src/sourcemaps/source_pairs.rs
+++ b/cli/src/sourcemaps/source_pairs.rs
@@ -1,6 +1,7 @@
 use crate::{
     api::symbol_sets::SymbolSetUpload,
-    sourcemaps::content::{MinifiedSourceFile, SourceMapFile},
+    sourcemaps::content::{strip_release_snippet, MinifiedSourceFile, SourceMapFile},
+    utils::files::content_hash,
 };
 use anyhow::{anyhow, Context, Result};
 use posthog_symbol_data::{write_symbol_data, SourceAndMap};
@@ -121,8 +122,15 @@ impl TryInto<SymbolSetUpload> for SourcePair {
         let chunk_id = self
             .get_chunk_id()
             .ok_or_else(|| anyhow!("Chunk ID not found"))?;
+        let release_id = self.sourcemap.get_release_id();
         let source_content = self.source.inner.content;
         let sourcemap_content = serde_json::to_string(&self.sourcemap.inner.content)?;
+        // Release-injected sources embed a release id that changes every release, so hash
+        // them with the snippet stripped or identical chunks would re-upload each time.
+        // Sources without that snippet keep hashing the raw payload, matching hashes the
+        // server already stores.
+        let content_hash = strip_release_snippet(&source_content, &chunk_id)
+            .map(|stripped| content_hash([stripped.as_bytes(), sourcemap_content.as_bytes()]));
         let data = SourceAndMap {
             minified_source: source_content,
             sourcemap: sourcemap_content,
@@ -133,7 +141,8 @@ impl TryInto<SymbolSetUpload> for SourcePair {
         Ok(SymbolSetUpload {
             chunk_id,
             data,
-            release_id: self.sourcemap.get_release_id(),
+            release_id,
+            content_hash,
         })
     }
 }

--- a/cli/tests/debug_symbols.rs
+++ b/cli/tests/debug_symbols.rs
@@ -313,6 +313,7 @@ fn dedup_preserves_per_format_chunk_id_casing() {
         chunk_id: chunk_id.to_string(),
         release_id: None,
         data: data.to_vec(),
+        content_hash: None,
     };
 
     let deduped = dedup_uploads_by_chunk_id(vec![

--- a/cli/tests/sourcemap.rs
+++ b/cli/tests/sourcemap.rs
@@ -241,6 +241,100 @@ fn test_reinject_is_idempotent() {
 }
 
 #[test]
+fn test_pair_remove_strips_release_variant_snippet() {
+    // Removal must strip the release-carrying snippet too, or updating a chunk would stack
+    // a second snippet on top of the old one.
+    let case_path = get_case_path("inject");
+    let mut pairs =
+        read_pairs(vec![case_path.clone()], vec![], vec![], &None).expect("Failed to read pairs");
+    let current_pair = pairs.first_mut().expect("Failed to get first pair");
+    let chunk_id = "00000-00000-00000";
+    current_pair
+        .add_chunk_id(
+            chunk_id.to_string(),
+            Some("0199f7c2-1c4e-7c3a-9f8b-2d6e4a1b7c05"),
+        )
+        .expect("Failed to set chunk ID");
+
+    current_pair
+        .remove_chunk_id(chunk_id.to_string())
+        .expect("Failed to remove chunk ID");
+
+    assert_file_eq(&case_path, "chunk.js", &current_pair.source.inner.content);
+
+    let expected_val: SourceMapContent =
+        serde_json::from_str(include_str!(case!("inject/chunk.js.map"))).unwrap();
+    assert_eq!(expected_val, current_pair.sourcemap.inner.content);
+}
+
+#[test]
+fn test_reinject_refreshes_stale_release_id() {
+    // Re-running inject over an already-injected dist with a new release must swap the
+    // embedded release id while keeping the content-addressed chunk id.
+    let case_path = get_case_path("inject");
+    let pairs =
+        read_pairs(vec![case_path.clone()], vec![], vec![], &None).expect("Failed to read pairs");
+    let injected = inject_pairs(pairs, Some("release-a")).expect("Failed to inject pairs");
+    let chunk_id = injected
+        .first()
+        .and_then(|p| p.get_chunk_id())
+        .expect("chunk id");
+
+    let refreshed = inject_pairs(injected, Some("release-b")).expect("Failed to re-inject pairs");
+    let pair = refreshed.first().expect("Failed to get first pair");
+
+    assert_eq!(pair.get_chunk_id().as_deref(), Some(chunk_id.as_str()));
+    let source = &pair.source.inner.content;
+    assert!(
+        source.contains(r#"_posthogReleaseId||"release-b""#),
+        "source: {source}"
+    );
+    assert!(!source.contains("release-a"), "source: {source}");
+}
+
+#[test]
+fn test_reinject_without_release_keeps_embedded_release_id() {
+    // A run that can't resolve a release has no information — it must not clear the
+    // release id a previous run embedded.
+    let case_path = get_case_path("inject");
+    let pairs =
+        read_pairs(vec![case_path.clone()], vec![], vec![], &None).expect("Failed to read pairs");
+    let injected = inject_pairs(pairs, Some("release-a")).expect("Failed to inject pairs");
+    let source_before = injected.first().unwrap().source.inner.content.clone();
+
+    let reinjected = inject_pairs(injected, None).expect("Failed to re-inject pairs");
+
+    assert_eq!(
+        reinjected.first().unwrap().source.inner.content,
+        source_before
+    );
+}
+
+#[test]
+fn test_reinject_adds_release_to_releaseless_chunk() {
+    // A chunk injected while no release was resolvable must pick the release up on a later
+    // run, keeping its content-addressed chunk id.
+    let case_path = get_case_path("inject");
+    let pairs =
+        read_pairs(vec![case_path.clone()], vec![], vec![], &None).expect("Failed to read pairs");
+    let injected = inject_pairs(pairs, None).expect("Failed to inject pairs");
+    let chunk_id = injected
+        .first()
+        .and_then(|p| p.get_chunk_id())
+        .expect("chunk id");
+
+    let refreshed = inject_pairs(injected, Some("release-a")).expect("Failed to re-inject pairs");
+    let pair = refreshed.first().expect("Failed to get first pair");
+
+    assert_eq!(pair.get_chunk_id().as_deref(), Some(chunk_id.as_str()));
+    assert!(pair
+        .source
+        .inner
+        .content
+        .contains(r#"_posthogReleaseId||"release-a""#));
+}
+
+#[test]
 fn test_inject_with_release_embeds_id_in_source() {
     // Injecting with a release must embed its id into the JS chunk itself — that global is the
     // SDK's only source of the release — and must leave the release out of the sourcemap, so

--- a/cli/tests/sourcemap.rs
+++ b/cli/tests/sourcemap.rs
@@ -1,6 +1,8 @@
 use posthog_cli::{
     sourcemaps::{
-        content::SourceMapContent, inject::inject_pairs, plain::inject::is_javascript_file,
+        content::SourceMapContent,
+        inject::{inject_pairs, inject_pairs_legacy},
+        plain::inject::is_javascript_file,
         source_pairs::SourcePair,
     },
     utils::files::FileSelection,
@@ -129,7 +131,7 @@ fn test_pair_inject() {
     let current_pair = pairs.first_mut().expect("Failed to get first pair");
     let chunk_id = "00000-00000-00000";
     current_pair
-        .add_chunk_id(chunk_id.to_string())
+        .add_chunk_id(chunk_id.to_string(), None)
         .expect("Failed to set chunk ID");
 
     assert_file_eq(
@@ -152,7 +154,7 @@ fn test_index_inject() {
     let current_pair = pairs.first_mut().expect("Failed to get first pair");
     let chunk_id = "00000-00000-00000";
     current_pair
-        .add_chunk_id(chunk_id.to_string())
+        .add_chunk_id(chunk_id.to_string(), None)
         .expect("Failed to set chunk ID");
 
     let bytes = serde_json::to_string(&current_pair.sourcemap.inner.content).unwrap();
@@ -177,7 +179,7 @@ fn test_index_inject_retains_extension_fields() {
 
     let chunk_id = "00000-00000-00000";
     current_pair
-        .add_chunk_id(chunk_id.to_string())
+        .add_chunk_id(chunk_id.to_string(), None)
         .expect("Failed to set chunk ID");
 
     // Extension field should be retained after flattening
@@ -206,7 +208,7 @@ fn test_pair_remove() {
     let current_pair = pairs.first_mut().expect("Failed to get first pair");
     let chunk_id = "00000-00000-00000";
     current_pair
-        .add_chunk_id(chunk_id.to_string())
+        .add_chunk_id(chunk_id.to_string(), None)
         .expect("Failed to set chunk ID");
 
     current_pair
@@ -222,12 +224,55 @@ fn test_pair_remove() {
 }
 
 #[test]
-fn test_reinject_without_new_release() {
+fn test_reinject_is_idempotent() {
+    // A chunk that already carries a content-addressed id must survive re-injection untouched.
+    // Regenerating the id on every build would orphan the already-uploaded symbol set.
     let case_path = get_case_path("reinject");
     let pairs =
         read_pairs(vec![case_path.clone()], vec![], vec![], &None).expect("Failed to read pairs");
     assert_eq!(pairs.len(), 1);
+    let source_before = pairs.first().unwrap().source.inner.content.clone();
+
     let injected_pairs = inject_pairs(pairs, None).expect("Failed to inject pairs");
+    let first_pair = injected_pairs.first().expect("Failed to get first pair");
+
+    assert_eq!(first_pair.source.get_chunk_id().as_deref(), Some("0"));
+    assert_eq!(first_pair.source.inner.content, source_before);
+}
+
+#[test]
+fn test_inject_with_release_embeds_id_in_source() {
+    // Injecting with a release must embed its id into the JS chunk itself — that global is the
+    // SDK's only source of the release — and must leave the release out of the sourcemap, so
+    // nothing binds the uploaded symbol set to it. The SDK ignores the global unless it is a
+    // non-empty string, so it has to be emitted as a quoted string literal.
+    let case_path = get_case_path("inject");
+    let pairs =
+        read_pairs(vec![case_path.clone()], vec![], vec![], &None).expect("Failed to read pairs");
+    assert_eq!(pairs.len(), 1);
+    let release_id = "0199f7c2-1c4e-7c3a-9f8b-2d6e4a1b7c05";
+
+    let injected_pairs = inject_pairs(pairs, Some(release_id)).expect("Failed to inject pairs");
+    let first_pair = injected_pairs.first().expect("Failed to get first pair");
+
+    let source = &first_pair.source.inner.content;
+    assert!(
+        source.contains(&format!(r#"_posthogReleaseId||"{release_id}""#)),
+        "source: {source}"
+    );
+    assert!(first_pair.source.get_chunk_id().is_some());
+    assert!(first_pair.sourcemap.get_release_id().is_none());
+}
+
+#[test]
+fn test_legacy_reinject_without_new_release() {
+    // Legacy path: with no release, an existing chunk carrying a stale release id is regenerated
+    // and the release id is cleared from the sourcemap.
+    let case_path = get_case_path("reinject");
+    let pairs =
+        read_pairs(vec![case_path.clone()], vec![], vec![], &None).expect("Failed to read pairs");
+    assert_eq!(pairs.len(), 1);
+    let injected_pairs = inject_pairs_legacy(pairs, None).expect("Failed to inject pairs");
     let first_pair = injected_pairs.first().expect("Failed to get first pair");
     assert_ne!(&first_pair.source.get_chunk_id().unwrap(), "0");
     assert_eq!(
@@ -238,14 +283,15 @@ fn test_reinject_without_new_release() {
 }
 
 #[test]
-fn test_reinject_with_new_release() {
+fn test_legacy_reinject_with_new_release() {
+    // Legacy path: a new release id regenerates the chunk id and is stamped into the sourcemap.
     let case_path = get_case_path("reinject");
     let pairs =
         read_pairs(vec![case_path.clone()], vec![], vec![], &None).expect("Failed to read pairs");
     assert_eq!(pairs.len(), 1);
     let release_id = uuid::Uuid::now_v7().to_string();
     let injected_pairs =
-        inject_pairs(pairs, Some(release_id.clone())).expect("Failed to inject pairs");
+        inject_pairs_legacy(pairs, Some(release_id.clone())).expect("Failed to inject pairs");
     let first_pair = injected_pairs.first().expect("Failed to get first pair");
     assert_ne!(&first_pair.source.get_chunk_id().unwrap(), "0");
     assert_eq!(


### PR DESCRIPTION
We have a new flag `--no-release-bind` for JS.

### What it does
- we no longer send release id when we send chunks to the server. Thanks to that symbol sets are not bound to a release,
- we create (or fetch existing) release during injection so we know what release id to inject,
- we have a way of generating stable UUID for a given source code.

## Some decisions

### Including source map in the chunk id calculation

When computing chunk ID, I decided to include source map content in it. That's because if we don't do this and someone changes for example a comment in a file, then chunk ID remains stable but source map hash changes (we are using source map hash to compute `content_hash` when uploading chunks). This causes content hash mismatch - that chunk already exists but map is different.

We could either:
- not include source map content at all anywhere - that works but then if you just change the comment in any file and reupload chunks, we will skip everything and in the UI you won't see the updated comment,
- include source map content both in chunk id calculation and in `content_hash` calculation during upload - this is what I did. There is a risk that different machines will produce different map files but the worst that can happen is that we will just re-upload. Today we re-upload everything every time so it's still a big win

## Some examples

### First ever upload

We communicate that release was not found and we create one. We upload all chunks.

| First ever upload |
|--------|
| <img width="2478" height="404" alt="CleanShot 2026-08-11 at 13 11 25@2x" src="https://github.com/user-attachments/assets/93f764c7-a32f-48dd-b93a-f27ccdc88ecc" /> | 

### Same commit, 2 files changed

We don't create new release because it was already found. We correctly skip 2/4 chunks. Only two need to be uploaded


| Same commit, 2 files changed |
|--------|
| <img width="2486" height="348" alt="CleanShot 2026-08-11 at 13 12 10@2x" src="https://github.com/user-attachments/assets/74d42487-4786-41aa-8b0b-a29c6a368154" /> | 



### Next commit, 1 file changed

We again create a new release and again only upload 1 chunk

| Next commit, 1 file changed |
|--------|
| <img width="2546" height="412" alt="CleanShot 2026-08-11 at 13 39 03@2x" src="https://github.com/user-attachments/assets/e2c62489-4426-487b-8a6a-244706b44e67" /> | 


