### PR TITLE
fix(data-imports): fail source config parsing with a clear, non-leaking error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/config.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/config.py
@@ -136,6 +136,15 @@ class UndecryptedConfigError(ValueError):
     """
 
 
+class ConfigValueError(ValueError):
+    """Raised when a config field's value can't be converted to its declared type.
+
+    A converter (e.g. ``int``) failing on user-supplied input would otherwise crash with an
+    opaque, value-leaking builtin error such as ``invalid literal for int() with base 10: 'lakjsd'``.
+    We name the field but never its value, so nothing a user typed reaches logs or error tracking.
+    """
+
+
 def _convert_value(
     convert: typing.Callable[[typing.Any], typing.Any], value: typing.Any, field_name: str
 ) -> typing.Any:
@@ -143,7 +152,10 @@ def _convert_value(
         raise UndecryptedConfigError(
             f"Config field '{field_name}' is still encrypted; the stored credentials could not be decrypted"
         )
-    return convert(value)
+    try:
+        return convert(value)
+    except (ValueError, TypeError) as e:
+        raise ConfigValueError(f"Config field '{field_name}' has a value that could not be parsed") from e
 
 
 @dataclasses.dataclass
@@ -209,6 +221,21 @@ def validate_config(
                         is_valid, nested_errors = validate_config(config_type, d, field_prefixes)
                         if not is_valid:
                             errors.extend(nested_errors)
+
+        elif field_meta and field_meta.converter != _noop_convert:
+            # Scalar field with a converter: presence is checked above, but a value that can't be
+            # converted to the declared type (e.g. `port: "lakjsd"`) would otherwise slip through and
+            # crash later in `to_config`. Run the converter now so it surfaces as a validation error.
+            if field_flat_key in d:
+                field_key = field_flat_key
+            elif field_nested_key in d:
+                field_key = field_nested_key
+            else:
+                field_key = field.name
+            try:
+                _convert_value(field_meta.converter, d[field_key], field.name)
+            except (ValueError, TypeError):
+                errors.append(f"Field '{field.name}' has an invalid value")
 
     return len(errors) == 0, errors
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_config.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_config.py
@@ -151,6 +151,38 @@ def test_from_dict_raises_clear_error_on_undecrypted_secret(config_dict):
     assert _UNDECRYPTED_TOKEN not in str(exc_info.value)
 
 
+def test_from_dict_raises_clear_error_on_unconvertible_value():
+    """A converter failing on bad user input must fail with a clear error that names the field but
+    not the value, instead of the opaque, value-leaking `invalid literal for int()` crash."""
+
+    @config.config
+    class TestConfig(config.Config):
+        host: str
+        port: int = config.value(converter=int)
+
+    with pytest.raises(config.ConfigValueError) as exc_info:
+        TestConfig.from_dict({"host": "db.example.com", "port": "not-a-number"})
+
+    assert "port" in str(exc_info.value)
+    assert "not-a-number" not in str(exc_info.value)
+
+
+def test_validate_dict_rejects_unconvertible_value():
+    """`validate_dict` must flag a value that can't convert to the declared type rather than pass and
+    defer the crash to `to_config`. The reported error came from a value that cleared validation."""
+
+    @config.config
+    class TestConfig(config.Config):
+        host: str
+        port: int = config.value(converter=int)
+
+    is_valid, errors = TestConfig.validate_dict({"host": "db.example.com", "port": "not-a-number"})
+
+    assert is_valid is False
+    assert len(errors) == 1
+    assert "not-a-number" not in errors[0]
+
+
 def test_nested_to_config_with_flat_dict():
     """Test `config.to_config` with a nested set of classes.
 


### PR DESCRIPTION
## Problem

- A user who types a non-numeric value into a numeric source-setup field (e.g. a port) gets a 500 from schema discovery instead of a "please enter a valid number" message.
- The converter (`int`) raised the builtin `invalid literal for int() with base 10: '...'`, which echoed the raw value the user typed into logs and error tracking and named no field.
- `validate_config` only checks that a field is present, so a value that cannot convert to the declared type cleared validation and crashed later in `to_config`.
- Observed in error tracking: [ValueError in source config parsing](https://us.posthog.com/project/2/error_tracking/019ff1a8-8b2c-7453-8fc4-5552a344131f), fired from `sources/common/config.py` during the `external_data_sources/database_schema` request.

## Changes

- `_convert_value` now wraps the converter call and re-raises `ConfigValueError` naming the field but never its value, so nothing a user typed reaches logs or error tracking.
- `validate_config` runs each scalar field's converter, so an unconvertible value surfaces as a validation error (a clean 400) rather than a deferred crash during parsing.
- The fix sits in the shared config layer, so it covers both source setup and the Temporal pipeline that parses stored job inputs.
- Mirrors the existing `UndecryptedConfigError` handling in the same file, which already turns a value-leaking converter crash into a clear, redacted error.

## How did you test this code?

- Added `test_from_dict_raises_clear_error_on_unconvertible_value`: locks in that a converter failure raises `ConfigValueError`, names the field, and omits the bad value. Catches a regression that reintroduces the opaque, value-leaking crash.
- Added `test_validate_dict_rejects_unconvertible_value`: locks in that validation flags an unconvertible value instead of passing it through to a parse-time crash.
- Both new tests fail on master and pass with this change. The full `test_config.py` suite passes locally (74 tests).
- The tests use an invented value (`not-a-number`), not any value from the reported error.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged from a PostHog error-tracking issue by Claude (Opus 4.8) via the PostHog error-tracking MCP tools. The reported top frame was `_convert_value` in `sources/common/config.py`, reached from the `database_schema` source-setup request.
- Decided this is a handling bug, not a candidate for `NonRetryableErrors`: the failure is synchronous source setup on bad user input, not a pipeline retry loop. The right outcome is a clear, redacted error and a 400, not a swallowed retry.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- No customer values appear in the diff, tests, or this description; the reported input value was not reused.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
