### PR TITLE
fix(desktop): default new canvases to scaffold

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/freeform/FreeformGenerateBar.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/FreeformGenerateBar.tsx
@@ -28,8 +28,7 @@ export const FreeformGenerateBar = forwardRef<
     name: string;
     templateId?: string;
     /** Whether the canvas already has published source. The agent re-reads the
-     * live source through the canvas tools, so this is purely the edit signal
-     * (starter toggle hidden, generation prompted as a follow-up edit). */
+     * live source through the canvas tools, so this is purely the edit signal. */
     isEdit?: boolean;
     // Keys the editor's draft/command state; distinct per canvas.
     sessionId: string;
@@ -53,12 +52,6 @@ export const FreeformGenerateBar = forwardRef<
     channelName,
   });
 
-  // On a FIRST build we seed the agent with a known-good starter scaffold by
-  // default (faster, more consistent than authoring from scratch). Uncheck to
-  // opt out and have the agent build from a blank canvas. Only meaningful on an
-  // empty canvas, so the toggle is hidden in edit mode.
-  const [useStarter, setUseStarter] = useState(true);
-
   // Generation always runs in the cloud, except the dev-only picker below lets a
   // local build of these features be tested before it's merged to the cloud env.
   const [workspaceMode, setWorkspaceMode] = useState<WorkspaceMode>("cloud");
@@ -72,7 +65,7 @@ export const FreeformGenerateBar = forwardRef<
       templateId,
       instruction,
       isEdit,
-      useStarter: !isEdit && useStarter,
+      useStarter: !isEdit,
       workspaceMode,
     });
     if (taskId) onStarted?.(taskId);
@@ -91,19 +84,6 @@ export const FreeformGenerateBar = forwardRef<
         hideDefaultToolbar
         onSubmit={(text) => void run(text)}
       />
-      {!isEdit && (
-        <label className="flex cursor-pointer select-none items-center gap-1.5 self-start px-1 text-muted-foreground text-xs">
-          <input
-            type="checkbox"
-            className="cursor-pointer"
-            checked={useStarter}
-            disabled={isStarting}
-            onChange={(e) => setUseStarter(e.target.checked)}
-          />
-          Start from scaffold (faster, more consistent — uncheck to build from
-          scratch)
-        </label>
-      )}
       {/* Dev-only: pick local vs cloud so a local build can be tested pre-merge. */}
       {import.meta.env.DEV && (
         <Tooltip>

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
@@ -73,7 +73,7 @@ export function useGenerateFreeformCanvas(args: {
       adapter?: Adapter;
       model?: string;
       reasoningLevel?: string;
-      // Default on (opt out in the bar): seed the starter scaffold on first build.
+      // Seed the starter scaffold on first build.
       useStarter?: boolean;
       // Dev-only override (the bar exposes a local/cloud picker in dev so a
       // local build of these features can be tested before merging). Production


### PR DESCRIPTION
## Problem

The New Canvas screen asks people to choose whether to use the standard scaffold, although new canvases should use it automatically.

**Why:** The scaffold gives new canvases a consistent starting point without exposing an implementation choice.

## Changes

- New canvas generation always starts from the scaffold.
- The New Canvas screen no longer shows the scaffold checkbox.
- Editing an existing canvas remains unchanged.
- Screenshot not included because this change only removes one checkbox.

## How did you test this code?

- `pnpm exec biome check packages/ui/src/features/canvas/freeform/FreeformGenerateBar.tsx packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts`
- `pnpm --filter @posthog/ui typecheck`
- `pnpm build`
- Manual UI testing was not run.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This change does not alter a documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and checked this change. It used the `/posthog-desktop`, `/writing-user-facing-copy`, `/canvas-templates`, and `/writing-pr-descriptions` skills.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
