### PR TITLE
feat(experiments): render the variant timeseries chart with quill charts

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -323,6 +323,7 @@ export const FEATURE_FLAGS = {
     EXPERIMENTS_FREEZE_EXPOSURE_AA_TEST: 'experiments-freeze-exposure-aa-test', // owner: @mp-hog #team-experiments multivariate=control,test, dogfood A/A used to validate the freeze-exposure lifecycle action
     EXPERIMENTS_LIST_AA_TEST: 'experiments-list-aa-test', // owner: @andehen #team-experiments multivariate=control,test, dogfood A/A exposed on the experiments list page
     EXPERIMENTS_METRICS_RECALCULATION: 'experiments-metrics-recalculation', // owner: @rodrigoi #team-experiments
+    EXPERIMENTS_QUILL_TIMESERIES_CHART: 'experiments-quill-timeseries-chart', // owner: @sampennington #team-product-analytics, renders the variant timeseries chart via @posthog/quill-charts instead of chart.js
     EXPERIMENTS_SHOW_SQL: 'experiments-show-sql', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_SYNC_QUERIES: 'experiments-sync-queries', // owner: @andehen #team-experiments
     EXPERIMENTS_TEMPLATES: 'experiments-templates', // owner: @rodrigoi #team-experiments

--- a/frontend/src/scenes/experiments/MetricsView/new/LegacyVariantTimeseriesChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/LegacyVariantTimeseriesChart.tsx
@@ -1,0 +1,140 @@
+import { useChart } from 'lib/hooks/useChart'
+import { useInsightTooltip } from 'scenes/insights/useInsightTooltip'
+
+import { useChartColors } from '../shared/colors'
+import type { VariantTimeseriesChartProps } from './VariantTimeseriesChart'
+import { VariantTimeseriesTooltip } from './VariantTimeseriesTooltip'
+
+export function LegacyVariantTimeseriesChart({
+    chartData: data,
+    isRatioMetric = false,
+}: VariantTimeseriesChartProps): JSX.Element {
+    const colors = useChartColors()
+    const { getTooltip, showTooltip, hideTooltip, positionTooltip } = useInsightTooltip()
+
+    const { canvasRef } = useChart<'line'>({
+        getConfig: () => {
+            if (!data) {
+                return null
+            }
+
+            const { labels, datasets, processedData, computedAt } = data
+
+            return {
+                type: 'line' as const,
+                data: { labels, datasets },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    interaction: {
+                        intersect: false,
+                        mode: 'nearest',
+                        axis: 'x',
+                    },
+                    scales: {
+                        y: {
+                            grid: {
+                                display: true,
+                                color: (context) => {
+                                    if (context.tick.value === 0) {
+                                        return colors.ZERO_LINE
+                                    }
+                                    return colors.EXPOSURES_AXIS_LINES
+                                },
+                                lineWidth: (context) => {
+                                    if (context.tick.value === 0) {
+                                        return 1.25
+                                    }
+                                    return 1
+                                },
+                            },
+                            ticks: {
+                                callback: (value) => {
+                                    const num = Number(value)
+                                    return `${(num * 100).toFixed(0)}%`
+                                },
+                            },
+                            afterBuildTicks: (axis) => {
+                                const ticks = axis.ticks.map((t) => t.value)
+                                if (!ticks.includes(0)) {
+                                    axis.ticks.push({ value: 0 })
+                                    axis.ticks.sort((a, b) => a.value - b.value)
+                                }
+                                // When 0 is the lowest tick, pad below so it doesn't
+                                // overlap with x-axis date labels
+                                if (axis.ticks.length > 1 && axis.ticks[0].value === 0) {
+                                    const tickStep = axis.ticks[1].value - axis.ticks[0].value
+                                    axis.min = -tickStep * 0.3
+                                }
+                            },
+                        },
+                        x: {
+                            grid: {
+                                display: false,
+                            },
+                            ticks: {
+                                maxRotation: 45,
+                                minRotation: 45,
+                            },
+                        },
+                    },
+                    plugins: {
+                        legend: {
+                            display: false,
+                        },
+                        tooltip: {
+                            enabled: false,
+                            external: ({ chart, tooltip }) => {
+                                const canvas = chart.canvas
+                                if (!canvas) {
+                                    return
+                                }
+
+                                const [tooltipRoot, tooltipEl] = getTooltip()
+
+                                if (tooltip.opacity === 0 || !tooltip.dataPoints?.length) {
+                                    hideTooltip()
+                                    return
+                                }
+
+                                const dataIndex = tooltip.dataPoints[0].dataIndex
+                                const dataPoint = processedData[dataIndex]
+                                if (!dataPoint) {
+                                    hideTooltip()
+                                    return
+                                }
+
+                                showTooltip()
+                                tooltipRoot.render(
+                                    <VariantTimeseriesTooltip
+                                        date={dataPoint.date}
+                                        delta={dataPoint.value}
+                                        lowerBound={dataPoint.lower_bound}
+                                        upperBound={dataPoint.upper_bound}
+                                        isRatioMetric={isRatioMetric}
+                                        exposures={dataPoint.number_of_samples}
+                                        denominator={dataPoint.denominator_sum}
+                                        significant={dataPoint.significant}
+                                        hasRealData={dataPoint.hasRealData}
+                                        computedAt={computedAt}
+                                    />
+                                )
+
+                                const bounds = canvas.getBoundingClientRect()
+                                positionTooltip(tooltipEl, bounds, tooltip.caretX, 0, false)
+                            },
+                        },
+                        crosshair: false,
+                    },
+                },
+            }
+        },
+        deps: [data, colors.EXPOSURES_AXIS_LINES, colors.ZERO_LINE, isRatioMetric],
+    })
+
+    return (
+        <div className="relative h-[224px]">
+            <canvas ref={canvasRef} />
+        </div>
+    )
+}

