### PR TITLE
feat(integrations): record who reads each credential, in Postgres

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -40,3 +40,5 @@ common/hogql_parser/HogQLParserVisitor.cpp linguist-generated
 common/hogql_parser/HogQLParserVisitor.h linguist-generated
 common/hogql_parser/HogQLParserBaseVisitor.cpp linguist-generated
 common/hogql_parser/HogQLParserBaseVisitor.h linguist-generated
+
+pnpm-lock.yaml merge=union

--- a/.gitattributes
+++ b/.gitattributes
@@ -40,5 +40,3 @@ common/hogql_parser/HogQLParserVisitor.cpp linguist-generated
 common/hogql_parser/HogQLParserVisitor.h linguist-generated
 common/hogql_parser/HogQLParserBaseVisitor.cpp linguist-generated
 common/hogql_parser/HogQLParserBaseVisitor.h linguist-generated
-
-pnpm-lock.yaml merge=union

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4734,6 +4734,9 @@ importers:
       jose:
         specifier: ^6.0.10
         version: 6.2.3
+      pg:
+        specifier: ^8.13.1
+        version: 8.22.0
       pino:
         specifier: ^8.6.0
         version: 8.11.0
@@ -4741,9 +4744,15 @@ importers:
         specifier: ^14.2.0
         version: 14.2.0
     devDependencies:
+      '@testcontainers/postgresql':
+        specifier: ^12.1.0
+        version: 12.1.0
       '@types/node':
         specifier: ^22.17.2
         version: 22.18.8
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.15.6
       esbuild:
         specifier: ^0.25.11
         version: 0.25.12
@@ -6190,6 +6199,9 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@balena/dockerignore@1.0.2':
+    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
 
   '@base-ui/react@1.6.0':
     resolution: {integrity: sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==}
@@ -8093,6 +8105,9 @@ packages:
 
   '@kurkle/color@0.3.2':
     resolution: {integrity: sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw==}
+
+  '@kwsites/file-exists@1.1.1':
+    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
 
   '@lezer/common@1.2.3':
     resolution: {integrity: sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==}
@@ -11993,6 +12008,9 @@ packages:
     resolution: {integrity: sha512-VaMhVtlA0hLLM/pna26vFSdn5W1Arq2+ccgItdbdRdZUa0X8eW2B7sl/PcUYQOWc4aMUGnvPATKUGUoFKyCxSg==}
     engines: {node: '>= 20.0.0'}
 
+  '@testcontainers/postgresql@12.1.0':
+    resolution: {integrity: sha512-Pjf2VSVNirEPfz36nidyrVAnZvc2YhajOznY4VgyEsvfTd5qiMNOuPq96drREvxAUtXl5SFLX7vXj7sSq4aTcA==}
+
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
     engines: {node: '>=18'}
@@ -12537,6 +12555,12 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/docker-modem@3.0.6':
+    resolution: {integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==}
+
+  '@types/dockerode@4.0.1':
+    resolution: {integrity: sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==}
+
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
 
@@ -12840,6 +12864,15 @@ packages:
 
   '@types/snowflake-sdk@1.6.12':
     resolution: {integrity: sha512-Ndz6x750TkuvHvdRBH8Cb7T8et2anyyY1j8kFChJ+s8FtURNRKut7DWaq9YdseKXZvqwA3ZYZxKaQRwtSq67eg==}
+
+  '@types/ssh2-streams@0.1.13':
+    resolution: {integrity: sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==}
+
+  '@types/ssh2@0.5.52':
+    resolution: {integrity: sha512-lbLLlXxdCZOSJMCInKH2+9V/77ET2J6NPQHpFI0kda61Dd1KglJs+fPQBchizmzYSOJBgdTajhPqBO1xxLywvg==}
+
+  '@types/ssh2@1.15.5':
+    resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -13575,6 +13608,14 @@ packages:
     resolution: {integrity: sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==}
     engines: {node: '>=8'}
 
+  archiver-utils@5.0.2:
+    resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
+    engines: {node: '>= 14'}
+
+  archiver@7.0.1:
+    resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
+    engines: {node: '>= 14'}
+
   archy@1.0.0:
     resolution: {integrity: sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==}
 
@@ -13690,6 +13731,9 @@ packages:
 
   async-limiter@1.0.1:
     resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
+
+  async-lock@1.4.1:
+    resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
 
   async-mutex@0.5.0:
     resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
@@ -14022,6 +14066,10 @@ packages:
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
+  buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
+
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
@@ -14054,6 +14102,10 @@ packages:
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
+
+  byline@5.0.0:
+    resolution: {integrity: sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==}
+    engines: {node: '>=0.10.0'}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -14425,6 +14477,10 @@ packages:
   component-emitter@1.3.1:
     resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
 
+  compress-commons@6.0.2:
+    resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
+    engines: {node: '>= 14'}
+
   compressible@2.0.18:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
     engines: {node: '>= 0.6'}
@@ -14549,6 +14605,15 @@ packages:
   cpu-features@0.0.10:
     resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
     engines: {node: '>=10.0.0'}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
+  crc32-stream@6.0.0:
+    resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
+    engines: {node: '>= 14'}
 
   create-ecdh@4.0.4:
     resolution: {integrity: sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==}
@@ -15135,6 +15200,18 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  docker-compose@1.4.2:
+    resolution: {integrity: sha512-rPHigTKGaEHpkUmfd69QgaOp+Os5vGJwG/Ry8lcr8W/382AmI+z/D7qoa9BybKIkqNppaIbs8RYeHSevdQjWww==}
+    engines: {node: '>= 6.0.0'}
+
+  docker-modem@5.0.7:
+    resolution: {integrity: sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==}
+    engines: {node: '>= 8.0'}
+
+  dockerode@5.0.1:
+    resolution: {integrity: sha512-avsq/xk4YPIrn0CgleX5bjT9Y8IT1p9PxrNQ++RBQ2WEyFfHCTDsT9kmyxz+H/axnjAwg8wJWEIuPGOUuNupiA==}
+    engines: {node: '>= 14.17'}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -16077,6 +16154,10 @@ packages:
   get-port@4.2.0:
     resolution: {integrity: sha512-/b3jarXkH8KJoOMQc3uVGHASwGLPq3gSFJ7tgJm2diza+bydJPTGOibin2steecKeOylE8oY2JERlVWkAJO6yw==}
     engines: {node: '>=6'}
+
+  get-port@5.1.1:
+    resolution: {integrity: sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==}
+    engines: {node: '>=8'}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -17692,6 +17773,10 @@ packages:
   layout-base@2.0.1:
     resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
+  lazystream@1.0.1:
+    resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
+    engines: {node: '>= 0.6.3'}
+
   less@3.13.1:
     resolution: {integrity: sha512-SwA1aQXGUvp+P5XdZslUOhhLnClSLIjWvJhmd+Vgib5BFIr9lMNlQwmwUNOjXThF/A0x+MCYYPeWEfeWiLRnTw==}
     engines: {node: '>=6'}
@@ -18505,6 +18590,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
@@ -19182,6 +19272,12 @@ packages:
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.14.0:
+    resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
+
   pg-connection-string@2.5.0:
     resolution: {integrity: sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==}
 
@@ -19189,10 +19285,18 @@ packages:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
 
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
   pg-pool@3.6.0:
     resolution: {integrity: sha512-clFRf2ksqd+F497kWFyM21tMjeikn60oGDmqMT8UBrynEwVEX/5R5xd2sdvdo1cZCFlguORNpVuqxIj+aK4cfQ==}
     peerDependencies:
       pg: '>=8.0'
+
+  pg-protocol@1.15.0:
+    resolution: {integrity: sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==}
 
   pg-protocol@1.6.0:
     resolution: {integrity: sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q==}
