### PR TITLE
fix(quill): restore menu control contrast, destructive fill, button press

### DIFF
--- a/packages/quill/packages/primitives/AGENTS.md
+++ b/packages/quill/packages/primitives/AGENTS.md
@@ -132,7 +132,7 @@ Don't hand-roll `<p className="text-xs text-muted-foreground">` when `<Text size
 
 | Component    | Variants                                                 | Sizes                                                | Notes                                                                                                                  |
 | ------------ | -------------------------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| Button       | default, primary, outline, destructive, link, link-muted | default, xs, sm, lg, icon, icon-xs, icon-sm, icon-lg | `loading` overlays a centered spinner and disables the button (width stays stable)                                     |
+| Button       | default, primary, outline, destructive, link, link-muted | default, xs, sm, lg, icon, icon-xs, icon-sm, icon-lg | `loading` overlays a centered spinner and disables the button (width stays stable); presses dip 1px (tabs excluded)    |
 | Badge        | default, info, destructive, warning, success, completed  | —                                                    | Semantic status                                                                                                        |
 | Toggle       | default, outline                                         | default, sm, lg, icon                                |                                                                                                                        |
 | Chip         | outline                                                  | sm                                                   | Use with ChipClose                                                                                                     |
@@ -496,7 +496,8 @@ Same shell as Dialog (shared `quill-dialog__*` styles) but `role="alertdialog"`,
 </DropdownMenu>
 ```
 
-Destructive items (`variant="destructive"` on DropdownMenuItem/ContextMenuItem/MenubarItem) render red text on a transparent background, with a red-tinted background only on hover/highlight — they are styled by the menu item itself, not by Button's filled `destructive` variant. Don't pass a Button variant through `render` to restyle a menu item.
+Destructive items (`variant="destructive"` on DropdownMenuItem/ContextMenuItem/MenubarItem) look exactly like a standalone destructive Button — the item forwards its variant to the Button it renders, so a delete row in a menu carries the same weight as a delete button anywhere else.
+Set `variant` on the item; don't pass a Button variant through `render` to restyle it.
 
 Checkbox/radio items:
 
@@ -1008,7 +1009,7 @@ Compose `Table > TableHeader/TableBody/TableFooter > TableRow > TableHead/TableC
 </Menubar>
 ```
 
-MenubarItem wraps DropdownMenuItem, so the same item API applies — including `variant="destructive"` (red text, red-tinted highlight, transparent at rest).
+MenubarItem wraps DropdownMenuItem, so the same item API applies — including `variant="destructive"`, which renders the filled destructive Button.
 
 ### Toast
 

--- a/packages/quill/packages/primitives/src/button.css
+++ b/packages/quill/packages/primitives/src/button.css
@@ -42,6 +42,18 @@
         opacity: 0.5;
     }
 
+    /* Press dips the button 1px. `primary` owns its own version (it rests
+       raised, so it drops back to 0), and tabs opt out — a trigger that moves
+       reads as jitter against the fixed tab strip. */
+    .quill-button:not(
+            .quill-button--variant-primary,
+            [data-slot='tabs-trigger'],
+            :disabled,
+            [aria-disabled='true']
+        ):active {
+        translate: 0 1px;
+    }
+
     .quill-button[aria-invalid='true'] {
         border-color: var(--destructive);
         box-shadow: 0 0 0 2px color-mix(in oklab, var(--destructive) 20%, transparent);
@@ -191,7 +203,9 @@
         background-color: color-mix(in oklab, var(--destructive) 50%, transparent);
     }
 
-    .quill-button--variant-destructive:not(:disabled, [aria-disabled='true']):hover {
+    /* `[data-highlighted]` covers keyboard navigation inside menus, where the
+       item never takes :hover. */
+    .quill-button--variant-destructive:not(:disabled, [aria-disabled='true']):is(:hover, [data-highlighted]) {
         background-color: var(--destructive);
     }
 

--- a/packages/quill/packages/primitives/src/context-menu.tsx
+++ b/packages/quill/packages/primitives/src/context-menu.tsx
@@ -99,18 +99,13 @@ function ContextMenuItem({
             data-variant={variant}
             className={cn(
                 "group/context-menu-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
-                // Same destructive treatment as DropdownMenuItem: red text at rest, red tint on
-                // hover/highlight — never Button's filled `destructive` variant inside a menu.
-                // Disabled destructive mirrors the disabled destructive Button: 50%-mix red fill
-                // under the item-level opacity-50.
-                'data-[variant=destructive]:text-destructive-foreground data-[variant=destructive]:hover:text-destructive-foreground data-[variant=destructive]:[&_svg]:text-destructive-foreground data-[variant=destructive]:hover:bg-destructive/10 data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:data-highlighted:bg-destructive/10 dark:data-[variant=destructive]:hover:bg-destructive/20 dark:data-[variant=destructive]:focus:bg-destructive/20 dark:data-[variant=destructive]:data-highlighted:bg-destructive/20 data-[variant=destructive]:data-disabled:bg-destructive/50',
                 inset && 'quill-menu-item--inset',
                 className
             )}
             // The default render is a real <button>; only declare nativeButton when the
             // caller hasn't overridden render (their element may not be a button).
             nativeButton={!('render' in props)}
-            render={<Button variant="default" className="w-full font-normal" left />}
+            render={<Button variant={variant} className="w-full font-normal" left />}
             {...props}
         >
             {children}

--- a/packages/quill/packages/primitives/src/dropdown-menu.tsx
+++ b/packages/quill/packages/primitives/src/dropdown-menu.tsx
@@ -99,19 +99,13 @@ function DropdownMenuItem({
             data-variant={variant}
             className={cn(
                 "group/dropdown-menu-item relative flex cursor-default items-center text-xs/relaxed outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
-                // Destructive menu items are transparent at rest (red text only) and get a red
-                // tint on hover/highlight — Button's standalone `destructive` variant (filled at
-                // rest) is wrong inside a menu, so the inner Button always stays `default`.
-                // Disabled destructive mirrors the disabled destructive Button: 50%-mix red fill
-                // under the item-level opacity-50.
-                'data-[variant=destructive]:text-destructive-foreground data-[variant=destructive]:hover:text-destructive-foreground data-[variant=destructive]:[&_svg]:text-destructive-foreground data-[variant=destructive]:hover:bg-destructive/10 data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:data-highlighted:bg-destructive/10 dark:data-[variant=destructive]:hover:bg-destructive/20 dark:data-[variant=destructive]:focus:bg-destructive/20 dark:data-[variant=destructive]:data-highlighted:bg-destructive/20 data-[variant=destructive]:data-disabled:bg-destructive/50',
                 inset && 'quill-menu-item--inset',
                 className
             )}
             // The default render is a real <button>; only declare nativeButton when the
             // caller hasn't overridden render (their element may not be a button).
             nativeButton={!('render' in props)}
-            render={<Button variant="default" className="w-full font-normal [&_kbd]:ml-auto" left />}
+            render={<Button variant={variant} className="w-full font-normal [&_kbd]:ml-auto" left />}
             {...props}
         />
     )

--- a/packages/quill/packages/primitives/src/menu.css
+++ b/packages/quill/packages/primitives/src/menu.css
@@ -109,6 +109,24 @@
     }
 
     /*
+     * The unchecked checkbox/radio glyph sits on the item's hover fill, where an
+     * `--input`/`--border` outline all but vanishes in dark mode. Lift it to a
+     * foreground mix while the item is hovered or highlighted so the control
+     * stays readable.
+     */
+    :is(
+            [data-slot='dropdown-menu-checkbox-item'],
+            [data-slot='dropdown-menu-radio-item'],
+            [data-slot='context-menu-checkbox-item'],
+            [data-slot='context-menu-radio-item'],
+            [data-slot='menubar-checkbox-item'],
+            [data-slot='menubar-radio-item']
+        ):is(:hover, [data-highlighted])
+        :is(.quill-checkbox:not([data-checked]), .quill-radio-indicator:not(.quill-radio-indicator--checked)) {
+        border-color: color-mix(in oklab, var(--foreground) 50%, transparent);
+    }
+
+    /*
      * Consecutive checked items merge corners into a seamless block — mirrors
      * the aria-selected/aria-checked Button rules, scoped to menu items so the
      * effect reads even when Base UI wraps items in a group/list container.
@@ -143,7 +161,10 @@
      * stylesheet order.)
      */
     :is(.quill-menu__content, .quill-menu__sub-content)
-        .quill-button--variant-default:is([data-highlighted], :focus-visible):not(:hover) {
+        :is(.quill-button--variant-default, .quill-button--variant-destructive):is(
+            [data-highlighted],
+            :focus-visible
+        ):not(:hover) {
         border-color: transparent;
         box-shadow: none;
     }

--- a/packages/quill/packages/primitives/src/menubar.tsx
+++ b/packages/quill/packages/primitives/src/menubar.tsx
@@ -85,10 +85,10 @@ function MenubarItem({
         <DropdownMenuItem
             data-slot="menubar-item"
             data-inset={inset}
-            // DropdownMenuItem owns destructive styling (red text at rest, red-tinted highlight).
+            // DropdownMenuItem owns destructive styling (Button's `destructive` variant).
             variant={variant}
             className={cn(
-                'group/menubar-item min-h-7 gap-2 rounded-sm px-2 py-1 text-xs/relaxed focus:bg-fill-hover data-disabled:opacity-50',
+                'group/menubar-item min-h-7 gap-2 rounded-sm px-2 py-1 text-xs/relaxed data-[variant=default]:focus:bg-fill-hover data-disabled:opacity-50',
                 className
             )}
             {...props}


### PR DESCRIPTION
## Problem

In dark mode, hovering a checkbox or radio row in a quill menu makes the control itself disappear — the row's hover fill sits at almost the same lightness as the control's outline, so you can no longer see what you are about to toggle.

Two more menu and button issues came in with it:

- A destructive item in a dropdown menu looks much weaker than a destructive button anywhere else, because the menu overrode it with its own transparent treatment.
- Quill buttons no longer dip when pressed, so a click gives no physical feedback.

## Changes

- Menu checkbox and radio glyphs take a foreground-mixed border while their row is hovered or highlighted.
- Destructive menu items forward `variant="destructive"` to the Button they render, so a delete row matches a delete button everywhere else. The menu-only red-text-on-transparent rules are gone from DropdownMenuItem, ContextMenuItem, and MenubarItem.
- Buttons translate 1px down on `:active`. Tabs triggers opt out, and `primary` keeps its own version (it rests raised and drops back to flat).
- Destructive buttons now also fill on `[data-highlighted]`, so keyboard navigation through a menu matches hover.

Hovered radio row, dark mode — before and after:

![before-radio](https://raw.githubusercontent.com/PostHog/pr-assets/08a841e35e2d0fcaf1054179d827778b3046f2bf/2026/08/b3eace59-a437-482f-bc2d-9591cc1650a3.png)
![after-radio](https://raw.githubusercontent.com/PostHog/pr-assets/08a841e35e2d0fcaf1054179d827778b3046f2bf/2026/08/ade5ca7c-36d9-4a14-9c17-ef54ca535798.png)

Destructive menu item, light mode — before and after:

![before-destructive](https://raw.githubusercontent.com/PostHog/pr-assets/08a841e35e2d0fcaf1054179d827778b3046f2bf/2026/08/0f7a61b0-034c-490c-ae93-2610252ec7e4.png)
![after-destructive](https://raw.githubusercontent.com/PostHog/pr-assets/08a841e35e2d0fcaf1054179d827778b3046f2bf/2026/08/f6e37653-0e81-4abf-90ca-64b2717af47e.png)

## How did you test this code?

No tests added — this is CSS and variant plumbing, and quill has no unit coverage for computed styles.

I (actually Claude) ran Storybook locally and drove it with Playwright to capture the screenshots above from `Primitives/DropdownMenu` and `Primitives/Button`, on the same stories before and after the change.

- Press dip: computed `translate` on a pressed outline button reads `0px 1px`; on a pressed tabs trigger it reads `0px`.
- Destructive parity: the menu item and the standalone destructive button render the same fill in both themes.
- Also ran: stylelint on the two CSS files, oxlint and oxfmt on the three components, `tsc` on the primitives package.
- Not checked: the desktop app and MCP app surfaces that consume quill, and the storybook visual snapshot suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated `packages/quill/packages/primitives/AGENTS.md`: the destructive menu item guidance and the Button catalog row.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (PostHog Code) from a report of the three issues, with the dark-mode screenshot attached. Skills invoked: `/writing-pr-descriptions`.

The contrast fix is scoped to the menu item slots rather than applied to `Checkbox`/`RadioIndicator` globally, so the standalone controls keep their existing resting outline.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
