### PR TITLE
feat(cdp): default cdp-functions-get-revision to the latest version

### DIFF
--- a/products/cdp/backend/api/hog_function.py
+++ b/products/cdp/backend/api/hog_function.py
@@ -1481,19 +1481,36 @@ class HogFunctionViewSet(
         return self.get_paginated_response(HogFunctionRevisionBasicSerializer(page, many=True).data)
 
     @extend_schema(
-        parameters=[OpenApiParameter("version", int, OpenApiParameter.PATH, description="Function version to fetch.")],
+        parameters=[
+            OpenApiParameter(
+                "version",
+                str,
+                OpenApiParameter.PATH,
+                description="Function version to fetch, or 'latest' for the newest published version.",
+            )
+        ],
         responses={200: HogFunctionRevisionSerializer},
         filters=False,
     )
-    @action(detail=True, methods=["GET"], url_path=r"revisions/(?P<version>\d+)", filter_backends=[])
+    @action(detail=True, methods=["GET"], url_path=r"revisions/(?P<version>\d+|latest)", filter_backends=[])
     def revision_detail(self, request: Request, version: Optional[str] = None, *args, **kwargs):
         if not use_destinations_revisions(self.team):
             raise exceptions.ValidationError(REVISIONS_DISABLED_MESSAGE)
         instance = self.get_object()
-        try:
-            revision = HogFunctionRevision.objects.get(hog_function=instance, version=int(version or 0))
-        except HogFunctionRevision.DoesNotExist:
-            raise exceptions.NotFound("No such revision for this function.")
+        if version == "latest":
+            revision = (
+                HogFunctionRevision.objects.filter(hog_function=instance)
+                .order_by("-version")
+                .select_related("created_by")
+                .first()
+            )
+            if revision is None:
+                raise exceptions.NotFound("No revisions exist for this function yet.")
+        else:
+            try:
+                revision = HogFunctionRevision.objects.get(hog_function=instance, version=int(version or 0))
+            except HogFunctionRevision.DoesNotExist:
+                raise exceptions.NotFound("No such revision for this function.")
         return Response(HogFunctionRevisionSerializer(revision).data)
 
     @extend_schema(

--- a/products/cdp/backend/api/test/test_hog_function_drafts.py
+++ b/products/cdp/backend/api/test/test_hog_function_drafts.py
@@ -475,6 +475,23 @@ class TestHogFunctionRevisions(DraftTestCase):
         assert response.json()["content"]["hog"] == LIVE_HOG
         assert "token" not in response.json()["content"]["inputs"]
 
+    def test_revision_detail_latest_returns_the_newest_version(self):
+        function_id = self._create()
+        self._live_edit(function_id, {"hog": EDITED_HOG})
+
+        response = self.client.get(self._url(function_id, "/revisions/latest"))
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert response.json()["version"] == 2
+        assert response.json()["content"]["hog"] == EDITED_HOG
+
+    def test_revision_detail_latest_404s_when_no_revisions_exist(self):
+        function_id = self._create()
+
+        response = self.client.get(self._url(function_id, "/revisions/latest"))
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
+
     def test_unknown_revision_is_a_404(self):
         function_id = self._create()
 

--- a/products/cdp/frontend/generated/api.ts
+++ b/products/cdp/frontend/generated/api.ts
@@ -442,14 +442,14 @@ export const hogFunctionsRevisionsList = async (
     )
 }
 
-export const getHogFunctionsRevisionsRetrieveUrl = (projectId: string, id: string, version: number) => {
+export const getHogFunctionsRevisionsRetrieveUrl = (projectId: string, id: string, version: string) => {
     return `/api/projects/${projectId}/hog_functions/${id}/revisions/${version}/`
 }
 
 export const hogFunctionsRevisionsRetrieve = async (
     projectId: string,
     id: string,
-    version: number,
+    version: string,
     options?: RequestInit
 ): Promise<HogFunctionRevisionApi> => {
     return apiMutator<HogFunctionRevisionApi>(getHogFunctionsRevisionsRetrieveUrl(projectId, id, version), {

--- a/products/cdp/mcp/cdp_functions.yaml
+++ b/products/cdp/mcp/cdp_functions.yaml
@@ -202,8 +202,15 @@ tools:
         title: Get function revision
         description: >
             Get one version of a function's config by version number, including the full snapshot (hog, inputs_schema,
-            inputs, filters, mappings, masking) as it was at that version. Secret input values are never included. Use
-            cdp-functions-list-revisions first to find the version you want.
+            inputs, filters, mappings, masking) as it was at that version. Secret input values are never included. Omit
+            version to fetch the latest published revision. Pass a specific version number (from
+            cdp-functions-list-revisions) to fetch that version.
+        param_overrides:
+            version:
+                default: latest
+                description: >
+                    Version number to fetch, or omit for the latest published revision. Get a specific number from
+                    cdp-functions-list-revisions.
     cdp-functions-icon-retrieve:
         operation: hog_functions_icon_retrieve
         enabled: false

--- a/products/cdp/mcp/cdp_functions.yaml
+++ b/products/cdp/mcp/cdp_functions.yaml
@@ -207,10 +207,10 @@ tools:
             cdp-functions-list-revisions) to fetch that version.
         param_overrides:
             version:
-                default: latest
                 description: >
                     Version number to fetch, or omit for the latest published revision. Get a specific number from
                     cdp-functions-list-revisions.
+                default: latest
     cdp-functions-icon-retrieve:
         operation: hog_functions_icon_retrieve
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1165,7 +1165,7 @@
         }
     },
     "cdp-functions-get-revision": {
-        "description": "Get one version of a function's config by version number, including the full snapshot (hog, inputs_schema, inputs, filters, mappings, masking) as it was at that version. Secret input values are never included. Use cdp-functions-list-revisions first to find the version you want.",
+        "description": "Get one version of a function's config by version number, including the full snapshot (hog, inputs_schema, inputs, filters, mappings, masking) as it was at that version. Secret input values are never included. Omit version to fetch the latest published revision. Pass a specific version number (from cdp-functions-list-revisions) to fetch that version.",
         "category": "Functions",
         "feature": "hog_functions",
         "summary": "Get function revision",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1180,7 +1180,7 @@
         }
     },
     "cdp-functions-get-revision": {
-        "description": "Get one version of a function's config by version number, including the full snapshot (hog, inputs_schema, inputs, filters, mappings, masking) as it was at that version. Secret input values are never included. Use cdp-functions-list-revisions first to find the version you want.",
+        "description": "Get one version of a function's config by version number, including the full snapshot (hog, inputs_schema, inputs, filters, mappings, masking) as it was at that version. Secret input values are never included. Omit version to fetch the latest published revision. Pass a specific version number (from cdp-functions-list-revisions) to fetch that version.",
         "category": "Functions",
         "feature": "hog_functions",
         "summary": "Get function revision",

--- a/services/mcp/src/generated/cdp_functions/api.ts
+++ b/services/mcp/src/generated/cdp_functions/api.ts
@@ -1138,7 +1138,7 @@ export const HogFunctionsRevisionsRetrieveParams = /* @__PURE__ */ zod.object({
         .describe(
             "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
         ),
-    version: zod.number().describe('Function version to fetch.'),
+    version: zod.string().describe("Function version to fetch, or 'latest' for the newest published version."),
 })
 
 export const HogFunctionsRevisionsRestoreCreateParams = /* @__PURE__ */ zod.object({

--- a/services/mcp/src/tools/generated/cdp_functions.ts
+++ b/services/mcp/src/tools/generated/cdp_functions.ts
@@ -130,7 +130,14 @@ const cdpFunctionsDiscardDraft = (): ToolBase<typeof CdpFunctionsDiscardDraftSch
     },
 })
 
