### PR TITLE
feat(desktop): add setting to toggle Mission Control overlay

### DIFF
--- a/products/desktop/apps/code/src/main/platform-adapters/electron-mission-control.test.ts
+++ b/products/desktop/apps/code/src/main/platform-adapters/electron-mission-control.test.ts
@@ -23,6 +23,15 @@ vi.mock("../services/mission-control/cg-window-list", () => ({
   createWindowListSampler: sampler.create,
 }));
 
+const settings = vi.hoisted(() => ({
+  enabled: true,
+  set: vi.fn<(value: boolean) => void>(),
+}));
+vi.mock("../services/settingsStore", () => ({
+  getMissionControlOverlayEnabled: () => settings.enabled,
+  setMissionControlOverlayEnabled: settings.set,
+}));
+
 vi.mock("electron", () => ({
   screen: {
     getAllDisplays: () => [
@@ -69,6 +78,8 @@ describe("MissionControlService", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     sampler.create.mockReset();
+    settings.enabled = true;
+    settings.set.mockReset();
     pretendPlatform("darwin");
   });
 
@@ -114,6 +125,43 @@ describe("MissionControlService", () => {
     state.windows = [MISSION_CONTROL_BACKING];
     vi.advanceTimersByTime(5000);
     expect(service.getState().active).toBe(false);
+  });
+
+  it("never touches the window list while the setting is off", () => {
+    settings.enabled = false;
+    const { state, impl } = fakeSampler([MISSION_CONTROL_BACKING]);
+    sampler.create.mockReturnValue(impl);
+    const service = new MissionControlService();
+
+    service.arm();
+    state.windows = [MISSION_CONTROL_BACKING];
+    vi.advanceTimersByTime(5000);
+
+    expect(sampler.create).not.toHaveBeenCalled();
+    expect(service.getState().active).toBe(false);
+  });
+
+  it("turning the setting off drops a live overlay, then back on resumes it", () => {
+    const { state, impl } = fakeSampler([MISSION_CONTROL_BACKING]);
+    sampler.create.mockReturnValue(impl);
+    const service = new MissionControlService();
+
+    service.arm();
+    vi.advanceTimersByTime(250);
+    expect(service.getState().active).toBe(true);
+
+    service.setEnabled(false);
+    expect(service.getState().active).toBe(false);
+    expect(settings.set).toHaveBeenLastCalledWith(false);
+
+    state.windows = [MISSION_CONTROL_BACKING];
+    vi.advanceTimersByTime(5000);
+    expect(service.getState().active).toBe(false);
+
+    service.setEnabled(true);
+    vi.advanceTimersByTime(250);
+    expect(settings.set).toHaveBeenLastCalledWith(true);
+    expect(service.getState().active).toBe(true);
   });
 
   it("gives up after repeated sampling failures instead of logging forever", () => {

--- a/products/desktop/apps/code/src/main/platform-adapters/electron-mission-control.ts
+++ b/products/desktop/apps/code/src/main/platform-adapters/electron-mission-control.ts
@@ -18,6 +18,10 @@ import type {
   Rect,
   WindowListSampler,
 } from "../services/mission-control/window-list";
+import {
+  getMissionControlOverlayEnabled,
+  setMissionControlOverlayEnabled,
+} from "../services/settingsStore";
 import { logger } from "../utils/logger";
 
 const log = logger.scope("mission-control");
@@ -39,12 +43,34 @@ export class MissionControlService extends TypedEventEmitter<MissionControlServi
   private active = false;
   private forced = false;
   private consecutiveErrors = 0;
+  private enabled = getMissionControlOverlayEnabled();
 
   getState(): MissionControlState {
     return { active: this.active };
   }
 
+  // Only macOS has Mission Control, and the overlay is the only thing the
+  // detection drives, so elsewhere the setting has nothing to control.
+  isSupported(): boolean {
+    return process.platform === "darwin";
+  }
+
+  getEnabled(): boolean {
+    return this.enabled;
+  }
+
+  setEnabled(enabled: boolean): void {
+    if (enabled === this.enabled) return;
+    this.enabled = enabled;
+    setMissionControlOverlayEnabled(enabled);
+    // The user turns this on or off from a visible settings window, so arming
+    // here matches the window state without waiting for the next show event.
+    if (enabled) this.arm();
+    else this.disarm();
+  }
+
   arm(): void {
+    if (!this.enabled) return;
     if (this.timer || !this.resolveSampler()) return;
     this.timer = setInterval(() => this.poll(), POLL_INTERVAL_MS);
   }

--- a/products/desktop/apps/code/src/main/services/settingsStore.ts
+++ b/products/desktop/apps/code/src/main/services/settingsStore.ts
@@ -14,6 +14,7 @@ interface SettingsSchema {
   discordPresenceEnabled: boolean;
   discordPresenceShowTaskTitle: boolean;
   discordPresenceShowRepoName: boolean;
+  missionControlOverlayEnabled: boolean;
 }
 
 function getDefaultWorktreeLocation(): string {
@@ -99,6 +100,10 @@ const schema = {
     type: "boolean" as const,
     default: false,
   },
+  missionControlOverlayEnabled: {
+    type: "boolean" as const,
+    default: true,
+  },
 };
 
 export const settingsStore = new Store<SettingsSchema>({
@@ -114,6 +119,7 @@ export const settingsStore = new Store<SettingsSchema>({
     discordPresenceEnabled: false,
     discordPresenceShowTaskTitle: false,
     discordPresenceShowRepoName: false,
+    missionControlOverlayEnabled: true,
   },
 });
 
@@ -191,4 +197,12 @@ export function getPreventSleepWhileRunning(): boolean {
 
 export function setPreventSleepWhileRunning(value: boolean): void {
   settingsStore.set("preventSleepWhileRunning", value);
+}
+
+export function getMissionControlOverlayEnabled(): boolean {
+  return settingsStore.get("missionControlOverlayEnabled", true);
+}
+
+export function setMissionControlOverlayEnabled(value: boolean): void {
+  settingsStore.set("missionControlOverlayEnabled", value);
 }

--- a/products/desktop/apps/code/src/main/services/settingsStore.ts
+++ b/products/desktop/apps/code/src/main/services/settingsStore.ts
@@ -102,7 +102,7 @@ const schema = {
   },
   missionControlOverlayEnabled: {
     type: "boolean" as const,
-    default: false,
+    default: true,
   },
 };
 
@@ -119,7 +119,7 @@ export const settingsStore = new Store<SettingsSchema>({
     discordPresenceEnabled: false,
     discordPresenceShowTaskTitle: false,
     discordPresenceShowRepoName: false,
-    missionControlOverlayEnabled: false,
+    missionControlOverlayEnabled: true,
   },
 });
 
@@ -200,7 +200,7 @@ export function setPreventSleepWhileRunning(value: boolean): void {
 }
 
 export function getMissionControlOverlayEnabled(): boolean {
-  return settingsStore.get("missionControlOverlayEnabled", false);
+  return settingsStore.get("missionControlOverlayEnabled", true);
 }
 
 export function setMissionControlOverlayEnabled(value: boolean): void {

--- a/products/desktop/apps/code/src/main/services/settingsStore.ts
+++ b/products/desktop/apps/code/src/main/services/settingsStore.ts
@@ -102,7 +102,7 @@ const schema = {
   },
   missionControlOverlayEnabled: {
     type: "boolean" as const,
-    default: true,
+    default: false,
   },
 };
 
@@ -119,7 +119,7 @@ export const settingsStore = new Store<SettingsSchema>({
     discordPresenceEnabled: false,
     discordPresenceShowTaskTitle: false,
     discordPresenceShowRepoName: false,
-    missionControlOverlayEnabled: true,
+    missionControlOverlayEnabled: false,
   },
 });
 
@@ -200,7 +200,7 @@ export function setPreventSleepWhileRunning(value: boolean): void {
 }
 
 export function getMissionControlOverlayEnabled(): boolean {
-  return settingsStore.get("missionControlOverlayEnabled", true);
+  return settingsStore.get("missionControlOverlayEnabled", false);
 }
 
 export function setMissionControlOverlayEnabled(value: boolean): void {

--- a/products/desktop/apps/code/src/main/trpc/routers/mission-control.ts
+++ b/products/desktop/apps/code/src/main/trpc/routers/mission-control.ts
@@ -1,14 +1,16 @@
+import { z } from "zod";
 import { container } from "../../di/container";
 import { MISSION_CONTROL_SERVICE } from "../../di/tokens";
 import type { MissionControlService } from "../../platform-adapters/electron-mission-control";
 import { MissionControlServiceEvent } from "../../services/mission-control/schemas";
 import { publicProcedure, router } from "../trpc";
 
+const getService = () =>
+  container.get<MissionControlService>(MISSION_CONTROL_SERVICE);
+
 export const missionControlRouter = router({
   onStateChanged: publicProcedure.subscription(async function* (opts) {
-    const service = container.get<MissionControlService>(
-      MISSION_CONTROL_SERVICE,
-    );
+    const service = getService();
     for await (const data of service.toIterable(
       MissionControlServiceEvent.StateChanged,
       { signal: opts.signal },
@@ -16,4 +18,9 @@ export const missionControlRouter = router({
       yield data;
     }
   }),
+  isSupported: publicProcedure.query(() => getService().isSupported()),
+  getEnabled: publicProcedure.query(() => getService().getEnabled()),
+  setEnabled: publicProcedure
+    .input(z.object({ enabled: z.boolean() }))
+    .mutation(({ input }) => getService().setEnabled(input.enabled)),
 });

--- a/products/desktop/apps/code/src/renderer/di/container.ts
+++ b/products/desktop/apps/code/src/renderer/di/container.ts
@@ -256,6 +256,10 @@ const missionControlClient: MissionControlClient = {
     });
     return () => sub.unsubscribe();
   },
+  isSupported: () => trpcClient.missionControl.isSupported.query(),
+  getEnabled: () => trpcClient.missionControl.getEnabled.query(),
+  setEnabled: (enabled) =>
+    trpcClient.missionControl.setEnabled.mutate({ enabled }),
 };
 container.bind(MISSION_CONTROL_CLIENT).toConstantValue(missionControlClient);
 

--- a/products/desktop/packages/ui/src/features/mission-control/MissionControlOverlay.test.tsx
+++ b/products/desktop/packages/ui/src/features/mission-control/MissionControlOverlay.test.tsx
@@ -1,14 +1,16 @@
-import { render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MissionControlOverlay } from "./MissionControlOverlay";
 import { useMissionControlStore } from "./missionControlStore";
 
 describe("MissionControlOverlay", () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     useMissionControlStore.setState({ active: false });
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     document.getElementById("portal-container")?.remove();
   });
 
@@ -33,6 +35,20 @@ describe("MissionControlOverlay", () => {
     expect(screen.getByTestId("mission-control-overlay").className).toContain(
       "pointer-events-none",
     );
+  });
+
+  it("stays mounted while fading out", () => {
+    useMissionControlStore.setState({ active: true });
+    render(<MissionControlOverlay />);
+    act(() => vi.runOnlyPendingTimers());
+
+    act(() => useMissionControlStore.setState({ active: false }));
+    expect(screen.getByTestId("mission-control-overlay")).toHaveClass(
+      "opacity-0",
+    );
+
+    act(() => vi.advanceTimersByTime(150));
+    expect(screen.queryByTestId("mission-control-overlay")).toBeNull();
   });
 
   it("portals into the theme container when one exists", () => {

--- a/products/desktop/packages/ui/src/features/mission-control/MissionControlOverlay.test.tsx
+++ b/products/desktop/packages/ui/src/features/mission-control/MissionControlOverlay.test.tsx
@@ -37,10 +37,17 @@ describe("MissionControlOverlay", () => {
     );
   });
 
-  it("stays mounted while fading out", () => {
+  it("fades in and stays mounted while fading out", () => {
     useMissionControlStore.setState({ active: true });
     render(<MissionControlOverlay />);
-    act(() => vi.runOnlyPendingTimers());
+
+    expect(screen.getByTestId("mission-control-overlay")).toHaveClass(
+      "opacity-0",
+    );
+    act(() => vi.runAllTimers());
+    expect(screen.getByTestId("mission-control-overlay")).toHaveClass(
+      "opacity-100",
+    );
 
     act(() => useMissionControlStore.setState({ active: false }));
     expect(screen.getByTestId("mission-control-overlay")).toHaveClass(

--- a/products/desktop/packages/ui/src/features/mission-control/MissionControlOverlay.tsx
+++ b/products/desktop/packages/ui/src/features/mission-control/MissionControlOverlay.tsx
@@ -39,7 +39,7 @@ export function MissionControlOverlay() {
     <div
       aria-hidden="true"
       data-testid="mission-control-overlay"
-      className={`pointer-events-none fixed inset-0 z-[300] flex flex-col items-center justify-center gap-[2.5vh] bg-(--gray-1)/65 backdrop-blur-md transition-opacity duration-150 ease-out motion-reduce:transition-none ${visible ? "opacity-100" : "opacity-0"}`}
+      className={`pointer-events-none fixed inset-0 z-[300] flex flex-col items-center justify-center gap-[2.5vh] bg-(--gray-1)/10 backdrop-blur-sm transition-opacity duration-150 ease-out motion-reduce:transition-none ${visible ? "opacity-100" : "opacity-0"}`}
     >
       {/* The logo-only variant reserves room for the wordmark, so crop to the
           logomark's own 52:28 box. */}

--- a/products/desktop/packages/ui/src/features/mission-control/MissionControlOverlay.tsx
+++ b/products/desktop/packages/ui/src/features/mission-control/MissionControlOverlay.tsx
@@ -1,13 +1,28 @@
 import LogosLandscape from "@posthog/ui/primitives/Logo";
+import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { useMissionControlStore } from "./missionControlStore";
 
-// Unanimated on purpose: at Mission Control's thumbnail scale a transition
-// reads as a rendering glitch.
+const FADE_DURATION_MS = 150;
+
 export function MissionControlOverlay() {
   const active = useMissionControlStore((state) => state.active);
+  const [rendered, setRendered] = useState(active);
+  const [visible, setVisible] = useState(false);
 
-  if (!active) return null;
+  useEffect(() => {
+    if (active) {
+      setRendered(true);
+      const timeout = setTimeout(() => setVisible(true), 0);
+      return () => clearTimeout(timeout);
+    }
+
+    setVisible(false);
+    const timeout = setTimeout(() => setRendered(false), FADE_DURATION_MS);
+    return () => clearTimeout(timeout);
+  }, [active]);
+
+  if (!rendered) return null;
 
   // Portalling to document.body would land outside the Radix <Theme> subtree
   // and render a light panel in dark mode.
@@ -18,7 +33,7 @@ export function MissionControlOverlay() {
     <div
       aria-hidden="true"
       data-testid="mission-control-overlay"
-      className="pointer-events-none fixed inset-0 z-[300] flex flex-col items-center justify-center gap-[2.5vh] bg-(--gray-1)/75 backdrop-blur-md"
+      className={`pointer-events-none fixed inset-0 z-[300] flex flex-col items-center justify-center gap-[2.5vh] bg-(--gray-1)/70 backdrop-blur-md transition-opacity duration-150 ease-out motion-reduce:transition-none ${visible ? "opacity-100" : "opacity-0"}`}
     >
       {/* The logo-only variant reserves room for the wordmark, so crop to the
           logomark's own 52:28 box. */}

--- a/products/desktop/packages/ui/src/features/mission-control/MissionControlOverlay.tsx
+++ b/products/desktop/packages/ui/src/features/mission-control/MissionControlOverlay.tsx
@@ -13,8 +13,14 @@ export function MissionControlOverlay() {
   useEffect(() => {
     if (active) {
       setRendered(true);
-      const timeout = setTimeout(() => setVisible(true), 0);
-      return () => clearTimeout(timeout);
+      let revealFrame = 0;
+      const mountedFrame = requestAnimationFrame(() => {
+        revealFrame = requestAnimationFrame(() => setVisible(true));
+      });
+      return () => {
+        cancelAnimationFrame(mountedFrame);
+        cancelAnimationFrame(revealFrame);
+      };
     }
 
     setVisible(false);
@@ -33,7 +39,7 @@ export function MissionControlOverlay() {
     <div
       aria-hidden="true"
       data-testid="mission-control-overlay"
-      className={`pointer-events-none fixed inset-0 z-[300] flex flex-col items-center justify-center gap-[2.5vh] bg-(--gray-1)/70 backdrop-blur-md transition-opacity duration-150 ease-out motion-reduce:transition-none ${visible ? "opacity-100" : "opacity-0"}`}
+      className={`pointer-events-none fixed inset-0 z-[300] flex flex-col items-center justify-center gap-[2.5vh] bg-(--gray-1)/65 backdrop-blur-md transition-opacity duration-150 ease-out motion-reduce:transition-none ${visible ? "opacity-100" : "opacity-0"}`}
     >
       {/* The logo-only variant reserves room for the wordmark, so crop to the
           logomark's own 52:28 box. */}

--- a/products/desktop/packages/ui/src/features/mission-control/identifiers.ts
+++ b/products/desktop/packages/ui/src/features/mission-control/identifiers.ts
@@ -4,6 +4,9 @@ export interface MissionControlState {
 
 export interface MissionControlClient {
   onStateChanged(onData: (state: MissionControlState) => void): () => void;
+  isSupported(): Promise<boolean>;
+  getEnabled(): Promise<boolean>;
+  setEnabled(enabled: boolean): Promise<void>;
 }
 
 export const MISSION_CONTROL_CLIENT = Symbol.for(

--- a/products/desktop/packages/ui/src/features/settings/sections/GeneralSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/GeneralSettings.tsx
@@ -1,5 +1,6 @@
 import { ArrowSquareOut } from "@phosphor-icons/react";
 import { buildPostHogUrl } from "@posthog/core/settings/posthogUrl";
+import { useServiceOptional } from "@posthog/di/react";
 import { useHostTRPC } from "@posthog/host-router/react";
 import { ANALYTICS_EVENTS } from "@posthog/shared";
 import {
@@ -8,6 +9,10 @@ import {
   EFFORT_LEVELS,
 } from "@posthog/shared/domain-types";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
+import {
+  MISSION_CONTROL_CLIENT,
+  type MissionControlClient,
+} from "@posthog/ui/features/mission-control/identifiers";
 import {
   ReasoningLevelDropdown,
   type ReasoningLevelOption,
@@ -27,7 +32,7 @@ import type { ThemePreference } from "@posthog/ui/shell/themeStore";
 import { useThemeStore } from "@posthog/ui/shell/themeStore";
 import { useHostCapabilities } from "@posthog/ui/shell/useHostCapabilities";
 import { Button, Flex, Link, Select, Switch, Text } from "@radix-ui/themes";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect } from "react";
 
 const DEFAULT_EFFORT_OPTIONS: ReasoningLevelOption[] = [
@@ -84,6 +89,40 @@ export function GeneralSettings() {
       preventSleepMutation.mutate({ enabled: checked });
     },
     [setPreventSleepWhileRunning, preventSleepMutation],
+  );
+
+  // Mission Control overlay state. The client is bound on desktop only, so on
+  // other hosts this resolves to null and the setting is hidden.
+  const queryClient = useQueryClient();
+  const missionControl = useServiceOptional<MissionControlClient>(
+    MISSION_CONTROL_CLIENT,
+  );
+  const { data: missionControlSupported } = useQuery({
+    queryKey: ["missionControlOverlay", "supported"],
+    queryFn: () => missionControl?.isSupported() ?? false,
+    enabled: missionControl != null,
+  });
+  const { data: missionControlEnabled } = useQuery({
+    queryKey: ["missionControlOverlay", "enabled"],
+    queryFn: () => missionControl?.getEnabled() ?? true,
+    enabled: missionControl != null && missionControlSupported === true,
+  });
+  const missionControlMutation = useMutation({
+    mutationFn: (enabled: boolean) =>
+      missionControl?.setEnabled(enabled) ?? Promise.resolve(),
+  });
+
+  const handleMissionControlOverlayChange = useCallback(
+    (checked: boolean) => {
+      track(ANALYTICS_EVENTS.SETTING_CHANGED, {
+        setting_name: "mission_control_overlay",
+        new_value: checked,
+        old_value: !checked,
+      });
+      queryClient.setQueryData(["missionControlOverlay", "enabled"], checked);
+      missionControlMutation.mutate(checked);
+    },
+    [missionControlMutation, queryClient],
   );
 
   // Chat state
@@ -287,6 +326,19 @@ export function GeneralSettings() {
           </Select.Content>
         </Select.Root>
       </SettingRow>
+
+      {missionControl != null && missionControlSupported === true && (
+        <SettingRow
+          label="Mission Control overlay"
+          description="Show the PostHog logo over the window while macOS Mission Control is open, so it's easy to spot among your other windows"
+        >
+          <Switch
+            checked={missionControlEnabled ?? true}
+            onCheckedChange={handleMissionControlOverlayChange}
+            size="1"
+          />
+        </SettingRow>
+      )}
 
       {/* Input */}
       <Text className="mb-2 block border-gray-6 border-t pt-4 font-medium text-sm">

--- a/products/desktop/packages/ui/src/features/settings/sections/GeneralSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/GeneralSettings.tsx
@@ -104,7 +104,7 @@ export function GeneralSettings() {
   });
   const { data: missionControlEnabled } = useQuery({
     queryKey: ["missionControlOverlay", "enabled"],
-    queryFn: () => missionControl?.getEnabled() ?? true,
+    queryFn: () => missionControl?.getEnabled() ?? false,
     enabled: missionControl != null && missionControlSupported === true,
   });
   const missionControlMutation = useMutation({
@@ -333,7 +333,7 @@ export function GeneralSettings() {
           description="Show the PostHog logo over the window while macOS Mission Control is open, so it's easy to spot among your other windows"
         >
           <Switch
-            checked={missionControlEnabled ?? true}
+            checked={missionControlEnabled ?? false}
             onCheckedChange={handleMissionControlOverlayChange}
             size="1"
           />


### PR DESCRIPTION
## Problem

The Mission Control overlay can feel disruptive, but people cannot disable it without also stopping the app.

**Why:** People need control over the overlay without paying for unnecessary background detection when it is disabled.

## Changes

<table>
<tr>
 <td>
<img width="786" height="670" alt="Mission Control overlay setting disabled" src="https://github.com/user-attachments/assets/fdb18a8d-6300-4554-bc07-96d1ff7d3123" />
</td>
 <td>
<img width="776" height="664" alt="Mission Control overlay setting enabled" src="https://github.com/user-attachments/assets/4356d36a-d9cb-456e-852d-043c584b4bf9" />
</td>
</tr>
</table>

- The overlay remains on by default, and macOS users can disable it under Appearance settings.
- The saved choice survives restarts.
- Disabling the overlay stops CoreGraphics polling and immediately removes an active overlay.
- Enabling it resumes detection without restarting the app.
- A short fade and lighter scrim soften transitions into and out of Mission Control.
- Other platforms hide the macOS-only setting.

## How did you test this code?

- Service tests guard disabled polling, persisted choices, and live enable or disable behavior.
- Overlay tests guard initial visibility, fade-in, delayed fade-out, portal placement, labeling, and pointer behavior.
- Biome checks pass for the changed files.
- Not run by the agent: manual macOS validation.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The PostHog Slack app and Codex implemented the requested toggle and visual refinements. Skills invoked: `/posthog-desktop`, `/writing-user-facing-copy`, `/writing-tests`, and `/writing-pr-descriptions`.

The design moved from opt-in to enabled by default. The setting gates detection itself, so disabling the overlay also stops polling.

Nothing in this PR derives from non-public material. Origin context: [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1786439393906019?thread_ts=1786439393.906019&cid=C09G8Q32R6F).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*