### PR TITLE
feat(et): stamp issue state mutations

### DIFF
--- a/products/error_tracking/backend/logic/issue_mutations.py
+++ b/products/error_tracking/backend/logic/issue_mutations.py
@@ -270,7 +270,7 @@ def _assign_one(
                 raise AssigneeValidationError("Assignee role does not belong to this organization.")
 
         serialized_assignment_after = {
-            "id": assignee["id"] if assignee["type"] == "user" else str(assignee["id"]),
+            "id": int(assignee["id"]) if assignee["type"] == "user" else str(assignee["id"]),
             "type": assignee["type"],
         }
         if serialized_assignment_before == serialized_assignment_after:

--- a/products/error_tracking/backend/logic/issue_mutations.py
+++ b/products/error_tracking/backend/logic/issue_mutations.py
@@ -9,6 +9,7 @@ from typing import Any
 from uuid import UUID
 
 from django.db import transaction
+from django.utils import timezone
 
 from posthog.models.activity_logging.activity_log import Change, Detail, log_activity
 from posthog.models.organization import OrganizationMembership
@@ -41,6 +42,9 @@ class InvalidIssueStatusError(Exception):
     pass
 
 
+_CLICKHOUSE_VISIBLE_ISSUE_STATE_FIELDS = ("status", "name", "description")
+
+
 def _get_issue(team_id: int, issue_id: UUID | str, *, select_related: tuple[str, ...] = ()) -> ErrorTrackingIssue:
     qs = ErrorTrackingIssue.objects.all()
     if select_related:
@@ -62,6 +66,17 @@ def _status_from_string(status: str) -> "ErrorTrackingIssue.Status | None":
     return None
 
 
+def _has_clickhouse_visible_state_change(issue: ErrorTrackingIssue, fields: dict[str, Any]) -> bool:
+    return any(
+        field in fields and fields[field] != getattr(issue, field) for field in _CLICKHOUSE_VISIBLE_ISSUE_STATE_FIELDS
+    )
+
+
+def _stamp_issue_state(*, team_id: int, issue_ids: list[UUID]) -> None:
+    if issue_ids:
+        ErrorTrackingIssue.objects.filter(team_id=team_id, id__in=issue_ids).update(state_updated_at=timezone.now())
+
+
 def update_issue(
     team_id: int, issue_id: UUID, *, fields: dict[str, Any], user: User, was_impersonated: bool
 ) -> ErrorTrackingIssue:
@@ -77,17 +92,21 @@ def update_issue(
     status_updated = "status" in fields and status_after != status_before
     severity_updated = "severity" in fields and severity_after != severity_before
     name_updated = "name" in fields and name_after != name_before
+    state_updated = _has_clickhouse_visible_state_change(issue, fields)
 
     for key in ("status", "severity", "name", "description"):
         if key in fields:
             setattr(issue, key, fields[key])
-    issue.save()
 
     changes = []
     if status_updated:
         changes.append(
             Change(
-                type="ErrorTrackingIssue", field="status", before=status_before, after=status_after, action="changed"
+                type="ErrorTrackingIssue",
+                field="status",
+                before=status_before,
+                after=status_after,
+                action="changed",
             )
         )
     if severity_updated:
@@ -105,17 +124,24 @@ def update_issue(
             Change(type="ErrorTrackingIssue", field="name", before=name_before, after=name_after, action="changed")
         )
 
-    if changes:
-        log_activity(
-            organization_id=issue.team.organization.id,
-            team_id=team_id,
-            user=user,
-            was_impersonated=was_impersonated,
-            item_id=str(issue.id),
-            scope="ErrorTrackingIssue",
-            activity="updated",
-            detail=Detail(name=issue.name, changes=changes),
-        )
+    with transaction.atomic():
+        if state_updated:
+            issue.state_updated_at = timezone.now()
+        issue.save()
+
+        if changes:
+            log_activity(
+                organization_id=issue.team.organization.id,
+                team_id=team_id,
+                user=user,
+                was_impersonated=was_impersonated,
+                item_id=str(issue.id),
+                scope="ErrorTrackingIssue",
+                activity="updated",
+                detail=Detail(name=issue.name, changes=changes),
+            )
+
+    if state_updated or severity_updated:
         sync_issues_to_clickhouse(issue_ids=[issue.id], team_id=team_id)
 
     return issue
@@ -147,9 +173,14 @@ def set_issue_cohort(team_id: int, issue_id: UUID, cohort_id: int) -> None:
 def assign_issue(
     team_id: int, issue_id: UUID, assignee: dict[str, Any] | None, *, user: User, was_impersonated: bool
 ) -> None:
-    issue = _get_issue(team_id, issue_id, select_related=("team__organization",))
-    _assign_one(issue, assignee, issue.team.organization, user, team_id, was_impersonated)
-    sync_issues_to_clickhouse(issue_ids=[issue.id], team_id=team_id)
+    with transaction.atomic():
+        issue = _get_issue(team_id, issue_id, select_related=("team__organization",))
+        assignment_changed = _assign_one(issue, assignee, issue.team.organization, user, team_id, was_impersonated)
+        if assignment_changed:
+            _stamp_issue_state(team_id=team_id, issue_ids=[issue.id])
+
+    if assignment_changed:
+        sync_issues_to_clickhouse(issue_ids=[issue.id], team_id=team_id)
 
 
 def bulk_update_issues(
@@ -162,7 +193,10 @@ def bulk_update_issues(
     user: User,
     was_impersonated: bool,
 ) -> None:
-    issues = ErrorTrackingIssue.objects.filter(team_id=team_id, id__in=issue_ids).select_related("team__organization")
+    issues = list(
+        ErrorTrackingIssue.objects.filter(team_id=team_id, id__in=issue_ids).select_related("team__organization")
+    )
+    changed_issue_ids: list[UUID] = []
 
     with transaction.atomic():
         if action == "set_status":
@@ -170,6 +204,9 @@ def bulk_update_issues(
             if new_status is None:
                 raise InvalidIssueStatusError
             for issue in issues:
+                if issue.status == new_status:
+                    continue
+                changed_issue_ids.append(issue.id)
                 log_activity(
                     organization_id=issue.team.organization_id,
                     team_id=team_id,
@@ -191,12 +228,17 @@ def bulk_update_issues(
                         ],
                     ),
                 )
-            issues.update(status=new_status)
+            if changed_issue_ids:
+                ErrorTrackingIssue.objects.filter(team_id=team_id, id__in=changed_issue_ids).update(
+                    status=new_status, state_updated_at=timezone.now()
+                )
         elif action == "assign":
             for issue in issues:
-                _assign_one(issue, assignee, issue.team.organization, user, team_id, was_impersonated)
+                if _assign_one(issue, assignee, issue.team.organization, user, team_id, was_impersonated):
+                    changed_issue_ids.append(issue.id)
+            _stamp_issue_state(team_id=team_id, issue_ids=changed_issue_ids)
 
-    sync_issues_to_clickhouse(issue_ids=[issue.id for issue in issues], team_id=team_id)
+    sync_issues_to_clickhouse(issue_ids=changed_issue_ids, team_id=team_id)
 
 
 def _assignment_repr(assignment: ErrorTrackingIssueAssignment | None) -> dict[str, Any] | None:
@@ -215,7 +257,7 @@ def _assign_one(
     user: User,
     team_id: int,
     was_impersonated: bool,
-) -> None:
+) -> bool:
     assignment_before = ErrorTrackingIssueAssignment.objects.filter(issue_id=issue.id).first()
     serialized_assignment_before = _assignment_repr(assignment_before)
 
@@ -226,6 +268,13 @@ def _assign_one(
         elif assignee["type"] == "role":
             if not Role.objects.filter(id=assignee["id"], organization=organization).exists():
                 raise AssigneeValidationError("Assignee role does not belong to this organization.")
+
+        serialized_assignment_after = {
+            "id": assignee["id"] if assignee["type"] == "user" else str(assignee["id"]),
+            "type": assignee["type"],
+        }
+        if serialized_assignment_before == serialized_assignment_after:
+            return False
 
         # nosemgrep: idor-lookup-without-team (assignee validated against org above)
         assignment_after, _ = ErrorTrackingIssueAssignment.objects.update_or_create(
@@ -244,11 +293,10 @@ def _assign_one(
             assignee=assignee,
             assigner=user,
         )
-
-        serialized_assignment_after = _assignment_repr(assignment_after)
     else:
-        if assignment_before:
-            assignment_before.delete()
+        if assignment_before is None:
+            return False
+        assignment_before.delete()
         serialized_assignment_after = None
 
     log_activity(
@@ -272,3 +320,4 @@ def _assign_one(
             ],
         ),
     )
+    return True

--- a/products/error_tracking/backend/logic/issue_mutations.py
+++ b/products/error_tracking/backend/logic/issue_mutations.py
@@ -42,7 +42,7 @@ class InvalidIssueStatusError(Exception):
     pass
 
 
-_CLICKHOUSE_VISIBLE_ISSUE_STATE_FIELDS = ("status", "name", "description")
+_CLICKHOUSE_VISIBLE_ISSUE_STATE_FIELDS = ("status", "severity", "name", "description")
 
 
 def _get_issue(team_id: int, issue_id: UUID | str, *, select_related: tuple[str, ...] = ()) -> ErrorTrackingIssue:
@@ -141,7 +141,7 @@ def update_issue(
                 detail=Detail(name=issue.name, changes=changes),
             )
 
-    if state_updated or severity_updated:
+    if state_updated:
         sync_issues_to_clickhouse(issue_ids=[issue.id], team_id=team_id)
 
     return issue

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -222,12 +222,13 @@ class TestErrorTracking(APIBaseTest):
 
     @parameterized.expand(
         [
+            ("severity", {"severity": "high"}),
             ("name", {"name": "Updated issue"}),
             ("description", {"description": "Updated description"}),
         ]
     )
     @freeze_time("2025-01-02")
-    def test_issue_update_stamps_denormalized_fields(self, _name: str, fields: dict[str, str]) -> None:
+    def test_issue_update_stamps_clickhouse_visible_fields(self, _name: str, fields: dict[str, str]) -> None:
         issue = self.create_issue(["fingerprint"])
 
         response = self.client.patch(
@@ -245,7 +246,7 @@ class TestErrorTracking(APIBaseTest):
 
         response = self.client.patch(
             f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}",
-            data={"status": "active", "name": None, "description": None},
+            data={"status": "active", "severity": None, "name": None, "description": None},
         )
 
         assert response.status_code == status.HTTP_200_OK

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -792,18 +792,40 @@ class TestErrorTracking(APIBaseTest):
         # cannot assign issues from other teams
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_assigning_same_assignee_does_not_stamp_issue(self) -> None:
+    @patch("products.error_tracking.backend.logic.issue_mutations.sync_issues_to_clickhouse")
+    @patch("products.error_tracking.backend.logic.issue_mutations.dispatch_issue_assigned_realtime")
+    @patch("products.error_tracking.backend.logic.issue_mutations.send_error_tracking_issue_assigned")
+    def test_assigning_same_user_with_string_id_does_not_mutate_issue(
+        self, mock_email: Mock, mock_realtime: Mock, mock_sync: Mock
+    ) -> None:
         issue = self.create_issue()
         ErrorTrackingIssueAssignment.objects.create(issue=issue, team=self.team, user=self.user)
 
         response = self.client.patch(
             f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}/assign",
-            data={"assignee": {"id": self.user.id, "type": "user"}},
+            data={"assignee": {"id": str(self.user.id), "type": "user"}},
         )
 
         assert response.status_code == status.HTTP_200_OK
         issue.refresh_from_db()
         assert issue.state_updated_at is None
+        self._assert_logs_the_activity(issue.id, [])
+        mock_email.delay.assert_not_called()
+        mock_realtime.assert_not_called()
+        mock_sync.assert_not_called()
+
+    def test_unassigning_unassigned_issue_does_not_mutate_issue(self) -> None:
+        issue = self.create_issue()
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}/assign",
+            data={"assignee": None},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        issue.refresh_from_db()
+        assert issue.state_updated_at is None
+        self._assert_logs_the_activity(issue.id, [])
 
     @patch("products.error_tracking.backend.logic.issue_mutations.dispatch_issue_assigned_realtime")
     @patch("products.error_tracking.backend.logic.issue_mutations.send_error_tracking_issue_assigned")

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -1,4 +1,5 @@
 import os
+from datetime import UTC, datetime
 
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
@@ -6,6 +7,7 @@ from unittest.mock import ANY, Mock, patch
 
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
+from django.utils import timezone
 
 from boto3 import resource
 from botocore.config import Config
@@ -181,6 +183,7 @@ class TestErrorTracking(APIBaseTest):
         }
         assert issue.status == ErrorTrackingIssue.Status.RESOLVED
         assert issue.severity == ErrorTrackingIssue.Severity.HIGH
