### PR TITLE
fix(desktop): keep model menu open after selection

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -591,6 +591,7 @@ export const ChannelHomeComposer = forwardRef<
               }
               thinkingLevels={piThinkingLevels}
               disabled={isBusy || isPiConfigLoading}
+              isLoading={isPiConfigLoading}
               onChange={handlePiModelChange}
               onThinkingLevelChange={handlePiThinkingLevelChange}
               onHarnessChange={handleHarnessChange}
@@ -600,7 +601,7 @@ export const ChannelHomeComposer = forwardRef<
           ) : null
         }
         reasoningSelector={
-          runtime === "pi" || isLoading ? null : (
+          runtime === "pi" ? null : (
             <ReasoningLevelSelector
               thoughtOption={thoughtOption}
               modelOption={modelOption}
@@ -618,6 +619,7 @@ export const ChannelHomeComposer = forwardRef<
               menuOpen={modelMenuOpen}
               onMenuOpenChange={setModelMenuOpen}
               disabled={isBusy}
+              isLoading={isLoading}
             />
           )
         }

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -146,6 +146,8 @@ export const ChannelHomeComposer = forwardRef<
 
   const adapter = lastUsedAdapter;
   const [runtime, setRuntime] = useState<AgentRuntime>("acp");
+  // Keep the menu open when a harness switch swaps its ACP/Pi control.
+  const [modelMenuOpen, setModelMenuOpen] = useState(false);
   const didResolveRuntimeRef = useRef(false);
   const [selectedPiModelId, setSelectedPiModelId] = useState<string | null>(
     null,
@@ -592,6 +594,8 @@ export const ChannelHomeComposer = forwardRef<
               onChange={handlePiModelChange}
               onThinkingLevelChange={handlePiThinkingLevelChange}
               onHarnessChange={handleHarnessChange}
+              menuOpen={modelMenuOpen}
+              onMenuOpenChange={setModelMenuOpen}
             />
           ) : null
         }
@@ -611,6 +615,8 @@ export const ChannelHomeComposer = forwardRef<
               }
               includePiHarness={piHarnessEnabled}
               onConfigOptionChange={setConfigOption}
+              menuOpen={modelMenuOpen}
+              onMenuOpenChange={setModelMenuOpen}
               disabled={isBusy}
             />
           )

--- a/products/desktop/packages/ui/src/features/message-editor/components/PromptInput.tsx
+++ b/products/desktop/packages/ui/src/features/message-editor/components/PromptInput.tsx
@@ -471,6 +471,14 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
                 enableCommands ? insertSlashCommand : undefined
               }
             />
+            {/* Direct flex children, not wrapped in a span: an inline wrapper
+                builds a line box whose leading pushes the trigger a pixel below
+                the toolbar's other buttons. The model chip renders before the
+                mode chip so its open menu stays anchored in place while a
+                harness switch changes which permission modes exist (and how
+                wide their labels are). */}
+            {modelSelector}
+            {reasoningSelector}
             {onModeChange && (
               <ModeSelector
                 modeOption={modeOption}
@@ -481,11 +489,6 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
                 canvas={canvas}
               />
             )}
-            {/* Direct flex children, not wrapped in a span: an inline wrapper
-                builds a line box whose leading pushes the trigger a pixel below
-                the toolbar's other buttons. */}
-            {modelSelector}
-            {reasoningSelector}
             {isBashMode && (
               <Text className="font-mono text-(--blue-9) text-[13px]">
                 ! bash

--- a/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.test.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.test.tsx
@@ -94,4 +94,24 @@ describe("PiModelSelector", () => {
       screen.getByRole("menuitem", { name: /^Harness/ }),
     ).toBeInTheDocument();
   });
+
+  it("keeps an open menu mounted while the Pi catalog loads", async () => {
+    render(
+      <Theme>
+        <PiModelSelector
+          models={[]}
+          isLoading
+          onChange={vi.fn()}
+          onHarnessChange={vi.fn()}
+          menuOpen
+          onMenuOpenChange={vi.fn()}
+        />
+      </Theme>,
+    );
+
+    expect(screen.getByRole("button", { name: /Loading/ })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("menuitem", { name: /^Harness/ }),
+    ).toBeInTheDocument();
+  });
 });

