### PR TITLE
chore(skills): enforce description length limit

### DIFF
--- a/.agents/skills/debugging-table-access-denied/SKILL.md
+++ b/.agents/skills/debugging-table-access-denied/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: debugging-table-access-denied
-description: Debug a TableAccessDeniedError — the "You don't have access to table `X`." error — from an error tracking issue, a Slack alert, or a user report. Use when investigating why HogQL denied a table (system.* or warehouse) and whether the occurrence is a real bug or working-as-designed. Trigger terms: TableAccessDeniedError, table_access_denied, "You don't have access to table".
+description: >-
+  Debugs a TableAccessDeniedError from an error tracking issue, Slack alert, or user report. Use when investigating why HogQL denied a system or warehouse table and whether the occurrence is a real bug or expected behavior. Trigger terms include TableAccessDeniedError, table_access_denied, and "You don't have access to table".
 ---
 
 # Debugging "You don't have access to table"

--- a/.agents/skills/writing-pr-descriptions/SKILL.md
+++ b/.agents/skills/writing-pr-descriptions/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: writing-pr-descriptions
-description: >
+description: >-
   Shapes a PR body into something a reviewer understands at a glance.
   Use ALWAYS before writing or editing a PR description, before `gh pr create` or `gh pr edit --body`, and when asked to improve an existing description.
   Puts the effect a person sees in the first line and the mechanism under it, routes each remaining fact to the form that carries it fastest (bullet, table, diagram, screenshot, collapsed block), cuts everything a reviewer does not need, then holds what survives to a checkable shape: one fact per bullet, sentences under 25 words, active voice, no idioms.
   Makes the body stand alone, so a reader who opens no files still knows why the PR is necessary and what it does, sizes the body to the change so a small PR reads as small, and makes every claim either linked to its evidence or labeled as unchecked.
-  Ends with a scan test the agent runs over its own draft, reading only the title and the first line of two sections.
+  Ends with a scan test over the title and the first lines of Problem and Changes.
   Not for commit messages (see AGENTS.md, "Commit types") or user-facing product copy (see `/writing-user-facing-copy`).
 ---
 

--- a/products/engineering_analytics/skills/turning-engineering-analytics-into-insights/SKILL.md
+++ b/products/engineering_analytics/skills/turning-engineering-analytics-into-insights/SKILL.md
@@ -2,16 +2,14 @@
 name: turning-engineering-analytics-into-insights
 description: >
   Converts engineering analytics (PR / CI) data into saved PostHog insights, dashboards, and subscriptions, and
-  explains what data the product reads so it can be queried directly with SQL. The engineering analytics dashboard
-  and MCP tools run curated HogQL privately over per-team GitHub warehouse tables; this skill teaches discovering
-  those tables via engineering-analytics-sources, replicating the curated column semantics in HogQL, reading the
-  exposed engineering_analytics_* warehouse views where product logic is involved (CI cost, fingerprinted failure
-  lines, commit attribution), saving the query with insight-create, and scheduling delivery with
-  subscriptions-create. Use when asked to "save this as an insight", "put CI health / merge times on a dashboard",
-  "email me PR throughput weekly", "chart CI cost", "track time to first review", "subscribe to these numbers",
-  "alert on CI success rate", or "what data/tables/views does engineering analytics read". For ad-hoc CI and merge
-  questions use diagnosing-ci-and-merge-bottlenecks; to investigate one specific CI failure use
-  investigating-ci-failures.
+  explains how to query the product data directly with SQL. Covers discovering per-team GitHub warehouse tables via
+  engineering-analytics-sources, replicating curated column semantics in HogQL, reading exposed
+  engineering_analytics_* warehouse views where product logic is involved (CI cost, fingerprinted failure lines,
+  commit attribution), saving queries with insight-create, and scheduling delivery with subscriptions-create. Use
+  when asked to "save this as an insight", "put CI health / merge times on a dashboard", "email me PR throughput
+  weekly", "chart CI cost", "track time to first review", "subscribe to these numbers", "alert on CI success rate",
+  or "what data/tables/views does engineering analytics read". For ad-hoc CI and merge questions use
+  diagnosing-ci-and-merge-bottlenecks; to investigate one specific CI failure use investigating-ci-failures.
 ---
 
 # Turning engineering analytics into insights and subscriptions

--- a/products/posthog_ai/scripts/build_skills.py
+++ b/products/posthog_ai/scripts/build_skills.py
@@ -47,6 +47,7 @@ _ZIP_FIXED_TIME = (2025, 1, 1, 0, 0, 0)
 
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 _BINARY_CHECK_SIZE = 8192
+_MAX_SKILL_DESCRIPTION_LENGTH = 1024
 _ALLOWED_SUBDIRS = {"references", "scripts"}
 
 # Tool/skill reference linting: skills must only reference MCP tools and skills that exist.
@@ -267,7 +268,7 @@ def _assert_text_file(file_path: Path) -> None:
 
 class SkillFrontmatter(BaseModel):
     name: str
-    description: str
+    description: str = Field(max_length=_MAX_SKILL_DESCRIPTION_LENGTH)
 
 
 class DiscoveredSkill(BaseModel):
@@ -472,20 +473,25 @@ class SkillBuilder:
         if skill.depth == 1:
             skill_dir = skill.source_file.parent
             skill_files = self.collect_skill_files(skill_dir, renderer)
