### PR TITLE
fix(aio): match production ai ingestion lane topology in dev and e2e

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -863,9 +863,9 @@ jobs:
                   # ingestion-error-tracking: error tracking ingestion (ingestion-errortracking mode)
                   # ingestion-logs: logs ingestion (ingestion-logs mode)
                   # ingestion-traces: traces ingestion (ingestion-traces mode)
-                  # capture-ai: AI event capture (/i/v0/ai/batch/, CAPTURE_MODE=events)
-                  # ingestion-ai: AI event ingestion incl. multimodal blob offload (INGESTION_PIPELINE=ai)
-                  COMPOSE_FILE=docker-compose.dev.yml COMPOSE_PROFILES=capture,ingestion bin/ci-wait-for-docker launch plugins ingestion-general ingestion-sessionreplay recording-api ingestion-error-tracking ingestion-logs ingestion-traces capture-ai ingestion-ai
+                  # capture-ai: AI event capture (/i/v0/ai/batch/, CAPTURE_MODE=ai); ingestion-general's
+                  # combined-mode AI consumer ingests the lane incl. multimodal blob offload
+                  COMPOSE_FILE=docker-compose.dev.yml COMPOSE_PROFILES=capture,ingestion bin/ci-wait-for-docker launch plugins ingestion-general ingestion-sessionreplay recording-api ingestion-error-tracking ingestion-logs ingestion-traces capture-ai
 
             # Install Playwright browsers while we wait for PostHog to be ready
             - name: Install Playwright browsers
@@ -883,7 +883,7 @@ jobs:
               env:
                   COMPOSE_FILE: docker-compose.dev.yml
                   COMPOSE_PROFILES: capture,ingestion
-              run: bin/ci-wait-for-docker wait plugins ingestion-general ingestion-sessionreplay recording-api ingestion-error-tracking ingestion-logs ingestion-traces capture-ai ingestion-ai
+              run: bin/ci-wait-for-docker wait plugins ingestion-general ingestion-sessionreplay recording-api ingestion-error-tracking ingestion-logs ingestion-traces capture-ai
 
             - name: Clean snapshot directory
               run: find playwright/__snapshots__ -name '*.png' -delete 2>/dev/null || true
@@ -1005,7 +1005,6 @@ jobs:
                   docker logs posthog-ingestion-logs-1 > playwright/test-results/docker-ingestion-logs.log 2>&1 || echo "No ingestion-logs container" > playwright/test-results/docker-ingestion-logs.log
                   docker logs posthog-ingestion-traces-1 > playwright/test-results/docker-ingestion-traces.log 2>&1 || echo "No ingestion-traces container" > playwright/test-results/docker-ingestion-traces.log
                   docker logs posthog-capture-ai-1 > playwright/test-results/docker-capture-ai.log 2>&1 || echo "No capture-ai container" > playwright/test-results/docker-capture-ai.log
-                  docker logs posthog-ingestion-ai-1 > playwright/test-results/docker-ingestion-ai.log 2>&1 || echo "No ingestion-ai container" > playwright/test-results/docker-ingestion-ai.log
 
             - name: Archive test artifacts
               if: always()

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -113,27 +113,6 @@ procs:
             layer: Ingestion pipeline
             tech: Node
 
-    ingestion-ai:
-        sandbox: true
-        shell: 'bin/wait-for-docker && PLUGIN_SERVER_MODE=ingestion-v2 INGESTION_PIPELINE=ai HTTP_SERVER_PORT=6746 ./bin/posthog-node'
-        capability: ai_capture
-        ready_pattern: 'All systems go'
-        groups:
-            layer: Ingestion pipeline
-            tech: Node
-        env:
-            INGESTION_CONSUMER_CONSUME_TOPIC: ai_events_ingestion
-            INGESTION_CONSUMER_GROUP_ID: ingestion-ai
-            PERSONHOG_ENABLED: 'true'
-            PERSONHOG_ADDR: '127.0.0.1:50052'
-            AI_BLOB_S3_BUCKET: ai-blobs
-            AI_BLOB_S3_PREFIX: 'aio/'
-            AI_BLOB_S3_ENDPOINT: 'http://localhost:19000'
-            AI_BLOB_S3_REGION: us-east-1
-            AI_BLOB_S3_ACCESS_KEY_ID: object_storage_root_user
-            AI_BLOB_S3_SECRET_ACCESS_KEY: object_storage_root_password
-            AI_BLOB_OFFLOAD_TEAMS: '*'
-
     ingestion:
         sandbox: true
         shell: 'bin/wait-for-docker && PLUGIN_SERVER_MODE=ingestion-v2-combined HTTP_SERVER_PORT=6739 ./bin/posthog-node'
