### PR TITLE
fix(data-modeling): tear down execute-dag schedules when a DAG or team is deleted

### DIFF
--- a/posthog/api/test/test_team_deletion.py
+++ b/posthog/api/test/test_team_deletion.py
@@ -270,9 +270,10 @@ class TestTeamDeletionSideEffects(NonAtomicBaseTest):
                 response = self.client.delete(f"/api/environments/{team.id}")
             assert response.status_code == 204
 
-    @patch("posthog.temporal.common.schedule.delete_schedule")
     @patch("posthog.models.team.util.sync_connect")
-    def test_delete_data_modeling_schedules(self, mock_sync_connect, mock_delete_schedule):
+    @patch("products.data_modeling.backend.logic.schedule_reconcile.delete_schedule")
+    @patch("products.data_modeling.backend.logic.schedule_reconcile.sync_connect")
+    def test_delete_data_modeling_schedules(self, mock_sync_connect, mock_delete_schedule, _batch_export_connect):
         from products.data_modeling.backend.facade.models import DataWarehouseSavedQuery
 
         team: Team = Team.objects.create_with_data(initiating_user=self.user, organization=self.organization)
@@ -293,9 +294,61 @@ class TestTeamDeletionSideEffects(NonAtomicBaseTest):
 
         mock_delete_schedule.assert_called_once_with(mock_temporal, schedule_id=str(saved_query.id))
 
-    @patch("posthog.temporal.common.schedule.delete_schedule")
     @patch("posthog.models.team.util.sync_connect")
-    def test_delete_data_modeling_schedules_handles_not_found(self, mock_sync_connect, mock_delete_schedule):
+    @patch("products.data_modeling.backend.logic.schedule_reconcile.delete_dag_schedules")
+    @patch("products.data_modeling.backend.logic.schedule_reconcile.delete_schedule")
+    @patch("products.data_modeling.backend.logic.schedule_reconcile.sync_connect")
+    def test_delete_data_modeling_schedules_covers_a_team_converted_to_dag_schedules(
+        self, mock_sync_connect, mock_delete_schedule, mock_delete_dag_schedules, _batch_export_connect
+    ):
+        from products.data_modeling.backend.facade.models import DAG, DataWarehouseSavedQuery
+        from products.data_modeling.backend.logic.schedule_reconcile import DagScheduleTeardown
+
+        team: Team = Team.objects.create_with_data(initiating_user=self.user, organization=self.organization)
+
+        # Conversion to DAG schedules nulls sync_frequency_interval and moves the schedule onto the DAG.
+        saved_query = DataWarehouseSavedQuery.objects.create(
+            team=team,
+            name="converted_query",
+            query={"kind": "HogQLQuery", "query": "SELECT 1"},
+            sync_frequency_interval=None,
+        )
+        dag = DAG.objects.create(team=team, name="Default")
+
+        mock_sync_connect.return_value = MagicMock()
+        mock_delete_dag_schedules.return_value = DagScheduleTeardown(ok=True, deleted=(str(dag.id),))
+
+        with execute_deletion_workflows_inline():
+            response = self.client.delete(f"/api/environments/{team.id}")
+        assert response.status_code == 204
+
+        mock_delete_dag_schedules.assert_called_once_with(str(dag.id))
+        mock_delete_schedule.assert_called_once_with(ANY, schedule_id=str(saved_query.id))
+
+    @patch("posthog.models.team.util.sync_connect")
+    @patch("products.data_modeling.backend.logic.schedule_reconcile.delete_dag_schedules")
+    def test_team_is_still_deleted_when_the_schedule_teardown_fails(
+        self, mock_delete_dag_schedules, _batch_export_connect
+    ):
+        from products.data_modeling.backend.facade.models import DAG
+        from products.data_modeling.backend.logic.schedule_reconcile import DagScheduleTeardown
+
+        team: Team = Team.objects.create_with_data(initiating_user=self.user, organization=self.organization)
+        DAG.objects.create(team=team, name="Default")
+        mock_delete_dag_schedules.return_value = DagScheduleTeardown(ok=False, deleted=())
+
+        with execute_deletion_workflows_inline():
+            response = self.client.delete(f"/api/environments/{team.id}")
+
+        assert response.status_code == 204
+        assert not Team.objects.filter(id=team.id).exists()
+
+    @patch("posthog.models.team.util.sync_connect")
+    @patch("products.data_modeling.backend.logic.schedule_reconcile.delete_schedule")
+    @patch("products.data_modeling.backend.logic.schedule_reconcile.sync_connect")
+    def test_delete_data_modeling_schedules_handles_not_found(
+        self, mock_sync_connect, mock_delete_schedule, _batch_export_connect
+    ):
         import temporalio.service
 
         from products.data_modeling.backend.facade.models import DataWarehouseSavedQuery

