### PR TITLE
fix(quill): menu indicator contrast, destructive items, button press

### DIFF
--- a/frontend/src/layout/scenes/components/SceneMenuBar.tsx
+++ b/frontend/src/layout/scenes/components/SceneMenuBar.tsx
@@ -252,7 +252,7 @@ type SceneMenuBarItemProps = ComponentProps<typeof MenubarItem> & {
 
 /**
  * Pass `variant="destructive"` for any "Delete X" / "Archive X" / "Remove X" action so the
- * visual signal (red text + icon) is consistent across PostHog scenes.
+ * visual signal is consistent across PostHog scenes.
  */
 export function SceneMenuBarItem({
     opensFloatingUi,

--- a/packages/quill/packages/primitives/AGENTS.md
+++ b/packages/quill/packages/primitives/AGENTS.md
@@ -496,7 +496,7 @@ Same shell as Dialog (shared `quill-dialog__*` styles) but `role="alertdialog"`,
 </DropdownMenu>
 ```
 
-Destructive items (`variant="destructive"` on DropdownMenuItem/ContextMenuItem/MenubarItem) render red text on a transparent background, with a red-tinted background only on hover/highlight — they are styled by the menu item itself, not by Button's filled `destructive` variant. Don't pass a Button variant through `render` to restyle a menu item.
+Destructive items (`variant="destructive"` on DropdownMenuItem/ContextMenuItem/MenubarItem) forward straight to Button's `destructive` variant, so a delete row in a menu reads exactly like a standalone destructive Button: a red fill at rest, brighter on hover or keyboard highlight. The item owns that mapping — don't pass a Button variant through `render` to restyle a menu item.
 
 Checkbox/radio items:
 
@@ -1008,7 +1008,7 @@ Compose `Table > TableHeader/TableBody/TableFooter > TableRow > TableHead/TableC
 </Menubar>
 ```
 
-MenubarItem wraps DropdownMenuItem, so the same item API applies — including `variant="destructive"` (red text, red-tinted highlight, transparent at rest).
+MenubarItem wraps DropdownMenuItem, so the same item API applies — including `variant="destructive"` (Button's filled destructive look).
 
 ### Toast
 

--- a/packages/quill/packages/primitives/src/button.css
+++ b/packages/quill/packages/primitives/src/button.css
@@ -31,6 +31,22 @@
         box-shadow: 0 0 0 2px color-mix(in oklab, var(--ring) 30%, transparent);
     }
 
+    /*
+     * Press feedback — the button dips 1px under the cursor. Excluded are the
+     * variants/components that own their own press motion: `primary` rests
+     * raised and settles to 0, `toggle` dips 2px, and tabs stay put (a tab
+     * that jumps would drag the whole strip's baseline with it).
+     */
+    .quill-button:not(
+        :disabled,
+        [aria-disabled='true'],
+        .quill-button--variant-primary,
+        .quill-tabs__trigger,
+        .quill-toggle
+    ):active {
+        translate: 0 1px;
+    }
+
     /* Disabled covers both paths: native :disabled (focusableWhenDisabled=false)
        and the focusable aria-disabled="true" path (the default). Loading is
        excluded — it's busy, not unavailable, so it keeps full-strength visuals
@@ -108,8 +124,8 @@
 
     /* Consecutive selected items collapse corners for a seamless stack */
     .quill-button--variant-default:is([aria-selected='true'], [aria-checked='true']):has(
-            + :is([aria-selected='true'], [aria-checked='true'])
-        ) {
+        + :is([aria-selected='true'], [aria-checked='true'])
+    ) {
         border-bottom-right-radius: 0;
         border-bottom-left-radius: 0;
     }
@@ -191,7 +207,11 @@
         background-color: color-mix(in oklab, var(--destructive) 50%, transparent);
     }
 
-    .quill-button--variant-destructive:not(:disabled, [aria-disabled='true']):hover {
+    /* `data-highlighted` is the keyboard equivalent of hover inside a menu —
+       both land on the same brighter fill so navigating by arrow keys reads
+       the same as pointing at the row. */
+    .quill-button--variant-destructive:not(:disabled, [aria-disabled='true']):hover,
+    .quill-button--variant-destructive:not(:disabled, [aria-disabled='true'])[data-highlighted] {
         background-color: var(--destructive);
     }
 

--- a/packages/quill/packages/primitives/src/context-menu.tsx
+++ b/packages/quill/packages/primitives/src/context-menu.tsx
@@ -99,18 +99,13 @@ function ContextMenuItem({
             data-variant={variant}
             className={cn(
                 "group/context-menu-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
-                // Same destructive treatment as DropdownMenuItem: red text at rest, red tint on
-                // hover/highlight — never Button's filled `destructive` variant inside a menu.
-                // Disabled destructive mirrors the disabled destructive Button: 50%-mix red fill
-                // under the item-level opacity-50.
-                'data-[variant=destructive]:text-destructive-foreground data-[variant=destructive]:hover:text-destructive-foreground data-[variant=destructive]:[&_svg]:text-destructive-foreground data-[variant=destructive]:hover:bg-destructive/10 data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:data-highlighted:bg-destructive/10 dark:data-[variant=destructive]:hover:bg-destructive/20 dark:data-[variant=destructive]:focus:bg-destructive/20 dark:data-[variant=destructive]:data-highlighted:bg-destructive/20 data-[variant=destructive]:data-disabled:bg-destructive/50',
                 inset && 'quill-menu-item--inset',
                 className
             )}
             // The default render is a real <button>; only declare nativeButton when the
             // caller hasn't overridden render (their element may not be a button).
             nativeButton={!('render' in props)}
-            render={<Button variant="default" className="w-full font-normal" left />}
+            render={<Button variant={variant} className="w-full font-normal" left />}
             {...props}
         >
             {children}

--- a/packages/quill/packages/primitives/src/dropdown-menu.tsx
+++ b/packages/quill/packages/primitives/src/dropdown-menu.tsx
@@ -99,19 +99,13 @@ function DropdownMenuItem({
             data-variant={variant}
             className={cn(
                 "group/dropdown-menu-item relative flex cursor-default items-center text-xs/relaxed outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
-                // Destructive menu items are transparent at rest (red text only) and get a red
-                // tint on hover/highlight — Button's standalone `destructive` variant (filled at
-                // rest) is wrong inside a menu, so the inner Button always stays `default`.
-                // Disabled destructive mirrors the disabled destructive Button: 50%-mix red fill
-                // under the item-level opacity-50.
-                'data-[variant=destructive]:text-destructive-foreground data-[variant=destructive]:hover:text-destructive-foreground data-[variant=destructive]:[&_svg]:text-destructive-foreground data-[variant=destructive]:hover:bg-destructive/10 data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:data-highlighted:bg-destructive/10 dark:data-[variant=destructive]:hover:bg-destructive/20 dark:data-[variant=destructive]:focus:bg-destructive/20 dark:data-[variant=destructive]:data-highlighted:bg-destructive/20 data-[variant=destructive]:data-disabled:bg-destructive/50',
                 inset && 'quill-menu-item--inset',
                 className
             )}
             // The default render is a real <button>; only declare nativeButton when the
             // caller hasn't overridden render (their element may not be a button).
             nativeButton={!('render' in props)}
-            render={<Button variant="default" className="w-full font-normal [&_kbd]:ml-auto" left />}
+            render={<Button variant={variant} className="w-full font-normal [&_kbd]:ml-auto" left />}
             {...props}
         />
     )

--- a/packages/quill/packages/primitives/src/menu.css
+++ b/packages/quill/packages/primitives/src/menu.css
@@ -98,14 +98,33 @@
      * while hovered/highlighted — those states own the hover fill.
      */
     :is(
+        [data-slot='dropdown-menu-checkbox-item'],
+        [data-slot='dropdown-menu-radio-item'],
+        [data-slot='context-menu-checkbox-item'],
+        [data-slot='context-menu-radio-item'],
+        [data-slot='menubar-checkbox-item'],
+        [data-slot='menubar-radio-item']
+    ):is([aria-checked='true'], [data-checked]):not(:hover, [data-highlighted]) {
+        background-color: var(--fill-selected);
+    }
+
+    /*
+     * An unchecked indicator outlines itself with `--border`, which in dark
+     * mode sits almost exactly at the lightness the hover fill lifts the row
+     * to — the box vanishes under the cursor. Mixing with `--foreground`
+     * instead keeps the outline readable against the hovered row in both
+     * themes. Checked indicators are filled, so they're left alone.
+     */
+    :is(
             [data-slot='dropdown-menu-checkbox-item'],
             [data-slot='dropdown-menu-radio-item'],
             [data-slot='context-menu-checkbox-item'],
             [data-slot='context-menu-radio-item'],
             [data-slot='menubar-checkbox-item'],
             [data-slot='menubar-radio-item']
-        ):is([aria-checked='true'], [data-checked]):not(:hover, [data-highlighted]) {
-        background-color: var(--fill-selected);
+        ):is(:hover, [data-highlighted])
+        :is(.quill-checkbox:not([data-checked]), .quill-radio-indicator:not(.quill-radio-indicator--checked)) {
+        border-color: color-mix(in oklab, var(--foreground) 40%, transparent);
     }
 
     /*
@@ -114,11 +133,11 @@
      * effect reads even when Base UI wraps items in a group/list container.
      */
     :is(
-            [data-slot='dropdown-menu-checkbox-item'],
-            [data-slot='dropdown-menu-radio-item'],
-            [data-slot='context-menu-checkbox-item'],
-            [data-slot='context-menu-radio-item']
-        ):is([aria-checked='true'], [data-checked]):has(+ :is([aria-checked='true'], [data-checked])) {
+        [data-slot='dropdown-menu-checkbox-item'],
+        [data-slot='dropdown-menu-radio-item'],
+        [data-slot='context-menu-checkbox-item'],
+        [data-slot='context-menu-radio-item']
+    ):is([aria-checked='true'], [data-checked]):has(+ :is([aria-checked='true'], [data-checked])) {
         border-bottom-right-radius: 0;
         border-bottom-left-radius: 0;
     }
@@ -138,12 +157,14 @@
      * Menu items show no focus ring — the `[data-highlighted]` background fill
      * is the sole active-item indicator for both mouse and keyboard. Suppress
      * both the `data-highlighted` ring and the `:focus-visible` ring Button
-     * carries. (Hover never paints a ring, so `:not(:hover)` only serves to
-     * outrank Button's `[data-highlighted]:not(:hover)` rule regardless of
-     * stylesheet order.)
+     * carries. The redundant `.quill-button` only raises specificity, so this
+     * outranks Button's own ring rules regardless of stylesheet order.
      */
     :is(.quill-menu__content, .quill-menu__sub-content)
-        .quill-button--variant-default:is([data-highlighted], :focus-visible):not(:hover) {
+        .quill-button:is(.quill-button--variant-default, .quill-button--variant-destructive):is(
+            [data-highlighted],
+            :focus-visible
+        ) {
         border-color: transparent;
         box-shadow: none;
     }

--- a/packages/quill/packages/primitives/src/menubar.tsx
+++ b/packages/quill/packages/primitives/src/menubar.tsx
@@ -85,10 +85,9 @@ function MenubarItem({
         <DropdownMenuItem
             data-slot="menubar-item"
             data-inset={inset}
-            // DropdownMenuItem owns destructive styling (red text at rest, red-tinted highlight).
             variant={variant}
             className={cn(
-                'group/menubar-item min-h-7 gap-2 rounded-sm px-2 py-1 text-xs/relaxed focus:bg-fill-hover data-disabled:opacity-50',
+                'group/menubar-item min-h-7 gap-2 rounded-sm px-2 py-1 text-xs/relaxed data-disabled:opacity-50',
                 className
             )}
             {...props}


### PR DESCRIPTION
## Problem

Hovering a checkbox or radio row in a quill menu makes its input invisible in dark mode. Two other quill surfaces read wrong alongside it.

- Unchecked indicators outline themselves with `--border`. In dark mode the hover fill lifts the row to nearly the same lightness, so the outline vanishes under the cursor.
- Destructive menu items overrode Button's `destructive` variant with red text on a transparent background, so a delete row read quieter than the destructive button it stands in for.
- Quill buttons stopped dipping on press, so a click gives no physical feedback. A comment in `collapsible.css` still describes the translate that was removed.

## Changes

I have before and after screenshots for all three, but this sandbox cannot run `hogli pr:upload-image` (see testing below), so they are not attached.

- Unchecked indicators mix their border with `--foreground` while the row is hovered or highlighted. This covers dropdown, context menu and menubar.
- Destructive menu items forward `variant` to the Button they render. The menu-specific Tailwind overrides are deleted.
- Button's brighter destructive fill now also applies on `[data-highlighted]`, so arrow keys match hover.
- The menu's focus-ring suppression now covers the destructive variant, which otherwise painted a red `:focus-visible` ring on keyboard highlight.
- `.quill-button:active` dips 1px again. Primary, `.quill-toggle` and `.quill-tabs__trigger` opt out inside the `:not()` list.
- `MenubarItem` drops `focus:bg-fill-hover`. That utility-layer class outranked the destructive fill on focus.

I listed the three press-motion exemptions inside the `:not()` rather than overriding each component in its own file. Rule order across files in `@layer components` is not guaranteed, and each override would have tied on specificity.

> [!NOTE]
> Every `SceneMenuBar` delete and archive action in the main app now renders as a filled destructive row rather than red text. That is the point of the change, but the blast radius reaches every scene with a menu bar, so the Storybook visual suite will report diffs for Visual Review to approve.

## How did you test this code?

I (actually Claude) verified each fix by rendering the affected Storybook stories in headless Chromium, before and after, in both themes. I did not test in the running app.

- The computed `border-color` of a hovered unchecked indicator changes only after the fix, in both the dropdown and context menus.
- The tabs press screenshots are byte-identical before and after, confirming the opt-out holds.
- No tests added. These are CSS hover and active states, and quill has no test harness that would catch a regression in them.
- Not run: `hogli ci:preflight`. This sandbox cannot build the Python venv, because `pyproject.toml` pins 3.13.13 and uv cannot download that build. I ran the formatters the commit hooks wrap directly instead: stylelint, oxfmt, oxlint, markdownlint and the AGENTS.md symlink check. All passed.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None beyond `packages/quill/packages/primitives/AGENTS.md`, which described the old destructive treatment in two places.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus). Skills invoked: `/writing-pr-descriptions`. I also read the quill primitives and workspace `AGENTS.md` guides before touching component CSS.

Two things changed during the session. My first attempt at the destructive item left the existing `:not(:hover)` on the menu's focus-ring suppression, and the screenshots showed the red ring surviving on hover; raising specificity with a redundant `.quill-button` fixed it without the hover exception. I also found `focus:bg-fill-hover` on `MenubarItem` only by checking the cascade layers, since a Tailwind utility beats a component-layer variant.

Nothing in this PR draws on non-public material. There was no customer conversation, ticket or log behind it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ljbx4PxYhkJ23YFnwM73xG)_