### PR TITLE
feat(sso): resolve IdP configs through the link table and domain_scope

### DIFF
--- a/ee/api/authentication.py
+++ b/ee/api/authentication.py
@@ -34,8 +34,9 @@ from social_django.utils import load_backend, load_strategy
 from posthog.cloud_utils import get_cached_instance_license
 from posthog.constants import AvailableFeature
 from posthog.exceptions_capture import capture_exception
+from posthog.models.identity_provider_config import IdentityProviderConfig
 from posthog.models.organization import OrganizationMembership
-from posthog.models.organization_domain import OrganizationDomain
+from posthog.models.organization_domain import OrganizationDomain, resolves_to_identity_provider_config_q
 
 from ee import settings
 from ee.api.scim.utils import mask_email
@@ -132,7 +133,9 @@ class MultitenantSAMLAuth(SAMLAuth):
         # source of truth for SAML settings, so match the issuer against its `saml_entity_id`.
         matches = list(
             # nosemgrep: idor-lookup-without-org (pre-auth SAML routing by IdP entity id; the assertion signature is verified afterwards)
-            OrganizationDomain.objects.verified_domains().filter(identity_provider_config__saml_entity_id=issuer)
+            OrganizationDomain.objects.verified_domains().filter(
+                resolves_to_identity_provider_config_q(IdentityProviderConfig.objects.filter(saml_entity_id=issuer))
+            )
         )
         if len(matches) != 1:
             if len(matches) > 1:

--- a/ee/api/scim/auth.py
+++ b/ee/api/scim/auth.py
@@ -52,18 +52,18 @@ class SCIMBearerTokenAuthentication(BaseAuthentication):
 
         try:
             # nosemgrep: idor-lookup-without-org (SCIM bearer token auth, domain_id is tenant identifier)
-            domain = OrganizationDomain.objects.select_related("identity_provider_config").get(id=domain_id)
+            domain = OrganizationDomain.objects.get(id=domain_id)
         except OrganizationDomain.DoesNotExist:
             raise exceptions.AuthenticationFailed("Invalid organization domain")
 
-        # Read the linked IdP config directly (the source of truth) rather than through the
+        # Resolve the IdP config directly (the source of truth) rather than through the
         # empty-config fallback, so a domain with no config fails clearly here instead of falling
         # through to a misleading "Invalid bearer token" on a null hash below.
         #
         # The domain must also be verified: SCIM can be enabled on a config independently of any
         # domain (the config API has no verification gate), so re-check verification here to keep
         # provisioning gated behind a verified domain.
