### PR TITLE
feat(desktop): capture model switches and attribute their source

### DIFF
--- a/products/desktop/apps/code/src/renderer/desktop-services.ts
+++ b/products/desktop/apps/code/src/renderer/desktop-services.ts
@@ -209,11 +209,21 @@ container
     setModel: (taskId, model) =>
       resolveService<SessionService>(
         SESSION_SERVICE,
-      ).setSessionConfigOptionByCategory(taskId, "model", model),
+      ).setSessionConfigOptionByCategory(
+        taskId,
+        "model",
+        model,
+        "autoresearch",
+      ),
     setEffort: (taskId, effort) =>
       resolveService<SessionService>(
         SESSION_SERVICE,
-      ).setSessionConfigOptionByCategory(taskId, "thought_level", effort),
+      ).setSessionConfigOptionByCategory(
+        taskId,
+        "thought_level",
+        effort,
+        "autoresearch",
+      ),
     reconnect: async (taskId) => {
       const workspaces = (await trpcClient.workspace.getAll.query()) as Record<
         string,

--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -43,7 +43,10 @@ import {
   type TaskRunArtifact,
   type TaskRunStatus,
 } from "@posthog/shared";
-import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import {
+  ANALYTICS_EVENTS,
+  type SessionConfigChangeSource,
+} from "@posthog/shared/analytics-events";
 import {
   type CloudTaskPermissionRequestUpdate,
   type CloudTaskUpdatePayload,
@@ -2534,11 +2537,19 @@ export class SessionService {
     this.d.store.setSession(session);
     this.subscribeToChannel(taskRun.id);
 
+    // The model the run opened on. Without it a mid-session switch is
+    // indistinguishable from a run that started on that model already.
+    const initialModel = getConfigOptionByCategory(
+      configOptions,
+      "model",
+    )?.currentValue;
+
     this.d.track(ANALYTICS_EVENTS.TASK_RUN_STARTED, {
       task_id: taskId,
       execution_type: "local",
       initial_mode: executionMode,
       adapter,
+      model: typeof initialModel === "string" ? initialModel : undefined,
     });
 
     if (initialPrompt?.length) {
@@ -5243,11 +5254,16 @@ export class SessionService {
   /**
    * Set a session configuration option with optimistic update and rollback.
    * This is the unified method for model, mode, thought level, etc.
+   *
+   * This is the only place a config change is tracked, so a change is captured
+   * whichever setter the caller used and never counted twice. Pass `source` to
+   * say what drove it.
    */
   async setSessionConfigOption(
     taskId: string,
     configId: string,
     value: string,
+    source: SessionConfigChangeSource = "unknown",
   ): Promise<void> {
     const session = this.d.store.getSessionByTaskId(taskId);
     if (!session) return;
@@ -5260,11 +5276,22 @@ export class SessionService {
       return;
     }
 
-    const previousValue = configOptions[optionIndex].currentValue;
+    const option = configOptions[optionIndex];
+    const previousValue = option.currentValue;
 
     // Skip if value is already set — avoids expensive IPC round-trip (e.g. setModel ~2s)
     if (previousValue === value) {
       return;
+    }
+
+    if (option.category) {
+      this.d.track(ANALYTICS_EVENTS.SESSION_CONFIG_CHANGED, {
+        task_id: taskId,
+        category: option.category,
+        from_value: String(previousValue),
+        to_value: value,
+        source,
+      });
     }
 
     // Optimistic update
@@ -5338,6 +5365,7 @@ export class SessionService {
     taskId: string,
     category: string,
     value: string,
+    source: SessionConfigChangeSource = "unknown",
   ): Promise<void> {
     const session = this.d.store.getSessionByTaskId(taskId);
     if (!session) return;
@@ -5354,16 +5382,7 @@ export class SessionService {
       return;
     }
 
-    if (configOption.currentValue !== value) {
-      this.d.track(ANALYTICS_EVENTS.SESSION_CONFIG_CHANGED, {
-        task_id: taskId,
-        category,
-        from_value: String(configOption.currentValue),
-        to_value: value,
-      });
-    }
-
-    await this.setSessionConfigOption(taskId, configOption.id, value);
+    await this.setSessionConfigOption(taskId, configOption.id, value, source);
   }
 
   /**
@@ -7266,7 +7285,12 @@ export class SessionService {
   ): void {
     const upgradeMode = resolveAllowAlwaysUpgradeMode(modeOption);
     if (!upgradeMode) return;
-    this.setSessionConfigOptionByCategory(taskId, "mode", upgradeMode);
+    this.setSessionConfigOptionByCategory(
+      taskId,
+      "mode",
+      upgradeMode,
+      "permission_upgrade",
+    );
   }
 
   async resolvePermissionSelection(
@@ -7323,7 +7347,12 @@ export class SessionService {
     if (!isBypass || !taskId) return;
     const target = resolveBypassRevertMode(options.modeOption);
     if (!target) return;
-    this.setSessionConfigOptionByCategory(taskId, "mode", target);
+    this.setSessionConfigOptionByCategory(
+      taskId,
+      "mode",
+      target,
+      "auto_revert",
+    );
   }
 
   /**

--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -352,11 +352,31 @@ export interface PermissionCancelledProperties {
 }
 
 // Session config events
+
+/**
+ * What caused a session config change. Separates a deliberate switch by the
+ * user from one an automated flow made on their behalf, so "did they pick this
+ * model?" is answerable without guessing from the generation stream.
+ */
+export type SessionConfigChangeSource =
+  /** Chosen in the UI (dropdown, ladder, settings row). */
+  | "picker"
+  /** Cycled with a keyboard shortcut. */
+  | "keyboard"
+  /** Swapped by an autoresearch stage, not by the user. */
+  | "autoresearch"
+  /** Mode bumped as a side effect of an "allow always" permission response. */
+  | "permission_upgrade"
+  /** Bypass mode reverted because the setting no longer permits it. */
+  | "auto_revert"
+  | "unknown";
+
 export interface SessionConfigChangedProperties {
   task_id: string;
   category: string;
   from_value: string;
   to_value: string;
+  source: SessionConfigChangeSource;
 }
 
 // Tour events

--- a/products/desktop/packages/ui/src/features/message-editor/components/PromptInput.tsx
+++ b/products/desktop/packages/ui/src/features/message-editor/components/PromptInput.tsx
@@ -8,6 +8,7 @@ import {
   InputGroupAddon,
   TooltipProvider,
 } from "@posthog/quill";
+import type { SessionConfigChangeSource } from "@posthog/shared/analytics-events";
 import { SHORTCUTS } from "@posthog/ui/features/command/keyboard-shortcuts";
 import type { PromptRecallHandler } from "@posthog/ui/features/sessions/components/chat-thread/composerPromptRecall";
 import { cycleModeOption } from "@posthog/ui/features/sessions/sessionStore";
@@ -51,7 +52,7 @@ export interface PromptInputProps {
   repoPath?: string | null;
   // mode
   modeOption?: SessionConfigOption;
-  onModeChange?: (value: string) => void;
+  onModeChange?: (value: string, source?: SessionConfigChangeSource) => void;
   allowBypassPermissions?: boolean;
   /**
    * When provided, the mode dropdown gains an "Autoresearch" toggle as its
@@ -345,7 +346,7 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
         });
         if (!nextMode) return;
         e.preventDefault();
-        onModeChange(nextMode);
+        onModeChange(nextMode, "keyboard");
       },
       {
         enableOnFormTags: true,

--- a/products/desktop/packages/ui/src/features/sessions/components/ModelSelector.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ModelSelector.tsx
@@ -77,7 +77,12 @@ export function ModelSelector({
 
     if (!taskId) return;
     if (sessionStatus !== "connected" && !sessionIsCloud) return;
-    sessionService.setSessionConfigOption(taskId, selectOption.id, value);
+    sessionService.setSessionConfigOption(
+      taskId,
+      selectOption.id,
+      value,
+      "picker",
+    );
   };
 
   const currentValue = selectOption.currentValue;

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -11,6 +11,7 @@ import {
 } from "@posthog/core/task-detail/previewConfig";
 import { useService } from "@posthog/di/react";
 import { type AcpMessage, FAST_MODE_FLAG } from "@posthog/shared";
+import type { SessionConfigChangeSource } from "@posthog/shared/analytics-events";
 import type { Task, TaskRunStatus } from "@posthog/shared/domain-types";
 import { showOfflineToast } from "@posthog/ui/features/connectivity/connectivityToast";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
@@ -282,9 +283,14 @@ export function SessionView({
   ]);
 
   const handleModeChange = useCallback(
-    (nextMode: string) => {
+    (nextMode: string, source: SessionConfigChangeSource = "picker") => {
       if (!taskId) return;
-      sessionService.setSessionConfigOptionByCategory(taskId, "mode", nextMode);
+      sessionService.setSessionConfigOptionByCategory(
+        taskId,
+        "mode",
+        nextMode,
+        source,
+      );
     },
     [taskId, sessionService],
   );
@@ -292,7 +298,12 @@ export function SessionView({
   const handleThoughtChange = useCallback(
     (value: string) => {
       if (!taskId || !thoughtOption) return;
-      sessionService.setSessionConfigOption(taskId, thoughtOption.id, value);
+      sessionService.setSessionConfigOption(
+        taskId,
+        thoughtOption.id,
+        value,
+        "picker",
+      );
     },
     [taskId, thoughtOption, sessionService],
   );
@@ -300,7 +311,7 @@ export function SessionView({
   const handleConfigOptionChange = useCallback(
     (configId: string, value: string) => {
       if (!taskId) return;
-      sessionService.setSessionConfigOption(taskId, configId, value);
+      sessionService.setSessionConfigOption(taskId, configId, value, "picker");
     },
     [taskId, sessionService],
   );

--- a/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -4,8 +4,10 @@ import type {
   SessionConfigSelectGroup,
 } from "@agentclientprotocol/sdk";
 import type { AcpMessage } from "@posthog/shared";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/domain-types";
 import type { AgentSession } from "@posthog/ui/features/sessions/sessionStore";
+import { track } from "@posthog/ui/shell/posthogAnalyticsImpl";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // --- Hoisted Mocks ---
@@ -8448,6 +8450,94 @@ describe("SessionService", () => {
         configId: "model",
         value: "claude-3-sonnet",
       });
+    });
+
+    const modelOption: SessionConfigOption = {
+      id: "model",
+      name: "Model",
+      type: "select",
+      category: "model",
+      currentValue: "claude-3-opus",
+      options: [],
+    };
+
+    it.each([
+      { source: "picker" as const, expected: "picker" },
+      { source: "autoresearch" as const, expected: "autoresearch" },
+      { source: undefined, expected: "unknown" },
+    ])(
+      "tracks the change with source $expected",
+      async ({ source, expected }) => {
+        const service = getSessionService();
+        mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
+          createMockSession({ configOptions: [modelOption] }),
+        );
+
+        await service.setSessionConfigOption(
+          "task-123",
+          "model",
+          "claude-3-sonnet",
+          source,
+        );
+
+        expect(track).toHaveBeenCalledWith(
+          ANALYTICS_EVENTS.SESSION_CONFIG_CHANGED,
+          {
+            task_id: "task-123",
+            category: "model",
+            from_value: "claude-3-opus",
+            to_value: "claude-3-sonnet",
+            source: expected,
+          },
+        );
+      },
+    );
+
+    it("does not track when the value is unchanged", async () => {
+      const service = getSessionService();
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
+        createMockSession({ configOptions: [modelOption] }),
+      );
+
+      await service.setSessionConfigOption(
+        "task-123",
+        "model",
+        "claude-3-opus",
+        "picker",
+      );
+
+      expect(track).not.toHaveBeenCalledWith(
+        ANALYTICS_EVENTS.SESSION_CONFIG_CHANGED,
+        expect.anything(),
+      );
+    });
+
+    it("tracks a change made by category exactly once", async () => {
+      const service = getSessionService();
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
+        createMockSession({ configOptions: [modelOption] }),
+      );
+      mockGetConfigOptionByCategory.mockImplementation(
+        (
+          configOptions: Array<{ category?: string }> | undefined,
+          category?: string,
+        ) => configOptions?.find((option) => option.category === category),
+      );
+
+      await service.setSessionConfigOptionByCategory(
+        "task-123",
+        "model",
+        "claude-3-sonnet",
+        "autoresearch",
+      );
+
+      const configChanges = vi
+        .mocked(track)
+        .mock.calls.filter(
+          ([event]) => event === ANALYTICS_EVENTS.SESSION_CONFIG_CHANGED,
+        );
+      expect(configChanges).toHaveLength(1);
+      expect(configChanges[0][1]).toMatchObject({ source: "autoresearch" });
     });
 
     it("rolls back on API failure", async () => {


### PR DESCRIPTION
## Problem

Nobody can tell whether a desktop user picked the model their session is burning cost on. The model picker in the app has never reported a change — of everyone who has switched models in the app, only a handful show up in analytics at all, and every one of those was an autoresearch run swapping stage models on their behalf.

`Session config changed` fires from `setSessionConfigOptionByCategory`, and the only caller for the `model` and `thought_level` categories is the autoresearch client. The UI pickers call `setSessionConfigOption` directly, which tracked nothing. `Task run started` declares a `model` property that its only call site never passes, so the model a run opened on is absent too.

Together that makes "did this person choose an expensive model, or did the session just stay on one?" unanswerable, and leaves cost-per-session analysis guessing at model changes from the `$ai_generation` stream — which cannot separate a user's pick from a harness pick, a subagent, or an autoresearch stage.

## Changes

- Track the change in `setSessionConfigOption` rather than the by-category wrapper, so a change is captured whichever setter the caller used. This is the fix that makes the pickers start reporting; the wrapper's own track is dropped so a by-category change still counts once.
- Add a `source` property to `Session config changed`: `picker`, `keyboard`, `autoresearch`, `permission_upgrade`, `auto_revert`, `unknown`.
- Attribute the two automated paths found while wiring it up. `applyAllowAlwaysUpgrade` bumps the mode after an "allow always" permission response; `maybeRevertBypassMode` reverts bypass mode when the setting no longer permits it. Both now name themselves rather than looking like user choices.
- Pass the `model` already declared on `Task run started`.
- Widen `PromptInput`'s `onModeChange` to take an optional source, so shift+tab reports `keyboard` while the dropdown falls through to `picker`.

Behavioural note for whoever reads the data: every config category now emits, not just `mode` and autoresearch's model swaps. Volume stays low — these are discrete user actions — but the `mode` series will step up as the previously-untracked picker and permission-upgrade paths start reporting.

The pre-run composer in `TaskInput` and `ChannelHomeComposer` is deliberately untouched. It writes draft config before a session exists, so there is nothing to track against; the new `Task run started.model` covers that case instead.

## How did you test this code?

Automated only. I did not run the Electron app, so the `keyboard` and `permission_upgrade` sources are verified by unit test and by reading their call sites, not by observing events land in PostHog.

Tests I ran locally in `products/desktop`:

- `pnpm typecheck` — 25 packages, clean.
- `pnpm --filter @posthog/ui test` — 2954 pass.
- `pnpm --filter @posthog/core --filter @posthog/shared test` — 3211 and 828 pass.
- `npx biome lint packages/core` — zero `noRestrictedImports`.
- `node scripts/check-host-boundaries.mjs` — no new violations.

Five tests added to `sessionServiceHost.test.ts`. The regressions they catch, none of which an existing test covered:

- A parameterised case asserting `source` reaches the event, including that an omitted source falls back to `unknown`. Nothing previously asserted the event's payload at all.
- The no-op case: setting a category to its current value must not emit. The early return exists for an unrelated reason (an expensive IPC round-trip), so a later refactor could move the track above it without any test objecting.
- A by-category change must emit exactly once. This is the specific way the change could regress — reinstating a track in the wrapper would double-count every autoresearch swap, and a test asserting "emitted" rather than "emitted once" would pass anyway.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) from a Slack thread, in response to a question about whether a heavy user's model switching was deliberate or drifting. Answering it from `$ai_generation` showed sessions changing model mid-trace but could not attribute the change to a person, which is what surfaced the instrumentation gap this PR closes. Skills invoked: `/exploring-llm-costs` for the analysis, `/writing-code-comments` and `/writing-pr-descriptions` for this PR.

Two decisions worth a reviewer's attention. Tracking moved into `setSessionConfigOption` rather than being added alongside the existing call, because adding a second track site is what would double-count; centralising it also means a future setter caller cannot silently skip instrumentation. And the `source` union covers only paths actually wired in this diff — the two automated ones were found by auditing callers, not assumed, so no value in the union is speculative.

The change was first written against `PostHog/code` before I learned that repo is archived, then reapplied here. Two hunks landed with fuzz during the move and were corrected by hand: one had inserted an import inside the `@posthog/quill` import block. I re-audited the call sites against this copy afterwards to confirm the premise still held, and it did.

No customer data, session content, or internal material is in this diff or description.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A3WRH1LHK/p1786459797475769?thread_ts=1786459797.475769&cid=C0A3WRH1LHK)*
