### PR TITLE
fix(insights): keep breakdown values readable in trends tooltips

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4714,10 +4714,10 @@ snapshots:
         hash: v1.k794b7964.ea754a4783f7653247f127337c407a8cdd4a9c6bc3f1b908d8d00dd1a090b966.KQ3yKnRzi4l3ZeYVThZdmo4L6mAbxtNa2uQh7y-kGWA
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--tile-filters-read-only--light:
         hash: v1.k794b7964.b2ca2efc52a9ccf56953159c66d3c8766acd1d3a17379d5faec45a4715ae24a9.fK76p7ZVcgvFJNcKJ5Ixy3YnBm_BcBSFnoytLS2jZdU
-    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark
-    :   hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
-    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light
-    :   hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
+    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark:
+        hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
+    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light:
+        hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--dark:
         hash: v1.k794b7964.b1e0f5f542426e34dec73826f3135902a392c0c13dade4fec14037c615186b13.kbxxijyDI1SdvgdKwkRnIRLLgmsine5AYvOcD79DYsY
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--light:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -2612,6 +2612,10 @@ snapshots:
         hash: v1.k794b7964.51c09169b5a57e217572bc35c0882b15252b4af936921569bf8d2a1d3a330f2f.red8aW6nElMIxDUdAHhilR3Ls2NgRChoEmFzfpGcgbU
     insights-funneltrendstable--default--light:
         hash: v1.k794b7964.f4486460f4481d343ecf8e0890d94f8d4c3da70164008d53bc762b6900623bc1.MRfTllR3ODYt6mNxjI-nTmfYZk0V2cXLMRmUwbKFC1Q
+    insights-insightseriestooltip--long-series-name-with-breakdown--dark:
+        hash: v1.k794b7964.199545e36ed0533f2e52b4e8a88497c4f3587208a61eb2bade6f19e09e6acb09.chYT5gr5mJZO2rmHIGW03J--hW6-dcHe9-3SSmlvfGc
+    insights-insightseriestooltip--long-series-name-with-breakdown--light:
+        hash: v1.k794b7964.7458a50ee4ac7fc39850215d33661ce955b9668aac29b58741f7972dfe97e02c.lNsTCNe5pr3yPPDVrpuuCvM02RTOqkomfXzb9jWJVdQ
     insights-insightseriestooltip--multiple-formulas-with-breakdown--dark:
         hash: v1.k794b7964.c2c1e9d12c2e6c27ebecdd94aaa799f9b49fd5b0f0b9e86c3ab126cab2b8ab3a.Mp3xiWvz6KnRuqNh4R3aBrrtVMdG-q0tTMyPvM4g35U
     insights-insightseriestooltip--multiple-formulas-with-breakdown--light:
@@ -4710,10 +4714,10 @@ snapshots:
         hash: v1.k794b7964.ea754a4783f7653247f127337c407a8cdd4a9c6bc3f1b908d8d00dd1a090b966.KQ3yKnRzi4l3ZeYVThZdmo4L6mAbxtNa2uQh7y-kGWA
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--tile-filters-read-only--light:
         hash: v1.k794b7964.b2ca2efc52a9ccf56953159c66d3c8766acd1d3a17379d5faec45a4715ae24a9.fK76p7ZVcgvFJNcKJ5Ixy3YnBm_BcBSFnoytLS2jZdU
-    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark:
-        hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
-    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light:
-        hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
+    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark
+    :   hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
+    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light
+    :   hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--dark:
         hash: v1.k794b7964.b1e0f5f542426e34dec73826f3135902a392c0c13dade4fec14037c615186b13.kbxxijyDI1SdvgdKwkRnIRLLgmsine5AYvOcD79DYsY
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--light:

--- a/products/product_analytics/frontend/insights/shared/InsightSeriesTooltip.stories.tsx
+++ b/products/product_analytics/frontend/insights/shared/InsightSeriesTooltip.stories.tsx
@@ -147,6 +147,46 @@ export const SameEventSeriesWithBreakdown: Story = {
     play: async ({ canvasElement }) => await playHoverAtFraction(canvasElement, 0.5),
 }
 
