### PR TITLE
fix(tasks): exempt user-created runs from duration cap

### DIFF
--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -209,22 +209,23 @@ class TaskProcessingContext:
 
     def inactivity_timeout(self) -> timedelta:
         """Idle time before the workflow times the run out; longer for user-driven runs."""
-        is_user_origin = not self.origin_product or self.origin_product in (
+        return resolve_inactivity_timeout(is_user_origin=self._is_user_origin(), state=self.state)
+
+    def _is_user_origin(self) -> bool:
+        return not self.origin_product or self.origin_product in (
             Task.OriginProduct.USER_CREATED.value,
             Task.OriginProduct.IMAGE_BUILDER.value,
         )
-        return resolve_inactivity_timeout(is_user_origin=is_user_origin, state=self.state)
 
     def max_run_duration(self) -> timedelta | None:
         """Hard wall-clock cap on total run time, or None when the run is exempt.
 
         Unlike the inactivity timeout, this is not reset by heartbeats, so it stops a
-        wedged-but-heartbeating agent that would otherwise run forever. Interactive
-        sessions can legitimately stay open for hours under a human, so they are
-        uncapped; autonomous runs get the cap as a safety net, unless the setting
-        disables it deployment-wide.
+        wedged-but-heartbeating agent that would otherwise run forever. User-driven
+        sessions can legitimately run for hours, so they are uncapped. Autonomous runs
+        get the cap as a safety net unless the setting disables it deployment-wide.
         """
-        if self.mode == "interactive":
+        if self.mode == "interactive" or self._is_user_origin():
             return None
         return resolve_max_run_duration()
 

--- a/products/tasks/backend/temporal/process_task/tests/test_max_run_duration.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_max_run_duration.py
@@ -2,13 +2,16 @@ from datetime import timedelta
 
 from django.test import override_settings
 
+from products.tasks.backend.models import Task
 from products.tasks.backend.temporal.constants import MAX_INACTIVITY_TIMEOUT_SECONDS, resolve_max_run_duration
 from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import TaskProcessingContext
 
 DEFAULT_CAP_SECONDS = 3 * 60 * 60
 
 
-def _context(state: dict | None) -> TaskProcessingContext:
+def _context(
+    state: dict | None, *, origin_product: str | None = Task.OriginProduct.AUTOMATION.value
+) -> TaskProcessingContext:
     return TaskProcessingContext(
         task_id="task-id",
         run_id="run-id",
@@ -19,6 +22,7 @@ def _context(state: dict | None) -> TaskProcessingContext:
         repository="posthog/posthog-js",
         distinct_id="distinct",
         state=state,
+        origin_product=origin_product,
     )
 
 
@@ -30,10 +34,21 @@ class TestMaxRunDuration:
         assert _context({"mode": "interactive"}).max_run_duration() is None
 
     @override_settings(TASKS_MAX_RUN_DURATION_SECONDS=DEFAULT_CAP_SECONDS)
-    def test_background_runs_get_the_default_cap(self):
+    def test_autonomous_background_runs_get_the_default_cap(self):
         assert _context({"mode": "background"}).max_run_duration() == timedelta(seconds=DEFAULT_CAP_SECONDS)
         # Default mode (no explicit mode in state) is background.
         assert _context(None).max_run_duration() == timedelta(seconds=DEFAULT_CAP_SECONDS)
+
+    @override_settings(TASKS_MAX_RUN_DURATION_SECONDS=DEFAULT_CAP_SECONDS)
+    def test_user_created_background_runs_are_uncapped(self):
+        assert (
+            _context(
+                {"mode": "background"},
+                origin_product=Task.OriginProduct.USER_CREATED.value,
+            ).max_run_duration()
+            is None
+        )
+        assert _context({"mode": "background"}, origin_product=None).max_run_duration() is None
 
     @override_settings(TASKS_MAX_RUN_DURATION_SECONDS=90)
     def test_setting_override_applies_to_capped_runs(self):

--- a/products/tasks/backend/temporal/process_task/tests/test_max_run_duration.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_max_run_duration.py
@@ -2,6 +2,8 @@ from datetime import timedelta
 
 from django.test import override_settings
 
+from parameterized import parameterized
+
 from products.tasks.backend.models import Task
 from products.tasks.backend.temporal.constants import MAX_INACTIVITY_TIMEOUT_SECONDS, resolve_max_run_duration
 from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import TaskProcessingContext
@@ -39,16 +41,15 @@ class TestMaxRunDuration:
         # Default mode (no explicit mode in state) is background.
         assert _context(None).max_run_duration() == timedelta(seconds=DEFAULT_CAP_SECONDS)
 
+    @parameterized.expand(
+        [
+            ("explicit_user_created", Task.OriginProduct.USER_CREATED.value),
+            ("missing_origin", None),
+        ]
+    )
     @override_settings(TASKS_MAX_RUN_DURATION_SECONDS=DEFAULT_CAP_SECONDS)
-    def test_user_created_background_runs_are_uncapped(self):
-        assert (
-            _context(
-                {"mode": "background"},
-                origin_product=Task.OriginProduct.USER_CREATED.value,
-            ).max_run_duration()
-            is None
-        )
-        assert _context({"mode": "background"}, origin_product=None).max_run_duration() is None
+    def test_user_created_background_runs_are_uncapped(self, _name: str, origin_product: str | None):
+        assert _context({"mode": "background"}, origin_product=origin_product).max_run_duration() is None
 
     @override_settings(TASKS_MAX_RUN_DURATION_SECONDS=90)
     def test_setting_override_applies_to_capped_runs(self):


### PR DESCRIPTION
## Problem

User-created cloud tasks can be stopped while they are still making progress because background mode receives the autonomous wall-clock cap.

[#74039](https://github.com/PostHog/posthog/pull/74039) introduced the regression.
User-created cloud tasks normally use background mode, so the exemption did not cover them.

## Changes

- Exempt user-created tasks from the wall-clock cap, including tasks with no explicit origin.
- Keep the cap for automation and other autonomous origins.
- Reuse the existing user-origin classification shared with inactivity timeouts.