### PR TITLE
feat(data-modeling): sweep execute-dag schedules whose DAG is gone

### DIFF
--- a/products/data_modeling/backend/management/commands/delete_orphaned_dag_schedules.py
+++ b/products/data_modeling/backend/management/commands/delete_orphaned_dag_schedules.py
@@ -1,0 +1,155 @@
+import sys
+import asyncio
+import logging
+from uuid import UUID
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+import structlog
+from asgiref.sync import sync_to_async
+from temporalio.client import ScheduleListActionStartWorkflow
+
+from posthog.temporal.common.client import async_connect
+from posthog.temporal.common.schedule import a_delete_schedule
+
+from products.data_modeling.backend.logic.cohort_scheduling import dag_id_from_schedule_id
+from products.data_modeling.backend.models.dag import DAG
+from products.data_modeling.backend.schedule import DATA_MODELING_EXECUTE_DAG_WORKFLOW
+
+logger = structlog.get_logger(__name__)
+
+
+def _live_dag_ids(candidate_ids: set[str]) -> set[str]:
+    return {str(pk) for pk in DAG.objects.filter(id__in=candidate_ids).values_list("id", flat=True)}
+
+
+class Command(BaseCommand):
+    help = "Delete execute-dag Temporal schedules whose DAG no longer exists"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--team-ids",
+            default=None,
+            type=str,
+            help="Comma-separated team IDs to filter by, via the PostHogTeamId search attribute",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            default=False,
+            help="Preview orphans without deleting",
+        )
+        parser.add_argument(
+            "--concurrency",
+            default=20,
+            type=int,
+            help="Max concurrent Temporal API calls (default: 20)",
+        )
+
+    def handle(self, **options):
+        logger.setLevel(logging.INFO)
+        asyncio.run(self._run(options))
+
+    async def _run(self, options):
+        team_ids: set[int] | None = None
+        if options["team_ids"]:
+            try:
+                team_ids = {int(tid) for tid in options["team_ids"].split(",")}
+            except ValueError:
+                raise CommandError("--team-ids must be a comma-separated list of integers")
+
+        temporal = await async_connect()
+        orphans = await self._find_orphans(temporal, team_ids)
+
+        if not orphans:
+            logger.info("No orphaned execute-dag schedules found")
+            return
+
+        logger.info(f"Found {len(orphans)} orphaned execute-dag schedule(s)")
+        for schedule_id in sorted(orphans):
+            logger.info("Orphaned schedule", schedule_id=schedule_id)
+
+        if options["dry_run"]:
+            logger.info(f"DRY RUN: Would delete {len(orphans)} schedule(s)")
+            return
+
+        if not settings.TEST:
+            confirm = input(f"\n\tWill delete {len(orphans)} orphaned schedule(s). Proceed? (y/n) ")
+            if confirm.strip().lower() != "y":
+                logger.info("Aborting")
+                return
+
+        deleted, failed = await self._delete_schedules(temporal, orphans, options["concurrency"])
+        logger.info(f"Done! Deleted: {deleted}, Failed: {failed}")
+
+    async def _find_orphans(self, temporal, team_ids: set[int] | None) -> set[str]:
+        """A DAG deleted without its schedules leaves no row to reconcile from, so the sweep
+        has to start from Temporal and resolve back into Postgres.
+        """
+        dag_id_by_schedule: dict[str, str] = {}
+        unparseable: set[str] = set()
+        count = 0
+
+        query = self._build_team_filter_query(team_ids) if team_ids else None
+        async for listing in await temporal.list_schedules(query=query):
+            action = listing.schedule.action
+            if not isinstance(action, ScheduleListActionStartWorkflow):
+                continue
+            if action.workflow != DATA_MODELING_EXECUTE_DAG_WORKFLOW:
+                continue
+            dag_id = dag_id_from_schedule_id(listing.id)
+            try:
+                UUID(dag_id)
+            except ValueError:
+                # Never delete on a guess: an id we can't resolve to a DAG gets reported, not swept.
+                unparseable.add(listing.id)
+                continue
+            dag_id_by_schedule[listing.id] = dag_id
+            count += 1
+            if count % 200 == 0:
+                sys.stderr.write(".")
+                sys.stderr.flush()
+
+        if count >= 200:
+            sys.stderr.write("\n")
+
+        for schedule_id in sorted(unparseable):
+            logger.warning("Schedule id does not carry a DAG UUID, skipping", schedule_id=schedule_id)
+
+        logger.info(f"Found {len(dag_id_by_schedule)} execute-dag schedule(s) in Temporal")
+        if not dag_id_by_schedule:
+            return set()
+
+        live = await sync_to_async(_live_dag_ids)(set(dag_id_by_schedule.values()))
+        return {schedule_id for schedule_id, dag_id in dag_id_by_schedule.items() if dag_id not in live}
+
+    @staticmethod
+    def _build_team_filter_query(team_ids: set[int]) -> str:
+        if len(team_ids) == 1:
+            return f"PostHogTeamId = {next(iter(team_ids))}"
+        return f"PostHogTeamId IN ({','.join(str(t) for t in sorted(team_ids))})"
+
+    async def _delete_schedules(self, temporal, orphans: set[str], concurrency: int) -> tuple[int, int]:
+        semaphore = asyncio.Semaphore(concurrency)
+        deleted = 0
+        failed = 0
+
+        async def delete_one(schedule_id: str) -> bool:
+            async with semaphore:
+                try:
+                    await a_delete_schedule(temporal, schedule_id)
+                    logger.info("Deleted schedule", schedule_id=schedule_id)
+                    return True
+                except Exception:
+                    logger.exception("Failed to delete schedule", schedule_id=schedule_id)
+                    return False
+
+        tasks = [asyncio.create_task(delete_one(sid)) for sid in orphans]
+        for task in asyncio.as_completed(tasks):
+            if await task:
+                deleted += 1
+            else:
+                failed += 1
+
+        return deleted, failed

