### PR TITLE
fix(signals): dismiss the inbox selection in one bulk-state call

### DIFF
--- a/products/signals/frontend/inbox/logics/inboxBulkActionsLogic.test.ts
+++ b/products/signals/frontend/inbox/logics/inboxBulkActionsLogic.test.ts
@@ -1,0 +1,119 @@
+/* oxlint-disable react-hooks/rules-of-hooks -- useMocks is a test helper, not a React hook */
+import { expectLogic } from 'kea-test-utils'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import type {
+    SignalReportBulkStateRequestApi,
+    SignalReportBulkStateResponseApi,
+} from 'products/signals/frontend/generated/api.schemas'
+
+import { inboxBulkActionsLogic } from './inboxBulkActionsLogic'
+
+const BULK_STATE_URL = '/api/projects/:team_id/signals/reports/bulk-state/'
+
+const bulkStateResponse = (
+    overrides: Partial<SignalReportBulkStateResponseApi> = {}
+): SignalReportBulkStateResponseApi => ({
+    results: [],
+    transitioned_count: 0,
+    skipped_count: 0,
+    failed_count: 0,
+    not_found_count: 0,
+    ...overrides,
+})
+
+describe('inboxBulkActionsLogic', () => {
+    let logic: ReturnType<typeof inboxBulkActionsLogic.build>
+    let requests: SignalReportBulkStateRequestApi[]
+
+    const mockBulkState = (
+        respond: (body: SignalReportBulkStateRequestApi) => SignalReportBulkStateResponseApi = (body) =>
+            bulkStateResponse({ transitioned_count: body.ids.length })
+    ): void => {
+        useMocks({
+            post: {
+                [BULK_STATE_URL]: async ({ request }) => {
+                    const body = (await request.json()) as SignalReportBulkStateRequestApi
+                    requests.push(body)
+                    return [200, respond(body)]
+                },
+            },
+        })
+    }
+
+    beforeEach(() => {
+        initKeaTests()
+        requests = []
+        logic = inboxBulkActionsLogic()
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+    })
+
+    it('dismisses the whole selection in one request rather than one per report', async () => {
+        mockBulkState()
+        logic.actions.setSelectedReportIds(['report-a', 'report-b', 'report-c'])
+
+        await expectLogic(logic, () => {
+            logic.actions.bulkDismiss('report_unclear', '  needs more detail  ')
+        }).toFinishAllListeners()
+
+        expect(requests).toHaveLength(1)
+        expect(requests[0]).toEqual({
+            ids: ['report-a', 'report-b', 'report-c'],
+            state: 'suppressed',
+            dismissal_reason: 'report_unclear',
+            dismissal_note: 'needs more detail',
+        })
+    })
+
+    it('omits the note when the user typed nothing', async () => {
+        mockBulkState()
+        logic.actions.setSelectedReportIds(['report-a'])
+
+        await expectLogic(logic, () => {
+            logic.actions.bulkDismiss('wontfix_irrelevant', '   ')
+        }).toFinishAllListeners()
+
+        expect(requests[0]).not.toHaveProperty('dismissal_note')
+    })
+
+    it('splits a selection larger than the endpoint limit into batches', async () => {
+        mockBulkState()
+        const reportIds = Array.from({ length: 150 }, (_, index) => `report-${index}`)
+        logic.actions.setSelectedReportIds(reportIds)
+
+        await expectLogic(logic, () => {
+            logic.actions.bulkDismiss('other', '')
+        }).toFinishAllListeners()
+
+        expect(requests.map((request) => request.ids.length)).toEqual([100, 50])
+        expect(requests.flatMap((request) => request.ids)).toEqual(reportIds)
+    })
+
+    it('treats a 200 that transitioned nothing as a failure', async () => {
+        mockBulkState((body) => bulkStateResponse({ skipped_count: body.ids.length }))
+        logic.actions.setSelectedReportIds(['report-a', 'report-b'])
+
+        await expectLogic(logic, () => {
+            logic.actions.bulkDismiss('already_fixed', '')
+        }).toDispatchActions(['bulkDismissFailure'])
+
+        expect(logic.values.isDismissing).toBe(false)
+    })
+
+    it('treats a partially skipped batch as a success so the list reloads', async () => {
+        mockBulkState(() => bulkStateResponse({ transitioned_count: 1, skipped_count: 1 }))
+        logic.actions.setSelectedReportIds(['report-a', 'report-b'])
+
+        await expectLogic(logic, () => {
+            logic.actions.bulkDismiss('analysis_wrong', '')
+        }).toDispatchActions(['bulkDismissSuccess'])
+
+        expect(logic.values.selectedReportIds).toEqual([])
+    })
+})

--- a/products/signals/frontend/inbox/logics/inboxBulkActionsLogic.ts
+++ b/products/signals/frontend/inbox/logics/inboxBulkActionsLogic.ts
@@ -2,12 +2,16 @@ import { MakeLogicType, actions, kea, listeners, path, reducers, selectors } fro
 
 import { lemonToast } from '@posthog/lemon-ui'
 
-import api from 'lib/api'
+import { ApiConfig } from 'lib/api'
 
+import { signalsReportsBulkStateCreate } from '../../generated/api'
 import { captureInboxReportAction } from '../inboxAnalytics'
 import type { DismissalReasonValue } from '../utils/dismissalReasons'
 
