### PR TITLE
fix(desktop): mobile preserve ordered list start values

### DIFF
--- a/products/desktop/apps/mobile/src/features/chat/components/MarkdownText.test.tsx
+++ b/products/desktop/apps/mobile/src/features/chat/components/MarkdownText.test.tsx
@@ -1,0 +1,58 @@
+import { createElement } from "react";
+import { act, create } from "react-test-renderer";
+import { describe, expect, it, vi } from "vitest";
+import { MarkdownText } from "./MarkdownText";
+
+vi.mock("./CopyButton", () => ({ CopyButton: () => null }));
+
+vi.mock("@/features/auth", () => ({
+  useAuthStore: (selector: (state: { cloudRegion: null }) => unknown) =>
+    selector({ cloudRegion: null }),
+  getCloudUrlFromRegion: () => null,
+}));
+
+function renderTree(content: string): string {
+  let renderer: ReturnType<typeof create> | null = null;
+  act(() => {
+    renderer = create(createElement(MarkdownText, { content }));
+  });
+  if (!renderer) throw new Error("Renderer not created");
+  return JSON.stringify((renderer as ReturnType<typeof create>).toJSON());
+}
+
+describe("MarkdownText", () => {
+  it.each([
+    {
+      name: "ordered list starting at 1",
+      content: "1. Alpha\n2. Beta\n3. Gamma",
+      present: ["1.", "2.", "3."],
+      absent: ["•"],
+    },
+    {
+      name: "ordered list starting above 1 preserves the source numbers",
+      content: "3. Alpha\n4. Beta\n5. Gamma",
+      present: ["3.", "4.", "5."],
+      absent: ["1.", "2."],
+    },
+    {
+      name: "unordered list uses bullets",
+      content: "- Alpha\n- Beta",
+      present: ["•"],
+      absent: ["1."],
+    },
+    {
+      name: "task list uses checkboxes",
+      content: "- [ ] Alpha\n- [x] Beta",
+      present: ["☐", "☑"],
+      absent: ["•", "1."],
+    },
+  ])("$name", ({ content, present, absent }) => {
+    const tree = renderTree(content);
+    for (const marker of present) {
+      expect(tree).toContain(marker);
+    }
+    for (const marker of absent) {
+      expect(tree).not.toContain(marker);
+    }
+  });
+});

--- a/products/desktop/apps/mobile/src/features/chat/components/MarkdownText.tsx
+++ b/products/desktop/apps/mobile/src/features/chat/components/MarkdownText.tsx
@@ -77,6 +77,7 @@ interface Block {
   level?: number;
   items?: string[];
   ordered?: boolean;
+  start?: number;
   rows?: string[][];
   url?: string;
   alt?: string;
@@ -159,13 +160,20 @@ function parseBlocks(text: string): Block[] {
     }
 
     // Ordered list (consecutive 1. 2. lines)
-    if (/^\s*\d+[.)]\s/.test(line)) {
+    const orderedMatch = line.match(/^\s*(\d+)[.)]\s/);
+    if (orderedMatch) {
       const items: string[] = [];
       while (i < lines.length && /^\s*\d+[.)]\s/.test(lines[i])) {
         items.push(lines[i].replace(/^\s*\d+[.)]\s+/, ""));
         i++;
       }
-      blocks.push({ type: "list", content: "", items, ordered: true });
+      blocks.push({
+        type: "list",
+        content: "",
+        items,
+        ordered: true,
+        start: Number(orderedMatch[1]),
+      });
       continue;
     }
 
@@ -519,7 +527,7 @@ export function MarkdownText({
                         </Text>
                       ) : (
                         <Text className="mr-2 text-[13px] text-gray-9">
-                          {block.ordered ? `${idx + 1}.` : "•"}
+                          {block.ordered ? `${(block.start ?? 1) + idx}.` : "•"}
                         </Text>
                       )}
                       <Text


### PR DESCRIPTION
## Problem

- On mobile, a chat message with an ordered list that does not start at 1 showed the wrong numbers. A list written as `3.` `4.` `5.`, or one continued after an intervening paragraph, was renumbered from 1.
- The numbers a reader saw then disagreed with the numbers the message wrote and referred to.

## Changes

- The mobile markdown parser now captures the first item's number from an ordered list.
- The renderer prints markers from that start value instead of always counting from 1.
- Unordered lists and task lists are unaffected.
- This ports the desktop fix in #80782 to `products/desktop/apps/mobile`. The desktop renderer is `react-markdown`; mobile hand-rolls the block parser, so the number is captured in the parser and used in the renderer rather than passed through an `<ol start>` attribute.

## How did you test this code?

- Added a parameterized test over four list inputs: a list starting at 1, a list starting at a higher number, an unordered list, and a task list. It catches a renderer that counts from 1 regardless of the source number, and guards that bullet and checkbox markers stay unchanged. Confirmed it fails when the fix is reverted.
- Ran the mobile lint and the full mobile test suite locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.
