### PR TITLE
fix(slack): unfurl links against the region named in the URL

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -2197,10 +2197,24 @@ def route_posthog_code_event_to_relevant_region(
         )
 
     # link_shared (unfurl) works with either integration kind.
+    #
+    # Slack posts every event to one Request URL (a single region), but a link names its own region
+    # in the host. When it names the other region, forward the event there instead of resolving its
+    # `/project/<id>` against a same-numbered project in this region — the regions number projects
+    # independently, so a us.posthog.com/project/2 link matched here on EU would look the resource
+    # up in EU's project 2 and silently find nothing. A bare posthog.com host, an unknown host, or a
+    # cross-region mix yields None and keeps the region-agnostic path below.
+    link_region = _link_shared_target_region(event)
+    if link_region is not None and link_region != get_instance_region() and can_defer_to_other_region:
+        return _proxy_event_and_return_route(request, other_domain)
+
     link_result = load_integrations(slack_team_id=slack_team_id, kinds=list(SLACK_INTEGRATION_KINDS))
     local_match = _link_shared_integration(event, link_result.candidates)
     if local_match:
-        if _us_should_handle_instead(
+        # The US-precedence probe matches on a region-blind team id, so skip it when the link
+        # explicitly names this region — otherwise a same-numbered project in the other region would
+        # still hand the event across (an eu. link to US, or a us. link to EU).
+        if link_region is None and _us_should_handle_instead(
             slack_team_id,
             list(SLACK_INTEGRATION_KINDS),
             can_defer_to_other_region,
@@ -3024,6 +3038,40 @@ def _is_posthog_app_url(url: str) -> bool:
         "posthog.com",
         "us.posthog.com",
     }
+
+
+# A modern PostHog Cloud app URL names its region in the host. ``app.posthog.com`` is the legacy
+# US primary and still resolves to US. Bare ``posthog.com`` (marketing/docs) carries no region and
+# is intentionally absent.
+_POSTHOG_HOST_REGION: dict[str, str] = {
+    "us.posthog.com": "US",
+    "app.posthog.com": "US",
+    "eu.posthog.com": "EU",
+}
+
+
+def _link_shared_target_region(event: dict[str, Any]) -> str | None:
+    """The Cloud region (``US``/``EU``) the shared links point at, read from their hosts.
+
+    Returns ``None`` when no link carries a region-bearing host (bare ``posthog.com``, an unknown
+    host) or when links disagree on the region, so the caller keeps the region-agnostic behavior.
+    Region ownership matters because the two regions number projects independently: a
+    ``us.posthog.com/project/2`` link resolved on EU would look the resource up in EU's project 2.
+    """
+    links = event.get("links")
+    if not isinstance(links, list):
+        return None
+    regions: set[str] = set()
+    for link in links:
+        if not isinstance(link, dict):
+            continue
+        url = link.get("url")
+        if not isinstance(url, str):
+            continue
+        region = _POSTHOG_HOST_REGION.get((urlparse(url).hostname or "").lower())
+        if region is not None:
+            regions.add(region)
+    return next(iter(regions)) if len(regions) == 1 else None
 
 
 def _link_shared_resource_refs(event: dict[str, Any]) -> list[dict[str, str]]:

--- a/products/slack_app/backend/tests/test_link_unfurl.py
+++ b/products/slack_app/backend/tests/test_link_unfurl.py
@@ -20,7 +20,12 @@ from posthog.models.user_integration import UserIntegration
 from products.conversations.backend.models.ticket import Ticket
 from products.dashboards.backend.models.dashboard import Dashboard
 from products.product_analytics.backend.models.insight import Insight
-from products.slack_app.backend.api import ROUTE_HANDLED_LOCALLY, route_posthog_code_event_to_relevant_region
+from products.slack_app.backend.api import (
+    ROUTE_HANDLED_LOCALLY,
+    ROUTE_PROXIED,
+    _link_shared_target_region,
+    route_posthog_code_event_to_relevant_region,
+)
 from products.slack_app.backend.models import SlackChannel
 from products.slack_app.backend.services.slack_auth import write_auth_state_ok
 from products.slack_app.backend.slack_link_unfurl import (
@@ -564,3 +569,101 @@ class TestLinkUnfurlChannelGate(TestCase):
 
         assert result == ROUTE_HANDLED_LOCALLY
         assert mock_unfurl.called is expect_unfurled
+
+
+class TestLinkSharedTargetRegion:
+    @parameterized.expand(
+        [
+            ("us_host", "https://us.posthog.com/project/2/dashboard/416809", "US"),
+            ("legacy_app_host", "https://app.posthog.com/project/2/dashboard/416809", "US"),
+            ("eu_host", "https://eu.posthog.com/project/9/dashboard/5", "EU"),
+            ("bare_marketing_host", "https://posthog.com/docs/slack", None),
+            ("unknown_host", "https://example.com/project/2/dashboard/1", None),
+        ]
+    )
+    def test_single_link_region(self, _name: str, url: str, expected: str | None) -> None:
+        assert _link_shared_target_region({"links": [{"url": url}]}) == expected
+
+    def test_mixed_regions_returns_none(self) -> None:
+        # One message naming both regions can't be resolved to a single owner — fall back.
+        event = {"links": [{"url": "https://us.posthog.com/i/a"}, {"url": "https://eu.posthog.com/i/b"}]}
+        assert _link_shared_target_region(event) is None
+
+    def test_no_links_returns_none(self) -> None:
+        assert _link_shared_target_region({}) is None
+
+
+class TestLinkUnfurlRegionRouting(TestCase):
+    """A shared link names its region in the host, so the ingress region forwards a link it doesn't
+    own instead of resolving the URL's project id against a same-numbered local project."""
+
+    SLACK_TEAM_ID = "TRegion01"
+
+    def setUp(self) -> None:
+        self.factory = RequestFactory()
+        self.organization = Organization.objects.create(name="Region Org")
+        self.team = Team.objects.create(organization=self.organization, name="Region Team")
+        self.integration = Integration.objects.create(
+            team=self.team,
+            kind="slack",
+            integration_id=self.SLACK_TEAM_ID,
+            config={"scope": ",".join(sorted(REQUIRED_SLACK_SCOPES))},
+            sensitive_config={"access_token": "xoxb-test"},
+        )
+        write_auth_state_ok(self.integration.id, bot_user_id=None)
+
+    def _route(self, *, host: str, url: str) -> str:
+        event = {
+            "type": "link_shared",
+            "channel": "C1",
+            "user": "U_SHARER",
+            "message_ts": "1.2",
+            "links": [{"url": url}],
+        }
+        request = self.factory.post("/slack/event-callback/", HTTP_HOST=host)
+        return route_posthog_code_event_to_relevant_region(request, event, self.SLACK_TEAM_ID)
+
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="EU")
+    @patch("products.slack_app.backend.api._proxy_event_to_region", return_value=MagicMock())
+    @patch("products.slack_app.backend.api.handle_posthog_link_unfurl")
+    def test_us_link_on_eu_ingress_forwards_to_us(self, mock_unfurl: MagicMock, mock_proxy: MagicMock) -> None:
+        # The reported bug: on EU this resolved against EU's own project of the same id and silently
+        # found nothing. It must forward to US, not unfurl locally.
+        result = self._route(host="eu.posthog.com", url=f"https://us.posthog.com/project/{self.team.pk}/dashboard/1")
+        assert result == ROUTE_PROXIED
+        assert mock_proxy.called
+        assert not mock_unfurl.called
+
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="EU")
+    @patch("products.slack_app.backend.api._proxy_event_to_region", return_value=MagicMock())
+    @patch("products.slack_app.backend.api.handle_posthog_link_unfurl")
+    def test_eu_link_on_eu_ingress_handled_locally(self, mock_unfurl: MagicMock, mock_proxy: MagicMock) -> None:
+        result = self._route(host="eu.posthog.com", url=f"https://eu.posthog.com/project/{self.team.pk}/dashboard/1")
+        assert result == ROUTE_HANDLED_LOCALLY
+        assert not mock_proxy.called
+        assert mock_unfurl.called
+
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
+    @patch("products.slack_app.backend.api._proxy_event_to_region", return_value=MagicMock())
+    @patch("products.slack_app.backend.api.handle_posthog_link_unfurl")
+    def test_us_link_on_us_ingress_handled_locally(self, mock_unfurl: MagicMock, mock_proxy: MagicMock) -> None:
+        result = self._route(host="us.posthog.com", url=f"https://us.posthog.com/project/{self.team.pk}/dashboard/1")
+        assert result == ROUTE_HANDLED_LOCALLY
+        assert not mock_proxy.called
+        assert mock_unfurl.called
+
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="EU")
+    @patch("products.slack_app.backend.api.does_other_region_claim_workspace", return_value=False)
+    @patch("products.slack_app.backend.api._proxy_event_to_region", return_value=MagicMock())
+    @patch("products.slack_app.backend.api.handle_posthog_link_unfurl")
+    def test_bare_domain_keeps_region_agnostic_path(
+        self, mock_unfurl: MagicMock, mock_proxy: MagicMock, _claims: MagicMock
+    ) -> None:
+        # No region in the host → the local-match + US-precedence probe still decides. With US not
+        # claiming the workspace, EU handles it locally rather than forwarding. The probe is still
+        # scoped to the URL's project id.
+        result = self._route(host="eu.posthog.com", url=f"https://posthog.com/project/{self.team.pk}/dashboard/1")
+        assert result == ROUTE_HANDLED_LOCALLY
+        assert not mock_proxy.called
+        assert mock_unfurl.called
+        assert _claims.call_args.kwargs["team_id"] == self.team.pk