+        assert issue.state_updated_at == datetime(2025, 1, 1, tzinfo=UTC)
 
         self._assert_logs_the_activity(
             issue.id,
@@ -216,6 +219,38 @@ class TestErrorTracking(APIBaseTest):
                 }
             ],
         )
+
+    @parameterized.expand(
+        [
+            ("name", {"name": "Updated issue"}),
+            ("description", {"description": "Updated description"}),
+        ]
+    )
+    @freeze_time("2025-01-02")
+    def test_issue_update_stamps_denormalized_fields(self, _name: str, fields: dict[str, str]) -> None:
+        issue = self.create_issue(["fingerprint"])
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}",
+            data=fields,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        issue.refresh_from_db()
+        assert issue.state_updated_at == datetime(2025, 1, 2, tzinfo=UTC)
+
+    @freeze_time("2025-01-02")
+    def test_issue_update_does_not_stamp_unchanged_state(self) -> None:
+        issue = self.create_issue(["fingerprint"])
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}",
+            data={"status": "active", "name": None, "description": None},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        issue.refresh_from_db()
+        assert issue.state_updated_at is None
 
     def test_issue_update_rejects_deprecated_status(self):
         issue = self.create_issue(["fingerprint"])
@@ -696,13 +731,18 @@ class TestErrorTracking(APIBaseTest):
         issue = self.create_issue()
 
         self.assertEqual(ErrorTrackingIssueAssignment.objects.count(), 0)
