### PR TITLE
feat(error-tracking): sync severity to ClickHouse

### DIFF
--- a/products/error_tracking/backend/management/commands/backfill_error_tracking_issue_state.py
+++ b/products/error_tracking/backend/management/commands/backfill_error_tracking_issue_state.py
@@ -200,6 +200,7 @@ class Command(BaseCommand):
             "issue_name": issue.name,
             "issue_description": issue.description,
             "issue_status": issue.status,
+            "issue_severity": issue.severity,
             "assigned_user_id": assigned_user_id,
             "assigned_role_id": assigned_role_id,
             "first_seen": first_seen,

--- a/products/error_tracking/backend/management/commands/test/test_backfill_error_tracking_issue_state.py
+++ b/products/error_tracking/backend/management/commands/test/test_backfill_error_tracking_issue_state.py
@@ -24,7 +24,7 @@ class TestBackfillErrorTrackingIssueState(ClickhouseTestMixin, BaseTest):
     def _get_rows(self, team_id: int) -> list[dict]:
         rows = sync_execute(
             """
-            SELECT fingerprint, issue_id, issue_name, issue_status, assigned_user_id, assigned_role_id, is_deleted, first_seen, version
+            SELECT fingerprint, issue_id, issue_name, issue_status, issue_severity, assigned_user_id, assigned_role_id, is_deleted, first_seen, version
             FROM error_tracking_fingerprint_issue_state
             WHERE team_id = %(team_id)s
             ORDER BY fingerprint
@@ -37,11 +37,12 @@ class TestBackfillErrorTrackingIssueState(ClickhouseTestMixin, BaseTest):
                 "issue_id": str(r[1]),
                 "issue_name": r[2],
                 "issue_status": r[3],
-                "assigned_user_id": r[4],
-                "assigned_role_id": r[5],
-                "is_deleted": r[6],
-                "first_seen": r[7],
-                "version": r[8],
+                "issue_severity": r[4],
+                "assigned_user_id": r[5],
+                "assigned_role_id": r[6],
+                "is_deleted": r[7],
+                "first_seen": r[8],
+                "version": r[9],
             }
             for r in rows
         ]
@@ -57,7 +58,12 @@ class TestBackfillErrorTrackingIssueState(ClickhouseTestMixin, BaseTest):
         )
 
     def test_backfill_creates_rows_in_clickhouse(self):
-        issue = ErrorTrackingIssue.objects.create(team=self.team, name="TestError", status="active")
+        issue = ErrorTrackingIssue.objects.create(
+            team=self.team,
+            name="TestError",
+            status="active",
+            severity=ErrorTrackingIssue.Severity.HIGH,
+        )
         ErrorTrackingIssueFingerprintV2.objects.create(team=self.team, issue=issue, fingerprint="fp_one")
         ErrorTrackingIssueFingerprintV2.objects.create(team=self.team, issue=issue, fingerprint="fp_two")
 
@@ -71,6 +77,7 @@ class TestBackfillErrorTrackingIssueState(ClickhouseTestMixin, BaseTest):
         self.assertEqual(rows[0]["issue_id"], str(issue.id))
         self.assertEqual(rows[0]["issue_name"], "TestError")
         self.assertEqual(rows[0]["issue_status"], "active")
+        self.assertEqual(rows[0]["issue_severity"], "high")
         self.assertEqual(rows[1]["fingerprint"], "fp_two")
 
     def test_backfill_includes_user_assignment(self):

--- a/products/error_tracking/backend/models.py
+++ b/products/error_tracking/backend/models.py
@@ -24,7 +24,7 @@ from posthog.models.utils import UUIDModel, UUIDTModel
 from posthog.storage import object_storage
 
 from products.error_tracking.backend.sql import (
-    INSERT_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE,
+    INSERT_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE_WITH_SEVERITY,
     INSERT_ERROR_TRACKING_ISSUE_FINGERPRINT_OVERRIDES,
 )
 
@@ -717,7 +717,7 @@ def sync_issues_to_clickhouse(*, issue_ids: list, team_id: int) -> None:
         first_seen_raw = fp.first_seen or issue.created_at
         first_seen = format_clickhouse_timestamp(first_seen_raw) if first_seen_raw else None
         producer.produce(
-            sql=INSERT_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE,
+            sql=INSERT_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE_WITH_SEVERITY,
             topic=KAFKA_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE,
             data={
                 "fingerprint": fp.fingerprint,
@@ -726,6 +726,7 @@ def sync_issues_to_clickhouse(*, issue_ids: list, team_id: int) -> None:
                 "issue_name": issue.name,
                 "issue_description": issue.description,
                 "issue_status": _clickhouse_status(issue.status),
+                "issue_severity": issue.severity,
                 "assigned_user_id": assigned_user_id,
                 "assigned_role_id": assigned_role_id,
                 "first_seen": first_seen,

--- a/products/error_tracking/backend/models.py
+++ b/products/error_tracking/backend/models.py
@@ -24,7 +24,7 @@ from posthog.models.utils import UUIDModel, UUIDTModel
 from posthog.storage import object_storage
 
 from products.error_tracking.backend.sql import (
-    INSERT_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE_WITH_SEVERITY,
+    INSERT_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE,
     INSERT_ERROR_TRACKING_ISSUE_FINGERPRINT_OVERRIDES,
 )
 
@@ -717,7 +717,7 @@ def sync_issues_to_clickhouse(*, issue_ids: list, team_id: int) -> None:
         first_seen_raw = fp.first_seen or issue.created_at
         first_seen = format_clickhouse_timestamp(first_seen_raw) if first_seen_raw else None
         producer.produce(
-            sql=INSERT_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE_WITH_SEVERITY,
+            sql=INSERT_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE,
             topic=KAFKA_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE,
             data={
                 "fingerprint": fp.fingerprint,

--- a/products/error_tracking/backend/sql.py
+++ b/products/error_tracking/backend/sql.py
@@ -307,10 +307,6 @@ ERROR_TRACKING_FINGERPRINT_ISSUE_STATE_TABLE_SQL = lambda: ERROR_TRACKING_FINGER
 
 
 INSERT_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE = """
-INSERT INTO error_tracking_fingerprint_issue_state (fingerprint, issue_id, team_id, issue_name, issue_description, issue_status, assigned_user_id, assigned_role_id, first_seen, is_deleted, version, _timestamp, _offset, _partition) SELECT %(fingerprint)s, %(issue_id)s, %(team_id)s, %(issue_name)s, %(issue_description)s, %(issue_status)s, %(assigned_user_id)s, %(assigned_role_id)s, %(first_seen)s, %(is_deleted)s, %(version)s, now(), 0, 0 VALUES
-"""
-
-INSERT_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE_WITH_SEVERITY = """
 INSERT INTO error_tracking_fingerprint_issue_state (fingerprint, issue_id, team_id, issue_name, issue_description, issue_status, issue_severity, assigned_user_id, assigned_role_id, first_seen, is_deleted, version, _timestamp, _offset, _partition) SELECT %(fingerprint)s, %(issue_id)s, %(team_id)s, %(issue_name)s, %(issue_description)s, %(issue_status)s, %(issue_severity)s, %(assigned_user_id)s, %(assigned_role_id)s, %(first_seen)s, %(is_deleted)s, %(version)s, now(), 0, 0 VALUES
 """
 

--- a/products/error_tracking/backend/sql.py
+++ b/products/error_tracking/backend/sql.py
@@ -310,6 +310,10 @@ INSERT_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE = """
 INSERT INTO error_tracking_fingerprint_issue_state (fingerprint, issue_id, team_id, issue_name, issue_description, issue_status, assigned_user_id, assigned_role_id, first_seen, is_deleted, version, _timestamp, _offset, _partition) SELECT %(fingerprint)s, %(issue_id)s, %(team_id)s, %(issue_name)s, %(issue_description)s, %(issue_status)s, %(assigned_user_id)s, %(assigned_role_id)s, %(first_seen)s, %(is_deleted)s, %(version)s, now(), 0, 0 VALUES
 """
 
+INSERT_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE_WITH_SEVERITY = """
+INSERT INTO error_tracking_fingerprint_issue_state (fingerprint, issue_id, team_id, issue_name, issue_description, issue_status, issue_severity, assigned_user_id, assigned_role_id, first_seen, is_deleted, version, _timestamp, _offset, _partition) SELECT %(fingerprint)s, %(issue_id)s, %(team_id)s, %(issue_name)s, %(issue_description)s, %(issue_status)s, %(issue_severity)s, %(assigned_user_id)s, %(assigned_role_id)s, %(first_seen)s, %(is_deleted)s, %(version)s, now(), 0, 0 VALUES
+"""
+
 # WarpStream-shared Kafka engine table + MV for error_tracking_fingerprint_issue_state.
 # Coexists with the MSK-pointed table during cut-over.
 

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -1312,7 +1312,7 @@ class TestIssueStateSync(ClickhouseTestMixin, APIBaseTest):
 
         return sync_execute(
             """
-            SELECT fingerprint, issue_id, issue_name, issue_status, assigned_user_id, assigned_role_id
+            SELECT fingerprint, issue_id, issue_name, issue_status, assigned_user_id, assigned_role_id, issue_severity
             FROM error_tracking_fingerprint_issue_state FINAL
             WHERE team_id = %(team_id)s AND is_deleted = 0
             ORDER BY fingerprint
@@ -1398,6 +1398,18 @@ class TestIssueStateSync(ClickhouseTestMixin, APIBaseTest):
         rows = self._get_issue_state_rows()
         assert len(rows) == 1
         assert rows[0][3] == "resolved"  # issue_status
+
+    def test_severity_change_syncs(self):
+        issue = self._create_issue(fingerprints=["fp_1"])
+
+        self.client.patch(
+            f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}",
+            data={"severity": "high"},
+        )
+
+        rows = self._get_issue_state_rows()
+        assert len(rows) == 1
+        assert rows[0][6] == "high"
 
     def test_bulk_status_change_syncs(self):
         issue_one = self._create_issue(fingerprints=["fp_one"])