-        config = domain.identity_provider_config
+        config = domain.identity_provider_configs.first()
         if not domain.is_verified or config is None or not config.has_scim:
             raise exceptions.AuthenticationFailed("SCIM not configured for this domain")
 

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -540,11 +540,14 @@ field_exclusions: dict[AuditableScope, list[str]] = {
         "scim_provisioned_users",
         # Internal link to the IdP config mirror; the mirrored fields themselves are already logged
         "identity_provider_config",
+        # Join table mirroring that link; not a plain field diff.
+        "linked_identity_provider_configs",
     ],
     "IdentityProviderConfig": [
         "organization",
-        # Reverse relation from `OrganizationDomain.identity_provider_config`; not a plain field diff.
+        # Reverse relations to `OrganizationDomain` (FK and join table); not plain field diffs.
         "domains",
+        "linked_identity_provider_configs",
     ],
     "Subscription": [
         # Scheduler-derived field; keep it out of user-facing change diffs even when another

--- a/posthog/models/identity_provider_config.py
+++ b/posthog/models/identity_provider_config.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 
@@ -6,12 +8,21 @@ import structlog
 from posthog.models.activity_logging.model_activity import ModelActivityMixin
 from posthog.models.utils import UUIDModel
 
+if TYPE_CHECKING:
+    from posthog.models.organization_domain import OrganizationDomain
+
 logger = structlog.get_logger(__name__)
 
 
 class DomainScope(models.TextChoices):
     ALL = "all"
     SELECTED = "selected"
+
+
+# `domain_scope` is nullable (the column was added to rows that predate it), so an unset scope has
+# to mean something. It means `SELECTED`: a config only ever reaches the domains it was explicitly
+# linked to until someone opts it into the whole organization.
+DEFAULT_DOMAIN_SCOPE = DomainScope.SELECTED
 
 
 class ConfigScope(models.TextChoices):
@@ -26,8 +37,8 @@ class IdentityProviderConfig(ModelActivityMixin, UUIDModel):
 
     Groups IdP-specific settings — SAML, SCIM, and ID-JAG (XAA) today, custom SSO in the
     future — in one place, decoupled from any single domain. One config can be mapped to
-    multiple `OrganizationDomain` rows (via `OrganizationDomain.identity_provider_config`),
-    and an organization can have zero, one, or many configs.
+    multiple `OrganizationDomain` rows (see `organization_domains`), and an organization can
+    have zero, one, or many configs.
 
     This model is the sole read/write interface for IdP settings (SAML/SCIM/ID-JAG). The legacy
     IdP columns on `OrganizationDomain` are no longer written to — they're frozen.
@@ -89,6 +100,34 @@ class IdentityProviderConfig(ModelActivityMixin, UUIDModel):
 
     def __str__(self) -> str:
         return self.name or str(self.id)
+
+    @property
+    def effective_domain_scope(self) -> str:
+        """`domain_scope` with the legacy unset value resolved to `DEFAULT_DOMAIN_SCOPE`."""
+        return self.domain_scope or DEFAULT_DOMAIN_SCOPE
+
+    @property
+    def applies_to_all_domains(self) -> bool:
+        return self.effective_domain_scope == DomainScope.ALL
+
+    @property
+    def organization_domains(self) -> models.QuerySet["OrganizationDomain"]:
+        """
+        The organization domains this config applies to.
+
+        With `domain_scope` `all` that's every domain in the config's organization; with
+        `selected` (or an unset scope) it's only the domains explicitly linked through
+        `LinkedIdentityProviderConfig`.
+        """
+        # Deferred: `organization_domain` imports this module at module level.
+        from posthog.models.organization_domain import OrganizationDomain
+
+        # The org filter is what makes `all` mean "all of *this* organization's domains"; for
+        # `selected` it's a redundant-but-cheap guard, since links are validated as same-org.
+        domains = OrganizationDomain.objects.filter(organization_id=self.organization_id)
+        if self.applies_to_all_domains:
+            return domains
+        return domains.filter(linked_identity_provider_configs__identity_provider_config=self)
 
     @property
     def has_saml(self) -> bool:

--- a/posthog/models/organization_domain.py
+++ b/posthog/models/organization_domain.py
@@ -7,6 +7,7 @@ from django.db import models, transaction
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
 from django.utils import timezone
+from django.utils.functional import cached_property
 
 import structlog
 import dns.resolver
@@ -14,7 +15,7 @@ import dns.resolver
 from posthog.constants import AvailableFeature
 from posthog.models import Organization
 from posthog.models.activity_logging.model_activity import ModelActivityMixin
-from posthog.models.identity_provider_config import IdentityProviderConfig
+from posthog.models.identity_provider_config import DomainScope, IdentityProviderConfig
 from posthog.models.linked_identity_provider_config import LinkedIdentityProviderConfig
 from posthog.models.utils import UUIDTModel
 from posthog.utils import get_instance_available_sso_providers
@@ -29,6 +30,22 @@ def generate_verification_challenge() -> str:
     return secrets.token_urlsafe(32)
 
 
+def resolves_to_identity_provider_config_q(configs: models.QuerySet[IdentityProviderConfig]) -> models.Q:
+    """
+    A filter on `OrganizationDomain` selecting the domains that resolve to any config in `configs`,
+    honouring each config's `domain_scope`: `selected` (and the legacy unset scope) matches only the
+    domains explicitly linked through `LinkedIdentityProviderConfig`, `all` matches every domain in
+    the config's organization.
+
+    Subqueries rather than joins, so the filter can't fan a domain out into duplicate rows.
+    """
+    explicitly_linked = LinkedIdentityProviderConfig.objects.filter(
+        organization_domain=models.OuterRef("pk"), identity_provider_config__in=configs
+    )
+    org_wide = configs.filter(domain_scope=DomainScope.ALL, organization_id=models.OuterRef("organization_id"))
+    return models.Q(models.Exists(explicitly_linked)) | models.Q(models.Exists(org_wide))
+
+
 class OrganizationDomainManager(models.Manager):
     def verified_domains(self):
         # TODO: Verification becomes stale on Cloud if not reverified after a certain period.
@@ -36,9 +53,10 @@ class OrganizationDomainManager(models.Manager):
         # has `enforce_verified_domains` on — the domain would drop out of the enforcement
         # allow-list and lock out every member on it at once, admins included. Suspend or flag
         # instead of clearing.
-        # `select_related` the IdP config since reads of SAML/SCIM/ID-JAG settings resolve through
-        # it (`OrganizationDomain.idp_config`) in the hot auth paths.
-        return self.exclude(verified_at__isnull=True).select_related("identity_provider_config")
+        # Reads of SAML/SCIM/ID-JAG settings resolve through `OrganizationDomain.idp_config`, which
+        # goes via `LinkedIdentityProviderConfig` rather than the FK — so there's nothing worth
+        # `select_related`ing here; `idp_config` caches its own lookup per instance instead.
+        return self.exclude(verified_at__isnull=True)
 
     def get_verified_for_email_address(self, email: str) -> Optional["OrganizationDomain"]:
         """
@@ -94,22 +112,22 @@ class OrganizationDomainManager(models.Manager):
         Returns whether SAML is available for a specific email address.
         """
         domain = email[email.index("@") + 1 :]
-        # SAML config is read from the linked `IdentityProviderConfig`. A domain with no linked
-        # config produces NULLs across the LEFT JOIN, so the `__isnull=True` excludes drop it.
+        # SAML config is read from the resolved `IdentityProviderConfig`s, so narrow to the domains
+        # that resolve to a fully-configured SAML config. Each SAML field is excluded on both ""
+        # and NULL — normally we'd have just one nil state (i.e. ""), but to avoid migration locks
+        # we had to introduce the nullable one too.
+        saml_configs = IdentityProviderConfig.objects.exclude(
+            models.Q(saml_entity_id="")
+            | models.Q(saml_entity_id__isnull=True)
+            | models.Q(saml_acs_url="")
+            | models.Q(saml_acs_url__isnull=True)
+            | models.Q(saml_x509_cert="")
+            | models.Q(saml_x509_cert__isnull=True)
+        )
         query = (
             self.verified_domains()
             .filter(domain__iexact=domain)
-            .exclude(
-                models.Q(identity_provider_config__saml_entity_id="")
-                | models.Q(identity_provider_config__saml_acs_url="")
-                | models.Q(identity_provider_config__saml_x509_cert="")
-                | models.Q(identity_provider_config__isnull=True)
-                | models.Q(
-                    identity_provider_config__saml_entity_id__isnull=True
-                )  # normally we would have just a nil state (i.e. ""), but to avoid migration locks we had to introduce this
-                | models.Q(identity_provider_config__saml_acs_url__isnull=True)
-                | models.Q(identity_provider_config__saml_x509_cert__isnull=True)
-            )
+            .filter(resolves_to_identity_provider_config_q(saml_configs))
             .values_list("organization__available_product_features", flat=True)
             .first()
         )
@@ -274,8 +292,12 @@ class OrganizationDomain(ModelActivityMixin, UUIDTModel):
 
     # ---- IdP config (home for SAML/SCIM/ID-JAG settings) ----
     # `IdentityProviderConfig` is the source of truth for SAML/SCIM/ID-JAG settings and can be
-    # shared by multiple domains. All reads and writes of those settings go through the linked
-    # config (`self.idp_config`); the FK link itself is still writable via this domain.
+    # shared by multiple domains. All reads and writes of those settings go through the resolved
+    # config (`self.idp_config`).
+    #
+    # This FK is the *write* interface for the domain<->config link and is kept mirrored into
+    # `LinkedIdentityProviderConfig` by `save()`. Reads resolve through that join table instead
+    # (`self.identity_provider_configs`), which is also how `domain_scope` gets honoured.
     identity_provider_config = models.ForeignKey(
         IdentityProviderConfig,
         on_delete=models.SET_NULL,
@@ -306,6 +328,16 @@ class OrganizationDomain(ModelActivityMixin, UUIDTModel):
                 )
         return errors
 
+    def _invalidate_idp_config_cache(self) -> None:
+        self.__dict__.pop("idp_config", None)
+
+    def refresh_from_db(self, *args: Any, **kwargs: Any) -> None:
+        # `idp_config` is resolved from other rows, so reloading this one has to drop it too —
+        # otherwise a caller that reads a setting, edits the config, then refreshes the domain
+        # would keep seeing the pre-edit config.
+        self._invalidate_idp_config_cache()
+        super().refresh_from_db(*args, **kwargs)
+
     def clean(self) -> None:
         errors = self._validate_identity_provider_config_organization()
         if errors:
@@ -322,9 +354,17 @@ class OrganizationDomain(ModelActivityMixin, UUIDTModel):
 
         with transaction.atomic():
             super().save(*args, **kwargs)
-            if self.identity_provider_config_id is None:
-                return
+            # The FK may have moved, so any cached resolution is stale now.
+            self._invalidate_idp_config_cache()
 
+            # Mirror the FK into the join table. The FK is still the only way to write the link, so
+            # links to any *other* config are leftovers from a previous value and have to go —
+            # otherwise this domain would keep resolving to the config it was just moved off.
+            links = LinkedIdentityProviderConfig.objects.filter(organization_domain=self)
+            if self.identity_provider_config_id is None:
+                links.delete()
+                return
+            links.exclude(identity_provider_config_id=self.identity_provider_config_id).delete()
             LinkedIdentityProviderConfig.objects.get_or_create(
                 organization_domain=self,
                 identity_provider_config_id=self.identity_provider_config_id,
@@ -347,13 +387,41 @@ class OrganizationDomain(ModelActivityMixin, UUIDTModel):
         return bool(self.verified_at)
 
     @property
+    def identity_provider_configs(self) -> models.QuerySet[IdentityProviderConfig]:
+        """
+        Every `IdentityProviderConfig` that applies to this domain: the ones explicitly linked
+        through `LinkedIdentityProviderConfig`, plus the organization's `all`-scoped ones (which
+        cover every domain without needing a link).
+
+        Explicitly linked configs sort first — a config picked for this domain beats one that
+        merely applies to the whole organization. Ties break on `created_at`, then `id`, so the
+        resolution is deterministic and can't be steered by row ordering.
+        """
+        if self.pk is None:
+            return IdentityProviderConfig.objects.none()
+        return (
+            IdentityProviderConfig.objects.filter(organization_id=self.organization_id)
+            .annotate(
+                is_explicitly_linked=models.Exists(
+                    LinkedIdentityProviderConfig.objects.filter(
+                        organization_domain=self, identity_provider_config=models.OuterRef("pk")
+                    )
+                )
+            )
+            .filter(models.Q(is_explicitly_linked=True) | models.Q(domain_scope=DomainScope.ALL))
+            .order_by("-is_explicitly_linked", "created_at", "id")
+        )
+
+    @cached_property
     def idp_config(self) -> IdentityProviderConfig:
         """
-        The linked `IdentityProviderConfig` (source of truth for SAML/SCIM/ID-JAG reads), or an
-        empty in-memory config when none is linked yet so reads resolve to safe empty values
-        without null-guards.
+        The `IdentityProviderConfig` that applies to this domain (source of truth for
+        SAML/SCIM/ID-JAG reads), or an empty in-memory config when none does, so reads resolve to
+        safe empty values without null-guards.
+
+        Cached per instance since resolving hits the database; `save()` clears the cache.
         """
-        return self.identity_provider_config or IdentityProviderConfig()
+        return self.identity_provider_configs.first() or IdentityProviderConfig()
 
     @property
     def has_saml(self) -> bool:
@@ -409,5 +477,12 @@ def delete_orphaned_identity_provider_config(
     Note: This is temporary. In the future IDP configs will be explicitly managed in the UI. However, they are currently implicitly
     managed by their relationship to the org domains so we need to make sure they get cleaned up when all linked org domains are deleted
     """
-    if instance.identity_provider_config_id is not None:
-        IdentityProviderConfig.objects.filter(pk=instance.identity_provider_config_id, domains__isnull=True).delete()
+    if instance.identity_provider_config_id is None:
+        return
+
+    # The deleted domain's join-table rows are already gone by the time this fires (cascade), so
+    # asking the config which domains it still applies to answers "is it orphaned?" directly — and
+    # keeps an `all`-scoped config alive as long as its organization has any domain left.
+    config = IdentityProviderConfig.objects.filter(pk=instance.identity_provider_config_id).first()
+    if config is not None and not config.organization_domains.exists():
+        config.delete()

--- a/posthog/models/organization_domain.py
+++ b/posthog/models/organization_domain.py
@@ -397,7 +397,9 @@ class OrganizationDomain(ModelActivityMixin, UUIDTModel):
         merely applies to the whole organization. Ties break on `created_at`, then `id`, so the
         resolution is deterministic and can't be steered by row ordering.
         """
-        if self.pk is None:
+        # An unsaved domain has no links and no organization to scope `all` against. Its `pk` is
+        # already populated (UUID default), so this has to test `_state.adding` rather than the pk.
+        if self._state.adding:
             return IdentityProviderConfig.objects.none()
         return (
             IdentityProviderConfig.objects.filter(organization_id=self.organization_id)

--- a/posthog/test/test_identity_provider_config.py
+++ b/posthog/test/test_identity_provider_config.py
@@ -2,8 +2,10 @@ import pytest
 from posthog.test.base import BaseTest
 
 from django.core.exceptions import ValidationError
+from django.utils import timezone
 
 from posthog.models import IdentityProviderConfig, LinkedIdentityProviderConfig, Organization, OrganizationDomain
+from posthog.models.identity_provider_config import DomainScope
 
 # Legacy `OrganizationDomain` columns that mirror fields on `IdentityProviderConfig`. Test-only:
 # used to build underscore-prefixed kwargs and to guard the two models' field shapes against drift.
@@ -182,3 +184,155 @@ class TestIdentityProviderConfig(BaseTest):
         assert not domain.has_saml
         assert not domain.has_scim
         assert not domain.has_id_jag
+
+
+class TestIdentityProviderConfigDomainScope(BaseTest):
+    SAML_KWARGS = {
+        "saml_entity_id": "entity-id",
+        "saml_acs_url": "https://idp.example.com/acs",
+        "saml_x509_cert": "cert-contents",
+    }
+
+    def _create_domain(self, domain: str = "posthog.com", **kwargs) -> OrganizationDomain:
+        return OrganizationDomain.objects.create(organization=self.organization, domain=domain, **kwargs)
+
+    def _create_config(self, **kwargs) -> IdentityProviderConfig:
+        return IdentityProviderConfig.objects.create(organization=self.organization, **kwargs)
+
+    def _create_config_with_identifiers(self, name: str, **kwargs) -> IdentityProviderConfig:
+        # `OrganizationDomain.save()` backfills empty identifiers with the domain's id, which
+        # collides across configs once a domain moves between them. Pre-set them so tests about
+        # linking aren't derailed by that.
+        return self._create_config(name=name, saml_relay_state=name, scim_slug=name, **kwargs)
+
+    def test_unset_domain_scope_is_treated_as_selected(self):
+        config = self._create_config()
+        assert config.domain_scope is None
+        assert config.effective_domain_scope == DomainScope.SELECTED
+        assert not config.applies_to_all_domains
+
+    def test_selected_scope_only_covers_linked_domains(self):
+        config = self._create_config(domain_scope=DomainScope.SELECTED)
+        linked = self._create_domain(identity_provider_config=config)
+        unlinked = self._create_domain("other.posthog.com")
+
+        assert list(config.organization_domains) == [linked]
+        assert list(unlinked.identity_provider_configs) == []
+        assert unlinked.idp_config._state.adding  # the empty in-memory fallback
+
+    def test_unset_scope_only_covers_linked_domains(self):
+        config = self._create_config()
+        linked = self._create_domain(identity_provider_config=config)
+        self._create_domain("other.posthog.com")
+
+        assert list(config.organization_domains) == [linked]
+
+    def test_all_scope_covers_every_domain_in_the_organization(self):
+        config = self._create_config(domain_scope=DomainScope.ALL, **self.SAML_KWARGS)
+        linked = self._create_domain(identity_provider_config=config)
+        unlinked = self._create_domain("other.posthog.com")
+
+        assert set(config.organization_domains) == {linked, unlinked}
+        # The unlinked domain resolves to the config without any join-table row of its own.
+        assert list(unlinked.identity_provider_configs) == [config]
+        assert unlinked.idp_config == config
+        assert unlinked.has_saml
+
+    def test_all_scope_does_not_cover_another_organizations_domains(self):
+        other_org = Organization.objects.create(name="Other")
+        other_domain = OrganizationDomain.objects.create(organization=other_org, domain="other.example.com")
+        config = self._create_config(domain_scope=DomainScope.ALL)
+
+        assert other_domain not in set(config.organization_domains)
+        assert list(other_domain.identity_provider_configs) == []
+
+    def test_explicitly_linked_config_wins_over_org_wide_one(self):
+        org_wide = self._create_config(domain_scope=DomainScope.ALL, name="org-wide")
+        linked = self._create_config(name="linked")
+        domain = self._create_domain(identity_provider_config=linked)
+
+        assert list(domain.identity_provider_configs) == [linked, org_wide]
+        assert domain.idp_config == linked
+
+    def test_org_wide_config_is_not_duplicated_by_links_to_other_domains(self):
+        config = self._create_config(domain_scope=DomainScope.ALL)
+        self._create_domain("a.posthog.com", identity_provider_config=config)
+        self._create_domain("b.posthog.com", identity_provider_config=config)
+        unlinked = self._create_domain("c.posthog.com")
+
+        assert list(unlinked.identity_provider_configs) == [config]
+
+    def test_repointing_the_domain_fk_drops_the_stale_link(self):
+        first = self._create_config_with_identifiers("first")
+        second = self._create_config_with_identifiers("second")
+        domain = self._create_domain(identity_provider_config=first)
+
+        domain.identity_provider_config = second
+        domain.save()
+
+        assert list(
+            LinkedIdentityProviderConfig.objects.filter(organization_domain=domain).values_list(
+                "identity_provider_config_id", flat=True
+            )
+        ) == [second.pk]
+        assert domain.idp_config == second
+        assert list(first.organization_domains) == []
+
+    def test_clearing_the_domain_fk_drops_the_link(self):
+        config = self._create_config()
+        domain = self._create_domain(identity_provider_config=config)
+
+        domain.identity_provider_config = None
+        domain.save()
+
+        assert not LinkedIdentityProviderConfig.objects.filter(organization_domain=domain).exists()
+        assert list(config.organization_domains) == []
+        assert domain.idp_config._state.adding
+
+    def test_deleting_domain_keeps_org_wide_config_while_other_domains_remain(self):
+        config = self._create_config(domain_scope=DomainScope.ALL)
+        domain = self._create_domain(identity_provider_config=config)
+        self._create_domain("other.posthog.com")
+
+        domain.delete()
+        assert IdentityProviderConfig.objects.filter(pk=config.pk).exists()
+
+    def test_deleting_the_last_domain_deletes_the_org_wide_config(self):
+        config = self._create_config(domain_scope=DomainScope.ALL)
+        domain = self._create_domain(identity_provider_config=config)
+
+        domain.delete()
+        assert not IdentityProviderConfig.objects.filter(pk=config.pk).exists()
+
+    def test_saml_availability_resolves_through_the_join_table(self):
+        config = self._create_config(**self.SAML_KWARGS)
+        domain = self._create_domain(identity_provider_config=config)
+        domain.verified_at = timezone.now()
+        domain.save()
+        self.organization.available_product_features = [{"key": "saml", "name": "saml"}]
+        self.organization.save()
+
+        assert OrganizationDomain.objects.get_is_saml_available_for_email("someone@posthog.com")
+
+        LinkedIdentityProviderConfig.objects.filter(organization_domain=domain).delete()
+        assert not OrganizationDomain.objects.get_is_saml_available_for_email("someone@posthog.com")
+
+    def test_saml_availability_resolves_through_an_org_wide_config(self):
+        self._create_config(domain_scope=DomainScope.ALL, **self.SAML_KWARGS)
+        domain = self._create_domain()  # never linked to the config
+        domain.verified_at = timezone.now()
+        domain.save()
+        self.organization.available_product_features = [{"key": "saml", "name": "saml"}]
+        self.organization.save()
+
+        assert OrganizationDomain.objects.get_is_saml_available_for_email("someone@posthog.com")
+
+    def test_saml_availability_ignores_a_partially_configured_config(self):
+        self._create_config(domain_scope=DomainScope.ALL, saml_entity_id="entity-id")  # no ACS URL or cert
+        domain = self._create_domain()
+        domain.verified_at = timezone.now()
+        domain.save()
+        self.organization.available_product_features = [{"key": "saml", "name": "saml"}]
+        self.organization.save()
+
+        assert not OrganizationDomain.objects.get_is_saml_available_for_email("someone@posthog.com")


### PR DESCRIPTION
## Problem

An earlier PR introduced the `LinkedIdentityProvider` model and the `domain_scope` column on the `IdentityProviderConfig` model. These changes will allow more generic mappings between idp configs and org domains. However, the logic has not yet been implemented to use these new models and fields.

This PR updates the backend logic so that the idp config -> org domain resolution passes through the new join table and vice versa.

## Changes

- `IdentityProviderConfig.organization_domains` returns the domains a config applies to.
- `domain_scope` decides the reach. `all` covers every domain in the organization, `selected` covers only the linked domains.
- An unset `domain_scope` reads as `selected`, so existing rows keep the reach they have today.
- `OrganizationDomain.identity_provider_configs` resolves the other direction, through the join table plus the organization's `all`-scoped configs.
- An explicit link sorts ahead of an `all`-scoped config, so a config chosen for one domain beats one that covers the organization.
- SAML availability, SAML issuer routing and SCIM bearer auth read the resolved config instead of the FK.
- The FK stays the only write interface for a link. `save()` mirrors it into the join table and drops links to configs the domain moved off.
- Orphan cleanup asks the config which domains it still applies to, which keeps an `all`-scoped config alive while its organization has any domain.
- `idp_config` caches its lookup per instance, because it no longer rides a `select_related` on the FK.
- `domain_scope` stays absent from the API, like `config_scope`. Nothing sets it yet, so production behavior does not change.

## How did you test this code?

New tests in `posthog/test/test_identity_provider_config.py`. Each group catches a regression no existing test did:

- Repointing a domain's FK left a stale join row, so the domain kept resolving to the config it moved off.
- An `all`-scoped config reached another organization's domains.
- An `all`-scoped config appeared once per link when it was linked to other domains.
- `get_is_saml_available_for_email` read the FK, so deleting the join row did not change the answer.

I ran the IdP config, organization domain, SCIM, SAML and ID-JAG suites locally, plus repo-wide mypy. I did no manual testing: the sandbox's ingestion service failed to build, so I did not start the app. The frontend suites went unrun, and this PR touches no frontend code.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. `domain_scope` is not reachable from the API yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via PostHog Code) wrote this. Skills invoked: `/writing-pr-descriptions`.

Two decisions worth a reviewer's attention. First, `save()` deletes a domain's links to other configs rather than only adding the current one. The FK is still the sole writer, so a second link can only be a leftover, and leaving it would make the domain resolve to the config it just moved off. Once links are managed directly, that reconciliation should go. Second, `idp_config` became a `cached_property` with invalidation in `save()` and `refresh_from_db()`, because resolving through the join table costs a query and `has_saml` / `has_scim` / `has_id_jag` each call it.
