### PR TITLE
fix(insights): auto-wrap bare journeys and web stats insight queries

### DIFF
--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -551,16 +551,25 @@ class QueryFieldSerializer(serializers.Serializer):
 # wrapper nodes and a few standalone kinds (e.g. WebOverviewQuery) to real renderers; the
 # kinds below have no bare renderer and fall through to a JSON-dump fallback that paints
 # ~0px inside a dashboard tile, so they are safe (and necessary) to auto-wrap on save.
+#
+# This is every InsightVizNode source kind except the ones Query.tsx renders bare, so a kind
+# added to that union has to be added here too. BARE_RENDERED_INSIGHT_VIZ_SOURCE_KINDS records
+# the exceptions, and a test pins the two sets against the schema so the split can't drift.
 AUTO_WRAPPED_INSIGHT_QUERY_KINDS = frozenset(
     {
         "TrendsQuery",
         "FunnelsQuery",
         "RetentionQuery",
         "PathsQuery",
+        "PathsV2Query",
         "StickinessQuery",
         "LifecycleQuery",
+        "WebStatsTableQuery",
     }
 )
+
+# InsightVizNode sources the UI also renders unwrapped, so saving them bare is legitimate.
+BARE_RENDERED_INSIGHT_VIZ_SOURCE_KINDS = frozenset({"WebOverviewQuery"})
 
 
 class InsightFilterOverrideContext(BaseModel):

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -552,9 +552,9 @@ class QueryFieldSerializer(serializers.Serializer):
 # kinds below have no bare renderer and fall through to a JSON-dump fallback that paints
 # ~0px inside a dashboard tile, so they are safe (and necessary) to auto-wrap on save.
 #
-# This is every InsightVizNode source kind except the ones Query.tsx renders bare, so a kind
-# added to that union has to be added here too. BARE_RENDERED_INSIGHT_VIZ_SOURCE_KINDS records
-# the exceptions, and a test pins the two sets against the schema so the split can't drift.
+# Keep this exhaustive over the InsightVizNode source union; BARE_RENDERED_INSIGHT_VIZ_SOURCE_KINDS
+# holds the exceptions. A test pins both sets against that union, so a new source kind fails
+# loudly — but it can't see Query.tsx, so a renderer added or dropped there still needs a human.
 AUTO_WRAPPED_INSIGHT_QUERY_KINDS = frozenset(
     {
         "TrendsQuery",

--- a/products/product_analytics/backend/api/test/test_insight_query.py
+++ b/products/product_analytics/backend/api/test/test_insight_query.py
@@ -1,10 +1,17 @@
+from typing import get_args
+
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, QueryMatchingTest
 
 from parameterized import parameterized
 from rest_framework import status
 
+from posthog import schema
 from posthog.api.test.dashboards import DashboardAPI
 
+from products.product_analytics.backend.api.insight import (
+    AUTO_WRAPPED_INSIGHT_QUERY_KINDS,
+    BARE_RENDERED_INSIGHT_VIZ_SOURCE_KINDS,
+)
 from products.product_analytics.backend.models.insight import Insight
 
 from ee.api.test.base import LicensedTestMixin
@@ -220,6 +227,23 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
                 "DataVisualizationNode",
                 "HogQLQuery",
             ),
+            (
+                "bare_paths_v2_query",
+                {"kind": "PathsV2Query", "dateRange": {"date_from": "-7d"}},
+                "InsightVizNode",
+                "PathsV2Query",
+            ),
+            (
+                "bare_web_stats_table_query",
+                {
+                    "kind": "WebStatsTableQuery",
+                    "breakdownBy": "Page",
+                    "properties": [],
+                    "dateRange": {"date_from": "-7d"},
+                },
+                "InsightVizNode",
+                "WebStatsTableQuery",
+            ),
         ]
     )
     def test_create_wraps_bare_query_sources(self, _name, query, expected_kind, expected_source_kind) -> None:
@@ -265,6 +289,14 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         insight_id, _ = self.dashboard_api.create_insight({"name": "Verbatim query insight", "query": query})
 
         assert Insight.objects.get(pk=insight_id).query == query
