### PR TITLE
fix(customer-analytics): decouple accounts loading states

### DIFF
--- a/products/customer_analytics/frontend/components/Accounts/AccountsTabContent.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsTabContent.tsx
@@ -20,20 +20,20 @@ export function AccountsTabContent(): JSX.Element {
                 query: accountsQuerySource,
             }}
         >
-            <BindLogic
-                logic={dataNodeLogic}
-                props={{
-                    key: ACCOUNTS_METRICS_DATA_NODE_KEY,
-                    query: metricsQuery,
-                }}
-            >
-                <div className="flex flex-col gap-3">
-                    <AccountsMaxTools />
-                    <AccountsTabFilters />
+            <div className="flex flex-col gap-3">
+                <AccountsMaxTools />
+                <AccountsTabFilters />
+                <BindLogic
+                    logic={dataNodeLogic}
+                    props={{
+                        key: ACCOUNTS_METRICS_DATA_NODE_KEY,
+                        query: metricsQuery,
+                    }}
+                >
                     <AccountsOverviewTiles />
-                    <AccountsHogQLTable />
-                </div>
-            </BindLogic>
+                </BindLogic>
+                <AccountsHogQLTable />
+            </div>
         </BindLogic>
     )
 }


### PR DESCRIPTION
## Problem

The Accounts table shows a loading skeleton while the independent overview request is still running.

Part of #78880.

## Changes

- Scope the metrics data provider to overview tiles only.
- Keep the table under the list data provider.
- No screenshot: the layout and rendered states are unchanged.

## How did you test this code?

- Ran the frontend TypeScript check.
- No new test: the provider boundary directly removes the shared loading-state lookup.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I used the OpenAI coding agent in pi. The session link is unavailable in this harness.

Skills invoked: `/stacking-prs`, `/writing-pr-descriptions`, and `/running-ci-preflight`.
