### PR TITLE
fix(desktop): stop opening the changelog automatically

### DIFF
--- a/products/desktop/apps/code/src/renderer/platform-adapters/updates.ts
+++ b/products/desktop/apps/code/src/renderer/platform-adapters/updates.ts
@@ -12,7 +12,6 @@ import {
   UPDATES_CLIENT,
   type UpdatesClient,
 } from "@posthog/ui/features/updates/updatesClient";
-import { useWhatsNewStore } from "@posthog/ui/features/updates/whatsNewStore";
 import { toast } from "@posthog/ui/primitives/toast";
 import { logger } from "@posthog/ui/shell/logger";
 import { posthogFeatureFlags } from "@posthog/ui/shell/posthogAnalyticsImpl";
@@ -150,48 +149,11 @@ function syncStagedUpdates(): void {
 }
 posthogFeatureFlags.onFlagsLoaded(syncStagedUpdates);
 
-// Auto-show "What's New" once on the first launch after the version changes.
-function maybeShowWhatsNew(): void {
-  void hostTrpcClient.os.getAppVersion
-    .query()
-    .then((currentVersion) => {
-      const settings = useSettingsStore.getState();
-      const lastSeen = settings.lastSeenChangelogVersion;
-      if (lastSeen && lastSeen !== currentVersion) {
-        useWhatsNewStore.getState().open();
-      }
-      if (lastSeen !== currentVersion) {
-        settings.setLastSeenChangelogVersion(currentVersion);
-      }
-    })
-    .catch((error: unknown) =>
-      log.error("Failed to evaluate What's New", { error }),
-    );
-}
-
-// The changelog defers to flag-driven surfaces (billing announcement, remote
-// announcements), so wait for flags before auto-opening — otherwise it can
-// open and immediately vanish behind an announcement that arrives with the
-// flag payload. The timeout keeps offline and keyless dev builds working.
-const FLAGS_SETTLE_TIMEOUT_MS = 3_000;
-
-function maybeShowWhatsNewOnceFlagsSettle(): void {
-  let evaluated = false;
-  const evaluate = () => {
-    if (evaluated) return;
-    evaluated = true;
-    maybeShowWhatsNew();
-  };
-  posthogFeatureFlags.onFlagsLoaded(evaluate);
-  setTimeout(evaluate, FLAGS_SETTLE_TIMEOUT_MS);
-}
-
 function onSettingsReady(): void {
   syncAutoDownload(useSettingsStore.getState().downloadUpdatesAutomatically);
   useSettingsStore.subscribe((state) =>
     syncAutoDownload(state.downloadUpdatesAutomatically),
   );
-  maybeShowWhatsNewOnceFlagsSettle();
 }
 
 if (useSettingsStore.persist.hasHydrated()) {

--- a/products/desktop/docs/ANNOUNCEMENTS.md
+++ b/products/desktop/docs/ANNOUNCEMENTS.md
@@ -74,10 +74,8 @@ next eligible item waits for the next launch, so overlapping announcements
 never show back to back. Required updates are exempt: one still blocks even
 after an announcement was handled in the same session.
 
-While an announcement is on stage, the What's New changelog auto-open is
-**cancelled** by default; set `suppressChangelog: false` at the top level of
-the payload to defer it instead so it shows once the announcement clears. A
-blocking announcement also suppresses `UpdateAvailableModal`.
+While an announcement is on stage, it hides the What's New changelog and
+`UpdateAvailableModal`.
 
 ## CTA rules
 

--- a/products/desktop/docs/ANNOUNCEMENTS.md
+++ b/products/desktop/docs/ANNOUNCEMENTS.md
@@ -74,8 +74,6 @@ next eligible item waits for the next launch, so overlapping announcements
 never show back to back. Required updates are exempt: one still blocks even
 after an announcement was handled in the same session.
 
-While an announcement is on stage, it hides `UpdateAvailableModal`.
-
 ## CTA rules
 
 `cta.url` is either `https://…` (opens the default browser) or a

--- a/products/desktop/docs/ANNOUNCEMENTS.md
+++ b/products/desktop/docs/ANNOUNCEMENTS.md
@@ -74,8 +74,7 @@ next eligible item waits for the next launch, so overlapping announcements
 never show back to back. Required updates are exempt: one still blocks even
 after an announcement was handled in the same session.
 
-While an announcement is on stage, it hides the What's New changelog and
-`UpdateAvailableModal`.
+While an announcement is on stage, it hides `UpdateAvailableModal`.
 
 ## CTA rules
 

--- a/products/desktop/packages/shared/src/announcements.test.ts
+++ b/products/desktop/packages/shared/src/announcements.test.ts
@@ -3,7 +3,6 @@ import {
   announcementSchema,
   announcementsEnvelopeSchema,
   announcementsPayloadSchema,
-  readSuppressChangelog,
 } from "./announcements";
 
 const validAnnouncement = {
@@ -190,14 +189,5 @@ describe("announcements schema", () => {
       announcements: [validAnnouncement, validRequiredUpdate],
     });
     expect(result.success).toBe(true);
-  });
-
-  it.each([
-    ["absent field", { announcements: [] }, true],
-    ["explicit false", { announcements: [], suppressChangelog: false }, false],
-    ["non-object payload", "garbage", true],
-    ["non-boolean value", { suppressChangelog: "yes" }, true],
-  ])("readSuppressChangelog: %s → %s", (_name, payload, expected) => {
-    expect(readSuppressChangelog(payload)).toBe(expected);
   });
 });