--- a/products/data_modeling/backend/test/test_delete_orphaned_dag_schedules.py
+++ b/products/data_modeling/backend/test/test_delete_orphaned_dag_schedules.py
@@ -1,0 +1,27 @@
+from uuid import uuid4
+
+from posthog.test.base import BaseTest
+
+from asgiref.sync import async_to_sync
+
+from products.data_modeling.backend.management.commands.delete_orphaned_dag_schedules import Command
+from products.data_modeling.backend.models.dag import DAG
+from products.data_modeling.backend.test.helpers import temporal_listing
+
+
+class TestDeleteOrphanedDagSchedules(BaseTest):
+    def _orphans(self, schedule_ids) -> set[str]:
+        return async_to_sync(Command()._find_orphans)(temporal_listing(schedule_ids), None)
+
+    def test_only_schedules_whose_dag_is_gone_are_orphans(self):
+        live = DAG.objects.create(team=self.team, name="live_dag")
+        gone = uuid4()
+
+        orphans = self._orphans([f"{live.id}:3600", str(live.id), f"{gone}:900", str(gone)])
+
+        assert orphans == {f"{gone}:900", str(gone)}
+
+    def test_a_schedule_id_without_a_dag_uuid_is_left_alone(self):
+        orphans = self._orphans(["data-modeling-run-legacy-thing"])
+
+        assert orphans == set()


### PR DESCRIPTION
## Problem

Earlier deletes removed DAG rows and left their Temporal schedules behind. Those schedules still fire, and every run does nothing, because the DAG they name no longer exists.

No existing tool can find them. `reconcile_dag_schedules` starts from a DAG row, and the row is gone. `delete_orphaned_saved_query_schedules` lists only `data-modeling-run` schedules and skips ids containing a colon, which is the id scheme cadence tiers use.

The PR below this one closes the paths that create these. This one clears the ones already out there.

## Changes

- I (actually Claude) added `delete_orphaned_dag_schedules`, a management command that starts from Temporal rather than from the database.
- It lists `data-modeling-execute-dag` schedules, parses the DAG id off each schedule id, and resolves the ids against `DataModelingDAG`.
- A schedule whose DAG id matches no row is an orphan, and the command deletes it.
- The command handles both id schemes: the bare `{dag_id}` and the cadence tier `{dag_id}:{seconds}`.
- A schedule id that carries no DAG UUID is reported and left alone.
- It lists every orphan, then asks for confirmation before deleting, matching `delete_orphaned_saved_query_schedules`.
- `--dry-run` stops after the listing. `--team-ids` narrows the sweep. `--concurrency` bounds the deletes.

## How did you test this code?

- I added two unit tests over the orphan detection, which is where a mistake deletes a live customer's schedule.
- The first pins that a schedule survives when its DAG row exists. The second pins that an id without a DAG UUID is skipped rather than swept.
- I ran `pytest products/data_modeling/backend/test/test_delete_orphaned_dag_schedules.py` and repo-wide `mypy`.
- I did no manual testing against Temporal, and I have not run the command against any environment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I am Claude, working in Claude Code. Jovan directed the work. This is the top layer of a three-PR stack.

Skills invoked: `/stacking-prs`, `/writing-tests`, `/writing-pr-descriptions`, `/writing-code-comments`.

The command resolves DAG ids against the database rather than trusting the `PostHogDagId` search attribute, because a schedule with a missing or wrong attribute would otherwise escape the sweep. Jovan runs it, starting with `--dry-run`. Nothing in this PR carries material that is not already in this repository.