--- a/products/slack_app/backend/tests/test_posthog_code_event_handler.py
+++ b/products/slack_app/backend/tests/test_posthog_code_event_handler.py
@@ -744,7 +744,9 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         result = route_posthog_code_event_to_relevant_region(request, event, "T12345")
 
         assert result == ROUTE_HANDLED_LOCALLY
-        assert mock_claims.call_args.kwargs["team_id"] == other_team.id
+        # The link names this region (us.posthog.com on a US instance), so it resolves straight to the
+        # URL's project integration without consulting the cross-region ownership probe.
+        mock_claims.assert_not_called()
         mock_unfurl.assert_called_once_with(event, other_integration)
 
     @patch("products.slack_app.backend.api.handle_posthog_link_unfurl")


### PR DESCRIPTION
## Problem

Pasting a PostHog app link like `https://us.posthog.com/project/<id>/dashboard/<id>` into Slack produced no unfurl for a workspace connected to PostHog in both the US and EU regions.

Slack posts every event to a single Request URL (one region), which then proxies the event to the region that owns the workspace. The `link_shared` handler resolved the URL's `/project/<id>` purely by numeric team id, with no awareness of the link's host. The two regions number projects independently, so when the ingress region also had the workspace connected, a `us.posthog.com` link matched that region's *own* same-numbered project, looked the resource up there, found nothing, and stayed silent. Scope (`links:read`), the app's unfurl domains, and the within-region routing were all correct — the resolution was just region-blind.

