### PR TITLE
fix(replay): dispatch comment bus notifications through a bound action

### DIFF
--- a/frontend/src/scenes/session-recordings/player/commenting/playerCommentModel.ts
+++ b/frontend/src/scenes/session-recordings/player/commenting/playerCommentModel.ts
@@ -19,6 +19,11 @@ export type playerCommentModelType = MakeLogicType<{}, playerCommentModelActions
  * the currently active player will listen to this
  * and can e.g. enter or exit comment mode in response
  * it relies on being used when there is always a mounted player with a logic listening for this
+ *
+ * dispatch into it from another logic with connect({ actions: [playerCommentModel, ['commentEdited']] })
+ * or from a component with useActions, so the action creator binds at build time
+ * calling playerCommentModel.actions.x() at runtime resolves through kea's wrapper proxy,
+ * which throws "is not mounted" once the built instance has been evicted from the build cache
  */
 export const playerCommentModel = kea<playerCommentModelType>([
     path(['scenes', 'session-recordings', 'player', 'playerCommentModel']),

--- a/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.test.ts
@@ -13,6 +13,7 @@ import { CommentType } from '~/types'
 
 import { recordingMetaJson } from '../../__mocks__/recording_meta'
 import { setupSessionRecordingTest } from '../__mocks__/test-setup'
+import { playerCommentModel } from './playerCommentModel'
 import { playerCommentOverlayLogic } from './playerFrameCommentOverlayLogic'
 
 jest.mock('../snapshot-processing/DecompressionWorkerManager')
@@ -90,7 +91,7 @@ describe('playerFrameCommentOverlayLogic', () => {
 
         await expectLogic(logic, () => {
             logic.actions.submitRecordingComment()
-        }).toDispatchActions(['submitRecordingCommentSuccess'])
+        }).toDispatchActions([playerCommentModel.actionTypes.commentEdited, 'submitRecordingCommentSuccess'])
 
         expect(createSpy).toHaveBeenCalledTimes(1)
         expect(createSpy.mock.calls[0][0].item_context).toMatchObject({

--- a/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/commenting/playerFrameCommentOverlayLogic.ts
@@ -66,6 +66,9 @@ export interface playerCommentOverlayLogicActions {
     ensureAllMembersLoaded: () => {
         value: true
     } // membersLogic
+    commentEdited: (recordingId: string) => {
+        recordingId: string
+    } // playerCommentModel
     setIsCommenting: (isCommenting: boolean) => {
         isCommenting: boolean
     } // sessionRecordingPlayerLogic
@@ -154,9 +157,15 @@ export const playerCommentOverlayLogic = kea<playerCommentOverlayLogicType>([
     props({} as PlayerCommentOverlayLogicProps),
     connect((props: PlayerCommentOverlayLogicProps) => ({
         values: [sessionRecordingPlayerLogic(props), ['currentPlayerTime', 'currentTimestamp', 'sessionPlayerData']],
-        actions: [sessionRecordingPlayerLogic(props), ['setIsCommenting'], membersLogic, ['ensureAllMembersLoaded']],
-        // its subscribers listen by actionTypes, which doesn't mount it, so keep the bus alive here
-        logic: [playerCommentModel],
+        actions: [
+            sessionRecordingPlayerLogic(props),
+            ['setIsCommenting'],
+            membersLogic,
+            ['ensureAllMembersLoaded'],
+            // bound at build time, so notifying the bus can't depend on it still being mounted
+            playerCommentModel,
+            ['commentEdited'],
+        ],
     })),
     actions({
         editComment: (comment: RecordingCommentForm) => ({ comment }),
@@ -292,7 +301,7 @@ export const playerCommentOverlayLogic = kea<playerCommentOverlayLogicType>([
                     },
                     slug: `/replay/${props.recordingId}#panel=discussion`,
                 })
-                playerCommentModel.actions.commentEdited(props.recordingId)
+                actions.commentEdited(props.recordingId)
             } catch (e) {
                 lemonToast.error(`Could not save your comment: ${(e as Error).message}`)
             } finally {
@@ -350,7 +359,7 @@ export const playerCommentOverlayLogic = kea<playerCommentOverlayLogicType>([
                     await api.comments.create({ ...apiPayload, is_task: values.asTask })
                 }
 
-                playerCommentModel.actions.commentEdited(props.recordingId)
+                actions.commentEdited(props.recordingId)
                 actions.resetRecordingComment()
                 actions.setAsTask(false)
                 actions.setIsCommenting(false)


### PR DESCRIPTION
## Problem

Saving a comment on a session replay still fails with "Could not save your comment: [KEA] Can not access "actions" on logic "...playerCommentModel" because it is not mounted!", roughly every second comment. The comment saves, but the overlay stays open with stale content and shows a failure toast.

#80744 tried to fix this by mounting the bus from the overlay's `connect`. That guarantee only holds for the overlay instance that built the bus.

- The overlay called `playerCommentModel.actions.commentEdited(...)` at runtime.
- That resolves through kea's wrapper proxy, which looks the logic up with `findMounted()`.
- `findMounted()` is a build-cache lookup plus a mount-counter check, wrapped in a try/catch. A cache miss throws the same "not mounted" error.
- `unmountLogic` evicts a built logic from the wrapper cache once its counter reaches 0, while still-mounted parents keep the old instance in `connections`. Two instances of one path can coexist.
- Which logic owns the bus mount is incidental. `getBuiltLogic` auto-connects a logic to whoever was mid-build when it was first built, and the cache-hit path skips that.

## Changes

- The overlay connects `commentEdited` as an action instead of reaching for the bus at runtime, so both call sites dispatch unconditionally.
- `connect` binds the action creator at build time and dispatches to the store, so this path never calls `findMounted()` and cannot throw whatever the bus's mount state is.
- The form submit path now reaches `resetRecordingComment()`, `setAsTask(false)` and `setIsCommenting(false)`, which the throw used to skip. The emoji path no longer toasts a failure for a comment that saved.
- `connect` still adds the connection, so the bus keeps the mount guarantee #80744 added. The now-redundant `logic: [playerCommentModel]` line is gone.
- Subscribers match on action type, so delivery is unchanged.
- `playerCommentModel`'s doc comment now states the dispatch contract, so a third producer does not reintroduce the crash.

I considered keeping the runtime call and guarding it with `findMounted()`. Skipping the notify would leave the comment list stale, and the dispatch is the thing that has to survive.

No visual change.

## How did you test this code?

I (actually Claude) ran the `session-recordings/player/commenting` Jest suite, kea typegen on the changed logic, oxlint and oxfmt on the changed files, and a frontend typecheck. No browser check.

One assertion added to the existing submit test: it now expects `playerCommentModel.actionTypes.commentEdited`. Nothing else pinned the notify, and the regression is silent, since the discussion panel just stops refreshing. No new test case, because I could not reach the failing state in jsdom: mounting `sessionRecordingPlayerLogic` alone already mounts the bus there, so a test for the crash would pass against the bug. Same wall #80744 hit.

The exact lifecycle that evicts the bus in the browser is unproven. This call site is immune either way.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code after Tue reported the error still firing after #80744, on the replay home scene with several recordings opened in sequence. I tried to reproduce the alternation in jsdom, failed, then read kea 4.0.0-pre.6's `build.ts`, `mount.ts` and `connect.ts` to work out why the mount guarantee is weaker than it looks. That reframed the fix from lifecycle to call site.

A console probe for the mount counter went nowhere, since kea's context is not exposed on `window` in the production bundle.

Skills invoked: `/writing-pr-descriptions`, `/shepherd-pr`, `/simplify`, `/code-review`, `/writing-code-comments`, `/writing-tests`. Claude and Codex both reviewed and found no correctness issues; the doc comment and the test assertion came from that pass.
