### PR TITLE
feat(notebooks): label node runs with the transport that served them

### DIFF
--- a/products/notebooks/backend/sandbox/kernel/data_plane.py
+++ b/products/notebooks/backend/sandbox/kernel/data_plane.py
@@ -36,6 +36,15 @@ _POLL_MAX_INTERVAL_SECONDS = 2.0
 class DataPlaneError(Exception):
     """A query the data plane rejected or failed to run; message is user-facing."""
 
+    def __init__(self, message: str, delivery: str | None = None) -> None:
+        super().__init__(message)
+        # The transport the server said it was serving this fetch with, when it is already
+        # known at the point of failure. A failure after the accept must still attribute to
+        # its transport: otherwise every failed run lands in the unlabeled bucket and the
+        # per-transport failure ratio reads near zero however badly a transport is doing.
+        # None means the request failed before any transport was chosen.
+        self.delivery = delivery
+
 
 class DataPlaneInterrupted(DataPlaneError):
     """The run's cancel event fired while waiting on the data plane."""
@@ -184,15 +193,22 @@ def _request_table(
     # one requested: an object request falls back to inline when the frame store is
     # unconfigured or the user is outside the rollout. A backend predating this field leaves
     # it None rather than guessing.
-    served_by = body.get("delivery")
-    fetched = _poll_for_table(
-        f"{url.rstrip('/')}/{query_id}/", token, expect_object=delivery == "object", cancel_event=cancel_event
-    )
+    served_by = body.get("delivery") if isinstance(body.get("delivery"), str) else None
+    try:
+        fetched = _poll_for_table(
+            f"{url.rstrip('/')}/{query_id}/", token, expect_object=delivery == "object", cancel_event=cancel_event
+        )
+    except DataPlaneError as exc:
+        # Polling, the presigned download, and Arrow decoding all raise from below here,
+        # where the transport is not known. Stamp it on the way out so the failed run keeps
+        # its attribution.
+        exc.delivery = served_by
+        raise
     return _FetchedTable(
         table=fetched.table,
         source=fetched.source,
         download_s=fetched.download_s,
-        delivery=served_by if isinstance(served_by, str) else None,
+        delivery=served_by,
     )
 
 

--- a/products/notebooks/backend/sandbox/kernel/data_plane.py
+++ b/products/notebooks/backend/sandbox/kernel/data_plane.py
@@ -14,6 +14,7 @@ import time
 import threading
 import urllib.error
 import urllib.request
+from dataclasses import dataclass
 from typing import Any
 
 import pyarrow as pa
@@ -58,6 +59,31 @@ class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
 _no_redirect_opener = urllib.request.build_opener(_NoRedirectHandler)
 
 
+@dataclass(frozen=True, kw_only=True)
+class _FetchedTable:
+    """One data-plane fetch: the rows plus how they got here."""
+
+    table: "pa.Table"
+    # Truncated presigned-URL preview when the rows came from an object download, else None.
+    source: str | None
+    # Wall time of the presigned download alone, 0.0 when the rows arrived inline.
+    download_s: float
+    # The transport the server reported serving this fetch with. Opaque here on purpose: the
+    # sandbox echoes it into the envelope and the backend validates it against its own
+    # allowlist, so a new server-side mode needs no sandbox release to be reported.
+    delivery: str | None
+
+
+@dataclass(frozen=True, kw_only=True)
+class MaterializedFrame:
+    """The outcome of writing one referenced frame to a local Arrow file."""
+
+    row_count: int
+    source: str | None
+    download_s: float
+    delivery: str | None
+
+
 # How much of a presigned frame URL may be surfaced for observability. The URL is a
 # bearer secret; the first 30 characters cover scheme + host (which store served the
 # frame) and never reach the signature query parameters.
@@ -73,8 +99,8 @@ def fetch_query_page(
     cancel_event: "threading.Event | None" = None,
 ) -> tuple[list[str], list[tuple[Any, ...]], list[list[str]]]:
     """Run `query` through the data plane; return (columns, rows, types) of the capped page."""
-    table, _source, _download_s = _request_table(url, token, query, limit, offset, cancel_event=cancel_event)
-    return _table_to_rows_and_types(table)
+    fetched = _request_table(url, token, query, limit, offset, cancel_event=cancel_event)
+    return _table_to_rows_and_types(fetched.table)
 
 
 def materialize_query_to_file(
@@ -85,27 +111,29 @@ def materialize_query_to_file(
     limit: int,
     offset: int = 0,
     cancel_event: "threading.Event | None" = None,
-) -> tuple[int, str | None, float]:
+) -> MaterializedFrame:
     """Fetch the full result of `query` and write it as a local Arrow IPC file for a Python/DuckDB node.
 
-    Returns (row count, truncated frame-store URL preview, presigned download seconds) —
-    the preview is set only when the frame actually came from a presigned object download
-    (None on the inline fallback, with 0.0 download seconds), so callers can surface which
-    store served the frame. Requests object delivery: the poll answers with a 302 to a
-    presigned object-store URL carrying the same Arrow bytes (falling back to the inline
-    body when the backend's frame store is unavailable). The file is written to a temp
+    The returned `source` preview is set only when the frame actually came from a presigned
+    object download (None on the inline fallback, with 0.0 download seconds), so callers can
+    surface which store served the frame. Requests object delivery: the poll answers with a
+    302 to a presigned object-store URL carrying the same Arrow bytes (falling back to the
+    inline body when the backend's frame store is unavailable). The file is written to a temp
     name and renamed on success so a torn write (e.g. a mid-stream failure) never leaves
     a half-frame the kernel could read.
     """
-    table, source, download_s = _request_table(
-        url, token, query, limit, offset, delivery="object", cancel_event=cancel_event
-    )
+    fetched = _request_table(url, token, query, limit, offset, delivery="object", cancel_event=cancel_event)
     temp_path = f"{dest_path}.partial"
     with pa.OSFile(temp_path, "wb") as sink:
-        with pa.ipc.new_file(sink, table.schema) as writer:
-            writer.write_table(table)
+        with pa.ipc.new_file(sink, fetched.table.schema) as writer:
+            writer.write_table(fetched.table)
     os.replace(temp_path, dest_path)
-    return table.num_rows, source, download_s
+    return MaterializedFrame(
+        row_count=fetched.table.num_rows,
+        source=fetched.source,
+        download_s=fetched.download_s,
+        delivery=fetched.delivery,
+    )
 
 
 def _check_cancelled(cancel_event: "threading.Event | None") -> None:
@@ -121,13 +149,8 @@ def _request_table(
     offset: int,
     delivery: str = "inline",
     cancel_event: "threading.Event | None" = None,
-) -> tuple["pa.Table", str | None, float]:
-    """POST the query and (once the async manager finishes) return the raw Arrow table.
-
-    The second element is a truncated presigned-URL preview when the rows came from an
-    object download, else None; the third is the presigned download's duration in
-    seconds (0.0 when the rows arrived inline).
-    """
+) -> _FetchedTable:
+    """POST the query and (once the async manager finishes) return the raw Arrow table."""
     _check_cancelled(cancel_event)
     body: dict[str, Any] = {"query": query, "limit": limit, "offset": offset}
     if delivery != "inline":
