### PR TITLE
chore(quill): upgrade to base ui 1.7.0 and forward its component docs

### DIFF
--- a/packages/quill/AGENTS.md
+++ b/packages/quill/AGENTS.md
@@ -40,6 +40,14 @@ const Button = React.forwardRef<HTMLButtonElement, Props>(({ className, variant,
 ))
 ```
 
+Always type the wrapper with the Base UI part's own props (`ButtonPrimitive.Props`, `Accordion.Root.Props`, or `React.ComponentProps<typeof X>`) and spread `...props` onto it.
+That is what makes every upstream prop — and the JSDoc attached to it — reachable from a consumer's editor.
+Intersect with a local object type for quill's own props; never replace the Base UI type with a hand-rolled one.
+
+Base UI also documents each component itself, and that prose is copied onto the wrappers by `pnpm --filter @posthog/quill-workspace sync:base-ui-docs`.
+Run it after upgrading `@base-ui/react` and commit the result, so hovering a quill primitive shows the upstream description and docs link.
+The generated text runs from the top of the doc block down to the `@baseui` tag; anything you write below that tag is yours and survives regeneration.
+
 ### 2. CVA for variants
 
 All variant styling uses `class-variance-authority`.

--- a/packages/quill/package.json
+++ b/packages/quill/package.json
@@ -7,10 +7,14 @@
         "dev": "pnpm --filter @posthog/quill-web dev",
         "storybook": "pnpm --filter @posthog/quill-tokens build && pnpm --filter @posthog/quill-storybook storybook",
         "build": "pnpm -r --filter '@posthog/quill-*' --filter '@posthog/quill' build",
-        "typecheck": "pnpm -r typecheck"
+        "typecheck": "pnpm -r typecheck",
+        "sync:base-ui-docs": "tsx scripts/sync-base-ui-docs.ts",
+        "sync:base-ui-docs:check": "tsx scripts/sync-base-ui-docs.ts --check"
     },
     "devDependencies": {
+        "@base-ui/react": "catalog:",
         "tailwindcss-scroll-mask": "^0.0.3",
+        "tsx": "^4.19.0",
         "typescript": "catalog:"
     }
 }

--- a/packages/quill/packages/components/vite.config.ts
+++ b/packages/quill/packages/components/vite.config.ts
@@ -25,9 +25,6 @@ export default defineConfig({
                 '@posthog/quill-tokens',
                 '@posthog/quill-primitives',
                 '@posthog/quill-charts',
-                // Surfaces in DataTable's public types, so @posthog/quill declares it as a real
-                // dependency — external here too rather than inlining a second copy.
-                '@tanstack/react-table',
             ],
         },
         cssCodeSplit: false,

--- a/packages/quill/packages/components/vite.config.ts
+++ b/packages/quill/packages/components/vite.config.ts
@@ -25,6 +25,9 @@ export default defineConfig({
                 '@posthog/quill-tokens',
                 '@posthog/quill-primitives',
                 '@posthog/quill-charts',
+                // Surfaces in DataTable's public types, so @posthog/quill declares it as a real
+                // dependency — external here too rather than inlining a second copy.
+                '@tanstack/react-table',
             ],
         },
         cssCodeSplit: false,

--- a/packages/quill/packages/primitives/src/accordion.tsx
+++ b/packages/quill/packages/primitives/src/accordion.tsx
@@ -5,6 +5,14 @@ import * as React from 'react'
 import './accordion.css'
 import { cn } from './lib/utils'
 
+/**
+ * Groups all parts of the accordion.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Accordion](https://base-ui.com/react/components/accordion)
+ *
+ * @baseui Accordion.Root
+ */
 function Accordion({ className, ...props }: AccordionPrimitive.Root.Props): React.ReactElement {
     return (
         <AccordionPrimitive.Root
@@ -15,6 +23,14 @@ function Accordion({ className, ...props }: AccordionPrimitive.Root.Props): Reac
     )
 }
 
+/**
+ * Groups an accordion header with the corresponding panel.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Accordion](https://base-ui.com/react/components/accordion)
+ *
+ * @baseui Accordion.Item
+ */
 function AccordionItem({ className, ...props }: AccordionPrimitive.Item.Props): React.ReactElement {
     return (
         <AccordionPrimitive.Item
@@ -26,6 +42,14 @@ function AccordionItem({ className, ...props }: AccordionPrimitive.Item.Props): 
     )
 }
 
+/**
+ * A button that opens and closes the corresponding panel.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Accordion](https://base-ui.com/react/components/accordion)
+ *
+ * @baseui Accordion.Trigger
+ */
 function AccordionTrigger({ className, children, ...props }: AccordionPrimitive.Trigger.Props): React.ReactElement {
     return (
         <AccordionPrimitive.Header className="flex">
@@ -53,6 +77,14 @@ function AccordionTrigger({ className, children, ...props }: AccordionPrimitive.
     )
 }
 
+/**
+ * A collapsible panel with the accordion item contents.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Accordion](https://base-ui.com/react/components/accordion)
+ *
+ * @baseui Accordion.Panel
+ */
 function AccordionContent({ className, children, ...props }: AccordionPrimitive.Panel.Props): React.ReactElement {
     return (
         <AccordionPrimitive.Panel data-slot="accordion-content" className="quill-accordion__panel" {...props}>

--- a/packages/quill/packages/primitives/src/alert-dialog.tsx
+++ b/packages/quill/packages/primitives/src/alert-dialog.tsx
@@ -14,22 +14,63 @@ import { cn } from './lib/utils'
  * is fully shared: every part reuses the `quill-dialog__*` styles from
  * dialog.css.
  */
+/**
+ * Groups all parts of the alert dialog.
+ * Doesn't render its own HTML element.
+ *
+ * Documentation: [Base UI Alert Dialog](https://base-ui.com/react/components/alert-dialog)
+ *
+ * @baseui AlertDialog.Root
+ */
 function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props): React.ReactElement {
     return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
 }
 
+/**
+ * A button that opens the alert dialog.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Alert Dialog](https://base-ui.com/react/components/alert-dialog)
+ *
+ * @baseui AlertDialog.Trigger
+ */
 function AlertDialogTrigger({ ...props }: AlertDialogPrimitive.Trigger.Props): React.ReactElement {
     return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
 }
 
+/**
+ * A portal element that moves the popup to a different part of the DOM.
+ * By default, the portal element is appended to `<body>`.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Dialog](https://base-ui.com/react/components/dialog)
+ *
+ * @baseui AlertDialog.Portal
+ */
 function AlertDialogPortal({ ...props }: AlertDialogPrimitive.Portal.Props): React.ReactElement {
     return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
 }
 
+/**
+ * A button that closes the dialog.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Dialog](https://base-ui.com/react/components/dialog)
+ *
+ * @baseui AlertDialog.Close
+ */
 function AlertDialogClose({ ...props }: AlertDialogPrimitive.Close.Props): React.ReactElement {
     return <AlertDialogPrimitive.Close data-slot="alert-dialog-close" {...props} />
 }
 
+/**
+ * An overlay displayed beneath the popup.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Dialog](https://base-ui.com/react/components/dialog)
+ *
+ * @baseui AlertDialog.Backdrop
+ */
 function AlertDialogOverlay({ className, ...props }: AlertDialogPrimitive.Backdrop.Props): React.ReactElement {
     return (
         <AlertDialogPrimitive.Backdrop
@@ -46,6 +87,14 @@ function AlertDialogOverlay({ className, ...props }: AlertDialogPrimitive.Backdr
  * Unlike DialogContent there is deliberately no `showCloseButton` — an alert
  * dialog must be resolved through one of its actions (or Esc), so an X would
  * just be an ambiguous third option.
+ */
+/**
+ * A container for the dialog contents.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Dialog](https://base-ui.com/react/components/dialog)
+ *
+ * @baseui AlertDialog.Popup
  */
 function AlertDialogContent({ className, children, ...props }: AlertDialogPrimitive.Popup.Props): React.ReactElement {
     return (
@@ -64,6 +113,14 @@ function AlertDialogContent({ className, children, ...props }: AlertDialogPrimit
     )
 }
 
+/**
+ * A heading that labels the dialog.
+ * Renders an `<h2>` element.
+ *
+ * Documentation: [Base UI Dialog](https://base-ui.com/react/components/dialog)
+ *
+ * @baseui AlertDialog.Title
+ */
 function AlertDialogTitle({ className, ...props }: AlertDialogPrimitive.Title.Props): React.ReactElement {
     return (
         <AlertDialogPrimitive.Title
@@ -74,6 +131,14 @@ function AlertDialogTitle({ className, ...props }: AlertDialogPrimitive.Title.Pr
     )
 }
 
+/**
+ * A paragraph with additional information about the dialog.
+ * Renders a `<p>` element.
+ *
+ * Documentation: [Base UI Dialog](https://base-ui.com/react/components/dialog)
+ *
+ * @baseui AlertDialog.Description
+ */
 function AlertDialogDescription({ className, ...props }: AlertDialogPrimitive.Description.Props): React.ReactElement {
     return (
         <AlertDialogPrimitive.Description

--- a/packages/quill/packages/primitives/src/autocomplete.tsx
+++ b/packages/quill/packages/primitives/src/autocomplete.tsx
@@ -37,10 +37,26 @@ function Autocomplete<Value>({
     )
 }
 
+/**
+ * The current value of the autocomplete.
+ * Doesn't render its own HTML element.
+ *
+ * Documentation: [Base UI Autocomplete](https://base-ui.com/react/components/autocomplete)
+ *
+ * @baseui Autocomplete.Value
+ */
 function AutocompleteValue({ ...props }: AutocompletePrimitive.Value.Props): React.ReactElement {
     return <AutocompletePrimitive.Value data-slot="autocomplete-value" {...props} />
 }
 
+/**
+ * A button that opens the popup.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Autocomplete](https://base-ui.com/react/components/autocomplete)
+ *
+ * @baseui Autocomplete.Trigger
+ */
 const AutocompleteTrigger = React.forwardRef<HTMLButtonElement, AutocompletePrimitive.Trigger.Props>(
     ({ className, children, ...props }, ref) => (
         <AutocompletePrimitive.Trigger
@@ -56,6 +72,14 @@ const AutocompleteTrigger = React.forwardRef<HTMLButtonElement, AutocompletePrim
 )
 AutocompleteTrigger.displayName = 'AutocompleteTrigger'
 
+/**
+ * Clears the value when clicked.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
+ *
+ * @baseui Autocomplete.Clear
+ */
 function AutocompleteClear({ className, ...props }: AutocompletePrimitive.Clear.Props): React.ReactElement {
     return (
         <AutocompletePrimitive.Clear
@@ -69,6 +93,14 @@ function AutocompleteClear({ className, ...props }: AutocompletePrimitive.Clear.
     )
 }
 
+/**
+ * A text input to search for items in the list.
+ * Renders an `<input>` element.
+ *
+ * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
+ *
+ * @baseui Autocomplete.Input
+ */
 function AutocompleteInput({
     className,
     children,
@@ -112,6 +144,14 @@ function AutocompleteInput({
     )
 }
 
+/**
+ * A container for the list.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
+ *
+ * @baseui Autocomplete.Popup
+ */
 function AutocompleteContent({
     className,
     side = 'bottom',
@@ -149,6 +189,14 @@ function AutocompleteContent({
     )
 }
 
+/**
+ * A list container for the items.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
+ *
+ * @baseui Autocomplete.List
+ */
 function AutocompleteList({ className, ...props }: AutocompletePrimitive.List.Props): React.ReactElement {
     return (
         <AutocompletePrimitive.List
@@ -159,6 +207,14 @@ function AutocompleteList({ className, ...props }: AutocompletePrimitive.List.Pr
     )
 }
 
+/**
+ * An individual item in the list.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Autocomplete](https://base-ui.com/react/components/autocomplete)
+ *
+ * @baseui Autocomplete.Item
+ */
 function AutocompleteItem({
     className,
     children,
@@ -184,10 +240,26 @@ function AutocompleteItem({
     )
 }
 
+/**
+ * Groups related items with the corresponding label.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
+ *
+ * @baseui Autocomplete.Group
+ */
 function AutocompleteGroup({ className, ...props }: AutocompletePrimitive.Group.Props): React.ReactElement {
     return <AutocompletePrimitive.Group data-slot="autocomplete-group" className={cn('pb-1', className)} {...props} />
 }
 
+/**
+ * An accessible label that is automatically associated with its parent group.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
+ *
+ * @baseui Autocomplete.GroupLabel
+ */
 function AutocompleteLabel({ className, ...props }: AutocompletePrimitive.GroupLabel.Props): React.ReactElement {
     return (
         <AutocompletePrimitive.GroupLabel
@@ -199,10 +271,34 @@ function AutocompleteLabel({ className, ...props }: AutocompletePrimitive.GroupL
     )
 }
 
+/**
+ * Renders filtered list items.
+ * Doesn't render its own HTML element.
+ *
+ * If rendering a flat list, pass a function child to the `List` component instead, which implicitly wraps it.
+ *
+ * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
+ *
+ * @baseui Autocomplete.Collection
+ */
 function AutocompleteCollection({ ...props }: AutocompletePrimitive.Collection.Props): React.ReactElement {
     return <AutocompletePrimitive.Collection data-slot="autocomplete-collection" {...props} />
 }
 
+/**
+ * Renders its children only when the list is empty.
+ * Requires the `items` prop on the root component.
+ * Announces changes politely to screen readers.
+ * This component's root element must remain mounted in the DOM to announce
+ * changes consistently across screen readers. Avoid hiding or removing the
+ * component itself with `display: none`, `hidden`, `aria-hidden`, or conditional
+ * rendering. Prefer updating or conditionally rendering its children instead.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
+ *
+ * @baseui Autocomplete.Empty
+ */
 function AutocompleteEmpty({ className, children, ...props }: AutocompletePrimitive.Empty.Props): React.ReactElement {
     // Nest MenuEmpty as a child rather than passing it via `render`. With
     // `render`, MenuEmpty's `buttonVariants` `inline-flex` would merge onto
@@ -221,6 +317,14 @@ function AutocompleteEmpty({ className, children, ...props }: AutocompletePrimit
     )
 }
 
+/**
+ * A visual separator between items or groups.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Autocomplete](https://base-ui.com/react/components/autocomplete)
+ *
+ * @baseui Autocomplete.Separator
+ */
 function AutocompleteSeparator({
     className,
     ...props
@@ -250,6 +354,18 @@ function countAutocompleteLeaves(items: unknown): number {
 }
 
 /**
+ * Displays a status message whose content changes are announced politely to screen readers.
+ * Useful for conveying the status of an asynchronously loaded list.
+ * This component's root element must remain mounted in the DOM to announce
+ * changes consistently across screen readers. Avoid hiding or removing the
+ * component itself with `display: none`, `hidden`, `aria-hidden`, or conditional
+ * rendering. Prefer updating or conditionally rendering its children instead.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
+ *
+ * @baseui Autocomplete.Status
+ *
  * Live region announcer that also renders visible status text. Default
  * content is "{count} results" pluralized; pass `emptyContent` to override
  * the zero-count state, or `children` (string / node / function) to fully

--- a/packages/quill/packages/primitives/src/avatar.tsx
+++ b/packages/quill/packages/primitives/src/avatar.tsx
@@ -7,6 +7,14 @@ import { cn } from './lib/utils'
 
 type AvatarSize = 'lg' | 'default' | 'sm' | 'xs'
 
+/**
+ * Displays a user's profile picture, initials, or fallback icon.
+ * Renders a `<span>` element.
+ *
+ * Documentation: [Base UI Avatar](https://base-ui.com/react/components/avatar)
+ *
+ * @baseui Avatar.Root
+ */
 const Avatar = React.forwardRef<
     HTMLSpanElement,
     React.ComponentProps<typeof AvatarPrimitive.Root> & { size?: AvatarSize }
@@ -23,6 +31,14 @@ const Avatar = React.forwardRef<
     )
 })
 
+/**
+ * The image to be displayed in the avatar.
+ * Renders an `<img>` element.
+ *
+ * Documentation: [Base UI Avatar](https://base-ui.com/react/components/avatar)
+ *
+ * @baseui Avatar.Image
+ */
 const AvatarImage = React.forwardRef<HTMLImageElement, React.ComponentProps<typeof AvatarPrimitive.Image>>(
     function AvatarImage({ className, ...props }, ref) {
         return (
@@ -36,6 +52,14 @@ const AvatarImage = React.forwardRef<HTMLImageElement, React.ComponentProps<type
     }
 )
 
+/**
+ * Rendered when the image fails to load or when no image is provided.
+ * Renders a `<span>` element.
+ *
+ * Documentation: [Base UI Avatar](https://base-ui.com/react/components/avatar)
+ *
+ * @baseui Avatar.Fallback
+ */
 const AvatarFallback = React.forwardRef<HTMLSpanElement, React.ComponentProps<typeof AvatarPrimitive.Fallback>>(
     function AvatarFallback({ className, ...props }, ref) {
         return (

--- a/packages/quill/packages/primitives/src/button.tsx
+++ b/packages/quill/packages/primitives/src/button.tsx
@@ -55,6 +55,14 @@ export type ButtonProps = ButtonPrimitive.Props &
         loading?: boolean
     }
 
+/**
+ * A button component that can be used to trigger actions.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Button](https://base-ui.com/react/components/button)
+ *
+ * @baseui Button
+ */
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     (
         {

--- a/packages/quill/packages/primitives/src/chat/chat-task-list.tsx
+++ b/packages/quill/packages/primitives/src/chat/chat-task-list.tsx
@@ -62,6 +62,14 @@ type ChatTaskListProps = React.ComponentProps<typeof CollapsiblePrimitive.Root> 
     total: number
 }
 
+/**
+ * Groups all parts of the collapsible.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Collapsible](https://base-ui.com/react/components/collapsible)
+ *
+ * @baseui Collapsible.Root
+ */
 function ChatTaskList({ value, total, className, ...props }: ChatTaskListProps): React.ReactElement {
     const context = React.useMemo(() => ({ value, total }), [value, total])
 
@@ -77,6 +85,14 @@ function ChatTaskList({ value, total, className, ...props }: ChatTaskListProps):
     )
 }
 
+/**
+ * A button that opens and closes the collapsible panel.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Collapsible](https://base-ui.com/react/components/collapsible)
+ *
+ * @baseui Collapsible.Trigger
+ */
 function ChatTaskListTrigger({
     className,
     children,

--- a/packages/quill/packages/primitives/src/chat/thread-item.tsx
+++ b/packages/quill/packages/primitives/src/chat/thread-item.tsx
@@ -121,6 +121,13 @@ function ThreadItemLink({ className, render, ...props }: useRender.ComponentProp
 }
 
 /**
+ * Groups all parts of the collapsible.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Collapsible](https://base-ui.com/react/components/collapsible)
+ *
+ * @baseui Collapsible.Root
+ *
  * Collapsible attachment (image/file preview) — a Base UI Collapsible, open by default. The
  * trigger carries the filename and a rotating chevron; keyboard/AT get `aria-expanded` for free.
  */
@@ -140,7 +147,16 @@ function ThreadItemAttachment({
     )
 }
 
-/** Filename row that toggles the attachment preview. Children become the visible label. */
+/**
+ * A button that opens and closes the collapsible panel.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Collapsible](https://base-ui.com/react/components/collapsible)
+ *
+ * @baseui Collapsible.Trigger
+ *
+ * Filename row that toggles the attachment preview. Children become the visible label.
+ */
 function ThreadItemAttachmentTrigger({
     children,
     className,
@@ -158,6 +174,14 @@ function ThreadItemAttachmentTrigger({
     )
 }
 
+/**
+ * A panel with the collapsible contents.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Collapsible](https://base-ui.com/react/components/collapsible)
+ *
+ * @baseui Collapsible.Panel
+ */
 function ThreadItemAttachmentContent({
     children,
     className,
@@ -207,6 +231,13 @@ function ThreadItemReactions({
 }
 
 /**
+ * A two-state button that can be on or off.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Toggle](https://base-ui.com/react/components/toggle)
+ *
+ * @baseui Toggle
+ *
  * A reaction pill — a Base UI Toggle, so `pressed`/`onPressedChange` and `aria-pressed` come for
  * free. Give it an `aria-label` naming the emoji and count ("victory hand, 1 reaction"); wrap the
  * emoji glyph in {@link ThreadItemReactionEmoji} so it stays out of the accessible name.
@@ -241,6 +272,13 @@ function ThreadItemReactionEmoji({ className, ...props }: React.ComponentProps<'
 const ThreadItemActionsContext = React.createContext(false)
 
 /**
+ * A container for grouping a set of controls, such as buttons, toggle groups, or menus.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Toolbar](https://base-ui.com/react/components/toolbar)
+ *
+ * @baseui Toolbar.Root
+ *
  * Hover-revealed actions toolbar, anchored to the item's top end corner. A Base UI Toolbar, so it
  * is one tab stop with arrow-key roving focus between actions. Hidden with opacity (not
  * `display: none`) so it stays keyboard-reachable — focus reveals it via `:focus-within`. Carries

--- a/packages/quill/packages/primitives/src/checkbox.tsx
+++ b/packages/quill/packages/primitives/src/checkbox.tsx
@@ -61,6 +61,14 @@ const checkboxVariants = cva('quill-checkbox peer flex shrink-0 items-center jus
     },
 })
 
+/**
+ * Represents the checkbox itself.
+ * Renders a `<span>` element and a hidden `<input>` beside.
+ *
+ * Documentation: [Base UI Checkbox](https://base-ui.com/react/components/checkbox)
+ *
+ * @baseui Checkbox.Root
+ */
 function Checkbox({
     className,
     size = 'default',

--- a/packages/quill/packages/primitives/src/collapsible.tsx
+++ b/packages/quill/packages/primitives/src/collapsible.tsx
@@ -15,6 +15,14 @@ type CollapsibleProps = CollapsiblePrimitive.Root.Props & {
     variant?: CollapsibleVariant
 }
 
+/**
+ * Groups all parts of the collapsible.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Collapsible](https://base-ui.com/react/components/collapsible)
+ *
+ * @baseui Collapsible.Root
+ */
 function Collapsible({ variant = 'default', className, ...props }: CollapsibleProps): React.ReactElement {
     return (
         <CollapsibleVariantContext.Provider value={variant}>
@@ -48,6 +56,14 @@ function CollapsibleHeader({ className, ...props }: React.ComponentProps<'div'>)
     )
 }
 
+/**
+ * A button that opens and closes the collapsible panel.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Collapsible](https://base-ui.com/react/components/collapsible)
+ *
+ * @baseui Collapsible.Trigger
+ */
 function CollapsibleTrigger({
     children,
     className,
@@ -135,6 +151,14 @@ function CollapsibleTrigger({
     )
 }
 
+/**
+ * A panel with the collapsible contents.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Collapsible](https://base-ui.com/react/components/collapsible)
+ *
+ * @baseui Collapsible.Panel
+ */
 function CollapsibleContent({ children, className, ...props }: CollapsiblePrimitive.Panel.Props): React.ReactElement {
     const variant = React.useContext(CollapsibleVariantContext)
 

--- a/packages/quill/packages/primitives/src/combobox.tsx
+++ b/packages/quill/packages/primitives/src/combobox.tsx
@@ -13,6 +13,14 @@ import { MenuLabel } from './menu-label'
 
 const ComboboxAnchorContext = React.createContext<React.RefObject<HTMLDivElement> | null>(null)
 
+/**
+ * Groups all parts of the combobox.
+ * Doesn't render its own HTML element.
+ *
+ * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
+ *
+ * @baseui Combobox.Root
+ */
 function Combobox<Value, Multiple extends boolean | undefined = false>({
     children,
     ...props
@@ -25,10 +33,26 @@ function Combobox<Value, Multiple extends boolean | undefined = false>({
     )
 }
 
+/**
+ * The current value of the combobox.
+ * Doesn't render its own HTML element.
+ *
+ * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
+ *
+ * @baseui Combobox.Value
+ */
 function ComboboxValue({ ...props }: ComboboxPrimitive.Value.Props): React.ReactElement {
     return <ComboboxPrimitive.Value data-slot="combobox-value" {...props} />
 }
 
+/**
+ * A button that opens the popup.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
+ *
+ * @baseui Combobox.Trigger
+ */
 const ComboboxTrigger = React.forwardRef<HTMLButtonElement, ComboboxPrimitive.Trigger.Props>(
     ({ className, children, ...props }, ref) => {
         return (
@@ -46,6 +70,14 @@ const ComboboxTrigger = React.forwardRef<HTMLButtonElement, ComboboxPrimitive.Tr
 )
 ComboboxTrigger.displayName = 'ComboboxTrigger'
 
+/**
+ * Clears the value when clicked.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
+ *
+ * @baseui Combobox.Clear
+ */
 function ComboboxClear({ className, ...props }: ComboboxPrimitive.Clear.Props): React.ReactElement {
     return (
         <ComboboxPrimitive.Clear
@@ -59,6 +91,14 @@ function ComboboxClear({ className, ...props }: ComboboxPrimitive.Clear.Props): 
     )
 }
 
+/**
+ * A text input to search for items in the list.
+ * Renders an `<input>` element.
+ *
+ * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
+ *
+ * @baseui Combobox.Input
+ */
 function ComboboxInput({
     className,
     children,
@@ -93,6 +133,14 @@ function ComboboxInput({
     )
 }
 
+/**
+ * A container for the list.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
+ *
+ * @baseui Combobox.Popup
+ */
 function ComboboxContent({
     className,
     side = 'bottom',
@@ -131,6 +179,14 @@ function ComboboxContent({
     )
 }
 
+/**
+ * A list container for the items.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
+ *
+ * @baseui Combobox.List
+ */
 function ComboboxList({ className, ...props }: ComboboxPrimitive.List.Props): React.ReactElement {
     return (
         <ComboboxPrimitive.List
@@ -151,6 +207,14 @@ function ComboboxList({ className, ...props }: ComboboxPrimitive.List.Props): Re
     )
 }
 
+/**
+ * An individual item in the list.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
+ *
+ * @baseui Combobox.Item
+ */
 function ComboboxItem({
     className,
     children,
@@ -178,10 +242,26 @@ function ComboboxItem({
     )
 }
 
+/**
+ * Groups related items with the corresponding label.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
+ *
+ * @baseui Combobox.Group
+ */
 function ComboboxGroup({ className, ...props }: ComboboxPrimitive.Group.Props): React.ReactElement {
     return <ComboboxPrimitive.Group data-slot="combobox-group" className={cn(className)} {...props} />
 }
 
+/**
+ * An accessible label that is automatically associated with its parent group.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
+ *
+ * @baseui Combobox.GroupLabel
+ */
 function ComboboxLabel({ className, ...props }: ComboboxPrimitive.GroupLabel.Props): React.ReactElement {
     return (
         <ComboboxPrimitive.GroupLabel
@@ -193,10 +273,34 @@ function ComboboxLabel({ className, ...props }: ComboboxPrimitive.GroupLabel.Pro
     )
 }
 
+/**
+ * Renders filtered list items.
+ * Doesn't render its own HTML element.
+ *
+ * If rendering a flat list, pass a function child to the `List` component instead, which implicitly wraps it.
+ *
+ * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
+ *
+ * @baseui Combobox.Collection
+ */
 function ComboboxCollection({ ...props }: ComboboxPrimitive.Collection.Props): React.ReactElement {
     return <ComboboxPrimitive.Collection data-slot="combobox-collection" {...props} />
 }
 
+/**
+ * Renders its children only when the list is empty.
+ * Requires the `items` prop on the root component.
+ * Announces changes politely to screen readers.
+ * This component's root element must remain mounted in the DOM to announce
+ * changes consistently across screen readers. Avoid hiding or removing the
+ * component itself with `display: none`, `hidden`, `aria-hidden`, or conditional
+ * rendering. Prefer updating or conditionally rendering its children instead.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
+ *
+ * @baseui Combobox.Empty
+ */
 function ComboboxEmpty({ className, children, ...props }: ComboboxPrimitive.Empty.Props): React.ReactElement {
     return (
         <ComboboxPrimitive.Empty
@@ -208,6 +312,14 @@ function ComboboxEmpty({ className, children, ...props }: ComboboxPrimitive.Empt
     )
 }
 
+/**
+ * A visual separator between items or groups.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
+ *
+ * @baseui Combobox.Separator
+ */
 function ComboboxSeparator({ className, ...props }: ComboboxPrimitive.Separator.Props): React.ReactElement {
     return (
         <ComboboxPrimitive.Separator
@@ -218,6 +330,14 @@ function ComboboxSeparator({ className, ...props }: ComboboxPrimitive.Separator.
     )
 }
 
+/**
+ * A container for the chips in a multiselectable input.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
+ *
+ * @baseui Combobox.Chips
+ */
 function ComboboxChips({
     className,
     ...props
@@ -231,6 +351,14 @@ function ComboboxChips({
     )
 }
 
+/**
+ * An individual chip that represents a value in a multiselectable input.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
+ *
+ * @baseui Combobox.Chip
+ */
 function ComboboxChip({
     className,
     children,
@@ -258,6 +386,14 @@ function ComboboxChip({
     )
 }
 
+/**
+ * A text input to search for items in the list.
+ * Renders an `<input>` element.
+ *
+ * Documentation: [Base UI Combobox](https://base-ui.com/react/components/combobox)
+ *
+ * @baseui Combobox.Input
+ */
 function ComboboxChipsInput({ className, ...props }: ComboboxPrimitive.Input.Props): React.ReactElement {
     return (
         <ComboboxPrimitive.Input

--- a/packages/quill/packages/primitives/src/context-menu.tsx
+++ b/packages/quill/packages/primitives/src/context-menu.tsx
@@ -10,14 +10,39 @@ import { Kbd } from './kbd'
 import { cn } from './lib/utils'
 import { RadioIndicator } from './radio-group'
 
+/**
+ * A component that creates a context menu activated by right clicking or long pressing.
+ * Doesn't render its own HTML element.
+ *
+ * Documentation: [Base UI Context Menu](https://base-ui.com/react/components/context-menu)
+ *
+ * @baseui ContextMenu.Root
+ */
 function ContextMenu({ ...props }: ContextMenuPrimitive.Root.Props): React.ReactElement {
     return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />
 }
 
+/**
+ * A portal element that moves the popup to a different part of the DOM.
+ * By default, the portal element is appended to `<body>`.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Menu](https://base-ui.com/react/components/menu)
+ *
+ * @baseui ContextMenu.Portal
+ */
 function ContextMenuPortal({ ...props }: ContextMenuPrimitive.Portal.Props): React.ReactElement {
     return <ContextMenuPrimitive.Portal data-slot="context-menu-portal" {...props} />
 }
 
+/**
+ * An area that opens the menu on right click or long press.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Context Menu](https://base-ui.com/react/components/context-menu)
+ *
+ * @baseui ContextMenu.Trigger
+ */
 function ContextMenuTrigger({ className, ...props }: ContextMenuPrimitive.Trigger.Props): React.ReactElement {
     return (
         <ContextMenuPrimitive.Trigger
@@ -28,6 +53,14 @@ function ContextMenuTrigger({ className, ...props }: ContextMenuPrimitive.Trigge
     )
 }
 
+/**
+ * A container for the menu items.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Menu](https://base-ui.com/react/components/menu)
+ *
+ * @baseui ContextMenu.Popup
+ */
 function ContextMenuContent({
     className,
     align = 'start',
@@ -61,10 +94,26 @@ function ContextMenuContent({
     )
 }
 
+/**
+ * Groups related menu items with the corresponding label.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Menu](https://base-ui.com/react/components/menu)
+ *
+ * @baseui ContextMenu.Group
+ */
 function ContextMenuGroup({ ...props }: ContextMenuPrimitive.Group.Props): React.ReactElement {
     return <ContextMenuPrimitive.Group data-slot="context-menu-group" {...props} />
 }
 
+/**
+ * An accessible label that is automatically associated with its parent group.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Menu](https://base-ui.com/react/components/menu)
+ *
+ * @baseui ContextMenu.GroupLabel
+ */
 function ContextMenuLabel({
     className,
     inset,
@@ -82,6 +131,14 @@ function ContextMenuLabel({
     )
 }
 
+/**
+ * An individual interactive item in the menu.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Menu](https://base-ui.com/react/components/menu)
+ *
+ * @baseui ContextMenu.Item
+ */
 function ContextMenuItem({
     className,
     inset,
@@ -118,10 +175,26 @@ function ContextMenuItem({
     )
 }
 
+/**
+ * Groups all parts of a submenu.
+ * Doesn't render its own HTML element.
+ *
+ * Documentation: [Base UI Menu](https://base-ui.com/react/components/menu)
+ *
+ * @baseui ContextMenu.SubmenuRoot
+ */
 function ContextMenuSub({ ...props }: ContextMenuPrimitive.SubmenuRoot.Props): React.ReactElement {
     return <ContextMenuPrimitive.SubmenuRoot data-slot="context-menu-sub" {...props} />
 }
 
+/**
+ * A menu item that opens a submenu.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Menu](https://base-ui.com/react/components/menu)
+ *
+ * @baseui ContextMenu.SubmenuTrigger
+ */
 function ContextMenuSubTrigger({
     className,
     inset,
@@ -172,6 +245,14 @@ function ContextMenuSubContent({
     )
 }
 
+/**
+ * A menu item that toggles a setting on or off.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Menu](https://base-ui.com/react/components/menu)
+ *
+ * @baseui ContextMenu.CheckboxItem
+ */
 function ContextMenuCheckboxItem({
     className,
     children,
@@ -207,10 +288,26 @@ function ContextMenuCheckboxItem({
     )
 }
 
+/**
+ * Groups related radio items.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Menu](https://base-ui.com/react/components/menu)
+ *
+ * @baseui ContextMenu.RadioGroup
+ */
 function ContextMenuRadioGroup({ ...props }: ContextMenuPrimitive.RadioGroup.Props): React.ReactElement {
     return <ContextMenuPrimitive.RadioGroup data-slot="context-menu-radio-group" {...props} />
 }
 
+/**
+ * A menu item that works like a radio button in a given group.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Menu](https://base-ui.com/react/components/menu)
+ *
+ * @baseui ContextMenu.RadioItem
+ */
 function ContextMenuRadioItem({
     className,
     children,
@@ -244,6 +341,14 @@ function ContextMenuRadioItem({
     )
 }
 
+/**
+ * A separator element accessible to screen readers.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Separator](https://base-ui.com/react/components/separator)
+ *
+ * @baseui ContextMenu.Separator
+ */
 function ContextMenuSeparator({ className, ...props }: ContextMenuPrimitive.Separator.Props): React.ReactElement {
     return (
         <ContextMenuPrimitive.Separator

--- a/packages/quill/packages/primitives/src/dialog.tsx
+++ b/packages/quill/packages/primitives/src/dialog.tsx
@@ -9,23 +9,65 @@ import './dialog.css'
 import { cn } from './lib/utils'
 import { ScrollArea } from './scroll-area'
 
-/** Note: if you're nesting dialogs, in order for you to click the overlay to close it, you must pass 'mounted: true' to the nested dialog*/
+/**
+ * Groups all parts of the dialog.
+ * Doesn't render its own HTML element.
+ *
+ * Documentation: [Base UI Dialog](https://base-ui.com/react/components/dialog)
+ *
+ * @baseui Dialog.Root
+ *
+ * Note: if you're nesting dialogs, in order for you to click the overlay to close it, you must pass 'mounted: true' to the nested dialog
+ */
 function Dialog({ ...props }: DialogPrimitive.Root.Props): React.ReactElement {
     return <DialogPrimitive.Root data-slot="dialog" {...props} />
 }
 
+/**
+ * A button that opens the dialog.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Dialog](https://base-ui.com/react/components/dialog)
+ *
+ * @baseui Dialog.Trigger
+ */
 function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props): React.ReactElement {
     return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
 }
 
+/**
+ * A portal element that moves the popup to a different part of the DOM.
+ * By default, the portal element is appended to `<body>`.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Dialog](https://base-ui.com/react/components/dialog)
+ *
+ * @baseui Dialog.Portal
+ */
 function DialogPortal({ ...props }: DialogPrimitive.Portal.Props): React.ReactElement {
     return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
 }
 
+/**
+ * A button that closes the dialog.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Dialog](https://base-ui.com/react/components/dialog)
+ *
+ * @baseui Dialog.Close
+ */
 function DialogClose({ ...props }: DialogPrimitive.Close.Props): React.ReactElement {
     return <DialogPrimitive.Close data-slot="dialog-close focus-visible:z-10" {...props} />
 }
 
+/**
+ * An overlay displayed beneath the popup.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Dialog](https://base-ui.com/react/components/dialog)
+ *
+ * @baseui Dialog.Backdrop
+ */
 function DialogOverlay({ className, ...props }: DialogPrimitive.Backdrop.Props): React.ReactElement {
     return (
         <DialogPrimitive.Backdrop
@@ -38,6 +80,14 @@ function DialogOverlay({ className, ...props }: DialogPrimitive.Backdrop.Props):
     )
 }
 
+/**
+ * A container for the dialog contents.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Dialog](https://base-ui.com/react/components/dialog)
+ *
+ * @baseui Dialog.Popup
+ */
 function DialogContent({
     className,
     children,
@@ -163,10 +213,26 @@ function DialogBody({
     })
 }
 
+/**
+ * A heading that labels the dialog.
+ * Renders an `<h2>` element.
+ *
+ * Documentation: [Base UI Dialog](https://base-ui.com/react/components/dialog)
+ *
+ * @baseui Dialog.Title
+ */
 function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props): React.ReactElement {
     return <DialogPrimitive.Title data-slot="dialog-title" className={cn('quill-dialog__title', className)} {...props} />
 }
 
+/**
+ * A paragraph with additional information about the dialog.
+ * Renders a `<p>` element.
+ *
+ * Documentation: [Base UI Dialog](https://base-ui.com/react/components/dialog)
+ *
+ * @baseui Dialog.Description
+ */
 function DialogDescription({ className, ...props }: DialogPrimitive.Description.Props): React.ReactElement {
     return (
         <DialogPrimitive.Description

--- a/packages/quill/packages/primitives/src/drawer.tsx
+++ b/packages/quill/packages/primitives/src/drawer.tsx
@@ -4,22 +4,63 @@ import * as React from 'react'
 import './drawer.css'
 import { cn } from './lib/utils'
 
+/**
+ * Groups all parts of the drawer.
+ * Doesn't render its own HTML element.
+ *
+ * Documentation: [Base UI Drawer](https://base-ui.com/react/components/drawer)
+ *
+ * @baseui Drawer.Root
+ */
 function Drawer({ ...props }: DrawerPrimitive.Root.Props): React.ReactElement {
     return <DrawerPrimitive.Root data-slot="drawer" {...props} />
 }
 
+/**
+ * A button that opens the drawer.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Drawer](https://base-ui.com/react/components/drawer)
+ *
+ * @baseui Drawer.Trigger
+ */
 function DrawerTrigger({ ...props }: DrawerPrimitive.Trigger.Props): React.ReactElement {
     return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />
 }
 
+/**
+ * A portal element that moves the popup to a different part of the DOM.
+ * By default, the portal element is appended to `<body>`.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Drawer](https://base-ui.com/react/components/drawer)
+ *
+ * @baseui Drawer.Portal
+ */
 function DrawerPortal({ ...props }: DrawerPrimitive.Portal.Props): React.ReactElement {
     return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />
 }
 
+/**
+ * A button that closes the drawer.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Drawer](https://base-ui.com/react/components/drawer)
+ *
+ * @baseui Drawer.Close
+ */
 function DrawerClose({ ...props }: DrawerPrimitive.Close.Props): React.ReactElement {
     return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />
 }
 
+/**
+ * An overlay displayed beneath the popup.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Drawer](https://base-ui.com/react/components/drawer)
+ *
+ * @baseui Drawer.Backdrop
+ */
 function DrawerBackdrop({ className, ...props }: DrawerPrimitive.Backdrop.Props): React.ReactElement {
     return (
         <DrawerPrimitive.Backdrop
@@ -32,6 +73,14 @@ function DrawerBackdrop({ className, ...props }: DrawerPrimitive.Backdrop.Props)
     )
 }
 
+/**
+ * A container for the drawer contents.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Drawer](https://base-ui.com/react/components/drawer)
+ *
+ * @baseui Drawer.Popup
+ */
 function DrawerContent({
     className,
     children,
@@ -93,6 +142,14 @@ function DrawerFooter({ className, ...props }: React.ComponentProps<'div'>): Rea
     )
 }
 
+/**
+ * A heading that labels the drawer.
+ * Renders an `<h2>` element.
+ *
+ * Documentation: [Base UI Drawer](https://base-ui.com/react/components/drawer)
+ *
+ * @baseui Drawer.Title
+ */
 function DrawerTitle({ className, ...props }: DrawerPrimitive.Title.Props): React.ReactElement {
     return (
         <DrawerPrimitive.Title
@@ -103,6 +160,14 @@ function DrawerTitle({ className, ...props }: DrawerPrimitive.Title.Props): Reac
     )
 }
 
+/**
+ * A paragraph with additional information about the drawer.
+ * Renders a `<p>` element.
+ *
+ * Documentation: [Base UI Drawer](https://base-ui.com/react/components/drawer)
+ *
+ * @baseui Drawer.Description
+ */
 function DrawerDescription({ className, ...props }: DrawerPrimitive.Description.Props): React.ReactElement {
     return (
         <DrawerPrimitive.Description

--- a/packages/quill/packages/primitives/src/dropdown-menu.tsx
+++ b/packages/quill/packages/primitives/src/dropdown-menu.tsx
@@ -11,18 +11,51 @@ import { cn } from './lib/utils'
 import { MenuLabel } from './menu-label'
 import { RadioIndicator } from './radio-group'
 
+/**
+ * Groups all parts of the menu.
+ * Doesn't render its own HTML element.
+ *
+ * Documentation: [Base UI Menu](https://base-ui.com/react/components/menu)
+ *
+ * @baseui Menu.Root
+ */
 function DropdownMenu({ ...props }: MenuPrimitive.Root.Props): React.ReactElement {
     return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />
 }
 
+/**
+ * A portal element that moves the popup to a different part of the DOM.
+ * By default, the portal element is appended to `<body>`.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Menu](https://base-ui.com/react/components/menu)
+ *
+ * @baseui Menu.Portal
+ */
 function DropdownMenuPortal({ ...props }: MenuPrimitive.Portal.Props): React.ReactElement {
     return <MenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
 }
 
+/**
+ * A button that opens the menu.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Menu](https://base-ui.com/react/components/menu)
+ *
+ * @baseui Menu.Trigger
+ */
 function DropdownMenuTrigger({ ...props }: MenuPrimitive.Trigger.Props): React.ReactElement {
     return <MenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
 }
 
+/**
+ * A container for the menu items.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Menu](https://base-ui.com/react/components/menu)
+ *
+ * @baseui Menu.Popup
+ */
 function DropdownMenuContent({
     align = 'start',
     alignOffset = 0,
@@ -61,10 +94,26 @@ function DropdownMenuContent({
     )
 }
 
+/**
+ * Groups related menu items with the corresponding label.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Menu](https://base-ui.com/react/components/menu)
+ *
+ * @baseui Menu.Group
+ */
 function DropdownMenuGroup({ ...props }: MenuPrimitive.Group.Props): React.ReactElement {
     return <MenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
 }
 
+/**
+ * An accessible label that is automatically associated with its parent group.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Menu](https://base-ui.com/react/components/menu)
+ *
+ * @baseui Menu.GroupLabel
+ */
 function DropdownMenuLabel({
     className,
     inset,
@@ -83,6 +132,14 @@ function DropdownMenuLabel({
     )
 }
 
+/**
+ * An individual interactive item in the menu.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Menu](https://base-ui.com/react/components/menu)
+ *
+ * @baseui Menu.Item
+ */
 function DropdownMenuItem({
     className,
     inset,
@@ -117,10 +174,26 @@ function DropdownMenuItem({
     )
 }
 
+/**
+ * Groups all parts of a submenu.
+ * Doesn't render its own HTML element.
+ *
+ * Documentation: [Base UI Menu](https://base-ui.com/react/components/menu)
+ *
+ * @baseui Menu.SubmenuRoot
+ */
 function DropdownMenuSub({ ...props }: MenuPrimitive.SubmenuRoot.Props): React.ReactElement {
     return <MenuPrimitive.SubmenuRoot data-slot="dropdown-menu-sub" {...props} />
 }
 
+/**
+ * A menu item that opens a submenu.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Menu](https://base-ui.com/react/components/menu)
+ *
+ * @baseui Menu.SubmenuTrigger
+ */
 function DropdownMenuSubTrigger({
     className,
     inset,
@@ -171,6 +244,14 @@ function DropdownMenuSubContent({
     )
 }
 
+/**
+ * A menu item that toggles a setting on or off.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Menu](https://base-ui.com/react/components/menu)
+ *
+ * @baseui Menu.CheckboxItem
+ */
 function DropdownMenuCheckboxItem({
     className,
     children,
@@ -209,10 +290,26 @@ function DropdownMenuCheckboxItem({
     )
 }
 
+/**
+ * Groups related radio items.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Menu](https://base-ui.com/react/components/menu)
+ *
+ * @baseui Menu.RadioGroup
+ */
 function DropdownMenuRadioGroup({ ...props }: MenuPrimitive.RadioGroup.Props): React.ReactElement {
     return <MenuPrimitive.RadioGroup data-slot="dropdown-menu-radio-group" {...props} />
 }
 
+/**
+ * A menu item that works like a radio button in a given group.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Menu](https://base-ui.com/react/components/menu)
+ *
+ * @baseui Menu.RadioItem
+ */
 function DropdownMenuRadioItem({
     className,
     children,
@@ -249,6 +346,14 @@ function DropdownMenuRadioItem({
     )
 }
 
+/**
+ * A separator element accessible to screen readers.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Separator](https://base-ui.com/react/components/separator)
+ *
+ * @baseui Menu.Separator
+ */
 function DropdownMenuSeparator({ className, ...props }: MenuPrimitive.Separator.Props): React.ReactElement {
     return (
         <MenuPrimitive.Separator

--- a/packages/quill/packages/primitives/src/input-group.tsx
+++ b/packages/quill/packages/primitives/src/input-group.tsx
@@ -128,6 +128,14 @@ interface InputGroupNumberInputProps extends Omit<NumberField.Root.Props, 'class
     inputRef?: React.Ref<HTMLInputElement>
 }
 
+/**
+ * Groups all parts of the number field and manages its state.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Number Field](https://base-ui.com/react/components/number-field)
+ *
+ * @baseui NumberField.Root
+ */
 function InputGroupNumberInput({
     className,
     inputRef,

--- a/packages/quill/packages/primitives/src/input.tsx
+++ b/packages/quill/packages/primitives/src/input.tsx
@@ -4,6 +4,14 @@ import * as React from 'react'
 import './input.css'
 import { cn } from './lib/utils'
 
+/**
+ * A native input element that automatically works with [Field](https://base-ui.com/react/components/field).
+ * Renders an `<input>` element.
+ *
+ * Documentation: [Base UI Input](https://base-ui.com/react/components/input)
+ *
+ * @baseui Input
+ */
 const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
     ({ className, type, ...props }, ref) => {
         return (

--- a/packages/quill/packages/primitives/src/menubar.tsx
+++ b/packages/quill/packages/primitives/src/menubar.tsx
@@ -23,6 +23,13 @@ import {
 import { cn } from './lib/utils'
 import { RadioIndicator } from './radio-group'
 
+/**
+ * The container for menus.
+ *
+ * Documentation: [Base UI Menubar](https://base-ui.com/react/components/menubar)
+ *
+ * @baseui Menubar
+ */
 function Menubar({ className, ...props }: MenubarPrimitive.Props): React.ReactElement {
     return (
         <MenubarPrimitive
@@ -96,6 +103,14 @@ function MenubarItem({
     )
 }
 
+/**
+ * A menu item that toggles a setting on or off.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Menu](https://base-ui.com/react/components/menu)
+ *
+ * @baseui Menu.CheckboxItem
+ */
 function MenubarCheckboxItem({
     className,
     children,
@@ -133,6 +148,14 @@ function MenubarRadioGroup({ ...props }: React.ComponentProps<typeof DropdownMen
     return <DropdownMenuRadioGroup data-slot="menubar-radio-group" {...props} />
 }
 
+/**
+ * A menu item that works like a radio button in a given group.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Menu](https://base-ui.com/react/components/menu)
+ *
+ * @baseui Menu.RadioItem
+ */
 function MenubarRadioItem({
     className,
     children,

--- a/packages/quill/packages/primitives/src/number-field.tsx
+++ b/packages/quill/packages/primitives/src/number-field.tsx
@@ -5,6 +5,14 @@ import * as React from 'react'
 import { cn } from './lib/utils'
 import './number-field.css'
 
+/**
+ * Groups all parts of the number field and manages its state.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Number Field](https://base-ui.com/react/components/number-field)
+ *
+ * @baseui NumberField.Root
+ */
 function NumberFieldRoot({
     className,
     ...props
@@ -19,6 +27,14 @@ function NumberFieldRoot({
     )
 }
 
+/**
+ * Groups the input with the increment and decrement buttons.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Number Field](https://base-ui.com/react/components/number-field)
+ *
+ * @baseui NumberField.Group
+ */
 function NumberFieldGroup({
     className,
     ...props
@@ -32,6 +48,14 @@ function NumberFieldGroup({
     )
 }
 
+/**
+ * The native input control in the number field.
+ * Renders an `<input>` element.
+ *
+ * Documentation: [Base UI Number Field](https://base-ui.com/react/components/number-field)
+ *
+ * @baseui NumberField.Input
+ */
 const NumberFieldInput = React.forwardRef<HTMLInputElement, NumberFieldPrimitive.Input.Props>(
     ({ className, ...props }, ref) => {
         return (
@@ -46,6 +70,14 @@ const NumberFieldInput = React.forwardRef<HTMLInputElement, NumberFieldPrimitive
 )
 NumberFieldInput.displayName = 'NumberFieldInput'
 
+/**
+ * A stepper button that increases the field value when clicked.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Number Field](https://base-ui.com/react/components/number-field)
+ *
+ * @baseui NumberField.Increment
+ */
 function NumberFieldIncrement({
     className,
     children,
@@ -62,6 +94,14 @@ function NumberFieldIncrement({
     )
 }
 
+/**
+ * A stepper button that decreases the field value when clicked.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Number Field](https://base-ui.com/react/components/number-field)
+ *
+ * @baseui NumberField.Decrement
+ */
 function NumberFieldDecrement({
     className,
     children,
@@ -78,6 +118,14 @@ function NumberFieldDecrement({
     )
 }
 
+/**
+ * An interactive area where the user can click and drag to change the field value.
+ * Renders a `<span>` element.
+ *
+ * Documentation: [Base UI Number Field](https://base-ui.com/react/components/number-field)
+ *
+ * @baseui NumberField.ScrubArea
+ */
 function NumberFieldScrubArea({
     className,
     ...props
@@ -91,6 +139,17 @@ function NumberFieldScrubArea({
     )
 }
 
+/**
+ * A custom element to display instead of the native cursor while using the scrub area.
+ * Renders a `<span>` element.
+ *
+ * This component uses the [Pointer Lock API](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_Lock_API), which may prompt the browser to display a related notification. It is disabled
+ * in Safari to avoid a layout shift that this notification causes there.
+ *
+ * Documentation: [Base UI Number Field](https://base-ui.com/react/components/number-field)
+ *
+ * @baseui NumberField.ScrubAreaCursor
+ */
 function NumberFieldScrubAreaCursor({
     className,
     ...props

--- a/packages/quill/packages/primitives/src/popover.tsx
+++ b/packages/quill/packages/primitives/src/popover.tsx
@@ -4,14 +4,38 @@ import * as React from 'react'
 import { cn } from './lib/utils'
 import './popover.css'
 
+/**
+ * Groups all parts of the popover.
+ * Doesn't render its own HTML element.
+ *
+ * Documentation: [Base UI Popover](https://base-ui.com/react/components/popover)
+ *
+ * @baseui Popover.Root
+ */
 function Popover({ ...props }: PopoverPrimitive.Root.Props): React.ReactElement {
     return <PopoverPrimitive.Root data-slot="popover" {...props} />
 }
 
+/**
+ * A button that opens the popover.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Popover](https://base-ui.com/react/components/popover)
+ *
+ * @baseui Popover.Trigger
+ */
 function PopoverTrigger({ ...props }: PopoverPrimitive.Trigger.Props): React.ReactElement {
     return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
 }
 
+/**
+ * A container for the popover contents.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Popover](https://base-ui.com/react/components/popover)
+ *
+ * @baseui Popover.Popup
+ */
 function PopoverContent({
     className,
     align = 'center',
@@ -62,6 +86,14 @@ function PopoverHeader({ className, ...props }: React.ComponentProps<'div'>): Re
     return <div data-slot="popover-header" className={cn('flex flex-col gap-1 text-xs', className)} {...props} />
 }
 
+/**
+ * A heading that labels the popover.
+ * Renders an `<h2>` element.
+ *
+ * Documentation: [Base UI Popover](https://base-ui.com/react/components/popover)
+ *
+ * @baseui Popover.Title
+ */
 function PopoverTitle({ className, ...props }: PopoverPrimitive.Title.Props): React.ReactElement {
     return (
         <PopoverPrimitive.Title
@@ -72,6 +104,14 @@ function PopoverTitle({ className, ...props }: PopoverPrimitive.Title.Props): Re
     )
 }
 
+/**
+ * A paragraph with additional information about the popover.
+ * Renders a `<p>` element.
+ *
+ * Documentation: [Base UI Popover](https://base-ui.com/react/components/popover)
+ *
+ * @baseui Popover.Description
+ */
 function PopoverDescription({ className, ...props }: PopoverPrimitive.Description.Props): React.ReactElement {
     return (
         <PopoverPrimitive.Description

--- a/packages/quill/packages/primitives/src/progress.tsx
+++ b/packages/quill/packages/primitives/src/progress.tsx
@@ -22,6 +22,14 @@ const progressIndicatorVariants = cva('quill-progress__indicator', {
 
 type ProgressVariantProps = VariantProps<typeof progressIndicatorVariants>
 
+/**
+ * Groups all parts of the progress bar and provides the task completion status to screen readers.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Progress](https://base-ui.com/react/components/progress)
+ *
+ * @baseui Progress.Root
+ */
 function Progress({
     className,
     children,
@@ -46,6 +54,14 @@ function Progress({
     )
 }
 
+/**
+ * Contains the progress bar indicator.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Progress](https://base-ui.com/react/components/progress)
+ *
+ * @baseui Progress.Track
+ */
 function ProgressTrack({ className, ...props }: ProgressPrimitive.Track.Props): React.ReactElement {
     return (
         <ProgressPrimitive.Track
@@ -56,6 +72,14 @@ function ProgressTrack({ className, ...props }: ProgressPrimitive.Track.Props): 
     )
 }
 
+/**
+ * Visualizes the completion status of the task.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Progress](https://base-ui.com/react/components/progress)
+ *
+ * @baseui Progress.Indicator
+ */
 function ProgressIndicator({
     className,
     variant = 'default',
@@ -71,6 +95,14 @@ function ProgressIndicator({
     )
 }
 
+/**
+ * An accessible label for the progress bar.
+ * Renders a `<span>` element.
+ *
+ * Documentation: [Base UI Progress](https://base-ui.com/react/components/progress)
+ *
+ * @baseui Progress.Label
+ */
 function ProgressLabel({ className, ...props }: ProgressPrimitive.Label.Props): React.ReactElement {
     return (
         <ProgressPrimitive.Label
@@ -81,6 +113,14 @@ function ProgressLabel({ className, ...props }: ProgressPrimitive.Label.Props): 
     )
 }
 
+/**
+ * A text element displaying the current value.
+ * Renders a `<span>` element.
+ *
+ * Documentation: [Base UI Progress](https://base-ui.com/react/components/progress)
+ *
+ * @baseui Progress.Value
+ */
 function ProgressValue({ className, ...props }: ProgressPrimitive.Value.Props): React.ReactElement {
     return (
         <ProgressPrimitive.Value

--- a/packages/quill/packages/primitives/src/radio-group.tsx
+++ b/packages/quill/packages/primitives/src/radio-group.tsx
@@ -45,6 +45,14 @@ function RadioIndicator({
     )
 }
 
+/**
+ * Provides a shared state to a series of radio buttons.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Radio Group](https://base-ui.com/react/components/radio)
+ *
+ * @baseui RadioGroup
+ */
 function RadioGroup({ className, ...props }: RadioGroupPrimitive.Props): React.ReactElement {
     return (
         <RadioGroupPrimitive
@@ -80,6 +88,14 @@ const radioGroupItemIndicatorVariants = cva('quill-radio__indicator', {
     },
 })
 
+/**
+ * Represents the radio button itself.
+ * Renders a `<span>` element and a hidden `<input>` beside.
+ *
+ * Documentation: [Base UI Radio](https://base-ui.com/react/components/radio)
+ *
+ * @baseui Radio.Root
+ */
 function RadioGroupItem({
     className,
     size = 'default',

--- a/packages/quill/packages/primitives/src/scroll-area.tsx
+++ b/packages/quill/packages/primitives/src/scroll-area.tsx
@@ -182,6 +182,14 @@ if (typeof document !== 'undefined' && !document.getElementById(SCROLL_SHADOWS_S
     document.head.appendChild(styleEl)
 }
 
+/**
+ * Groups all parts of the scroll area.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Scroll Area](https://base-ui.com/react/components/scroll-area)
+ *
+ * @baseui ScrollArea.Root
+ */
 function ScrollArea({
     className,
     children,
@@ -246,6 +254,14 @@ function ScrollArea({
     )
 }
 
+/**
+ * A vertical or horizontal scrollbar for the scroll area.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Scroll Area](https://base-ui.com/react/components/scroll-area)
+ *
+ * @baseui ScrollArea.Scrollbar
+ */
 function ScrollBar({
     className,
     orientation = 'vertical',

--- a/packages/quill/packages/primitives/src/select.tsx
+++ b/packages/quill/packages/primitives/src/select.tsx
@@ -10,12 +10,28 @@ import { MenuLabel } from './menu-label'
 
 const Select = SelectPrimitive.Root
 
+/**
+ * Groups related select items with the corresponding label.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Select](https://base-ui.com/react/components/select)
+ *
+ * @baseui Select.Group
+ */
 function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props): React.ReactElement {
     return (
         <SelectPrimitive.Group data-slot="select-group" className={cn('quill-select__group', className)} {...props} />
     )
 }
 
+/**
+ * A text label of the currently selected item.
+ * Renders a `<span>` element.
+ *
+ * Documentation: [Base UI Select](https://base-ui.com/react/components/select)
+ *
+ * @baseui Select.Value
+ */
 function SelectValue({ className, ...props }: SelectPrimitive.Value.Props): React.ReactElement {
     return (
         <SelectPrimitive.Value data-slot="select-value" className={cn('quill-select__value', className)} {...props} />
@@ -26,6 +42,14 @@ function SelectTriggerIcon({ className, ...props }: React.ComponentProps<typeof 
     return <ChevronDownIcon className={cn('quill-select__icon', className)} {...props} />
 }
 
+/**
+ * A button that opens the select popup.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Select](https://base-ui.com/react/components/select)
+ *
+ * @baseui Select.Trigger
+ */
 function SelectTrigger({
     className,
     size = 'default',
@@ -51,6 +75,14 @@ function SelectTrigger({
     )
 }
 
+/**
+ * A container for the select list.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Select](https://base-ui.com/react/components/select)
+ *
+ * @baseui Select.Popup
+ */
 function SelectContent({
     className,
     children,
@@ -94,12 +126,28 @@ function SelectContent({
     )
 }
 
+/**
+ * An accessible label that is automatically associated with its parent group.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Select](https://base-ui.com/react/components/select)
+ *
+ * @baseui Select.GroupLabel
+ */
 function SelectGroupLabel({ className, ...props }: SelectPrimitive.GroupLabel.Props): React.ReactElement {
     return (
         <SelectPrimitive.GroupLabel data-slot="select-label" className={className} render={<MenuLabel />} {...props} />
     )
 }
 
+/**
+ * An individual option in the select popup.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Select](https://base-ui.com/react/components/select)
+ *
+ * @baseui Select.Item
+ */
 function SelectItem({ className, children, ...props }: SelectPrimitive.Item.Props): React.ReactElement {
     return (
         <SelectPrimitive.Item
@@ -122,6 +170,14 @@ function SelectItem({ className, children, ...props }: SelectPrimitive.Item.Prop
     )
 }
 
+/**
+ * A visual separator between items or groups.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Select](https://base-ui.com/react/components/select)
+ *
+ * @baseui Select.Separator
+ */
 function SelectSeparator({ className, ...props }: SelectPrimitive.Separator.Props): React.ReactElement {
     return (
         <SelectPrimitive.Separator
@@ -132,6 +188,14 @@ function SelectSeparator({ className, ...props }: SelectPrimitive.Separator.Prop
     )
 }
 
+/**
+ * An element that scrolls the select popup up when hovered. Does not render when using touch input.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Select](https://base-ui.com/react/components/select)
+ *
+ * @baseui Select.ScrollUpArrow
+ */
 function SelectScrollUpButton({
     className,
     ...props
@@ -148,6 +212,14 @@ function SelectScrollUpButton({
     )
 }
 
+/**
+ * An element that scrolls the select popup down when hovered. Does not render when using touch input.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Select](https://base-ui.com/react/components/select)
+ *
+ * @baseui Select.ScrollDownArrow
+ */
 function SelectScrollDownButton({
     className,
     ...props

--- a/packages/quill/packages/primitives/src/separator.tsx
+++ b/packages/quill/packages/primitives/src/separator.tsx
@@ -4,6 +4,14 @@ import * as React from 'react'
 import './separator.css'
 import { cn } from './lib/utils'
 
+/**
+ * A separator element accessible to screen readers.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Separator](https://base-ui.com/react/components/separator)
+ *
+ * @baseui Separator
+ */
 function Separator({ className, orientation = 'horizontal', ...props }: SeparatorPrimitive.Props): React.ReactElement {
     return (
         <SeparatorPrimitive

--- a/packages/quill/packages/primitives/src/slider.tsx
+++ b/packages/quill/packages/primitives/src/slider.tsx
@@ -4,6 +4,14 @@ import * as React from 'react'
 import { cn } from './lib/utils'
 import './slider.css'
 
+/**
+ * Groups all parts of the slider.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Slider](https://base-ui.com/react/components/slider)
+ *
+ * @baseui Slider.Root
+ */
 function Slider({
     className,
     defaultValue,

--- a/packages/quill/packages/primitives/src/switch.tsx
+++ b/packages/quill/packages/primitives/src/switch.tsx
@@ -4,6 +4,14 @@ import * as React from 'react'
 import './switch.css'
 import { cn } from './lib/utils'
 
+/**
+ * Represents the switch itself.
+ * Renders a `<span>` element and a hidden `<input>` beside.
+ *
+ * Documentation: [Base UI Switch](https://base-ui.com/react/components/switch)
+ *
+ * @baseui Switch.Root
+ */
 function Switch({
     className,
     size = 'default',

--- a/packages/quill/packages/primitives/src/tabs.tsx
+++ b/packages/quill/packages/primitives/src/tabs.tsx
@@ -7,6 +7,14 @@ import * as React from 'react'
 import { Button } from './button'
 import { cn } from './lib/utils'
 
+/**
+ * Groups the tabs and the corresponding panels.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Tabs](https://base-ui.com/react/components/tabs)
+ *
+ * @baseui Tabs.Root
+ */
 function Tabs({ className, orientation = 'horizontal', ...props }: TabsPrimitive.Root.Props): React.ReactElement {
     return (
         <TabsPrimitive.Root
@@ -45,6 +53,14 @@ const tabsIndicatorVariants = cva('quill-tabs__indicator', {
     },
 })
 
+/**
+ * Groups the individual tab buttons.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Tabs](https://base-ui.com/react/components/tabs)
+ *
+ * @baseui Tabs.List
+ */
 function TabsList({
     className,
     variant = 'default',
@@ -64,6 +80,14 @@ function TabsList({
     )
 }
 
+/**
+ * An individual interactive tab button that toggles the corresponding panel.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Tabs](https://base-ui.com/react/components/tabs)
+ *
+ * @baseui Tabs.Tab
+ */
 function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props): React.ReactElement {
     return (
         <TabsPrimitive.Tab
@@ -78,6 +102,14 @@ function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props): React.Re
     )
 }
 
+/**
+ * A panel displayed when the corresponding tab is active.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Tabs](https://base-ui.com/react/components/tabs)
+ *
+ * @baseui Tabs.Panel
+ */
 function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props): React.ReactElement {
     return <TabsPrimitive.Panel data-slot="tabs-content" className={cn('quill-tabs__panel', className)} {...props} />
 }

--- a/packages/quill/packages/primitives/src/toggle-group.tsx
+++ b/packages/quill/packages/primitives/src/toggle-group.tsx
@@ -20,6 +20,13 @@ const ToggleGroupContext = React.createContext<
     orientation: 'horizontal',
 })
 
+/**
+ * Provides a shared state to a series of toggle buttons.
+ *
+ * Documentation: [Base UI Toggle Group](https://base-ui.com/react/components/toggle-group)
+ *
+ * @baseui ToggleGroup
+ */
 function ToggleGroup({
     className,
     variant,
@@ -55,6 +62,14 @@ function ToggleGroup({
     )
 }
 
+/**
+ * A two-state button that can be on or off.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Toggle](https://base-ui.com/react/components/toggle)
+ *
+ * @baseui Toggle
+ */
 function ToggleGroupItem({
     className,
     children,

--- a/packages/quill/packages/primitives/src/toggle.tsx
+++ b/packages/quill/packages/primitives/src/toggle.tsx
@@ -27,6 +27,14 @@ const toggleVariants = cva(
     }
 )
 
+/**
+ * A two-state button that can be on or off.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Toggle](https://base-ui.com/react/components/toggle)
+ *
+ * @baseui Toggle
+ */
 function Toggle({
     className,
     variant = 'default',

--- a/packages/quill/packages/primitives/src/tooltip.tsx
+++ b/packages/quill/packages/primitives/src/tooltip.tsx
@@ -4,18 +4,50 @@ import * as React from 'react'
 import { cn } from './lib/utils'
 import './tooltip.css'
 
+/**
+ * Provides a shared delay for multiple tooltips. The grouping logic ensures that
+ * once a tooltip becomes visible, the adjacent tooltips will be shown instantly.
+ *
+ * Documentation: [Base UI Tooltip](https://base-ui.com/react/components/tooltip)
+ *
+ * @baseui Tooltip.Provider
+ */
 function TooltipProvider({ delay = 250, ...props }: TooltipPrimitive.Provider.Props): React.ReactElement {
     return <TooltipPrimitive.Provider data-slot="tooltip-provider" delay={delay} {...props} />
 }
 
+/**
+ * Groups all parts of the tooltip.
+ * Doesn't render its own HTML element.
+ *
+ * Documentation: [Base UI Tooltip](https://base-ui.com/react/components/tooltip)
+ *
+ * @baseui Tooltip.Root
+ */
 function Tooltip({ ...props }: TooltipPrimitive.Root.Props): React.ReactElement {
     return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
 }
 
+/**
+ * An element to attach the tooltip to.
+ * Renders a `<button>` element.
+ *
+ * Documentation: [Base UI Tooltip](https://base-ui.com/react/components/tooltip)
+ *
+ * @baseui Tooltip.Trigger
+ */
 function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props): React.ReactElement {
     return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
 }
 
+/**
+ * A container for the tooltip contents.
+ * Renders a `<div>` element.
+ *
+ * Documentation: [Base UI Tooltip](https://base-ui.com/react/components/tooltip)
+ *
+ * @baseui Tooltip.Popup
+ */
 function TooltipContent({
     className,
     side = 'top',

--- a/packages/quill/packages/primitives/vite.config.ts
+++ b/packages/quill/packages/primitives/vite.config.ts
@@ -27,6 +27,10 @@ export default defineConfig({
                 '@posthog/quill-tokens',
                 '@base-ui/react',
                 /^@base-ui\/react\//,
+                // Surfaces in the chat scroller's public types, so @posthog/quill declares it as a
+                // real dependency — external here too rather than inlining a second copy.
+                '@shadcn/react',
+                /^@shadcn\/react\//,
                 'lucide-react',
                 'vaul',
                 'react-resizable-panels',

--- a/packages/quill/packages/primitives/vite.config.ts
+++ b/packages/quill/packages/primitives/vite.config.ts
@@ -27,10 +27,6 @@ export default defineConfig({
                 '@posthog/quill-tokens',
                 '@base-ui/react',
                 /^@base-ui\/react\//,
-                // Surfaces in the chat scroller's public types, so @posthog/quill declares it as a
-                // real dependency — external here too rather than inlining a second copy.
-                '@shadcn/react',
-                /^@shadcn\/react\//,
                 'lucide-react',
                 'vaul',
                 'react-resizable-panels',

--- a/packages/quill/packages/quill/package.json
+++ b/packages/quill/packages/quill/package.json
@@ -44,6 +44,8 @@
         "build:js": "vite build"
     },
     "dependencies": {
+        "@shadcn/react": "^0.1.0",
+        "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.577.0",
@@ -61,7 +63,7 @@
         "vite-plugin-dts": "^4.5.4"
     },
     "peerDependencies": {
-        "@base-ui/react": "^1.4.0",
+        "@base-ui/react": "^1.7.0",
         "react": "^18.3.1 || ^19.0.0",
         "react-dom": "^18.3.1 || ^19.0.0",
         "tailwindcss": "^4.0.0"

--- a/packages/quill/packages/quill/vite.config.ts
+++ b/packages/quill/packages/quill/vite.config.ts
@@ -53,12 +53,6 @@ export default defineConfig({
                 '@posthog/quill-tokens',
                 '@base-ui/react',
                 /^@base-ui\/react\//,
-                // Both leak into the public type signatures (DataTable's ColumnDef, the chat
-                // scroller hooks), so they are declared as real dependencies and kept external.
-                // Inlining them leaves consumers with type imports they cannot resolve.
-                '@tanstack/react-table',
-                '@shadcn/react',
-                /^@shadcn\/react\//,
                 'class-variance-authority',
                 'clsx',
                 'lucide-react',

--- a/packages/quill/packages/quill/vite.config.ts
+++ b/packages/quill/packages/quill/vite.config.ts
@@ -53,6 +53,12 @@ export default defineConfig({
                 '@posthog/quill-tokens',
                 '@base-ui/react',
                 /^@base-ui\/react\//,
+                // Both leak into the public type signatures (DataTable's ColumnDef, the chat
+                // scroller hooks), so they are declared as real dependencies and kept external.
+                // Inlining them leaves consumers with type imports they cannot resolve.
+                '@tanstack/react-table',
+                '@shadcn/react',
+                /^@shadcn\/react\//,
                 'class-variance-authority',
                 'clsx',
                 'lucide-react',

--- a/packages/quill/scripts/sync-base-ui-docs.ts
+++ b/packages/quill/scripts/sync-base-ui-docs.ts
@@ -1,0 +1,248 @@
+/**
+ * Copies Base UI's component documentation onto the quill wrappers that render it.
+ *
+ * Quill primitives already forward Base UI's prop *types*, so hovering an individual prop
+ * shows Base UI's JSDoc for it. Hovering the component itself showed nothing, because the
+ * wrapper carried no doc comment of its own. This script closes that gap: for every wrapper
+ * that spreads its rest props onto a Base UI element, it reads the doc comment off that Base
+ * UI component (via the TypeScript checker, so it always matches the installed version) and
+ * writes it above the wrapper.
+ *
+ * Generated content sits at the top of the block and ends at the `@baseui` tag. Anything
+ * after that tag is hand-written and is preserved verbatim across runs, so re-running after
+ * a Base UI upgrade refreshes the upstream prose without touching quill's own notes.
+ *
+ * Usage: pnpm --filter @posthog/quill-workspace sync:base-ui-docs [--check]
+ */
+import { writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const PACKAGES = ['primitives', 'components', 'blocks'].map((name) => join(HERE, '..', 'packages', name))
+const BASE_UI_MODULE = /^@base-ui\/react(\/|$)/
+const TAG = 'baseui'
+
+interface Wrapper {
+    /** Declaration the doc block is attached to (the `function`/`const` statement). */
+    node: ts.Node
+    /** Qualified Base UI name, e.g. `Accordion.Root`. */
+    baseUiName: string
+    /** Base UI's own doc comment for that component. */
+    doc: string
+}
+
+/** The rest-element name of a destructured first parameter, e.g. `props` in `({ className, ...props })`. */
+function restParamName(params: ts.NodeArray<ts.ParameterDeclaration>): string | undefined {
+    const binding = params[0]?.name
+    if (!binding || !ts.isObjectBindingPattern(binding)) {
+        return undefined
+    }
+    const rest = binding.elements.find((element) => element.dotDotDotToken)
+    return rest && ts.isIdentifier(rest.name) ? rest.name.text : undefined
+}
+
+/** The JSX element that receives `{...rest}` — the one the wrapper actually forwards props to. */
+function findForwardTarget(body: ts.Node, rest: string): ts.JsxOpeningLikeElement | undefined {
+    let found: ts.JsxOpeningLikeElement | undefined
+    const visit = (node: ts.Node): void => {
+        if (found) {
+            return
+        }
+        if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
+            const spreads = node.attributes.properties.some(
+                (attribute) =>
+                    ts.isJsxSpreadAttribute(attribute) &&
+                    ts.isIdentifier(attribute.expression) &&
+                    attribute.expression.text === rest
+            )
+            if (spreads) {
+                found = node
+                return
+            }
+        }
+        ts.forEachChild(node, visit)
+    }
+    visit(body)
+    return found
+}
+
+/** Walks an import alias back to the module it came from. */
+function declaringModule(symbol: ts.Symbol): string | undefined {
+    const declaration = symbol.declarations?.[0]
+    const importClause = declaration && ts.isImportSpecifier(declaration) ? declaration : undefined
+    if (!importClause) {
+        return undefined
+    }
+    const specifier = importClause.parent.parent.parent.moduleSpecifier
+    return ts.isStringLiteral(specifier) ? specifier.text : undefined
+}
+
+/** Resolves `<AccordionPrimitive.Root>` to `{ name: 'Accordion.Root', doc }` when it comes from Base UI. */
+function resolveBaseUi(
+    checker: ts.TypeChecker,
+    tag: ts.JsxTagNameExpression
+): { name: string; doc: string } | undefined {
+    const root = ts.isPropertyAccessExpression(tag) ? tag.expression : tag
+    if (!ts.isIdentifier(root)) {
+        return undefined
+    }
+    const rootSymbol = checker.getSymbolAtLocation(root)
+    if (!rootSymbol) {
+        return undefined
+    }
+    const module = declaringModule(rootSymbol)
+    if (!module || !BASE_UI_MODULE.test(module)) {
+        return undefined
+    }
+    // Prefer the imported name over the local alias, so the tag reads `Accordion.Root`
+    // rather than quill's `AccordionPrimitive.Root`.
+    const declaration = rootSymbol.declarations?.[0] as ts.ImportSpecifier
+    const upstreamRoot = (declaration.propertyName ?? declaration.name).text
+    const part = ts.isPropertyAccessExpression(tag) ? `.${tag.name.text}` : ''
+
+    const symbol = checker.getSymbolAtLocation(tag)
+    if (!symbol) {
+        return undefined
+    }
+    const target = symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol
+    const doc = ts.displayPartsToString(target.getDocumentationComment(checker)).trim()
+    if (!doc) {
+        return undefined
+    }
+    return { name: `${upstreamRoot}${part}`, doc }
+}
+
+/** Existing doc block on a declaration, if it has one. */
+function existingDoc(node: ts.Node, text: string): ts.CommentRange | undefined {
+    const ranges = ts.getLeadingCommentRanges(text, node.pos) ?? []
+    const block = ranges.filter((range) => text.slice(range.pos, range.pos + 3) === '/**').pop()
+    return block
+}
+
+/** Hand-written prose lives after the `@baseui` tag; a block without the tag is hand-written whole. */
+function handWrittenTail(block: string): string {
+    const inner = block
+        .replace(/^\/\*\*/, '')
+        .replace(/\*\/$/, '')
+        .split('\n')
+        .map((line) => line.replace(/^\s*\* ?/, ''))
+    const tagIndex = inner.findIndex((line) => line.trimStart().startsWith(`@${TAG} `))
+    const tail = tagIndex === -1 ? inner : inner.slice(tagIndex + 1)
+    return tail.join('\n').trim()
+}
+
+function renderDoc(wrapper: Wrapper, tail: string, indent: string): string {
+    const lines = [...wrapper.doc.split('\n'), '', `@${TAG} ${wrapper.baseUiName}`]
+    if (tail) {
+        lines.push('', ...tail.split('\n'))
+    }
+    const body = lines.map((line) => `${indent} *${line ? ` ${line}` : ''}`).join('\n')
+    return `${indent}/**\n${body}\n${indent} */`
+}
+
+function collectWrappers(source: ts.SourceFile, checker: ts.TypeChecker): Wrapper[] {
+    const wrappers: Wrapper[] = []
+    const consider = (
+        statement: ts.Node,
+        fn: ts.FunctionDeclaration | ts.FunctionExpression | ts.ArrowFunction
+    ): void => {
+        const rest = restParamName(fn.parameters)
+        if (!rest || !fn.body) {
+            return
+        }
+        const target = findForwardTarget(fn.body, rest)
+        if (!target) {
+            return
+        }
+        const resolved = resolveBaseUi(checker, target.tagName)
+        if (resolved) {
+            wrappers.push({ node: statement, baseUiName: resolved.name, doc: resolved.doc })
+        }
+    }
+
+    for (const statement of source.statements) {
+        if (ts.isFunctionDeclaration(statement)) {
+            consider(statement, statement)
+            continue
+        }
+        if (!ts.isVariableStatement(statement) || statement.declarationList.declarations.length !== 1) {
+            continue
+        }
+        const initializer = statement.declarationList.declarations[0].initializer
+        if (!initializer) {
+            continue
+        }
+        // `const X = React.forwardRef(function X(props, ref) { … })` and plain arrow/function forms.
+        const inner = ts.isCallExpression(initializer) ? initializer.arguments[0] : initializer
+        if (inner && (ts.isArrowFunction(inner) || ts.isFunctionExpression(inner))) {
+            consider(statement, inner)
+        }
+    }
+    return wrappers
+}
+
+function main(): void {
+    const check = process.argv.includes('--check')
+    let changed = 0
+
+    for (const packageDir of PACKAGES) {
+        const configPath = ts.findConfigFile(packageDir, ts.sys.fileExists, 'tsconfig.json')
+        if (!configPath) {
+            continue
+        }
+        const config = ts.readConfigFile(configPath, ts.sys.readFile)
+        const parsed = ts.parseJsonConfigFileContent(config.config, ts.sys, dirname(configPath))
+        const program = ts.createProgram(parsed.fileNames, parsed.options)
+        const checker = program.getTypeChecker()
+
+        for (const source of program.getSourceFiles()) {
+            if (source.isDeclarationFile || !source.fileName.startsWith(resolve(packageDir))) {
+                continue
+            }
+            if (source.fileName.includes('.stories.')) {
+                continue
+            }
+            const wrappers = collectWrappers(source, checker)
+            if (wrappers.length === 0) {
+                continue
+            }
+
+            const original = source.getFullText()
+            let text = original
+            // Rewrite bottom-up so earlier edits don't shift later offsets.
+            for (const wrapper of [...wrappers].reverse()) {
+                const start = wrapper.node.getStart(source)
+                const line = text.lastIndexOf('\n', start - 1) + 1
+                const indent = text.slice(line, start)
+                if (indent.trim() !== '') {
+                    continue
+                }
+                const block = existingDoc(wrapper.node, text)
+                const tail = block ? handWrittenTail(text.slice(block.pos, block.end)) : ''
+                const rendered = renderDoc(wrapper, tail, indent)
+                text = block
+                    ? `${text.slice(0, block.pos)}${rendered.trimStart()}${text.slice(block.end)}`
+                    : `${text.slice(0, line)}${rendered}\n${text.slice(line)}`
+            }
+
+            if (text === original) {
+                continue
+            }
+            changed += 1
+            if (!check) {
+                writeFileSync(source.fileName, text)
+            }
+            process.stdout.write(`${check ? 'stale' : 'updated'}: ${source.fileName}\n`)
+        }
+    }
+
+    if (check && changed > 0) {
+        process.stderr.write(`\n${changed} file(s) out of sync — run pnpm sync:base-ui-docs\n`)
+        process.exit(1)
+    }
+    process.stdout.write(`${changed} file(s) ${check ? 'stale' : 'updated'}\n`)
+}
+
+main()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@base-ui/react':
-      specifier: 1.6.0
-      version: 1.6.0
+      specifier: 1.7.0
+      version: 1.7.0
     '@parcel/packager-ts':
       specifier: 2.16.4
       version: 2.16.4
@@ -568,7 +568,7 @@ importers:
     dependencies:
       '@base-ui/react':
         specifier: 'catalog:'
-        version: 1.6.0(@date-fns/tz@1.4.1)(@types/react@18.3.27)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 1.7.0(@date-fns/tz@1.4.1)(@types/react@18.3.27)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@dagrejs/dagre':
         specifier: ^1.1.5
         version: 1.1.5
@@ -946,7 +946,7 @@ importers:
         version: 3.20.6
       '@tiptap/react':
         specifier: 3.20.6
-        version: 3.20.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.20.6(@tiptap/pm@3.20.6))(@tiptap/pm@3.20.6)(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.20.6(@floating-ui/dom@1.8.0)(@tiptap/core@3.20.6(@tiptap/pm@3.20.6))(@tiptap/pm@3.20.6)(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tiptap/starter-kit':
         specifier: 3.20.6
         version: 3.20.6
@@ -1895,9 +1895,15 @@ importers:
 
   packages/quill:
     devDependencies:
+      '@base-ui/react':
+        specifier: 'catalog:'
+        version: 1.7.0(@date-fns/tz@1.4.1)(@types/react@18.3.27)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwindcss-scroll-mask:
         specifier: ^0.0.3
         version: 0.0.3(tailwindcss@4.3.0)
+      tsx:
+        specifier: ^4.19.0
+        version: 4.20.5
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -2144,7 +2150,7 @@ importers:
     dependencies:
       '@base-ui/react':
         specifier: 'catalog:'
-        version: 1.6.0(@date-fns/tz@1.4.1)(@types/react@18.3.27)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 1.7.0(@date-fns/tz@1.4.1)(@types/react@18.3.27)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/quill-tokens':
         specifier: workspace:^
         version: link:../tokens
@@ -2197,6 +2203,12 @@ importers:
 
   packages/quill/packages/quill:
     dependencies:
+      '@shadcn/react':
+        specifier: ^0.1.0
+        version: 0.1.0(@types/react@18.3.27)(react@18.3.1)
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2224,7 +2236,7 @@ importers:
     devDependencies:
       '@base-ui/react':
         specifier: 'catalog:'
-        version: 1.6.0(@date-fns/tz@1.4.1)(@types/react@18.3.27)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 1.7.0(@date-fns/tz@1.4.1)(@types/react@18.3.27)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/quill-blocks':
         specifier: workspace:*
         version: link:../blocks
@@ -2628,7 +2640,7 @@ importers:
         version: 3.20.6
       '@tiptap/react':
         specifier: 3.20.6
-        version: 3.20.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.20.6(@tiptap/pm@3.20.6))(@tiptap/pm@3.20.6)(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.20.6(@floating-ui/dom@1.8.0)(@tiptap/core@3.20.6(@tiptap/pm@3.20.6))(@tiptap/pm@3.20.6)(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tiptap/starter-kit':
         specifier: 3.20.6
         version: 3.20.6
@@ -6096,8 +6108,8 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@base-ui/react@1.6.0':
-    resolution: {integrity: sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==}
+  '@base-ui/react@1.7.0':
+    resolution: {integrity: sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@date-fns/tz': ^1.2.0
@@ -6113,8 +6125,8 @@ packages:
       date-fns:
         optional: true
 
-  '@base-ui/utils@0.3.1':
-    resolution: {integrity: sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==}
+  '@base-ui/utils@0.3.2':
+    resolution: {integrity: sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==}
     peerDependencies:
       '@types/react': 18.3.27
       react: 18.3.1
@@ -7268,11 +7280,23 @@ packages:
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
+
   '@floating-ui/dom@1.7.6':
     resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
 
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
+
   '@floating-ui/react-dom@2.1.8':
     resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1
+
+  '@floating-ui/react-dom@2.1.9':
+    resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
     peerDependencies:
       react: 18.3.1
       react-dom: 18.3.1
@@ -7285,6 +7309,9 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
   '@fontsource-variable/inter@5.2.8':
     resolution: {integrity: sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==}
@@ -22195,8 +22222,8 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
-  unlayer-types@1.462.0:
-    resolution: {integrity: sha512-4evP8KinGyhYVSV9NLb2eBHUv8Th1kP1skT3B3Xwv9sbMCUXfedOYpDsC0yr78HvFj/t7fd2KyVnn5RhlnUXRA==}
+  unlayer-types@1.464.0:
+    resolution: {integrity: sha512-z4Bi5gkA1BOpl0YLpbJZwVI1L3vj4I5T71cbeYVdC3qHeoeMHqiM8g4j5tmJNoRczAMYdrjBQRDA1DeDzg4XWg==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -25217,12 +25244,12 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-ui/react@1.6.0(@date-fns/tz@1.4.1)(@types/react@18.3.27)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@base-ui/react@1.7.0(@date-fns/tz@1.4.1)(@types/react@18.3.27)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@base-ui/utils': 0.3.1(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@floating-ui/utils': 0.2.11
+      '@base-ui/utils': 0.3.2(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/react-dom': 2.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/utils': 0.2.12
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       use-sync-external-store: 1.6.0(react@18.3.1)
@@ -25231,10 +25258,10 @@ snapshots:
       '@types/react': 18.3.27
       date-fns: 4.1.0
 
-  '@base-ui/utils@0.3.1(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@base-ui/utils@0.3.2(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@floating-ui/utils': 0.2.11
+      '@floating-ui/utils': 0.2.12
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       reselect: 5.2.0
@@ -26098,14 +26125,29 @@ snapshots:
     dependencies:
       '@floating-ui/utils': 0.2.11
 
+  '@floating-ui/core@1.8.0':
+    dependencies:
+      '@floating-ui/utils': 0.2.12
+
   '@floating-ui/dom@1.7.6':
     dependencies:
       '@floating-ui/core': 1.7.5
       '@floating-ui/utils': 0.2.11
 
+  '@floating-ui/dom@1.8.0':
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
+
   '@floating-ui/react-dom@2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/dom': 1.7.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@floating-ui/react-dom@2.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
@@ -26118,6 +26160,8 @@ snapshots:
       tabbable: 6.4.0
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@floating-ui/utils@0.2.12': {}
 
   '@fontsource-variable/inter@5.2.8': {}
 
@@ -31788,9 +31832,9 @@ snapshots:
     dependencies:
       '@tiptap/extensions': 3.20.6(@tiptap/core@3.20.6(@tiptap/pm@3.20.6))(@tiptap/pm@3.20.6)
 
-  '@tiptap/extension-floating-menu@3.20.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.20.6(@tiptap/pm@3.20.6))(@tiptap/pm@3.20.6)':
+  '@tiptap/extension-floating-menu@3.20.6(@floating-ui/dom@1.8.0)(@tiptap/core@3.20.6(@tiptap/pm@3.20.6))(@tiptap/pm@3.20.6)':
     dependencies:
-      '@floating-ui/dom': 1.7.6
+      '@floating-ui/dom': 1.8.0
       '@tiptap/core': 3.20.6(@tiptap/pm@3.20.6)
       '@tiptap/pm': 3.20.6
     optional: true
@@ -31914,7 +31958,7 @@ snapshots:
       prosemirror-transform: 1.10.4
       prosemirror-view: 1.40.1
 
-  '@tiptap/react@3.20.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.20.6(@tiptap/pm@3.20.6))(@tiptap/pm@3.20.6)(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@tiptap/react@3.20.6(@floating-ui/dom@1.8.0)(@tiptap/core@3.20.6(@tiptap/pm@3.20.6))(@tiptap/pm@3.20.6)(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@tiptap/core': 3.20.6(@tiptap/pm@3.20.6)
       '@tiptap/pm': 3.20.6
@@ -31927,7 +31971,7 @@ snapshots:
       use-sync-external-store: 1.6.0(react@18.3.1)
     optionalDependencies:
       '@tiptap/extension-bubble-menu': 3.20.6(@tiptap/core@3.20.6(@tiptap/pm@3.20.6))(@tiptap/pm@3.20.6)
-      '@tiptap/extension-floating-menu': 3.20.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.20.6(@tiptap/pm@3.20.6))(@tiptap/pm@3.20.6)
+      '@tiptap/extension-floating-menu': 3.20.6(@floating-ui/dom@1.8.0)(@tiptap/core@3.20.6(@tiptap/pm@3.20.6))(@tiptap/pm@3.20.6)
     transitivePeerDependencies:
       - '@floating-ui/dom'
 
@@ -42621,7 +42665,7 @@ snapshots:
   react-email-editor@1.7.11(react@18.3.1):
     dependencies:
       react: 18.3.1
-      unlayer-types: 1.462.0
+      unlayer-types: 1.464.0
 
   react-grid-layout@2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -44941,7 +44985,7 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unlayer-types@1.462.0: {}
+  unlayer-types@1.464.0: {}
 
   unpipe@1.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -173,7 +173,7 @@ catalog:
     # React types
     '@types/react': ^18.3.27
     '@types/react-dom': ^18.3.7
-    '@base-ui/react': 1.6.0
+    '@base-ui/react': 1.7.0
     # Other shared
     husky: ^7.0.4
     lint-staged: ~15.4.3

--- a/products/desktop/packages/ui/package.json
+++ b/products/desktop/packages/ui/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "0.22.1",
-    "@base-ui/react": "^1.3.0",
+    "@base-ui/react": "^1.7.0",
     "@codemirror/lang-angular": "^0.1.4",
     "@codemirror/lang-cpp": "^6.0.3",
     "@codemirror/lang-css": "^6.3.1",

--- a/products/desktop/packages/ui/src/features/git-interaction/components/BranchSelector.test.tsx
+++ b/products/desktop/packages/ui/src/features/git-interaction/components/BranchSelector.test.tsx
@@ -124,11 +124,10 @@ describe("BranchSelector cloud mode", () => {
 
     expect(await screen.findByRole("option", { name: "main" })).toBeVisible();
     expect(screen.getByText("Loading branches…")).toBeVisible();
-    // The seeded row makes the list non-empty, so the empty-state stays gated
-    // off (Base UI only reveals it when the content group is data-empty) — it
-    // keeps the `hidden` class rather than flashing "No branches found." above
-    // the trunk row.
-    expect(screen.getByText("No branches found.")).toHaveClass("hidden");
+    // The seeded row makes the list non-empty, so the empty state stays gated
+    // off. Base UI renders the empty part's children only while the filtered list
+    // is empty, so "No branches found." never reaches the DOM above the trunk row.
+    expect(screen.queryByText("No branches found.")).not.toBeInTheDocument();
   });
 
   it("does not seed the default branch once the user is searching", async () => {

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
@@ -21,6 +21,12 @@ vi.mock("@posthog/ui/features/feature-flags/useFeatureFlag", () => ({
 
 const ultracodeDocsUrl = "https://code.claude.com/docs/en/workflows";
 
+// The slider thumb's `input[type="range"]` is what carries the `slider` role, and
+// Base UI keeps the thumb `visibility: hidden` until it has measured the track.
+// jsdom does no layout, so that measurement never lands and the role query has to
+// opt into hidden elements. A missing slider still means it was never rendered.
+const SLIDER_QUERY = { hidden: true } as const;
+
 function thoughtOption(
   overrides?: Partial<SessionConfigOption>,
 ): SessionConfigOption {
@@ -155,7 +161,7 @@ describe("ReasoningLevelSelector", () => {
     );
 
     await user.click(screen.getByRole("button", { name: "Reasoning: High" }));
-    expect(await screen.findByRole("slider")).toBeInTheDocument();
+    expect(await screen.findByRole("slider", SLIDER_QUERY)).toBeInTheDocument();
     expect(screen.getByText("Faster ($)")).toBeInTheDocument();
     expect(screen.getByText("Smarter ($$$)")).toBeInTheDocument();
     expect(screen.queryByRole("menuitemradio")).not.toBeInTheDocument();
@@ -316,7 +322,7 @@ describe("ReasoningLevelSelector", () => {
     await user.click(
       screen.getByRole("button", { name: /Model and reasoning/ }),
     );
-    expect(await screen.findByRole("slider")).toBeInTheDocument();
+    expect(await screen.findByRole("slider", SLIDER_QUERY)).toBeInTheDocument();
   });
 
   it("hides the slider when the combo is off the preset ladder", async () => {
@@ -337,7 +343,7 @@ describe("ReasoningLevelSelector", () => {
     expect(
       await screen.findByRole("menuitem", { name: /^Reasoning/ }),
     ).toBeInTheDocument();
-    expect(screen.queryByRole("slider")).not.toBeInTheDocument();
+    expect(screen.queryByRole("slider", SLIDER_QUERY)).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Back" }),
     ).not.toBeInTheDocument();
@@ -488,7 +494,7 @@ describe("ReasoningLevelSelector", () => {
     await user.click(
       screen.getByRole("button", { name: /Model and reasoning/ }),
     );
-    const slider = await screen.findByRole("slider");
+    const slider = await screen.findByRole("slider", SLIDER_QUERY);
     fireEvent.keyDown(slider, { key: "ArrowRight" });
 
     await pollUntil(
@@ -580,7 +586,7 @@ describe("ReasoningLevelSelector", () => {
     expect(
       screen.queryByRole("menuitem", { name: /^Reasoning/ }),
     ).not.toBeInTheDocument();
-    expect(screen.queryByRole("slider")).not.toBeInTheDocument();
+    expect(screen.queryByRole("slider", SLIDER_QUERY)).not.toBeInTheDocument();
   });
 
   it("drops the stale effort label when switching to an effort-less model", () => {

--- a/products/desktop/pnpm-lock.yaml
+++ b/products/desktop/pnpm-lock.yaml
@@ -84,7 +84,7 @@ overrides:
   react-test-renderer: 19.2.6
   '@types/react': ^19.2.15
   '@types/react-dom': ^19.2.3
-  '@posthog/quill>@base-ui/react': ^1.3.0
+  '@posthog/quill>@base-ui/react': ^1.7.0
   node-gyp>undici: 8.5.0
   vite: npm:rolldown-vite@7.3.1
   protobufjs: 7.6.5
@@ -218,7 +218,7 @@ importers:
         version: link:../../packages/platform
       '@posthog/quill':
         specifier: 'catalog:'
-        version: 0.3.0-beta.24(@base-ui/react@1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.1)
+        version: 0.3.0-beta.24(@base-ui/react@1.7.0(@types/react@19.2.17)(date-fns@4.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.1)
       '@posthog/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -903,7 +903,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/api-client:
     dependencies:
@@ -919,7 +919,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/core:
     dependencies:
@@ -983,7 +983,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/di:
     dependencies:
@@ -1005,7 +1005,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/electron-trpc:
     devDependencies:
@@ -1060,7 +1060,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/git:
     dependencies:
@@ -1082,7 +1082,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/harness:
     dependencies:
@@ -1128,7 +1128,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@22.20.0)(typescript@5.9.3))(vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@22.20.0)(typescript@5.9.3))(vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/host-router:
     dependencies:
@@ -1233,7 +1233,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/ui:
     dependencies:
@@ -1241,8 +1241,8 @@ importers:
         specifier: 0.22.1
         version: 0.22.1(zod@4.4.3)
       '@base-ui/react':
-        specifier: ^1.3.0
-        version: 1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^1.7.0
+        version: 1.7.0(@types/react@19.2.17)(date-fns@4.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@codemirror/lang-angular':
         specifier: ^0.1.4
         version: 0.1.4
@@ -1407,7 +1407,7 @@ importers:
         version: 3.19.0
       '@tiptap/react':
         specifier: ^3.13.0
-        version: 3.19.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 3.19.0(@floating-ui/dom@1.8.0)(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tiptap/starter-kit':
         specifier: ^3.13.0
         version: 3.19.0
@@ -1522,7 +1522,7 @@ importers:
         version: 2.1.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@posthog/quill':
         specifier: 'catalog:'
-        version: 0.3.0-beta.24(@base-ui/react@1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.2)
+        version: 0.3.0-beta.24(@base-ui/react@1.7.0(@types/react@19.2.17)(date-fns@4.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.2)
       '@posthog/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/typescript
@@ -1561,7 +1561,7 @@ importers:
         version: 5.0.6
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.7.0(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.7.0(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
       jsdom:
         specifier: ^26.0.0
         version: 26.1.0
@@ -1576,7 +1576,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/workspace-client:
     dependencies:
@@ -1610,7 +1610,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/workspace-server:
     dependencies:
@@ -1710,7 +1710,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.41)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@20.19.41)(typescript@5.9.3))(vite@7.3.5(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.41)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@20.19.41)(typescript@5.9.3))(vite@7.3.5(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
 
   tooling/tsup-config:
     dependencies:
@@ -2792,19 +2792,25 @@ packages:
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
-  '@base-ui/react@1.3.0':
-    resolution: {integrity: sha512-FwpKqZbPz14AITp1CVgf4AjhKPe1OeeVKSBMdgD10zbFlj3QSWelmtCMLi2+/PFZZcIm3l87G7rwtCZJwHyXWA==}
+  '@base-ui/react@1.7.0':
+    resolution: {integrity: sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
+      '@date-fns/tz': ^1.2.0
       '@types/react': ^19.2.15
+      date-fns: ^4.0.0
       react: 19.2.6
       react-dom: 19.2.6
     peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
       '@types/react':
         optional: true
+      date-fns:
+        optional: true
 
-  '@base-ui/utils@0.2.6':
-    resolution: {integrity: sha512-yQ+qeuqohwhsNpoYDqqXaLllYAkPCP4vYdDrVo8FQXaAPfHWm1pG/Vm+jmGTA5JFS0BAIjookyapuJFY8F9PIw==}
+  '@base-ui/utils@0.3.2':
+    resolution: {integrity: sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==}
     peerDependencies:
       '@types/react': ^19.2.15
       react: 19.2.6
@@ -4103,14 +4109,26 @@ packages:
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
+
   '@floating-ui/dom@1.7.5':
     resolution: {integrity: sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==}
 
   '@floating-ui/dom@1.7.6':
     resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
 
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
+
   '@floating-ui/react-dom@2.1.8':
     resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: 19.2.6
+      react-dom: 19.2.6
+
+  '@floating-ui/react-dom@2.1.9':
+    resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
     peerDependencies:
       react: 19.2.6
       react-dom: 19.2.6
@@ -4123,6 +4141,9 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
   '@fontsource-variable/inter@5.2.8':
     resolution: {integrity: sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==}
@@ -6290,7 +6311,7 @@ packages:
     resolution: {integrity: sha512-lBnnFqX3aVNXPPc5j8pO2cGr99IeClIr2ByVTdote477Bnqwt8HDX7jbFxCwiUr8ARnuSTvhDrqeagZzplwE9Q==}
     engines: {node: '>=20'}
     peerDependencies:
-      '@base-ui/react': ^1.3.0
+      '@base-ui/react': ^1.7.0
       react: 19.2.6
       react-dom: 19.2.6
       tailwindcss: ^4.0.0
@@ -10313,8 +10334,8 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
-  deslop-js@0.9.3:
-    resolution: {integrity: sha512-sJcR5LLnEG+w58Oy5CdZfwAfm8XiERbXp9c941Aoeb8JmBHk/56TbZQlLJseJtClg0dkn88wpmnI82+iF0jagg==}
+  deslop-js@0.9.4:
+    resolution: {integrity: sha512-tiUyzTadQM0BWSGaP0u347c4q2vDIHyY0GUg0jY3Py6nEU0uaB6P0fKevWJmaYK4N+i+H7oE3GYdumfx/AcsUw==}
 
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
@@ -11651,6 +11672,10 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-flag@5.0.1:
+    resolution: {integrity: sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==}
+    engines: {node: '>=12'}
+
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
@@ -11905,6 +11930,12 @@ packages:
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  ink-link@5.0.0:
+    resolution: {integrity: sha512-TFDXc/0mwUW7LMjsr0/LeLxPVV5BnHDuDQff9RCgP4rb3R+V/4dIwGBZbCevcJZtQnVcW+Iz1LUrUbpq+UDwYA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      ink: '>=6'
 
   ink-spinner@5.0.0:
     resolution: {integrity: sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA==}
@@ -12524,6 +12555,12 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.27.0:
     resolution: {integrity: sha512-Gl/lqIXY+d+ySmMbgDf0pgaWSqrWYxVHoc88q+Vhf2YNzZ8DwoRzGt5NZDVqqIW5ScpSnmmjcgXP87Dn2ylSSQ==}
     engines: {node: '>= 12.0.0'}
@@ -12532,6 +12569,12 @@ packages:
 
   lightningcss-darwin-arm64@1.32.0:
     resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -12548,6 +12591,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.27.0:
     resolution: {integrity: sha512-n1sEf85fePoU2aDN2PzYjoI8gbBqnmLGEhKq7q0DKLj0UTVmOTwDC7PtLcy/zFxzASTSBlVQYJUhwIStQMIpRA==}
     engines: {node: '>= 12.0.0'}
@@ -12556,6 +12605,12 @@ packages:
 
   lightningcss-freebsd-x64@1.32.0:
     resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -12572,6 +12627,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.27.0:
     resolution: {integrity: sha512-cPsxo1QEWq2sfKkSq2Bq5feQDHdUEwgtA9KaB27J5AX22+l4l0ptgjMZZtYtUnteBofjee+0oW1wQ1guv04a7A==}
     engines: {node: '>= 12.0.0'}
@@ -12581,6 +12642,13 @@ packages:
 
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -12600,6 +12668,13 @@ packages:
     os: [linux]
     libc: [musl]
 
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-linux-x64-gnu@1.27.0:
     resolution: {integrity: sha512-Dk/jovSI7qqhJDiUibvaikNKI2x6kWPN79AQiD/E/KeQWMjdGe9kw51RAgoWFDi0coP4jinaH14Nrt/J8z3U4A==}
     engines: {node: '>= 12.0.0'}
@@ -12609,6 +12684,13 @@ packages:
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -12628,6 +12710,13 @@ packages:
     os: [linux]
     libc: [musl]
 
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-win32-arm64-msvc@1.27.0:
     resolution: {integrity: sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ==}
     engines: {node: '>= 12.0.0'}
@@ -12636,6 +12725,12 @@ packages:
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -12652,12 +12747,22 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.27.0:
     resolution: {integrity: sha512-8f7aNmS1+etYSLHht0fQApPc2kNO8qGRutifN5rVIc6Xo6ABsEbqOr758UwI7ALVbTt4x1fllKt0PYgzD9S3yQ==}
     engines: {node: '>= 12.0.0'}
 
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
   lilconfig@3.1.3:
@@ -13547,8 +13652,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  oxlint-plugin-react-doctor@0.9.3:
-    resolution: {integrity: sha512-7XDOw+zjVquh0yqX3zvGQC2zzWIp2rXyMjLDqFzzQ8t7TZXfIQ6ttQhBwckQSk4c7kD7Cy9If0F4LI4XXI4Gsg==}
+  oxlint-plugin-react-doctor@0.9.4:
+    resolution: {integrity: sha512-JydpWgYo2nZPAO+9Zc3H7SzwPaqsCMTPHMRHHbtXdjL440y/aU/89gV8hfNCXhoNBafVRAg9Z9Jjl9uGg1hfWA==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
   oxlint@1.76.0:
@@ -14179,8 +14284,8 @@ packages:
     resolution: {integrity: sha512-+NRMYs2DyTP4/tqWz371Oo50JqmWltR1h2gcdgUMAWZJIAvrd0/SqlCfx7tpzpl/s36rzw6qH2MjoNrxtRNYhA==}
     engines: {node: ^20.9.0 || >=22}
 
-  react-doctor@0.9.3:
-    resolution: {integrity: sha512-s8kWwfFKZA3e9AT5wwFilQNjxKFP30ceFIXOZDrmLPstFodbHOpE0Mv+fEY0/04uZbhRdVYKoaHYb+yaAIEwPw==}
+  react-doctor@0.9.4:
+    resolution: {integrity: sha512-Zq8dmmLOyuyJselHQVJhsfCATjYN5+TeXSJmbC1IUH2kfmD8hC4NomV5A4ZrarSG5lqIwlar4ehYGlXDMBNokw==}
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
@@ -14553,8 +14658,8 @@ packages:
     resolution: {integrity: sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==}
     engines: {node: '>=12', npm: '>=6'}
 
-  reselect@5.1.1:
-    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
@@ -15200,6 +15305,10 @@ packages:
     resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
     engines: {node: '>=16'}
 
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -15215,6 +15324,10 @@ packages:
   supports-hyperlinks@2.3.0:
     resolution: {integrity: sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==}
     engines: {node: '>=8'}
+
+  supports-hyperlinks@4.5.0:
+    resolution: {integrity: sha512-ZW2OvfeCXrNTbLakPUzjQG922EeGCOteFSVoek5DKStTh898wf7zgtuFlzQN8HfZCxC3Eh02yJVrRW51hADf+w==}
+    engines: {node: '>=20'}
 
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -15293,6 +15406,10 @@ packages:
   terminal-link@2.1.1:
     resolution: {integrity: sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==}
     engines: {node: '>=8'}
+
+  terminal-link@5.0.0:
+    resolution: {integrity: sha512-qFAy10MTMwjzjU8U16YS4YoZD+NQLHzLssFMNqgravjbvIPNiqkGFR4yjhJfmY9R5OFU7+yHxc6y+uGHkKwLRA==}
+    engines: {node: '>=20'}
 
   terminal-size@4.0.1:
     resolution: {integrity: sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==}
@@ -17682,26 +17799,26 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@base-ui/react@1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@base-ui/react@1.7.0(@types/react@19.2.17)(date-fns@4.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@babel/runtime': 7.29.2
-      '@base-ui/utils': 0.2.6(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@floating-ui/utils': 0.2.11
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.3.2(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@floating-ui/utils': 0.2.12
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      tabbable: 6.4.0
       use-sync-external-store: 1.6.0(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.17
+      date-fns: 4.1.0
 
-  '@base-ui/utils@0.2.6(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@base-ui/utils@0.3.2(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@babel/runtime': 7.29.2
-      '@floating-ui/utils': 0.2.11
+      '@babel/runtime': 7.29.7
+      '@floating-ui/utils': 0.2.12
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      reselect: 5.1.1
+      reselect: 5.2.0
       use-sync-external-store: 1.6.0(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.17
@@ -19060,6 +19177,10 @@ snapshots:
     dependencies:
       '@floating-ui/utils': 0.2.11
 
+  '@floating-ui/core@1.8.0':
+    dependencies:
+      '@floating-ui/utils': 0.2.12
+
   '@floating-ui/dom@1.7.5':
     dependencies:
       '@floating-ui/core': 1.7.4
@@ -19071,9 +19192,20 @@ snapshots:
       '@floating-ui/core': 1.7.5
       '@floating-ui/utils': 0.2.11
 
+  '@floating-ui/dom@1.8.0':
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
+
   '@floating-ui/react-dom@2.1.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@floating-ui/dom': 1.7.6
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@floating-ui/react-dom@2.1.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
@@ -19086,6 +19218,8 @@ snapshots:
       tabbable: 6.4.0
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@floating-ui/utils@0.2.12': {}
 
   '@fontsource-variable/inter@5.2.8': {}
 
@@ -21108,9 +21242,9 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       simple-statistics: 7.8.9
 
-  '@posthog/quill@0.3.0-beta.24(@base-ui/react@1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.2)':
+  '@posthog/quill@0.3.0-beta.24(@base-ui/react@1.7.0(@types/react@19.2.17)(date-fns@4.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.2)':
     dependencies:
-      '@base-ui/react': 1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@base-ui/react': 1.7.0(@types/react@19.2.17)(date-fns@4.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       class-variance-authority: 0.7.1
       clsx: 2.1.1
       lucide-react: 0.577.0(react@19.2.6)
@@ -21120,9 +21254,9 @@ snapshots:
       tailwind-merge: 2.6.1
       tailwindcss: 4.2.2
 
-  '@posthog/quill@0.3.0-beta.24(@base-ui/react@1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.1)':
+  '@posthog/quill@0.3.0-beta.24(@base-ui/react@1.7.0(@types/react@19.2.17)(date-fns@4.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.1)':
     dependencies:
-      '@base-ui/react': 1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@base-ui/react': 1.7.0(@types/react@19.2.17)(date-fns@4.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       class-variance-authority: 0.7.1
       clsx: 2.1.1
       lucide-react: 0.577.0(react@19.2.6)
@@ -23218,9 +23352,9 @@ snapshots:
     dependencies:
       '@tiptap/extensions': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
 
-  '@tiptap/extension-floating-menu@3.19.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
+  '@tiptap/extension-floating-menu@3.19.0(@floating-ui/dom@1.8.0)(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)':
     dependencies:
-      '@floating-ui/dom': 1.7.6
+      '@floating-ui/dom': 1.8.0
       '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
       '@tiptap/pm': 3.19.0
     optional: true
@@ -23321,7 +23455,7 @@ snapshots:
       prosemirror-transform: 1.11.0
       prosemirror-view: 1.41.5
 
-  '@tiptap/react@3.19.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@tiptap/react@3.19.0(@floating-ui/dom@1.8.0)(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@tiptap/core': 3.19.0(@tiptap/pm@3.19.0)
       '@tiptap/pm': 3.19.0
@@ -23334,7 +23468,7 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.6)
     optionalDependencies:
       '@tiptap/extension-bubble-menu': 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
-      '@tiptap/extension-floating-menu': 3.19.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@tiptap/extension-floating-menu': 3.19.0(@floating-ui/dom@1.8.0)(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
     transitivePeerDependencies:
       - '@floating-ui/dom'
 
@@ -23797,7 +23931,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitejs/plugin-react@4.7.0(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -23805,7 +23939,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -23870,23 +24004,23 @@ snapshots:
       msw: 2.12.8(@types/node@25.2.0)(typescript@5.9.3)
       vite: rolldown-vite@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@25.2.0)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  '@vitest/mocker@4.1.8(msw@2.12.8(@types/node@20.19.41)(typescript@5.9.3))(vite@7.3.5(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.8(msw@2.12.8(@types/node@20.19.41)(typescript@5.9.3))(vite@7.3.5(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.8(@types/node@20.19.41)(typescript@5.9.3)
-      vite: 7.3.5(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  '@vitest/mocker@4.1.8(msw@2.12.8(@types/node@22.20.0)(typescript@5.9.3))(vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.8(msw@2.12.8(@types/node@22.20.0)(typescript@5.9.3))(vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.8(@types/node@22.20.0)(typescript@5.9.3)
-      vite: 7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.8(msw@2.12.8(@types/node@24.12.0)(typescript@5.9.3))(rolldown-vite@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@24.12.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
@@ -23897,23 +24031,23 @@ snapshots:
       msw: 2.12.8(@types/node@24.12.0)(typescript@5.9.3)
       vite: rolldown-vite@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@24.12.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  '@vitest/mocker@4.1.8(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.8(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.8(@types/node@25.2.0)(typescript@5.9.3)
-      vite: 7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@vitest/mocker@4.1.8(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.8(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.8(@types/node@25.2.0)(typescript@5.9.3)
-      vite: 7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -25330,7 +25464,7 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  deslop-js@0.9.3:
+  deslop-js@0.9.4:
     dependencies:
       '@oxc-project/types': 0.142.0
       fast-glob: 3.3.3
@@ -26912,6 +27046,8 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  has-flag@5.0.1: {}
+
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
@@ -27236,6 +27372,11 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
+
+  ink-link@5.0.0(ink@7.1.1(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.6)):
+    dependencies:
+      ink: 7.1.1(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.6)
+      terminal-link: 5.0.0
 
   ink-spinner@5.0.0(ink@7.1.1(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -28195,10 +28336,16 @@ snapshots:
   lightningcss-android-arm64@1.32.0:
     optional: true
 
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.27.0:
     optional: true
 
   lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
     optional: true
 
   lightningcss-darwin-x64@1.27.0:
@@ -28207,10 +28354,16 @@ snapshots:
   lightningcss-darwin-x64@1.32.0:
     optional: true
 
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.27.0:
     optional: true
 
   lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.27.0:
@@ -28219,10 +28372,16 @@ snapshots:
   lightningcss-linux-arm-gnueabihf@1.32.0:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.27.0:
     optional: true
 
   lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.27.0:
@@ -28231,10 +28390,16 @@ snapshots:
   lightningcss-linux-arm64-musl@1.32.0:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.27.0:
     optional: true
 
   lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.27.0:
@@ -28243,16 +28408,25 @@ snapshots:
   lightningcss-linux-x64-musl@1.32.0:
     optional: true
 
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.27.0:
     optional: true
 
   lightningcss-win32-arm64-msvc@1.32.0:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.27.0:
     optional: true
 
   lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
     optional: true
 
   lightningcss@1.27.0:
@@ -28285,6 +28459,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
 
   lilconfig@3.1.3: {}
 
@@ -29712,12 +29902,13 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.45.0
       '@oxfmt/binding-win32-x64-msvc': 0.45.0
 
-  oxlint-plugin-react-doctor@0.9.3:
+  oxlint-plugin-react-doctor@0.9.4:
     dependencies:
       '@shaderfrog/glsl-parser': 7.0.1
       '@typescript-eslint/types': 8.65.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
+      lightningcss: 1.33.0
       oxc-parser: 0.142.0
 
   oxlint@1.76.0:
@@ -30450,7 +30641,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-doctor@0.9.3(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.208.0(@opentelemetry/api@1.9.1))(@types/react@19.2.17)(eslint@10.5.0(jiti@2.7.0))(react-devtools-core@6.1.5):
+  react-doctor@0.9.4(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.208.0(@opentelemetry/api@1.9.1))(@types/react@19.2.17)(eslint@10.5.0(jiti@2.7.0))(react-devtools-core@6.1.5):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@babel/code-frame': 7.29.7
@@ -30458,16 +30649,17 @@ snapshots:
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.9.3
+      deslop-js: 0.9.4
       eslint-plugin-react-hooks: 7.1.1(eslint@10.5.0(jiti@2.7.0))
       figures: 6.1.0
       ink: 7.1.1(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.6)
+      ink-link: 5.0.0(ink@7.1.1(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.6))
       ink-spinner: 5.0.0(ink@7.1.1(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.6))(react@19.2.6)
       jiti: 2.7.0
       magicast: 0.5.3
       oxc-resolver: 11.24.2
       oxlint: 1.76.0
-      oxlint-plugin-react-doctor: 0.9.3
+      oxlint-plugin-react-doctor: 0.9.4
       prompts: 2.4.2
       react: 19.2.6
       typescript: 5.9.3
@@ -30769,7 +30961,7 @@ snapshots:
       preact: 10.29.2
       prompts: 2.4.2
       react: 19.2.6
-      react-doctor: 0.9.3(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.208.0(@opentelemetry/api@1.9.1))(@types/react@19.2.17)(eslint@10.5.0(jiti@2.7.0))(react-devtools-core@6.1.5)
+      react-doctor: 0.9.4(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.208.0(@opentelemetry/api@1.9.1))(@types/react@19.2.17)(eslint@10.5.0(jiti@2.7.0))(react-devtools-core@6.1.5)
       react-dom: 19.2.6(react@19.2.6)
       react-grab: 0.1.50(react@19.2.6)
     optionalDependencies:
@@ -30966,7 +31158,7 @@ snapshots:
     dependencies:
       pe-library: 0.4.1
 
-  reselect@5.1.1: {}
+  reselect@5.2.0: {}
 
   resolve-alpn@1.2.1: {}
 
@@ -31769,6 +31961,8 @@ snapshots:
     dependencies:
       copy-anything: 4.0.5
 
+  supports-color@10.2.2: {}
+
   supports-color@5.5.0:
     dependencies:
       has-flag: 3.0.0
@@ -31785,6 +31979,11 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
       supports-color: 7.2.0
+
+  supports-hyperlinks@4.5.0:
+    dependencies:
+      has-flag: 5.0.1
+      supports-color: 10.2.2
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
@@ -31895,6 +32094,11 @@ snapshots:
     dependencies:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
+
+  terminal-link@5.0.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      supports-hyperlinks: 4.5.0
 
   terminal-size@4.0.1: {}
 
@@ -32503,7 +32707,7 @@ snapshots:
       - supports-color
       - typescript
 
-  vite@7.3.5(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite@7.3.5(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.5)
@@ -32515,12 +32719,12 @@ snapshots:
       '@types/node': 20.19.41
       fsevents: 2.3.3
       jiti: 2.7.0
-      lightningcss: 1.32.0
+      lightningcss: 1.33.0
       terser: 5.46.0
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.5)
@@ -32532,12 +32736,12 @@ snapshots:
       '@types/node': 22.20.0
       fsevents: 2.3.3
       jiti: 2.7.0
-      lightningcss: 1.32.0
+      lightningcss: 1.33.0
       terser: 5.46.0
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0):
+  vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.5)
@@ -32549,12 +32753,12 @@ snapshots:
       '@types/node': 25.2.0
       fsevents: 2.3.3
       jiti: 2.7.0
-      lightningcss: 1.32.0
+      lightningcss: 1.33.0
       terser: 5.46.0
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.5)
@@ -32566,7 +32770,7 @@ snapshots:
       '@types/node': 25.2.0
       fsevents: 2.3.3
       jiti: 2.7.0
-      lightningcss: 1.32.0
+      lightningcss: 1.33.0
       terser: 5.46.0
       tsx: 4.22.4
       yaml: 2.9.0
@@ -32600,10 +32804,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.41)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@20.19.41)(typescript@5.9.3))(vite@7.3.5(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.41)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@20.19.41)(typescript@5.9.3))(vite@7.3.5(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(msw@2.12.8(@types/node@20.19.41)(typescript@5.9.3))(vite@7.3.5(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.8(msw@2.12.8(@types/node@20.19.41)(typescript@5.9.3))(vite@7.3.5(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -32620,7 +32824,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.5(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -32630,10 +32834,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@22.20.0)(typescript@5.9.3))(vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@22.20.0)(typescript@5.9.3))(vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(msw@2.12.8(@types/node@22.20.0)(typescript@5.9.3))(vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.8(msw@2.12.8(@types/node@22.20.0)(typescript@5.9.3))(vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -32650,7 +32854,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -32721,10 +32925,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.8(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -32741,7 +32945,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -32751,10 +32955,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.8(msw@2.12.8(@types/node@25.2.0)(typescript@5.9.3))(vite@7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -32771,7 +32975,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1

--- a/products/desktop/pnpm-workspace.yaml
+++ b/products/desktop/pnpm-workspace.yaml
@@ -94,10 +94,11 @@ overrides:
     # makes nominally-distinct Ref types and breaks ref props in packages/ui).
     '@types/react': ^19.2.15
     '@types/react-dom': ^19.2.3
-    # quill 0.3.0-beta.14 ships a broken `@base-ui/react: catalog:` dependency (the
+    # quill 0.3.0-beta.14 shipped a broken `@base-ui/react: catalog:` dependency (the
     # catalog protocol leaked into the published package and can't resolve for an
-    # external dep); pin it to a real version so installs of quill succeed.
-    '@posthog/quill>@base-ui/react': ^1.3.0
+    # external dep); pin it to a real version so installs of quill succeed. It also
+    # keeps quill on the same Base UI copy as packages/ui, so their types unify.
+    '@posthog/quill>@base-ui/react': ^1.7.0
     # node-gyp 12 downloads Node headers via undici (^6.25.0). undici through 7.27.2
     # crashes intermittently with `assert(!this.paused)` in the H1 parser's finish()
     # when the socket ends while the body stream is paused, which happens when a


### PR DESCRIPTION
## Problem

Hovering a quill primitive in the editor showed no documentation, so anyone building UI had to open base-ui.com to learn what a component does. Individual props already carried Base UI's JSDoc, because the wrappers forward Base UI's prop types. The components themselves carried nothing, because the wrappers had no doc comment of their own.

Two type imports also leaked out of `@posthog/quill` undeclared. `dist/index.d.ts` imports `ColumnDef` from `@tanstack/react-table` and the scroller hooks from `@shadcn/react/message-scroller`, but neither package was a dependency of the published module, so a consumer could not resolve either one.

Base UI was four minor versions behind at 1.6.0 (desktop resolved 1.3.0).

## Changes

- Hovering a quill primitive now shows Base UI's description and its documentation link.
- `packages/quill/scripts/sync-base-ui-docs.ts` generates those comments. For each wrapper that spreads `...props` onto a Base UI element, it reads that component's doc comment through the TypeScript checker and writes it above the wrapper.
- Generated text ends at the `@baseui` tag. Anything below the tag is hand-written and survives a re-run, so the existing quill notes on `Dialog`, `ThreadItem` and others stay.
- Run `pnpm --filter @posthog/quill-workspace sync:base-ui-docs` after a Base UI upgrade. `--check` fails when the comments are stale.
- `@base-ui/react` moves to 1.7.0 in the root catalog, quill's peer range, and the desktop workspace.
- `@posthog/quill` declares `@tanstack/react-table` and `@shadcn/react` as dependencies. Both stay bundled, as before. Declaring them is what makes the type imports resolvable; externalizing them broke the frontend build, because esbuild resolves quill's dist from `@posthog/frontend`, which depends on neither.
- Two desktop test groups asserted Base UI behavior that 1.7.0 changed. The slider thumb now stays `visibility: hidden` until Base UI measures the track, where before a NaN position leaked through as visible, so the role query opts into hidden elements under jsdom. Combobox renders its empty part's children only while the filtered list is empty, instead of always rendering them behind a `hidden` class, so the test asserts absence.
- No visual change. Outside those two test files, this PR touches doc comments, package manifests, and build config only.

## How did you test this code?

I (actually Claude) built the quill chain and probed the built `dist/index.d.ts` from a scratch consumer project with the TypeScript language service, asking for hover info the way an editor does:

- Hovering `Accordion` returns "Groups all parts of the accordion. Renders a `<div>` element." plus the docs link. Before this change it returned nothing.
- Hovering the `multiple` prop returns Base UI's JSDoc for it, confirming prop pass-through still works.
- `DataTable`'s `columns` prop resolves to `ColumnDef<TData, TValue>[]` with no unresolved-module error.

For the version bump and the CI fixes:

- The full `@posthog/ui` vitest suite passes: 2963 tests across 348 files.
- `pnpm --filter @posthog/ui typecheck` passes against 1.7.0.
- `pnpm --filter=@posthog/frontend build` completes and emits `frontend/dist/toolbar.js`, the file the CSP check could not find on the first push.
- `tsc --noEmit` on `packages/quill/packages/primitives` reports only the pre-existing `progress.stories.tsx` strict-args errors, which reproduce on 1.6.0 too.
- `pnpm --filter=@posthog/frontend typescript:check` reports no Base UI errors.
- The doc sync is idempotent: a second run reports 0 files stale, including after merging master.

Not run: the Playwright and Storybook suites.

No new tests. The change adds doc comments and dependency declarations, and `sync:base-ui-docs:check` is the regression guard for the comments going stale.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (Claude Code) on request to bump quill to the latest Base UI and make Base UI props and JSDoc visible on hover.

Skills invoked: `/writing-pr-descriptions`.

I first audited whether the wrappers dropped Base UI props, since that was the suspected cause. They do not: every wrapper already types with the Base UI part's props and spreads the rest. Probing the language service against the published package narrowed the gap to the missing component-level doc comment and the two undeclared type dependencies.

I chose a generator over hand-writing roughly 200 comments so the prose stays correct across future Base UI upgrades. The `@baseui` tag is the boundary that lets it regenerate without eating quill's own notes.

The first push also externalized the two newly declared dependencies, which broke the frontend build. Declaring them is sufficient for the type resolution this PR is about, so the second commit reverts the externalization and keeps them inlined.

`products/desktop` still consumes published quill `0.3.0-beta.24`, so the doc comments reach the desktop app only after the next quill publish. The Base UI bump there applies immediately.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