@@ -147,6 +126,16 @@ procs:
             # event_ingestion capability pulls the personhog services in.
             PERSONHOG_ENABLED: 'true'
             PERSONHOG_ADDR: '127.0.0.1:50052'
+            # Combined mode's AI consumer owns the events_plugin_ingestion_ai lane locally;
+            # without a bucket it silently skips blob offload, so give it the same store the
+            # compose stacks use.
+            AI_BLOB_S3_BUCKET: ai-blobs
+            AI_BLOB_S3_PREFIX: 'aio/'
+            AI_BLOB_S3_ENDPOINT: 'http://localhost:19000'
+            AI_BLOB_S3_REGION: us-east-1
+            AI_BLOB_S3_ACCESS_KEY_ID: object_storage_root_user
+            AI_BLOB_S3_SECRET_ACCESS_KEY: object_storage_root_password
+            AI_BLOB_OFFLOAD_TEAMS: '*'
 
     ingestion-sessionreplay:
         sandbox: true

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -115,7 +115,7 @@ procs:
 
     ingestion:
         sandbox: true
-        shell: 'bin/wait-for-docker && PLUGIN_SERVER_MODE=ingestion-v2-combined HTTP_SERVER_PORT=6739 ./bin/posthog-node'
+        shell: 'bin/wait-for-docker objectstorage && PLUGIN_SERVER_MODE=ingestion-v2-combined HTTP_SERVER_PORT=6739 ./bin/posthog-node'
         capability: event_ingestion
         ready_pattern: 'All systems go'
         groups:

--- a/bin/start-rust-service
+++ b/bin/start-rust-service
@@ -93,10 +93,11 @@ case "$RS_SVC" in
     export RUST_BACKTRACE=1
     export ADDRESS=0.0.0.0:3309 # avoid port conflict in local dev (3308 is used by llm-gateway)
     export KAFKA_HOSTS="$DEFAULT_KAFKA"
-    export KAFKA_TOPIC=ai_events_ingestion
+    export KAFKA_TOPIC=events_plugin_ingestion_ai
     export REDIS_URL="$DEFAULT_REDIS"
     export DATABASE_URL="${DATABASE_URL:-$DEFAULT_PG}"
-    export CAPTURE_MODE=events
+    # `ai` mode produces to the AI lane as its main topic, matching prod capture-ai
+    export CAPTURE_MODE=ai
     export LOG_LEVEL=debug
     export DEBUG=1
     # AI endpoint S3 blob storage (MinIO)

--- a/bin/verify-ai-ingestion-stack
+++ b/bin/verify-ai-ingestion-stack
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verifies capture-ai -> Kafka -> ingestion-ai (blob offload) -> ClickHouse ai_events.
+# Verifies capture-ai -> Kafka -> combined ingestion's AI consumer (blob offload) -> ClickHouse ai_events.
 set -euo pipefail
 
 PROXY="${PROXY:-http://localhost:8010}"

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -414,10 +414,12 @@ services:
         restart: on-failure
         environment:
             ADDRESS: '0.0.0.0:3000'
-            KAFKA_TOPIC: 'ai_events_ingestion'
+            KAFKA_TOPIC: 'events_plugin_ingestion_ai'
             KAFKA_HOSTS: 'kafka:9092'
             REDIS_URL: 'redis://redis7:6379/'
-            CAPTURE_MODE: events
+            # `ai` mode produces to the AI lane as its main topic (no $ai_* divert needed),
+            # matching the production capture-ai deployment.
+            CAPTURE_MODE: ai
             RUST_LOG: 'info,rdkafka=warn'
             # AI endpoint S3 blob storage
             AI_S3_BUCKET: ai-blobs