-const CdpFunctionsGetRevisionSchema = HogFunctionsRevisionsRetrieveParams.omit({ project_id: true })
+const CdpFunctionsGetRevisionSchema = HogFunctionsRevisionsRetrieveParams.omit({ project_id: true }).extend({
+    version: HogFunctionsRevisionsRetrieveParams.shape['version']
+        .default('latest')
+        .optional()
+        .describe(
+            'Version number to fetch, or omit for the latest published revision. Get a specific number from cdp-functions-list-revisions.'
+        ),
+})
 
 const cdpFunctionsGetRevision = (): ToolBase<typeof CdpFunctionsGetRevisionSchema, Schemas.HogFunctionRevision> => ({
     name: 'cdp-functions-get-revision',

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-get-revision.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/cdp-functions-get-revision.json
@@ -6,10 +6,11 @@
             "type": "string"
         },
         "version": {
-            "description": "Function version to fetch.",
-            "type": "number"
+            "default": "latest",
+            "description": "Version number to fetch, or omit for the latest published revision. Get a specific number from cdp-functions-list-revisions.",
+            "type": "string"
         }
     },
-    "required": ["id", "version"],
+    "required": ["id"],
     "type": "object"
 }


### PR DESCRIPTION
## Problem

Agents calling `cdp-functions-get-revision` over MCP omit the required `version` path parameter most of the time and get a tool-input schema rejection before the request reaches the API. The tool description told them to call `cdp-functions-list-revisions` first to find a version, but that step is friction agents routinely skip, so the call fails with `missing required parameter: version` and the agent never sees the config it asked for.

## Changes

- The `revision_detail` route accepts `latest` as a path sentinel (`revisions/(?P<version>\d+|latest)`) and returns the newest published revision for the function, 404ing when none exist.
- The OpenAPI `version` parameter type moves from `int` to `str` so the generated tool schema accepts both a number and `latest`.
- The `cdp-functions-get-revision` MCP tool makes `version` optional with a default of `latest`, so an agent calling it with only an `id` gets the latest revision. The description now says to omit `version` for the latest and to pass a specific number from `cdp-functions-list-revisions` otherwise.
- Regenerated OpenAPI types, generated MCP tool handlers, and the tool schema snapshot.

## How did you test this code

- `test_revision_detail_latest_returns_the_newest_version` - after a live edit creates v1 and v2, `revisions/latest` returns v2. Catches the route being narrowed back to digits-only or the latest-fetch resolving the wrong row.
- `test_revision_detail_latest_404s_when_no_revisions_exist` - a freshly created function has no revisions, so `revisions/latest` returns 404 rather than a phantom or empty response.
- The existing `revisions/{number}` and 404-on-unknown-version tests still pass, confirming the numeric path still works alongside the sentinel.

Ran the `TestHogFunctionRevisions` suite and the MCP tool schema snapshot test. Not run: the full backend and MCP unit suites across the repo.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing docs exist for the destinations revision cycle yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Harley directed the work after reviewing MCP analytics that showed an 80% error rate on `cdp-functions-get-revision`, all `missing required parameter: version`. Skills invoked: `/improving-drf-endpoints`, `/implementing-mcp-tools`, `/writing-tests`, `/writing-pr-descriptions`.

The obvious alternative was to sharpen the description to force agents to pass a version. Rejected: the failure rate showed agents already skip that step, so making `version` optional with a `latest` default removes the failure mode instead of warning against it. A separate `revisions/latest` route was considered over a sentinel on the existing route; the sentinel keeps one endpoint and one tool, and the `str` param type carries both shapes through codegen.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*