### PR TITLE
fix(tasks): clean up abandoned prewarm tasks

### DIFF
--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -87,6 +87,16 @@ PREWARMED_QUEUED_TASK_RUN_ERRORS_COUNTER = Counter(
     "Errors raised while marking an orphaned prewarmed TaskRun FAILED in the prewarmed-queued cleanup sweep",
 )
 
+PREWARMED_TERMINAL_TASK_SWEPT_COUNTER = Counter(
+    "posthog_task_prewarmed_terminal_swept_total",
+    "Empty tasks hidden after their unclaimed prewarmed run reached a terminal status",
+)
+
+PREWARMED_TERMINAL_TASK_ERRORS_COUNTER = Counter(
+    "posthog_task_prewarmed_terminal_errors_total",
+    "Errors raised while hiding empty tasks left by terminal unclaimed prewarmed runs",
+)
+
 STALE_LOCAL_QUEUED_TASK_RUN_COMPLETED_COUNTER = Counter(
     "posthog_task_run_stale_local_queued_completed_total",
     "Idle local (desktop-driven) TaskRuns quietly marked COMPLETED by the stale-queued cleanup sweep",
@@ -249,7 +259,20 @@ def kill_stale_queued_task_runs() -> None:
         PREWARMED_QUEUED_TASK_RUN_ERRORS_COUNTER,
     )
 
-    saturated = len(stale_ids) >= BATCH_SIZE or len(local_ids) >= BATCH_SIZE or len(prewarmed_ids) >= BATCH_SIZE
+    terminal_prewarmed_ids = tasks_facade.get_stale_terminal_prewarmed_task_run_ids(PREWARMED_STALE_AFTER, BATCH_SIZE)
+    terminal_prewarmed_swept, terminal_prewarmed_errors = _sweep_each(
+        terminal_prewarmed_ids,
+        tasks_facade.soft_delete_unclaimed_prewarm_task,
+        PREWARMED_TERMINAL_TASK_SWEPT_COUNTER,
+        PREWARMED_TERMINAL_TASK_ERRORS_COUNTER,
+    )
+
+    saturated = (
+        len(stale_ids) >= BATCH_SIZE
+        or len(local_ids) >= BATCH_SIZE
+        or len(prewarmed_ids) >= BATCH_SIZE
+        or len(terminal_prewarmed_ids) >= BATCH_SIZE
+    )
     log = logger.warning if saturated else logger.info
     log(
         "kill_stale_queued_task_runs.sweep_done",
@@ -262,6 +285,9 @@ def kill_stale_queued_task_runs() -> None:
         prewarmed_candidates=len(prewarmed_ids),
         prewarmed_swept=prewarmed_swept,
         prewarmed_errors=prewarmed_errors,
+        terminal_prewarmed_candidates=len(terminal_prewarmed_ids),
+        terminal_prewarmed_swept=terminal_prewarmed_swept,
+        terminal_prewarmed_errors=terminal_prewarmed_errors,
         batch_size=BATCH_SIZE,
         saturated=saturated,
     )

--- a/posthog/tasks/test/test_kill_stale_queued_task_runs.py
+++ b/posthog/tasks/test/test_kill_stale_queued_task_runs.py
@@ -143,6 +143,28 @@ class TestKillStaleQueuedTaskRuns(TestCase):
         self.assertIn("orphaned in QUEUED", run.error_message or "")
         self.assertIsNotNone(run.completed_at)
 
+    def test_reaps_task_shell_for_orphaned_prewarmed_run(self) -> None:
+        Task = apps.get_model("tasks", "Task")
+        TaskRun = apps.get_model("tasks", "TaskRun")
+        task = Task.objects.create(
+            team=self.team,
+            title="",
+            description="",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+        run = TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            status=TaskRun.Status.QUEUED,
+            state={"prewarmed": True, "await_user_message": True},
+        )
+        TaskRun.objects.filter(pk=run.pk).update(updated_at=timezone.now() - datetime.timedelta(minutes=31))
+
+        kill_stale_queued_task_runs()
+
+        task.refresh_from_db()
+        self.assertTrue(task.deleted)
+
     def test_spares_prewarmed_run_still_inside_idle_window(self) -> None:
         # A live warm run idles in QUEUED awaiting its first message; it must not be killed before
         # the in-workflow WARM_IDLE_TIMEOUT (10m) has had a chance to finalize an abandoned one.
@@ -154,6 +176,28 @@ class TestKillStaleQueuedTaskRuns(TestCase):
         run.refresh_from_db()
         self.assertEqual(run.status, TaskRun.Status.QUEUED)
         self.assertIsNone(run.error_message)