--- a/frontend/src/scenes/experiments/MetricsView/new/QuillVariantTimeseriesChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/QuillVariantTimeseriesChart.tsx
@@ -1,0 +1,95 @@
+import { useValues } from 'kea'
+import { useMemo } from 'react'
+
+import { TimeSeriesLineChart, type Series, type TimeSeriesLineChartConfig } from '@posthog/quill-charts'
+
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
+import { findLastIndex } from 'lib/utils/arrays'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { useChartColors } from '../shared/colors'
+import type { VariantTimeseriesChartProps } from './VariantTimeseriesChart'
+import { VariantTimeseriesTooltip } from './VariantTimeseriesTooltip'
+
+const DELTA_SERIES_KEY = 'delta'
+const PENDING_DASH_PATTERN = [5, 5]
+
+export function QuillVariantTimeseriesChart({
+    chartData: data,
+    isRatioMetric = false,
+}: VariantTimeseriesChartProps): JSX.Element {
+    const { timezone } = useValues(teamLogic)
+    const theme = useChartTheme()
+    const colors = useChartColors()
+
+    const { labels, processedData, computedAt, variantColor } = data
+
+    const { series, lowerBounds, upperBounds } = useMemo(() => {
+        // Days the daily job hasn't computed yet carry the last known value forward, so the line
+        // stays continuous — dash the tail to show it isn't measured data. `fromIndex` dashes the
+        // segment arriving at that point, so the first dashed segment leaves the last measured day.
+        const lastRealIndex = findLastIndex(processedData, (point) => point.hasRealData)
+        const firstPendingIndex = lastRealIndex + 1
+        const hasPendingTail = lastRealIndex >= 0 && firstPendingIndex < processedData.length
+
+        return {
+            series: [
+                {
+                    key: DELTA_SERIES_KEY,
+                    label: 'Delta',
+                    data: processedData.map((point) => point.value ?? 0),
+                    color: variantColor,
+                    points: { radius: 3 },
+                    stroke: hasPendingTail
+                        ? { partial: { fromIndex: firstPendingIndex, pattern: PENDING_DASH_PATTERN } }
+                        : undefined,
+                },
+            ] satisfies Series[],
+            lowerBounds: processedData.map((point) => point.lower_bound ?? 0),
+            upperBounds: processedData.map((point) => point.upper_bound ?? 0),
+        }
+    }, [processedData, variantColor])
+
+    const config = useChartConfig<TimeSeriesLineChartConfig>(
+        () => ({
+            xAxis: { interval: 'day', timezone, tickLabelRotation: -45 },
+            yAxis: { format: 'percentage_scaled', decimalPlaces: 0 },
+            confidenceIntervals: [{ seriesKey: DELTA_SERIES_KEY, lower: lowerBounds, upper: upperBounds }],
+            // A goal line rather than an overlay child: it also stretches the axis so zero stays
+            // on-plot when every delta sits on one side of it.
+            goalLines: [{ value: 0, displayLabel: false, color: colors.ZERO_LINE }],
+        }),
+        [timezone, lowerBounds, upperBounds, colors.ZERO_LINE]
+    )
+
+    return (
+        <div className="relative h-[224px] flex flex-col">
+            <TimeSeriesLineChart
+                series={series}
+                labels={labels}
+                theme={theme}
+                config={config}
+                tooltip={({ dataIndex }) => {
+                    const point = processedData[dataIndex]
+                    if (!point) {
+                        return null
+                    }
+                    return (
+                        <VariantTimeseriesTooltip
+                            date={point.date}
+                            delta={point.value}
+                            lowerBound={point.lower_bound}
+                            upperBound={point.upper_bound}
+                            isRatioMetric={isRatioMetric}
+                            exposures={point.number_of_samples}
+                            denominator={point.denominator_sum}
+                            significant={point.significant}
+                            hasRealData={point.hasRealData}
+                            computedAt={computedAt}
+                        />
+                    )
+                }}
+            />
+        </div>
+    )
+}