--- a/posthog/api/test/test_team_deletion.py
+++ b/posthog/api/test/test_team_deletion.py
@@ -295,52 +295,16 @@ class TestTeamDeletionSideEffects(NonAtomicBaseTest):
         mock_delete_schedule.assert_called_once_with(mock_temporal, schedule_id=str(saved_query.id))
 
     @patch("posthog.models.team.util.sync_connect")
-    @patch("products.data_modeling.backend.logic.schedule_reconcile.delete_dag_schedules")
-    @patch("products.data_modeling.backend.logic.schedule_reconcile.delete_schedule")
-    @patch("products.data_modeling.backend.logic.schedule_reconcile.sync_connect")
-    def test_delete_data_modeling_schedules_covers_a_team_converted_to_dag_schedules(
-        self, mock_sync_connect, mock_delete_schedule, mock_delete_dag_schedules, _batch_export_connect
-    ):
-        from products.data_modeling.backend.facade.models import DAG, DataWarehouseSavedQuery
-        from products.data_modeling.backend.logic.schedule_reconcile import DagScheduleTeardown
-
+    @patch("products.data_modeling.backend.facade.api.delete_team_data_modeling_schedules")
+    def test_team_is_still_deleted_when_the_schedule_teardown_fails(self, mock_delete_schedules, _batch_export_connect):
         team: Team = Team.objects.create_with_data(initiating_user=self.user, organization=self.organization)
-
-        # Conversion to DAG schedules nulls sync_frequency_interval and moves the schedule onto the DAG.
-        saved_query = DataWarehouseSavedQuery.objects.create(
-            team=team,
-            name="converted_query",
-            query={"kind": "HogQLQuery", "query": "SELECT 1"},
-            sync_frequency_interval=None,
-        )
-        dag = DAG.objects.create(team=team, name="Default")
-
-        mock_sync_connect.return_value = MagicMock()
-        mock_delete_dag_schedules.return_value = DagScheduleTeardown(ok=True, deleted=(str(dag.id),))
-
-        with execute_deletion_workflows_inline():
-            response = self.client.delete(f"/api/environments/{team.id}")
-        assert response.status_code == 204
-
-        mock_delete_dag_schedules.assert_called_once_with(str(dag.id))
-        mock_delete_schedule.assert_called_once_with(ANY, schedule_id=str(saved_query.id))
-
-    @patch("posthog.models.team.util.sync_connect")
-    @patch("products.data_modeling.backend.logic.schedule_reconcile.delete_dag_schedules")
-    def test_team_is_still_deleted_when_the_schedule_teardown_fails(
-        self, mock_delete_dag_schedules, _batch_export_connect
-    ):
-        from products.data_modeling.backend.facade.models import DAG
-        from products.data_modeling.backend.logic.schedule_reconcile import DagScheduleTeardown
-
-        team: Team = Team.objects.create_with_data(initiating_user=self.user, organization=self.organization)
-        DAG.objects.create(team=team, name="Default")
-        mock_delete_dag_schedules.return_value = DagScheduleTeardown(ok=False, deleted=())
+        mock_delete_schedules.side_effect = Exception("temporal is unreachable")
 
         with execute_deletion_workflows_inline():
             response = self.client.delete(f"/api/environments/{team.id}")
 
         assert response.status_code == 204
+        mock_delete_schedules.assert_any_call(team.id)
         assert not Team.objects.filter(id=team.id).exists()
 
     @patch("posthog.models.team.util.sync_connect")

--- a/posthog/models/team/util.py
+++ b/posthog/models/team/util.py
@@ -7,7 +7,6 @@ from django.apps import apps
 import structlog
 
 from posthog.cache_utils import cache_for
-from posthog.exceptions_capture import capture_exception
 from posthog.models.async_migration import is_async_migration_complete
 from posthog.temporal.common.client import sync_connect
 
@@ -323,44 +322,6 @@ def delete_batch_exports(team_ids: list[int]):
                 "Schedule not found during team deletion",
                 schedule_id=e.schedule_id,
             )