-/** Tally of a bulk operation that ran one request per selected report. */
+/** Matches `SIGNAL_REPORT_BULK_STATE_MAX_IDS` on the backend serializer. */
+const BULK_STATE_MAX_IDS = 100
+
+/** Tally of a bulk operation across every batch it took to cover the selection. */
 interface BulkActionResult {
     successCount: number
     failureCount: number
@@ -155,20 +159,38 @@ export const inboxBulkActionsLogic = kea<inboxBulkActionsLogicType>([
                 bulkSize: reportIds.length,
                 extra: { dismissal_reason: reason },
             })
-            const results = await Promise.allSettled(
-                reportIds.map((id) =>
-                    api.signalReports.setState(id, {
+            // One request per batch rather than per report: the endpoint forwards a single scout note
+            // per targeted scout for everything in the call, so a per-report loop teaches the scout the
+            // same thing N times over.
+            const batches: string[][] = []
+            for (let start = 0; start < reportIds.length; start += BULK_STATE_MAX_IDS) {
+                batches.push(reportIds.slice(start, start + BULK_STATE_MAX_IDS))
+            }
+            const projectId = String(ApiConfig.getCurrentTeamId())
+            const responses = await Promise.allSettled(
+                batches.map((ids) =>
+                    signalsReportsBulkStateCreate(projectId, {
+                        ids,
                         state: 'suppressed',
                         dismissal_reason: reason,
                         ...(trimmedNote ? { dismissal_note: trimmedNote } : {}),
                     })
                 )
             )
-            const successCount = results.filter((r) => r.status === 'fulfilled').length
-            const result: BulkActionResult = {
-                successCount,
-                failureCount: results.length - successCount,
-            }
+            const result = responses.reduce<BulkActionResult>(
+                (tally, response, index) => {
+                    if (response.status !== 'fulfilled') {
+                        // The batch never landed, so every id in it is unaccounted for.
+                        return { ...tally, failureCount: tally.failureCount + batches[index].length }
+                    }
+                    const { transitioned_count, skipped_count, failed_count, not_found_count } = response.value
+                    return {
+                        successCount: tally.successCount + transitioned_count,
+                        failureCount: tally.failureCount + skipped_count + failed_count + not_found_count,
+                    }
+                },
+                { successCount: 0, failureCount: 0 }
+            )
 
             actions.clearSelection()
 


### PR DESCRIPTION
## Problem

Dismissing a large selection from the inbox tells the authoring scout the same thing once per report, so a 40-report cleanup lands 40 near-identical notes in the window that scout reads at cold start.

- `inboxBulkActionsLogic` looped `api.signalReports.setState` over every selected id through `Promise.allSettled`, one request each.
- Every one of those requests forwards independently, and `forward_dismissal_note` was written to batch exactly this case into one note per targeted scout.
- `DERIVED_NOTE_TTL` exists so a stream of dismissals cannot crowd deliberate human steering out of the newest-first window a run reads. A per-report loop defeats it.
- The `bulk-state` endpoint already existed and already batched the forwarding. Only the frontend was bypassing it.

Gap 3 of #76929. The other gaps in that issue are untouched here.

## Changes

- Bulk dismiss now issues one `bulk-state` request per batch of selected reports instead of one request per report.
- Batches are capped at 100 ids, matching `SIGNAL_REPORT_BULK_STATE_MAX_IDS` on the serializer. Without the cap a selection over 100 would fail outright, where the old loop partially succeeded.
- The toast tally now reads the endpoint's per-outcome counts, so a `200` that transitioned nothing reports as a failure. Previously any fulfilled promise counted as a success.
- Calls the generated `signalsReportsBulkStateCreate` client rather than adding a method to the handwritten `lib/api` layer.

> [!NOTE]
> No visible change. Same dialog, same toast copy, same reasons. The difference is how many requests leave the browser and how many notes reach the scout.

## How did you test this code?

`inboxBulkActionsLogic` had no test file. Added one, covering the regressions that let this bug exist:

- One request carries the whole selection. This is the actual bug: the old code passed every assertion about dismissal working while still sending N requests.
- A selection over the 100-id limit splits into batches that cover every id in order. Nothing existing pinned the cap.
- A `200` with `transitioned_count: 0` is a failure, and a partially skipped batch is a success that clears the selection. The old code could not distinguish either case, since it only looked at promise settlement.
- A blank note is omitted rather than sent as an empty string.

Ran the new Jest file, oxlint and oxfmt on a local checkout of `master`. To check the tests are worth their place, I reverted the logic file to its `master` version and re-ran them: four of the five fail without the change. The fifth (partial skip is still a success) passes either way, since the old code reached the same outcome by counting settled promises. It stays as a guard against a future tally that treats any skip as total failure, which would break the list reload.

I did not exercise this in a running instance. The request shape is verified against the generated client and the serializer, not against a live inbox, and I have not seen the toast render.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). The PR author is the DRI. Assignment is left empty because an outside contributor cannot be set as assignee on this repo.

Written with Claude Code. Skills invoked: `/adopting-generated-api-types` and `/writing-pr-descriptions`.

The first plan was to add a `bulkState` method to `api.signalReports`, since the handwritten client only exposes `setState`. That was wrong: `signalsReportsBulkStateCreate` is already generated into `products/signals/frontend/generated/api.ts` from the serializer, and `/adopting-generated-api-types` treats `lib/api` as the layer to migrate off. The generated client is used instead, which is why the diff adds no API client code at all.

Batching at 100 was the other decision worth flagging. Sending the whole selection in one request is simpler, but the serializer caps `ids` at 100, so a large selection would have started failing where it previously partially succeeded.

Nothing in this PR draws on material outside this repository.