-            entry_content = skill_files[0].content
-            metadata, _body = parse_frontmatter(entry_content)
+            rendered_entry_content = skill_files[0].content
+            metadata, _body = parse_frontmatter(rendered_entry_content)
             source = str(skill_dir.relative_to(self.repo_root))
         else:
-            rendered = renderer.render(skill.source_file)
-            metadata, _body = parse_frontmatter(rendered)
+            rendered_entry_content = renderer.render(skill.source_file)
+            metadata, _body = parse_frontmatter(rendered_entry_content)
             out_name = skill.source_file.name
             if out_name.endswith(".j2"):
                 out_name = out_name.removesuffix(".j2")
-            skill_files = [SkillFile(path=out_name, content=rendered.strip())]
+            skill_files = [SkillFile(path=out_name, content=rendered_entry_content.strip())]
             source = str(skill.source_file.relative_to(self.repo_root))
 
-        display_name = metadata.get("name", skill.name)
-        description = metadata.get("description", f"Skill: {skill.name}")
+        if metadata:
+            validated_metadata = validate_frontmatter(rendered_entry_content, source)
+            display_name = validated_metadata.name
+            description = validated_metadata.description
+        else:
+            display_name = skill.name
+            description = f"Skill: {skill.name}"
 
         return SkillResource(
             name=display_name,
@@ -559,7 +565,7 @@ class SkillBuilder:
         - Binary file detection (only text files allowed)
         - Duplicate skill name detection (across products)
         - Jinja2 syntax validation via parse-only (all .j2 files)
-        - Frontmatter validation for static .md entry points (required: name, description)
+        - Frontmatter validation for product and project skill entry points
         - Tool/skill reference validation in markdown (against the MCP schema registries)
 
         Returns True if all checks pass, False otherwise.
@@ -585,8 +591,21 @@ class SkillBuilder:
             print("WARNING: MCP schema registries not found; skipping tool reference checks.", file=sys.stderr)
         skill_names = set(seen)
         agents_skills_dir = self.repo_root / ".agents" / "skills"
+        project_skill_files: list[Path] = []
         if agents_skills_dir.is_dir():
-            skill_names.update(entry.name for entry in agents_skills_dir.iterdir() if entry.is_dir())
+            for entry in sorted(agents_skills_dir.iterdir()):
+                if entry.is_dir():
+                    skill_names.add(entry.name)
+                    skill_file = entry / "SKILL.md"
+                    if skill_file.is_file():
+                        project_skill_files.append(skill_file)
+
+        for skill_file in project_skill_files:
+            source_label = str(skill_file.relative_to(self.repo_root))
+            try:
+                validate_frontmatter(skill_file.read_text(), source_label)
+            except ValueError as e:
+                errors.append(str(e))
 
         jinja_env = _create_jinja_env()
 
@@ -632,7 +651,7 @@ class SkillBuilder:
                 print(f"ERROR: {err}", file=sys.stderr)
             return False
 
-        print(f"OK: {len(skills)} skill(s) passed lint checks.")
+        print(f"OK: {len(skills)} product skill(s) and {len(project_skill_files)} project skill(s) passed lint checks.")
         return True
 
     def init_skill(self, product_name: str, skill_name: str, *, template: bool = False) -> Path:

--- a/products/posthog_ai/scripts/test/test_build_skills.py
+++ b/products/posthog_ai/scripts/test/test_build_skills.py
@@ -462,6 +462,19 @@ def test_lint_all_catches_missing_frontmatter(tmp_path: Path) -> None:
     assert builder.lint_all() is False
 
 
+def test_lint_all_catches_overlong_project_skill_description(tmp_path: Path) -> None:
+    skill_dir = tmp_path / ".agents" / "skills" / "bad-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(f"---\nname: bad-skill\ndescription: {'x' * 1025}\n---\n# Body\n")
+
+    builder = SkillBuilder(
+        repo_root=tmp_path,
+        products_dir=tmp_path / "products",
+        output_dir=tmp_path / "output",
+    )
+    assert builder.lint_all() is False
+
+
 def test_lint_all_catches_bad_jinja2_syntax(tmp_path: Path) -> None:
     skill_dir = tmp_path / "products" / "alpha" / "skills" / "broken-j2"
     skill_dir.mkdir(parents=True)


### PR DESCRIPTION
## Problem

Skill authors could pass local lint with descriptions that pi rejects while loading project skills.

Descriptions above 1,024 characters were not validated in product builds or `.agents/skills/`.

## Changes

- `lint:skills` now validates product and project skill frontmatter against the loader limit.
- Skill builds validate rendered descriptions before packaging.
- The affected descriptions now stay below the limit while preserving their trigger coverage.

## How did you test this code?

- Added a regression test that rejects a 1,025-character project skill description.
- Ran `./bin/hogli test products/posthog_ai/scripts/test/test_build_skills.py`.
- Ran `./bin/hogli lint:skills` and `./bin/hogli build:skills`.
- Ran `uv run mypy --cache-fine-grained .`.
- Ran `./bin/hogli ci:preflight --fix`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation update. The skill-writing guide already documents the 1,024-character limit.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Pi authored the change with `gpt-5.6-sol` under human direction. A shareable session link was unavailable.
- Skills invoked: `/writing-skills`, `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/running-ci-preflight`, `/writing-pr-descriptions`, and `/pr`.
- The implementation expanded to project skills so local lint catches the reported loader failure.