-
-
-def delete_data_modeling_schedules(team_ids: list[int]) -> None:
-    """Delete Temporal schedules for data modeling saved queries in deleted teams.
-
-    Django CASCADE deletes the DataWarehouseSavedQuery records but doesn't
-    call revert_materialization(), leaving orphaned Temporal schedules.
-    """
-    import temporalio.service
-
-    from posthog.temporal.common.schedule import delete_schedule
-
-    from products.data_modeling.backend.facade.models import DataWarehouseSavedQuery
-
-    saved_queries = list(
-        DataWarehouseSavedQuery.objects.filter(
-            team_id__in=team_ids,
-            sync_frequency_interval__isnull=False,
-        ).exclude(deleted=True)  # as it's nullable
-    )
-
-    if not saved_queries:
-        return
-
-    temporal = sync_connect()
-
-    for saved_query in saved_queries:
-        try:
-            delete_schedule(temporal, schedule_id=str(saved_query.id))
-        except temporalio.service.RPCError as e:
-            if e.status == temporalio.service.RPCStatusCode.NOT_FOUND:
-                logger.warning(
-                    "Data modeling schedule not found during team deletion",
-                    schedule_id=str(saved_query.id),
-                    team_id=saved_query.team_id,
-                )
-                continue
-            capture_exception(e)
 
 
 def delete_team_records(team_ids: list[int]) -> None:

--- a/posthog/temporal/delete_teams/activities.py
+++ b/posthog/temporal/delete_teams/activities.py
@@ -80,10 +80,14 @@ async def delete_batch_exports_activity(inputs: TeamDataActivityInputs) -> None:
 
 @temporalio.activity.defn
 async def delete_data_modeling_schedules_activity(inputs: TeamDataActivityInputs) -> None:
+    """Tear down data modeling's Temporal Schedules for the teams. CASCADE removes the saved query
+    and DAG rows but never talks to Temporal, so without this the Schedules keep firing forever into
+    a team that no longer exists."""
     async with Heartbeater():
-        from posthog.models.team.util import delete_data_modeling_schedules
+        from products.data_modeling.backend.facade.api import delete_team_data_modeling_schedules
 
-        await database_sync_to_async_pool(delete_data_modeling_schedules)(inputs.team_ids)
+        for team_id in inputs.team_ids:
+            await database_sync_to_async_pool(delete_team_data_modeling_schedules)(team_id)
 
 
 @temporalio.activity.defn

--- a/posthog/temporal/delete_teams/workflows.py
+++ b/posthog/temporal/delete_teams/workflows.py
@@ -122,13 +122,21 @@ class DeleteTeamsDataWorkflow(PostHogWorkflow):
             heartbeat_timeout=LIGHT_HEARTBEAT_TIMEOUT,
             retry_policy=SIDE_EFFECT_RETRY_POLICY,
         )
-        await temporalio.workflow.execute_activity(
-            delete_data_modeling_schedules_activity,
-            team_inputs,
-            start_to_close_timeout=LIGHT_ACTIVITY_TIMEOUT,
-            heartbeat_timeout=LIGHT_HEARTBEAT_TIMEOUT,
-            retry_policy=SIDE_EFFECT_RETRY_POLICY,
-        )
+        # Best-effort, like the loop schedules below: a schedule we fail to delete is a nuisance the
+        # orphan sweeps clean up later, and never a reason to leave a team's data in place.
+        try:
+            await temporalio.workflow.execute_activity(
+                delete_data_modeling_schedules_activity,
+                team_inputs,
+                start_to_close_timeout=LIGHT_ACTIVITY_TIMEOUT,
+                heartbeat_timeout=LIGHT_HEARTBEAT_TIMEOUT,
+                retry_policy=SIDE_EFFECT_RETRY_POLICY,
+            )
+        except temporalio.exceptions.ActivityError:
+            temporalio.workflow.logger.warning(
+                "delete_data_modeling_schedules_activity failed; continuing team deletion without it",
+                exc_info=True,
+            )
         # Gated with `patched` so in-flight deletions from before this deploy don't fail replay on a
         # new command. Best-effort: a loop-schedule teardown failure must never wedge team deletion,
         # the schedules it misses are a nuisance, not a blocker (reconciliation/one-off GC catch up).