+        before_assignment = timezone.now()
         self.client.patch(
             f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}/assign",
             data={"assignee": {"id": self.user.id, "type": "user"}},
         )
+        after_assignment = timezone.now()
         # assigns the issue
         self.assertEqual(ErrorTrackingIssueAssignment.objects.count(), 1)
         self.assertEqual(ErrorTrackingIssueAssignment.objects.filter(issue=issue, user_id=self.user.id).count(), 1)
+        issue.refresh_from_db()
+        assert issue.state_updated_at is not None
+        assert before_assignment <= issue.state_updated_at <= after_assignment
 
         self._assert_logs_the_activity(
             issue.id,
@@ -732,12 +772,17 @@ class TestErrorTracking(APIBaseTest):
             ],
         )
 
+        before_unassignment = timezone.now()
         self.client.patch(
             f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}/assign",
             data={"assignee": None},
         )
+        after_unassignment = timezone.now()
         # deletes the assignment
         self.assertEqual(ErrorTrackingIssueAssignment.objects.count(), 0)
+        issue.refresh_from_db()
+        assert issue.state_updated_at is not None
+        assert before_unassignment <= issue.state_updated_at <= after_unassignment
 
         other_team = self.create_team_with_organization(organization=self.organization)
         response = self.client.patch(
@@ -746,6 +791,19 @@ class TestErrorTracking(APIBaseTest):
         )
         # cannot assign issues from other teams
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_assigning_same_assignee_does_not_stamp_issue(self) -> None:
+        issue = self.create_issue()
+        ErrorTrackingIssueAssignment.objects.create(issue=issue, team=self.team, user=self.user)
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}/assign",
+            data={"assignee": {"id": self.user.id, "type": "user"}},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        issue.refresh_from_db()
+        assert issue.state_updated_at is None
 
     @patch("products.error_tracking.backend.logic.issue_mutations.dispatch_issue_assigned_realtime")
     @patch("products.error_tracking.backend.logic.issue_mutations.send_error_tracking_issue_assigned")
