### PR TITLE
fix(snowflake): stop retrying when a passphrase is set on an unencrypted key

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/source.py
@@ -53,6 +53,14 @@ _WRONG_KEY_PASSPHRASE_MESSAGE = (
     "Enter the passphrase that decrypts your private key (or paste an unencrypted key), then {action}"
 )
 
+# The inverse of `_WRONG_KEY_PASSPHRASE_MESSAGE`: `load_pem_private_key` raises
+# TypeError "Password was given but private key is not encrypted." when a passphrase is supplied
+# for an unencrypted key-pair private key. Same `{action}` placeholder convention.
+_UNENCRYPTED_KEY_WITH_PASSPHRASE_MESSAGE = (
+    "You entered a passphrase, but the Snowflake key-pair private key you pasted is not encrypted. "
+    "Remove the passphrase, or paste your encrypted private key, then {action}"
+)
+
 SnowflakeErrors = {
     "No active warehouse selected in the current session": "No active warehouse is available for this connection. Check that the configured warehouse exists, is running, and that the connecting role has USAGE on it, then try again.",
     "or attempt to login with another role": "Role specified doesn't exist or is not authorized",
@@ -276,6 +284,12 @@ class SnowflakeSource(SQLSource[SnowflakeSourceConfig]):
             "Password was not given but private key is encrypted": _WRONG_KEY_PASSPHRASE_MESSAGE.format(
                 action="resync."
             ),
+            # See `_UNENCRYPTED_KEY_WITH_PASSPHRASE_MESSAGE`: a passphrase was supplied for an
+            # unencrypted key-pair private key, which fails to parse before we reach Snowflake, so
+            # retrying can never succeed until the user removes the passphrase or pastes an encrypted key.
+            "Password was given but private key is not encrypted": _UNENCRYPTED_KEY_WITH_PASSPHRASE_MESSAGE.format(
+                action="resync."
+            ),
             # Snowflake error 002003 (SQLSTATE 42S02 for tables / 02000 for schemas): a table or
             # schema the source syncs was dropped or renamed in Snowflake, or the role's grant on it
             # was revoked, after the schema was discovered. The driver raises "<object> does not exist
@@ -377,6 +391,9 @@ class SnowflakeSource(SQLSource[SnowflakeSourceConfig]):
                 or "Password was not given but private key is encrypted" in error_str
             ):
                 return False, _WRONG_KEY_PASSPHRASE_MESSAGE.format(action="try again.")
+            # The inverse: a passphrase was supplied for an unencrypted private key (TypeError).
+            if "Password was given but private key is not encrypted" in error_str:
+                return False, _UNENCRYPTED_KEY_WITH_PASSPHRASE_MESSAGE.format(action="try again.")
             capture_exception(e)
             return False, "Could not connect to Snowflake. Please check all connection details are valid."
         except Exception as e:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
@@ -895,6 +895,14 @@ class TestSnowflakeSourceNonRetryableErrors:
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert is_non_retryable, f"Encrypted-key passphrase error should be non-retryable: {error_msg}"
 
+    def test_unencrypted_key_with_passphrase_is_non_retryable(self, source):
+        # A passphrase supplied for an unencrypted key (cryptography TypeError) — the inverse of the
+        # encrypted-key cases above. Fails to parse before reaching Snowflake, so retrying can't help.
+        error_msg = "Password was given but private key is not encrypted."
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Unencrypted-key-with-passphrase error should be non-retryable: {error_msg}"
+
     @pytest.mark.parametrize(
         "error_msg",
         [
@@ -984,6 +992,22 @@ class TestSnowflakeValidateCredentials:
 
         assert ok is False
         assert message is not None and "passphrase" in message
+        mock_capture.assert_not_called()
+
+    def test_unencrypted_key_with_passphrase_returns_friendly_message_without_capture(self, source):
+        # A passphrase supplied for an unencrypted key — a TypeError raised while parsing, so it's a
+        # user config error that should surface an actionable message, not be captured.
+        error = TypeError("Password was given but private key is not encrypted.")
+        with (
+            patch.object(source, "get_schemas", side_effect=error),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.snowflake.source.capture_exception"
+            ) as mock_capture,
+        ):
+            ok, message = source.validate_credentials(_make_config("keypair"), team_id=1)
+
+        assert ok is False
+        assert message is not None and "not encrypted" in message
         mock_capture.assert_not_called()
 
     def test_mfa_enrollment_required_returns_friendly_message_without_capture(self, source):


### PR DESCRIPTION
## Problem

A user connecting a Snowflake key-pair source who pastes an unencrypted private key but also fills in the passphrase field gets a sync that never succeeds and a generic "Could not connect to Snowflake" during setup.

- `load_pem_private_key` raises `TypeError "Password was given but private key is not encrypted."` when a passphrase is supplied for an unencrypted key.
- This is the mirror image of the encrypted-key cases the source already handles.
- It fails locally before reaching Snowflake, so it can never succeed on retry with the same config.
- On the sync path the message was not in `NonRetryableErrors`, so the import retried pointlessly.
- On the setup path it fell through to `capture_exception` and returned a generic message, adding error-tracking noise instead of telling the user what to fix.

Confirmed in error tracking: the failure raises at `snowflake/snowflake.py:257` in `connect`, on the `external_data_sources/database_schema/` validation path.

## Changes

- Classify `Password was given but private key is not encrypted` as non-retryable in `SnowflakeSource.get_non_retryable_errors`.
- Return an actionable message on the validation path telling the user to remove the passphrase or paste an encrypted key.
- Match the stable substring only, since the surrounding text is fixed by the `cryptography` library.

## How did you test this code?

- Added `test_unencrypted_key_with_passphrase_is_non_retryable`: guards that the new message is classified non-retryable, so a regression that drops the entry would resume the pointless retries.
- Added `test_unencrypted_key_with_passphrase_returns_friendly_message_without_capture`: guards that validation returns the actionable message and does not call `capture_exception`.
- Ran the Snowflake retry/validation tests locally: 39 passed. Not run: the full warehouse-sources suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Automated triage of a Snowflake error-tracking issue, authored by Claude (`claude-opus-4-8`) via the PostHog Desktop task runner. Invoked skills: `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

Decision: treated as a user/upstream config error rather than a code bug. The error is a local parse failure that can never succeed on retry, and the existing code deliberately handles the three sibling key-pair cases (wrong passphrase, missing passphrase, malformed PEM) as non-retryable with actionable messages, so this inverse case follows the same pattern.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