@@ -19204,6 +19308,15 @@ packages:
   pg@8.10.0:
     resolution: {integrity: sha512-ke7o7qSTMb47iwzOSaZMfeR7xToFdkE71ifIipOAAaLIM0DYzfOAXlgFFmYUIE2BcJtvnVlGCID84ZzCegE8CQ==}
     engines: {node: '>= 8.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pg@8.22.0:
+    resolution: {integrity: sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==}
+    engines: {node: '>= 16.0.0'}
     peerDependencies:
       pg-native: '>=3.0.1'
     peerDependenciesMeta:
@@ -19818,6 +19931,13 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
+  properties-reader@3.0.1:
+    resolution: {integrity: sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==}
+    engines: {node: '>=18'}
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
@@ -20477,6 +20597,9 @@ packages:
   readable-stream@4.7.0:
     resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  readdir-glob@1.1.3:
+    resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -21169,6 +21292,9 @@ packages:
     resolution: {integrity: sha512-WgxL1K0MXNXW7+4fn11B6rtJ+jZTnCQMkJ44yV3XmFDcpGBqFJrDEHouGuFryqB5hoG1ksE2zlss/m6KOWnbPA==}
     hasBin: true
 
+  split-ca@1.0.1:
+    resolution: {integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==}
+
   split-string@3.1.0:
     resolution: {integrity: sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==}
     engines: {node: '>=0.10.0'}
@@ -21182,6 +21308,9 @@ packages:
 
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
+  ssh-remote-port-forward@1.0.4:
+    resolution: {integrity: sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==}
 
   ssh2-sftp-client@10.0.3:
     resolution: {integrity: sha512-Wlhasz/OCgrlqC8IlBZhF19Uw/X/dHI8ug4sFQybPE+0sDztvgvDf7Om6o7LbRLe68E7XkFZf3qMnqAvqn1vkQ==}
@@ -21635,6 +21764,9 @@ packages:
   tar-fs@3.1.2:
     resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
 
+  tar-fs@3.1.3:
+    resolution: {integrity: sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==}
+
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
@@ -21719,6 +21851,10 @@ packages:
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
+
+  testcontainers@12.1.0:
+    resolution: {integrity: sha512-YjDLqIITuhGLMnM10yhg3oV6lIG5IMpz1R1DPBZoOOks83q7i7IVpeSWRTiyl7roozjiyLmwIoLK/KY8OnZmIA==}
+    engines: {node: '>= 22.22'}
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
@@ -21824,6 +21960,10 @@ packages:
   tldts@7.0.28:
     resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
     hasBin: true
+
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
+    engines: {node: '>=14.14'}
 
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
@@ -22213,6 +22353,10 @@ packages:
   undici@7.24.8:
     resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
     engines: {node: '>=20.18.1'}
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
@@ -23041,6 +23185,10 @@ packages:
 
   youch@4.1.0-beta.10:
     resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
+
+  zip-stream@6.0.1:
+    resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
+    engines: {node: '>= 14'}
 
   zod-to-json-schema@3.25.1:
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
@@ -25367,6 +25515,8 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@balena/dockerignore@1.0.2': {}
+
   '@base-ui/react@1.6.0(@date-fns/tz@1.4.1)(@types/react@18.3.27)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -27412,6 +27562,12 @@ snapshots:
   '@juggle/resize-observer@3.4.0': {}
 
   '@kurkle/color@0.3.2': {}
+
+  '@kwsites/file-exists@1.1.1':
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@lezer/common@1.2.3': {}
 
@@ -31809,6 +31965,15 @@ snapshots:
       '@temporalio/proto': 1.15.0
       nexus-rpc: 0.0.1
 
+  '@testcontainers/postgresql@12.1.0':
+    dependencies:
+      testcontainers: 12.1.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+
   '@testing-library/dom@10.4.0':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -32440,6 +32605,17 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/docker-modem@3.0.6':
+    dependencies:
+      '@types/node': 22.18.8
+      '@types/ssh2': 1.15.5
+
+  '@types/dockerode@4.0.1':
+    dependencies:
+      '@types/docker-modem': 3.0.6
+      '@types/node': 22.18.8
+      '@types/ssh2': 1.15.5
+
   '@types/doctrine@0.0.9': {}
 
   '@types/dom-mediacapture-record@1.0.22': {}
@@ -32801,6 +32977,19 @@ snapshots:
     dependencies:
       '@types/node': 22.18.8
       generic-pool: 3.9.0
+
+  '@types/ssh2-streams@0.1.13':
+    dependencies:
+      '@types/node': 22.18.8
+
+  '@types/ssh2@0.5.52':
+    dependencies:
+      '@types/node': 22.18.8
+      '@types/ssh2-streams': 0.1.13
+
+  '@types/ssh2@1.15.5':
+    dependencies:
+      '@types/node': 18.19.130
 
   '@types/stack-utils@2.0.3': {}
 
@@ -33705,6 +33894,30 @@ snapshots:
     dependencies:
       default-require-extensions: 3.0.1
 
+  archiver-utils@5.0.2:
+    dependencies:
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      is-stream: 2.0.1
+      lazystream: 1.0.1
+      lodash: 4.18.1
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
+  archiver@7.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      async: 3.2.6
+      buffer-crc32: 1.0.0
+      readable-stream: 4.7.0
+      readdir-glob: 1.1.3
+      tar-stream: 3.2.0
+      zip-stream: 6.0.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
   archy@1.0.0: {}
 
   arg@4.1.3: {}
@@ -33840,6 +34053,8 @@ snapshots:
   async-function@1.0.0: {}
 
   async-limiter@1.0.1: {}
+
+  async-lock@1.4.1: {}
 
   async-mutex@0.5.0:
     dependencies:
@@ -34266,6 +34481,8 @@ snapshots:
 
   buffer-crc32@0.2.13: {}
 
+  buffer-crc32@1.0.0: {}
+
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
@@ -34301,6 +34518,8 @@ snapshots:
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
+
+  byline@5.0.0: {}
 
   bytes@3.1.2: {}
 
@@ -34657,6 +34876,14 @@ snapshots:
 
   component-emitter@1.3.1: {}
 
+  compress-commons@6.0.2:
+    dependencies:
+      crc-32: 1.2.2
+      crc32-stream: 6.0.0
+      is-stream: 2.0.1
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
   compressible@2.0.18:
     dependencies:
       mime-db: 1.54.0
@@ -34781,6 +35008,13 @@ snapshots:
       buildcheck: 0.0.6
       nan: 2.27.0
     optional: true
+
+  crc-32@1.2.2: {}
+
+  crc32-stream@6.0.0:
+    dependencies:
+      crc-32: 1.2.2
+      readable-stream: 4.7.0
 
   create-ecdh@4.0.4:
     dependencies:
@@ -35418,6 +35652,30 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  docker-compose@1.4.2:
+    dependencies:
+      yaml: 2.9.0
+
+  docker-modem@5.0.7:
+    dependencies:
+      debug: 4.4.3
+      readable-stream: 3.6.2
+      split-ca: 1.0.1
+      ssh2: 1.16.0
+    transitivePeerDependencies:
+      - supports-color
+
+  dockerode@5.0.1:
+    dependencies:
+      '@balena/dockerignore': 1.0.2
+      '@grpc/grpc-js': 1.14.4
+      '@grpc/proto-loader': 0.7.15
+      docker-modem: 5.0.7
+      protobufjs: 7.6.1
+      tar-fs: 2.1.4
+    transitivePeerDependencies:
+      - supports-color
 
   doctrine@2.1.0:
     dependencies:
@@ -36700,6 +36958,8 @@ snapshots:
   get-package-type@0.1.0: {}
 
   get-port@4.2.0: {}
+
+  get-port@5.1.1: {}
 
   get-proto@1.0.1:
     dependencies:
@@ -39435,6 +39695,10 @@ snapshots:
 
   layout-base@2.0.1: {}
 
+  lazystream@1.0.1:
+    dependencies:
+      readable-stream: 2.3.8
+
   less@3.13.1:
     dependencies:
       copy-anything: 2.0.6
@@ -40503,6 +40767,8 @@ snapshots:
 
   mkdirp@1.0.4: {}
 
+  mkdirp@3.0.1: {}
+
   mlly@1.8.2:
     dependencies:
       acorn: 8.16.0
@@ -41355,13 +41621,24 @@ snapshots:
 
   pend@1.2.0: {}
 
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.14.0: {}
+
   pg-connection-string@2.5.0: {}
 
   pg-int8@1.0.1: {}
 
+  pg-pool@3.14.0(pg@8.22.0):
+    dependencies:
+      pg: 8.22.0
+
   pg-pool@3.6.0(pg@8.10.0):
     dependencies:
       pg: 8.10.0
+
+  pg-protocol@1.15.0: {}
 
   pg-protocol@1.6.0: {}
 
@@ -41382,6 +41659,16 @@ snapshots:
       pg-protocol: 1.6.0
       pg-types: 2.2.0
       pgpass: 1.0.5
+
+  pg@8.22.0:
+    dependencies:
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.22.0)
+      pg-protocol: 1.15.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
 
   pgpass@1.0.5:
     dependencies:
@@ -42065,6 +42352,19 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
+  properties-reader@3.0.1:
+    dependencies:
+      '@kwsites/file-exists': 1.1.1
+      mkdirp: 3.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   property-information@7.1.0: {}
 
@@ -42978,6 +43278,10 @@ snapshots:
       process: 0.11.10
       string_decoder: 1.3.0
 
+  readdir-glob@1.1.3:
+    dependencies:
+      minimatch: 5.1.9
+
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.2
@@ -43812,6 +44116,8 @@ snapshots:
       commander: 14.0.3
       wicked-good-xpath: 1.3.0
 
+  split-ca@1.0.1: {}
+
   split-string@3.1.0:
     dependencies:
       extend-shallow: 3.0.2
@@ -43821,6 +44127,11 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   sprintf-js@1.1.3: {}
+
+  ssh-remote-port-forward@1.0.4:
+    dependencies:
+      '@types/ssh2': 0.5.52
+      ssh2: 1.16.0
 
   ssh2-sftp-client@10.0.3:
     dependencies:
@@ -44409,6 +44720,18 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
+  tar-fs@3.1.3:
+    dependencies:
+      pump: 3.0.4
+      tar-stream: 3.2.0
+    optionalDependencies:
+      bare-fs: 4.7.1
+      bare-path: 3.0.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
   tar-stream@2.2.0:
     dependencies:
       bl: 4.1.0
@@ -44502,6 +44825,29 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.5
 
+  testcontainers@12.1.0:
+    dependencies:
+      '@balena/dockerignore': 1.0.2
+      '@types/dockerode': 4.0.1
+      archiver: 7.0.1
+      async-lock: 1.4.1
+      byline: 5.0.0
+      debug: 4.4.3
+      docker-compose: 1.4.2
+      dockerode: 5.0.1
+      get-port: 5.1.1
+      proper-lockfile: 4.1.2
+      properties-reader: 3.0.1
+      ssh-remote-port-forward: 1.0.4
+      tar-fs: 3.1.3
+      tmp: 0.2.7
+      undici: 8.10.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+
   text-decoder@1.2.7:
     dependencies:
       b4a: 1.8.1
@@ -44590,6 +44936,8 @@ snapshots:
   tldts@7.0.28:
     dependencies:
       tldts-core: 7.0.28
+
+  tmp@0.2.7: {}
 
   tmpl@1.0.5: {}
 
@@ -45001,6 +45349,8 @@ snapshots:
   undici@6.25.0: {}
 
   undici@7.24.8: {}
+
+  undici@8.10.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:
@@ -46003,6 +46353,12 @@ snapshots:
       '@speed-highlight/core': 1.2.14
       cookie: 1.1.1
       youch-core: 0.3.3
+
+  zip-stream@6.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      compress-commons: 6.0.2
+      readable-stream: 4.7.0
 
   zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:

--- a/services/integration-service/README.md
+++ b/services/integration-service/README.md
@@ -89,8 +89,8 @@ label, because prom-client keeps every series in process memory for the pod's li
 
 **There is no per-deployment allowlist.** Every authenticated deployment may read any credential
 on the mount: a list bounds nothing the signing key does not already bound, and a compromised
-deployment is contained by revoking its key. What a deployment actually read is in the audit
-log.
+deployment is contained by revoking its key. What a deployment actually read is in the audit log
+and the usage rollup.
 
 So one thing bounds a request: the `keys` claim, which _is_ the request, for as long as the token
 has left to run — the verifier requires an `exp`.
@@ -163,24 +163,66 @@ this secret.
 `__` is the one thing the mount will not serve, whatever a token asks for. The caller signing keys
 carry that prefix, which is why they can share a secret with the credentials they protect.
 