+
+    def test_every_insight_viz_source_kind_is_either_auto_wrapped_or_bare_rendered(self) -> None:
+        source_annotation = schema.InsightVizNode.model_fields["source"].annotation
+        schema_kinds = {get_args(member.model_fields["kind"].annotation)[0] for member in get_args(source_annotation)}
+
+        assert AUTO_WRAPPED_INSIGHT_QUERY_KINDS.isdisjoint(BARE_RENDERED_INSIGHT_VIZ_SOURCE_KINDS)
+        # A kind added to the union but to neither set would save bare and render as a blank tile.
+        assert AUTO_WRAPPED_INSIGHT_QUERY_KINDS | BARE_RENDERED_INSIGHT_VIZ_SOURCE_KINDS == schema_kinds
 
     def test_update_wraps_bare_query_sources(self) -> None:
         insight_id, _ = self.dashboard_api.create_insight(


### PR DESCRIPTION
## Problem

Someone who saves a Journeys or Web analytics insight through the API or MCP gets a blank tile — the save returns 201, and the insight renders as an empty box.

- `PathsV2Query` (Journeys) and `WebStatsTableQuery` (Web analytics) are valid `InsightVizNode` sources, but `Query.tsx` has no bare renderer for either.
- Saved unwrapped, `insightNavLogic`'s `activeView` falls through to `InsightType.JSON`, so `InsightVizDisplay` never reaches the `JOURNEYS` or `WEB_ANALYTICS` case.
- `InsightSerializer.validate_query` already auto-wraps bare sources for exactly this reason, but its `AUTO_WRAPPED_INSIGHT_QUERY_KINDS` set listed only six of the union's nine kinds.
- Nothing errors, so the failure is invisible to callers and to error rates — the insight is simply empty.

Wrapped in an `InsightVizNode`, both kinds already render: `nodeKindToInsightType` maps `PathsV2Query` to `JOURNEYS`, and `isWebAnalyticsInsightQuery` routes `WebStatsTableQuery` to `WebAnalyticsInsight`.

## Changes

- Add `PathsV2Query` and `WebStatsTableQuery` to `AUTO_WRAPPED_INSIGHT_QUERY_KINDS`, so both wrap on save like the other bare sources.
- Add `BARE_RENDERED_INSIGHT_VIZ_SOURCE_KINDS`, holding the one deliberate exception: `WebOverviewQuery`, which the UI does render unwrapped.

The set was a hand-maintained subset of a schema union, which is why it drifted. Splitting it into "wrap" and "renders bare" makes every union member a recorded decision, and the new test fails when a member belongs to neither — so the next kind added to the union can't repeat this silently.

Already-wrapped nodes still round-trip verbatim, and unrecognized payloads keep today's accept-as-is behavior. Hard rejection stays MCP-only.

## How did you test this code?

Automated tests, all in `products/product_analytics/backend/api/test/test_insight_query.py`:

- Two cases added to the existing `test_create_wraps_bare_query_sources`. Catches the regression in this PR: a bare `PathsV2Query` or `WebStatsTableQuery` persisted unwrapped. No existing case covered either kind.
- `test_every_insight_viz_source_kind_is_either_auto_wrapped_or_bare_rendered` asserts the two sets partition the `InsightVizNode` source union. Catches the class of bug this PR fixes — a kind added to the union but to neither set — which no existing test caught.

**I did not run the Django test suite.** This sandbox has no Postgres or ClickHouse, and these are `ClickhouseTestMixin`/`APIBaseTest` integration tests. CI checks are the authority here.

What I did verify directly, by loading `posthog/schema.py` against pydantic 2.13 outside Django:

- The union resolves to exactly nine kinds, and the two sets partition them with no overlap — so the new assertion passes rather than merely compiling.
- Both new payloads validate through `InsightVizNode.model_validate` and dump to `InsightVizNode` with the expected `source.kind`, confirming the fixtures are valid and not silently falling through the `PydanticValidationError` path.

I did not verify the rendered result in a browser, so the frontend claims rest on reading `Query.tsx`, `insightNavLogic.tsx`, and `InsightVizDisplay.tsx` rather than on seeing a chart appear.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing API contract change; a payload that used to save blank now saves renderable.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) from a [Slack thread](https://posthog.slack.com/archives/C0368RPHLQH/p1786474565717869), implementing signals inbox report [019ee6a4](https://us.posthog.com/project/2/inbox/019ee6a4-e53b-75b3-9e4a-9d71628e0cb6).

Skills invoked: `/writing-tests` (gated both test additions), `/writing-code-comments`, `/writing-pr-descriptions`. Also read `.claude/rules/product-isolation.md` and `.claude/rules/drf-endpoints.md`; no viewset or serializer field changed, so no schema annotations were added and `hogli build:openapi` was not needed.

Two notes for reviewers on how the scope landed here. The report's headline recommendation was to decouple normalization from the `x-posthog-client: mcp` header — but that has since largely shipped: the base `InsightSerializer` now auto-wraps, and the report predates it. Re-deriving the root cause against `master` turned up this narrower, still-live gap instead. The report's other half, making the base serializer hard-reject unrenderable queries, is deliberately left alone: the existing docstring records hard rejection as MCP-only, and flipping it would be a breaking change for existing API callers. That's a product decision, not a cleanup, and it wants its own PR.

The report also cites public complaints about API-created insights appearing empty; no material from that source is in this diff.
