### PR TITLE
fix(paths): validate path cleaning regexes against re2, not JavaScript

### DIFF
--- a/frontend/src/lib/components/PathCleanFilters/PathCleanFilterItem.tsx
+++ b/frontend/src/lib/components/PathCleanFilters/PathCleanFilterItem.tsx
@@ -8,7 +8,7 @@ import { LemonSnack, Tooltip } from '@posthog/lemon-ui'
 
 import { PathCleaningFilter } from '~/types'
 
-import { isValidPathCleaningRegex } from './pathCleaningUtils'
+import { pathCleaningRegexError } from './pathCleaningUtils'
 import { PathRegexModal } from './PathRegexModal'
 
 interface PathCleanFilterItem {
@@ -22,7 +22,7 @@ export function PathCleanFilterItem({ filter, onChange, onRemove }: PathCleanFil
     const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: String(filter.alias) })
 
     const regex = filter.regex ?? ''
-    const isInvalidRegex = !isValidPathCleaningRegex(regex)
+    const regexError = pathCleaningRegexError(regex)
 
     return (
         <>
@@ -45,13 +45,13 @@ export function PathCleanFilterItem({ filter, onChange, onRemove }: PathCleanFil
                 // eslint-disable-next-line react/forbid-dom-props
                 style={{ transform: CSS.Translate.toString(transform), transition }}
             >
-                <Tooltip title={isInvalidRegex ? 'NOTE: Invalid Regex, will be skipped' : null}>
+                <Tooltip title={regexError}>
                     <LemonSnack
                         type="pill"
                         onClick={onChange ? () => setVisible(!visible) : undefined}
                         onClose={onRemove}
                         title={`${filter.regex} is mapped to ${filter.alias}`}
-                        className={clsx({ 'border border-accent': isInvalidRegex })}
+                        className={clsx({ 'border border-accent': regexError !== null })}
                     >
                         <span className="inline-flex items-center">
                             <span className="font-mono text-accent text-xs">{filter.regex ?? '(Empty)'}</span>

--- a/frontend/src/lib/components/PathCleanFilters/PathCleanFilterItem.tsx
+++ b/frontend/src/lib/components/PathCleanFilters/PathCleanFilterItem.tsx
@@ -6,10 +6,9 @@ import { useState } from 'react'
 import { IconArrowCircleRight } from '@posthog/icons'
 import { LemonSnack, Tooltip } from '@posthog/lemon-ui'
 
-import { isValidRegexp } from 'lib/utils/regexp'
-
 import { PathCleaningFilter } from '~/types'
 
+import { isValidPathCleaningRegex } from './pathCleaningUtils'
 import { PathRegexModal } from './PathRegexModal'
 
 interface PathCleanFilterItem {
@@ -23,7 +22,7 @@ export function PathCleanFilterItem({ filter, onChange, onRemove }: PathCleanFil
     const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: String(filter.alias) })
 
     const regex = filter.regex ?? ''
-    const isInvalidRegex = !isValidRegexp(regex)
+    const isInvalidRegex = !isValidPathCleaningRegex(regex)
 
     return (
         <>

--- a/frontend/src/lib/components/PathCleanFilters/PathCleanFiltersTable.tsx
+++ b/frontend/src/lib/components/PathCleanFilters/PathCleanFiltersTable.tsx
@@ -19,13 +19,12 @@ import { LemonButton, Tooltip } from '@posthog/lemon-ui'
 
 import { TeamMembershipLevel } from 'lib/constants'
 import { SortableDragIcon } from 'lib/lemon-ui/icons'
-import { isValidRegexp } from 'lib/utils/regexp'
 
 import { PathCleaningFilter } from '~/types'
 
 import { RestrictionScope, useRestrictedArea } from '../RestrictedArea'
 import { parseAliasToReadable } from './PathCleanFilterItem'
-import { ensureFilterOrder, updateFilterOrder } from './pathCleaningUtils'
+import { ensureFilterOrder, isValidPathCleaningRegex, updateFilterOrder } from './pathCleaningUtils'
 import { PathRegexModal } from './PathRegexModal'
 
 export interface PathCleanFiltersTableProps {
@@ -48,7 +47,7 @@ function SortableRow({ filter, index, onEdit, onRemove, disabledReason }: Sortab
     })
 
     const regex = filter.regex ?? ''
-    const isInvalidRegex = !isValidRegexp(regex)
+    const isInvalidRegex = !isValidPathCleaningRegex(regex)
 
     const style = {
         transform: CSS.Transform.toString(transform),

--- a/frontend/src/lib/components/PathCleanFilters/PathCleanFiltersTable.tsx
+++ b/frontend/src/lib/components/PathCleanFilters/PathCleanFiltersTable.tsx
@@ -24,7 +24,7 @@ import { PathCleaningFilter } from '~/types'
 
 import { RestrictionScope, useRestrictedArea } from '../RestrictedArea'
 import { parseAliasToReadable } from './PathCleanFilterItem'
-import { ensureFilterOrder, isValidPathCleaningRegex, updateFilterOrder } from './pathCleaningUtils'
+import { ensureFilterOrder, pathCleaningRegexError, updateFilterOrder } from './pathCleaningUtils'
 import { PathRegexModal } from './PathRegexModal'
 
 export interface PathCleanFiltersTableProps {
@@ -47,7 +47,8 @@ function SortableRow({ filter, index, onEdit, onRemove, disabledReason }: Sortab
     })
 
     const regex = filter.regex ?? ''
-    const isInvalidRegex = !isValidPathCleaningRegex(regex)
+    const regexError = pathCleaningRegexError(regex)
+    const isInvalidRegex = regexError !== null
 
     const style = {
         transform: CSS.Transform.toString(transform),
@@ -89,7 +90,7 @@ function SortableRow({ filter, index, onEdit, onRemove, disabledReason }: Sortab
                 </td>
                 <td className="py-1 px-2 w-12 text-center text-muted font-medium text-sm">{index + 1}</td>
                 <td className="py-1 px-2 min-w-0">
-                    <Tooltip title={isInvalidRegex ? 'Invalid regex pattern' : regex}>
+                    <Tooltip title={regexError ?? regex}>
                         <code
                             className={clsx(
                                 'font-mono text-xs px-1 py-0.5 rounded bg-accent-light text-accent block truncate',

--- a/frontend/src/lib/components/PathCleanFilters/PathCleaningRulesDebugger.stories.tsx
+++ b/frontend/src/lib/components/PathCleanFilters/PathCleaningRulesDebugger.stories.tsx
@@ -17,6 +17,8 @@ export const Default: StoryObj<PathCleaningRulesDebuggerProps> = {
             { alias: 'recordings', regex: '/replay/\\w+', order: 2 },
             { alias: '', regex: '/api/v1/.*', order: 3 }, // Empty alias
             { alias: 'invalid', regex: '[invalid(regex', order: 4 }, // Invalid regex
+            { alias: '/users/\\1', regex: '(?i)/Users/(\\d+)', order: 5 }, // Inline re2 flag group and a capture group
+            { alias: '/orders/\\1', regex: '/orders/(?P<id>\\d+)', order: 6 }, // Valid re2 the preview can't run
         ],
         finalResult: 'dashboard',
     },

--- a/frontend/src/lib/components/PathCleanFilters/PathCleaningRulesDebugger.tsx
+++ b/frontend/src/lib/components/PathCleanFilters/PathCleaningRulesDebugger.tsx
@@ -1,12 +1,10 @@
 import { IconChevronRight } from '@posthog/icons'
 import { LemonCollapse } from '@posthog/lemon-ui'
 
-import { isValidRegexp } from 'lib/utils/regexp'
-
 import { PathCleaningFilter } from '~/types'
 
 import { parseAliasToReadable } from './PathCleanFilterItem'
-import { applyPathCleaningRule } from './pathCleaningUtils'
+import { applyPathCleaningRule, canPreviewPathCleaningRegex, isValidPathCleaningRegex } from './pathCleaningUtils'
 
 interface ProcessingStep {
     stepNumber: number
@@ -15,6 +13,8 @@ interface ProcessingStep {
     outputPath: string
     wasModified: boolean
     isValidRegex: boolean
+    /** False when `outputPath` is a passthrough because the preview couldn't run the regex. */
+    canPreview: boolean
 }
 
 export interface PathCleaningRulesDebuggerProps {
@@ -28,7 +28,7 @@ const cleanPathWithDebugSteps = (path: string, filters: PathCleaningFilter[]): P
     let currentPath = path
 
     filters.forEach((filter, index) => {
-        const isValidRegex = isValidRegexp(filter.regex ?? '')
+        const regex = filter.regex ?? ''
         const outputPath = applyPathCleaningRule(currentPath, filter)
 
         steps.push({
@@ -37,7 +37,8 @@ const cleanPathWithDebugSteps = (path: string, filters: PathCleaningFilter[]): P
             inputPath: currentPath,
             outputPath,
             wasModified: currentPath !== outputPath,
-            isValidRegex,
+            isValidRegex: isValidPathCleaningRegex(regex),
+            canPreview: canPreviewPathCleaningRegex(regex),
         })
 
         currentPath = outputPath
@@ -120,7 +121,12 @@ export function PathCleaningRulesDebugger({
                                             </span>
                                         </div>
                                         <div className="w-6 flex-shrink-0 flex justify-center">
-                                            {step.wasModified ? (
+                                            {step.isValidRegex && !step.canPreview ? (
+                                                <div
+                                                    className="w-2 h-2 rounded-full bg-warning"
+                                                    title="Can't be previewed here. This rule is valid and the query still applies it, but its regex uses syntax the preview can't run."
+                                                />
+                                            ) : step.wasModified ? (
                                                 <div
                                                     className="w-2 h-2 rounded-full bg-success"
                                                     title="Matched and modified"

--- a/frontend/src/lib/components/PathCleanFilters/PathRegexModal.tsx
+++ b/frontend/src/lib/components/PathCleanFilters/PathRegexModal.tsx
@@ -7,7 +7,7 @@ import { AiRegexHelper } from 'scenes/session-recordings/components/AiRegexHelpe
 
 import { PathCleaningFilter } from '~/types'
 
-import { isValidPathCleaningRegex } from './pathCleaningUtils'
+import { pathCleaningRegexError } from './pathCleaningUtils'
 
 export interface PathRegexModalProps {
     isOpen: boolean
@@ -21,13 +21,8 @@ export function PathRegexModal({ filter, isOpen, onSave, onClose }: PathRegexMod
     const [regex, setRegex] = useState(filter?.regex ?? '')
 
     const isNew = !filter
-    const disabledReason = !alias
-        ? 'Alias is required'
-        : !regex
-          ? 'Regex is required'
-          : !isValidPathCleaningRegex(regex)
-            ? 'Malformed regex'
-            : null
+    const regexError = pathCleaningRegexError(regex)
+    const disabledReason = !alias ? 'Alias is required' : regexError
 
     // Reset state when reopening the modal with a different filter (or none)
     useEffect(() => {
@@ -53,6 +48,7 @@ export function PathRegexModal({ filter, isOpen, onSave, onClose }: PathRegexMod
                                 onChange={(regex) => setRegex(regex)}
                                 onPressEnter={() => false}
                             />
+                            {regex && regexError ? <p className="text-danger">{regexError}</p> : null}
                             <p className="text-muted">
                                 <span>
                                     Example:{' '}

--- a/frontend/src/lib/components/PathCleanFilters/pathCleaningUtils.test.ts
+++ b/frontend/src/lib/components/PathCleanFilters/pathCleaningUtils.test.ts
@@ -1,4 +1,11 @@
-import { applyPathCleaning, applyPathCleaningRule, expandAlias } from './pathCleaningUtils'
+import {
+    applyPathCleaning,
+    applyPathCleaningRule,
+    canPreviewPathCleaningRegex,
+    expandAlias,
+    isValidPathCleaningRegex,
+    pathCleaningRegexError,
+} from './pathCleaningUtils'
 
 // [name, alias, groups (index 0 is the whole match), expected]
 const EXPAND_CASES: [string, string, (string | undefined)[], string][] = [
@@ -50,6 +57,35 @@ describe('pathCleaningUtils', () => {
         expect(applyPathCleaningRule('/x', { regex: '(', alias: '/y' })).toBe('/x')
         expect(applyPathCleaningRule('/x', { regex: '', alias: '/y' })).toBe('/x')
         expect(applyPathCleaningRule('/x', { regex: '(?i)', alias: '/y' })).toBe('/x')
+    })
+
+    it.each([
+        // `(?i)` is how re2 asks for case-insensitive matching, and JavaScript rejects it outright, so
+        // validating with JavaScript would call a documented, working rule invalid.
+        ['an inline (?i) flag group is valid', '(?i)/Users/(\\d+)', true],
+        ['a plain pattern is valid', '/users/(\\d+)', true],
+        // The reverse direction: JavaScript accepts lookahead and re2 has no support for it, so
+        // validating with JavaScript would enable Save and leave the backend to reject the rule.
+        ['a lookahead is rejected', '/api(?!/internal)/', false],
+        ['an unclosed group is rejected', '(', false],
+        // ClickHouse `replaceRegexpAll` matches an empty pattern at every position, so the backend
+        // refuses a rule without a regex too.
+        ['an empty regex is rejected', '', false],
+    ])('isValidPathCleaningRegex: %s', (_name, regex, expected) => {
+        expect(isValidPathCleaningRegex(regex)).toBe(expected)
+    })
+
+    it('sends a capture-group reference in the regex to the alias', () => {
+        expect(pathCleaningRegexError('/user/(\\d+)/\\1')).toContain('alias')
+    })
+
+    it('separates a regex the query can run from one the preview can run', () => {
+        // re2 spells a named group `(?P<id>...)`, which JavaScript has no equivalent for. The rule
+        // cleans paths in the query, so the preview has to report that it can't show it rather than
+        // report that the rule didn't match.
+        expect(isValidPathCleaningRegex('(?P<id>\\d+)')).toBe(true)
+        expect(canPreviewPathCleaningRegex('(?P<id>\\d+)')).toBe(false)
+        expect(canPreviewPathCleaningRegex('/users/(\\d+)')).toBe(true)
     })
 
     it('chains rules in order, each feeding the next', () => {

--- a/frontend/src/lib/components/PathCleanFilters/pathCleaningUtils.ts
+++ b/frontend/src/lib/components/PathCleanFilters/pathCleaningUtils.ts
@@ -1,3 +1,7 @@
+import { RE2JS } from 're2js'
+
+import { formatRE2Error } from 'lib/utils/regexp'
+
 import { PathCleaningFilter } from '~/types'
 
 /**
@@ -62,9 +66,47 @@ function compileForPreview(regex: string): RegExp | null {
     }
 }
 
-/** Whether the preview can run this regex, so the editor refuses what it would not be able to show. */
+/**
+ * Why a path-cleaning regex can't be used, phrased for the person editing it, or null when it's fine.
+ *
+ * Judged by re2, because that is the engine ClickHouse `replaceRegexpAll` and the save-time backend
+ * check both run. JavaScript's own engine disagrees with re2 in both directions, so using it here
+ * would either block a working rule or wave through one the backend then rejects: JS accepts a
+ * lookahead like `/api(?!/internal)/` that re2 has no support for, and rejects the inline `(?i)` flag
+ * group that is how re2 asks for case-insensitive matching.
+ */
+export function pathCleaningRegexError(regex: string): string | null {
+    if (!regex) {
+        return 'Regex is required'
+    }
+    try {
+        RE2JS.compile(regex)
+    } catch (error) {
+        if (!(error instanceof Error)) {
+            return 'Invalid regex'
+        }
+        // Now that the alias documents `\1` for reusing a captured value, putting it in the regex by
+        // mistake is the re2 rejection to expect, so name the field that does take it.
+        if (error.message.includes('invalid escape sequence') && /\\[1-9]/.test(regex)) {
+            return "A regex can't reference its own capture groups. To reuse a captured value in the cleaned path, put \\1 in the alias instead."
+        }
+        return formatRE2Error(error, regex)
+    }
+    return null
+}
+
+/** Whether a rule's regex is one the query can run, so the editor and the debugger agree with it. */
 export function isValidPathCleaningRegex(regex: string): boolean {
-    return compileForPreview(regex) !== null
+    return pathCleaningRegexError(regex) === null
+}
+
+/**
+ * Whether the in-app preview can run this regex. Valid re2 with no JavaScript equivalent, such as a
+ * `(?P<id>...)` named group, still cleans paths in the real query, but the preview passes the path
+ * through untouched. Anything showing a preview has to say so rather than imply the rule didn't match.
+ */
+export function canPreviewPathCleaningRegex(regex: string): boolean {
+    return !!regex && compileForPreview(regex) !== null
 }
 
 /**


### PR DESCRIPTION
## Problem

Anyone editing path cleaning rules can be told a working rule is broken, and can be let through with a rule that isn't. A rule starting with `(?i)`, which is how the settings docs say to match case-insensitively, is marked invalid in the rules list and shows a red pattern in the step-by-step debugger, next to output proving it matched. A rule using a lookahead passes the editor's Save gate and is then rejected by the API.

Path cleaning runs through ClickHouse `replaceRegexpAll`, so re2 decides what is valid. The frontend was asking JavaScript's regex engine, and the two disagree in both directions: JavaScript rejects re2's inline `(?i)` flag group, and accepts a lookahead re2 has no support for. [#78193](https://github.com/PostHog/posthog/pull/78193) routed path previews through a re2-aware helper but left the validity checks on the JavaScript one, which is where the debugger started contradicting itself.

Refs #13872. Follow-up to [#78193](https://github.com/PostHog/posthog/pull/78193), from two review comments that landed after it merged.

## Changes

- Validate with `RE2JS` in one shared helper, so the Save gate, the rules list, the rules table, and the debugger all agree with the query and with the save-time backend check.
- Report the reason inline under the regex field, from `formatRE2Error`, the same way every other re2-backed regex input in the app does. A `\1` in the regex gets a message pointing at the alias, since that is the field that takes it.
- Split "can the query run this" from "can the preview show this". Valid re2 with no JavaScript equivalent, such as a `(?P<id>...)` named group, now gets its own debugger indicator instead of reading as a rule that didn't match.
- A rule saved without a regex is now marked invalid in the list. The API already refuses to save one, because an empty pattern matches at every position and threads the alias through the whole path.

Debugger, before and after. Rules 6 and 7 are valid re2; only rule 5 is genuinely malformed. Rule 7 is the one the preview can't run.

![debugger before](https://raw.githubusercontent.com/PostHog/pr-assets/6b635ca531b27fb4e1a1a8f3bbebeda317a941c7/2026/08/99a27e77-b025-4d95-87d1-501a1d4a0d94.png)

![debugger after](https://raw.githubusercontent.com/PostHog/pr-assets/0dbcc09b46f5debe0c5010b04dc3ced55af07273/2026/08/e24d6d82-c463-41ea-9b67-fb58d94d1cff.png)

A lookahead is now caught in the editor rather than by the API, and a capture-group reference in the regex says which field takes it.

![lookahead rejected in the rule editor](https://raw.githubusercontent.com/PostHog/pr-assets/b62b3de6512f6a7612d4465ca1a69e078abfac62/2026/08/11ab08af-4b76-4829-a77c-4196a220a109.png)

![backreference in the regex points at the alias](https://raw.githubusercontent.com/PostHog/pr-assets/d9df4c4e65bd7429bc1e963f50ccb49461d08af5/2026/08/3ae82463-a301-4462-af16-c6548036dd44.png)

The query layer and the backend validator are unchanged.

Visual Review shows 2 changed snapshots on `filters-pathcleanfilters--default` (light and dark), and both are intended. The only delta is an invalid-rule border appearing on the story's third pill, the fixture rule with no regex. Every other pill is byte-identical, and the 2px width growth is that border.

## How did you test this code?

Rendered the two affected Storybook stories in a headless browser, before and after, which produced the screenshots above. That is where the debugger's `(?i)` red pattern and the editor's inline error were confirmed by eye.

Extended `pathCleaningUtils.test.ts` with three groups (21 cases in the file pass locally):

- A parameterized validity matrix. Catches a revert to JavaScript compileability in either direction: `(?i)` becoming invalid, or a lookahead becoming valid and pushing the rejection back to the API.
- The message for a `\1` in the regex. Catches a change that drops the field-specific hint and falls back to the generic re2 error.
- Validity against previewability for a `(?P<id>...)` group. Catches a collapse of the two back into one check, which is what made the debugger's pattern and output disagree.

Frontend lint, format, and `tsgo` are clean for the changed files. The only `tsgo` failures are the pre-existing unbuilt `@posthog/quill` workspace, unrelated to this change.

Not checked here: no ClickHouse or Postgres in this environment, so nothing exercised the backend validator or a real cleaned query. Neither is touched by this diff.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None in this repo. The public path cleaning docs live in the external docs repo and still need the capture-group syntax, already flagged as a follow-up on [#78193](https://github.com/PostHog/posthog/pull/78193).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Left unassigned: the requester's GitHub handle wasn't provided, and I won't guess one.

Authored with PostHog Code (Claude). Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-pr-descriptions`.

Key decisions:

- Both review comments were confirmed against the merged code before changing anything: `RE2JS` accepts `(?i)` and rejects a lookahead, and the plain `RegExp` check does the reverse.
- The comments named the debugger and the Save gate. The same JavaScript check was also driving the invalid-rule indicators in `PathCleanFilterItem` and `PathCleanFiltersTable`, with the same misclassification, so those moved onto the shared helper too.
- Added a third debugger state rather than only swapping the check. Once validity is judged by re2, a valid rule the preview can't run would otherwise render as a rule that found no match, which is the same class of self-contradiction the review flagged.
- Kept the JavaScript-based `compileForPreview` for the preview itself. It is the only engine available in the browser for substitution, and it is unrelated to the question of what the query accepts.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

