### PR TITLE
fix(desktop): mobile re-expand files box when artifacts change

### DIFF
--- a/products/desktop/apps/mobile/src/features/tasks/components/TaskArtifacts.test.tsx
+++ b/products/desktop/apps/mobile/src/features/tasks/components/TaskArtifacts.test.tsx
@@ -33,20 +33,32 @@ vi.mock("@/lib/theme", () => ({
   useThemeColors: () => ({ gray: { 9: "#777", 11: "#555" } }),
 }));
 
+function element() {
+  return createElement(TaskArtifacts, {
+    taskId: "t1",
+    runId: "r1",
+    enabled: true,
+  });
+}
+
 function mount(artifacts: TaskRunArtifact[] | undefined) {
   mockUseTaskArtifacts.mockReturnValue({ data: artifacts });
   let renderer: ReturnType<typeof create> | null = null;
   act(() => {
-    renderer = create(
-      createElement(TaskArtifacts, {
-        taskId: "t1",
-        runId: "r1",
-        enabled: true,
-      }),
-    );
+    renderer = create(element());
   });
   if (!renderer) throw new Error("Renderer not created");
   return renderer as ReturnType<typeof create>;
+}
+
+function update(
+  renderer: ReturnType<typeof create>,
+  artifacts: TaskRunArtifact[] | undefined,
+) {
+  mockUseTaskArtifacts.mockReturnValue({ data: artifacts });
+  act(() => {
+    renderer.update(element());
+  });
 }
 
 function json(renderer: ReturnType<typeof create>) {
@@ -95,5 +107,33 @@ describe("TaskArtifacts", () => {
 
     pressHeader(renderer);
     expect(json(renderer)).toContain("report.md");
+  });
+
+  it("stays collapsed across a re-render with the same files", () => {
+    const files: TaskRunArtifact[] = [
+      { id: "a1", name: "report.md", type: "output", size: 2_400 },
+    ];
+    const renderer = mount(files);
+    pressHeader(renderer);
+    expect(json(renderer)).not.toContain("report.md");
+
+    update(renderer, [...files]);
+    expect(json(renderer)).not.toContain("report.md");
+  });
+
+  it("re-expands when the file list changes", () => {
+    const renderer = mount([
+      { id: "a1", name: "report.md", type: "output", size: 2_400 },
+    ]);
+    pressHeader(renderer);
+    expect(json(renderer)).not.toContain("report.md");
+
+    update(renderer, [
+      { id: "a1", name: "report.md", type: "output", size: 2_400 },
+      { id: "a2", name: "chart.png", type: "output", size: 512 },
+    ]);
+    const shown = json(renderer);
+    expect(shown).toContain("report.md");
+    expect(shown).toContain("chart.png");
   });
 });

