### PR TITLE
fix(data-warehouse): open integration settings links in a new tab

### DIFF
--- a/frontend/src/lib/components/CyclotronJob/integrations/IntegrationChoice.tsx
+++ b/frontend/src/lib/components/CyclotronJob/integrations/IntegrationChoice.tsx
@@ -100,6 +100,7 @@ export function IntegrationChoice({
         : oauthUnavailable
           ? {
                 to: urls.settings('project-integrations'),
+                targetBlank: true,
                 sideIcon: <IconExternal />,
                 label: `${kindName} is not configured on this instance`,
             }
@@ -138,6 +139,7 @@ export function IntegrationChoice({
                     items: [
                         {
                             to: urls.settings('project-integrations'),
+                            targetBlank: true,
                             label: 'Manage integrations',
                             sideIcon: <IconExternal />,
                         },


### PR DESCRIPTION
## Problem

Someone connecting an OAuth data warehouse source (Google Ads, Meta Ads, HubSpot, and similar) opens the connection picker's dropdown and clicks "Manage integrations" to check a connected account.
That link, and the "not configured on this instance" link beside it, navigated in the same tab — dropping the person out of the source wizard and discarding the connection details they had already entered.
Both links render an external-link icon, so the same-tab navigation also contradicted what the icon promised.

## Changes

- Open the two integration-settings links in the connection picker dropdown in a new tab (`targetBlank`), so the wizard stays open behind them.
- No behavior change beyond the navigation target; the links still point at the project integrations settings.

## How did you test this code?

Not manually tested by the agent. The change adds `targetBlank: true` to two `LemonMenuItem` link entries, a supported field on `LemonMenuItemLeafLink`.
No automated tests were added — the change is a one-field navigation-target tweak with no existing test asserting the link's tab behavior.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Opened from an analysis of data-warehouse source onboarding session summaries, which surfaced a person clicking "Manage integrations" mid-setup and being navigated away from the wizard, then abandoning the connection.
The links already carried an external-link icon, so the fix aligns behavior with that affordance and keeps in-progress setup state.
No repo skills were required for this change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*