+
+    def test_cleans_up_existing_terminal_prewarm_task_shell(self) -> None:
+        Task = apps.get_model("tasks", "Task")
+        TaskRun = apps.get_model("tasks", "TaskRun")
+        task = Task.objects.create(
+            team=self.team,
+            title="",
+            description="",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+        run = TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            state={"prewarmed": True, "await_user_message": True},
+        )
+        TaskRun.objects.filter(pk=run.pk).update(updated_at=timezone.now() - datetime.timedelta(minutes=31))
+
+        kill_stale_queued_task_runs()
+
+        task.refresh_from_db()
+        self.assertTrue(task.deleted)
 
     def test_hard_cap_reaps_ancient_run_with_bumped_updated_at(self) -> None:
         TaskRun = apps.get_model("tasks", "TaskRun")

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -177,6 +177,7 @@ __all__ = [
     "get_sandbox_environment",
     "get_sandbox_snapshot",
     "get_stale_prewarmed_queued_task_run_ids",
+    "get_stale_terminal_prewarmed_task_run_ids",
     "get_stale_queued_task_run_ids",
     "get_task_automation",
     "get_task_detail",
@@ -944,6 +945,23 @@ def get_stale_prewarmed_queued_task_run_ids(older_than: timedelta, limit: int) -
     )
 
 
+def get_stale_terminal_prewarmed_task_run_ids(older_than: timedelta, limit: int) -> list[UUID]:
+    now = django_timezone.now()
+    return list(
+        TaskRun.objects.filter(  # nosemgrep: celery-task-team-scope-audit
+            status__in=[TaskRun.Status.COMPLETED, TaskRun.Status.FAILED, TaskRun.Status.CANCELLED],
+            state__prewarmed=True,
+            state__await_user_message=True,
+            task__deleted=False,
+            task__title="",
+            task__description="",
+            updated_at__lt=now - older_than,
+        )
+        .order_by("updated_at")
+        .values_list("id", flat=True)[:limit]
+    )
+
+
 def _gauge_rows(values_qs, value_key: str, *, with_status: bool, now=None) -> list[contracts.TaskRunGaugeRow]:
     rows = []
     for row in values_qs:
@@ -1240,7 +1258,13 @@ def fail_task_run(run_id: str | UUID, error: str, error_type: str | None = None)
     if run is None:
         return False
     run.mark_failed(error, error_type=error_type)
+    run.task.soft_delete_if_unclaimed_prewarm(run)
     return True
+
+
+def soft_delete_unclaimed_prewarm_task(run_id: str | UUID) -> bool:
+    run = TaskRun.objects.select_related("task").filter(pk=run_id).first()  # nosemgrep: celery-task-team-scope-audit
+    return run.task.soft_delete_if_unclaimed_prewarm(run) if run is not None else False
 
 
 def complete_idle_local_task_run(run_id: str | UUID) -> bool:

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -514,6 +514,14 @@ class Task(DeletedMetaFields, models.Model):
             capture_fn=capture_fn,
         )
 
+    def soft_delete_if_unclaimed_prewarm(self, task_run: "TaskRun") -> bool:
+        if not (task_run.state or {}).get("prewarmed") or not (task_run.state or {}).get("await_user_message"):
+            return False
+        if self.deleted or self.title.strip() or self.description.strip():
+            return False
+        self.soft_delete()
+        return True
+
     def delete(self, *args, **kwargs):
         raise Exception("Cannot hard delete Task. Use soft_delete() instead.")
 

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -515,11 +515,24 @@ class Task(DeletedMetaFields, models.Model):
         )
 
     def soft_delete_if_unclaimed_prewarm(self, task_run: "TaskRun") -> bool:
-        if not (task_run.state or {}).get("prewarmed") or not (task_run.state or {}).get("await_user_message"):
+        deleted_at = django_timezone.now()
+        updated = Task.objects.filter(
+            pk=self.pk,
+            deleted=False,
+            title="",
+            description="",
+            runs__id=task_run.id,
+            runs__state__prewarmed=True,
+            runs__state__await_user_message=True,
+        ).update(deleted=True, deleted_at=deleted_at, updated_at=deleted_at)
+        if not updated:
             return False
-        if self.deleted or self.title.strip() or self.description.strip():
-            return False
-        self.soft_delete()
+        self.deleted = True
+        self.deleted_at = deleted_at
+        self.updated_at = deleted_at
+        self.capture_event(
+            "task_deleted", {"duration_seconds": round((deleted_at - self.created_at).total_seconds(), 1)}
+        )
         return True
 
     def delete(self, *args, **kwargs):

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
@@ -16,6 +16,12 @@ from products.tasks.backend.temporal.process_task.activities.update_task_run_sta
 TOKEN_USAGE = {"input_tokens": 1200, "output_tokens": 300, "total_tokens": 1500, "turns": 3}
 
 
+async def _run_update_task_run_status(
+    activity_environment: ActivityEnvironment, input_data: UpdateTaskRunStatusInput
+) -> None:
+    await activity_environment.run(update_task_run_status, input_data)
+
+
 @pytest.mark.requires_secrets
 class TestUpdateTaskRunStatusActivity:
     @pytest.mark.django_db(transaction=True)