@@ -762,20 +820,33 @@ class TestErrorTracking(APIBaseTest):
     def test_error_tracking_issue_bulk_resolve(self):
         issue_one = self.create_issue()
         issue_two = self.create_issue()
+        unchanged_issue = self.create_issue()
+        ErrorTrackingIssue.objects.filter(id=unchanged_issue.id).update(status=ErrorTrackingIssue.Status.RESOLVED)
 
         self.assertEqual(issue_one.status, ErrorTrackingIssue.Status.ACTIVE)
         self.assertEqual(issue_two.status, ErrorTrackingIssue.Status.ACTIVE)
 
+        before_update = timezone.now()
         self.client.post(
             f"/api/environments/{self.team.id}/error_tracking/issues/bulk",
-            data={"ids": [issue_one.id, issue_two.id], "action": "set_status", "status": "resolved"},
+            data={
+                "ids": [issue_one.id, issue_two.id, unchanged_issue.id],
+                "action": "set_status",
+                "status": "resolved",
+            },
         )
+        after_update = timezone.now()
 
         issue_one.refresh_from_db()
         issue_two.refresh_from_db()
+        unchanged_issue.refresh_from_db()
 
         self.assertEqual(issue_one.status, ErrorTrackingIssue.Status.RESOLVED)
         self.assertEqual(issue_two.status, ErrorTrackingIssue.Status.RESOLVED)
