### PR TITLE
feat(notebooks): cap the height of Python cells

### DIFF
--- a/frontend/src/lib/monaco/CodeEditorResizable.tsx
+++ b/frontend/src/lib/monaco/CodeEditorResizable.tsx
@@ -53,7 +53,9 @@ export function CodeEditorResizeable({
             // eslint-disable-next-line react/forbid-dom-props
             style={{
                 minHeight,
-                maxHeight,
+                // `maxHeight` caps how tall the editor grows on its own. A drag is a deliberate
+                // choice, so it overrides the cap instead of being clamped by it.
+                maxHeight: manualHeight ?? maxHeight,
                 height: manualHeight ?? height,
             }}
         >

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePythonV2.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePythonV2.tsx
@@ -34,6 +34,12 @@ export type NotebookNodePythonV2Attributes = {
     runStatus?: NotebookNodeRunTerminalStatus | null
 }
 
+const PYTHON_EDITOR_MIN_HEIGHT = 160
+// About 20 lines at Monaco's 18px line height. An MCP-written cell is often far longer than that,
+// and an editor that grows with the code pushes the output and the next cell off the screen.
+// Past the cap the editor scrolls, and the drag handle expands it.
+const PYTHON_EDITOR_MAX_HEIGHT = 360
+
 const toDataframeResult = (result: NotebookNodeSQLV2Result): NotebookDataframeResult => {
     const columns = result.columns ?? []
     const firstPage = result.first_page ?? []
@@ -288,14 +294,20 @@ const Settings = ({
                     {isRunning ? 'Cancel' : 'Run'}
                 </LemonButton>
             </div>
-            <div className="min-h-0 flex-1">
+            <div
+                className="min-h-0 flex-1"
+                // The editor owns pointer drags in here. Without this the resize handle drags the
+                // node around the markdown notebook instead of resizing the editor.
+                onMouseDown={(event) => event.stopPropagation()}
+                onDragStart={(event) => event.stopPropagation()}
+            >
                 <CodeEditorResizeable
                     language="python"
                     value={typeof attributes.code === 'string' ? attributes.code : ''}
                     onChange={(value) => updateAttributes({ code: value ?? '' })}
                     onPressCmdEnter={() => runRef.current()}
-                    allowManualResize={false}
-                    minHeight={160}
+                    minHeight={PYTHON_EDITOR_MIN_HEIGHT}
+                    maxHeight={PYTHON_EDITOR_MAX_HEIGHT}
                     embedded
                 />
             </div>


### PR DESCRIPTION
## Problem

A person who opens a notebook with an MCP-written Python cell sees the code fill the screen.
The cell has no maximum height, so it grows one line taller for every line of code.
The MCP writes long cells, so the output panel and the next cell fall below the fold.

SQL cells do not have this problem.
Their editor sits in a fixed-height box and scrolls.
Python cells pass no `maxHeight`, so they fall back to `CodeEditorResizeable`'s `90vh` default, which a 60-line cell does not even reach.

## Changes

- The Python cell editor stops at 360px, about 20 lines. Past that it scrolls.
- A drag handle at the bottom right expands the editor. The cell already had one for its output, not for its code.
- `CodeEditorResizeable` now treats `maxHeight` as a cap on auto-growth only. A drag overrides it.
- The editor wrapper stops mouse-down and drag-start events. Without this the new handle drags the node around the notebook.

The height is not persisted. A drag lasts for the session, like every other `CodeEditorResizeable` in the app. Persisting it would add an attribute to the markdown that the MCP writes, and the ask does not need that.

> [!NOTE]
> Two other editors allow a manual drag and set a `maxHeight`: the feature flag JSON editor (`24em`) and the LLM evaluation code editor (`60vh`). Their drag handle does nothing past the cap today. This change makes it work.

The legacy `ph-python` cell has the same unbounded editor. I left it alone. The markdown notebook cannot insert it.

Screenshots: I could not produce a useful one. Monaco does not load in Storybook in this worktree, so both editors render as a spinner. I measured the boxes instead, below.

## How did you test this code?

I (actually Claude) rendered `CodeEditorResizeable` in Storybook with a 60-line Python value, in a temporary story that I deleted before committing. Measured `offsetHeight`:

- Today's props: 1098px. The `90vh` cap sat at 1289px and never applied.
- New props: 360px, with the drag handle present.
- After a drag of 187px on the handle: 547px. This confirms a drag passes the cap.

Not checked: the cell inside a real notebook, and Monaco's internal scrolling. Monaco never mounted in Storybook here. The fixed-height-box-plus-internal-scroll pattern is what the SQL V2 cell already ships.

No tests added. The change is a CSS cap and an existing drag handle. A test asserting the `max-height` style would restate the props rather than catch a regression.

Ran locally: `pnpm --filter=@posthog/frontend typescript:check`, `pnpm --filter=@posthog/frontend fix`, `hogli ci:preflight --fix`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I am Claude Code (Opus 5), working in a git worktree off master.
Sinan asked for a maximum default height on markdown-notebook V2 Python cells, with manual scroll and expand.

Skills invoked: `/writing-pr-descriptions`. I read `frontend/src/CLAUDE.md` and the repo `AGENTS.md` for frontend and comment conventions.

Decisions along the way:

- I first considered a fixed 150px editor, to match the SQL cell exactly. I kept auto-growth under a cap instead, so a three-line cell stays small.
- I considered persisting the dragged height as a node attribute. I dropped it to keep the markdown schema unchanged.
- I checked all 17 `CodeEditorResizeable` call sites before changing the shared component, to bound the effect. Only the two in the note above change behavior.

Nothing in this PR draws on material outside this repository.
