### PR TITLE
fix(slack): resolve unfurls in the region the link points at

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -97,7 +97,11 @@ from products.slack_app.backend.services.slack_user_oauth import (
     find_linked_posthog_user,
     post_link_invite_message,
 )
-from products.slack_app.backend.slack_link_unfurl import handle_posthog_link_unfurl, parse_posthog_resource_link
+from products.slack_app.backend.slack_link_unfurl import (
+    handle_posthog_link_unfurl,
+    link_url_region,
+    parse_posthog_resource_link,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -2193,29 +2197,29 @@ def route_posthog_code_event_to_relevant_region(
             incoming_host=incoming_host,
         )
 
+    # The link's own host decides the region, from URL parsing alone — ahead of ``load_integrations``,
+    # whose query and Slack auth check would be thrown away on the forward. A workspace connected in
+    # both regions otherwise resolves a `us.` link's `/project/:id` against this region's project of
+    # the same number, which holds someone else's data or nothing at all.
+    link_region = _link_shared_url_region(event) if event_type == "link_shared" else None
+    if (
+        link_region is not None
+        and link_region != get_instance_region()
+        and not proxied
+        and cross_region_routing_enabled()
+    ):
+        logger.info(
+            "slack_app_link_unfurl_region_forward",
+            slack_team_id=slack_team_id,
+            event_id=event_id,
+            link_region=link_region,
+            incoming_host=incoming_host,
+        )
+        return _proxy_event_and_return_route(request, other_domain)
+
     # link_shared (unfurl) works with either integration kind.
     link_result = load_integrations(slack_team_id=slack_team_id, kinds=list(SLACK_INTEGRATION_KINDS))
-    link_region: str | None = None
     if event_type == "link_shared":
-        # The link's own host decides the region before anything is resolved locally. A workspace
-        # connected in both regions otherwise resolves a `us.` link's `/project/:id` against this
-        # region's project of the same number, which holds someone else's data or nothing at all.
-        link_region = _link_shared_url_region(event)
-        if (
-            link_region is not None
-            and link_region != get_instance_region()
-            and not proxied
-            and cross_region_routing_enabled()
-        ):
-            logger.info(
-                "slack_app_link_unfurl_region_forward",
-                slack_team_id=slack_team_id,
-                event_id=event_id,
-                link_region=link_region,
-                incoming_host=incoming_host,
-            )
-            return _proxy_event_and_return_route(request, other_domain)
-
         link_target = _link_shared_target(event, link_result.candidates, slack_team_id=slack_team_id)
         logger.info(
             "slack_app_link_unfurl_target_selected",
@@ -3085,15 +3089,6 @@ class LinkSharedTarget:
     source: str
 
 
-# App hosts that name a Cloud region. `app.posthog.com` is the legacy alias for US Cloud. A bare
-# `posthog.com` link names no region, so it stays out.
-_APP_HOST_REGIONS: dict[str, str] = {
-    "us.posthog.com": "US",
-    "app.posthog.com": "US",
-    "eu.posthog.com": "EU",
-}
-
-
 def _link_shared_resource_urls(event: dict[str, Any]) -> list[str]:
     """The event's links that parse as a resource we can unfurl.
 
@@ -3121,11 +3116,7 @@ def _link_shared_url_region(event: dict[str, Any]) -> str | None:
     link are unrelated projects. Reading the region off the host is what keeps a link from being
     resolved against the same number in the wrong region.
     """
-    regions = set()
-    for url in _link_shared_resource_urls(event):
-        region = _APP_HOST_REGIONS.get(urlparse(url).hostname or "")
-        if region is not None:
-            regions.add(region)
+    regions = {region for url in _link_shared_resource_urls(event) if (region := link_url_region(url)) is not None}
     return regions.pop() if len(regions) == 1 else None
 
 

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -627,22 +627,24 @@ def _proxy_event_and_return_route(request: HttpRequest, target_domain: str) -> s
     return ROUTE_PROXIED if _proxy_event_to_region(request, target_domain) is not None else ROUTE_PROXY_FAILED
 
 
-def _workspace_claims_cache_key(slack_team_id: str, kinds: list[str], team_id: int | None = None) -> str:
+def _workspace_claims_cache_key(slack_team_id: str, kinds: list[str]) -> str:
     kinds_token = ",".join(sorted(kinds))
-    team_token = team_id if team_id is not None else "*"
-    return f"slack_app:ws_claims:{slack_team_id}:{kinds_token}:{team_token}"
+    return f"slack_app:ws_claims:{slack_team_id}:{kinds_token}"
 
 
-def does_other_region_claim_workspace(
-    *, slack_team_id: str, kinds: list[str], incoming_host: str, team_id: int | None = None
-) -> bool | None:
+def does_other_region_claim_workspace(*, slack_team_id: str, kinds: list[str], incoming_host: str) -> bool | None:
     """Ask the other region whether it claims the given workspace for any of the kinds.
+
+    Ownership is asked at workspace granularity on purpose. Project ids are issued per region, so
+    "does the other region hold project 2 for this workspace" compares two unrelated numbering
+    spaces and answers no almost every time — which reads as "we own this" and pins the event to
+    whichever region Slack happened to deliver it to.
 
     Returns True/False on a definitive answer, or None on transport failure or bad response.
     Definitive answers are cached for ``WORKSPACE_CLAIMS_CACHE_TTL_SECONDS`` so a single probe
     flake does not reroute the next event. None is never cached so the next event re-probes.
     """
-    cache_key = _workspace_claims_cache_key(slack_team_id, kinds, team_id)
+    cache_key = _workspace_claims_cache_key(slack_team_id, kinds)
     cached = cache.get(cache_key)
     if isinstance(cached, bool):
         logger.info(
@@ -656,7 +658,7 @@ def does_other_region_claim_workspace(
     scheme = "http" if settings.DEBUG else "https"
     target_url = f"{scheme}://{target_domain}/slack/workspace/claims/"
 
-    body = json.dumps({"slack_team_id": slack_team_id, "kinds": kinds, "team_id": team_id}).encode("utf-8")
+    body = json.dumps({"slack_team_id": slack_team_id, "kinds": kinds}).encode("utf-8")
     signing_secret = SlackIntegration.slack_config()["SLACK_APP_SIGNING_SECRET"]
     signed = sign_slack_request(body, signing_secret)
 
@@ -709,7 +711,7 @@ def slack_workspace_claims_view(request: HttpRequest) -> HttpResponse:
     Both Cloud regions provision the PostHog Desktop Slack signing secret, so a region can HMAC-sign
     a small JSON body and the receiver can verify it with the same routine that validates real
     Slack webhooks. The signed body covers every filter, so a captured signature cannot be replayed
-    against a different workspace or project.
+    against a different workspace.
     """
     if request.method != "POST":
         return HttpResponse(status=405)
@@ -728,7 +730,6 @@ def slack_workspace_claims_view(request: HttpRequest) -> HttpResponse:
 
     slack_team_id = data.get("slack_team_id")
     kinds = data.get("kinds")
-    team_id = data.get("team_id")
     if not isinstance(slack_team_id, str) or not slack_team_id:
         return HttpResponse("Missing slack_team_id", status=400)
     if not isinstance(kinds, list) or not kinds:
@@ -736,16 +737,11 @@ def slack_workspace_claims_view(request: HttpRequest) -> HttpResponse:
     filtered = [k for k in kinds if isinstance(k, str) and k in _VALID_WORKSPACE_CLAIM_KINDS]
     if not filtered:
         return HttpResponse("No valid kinds", status=400)
-    if team_id is not None and (not isinstance(team_id, int) or isinstance(team_id, bool)):
-        return HttpResponse("Invalid team_id", status=400)
 
-    integrations = Integration.objects.filter(  # nosemgrep: idor-lookup-without-team
+    claimed = Integration.objects.filter(  # nosemgrep: idor-lookup-without-team
         kind__in=filtered,
         integration_id=slack_team_id,
-    )
-    if team_id is not None:
-        integrations = integrations.filter(team_id=team_id)
-    claimed = integrations.exists()
+    ).exists()
     return JsonResponse({"claimed": claimed})
 
 
@@ -2199,13 +2195,34 @@ def route_posthog_code_event_to_relevant_region(
 
     # link_shared (unfurl) works with either integration kind.
     link_result = load_integrations(slack_team_id=slack_team_id, kinds=list(SLACK_INTEGRATION_KINDS))
+    link_region: str | None = None
     if event_type == "link_shared":
+        # The link's own host decides the region before anything is resolved locally. A workspace
+        # connected in both regions otherwise resolves a `us.` link's `/project/:id` against this
+        # region's project of the same number, which holds someone else's data or nothing at all.
+        link_region = _link_shared_url_region(event)
+        if (
+            link_region is not None
+            and link_region != get_instance_region()
+            and not proxied
+            and cross_region_routing_enabled()
+        ):
+            logger.info(
+                "slack_app_link_unfurl_region_forward",
+                slack_team_id=slack_team_id,
+                event_id=event_id,
+                link_region=link_region,
+                incoming_host=incoming_host,
+            )
+            return _proxy_event_and_return_route(request, other_domain)
+
         link_target = _link_shared_target(event, link_result.candidates, slack_team_id=slack_team_id)
         logger.info(
             "slack_app_link_unfurl_target_selected",
             slack_team_id=slack_team_id,
             event_id=event_id,
             source=link_target.source,
+            link_region=link_region,
             candidate_count=len(link_result.candidates),
             integration_id=link_target.integration.id if link_target.integration else None,
             team_id=link_target.integration.team_id if link_target.integration else None,
@@ -2217,15 +2234,14 @@ def route_posthog_code_event_to_relevant_region(
 
     local_match = link_target.integration
     if local_match:
-        # A link naming a project this region holds is an unambiguous claim on the event, so skip
-        # the precedence probe: a probe flake proxies to a region that has no row for the
-        # workspace, which drops the event and loses an unfurl we could have served.
-        if not link_target.explicit and _us_should_handle_instead(
+        # A link whose host names this region belongs here, whatever the other region claims about
+        # the workspace. Links with no region in the host say nothing about ownership, so those fall
+        # back to the workspace-level precedence every other surface uses.
+        if link_region != get_instance_region() and _us_should_handle_instead(
             slack_team_id,
             list(SLACK_INTEGRATION_KINDS),
             can_defer_to_other_region,
             incoming_host,
-            team_id=local_match.team_id,
         ):
             return _proxy_event_and_return_route(request, other_domain)
         if event_type == "link_shared":
@@ -2244,9 +2260,7 @@ def route_posthog_code_event_to_relevant_region(
     return _route_to_other_region_or_drop(request, slack_team_id, proxied=proxied, other_domain=other_domain)
 
 
-def _us_should_handle_instead(
-    slack_team_id: str, kinds: list[str], can_defer: bool, incoming_host: str, *, team_id: int | None = None
-) -> bool:
+def _us_should_handle_instead(slack_team_id: str, kinds: list[str], can_defer: bool, incoming_host: str) -> bool:
     """US-precedence guard. EU yields to US when both claim a workspace.
 
     Skipped when we're already US (we win) or when we were proxied to (the other region already
@@ -2258,9 +2272,7 @@ def _us_should_handle_instead(
     """
     if not can_defer:
         return False
-    claimed = does_other_region_claim_workspace(
-        slack_team_id=slack_team_id, kinds=kinds, incoming_host=incoming_host, team_id=team_id
-    )
+    claimed = does_other_region_claim_workspace(slack_team_id=slack_team_id, kinds=kinds, incoming_host=incoming_host)
     decision = True if claimed is None else claimed
     logger.info(
         "slack_app_route_us_probe_result",
@@ -3067,35 +3079,60 @@ def _link_shared_resource_refs(event: dict[str, Any]) -> list[dict[str, str]]:
 
 @dataclass(frozen=True)
 class LinkSharedTarget:
-    """The install that serves a ``link_shared`` event, and how it was chosen.
-
-    ``explicit`` is set only when one of the shared links names a ``/project/:id`` this region
-    holds. That is an unambiguous claim on the event, which lets the caller skip the cross-region
-    precedence probe.
-    """
+    """The install that serves a ``link_shared`` event, and how it was chosen."""
 
     integration: Integration | None
     source: str
-    explicit: bool = False
 
 
-def _link_shared_url_team_ids(event: dict[str, Any]) -> set[int]:
-    """Team ids named by ``/project/:id`` in the event's links, counting only unfurlable ones.
+# App hosts that name a Cloud region. `app.posthog.com` is the legacy alias for US Cloud. A bare
+# `posthog.com` link names no region, so it stays out.
+_APP_HOST_REGIONS: dict[str, str] = {
+    "us.posthog.com": "US",
+    "app.posthog.com": "US",
+    "eu.posthog.com": "EU",
+}
+
+
+def _link_shared_resource_urls(event: dict[str, Any]) -> list[str]:
+    """The event's links that parse as a resource we can unfurl.
 
     A shared replay or settings link carries a project id but can never produce an unfurl, so
-    letting it name the project would route a resource link in the same message to a project that
-    doesn't hold it.
+    letting it speak for the event would route a resource link in the same message to a project
+    that doesn't hold it.
     """
-    team_ids: set[int] = set()
     links = event.get("links")
     if not isinstance(links, list):
-        return team_ids
+        return []
+    urls: list[str] = []
     for link in links:
         if not isinstance(link, dict):
             continue
         url = link.get("url")
-        if not isinstance(url, str) or parse_posthog_resource_link(url) is None:
-            continue
+        if isinstance(url, str) and parse_posthog_resource_link(url) is not None:
+            urls.append(url)
+    return urls
+
+
+def _link_shared_url_region(event: dict[str, Any]) -> str | None:
+    """The Cloud region the event's links name, when they agree on one.
+
+    Project ids are issued per region, so `/project/2` on a `us.` link and `/project/2` on an `eu.`
+    link are unrelated projects. Reading the region off the host is what keeps a link from being
+    resolved against the same number in the wrong region.
+    """
+    regions = set()
+    for url in _link_shared_resource_urls(event):
+        region = _APP_HOST_REGIONS.get(urlparse(url).hostname or "")
+        if region is not None:
+            regions.add(region)
+    return regions.pop() if len(regions) == 1 else None
+
+
+def _link_shared_url_team_ids(event: dict[str, Any]) -> set[int]:
+    """Team ids named by ``/project/:id`` in the event's unfurlable links."""
+    team_ids: set[int] = set()
+    for url in _link_shared_resource_urls(event):
         parts = [part for part in urlparse(url).path.split("/") if part]
         if len(parts) >= 2 and parts[0] == "project":
             try:
@@ -3115,7 +3152,7 @@ def _link_shared_target(
         team_id = next(iter(team_ids))
         match = next((candidate for candidate in candidates if candidate.team_id == team_id), None)
         if match is not None:
-            return LinkSharedTarget(match, "url_project", explicit=True)
+            return LinkSharedTarget(match, "url_project")
         # The link names a project no install in this region covers. Refusing lets the caller fall
         # through to the other region rather than unfurling out of an unrelated project.
         return LinkSharedTarget(None, "url_project_not_local")

--- a/products/slack_app/backend/slack_link_unfurl.py
+++ b/products/slack_app/backend/slack_link_unfurl.py
@@ -15,6 +15,7 @@ from posthog.models.comment import Comment
 from posthog.models.integration import Integration, SlackIntegration
 from posthog.models.user_integration import UserIntegration
 from posthog.rbac.user_access_control import UserAccessControl, access_level_satisfied_for_resource
+from posthog.utils import get_instance_region
 
 from products.conversations.backend.models.ticket import Ticket
 from products.dashboards.backend.models.dashboard import Dashboard
@@ -65,6 +66,20 @@ def _truncate(text: str, max_len: int) -> str:
     if len(text) <= max_len:
         return text
     return text[: max_len - 1] + "…"
+
+
+# App hosts that name a Cloud region. `app.posthog.com` is the legacy alias for US Cloud; a bare
+# `posthog.com` link names no region at all.
+_APP_HOST_REGIONS: dict[str, str] = {
+    "us.posthog.com": "US",
+    "app.posthog.com": "US",
+    "eu.posthog.com": "EU",
+}
+
+
+def link_url_region(url: str) -> str | None:
+    """The Cloud region a link's host names, or None when the host doesn't say."""
+    return _APP_HOST_REGIONS.get(urlparse(url).hostname or "")
 
 
 def parse_posthog_resource_link(
@@ -423,6 +438,15 @@ def handle_posthog_link_unfurl(event: dict, integration: Integration) -> None:
             continue
 
         kind, ref = parsed
+
+        # Resource ids repeat across regions, so a link for the other region would otherwise resolve
+        # to whatever local resource carries the same id and unfurl the wrong thing. Routing sends
+        # single-region messages to the region that owns them; this catches the leftover case of one
+        # message carrying links for both.
+        url_region = link_url_region(raw_url)
+        if url_region is not None and url_region != get_instance_region():
+            skipped.append({"kind": kind, "ref": str(ref), "reason": "other_region"})
+            continue
 
         if kind == "insight":
             if not isinstance(ref, str):

--- a/products/slack_app/backend/tests/test_link_unfurl.py
+++ b/products/slack_app/backend/tests/test_link_unfurl.py
@@ -276,6 +276,30 @@ class TestHandlePosthogLinkUnfurl(APIBaseTest):
 
     @patch("products.slack_app.backend.api.resolve_slack_user")
     @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
+    def test_skips_a_link_belonging_to_the_other_region(
+        self, mock_slack_integration_class: MagicMock, mock_resolve: MagicMock
+    ) -> None:
+        # Resource ids repeat across regions, so resolving an eu.posthog.com link here would unfurl
+        # whichever local insight happens to carry the same short id — a card of the wrong data
+        # attached to someone else's link.
+        mock_resolve.return_value = MagicMock(user=self.user)
+        mock_client = MagicMock()
+        mock_slack_integration_class.return_value.client = mock_client
+
+        url = f"https://eu.posthog.com/project/{self.team.pk}/insights/{self.insight.short_id}"
+        with capture_logs() as logs:
+            handle_posthog_link_unfurl(
+                {"channel": "C1", "message_ts": "123.456", "user": "U1", "links": [{"url": url}]},
+                self.integration,
+            )
+
+        mock_client.chat_unfurl.assert_not_called()
+        result = next(log for log in logs if log["event"] == "slack_app_link_unfurl_result")
+        assert result["skipped"] == [{"kind": "insight", "ref": self.insight.short_id, "reason": "other_region"}]
+
+    @patch("products.slack_app.backend.api.resolve_slack_user")
+    @patch("products.slack_app.backend.slack_link_unfurl.SlackIntegration")
     def test_reports_why_recognized_links_were_not_unfurled(
         self, mock_slack_integration_class: MagicMock, mock_resolve: MagicMock
     ) -> None:

--- a/products/slack_app/backend/tests/test_posthog_code_event_handler.py
+++ b/products/slack_app/backend/tests/test_posthog_code_event_handler.py
@@ -20,6 +20,33 @@ from products.slack_app.backend.models import SlackSettings, SlackUserProfileCac
 from products.slack_app.backend.tests.helpers import sign_slack_request
 
 
+class TestLinkSharedUrlRegion(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("us_host", ["https://us.posthog.com/project/2/insights/abc"], "US"),
+            ("legacy_app_host", ["https://app.posthog.com/i/abc"], "US"),
+            ("eu_host", ["https://eu.posthog.com/project/2/insights/abc"], "EU"),
+            ("bare_domain_names_no_region", ["https://posthog.com/i/abc"], None),
+            (
+                "conflicting_regions",
+                ["https://us.posthog.com/i/abc", "https://eu.posthog.com/i/def"],
+                None,
+            ),
+            # A replay link can never unfurl, so it must not speak for the event's region either.
+            (
+                "unfurlable_links_only",
+                ["https://eu.posthog.com/project/2/replay/abc", "https://us.posthog.com/i/abc"],
+                "US",
+            ),
+        ]
+    )
+    def test_region_from_link_hosts(self, _name: str, urls: list[str], expected: str | None) -> None:
+        from products.slack_app.backend.api import _link_shared_url_region
+
+        event = {"type": "link_shared", "links": [{"url": url} for url in urls]}
+        assert _link_shared_url_region(event) == expected
+
+
 class TestPostHogCodeEventHandler(SimpleTestCase):
     def setUp(self):
         self.client = APIClient()
@@ -817,16 +844,15 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
     @patch("products.slack_app.backend.api.handle_posthog_link_unfurl")
     @patch("products.slack_app.backend.api.does_other_region_claim_workspace", return_value=None)
     @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
-    def test_link_shared_for_local_project_ignores_inconclusive_region_probe(self, mock_claims, mock_unfurl):
-        # The link names a project this region holds, which settles ownership on its own. Deferring
-        # to the other region on an inconclusive probe would hand the event to a region with no row
-        # for the workspace, where it is dropped and the unfurl is lost.
+    def test_link_shared_for_this_region_skips_precedence_probe(self, mock_claims, mock_unfurl):
+        # A link whose host names this region belongs here. Deferring to the other region on an
+        # inconclusive probe would hand it to a region that cannot resolve it, and the unfurl is lost.
         event = {
             "type": "link_shared",
             "channel": "C001",
             "user": "U123",
             "message_ts": "1234.5678",
-            "links": [{"url": f"https://eu.posthog.com/project/{self.team.pk}/insights/abc123"}],
+            "links": [{"url": f"https://us.posthog.com/project/{self.team.pk}/insights/abc123"}],
         }
 
         from products.slack_app.backend.api import ROUTE_HANDLED_LOCALLY, route_posthog_code_event_to_relevant_region
@@ -837,6 +863,55 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         assert result == ROUTE_HANDLED_LOCALLY
         mock_claims.assert_not_called()
         mock_unfurl.assert_called_once_with(event, self.posthog_code_integration)
+
+    @patch("products.slack_app.backend.api.handle_posthog_link_unfurl")
+    @patch("products.slack_app.backend.api._proxy_event_and_return_route", return_value="proxied")
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
+    def test_link_shared_for_other_region_forwards_before_resolving(self, mock_proxy, mock_unfurl):
+        # Project ids are issued per region, so this region holding a project of the same number
+        # means nothing for an eu.posthog.com link. Resolving it locally looks the resource up in an
+        # unrelated project, finds nothing, and stays silent — the event has to cross first.
+        event = {
+            "type": "link_shared",
+            "channel": "C001",
+            "user": "U123",
+            "message_ts": "1234.5678",
+            "links": [{"url": f"https://eu.posthog.com/project/{self.team.pk}/insights/abc123"}],
+        }
+
+        from products.slack_app.backend.api import route_posthog_code_event_to_relevant_region
+
+        request = self.factory.post("/slack/event-callback/", HTTP_HOST="us.posthog.com")
+        result = route_posthog_code_event_to_relevant_region(request, event, "T12345")
+
+        assert result == "proxied"
+        mock_proxy.assert_called_once()
+        mock_unfurl.assert_not_called()
+
+    @patch("products.slack_app.backend.api.handle_posthog_link_unfurl")
+    @patch("products.slack_app.backend.api._proxy_event_and_return_route", return_value="proxied")
+    @patch("products.slack_app.backend.api.does_other_region_claim_workspace", return_value=True)
+    @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
+    def test_link_shared_without_region_in_host_yields_to_workspace_owner(self, mock_claims, mock_proxy, mock_unfurl):
+        # A bare posthog.com link names no region, so ownership falls back to the workspace-level
+        # precedence every other surface uses. Asking per-project instead compares team ids across
+        # two independent numbering spaces, which answers "no" and pins the event to this region.
+        event = {
+            "type": "link_shared",
+            "channel": "C001",
+            "user": "U123",
+            "message_ts": "1234.5678",
+            "links": [{"url": "https://posthog.com/i/abc123"}],
+        }
+
+        from products.slack_app.backend.api import route_posthog_code_event_to_relevant_region
+
+        request = self.factory.post("/slack/event-callback/", HTTP_HOST="eu.posthog.com")
+        result = route_posthog_code_event_to_relevant_region(request, event, "T12345")
+
+        assert result == "proxied"
+        assert "team_id" not in mock_claims.call_args.kwargs
+        mock_unfurl.assert_not_called()
 
     @patch("products.slack_app.backend.api.handle_posthog_link_unfurl")
     @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")

--- a/products/slack_app/backend/tests/test_workspace_claims.py
+++ b/products/slack_app/backend/tests/test_workspace_claims.py
@@ -59,22 +59,6 @@ class TestSlackWorkspaceClaimsView(TestCase):
         assert response.json() == {"claimed": True}
 
     @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
-    def test_team_id_limits_claim_to_that_project(self, mock_config):
-        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
-        Integration.objects.create(
-            team=self.team,
-            kind="slack",
-            integration_id="T_PRESENT",
-            sensitive_config={"access_token": "xoxb"},
-        )
-        other_team = Team.objects.create(organization=self.organization, name="Other")
-
-        response = self._post({"slack_team_id": "T_PRESENT", "kinds": ["slack"], "team_id": other_team.id})
-
-        assert response.status_code == 200
-        assert response.json() == {"claimed": False}
-
-    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
     def test_any_of_kinds_match_returns_claimed(self, mock_config):
         mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
         Integration.objects.create(
@@ -290,23 +274,6 @@ class TestDoesOtherRegionClaimWorkspace(TestCase):
             mock_post.return_value = self._response(200, {"claimed": True})
             does_other_region_claim_workspace(slack_team_id="T_KIND", kinds=["slack"], incoming_host="eu.posthog.com")
             assert mock_post.call_count == 1
-
-    def test_cache_is_keyed_by_team_id(self):
-        from products.slack_app.backend.api import does_other_region_claim_workspace
-
-        with (
-            patch("products.slack_app.backend.api.SlackIntegration.slack_config") as mock_config,
-            patch("products.slack_app.backend.api.requests.post") as mock_post,
-        ):
-            mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
-            mock_post.return_value = self._response(200, {"claimed": True})
-            does_other_region_claim_workspace(
-                slack_team_id="T_TEAM", kinds=["slack"], incoming_host="eu.posthog.com", team_id=1
-            )
-            does_other_region_claim_workspace(
-                slack_team_id="T_TEAM", kinds=["slack"], incoming_host="eu.posthog.com", team_id=2
-            )
-            assert mock_post.call_count == 2
 
     def test_signed_request_is_accepted_by_validator(self):
         # End-to-end roundtrip: the sent headers + body, fed into the receiver's verifier, must


### PR DESCRIPTION
## Problem

A Slack workspace connected to projects in **both** Cloud regions gets no unfurl for links belonging to one of them.

Slack delivers every event to one region first, which then decides who owns it. For `link_shared` that decision went wrong in two ways:

- **Project ids are per-region.** `/project/2` on a `us.posthog.com` link and `/project/2` on an `eu.posthog.com` link are unrelated projects. The handler matched the number without looking at the host, so a link for one region was resolved against the other region's project of the same number — which holds someone else's data, or nothing. The lookup missed and the handler stopped, never forwarding to the region that actually holds the resource.
- **`link_shared` stopped honoring workspace precedence.** Every other surface asks "does the other region hold this workspace?" `link_shared` asked "does the other region hold *this project id*?" — comparing two independent numbering spaces. That answers no almost every time, so each event stayed wherever Slack happened to deliver it.

## Changes

```
BEFORE                                   AFTER
──────                                   ─────
link_shared arrives                      link_shared arrives
      │                                        │
      ▼                                  host names a region?
 match /project/:id                       ┌────┴────┐
 against local teams                    other      this / none
      │                                   │            │
      ▼                                   ▼            ▼
 team 2 exists here?                  forward     match /project/:id
      │                               to that      against local teams
   yes → resolve locally ✗ wrong       region             │
        region's project 2                                ▼
                                                    host named this region?
                                                     ┌────┴────┐
                                                    yes        no
                                                     │          │
                                                  ours     workspace-level
                                                            precedence probe
```

- The link's host picks the region — `us.` / `app.` → US, `eu.` → EU — and the event is forwarded before anything is resolved locally.
- A link naming this region settles ownership on its own, so no probe.
- A link naming no region (bare `posthog.com`) falls back to the workspace-level probe mentions use, restoring US precedence.
- The per-project probe is removed, along with its `team_id` plumbing through the claims endpoint and cache key. Cross-region team id comparison has no valid meaning, so leaving the parameter in place invites the same bug back.

Region classification counts only links that parse as an unfurlable resource, matching how project ids are already collected — a shared replay link can't produce an unfurl and shouldn't speak for the event's region.

## How did you test this code?

Automated only — not exercised against a live Slack workspace.

Three routing tests plus a classifier table, each confirmed to fail before the change and pass after:

- `..._for_other_region_forwards_before_resolving` — the reported bug: an `eu.` link arriving where a same-numbered local project exists.
- `..._for_this_region_skips_precedence_probe` — a link naming this region is handled locally even on an inconclusive probe.
- `..._without_region_in_host_yields_to_workspace_owner` — a bare-domain link defers to the workspace owner, and the probe carries no `team_id`.
- `TestLinkSharedUrlRegion` — host→region mapping, including conflicting hosts and the replay-link exclusion.

Two `team_id` tests in `test_workspace_claims.py` are removed with the parameter they covered.

Local: `products/slack_app/backend/tests/` (848), `ruff`, and `ty check` clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no documented behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. This corrects two earlier changes of mine: #80521 introduced the per-project probe, and my follow-up widened it by skipping the probe whenever a URL named a locally-held project. Both looked right in a single-region reading and are wrong once a workspace is connected in both.

Found by comparing production routing logs on both ingress regions against the mention path, which still defers correctly. Supersedes #81145, which fixes the same class of bug — I'd close that in favor of this.

Region is read from the host rather than inferred from which region holds a matching project id, because the numbering spaces overlap by construction and a match proves nothing.

No skills invoked. Test data is synthetic; no workspace identifiers or log contents appear in this PR.
