### PR TITLE
fix(cd): stop passing the ECR repository through job outputs

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -31,13 +31,17 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.sha }}
     cancel-in-progress: false
 
+# ECR_REPOSITORY is workflow-level so ordered_image_alias reads it directly instead of
+# through a job output: the runner refuses to export job outputs whose value contains a
+# masked secret, and this value matches one, so a cross-job output of it arrives empty.
+env:
+    ECR_REPOSITORY: posthog-cloud
+
 jobs:
     posthog_build:
         name: Build and push PostHog
         outputs:
             image-digest: ${{ steps.image.outputs.digest }}
-            ecr-registry: ${{ steps.docker-meta.outputs.ecr-registry }}
-            ecr-repository: ${{ steps.ecr-repository.outputs.name }}
         # Production build/deploy runs only from the canonical deploy repo (CD_DEPLOY_ENABLED).
         if: github.repository_owner == 'PostHog' && vars.CD_DEPLOY_ENABLED == 'true'
         runs-on: depot-ubuntu-24.04
@@ -47,8 +51,6 @@ jobs:
             id-token: write # allow issuing OIDC tokens for this workflow run
             contents: read # allow at least reading the repo contents, add other permissions if necessary
             packages: write # allow push to ghcr.io
-        env:
-            ECR_REPOSITORY: posthog-cloud
 
         steps:
             - name: Check out
@@ -61,12 +63,6 @@ jobs:
 
             - name: Set up Depot CLI
               uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
-
-            - name: Expose ECR repository
-              id: ecr-repository
-              shell: bash
-              run: |
-                  echo "name=${ECR_REPOSITORY:?ECR_REPOSITORY is unset}" >> "$GITHUB_OUTPUT"
 
             - name: Docker meta and registry login
               id: docker-meta
@@ -1254,6 +1250,7 @@ jobs:
 
             - name: Log in to Amazon ECR for ordered image alias
               if: ${{ steps.ordered-release.outputs.tag != '' }}
+              id: ecr-login
               uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
 
             - name: Publish and read back ordered image alias
@@ -1261,8 +1258,8 @@ jobs:
               timeout-minutes: 2
               shell: bash
               env:
-                  ECR_REGISTRY: ${{ needs.posthog_build.outputs.ecr-registry }}
-                  ECR_REPO: ${{ needs.posthog_build.outputs.ecr-repository }}
+                  ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+                  ECR_REPO: ${{ env.ECR_REPOSITORY }}
                   EXPECTED_DIGEST: ${{ needs.posthog_build.outputs.image-digest }}
                   ORDERED_ALIAS: ${{ steps.ordered-release.outputs.tag }}
               run: |
@@ -1270,6 +1267,11 @@ jobs:
 
                   if [ -z "$EXPECTED_DIGEST" ]; then
                       echo "::warning title=Ordered image alias source digest unavailable::Ordered image alias publication was skipped because no image digest was resolved."
+                      exit 0
+                  fi
+
+                  if [ -z "$ECR_REGISTRY" ] || [ -z "$ECR_REPO" ]; then
+                      echo "::warning title=Ordered image alias destination unavailable::Ordered image alias publication was skipped because the ECR registry or repository name resolved empty."
                       exit 0
                   fi
 


### PR DESCRIPTION
## Problem

Every master build since #80240 still publishes no ordered release alias, so rollout tooling still cannot order posthog-cloud images from the registry.

- #80716 fixed the empty `ecr-repository` output, but [runs after it](https://github.com/PostHog/posthog/actions/runs/31489487440/job/93775707537) carry the same two failure annotations as before, hidden behind a green job.
- The alias job still receives an empty repository name, so the publish and the read-back both fail.
- The [build job's log](https://github.com/PostHog/posthog/actions/runs/31489487440/job/93772347157) shows why: `##[warning]Skip output 'ecr-repository' since it may contain secret.`
- The runner [refuses to export a job output](https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs) whose value contains a masked secret. A repo secret holds the literal string `posthog` (the Docker Hub username), so `posthog-cloud` never leaves the build job.

## Changes

- The repository name moves to workflow-level `env`, and both jobs read it directly instead of through a job output.
- The alias job reads the registry from its own ECR login step; only the image digest still crosses the job boundary, and a hex digest cannot contain a secret string.
- An empty registry or repository name now produces a titled skip warning instead of a bare `invalid reference format`.
- The alias path stays fail-soft end to end: every outcome annotates and exits 0, and job-level `continue-on-error` still protects the run.

> [!NOTE]
> Follow-up outside this PR: any job output in this repo whose value contains `posthog` is dropped the same way. Moving the Docker Hub username from a secret to a repository variable removes the failure class, since a public username is not a secret.

## How did you test this code?

- I extracted the publish script and drove all eight outcome paths with stubbed `docker` and `aws`, under the runner's exact bash invocation.
- Every path exits 0 and produces its designed annotation: the "present" notice on the happy and idempotent re-run paths, the new destination skip warning on an empty registry or repository, and the existing warnings and errors elsewhere.
- `actionlint` reports the same 38 pre-existing info findings as master and none new; `bin/hogli lint:workflows` passes all 8 checks.
- Not run: the workflow live. The first master push after merge verifies end to end; the alias job should end with the "Ordered image alias present" notice, and `aws ecr batch-get-image` on posthog-cloud should resolve the new `r<position>-<sha6>` tag to the build digest.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: internal CI change with no user-facing behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Code (Claude) diagnosed the failure from public check-run annotations across all post-#80240 runs, then from the build and alias job logs, and authored this fix. Stephen Schmidt directed the session and is the DRI.
- Skills invoked: /debugging-ci-failures, /authoring-ci-workflows, /gating-production-deploys, /writing-pr-descriptions.
- A working internal reference implementation of the same alias scheme shaped the diagnosis: it publishes the identical tag format with no cross-job outputs, which isolated the output redaction as the only difference.
- Session decision: an earlier revision failed the publish step on bad read-back outcomes; Stephen chose to keep the alias path fully fail-soft for now.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
