### PR TITLE
fix(desktop): show the needs-input dot before you open the task

### DIFF
--- a/products/desktop/packages/api-client/src/generated.ts
+++ b/products/desktop/packages/api-client/src/generated.ts
@@ -11078,6 +11078,7 @@ export namespace Schemas {
     error_message?: (string | null) | undefined;
     output?: (unknown | null) | undefined;
     state?: unknown | undefined;
+    awaiting_input?: boolean | undefined;
     artifacts: Array<TaskRunArtifactResponse>;
     created_at: string;
     updated_at: string;
@@ -11092,6 +11093,7 @@ export namespace Schemas {
   export type TaskRunSummary = {
     status: (StatusA35Enum | NullEnum) | null;
     environment: (EnvironmentC1cEnum | NullEnum) | null;
+    awaiting_input?: boolean | undefined;
   };
   export type TaskSummary = {
     id: string;

--- a/products/desktop/packages/core/src/canvas/channelItems.ts
+++ b/products/desktop/packages/core/src/canvas/channelItems.ts
@@ -161,7 +161,11 @@ export function buildChannelItems({
               sessionFacts.workspaceModeByTaskId.get(task.id),
             ),
             source: sourceOf(task),
-            needsInput: sessionFacts.needsInputTaskIds.has(task.id),
+            // Either a live session here holds the prompt, or the backend says the run is
+            // waiting on one — the second is the only route for a task with no session here.
+            needsInput:
+              sessionFacts.needsInputTaskIds.has(task.id) ||
+              task.latest_run?.awaiting_input === true,
             unread: isTaskUnread(
               task.updated_at,
               sessionFacts.viewedTimestamps[task.id],

--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -7541,10 +7541,20 @@ export class SessionService {
       update,
     );
 
+    // Logs as well as snapshots: a snapshot is what a watch starts from, so covering only that
+    // recovers a prompt raised before the app opened the run and misses one raised while it is
+    // watching — the case where the live `permission_request` frame never lands (a reconnect
+    // that replays the request as a log line rather than re-emitting it). The request only
+    // reaches the reader once, either way: an answered or already-surfaced one is dropped by
+    // `handleCloudPermissionRequest`.
+    const isLiveLogBatch =
+      update.kind === "logs" &&
+      !isTerminalStatus(this.d.store.getSessions()[taskRunId]?.cloudStatus);
     if (
-      update.kind === "snapshot" &&
-      !isTerminalStatus(update.status) &&
-      !isStaleNonTerminalStatus
+      isLiveLogBatch ||
+      (update.kind === "snapshot" &&
+        !isTerminalStatus(update.status) &&
+        !isStaleNonTerminalStatus)
     ) {
       this.surfacePersistedPendingPermissions(taskRunId, update.newEntries);
     }

--- a/products/desktop/packages/core/src/sidebar/buildSidebarData.test.ts
+++ b/products/desktop/packages/core/src/sidebar/buildSidebarData.test.ts
@@ -16,6 +16,7 @@ function makeTask(id: string): TaskData {
     isUnread: false,
     isPinned: false,
     needsPermission: false,
+    awaitsInput: false,
     repository: null,
     isSuspended: false,
     folderPath: null,

--- a/products/desktop/packages/core/src/sidebar/buildSidebarData.ts
+++ b/products/desktop/packages/core/src/sidebar/buildSidebarData.ts
@@ -18,6 +18,7 @@ export interface FullTask {
     environment?: "local" | "cloud" | null;
     output?: { pr_url?: unknown } | null;
     state?: Record<string, unknown> | null;
+    awaiting_input?: boolean | null;
   } | null;
 }
 
@@ -35,6 +36,8 @@ export interface SidebarTask {
     output?: { pr_url?: unknown } | null;
     /** "interactive" or "background"; see `readRunMode`. */
     mode?: RunMode | null;
+    /** The agent is blocked on a question to the user; see `TaskData.awaitsInput`. */
+    awaiting_input?: boolean | null;
   } | null;
 }
 
@@ -76,6 +79,7 @@ export function narrowFullTask(task: FullTask | Task): SidebarTask {
           environment: task.latest_run.environment ?? null,
           output: task.latest_run.output ?? null,
           mode: readRunMode(task.latest_run.state),
+          awaiting_input: task.latest_run.awaiting_input ?? null,
         }
       : null,
     origin_product: task.origin_product,
@@ -223,6 +227,7 @@ export function deriveTaskData(
     isPinned: ctx.pinnedIds.has(task.id),
     isSuspended: ctx.suspendedIds.has(task.id),
     needsPermission: (session?.pendingPermissions?.size ?? 0) > 0,
+    awaitsInput: task.latest_run?.awaiting_input === true,
     repository: getRepositoryInfo(task, workspace?.folderPath ?? undefined),
     folderId: workspace?.folderId || undefined,
     taskRunStatus: session?.cloudStatus ?? task.latest_run?.status ?? undefined,

--- a/products/desktop/packages/core/src/sidebar/filterByWorkspaceMode.test.ts
+++ b/products/desktop/packages/core/src/sidebar/filterByWorkspaceMode.test.ts
@@ -12,6 +12,7 @@ const task = (overrides: Partial<TaskData>): TaskData => ({
   isUnread: false,
   isPinned: false,
   needsPermission: false,
+  awaitsInput: false,
   repository: null,
   isSuspended: false,
   folderPath: null,

--- a/products/desktop/packages/core/src/sidebar/runEnvironment.test.ts
+++ b/products/desktop/packages/core/src/sidebar/runEnvironment.test.ts
@@ -11,6 +11,7 @@ const task = (overrides: Partial<TaskData>): TaskData => ({
   isUnread: false,
   isPinned: false,
   needsPermission: false,
+  awaitsInput: false,
   repository: null,
   isSuspended: false,
   folderPath: null,

--- a/products/desktop/packages/core/src/sidebar/selection.test.ts
+++ b/products/desktop/packages/core/src/sidebar/selection.test.ts
@@ -20,6 +20,7 @@ function makeTaskData(id: string, overrides: Partial<TaskData> = {}): TaskData {
     isUnread: false,
     isPinned: false,
     needsPermission: false,
+    awaitsInput: false,
     repository: null,
     isSuspended: false,
     folderPath: null,

--- a/products/desktop/packages/core/src/sidebar/sidebarData.types.ts
+++ b/products/desktop/packages/core/src/sidebar/sidebarData.types.ts
@@ -14,7 +14,14 @@ export interface TaskData {
   isGenerating: boolean;
   isUnread: boolean;
   isPinned: boolean;
+  /** A live session in this app is holding a prompt only this app can answer. */
   needsPermission: boolean;
+  /**
+   * The run is blocked on a question to the user, as the backend reports it. This is the only
+   * route for a task no session in this app is attached to: the agent's prompts live in the
+   * run's log, so without one the row would read as plain "working".
+   */
+  awaitsInput: boolean;
   repository: TaskRepositoryInfo | null;
   isSuspended: boolean;
   folderId?: string;

--- a/products/desktop/packages/core/src/sidebar/taskRunning.test.ts
+++ b/products/desktop/packages/core/src/sidebar/taskRunning.test.ts
@@ -12,6 +12,7 @@ const task = (overrides: Partial<TaskData>): TaskData => ({
   isUnread: false,
   isPinned: false,
   needsPermission: false,
+  awaitsInput: false,
   repository: null,
   isSuspended: false,
   folderPath: null,

--- a/products/desktop/packages/shared/src/domain-types.ts
+++ b/products/desktop/packages/shared/src/domain-types.ts
@@ -298,6 +298,9 @@ export interface TaskRun {
   error_message: string | null;
   output: Record<string, unknown> | null; // Structured output (PR URL, commit SHA, etc.)
   state: Record<string, unknown>; // Intermediate run state (defaults to {}, never null)
+  /** The agent has asked the user something and is blocked on the answer. `status`
+   * stays `in_progress` throughout, so this is the only field that says so. */
+  awaiting_input?: boolean;
   artifacts?: TaskRunArtifact[];
   created_at: string;
   updated_at: string;

--- a/products/desktop/packages/ui/src/features/browser-tabs/TaskTabIcon.tsx
+++ b/products/desktop/packages/ui/src/features/browser-tabs/TaskTabIcon.tsx
@@ -40,6 +40,7 @@ export function TaskTabIcon({
       isPinned={taskData.isPinned}
       isSuspended={taskData.isSuspended}
       needsPermission={taskData.needsPermission}
+      awaitsInput={taskData.awaitsInput}
       taskRunStatus={taskData.taskRunStatus}
       runMode={taskData.runMode}
       originProduct={taskData.originProduct}

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useBlockedSessionCount.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useBlockedSessionCount.ts
@@ -49,12 +49,15 @@ export function useBlockedSessionCount(): (
   const blocked = useBlockedTaskIds();
   const archivedTaskIds = useArchivedTaskIds();
   const counts = useMemo(() => {
-    if (blocked.size === 0) return new Map<string, number>();
     // Archived alongside the yellow count, for the same reason: a space's
     // lists drop them, so a dot for one points at a row you cannot reach.
     return countSessionsByChannel(
       tasks ?? [],
-      (task) => blocked.has(task.id) && !archivedTaskIds.has(task.id),
+      (task) =>
+        // A session here holding the prompt, or the run itself reporting that it
+        // waits — the second is the only route for a task nothing here has open.
+        (blocked.has(task.id) || task.latest_run?.awaiting_input === true) &&
+        !archivedTaskIds.has(task.id),
     );
   }, [blocked, tasks, archivedTaskIds]);
   return useMemo(

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTaskStatus.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useChannelTaskStatus.ts
@@ -48,6 +48,7 @@ export function useChannelTaskStatus(
     isPinned: taskData.isPinned,
     isSuspended: taskData.isSuspended,
     needsPermission: taskData.needsPermission,
+    awaitsInput: taskData.awaitsInput,
     taskRunStatus: taskData.taskRunStatus,
     runMode: taskData.runMode,
     originProduct: taskData.originProduct,

--- a/products/desktop/packages/ui/src/features/sidebar/components/TaskListView.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/TaskListView.tsx
@@ -116,6 +116,7 @@ function TaskRow({
       isUnread={task.isUnread}
       isPinned={task.isPinned}
       needsPermission={task.needsPermission}
+      awaitsInput={task.awaitsInput}
       taskRunStatus={task.taskRunStatus}
       runMode={task.runMode}
       originProduct={task.originProduct}

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
@@ -273,7 +273,14 @@ export interface TaskIconProps {
   isUnread?: boolean;
   isPinned?: boolean;
   isSuspended?: boolean;
+  /** A live session in this app holds a prompt only this app can answer. */
   needsPermission?: boolean;
+  /**
+   * The backend reports the run is blocked on a question to the user. Reads the same as
+   * `needsPermission` — which app holds the prompt is not the reader's problem — but it also
+   * arrives for tasks nothing here has a session for.
+   */
+  awaitsInput?: boolean;
   taskRunStatus?: TaskRunStatus;
   /** Whether anyone follows this run. Only a background run's status claims work. */
   runMode?: RunMode;
@@ -299,6 +306,7 @@ export function TaskIcon({
   isPinned,
   isSuspended,
   needsPermission,
+  awaitsInput,
   taskRunStatus,
   originProduct,
   slackThreadUrl,
@@ -310,7 +318,7 @@ export function TaskIcon({
   const isTerminalCloud = isCloudTask && isTerminalStatus(taskRunStatus);
   const originProductMeta = getOriginProductMeta(originProduct);
 
-  if (needsPermission) {
+  if (needsPermission || awaitsInput) {
     return (
       <Tooltip content="Needs your input" side="right">
         <span className="flex items-center justify-center">

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
@@ -45,6 +45,7 @@ interface TaskItemProps {
   isPinned?: boolean;
   isSuspended?: boolean;
   needsPermission?: boolean;
+  awaitsInput?: boolean;
   taskRunStatus?: TaskRunStatus;
   runMode?: RunMode;
   originProduct?: string;
@@ -118,6 +119,7 @@ export function TaskItem({
   isUnread,
   isPinned = false,
   needsPermission = false,
+  awaitsInput = false,
   taskRunStatus,
   runMode,
   originProduct,
@@ -145,6 +147,7 @@ export function TaskItem({
       isPinned={isPinned}
       isSuspended={isSuspended}
       needsPermission={needsPermission}
+      awaitsInput={awaitsInput}
       taskRunStatus={taskRunStatus}
       runMode={runMode}
       originProduct={originProduct}

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.test.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.test.ts
@@ -2,7 +2,26 @@ import { ArrowSquareIn, type Icon } from "@phosphor-icons/react";
 import { SlackMark } from "@posthog/ui/primitives/SlackMark";
 import { describe, expect, it } from "vitest";
 
-import { taskBadges } from "./taskStatusVocabulary";
+import { taskBadges, taskDot } from "./taskStatusVocabulary";
+
+describe("taskDot", () => {
+  it.each([
+    ["a session here holds the prompt", { needsPermission: true }],
+    ["the backend says the run is waiting", { awaitsInput: true }],
+  ])("wants an answer when %s", (_case, waiting) => {
+    // Both arrive alongside a run that still claims to be working, and both have to beat it:
+    // a row that reads as "working" while the agent waits is the one the reader walks past.
+    const dot = taskDot({
+      ...waiting,
+      isGenerating: true,
+      taskRunStatus: "in_progress",
+      runMode: "background",
+    });
+
+    expect(dot.tone).toBe("blue");
+    expect(dot.label).toBe("Needs your input");
+  });
+});
 
 describe("taskBadges", () => {
   it.each([

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.ts
@@ -124,7 +124,10 @@ export interface TaskDot {
  * with last run's PR still on the task.
  */
 export function taskDot(props: TaskStatusInput): TaskDot {
-  if (props.needsPermission) {
+  // Either route to the same fact: a live session here holding the prompt, or the backend
+  // reporting the run is blocked on one. The second is what a row nothing here has a session
+  // for is drawn from — without it such a row reads as "working" for as long as it waits.
+  if (props.needsPermission || props.awaitsInput) {
     // Not flashing. Blue already reads as the one thing in the list that is
     // yours to answer, and a blink on top of that argues with every quiet row
     // around it — in a sidebar of a dozen spaces it is the whole tree moving.

--- a/products/desktop/packages/ui/src/features/sidebar/useTaskPrStatus.test.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/useTaskPrStatus.test.ts
@@ -33,6 +33,7 @@ function makeTask(overrides: Partial<TaskData> = {}): TaskData {
     isUnread: false,
     isPinned: false,
     needsPermission: false,
+    awaitsInput: false,
     repository: null,
     isSuspended: false,
     taskRunEnvironment: "local" as const,

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -366,6 +366,17 @@ def _task_run_log_url(run: TaskRun) -> str | None:
     return presigned_url
 
 
+def _run_is_awaiting_input(awaiting_input_request_id: str | None, status: str | None) -> bool:
+    """Whether the run is blocked on a question to the user.
+
+    A settled run is never waiting, however its last permission request was recorded — reading
+    the status here saves every path that ends a run from having to clear the request id too.
+    """
+    if not awaiting_input_request_id:
+        return False
+    return status not in (TaskRun.Status.COMPLETED, TaskRun.Status.FAILED, TaskRun.Status.CANCELLED)
+
+
 def _task_run_detail_to_dto(run: TaskRun) -> contracts.TaskRunDetailDTO:
     """Map a ``TaskRun`` to its HTTP detail DTO.
 
@@ -393,6 +404,7 @@ def _task_run_detail_to_dto(run: TaskRun) -> contracts.TaskRunDetailDTO:
         error_message=run.error_message,
         output=run.output,
         state=run.state or {},
+        awaiting_input=_run_is_awaiting_input(run.awaiting_input_request_id, run.status),
         artifacts=run.artifacts or [],
         created_at=run.created_at,
         updated_at=run.updated_at,
@@ -4383,7 +4395,13 @@ def get_task_summaries(team_id: int, user_id: int | None, *, ids: list) -> list[
     latest_run = (
         TaskRun.objects.filter(task=OuterRef("pk"), team_id=team_id)
         .order_by("-created_at", "-id")
-        .annotate(_data=JSONObject(status="status", environment="environment"))
+        .annotate(
+            _data=JSONObject(
+                status="status",
+                environment="environment",
+                awaiting_input_request_id="awaiting_input_request_id",
+            )
+        )
     )
     tasks = (
         Task.objects.filter(team_id=team_id, deleted=False, id__in=ids)
@@ -4395,7 +4413,11 @@ def get_task_summaries(team_id: int, user_id: int | None, *, ids: list) -> list[
     for task in tasks:
         raw = getattr(task, "_latest_run", None)
         latest = (
-            contracts.TaskLatestRunSummaryDTO(status=raw.get("status"), environment=raw.get("environment"))
+            contracts.TaskLatestRunSummaryDTO(
+                status=raw.get("status"),
+                environment=raw.get("environment"),
+                awaiting_input=_run_is_awaiting_input(raw.get("awaiting_input_request_id"), raw.get("status")),
+            )
             if isinstance(raw, dict)
             else None
         )

--- a/products/tasks/backend/facade/contracts.py
+++ b/products/tasks/backend/facade/contracts.py
@@ -350,10 +350,15 @@ class TaskCommentDetailDTO:
 
 @dataclass(frozen=True)
 class TaskLatestRunSummaryDTO:
-    """The latest-run status/environment pair nested in a task summary response."""
+    """The latest-run status/environment pair nested in a task summary response.
+
+    ``awaiting_input`` says the agent has asked the user something and is blocked on the answer,
+    which a run's ``status`` cannot express — it stays ``in_progress`` throughout.
+    """
 
     status: str | None
     environment: str | None
+    awaiting_input: bool = False
 
 
 @dataclass(frozen=True)
@@ -526,8 +531,9 @@ class TaskRunDetailDTO:
     The SMF-derived fields are computed in the facade mapper ``_task_run_detail_to_dto``:
     ``log_url`` is a presigned S3 URL (cached); ``runtime_adapter`` / ``provider`` / ``model`` /
     ``reasoning_effort`` are parsed off the run ``state``. ``artifacts`` carries the run's
-    artifact manifest entries verbatim. Reused by the run-detail responses and nested as
-    ``latest_run`` by the task detail response.
+    artifact manifest entries verbatim. ``awaiting_input`` says the agent is blocked on a
+    question to the user, which ``status`` cannot express — it stays ``in_progress`` throughout.
+    Reused by the run-detail responses and nested as ``latest_run`` by the task detail response.
     """
 
     id: UUID
@@ -544,6 +550,7 @@ class TaskRunDetailDTO:
     error_message: str | None
     output: dict | None
     state: dict
+    awaiting_input: bool = False
     artifacts: list = Field(default_factory=list)
     created_at: datetime | None = None
     updated_at: datetime | None = None

--- a/products/tasks/backend/logic/services/awaiting_input.py
+++ b/products/tasks/backend/logic/services/awaiting_input.py
@@ -1,0 +1,92 @@
+"""Tracks which permission request a run is blocked on, from the sandbox event stream.
+
+The agent's permission prompts live in the run's log, so only a client with a live session
+attached to the run knows the agent is waiting on a person. Everything else — a task list, a
+second device, a client that has not opened the task — polls the API and sees a run that is
+still ``in_progress``, which reads as "working" when it is really "waiting". Recording the
+request id on the run turns that into a polled fact.
+"""
+
+from typing import Any
+
+import structlog
+
+from products.tasks.backend.logic.services.permission_broker import (
+    POSTHOG_PERMISSION_REQUEST_METHOD,
+    parse_permission_request,
+)
+from products.tasks.backend.models import TaskRun
+
+logger = structlog.get_logger(__name__)
+
+PERMISSION_RESOLVED_METHOD = "_posthog/permission_resolved"
+
+
+def _notification_params(event_data: Any, method: str) -> dict[str, Any] | None:
+    if not isinstance(event_data, dict):
+        return None
+    notification = event_data.get("notification")
+    if not isinstance(notification, dict) or notification.get("method") != method:
+        return None
+    params = notification.get("params")
+    return params if isinstance(params, dict) else None
+
+
+def is_permission_lifecycle_event(event_data: Any) -> bool:
+    """Whether this event can change the run's awaiting-input state.
+
+    Pure, so the ingest path can skip the database for the overwhelming majority of events.
+    """
+    if not isinstance(event_data, dict):
+        return False
+    if event_data.get("type") == "permission_request":
+        return True
+    notification = event_data.get("notification")
+    if not isinstance(notification, dict):
+        return False
+    return notification.get("method") in (POSTHOG_PERMISSION_REQUEST_METHOD, PERMISSION_RESOLVED_METHOD)
+
+
+def parse_permission_resolved_request_id(event_data: Any) -> str | None:
+    """The request id an ACP ``permission_resolved`` notification settles, if it is one."""
+    params = _notification_params(event_data, PERMISSION_RESOLVED_METHOD)
+    if params is None:
+        return None
+    request_id = params.get("requestId")
+    return request_id if isinstance(request_id, str) and request_id else None
+
+
+def mark_run_awaiting_input(run_id: str, request_id: str) -> None:
+    """Record that ``run_id`` is blocked on ``request_id``."""
+    TaskRun.objects.filter(id=run_id).update(awaiting_input_request_id=request_id)
+
+
+def clear_run_awaiting_input(run_id: str, request_id: str | None = None) -> None:
+    """Record that ``run_id`` is no longer blocked.
+
+    Pass ``request_id`` when a specific request was answered, so settling an earlier request
+    cannot clear a newer one the agent has since raised. Omit it where the run cannot be
+    waiting on anything — the end of a turn, or a run reaching a terminal status.
+    """
+    runs = TaskRun.objects.filter(id=run_id, awaiting_input_request_id__isnull=False)
+    if request_id is not None:
+        runs = runs.filter(awaiting_input_request_id=request_id)
+    runs.update(awaiting_input_request_id=None)
+
+
+def track_permission_state(run_id: str, event_data: Any) -> None:
+    """Apply one sandbox event to the run's awaiting-input state. Never raises.
+
+    Sits on the event ingest path, so a failure here must not cost the run its event.
+    """
+    try:
+        resolved_request_id = parse_permission_resolved_request_id(event_data)
+        if resolved_request_id is not None:
+            clear_run_awaiting_input(run_id, resolved_request_id)
+            return
+
+        request = parse_permission_request(event_data)
+        if request is not None:
+            mark_run_awaiting_input(run_id, request["request_id"])
+    except Exception:
+        logger.warning("task_run_awaiting_input_track_failed", run_id=run_id, exc_info=True)

--- a/products/tasks/backend/logic/stream/event_ingest.py
+++ b/products/tasks/backend/logic/stream/event_ingest.py
@@ -17,6 +17,11 @@ from jwt import PyJWTError
 
 from posthog.ph_client import ph_scoped_capture
 
+from products.tasks.backend.logic.services.awaiting_input import (
+    clear_run_awaiting_input,
+    is_permission_lifecycle_event,
+    track_permission_state,
+)
 from products.tasks.backend.logic.services.connection_token import (
     SandboxEventIngestTokenPayload,
     validate_sandbox_event_ingest_token,
@@ -207,6 +212,7 @@ async def _ingest_event_lines(
 
             result.accepted += 1
             result.last_accepted_seq = sequence
+            await _track_awaiting_input(claims.run_id, event)
             await _heartbeat_workflow_if_needed(redis_stream, claims.run_id, event)
     except EventIngestPayloadTooLarge as error:
         if result.last_accepted_seq and error.last_accepted_seq == 0:
@@ -369,9 +375,33 @@ def _parse_ingest_line(line: str) -> EventIngestEventLine | EventIngestCompleteL
     return EventIngestEventLine(sequence=sequence, event=event)
 
 
+async def _track_awaiting_input(run_id: str, event: dict) -> None:
+    """Keep the run's awaiting-input flag in step with the agent's permission prompts."""
+    if not is_permission_lifecycle_event(event):
+        return
+    await sync_to_async(_track_awaiting_input_sync, thread_sensitive=True)(run_id, event)
+
+
+def _track_awaiting_input_sync(run_id: str, event: dict) -> None:
+    # Same connection caveat as `_heartbeat_workflow`: this thread's pooled connection is
+    # never health-checked by Django, so clear stale ones first.
+    if not settings.TEST:
+        close_old_connections()
+    track_permission_state(run_id, event)
+
+
+def _clear_awaiting_input_sync(run_id: str) -> None:
+    if not settings.TEST:
+        close_old_connections()
+    clear_run_awaiting_input(run_id)
+
+
 async def _heartbeat_workflow_if_needed(redis_stream: TaskRunRedisStream, run_id: str, event: dict) -> None:
     if is_turn_complete(event):
         await redis_stream.set_agent_active(False)
+        # An agent that has finished its turn is not waiting on a permission, whatever the
+        # last request event said — this is the backstop against a stuck "needs input".
+        await sync_to_async(_clear_awaiting_input_sync, thread_sensitive=True)(run_id)
         await _dispatch_turn_completed_if_interactive(run_id)
         return
 

--- a/products/tasks/backend/migrations/0087_taskrun_awaiting_input_request_id.py
+++ b/products/tasks/backend/migrations/0087_taskrun_awaiting_input_request_id.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("tasks", "0086_clear_disconnected_channel_repositories")]
+
+    operations = [
+        migrations.AddField(
+            model_name="taskrun",
+            name="awaiting_input_request_id",
+            field=models.CharField(
+                blank=True,
+                default=None,
+                help_text="Id of the permission request this run is waiting on, or null when it is not waiting on one.",
+                max_length=255,
+                null=True,
+            ),
+        ),
+    ]

--- a/products/tasks/backend/migrations/max_migration.txt
+++ b/products/tasks/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0086_clear_disconnected_channel_repositories
+0087_taskrun_awaiting_input_request_id

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -1841,6 +1841,18 @@ class TaskRun(models.Model):
         help_text="Names of desktop-only MCP servers the creating client relays into this run (docs/cloud-mcp-relay.md). Names only — configuration never crosses the wire.",
     )
 
+    # Which permission request the agent is currently blocked on, if any. Held here rather than
+    # derived from the log because a client that only polls the API — a task list with no live
+    # session attached to the run — otherwise cannot tell "the agent is working" from "the agent
+    # is waiting on a person".
+    awaiting_input_request_id = models.CharField(
+        max_length=255,
+        blank=True,
+        null=True,
+        default=None,
+        help_text="Id of the permission request this run is waiting on, or null when it is not waiting on one.",
+    )
+
     created_at = models.DateTimeField(default=django_timezone.now)
     updated_at = models.DateTimeField(auto_now=True)
     completed_at = models.DateTimeField(null=True, blank=True)

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -353,6 +353,13 @@ class TaskRunDetailSerializer(DataclassSerializer):
         required=False,
         help_text="Configured reasoning effort for this run when the selected model supports it.",
     )
+    awaiting_input = serializers.BooleanField(
+        required=False,
+        help_text=(
+            "Whether the agent has asked the user something and is blocked on the answer. "
+            "The run stays 'in_progress' while it waits, so this is the only field that says so."
+        ),
+    )
 
     class Meta:
         dataclass = TaskRunDetailDTO
@@ -371,6 +378,7 @@ class TaskRunDetailSerializer(DataclassSerializer):
             "error_message",
             "output",
             "state",
+            "awaiting_input",
             "artifacts",
             "created_at",
             "updated_at",
@@ -1466,6 +1474,13 @@ class TaskSummariesRequestSerializer(serializers.Serializer):
 class TaskRunSummarySerializer(serializers.Serializer):
     status = serializers.ChoiceField(choices=tasks_facade.TaskRunStatus.choices, allow_null=True)
     environment = serializers.ChoiceField(choices=tasks_facade.TaskRunEnvironment.choices, allow_null=True)
+    awaiting_input = serializers.BooleanField(
+        required=False,
+        help_text=(
+            "Whether the agent has asked the user something and is blocked on the answer. "
+            "The run stays 'in_progress' while it waits, so this is the only field that says so."
+        ),
+    )
 
 
 class TaskSummarySerializer(DataclassSerializer):

--- a/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
@@ -20,6 +20,12 @@ from temporalio.exceptions import ApplicationError
 from posthog.temporal.common.utils import close_db_connections
 
 from products.tasks.backend.logic.services.agent_command import validate_sandbox_url
+from products.tasks.backend.logic.services.awaiting_input import (
+    clear_run_awaiting_input,
+    is_permission_lifecycle_event,
+    mark_run_awaiting_input,
+    track_permission_state,
+)
 from products.tasks.backend.logic.services.connection_token import create_sandbox_connection_token
 from products.tasks.backend.logic.services.permission_broker import (
     parse_permission_request,
@@ -414,6 +420,8 @@ async def _relay_loop(
                                 permission_request = parse_permission_request(event_data)
                                 if permission_request is not None:
                                     await asyncio.to_thread(_broker_permission_request, task_run, permission_request)
+                                elif is_permission_lifecycle_event(event_data):
+                                    await asyncio.to_thread(_track_awaiting_input, task_run, event_data)
                             reconnect_count = 0
                             last_event_time[0] = time.monotonic()
 
@@ -421,6 +429,10 @@ async def _relay_loop(
 
                             if _is_end_of_turn(event_data):
                                 agent_active[0] = False
+                                if task_run is not None:
+                                    # An agent that has finished its turn is not waiting on a
+                                    # permission, whatever the last request event said.
+                                    await asyncio.to_thread(_clear_awaiting_input, task_run)
                                 if sandbox_id and background_logs_enabled:
                                     asyncio.create_task(_emit_agentsh_events(sandbox_id, run_id, last_audit_ts_ns))
                                 if task_run is not None and task_run.mode == "interactive":
@@ -870,10 +882,26 @@ def _broker_permission_request(task_run: TaskRunModel, permission_request: dict)
         # it would close the test transaction's connection).
         if not settings.TEST:
             close_old_connections()
-        try_auto_respond_permission_request(task_run, permission_request)
+        if not try_auto_respond_permission_request(task_run, permission_request):
+            # Nobody answered it for the user, so the run is now waiting on one.
+            mark_run_awaiting_input(str(task_run.id), permission_request["request_id"])
     except Exception:
         logger.warning(
             "relay_sandbox_events_permission_broker_failed",
             run_id=str(task_run.id),
             exc_info=True,
         )
+
+
+def _track_awaiting_input(task_run: TaskRunModel, event_data: dict) -> None:
+    """Sync DB write; call via asyncio.to_thread."""
+    if not settings.TEST:
+        close_old_connections()
+    track_permission_state(str(task_run.id), event_data)
+
+
+def _clear_awaiting_input(task_run: TaskRunModel) -> None:
+    """Sync DB write; call via asyncio.to_thread."""
+    if not settings.TEST:
+        close_old_connections()
+    clear_run_awaiting_input(str(task_run.id))

--- a/products/tasks/backend/tests/test_awaiting_input.py
+++ b/products/tasks/backend/tests/test_awaiting_input.py
@@ -1,0 +1,89 @@
+from django.test import TestCase
+
+from parameterized import parameterized
+
+from posthog.models import Organization, Team
+
+from products.tasks.backend.facade.api import _task_run_detail_to_dto
+from products.tasks.backend.logic.services.awaiting_input import clear_run_awaiting_input, track_permission_state
+from products.tasks.backend.models import Task, TaskRun
+
+
+def _request_event(request_id: str) -> dict:
+    return {
+        "type": "notification",
+        "notification": {
+            "method": "_posthog/permission_request",
+            "params": {
+                "requestId": request_id,
+                "toolCall": {"toolCallId": f"tool-{request_id}"},
+                "options": [{"optionId": "allow", "kind": "allow_once", "name": "Yes"}],
+            },
+        },
+    }
+
+
+def _resolved_event(request_id: str) -> dict:
+    return {
+        "type": "notification",
+        "notification": {
+            "method": "_posthog/permission_resolved",
+            "params": {"requestId": request_id, "optionId": "allow"},
+        },
+    }
+
+
+class TestRunAwaitingInput(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=organization, name="Test Team")
+        self.task = Task.objects.create(team=self.team, title="Test Task", description="Test Description")
+        self.task_run: TaskRun = self.task.create_run()
+
+    def _track(self, event: dict) -> None:
+        track_permission_state(str(self.task_run.id), event)
+        self.task_run.refresh_from_db()
+
+    @parameterized.expand(
+        [
+            ("answered", "req-1", None),
+            # A stale answer must not clear a question the agent has since asked.
+            ("answered_a_different_request", "req-other", "req-1"),
+        ]
+    )
+    def test_resolving_a_request(self, _name: str, resolved_id: str, expected: str | None) -> None:
+        self._track(_request_event("req-1"))
+        self.assertEqual(self.task_run.awaiting_input_request_id, "req-1")
+
+        self._track(_resolved_event(resolved_id))
+        self.assertEqual(self.task_run.awaiting_input_request_id, expected)
+
+    def test_a_later_request_replaces_the_one_before_it(self) -> None:
+        self._track(_request_event("req-1"))
+        self._track(_request_event("req-2"))
+        self.assertEqual(self.task_run.awaiting_input_request_id, "req-2")
+
+    def test_clearing_drops_whatever_the_run_was_waiting_on(self) -> None:
+        self._track(_request_event("req-1"))
+
+        clear_run_awaiting_input(str(self.task_run.id))
+        self.task_run.refresh_from_db()
+        self.assertIsNone(self.task_run.awaiting_input_request_id)
+
+    @parameterized.expand(
+        [
+            (TaskRun.Status.IN_PROGRESS, True),
+            (TaskRun.Status.QUEUED, True),
+            # A run that has ended is not waiting on anyone, whatever it last asked.
+            (TaskRun.Status.COMPLETED, False),
+            (TaskRun.Status.FAILED, False),
+            (TaskRun.Status.CANCELLED, False),
+        ]
+    )
+    def test_reported_awaiting_input_by_run_status(self, status: str, expected: bool) -> None:
+        self.task_run.status = status
+        self.task_run.awaiting_input_request_id = "req-1"
+        self.task_run.save(update_fields=["status", "awaiting_input_request_id"])
+
+        self.assertEqual(_task_run_detail_to_dto(self.task_run).awaiting_input, expected)

--- a/products/tasks/backend/tests/test_event_ingest.py
+++ b/products/tasks/backend/tests/test_event_ingest.py
@@ -343,6 +343,49 @@ class TestTaskRunEventIngest(TestCase):
         self.assertEqual(notify_turn_completed.call_args.args[0].id, self.task_run.id)
 
     @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
+    def test_permission_request_ingest_records_what_the_run_waits_on(self) -> None:
+        token = self._create_token()
+
+        status, _ = self._call_ingest(
+            token,
+            [
+                {
+                    "seq": 1,
+                    "event": {
+                        "type": "notification",
+                        "notification": {
+                            "method": "_posthog/permission_request",
+                            "params": {
+                                "requestId": "req-1",
+                                "toolCall": {"toolCallId": "tool-1"},
+                                "options": [{"optionId": "allow", "kind": "allow_once", "name": "Yes"}],
+                            },
+                        },
+                    },
+                }
+            ],
+        )
+        self.assertEqual(status, 200)
+        self.task_run.refresh_from_db()
+        self.assertEqual(self.task_run.awaiting_input_request_id, "req-1")
+
+        status, _ = self._call_ingest(
+            token,
+            [
+                {
+                    "seq": 2,
+                    "event": {
+                        "type": "notification",
+                        "notification": {"method": "_posthog/turn_complete"},
+                    },
+                }
+            ],
+        )
+        self.assertEqual(status, 200)
+        self.task_run.refresh_from_db()
+        self.assertIsNone(self.task_run.awaiting_input_request_id)
+
+    @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
     def test_workflow_heartbeat_does_not_block_event_loop(self) -> None:
         token = self._create_token()
         heartbeat_entered = threading.Event()

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -1544,6 +1544,8 @@ export interface TaskRunDetailDTOApi {
     /** @nullable */
     output: TaskRunDetailDTOApiOutput
     state: TaskRunDetailDTOApiState
+    /** Whether the agent has asked the user something and is blocked on the answer. The run stays 'in_progress' while it waits, so this is the only field that says so. */
+    awaiting_input?: boolean
     readonly artifacts: readonly TaskRunArtifactResponseApi[]
     /** @nullable */
     created_at?: string | null
@@ -3981,6 +3983,8 @@ export const TaskRunEnvironmentEnumApi = {
 export interface TaskRunSummaryApi {
     status: TaskRunStatusEnumApi | null
     environment: TaskRunEnvironmentEnumApi | null
+    /** Whether the agent has asked the user something and is blocked on the answer. The run stays 'in_progress' while it waits, so this is the only field that says so. */
+    awaiting_input?: boolean
 }
 
 /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -51140,6 +51140,8 @@ export namespace Schemas {
       /** @nullable */
       output: TaskRunDetailDTOOutput;
       state: TaskRunDetailDTOState;
+      /** Whether the agent has asked the user something and is blocked on the answer. The run stays 'in_progress' while it waits, so this is the only field that says so. */
+      awaiting_input?: boolean;
       readonly artifacts: readonly TaskRunArtifactResponse[];
       /** @nullable */
       created_at?: string | null;
@@ -51290,6 +51292,8 @@ export namespace Schemas {
     export interface TaskRunSummary {
       status: TaskRunStatusEnum | null;
       environment: TaskRunEnvironmentEnum | null;
+      /** Whether the agent has asked the user something and is blocked on the answer. The run stays 'in_progress' while it waits, so this is the only field that says so. */
+      awaiting_input?: boolean;
     }
 
     /**


### PR DESCRIPTION
## Problem

A task that is waiting on your answer looks like it is still working in the session list. Its dot stays yellow until you click into it, and then it turns blue.

The blue dot is drawn from a permission prompt held by a live session in the app. A session only exists for a task this app has open or opened earlier, so a task running in the background has nothing to report the wait. Every other fact on the row comes from the polled task list, which keeps claiming "working" for as long as the agent waits.

## Changes

- `TaskRun` records the permission request the agent is blocked on, and the API reports it as `awaiting_input` on the task detail and on the summaries poll the session list reads.
- The sandbox event ingest sets that field when the agent raises a prompt and clears it on the answer or at the end of a turn. A run that has already settled never reports it.
- The task dot and icon read the new flag alongside the live session's own prompt, so both routes paint the same blue and the same "Needs your input" label.
- A space's blue count and the channel list's needs-input filter read it too, so the row and the counts above it agree.
- The desktop now also recovers a persisted prompt from a live log batch, not only from the snapshot a watch starts from. That gap is why the state was right after a restart and wrong on the transition.

The alternative was the `awaiting_input` activity row the backend already writes. That row records that the agent asked at a moment in time, and nothing retracts it when the question is answered, so a dot drawn from it would stick. A field on the run has one writer and a clear.

No screenshot: the dot and its label already exist, and this changes when they appear rather than how they look.

## How did you test this code?

Automated, run locally:

- `products/tasks/backend/tests/test_awaiting_input.py` (new) covers the state machine: a later request replaces an earlier one, an answer to a different request does not clear a newer one, and a settled run reports no wait however its last request was recorded. Nothing covered this before, and each case is a way the dot could stick after the agent moved on.
- One case added to `test_event_ingest.py` guards the wiring: a permission request through the real ingest path records what the run waits on, and a turn-complete clears it. The unit tests above pass even if the ingest path never calls them.
- `taskStatusVocabulary.test.ts` gains the precedence case: both routes to "waiting" beat a run that still claims to be working. That is the bug being fixed.

Not run: the Electron app itself. This sandbox has no display and no cloud run to drive, so I did not watch a real task go from working to waiting.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via PostHog Code) wrote this. Skills invoked: `/django-migrations` for the new column, `/writing-tests` before each test group, and `/writing-pr-descriptions` for this body.

The session started by tracing why the dot behaves this way. The renderer is consistent end to end, and a subagent trace of the live path found no defect in it, so the fix is not a render bug: blue was only ever derivable from a session this app holds, which the code says out loud. I checked with the DRI whether to source the missing signal from the existing activity feed or from a new run field, and they chose the field.

The log-batch change is the smaller half. It closes the one real asymmetry in the existing code, where only a watch's opening snapshot recovered a persisted prompt.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