--- a/products/desktop/apps/mobile/src/features/tasks/components/TaskArtifacts.tsx
+++ b/products/desktop/apps/mobile/src/features/tasks/components/TaskArtifacts.tsx
@@ -1,3 +1,4 @@
+import { artifactFilesListKey } from "@posthog/core/sessions/artifactFilesListKey";
 import type { TaskRunArtifact } from "@posthog/shared";
 import {
   ArrowSquareOut,
@@ -26,7 +27,18 @@ export function TaskArtifacts({ taskId, runId, enabled }: TaskArtifactsProps) {
   const { data: artifacts } = useTaskArtifacts(taskId, runId, enabled);
   const [preview, setPreview] = useState<TaskRunArtifact | null>(null);
   const [sharingId, setSharingId] = useState<string | null>(null);
-  const [collapsed, setCollapsed] = useState(false);
+  const fileListKey = artifactFilesListKey(
+    runId,
+    (artifacts ?? []).map((artifact) => artifact.name ?? ""),
+  );
+  const [collapse, setCollapse] = useState({
+    collapsed: false,
+    key: fileListKey,
+  });
+  if (collapse.key !== fileListKey) {
+    setCollapse({ collapsed: false, key: fileListKey });
+  }
+  const collapsed = collapse.collapsed;
 
   const shareArtifact = useCallback(
     async (artifact: TaskRunArtifact): Promise<void> => {
@@ -53,7 +65,7 @@ export function TaskArtifacts({ taskId, runId, enabled }: TaskArtifactsProps) {
   return (
     <View className="mx-4 mb-2 rounded-lg border border-gray-5 bg-gray-2 p-3">
       <Pressable
-        onPress={() => setCollapsed((value) => !value)}
+        onPress={() => setCollapse({ collapsed: !collapsed, key: fileListKey })}
         hitSlop={6}
         accessibilityRole="button"
         accessibilityLabel={`Files (${artifacts.length})`}

--- a/products/desktop/packages/core/src/sessions/artifactFilesListKey.test.ts
+++ b/products/desktop/packages/core/src/sessions/artifactFilesListKey.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { artifactFilesListKey } from "./artifactFilesListKey";
+
+describe("artifactFilesListKey", () => {
+  it("ignores file order", () => {
+    expect(artifactFilesListKey("r1", ["b.md", "a.md"])).toBe(
+      artifactFilesListKey("r1", ["a.md", "b.md"]),
+    );
+  });
+
+  it("changes when the set of files changes", () => {
+    expect(artifactFilesListKey("r1", ["a.md"])).not.toBe(
+      artifactFilesListKey("r1", ["a.md", "b.md"]),
+    );
+  });
+
+  it("changes with the run", () => {
+    expect(artifactFilesListKey("r1", ["a.md"])).not.toBe(
+      artifactFilesListKey("r2", ["a.md"]),
+    );
+  });
+});

--- a/products/desktop/packages/core/src/sessions/artifactFilesListKey.ts
+++ b/products/desktop/packages/core/src/sessions/artifactFilesListKey.ts
@@ -1,0 +1,12 @@
+/**
+ * Stable identity for a run's set of output files. When it changes, a Files box
+ * the user collapsed should re-expand so newly produced artifacts are not hidden
+ * behind a box dismissed for the previous set. Order-independent by name; the
+ * null separator cannot collide with a filename.
+ */
+export function artifactFilesListKey(
+  runId: string | undefined,
+  fileNames: readonly string[],
+): string {
+  return `${runId ?? ""}:${[...fileNames].sort().join("\u0000")}`;
+}

--- a/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.tsx
@@ -11,6 +11,7 @@ import {
   runArtifactVersionKey,
   runArtifactVersionLabel,
 } from "@posthog/core/canvas/runArtifactSchemas";
+import { artifactFilesListKey } from "@posthog/core/sessions/artifactFilesListKey";
 import {
   SESSION_SERVICE,
   type SessionService,
@@ -149,10 +150,10 @@ export function CloudArtifactDownloads({
   const visibleGroups = groups.filter((group) => !group.dismissed);
   const dismissedGroups = groups.filter((group) => group.dismissed);
   const fileListKey = artifactManifest
-    ? `${runId ?? ""}:${visibleGroups
-        .map((group) => group.name)
-        .sort()
-        .join("\u0000")}`
+    ? artifactFilesListKey(
+        runId,
+        visibleGroups.map((group) => group.name),
+      )
     : undefined;
   const collapsed = useArtifactFilesCollapsed(taskId, fileListKey);
 


### PR DESCRIPTION
## Problem

On the mobile app, a user who collapsed a session's "Files" box stayed looking at a collapsed box even after the run produced a different set of files. The new artifacts were hidden behind a box the user had already dismissed.

The box tracked collapse state in a plain boolean with no awareness of the file list, so it never reopened.

port of #80815

## Changes

- The Files box re-expands when the run's set of output files changes.
- The box keeps the user's collapse choice while the file list is unchanged.
- Mobile derives a stable key from the file list and resets the collapse when that key changes.
- The key derivation moved to a shared `@posthog/core` helper, imported by both the desktop and mobile Files boxes.

No visual change: the box looks the same, only its reopen behavior changed.

## How did you test this code?

Automated tests, run locally:

- `TaskArtifacts.test.tsx`: collapse survives a re-render with the same files; collapse resets when the file list changes. These guard the reported bug and an over-eager reset.
- `artifactFilesListKey.test.ts`: the key is order-independent and changes with the file set and the run.

Not run: the desktop end-to-end suite and a live device.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.
