### PR TITLE
fix(warehouse_sources): drop leaked exception class name from sync errors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
@@ -156,6 +156,9 @@ Any_Source_Errors: dict[str, str | None] = {
 }
 
 
+UNEXPECTED_ERROR_MESSAGE = "An unexpected error has occurred"
+
+
 def _customer_facing_error(cause: BaseException | None) -> str:
     """`latest_error` text a customer reads, without the leaked internal exception class name.
 
@@ -168,6 +171,9 @@ def _customer_facing_error(cause: BaseException | None) -> str:
     the non-retryable map below (retryable exhaustion and unclassified failures); ``internal_error``
     still records the full ``str(cause)`` for debugging.
     """
+    # A wrapped ActivityError can carry no cause; `str(None)` would show the customer "None".
+    if cause is None:
+        return UNEXPECTED_ERROR_MESSAGE
     message = getattr(cause, "message", None)
     return message or str(cause)
 
@@ -865,7 +871,7 @@ class ExternalDataJobWorkflow(PostHogWorkflow):
         except Exception as e:
             # Catch all
             update_inputs.internal_error = str(e)
-            update_inputs.latest_error = "An unexpected error has ocurred"
+            update_inputs.latest_error = UNEXPECTED_ERROR_MESSAGE
             update_inputs.status = ExternalDataJob.Status.FAILED
             raise
         finally:

--- a/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
@@ -156,6 +156,22 @@ Any_Source_Errors: dict[str, str | None] = {
 }
 
 
+def _customer_facing_error(cause: BaseException | None) -> str:
+    """`latest_error` text a customer reads, without the leaked internal exception class name.
+
+    Temporal renders a wrapped activity failure as ``<ExceptionClass>: <message>`` (see
+    `ApplicationError.__str__`), so ``str(cause)`` prefixes the customer-facing error with an
+    internal Python class name that means nothing to them: ``RESTClientRetryableError`` for a
+    REST source that exhausted its retries on an HTTP 429/5xx, ``NonReportableError`` for a
+    retryable connection drop, or a raw driver ``OperationalError``. The wrapped ``message``
+    carries the same detail without that prefix. This only affects errors we don't rewrite via
+    the non-retryable map below (retryable exhaustion and unclassified failures); ``internal_error``
+    still records the full ``str(cause)`` for debugging.
+    """
+    message = getattr(cause, "message", None)
+    return message or str(cause)
+
+
 @dataclasses.dataclass
 class UpdateExternalDataJobStatusInputs:
     team_id: int
@@ -844,7 +860,7 @@ class ExternalDataJobWorkflow(PostHogWorkflow):
                 # Handle other activity errors normally
                 update_inputs.status = ExternalDataJob.Status.FAILED
                 update_inputs.internal_error = str(e.cause)
-                update_inputs.latest_error = str(e.cause)
+                update_inputs.latest_error = _customer_facing_error(e.cause)
                 raise
         except Exception as e:
             # Catch all

--- a/products/warehouse_sources/backend/temporal/data_imports/tests/test_external_data_job_activities.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/test_external_data_job_activities.py
@@ -3,7 +3,10 @@ import asyncio
 from posthog.test.base import BaseTest
 from unittest import mock
 
+from django.test import SimpleTestCase
+
 from parameterized import parameterized
+from temporalio.exceptions import ApplicationError
 from temporalio.testing import ActivityEnvironment
 
 from posthog.temporal.utils import ExternalDataWorkflowInputs
@@ -13,9 +16,27 @@ from products.warehouse_sources.backend.models.external_data_schema import Exter
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 from products.warehouse_sources.backend.temporal.data_imports.external_data_job import (
     UpdateExternalDataJobStatusInputs,
+    _customer_facing_error,
     trigger_schedule_buffer_one_activity,
     update_external_data_job_model,
 )
+
+
+class TestCustomerFacingError(SimpleTestCase):
+    @parameterized.expand(
+        [
+            # Temporal wraps a retryable REST exhaustion / connection drop as an ApplicationError
+            # whose str() is "<ClassName>: <message>". The customer-facing latest_error must be the
+            # message alone, not the internal class name.
+            ("rest_retryable", "RESTClientRetryableError", "HTTP 429 for https://api.example.com/usage"),
+            ("driver_drop", "OperationalError", "connection failed: server closed the connection unexpectedly"),
+        ]
+    )
+    def test_strips_leaked_internal_exception_class_name(self, _name: str, exc_type: str, message: str) -> None:
+        assert _customer_facing_error(ApplicationError(message, type=exc_type)) == message
+
+    def test_falls_back_to_str_when_cause_has_no_message(self) -> None:
+        assert _customer_facing_error(ValueError("connection reset")) == "connection reset"
 
 
 class TestTriggerScheduleBufferOneActivity(BaseTest):

--- a/products/warehouse_sources/backend/temporal/data_imports/tests/test_external_data_job_activities.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/test_external_data_job_activities.py
@@ -15,6 +15,7 @@ from products.warehouse_sources.backend.models.external_data_job import External
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 from products.warehouse_sources.backend.temporal.data_imports.external_data_job import (
+    UNEXPECTED_ERROR_MESSAGE,
     UpdateExternalDataJobStatusInputs,
     _customer_facing_error,
     trigger_schedule_buffer_one_activity,
@@ -37,6 +38,9 @@ class TestCustomerFacingError(SimpleTestCase):
 
     def test_falls_back_to_str_when_cause_has_no_message(self) -> None:
         assert _customer_facing_error(ValueError("connection reset")) == "connection reset"
+
+    def test_missing_cause_does_not_show_the_customer_none(self) -> None:
+        assert _customer_facing_error(None) == UNEXPECTED_ERROR_MESSAGE
 
 
 class TestTriggerScheduleBufferOneActivity(BaseTest):


### PR DESCRIPTION
## Problem

- A customer whose warehouse sync keeps failing on a retryable error saw an internal Python class name in the sync error, with nothing to act on.
- The finalizer stored `latest_error` as `str(cause)`. Temporal renders a wrapped activity failure as `<ExceptionClass>: <message>`, so the class name leaked into the field customers read.
- Examples seen across sources: `RESTClientRetryableError: HTTP 429 for ...` (a REST source that exhausted its retries), `NonReportableError: connection failed: ...` and a raw `OperationalError: ...` (a database connection drop).
- Only retryable-but-exhausted and unclassified failures were affected. Non-retryable failures already get a friendly message from the source's non-retryable map, so they never showed this.

## Changes

- Use the wrapped `ApplicationError.message` for the customer-facing `latest_error`, which is the same text without the class-name prefix.
- Keep the full `str(cause)` on `internal_error` for debugging and telemetry.
- Scope is the generic activity-error branch of the sync workflow finalizer. Non-retryable errors are untouched: the finalizer still overwrites their `latest_error` from the non-retryable map after this runs.

## How did you test this code?

- Added `TestCustomerFacingError` (a no-DB `SimpleTestCase`): asserts the helper returns the bare message for a Temporal-wrapped `RESTClientRetryableError` and `OperationalError`, and falls back to `str` when the cause has no message. It catches a regression to `str(cause)`, which would re-leak the class name.
- Not run: the database-backed tests in this file, because the sandbox has no Postgres. The three new cases pass; the pre-existing DB-backed cases error only on the missing database.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) wrote this while triaging a day of data-warehouse sync failures. Most classes were already handled well; this leak was the one shared root cause behind several raw, unactionable messages, so it became its own PR. I deliberately did not change retryability for the connection-drop classes: those are kept retryable by design, and a separate open PR already backs off schemas that keep failing.

Skills invoked: `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.