@@ -145,7 +168,7 @@ def _request_table(
         with urllib.request.urlopen(request, timeout=_REQUEST_TIMEOUT_SECONDS) as response:
             if _is_arrow(response):
                 # A pre-async-manager backend answers the POST with the rows directly.
-                return _read_table(response), None, 0.0
+                return _FetchedTable(table=_read_table(response), source=None, download_s=0.0, delivery=None)
             body = json.loads(response.read() or b"{}")
     except urllib.error.HTTPError as exc:
         raise DataPlaneError(_error_detail(exc)) from exc
@@ -157,8 +180,19 @@ def _request_table(
     query_id = body.get("query_id")
     if not query_id:
         raise DataPlaneError("Data plane did not accept the query")
-    return _poll_for_table(
+    # The accept body names the transport the server actually chose, which is not always the
+    # one requested: an object request falls back to inline when the frame store is
+    # unconfigured or the user is outside the rollout. A backend predating this field leaves
+    # it None rather than guessing.
+    served_by = body.get("delivery")
+    fetched = _poll_for_table(
         f"{url.rstrip('/')}/{query_id}/", token, expect_object=delivery == "object", cancel_event=cancel_event
+    )
+    return _FetchedTable(
+        table=fetched.table,
+        source=fetched.source,
+        download_s=fetched.download_s,
+        delivery=served_by if isinstance(served_by, str) else None,
     )
 
 
@@ -167,7 +201,7 @@ def _poll_for_table(
     token: str,
     expect_object: bool = False,
     cancel_event: "threading.Event | None" = None,
-) -> tuple["pa.Table", str | None, float]:
+) -> _FetchedTable:
     request = urllib.request.Request(status_url, headers={"Authorization": f"Bearer {token}"}, method="GET")
     # Only object-delivery polls intercept the completion 302 (a presigned frame handoff).
     # Inline polls keep urllib's transparent redirect-following, so an infrastructure
@@ -184,7 +218,7 @@ def _poll_for_table(
             # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
             with opener(request, timeout=_REQUEST_TIMEOUT_SECONDS) as response:
                 if _is_arrow(response):
-                    return _read_table(response), None, 0.0
+                    return _FetchedTable(table=_read_table(response), source=None, download_s=0.0, delivery=None)
                 # 202 — still running.
         except urllib.error.HTTPError as exc:
             if expect_object and exc.code == 302:
@@ -203,13 +237,13 @@ def _poll_for_table(
     raise DataPlaneError("Timed out waiting for the query to finish")
 
 
-def _fetch_presigned_table(presigned_url: str) -> tuple["pa.Table", str, float]:
+def _fetch_presigned_table(presigned_url: str) -> _FetchedTable:
     """Download the frame object from the presigned URL — deliberately credential-free.
 
     The URL is its own short-lived authorization; the data-plane token must never reach
     the object-store host. Range-based resume of an interrupted download is deferred.
-    Returns the table, a truncated URL preview — never the full URL, which is a bearer
-    secret and must not travel beyond this fetch — and the download's wall time.
+    The reported source is a truncated preview, never the full URL, which is a bearer
+    secret and must not travel beyond this fetch.
     """
     if not presigned_url:
         raise DataPlaneError("Data plane redirect carried no download URL")
@@ -221,7 +255,12 @@ def _fetch_presigned_table(presigned_url: str) -> tuple["pa.Table", str, float]:
         # never from user input.
         # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
         with urllib.request.urlopen(request, timeout=_REQUEST_TIMEOUT_SECONDS) as response:
-            return _read_table(response), source_preview, time.monotonic() - started
+            return _FetchedTable(
+                table=_read_table(response),
+                source=source_preview,
+                download_s=time.monotonic() - started,
+                delivery=None,
+            )
     except urllib.error.HTTPError as exc:
         raise DataPlaneError(f"Frame download failed with HTTP {exc.code}") from exc
     except urllib.error.URLError as exc:

--- a/products/notebooks/backend/sandbox/kernel/executor.py
+++ b/products/notebooks/backend/sandbox/kernel/executor.py
@@ -189,6 +189,13 @@ class KernelExecutor:
                     download_s = materialized.download_s
                     if deliveries is not None and materialized.delivery:
                         deliveries.add(materialized.delivery)
+                except data_plane.DataPlaneError as exc:
+                    # Same reason the wait is accumulated below: a failed fetch is exactly the
+                    # one whose transport has to stay attributable, or the per-transport
+                    # failure ratio only ever counts successes.
+                    if deliveries is not None and exc.delivery:
+                        deliveries.add(exc.delivery)
+                    raise
                 finally:
                     # Accumulated even when the fetch raises — a run that died waiting on the
                     # data plane is exactly the one whose wait must stay visible.

--- a/products/notebooks/backend/sandbox/kernel/executor.py
+++ b/products/notebooks/backend/sandbox/kernel/executor.py
@@ -63,6 +63,9 @@ class KernelExecutor:
             # on the data plane still reports where its time went (the backend turns these
             # into the kernel-phase metrics).
             timings: dict[str, float] = {}
+            # Declared out here so the transport is still reported when the run dies after
+            # some inputs were already fetched, which is exactly when it explains the failure.
+            deliveries: set[str] = set()
             try:
                 boot_started = time.monotonic()
                 try:
@@ -72,7 +75,7 @@ class KernelExecutor:
                     # failure — shows up as its own phase instead of unattributed time.
                     timings["kernel_boot_s"] = round(time.monotonic() - boot_started, 3)
                 fetch_notes: list[str] = []
-                inputs = self._materialize_inputs(payload, cancel_event, fetch_notes, timings)
+                inputs = self._materialize_inputs(payload, cancel_event, fetch_notes, timings, deliveries)
                 exec_started = time.monotonic()
                 result = self._invoke_run_node(payload, inputs)
                 timings["exec_s"] = round(time.monotonic() - exec_started, 3)
@@ -88,6 +91,12 @@ class KernelExecutor:
                 result = envelope.from_python_execution(status="error", error=f"Kernel run failed: {exc}")
             if timings:
                 result["timings"] = {**timings, **(result.get("timings") or {})}
+            if deliveries:
+                # A run reading several ClickHouse-backed frames normally gets one transport
+                # for all of them, since the same gates decide every fetch. Reporting the
+                # disagreement rather than picking a winner keeps the metric label honest
+                # when a fallback fires partway through.
+                result["delivery"] = deliveries.pop() if len(deliveries) == 1 else "mixed"
             return result
 
     def interrupt(self) -> None:
@@ -141,6 +150,7 @@ class KernelExecutor:
         cancel_event: threading.Event | None = None,
         fetch_notes: list[str] | None = None,
         timings: dict[str, float] | None = None,
+        deliveries: set[str] | None = None,
     ) -> list[dict[str, Any]]:
         """Fetch each HogQL input to a local Arrow file; return the kernel-facing input specs (paths only).
 
@@ -167,7 +177,7 @@ class KernelExecutor:
                 self._evict_superseded_frames(node_token, keep=frame_path)
                 wait_started = time.monotonic()
                 try:
-                    _row_count, fetched_from, download_s = data_plane.materialize_query_to_file(
+                    materialized = data_plane.materialize_query_to_file(
                         payload["data_plane_url"],
                         payload["data_plane_token"],
                         spec["query"],
@@ -175,6 +185,10 @@ class KernelExecutor:
                         limit=_MATERIALIZE_ROW_CAP,
                         cancel_event=cancel_event,
                     )
+                    fetched_from = materialized.source
+                    download_s = materialized.download_s
+                    if deliveries is not None and materialized.delivery:
+                        deliveries.add(materialized.delivery)
                 finally:
                     # Accumulated even when the fetch raises — a run that died waiting on the
                     # data plane is exactly the one whose wait must stay visible.

--- a/products/notebooks/backend/sql_v2.py
+++ b/products/notebooks/backend/sql_v2.py
@@ -33,6 +33,19 @@ logger = structlog.get_logger(__name__)
 REVAMPED_PY_NOTEBOOKS_FLAG = "revamped-py-notebooks"
 NOTEBOOKS_FRAME_STORE_FLAG = "notebooks-frame-store"
 
+# How a run's result rows reached whoever consumes them. The data plane resolves this at
+# the moment it picks a transport and reports it in the 202 accept body; the sandbox echoes
+# it back in the envelope without interpreting it, and `sql_v2_metrics` turns it into a
+# metric label. Because the value crosses the sandbox boundary, where user code can forge
+# an envelope, `sql_v2_metrics.DELIVERY_LABEL_VALUES` is the allowlist that bounds label
+# cardinality; add any new mode to both places.
+DELIVERY_DIRECT = "direct"  # direct lane: ClickHouse to Redis to the UI, no sandbox involved
+DELIVERY_INLINE = "inline"  # sandbox fetch over the inline (Redis) transport, clamped at the async row ceiling
+DELIVERY_OBJECT_RELAY = "object_relay"  # a Temporal worker streams ClickHouse rows to object storage
+DELIVERY_OBJECT_CH_WRITES = "object_ch_writes"  # ClickHouse writes the object itself via INSERT INTO FUNCTION s3
+DELIVERY_NONE = "none"  # kernel run that read no ClickHouse result, so no transport was involved
+DELIVERY_MIXED = "mixed"  # one run materialized several inputs and they did not agree on a transport
+
 _CALLBACK_TOKEN_SALT = "notebooks.sql_v2.callback"
 _CALLBACK_TOKEN_MAX_AGE_SECONDS = 3600
 _DATA_PLANE_TOKEN_SALT = "notebooks.sql_v2.data_plane"

--- a/products/notebooks/backend/sql_v2_data_plane.py
+++ b/products/notebooks/backend/sql_v2_data_plane.py
@@ -36,7 +36,12 @@ from posthog.models import Team, User
 
 from products.notebooks.backend import frame_store
 from products.notebooks.backend.models import Notebook
-from products.notebooks.backend.sql_v2 import is_frame_store_enabled, verify_data_plane_token
+from products.notebooks.backend.sql_v2 import (
+    DELIVERY_INLINE,
+    DELIVERY_OBJECT_RELAY,
+    is_frame_store_enabled,
+    verify_data_plane_token,
+)
 from products.notebooks.backend.sql_v2_direct import apply_page_bounds
 from products.notebooks.backend.sql_v2_serializers import NotebookSQLV2DataPlaneRequestSerializer
 
@@ -173,7 +178,7 @@ def notebook_sql_v2_data_plane(request: HttpRequest) -> HttpResponse:
             except Exception:
                 logger.exception("notebook_frame_materialize_enqueue_failed", notebook_short_id=notebook_short_id)
                 return JsonResponse({"error": "Query could not be scheduled."}, status=500)
-            return JsonResponse({"query_id": status.id}, status=202)
+            return JsonResponse({"query_id": status.id, "delivery": DELIVERY_OBJECT_RELAY}, status=202)
         if frame_store_configured:
             # The environment is provisioned but this user is outside the rollout, which is
             # the expected state for most users while the flag ramps. Counted, not logged:
@@ -205,7 +210,9 @@ def notebook_sql_v2_data_plane(request: HttpRequest) -> HttpResponse:
         logger.exception("notebook_sql_v2_data_plane_enqueue_failed", notebook_short_id=notebook_short_id)
         return JsonResponse({"error": "Query could not be scheduled."}, status=500)
 
-    return JsonResponse({"query_id": status.id}, status=202)
+    # Reached either because the caller wanted inline delivery or because an object request
+    # fell through the two gates above, so this is also the honest label for a fallback.
+    return JsonResponse({"query_id": status.id, "delivery": DELIVERY_INLINE}, status=202)
 
 
 @extend_schema(

--- a/products/notebooks/backend/sql_v2_direct.py
+++ b/products/notebooks/backend/sql_v2_direct.py
@@ -35,7 +35,7 @@ from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 
 from products.notebooks.backend.models import NotebookNodeRun
 from products.notebooks.backend.sandbox.kernel import envelope as kernel_envelope
-from products.notebooks.backend.sql_v2 import DISPLAY_PAGE_LIMIT, RESULT_CACHE_ROWS
+from products.notebooks.backend.sql_v2 import DELIVERY_DIRECT, DISPLAY_PAGE_LIMIT, RESULT_CACHE_ROWS
 from products.notebooks.backend.sql_v2_metrics import OUTCOME_TIMED_OUT
 from products.notebooks.backend.sql_v2_runs import finish_node_run
 
@@ -309,6 +309,10 @@ def sync_direct_run(run: NotebookNodeRun) -> list[list[Any]] | None:
         timings = _query_status_timings(status)
         if timings:
             envelope["timings"] = timings
+        # The direct lane never involves the sandbox or the frame store, so labeling it
+        # keeps those runs out of the inline bucket they would otherwise fall into and makes
+        # a transport comparison count only the runs a transport choice applies to.
+        envelope["delivery"] = DELIVERY_DIRECT
         finish_node_run(run, NotebookNodeRun.Status.DONE, envelope=envelope, error=None)
         # Lost transitions land here too (an interrupt, or another poller); the
         # refreshed row's status decides whether the rows may be served.

--- a/products/notebooks/backend/sql_v2_metrics.py
+++ b/products/notebooks/backend/sql_v2_metrics.py
@@ -9,6 +9,12 @@ measures end-to-end duration against the run row's ``created_at``
 - its OTLP twin (the PostHog Metrics product),
 - a ``notebook node run completed`` event (product analytics, sliceable per notebook).
 
+Every sink also carries ``delivery``: which transport served the run's rows
+(``direct`` / ``inline`` / ``object_relay`` / ``object_ch_writes`` / ``none`` / ``mixed``).
+The data plane resolves it when it picks a transport, so it reflects what actually
+happened rather than what the flags asked for, which makes a fallback visible instead of
+silently landing in the wrong bucket. This is the dimension a transport A/B splits on.
+
 Runs additionally carry phase timings in the envelope's ``timings`` dict. Kernel runs
 report them from the sandbox (``sandbox/kernel/runner.py``): ``input_wait_s`` (waiting on
 the data plane for referenced frames or the display fetch), ``download_s`` (the presigned
@@ -33,6 +39,14 @@ from posthog.models import Team
 from posthog.otel_metrics import OtelInstrumentFactory
 
 from products.notebooks.backend.models import NotebookNodeRun
+from products.notebooks.backend.sql_v2 import (
+    DELIVERY_DIRECT,
+    DELIVERY_INLINE,
+    DELIVERY_MIXED,
+    DELIVERY_NONE,
+    DELIVERY_OBJECT_CH_WRITES,
+    DELIVERY_OBJECT_RELAY,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -69,12 +83,27 @@ _PHASE_BY_TIMING_KEY = {
 # the run's real wall clock.
 _TIMING_CLOCK_SLACK_SECONDS = 60.0
 
+# The envelope's `delivery` reaches us through the sandbox, where user code can forge it, so
+# only these values may become a label. Anything else collapses to DELIVERY_NONE rather than
+# minting a new time series per forged string. Keep in sync with the DELIVERY_* constants in
+# sql_v2.py when a transport is added.
+DELIVERY_LABEL_VALUES = frozenset(
+    {
+        DELIVERY_DIRECT,
+        DELIVERY_INLINE,
+        DELIVERY_OBJECT_RELAY,
+        DELIVERY_OBJECT_CH_WRITES,
+        DELIVERY_NONE,
+        DELIVERY_MIXED,
+    }
+)
+
 _otel = OtelInstrumentFactory("notebooks")
 
 NODE_RUN_SECONDS = Histogram(
     "posthog_notebooks_node_run_seconds",
     "End-to-end notebook node run duration: run-row creation to its terminal transition.",
-    labelnames=["node_type", "outcome"],
+    labelnames=["node_type", "outcome", "delivery"],
     buckets=[0.5, 1, 2, 5, 10, 30, 60, 120, 300, 600, 1200, 1800, 2700],
 )
 NODE_RUN_PHASE_SECONDS = Histogram(
@@ -97,15 +126,17 @@ def record_node_run_terminal(run: NotebookNodeRun, outcome: str) -> None:
     """
     try:
         duration = max((timezone.now() - run.created_at).total_seconds(), 0.0)
-        NODE_RUN_SECONDS.labels(node_type=run.node_type, outcome=outcome).observe(duration)
-        _otel.record_histogram_twin(NODE_RUN_SECONDS, duration, {"node_type": run.node_type, "outcome": outcome})
+        delivery = _sanitized_delivery(run.envelope)
+        run_labels = {"node_type": run.node_type, "outcome": outcome, "delivery": delivery}
+        NODE_RUN_SECONDS.labels(**run_labels).observe(duration)
+        _otel.record_histogram_twin(NODE_RUN_SECONDS, duration, run_labels)
 
         timings = _sanitized_timings(run.envelope, max_seconds=duration + _TIMING_CLOCK_SLACK_SECONDS)
         for phase, seconds in timings.items():
             NODE_RUN_PHASE_SECONDS.labels(phase=phase, node_type=run.node_type).observe(seconds)
             _otel.record_histogram_twin(NODE_RUN_PHASE_SECONDS, seconds, {"phase": phase, "node_type": run.node_type})
 
-        _capture_completed_event(run, outcome, duration, timings)
+        _capture_completed_event(run, outcome, duration, timings, delivery)
     except Exception:
         logger.exception("notebook_node_run_metrics_failed", run_id=str(run.id), outcome=outcome)
 
@@ -128,17 +159,30 @@ def _sanitized_timings(envelope: Any, max_seconds: float) -> dict[str, float]:
     }
 
 
+def _sanitized_delivery(envelope: Any) -> str:
+    """Resolve the transport that served this run's rows, bounded to the known modes.
+
+    A kernel run that read no ClickHouse-backed frame reports nothing, which is
+    DELIVERY_NONE rather than a missing label: a run with no transport is a real bucket,
+    and it must not be averaged in with the runs a transport comparison is about.
+    """
+    reported = envelope.get("delivery") if isinstance(envelope, dict) else None
+    return reported if reported in DELIVERY_LABEL_VALUES else DELIVERY_NONE
+
+
 def _capture_completed_event(
     run: NotebookNodeRun,
     outcome: str,
     duration: float,
     timings: dict[str, float],
+    delivery: str,
 ) -> None:
     envelope = run.envelope if isinstance(run.envelope, dict) else {}
     properties: dict[str, Any] = {
         "notebook_short_id": run.notebook.short_id,
         "node_type": run.node_type,
         "outcome": outcome,
+        "delivery": delivery,
         "duration_seconds": round(duration, 3),
         "row_count": envelope.get("row_count"),
         "has_error": bool(run.error),

--- a/products/notebooks/backend/sql_v2_observability.md
+++ b/products/notebooks/backend/sql_v2_observability.md
@@ -5,8 +5,9 @@ Companion to [`sql_v2_frame_store.md`](./sql_v2_frame_store.md) — that doc dec
 
 Artifacts:
 
-- [`observability/notebooks-rollout.grafana.json`](../observability/notebooks-rollout.grafana.json) — importable Grafana dashboard (Prometheus/VictoriaMetrics).
-- [`observability/notebooks-query-log.sql`](../observability/notebooks-query-log.sql) — `query_log_archive` query pack (ClickHouse per-query cost).
+- [`observability/notebooks-rollout.grafana.json`](../observability/notebooks-rollout.grafana.json) — importable Grafana dashboard (Prometheus/VictoriaMetrics). Its "Transport A/B" row is the flag-on vs flag-off comparison.
+- [`observability/notebooks-query-log.sql`](../observability/notebooks-query-log.sql) — `query_log_archive` query pack (ClickHouse per-query cost). SQL 9 is the same comparison on the ClickHouse side.
+- Notebook `Vs0Gjpqb` in project 2 ("SQLV2 transport benchmark") — the graduated workload to run under each arm.
 
 ## The split: two surfaces, and why
 
@@ -39,18 +40,20 @@ The dashboard uses the `_total` names; the source code does not have them.
 
 ## Coverage against what you asked for
 
-| Want                              | Where                                                                                               | State                                                           |
-| --------------------------------- | --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| Notebook request E2E latency      | `posthog_notebooks_node_run_seconds{node_type,outcome}` + `notebook node run completed` event       | Covered — see "Node-run instrumentation" below                  |
-| CH latency for notebook queries   | `query_log_archive.query_duration_ms` (SQL 1)                                                       | Covered                                                         |
-| CH scanned bytes                  | `query_log_archive.read_bytes` (SQL 1, 6)                                                           | Covered                                                         |
-| CH bytes returned                 | `result_bytes` / `WriteBufferFromS3Bytes` (SQL 4)                                                   | Covered, but mode-dependent — see below                         |
-| CH rows returned                  | `result_rows` / `written_rows` (SQL 4)                                                              | Covered, mode-dependent                                         |
-| Overall CH health                 | Existing shared CH Grafana dashboards + SQL 8                                                       | Covered by platform; SQL 8 gives notebooks' share of offline    |
-| Throttled queries                 | `posthog_clickhouse_query_concurrency_limit_exceeded_total{limit_name=~"notebooks_materialize_.*"}` | Covered (rejections only)                                       |
-| Parallel queries per team         | Reconstructed from `query_log_archive` (SQL 5)                                                      | Covered by SQL; **no live gauge** — gap 3                       |
-| Parallel queries per user         | Same, group by `lc_user_id`                                                                         | Same                                                            |
-| Per-notebook / per-node breakdown | `NotebookNodeRun` in Postgres (gap 4)                                                               | Available in Postgres — runs, node type, status, rough duration |
+| Want                              | Where                                                                                                  | State                                                           |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
+| Notebook request E2E latency      | `posthog_notebooks_node_run_seconds{node_type,outcome,delivery}` + `notebook node run completed` event | Covered — see "Node-run instrumentation" below                  |
+| CH latency for notebook queries   | `query_log_archive.query_duration_ms` (SQL 1)                                                          | Covered                                                         |
+| CH scanned bytes                  | `query_log_archive.read_bytes` (SQL 1, 6)                                                              | Covered                                                         |
+| CH bytes returned                 | `result_bytes` / `WriteBufferFromS3Bytes` (SQL 4)                                                      | Covered, but mode-dependent — see below                         |
+| CH rows returned                  | `result_rows` / `written_rows` (SQL 4)                                                                 | Covered, mode-dependent                                         |
+| Overall CH health                 | Existing shared CH Grafana dashboards + SQL 8                                                          | Covered by platform; SQL 8 gives notebooks' share of offline    |
+| Throttled queries                 | `posthog_clickhouse_query_concurrency_limit_exceeded_total{limit_name=~"notebooks_materialize_.*"}`    | Covered (rejections only)                                       |
+| Parallel queries per team         | Reconstructed from `query_log_archive` (SQL 5)                                                         | Covered by SQL; **no live gauge** — gap 3                       |
+| Parallel queries per user         | Same, group by `lc_user_id`                                                                            | Same                                                            |
+| Per-notebook / per-node breakdown | `NotebookNodeRun` in Postgres (gap 4)                                                                  | Available in Postgres — runs, node type, status, rough duration |
+| E2E latency per transport         | `posthog_notebooks_node_run_seconds{delivery}` + the event's `delivery` property                       | Covered — see "The `delivery` dimension" below                  |
+| CH cost per transport             | `query_log_archive` split on `query_kind` (SQL 9)                                                      | Covered                                                         |
 
 "Bytes/rows returned" is mode-dependent and averaging the modes together is wrong:
 the streaming path returns a result set (`result_bytes`, `result_rows`), while the CH-writes path is an `INSERT` whose result set is empty and whose delivered bytes show up as `ProfileEvents['WriteBufferFromS3Bytes']` and `written_rows`.
@@ -61,11 +64,36 @@ The Prometheus `posthog_notebooks_frame_object_bytes` histogram is the mode-inde
 
 Every terminal transition of a `NotebookNodeRun` — the sandbox callback, the direct-lane finish, dispatch failures, and interrupts — reports once through `sql_v2_metrics.record_node_run_terminal`, emitting three sinks:
 
-- **`posthog_notebooks_node_run_seconds{node_type,outcome}`** — end-to-end duration, run-row `created_at` to the terminal transition. `outcome` is `done` / `failed` / `interrupted` / `timed_out`; the direct lane's grace-expiry watchdog reports `timed_out`, so an expired query is a bucket, not a user error.
+- **`posthog_notebooks_node_run_seconds{node_type,outcome,delivery}`** — end-to-end duration, run-row `created_at` to the terminal transition. `outcome` is `done` / `failed` / `interrupted` / `timed_out`; the direct lane's grace-expiry watchdog reports `timed_out`, so an expired query is a bucket, not a user error.
 - **`posthog_notebooks_node_run_phase_seconds{phase,node_type}`** — the decomposition, from the run envelope's `timings` dict. Sandbox-reported: `input_wait` (data-plane wait for referenced frames or the display fetch), `download` (presigned frame downloads), `exec` (ipykernel cell), `sandbox_total`. Direct lane, from `QueryStatus`: `queued` (enqueue → Celery pickup), `clickhouse` (pickup → completion).
-- **`notebook node run completed`** PostHog event with `duration_seconds`, the phase seconds, `row_count`, `outcome`, `notebook_short_id` — the per-notebook/per-team view Prometheus label cardinality can't hold.
+- **`notebook node run completed`** PostHog event with `duration_seconds`, the phase seconds, `row_count`, `outcome`, `delivery`, `notebook_short_id` — the per-notebook/per-team view Prometheus label cardinality can't hold.
 
 Both histograms also stream into the PostHog Metrics product via their OTLP twins (`posthog/otel_metrics.py`).
+
+### The `delivery` dimension
+
+`delivery` names the transport that actually served a run's rows, and it is what a transport A/B splits on:
+
+| Value              | Meaning                                                                            |
+| ------------------ | ---------------------------------------------------------------------------------- |
+| `direct`           | Direct lane: ClickHouse to Redis to the UI. The sandbox is never involved.         |
+| `inline`           | Sandbox fetch over the inline (Redis) transport, clamped at the async row ceiling. |
+| `object_relay`     | Phase 1: a Temporal worker streams ClickHouse rows to object storage.              |
+| `object_ch_writes` | Phase 2: ClickHouse writes the object itself via `INSERT INTO FUNCTION s3`.        |
+| `none`             | Kernel run that read no ClickHouse-backed frame, so no transport applied.          |
+| `mixed`            | One run materialized several inputs and they did not agree on a transport.         |
+
+The data plane resolves the value where it picks a transport (`sql_v2_data_plane.py`) and reports it in the 202 accept body; the sandbox echoes it into the envelope without interpreting it.
+That ordering matters: an object request that falls through either gate is labeled `inline`, so a silent fallback lands in the bucket it really used rather than the one the flags asked for.
+
+The value crosses the sandbox boundary, where user code can forge an envelope, so `sql_v2_metrics.DELIVERY_LABEL_VALUES` is the allowlist bounding label cardinality.
+Anything outside it collapses to `none`.
+Adding a transport means adding it in both `sql_v2.DELIVERY_*` and that allowlist.
+
+Two caveats when reading a comparison:
+
+- `direct` and `none` runs have no transport choice, so including them dilutes the split. The dashboard's A/B panels select `delivery=~"object_relay|object_ch_writes|inline"`.
+- The label describes delivery, not the ClickHouse write mode behind it. `query_log_archive.query_kind` (`Select` vs `Insert`) is the authoritative server-side split, and SQL 9 in the query pack uses it.
 
 One deliberate hole: the callback is best-effort, so a kernel-lane run whose sandbox dies without delivering stays RUNNING and contributes **no** sample — the row remains visible in Postgres and the node can be re-run. A periodic reaper that would fail such rows (and record them as `timed_out`) was built and dropped as more complexity than the case warrants; revisit if stranded rows become common.
 

--- a/products/notebooks/backend/test/test_sql_v2.py
+++ b/products/notebooks/backend/test/test_sql_v2.py
@@ -2338,10 +2338,10 @@ class TestSQLV2KernelPackage(SimpleTestCase):
                 patch.object(kernel_data_plane.urllib.request, "urlopen", side_effect=fake_urlopen),
                 patch.object(kernel_data_plane._no_redirect_opener, "open", side_effect=fake_poll_open),
             ):
-                rows, fetched_from, _download_s = kernel_data_plane.materialize_query_to_file(
+                materialized = kernel_data_plane.materialize_query_to_file(
                     "http://backend/dp", "secret-token", "select 1", dest, limit=1000
                 )
-            self.assertEqual(rows, 2)
+            self.assertEqual(materialized.row_count, 2)
             self.assertEqual(pa.ipc.open_file(pa.memory_map(dest)).read_all().num_rows, 2)
 
         (download,) = download_requests
@@ -2349,8 +2349,8 @@ class TestSQLV2KernelPackage(SimpleTestCase):
         self.assertFalse(download.has_header("Authorization"))
         # The surfaced source is a bearer secret truncated to a host-only preview: it must
         # never carry the signature query parameters.
-        self.assertEqual(fetched_from, presigned_url[:30])
-        self.assertNotIn("X-Amz-Signature", fetched_from or "")
+        self.assertEqual(materialized.source, presigned_url[:30])
+        self.assertNotIn("X-Amz-Signature", materialized.source or "")
 
     def test_tarball_contains_the_package(self):
         package, version = kernel_package_bytes_and_hash()
@@ -2389,11 +2389,11 @@ class TestSQLV2PythonNodeRun(SimpleTestCase):
                 "urlopen",
                 side_effect=lambda request, timeout=None: _FakeResponse(arrow_bytes),
             ):
-                rows, fetched_from, _download_s = kernel_data_plane.materialize_query_to_file(
+                materialized = kernel_data_plane.materialize_query_to_file(
                     "http://backend/dp", "t", "select 1", dest, limit=1000
                 )
-            self.assertEqual(rows, 2)
-            self.assertIsNone(fetched_from)  # inline body — no presigned source to surface
+            self.assertEqual(materialized.row_count, 2)
+            self.assertIsNone(materialized.source)  # inline body — no presigned source to surface
             table = pa.ipc.open_file(pa.memory_map(dest)).read_all()
             self.assertEqual(table.num_rows, 2)
             self.assertEqual(table.column_names, ["id", "v"])
@@ -2511,7 +2511,8 @@ class TestSQLV2NodeRunMetrics(APIBaseTest):
     def test_callback_reports_the_run_with_its_outcome(self, envelope_status, expected_outcome, mock_report):
         run = self._create_run()
         token = mint_callback_token(str(run.id), self.team.id)
-        before = self._histogram_count({"node_type": "hogql", "outcome": expected_outcome})
+        labels = {"node_type": "hogql", "outcome": expected_outcome, "delivery": "object_relay"}
+        before = self._histogram_count(labels)
         response = self.client.post(
             f"/internal/notebooks/runs/{run.id}/result/",
             data=json.dumps(
@@ -2519,6 +2520,7 @@ class TestSQLV2NodeRunMetrics(APIBaseTest):
                     "envelope": {
                         "status": envelope_status,
                         "row_count": 3,
+                        "delivery": "object_relay",
                         "timings": {"input_wait_s": 1.5, "exec_s": 0.4, "sandbox_total_s": 2.0},
                     }
                 }
@@ -2534,13 +2536,14 @@ class TestSQLV2NodeRunMetrics(APIBaseTest):
         self.assertEqual(properties["notebook_short_id"], "nbmet01")
         self.assertEqual(properties["node_type"], "hogql")
         self.assertEqual(properties["row_count"], 3)
+        self.assertEqual(properties["delivery"], "object_relay")
         self.assertEqual(properties["input_wait_seconds"], 1.5)
         self.assertEqual(properties["exec_seconds"], 0.4)
         self.assertEqual(properties["sandbox_total_seconds"], 2.0)
         self.assertGreaterEqual(properties["duration_seconds"], 0)
         # $groups must come from the run's own team, not the user's currently active project.
         self.assertEqual(mock_report.call_args.kwargs["team"].id, self.team.id)
-        after = self._histogram_count({"node_type": "hogql", "outcome": expected_outcome})
+        after = self._histogram_count(labels)
         self.assertEqual(after, before + 1)
 
     @patch("products.notebooks.backend.sql_v2_metrics.report_user_or_team_action")
@@ -2671,6 +2674,30 @@ class TestSQLV2NodeRunMetrics(APIBaseTest):
         self.assertEqual(run.status, NotebookNodeRun.Status.DONE)
         properties = mock_report.call_args[0][1]
         self.assertNotIn("exec_seconds", properties)
+
+    @parameterized.expand(
+        [
+            ("forged_string", "'; drop--"),
+            ("unknown_mode", "object_something_new"),
+            ("not_a_string", 17),
+        ]
+    )
+    @patch("products.notebooks.backend.sql_v2_metrics.report_user_or_team_action")
+    def test_an_unrecognized_delivery_never_becomes_a_metric_label(self, _name, delivery, mock_report):
+        # The envelope is built inside the sandbox, where user code can forge it, and
+        # `delivery` becomes a Prometheus label. Anything outside the known transports must
+        # collapse to "none" rather than minting a new time series per forged value.
+        run = self._create_run()
+        token = mint_callback_token(str(run.id), self.team.id)
+        response = self.client.post(
+            f"/internal/notebooks/runs/{run.id}/result/",
+            data=json.dumps({"envelope": {"status": "ok", "delivery": delivery}}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(mock_report.call_args[0][1]["delivery"], "none")
+        self.assertEqual(self._histogram_count({"node_type": "hogql", "outcome": "done", "delivery": delivery}), 0.0)
 
     @patch("products.notebooks.backend.sql_v2_metrics.report_user_or_team_action")
     def test_completed_event_survives_a_hard_deleted_user(self, mock_report):

--- a/products/notebooks/backend/test/test_sql_v2.py
+++ b/products/notebooks/backend/test/test_sql_v2.py
@@ -1,10 +1,13 @@
 import io
+import os
 import json
 import math
 import tarfile
 import datetime
+import tempfile
 import threading
 import urllib.error
+import email.message
 import urllib.request
 from http.server import ThreadingHTTPServer
 from types import SimpleNamespace
@@ -2351,6 +2354,55 @@ class TestSQLV2KernelPackage(SimpleTestCase):
         # never carry the signature query parameters.
         self.assertEqual(materialized.source, presigned_url[:30])
         self.assertNotIn("X-Amz-Signature", materialized.source or "")
+
+    def test_a_failure_after_the_accept_keeps_the_transport_it_was_served_by(self):
+        # The transport is only known from the accept body, and everything below the poll
+        # raises without it. If the failure path drops it, every failed run is recorded as
+        # delivery="none" and the per-transport failure ratio only ever counts successes.
+        from products.notebooks.backend.sandbox.kernel import data_plane as kernel_data_plane
+
+        class _FakeResponse(io.BytesIO):
+            def __init__(self, content_type: str, body: bytes):
+                super().__init__(body)
+                self.headers = {"Content-Type": content_type}
+
+            def __exit__(self, *args):
+                return False
+
+        def fake_urlopen(request, timeout=None):
+            return _FakeResponse("application/json", b'{"query_id": "q1", "delivery": "object_relay"}')
+
+        def fake_poll_open(request, timeout=None):
+            raise urllib.error.HTTPError(request.full_url, 500, "Boom", email.message.Message(), None)
+
+        with (
+            patch.object(kernel_data_plane.urllib.request, "urlopen", side_effect=fake_urlopen),
+            patch.object(kernel_data_plane._no_redirect_opener, "open", side_effect=fake_poll_open),
+            tempfile.TemporaryDirectory() as directory,
+        ):
+            with self.assertRaises(kernel_data_plane.DataPlaneError) as caught:
+                kernel_data_plane.materialize_query_to_file(
+                    "http://backend/dp", "t", "select 1", os.path.join(directory, "df.arrow"), limit=1000
+                )
+        self.assertEqual(caught.exception.delivery, "object_relay")
+
+    def test_a_failure_before_the_accept_has_no_transport_to_report(self):
+        # Nothing chose a transport yet, so the run belongs in the unlabeled bucket rather
+        # than being attributed to whichever transport it would have used.
+        from products.notebooks.backend.sandbox.kernel import data_plane as kernel_data_plane
+
+        def fake_urlopen(request, timeout=None):
+            raise urllib.error.HTTPError(request.full_url, 400, "Bad query", email.message.Message(), None)
+
+        with (
+            patch.object(kernel_data_plane.urllib.request, "urlopen", side_effect=fake_urlopen),
+            tempfile.TemporaryDirectory() as directory,
+        ):
+            with self.assertRaises(kernel_data_plane.DataPlaneError) as caught:
+                kernel_data_plane.materialize_query_to_file(
+                    "http://backend/dp", "t", "select 1", os.path.join(directory, "df.arrow"), limit=1000
+                )
+        self.assertIsNone(caught.exception.delivery)
 
     def test_tarball_contains_the_package(self):
         package, version = kernel_package_bytes_and_hash()

--- a/products/notebooks/observability/notebooks-query-log.sql
+++ b/products/notebooks/observability/notebooks-query-log.sql
@@ -238,3 +238,48 @@ WHERE event_date >= today() - 3
   AND is_initial_query
 GROUP BY hour, bucket
 ORDER BY hour, bucket;
+
+
+-- ---------------------------------------------------------------------------
+-- 9. Transport A/B: worker relay (phase 1) vs ClickHouse writing S3 itself
+--    (phase 2), on identical work.
+--
+--    `query_kind` is the discriminator and needs no new instrumentation: the relay
+--    is a Select whose rows stream back through a worker, the CH-writes path is an
+--    `INSERT INTO FUNCTION s3(...)` that returns no result set.
+--
+--    That difference is also why the delivered-size columns differ per mode, and why
+--    averaging the two together is wrong. A Select reports what it handed back in
+--    `result_bytes`/`result_rows`; an Insert leaves both at zero and reports what it
+--    pushed to S3 in `WriteBufferFromS3Bytes`/`written_rows`. `delivered_*` below
+--    coalesces the pair so one column is comparable across modes.
+--
+--    Read `scanned` as the control: the two modes run the same user query, so a
+--    materially different scan between them means the arms are not comparable
+--    (different date ranges, or ClickHouse cache state) and the latency delta is
+--    not yet evidence.
+-- ---------------------------------------------------------------------------
+SELECT
+    if(query_kind = 'Insert', 'ch_writes', 'worker_relay')      AS mode,
+    count()                                                     AS queries,
+    round(quantile(0.5)(query_duration_ms))                     AS p50_ms,
+    round(quantile(0.95)(query_duration_ms))                    AS p95_ms,
+    formatReadableSize(quantile(0.5)(read_bytes))               AS p50_scanned,
+    formatReadableSize(
+        quantile(0.5)(
+            if(query_kind = 'Insert',
+               ProfileEvents['WriteBufferFromS3Bytes'],
+               result_bytes)
+        )
+    )                                                           AS p50_delivered_bytes,
+    round(quantile(0.5)(
+        if(query_kind = 'Insert', written_rows, result_rows)
+    ))                                                          AS p50_delivered_rows,
+    round(quantile(0.95)(memory_usage) / 1e6)                   AS p95_memory_mb,
+    countIf(exception_code != 0)                                AS failures
+FROM query_log_archive
+WHERE event_date >= today() - 1
+  AND lc_product = 'notebooks'
+  AND is_initial_query
+GROUP BY mode
+ORDER BY mode;

--- a/products/notebooks/observability/notebooks-query-log.sql
+++ b/products/notebooks/observability/notebooks-query-log.sql
@@ -248,6 +248,14 @@ ORDER BY hour, bucket;
 --    is a Select whose rows stream back through a worker, the CH-writes path is an
 --    `INSERT INTO FUNCTION s3(...)` that returns no result set.
 --
+--    `query_kind` alone is not enough to scope the arms, though. `lc_product =
+--    'notebooks'` also covers the direct lane (`sql_v2_direct.py`) and the data
+--    plane's inline transport, and both of those are Selects too. Without the
+--    workflow filter below they all land in the worker-relay arm and corrupt its
+--    counts, latency, and scan size. Only the materialize activity runs under
+--    `notebook-frame-materialize`, so that filter is what makes the two arms
+--    comparable rather than one arm plus everything else.
+--
 --    That difference is also why the delivered-size columns differ per mode, and why
 --    averaging the two together is wrong. A Select reports what it handed back in
 --    `result_bytes`/`result_rows`; an Insert leaves both at zero and reports what it
@@ -281,5 +289,6 @@ FROM query_log_archive
 WHERE event_date >= today() - 1
   AND lc_product = 'notebooks'
   AND is_initial_query
+  AND lc_temporal__workflow_type = 'notebook-frame-materialize'
 GROUP BY mode
 ORDER BY mode;

--- a/products/notebooks/observability/notebooks-rollout.grafana.json
+++ b/products/notebooks/observability/notebooks-rollout.grafana.json
@@ -124,12 +124,111 @@
         },
         {
             "type": "row",
-            "title": "Rollout state \u2014 is the new path actually engaged?",
+            "title": "Transport A/B \u2014 worker relay vs ClickHouse writes",
+            "collapsed": false,
             "gridPos": {
                 "h": 1,
                 "w": 24,
                 "x": 0,
                 "y": 9
+            },
+            "panels": []
+        },
+        {
+            "type": "timeseries",
+            "title": "End-to-end run duration by transport",
+            "description": "The headline A/B: what a user waits, split by the transport that actually served the run's rows. `delivery` is resolved where the data plane picks a transport, so a fallback lands in the bucket it really used, not the one the flags asked for. `direct` and `none` runs are excluded because no transport choice applies to them.",
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 10
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "s"
+                }
+            },
+            "targets": [
+                {
+                    "refId": "A",
+                    "expr": "histogram_quantile(0.95, sum by (le, delivery) (rate(posthog_notebooks_node_run_seconds_bucket{delivery=~\"object_relay|object_ch_writes|inline\"}[$__rate_interval])))",
+                    "legendFormat": "p95 {{delivery}}"
+                },
+                {
+                    "refId": "B",
+                    "expr": "histogram_quantile(0.50, sum by (le, delivery) (rate(posthog_notebooks_node_run_seconds_bucket{delivery=~\"object_relay|object_ch_writes|inline\"}[$__rate_interval])))",
+                    "legendFormat": "p50 {{delivery}}"
+                }
+            ]
+        },
+        {
+            "type": "timeseries",
+            "title": "Runs per transport \u2014 is each arm actually running?",
+            "description": "Read this before trusting the latency panel. A flat line on one transport means that arm produced no runs, so its percentiles are stale or empty rather than fast. This is also where a silent fallback shows up: object runs collapsing into `inline` while the flag is on means the deployment gate failed, not that the new path is slow.",
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 10
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "reqps"
+                }
+            },
+            "targets": [
+                {
+                    "refId": "A",
+                    "expr": "sum by (delivery) (rate(posthog_notebooks_node_run_seconds_count{delivery=~\"object_relay|object_ch_writes|inline\"}[$__rate_interval]))",
+                    "legendFormat": "{{delivery}}"
+                }
+            ]
+        },
+        {
+            "type": "timeseries",
+            "title": "Failure ratio by transport",
+            "description": "A transport that returns faster while failing more is not faster. Any outcome other than `done` counts, so a materialization dying at its deadline shows up here as well as in the success-only frame histograms further down.",
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 18
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "unit": "percentunit",
+                    "min": 0
+                }
+            },
+            "targets": [
+                {
+                    "refId": "A",
+                    "expr": "sum by (delivery) (rate(posthog_notebooks_node_run_seconds_count{delivery=~\"object_relay|object_ch_writes|inline\",outcome!=\"done\"}[$__rate_interval])) / clamp_min(sum by (delivery) (rate(posthog_notebooks_node_run_seconds_count{delivery=~\"object_relay|object_ch_writes|inline\"}[$__rate_interval])), 1e-9)",
+                    "legendFormat": "{{delivery}}"
+                }
+            ]
+        },
+        {
+            "type": "row",
+            "title": "Rollout state \u2014 is the new path actually engaged?",
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 26
             },
             "collapsed": false
         },