+### Knowing when the old value is safe to delete
+
+Nothing is reported to this service by a caller: usage is measured here, so it does not depend on
+a client being well behaved, current, or honest. The rows answer one question during a rotation:
+has every deployment known to read this key read it since the secret last changed? Callers do not
+cache, so a read after activation necessarily returned the new value. The surface that renders
+that answer ships with the secrets UI follow-up; this layer records the data it needs.
+
+## Postgres
+
+Postgres carries the usage counters and the version-observation log, and holds no credential.
+Durability is the point: the counters decide whether an old credential is safe to retire, and
+losing a stale reader's row makes a rotation look quieter than it is. A store with an eviction
+policy cannot be trusted with an input to that decision.
+
+Writes are batched in memory and flushed on a timer; an upsert per read would put a write on the
+hot path for nothing. A crash loses at most one flush interval of counts — and only that much,
+because shutdown (including `unhandledRejection` and `uncaughtException`) drains the server, then
+flushes the recorder, then closes the pool.
+
+Three tables, applied as idempotent DDL at boot (retried once, since replicas booting together
+can race the `CREATE TABLE IF NOT EXISTS` statements):
+
+| Table                          | Holds                                    | Pruned?                        |
+| ------------------------------ | ---------------------------------------- | ------------------------------ |
+| `integration_secret_usage`     | read counts per key, deployment and hour | yes, past the retention window |
+| `integration_secret_last_seen` | when each deployment last read each key  | **never**                      |
+| `integration_secret_version`   | when each content hash was first seen    | no                             |
+
+`integration_secret_last_seen` is separate from the counts and never pruned on purpose: the
+retirement verdict has to consider every deployment known to read a key, not only those active
+inside the rolling window, or a consumer that reads rarely would drop out of the verdict.
+
+A mounted secret carries no AWS version, so `integration_secret_version` is what "the value
+changed at" means: the first time any replica saw this content hash, recorded centrally so
+replicas agree and the answer survives a restart.
+
+The DSN comes from the `psql:` harness in the `posthog-app` chart, so connections go through
+PgBouncer in transaction mode. Nothing here may rely on session state: no `LISTEN`/`NOTIFY`, no
+session-scoped settings, no server-side named prepared statements.
+
 ## Metrics
 
 No label value comes from a request. A key name becomes a label only once the mount is known to
 carry it; anything else collapses to a constant, and the `caller` claim is not a label at all.
 
-| Metric                                                                   | What it answers                                               |
-| ------------------------------------------------------------------------ | ------------------------------------------------------------- |
-| `integration_secret_resolve_total{deployment,key,result}`                | who read what, and whether it resolved                        |
-| `integration_secret_last_resolved_timestamp{key}`                        | which credentials nothing reads any more                      |
-| `integration_secret_previous_version_served_total{key}`                  | how much traffic is reading a key mid-rotation                |
-| `integration_secret_serving_stale_seconds`                               | how long this pod has served credentials it could not refresh |
-| `integration_secret_store_errors_total`                                  | mount reads that returned nothing                             |
-| `integration_service_signing_keys_last_loaded_timestamp`                 | staleness means a revocation has not landed on this pod       |
-| `integration_service_signing_key_reload_failures_total`                  | reloads that kept the previous key set                        |
-| `integration_service_auth_failures_total{reason}`                        | rejected tokens, by why                                       |
-| `integration_service_http_requests_total{method,route,status}`           | request volume, with an unmatched path collapsed to `other`   |
-| `integration_service_http_request_duration_seconds{method,route,status}` | request latency                                               |
-| `integration_service_shutting_down`                                      | 1 while draining                                              |
+| Metric                                                                   | What it answers                                                     |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------- |
+| `integration_secret_resolve_total{deployment,key,result}`                | who read what, and whether it resolved                              |
+| `integration_secret_last_resolved_timestamp{key}`                        | which credentials nothing reads any more                            |
+| `integration_secret_previous_version_served_total{key}`                  | how much traffic is reading a key mid-rotation                      |
+| `integration_secret_age_seconds`                                         | time since the secret last changed — drives "not rotated in N days" |
+| `integration_secret_serving_stale_seconds`                               | how long this pod has served credentials it could not refresh       |
+| `integration_secret_store_errors_total`                                  | mount reads that returned nothing                                   |
+| `integration_service_signing_keys_last_loaded_timestamp`                 | staleness means a revocation has not landed on this pod             |
+| `integration_service_signing_key_reload_failures_total`                  | reloads that kept the previous key set                              |
+| `integration_service_auth_failures_total{reason}`                        | rejected tokens, by why                                             |
+| `integration_service_http_requests_total{method,route,status}`           | request volume, with an unmatched path collapsed to `other`         |
+| `integration_service_http_request_duration_seconds{method,route,status}` | request latency                                                     |
+| `integration_service_shutting_down`                                      | 1 while draining                                                    |
 
 Two of these exist because a fail-open needs to be visible: the signing-key reload keeps the
 previous keys when an edit is malformed, and an unreadable mount keeps what is already held. Alert
@@ -206,27 +248,33 @@ the npm-specific supply-chain path worth closing here.
 pnpm --filter @posthog/integration-service dev                # tsx watch, pretty logs
 pnpm --filter @posthog/integration-service typecheck
 pnpm --filter @posthog/integration-service test:unit
-pnpm --filter @posthog/integration-service test:integration   # boots a real server on a temp mount
+pnpm --filter @posthog/integration-service test:integration   # needs Docker (testcontainers)
 ```
 
-The integration suite boots a real `IntegrationServer` against a temp-dir mount and a real
-socket, so it covers the wiring the unit suite fakes. Neither suite needs a database or Docker.
+`pnpm vitest run` with no path runs both suites, so it needs Docker; without Docker, run
+`test:unit`. The integration suite starts a disposable Postgres with testcontainers and boots a
+real `IntegrationServer` against a temp-dir mount, so it covers the SQL and the HTTP wiring the
+unit suite fakes.
 
 Point `INTEGRATION_SERVICE_SECRETS_DIR` at a directory of files, one per key, to stand in for the
-mount.
+mount. With `INTEGRATION_SERVICE_DATABASE_URL` unset the service runs without usage recording,
+which costs the rollup and nothing else.
 
 ## Configuration
 
-| Variable                             | Default                    | Notes                                                   |
-| ------------------------------------ | -------------------------- | ------------------------------------------------------- |
-| `INTEGRATION_SERVICE_ENV`            | `dev`                      | Logical env, recorded on every startup log line         |
-| `INTEGRATION_SERVICE_SECRETS_DIR`    | `/etc/integration-secrets` | Where the Kubernetes Secret is mounted                  |
-| `INTEGRATION_SERVICE_RELOAD_SECONDS` | `30`                       | How often to re-read the mount                          |
-| `INTEGRATION_SERVICE_METRICS_PORT`   | `9090`                     | Dedicated `/metrics` listener, kept off the ingress     |
-| `INTEGRATION_SERVICE_LOG_LEVEL`      | by `NODE_ENV`              | `debug`, `info`, `warn` or `error`                      |
-| `PORT`                               | `8004`                     |                                                         |
-| `HOST`                               | `0.0.0.0`                  |                                                         |
-| `SHUTDOWN_PRESTOP_DELAY_MS`          | `5000`                     | Wait before draining, for the Kubernetes prestop window |
+| Variable                             | Default                    | Notes                                                    |
+| ------------------------------------ | -------------------------- | -------------------------------------------------------- |
+| `INTEGRATION_SERVICE_ENV`            | `dev`                      | Logical env; recorded on the usage rollup                |
+| `INTEGRATION_SERVICE_SECRETS_DIR`    | `/etc/integration-secrets` | Where the Kubernetes Secret is mounted                   |
+| `INTEGRATION_SERVICE_DATABASE_URL`   | —                          | From the chart's `psql:` harness. Required in production |
+| `INTEGRATION_SERVICE_RELOAD_SECONDS` | `30`                       | How often to re-read the mount                           |
+| `INTEGRATION_SERVICE_USAGE_FLUSH_MS` | `10000`                    | How often to flush batched usage counters                |
+| `INTEGRATION_SERVICE_RETENTION_DAYS` | `9`                        | How long usage buckets are kept                          |
+| `INTEGRATION_SERVICE_METRICS_PORT`   | `9090`                     | Dedicated `/metrics` listener, kept off the ingress      |
+| `INTEGRATION_SERVICE_LOG_LEVEL`      | by `NODE_ENV`              | `debug`, `info`, `warn` or `error`                       |
+| `PORT`                               | `8004`                     |                                                          |
+| `HOST`                               | `0.0.0.0`                  |                                                          |
+| `SHUTDOWN_PRESTOP_DELAY_MS`          | `5000`                     | Wait before draining, for the Kubernetes prestop window  |
 
 The service exits at boot rather than starting degraded: a missing production variable, or a
 numeric variable that does not parse. An empty secret mount does not exit; the pod fails its

--- a/services/integration-service/package.json
+++ b/services/integration-service/package.json
@@ -22,11 +22,14 @@
         "@hono/node-server": "^2.0.2",
         "hono": "^4.12.18",
         "jose": "^6.0.10",
+        "pg": "^8.13.1",
         "pino": "^8.6.0",
         "prom-client": "^14.2.0"
     },
     "devDependencies": {
+        "@testcontainers/postgresql": "^12.1.0",
         "@types/node": "^22.17.2",
+        "@types/pg": "^8.11.10",
         "esbuild": "^0.25.11",
         "oxfmt": "catalog:",
         "oxlint": "^1.72.0",

--- a/services/integration-service/src/db/client.ts
+++ b/services/integration-service/src/db/client.ts
@@ -1,0 +1,85 @@
+// Postgres holds the usage counters and the version-observation log, never a credential.
+// Losing a stale reader's row makes a rotation look quieter than it is, so durability is
+// the point.
+//
+// The DSN goes through PgBouncer in transaction mode: no LISTEN/NOTIFY, no session-scoped
+// settings, no server-side named prepared statements.
+
+import { Pool } from 'pg'
+
+import { logger } from '../lib/logging'
+
+// Idempotent DDL, applied at boot. Three small tables do not justify a migration runner.
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS integration_secret_usage (
+    secret_key  text        NOT NULL,
+    deployment  text        NOT NULL,
+    bucket      timestamptz NOT NULL,
+    reads       bigint      NOT NULL DEFAULT 0,
+    last_seen   timestamptz NOT NULL,
+    PRIMARY KEY (secret_key, deployment, bucket)
+);
+
+CREATE INDEX IF NOT EXISTS integration_secret_usage_bucket_idx
+    ON integration_secret_usage (bucket);
+
+-- Last-seen, separate from the bucketed counts and never pruned: safeToRetirePrevious has
+-- to consider every deployment known to read a key, however rarely it reads, and keeping
+-- this out of the bucketed table is what makes "known to read" mean all time.
+CREATE TABLE IF NOT EXISTS integration_secret_last_seen (
+    secret_key text        NOT NULL,
+    deployment text        NOT NULL,
+    last_seen  timestamptz NOT NULL,
+    PRIMARY KEY (secret_key, deployment)
+);
+
+-- When this content first appeared, agreed across replicas and surviving a restart. A
+-- mounted secret carries no AWS version, so first-observation is what "the value changed
+-- at" means.
+CREATE TABLE IF NOT EXISTS integration_secret_version (
+    content_hash      text        PRIMARY KEY,
+    first_observed_at timestamptz NOT NULL DEFAULT now()
+);
+`
+
+/**
+ * Apply the schema, retrying once. `CREATE TABLE IF NOT EXISTS` from replicas booting
+ * together can still race Postgres's catalog inserts and fail; by the second attempt the
+ * winner's tables exist and the statements no-op.
+ */
+export async function applySchema(pool: Pool): Promise<void> {
+    try {
+        await pool.query(SCHEMA)
+    } catch (err) {
+        logger.warn('db:schema_apply_retry', { error: err instanceof Error ? err.message : String(err) })
+        await pool.query(SCHEMA)
+    }
+}
+
+export async function createPool(dsn: string): Promise<Pool> {
+    const pool = new Pool({
+        connectionString: dsn,
+        max: 8,
+        idleTimeoutMillis: 30_000,
+        connectionTimeoutMillis: 5_000,
+    })
+    pool.on('error', (err: Error) => logger.error('db:pool_error', { error: err.message }))
+    await applySchema(pool)
+    return pool
+}
+
+/**
+ * Record that this content hash exists and return when it was first seen anywhere. The
+ * insert and the read are separate statements because ON CONFLICT DO NOTHING with
+ * RETURNING answers null for a hash we already know.
+ */
+export async function observeVersion(pool: Pool, contentHash: string): Promise<string | null> {
+    await pool.query(`INSERT INTO integration_secret_version (content_hash) VALUES ($1) ON CONFLICT DO NOTHING`, [
+        contentHash,
+    ])
+    const { rows } = await pool.query<{ first_observed_at: Date }>(
+        `SELECT first_observed_at FROM integration_secret_version WHERE content_hash = $1`,
+        [contentHash]
+    )
+    return rows[0] ? rows[0].first_observed_at.toISOString() : null
+}