--- a/products/desktop/packages/shared/src/announcements.ts
+++ b/products/desktop/packages/shared/src/announcements.ts
@@ -136,11 +136,6 @@ export const announcementsEnvelopeSchema = z.object({
 export const announcementsPayloadSchema = z
   .object({
     announcements: z.array(announcementSchema),
-    /**
-     * An on-stage announcement cancels the auto-opened What's New changelog.
-     * Set false to defer it instead, showing both back to back.
-     */
-    suppressChangelog: z.boolean().default(true),
   })
   .superRefine((payload, ctx) => {
     // Dismissals persist per id, so a duplicate would let dismissing one
@@ -158,16 +153,6 @@ export const announcementsPayloadSchema = z
       seenAt.set(item.id, index);
     });
   });
-
-const changelogInterplaySchema = z.object({
-  suppressChangelog: z.boolean().default(true),
-});
-
-/** Tolerant read of the payload's changelog policy — garbage means default. */
-export function readSuppressChangelog(payload: unknown): boolean {
-  const result = changelogInterplaySchema.safeParse(payload);
-  return result.success ? result.data.suppressChangelog : true;
-}
 
 export type Announcement = z.infer<typeof announcementSchema>;
 export type AnnouncementHero = z.infer<typeof heroSchema>;

--- a/products/desktop/packages/ui/src/features/announcements/useSuppressChangelog.ts
+++ b/products/desktop/packages/ui/src/features/announcements/useSuppressChangelog.ts
@@ -1,9 +1,0 @@
-import { ANNOUNCEMENTS_FLAG } from "@posthog/shared";
-import { readSuppressChangelog } from "@posthog/shared/announcements";
-import { useFeatureFlagPayload } from "../feature-flags/useFeatureFlagPayload";
-
-/** The payload's changelog policy: on-stage announcements cancel it (default). */
-export function useSuppressChangelog(): boolean {
-  const payload = useFeatureFlagPayload(ANNOUNCEMENTS_FLAG);
-  return readSuppressChangelog(payload);
-}