@@ -145,7 +244,7 @@
                 "h": 8,
                 "w": 8,
                 "x": 0,
-                "y": 10
+                "y": 27
             },
             "fieldConfig": {
                 "defaults": {
@@ -167,7 +266,7 @@
                 "h": 8,
                 "w": 8,
                 "x": 8,
-                "y": 10
+                "y": 27
             },
             "options": {
                 "mode": "markdown",
@@ -186,7 +285,7 @@
                 "h": 8,
                 "w": 8,
                 "x": 16,
-                "y": 10
+                "y": 27
             },
             "fieldConfig": {
                 "defaults": {
@@ -224,7 +323,7 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 18
+                "y": 35
             },
             "collapsed": false
         },
@@ -239,7 +338,7 @@
                 "h": 8,
                 "w": 8,
                 "x": 0,
-                "y": 19
+                "y": 36
             },
             "fieldConfig": {
                 "defaults": {
@@ -267,7 +366,7 @@
                 "h": 8,
                 "w": 4,
                 "x": 8,
-                "y": 19
+                "y": 36
             },
             "fieldConfig": {
                 "defaults": {
@@ -311,7 +410,7 @@
                 "h": 8,
                 "w": 4,
                 "x": 12,
-                "y": 19
+                "y": 36
             },
             "fieldConfig": {
                 "defaults": {
@@ -356,7 +455,7 @@
                 "h": 8,
                 "w": 8,
                 "x": 16,
-                "y": 19
+                "y": 36
             },
             "fieldConfig": {
                 "defaults": {
@@ -378,7 +477,7 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 27
+                "y": 44
             },
             "collapsed": false
         },
@@ -394,7 +493,7 @@
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 28
+                "y": 45
             },
             "fieldConfig": {
                 "defaults": {
@@ -431,7 +530,7 @@
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 28
+                "y": 45
             },
             "fieldConfig": {
                 "defaults": {
@@ -458,7 +557,7 @@
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 36
+                "y": 53
             },
             "fieldConfig": {
                 "defaults": {
@@ -490,7 +589,7 @@
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 36
+                "y": 53
             },
             "fieldConfig": {
                 "defaults": {
@@ -522,7 +621,7 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 44
+                "y": 61
             },
             "collapsed": false
         },
@@ -538,7 +637,7 @@
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 45
+                "y": 62
             },
             "fieldConfig": {
                 "defaults": {
@@ -565,7 +664,7 @@
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 45
+                "y": 62
             },
             "fieldConfig": {
                 "defaults": {
@@ -587,7 +686,7 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 53
+                "y": 70
             },
             "collapsed": false
         },
@@ -603,7 +702,7 @@
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 54
+                "y": 71
             },
             "fieldConfig": {
                 "defaults": {
@@ -630,7 +729,7 @@
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 54
+                "y": 71
             },
             "fieldConfig": {
                 "defaults": {
@@ -656,7 +755,7 @@
                 "h": 8,
                 "w": 24,
                 "x": 0,
-                "y": 62
+                "y": 79
             },
             "fieldConfig": {
                 "defaults": {


### PR DESCRIPTION
## Problem

Anyone rolling out a change to how notebook results reach the sandbox cannot tell whether it helped, because every run's latency lands in one undifferentiated bucket.

- `posthog_notebooks_node_run_seconds` carries `node_type` and `outcome` only.
- The `notebook node run completed` event carries no transport either.
- `posthog_notebooks_frame_store_fallback_inline` counts fallbacks, but does not join to a run.

The next step in the frame store plan replaces the worker relay with ClickHouse writing S3 directly. Both paths deliver an object, so neither the histogram nor the event can separate them today.

## Changes

- Runs now report `delivery`: `direct`, `inline`, `object_relay`, `object_ch_writes`, `none`, or `mixed`.
- The histogram, its OTLP twin, and the event all carry it, so Grafana and product analytics split on the same dimension.
- The data plane resolves the value where it picks a transport, not from the flags. An object request that falls through either gate reports `inline`, so a silent fallback lands in the bucket it really used.
- The sandbox echoes the value into the envelope without interpreting it. A new server-side transport needs no sandbox release to be reported.
- `sql_v2_metrics.DELIVERY_LABEL_VALUES` bounds the label. The envelope crosses a boundary where user code can forge it, so an unknown value collapses to `none` rather than minting a time series.
- `object_ch_writes` is declared and allowlisted but nothing sets it yet. Landing it now means the first CH-writes run is measured instead of swallowed as `none`.
- `materialize_query_to_file` returns a frozen dataclass. Its tuple reached four elements, two of which are strings.
- Adds a "Transport A/B" row to the Grafana dashboard and query 9 to the `query_log_archive` pack, which splits ClickHouse cost on `query_kind`.

> [!NOTE]
> Adding a label changes the metric's series. Existing queries that do not select on `delivery` keep working; anything pinned to an exact label set needs updating.

No UI changes, so no screenshots.

## How did you test this code?

I (actually Claude) wrote this change. Tests I ran locally:

- `products/notebooks/backend/test/test_sql_v2.py`, and `uv run mypy --cache-fine-grained .` repo-wide.
- `test_object_delivery_redirects_to_a_team_scoped_presigned_frame` fails on this branch and on an unmodified master checkout alike. It downloads from object storage, which this machine cannot reach.

New tests: `test_an_unrecognized_delivery_never_becomes_a_metric_label` covers three forged envelope values. It catches a loosened allowlist letting sandbox-supplied strings become Prometheus labels. The existing `test_malformed_envelope_timings_never_strand_the_run` covers the timings field only, so nothing guarded `delivery`.

Not checked: no run exercised `object_ch_writes`, because no code produces it yet. I did not verify the Grafana JSON against a live Grafana, only that it parses and that its panel grid does not overlap.

I ran the graduated benchmark notebook against production with the frame store on. A first pass suggests the wait is dominated by fixed dispatch overhead rather than result size, which is the thing the CH-writes path should be measured against. That notebook lives in PostHog, not in this diff.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`sql_v2_observability.md` gains a section on the dimension, its values, and the two caveats when reading a comparison.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I am Claude Opus 5, working in Claude Code. Skills invoked: `/writing-code-comments`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.

The session started as a debugging question about notebook dataframes and moved to instrumenting the transport rollout. Two designs were rejected before this one. Stamping the intended transport on the run row at dispatch was simpler but would have labeled a fallback by what the flags asked for rather than what happened. Reading the delivery from the sandbox alone could not tell the relay apart from CH writes, since both arrive as a presigned download. Returning the resolved value in the accept body keeps the sandbox ignorant of the taxonomy and the label honest about fallbacks.

Nothing here draws on non-public material. The benchmark queries are synthetic or plain event aggregates.
