### PR TITLE
fix(desktop): keep model picker open after selections

### DIFF
--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
@@ -161,7 +161,7 @@ describe("ReasoningLevelSelector", () => {
     expect(screen.queryByRole("menuitemradio")).not.toBeInTheDocument();
   });
 
-  it("emits the raw value via onChange once the advanced menu closes", async () => {
+  it("keeps the advanced menu open after changing reasoning", async () => {
     const onChange = vi.fn();
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     render(
@@ -181,6 +181,9 @@ describe("ReasoningLevelSelector", () => {
     await pollUntil(() => onChange.mock.calls.length > 0);
     expect(onChange).toHaveBeenCalledWith("low");
     expect(onChange).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByRole("menuitem", { name: /^Reasoning/ }),
+    ).toBeInTheDocument();
   });
 
   it("marks the adapter default level with a Default badge", async () => {
@@ -394,6 +397,40 @@ describe("ReasoningLevelSelector", () => {
     await pollUntil(() => onModelChange.mock.calls.length > 0);
     expect(onModelChange).toHaveBeenCalledWith("claude-opus-5");
     expect(onModelChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows changing model and reasoning without reopening the picker", async () => {
+    const onChange = vi.fn();
+    const onModelChange = vi.fn();
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(
+      <Theme>
+        <ReasoningLevelSelector
+          thoughtOption={thoughtOption()}
+          modelOption={claudeModelOption("claude-sonnet-5")}
+          adapter="claude"
+          onChange={onChange}
+          onModelChange={onModelChange}
+        />
+      </Theme>,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /Model and reasoning/ }),
+    );
+    await user.click(await screen.findByRole("button", { name: "Advanced" }));
+    await openSub(user, /^Model/);
+    fireEvent.click(
+      await screen.findByRole("menuitemradio", { name: "Claude Opus 5" }),
+    );
+    await pollUntil(() => onModelChange.mock.calls.length > 0);
+
+    await openSub(user, /^Reasoning/);
+    fireEvent.click(await screen.findByRole("menuitemradio", { name: "Low" }));
+    await pollUntil(() => onChange.mock.calls.length > 0);
+
+    expect(onModelChange).toHaveBeenCalledWith("claude-opus-5");
+    expect(onChange).toHaveBeenCalledWith("low");
   });
 
   it("moves the model and effort together on a ladder notch that changes both", async () => {

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
@@ -108,6 +108,9 @@ export function ReasoningLevelSelector({
   const [open, setOpen] = useState(false);
   const [advanced, setAdvanced] = useState(false);
   const pendingChangeRef = useRef<(() => void) | null>(null);
+  // Radio selections normally close the menu. Consume that close request so
+  // advanced settings can be changed one after another.
+  const keepOpenRef = useRef(false);
   const displayThought = useRetainedConfigOption(thoughtOption);
   const displayModel = useRetainedConfigOption(modelOption);
   const fastModeFlagEnabled = useFeatureFlag(FAST_MODE_FLAG);
@@ -262,6 +265,11 @@ export function ReasoningLevelSelector({
     setOpen(false);
   };
 
+  const selectAndKeepOpen = (apply: () => void) => {
+    keepOpenRef.current = true;
+    apply();
+  };
+
   const resetToDefaults = () => {
     selectAndClose(() => {
       if (useLadder) {
@@ -303,6 +311,9 @@ export function ReasoningLevelSelector({
     <DropdownMenu
       open={open}
       onOpenChange={(nextOpen) => {
+        if (!nextOpen && keepOpenRef.current) {
+          return;
+        }
         // Only on the closed-to-open transition: submenu opens re-fire this
         // with true and must not yank the view back.
         if (nextOpen && !open) setAdvanced(!onNotch);
@@ -310,6 +321,10 @@ export function ReasoningLevelSelector({
       }}
       onOpenChangeComplete={(isOpen) => {
         if (!isOpen) {
+          if (keepOpenRef.current) {
+            keepOpenRef.current = false;
+            return;
+          }
           setAdvanced(false);
           if (pendingChangeRef.current !== null) {
             pendingChangeRef.current();
@@ -381,7 +396,7 @@ export function ReasoningLevelSelector({
                         return;
                       }
 
-                      selectAndClose(() => {
+                      selectAndKeepOpen(() => {
                         if (harness === "pi") {
                           onHarnessChange?.(harness);
                           return;
@@ -415,7 +430,7 @@ export function ReasoningLevelSelector({
                             setOpen(false);
                             return;
                           }
-                          selectAndClose(() => changeModel(value));
+                          selectAndKeepOpen(() => changeModel(value));
                         }}
                       >
                         {modelGroups.length > 0
@@ -460,7 +475,7 @@ export function ReasoningLevelSelector({
                       <DropdownMenuRadioGroup
                         value={currentEffort ?? ""}
                         onValueChange={(value) =>
-                          selectAndClose(() => onChange?.(value))
+                          selectAndKeepOpen(() => onChange?.(value))
                         }
                       >
                         {effortOptions.map((option) => (
@@ -482,7 +497,7 @@ export function ReasoningLevelSelector({
                       <DropdownMenuRadioGroup
                         value={row.value}
                         onValueChange={(value) =>
-                          selectAndClose(() =>
+                          selectAndKeepOpen(() =>
                             onConfigOptionChange?.(row.id, value),
                           )
                         }


### PR DESCRIPTION
## Problem

Changing the harness, model, or reasoning level in the desktop chat composer closes the picker, forcing users to reopen it for each setting.

## Changes

- Keep the advanced model picker open while applying harness, model, reasoning, and related configuration selections.
- Add regression coverage for changing model and reasoning in one open picker.

## How did you test this code?

- `git diff --check`
- Added Vitest coverage in `ReasoningLevelSelector.test.tsx`.
- The focused Vitest and UI typecheck commands could not run because this checkout does not have the UI package dependencies installed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*