### PR TITLE
feat(personhog): add tmp shadow tables for lifecycle op saga state

### DIFF
--- a/rust/persons_migrations/20260811000002_add_tmp_lifecycle_op_tables.sql
+++ b/rust/persons_migrations/20260811000002_add_tmp_lifecycle_op_tables.sql
@@ -1,0 +1,53 @@
+-- Shadow tables for the lifecycle-manager saga state (see
+-- 20260727000001_add_lifecycle_op_tables.sql), used to dual-write saga rows
+-- against the validation table set. The FK stays inside the tmp namespace so
+-- the shadow pair is self-contained: op rows and their per-person claims
+-- cascade together without touching the real tables.
+--
+-- SAFE: creates new empty tables and indexes only; takes no locks on
+-- existing tables. This migration is idempotent and safe to re-run.
+
+CREATE TABLE IF NOT EXISTS lifecycle_op_tmp (
+    op_id            UUID,
+    op_type          TEXT NOT NULL CHECK (op_type IN ('merge', 'delete')),
+    team_id          INTEGER NOT NULL,
+    step             TEXT NOT NULL,
+    attempt          INTEGER NOT NULL DEFAULT 0,
+    lease_expires_at TIMESTAMP WITH TIME ZONE,
+    request          JSONB NOT NULL,
+    outcome          JSONB,
+    created_at       TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    completed_at     TIMESTAMP WITH TIME ZONE,
+    parked_at        TIMESTAMP WITH TIME ZONE,
+    parked_reason    TEXT,
+    CONSTRAINT lifecycle_op_tmp_pkey PRIMARY KEY (op_id)
+);
+
+-- Sweeper scan: incomplete ops whose lease has expired.
+CREATE INDEX IF NOT EXISTS lifecycle_op_tmp_sweep ON lifecycle_op_tmp (lease_expires_at)
+    WHERE completed_at IS NULL;
+
+-- Garbage collection: completed ops past retention.
+CREATE INDEX IF NOT EXISTS lifecycle_op_tmp_gc ON lifecycle_op_tmp (completed_at)
+    WHERE completed_at IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS lifecycle_op_person_tmp (
+    op_id       UUID NOT NULL,
+    team_id     INTEGER NOT NULL,
+    person_id   BIGINT NOT NULL,
+    person_uuid UUID NOT NULL,
+    role        TEXT NOT NULL,
+    ordinal     INTEGER,
+    status      TEXT NOT NULL,
+    sealed      JSONB,
+    moved       JSONB,
+    CONSTRAINT lifecycle_op_person_tmp_pkey PRIMARY KEY (op_id, person_id),
+    CONSTRAINT lifecycle_op_person_tmp_op_id_fkey
+        FOREIGN KEY (op_id) REFERENCES lifecycle_op_tmp (op_id) ON DELETE CASCADE
+);
+
+-- The mark: at most one live op may claim a person.
+-- Inserting a row is marking; a unique violation IS the conflict.
+CREATE UNIQUE INDEX IF NOT EXISTS lifecycle_op_person_tmp_mark
+    ON lifecycle_op_person_tmp (team_id, person_id)
+    WHERE status IN ('marked', 'sealed');


### PR DESCRIPTION
## Problem

The persons database tracks every person merge and delete in two tables, `lifecycle_op` and `lifecycle_op_person`.
We want to dual write that state to a shadow copy of those tables, so we can validate the new write path against the real one.
The shadow tables do not exist yet.

## Changes

- Adds one sqlx migration that creates `lifecycle_op_tmp` and `lifecycle_op_person_tmp`.
- The tmp tables match the real ones exactly: same columns, checks, and indexes, including the parked columns added in #79227.
- The foreign key on `lifecycle_op_person_tmp` points at `lifecycle_op_tmp`, so the shadow pair stands alone and deletes cascade within it. Same pattern as the existing identity tmp tables.
- The migration only creates new empty tables. It takes no locks on existing tables and is safe to re-run.

## How did you test this code?

- Applied the migration to a local persons database with `cargo sqlx migrate run`.
- Compared the tmp and real tables in `information_schema`: columns, types, and nullability are identical.
- No automated tests added. The migration creates empty tables and has no behavior to regress.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: /writing-pr-descriptions.
The agent mirrored the schema and naming conventions of the existing tmp identity tables migration, folded in the parked columns from the latest lifecycle_op migration, and verified the applied schema against a local database.