--- a/frontend/src/scenes/experiments/MetricsView/new/VariantTimeseriesChart.test.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/VariantTimeseriesChart.test.tsx
@@ -1,0 +1,122 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render } from '@testing-library/react'
+
+import { getHogChart, hoverUntilTooltip, setupJsdom, setupSyncRaf } from '@posthog/quill-charts/testing'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+
+import { initKeaTests } from '~/test/init'
+
+import type { ProcessedChartData, ProcessedTimeseriesDataPoint } from '../../experimentTimeseriesLogic'
+import { VariantTimeseriesChart } from './VariantTimeseriesChart'
+
+let cleanupJsdom: () => void
+let cleanupRaf: () => void
+
+beforeEach(() => {
+    cleanupJsdom = setupJsdom()
+    cleanupRaf = setupSyncRaf()
+})
+
+afterEach(() => {
+    cleanupRaf()
+    cleanupJsdom()
+    cleanup()
+})
+
+const POINTS: ProcessedTimeseriesDataPoint[] = [
+    {
+        date: '2026-06-01',
+        value: 0.04,
+        lower_bound: 0.01,
+        upper_bound: 0.07,
+        hasRealData: true,
+        number_of_samples: 1200,
+        significant: true,
+    },
+    {
+        date: '2026-06-02',
+        value: 0.06,
+        lower_bound: 0.03,
+        upper_bound: 0.09,
+        hasRealData: true,
+        number_of_samples: 2400,
+        significant: true,
+    },
+    // Not computed yet — the logic carries the previous day's value forward.
+    {
+        date: '2026-06-03',
+        value: 0.06,
+        lower_bound: 0.03,
+        upper_bound: 0.09,
+        hasRealData: false,
+        number_of_samples: 2400,
+        significant: true,
+    },
+]
+
+const CHART_DATA: ProcessedChartData = {
+    labels: POINTS.map((point) => point.date),
+    // Only the legacy Chart.js path reads `datasets`; the quill path builds series from `processedData`.
+    datasets: [],
+    processedData: POINTS,
+    computedAt: null,
+    variantColor: '#1d4aff',
+}
+
+function renderChart(quillFlag: boolean): void {
+    initKeaTests()
+    const ffLogic = featureFlagLogic()
+    ffLogic.mount()
+    // The featureFlags reducer is kea-persisted to localStorage and survives across tests in this
+    // file, so set the flag explicitly in both directions rather than relying on "unset means off".
+    ffLogic.actions.setFeatureFlags([FEATURE_FLAGS.EXPERIMENTS_QUILL_TIMESERIES_CHART], {
+        [FEATURE_FLAGS.EXPERIMENTS_QUILL_TIMESERIES_CHART]: quillFlag,
+    })
+    render(<VariantTimeseriesChart chartData={CHART_DATA} />)
+}
+
+// Quill labels its main canvas for a11y and adds an aria-hidden hover overlay; the Chart.js
+// canvas carries neither attribute.
+const quillCanvas = (): Element | null => document.querySelector('canvas[aria-label]')
+const legacyCanvas = (): Element | null => document.querySelector('canvas:not([aria-label]):not([aria-hidden])')
+
+describe('VariantTimeseriesChart', () => {
+    it('renders via quill when the flag is on', () => {
+        renderChart(true)
+        expect(quillCanvas()).toBeTruthy()
+        expect(legacyCanvas()).toBeNull()
+    })
+
+    it('renders via Chart.js when the flag is off', () => {
+        renderChart(false)
+        expect(legacyCanvas()).toBeTruthy()
+        expect(quillCanvas()).toBeNull()
+    })
+
+    it('draws the delta line with a confidence interval band', () => {
+        renderChart(true)
+        // The delta series plus the band derived from it — a mismatched CI `seriesKey` would
+        // silently drop the band and leave one series.
+        expect(getHogChart().seriesCount).toBe(2)
+    })
+
+    it('labels the value axis as whole percentages', () => {
+        renderChart(true)
+        // Deltas arrive as fractions, so the axis needs the 0–1 percentage format; the 0–100 one
+        // would render 0.06 as "0.06%".
+        expect(getHogChart().yTicks()).toContain('6%')
+    })
+
+    it('shows the hovered day in the tooltip', async () => {
+        renderChart(true)
+        const tooltip = await hoverUntilTooltip(getHogChart().element, 1, POINTS.length)
+
+        expect(tooltip).toHaveTextContent('Jun 2, 2026')
+        expect(tooltip).toHaveTextContent('6.00%')
+        expect(tooltip).toHaveTextContent('3.00% → 9.00%')
+        expect(tooltip).toHaveTextContent('2,400')
+    })
+})

