### PR TITLE
fix(cloud-agent): forward cloud steer intent

### DIFF
--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -3604,18 +3604,18 @@ export class SessionService {
     // Steer: the user sent a message mid-turn and asked to fold it into the
     // running turn rather than queue it. Adapters that negotiated
     // `steering: "native"` (Claude, codex) inject at the next tool boundary;
-    // unknown local adapters cancel and resend. Cloud sessions only enter this
-    // path after the sandbox advertises native steering; compaction still queues.
+    // unknown local adapters cancel and resend. Cloud runs negotiate steering
+    // in the task workflow, so always forward the user's intent and let that
+    // authoritative layer choose the compatible signal. Compaction still queues.
     if (options?.steer && session.isPromptPending && !session.isCompacting) {
+      if (session.isCloud && session.status === "connected") {
+        return this.sendCloudPrompt(session, prompt, {
+          skipQueueGuard: true,
+          steer: true,
+        });
+      }
       if (sessionSupportsNativeSteer(session)) {
-        if (session.isCloud) {
-          if (session.status === "connected") {
-            return this.sendCloudPrompt(session, prompt, {
-              skipQueueGuard: true,
-              steer: true,
-            });
-          }
-        } else {
+        if (!session.isCloud) {
           return this.sendSteerPrompt(session, prompt);
         }
       }

--- a/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -6239,7 +6239,7 @@ describe("SessionService", () => {
       );
     });
 
-    it("queues a cloud steer when the sandbox lacks the capability", async () => {
+    it("forwards a cloud steer when cached capability metadata is missing", async () => {
       const service = getSessionService();
       mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
         createMockSession({
@@ -6250,19 +6250,24 @@ describe("SessionService", () => {
           steering: undefined,
         }),
       );
+      mockTrpcCloudTask.sendCommand.mutate.mockResolvedValue({
+        success: true,
+        result: { stopReason: "steered", steered: true },
+      });
 
       const prompt: ContentBlock[] = [{ type: "text", text: "steer me" }];
       const result = await service.sendPrompt("task-123", prompt, {
         steer: true,
       });
 
-      expect(result.stopReason).toBe("queued");
-      expect(mockSessionStoreSetters.enqueueMessage).toHaveBeenCalledWith(
-        "task-123",
-        "steer me",
-        prompt,
+      expect(result.stopReason).toBe("steered");
+      expect(mockSessionStoreSetters.enqueueMessage).not.toHaveBeenCalled();
+      expect(mockTrpcCloudTask.sendCommand.mutate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "user_message",
+          params: { content: "steer me", steer: true },
+        }),
       );
-      expect(mockTrpcCloudTask.sendCommand.mutate).not.toHaveBeenCalled();
     });
 
     it("kicks an SSE retry when queueing on a disconnected cloud session", async () => {


### PR DESCRIPTION
## Problem

Cloud task messages selected as Steer can remain queued when Desktop lacks cached steering capability metadata.

**Why:** People expect Steer to affect the active turn immediately, including after reconnecting to an existing cloud run.

## Changes

- Always forward explicit cloud Steer intent to the task workflow.
- Keep capability negotiation in the workflow, which selects the compatible signal.