### PR TITLE
fix(notebooks): halve the kernel sandbox lifetime to 1 hour

### DIFF
--- a/products/notebooks/backend/kernel_runtime.py
+++ b/products/notebooks/backend/kernel_runtime.py
@@ -38,7 +38,7 @@ logger = structlog.get_logger(__name__)
 # `kernel_idle_timeout_seconds`. A kernel serves one interactive session, so nobody waits on it
 # once the tab closes and this TTL is what reclaims it. The task-agent default
 # (`SANDBOX_TTL_SECONDS`) is longer because it has to outlast an unattended agent run.
-NOTEBOOK_KERNEL_TTL_SECONDS = 2 * 60 * 60
+NOTEBOOK_KERNEL_TTL_SECONDS = 1 * 60 * 60
 
 
 @dataclass


### PR DESCRIPTION
## Problem

A notebook kernel that nobody uses holds its Modal sandbox for 2 hours, and the sandbox bills for that whole window.

- `NOTEBOOK_KERNEL_TTL_SECONDS` is the only bound on a notebook sandbox.
- Modal counts it from creation, so nothing shortens it when the person closes the tab.

## Changes

- `NOTEBOOK_KERNEL_TTL_SECONDS` drops from 2 hours to 1 hour.
- A notebook that sets its own `kernel_idle_timeout_seconds` still overrides the constant, so the picker's 3, 6, and 12 hour options are unaffected.

> [!WARNING]
> This clock runs from creation, not from the last cell run. A person who works in a notebook for more than 1 hour now loses the kernel mid-session, along with its in-memory dataframes.

## How did you test this code?

- `hogli test products/notebooks/backend/test/test_kernel_runtime.py`. The existing `build_notebook_sandbox_config` cases assert against the constant, so they cover the new value without a change.
- I added no test. The change is a constant, and a test that asserts the constant equals 3600 would restate the code.
- Not done: I never started a Modal sandbox, so I did not watch a kernel get reclaimed at 1 hour.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No doc states the notebook kernel lifetime.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) made the change in a git worktree off master. Skills invoked: `/writing-pr-descriptions`, `/writing-code-comments`, `/writing-tests`.

Sinan asked for this one-line change on its own branch. A wider PR (#81147) adds Modal's `idle_timeout` to reclaim an abandoned kernel without ending a live session; this PR deliberately excludes that work.