+        assert issue_one.state_updated_at is not None
+        assert before_update <= issue_one.state_updated_at <= after_update
+        assert issue_two.state_updated_at == issue_one.state_updated_at
+        assert unchanged_issue.state_updated_at is None
 
     def test_error_tracking_issue_bulk_assign(self):
         issue_one = self.create_issue()
@@ -785,6 +856,7 @@ class TestErrorTracking(APIBaseTest):
         role = Role.objects.create(name="Team role", organization=self.organization)
         role.members.set([self.user])
 
+        before_update = timezone.now()
         self.client.post(
             f"/api/environments/{self.team.id}/error_tracking/issues/bulk",
             data={
@@ -793,11 +865,17 @@ class TestErrorTracking(APIBaseTest):
                 "assignee": {"id": role.id, "type": "role"},
             },
         )
+        after_update = timezone.now()
 
         self.assertEqual(len(ErrorTrackingIssueAssignment.objects.filter(issue=issue_one, user=self.user)), 0)
         self.assertEqual(
             len(ErrorTrackingIssueAssignment.objects.filter(issue__in=[issue_one, issue_two], role=role)), 2
         )
+        issue_one.refresh_from_db()
+        issue_two.refresh_from_db()
+        assert issue_one.state_updated_at is not None
+        assert before_update <= issue_one.state_updated_at <= after_update
+        assert issue_two.state_updated_at == issue_one.state_updated_at
 
     def test_can_start_bulk_symbol_set_upload(self) -> None:
         chunk_id_one = uuid7()


### PR DESCRIPTION
## Problem

Error tracking needs an authoritative change timestamp before issue lists can reconcile recent Postgres mutations with ClickHouse state.

## Changes

- Stamps real status, name, and description changes in the mutation transaction.
- Stamps assignment and unassignment changes after assignee validation.
- Gives every affected issue in a bulk mutation the same server timestamp.
- Skips timestamps, activity entries, and ClickHouse publishing for no-op mutations.
- Keeps ClickHouse publishing after the Postgres transaction commits.

This PR is stacked on #81355, which adds the nullable field and index.

## How did you test this code?

- Extended API coverage for single and bulk status changes, assignment, unassignment, denormalized fields, and no-op mutations.
- Ran `hogli test products/error_tracking/backend/tests/api/test_error_tracking_api.py`.
- Ran repo-wide mypy with `uv run mypy --cache-fine-grained .`.
- Ran focused Ruff checks and `hogli ci:preflight --fix`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This PR changes internal mutation bookkeeping without changing the API or user workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with the Pi coding agent using GPT-5.6.
- Invoked `/error-tracking`, `/writing-tests`, `/writing-code-comments`, `/running-ci-preflight`, `/stacking-prs`, and `/writing-pr-descriptions`.
- Kept timestamp writes transactional while leaving Kafka publishing outside the transaction.
- The diff contains no customer data or material copied from signal reports.