--- a/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.test.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.test.tsx
@@ -1,12 +1,15 @@
 import { Theme } from "@radix-ui/themes";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { PiModelSelector } from "./PiSessionControls";
 
 describe("PiModelSelector", () => {
-  it("keeps Pi configuration in the same nested menu shape as ACP", async () => {
+  it("keeps Pi configuration open while changing the model", async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const onChange = vi.fn();
+    const onThinkingLevelChange = vi.fn();
+    const onHarnessChange = vi.fn();
     render(
       <Theme>
         <PiModelSelector
@@ -29,9 +32,9 @@ describe("PiModelSelector", () => {
           }}
           thinkingLevel="medium"
           thinkingLevels={["low", "medium", "high"]}
-          onChange={vi.fn()}
-          onThinkingLevelChange={vi.fn()}
-          onHarnessChange={vi.fn()}
+          onChange={onChange}
+          onThinkingLevelChange={onThinkingLevelChange}
+          onHarnessChange={onHarnessChange}
         />
       </Theme>,
     );
@@ -57,8 +60,38 @@ describe("PiModelSelector", () => {
 
     await user.click(screen.getByRole("menuitem", { name: /^Model/ }));
 
+    const terra = await screen.findByRole("menuitemradio", {
+      name: "GPT-5.6 Terra",
+    });
+    expect(terra).toBeInTheDocument();
+
+    fireEvent.click(terra);
+
+    expect(onChange).toHaveBeenCalledWith({
+      provider: "posthog",
+      id: "gpt-5.6-terra",
+      name: "GPT-5.6 Terra",
+    });
     expect(
-      await screen.findByRole("menuitemradio", { name: "GPT-5.6 Terra" }),
+      screen.getByRole("menuitem", { name: /^Model/ }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("menuitem", { name: /^Reasoning/ }));
+    fireEvent.click(await screen.findByRole("menuitemradio", { name: "High" }));
+
+    expect(onThinkingLevelChange).toHaveBeenCalledWith("high");
+    expect(
+      screen.getByRole("menuitem", { name: /^Reasoning/ }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("menuitem", { name: /^Harness/ }));
+    fireEvent.click(
+      await screen.findByRole("menuitemradio", { name: "Codex" }),
+    );
+
+    expect(onHarnessChange).toHaveBeenCalledWith("codex");
+    expect(
+      screen.getByRole("menuitem", { name: /^Harness/ }),
     ).toBeInTheDocument();
   });
 });

--- a/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.tsx
@@ -20,7 +20,7 @@ import {
   HarnessSubmenu,
 } from "@posthog/ui/features/sessions/components/HarnessSubmenu";
 import type { MessagingMode } from "@posthog/ui/features/sessions/messagingModeStore";
-import { useRef, useState } from "react";
+import { useState } from "react";
 
 type PiModelOption = PiModelSelection & { name?: string };
 
@@ -33,6 +33,8 @@ interface PiModelSelectorProps {
   onChange: (model: PiModelSelection) => void;
   onThinkingLevelChange?: (level: PiThinkingLevel) => void;
   onHarnessChange?: (harness: AgentHarness) => void;
+  menuOpen?: boolean;
+  onMenuOpenChange?: (open: boolean) => void;
 }
 
 function modelKey(model: PiModelSelection): string {
@@ -62,9 +64,12 @@ export function PiModelSelector({
   onChange,
   onThinkingLevelChange,
   onHarnessChange,
+  menuOpen,
+  onMenuOpenChange,
 }: PiModelSelectorProps) {
-  const [open, setOpen] = useState(false);
-  const pendingChangeRef = useRef<(() => void) | null>(null);
+  const [internalMenuOpen, setInternalMenuOpen] = useState(false);
+  const open = menuOpen ?? internalMenuOpen;
+  const setOpen = onMenuOpenChange ?? setInternalMenuOpen;
 
   if (models.length === 0) {
     return null;
@@ -78,22 +83,8 @@ export function PiModelSelector({
     ? (thinkingLevelLabels[thinkingLevel] ?? thinkingLevel)
     : undefined;
 
-  const selectAndClose = (apply: () => void) => {
-    pendingChangeRef.current = apply;
-    setOpen(false);
-  };
-
   return (
-    <DropdownMenu
-      open={open}
-      onOpenChange={setOpen}
-      onOpenChangeComplete={(isOpen) => {
-        if (!isOpen && pendingChangeRef.current !== null) {
-          pendingChangeRef.current();
-          pendingChangeRef.current = null;
-        }
-      }}
-    >
+    <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger
         render={
           <Button
@@ -134,9 +125,10 @@ export function PiModelSelector({
           <HarnessSubmenu
             value="pi"
             includePi
+            closeOnChange={false}
             onChange={(harness) => {
               if (harness !== "pi") {
-                selectAndClose(() => onHarnessChange(harness));
+                onHarnessChange(harness);
               }
             }}
           />
@@ -156,7 +148,7 @@ export function PiModelSelector({
                   (candidate) => modelKey(candidate) === value,
                 );
                 if (model) {
-                  selectAndClose(() => onChange(model));
+                  onChange(model);
                 }
               }}
             >
@@ -164,6 +156,7 @@ export function PiModelSelector({
                 <DropdownMenuRadioItem
                   key={modelKey(model)}
                   value={modelKey(model)}
+                  closeOnClick={false}
                 >
                   <span className="whitespace-nowrap">{modelLabel(model)}</span>
                 </DropdownMenuRadioItem>
@@ -185,13 +178,15 @@ export function PiModelSelector({
                 <DropdownMenuRadioGroup
                   value={thinkingLevel}
                   onValueChange={(value) =>
-                    selectAndClose(() =>
-                      onThinkingLevelChange(value as PiThinkingLevel),
-                    )
+                    onThinkingLevelChange(value as PiThinkingLevel)
                   }
                 >
                   {thinkingLevels.map((level) => (
-                    <DropdownMenuRadioItem key={level} value={level}>
+                    <DropdownMenuRadioItem
+                      key={level}
+                      value={level}
+                      closeOnClick={false}
+                    >
                       {thinkingLevelLabels[level] ?? level}
                     </DropdownMenuRadioItem>
                   ))}

--- a/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.tsx
@@ -1,4 +1,10 @@
-import { CaretDown, Lightning, PiIcon, Stack } from "@phosphor-icons/react";
+import {
+  CaretDown,
+  Lightning,
+  PiIcon,
+  Spinner,
+  Stack,
+} from "@phosphor-icons/react";
 import type {
   PiModelSelection,
   PiThinkingLevel,
@@ -7,6 +13,7 @@ import {
   Button,
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuItem,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSub,
@@ -30,6 +37,7 @@ interface PiModelSelectorProps {
   thinkingLevel?: PiThinkingLevel;
   thinkingLevels?: PiThinkingLevel[];
   disabled?: boolean;
+  isLoading?: boolean;
   onChange: (model: PiModelSelection) => void;
   onThinkingLevelChange?: (level: PiThinkingLevel) => void;
   onHarnessChange?: (harness: AgentHarness) => void;
@@ -61,6 +69,7 @@ export function PiModelSelector({
   thinkingLevel,
   thinkingLevels = [],
   disabled,
+  isLoading,
   onChange,
   onThinkingLevelChange,
   onHarnessChange,
@@ -72,6 +81,49 @@ export function PiModelSelector({
   const setOpen = onMenuOpenChange ?? setInternalMenuOpen;
 
   if (models.length === 0) {
+    if (isLoading) {
+      // Keep the dropdown mounted while the Pi catalog first loads (a
+      // harness switch to Pi): unmounting it closes a menu the user is
+      // mid-interaction with.
+      return (
+        <DropdownMenu open={open} onOpenChange={setOpen}>
+          <DropdownMenuTrigger
+            render={
+              <Button type="button" variant="default" size="sm">
+                <span className="text-muted-foreground">
+                  <PiIcon size={14} weight="bold" className="translate-y-px" />
+                </span>
+                <Spinner size={12} className="animate-spin" />
+                Loading...
+              </Button>
+            }
+          />
+          <DropdownMenuContent
+            align="start"
+            side="top"
+            sideOffset={6}
+            className="min-w-[230px]"
+          >
+            {onHarnessChange && (
+              <HarnessSubmenu
+                value="pi"
+                includePi
+                closeOnChange={false}
+                onChange={(harness) => {
+                  if (harness !== "pi") {
+                    onHarnessChange(harness);
+                  }
+                }}
+              />
+            )}
+            <DropdownMenuItem disabled>
+              <Spinner size={12} className="animate-spin" />
+              Loading models...
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      );
+    }
     return null;
   }
 

--- a/products/desktop/packages/ui/src/features/sessions/components/HarnessSubmenu.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/HarnessSubmenu.tsx
@@ -18,12 +18,14 @@ const harnessLabels: Record<AgentHarness, string> = {
 interface HarnessSubmenuProps {
   value: AgentHarness;
   includePi?: boolean;
+  closeOnChange?: boolean;
   onChange: (harness: AgentHarness) => void;
 }
 
 export function HarnessSubmenu({
   value,
   includePi,
+  closeOnChange = true,
   onChange,
 }: HarnessSubmenuProps): React.JSX.Element {
   return (
@@ -47,12 +49,16 @@ export function HarnessSubmenu({
             }
           }}
         >
-          <DropdownMenuRadioItem value="claude">
+          <DropdownMenuRadioItem value="claude" closeOnClick={closeOnChange}>
             Claude Code
           </DropdownMenuRadioItem>
-          <DropdownMenuRadioItem value="codex">Codex</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="codex" closeOnClick={closeOnChange}>
+            Codex
+          </DropdownMenuRadioItem>
           {includePi && (
-            <DropdownMenuRadioItem value="pi">Pi</DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="pi" closeOnClick={closeOnChange}>
+              Pi
+            </DropdownMenuRadioItem>
           )}
         </DropdownMenuRadioGroup>
       </DropdownMenuSubContent>

--- a/products/desktop/packages/ui/src/features/sessions/components/ModelRadioItem.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ModelRadioItem.tsx
@@ -9,17 +9,20 @@ import { isRestrictedModel } from "@posthog/ui/features/billing/modelGate";
  */
 export function ModelRadioItem({
   model,
+  closeOnClick,
 }: {
   model: {
     value: string;
     name: string;
     _meta?: Record<string, unknown> | null;
   };
+  closeOnClick?: boolean;
 }) {
   const restricted = isRestrictedModel(model);
   return (
     <DropdownMenuRadioItem
       value={model.value}
+      closeOnClick={closeOnClick}
       className={restricted ? "opacity-60" : undefined}
     >
       <span className="whitespace-nowrap">{model.name}</span>

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelDropdown.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelDropdown.tsx
@@ -377,9 +377,15 @@ export function ReasoningSliderFace({
   );
 }
 
-export function LevelItem({ option }: { option: ReasoningLevelOption }) {
+export function LevelItem({
+  option,
+  closeOnClick,
+}: {
+  option: ReasoningLevelOption;
+  closeOnClick?: boolean;
+}) {
   return (
-    <DropdownMenuRadioItem value={option.value}>
+    <DropdownMenuRadioItem value={option.value} closeOnClick={closeOnClick}>
       <span className="flex min-w-0 flex-col">
         <span className="whitespace-nowrap">{option.label}</span>
         {option.description && (

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
@@ -161,7 +161,7 @@ describe("ReasoningLevelSelector", () => {
     expect(screen.queryByRole("menuitemradio")).not.toBeInTheDocument();
   });
 
-  it("emits the raw value via onChange once the advanced menu closes", async () => {
+  it("changes reasoning without closing the advanced menu", async () => {
     const onChange = vi.fn();
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     render(
@@ -178,9 +178,11 @@ describe("ReasoningLevelSelector", () => {
     const lowItem = await screen.findByRole("menuitemradio", { name: "Low" });
     fireEvent.click(lowItem);
 
-    await pollUntil(() => onChange.mock.calls.length > 0);
     expect(onChange).toHaveBeenCalledWith("low");
     expect(onChange).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByRole("menuitem", { name: /^Reasoning/ }),
+    ).toBeInTheDocument();
   });
 
   it("marks the adapter default level with a Default badge", async () => {
@@ -363,9 +365,11 @@ describe("ReasoningLevelSelector", () => {
     await openSub(user, /^Harness/);
     fireEvent.click(await screen.findByRole("menuitemradio", { name: "Pi" }));
 
-    await pollUntil(() => onHarnessChange.mock.calls.length > 0);
     expect(onHarnessChange).toHaveBeenCalledWith("pi");
     expect(onHarnessChange).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByRole("menuitem", { name: /^Harness/ }),
+    ).toBeInTheDocument();
   });
 
   it("changes the model from its advanced submenu", async () => {
@@ -391,9 +395,11 @@ describe("ReasoningLevelSelector", () => {
       await screen.findByRole("menuitemradio", { name: "Claude Opus 5" }),
     );
 
-    await pollUntil(() => onModelChange.mock.calls.length > 0);
     expect(onModelChange).toHaveBeenCalledWith("claude-opus-5");
     expect(onModelChange).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByRole("menuitem", { name: /^Model/ }),
+    ).toBeInTheDocument();
   });
 
   it("moves the model and effort together on a ladder notch that changes both", async () => {

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
@@ -343,6 +343,73 @@ describe("ReasoningLevelSelector", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("keeps the Back row when a model change moves off the preset ladder", async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const { rerender } = render(
+      <Theme>
+        <ReasoningLevelSelector
+          thoughtOption={thoughtOption({ currentValue: "xhigh" })}
+          modelOption={claudeModelOption("claude-opus-5")}
+          adapter="claude"
+        />
+      </Theme>,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /Model and reasoning/ }),
+    );
+    await user.click(await screen.findByRole("button", { name: "Advanced" }));
+    expect(
+      await screen.findByRole("button", { name: "Back" }),
+    ).toBeInTheDocument();
+
+    rerender(
+      <Theme>
+        <ReasoningLevelSelector
+          thoughtOption={thoughtOption({ currentValue: "xhigh" })}
+          modelOption={claudeModelOption("claude-sonnet-5")}
+          adapter="claude"
+        />
+      </Theme>,
+    );
+
+    expect(screen.getByRole("button", { name: "Back" })).toBeInTheDocument();
+  });
+
+  it("does not grow a Back row when a model change lands on the ladder", async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const { rerender } = render(
+      <Theme>
+        <ReasoningLevelSelector
+          thoughtOption={thoughtOption({ currentValue: "low" })}
+          modelOption={claudeModelOption("claude-opus-5")}
+          adapter="claude"
+        />
+      </Theme>,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /Model and reasoning/ }),
+    );
+    expect(
+      await screen.findByRole("menuitem", { name: /^Model/ }),
+    ).toBeInTheDocument();
+
+    rerender(
+      <Theme>
+        <ReasoningLevelSelector
+          thoughtOption={thoughtOption({ currentValue: "medium" })}
+          modelOption={claudeModelOption("claude-opus-5")}
+          adapter="claude"
+        />
+      </Theme>,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Back" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("switches to Pi from the harness submenu", async () => {
     const onHarnessChange = vi.fn();
     const user = userEvent.setup({ pointerEventsCheck: 0 });
@@ -549,9 +616,25 @@ describe("ReasoningLevelSelector", () => {
       </Theme>,
     );
 
-    expect(screen.getByRole("button", { name: /Loading/ })).toHaveAttribute(
-      "aria-disabled",
-      "true",
+    expect(screen.getByRole("button", { name: /Loading/ })).toBeInTheDocument();
+  });
+
+  it("keeps an open menu mounted while a harness switch reloads the config", async () => {
+    render(
+      <Theme>
+        <ReasoningLevelSelector
+          isLoading
+          adapter="claude"
+          onHarnessChange={() => {}}
+          includePiHarness
+          menuOpen
+          onMenuOpenChange={() => {}}
+        />
+      </Theme>,
     );
+
+    expect(
+      await screen.findByRole("menuitem", { name: /Harness/ }),
+    ).toBeInTheDocument();
   });
 });

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
@@ -69,6 +69,8 @@ interface ReasoningLevelSelectorProps {
   onHarnessChange?: (harness: AgentHarness) => void;
   includePiHarness?: boolean;
   onConfigOptionChange?: (configId: string, value: string) => void;
+  menuOpen?: boolean;
+  onMenuOpenChange?: (open: boolean) => void;
   disabled?: boolean;
   isLoading?: boolean;
 }
@@ -102,10 +104,14 @@ export function ReasoningLevelSelector({
   onHarnessChange,
   includePiHarness,
   onConfigOptionChange,
+  menuOpen,
+  onMenuOpenChange,
   disabled,
   isLoading,
 }: ReasoningLevelSelectorProps) {
-  const [open, setOpen] = useState(false);
+  const [internalMenuOpen, setInternalMenuOpen] = useState(false);
+  const open = menuOpen ?? internalMenuOpen;
+  const setOpen = onMenuOpenChange ?? setInternalMenuOpen;
   const [advanced, setAdvanced] = useState(false);
   const pendingChangeRef = useRef<(() => void) | null>(null);
   const displayThought = useRetainedConfigOption(thoughtOption);
@@ -376,24 +382,23 @@ export function ReasoningLevelSelector({
                   <HarnessSubmenu
                     value={adapter}
                     includePi={includePiHarness && !!onHarnessChange}
+                    closeOnChange={false}
                     onChange={(harness) => {
                       if (harness === adapter) {
                         return;
                       }
 
-                      selectAndClose(() => {
-                        if (harness === "pi") {
-                          onHarnessChange?.(harness);
-                          return;
-                        }
+                      if (harness === "pi") {
+                        onHarnessChange?.(harness);
+                        return;
+                      }
 
-                        if (onHarnessChange) {
-                          onHarnessChange(harness);
-                          return;
-                        }
+                      if (onHarnessChange) {
+                        onHarnessChange(harness);
+                        return;
+                      }
 
-                        onAdapterChange?.(harness);
-                      });
+                      onAdapterChange?.(harness);
                     }}
                   />
                 )}
@@ -415,7 +420,7 @@ export function ReasoningLevelSelector({
                             setOpen(false);
                             return;
                           }
-                          selectAndClose(() => changeModel(value));
+                          changeModel(value);
                         }}
                       >
                         {modelGroups.length > 0
@@ -430,6 +435,7 @@ export function ReasoningLevelSelector({
                                     <ModelRadioItem
                                       key={model.value}
                                       model={model}
+                                      closeOnClick={false}
                                     />
                                   ))}
                               </Fragment>
@@ -442,6 +448,7 @@ export function ReasoningLevelSelector({
                                 <ModelRadioItem
                                   key={model.value}
                                   model={model}
+                                  closeOnClick={false}
                                 />
                               ))}
                       </DropdownMenuRadioGroup>
@@ -459,12 +466,14 @@ export function ReasoningLevelSelector({
                     <DropdownMenuSubContent>
                       <DropdownMenuRadioGroup
                         value={currentEffort ?? ""}
-                        onValueChange={(value) =>
-                          selectAndClose(() => onChange?.(value))
-                        }
+                        onValueChange={(value) => onChange?.(value)}
                       >
                         {effortOptions.map((option) => (
-                          <LevelItem key={option.value} option={option} />
+                          <LevelItem
+                            key={option.value}
+                            option={option}
+                            closeOnClick={false}
+                          />
                         ))}
                       </DropdownMenuRadioGroup>
                     </DropdownMenuSubContent>
@@ -482,13 +491,15 @@ export function ReasoningLevelSelector({
                       <DropdownMenuRadioGroup
                         value={row.value}
                         onValueChange={(value) =>
-                          selectAndClose(() =>
-                            onConfigOptionChange?.(row.id, value),
-                          )
+                          onConfigOptionChange?.(row.id, value)
                         }
                       >
                         {row.options.map((option) => (
-                          <LevelItem key={option.value} option={option} />
+                          <LevelItem
+                            key={option.value}
+                            option={option}
+                            closeOnClick={false}
+                          />
                         ))}
                       </DropdownMenuRadioGroup>
                     </DropdownMenuSubContent>

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
@@ -113,6 +113,10 @@ export function ReasoningLevelSelector({
   const open = menuOpen ?? internalMenuOpen;
   const setOpen = onMenuOpenChange ?? setInternalMenuOpen;
   const [advanced, setAdvanced] = useState(false);
+  // Frozen when the Advanced view is entered: deriving it live from the
+  // ladder makes the Back row flash in and out as model picks move on and
+  // off a notch while the menu is open.
+  const [showBack, setShowBack] = useState(false);
   const pendingChangeRef = useRef<(() => void) | null>(null);
   const displayThought = useRetainedConfigOption(thoughtOption);
   const displayModel = useRetainedConfigOption(modelOption);
@@ -131,13 +135,58 @@ export function ReasoningLevelSelector({
   const modelSelect =
     displayModel?.type === "select" ? displayModel : undefined;
 
+  const handleHarnessSelect = (harness: AgentHarness) => {
+    if (harness === adapter) {
+      return;
+    }
+
+    if (harness === "pi") {
+      onHarnessChange?.(harness);
+      return;
+    }
+
+    if (onHarnessChange) {
+      onHarnessChange(harness);
+      return;
+    }
+
+    onAdapterChange?.(harness);
+  };
+
   if (!hasEffort && !modelSelect) {
     if (isLoading) {
+      // Keep the dropdown mounted while a harness switch reloads the config:
+      // unmounting it here closes a menu the user is mid-interaction with.
       return (
-        <Button type="button" variant="default" size="sm" disabled>
-          <Spinner size={12} className="animate-spin" />
-          Loading...
-        </Button>
+        <DropdownMenu open={open} onOpenChange={setOpen}>
+          <DropdownMenuTrigger
+            render={
+              <Button type="button" variant="default" size="sm">
+                <Spinner size={12} className="animate-spin" />
+                Loading...
+              </Button>
+            }
+          />
+          <DropdownMenuContent
+            align="start"
+            side="top"
+            sideOffset={6}
+            className="min-w-[230px]"
+          >
+            {adapter && (onAdapterChange || onHarnessChange) && (
+              <HarnessSubmenu
+                value={adapter}
+                includePi={includePiHarness && !!onHarnessChange}
+                closeOnChange={false}
+                onChange={handleHarnessSelect}
+              />
+            )}
+            <DropdownMenuItem disabled>
+              <Spinner size={12} className="animate-spin" />
+              Loading models...
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       );
     }
     return null;
@@ -311,12 +360,16 @@ export function ReasoningLevelSelector({
       onOpenChange={(nextOpen) => {
         // Only on the closed-to-open transition: submenu opens re-fire this
         // with true and must not yank the view back.
-        if (nextOpen && !open) setAdvanced(!onNotch);
+        if (nextOpen && !open) {
+          setAdvanced(!onNotch);
+          setShowBack(false);
+        }
         setOpen(nextOpen);
       }}
       onOpenChangeComplete={(isOpen) => {
         if (!isOpen) {
           setAdvanced(false);
+          setShowBack(false);
           if (pendingChangeRef.current !== null) {
             pendingChangeRef.current();
             pendingChangeRef.current = null;
@@ -377,29 +430,13 @@ export function ReasoningLevelSelector({
                 exit={{ opacity: 0, y: -8 }}
                 transition={{ duration: 0.12, ease: "easeOut" }}
               >
-                {onNotch && <BackRow onClick={() => setAdvanced(false)} />}
+                {showBack && <BackRow onClick={() => setAdvanced(false)} />}
                 {adapter && (onAdapterChange || onHarnessChange) && (
                   <HarnessSubmenu
                     value={adapter}
                     includePi={includePiHarness && !!onHarnessChange}
                     closeOnChange={false}
-                    onChange={(harness) => {
-                      if (harness === adapter) {
-                        return;
-                      }
-
-                      if (harness === "pi") {
-                        onHarnessChange?.(harness);
-                        return;
-                      }
-
-                      if (onHarnessChange) {
-                        onHarnessChange(harness);
-                        return;
-                      }
-
-                      onAdapterChange?.(harness);
-                    }}
+                    onChange={handleHarnessSelect}
                   />
                 )}
                 {modelSelect && (
@@ -523,7 +560,10 @@ export function ReasoningLevelSelector({
                   stops={stops}
                   currentKey={currentStopKey}
                   onSelect={handleStopSelect}
-                  onAdvanced={() => setAdvanced(true)}
+                  onAdvanced={() => {
+                    setShowBack(true);
+                    setAdvanced(true);
+                  }}
                   fastToggle={fastToggle}
                 />
               </motion.div>

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -1495,6 +1495,7 @@ export function TaskInput({
                         }
                         thinkingLevels={piThinkingLevels}
                         disabled={isCreatingTask || isPiConfigLoading}
+                        isLoading={isPiConfigLoading}
                         onChange={handlePiModelChange}
                         onThinkingLevelChange={handlePiThinkingLevelChange}
                         onHarnessChange={handleHarnessChange}

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -296,6 +296,8 @@ export function TaskInput({
   const [isCreatingBranch, setIsCreatingBranch] = useState(false);
   const [selectedBranch, setSelectedBranch] = useState<string | null>(null);
   const [runtime, setRuntime] = useState<AgentRuntime>("acp");
+  // Keep the menu open when a harness switch swaps its ACP/Pi control.
+  const [modelMenuOpen, setModelMenuOpen] = useState(false);
   const didResolveRuntimeRef = useRef(false);
   const [selectedPiModelId, setSelectedPiModelId] = useState<string | null>(
     null,
@@ -1496,6 +1498,8 @@ export function TaskInput({
                         onChange={handlePiModelChange}
                         onThinkingLevelChange={handlePiThinkingLevelChange}
                         onHarnessChange={handleHarnessChange}
+                        menuOpen={modelMenuOpen}
+                        onMenuOpenChange={setModelMenuOpen}
                       />
                     ) : null
                   }
@@ -1522,6 +1526,8 @@ export function TaskInput({
                         }
                         includePiHarness={piHarnessEnabled}
                         onConfigOptionChange={setConfigOption}
+                        menuOpen={modelMenuOpen}
+                        onMenuOpenChange={setModelMenuOpen}
                         disabled={isCreatingTask}
                         isLoading={isPreviewLoading}
                       />


### PR DESCRIPTION
## Summary
- keep the desktop composer model menu open after harness, model, reasoning, and related configuration selections
- preserve the open menu while switching between ACP and Pi harness controls
- cover consecutive Pi harness, model, and reasoning changes without reopening the menu

## Testing
- `pnpm exec biome check <changed files>`
- `pnpm exec vitest run src/features/sessions/components/ReasoningLevelSelector.test.tsx src/features/pi-sessions/PiSessionControls.test.tsx src/features/pi-sessions/PiSessionModelControls.test.tsx --reporter=dot`
- `pnpm --filter @posthog/ui typecheck`