--- a/services/integration-service/src/http/app.ts
+++ b/services/integration-service/src/http/app.ts
@@ -10,11 +10,13 @@ import { logger } from '../lib/logging'
 import { authFailuresTotal, httpRequestDurationSeconds, httpRequestsTotal } from '../metrics'
 import { resolveKeys } from '../resolve'
 import type { Lifecycle, MountedSecrets } from '../types'
+import type { UsageRecorder } from '../usage/recorder'
 
 export interface AppOptions {
     verifier: JwtVerifier
     lifecycle: Lifecycle
     secrets: () => MountedSecrets | null
+    recorder: UsageRecorder
 }
 
 export function createApp(opts: AppOptions): Hono {
@@ -70,7 +72,7 @@ export function createApp(opts: AppOptions): Hono {
             return c.json({ error: 'Secret store unavailable' }, 503)
         }
 
-        return c.json(resolveKeys(identity, mounted))
+        return c.json(resolveKeys(identity, mounted, opts.recorder))
     })
 
     return app

--- a/services/integration-service/src/lib/config.ts
+++ b/services/integration-service/src/lib/config.ts
@@ -7,14 +7,18 @@ export interface Config {
     /** Wait before draining, so Kubernetes has removed the pod from its endpoints first. */
     shutdownPrestopDelayMs: number
 
-    /** Logical environment (dev | prod-us | prod-eu). */
+    /** Logical environment (dev | prod-us | prod-eu). Recorded on the usage rollup. */
     env: string
 
     /** Directory the Kubernetes Secret is mounted at. */
     mountDir: string
+    /** From the chart's `psql:` harness. Unset disables usage recording (local dev). */
+    databaseUrl: string | undefined
 
     /** How often to re-read the mount. Kubelet updates it in roughly 60-90s. */
     reloadSeconds: number
+    usageFlushMs: number
+    retentionDays: number
 
     /** Serves /metrics on its own listener, kept off the ingress like every other service. */
     metricsPort: number
@@ -42,16 +46,30 @@ export function loadConfig(): Config {
         env: process.env.INTEGRATION_SERVICE_ENV ?? 'dev',
 
         mountDir: process.env.INTEGRATION_SERVICE_SECRETS_DIR ?? '/etc/integration-secrets',
+        databaseUrl: process.env.INTEGRATION_SERVICE_DATABASE_URL,
 
         // Shorter than kubelet's own sync so a rotation is visible within about a minute
         // of the mount changing.
         reloadSeconds: intFromEnv('INTEGRATION_SERVICE_RELOAD_SECONDS', 30, 1),
+        usageFlushMs: intFromEnv('INTEGRATION_SERVICE_USAGE_FLUSH_MS', 10000, 1),
+        retentionDays: intFromEnv('INTEGRATION_SERVICE_RETENTION_DAYS', 9, 1),
 
         metricsPort: intFromEnv('INTEGRATION_SERVICE_METRICS_PORT', 9090),
     }
 
-    if (process.env.NODE_ENV === 'production' && !process.env.INTEGRATION_SERVICE_ENV) {
-        throw new Error('missing required configuration: INTEGRATION_SERVICE_ENV')
+    if (process.env.NODE_ENV === 'production') {
+        const missing: string[] = []
+        if (!process.env.INTEGRATION_SERVICE_ENV) {
+            missing.push('INTEGRATION_SERVICE_ENV')
+        }
+        // Without it the usage rollup silently stops, and the rollup is what decides when
+        // an old credential is safe to retire.
+        if (!config.databaseUrl) {
+            missing.push('INTEGRATION_SERVICE_DATABASE_URL')
+        }
+        if (missing.length > 0) {
+            throw new Error(`missing required configuration: ${missing.join(', ')}`)
+        }
     }
 
     return config

--- a/services/integration-service/src/metrics.ts
+++ b/services/integration-service/src/metrics.ts
@@ -34,6 +34,12 @@ export const previousVersionServedTotal = new Counter({
     registers: [register],
 })
 
+export const secretAgeSeconds = new Gauge({
+    name: 'integration_secret_age_seconds',
+    help: 'Time since the mounted secret last changed, for "not rotated in N days" alerting',
+    registers: [register],
+})
+
 // An unreadable mount keeps the secrets already held rather than failing every read, so
 // this gauge is the only sign of that degradation. Alert on it.
 export const servingStaleSeconds = new Gauge({

--- a/services/integration-service/src/mount.ts
+++ b/services/integration-service/src/mount.ts
@@ -9,7 +9,7 @@ import { readFile, readdir, readlink } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import { logger } from './lib/logging'
-import { mountErrorsTotal, servingStaleSeconds } from './metrics'
+import { mountErrorsTotal, secretAgeSeconds, servingStaleSeconds } from './metrics'
 import type { Secret, MountedSecrets } from './types'
 
 /**
@@ -75,6 +75,11 @@ export async function readMount(dir: string): Promise<Record<string, string> | n
 export interface SecretMountOptions {
     /** Directory the Kubernetes Secret is mounted at. */
     dir: string
+    /**
+     * Records when a content hash was first seen and returns that timestamp. Persisted, so
+     * every replica agrees and the answer survives a restart.
+     */
+    observeVersion: (contentHash: string) => Promise<string | null>
     now?: () => number
 }
 
@@ -100,10 +105,13 @@ export class SecretMount {
     async reload(): Promise<void> {
         const now = this.opts.now ?? Date.now
         const values = await readMount(this.opts.dir)
-        const next = values ? this.build(values) : null
+        const next = values ? await this.build(values) : null
         if (next) {
             this.held = next
             servingStaleSeconds.set(0)
+            if (next.changedAt) {
+                secretAgeSeconds.set((now() - Date.parse(next.changedAt)) / 1000)
+            }
         } else {
             mountErrorsTotal.inc()
             if (this.held) {
@@ -112,7 +120,7 @@ export class SecretMount {
         }
     }
 
-    private build(values: Record<string, string>): MountedSecrets | null {
+    private async build(values: Record<string, string>): Promise<MountedSecrets | null> {
         // Sorted so the same content always hashes to the same version id.
         const contentHash = createHash('sha256')
             .update(
@@ -155,6 +163,11 @@ export class SecretMount {
             return null
         }
 
-        return { fetchedAt, versionId: contentHash, secrets }
+        return {
+            fetchedAt,
+            versionId: contentHash,
+            changedAt: await this.opts.observeVersion(contentHash),
+            secrets,
+        }
     }
 }

--- a/services/integration-service/src/resolve.ts
+++ b/services/integration-service/src/resolve.ts
@@ -10,6 +10,7 @@
 import { logger } from './lib/logging'
 import { observeResolve, previousVersionServedTotal } from './metrics'
 import type { CallerIdentity, MountedSecrets, ResolveOutcome } from './types'
+import type { UsageRecorder } from './usage/recorder'
 
 /** Stand-in label for a name the mount does not carry, which is caller-supplied text. */
 const UNKNOWN_KEY = 'unknown'
@@ -28,7 +29,11 @@ export interface ResolveResponse {
     missing: string[]
 }
 
-export function resolveKeys(identity: CallerIdentity, mounted: MountedSecrets): ResolveResponse {
+export function resolveKeys(
+    identity: CallerIdentity,
+    mounted: MountedSecrets,
+    recorder: UsageRecorder
+): ResolveResponse {
     const secrets: Record<string, WireSecret> = {}
     const missing: string[] = []
     const served: string[] = []
@@ -64,6 +69,8 @@ export function resolveKeys(identity: CallerIdentity, mounted: MountedSecrets): 
     // One audit line per request rather than per key, so Loki keeps the whole request
     // together. The key list is bounded by the token scope, so it stays readable.
     logger.info('secrets:resolved', { deployment: identity.deployment, caller: identity.caller, served, missing })
+
+    recorder.record(identity.deployment, served)
 
     return { secrets, missing }
 }

--- a/services/integration-service/src/server.ts
+++ b/services/integration-service/src/server.ts
@@ -1,25 +1,31 @@
 // Wires the service together and owns its lifecycle.
 //
-// Shutdown order is fixed: mark draining, wait out the prestop delay so Kubernetes has
-// stopped routing here, drain the HTTP server, exit. unhandledRejection and
-// uncaughtException take the same path rather than dropping in-flight requests.
+// Shutdown order is fixed: mark draining, wait out the prestop delay, drain the HTTP server,
+// flush the usage recorder, end the pool. The flush sits after the drain so in-flight
+// requests still record, and before the pool closes so it has somewhere to write. A crash
+// takes the same path, so it still flushes the reads that prove a caller has moved on.
 
 import { serve } from '@hono/node-server'
 import type { Hono } from 'hono'
 import { createServer, type Server } from 'node:http'
 import type { AddressInfo } from 'node:net'
+import type { Pool } from 'pg'
 
 import { JwtVerifier } from './auth/jwt'
 import { SigningKeyLoader } from './auth/registry'
+import { createPool, observeVersion } from './db/client'
 import { createApp } from './http/app'
 import type { Config } from './lib/config'
 import { logger } from './lib/logging'
 import { register, shuttingDown } from './metrics'
 import { SecretMount } from './mount'
 import type { Lifecycle } from './types'
+import { UsageRecorder } from './usage/recorder'
 
 /** How long a drain may take once the prestop window has passed. */
 const DRAIN_TIMEOUT_MS = 10_000
+
+const PRUNE_INTERVAL_MS = 24 * 60 * 60 * 1000
 
 interface DrainableServer {
     close(cb: () => void): void
@@ -32,6 +38,7 @@ type ServeFn = (
 
 /** Test seams. Production construction passes none of these. */
 export interface IntegrationServerOverrides {
+    pool?: Pool
     serve?: ServeFn
     exit?: (code: number) => void
 }
@@ -53,8 +60,10 @@ export function every(intervalMs: number, task: () => Promise<void>): () => void
 
 export class IntegrationServer {
     private readonly lifecycle: Lifecycle = { shuttingDown: false, ready: false }
+    private pool: Pool | undefined
     private server: DrainableServer | undefined
     private metricsServer: Server | undefined
+    private recorder: UsageRecorder | undefined
     private mount: SecretMount | undefined
     private signingKeys: SigningKeyLoader | undefined
     private cancelTimers: (() => void)[] = []
@@ -89,17 +98,36 @@ export class IntegrationServer {
     async start(): Promise<void> {
         const config = this.config
 
+        if (this.overrides.pool) {
+            this.pool = this.overrides.pool
+        } else if (config.databaseUrl) {
+            this.pool = await createPool(config.databaseUrl)
+            logger.info('db:connected', {})
+        } else {
+            // Guarded in loadConfig for production. Locally the service runs without usage
+            // recording, which costs the rollup and nothing else.
+            logger.warn('db:disabled', { reason: 'INTEGRATION_SERVICE_DATABASE_URL is unset, so no usage recording' })
+        }
+        const pool = this.pool
+
         const signingKeys = new SigningKeyLoader(config.mountDir)
         this.signingKeys = signingKeys
         await signingKeys.load()
 
-        const mount = new SecretMount({ dir: config.mountDir })
+        const recorder = new UsageRecorder({ pool })
+        this.recorder = recorder
+        const mount = new SecretMount({
+            dir: config.mountDir,
+            // Without Postgres there is no shared record of when content first appeared.
+            observeVersion: (hash) => (pool ? observeVersion(pool, hash) : Promise.resolve(null)),
+        })
         this.mount = mount
 
         const app = createApp({
             verifier: new JwtVerifier(signingKeys),
             lifecycle: this.lifecycle,
             secrets: () => mount.current(),
+            recorder,
         })
 
         await mount.reload()
@@ -135,7 +163,11 @@ export class IntegrationServer {
         })
         this.metricsServer.listen(config.metricsPort, config.host)
 
-        this.cancelTimers.push(every(config.reloadSeconds * 1000, () => this.reload()))
+        this.cancelTimers.push(
+            every(config.reloadSeconds * 1000, () => this.reload()),
+            every(config.usageFlushMs, () => recorder.flush()),
+            every(PRUNE_INTERVAL_MS, () => recorder.prune(config.retentionDays))
+        )
 
         this.setupProcessListeners()
     }
@@ -164,6 +196,14 @@ export class IntegrationServer {
         }
         this.metricsServer?.close()
 
+        // Write what accumulated since the last flush, so a rolling restart does not lose
+        // the reads that prove a caller has moved onto a new value.
+        await this.recorder?.flush()
+        if (this.pool) {
+            await this.pool.end().catch((err: unknown) => {
+                logger.error('shutdown:db_close_failed', { error: err instanceof Error ? err.message : String(err) })
+            })
+        }
         logger.info('shutdown:complete', {})
         const exit = this.overrides.exit ?? process.exit
         exit(error ? 1 : 0)

--- a/services/integration-service/src/types.ts
+++ b/services/integration-service/src/types.ts
@@ -26,6 +26,11 @@ export interface MountedSecrets {
     fetchedAt: string
     /** Hash of the whole mounted key set, so unchanged content keeps one id. */
     versionId: string
+    /**
+     * When this content was first seen, from the version table so every replica agrees and a
+     * restart does not reset it. Reads since this moment necessarily returned the new value.
+     */
+    changedAt: string | null
     secrets: Record<string, Secret>
 }
 

--- a/services/integration-service/src/usage/recorder.ts
+++ b/services/integration-service/src/usage/recorder.ts
@@ -110,6 +110,13 @@ export class UsageRecorder {
     /**
      * Drop buckets past the retention window. Never touches integration_secret_last_seen: a
      * dormant deployment holds the retirement verdict back however long it has been quiet.
+     *
+     * A deployment whose signing key is later revoked keeps its last_seen row too — this
+     * table records what was read, not who is still allowed to read it. Judging a row against
+     * "is this deployment still active" is the retirement verdict's job (the follow-up UI PR),
+     * which can filter by currently active deployments; guessing at revocation here by pruning
+     * would reintroduce the exact failure mode last_seen exists to prevent, a rotation looking
+     * safe to complete because a caller went quiet.
      */
     async prune(retentionDays: number): Promise<void> {
         if (!this.pool) {

--- a/services/integration-service/src/usage/recorder.ts
+++ b/services/integration-service/src/usage/recorder.ts
@@ -1,0 +1,127 @@
+// Per-key, per-deployment usage counters in Postgres: who actually reads this credential,
+// and have they picked up the new value. Writes are batched and flushed on a timer, so an
+// upsert never lands on the hot path and a crash loses at most one interval of counts.
+//
+// No credential value reaches this module — key names, deployment names, counts, timestamps.
+
+import type { Pool } from 'pg'
+
+import { logger } from '../lib/logging'
+
+interface Pending {
+    key: string
+    deployment: string
+    reads: number
+    lastSeen: number
+}
+
+// Composite lookup key. Never parsed back apart: the fields travel on the Pending entry.
+function pendingId(key: string, deployment: string): string {
+    return `${key}|${deployment}`
+}
+
+/** Truncate to the hour, so a rolling window is a sum over a small number of rows. */
+function hourBucket(at: number): Date {
+    const d = new Date(at)
+    d.setUTCMinutes(0, 0, 0)
+    return d
+}
+
+export interface UsageRecorderOptions {
+    pool?: Pool | undefined
+    now?: () => number
+}
+
+export class UsageRecorder {
+    private readonly pool: Pool | undefined
+    private readonly now: () => number
+    private pending = new Map<string, Pending>()
+
+    constructor(opts: UsageRecorderOptions) {
+        this.pool = opts.pool
+        this.now = opts.now ?? Date.now
+    }
+
+    /** Accumulate a batch of reads. Never touches the database on the request path. */
+    record(deployment: string, servedKeys: readonly string[]): void {
+        if (servedKeys.length === 0) {
+            return
+        }
+        const at = this.now()
+        for (const key of servedKeys) {
+            const entry = this.pending.get(pendingId(key, deployment))
+            if (entry) {
+                entry.reads += 1
+                entry.lastSeen = Math.max(entry.lastSeen, at)
+            } else {
+                this.pending.set(pendingId(key, deployment), { key, deployment, reads: 1, lastSeen: at })
+            }
+        }
+    }
+
+    /** Write what has accumulated. Safe to call when nothing is pending. */
+    async flush(): Promise<void> {
+        if (!this.pool || this.pending.size === 0) {
+            return
+        }
+        // Swap first: a failed write must not block the next request from accumulating,
+        // and re-queueing on failure would let a broken database grow this map without
+        // bound. Losing a flush costs counts, not correctness of `last_seen` ordering.
+        const batch = this.pending
+        this.pending = new Map()
+
+        const keys: string[] = []
+        const deployments: string[] = []
+        const buckets: Date[] = []
+        const reads: number[] = []
+        const lastSeen: Date[] = []
+        for (const entry of batch.values()) {
+            keys.push(entry.key)
+            deployments.push(entry.deployment)
+            buckets.push(hourBucket(entry.lastSeen))
+            reads.push(entry.reads)
+            lastSeen.push(new Date(entry.lastSeen))
+        }
+
+        try {
+            await this.pool.query(
+                `INSERT INTO integration_secret_usage (secret_key, deployment, bucket, reads, last_seen)
+                 SELECT * FROM unnest($1::text[], $2::text[], $3::timestamptz[], $4::bigint[], $5::timestamptz[])
+                 ON CONFLICT (secret_key, deployment, bucket) DO UPDATE
+                 SET reads = integration_secret_usage.reads + EXCLUDED.reads,
+                     last_seen = GREATEST(integration_secret_usage.last_seen, EXCLUDED.last_seen)`,
+                [keys, deployments, buckets, reads, lastSeen]
+            )
+            await this.pool.query(
+                `INSERT INTO integration_secret_last_seen (secret_key, deployment, last_seen)
+                 SELECT * FROM unnest($1::text[], $2::text[], $3::timestamptz[])
+                 ON CONFLICT (secret_key, deployment) DO UPDATE
+                 SET last_seen = GREATEST(integration_secret_last_seen.last_seen, EXCLUDED.last_seen)`,
+                [keys, deployments, lastSeen]
+            )
+        } catch (err) {
+            logger.warn('usage:flush_failed', {
+                entries: batch.size,
+                error: err instanceof Error ? err.message : String(err),
+            })
+        }
+    }
+
+    /**
+     * Drop buckets past the retention window. Never touches integration_secret_last_seen: a
+     * dormant deployment holds the retirement verdict back however long it has been quiet.
+     */
+    async prune(retentionDays: number): Promise<void> {
+        if (!this.pool) {
+            return
+        }
+        try {
+            await this.pool.query(
+                `DELETE FROM integration_secret_usage WHERE bucket < now() - make_interval(days => $1)`,
+                [retentionDays]
+            )
+        } catch (err) {
+            logger.warn('usage:prune_failed', { error: err instanceof Error ? err.message : String(err) })
+        }
+    }
+}

--- a/services/integration-service/tests/integration/db.integration.test.ts
+++ b/services/integration-service/tests/integration/db.integration.test.ts
@@ -1,0 +1,153 @@
+// Runs the real SQL against a real Postgres (testcontainers). The unit suite exercises the
+// recorder against a fake pool, so nothing there would catch a broken upsert conflict
+// clause, a window applied to the wrong query, or DDL that no longer applies.
+
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql'
+import { Pool } from 'pg'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+
+import { applySchema } from '@/db/client'
+import { UsageRecorder } from '@/usage/recorder'
+
+const KEY = 'HUBSPOT_APP_CLIENT_SECRET'
+const WORKER = 'temporal-worker-data-warehouse'
+const DJANGO = 'posthog-django'
+
+let container: StartedPostgreSqlContainer
+let pool: Pool
+
+beforeAll(async () => {
+    container = await new PostgreSqlContainer('postgres:16-alpine').start()
+    pool = new Pool({ connectionString: container.getConnectionUri(), max: 10 })
+    await applySchema(pool)
+}, 120_000)
+
+afterAll(async () => {
+    await pool?.end()
+    await container?.stop()
+})
+
+beforeEach(async () => {
+    await pool.query('TRUNCATE integration_secret_usage, integration_secret_last_seen, integration_secret_version')
+})
+
+describe('usage tables on a real Postgres', () => {
+    it('applies the boot DDL, and concurrent replicas applying it together do not fail', async () => {
+        await pool.query('CREATE DATABASE ddl_race')
+        const uri = container.getConnectionUri().replace(/\/[^/?]+(\?|$)/, '/ddl_race$1')
+        const pools = Array.from({ length: 4 }, () => new Pool({ connectionString: uri, max: 1 }))
+        try {
+            await Promise.all(pools.map((p) => applySchema(p)))
+            const { rows } = await pools[0]!.query<{ table_name: string }>(
+                `SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' ORDER BY table_name`
+            )
+            expect(rows.map((r) => r.table_name)).toEqual([
+                'integration_secret_last_seen',
+                'integration_secret_usage',
+                'integration_secret_version',
+            ])
+        } finally {
+            await Promise.all(pools.map((p) => p.end()))
+        }
+    }, 60_000)
+
+    it('round-trips reads: repeated reads collapse into counted rows and last-seen upserts forward', async () => {
+        const t0 = Date.parse('2026-08-01T10:15:00.000Z')
+        let now = t0
+        const recorder = new UsageRecorder({ pool, now: () => now })
+
+        recorder.record(WORKER, [KEY])
+        recorder.record(WORKER, [KEY])
+        recorder.record(DJANGO, [KEY])
+        await recorder.flush()
+
+        // A second flush in the same hour bucket must accumulate, not duplicate or reset.
+        now = t0 + 5 * 60 * 1000
+        recorder.record(WORKER, [KEY])
+        await recorder.flush()
+
+        const counts = await pool.query<{ deployment: string; reads: number }>(
+            `SELECT deployment, reads::int AS reads FROM integration_secret_usage
+             WHERE secret_key = $1 ORDER BY deployment`,
+            [KEY]
+        )
+        expect(counts.rows).toEqual([
+            { deployment: DJANGO, reads: 1 },
+            { deployment: WORKER, reads: 3 },
+        ])
+
+        const seen = await pool.query<{ deployment: string; last_seen: Date }>(
+            `SELECT deployment, last_seen FROM integration_secret_last_seen
+             WHERE secret_key = $1 ORDER BY deployment`,
+            [KEY]
+        )
+        expect(seen.rows.map((r) => ({ deployment: r.deployment, at: r.last_seen.getTime() }))).toEqual([
+            { deployment: DJANGO, at: t0 },
+            { deployment: WORKER, at: t0 + 5 * 60 * 1000 },
+        ])
+    })
+
+    // Two replicas flush the same (key, deployment, bucket) row at the same moment. If the
+    // upsert ever stops summing, a rotation looks quieter than it is.
+    it('sums concurrent flushes of the same key and deployment', async () => {
+        const at = Date.parse('2026-08-01T10:15:00.000Z')
+        const recorders = Array.from({ length: 4 }, () => new UsageRecorder({ pool, now: () => at }))
+        for (const recorder of recorders) {
+            recorder.record(WORKER, [KEY])
+            recorder.record(WORKER, [KEY])
+        }
+
+        await Promise.all(recorders.map((recorder) => recorder.flush()))
+
+        const { rows } = await pool.query<{ reads: number }>(
+            `SELECT reads::int AS reads FROM integration_secret_usage WHERE secret_key = $1`,
+            [KEY]
+        )
+        expect(rows).toEqual([{ reads: 8 }])
+    })
+
+    // Durability is the reason these counters live in Postgres rather than a cache: a lost
+    // last-seen row would make a rotation look quieter than it is. A new pool stands in for
+    // the pod that wrote them having gone away.
+    it('keeps last-seen readable after the writing pool is gone', async () => {
+        const at = Date.parse('2026-08-01T10:15:00.000Z')
+        const writer = new Pool({ connectionString: container.getConnectionUri(), max: 1 })
+        try {
+            const recorder = new UsageRecorder({ pool: writer, now: () => at })
+            recorder.record(DJANGO, [KEY])
+            await recorder.flush()
+        } finally {
+            await writer.end()
+        }
+
+        const { rows } = await pool.query<{ last_seen: Date }>(
+            `SELECT last_seen FROM integration_secret_last_seen WHERE secret_key = $1 AND deployment = $2`,
+            [KEY, DJANGO]
+        )
+        expect(rows.map((r) => r.last_seen.getTime())).toEqual([at])
+    })
+
+    it('prune deletes count rows past retention and never touches last-seen', async () => {
+        await pool.query(
+            `INSERT INTO integration_secret_usage (secret_key, deployment, bucket, reads, last_seen) VALUES
+             ($1, $2, now() - interval '10 days', 5, now() - interval '10 days'),
+             ($1, $2, now() - interval '1 hour', 3, now() - interval '1 hour')`,
+            [KEY, WORKER]
+        )
+        await pool.query(
+            `INSERT INTO integration_secret_last_seen (secret_key, deployment, last_seen)
+             VALUES ($1, $2, now() - interval '10 days')`,
+            [KEY, WORKER]
+        )
+
+        await new UsageRecorder({ pool }).prune(9)
+
+        const counts = await pool.query<{ reads: number }>(
+            `SELECT reads::int AS reads FROM integration_secret_usage WHERE secret_key = $1`,
+            [KEY]
+        )
+        expect(counts.rows).toEqual([{ reads: 3 }])
+        const seen = await pool.query(`SELECT 1 FROM integration_secret_last_seen WHERE secret_key = $1`, [KEY])
+        expect(seen.rowCount).toBe(1)
+    })
+})

--- a/services/integration-service/tests/integration/server.e2e.test.ts
+++ b/services/integration-service/tests/integration/server.e2e.test.ts
@@ -26,7 +26,10 @@ function config(mountDir: string): Config {
         shutdownPrestopDelayMs: 0,
         env: 'test',
         mountDir,
+        databaseUrl: undefined,
         reloadSeconds: 3600,
+        usageFlushMs: 3_600_000,
+        retentionDays: 9,
         metricsPort: 0,
     }
 }

--- a/services/integration-service/tests/unit/app.test.ts
+++ b/services/integration-service/tests/unit/app.test.ts
@@ -1,5 +1,5 @@
 import { SignJWT } from 'jose'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { JwtVerifier } from '@/auth/jwt'
 import type { SigningKeyLoader } from '@/auth/registry'
@@ -7,6 +7,7 @@ import { AUDIENCE, type SigningKeys } from '@/auth/types'
 import { createApp } from '@/http/app'
 import { httpRequestsTotal, register } from '@/metrics'
 import type { Lifecycle, MountedSecrets } from '@/types'
+import type { UsageRecorder } from '@/usage/recorder'
 
 const RESOLVE_PATH = '/v1/secrets/resolve'
 
@@ -18,6 +19,7 @@ const KEY = 'HUBSPOT_APP_CLIENT_SECRET'
 const MOUNTED: MountedSecrets = {
     fetchedAt: '2026-08-06T00:00:00.000Z',
     versionId: 'v1',
+    changedAt: '2026-08-01T00:00:00.000Z',
     secrets: { [KEY]: { state: 'steady', value: 'hunter2-zx9q', versionId: 'v1', fetchedAt: 'now' } },
 }
 
@@ -43,6 +45,7 @@ function build(
         verifier: new JwtVerifier({ entries: () => Object.entries(KEYS) } as SigningKeyLoader),
         lifecycle,
         secrets: overrides.secrets ?? ((): MountedSecrets | null => MOUNTED),
+        recorder: { record: vi.fn() } as unknown as UsageRecorder,
     })
     return { app, lifecycle }
 }

--- a/services/integration-service/tests/unit/config.test.ts
+++ b/services/integration-service/tests/unit/config.test.ts
@@ -28,7 +28,7 @@ describe('loadConfig integers', () => {
 })
 
 describe('loadConfig production guards', () => {
-    const PROD_VARS = ['NODE_ENV', 'INTEGRATION_SERVICE_ENV']
+    const PROD_VARS = ['NODE_ENV', 'INTEGRATION_SERVICE_ENV', 'INTEGRATION_SERVICE_DATABASE_URL']
 
     afterEach(() => {
         for (const key of PROD_VARS) {
@@ -36,14 +36,24 @@ describe('loadConfig production guards', () => {
         }
     })
 
-    it('refuses to boot in production without INTEGRATION_SERVICE_ENV', () => {
-        process.env.NODE_ENV = 'production'
-        expect(() => loadConfig()).toThrow('INTEGRATION_SERVICE_ENV')
-    })
-
-    it('boots in production once every required variable is set', () => {
+    function setProduction(): void {
         process.env.NODE_ENV = 'production'
         process.env.INTEGRATION_SERVICE_ENV = 'prod-us'
+        process.env.INTEGRATION_SERVICE_DATABASE_URL = 'postgres://usage:usage@localhost:5432/usage'
+    }
+
+    it.each([['INTEGRATION_SERVICE_ENV'], ['INTEGRATION_SERVICE_DATABASE_URL']])(
+        'refuses to boot in production without %s',
+        (missing) => {
+            setProduction()
+            delete process.env[missing]
+
+            expect(() => loadConfig()).toThrow(missing)
+        }
+    )
+
+    it('boots in production once every required variable is set', () => {
+        setProduction()
         expect(loadConfig().env).toBe('prod-us')
     })
 })

--- a/services/integration-service/tests/unit/db.test.ts
+++ b/services/integration-service/tests/unit/db.test.ts
@@ -1,0 +1,25 @@
+import type { Pool } from 'pg'
+import { describe, expect, it, vi } from 'vitest'
+
+import { applySchema } from '@/db/client'
+
+describe('applySchema', () => {
+    it('retries once when concurrent boots race the catalog', async () => {
+        const query = vi
+            .fn()
+            .mockRejectedValueOnce(
+                new Error('duplicate key value violates unique constraint "pg_type_typname_nsp_index"')
+            )
+            .mockResolvedValue({ rows: [] })
+
+        await expect(applySchema({ query } as unknown as Pool)).resolves.toBeUndefined()
+        expect(query).toHaveBeenCalledTimes(2)
+    })
+
+    it('surfaces the error when the retry also fails', async () => {
+        const query = vi.fn().mockRejectedValue(new Error('permission denied'))
+
+        await expect(applySchema({ query } as unknown as Pool)).rejects.toThrow('permission denied')
+        expect(query).toHaveBeenCalledTimes(2)
+    })
+})

--- a/services/integration-service/tests/unit/mount.test.ts
+++ b/services/integration-service/tests/unit/mount.test.ts
@@ -25,7 +25,7 @@ async function mount(values: Record<string, string>): Promise<string> {
 }
 
 function secretMount(dir: string, opts: { now?: () => number } = {}): SecretMount {
-    return new SecretMount({ dir, ...(opts.now && { now: opts.now }) })
+    return new SecretMount({ dir, observeVersion: () => Promise.resolve(null), ...(opts.now && { now: opts.now }) })
 }
 
 async function load(values: Record<string, string>): Promise<MountedSecrets | null> {

--- a/services/integration-service/tests/unit/recorder.test.ts
+++ b/services/integration-service/tests/unit/recorder.test.ts
@@ -1,0 +1,106 @@
+import type { Pool } from 'pg'
+import { describe, expect, it, vi } from 'vitest'
+
+import { UsageRecorder } from '@/usage/recorder'
+
+interface Call {
+    sql: string
+    params: unknown[]
+}
+
+/** A Pool stand-in that records the SQL it is given and answers from canned rows. */
+function fakePool(rows: (sql: string) => unknown[] = () => []): { pool: Pool; calls: Call[] } {
+    const calls: Call[] = []
+    const pool = {
+        query: (sql: string, params: unknown[] = []) => {
+            calls.push({ sql, params })
+            return Promise.resolve({ rows: rows(sql) })
+        },
+    }
+    return { pool: pool as unknown as Pool, calls }
+}
+
+const KEY = 'HUBSPOT_APP_CLIENT_SECRET'
+const WORKER = 'temporal-worker-data-warehouse'
+
+describe('usage recorder', () => {
+    it('writes nothing until it is flushed', async () => {
+        const { pool, calls } = fakePool()
+        const recorder = new UsageRecorder({ pool })
+
+        recorder.record(WORKER, [KEY])
+        expect(calls).toHaveLength(0)
+
+        await recorder.flush()
+        expect(calls.length).toBeGreaterThan(0)
+    })
+
+    it('collapses repeated reads of one key into a single counted row', async () => {
+        const { pool, calls } = fakePool()
+        const recorder = new UsageRecorder({ pool, now: () => 1_700_000_000_000 })
+
+        for (let i = 0; i < 5; i++) {
+            recorder.record(WORKER, [KEY])
+        }
+        await recorder.flush()
+
+        const counts = calls.find((c) => c.sql.includes('integration_secret_usage'))
+        expect(counts?.params[0]).toEqual([KEY])
+        expect(counts?.params[3]).toEqual([5])
+    })
+
+    // Guards the typed pending entries: key and deployment reach the write as the exact
+    // strings recorded, not whatever a string parse of a composite id yields.
+    it('flushes the exact key and deployment even when a name contains the separator', async () => {
+        const { pool, calls } = fakePool()
+        const recorder = new UsageRecorder({ pool })
+
+        recorder.record('oddly|named-deployment', [KEY])
+        await recorder.flush()
+
+        const counts = calls.find((c) => c.sql.includes('integration_secret_usage'))
+        expect(counts?.params[0]).toEqual([KEY])
+        expect(counts?.params[1]).toEqual(['oddly|named-deployment'])
+    })
+
+    it('records last-seen separately from the bucketed counts', async () => {
+        const { pool, calls } = fakePool()
+        const recorder = new UsageRecorder({ pool })
+
+        recorder.record(WORKER, [KEY])
+        await recorder.flush()
+
+        expect(calls.some((c) => c.sql.includes('integration_secret_last_seen'))).toBe(true)
+    })
+
+    it('does not re-queue a failed batch, so a broken database cannot grow the buffer', async () => {
+        const pool = { query: vi.fn().mockRejectedValue(new Error('down')) } as unknown as Pool
+        const recorder = new UsageRecorder({ pool })
+
+        recorder.record(WORKER, [KEY])
+        await recorder.flush()
+        await recorder.flush()
+
+        // Two calls for the first flush's two statements, none for the second.
+        expect((pool.query as ReturnType<typeof vi.fn>).mock.calls.length).toBeLessThanOrEqual(2)
+    })
+
+    // A dormant deployment has to keep holding the retirement decision back however long it
+    // has been quiet, so retention must not reach its last-seen row.
+    it('prunes only the bucketed counts, never last-seen', async () => {
+        const { pool, calls } = fakePool()
+        await new UsageRecorder({ pool }).prune(9)
+
+        expect(calls).toHaveLength(1)
+        expect(calls[0]?.sql).toContain('DELETE FROM integration_secret_usage')
+        expect(calls[0]?.sql).not.toContain('integration_secret_last_seen')
+    })
+
+    it('does nothing at all without a database', async () => {
+        const recorder = new UsageRecorder({})
+        recorder.record(WORKER, [KEY])
+
+        await expect(recorder.flush()).resolves.toBeUndefined()
+        await expect(recorder.prune(9)).resolves.toBeUndefined()
+    })
+})

--- a/services/integration-service/tests/unit/resolve.test.ts
+++ b/services/integration-service/tests/unit/resolve.test.ts
@@ -1,11 +1,17 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { register, resolveTotal } from '@/metrics'
 import { resolveKeys } from '@/resolve'
 import type { CallerIdentity, MountedSecrets } from '@/types'
+import type { UsageRecorder } from '@/usage/recorder'
 
 function mounted(secrets: MountedSecrets['secrets']): MountedSecrets {
-    return { fetchedAt: '2026-08-06T00:00:00.000Z', versionId: 'v1', secrets }
+    return {
+        fetchedAt: '2026-08-06T00:00:00.000Z',
+        versionId: 'v1',
+        changedAt: '2026-01-01T00:00:00.000Z',
+        secrets,
+    }
 }
 
 const MOUNTED = mounted({
@@ -20,6 +26,10 @@ const MOUNTED = mounted({
     STRIPE_APP_SECRET_KEY: { state: 'steady', value: 'sk-live', versionId: 'v1', fetchedAt: 'now' },
 })
 
+function recorder(record = vi.fn()): UsageRecorder {
+    return { record } as unknown as UsageRecorder
+}
+
 function identity(requestedKeys: string[]): CallerIdentity {
     return { deployment: 'temporal-worker-data-warehouse', caller: 'warehouse-sources', requestedKeys }
 }
@@ -29,14 +39,22 @@ describe('resolve', () => {
     // on the mount. Containment is revoking that deployment's signing key, not a list
     // somebody has to keep current.
     it('serves anything on the mount to an authenticated deployment', async () => {
-        const response = resolveKeys(identity(['GOOGLE_ADS_APP_CLIENT_ID', 'STRIPE_APP_SECRET_KEY']), MOUNTED)
+        const response = resolveKeys(
+            identity(['GOOGLE_ADS_APP_CLIENT_ID', 'STRIPE_APP_SECRET_KEY']),
+            MOUNTED,
+            recorder()
+        )
 
         expect(Object.keys(response.secrets).sort()).toEqual(['GOOGLE_ADS_APP_CLIENT_ID', 'STRIPE_APP_SECRET_KEY'])
         expect(response.missing).toEqual([])
     })
 
     it('serves the requested fields with their rotation state', async () => {
-        const response = resolveKeys(identity(['GOOGLE_ADS_APP_CLIENT_ID', 'GOOGLE_ADS_APP_CLIENT_SECRET']), MOUNTED)
+        const response = resolveKeys(
+            identity(['GOOGLE_ADS_APP_CLIENT_ID', 'GOOGLE_ADS_APP_CLIENT_SECRET']),
+            MOUNTED,
+            recorder()
+        )
 
         expect(response.secrets['GOOGLE_ADS_APP_CLIENT_ID']).toMatchObject({ state: 'steady', value: 'ga-id' })
         expect(response.secrets['GOOGLE_ADS_APP_CLIENT_SECRET']).toMatchObject({
@@ -50,7 +68,7 @@ describe('resolve', () => {
     // nothing else. The route-level half — a request body cannot widen it — is pinned in
     // app.test.ts, since this function never sees an HTTP request.
     it('serves nothing outside the token scope even though the caller may read it', async () => {
-        const response = resolveKeys(identity(['GOOGLE_ADS_APP_CLIENT_ID']), MOUNTED)
+        const response = resolveKeys(identity(['GOOGLE_ADS_APP_CLIENT_ID']), MOUNTED, recorder())
 
         expect(Object.keys(response.secrets)).toEqual(['GOOGLE_ADS_APP_CLIENT_ID'])
         expect(response.secrets).not.toHaveProperty('STRIPE_APP_SECRET_KEY')
@@ -62,7 +80,7 @@ describe('resolve', () => {
         // signing key gets the same answer as a token naming nonsense.
         ['a reserved entry a token asked for by name', '__CALLER_KEY_POSTHOG_DJANGO'],
     ])('reports %s as missing rather than failing the request', async (_label, key) => {
-        const response = resolveKeys(identity([key, 'GOOGLE_ADS_APP_CLIENT_ID']), MOUNTED)
+        const response = resolveKeys(identity([key, 'GOOGLE_ADS_APP_CLIENT_ID']), MOUNTED, recorder())
 
         expect(response.missing).toContain(key)
         expect(response.secrets).not.toHaveProperty(key)
@@ -72,7 +90,8 @@ describe('resolve', () => {
     it('serves a recovery field with no value so the caller fails fast', async () => {
         const response = resolveKeys(
             identity(['STRIPE_APP_SECRET_KEY']),
-            mounted({ STRIPE_APP_SECRET_KEY: { state: 'recovery', versionId: 'v1', fetchedAt: 'now' } })
+            mounted({ STRIPE_APP_SECRET_KEY: { state: 'recovery', versionId: 'v1', fetchedAt: 'now' } }),
+            recorder()
         )
 
         expect(response.secrets['STRIPE_APP_SECRET_KEY']).toMatchObject({ state: 'recovery' })
@@ -90,7 +109,8 @@ describe('resolve', () => {
 
         const response = resolveKeys(
             { deployment: 'posthog-django', caller: claimedCaller, requestedKeys: [invented] },
-            MOUNTED
+            MOUNTED,
+            recorder()
         )
 
         const labelValues = (await resolveTotal.get()).values.flatMap((v) => Object.values(v.labels).map(String))
@@ -98,5 +118,12 @@ describe('resolve', () => {
         expect(labelValues).not.toContain(claimedCaller)
         // The real name still reaches the caller, just not the metric.
         expect(response.missing).toContain(invented)
+    })
+
+    it('records only successfully served keys against the usage rollup', async () => {
+        const record = vi.fn()
+        resolveKeys(identity(['GOOGLE_ADS_APP_CLIENT_ID', 'NOT_A_REAL_KEY']), MOUNTED, recorder(record))
+
+        expect(record).toHaveBeenCalledWith('temporal-worker-data-warehouse', ['GOOGLE_ADS_APP_CLIENT_ID'])
     })
 })

--- a/services/integration-service/tests/unit/server.test.ts
+++ b/services/integration-service/tests/unit/server.test.ts
@@ -2,6 +2,7 @@ import { SignJWT } from 'jose'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import type { Pool } from 'pg'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { AUDIENCE } from '@/auth/types'
@@ -32,7 +33,10 @@ function config(mountDir: string, prestopDelayMs: number): Config {
         shutdownPrestopDelayMs: prestopDelayMs,
         env: 'test',
         mountDir,
+        databaseUrl: undefined,
         reloadSeconds: 3600,
+        usageFlushMs: 3_600_000,
+        retentionDays: 9,
         metricsPort: 0,
     }
 }
@@ -53,13 +57,27 @@ interface Started {
     exitCode: () => number | undefined
 }
 
-/** Start a real IntegrationServer with a fake listener and a captured exit. */
+/** Start a real IntegrationServer with a fake pool, a fake listener and a captured exit. */
 async function startServer(prestopDelayMs = 0): Promise<Started> {
     const events: string[] = []
     let exitCode: number | undefined
     let fetch!: Started['fetch']
 
+    const pool = {
+        query: (sql: string) => {
+            if (sql.includes('INSERT INTO integration_secret_usage')) {
+                events.push('flush')
+            }
+            return Promise.resolve({ rows: [] })
+        },
+        end: () => {
+            events.push('pool.end')
+            return Promise.resolve()
+        },
+    } as unknown as Pool
+
     const server = new IntegrationServer(config(await secretsDir(), prestopDelayMs), {
+        pool,
         serve: (options) => {
             fetch = options.fetch as Started['fetch']
             return {
@@ -78,9 +96,10 @@ async function startServer(prestopDelayMs = 0): Promise<Started> {
 }
 
 describe('integration server', () => {
-    it('marks itself draining and waits out the prestop delay before draining the server', async () => {
+    it('shuts down in order: mark draining, prestop delay, drain, flush, end pool', async () => {
         const { server, events, fetch } = await startServer(30)
 
+        // A served credential leaves a pending usage read, so the flush has work to order.
         const res = await fetch(
             new Request('http://svc/v1/secrets/resolve', {
                 method: 'POST',
@@ -92,8 +111,8 @@ describe('integration server', () => {
         const stoppedAt = Date.now()
         await server.stop('SIGTERM')
 
-        expect(events).toEqual(['drain draining=true'])
-        // Kubernetes has to see the pod leave its endpoints before the listener closes.
+        expect(events).toEqual(['drain draining=true', 'flush', 'pool.end'])
+        // The drain must not start before the prestop window has passed.
         expect(Date.now() - stoppedAt).toBeGreaterThanOrEqual(25)
     })
 
@@ -102,7 +121,7 @@ describe('integration server', () => {
 
         await server.stop('uncaughtException', new Error('boom'))
 
-        expect(events).toEqual(['drain draining=true'])
+        expect(events).toEqual(['drain draining=true', 'pool.end'])
         expect(exitCode()).toBe(1)
     })
 
@@ -115,7 +134,7 @@ describe('integration server', () => {
         await server.stop('SIGTERM')
 
         expect(process.listenerCount('SIGTERM')).toBe(before)
-        expect(events).toHaveLength(1)
+        expect(events.filter((e) => e === 'pool.end')).toHaveLength(1)
         expect(exitCode()).toBe(0)
     })
 })


### PR DESCRIPTION
## Problem

An engineer who has rotated a credential cannot tell when the old value is safe to delete.

- The base PR (#79462) serves both values while a rotation is in flight, and never says when the overlap can end.
- Deleting the old value too early breaks whichever caller has not picked up the new one.
- Nobody can answer "does anything still read this key" either, so a credential nothing uses is never retired.

Answering needs data nothing collects today: who reads each key, and when. Asking callers to report it does not work, because the caller with the stale value is exactly the one you cannot trust to be current.

## Changes

The service records its own reads in Postgres. Every resolve is attributed to the deployment whose signing key verified the token, so none of this depends on a client being well behaved.

The surface that renders the retirement answer ships with the secrets UI follow-up. This layer records what that answer needs.

### Three tables, and why last-seen is separate

| Table | Holds | Pruned? |
| --- | --- | --- |
| `integration_secret_usage` | read counts per key, deployment and hour | yes, past the retention window |
| `integration_secret_last_seen` | when each deployment last read each key | **never** |
| `integration_secret_version` | when each content hash was first seen | no |

Last-seen sits in its own table and is never pruned. A deployment that reads a key rarely is exactly the one still on the old value during a rotation, and losing its row makes the rotation look quieter than it is. That durability requirement is why this is Postgres and not a cache.

A mounted secret carries no AWS version, so `integration_secret_version` is what "the value changed at" means: the first time any replica saw this content hash. That feeds `changedAt` and the `integration_secret_age_seconds` gauge, which drives "not rotated in N days" alerting.

### Writes stay off the request path

Reads accumulate in memory and flush on a timer. A crash loses at most one flush interval of counts.

Shutdown gains two stages: the flush runs after the drain, so in-flight requests still record, and before the pool closes, so it has somewhere to write. `unhandledRejection` and `uncaughtException` take the same path.

A failed flush is never re-queued. Re-queueing would let a broken database grow the pending map without bound, and losing a flush costs counts rather than the ordering of `last_seen`.

The DDL is idempotent and applied at boot, retried once. Replicas booting together can race Postgres's catalog inserts even with `CREATE TABLE IF NOT EXISTS`.

### Configuration this adds

```diff
+ INTEGRATION_SERVICE_DATABASE_URL    # from the chart's psql: harness, required in production
+ INTEGRATION_SERVICE_USAGE_FLUSH_MS  # default 10000
+ INTEGRATION_SERVICE_RETENTION_DAYS  # default 9
```

With `INTEGRATION_SERVICE_DATABASE_URL` unset the service runs without usage recording, which costs the rollup and nothing else. Production boot fails without it.

The DSN goes through PgBouncer in transaction mode, so nothing here relies on session state.

**Not here:** the retirement verdict and its publication to the secrets UI. Both wait for the follow-up PR that adds the UI page; carrying the verdict code before that PR left it reachable only from tests, so it was removed rather than shipped dead.

## How did you test this code?

Automated only. I have not run this against a production database.

The integration suite runs the real SQL against a real Postgres via testcontainers. The unit suite exercises the recorder against a fake pool, so nothing there would catch a broken upsert conflict clause, a window applied to the wrong query, or DDL that no longer applies.

New cases in this layer, and the regression each catches:

- Four recorders flush the same `(key, deployment, bucket)` row at once. A conflict clause that stops summing makes a rotation look quieter than it is. The sequential single-recorder test cannot reach this.
- A last-seen row stays readable after the pool that wrote it has ended. This is the property that makes Postgres the right store rather than a cache.
- The boot DDL survives four replicas applying it concurrently. The catalog race fires for real and the retry absorbs it.
- Prune deletes count rows past retention and never touches last-seen.
- Shutdown and crash paths flush pending rows before the pool closes, in a pinned order.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal service with no user-facing surface. The Postgres section of `services/integration-service/README.md` documents it.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, directed by @Gilbert09. Skills invoked: `/writing-pr-descriptions`, `/writing-tests`, `/stacking-prs`.

This content began life inside #79462. @Gilbert09 asked for the split once the base service stopped needing a database for anything on the credential path. Serving credentials and counting who reads them are separable, and the second one drags in a driver, a connection pool, an extra shutdown stage and a testcontainers suite that the first does not need to be reviewed against.

The split is a pair of ordinary commits rather than a history rewrite, so #79462 keeps its identity and was never force-pushed.

Public artifact: nothing here draws on non-public material. No customer data, tickets, or logs reached the code, fixtures, comments, or this description.
