### PR TITLE
feat(subscriptions): add dashboard context to ai reports

### DIFF
--- a/products/exports/backend/temporal/subscriptions/ai_subscription/prompts.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/prompts.py
@@ -107,7 +107,7 @@ Output rules:
   When context lists "Events matching your request", prefer those exact event names — they were
   selected for this prompt. For an event's properties, use only the names listed under its
   "`<event>` properties" line (access as `properties.<name>`); do not invent property names.
-- The analysis window is fixed, but you must NOT write its dates yourself. Filter EVERY query on the
+- The analysis window is fixed, but you must NOT write its dates yourself. Filter every event-data query on the
   window using the literal placeholder token `{{date_range}}` — write it verbatim where the timestamp
   predicate goes, e.g. `WHERE {{date_range}}` or `WHERE event = '$pageview' AND {{date_range}}`. The
   system substitutes the concrete half-open range at run time, so the plan stays reusable as the window
@@ -119,6 +119,12 @@ Output rules:
   is period-over-period growth ("vs last week/yesterday"), which uses `{{compare_date_range}}` and
   `{{window_start}}` — see the growth reference pattern below. Boundary tokens `{{window_start}}` /
   `{{window_end}}` substitute to bare `toDateTime('…')` literals where a pattern needs a single bound.
+- For a request about a dashboard or its tiles, query `system.dashboards`, `system.dashboard_tiles`, and
+  `system.insights`. Join `system.dashboard_tiles.dashboard_id` to `system.dashboards.id` and
+  `system.dashboard_tiles.insight_id` to `system.insights.id`. These tables expose dashboard and tile metadata,
+  including saved insight names and definitions. Metadata-only queries against these tables have no event timestamp,
+  so do not add `{{date_range}}` to them. They do not contain rendered tile values; use the saved insight definition
+  and event data to calculate those values when the request needs them.
 - Each step's `description` must briefly explain *why* that query is relevant to the prompt.
 - Keep queries cheap: prefer aggregation over raw selects; cap with LIMIT 50; avoid wildcards on large tables.
 - Format each query for readability: each clause (SELECT, FROM, WHERE, GROUP BY, ORDER BY, LIMIT) on

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_spec_generator.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_spec_generator.py
@@ -855,6 +855,9 @@ class TestGenerateQueryPlanSubstitution(APIBaseTest):
         (_role, system_content) = messages[0]
         assert "CLEANED_PROMPT_MARKER" in system_content
         assert "CONTEXT_BLOB_MARKER" in system_content
+        assert "system.dashboard_tiles" in system_content
+        assert "system.insights" in system_content
+        assert "Metadata-only queries" in system_content
         # The template's `{{{...}}}` placeholders must be gone — proving substitution ran.
         assert "{{{" not in system_content
 


### PR DESCRIPTION
## Problem

- AI prompt reports cannot reliably use dashboard tiles because the planner only receives event-related query guidance.
- **Why:** Recurring reports need dashboard structure to answer questions about a dashboard and its saved insights.

## Changes

```mermaid
flowchart LR
    Before[Planner] --> Events[Event context]
    After[Planner] --> Dashboard[Dashboard and tile metadata]
    Dashboard --> Insights[Saved insight definitions]
```

- The planner can query dashboard, tile, and saved-insight metadata.
- Metadata queries omit the event date-range filter.
- Reports use event data to calculate values because tiles do not store rendered values.

## How did you test this code?

- Added a regression check that the planner receives dashboard schema guidance and the metadata query exception.
- Not run: database-backed pytest cases. Local PostgreSQL was unavailable.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. This changes internal planner guidance only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Used `/writing-tests` and `/writing-pr-descriptions`.
- The committed change contains no private source material.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*