### PR TITLE
feat(logs): rename bucket_start to time_bucket in logs_volume_buckets

### DIFF
--- a/posthog/clickhouse/hcl/golden/dev/logs.hcl
+++ b/posthog/clickhouse/hcl/golden/dev/logs.hcl
@@ -696,9 +696,9 @@ database "posthog" {
   }
 
   table "logs_volume_buckets" {
-    order_by     = ["team_id", "bucket_start", "generation", "service_name", "namespace", "environment", "severity_text"]
-    partition_by = "toDate(bucket_start)"
-    ttl          = "bucket_start + toIntervalDay(42)"
+    order_by     = ["team_id", "time_bucket", "generation", "service_name", "namespace", "environment", "severity_text"]
+    partition_by = "toDate(time_bucket)"
+    ttl          = "time_bucket + toIntervalDay(42)"
     settings = {
       index_granularity   = "8192"
       ttl_only_drop_parts = "1"
@@ -706,7 +706,7 @@ database "posthog" {
     column "team_id" {
       type = "Int32"
     }
-    column "bucket_start" {
+    column "time_bucket" {
       type  = "DateTime('UTC')"
       codec = "DoubleDelta, ZSTD(1)"
     }
@@ -738,7 +738,7 @@ database "posthog" {
     column "team_id" {
       type = "Int32"
     }
-    column "bucket_start" {
+    column "time_bucket" {
       type  = "DateTime('UTC')"
       codec = "DoubleDelta, ZSTD(1)"
     }

--- a/posthog/clickhouse/hcl/golden/local-multi/logs.hcl
+++ b/posthog/clickhouse/hcl/golden/local-multi/logs.hcl
@@ -1119,9 +1119,9 @@ SQL
   }
 
   table "logs_volume_buckets" {
-    order_by     = ["team_id", "bucket_start", "generation", "service_name", "namespace", "environment", "severity_text"]
-    partition_by = "toDate(bucket_start)"
-    ttl          = "bucket_start + toIntervalDay(42)"
+    order_by     = ["team_id", "time_bucket", "generation", "service_name", "namespace", "environment", "severity_text"]
+    partition_by = "toDate(time_bucket)"
+    ttl          = "time_bucket + toIntervalDay(42)"
     settings = {
       index_granularity   = "8192"
       ttl_only_drop_parts = "1"
@@ -1129,7 +1129,7 @@ SQL
     column "team_id" {
       type = "Int32"
     }
-    column "bucket_start" {
+    column "time_bucket" {
       type  = "DateTime('UTC')"
       codec = "DoubleDelta, ZSTD(1)"
     }
@@ -1161,7 +1161,7 @@ SQL
     column "team_id" {
       type = "Int32"
     }
-    column "bucket_start" {
+    column "time_bucket" {
       type  = "DateTime('UTC')"
       codec = "DoubleDelta, ZSTD(1)"
     }

--- a/posthog/clickhouse/hcl/golden/prod-eu/logs.hcl
+++ b/posthog/clickhouse/hcl/golden/prod-eu/logs.hcl
@@ -777,9 +777,9 @@ database "posthog" {
   }
 
   table "logs_volume_buckets" {
-    order_by     = ["team_id", "bucket_start", "generation", "service_name", "namespace", "environment", "severity_text"]
-    partition_by = "toDate(bucket_start)"
-    ttl          = "bucket_start + toIntervalDay(42)"
+    order_by     = ["team_id", "time_bucket", "generation", "service_name", "namespace", "environment", "severity_text"]
+    partition_by = "toDate(time_bucket)"
+    ttl          = "time_bucket + toIntervalDay(42)"
     settings = {
       index_granularity   = "8192"
       ttl_only_drop_parts = "1"
@@ -787,7 +787,7 @@ database "posthog" {
     column "team_id" {
       type = "Int32"
     }
-    column "bucket_start" {
+    column "time_bucket" {
       type  = "DateTime('UTC')"
       codec = "DoubleDelta, ZSTD(1)"
     }
@@ -819,7 +819,7 @@ database "posthog" {
     column "team_id" {
       type = "Int32"
     }
-    column "bucket_start" {
+    column "time_bucket" {
       type  = "DateTime('UTC')"
       codec = "DoubleDelta, ZSTD(1)"
     }

--- a/posthog/clickhouse/hcl/golden/prod-us/logs.hcl
+++ b/posthog/clickhouse/hcl/golden/prod-us/logs.hcl
@@ -776,9 +776,9 @@ database "posthog" {
   }
 
   table "logs_volume_buckets" {
-    order_by     = ["team_id", "bucket_start", "generation", "service_name", "namespace", "environment", "severity_text"]
-    partition_by = "toDate(bucket_start)"
-    ttl          = "bucket_start + toIntervalDay(42)"
+    order_by     = ["team_id", "time_bucket", "generation", "service_name", "namespace", "environment", "severity_text"]
+    partition_by = "toDate(time_bucket)"
+    ttl          = "time_bucket + toIntervalDay(42)"
     settings = {
       index_granularity   = "8192"
       ttl_only_drop_parts = "1"
@@ -786,7 +786,7 @@ database "posthog" {
     column "team_id" {
       type = "Int32"
     }
-    column "bucket_start" {
+    column "time_bucket" {
       type  = "DateTime('UTC')"
       codec = "DoubleDelta, ZSTD(1)"
     }
@@ -818,7 +818,7 @@ database "posthog" {
     column "team_id" {
       type = "Int32"
     }
-    column "bucket_start" {
+    column "time_bucket" {
       type  = "DateTime('UTC')"
       codec = "DoubleDelta, ZSTD(1)"
     }

--- a/posthog/clickhouse/hcl/roles/logs/base/tables.hcl
+++ b/posthog/clickhouse/hcl/roles/logs/base/tables.hcl
@@ -692,9 +692,9 @@ database "posthog" {
   }
 
   table "logs_volume_buckets" {
-    order_by     = ["team_id", "bucket_start", "generation", "service_name", "namespace", "environment", "severity_text"]
-    partition_by = "toDate(bucket_start)"
-    ttl          = "bucket_start + toIntervalDay(42)"
+    order_by     = ["team_id", "time_bucket", "generation", "service_name", "namespace", "environment", "severity_text"]
+    partition_by = "toDate(time_bucket)"
+    ttl          = "time_bucket + toIntervalDay(42)"
     settings = {
       index_granularity   = "8192"
       ttl_only_drop_parts = "1"
@@ -702,7 +702,7 @@ database "posthog" {
     column "team_id" {
       type = "Int32"
     }
-    column "bucket_start" {
+    column "time_bucket" {
       type  = "DateTime('UTC')"
       codec = "DoubleDelta, ZSTD(1)"
     }
@@ -733,7 +733,7 @@ database "posthog" {
     column "team_id" {
       type = "Int32"
     }
-    column "bucket_start" {
+    column "time_bucket" {
       type  = "DateTime('UTC')"
       codec = "DoubleDelta, ZSTD(1)"
     }

--- a/posthog/clickhouse/hcl/sql/dev/logs.sql
+++ b/posthog/clickhouse/hcl/sql/dev/logs.sql
@@ -192,17 +192,17 @@ CREATE TABLE posthog.logs_kafka_metrics_distributed (
 ) ENGINE = Distributed('logs', 'posthog', 'logs_kafka_metrics');
 CREATE TABLE posthog.logs_volume_buckets (
   team_id Int32,
-  bucket_start DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
+  time_bucket DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
   generation UInt64,
   service_name LowCardinality(String),
   namespace LowCardinality(String),
   environment LowCardinality(String),
   severity_text LowCardinality(String),
   log_count UInt64
-) ENGINE = ReplicatedMergeTree('/clickhouse/tables/noshard/posthog.logs_volume_buckets', '{replica}-{shard}') ORDER BY (team_id, bucket_start, generation, service_name, namespace, environment, severity_text) PARTITION BY toDate(bucket_start) TTL bucket_start + toIntervalDay(42) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+) ENGINE = ReplicatedMergeTree('/clickhouse/tables/noshard/posthog.logs_volume_buckets', '{replica}-{shard}') ORDER BY (team_id, time_bucket, generation, service_name, namespace, environment, severity_text) PARTITION BY toDate(time_bucket) TTL time_bucket + toIntervalDay(42) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 CREATE TABLE posthog.logs_volume_buckets_distributed (
   team_id Int32,
-  bucket_start DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
+  time_bucket DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
   generation UInt64,
   service_name LowCardinality(String),
   namespace LowCardinality(String),

--- a/posthog/clickhouse/hcl/sql/local-multi/logs.sql
+++ b/posthog/clickhouse/hcl/sql/local-multi/logs.sql
@@ -269,17 +269,17 @@ CREATE TABLE posthog.logs_kafka_metrics_distributed (
 ) ENGINE = Distributed('posthog_single_shard', 'posthog', 'logs_kafka_metrics');
 CREATE TABLE posthog.logs_volume_buckets (
   team_id Int32,
-  bucket_start DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
+  time_bucket DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
   generation UInt64,
   service_name LowCardinality(String),
   namespace LowCardinality(String),
   environment LowCardinality(String),
   severity_text LowCardinality(String),
   log_count UInt64
-) ENGINE = ReplicatedMergeTree('/clickhouse/tables/noshard/posthog.logs_volume_buckets', '{replica}-{shard}') ORDER BY (team_id, bucket_start, generation, service_name, namespace, environment, severity_text) PARTITION BY toDate(bucket_start) TTL bucket_start + toIntervalDay(42) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+) ENGINE = ReplicatedMergeTree('/clickhouse/tables/noshard/posthog.logs_volume_buckets', '{replica}-{shard}') ORDER BY (team_id, time_bucket, generation, service_name, namespace, environment, severity_text) PARTITION BY toDate(time_bucket) TTL time_bucket + toIntervalDay(42) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 CREATE TABLE posthog.logs_volume_buckets_distributed (
   team_id Int32,
-  bucket_start DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
+  time_bucket DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
   generation UInt64,
   service_name LowCardinality(String),
   namespace LowCardinality(String),

--- a/posthog/clickhouse/hcl/sql/prod-eu/logs.sql
+++ b/posthog/clickhouse/hcl/sql/prod-eu/logs.sql
@@ -216,17 +216,17 @@ CREATE TABLE posthog.logs_kafka_metrics_distributed (
 ) ENGINE = Distributed('logs', 'posthog', 'logs_kafka_metrics');
 CREATE TABLE posthog.logs_volume_buckets (
   team_id Int32,
-  bucket_start DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
+  time_bucket DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
   generation UInt64,
   service_name LowCardinality(String),
   namespace LowCardinality(String),
   environment LowCardinality(String),
   severity_text LowCardinality(String),
   log_count UInt64
-) ENGINE = ReplicatedMergeTree('/clickhouse/tables/noshard/posthog.logs_volume_buckets', '{replica}-{shard}') ORDER BY (team_id, bucket_start, generation, service_name, namespace, environment, severity_text) PARTITION BY toDate(bucket_start) TTL bucket_start + toIntervalDay(42) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+) ENGINE = ReplicatedMergeTree('/clickhouse/tables/noshard/posthog.logs_volume_buckets', '{replica}-{shard}') ORDER BY (team_id, time_bucket, generation, service_name, namespace, environment, severity_text) PARTITION BY toDate(time_bucket) TTL time_bucket + toIntervalDay(42) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 CREATE TABLE posthog.logs_volume_buckets_distributed (
   team_id Int32,
-  bucket_start DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
+  time_bucket DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
   generation UInt64,
   service_name LowCardinality(String),
   namespace LowCardinality(String),

--- a/posthog/clickhouse/hcl/sql/prod-us/logs.sql
+++ b/posthog/clickhouse/hcl/sql/prod-us/logs.sql
@@ -215,17 +215,17 @@ CREATE TABLE posthog.logs_kafka_metrics_distributed (
 ) ENGINE = Distributed('logs', 'posthog', 'logs_kafka_metrics');
 CREATE TABLE posthog.logs_volume_buckets (
   team_id Int32,
-  bucket_start DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
+  time_bucket DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
   generation UInt64,
   service_name LowCardinality(String),
   namespace LowCardinality(String),
   environment LowCardinality(String),
   severity_text LowCardinality(String),
   log_count UInt64
-) ENGINE = ReplicatedMergeTree('/clickhouse/tables/noshard/posthog.logs_volume_buckets', '{replica}-{shard}') ORDER BY (team_id, bucket_start, generation, service_name, namespace, environment, severity_text) PARTITION BY toDate(bucket_start) TTL bucket_start + toIntervalDay(42) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+) ENGINE = ReplicatedMergeTree('/clickhouse/tables/noshard/posthog.logs_volume_buckets', '{replica}-{shard}') ORDER BY (team_id, time_bucket, generation, service_name, namespace, environment, severity_text) PARTITION BY toDate(time_bucket) TTL time_bucket + toIntervalDay(42) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 CREATE TABLE posthog.logs_volume_buckets_distributed (
   team_id Int32,
-  bucket_start DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
+  time_bucket DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
   generation UInt64,
   service_name LowCardinality(String),
   namespace LowCardinality(String),

--- a/posthog/clickhouse/logs/logs_volume_buckets.py
+++ b/posthog/clickhouse/logs/logs_volume_buckets.py
@@ -11,7 +11,7 @@ from posthog.clickhouse.table_engines import Distributed, MergeTreeEngine, Repli
 # Buckets are fixed wall-clock windows on a 5-minute UTC grid, never sliding.
 # `generation` is the unix-millis start of one insert attempt, allocated and
 # committed in Postgres (LogsVolumeBucketCompletion); storage here is immutable
-# append-only and readers must filter to committed (bucket_start, generation)
+# append-only and readers must filter to committed (time_bucket, generation)
 # pairs — visibility is protocol-level, which is why this is a plain MergeTree
 # rather than a Replacing/Collapsing variant (those can't express keys that
 # vanish in a later generation, or double-count across generations).
@@ -35,7 +35,7 @@ def LOGS_VOLUME_BUCKETS_TABLE_SQL():
 CREATE TABLE IF NOT EXISTS {settings.CLICKHOUSE_LOGS_CLUSTER_DATABASE}.{TABLE_NAME}
 (
     `team_id` Int32,
-    `bucket_start` DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
+    `time_bucket` DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
     `generation` UInt64,
     `service_name` LowCardinality(String),
     `namespace` LowCardinality(String),
@@ -44,9 +44,9 @@ CREATE TABLE IF NOT EXISTS {settings.CLICKHOUSE_LOGS_CLUSTER_DATABASE}.{TABLE_NA
     `log_count` UInt64
 )
 ENGINE = {MergeTreeEngine(TABLE_NAME, replication_scheme=ReplicationScheme.REPLICATED)}
-PARTITION BY toDate(bucket_start)
-ORDER BY (team_id, bucket_start, generation, service_name, namespace, environment, severity_text)
-TTL bucket_start + INTERVAL 42 DAY
+PARTITION BY toDate(time_bucket)
+ORDER BY (team_id, time_bucket, generation, service_name, namespace, environment, severity_text)
+TTL time_bucket + INTERVAL 42 DAY
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
 """
 

--- a/posthog/clickhouse/migrations/0296_logs_volume_buckets_time_bucket.py
+++ b/posthog/clickhouse/migrations/0296_logs_volume_buckets_time_bucket.py
@@ -1,0 +1,26 @@
+from django.conf import settings
+
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.clickhouse.logs.logs_volume_buckets import (
+    DISTRIBUTED_TABLE_NAME,
+    LOGS_VOLUME_BUCKETS_DISTRIBUTED_TABLE_SQL,
+    LOGS_VOLUME_BUCKETS_TABLE_SQL,
+    TABLE_NAME,
+)
+
+# Renames bucket_start to time_bucket to match the other logs tables. RENAME
+# COLUMN is impossible here — the column is part of the key expression
+# (ORDER BY / PARTITION BY / TTL), which ClickHouse rejects with Code 524 —
+# so this drops and recreates instead. Safe only because the table is empty:
+# it shipped in 0294 and the aggregation writer does not exist yet.
+
+DROP_DISTRIBUTED_SQL = f"DROP TABLE IF EXISTS {settings.CLICKHOUSE_LOGS_CLUSTER_DATABASE}.{DISTRIBUTED_TABLE_NAME} SYNC"
+DROP_LOCAL_SQL = f"DROP TABLE IF EXISTS {settings.CLICKHOUSE_LOGS_CLUSTER_DATABASE}.{TABLE_NAME} SYNC"
+
+operations = [
+    run_sql_with_exceptions(DROP_DISTRIBUTED_SQL, node_roles=[NodeRole.LOGS]),
+    run_sql_with_exceptions(DROP_LOCAL_SQL, node_roles=[NodeRole.LOGS]),
+    run_sql_with_exceptions(LOGS_VOLUME_BUCKETS_TABLE_SQL(), node_roles=[NodeRole.LOGS]),
+    run_sql_with_exceptions(LOGS_VOLUME_BUCKETS_DISTRIBUTED_TABLE_SQL(), node_roles=[NodeRole.LOGS]),
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0295_add_error_tracking_issue_severity
+0296_logs_volume_buckets_time_bucket

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -3837,7 +3837,7 @@
   CREATE TABLE IF NOT EXISTS posthog_test.logs_volume_buckets
   (
       `team_id` Int32,
-      `bucket_start` DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
+      `time_bucket` DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
       `generation` UInt64,
       `service_name` LowCardinality(String),
       `namespace` LowCardinality(String),
@@ -3846,9 +3846,9 @@
       `log_count` UInt64
   )
   ENGINE = ReplicatedMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_noshard/posthog.logs_volume_buckets', '{replica}-{shard}')
-  PARTITION BY toDate(bucket_start)
-  ORDER BY (team_id, bucket_start, generation, service_name, namespace, environment, severity_text)
-  TTL bucket_start + INTERVAL 42 DAY
+  PARTITION BY toDate(time_bucket)
+  ORDER BY (team_id, time_bucket, generation, service_name, namespace, environment, severity_text)
+  TTL time_bucket + INTERVAL 42 DAY
   SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
   
   '''
@@ -10718,7 +10718,7 @@
   CREATE TABLE IF NOT EXISTS posthog_test.logs_volume_buckets
   (
       `team_id` Int32,
-      `bucket_start` DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
+      `time_bucket` DateTime('UTC') CODEC(DoubleDelta, ZSTD(1)),
       `generation` UInt64,
       `service_name` LowCardinality(String),
       `namespace` LowCardinality(String),
@@ -10727,9 +10727,9 @@
       `log_count` UInt64
   )
   ENGINE = ReplicatedMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_noshard/posthog.logs_volume_buckets', '{replica}-{shard}')
-  PARTITION BY toDate(bucket_start)
-  ORDER BY (team_id, bucket_start, generation, service_name, namespace, environment, severity_text)
-  TTL bucket_start + INTERVAL 42 DAY
+  PARTITION BY toDate(time_bucket)
+  ORDER BY (team_id, time_bucket, generation, service_name, namespace, environment, severity_text)
+  TTL time_bucket + INTERVAL 42 DAY
   SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
   
   '''


### PR DESCRIPTION
## Problem

`logs_volume_buckets` (shipped in #80503) named its bucket column `bucket_start`, but every other logs table uses `time_bucket`. Flagged in review on #80504.

## Changes

Renames the column to `time_bucket` on the local and distributed tables, plus the DDL source and HCL schema (base layer + regenerated goldens/SQL for dev, local-multi, prod-us, prod-eu).

> [!NOTE]
> This is a drop-and-recreate, not a `RENAME COLUMN`. ClickHouse rejects renaming a key column (Code 524: "Trying to ALTER RENAME key ... column which is a part of key expression") and `bucket_start` is in the ORDER BY, PARTITION BY, and TTL. Dropping is safe only because the table is empty: it shipped this morning and the aggregation writer does not exist yet. Replicated drops use `SYNC` so the ZooKeeper path is free before the recreate.

## How did you test this code?

- Ran all four migration statements against local ClickHouse: both drops, both creates, all succeed.
- Verified the recreated table: `time_bucket` present in columns, sorting key (`team_id, time_bucket, generation, ...`), and partition key (`toDate(time_bucket)`).
- Also verified the naive `RENAME COLUMN` genuinely fails with Code 524 locally — that failure is why this PR drops and recreates.
- `posthog/clickhouse/hcl/check.sh`: goldens match, SQL up to date.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal schema consistency; no user-facing behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code in response to a review comment on #80504. Skills invoked: /clickhouse-migrations, /writing-code-comments. First attempt used `ALTER TABLE ... RENAME COLUMN`; local validation surfaced the key-column restriction (Code 524), so the migration was rewritten as drop-and-recreate while the table is still empty. Migration-only PR per the ClickHouse migration rule.