@@ -97,8 +103,8 @@ class TestUpdateTaskRunStatusActivity:
         test_task_run.state = {"prewarmed": True, "await_user_message": True}
         test_task_run.save(update_fields=["state", "updated_at"])
 
-        async_to_sync(activity_environment.run)(
-            update_task_run_status,
+        async_to_sync(_run_update_task_run_status)(
+            activity_environment,
             UpdateTaskRunStatusInput(
                 run_id=str(test_task_run.id),
                 status=TaskRun.Status.COMPLETED,

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
@@ -87,6 +87,26 @@ class TestUpdateTaskRunStatusActivity:
         assert test_task_run.state.get("existing_key") == "kept"
 
     @pytest.mark.django_db(transaction=True)
+    def test_timed_out_unclaimed_prewarm_soft_deletes_task(self, activity_environment, test_task_run):
+        test_task_run.task.title = ""
+        test_task_run.task.description = ""
+        test_task_run.task.save(update_fields=["title", "description", "updated_at"])
+        test_task_run.state = {"prewarmed": True, "await_user_message": True}
+        test_task_run.save(update_fields=["state", "updated_at"])
+
+        async_to_sync(activity_environment.run)(
+            update_task_run_status,
+            UpdateTaskRunStatusInput(
+                run_id=str(test_task_run.id),
+                status=TaskRun.Status.COMPLETED,
+                timed_out_inactivity=True,
+            ),
+        )
+
+        test_task_run.task.refresh_from_db()
+        assert test_task_run.task.deleted is True
+
+    @pytest.mark.django_db(transaction=True)
     @pytest.mark.parametrize(
         "marker",
         [TIMED_OUT_WALL_CLOCK_STATE_KEY, SANDBOX_GONE_STATE_KEY],

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from asgiref.sync import async_to_sync
 from temporalio.exceptions import ApplicationError
+from temporalio.testing import ActivityEnvironment
 
 from products.tasks.backend.models import Loop, TaskRun
 from products.tasks.backend.temporal.process_task.activities.update_task_run_status import (
@@ -87,7 +88,9 @@ class TestUpdateTaskRunStatusActivity:
         assert test_task_run.state.get("existing_key") == "kept"
 
     @pytest.mark.django_db(transaction=True)
-    def test_timed_out_unclaimed_prewarm_soft_deletes_task(self, activity_environment, test_task_run):
+    def test_timed_out_unclaimed_prewarm_soft_deletes_task(
+        self, activity_environment: ActivityEnvironment, test_task_run: TaskRun
+    ) -> None:
         test_task_run.task.title = ""
         test_task_run.task.description = ""
         test_task_run.task.save(update_fields=["title", "description", "updated_at"])

--- a/products/tasks/backend/temporal/process_task/activities/update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/update_task_run_status.py
@@ -117,6 +117,9 @@ def update_task_run_status(input: UpdateTaskRunStatusInput) -> None:
     if input.status in [TaskRun.Status.COMPLETED, TaskRun.Status.FAILED] and old_status != input.status:
         _capture_terminal_analytics(task_run, input)
 
+    if input.timed_out_inactivity and old_status != input.status:
+        task_run.task.soft_delete_if_unclaimed_prewarm(task_run)
+
     # This activity is how workflow-driven runs (finish tool, failures, timeouts, cancellations)
     # reach a terminal status, so loop bookkeeping must hook in here, not only in the HTTP PATCH
     # path (facade.api.update_task_run). Guarded on the actual transition so repeats and the

--- a/products/tasks/backend/tests/test_models.py
+++ b/products/tasks/backend/tests/test_models.py
@@ -407,6 +407,29 @@ class TestTask(TestCase):
         self.assertTrue(task.deleted)
         self.assertIsNotNone(task.deleted_at)
 
+    def test_unclaimed_prewarm_cleanup_does_not_overwrite_claimed_task(self) -> None:
+        task = Task.objects.create(
+            team=self.team,
+            title="",
+            description="",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+        run = TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            status=TaskRun.Status.QUEUED,
+            state={"prewarmed": True, "await_user_message": True},
+        )
+        Task.objects.filter(pk=task.pk).update(title="Claimed task", description="User prompt")
+
+        cleaned_up = task.soft_delete_if_unclaimed_prewarm(run)
+
+        task.refresh_from_db()
+        self.assertFalse(cleaned_up)
+        self.assertFalse(task.deleted)
+        self.assertEqual(task.title, "Claimed task")
+        self.assertEqual(task.description, "User prompt")
+
     def test_hard_delete_blocked(self):
         task = Task.objects.create(
             team=self.team,


### PR DESCRIPTION
## Problem

Abandoned prewarm sessions leave identifier-only tasks in the task list after their runs expire.

**Why:** Prewarming should reduce startup time without creating task history that the user never submitted.

## Changes

- Unclaimed prewarm tasks are soft-deleted when their runs time out or fail orphan cleanup.
- The janitor also removes existing empty shells after terminal runs.
- Cleanup requires the prewarm and awaiting-message markers plus an empty title and description.


