### PR TITLE
fix(close): classify exhausted connection retries as noise, not bugs

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/close/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/close/source.py
@@ -45,6 +45,15 @@ class CloseSource(ResumableSource[CloseSourceConfig, CloseResumeConfig]):
             "403 Client Error: Forbidden for url": "Your Close API key does not have access to this resource. Please check the key's permissions.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # Both `CLOSE_RETRY` (Advanced Filtering search) and `DEFAULT_RETRY` (the list endpoints)
+        # already retry a dropped connection or read timeout before re-raising once that budget is
+        # exhausted. urllib3 wraps all of those as "... Max retries exceeded with url: ..."
+        # regardless of the underlying cause (refused connection, read timeout, dropped socket), so
+        # match that stable prefix rather than the per-request URL or nested error detail. Temporal
+        # then retries the whole activity, so the failure is transient and self-recovering.
+        return {"Max retries exceeded with url"}
+
     def get_canonical_descriptions(self) -> CanonicalDescriptions:
         from products.warehouse_sources.backend.temporal.data_imports.sources.close.canonical_descriptions import (
             CANONICAL_DESCRIPTIONS,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/close/tests/test_close_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/close/tests/test_close_source.py
@@ -104,6 +104,14 @@ class TestCloseSource:
     def test_non_retryable_errors(self, expected_key: str) -> None:
         assert expected_key in self.source.get_non_retryable_errors()
 
+    def test_retryable_errors_match_exhausted_connection_retries(self) -> None:
+        error_msg = (
+            "HTTPSConnectionPool(host='api.close.com', port=443): Max retries exceeded with "
+            'url: /api/v1/data/search/ (Caused by ReadTimeoutError("HTTPSConnectionPool(host='
+            "'api.close.com', port=443): Read timed out. (read timeout=60)\"))"
+        )
+        assert any(pattern in error_msg for pattern in self.source.get_retryable_errors())
+
     def test_get_resumable_source_manager_binds_data_class(self) -> None:
         inputs = MagicMock()
         inputs.logger = MagicMock()


### PR DESCRIPTION
## Problem

A Close sync that hits a dropped connection or read timeout against `api.close.com` shows up in error tracking as a `ConnectionError`/`MaxRetryError` exception, even though nothing needs fixing — see [this issue](https://us.posthog.com/project/2/error_tracking/019ff0fc-a75e-7581-86ef-601c531f4bcb).

Both HTTP sessions the Close source uses already retry a dropped connection or read timeout (`CLOSE_RETRY` for the Advanced Filtering search endpoint, `DEFAULT_RETRY` for the list endpoints) before re-raising once that budget is exhausted. Temporal then retries the whole sync activity, with checkpointed resume, so the failure recovers on its own. It was still logged at `exception` level, so it lands in error tracking as noise on top of real bugs.

## Changes

- Add `get_retryable_errors()` to `CloseSource`, matching urllib3's stable `Max retries exceeded with url` prefix so this class of error logs as a `warning` instead.
- The same pattern already covers this exact class of error for the Google Sheets, Notion, and Signoz sources.
- Scoped to the connection-level retry exhaustion only. A related open PR, [#81218](https://github.com/PostHog/posthog/pull/81218), covers a different Close error shape (exhausted HTTP-status retries surfaced via `raise_for_status`, e.g. `5xx`/`429`) with the same mechanism — the two are independent and don't overlap.

## How did you test this code?

Added `test_retryable_errors_match_exhausted_connection_retries`, asserting a representative `Max retries exceeded` message (matching the one from the error tracking issue) matches `get_retryable_errors()`. Ran the full Close source test suite (108 tests) and `ruff check`/`ruff format` on the changed files; both pass. Did not run the repo-wide mypy check or the broader test suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing or API behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via Claude Code, triggered by a PostHog error tracking webhook for the linked issue. Invoked `/writing-tests` before adding the test and `/writing-pr-descriptions` before writing this body. Pulled the full stack trace and a representative event via the PostHog MCP error-tracking tools, confirming the failure originates in `search.py`'s `_post_search` (called from `close.py`'s `close_search_source`), not in serialized log context. Checked the Temporal retry policy in `external_data_job.py` and confirmed Close is a resumable source with up to 15 activity retries plus checkpointed resume, so the existing `get_retryable_errors()` hook (already used by other sources for the same purpose) was the right fix rather than changing retry/backoff/timeout behavior. Searched open PRs before starting; found #81218 addresses a different error shape in the same file, so scoped this PR to avoid overlap.