### PR TITLE
chore(flags): rename early exit checkbox to name what must match

### DIFF
--- a/frontend/src/scenes/feature-flags/EarlyExitIndicator.tsx
+++ b/frontend/src/scenes/feature-flags/EarlyExitIndicator.tsx
@@ -4,10 +4,10 @@ import { Tooltip } from '@posthog/lemon-ui'
 export function EarlyExitIndicator(): JSX.Element {
     return (
         <div className="flex items-center gap-1.5 text-xs text-muted">
-            <Tooltip title="Conditions are evaluated in order — the first matching condition set determines the result and later conditions are skipped.">
+            <Tooltip title="Condition sets are evaluated in order. The first set whose property filters match decides the result — if that set's rollout percentage excludes the user, the flag returns false and later sets are skipped.">
                 <IconInfo className="text-sm" />
             </Tooltip>
-            <span>Stops evaluation at first matching condition set</span>
+            <span>Stops at the first condition set whose property filters match</span>
         </div>
     )
 }

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -1087,8 +1087,8 @@ export function FeatureFlagReleaseConditionsCollapsible({
                             data-attr="flag-early-exit"
                             checked={releaseFilters.early_exit ?? false}
                             onChange={(checked) => setEarlyExit(checked)}
-                            label="Stop evaluation at first matching condition set"
-                            info="When enabled, conditions are evaluated in order — the first matching condition set determines the result and later conditions are skipped. When disabled, all conditions are evaluated, and a pass on any condition is a pass."
+                            label="Stop at the first condition set whose property filters match"
+                            info="Condition sets are evaluated in order. When enabled, the first set whose property filters match decides the result — if that set's rollout percentage excludes the user, the flag returns false and later sets are skipped. When disabled, the user falls through to the next set instead, and a pass on any set is a pass."
                         />
                     </div>
                     {releaseFilters.early_exit && (


### PR DESCRIPTION
## Problem

Someone configuring a flag can't tell from the early exit checkbox what it will do, and the label actively misleads them.

The label reads "Stop evaluation at first matching condition set". Two lines above it, the same panel defines a match as "all property filters pass AND the target falls within the rollout percentage." Under that definition the checkbox is a no-op — a fully matching set already stops evaluation and returns `true`. The label means "matching" in a narrower sense: property filters matched, rollout ignored. So the one case the setting actually changes — property filters match but the rollout excludes the user, and the flag returns `false` instead of falling through — is the case the label never mentions.

## Changes

- Label is now "Stop at the first condition set whose property filters match", which names which part has to match. "Property filters" is already the panel's own term.
- Read-only indicator follows suit: "Stops at the first condition set whose property filters match".
- Both tooltips now state the rollout-exclusion case outright, and the checkbox tooltip contrasts it with the fall-through behavior you get when the box is unchecked.

Copy only — no behavior change. `early_exit` still evaluates exactly as before: `flag_matching.rs` short-circuits only on an `OutOfRolloutBound` reason, which `check_rollout` alone produces.

Not in this PR: the `early_exit` `help_text` in `products/feature_flags/backend/api/filters_schema.py` has the same ambiguity, but it feeds ~8 generated schema files and MCP snapshots. Worth a follow-up that can run codegen.

## How did you test this code?

Not manually tested — I had no dev environment to render the panel, and I ran no automated tests. The change is two string literals in two components.

No test asserts on either string (grepped the repo for both, plus "Stops evaluation at"), so nothing needed updating. Prettier can't break string literals and each JSX attribute was already on its own line, so formatting is unchanged in shape.

Worth a reviewer eyeballing the checkbox label for wrapping at narrow widths — it is 7 characters longer than the old one.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Matching docs change on posthog.com: PostHog/posthog.com#19388, which rewrites the section this label links to.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude Opus 5) from a Slack thread. No repo skills were invoked.

The thread started as a docs request — a teammate found this setting's documentation hard to follow and asked for a clearer explanation with an example. Verifying the explanation against `rust/feature-flags/src/flags/flag_matching.rs` confirmed it was accurate but surfaced the label problem above, which is the likely root cause of the confusion, so the rename became its own change. Considered several alternatives that read more naturally but reintroduce the bug — "that applies to the user", "the user qualifies for" — since both imply the user gets the flag, when the whole point is that a set can match and still return `false`.

No assignee set: the requester directed this work, but I could not verify their GitHub handle from Slack, and guessing one would tag an unrelated account. Please assign the DRI on triage.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1786466859234729)*