--- a/products/data_modeling/backend/facade/api.py
+++ b/products/data_modeling/backend/facade/api.py
@@ -24,6 +24,7 @@ _LAZY = {
     "saved_query_materialized_at": "logic.saved_query_freshness",
     "start_node_materialization": "logic.node_materialization",
     "delete_dag_schedules": "logic.schedule_reconcile",
+    "delete_team_data_modeling_schedules": "logic.schedule_reconcile",
     "apply_saved_query_frequency_anchor": "logic.schedule_reconcile",
     "apply_saved_query_frequency_target": "logic.schedule_reconcile",
     "tiered_schedules_enabled": "logic.schedule_reconcile",

--- a/products/data_modeling/backend/logic/schedule_reconcile.py
+++ b/products/data_modeling/backend/logic/schedule_reconcile.py
@@ -474,6 +474,51 @@ async def delete_dag_schedules(dag_id: str) -> DagScheduleTeardown:
     return DagScheduleTeardown(ok=ok, deleted=tuple(deleted))
 
 
+class TeamScheduleTeardownError(Exception):
+    pass
+
+
+def delete_team_data_modeling_schedules(team_id: int) -> None:
+    """Tear down every Temporal schedule data modeling owns for a team, before CASCADE removes the
+    rows that name them. A team runs per-saved-query schedules or per-DAG ones, and converting
+    between the two nulls `sync_frequency_interval`, so no field can decide which half to sweep —
+    both are swept unconditionally.
+
+    Raises `TeamScheduleTeardownError` if any delete failed, so the caller can retry. What outlives
+    the retries is left to the orphan sweeps, which start from Temporal and so can still find a
+    schedule after its rows are gone.
+    """
+    from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
+
+    failed = 0
+
+    saved_query_ids = list(
+        DataWarehouseSavedQuery.objects.filter(team_id=team_id).exclude(deleted=True).values_list("id", flat=True)
+    )
+    if saved_query_ids:
+        temporal = sync_connect()
+        for saved_query_id in saved_query_ids:
+            try:
+                delete_schedule(temporal, schedule_id=str(saved_query_id))
+            except RPCError as error:
+                if error.status == RPCStatusCode.NOT_FOUND:
+                    continue
+                failed += 1
+                logger.exception(
+                    "Failed to delete a saved query schedule for a deleted team",
+                    saved_query_id=str(saved_query_id),
+                    team_id=team_id,
+                )
+                capture_exception(error)
+
+    for dag_id in DAG.objects.filter(team_id=team_id).values_list("id", flat=True):
+        if not delete_dag_schedules(str(dag_id)).ok:
+            failed += 1
+
+    if failed:
+        raise TeamScheduleTeardownError(f"Failed to delete {failed} data modeling schedules for team {team_id}")
+
+
 @async_to_sync
 async def _apply_reconciliation(
     *,

--- a/products/data_modeling/backend/presentation/views/dag.py
+++ b/products/data_modeling/backend/presentation/views/dag.py
@@ -4,12 +4,12 @@ from typing import Any, cast
 from django.db.models import Count
 
 from drf_spectacular.utils import extend_schema_field
-from rest_framework import serializers, viewsets
-from rest_framework.exceptions import ValidationError
+from rest_framework import serializers, status, viewsets
+from rest_framework.exceptions import APIException, ValidationError
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 
-from products.data_modeling.backend.facade.api import tiered_schedules_enabled
+from products.data_modeling.backend.facade.api import delete_dag_schedules, tiered_schedules_enabled
 from products.data_modeling.backend.facade.models import DAG, RESERVED_DAG_NAMES
 from products.warehouse_sources.backend.facade.models import (
     sync_frequency_interval_to_sync_frequency,
@@ -18,6 +18,11 @@ from products.warehouse_sources.backend.facade.models import (
 
 # C0 controls, DEL, C1 controls, and the Unicode line/paragraph separators.
 CONTROL_CHARACTERS = re.compile(r"[\x00-\x1f\x7f-\x9f\u2028\u2029]")
+
+
+class ScheduleTeardownUnavailable(APIException):
+    status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    default_detail = "Couldn't remove this DAG's schedules, so it wasn't deleted. Try again in a few minutes."
 
 
 class DAGSerializer(serializers.ModelSerializer):
@@ -141,4 +146,7 @@ class DAGViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             raise ValidationError("The default DAG cannot be deleted.")
         if instance.is_managed:
             raise ValidationError("System-managed DAGs cannot be deleted.")
+        # Keep the DAG row when teardown fails: it is the only handle left for finding the schedules.
+        if not delete_dag_schedules(str(instance.id)).ok:
+            raise ScheduleTeardownUnavailable()
         instance.delete()

--- a/products/data_modeling/backend/test/test_schedule_reconcile.py
+++ b/products/data_modeling/backend/test/test_schedule_reconcile.py
@@ -30,6 +30,7 @@ from products.data_modeling.backend.logic.schedule_reconcile import (
     reconcile_dag_schedules,
 )
 from products.data_modeling.backend.models.dag import DAG
+from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
 from products.data_modeling.backend.models.edge import Edge
 from products.data_modeling.backend.models.node import NodeType
 from products.data_modeling.backend.schedule import DATA_MODELING_EXECUTE_DAG_WORKFLOW
@@ -580,11 +581,34 @@ class TestDeleteDagSchedules(SimpleTestCase):
 
 
 class TestDeleteTeamDataModelingSchedules(BaseTest):
+    def test_sweeps_both_halves_for_a_team_converted_to_dag_schedules(self):
+        # Conversion nulls sync_frequency_interval, so no field can decide which half to sweep.
+        saved_query = DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="converted_query",
+            query={"kind": "HogQLQuery", "query": "SELECT 1"},
+            sync_frequency_interval=None,
+        )
+        dag = DAG.objects.create(team=self.team, name="Default")
+
+        with (
+            mock.patch(f"{RECONCILE}.sync_connect"),
+            mock.patch(f"{RECONCILE}.delete_schedule") as delete_query,
+            mock.patch(
+                f"{RECONCILE}.delete_dag_schedules",
+                return_value=DagScheduleTeardown(ok=True, deleted=(str(dag.id),)),
+            ) as delete_dag,
+        ):
+            delete_team_data_modeling_schedules(self.team.id)
+
+        delete_query.assert_called_once_with(mock.ANY, schedule_id=str(saved_query.id))
+        delete_dag.assert_called_once_with(str(dag.id))
+
     def test_raises_when_a_dag_teardown_fails_so_the_activity_retries(self):
         DAG.objects.create(team=self.team, name="Default")
 
         with mock.patch(
-            "products.data_modeling.backend.logic.schedule_reconcile.delete_dag_schedules",
+            f"{RECONCILE}.delete_dag_schedules",
             return_value=DagScheduleTeardown(ok=False, deleted=()),
         ):
             with pytest.raises(TeamScheduleTeardownError):

--- a/products/data_modeling/backend/test/test_schedule_reconcile.py
+++ b/products/data_modeling/backend/test/test_schedule_reconcile.py
@@ -20,9 +20,12 @@ from products.data_modeling.backend.logic.node_frequency import (
 )
 from products.data_modeling.backend.logic.saved_query_dag_sync import promote_dag_view_nodes_to_matview
 from products.data_modeling.backend.logic.schedule_reconcile import (
+    DagScheduleTeardown,
+    TeamScheduleTeardownError,
     apply_saved_query_frequency_anchor,
     convert_dag_to_tiers,
     delete_dag_schedules,
+    delete_team_data_modeling_schedules,
     maybe_reconcile_dag,
     reconcile_dag_schedules,
 )
@@ -574,3 +577,15 @@ class TestDeleteDagSchedules(SimpleTestCase):
         assert not teardown.ok
         assert teardown.deleted == ("dag-1:86400",)
         assert deleter.await_count == 2
+
+
+class TestDeleteTeamDataModelingSchedules(BaseTest):
+    def test_raises_when_a_dag_teardown_fails_so_the_activity_retries(self):
+        DAG.objects.create(team=self.team, name="Default")
+
+        with mock.patch(
+            "products.data_modeling.backend.logic.schedule_reconcile.delete_dag_schedules",
+            return_value=DagScheduleTeardown(ok=False, deleted=()),
+        ):
+            with pytest.raises(TeamScheduleTeardownError):
+                delete_team_data_modeling_schedules(self.team.id)

--- a/products/data_modeling/backend/tests/api/test_dag_api.py
+++ b/products/data_modeling/backend/tests/api/test_dag_api.py
@@ -6,7 +6,14 @@ from unittest import mock
 from parameterized import parameterized
 from rest_framework import status
 
+from products.data_modeling.backend.logic.schedule_reconcile import DagScheduleTeardown
 from products.data_modeling.backend.models import DAG, Node, NodeType
+
+VIEW = "products.data_modeling.backend.presentation.views.dag"
+
+
+def _teardown(*, ok: bool) -> DagScheduleTeardown:
+    return DagScheduleTeardown(ok=ok, deleted=())
 
 
 class TestDAGViewSet(APIBaseTest):
@@ -57,10 +64,21 @@ class TestDAGViewSet(APIBaseTest):
     def test_delete_dag(self):
         dag = DAG.objects.create(team=self.team, name="my_dag")
 
-        response = self.client.delete(f"/api/environments/{self.team.id}/data_modeling_dags/{dag.id}/")
+        with mock.patch(f"{VIEW}.delete_dag_schedules", return_value=_teardown(ok=True)) as teardown:
+            response = self.client.delete(f"/api/environments/{self.team.id}/data_modeling_dags/{dag.id}/")
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(DAG.objects.filter(team=self.team, id=dag.id).exists())
+        teardown.assert_called_once_with(str(dag.id))
+
+    def test_dag_survives_a_failed_schedule_teardown(self):
+        dag = DAG.objects.create(team=self.team, name="my_dag")
+
+        with mock.patch(f"{VIEW}.delete_dag_schedules", return_value=_teardown(ok=False)):
+            response = self.client.delete(f"/api/environments/{self.team.id}/data_modeling_dags/{dag.id}/")
+
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        self.assertTrue(DAG.objects.filter(team=self.team, id=dag.id).exists())
 
     def test_cannot_delete_default_dag(self):
         dag = DAG.get_or_create_default(self.team)


### PR DESCRIPTION
## Problem

Deleting a DAG through the API removed the row and left its Temporal schedules running. The schedules keep firing, and every run is guaranteed to do nothing, because the DAG they name is gone.

Team deletion had the same hole through a different route. `delete_data_modeling_schedules` selected saved queries with a `sync_frequency_interval` set. Converting a team to DAG schedules nulls that field, so the queryset came back empty and the function returned early. For a converted team it deleted nothing at all, v1 or v2.

Nothing recovers from either leak. Both the reconciler and the existing cleanup command start from a DAG row, and that row is what the delete just removed.

## Changes

- `DAGViewSet.perform_destroy` tears the schedules down before it deletes the row.
- A failed teardown returns 503 and keeps the DAG row, because that row is the only handle left for finding those schedules.
- Team teardown moves into the data modeling product as `delete_team_data_modeling_schedules`, the way loops owns `delete_team_loop_schedules`. `posthog/models/team/util.py` no longer reaches into data modeling internals.
- The team sweep covers saved queries and DAGs unconditionally, instead of picking between them on a field that conversion nulls.
- A failed team sweep raises, so the Temporal activity retries. The workflow treats a still-failing sweep as best-effort and carries on, like the loop schedules beside it.

> [!NOTE]
> Team deletion is never blocked by this. The teardown runs before the team row is deleted, so a raise used to strand the whole workflow after its retries. It is now caught and logged. A schedule we cannot delete is a nuisance for the orphan sweep in the layer above, never a reason to leave a deleted team's data in place.

> [!WARNING]
> Deleting a DAG through the API can now fail with 503 when Temporal is unreachable. The alternative is deleting the row and orphaning the schedules, which is the bug this PR fixes.

## How did you test this code?

- Two DAG API tests: a delete calls the teardown, and a failed teardown returns 503 with the row still present.
- Two team teardown tests in the data modeling suite: a converted team is covered, which the old code skipped entirely, and a failed DAG teardown raises so the activity retries.
- One workflow test: the team is still deleted when the teardown keeps failing.
- I confirmed the converted-team test fails on master, with the teardown called zero times.
- I ran the data modeling schedule and DAG API suites, the data modeling tests in `posthog/api/test/test_team_deletion.py`, and repo-wide `mypy`.
- Some unrelated tests in `test_team_deletion.py` fail locally on object storage clock skew. They fail on master too, and I did not touch them.
- I did no manual testing against Temporal.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

Human-driven (agent-assisted).

I am working in Claude Code. Jovan directed the work. This is the middle layer of a three-PR stack: the layer below shares the teardown, and the layer above sweeps schedules that earlier deletes already orphaned.

Skills used: `/stacking-prs`, `/writing-tests`, `/improving-drf-endpoints`, `/writing-user-facing-copy`, `/writing-pr-descriptions`, `/writing-code-comments`.

Team deletion sweeps every DAG the team owns, including default and managed ones. The API guards that protect those two from user deletion do not apply, since the team itself is going away.

Nothing in this PR carries material that is not already in this repository.