--- a/frontend/src/scenes/experiments/MetricsView/new/VariantTimeseriesChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/VariantTimeseriesChart.tsx
@@ -1,145 +1,23 @@
-import { useChart } from 'lib/hooks/useChart'
-import { useInsightTooltip } from 'scenes/insights/useInsightTooltip'
+import { useValues } from 'kea'
 
-import { ProcessedChartData } from '../../experimentTimeseriesLogic'
-import { useChartColors } from '../shared/colors'
-import { VariantTimeseriesTooltip } from './VariantTimeseriesTooltip'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
-interface VariantTimeseriesChartProps {
+import type { ProcessedChartData } from '../../experimentTimeseriesLogic'
+import { LegacyVariantTimeseriesChart } from './LegacyVariantTimeseriesChart'
+import { QuillVariantTimeseriesChart } from './QuillVariantTimeseriesChart'
+
+export interface VariantTimeseriesChartProps {
     chartData: ProcessedChartData
     isRatioMetric?: boolean
 }
 
-export function VariantTimeseriesChart({
-    chartData: data,
-    isRatioMetric = false,
-}: VariantTimeseriesChartProps): JSX.Element {
-    const colors = useChartColors()
-    const { getTooltip, showTooltip, hideTooltip, positionTooltip } = useInsightTooltip()
+export function VariantTimeseriesChart(props: VariantTimeseriesChartProps): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
 
-    const { canvasRef } = useChart<'line'>({
-        getConfig: () => {
-            if (!data) {
-                return null
-            }
+    if (featureFlags[FEATURE_FLAGS.EXPERIMENTS_QUILL_TIMESERIES_CHART]) {
+        return <QuillVariantTimeseriesChart {...props} />
+    }
 
-            const { labels, datasets, processedData, computedAt } = data
-
-            return {
-                type: 'line' as const,
-                data: { labels, datasets },
-                options: {
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    interaction: {
-                        intersect: false,
-                        mode: 'nearest',
-                        axis: 'x',
-                    },
-                    scales: {
-                        y: {
-                            grid: {
-                                display: true,
-                                color: (context) => {
-                                    if (context.tick.value === 0) {
-                                        return colors.ZERO_LINE
-                                    }
-                                    return colors.EXPOSURES_AXIS_LINES
-                                },
-                                lineWidth: (context) => {
-                                    if (context.tick.value === 0) {
-                                        return 1.25
-                                    }
-                                    return 1
-                                },
-                            },
-                            ticks: {
-                                callback: (value) => {
-                                    const num = Number(value)
-                                    return `${(num * 100).toFixed(0)}%`
-                                },
-                            },
-                            afterBuildTicks: (axis) => {
-                                const ticks = axis.ticks.map((t) => t.value)
-                                if (!ticks.includes(0)) {
-                                    axis.ticks.push({ value: 0 })
-                                    axis.ticks.sort((a, b) => a.value - b.value)
-                                }
-                                // When 0 is the lowest tick, pad below so it doesn't
-                                // overlap with x-axis date labels
-                                if (axis.ticks.length > 1 && axis.ticks[0].value === 0) {
-                                    const tickStep = axis.ticks[1].value - axis.ticks[0].value
-                                    axis.min = -tickStep * 0.3
-                                }
-                            },
-                        },
-                        x: {
-                            grid: {
-                                display: false,
-                            },
-                            ticks: {
-                                maxRotation: 45,
-                                minRotation: 45,
-                            },
-                        },
-                    },
-                    plugins: {
-                        legend: {
-                            display: false,
-                        },
-                        tooltip: {
-                            enabled: false,
-                            external: ({ chart, tooltip }) => {
-                                const canvas = chart.canvas
-                                if (!canvas) {
-                                    return
-                                }
-
-                                const [tooltipRoot, tooltipEl] = getTooltip()
-
-                                if (tooltip.opacity === 0 || !tooltip.dataPoints?.length) {
-                                    hideTooltip()
-                                    return
-                                }
-
-                                const dataIndex = tooltip.dataPoints[0].dataIndex
-                                const dataPoint = processedData[dataIndex]
-                                if (!dataPoint) {
-                                    hideTooltip()
-                                    return
-                                }
-
-                                showTooltip()
-                                tooltipRoot.render(
-                                    <VariantTimeseriesTooltip
-                                        date={dataPoint.date}
-                                        delta={dataPoint.value}
-                                        lowerBound={dataPoint.lower_bound}
-                                        upperBound={dataPoint.upper_bound}
-                                        isRatioMetric={isRatioMetric}
-                                        exposures={dataPoint.number_of_samples}
-                                        denominator={dataPoint.denominator_sum}
-                                        significant={dataPoint.significant}
-                                        hasRealData={dataPoint.hasRealData}
-                                        computedAt={computedAt}
-                                    />
-                                )
-
-                                const bounds = canvas.getBoundingClientRect()
-                                positionTooltip(tooltipEl, bounds, tooltip.caretX, 0, false)
-                            },
-                        },
-                        crosshair: false,
-                    },
-                },
-            }
-        },
-        deps: [data, colors.EXPOSURES_AXIS_LINES, colors.ZERO_LINE, isRatioMetric],
-    })
-
-    return (
-        <div className="relative h-[224px]">
-            <canvas ref={canvasRef} />
-        </div>
-    )
+    return <LegacyVariantTimeseriesChart {...props} />
 }

--- a/frontend/src/scenes/experiments/MetricsView/new/VariantTimeseriesChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/VariantTimeseriesChart.tsx
@@ -1,7 +1,4 @@
-import { useValues } from 'kea'
-
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 
 import type { ProcessedChartData } from '../../experimentTimeseriesLogic'
 import { LegacyVariantTimeseriesChart } from './LegacyVariantTimeseriesChart'
@@ -13,9 +10,9 @@ export interface VariantTimeseriesChartProps {
 }
 
 export function VariantTimeseriesChart(props: VariantTimeseriesChartProps): JSX.Element {
-    const { featureFlags } = useValues(featureFlagLogic)
+    const quillEnabled = useFeatureFlag('EXPERIMENTS_QUILL_TIMESERIES_CHART')
 
-    if (featureFlags[FEATURE_FLAGS.EXPERIMENTS_QUILL_TIMESERIES_CHART]) {
+    if (quillEnabled) {
         return <QuillVariantTimeseriesChart {...props} />
     }
 

--- a/frontend/src/scenes/experiments/experimentTimeseriesLogic.ts
+++ b/frontend/src/scenes/experiments/experimentTimeseriesLogic.ts
@@ -52,6 +52,8 @@ export interface ProcessedChartData {
     processedData: ProcessedTimeseriesDataPoint[]
     /** When the timeseries was last computed (ISO string), shared across all data points. */
     computedAt: string | null
+    /** Color of the variant's line, from the experiment's stable variant order. */
+    variantColor: string
 }
 
 export interface ExperimentTimeseriesLogicProps {
@@ -513,6 +515,7 @@ export const experimentTimeseriesLogic = kea<experimentTimeseriesLogicType>([
                         datasets,
                         processedData: trimmedData,
                         computedAt: timeseries?.computed_at ?? null,
+                        variantColor,
                     }
                 }
             },


### PR DESCRIPTION
## Problem

- The variant timeseries chart is the last chart in experiments still drawn by chart.js, so the product cannot come off the legacy renderer.
- Deleting `lib/Chart.ts`, `lib/hooks/useChart.ts`, and eight chart.js packages waits on every remaining consumer.
- The new metrics view is the live default and is not flag-gated, so a direct swap would ship to everyone unverified.

## Changes

`QuillVariantTimeseriesChart` draws the delta line through `TimeSeriesLineChart`.

![experiments-quill-variant-timeseries](https://raw.githubusercontent.com/PostHog/pr-assets/59333e8b890c24a1135c30044bd9f62833f449cb/2026/08/dc105d39-8c70-4d60-a5d1-b8733d3a5dc9.png)

- The confidence interval comes from `config.confidenceIntervals` rather than a pair of hand-built bound datasets.
- Days the daily job has not computed dash the line from the last measured day, replacing per-segment chart.js callbacks.
- Zero sits on a goal line, which also stretches the axis so zero stays on-plot when every delta falls on one side of it.
- `experiments-quill-timeseries-chart` picks the renderer. The chart.js version moves to `LegacyVariantTimeseriesChart` unchanged, so the default path is byte-identical.
- The logic now carries `variantColor` on its chart data. The quill path reads the color directly instead of unpacking a chart.js dataset.

> [!NOTE]
> The confidence band no longer tints green or red by significance. Quill fills an area with one color, so the band takes the variant color and significance stays in the tooltip, which already reports it per day.

## How did you test this code?

- New `VariantTimeseriesChart.test.tsx`, five cases. Each covers a regression no existing test did, because the file had no tests: flag on renders quill, flag off renders chart.js, the confidence band survives (a mismatched `seriesKey` drops it silently), the axis reads `6%` and not `0.06%`, and the tooltip reports the hovered day.
- I rendered the component in Storybook and screenshotted it with Playwright. That is the screenshot above, and it is how I caught the dashed tail starting one segment early: quill's `stroke.partial.fromIndex` dashes the segment arriving at that index, not leaving it.
- Not checked: the chart in the running app. I cannot drive a browser through the experiment scene here, so the modal open path, the recalculation banners, and the resize behaviour are unverified.
- Not checked: dark mode. Storybook's theme keys off `document.body[theme]`, which the Playwright `colorScheme` option does not set.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Sam asked for the last experiments chart to move to quill. I (actually Claude) wrote it. Skills invoked: `/writing-pr-descriptions`.

Two decisions worth a reviewer's attention. The flag exists only because the new metrics view ships unconditionally, so it should come out once the chart is verified in production. And the significance tinting was dropped rather than reproduced: an area fill takes one color in quill, and threading per-segment colors through would mean a new capability in the charts package for one surface.

Related, not in this PR: the funnel metric chart migration in #70991, and the two remaining Chart.js consumers in alerts.