+// A long event name doesn't fit beside the breakdown value at the tooltip's max width.
+// The name truncates and the breakdown value stays readable, not the other way round.
+export const LongSeriesNameWithBreakdown: Story = {
+    render: () => (
+        <TooltipChart
+            fixtures={[
+                {
+                    label: 'true',
+                    data: [45, 82, 134, 210, 95],
+                    event: 'subscription_renewal_reminder_delivered',
+                    seriesOrder: 0,
+                    breakdown_value: 'true',
+                },
+                {
+                    label: 'false',
+                    data: [20, 31, 46, 70, 38],
+                    event: 'subscription_renewal_reminder_delivered',
+                    seriesOrder: 0,
+                    breakdown_value: 'false',
+                },
+                {
+                    label: 'true',
+                    data: [8, 12, 21, 30, 14],
+                    event: 'subscription_renewal_reminder_delivered',
+                    seriesOrder: 1,
+                    breakdown_value: 'true',
+                },
+                {
+                    label: 'false',
+                    data: [2, 4, 5, 9, 3],
+                    event: 'subscription_renewal_reminder_delivered',
+                    seriesOrder: 1,
+                    breakdown_value: 'false',
+                },
+            ]}
+        />
+    ),
+    play: async ({ canvasElement }) => await playHoverAtFraction(canvasElement, 0.5),
+}
+
 // Formula series have no `action`; their `order` and `series_name` keep the repeated
 // breakdown values from separate formulas attributable.
 export const MultipleFormulasWithBreakdown: Story = {

--- a/products/product_analytics/frontend/insights/shared/InsightSeriesTooltip.tsx
+++ b/products/product_analytics/frontend/insights/shared/InsightSeriesTooltip.tsx
@@ -186,12 +186,17 @@ export function SeriesLabel({
             </>
         ) : null
 
-    // inline-flex: the series name absorbs the overflow, breakdown and period label stay visible.
+    // Three levels of priority, in order: the period label never shrinks, the breakdown value
+    // shrinks only once the row runs out of name, and the name absorbs everything before that.
+    // The breakdown and the period share a shrink-0 group so shrinking is sequential — a group
+    // that shrinks proportionally costs a short value two characters to the ellipsis.
     return (
         <span className="inline-flex items-center w-full overflow-hidden">
             {seriesPrefix}
-            <span className="truncate min-w-0 shrink-0 max-w-full">{breakdownTitle ?? datum.label}</span>
-            {comparePeriod && <span className="shrink-0 opacity-60">&nbsp;·&nbsp;{comparePeriod}</span>}
+            <span className="inline-flex items-center min-w-0 shrink-0 max-w-full">
+                <span className="truncate min-w-0 shrink">{breakdownTitle ?? datum.label}</span>
+                {comparePeriod && <span className="shrink-0 opacity-60">&nbsp;·&nbsp;{comparePeriod}</span>}
+            </span>
         </span>
     )
 }

--- a/products/product_analytics/frontend/insights/shared/InsightSeriesTooltip.tsx
+++ b/products/product_analytics/frontend/insights/shared/InsightSeriesTooltip.tsx
@@ -174,20 +174,23 @@ export function SeriesLabel({
 
     const seriesPrefix =
         seriesIdentification !== 'none' ? (
-            <span className="opacity-50 shrink-0 inline-flex items-center">
+            <>
                 {seriesLetter}
-                <span>
+                {/* The name is the same on every row, so it gives up space first — the breakdown
+                    value is what tells the rows apart, and a long event name would otherwise
+                    truncate it away. The letter and the separator stay put. */}
+                <span className="opacity-50 truncate min-w-0 shrink">
                     {(datum.action ? getDisplayNameFromEntityFilter(datum.action) : datum.series_name) ?? datum.label}
-                    &nbsp;·&nbsp;
                 </span>
-            </span>
+                <span className="opacity-50 shrink-0">&nbsp;·&nbsp;</span>
+            </>
         ) : null
 
-    // inline-flex: breakdown span truncates (flex-1), period label stays visible (shrink-0).
+    // inline-flex: the series name absorbs the overflow, breakdown and period label stay visible.
     return (
         <span className="inline-flex items-center w-full overflow-hidden">
             {seriesPrefix}
-            <span className="truncate min-w-0 flex-1">{breakdownTitle ?? datum.label}</span>
+            <span className="truncate min-w-0 shrink-0 max-w-full">{breakdownTitle ?? datum.label}</span>
             {comparePeriod && <span className="shrink-0 opacity-60">&nbsp;·&nbsp;{comparePeriod}</span>}
         </span>
     )


### PR DESCRIPTION
## Problem

Hovering a trends chart with two series and a breakdown, a user could not read which breakdown value a row belonged to: the value was clipped away entirely. Their event name was 33 characters, and every row repeated it.

- The series-name prefix is `shrink-0`, so the name keeps its full width.
- The breakdown value is `flex-1`, so it absorbs every pixel of overflow.
- The tooltip caps at 20rem, so a long event name leaves the value nothing.

The name is identical on every row. The breakdown value is the only part that differs, so the part that clips is the part that carries the information.

## Changes

Rows now shrink in priority order. The series name yields first, the breakdown value truncates only once the name is spent, and the comparison period never shrinks.

- The breakdown value and the period label share a `shrink-0` group, so shrinking runs sequentially.
- A group that shrinks proportionally instead costs a short value like `true` two characters to the ellipsis, which is why the group is fixed and only its contents flex.
- Adds a story with a long event name, since only a rendered row shows the clipping.

![before and after](https://raw.githubusercontent.com/PostHog/pr-assets/1c5e7fb11e17b71a79238f492a20e8441c36f92e/2026/08/72b358b1-d81c-4548-a252-0e0c467951dc.png)

Row 4 is the pathological case: a breakdown value wider than the whole tooltip. Before, the period label is cut to `· Pr`. After, the value truncates with an ellipsis and the label reads. It still clips by about the width of the series letter, which sits outside the group.

The second commit also reformats `frontend/snapshots.yml`. The visual baseline bot pushed two unrelated entries in explicit-key form, which oxfmt rejects.

## How did you test this code?

I (actually Claude) ran the existing `TrendsLineChart` tooltip tests, which assert the prefix text on breakdown rows and cover this markup. They pass unchanged, because truncation is CSS and jsdom cannot observe it.

The image above comes from a standalone page reproducing the row markup and the 20rem cap, not from the app. I could not run Storybook in this sandbox: `global.scss` failed to resolve `@posthog/quill/dist/tokens.scoped.css` even after building the quill workspace. The new story is there so CI's visual-regression job covers the real rendering.

Not checked: the app itself, and the other charts that render `InsightSeriesTooltip` (bar, pie, lifecycle, stickiness, retention). They share this label component, so the change applies to them too.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Opus 5 via PostHog Code, directed by the PR assignee while diagnosing a user report.

- Skills invoked: `/checking-deploy-timing` (to confirm the earlier fix had shipped before ruling out a deploy lag), `/writing-pr-descriptions`.
- The report first looked like a regression in the series-attribution logic from #78534. Deploy annotations plus `gh api compare` showed that change was live, and the reporter's screenshot matched the pre-fix rendering, which pointed at a stale bundle rather than the logic. Reproducing on the same insight then surfaced this separate layout problem.
- Greptile caught that the first commit's `shrink-0 max-w-full` breakdown could push the comparison period out of the row. I confirmed it in the harness and restructured into the group described above. Two intermediate attempts failed: proportional shrink factors ate characters from short values, because a span one pixel narrower than its text loses about two characters to the ellipsis glyph.
- I considered dropping the repeated name and keeping only the A/B letter, which frees the most width. I kept the name because a dashboard tile has no series editor beside it to resolve the letter against.
- The story's event name and breakdown values are invented. The user's own event name and breakdown values appear nowhere in this PR.
