### PR TITLE
fix(data-warehouse): give an actionable message when source credentials fail

### DIFF
--- a/products/warehouse_sources/backend/presentation/views/external_data_source.py
+++ b/products/warehouse_sources/backend/presentation/views/external_data_source.py
@@ -170,6 +170,9 @@ logger = structlog.get_logger(__name__)
 
 REFRESH_SCHEMAS_FALLBACK_ERROR_MESSAGE = "Could not fetch schemas from source."
 RESERVED_SOURCE_NAME_MESSAGE = "This source name is reserved by PostHog."
+INVALID_CREDENTIALS_FALLBACK_MESSAGE = (
+    "We couldn't validate those credentials. Check they're correct and have the required access, then try again."
+)
 
 REFRESH_SCHEMAS_EXPECTED_ERROR_MESSAGES = {
     "timeout": "Connection timed out while fetching schemas from the source.",
@@ -1220,7 +1223,7 @@ class ExternalDataSourceSerializers(UserAccessControlSerializerMixin, serializer
                     source_config, instance.team_id, api_version=effective_api_version
                 )
             if not credentials_valid:
-                raise ValidationError(credentials_error or "Invalid credentials")
+                raise ValidationError(credentials_error or INVALID_CREDENTIALS_FALLBACK_MESSAGE)
             if instance.is_direct_query:
                 discovered_schemas = source.get_schemas(
                     source_config, instance.team_id, api_version=effective_api_version
@@ -3107,7 +3110,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
         if not credentials_valid:
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
-                data={"message": credentials_error or "Invalid credentials"},
+                data={"message": credentials_error or INVALID_CREDENTIALS_FALLBACK_MESSAGE},
             )
 
         try:
@@ -3544,7 +3547,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
             return (
                 Response(
                     status=status.HTTP_400_BAD_REQUEST,
-                    data={"message": credentials_error or "Invalid credentials"},
+                    data={"message": credentials_error or INVALID_CREDENTIALS_FALLBACK_MESSAGE},
                 ),
                 None,
             )


### PR DESCRIPTION
## Problem

Someone connecting a data warehouse source enters their credentials and, when the live check fails, some connectors have no message of their own to show.
In that case the connect flow surfaced a bare "Invalid credentials" toast — it reported the failure but gave no next step, leaving people re-entering the same values with nothing to change.

## Changes

- Replace the fallback "Invalid credentials" string with copy that says what happened and what to do: check the values are correct and have the required access, then try again.
- Share it as one constant across the three connect-time validation paths (source create, store-credentials, and pre-create schema discovery), so the message stays consistent.
- Connectors that already return their own specific validation message are unaffected; this only changes the generic fallback.

## How did you test this code?

Ran `ruff format` and `ruff check` over the changed file (both pass). No behavior changed beyond the fallback string, and no existing test asserts the old fallback text, so no tests were added or updated.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Opened from an analysis of data warehouse source onboarding session summaries, where credential-rejection was a recurring dead-end.
This hardens the shared fallback rather than any single connector; the specific-message connectors already read well.
Invoked the `/writing-user-facing-copy` skill for the message wording.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*