### PR TITLE
fix(desktop): preserve Codex full access in tasks

### DIFF
--- a/products/desktop/packages/core/src/sessions/cloudRunOptions.test.ts
+++ b/products/desktop/packages/core/src/sessions/cloudRunOptions.test.ts
@@ -6,7 +6,28 @@ import {
   getCloudRunSource,
   getCloudRuntimeOptions,
   resolveCloudResumeOptions,
+  resolveCloudRunAdapter,
 } from "./cloudRunOptions";
+
+describe("resolveCloudRunAdapter", () => {
+  it.each([
+    [{ runtime_adapter: "codex" }, "codex"],
+    [{ runtime_adapter: null, state: { runtime_adapter: "codex" } }, "codex"],
+    [
+      {
+        runtime_adapter: null,
+        state: { initial_permission_mode: "full-access" },
+      },
+      "codex",
+    ],
+    [
+      { runtime_adapter: null, state: { initial_permission_mode: "auto" } },
+      "claude",
+    ],
+  ] as const)("uses persisted run data for %o", (run, expected) => {
+    expect(resolveCloudRunAdapter(run as TaskRun)).toBe(expected);
+  });
+});
 
 describe("getCloudPrAuthorshipMode", () => {
   it("honors an explicit user/bot mode", () => {

--- a/products/desktop/packages/core/src/sessions/cloudRunOptions.ts
+++ b/products/desktop/packages/core/src/sessions/cloudRunOptions.ts
@@ -47,6 +47,23 @@ export interface StoredCloudComposerConfig {
   mode?: ExecutionMode;
 }
 
+export function resolveCloudRunAdapter(run: TaskRun | undefined): Adapter {
+  if (run?.runtime_adapter === "codex") return "codex";
+  if (run?.runtime_adapter === "claude") return "claude";
+
+  const stateAdapter = run?.state?.runtime_adapter;
+  if (stateAdapter === "codex" || stateAdapter === "claude") {
+    return stateAdapter;
+  }
+
+  const initialMode = run?.state?.initial_permission_mode;
+  if (initialMode === "full-access" || initialMode === "read-only") {
+    return "codex";
+  }
+
+  return "claude";
+}
+
 export function resolveCloudResumeOptions(
   composerConfig: StoredCloudComposerConfig | undefined,
   previousRun: TaskRun | undefined,

--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -77,6 +77,7 @@ import {
   getCloudPrAuthorshipMode,
   getCloudRunSource,
   getCloudRuntimeOptions,
+  resolveCloudRunAdapter,
 } from "./cloudRunOptions";
 import {
   addMissingCloudRuntimeConfigOptions,
@@ -7082,7 +7083,7 @@ export class SessionService {
       typeof run.state?.initial_permission_mode === "string"
         ? run.state.initial_permission_mode
         : undefined,
-      run.runtime_adapter === "codex" ? "codex" : "claude",
+      resolveCloudRunAdapter(run),
       run.model ?? undefined,
       task.description ?? undefined,
       undefined,
@@ -7144,8 +7145,7 @@ export class SessionService {
       typeof task.latest_run?.state?.initial_permission_mode === "string"
         ? task.latest_run.state.initial_permission_mode
         : undefined;
-    const adapter =
-      task.latest_run?.runtime_adapter === "codex" ? "codex" : "claude";
+    const adapter = resolveCloudRunAdapter(task.latest_run);
     const initialModel = task.latest_run?.model ?? undefined;
     const initialReasoningEffort =
       task.latest_run?.reasoning_effort ?? undefined;


### PR DESCRIPTION
## Problem

- Codex users who start a task with Full access see Automatic after the live task opens.

**Why:** The live task must preserve the permission level selected before the run starts.

## Changes

- The live session recovers the Codex adapter from persisted run state when the response omits its top-level adapter.
- Codex-only modes also identify the adapter when older run state lacks the adapter field.
- No visible layout or copy changes.

## How did you test this code?

- Added a unit regression for missing adapter data with a persisted Full access mode.
- Checked adapter precedence for explicit, persisted, and fallback values.
- Ran the core TypeScript check and Biome lint.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No docs update. This restores the existing task mode behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex implemented and tested the fix.
- Skills: `posthog-desktop`, `writing-user-facing-copy`, `writing-tests`, and `writing-pr-descriptions`.
- Public artifact check: the diff contains no private session data.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