--- a/products/posthog_ai/evals/error_tracking/seeders.py
+++ b/products/posthog_ai/evals/error_tracking/seeders.py
@@ -267,6 +267,7 @@ def _insert_fingerprint_issue_state(
             "issue_name": issue.name,
             "issue_description": issue.description,
             "issue_status": issue.status,
+            "issue_severity": issue.severity,
             "assigned_user_id": None,
             "assigned_role_id": None,
             "first_seen": format_clickhouse_timestamp(first_seen) if first_seen else None,


### PR DESCRIPTION
## Problem

Error tracking severity updates reach Postgres but remain null in the ClickHouse issue state.

## Changes

- Publishes severity with issue-state updates after issue endpoint mutations.
- Includes severity when the existing command backfills issue state.
- Keeps error tracking eval seeding compatible with the canonical issue-state payload.
- Builds on #81232, which adds the nullable ClickHouse column first.

## How did you test this code?

- Added endpoint coverage that verifies a severity update reaches ClickHouse.
- Added backfill coverage that verifies stored severity reaches ClickHouse.
- Ran the issue-state sync tests and the backfill command tests.
- Import-checked the eval suites with `hogli evals --list`.
- Ran Ruff and `hogli ci:preflight --fix`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This synchronizes existing API behavior with internal issue state.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

OpenAI Codex through pi implemented and validated this follow-up under human direction.

Skills invoked: `/error-tracking`, `/improving-drf-endpoints`, `/writing-tests`, `/writing-evals`, `/stacking-prs`, `/running-ci-preflight`, `/writing-pr-descriptions`, and `/pr`.

No customer data or private operational material informed this change.