--- a/products/desktop/packages/ui/src/features/settings/settingsStore.ts
+++ b/products/desktop/packages/ui/src/features/settings/settingsStore.ts
@@ -248,14 +248,12 @@ interface SettingsStore {
   mcpAppsDisabledServers: string[];
   downloadUpdatesAutomatically: boolean;
   dismissibleUpdateBanners: boolean;
-  lastSeenChangelogVersion: string | null;
   setHedgehogMode: (enabled: boolean) => void;
   setSlotMachineMode: (enabled: boolean) => void;
   setBrainrotMode: (enabled: boolean) => void;
   setMcpAppsDisabledServers: (servers: string[]) => void;
   setDownloadUpdatesAutomatically: (enabled: boolean) => void;
   setDismissibleUpdateBanners: (enabled: boolean) => void;
-  setLastSeenChangelogVersion: (version: string | null) => void;
 
   // Onboarding hints
   hints: Record<string, HintState>;
@@ -476,7 +474,6 @@ export const useSettingsStore = create<SettingsStore>()(
       mcpAppsDisabledServers: [],
       downloadUpdatesAutomatically: true,
       dismissibleUpdateBanners: false,
-      lastSeenChangelogVersion: null,
       setHedgehogMode: (enabled) => set({ hedgehogMode: enabled }),
       setSlotMachineMode: (enabled) => set({ slotMachineMode: enabled }),
       setBrainrotMode: (enabled) => set({ brainrotMode: enabled }),
@@ -484,8 +481,6 @@ export const useSettingsStore = create<SettingsStore>()(
         set({ downloadUpdatesAutomatically: enabled }),
       setDismissibleUpdateBanners: (enabled) =>
         set({ dismissibleUpdateBanners: enabled }),
-      setLastSeenChangelogVersion: (version) =>
-        set({ lastSeenChangelogVersion: version }),
       setMcpAppsDisabledServers: (servers) =>
         set({ mcpAppsDisabledServers: servers }),
 
@@ -611,7 +606,6 @@ export const useSettingsStore = create<SettingsStore>()(
         mcpAppsDisabledServers: state.mcpAppsDisabledServers,
         downloadUpdatesAutomatically: state.downloadUpdatesAutomatically,
         dismissibleUpdateBanners: state.dismissibleUpdateBanners,
-        lastSeenChangelogVersion: state.lastSeenChangelogVersion,
 
         // Onboarding hints
         hints: state.hints,

--- a/products/desktop/packages/ui/src/features/updates/UpdateAvailableModal.tsx
+++ b/products/desktop/packages/ui/src/features/updates/UpdateAvailableModal.tsx
@@ -1,5 +1,6 @@
 import { X } from "@phosphor-icons/react";
 import { useHostTRPC } from "@posthog/host-router/react";
+import { useBlockingAnnouncementVisible } from "@posthog/ui/features/announcements/useAnnouncementVisible";
 import { ReleaseNotesSections } from "@posthog/ui/features/updates/ReleaseNotesSections";
 import { parseReleaseNotes } from "@posthog/ui/features/updates/releaseNotes";
 import { useUpdateModalStore } from "@posthog/ui/features/updates/updateModalStore";
@@ -19,6 +20,7 @@ import {
   Text,
 } from "@radix-ui/themes";
 import { useMutation, useQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
 
 function formatSpeed(bytesPerSecond: number | null): string {
   if (!bytesPerSecond || bytesPerSecond <= 0) return "";
@@ -49,6 +51,11 @@ function ReleaseNotesSkeleton() {
 export function UpdateAvailableModal() {
   const isOpen = useUpdateModalStore((state) => state.isOpen);
   const close = useUpdateModalStore((state) => state.close);
+  const blockingAnnouncementVisible = useBlockingAnnouncementVisible();
+
+  useEffect(() => {
+    if (isOpen && blockingAnnouncementVisible) close();
+  }, [isOpen, blockingAnnouncementVisible, close]);
   const {
     status,
     version,

--- a/products/desktop/packages/ui/src/features/updates/UpdateAvailableModal.tsx
+++ b/products/desktop/packages/ui/src/features/updates/UpdateAvailableModal.tsx
@@ -1,6 +1,5 @@
 import { X } from "@phosphor-icons/react";
 import { useHostTRPC } from "@posthog/host-router/react";
-import { useBlockingAnnouncementVisible } from "@posthog/ui/features/announcements/useAnnouncementVisible";
 import { ReleaseNotesSections } from "@posthog/ui/features/updates/ReleaseNotesSections";
 import { parseReleaseNotes } from "@posthog/ui/features/updates/releaseNotes";
 import { useUpdateModalStore } from "@posthog/ui/features/updates/updateModalStore";
@@ -50,9 +49,6 @@ function ReleaseNotesSkeleton() {
 export function UpdateAvailableModal() {
   const isOpen = useUpdateModalStore((state) => state.isOpen);
   const close = useUpdateModalStore((state) => state.close);
-  // The blocking required-update announcement subsumes this dialog — never
-  // stack the two update prompts.
-  const blockingAnnouncementVisible = useBlockingAnnouncementVisible();
   const {
     status,
     version,
@@ -95,7 +91,7 @@ export function UpdateAvailableModal() {
 
   return (
     <Dialog.Root
-      open={isOpen && !blockingAnnouncementVisible}
+      open={isOpen}
       onOpenChange={(open) => {
         if (!open) close();
       }}

--- a/products/desktop/packages/ui/src/features/updates/WhatsNewModal.tsx
+++ b/products/desktop/packages/ui/src/features/updates/WhatsNewModal.tsx
@@ -1,6 +1,5 @@
 import { X } from "@phosphor-icons/react";
 import { useHostTRPC } from "@posthog/host-router/react";
-import { useAnnouncementVisible } from "@posthog/ui/features/announcements/useAnnouncementVisible";
 import { ReleaseNotesSections } from "@posthog/ui/features/updates/ReleaseNotesSections";
 import {
   groupReleases,
@@ -43,7 +42,6 @@ function ChangelogSkeleton() {
 export function WhatsNewModal() {
   const isOpen = useWhatsNewStore((state) => state.isOpen);
   const close = useWhatsNewStore((state) => state.close);
-  const announcementVisible = useAnnouncementVisible();
   const prefetchForActiveUpdate = useHasActiveUpdate();
   const hostTRPC = useHostTRPC();
   const { data: currentVersion, isError: isVersionError } = useQuery(
@@ -65,7 +63,7 @@ export function WhatsNewModal() {
 
   return (
     <Dialog.Root
-      open={isOpen && !announcementVisible}
+      open={isOpen}
       onOpenChange={(open) => {
         if (!open) close();
       }}

--- a/products/desktop/packages/ui/src/features/updates/WhatsNewModal.tsx
+++ b/products/desktop/packages/ui/src/features/updates/WhatsNewModal.tsx
@@ -1,7 +1,6 @@
 import { X } from "@phosphor-icons/react";
 import { useHostTRPC } from "@posthog/host-router/react";
 import { useAnnouncementVisible } from "@posthog/ui/features/announcements/useAnnouncementVisible";
-import { useSuppressChangelog } from "@posthog/ui/features/announcements/useSuppressChangelog";
 import { ReleaseNotesSections } from "@posthog/ui/features/updates/ReleaseNotesSections";
 import {
   groupReleases,
@@ -19,7 +18,6 @@ import {
   Text,
 } from "@radix-ui/themes";
 import { useQuery } from "@tanstack/react-query";
-import { useEffect } from "react";
 
 function ChangelogSkeleton() {
   return (
@@ -45,17 +43,7 @@ function ChangelogSkeleton() {
 export function WhatsNewModal() {
   const isOpen = useWhatsNewStore((state) => state.isOpen);
   const close = useWhatsNewStore((state) => state.close);
-  // A remote announcement takes the stage alone — the post-update auto-open
-  // waits here until it clears.
   const announcementVisible = useAnnouncementVisible();
-  const suppressChangelog = useSuppressChangelog();
-
-  // By default an on-stage announcement cancels the pending auto-open
-  // outright; suppressChangelog: false in the payload defers it instead, so
-  // the changelog shows once the announcement clears.
-  useEffect(() => {
-    if (isOpen && announcementVisible && suppressChangelog) close();
-  }, [isOpen, announcementVisible, suppressChangelog, close]);
   const prefetchForActiveUpdate = useHasActiveUpdate();
   const hostTRPC = useHostTRPC();
   const { data: currentVersion, isError: isVersionError } = useQuery(

--- a/products/desktop/tools/announcements-admin/src/Editor.tsx
+++ b/products/desktop/tools/announcements-admin/src/Editor.tsx
@@ -86,8 +86,6 @@ function surfaceLabel(item: EditableItem): string {
 function describeChanges(
   before: EditableItem[],
   after: EditableItem[],
-  beforeSuppress: boolean,
-  afterSuppress: boolean,
 ): string[] {
   const beforeById = new Map(
     before.filter((item) => item.id).map((item) => [item.id, item]),
@@ -127,13 +125,6 @@ function describeChanges(
   if (beforeOrder.join("\n") !== afterOrder.join("\n")) {
     lines.push("Reordered — the top item shows first");
   }
-  if (beforeSuppress !== afterSuppress) {
-    lines.push(
-      afterSuppress
-        ? "What's New: now muted while an announcement shows"
-        : "What's New: now allowed once announcements clear",
-    );
-  }
   return lines;
 }
 
@@ -151,17 +142,11 @@ export function Editor({
   const initial = useMemo(() => {
     const parsed = announcementsPayloadSchema.safeParse(readPayload(flag));
     return parsed.success
-      ? {
-          items: toEditable(parsed.data.announcements),
-          suppressChangelog: parsed.data.suppressChangelog,
-        }
+      ? { items: toEditable(parsed.data.announcements) }
       : null;
   }, [flag]);
 
   const [items, setItems] = useState<EditableItem[]>(initial?.items ?? []);
-  const [suppressChangelog, setSuppressChangelog] = useState(
-    initial?.suppressChangelog ?? true,
-  );
   const [selected, setSelected] = useState(0);
   const [errors, setErrors] = useState<string[]>([]);
   const [saving, setSaving] = useState(false);
@@ -175,13 +160,8 @@ export function Editor({
   const selectedItem = items[selIndex] ?? null;
 
   const payloadJson = useMemo(
-    () =>
-      JSON.stringify(
-        { announcements: items.map(toPayloadItem), suppressChangelog },
-        null,
-        2,
-      ),
-    [items, suppressChangelog],
+    () => JSON.stringify({ announcements: items.map(toPayloadItem) }, null, 2),
+    [items],
   );
 
   // The live payload, normalized through the same editor model so the diff
@@ -191,10 +171,7 @@ export function Editor({
       initial === null
         ? null
         : JSON.stringify(
-            {
-              announcements: initial.items.map(toPayloadItem),
-              suppressChangelog: initial.suppressChangelog,
-            },
+            { announcements: initial.items.map(toPayloadItem) },
             null,
             2,
           ),
@@ -203,16 +180,8 @@ export function Editor({
   const dirty = liveJson !== payloadJson;
 
   const changes = useMemo(
-    () =>
-      initial === null
-        ? []
-        : describeChanges(
-            initial.items,
-            items,
-            initial.suppressChangelog,
-            suppressChangelog,
-          ),
-    [initial, items, suppressChangelog],
+    () => (initial === null ? [] : describeChanges(initial.items, items)),
+    [initial, items],
   );
 
   useEffect(() => {
@@ -263,7 +232,6 @@ export function Editor({
       flag_id: flag.id,
     });
     setItems(initial.items);
-    setSuppressChangelog(initial.suppressChangelog);
     setSelected((index) =>
       Math.min(index, Math.max(0, initial.items.length - 1)),
     );
@@ -278,7 +246,6 @@ export function Editor({
     try {
       const parsed = announcementsPayloadSchema.parse(JSON.parse(jsonDraft));
       setItems(toEditable(parsed.announcements));
-      setSuppressChangelog(parsed.suppressChangelog);
       setJsonDraft(null);
       setErrors([]);
     } catch (error) {
@@ -295,7 +262,6 @@ export function Editor({
   const requestPublish = () => {
     const parsed = announcementsPayloadSchema.safeParse({
       announcements: items.map(toPayloadItem),
-      suppressChangelog,
     });
     if (!parsed.success) {
       setErrors(
@@ -320,7 +286,6 @@ export function Editor({
   const confirmPublish = async () => {
     const parsed = announcementsPayloadSchema.safeParse({
       announcements: items.map(toPayloadItem),
-      suppressChangelog,
     });
     if (!parsed.success) return;
     setSaving(true);
@@ -465,20 +430,6 @@ export function Editor({
           <p className="rail-note">
             Top item shows first — one announcement per app session.
           </p>
-          <label
-            className="check rail-policy"
-            title="While an announcement is showing, the What's New changelog stays hidden. Uncheck to show both, back to back."
-          >
-            <input
-              type="checkbox"
-              checked={suppressChangelog}
-              onChange={(e) => {
-                setSuppressChangelog(e.target.checked);
-                setPublished(false);
-              }}
-            />
-            mute What's New
-          </label>
         </aside>
 
         <main className="work">

--- a/products/desktop/tools/announcements-admin/src/styles.css
+++ b/products/desktop/tools/announcements-admin/src/styles.css
@@ -261,10 +261,6 @@ h1 {
   margin: 0;
 }
 
-.rail-policy {
-  font-size: 11.5px;
-}
-
 .work-empty {
   font-family: "IBM Plex Mono", ui-monospace, monospace;
   font-size: 12px;


### PR DESCRIPTION
## Problem

The desktop app interrupts people with the What’s New dialog after version changes.

**Why:** Remote announcements now handle features that need a modal, so routine changelog entries should stay out of the way.

## Changes

- The app no longer opens the changelog automatically after an update.
- People can still open the changelog from the project menu or update settings.
- Remote announcement payloads no longer carry the obsolete changelog suppression option.
- No screenshot: this removes an automatic modal without changing the changelog UI.

## How did you test this code?

- Ran the desktop workspace type checks successfully.
- Ran the shared package test suite successfully.
- Ran the formatter and linter; the linter reported existing warnings only.
- The full local test matrix did not complete successfully. CI will run the remaining tests.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the announcements documentation to remove the obsolete changelog coordination setting.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and published this change. It used the `/posthog-desktop`, `/writing-tests`, `/writing-user-facing-copy`, and `/writing-pr-descriptions` skills.

The change removes the automatic trigger and its persisted state while preserving both manual changelog entry points.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*