## Changes

- Read the target region from each link's host: `us.posthog.com` and the legacy `app.posthog.com` map to US, `eu.posthog.com` to EU.
- In the `link_shared` branch, when the link names the *other* region, forward the event there instead of resolving `/project/<id>` against a same-numbered project locally.
- When the link names *this* region, handle it locally and skip the cross-region ownership probe — the region is already known from the host, so the probe (which matches on a region-blind team id) can't add anything and could otherwise hand the event across when both regions reuse a project id.
- A bare `posthog.com` host, an unknown host, or a mix of regions in one message yields no region signal and keeps the previous region-agnostic behavior (local match plus the US-precedence probe).

Chosen over widening the cross-region ownership probe: the link already carries its region in the host, so routing on that is exact and needs no extra probe round-trip, whereas the probe can only ask "does the other region hold this workspace" and can't tell which region a specific link belongs to.

## How did you test this code?

Added tests, all run locally against the dev stack (Postgres + ClickHouse):

- `TestLinkSharedTargetRegion` — unit coverage for the host→region classifier (us./app.→US, eu.→EU, bare `posthog.com`/unknown/mixed→none). Catches a regression where a host stops mapping to its region or a bare/marketing link gets misclassified.
- `TestLinkUnfurlRegionRouting` — routing coverage: a US link on the EU ingress forwards to US (the reported bug — previously handled locally against the wrong project); an EU link on EU and a US link on US are handled locally; a bare `posthog.com` link keeps the probe path and still scopes the probe to the URL's project id. No existing test built a two-region scenario, so this path was uncovered.
- Updated one existing routing test whose assertion (the ownership probe is consulted for a same-region link) no longer holds, since that link now resolves locally without the probe.

Full `products/slack_app/backend/tests/` suite passes locally; `ruff` and `mypy` clean on the changed module. I could not reproduce the end-to-end Slack delivery by hand — verification is via the automated tests.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing copy or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a report that a dashboard link didn't unfurl, raised in a [Slack thread](https://posthog.slack.com/archives/CU54W0FK8/p1786363609671859?thread_ts=1786363609.671859&cid=CU54W0FK8). Reading the backend logs showed the ingress region receives every event and proxies workspace-owned events across, while unfurls resolved the project id without regard to the link's region — so a link to one region's project was resolved against the other region's project of the same id. Earlier theories (missing `links:read` scope, unregistered unfurl domain, the within-region project routing) were ruled out against the live app manifest and logs before landing on the region-blind resolution.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

---

*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/CU54W0FK8/p1786363609671859?thread_ts=1786363609.671859&cid=CU54W0FK8)*
