### PR TITLE
fix(warehouse_sources): stop reporting exhausted Close search retries as bugs

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/close/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/close/source.py
@@ -45,6 +45,14 @@ class CloseSource(ResumableSource[CloseSourceConfig, CloseResumeConfig]):
             "403 Client Error: Forbidden for url": "Your Close API key does not have access to this resource. Please check the key's permissions.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # Leads/Contacts go through the Advanced Filtering search session (see search.py), whose
+        # `CLOSE_RETRY` already retries 429/5xx at the urllib3 layer before `raise_for_status` can
+        # even raise. A response that still exhausts that budget is a transient Close-side blip, not
+        # a bug, and Temporal's activity retry recovers once it clears. `raise_for_status` derives
+        # these prefixes from the status code alone, not Close's reason text, so they're stable.
+        return {"Server Error", "429 Client Error"}
+
     def get_canonical_descriptions(self) -> CanonicalDescriptions:
         from products.warehouse_sources.backend.temporal.data_imports.sources.close.canonical_descriptions import (
             CANONICAL_DESCRIPTIONS,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/close/tests/test_close_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/close/tests/test_close_source.py
@@ -7,6 +7,7 @@ from posthog.schema import SourceFieldInputConfig, SourceFieldInputConfigType
 from products.warehouse_sources.backend.temporal.data_imports.sources.close.close import CloseResumeConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.close.settings import ENDPOINTS
 from products.warehouse_sources.backend.temporal.data_imports.sources.close.source import CloseSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import error_message_matches
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.close import CloseSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
@@ -103,6 +104,17 @@ class TestCloseSource:
     )
     def test_non_retryable_errors(self, expected_key: str) -> None:
         assert expected_key in self.source.get_non_retryable_errors()
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            "500 Server Error: Internal Server Error for url: https://api.close.com/api/v1/data/search/",
+            "503 Server Error: Service Unavailable for url: https://api.close.com/api/v1/data/search/",
+            "429 Client Error: Too Many Requests for url: https://api.close.com/api/v1/data/search/",
+        ],
+    )
+    def test_retryable_errors_match_exhausted_search_retries(self, error_msg: str) -> None:
+        assert error_message_matches(error_msg, self.source.get_retryable_errors())
 
     def test_get_resumable_source_manager_binds_data_class(self) -> None:
         inputs = MagicMock()


### PR DESCRIPTION
## Problem

The Close source reports an already-retried, self-recovering Close-side 500 as a tracked exception, paging on noise instead of letting Temporal's activity retry recover it. Seen in [error tracking](https://us.posthog.com/project/2/error_tracking/019ff0f5-c94a-7df2-a418-9525c753cde1): `HTTPError: 500 Server Error: Internal Server Error for url: https://api.close.com/api/v1/data/search/`.

## Changes

- The Leads/Contacts search endpoint (`search.py`) already retries 429/5xx at the transport layer via `CLOSE_RETRY` before `raise_for_status()` can raise.
- Once that retry budget exhausts, the plain `HTTPError` fell through `_handle_import_error`'s classification and got logged as an exception, unlike the shared REST engine's 5xx path (used by every other Close endpoint), which already classifies exhausted retries as self-recovering.
- Added `CloseSource.get_retryable_errors()` matching `"Server Error"` and `"429 Client Error"`, the same pattern Convex and Checkout.com already use for endpoints with their own in-process retry. Temporal still retries the whole activity; only the exception-tracking noise goes away.

## How did you test this code?

Added `test_retryable_errors_match_exhausted_search_retries`, parametrized over a 500, a 503, and a 429 message shape for the search endpoint - guards that an exhausted-retry response from Close's search API stays classified as self-recovering rather than falling through to the generic exception path.

Ran locally: `pytest products/warehouse_sources/backend/temporal/data_imports/sources/close/tests/test_close_source.py` (27 passed), `ruff check`/`ruff format --check` on the changed files, and `mypy` scoped to the `close` source directory - all clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal error-classification change, no user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a webhook-delivered error tracking alert for the Close source. I (Claude) pulled the issue's full stack trace and a representative event via the error-tracking MCP tools, traced the call path from the Temporal activity into `_post_search`, and read `_handle_import_error`'s error-classification chain to see why this already-retried failure still got logged as an exception. Confirmed no open human-authored PR already covers this by searching PR titles/bodies for the exception type, message, and module path, and checking Gilbert09's own open PRs.

No skills were invoked beyond `/writing-tests` and `/writing-pr-descriptions` (both mandated by this repo's CLAUDE.md).