### PR TITLE
feat(desktop): add channel breadcrumb actions

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelBreadcrumb.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelBreadcrumb.test.tsx
@@ -8,6 +8,19 @@ const router = vi.hoisted(() => ({
   pathname: "/website/team/artifacts",
   navigate: vi.fn(),
 }));
+const channels = vi.hoisted(() => ({
+  current: [
+    {
+      id: "team",
+      name: "Team",
+      channelType: "public" as const,
+      starred: false,
+    },
+  ],
+  star: vi.fn().mockResolvedValue(undefined),
+  unstar: vi.fn().mockResolvedValue(undefined),
+  copyLink: vi.fn().mockResolvedValue(undefined),
+}));
 
 vi.mock("@tanstack/react-router", () => ({
   useNavigate: () => router.navigate,
@@ -20,6 +33,18 @@ vi.mock("@tanstack/react-router", () => ({
 vi.mock("@posthog/ui/features/canvas/hooks/useChannelsLayout", () => ({
   useChannelsLayout: () => true,
 }));
+vi.mock("@posthog/ui/features/canvas/hooks/useChannels", () => ({
+  useChannels: () => ({ channels: channels.current, isLoading: false }),
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useChannelStars", () => ({
+  useChannelStarMutations: () => ({
+    star: channels.star,
+    unstar: channels.unstar,
+  }),
+}));
+vi.mock("@posthog/ui/features/canvas/utils/copyChannelLink", () => ({
+  copyChannelLink: channels.copyLink,
+}));
 
 import { ChannelBreadcrumb } from "./ChannelBreadcrumb";
 
@@ -27,6 +52,10 @@ describe("ChannelBreadcrumb", () => {
   beforeEach(() => {
     router.pathname = "/website/team/artifacts";
     router.navigate.mockClear();
+    channels.star.mockClear();
+    channels.unstar.mockClear();
+    channels.copyLink.mockClear();
+    channels.current[0].starred = false;
   });
 
   it("closes title editing when the editable leaf changes", () => {
@@ -127,5 +156,53 @@ describe("ChannelBreadcrumb", () => {
     expect(root).toHaveAttribute("aria-disabled", "true");
     fireEvent.click(root);
     expect(router.navigate).not.toHaveBeenCalled();
+  });
+
+  it("opens channel actions from the root segment", async () => {
+    render(
+      <Theme>
+        <ChannelBreadcrumb
+          channelName="Team"
+          channelId="team"
+          leafLabel="Artifacts"
+        />
+      </Theme>,
+    );
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: /Team/ }));
+
+    expect(await screen.findByText("Star channel")).toBeInTheDocument();
+    expect(screen.getByText("Copy link to channel")).toBeInTheDocument();
+  });
+
+  it("runs star and copy actions for the channel", async () => {
+    render(
+      <Theme>
+        <ChannelBreadcrumb channelName="Team" channelId="team" />
+      </Theme>,
+    );
+
+    const root = screen.getByRole("button", { name: /Team/ });
+    fireEvent.contextMenu(root);
+    fireEvent.click(await screen.findByText("Star channel"));
+    expect(channels.star).toHaveBeenCalledWith("team");
+
+    fireEvent.contextMenu(root);
+    fireEvent.click(await screen.findByText("Copy link to channel"));
+    expect(channels.copyLink).toHaveBeenCalledWith("team", "title_bar");
+  });
+
+  it("offers to unstar a starred channel", async () => {
+    channels.current[0].starred = true;
+    render(
+      <Theme>
+        <ChannelBreadcrumb channelName="Team" channelId="team" />
+      </Theme>,
+    );
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: /Team/ }));
+    fireEvent.click(await screen.findByText("Unstar channel"));
+
+    expect(channels.unstar).toHaveBeenCalledWith("team");
   });
 });

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelBreadcrumb.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelBreadcrumb.tsx
@@ -1,13 +1,25 @@
+import { LinkIcon, StarIcon } from "@phosphor-icons/react";
 import {
   Button,
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
   cn,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@posthog/quill";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { channelGlyph } from "@posthog/ui/features/canvas/components/channelGlyph";
+import { useChannelStarMutations } from "@posthog/ui/features/canvas/hooks/useChannelStars";
+import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
+import { copyChannelLink } from "@posthog/ui/features/canvas/utils/copyChannelLink";
 import { HeaderTitleEditor } from "@posthog/ui/features/task-detail/HeaderTitleEditor";
+import { toast } from "@posthog/ui/primitives/toast";
+import { track } from "@posthog/ui/shell/analytics";
 import { Flex, Text } from "@radix-ui/themes";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 import { type ReactNode, useState } from "react";
@@ -69,31 +81,40 @@ export function ChannelBreadcrumb({
     ? pathname === `/website/${channelId}`
     : false;
 
+  const channelSegment = (
+    <BreadcrumbSegment
+      icon={channelGlyph(channelName, {
+        size: 12,
+        space: spacesLayout,
+        className: "shrink-0 text-muted-foreground/80",
+      })}
+      label={channelName}
+      strong
+      onClick={
+        channelId && !atChannelHome
+          ? () =>
+              void navigate({
+                to: "/website/$channelId",
+                params: { channelId },
+              })
+          : undefined
+      }
+      contextMenu={Boolean(channelId)}
+    />
+  );
+
   return (
     <Flex align="center" justify="between" gap="2" className="w-full min-w-0">
       {/* flex-1 so the inline editor can stretch across the row; the trailing
           slot still sits at the far end. */}
       <Flex align="center" gap="0.5" className="min-w-0 flex-1">
-        <BreadcrumbSegment
-          icon={channelGlyph(channelName, {
-            size: 12,
-            space: spacesLayout,
-            className: "shrink-0 text-muted-foreground/80",
-          })}
-          label={channelName}
-          strong
-          // Nowhere to go from the space's own index, and no channelId means no
-          // route at all — either way the segment stops responding.
-          onClick={
-            channelId && !atChannelHome
-              ? () =>
-                  void navigate({
-                    to: "/website/$channelId",
-                    params: { channelId },
-                  })
-              : undefined
-          }
-        />
+        {channelId ? (
+          <ChannelSegmentContextMenu channelId={channelId}>
+            {channelSegment}
+          </ChannelSegmentContextMenu>
+        ) : (
+          channelSegment
+        )}
         {middle && (
           <>
             <BreadcrumbSeparator />
@@ -165,6 +186,7 @@ function BreadcrumbSegment({
   strong,
   muted,
   onClick,
+  contextMenu = false,
   ...rest
 }: {
   icon?: ReactNode;
@@ -175,6 +197,7 @@ function BreadcrumbSegment({
   muted?: boolean;
   /** Navigates, or (on a renamable leaf) opens the inline editor. */
   onClick?: () => void;
+  contextMenu?: boolean;
 }) {
   const interactive = Boolean(onClick);
 
@@ -192,7 +215,7 @@ function BreadcrumbSegment({
         // any other button: pointer cursor and hover fill. Inert ones read as
         // plain text — full opacity, ordinary cursor, and no hover (quill's
         // hover rules already skip aria-disabled) — and leave the tab order.
-        interactive
+        interactive || contextMenu
           ? "cursor-pointer!"
           : "pointer-events-none cursor-default! opacity-100!",
       )}
@@ -212,6 +235,63 @@ function BreadcrumbSegment({
         {label}
       </Text>
     </Button>
+  );
+}
+
+function ChannelSegmentContextMenu({
+  channelId,
+  children,
+}: {
+  channelId: string;
+  children: ReactNode;
+}) {
+  const { channels } = useChannels();
+  const { star, unstar } = useChannelStarMutations();
+  const channel = channels.find((candidate) => candidate.id === channelId);
+  const canStar = channel != null && channel.channelType !== "personal";
+  const isStarred = channel?.starred ?? false;
+
+  const toggleStar = async () => {
+    try {
+      await (isStarred ? unstar(channelId) : star(channelId));
+      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+        action_type: isStarred ? "unstar" : "star",
+        surface: "title_bar",
+        channel_id: channelId,
+      });
+    } catch (error) {
+      toast.error(
+        isStarred ? "Couldn't unstar channel" : "Couldn't star channel",
+        {
+          description: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+  };
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger render={<span className="flex min-w-0" />}>
+        {children}
+      </ContextMenuTrigger>
+      <ContextMenuContent className="no-drag">
+        {canStar && (
+          <>
+            <ContextMenuItem onClick={() => void toggleStar()}>
+              <StarIcon size={14} weight={isStarred ? "fill" : "regular"} />
+              {isStarred ? "Unstar channel" : "Star channel"}
+            </ContextMenuItem>
+            <ContextMenuSeparator />
+          </>
+        )}
+        <ContextMenuItem
+          onClick={() => void copyChannelLink(channelId, "title_bar")}
+        >
+          <LinkIcon size={14} />
+          Copy link to channel
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }
 

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteLayout.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteLayout.test.tsx
@@ -50,6 +50,12 @@ vi.mock("@posthog/ui/features/canvas/hooks/useChannels", () => ({
     channels: [{ id: "chan-1", name: "project-bluebird" }],
   }),
 }));
+vi.mock("@posthog/ui/features/canvas/hooks/useChannelStars", () => ({
+  useChannelStarMutations: () => ({
+    star: vi.fn(),
+    unstar: vi.fn(),
+  }),
+}));
 vi.mock("@posthog/ui/features/canvas/hooks/useDashboards", () => ({
   useDashboard,
   useDashboardMutations: () => ({}),


### PR DESCRIPTION
## Problem

People cannot manage a channel from its top navigation breadcrumb.

**Why:** Channel actions should be available where people already identify their current channel.

## Changes

- Right-clicking the channel name opens actions to star, unstar, or copy its link.
- Personal channels show only the copy-link action.
- The shared breadcrumb provides the menu across channel pages, threads, loops, and canvases.

| Dark mode | Light mode |
| --- | --- |
| ![Channel breadcrumb actions in dark mode](https://raw.githubusercontent.com/PostHog/pr-assets/9afa7dff9356c0437740ba59e35206a02884bd22/2026/08/71888380-ea7d-4849-88ee-560960ce77b7.png) | ![Channel breadcrumb actions in light mode](https://raw.githubusercontent.com/PostHog/pr-assets/594ba3c642c84b25772b4f04fdd1278371034782/2026/08/e51edd5e-cc49-4a7c-8ba5-1ac6a6a57a18.png) |

## How did you test this code?

- Added UI tests that catch missing star, unstar, and copy-link actions.
- Ran the full desktop TypeScript check.
- Ran desktop lint; it reported existing warnings outside the changed files.
- Verified the menu visually in light and dark themes with the app theme class applied.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update is required.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and tested this change. It used the posthog-desktop, writing-user-facing-copy, writing-pr-descriptions, and Electron-testing skills.

The change reuses the existing channel star mutations and share-link behavior in the shared breadcrumb.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*