@@ -575,26 +577,9 @@ services:
             COOKIELESS_REDIS_PORT: 6379
             CDP_REDIS_HOST: redis7
             ENCRYPTION_SALT_KEYS: '00beef0000beef0000beef0000beef00'
-
-    ingestion-ai:
-        command: node nodejs/dist/index.js
-        restart: on-failure
-        environment:
-            PLUGIN_SERVER_MODE: 'ingestion-v2'
-            INGESTION_PIPELINE: 'ai'
-            INGESTION_CONSUMER_CONSUME_TOPIC: 'ai_events_ingestion'
-            INGESTION_CONSUMER_GROUP_ID: 'ingestion-ai'
-            DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
-            PERSONS_DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
-            KAFKA_HOSTS: 'kafka:9092'
-            REDIS_URL: 'redis://redis7:6379/'
-            CLICKHOUSE_HOST: 'clickhouse'
-            CLICKHOUSE_DATABASE: 'posthog'
-            CLICKHOUSE_SECURE: 'false'
-            CLICKHOUSE_VERIFY: 'false'
-            COOKIELESS_REDIS_HOST: redis7
-            COOKIELESS_REDIS_PORT: 6379
-            ENCRYPTION_SALT_KEYS: '00beef0000beef0000beef0000beef00'
+            # Combined mode consumes the events_plugin_ingestion_ai lane, where capture diverts
+            # $ai_* events, so it owns AI blob offload. Without a bucket, buildAiBlobStore returns
+            # null and multimodal payloads are stored inline instead of as phaiblob:// pointers.
             AI_BLOB_S3_BUCKET: ai-blobs
             AI_BLOB_S3_PREFIX: 'aio/'
             AI_BLOB_S3_ENDPOINT: 'http://objectstorage:19000'

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -238,42 +238,9 @@ services:
                 condition: service_healthy
             db:
                 condition: service_healthy
-            personhog-router:
-                condition: service_started
-        healthcheck:
-            test: ['CMD', 'curl', '-f', 'http://localhost:6738/_ready']
-            interval: 5s
-            timeout: 5s
-            retries: 30
-            start_period: 15s
-        profiles:
-            - ingestion
-
-    ingestion-ai:
-        extends:
-            file: docker-compose.base.yml
-            service: ingestion-ai
-        image: ghcr.io/posthog/posthog-node:${POSTHOG_NODE_TAG:-master}
-        ports:
-            - '6746:6738'
-        environment:
-            DATABASE_URL: postgres://posthog:posthog@db:5432/${POSTHOG_DB_NAME:-posthog}
-            PERSONS_DATABASE_URL: postgres://posthog:posthog@db:5432/${POSTHOG_PERSONS_DB_NAME:-posthog}
-            CLICKHOUSE_DATABASE: ${CLICKHOUSE_DATABASE:-posthog}
-            # CDP Redis defaults to 127.0.0.1 — must point to the Docker service
-            CDP_REDIS_HOST: redis7
-            PERSONHOG_ADDR: 'personhog-router:50052'
-            PERSONHOG_ENABLED: 'true'
-        depends_on:
-            kafka:
-                condition: service_started
-            redis7:
-                condition: service_healthy
-            db:
-                condition: service_healthy
             objectstorage:
-                # SeaweedFS creates the ai-blobs bucket asynchronously, and this service exits
-                # at startup if the bucket is missing, so wait for the bootstrap sentinel.
+                # The combined AI consumer's blob store healthchecks the ai-blobs bucket at
+                # startup, and SeaweedFS creates it asynchronously, so wait for the sentinel.
                 condition: service_healthy
             personhog-router:
                 condition: service_started

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -242,6 +242,8 @@ services:
             - redis7
             - clickhouse
             - kafka
+            # The combined AI consumer's blob store healthchecks the ai-blobs bucket at startup
+            - objectstorage
             - personhog-router
 
     ingestion-sessionreplay:

--- a/hogli.yaml
+++ b/hogli.yaml
@@ -1201,5 +1201,5 @@ environment:
         hidden: true
     verify:ai:ingestion:stack:
         bin_script: verify-ai-ingestion-stack
