### PR TITLE
fix(notebooks): don't load notebook content on the collab hot path

### DIFF
--- a/products/notebooks/backend/presentation/views/notebook.py
+++ b/products/notebooks/backend/presentation/views/notebook.py
@@ -558,6 +558,13 @@ def _format_hogql_response_payload(response: Any) -> dict[str, Any]:
     return response_payload
 
 
+# Detail actions that resolve a notebook only to authorize the caller and read its identity
+# (team_id / short_id), never its document. They sit on the collab hot path (one presence POST per
+# caret move, one lookup per opened SSE stream), so loading content/text_content for them holds a
+# whole document in memory per in-flight request for fields the handler never reads.
+IDENTITY_ONLY_DETAIL_ACTIONS = frozenset({"collab_presence", "collab_stream", "activity"})
+
+
 @extend_schema(
     description="The API for interacting with Notebooks. This feature is in early access and the API can have "
     "breaking changes without announcement.",
@@ -690,6 +697,8 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
             # The list serializer omits content/text_content, but both are large columns
             # (ProseMirror JSON + full plaintext) that we'd otherwise load and JSON-decode per row.
             # search/contains filters run as WHERE-clause predicates, so they don't need the columns in Python.
+            queryset = queryset.defer("content", "text_content")
+        elif self.action in IDENTITY_ONLY_DETAIL_ACTIONS:
             queryset = queryset.defer("content", "text_content")
 
         order = self.request.GET.get("order", None)

--- a/products/notebooks/backend/presentation/views/notebook.py
+++ b/products/notebooks/backend/presentation/views/notebook.py
@@ -558,10 +558,6 @@ def _format_hogql_response_payload(response: Any) -> dict[str, Any]:
     return response_payload
 
 
-# Detail actions that resolve a notebook only to authorize the caller and read its identity
-# (team_id / short_id), never its document. They sit on the collab hot path (one presence POST per
-# caret move, one lookup per opened SSE stream), so loading content/text_content for them holds a
-# whole document in memory per in-flight request for fields the handler never reads.
 IDENTITY_ONLY_DETAIL_ACTIONS = frozenset({"collab_presence", "collab_stream", "activity"})
 
 

--- a/products/notebooks/backend/test/test_collab_api.py
+++ b/products/notebooks/backend/test/test_collab_api.py
@@ -5,8 +5,11 @@ from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
 from django.conf import settings
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 
 import fakeredis
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog import redis as redis_module
@@ -564,6 +567,34 @@ class TestNotebookCollabStreamAPI(APIBaseTest):
             HTTP_AUTHORIZATION=f"Bearer {key_value}",
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @parameterized.expand([("presence", "post"), ("stream", "get"), ("activity", "get")])
+    def test_identity_only_endpoints_do_not_select_notebook_content(self, action: str, method: str):
+        notebook = self._create_notebook()
+        urls = {
+            "presence": self._presence_url(notebook["short_id"]),
+            "stream": self._stream_url(notebook["short_id"]),
+            "activity": f"/api/projects/{self.team.id}/notebooks/{notebook['short_id']}/activity/",
+        }
+
+        with CaptureQueriesContext(connection) as captured:
+            if method == "post":
+                response = self.client.post(
+                    urls[action],
+                    data={"client_id": "caret-client", "version": notebook["version"], "cursor": {"head": 1}},
+                    format="json",
+                )
+            else:
+                response = self.client.get(urls[action])
+            assert response.status_code in (status.HTTP_200_OK, status.HTTP_204_NO_CONTENT)
+            if response.streaming:
+                self._consume_stream(response)
+
+        notebook_queries = [q["sql"] for q in captured.captured_queries if "posthog_notebook" in q["sql"]]
+        assert notebook_queries
+        for sql in notebook_queries:
+            assert '"posthog_notebook"."content"' not in sql
+            assert '"posthog_notebook"."text_content"' not in sql
 
 
 def _markdown_doc(markdown: str) -> dict:


### PR DESCRIPTION
## Problem

Fixes #81125

Someone editing a notebook triggers a presence POST on every caret move and a lookup for every opened collaboration stream. Each of those loaded the entire notebook document into memory, twice: the ProseMirror JSON in `content` and the full plaintext in `text_content`. Neither handler reads either field — they need `team_id` and `short_id` to authorize the caller and route to Redis.

`NotebookViewSet.safely_get_queryset` deferred both columns, but only for the `list` action. Detail actions fell through and fetched the whole row.

This shows up as memory pressure on the tier serving notebook streams, where the load is proportional to document size times editing activity rather than to anything the endpoints actually return.

## Changes

- Defer `content` and `text_content` for the detail actions that only need the notebook's identity: `collab/presence`, `collab/stream`, and `activity`.
- Keep them loaded everywhere else. `markdown`, `sql_v2/state`, `collab/save`, `collab/markdown_save`, and `retrieve` all read the document.
- The action list is an explicit allowlist rather than a blocklist, so a new detail action loads content by default and has to opt in.

Deferring is safe if an unlisted field is later read: Django refetches it rather than failing. The allowlist keeps that from happening silently on the hot path.

## How did you test this code?

Added `test_identity_only_endpoints_do_not_select_notebook_content`, a parameterized test over the three endpoints that asserts no query against `posthog_notebook` selects the two large columns. It catches a regression no existing test does: dropping the defer, or adding a hot-path action outside the allowlist, silently restores the full-row read.

I ran `pytest products/notebooks/backend/test/test_collab_api.py` locally against the dev stack: 37 passed. I also verified the new test fails on all three cases with the defer removed, so it is guarding the fix rather than passing vacuously.

No manual browser testing.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or API contract changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app from a Slack thread where the root cause had already been diagnosed by a person; the agent's job was to locate and land the fix. Skills invoked: `/improving-drf-endpoints` and `/writing-tests` (both mandatory for this area per AGENTS.md).

One decision worth flagging for review: the allowlist is deliberately narrow. `kernel/*`, `sql_v2/run`, and `hogql/execute` also look like they may not need the document, but I did not trace every callee they pass the notebook into, so I left them alone rather than guess. Widening the set is a follow-up someone with more context on those paths should make.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09KUMHT64A/p1786433108606749?thread_ts=1786433108.606749&cid=C09KUMHT64A)*