-        description: 'Check the multimodal AI ingestion path at the data layer: send an $ai_generation with an inline base64 image through capture-ai and assert ingestion-ai offloaded it to a blob pointer in ClickHouse'
+        description: 'Check the multimodal AI ingestion path at the data layer: send an $ai_generation with an inline base64 image through capture-ai and assert ingestion offloaded it to a blob pointer in ClickHouse'
         hidden: true

--- a/products/ai_observability/frontend/e2e/multimodal-trace.spec.ts
+++ b/products/ai_observability/frontend/e2e/multimodal-trace.spec.ts
@@ -16,11 +16,6 @@ const SCREENSHOT_BYTES = fs.readFileSync(path.join(FIXTURE_DIR, 'screenshot.png'
 const POINTER_RE = /phaiblob:\/\/v1\/sha256\/(?<hash>[0-9a-f]{64})\?mime=(?<mime>[^&]+)&size=(?<size>\d+)/
 
 test.describe('AI observability multimodal trace', () => {
-    test.skip(
-        true,
-        'Flaky: blob offloading can exceed the CI polling window. Follow-up: https://github.com/PostHog/posthog/issues/80843'
-    )
-
     test('a screenshot sent through ingestion renders in the trace view', async ({
         page,
         request,


### PR DESCRIPTION
## Problem

Dev, E2E, and local stacks route AI capture through `ai_events_ingestion` — a topic that exists nowhere in production — with `capture-ai` in `events` mode. Since #78260 made analytics-mode capture divert every `$ai_*` event to the real AI lane (`events_plugin_ingestion_ai`), those diverted events now land on a consumer with no blob-offload config, so multimodal images are stored inline instead of as `phaiblob://` pointers. That broke the multimodal AI-observability E2E test on master; it was skipped in #79989 (follow-up #80843).

The root cause is a dev-only topology that never matched production: a bespoke topic and a dedicated `ingestion-ai` service production doesn't run.

## Changes

- `capture-ai` runs `CAPTURE_MODE: ai` and produces to `events_plugin_ingestion_ai`, the lane it owns as its main topic — the production `capture-ai` shape.
- Remove the dedicated `ingestion-ai` service (compose base + dev) and its local mprocs proc. Combined-mode `ingestion-general` already consumes that lane, matching hobby and production's single-consumer shape.
- Configure AI blob offload on the combined consumer that now owns the lane: `AI_BLOB_*` on `ingestion-general` (compose) and on the local mprocs combined proc, plus an `objectstorage` startup dependency in dev and hobby so the bucket healthcheck doesn't race container start. This supersedes #80799, which made the same `ingestion-general` change; closing that in favor of this.
- Delete the invented `ai_events_ingestion` topic; update the E2E workflow, the verify script, and the hogli command description to the real path.
- Un-skip the multimodal E2E test (reverts #79989's skip).

<!-- Closes #80843 -->

## How did you test this code?

Agent-authored; I did not boot the stack or run the Playwright suite locally.

- `docker compose -f docker-compose.dev.yml --profile capture --profile ingestion config` resolves with `capture-ai` in `ai` mode on `events_plugin_ingestion_ai`, `ingestion-general` carrying the `AI_BLOB_*` config and an `objectstorage: service_healthy` dependency, and no `ingestion-ai` service. Hobby resolves with the same `objectstorage` ordering.
- YAML parse and `bash -n` on every touched config file and script.
- The E2E paths filter covers `docker-compose.dev.yml` and the spec, so this PR's own Playwright run — with the blob config and the un-skipped test both present — is the real check.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Add `skip-inkeep-docs`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Carlos directed this while investigating why the multimodal E2E test broke. Traced the break to #78260 completing the `$ai_*` capture-divert migration, which the dev/E2E topology never modeled — dev used a made-up topic and a dedicated consumer production doesn't run. Chose the combined-centric shape (delete the dedicated service, let combined own the lane) over adding a dev-only gate flag to ingestion code, so no production code changes. Folded in #80799's `ingestion-general` blob config rather than stacking, because #80799's branch predated the test skip and would have made the un-skip a silent no-op; also carried forward the objectstorage startup-race fix its review raised, extended to hobby. Tool: PostHog Code.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
