### PR TITLE
fix(feature-flags): hide misleading match estimate for flag deps

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.flagDependencyEstimate.test.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.flagDependencyEstimate.test.tsx
@@ -1,0 +1,85 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { Provider } from 'kea'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+import {
+    FeatureFlagGroupType,
+    FeatureFlagType,
+    FlagPropertyFilter,
+    PersonPropertyFilter,
+    PropertyFilterType,
+    PropertyOperator,
+} from '~/types'
+
+import { FeatureFlagReleaseConditionsCollapsible } from './FeatureFlagReleaseConditionsCollapsible'
+
+const flagDependencyFilter: FlagPropertyFilter = {
+    type: PropertyFilterType.Flag,
+    key: '42',
+    operator: PropertyOperator.FlagEvaluatesTo,
+    value: 'variant',
+}
+const personFilter: PersonPropertyFilter = {
+    type: PropertyFilterType.Person,
+    key: 'email',
+    operator: PropertyOperator.Exact,
+    value: ['someone@example.com'],
+}
+
+function buildFilters(properties: FeatureFlagGroupType['properties']): FeatureFlagType['filters'] {
+    const group: FeatureFlagGroupType = {
+        properties,
+        rollout_percentage: 100,
+        variant: null,
+        sort_key: 'group-1',
+    }
+    return { groups: [group], multivariate: null, payloads: {} }
+}
+
+describe('feature flag release conditions flag dependency estimate', () => {
+    beforeEach(() => {
+        initKeaTests()
+        useMocks({
+            post: {
+                '/api/projects/:team/feature_flags/bulk_keys/': [200, { keys: { '42': 'beta-banner' } }],
+                // The estimate ignores flag dependencies and would otherwise report the whole person base.
+                '/api/projects/:team/feature_flags/user_blast_radius': [200, { affected: 500000, total: 500000 }],
+            },
+        })
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('hides the misleading count when the only filter is a flag dependency', async () => {
+        render(
+            <Provider>
+                <FeatureFlagReleaseConditionsCollapsible id="1234" filters={buildFilters([flagDependencyFilter])} />
+            </Provider>
+        )
+
+        await waitFor(() => {
+            expect(document.body).toHaveTextContent('Depends on another feature flag')
+        })
+        expect(document.body.textContent).not.toContain('500,000')
+    })
+
+    it('marks the count as an upper bound when a flag dependency is mixed with other filters', async () => {
+        render(
+            <Provider>
+                <FeatureFlagReleaseConditionsCollapsible
+                    id="1234"
+                    filters={buildFilters([flagDependencyFilter, personFilter])}
+                />
+            </Provider>
+        )
+
+        await waitFor(() => {
+            expect(document.body).toHaveTextContent('at most')
+        })
+    })
+})

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -44,7 +44,7 @@ import {
 } from '~/types'
 
 import { resolveAggregationGroupTypeIndex } from './aggregation'
-import { MATCHING_ESTIMATE_TOOLTIP } from './constants'
+import { FLAG_DEPENDENCY_ESTIMATE_TOOLTIP, MATCHING_ESTIMATE_TOOLTIP } from './constants'
 import { featureFlagLogic } from './featureFlagLogic'
 import {
     FeatureFlagReleaseConditionsLogicProps,
@@ -53,6 +53,7 @@ import {
     withResolvedFlagLabels,
 } from './featureFlagReleaseConditionsLogic'
 import { getPropertySelectErrorMessages } from './propertySelectErrorMessages'
+import { conditionHasFlagDependency, conditionOnlyFlagDependencies } from './releaseConditionEstimateUtils'
 
 function PropertyValueComponent({
     property,
@@ -487,22 +488,43 @@ export function FeatureFlagReleaseConditions({
                                             </div>
                                         )
                                     }
+                                    // Flag dependencies are evaluated per user at serve time, so the estimate
+                                    // can't account for them and would count everyone.
+                                    if (conditionOnlyFlagDependencies(group.properties)) {
+                                        return (
+                                            <div className="basis-full flex flex-col mt-1 text-secondary">
+                                                <span>
+                                                    Depends on another feature flag, so the match estimate isn't shown.
+                                                    <Tooltip title={FLAG_DEPENDENCY_ESTIMATE_TOOLTIP} interactive>
+                                                        <IconInfo className="text-muted text-xs ml-0.5" />
+                                                    </Tooltip>
+                                                </span>
+                                            </div>
+                                        )
+                                    }
                                     const rolloutPct = Number.isNaN(group.rollout_percentage)
                                         ? 0
                                         : (group.rollout_percentage ?? 100)
+                                    const hasFlagDependency = conditionHasFlagDependency(group.properties)
+                                    const atMost = hasFlagDependency ? 'at most ' : ''
+                                    const estimateTooltip = hasFlagDependency
+                                        ? FLAG_DEPENDENCY_ESTIMATE_TOOLTIP
+                                        : MATCHING_ESTIMATE_TOOLTIP
                                     const receivingFlag = Math.floor((affected * clamp(rolloutPct, 0, 100)) / 100)
                                     return (
                                         <div className="basis-full flex flex-col mt-1 text-secondary tabular-nums">
                                             <span>
-                                                Filters match: <b>~{pluralize(affected, singularName, pluralName)}</b>
-                                                {filters.aggregation_group_type_index == null && (
-                                                    <Tooltip title={MATCHING_ESTIMATE_TOOLTIP} interactive>
+                                                Filters match: {atMost}
+                                                <b>~{pluralize(affected, singularName, pluralName)}</b>
+                                                {(hasFlagDependency ||
+                                                    filters.aggregation_group_type_index == null) && (
+                                                    <Tooltip title={estimateTooltip} interactive>
                                                         <IconInfo className="text-muted text-xs ml-0.5" />
                                                     </Tooltip>
                                                 )}
                                             </span>
                                             <span>
-                                                Rollout will be to{' '}
+                                                Rollout will be to {atMost}
                                                 <b>~{pluralize(receivingFlag, singularName, pluralName)}</b> -{' '}
                                                 <b>{rolloutPct}%</b>
                                             </span>

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -44,7 +44,6 @@ import {
 } from '~/types'
 
 import { resolveAggregationGroupTypeIndex } from './aggregation'
-import { FLAG_DEPENDENCY_ESTIMATE_TOOLTIP, MATCHING_ESTIMATE_TOOLTIP } from './constants'
 import { featureFlagLogic } from './featureFlagLogic'
 import {
     FeatureFlagReleaseConditionsLogicProps,
@@ -52,8 +51,9 @@ import {
     isDistinctIdFilter,
     withResolvedFlagLabels,
 } from './featureFlagReleaseConditionsLogic'
+import { FlagDependencyEstimateCaveat } from './FlagDependencyEstimateCaveat'
 import { getPropertySelectErrorMessages } from './propertySelectErrorMessages'
-import { conditionHasFlagDependency, conditionOnlyFlagDependencies } from './releaseConditionEstimateUtils'
+import { conditionOnlyFlagDependencies, getEstimateLabelParts } from './releaseConditionEstimateUtils'
 
 function PropertyValueComponent({
     property,
@@ -492,24 +492,17 @@ export function FeatureFlagReleaseConditions({
                                     // can't account for them and would count everyone.
                                     if (conditionOnlyFlagDependencies(group.properties)) {
                                         return (
-                                            <div className="basis-full flex flex-col mt-1 text-secondary">
-                                                <span>
-                                                    Depends on another feature flag, so the match estimate isn't shown.
-                                                    <Tooltip title={FLAG_DEPENDENCY_ESTIMATE_TOOLTIP} interactive>
-                                                        <IconInfo className="text-muted text-xs ml-0.5" />
-                                                    </Tooltip>
-                                                </span>
-                                            </div>
+                                            <FlagDependencyEstimateCaveat className="basis-full flex flex-col mt-1 text-secondary" />
                                         )
                                     }
                                     const rolloutPct = Number.isNaN(group.rollout_percentage)
                                         ? 0
                                         : (group.rollout_percentage ?? 100)
-                                    const hasFlagDependency = conditionHasFlagDependency(group.properties)
-                                    const atMost = hasFlagDependency ? 'at most ' : ''
-                                    const estimateTooltip = hasFlagDependency
-                                        ? FLAG_DEPENDENCY_ESTIMATE_TOOLTIP
-                                        : MATCHING_ESTIMATE_TOOLTIP
+                                    const {
+                                        hasFlagDependency,
+                                        atMostPrefix: atMost,
+                                        tooltip: estimateTooltip,
+                                    } = getEstimateLabelParts(group.properties)
                                     const receivingFlag = Math.floor((affected * clamp(rolloutPct, 0, 100)) / 100)
                                     return (
                                         <div className="basis-full flex flex-col mt-1 text-secondary tabular-nums">

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -73,7 +73,7 @@ import {
 import { INTENT_METADATA } from 'products/feature_flags/frontend/featureFlagTemplateConstants'
 
 import { resolveAggregationGroupTypeIndex } from './aggregation'
-import { MATCHING_ESTIMATE_TOOLTIP } from './constants'
+import { FLAG_DEPENDENCY_ESTIMATE_TOOLTIP, MATCHING_ESTIMATE_TOOLTIP } from './constants'
 import { EarlyExitIndicator } from './EarlyExitIndicator'
 import { FeatureFlagConditionDragHandle } from './FeatureFlagConditionDragHandle'
 import { FeatureFlagConditionWarning } from './FeatureFlagConditionWarning'
@@ -87,6 +87,7 @@ import {
     withResolvedFlagLabels,
 } from './featureFlagReleaseConditionsLogic'
 import { getPropertySelectErrorMessages, PropertySelectError } from './propertySelectErrorMessages'
+import { conditionHasFlagDependency, conditionOnlyFlagDependencies } from './releaseConditionEstimateUtils'
 
 interface FeatureFlagReleaseConditionsCollapsibleProps extends FeatureFlagReleaseConditionsLogicProps {
     flagId?: FeatureFlagLogicProps['id']
@@ -208,7 +209,14 @@ function ConditionHeader({
             ? Math.floor((affectedCount * clamp(rollout, 0, 100)) / 100)
             : null
 
-    const countSummary = actualCount !== null ? `${humanFriendlyNumber(actualCount)} ${aggregationTargetName}` : null
+    // Flag dependencies are evaluated per user at serve time, so the estimate can't account
+    // for them: drop the count when it's the only filter, and mark it an upper bound otherwise.
+    const countSummary =
+        actualCount !== null && !conditionOnlyFlagDependencies(group.properties)
+            ? `${conditionHasFlagDependency(group.properties) ? 'at most ' : ''}${humanFriendlyNumber(
+                  actualCount
+              )} ${aggregationTargetName}`
+            : null
 
     return (
         <div className="flex items-center justify-between w-full gap-2">
@@ -717,13 +725,39 @@ const ConditionContent = ({
                                                         return null
                                                     }
 
+                                                    // Flag dependencies are evaluated per user at serve time, so the
+                                                    // estimate can't account for them and would count everyone.
+                                                    if (conditionOnlyFlagDependencies(group.properties)) {
+                                                        return (
+                                                            <div className="flex flex-col">
+                                                                <span>
+                                                                    Depends on another feature flag, so the match
+                                                                    estimate isn't shown.
+                                                                    <Tooltip
+                                                                        title={FLAG_DEPENDENCY_ESTIMATE_TOOLTIP}
+                                                                        interactive
+                                                                    >
+                                                                        <IconInfo className="text-muted text-xs ml-0.5" />
+                                                                    </Tooltip>
+                                                                </span>
+                                                            </div>
+                                                        )
+                                                    }
+
+                                                    const hasFlagDependency = conditionHasFlagDependency(
+                                                        group.properties
+                                                    )
+                                                    const atMost = hasFlagDependency ? 'at most ' : ''
+                                                    const estimateTooltip = hasFlagDependency
+                                                        ? FLAG_DEPENDENCY_ESTIMATE_TOOLTIP
+                                                        : MATCHING_ESTIMATE_TOOLTIP
                                                     const receivingFlag = Math.floor(
                                                         (affected * clamp(rolloutPct, 0, 100)) / 100
                                                     )
                                                     return (
                                                         <div className="flex flex-col">
                                                             <span>
-                                                                Filters match:{' '}
+                                                                Filters match: {atMost}
                                                                 <b className="tabular-nums">
                                                                     ~
                                                                     {pluralize(
@@ -732,20 +766,18 @@ const ConditionContent = ({
                                                                         resolvedTargetName
                                                                     )}
                                                                 </b>
-                                                                {resolveAggregationGroupTypeIndex(
-                                                                    group.aggregation_group_type_index,
-                                                                    releaseFilters.aggregation_group_type_index
-                                                                ) == null && (
-                                                                    <Tooltip
-                                                                        title={MATCHING_ESTIMATE_TOOLTIP}
-                                                                        interactive
-                                                                    >
+                                                                {(hasFlagDependency ||
+                                                                    resolveAggregationGroupTypeIndex(
+                                                                        group.aggregation_group_type_index,
+                                                                        releaseFilters.aggregation_group_type_index
+                                                                    ) == null) && (
+                                                                    <Tooltip title={estimateTooltip} interactive>
                                                                         <IconInfo className="text-muted text-xs ml-0.5" />
                                                                     </Tooltip>
                                                                 )}
                                                             </span>
                                                             <span>
-                                                                Rollout will be to{' '}
+                                                                Rollout will be to {atMost}
                                                                 <b className="tabular-nums">
                                                                     ~
                                                                     {pluralize(

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -73,7 +73,6 @@ import {
 import { INTENT_METADATA } from 'products/feature_flags/frontend/featureFlagTemplateConstants'
 
 import { resolveAggregationGroupTypeIndex } from './aggregation'
-import { FLAG_DEPENDENCY_ESTIMATE_TOOLTIP, MATCHING_ESTIMATE_TOOLTIP } from './constants'
 import { EarlyExitIndicator } from './EarlyExitIndicator'
 import { FeatureFlagConditionDragHandle } from './FeatureFlagConditionDragHandle'
 import { FeatureFlagConditionWarning } from './FeatureFlagConditionWarning'
@@ -86,8 +85,9 @@ import {
     isDistinctIdFilter,
     withResolvedFlagLabels,
 } from './featureFlagReleaseConditionsLogic'
+import { FlagDependencyEstimateCaveat } from './FlagDependencyEstimateCaveat'
 import { getPropertySelectErrorMessages, PropertySelectError } from './propertySelectErrorMessages'
-import { conditionHasFlagDependency, conditionOnlyFlagDependencies } from './releaseConditionEstimateUtils'
+import { conditionOnlyFlagDependencies, getEstimateLabelParts } from './releaseConditionEstimateUtils'
 
 interface FeatureFlagReleaseConditionsCollapsibleProps extends FeatureFlagReleaseConditionsLogicProps {
     flagId?: FeatureFlagLogicProps['id']
@@ -213,7 +213,7 @@ function ConditionHeader({
     // for them: drop the count when it's the only filter, and mark it an upper bound otherwise.
     const countSummary =
         actualCount !== null && !conditionOnlyFlagDependencies(group.properties)
-            ? `${conditionHasFlagDependency(group.properties) ? 'at most ' : ''}${humanFriendlyNumber(
+            ? `${getEstimateLabelParts(group.properties).atMostPrefix}${humanFriendlyNumber(
                   actualCount
               )} ${aggregationTargetName}`
             : null
@@ -729,28 +729,15 @@ const ConditionContent = ({
                                                     // estimate can't account for them and would count everyone.
                                                     if (conditionOnlyFlagDependencies(group.properties)) {
                                                         return (
-                                                            <div className="flex flex-col">
-                                                                <span>
-                                                                    Depends on another feature flag, so the match
-                                                                    estimate isn't shown.
-                                                                    <Tooltip
-                                                                        title={FLAG_DEPENDENCY_ESTIMATE_TOOLTIP}
-                                                                        interactive
-                                                                    >
-                                                                        <IconInfo className="text-muted text-xs ml-0.5" />
-                                                                    </Tooltip>
-                                                                </span>
-                                                            </div>
+                                                            <FlagDependencyEstimateCaveat className="flex flex-col" />
                                                         )
                                                     }
 
-                                                    const hasFlagDependency = conditionHasFlagDependency(
-                                                        group.properties
-                                                    )
-                                                    const atMost = hasFlagDependency ? 'at most ' : ''
-                                                    const estimateTooltip = hasFlagDependency
-                                                        ? FLAG_DEPENDENCY_ESTIMATE_TOOLTIP
-                                                        : MATCHING_ESTIMATE_TOOLTIP
+                                                    const {
+                                                        hasFlagDependency,
+                                                        atMostPrefix: atMost,
+                                                        tooltip: estimateTooltip,
+                                                    } = getEstimateLabelParts(group.properties)
                                                     const receivingFlag = Math.floor(
                                                         (affected * clamp(rolloutPct, 0, 100)) / 100
                                                     )

--- a/frontend/src/scenes/feature-flags/FlagDependencyEstimateCaveat.tsx
+++ b/frontend/src/scenes/feature-flags/FlagDependencyEstimateCaveat.tsx
@@ -1,0 +1,19 @@
+import { IconInfo } from '@posthog/icons'
+import { Tooltip } from '@posthog/lemon-ui'
+
+import { FLAG_DEPENDENCY_ESTIMATE_TOOLTIP } from './constants'
+
+// Shown in place of the blast-radius count when a condition's only filter is a flag dependency,
+// which the estimate can't evaluate and would otherwise count as everyone.
+export function FlagDependencyEstimateCaveat({ className }: { className?: string }): JSX.Element {
+    return (
+        <div className={className}>
+            <span>
+                Depends on another feature flag, so the match estimate isn't shown.
+                <Tooltip title={FLAG_DEPENDENCY_ESTIMATE_TOOLTIP} interactive>
+                    <IconInfo className="text-muted text-xs ml-0.5" />
+                </Tooltip>
+            </span>
+        </div>
+    )
+}

--- a/frontend/src/scenes/feature-flags/constants.tsx
+++ b/frontend/src/scenes/feature-flags/constants.tsx
@@ -20,3 +20,14 @@ export const MATCHING_ESTIMATE_TOOLTIP = (
         </div>
     </>
 )
+
+export const FLAG_DEPENDENCY_ESTIMATE_TOOLTIP = (
+    <>
+        <div>This condition depends on another feature flag.</div>
+        <div className="mt-1">
+            Flag dependencies are evaluated for each user when the flag is served, so they aren't included in this
+            estimate. The real audience is usually smaller than the total shown. Check the Usage tab for the number of
+            users actually served each value.
+        </div>
+    </>
+)

--- a/frontend/src/scenes/feature-flags/releaseConditionEstimateUtils.test.ts
+++ b/frontend/src/scenes/feature-flags/releaseConditionEstimateUtils.test.ts
@@ -1,0 +1,46 @@
+import { AnyPropertyFilter, PropertyFilterType, PropertyOperator } from '~/types'
+
+import { conditionHasFlagDependency, conditionOnlyFlagDependencies } from './releaseConditionEstimateUtils'
+
+const flagDependency: AnyPropertyFilter = {
+    type: PropertyFilterType.Flag,
+    key: '123',
+    operator: PropertyOperator.FlagEvaluatesTo,
+    value: 'variant',
+}
+const personProperty: AnyPropertyFilter = {
+    type: PropertyFilterType.Person,
+    key: 'email',
+    operator: PropertyOperator.Exact,
+    value: ['someone@example.com'],
+}
+const cohortProperty: AnyPropertyFilter = {
+    type: PropertyFilterType.Cohort,
+    key: 'id',
+    operator: PropertyOperator.In,
+    value: 42,
+}
+const emptyProperty: AnyPropertyFilter = {
+    type: PropertyFilterType.Person,
+    key: 'email',
+    operator: PropertyOperator.Exact,
+    value: null,
+}
+
+describe('releaseConditionEstimateUtils', () => {
+    // Guards the fix for the misleadingly large blast-radius estimate: a condition whose only
+    // filter is a flag dependency must be detected so the UI hides the "everyone" count.
+    it.each<[string, AnyPropertyFilter[] | null | undefined, boolean, boolean]>([
+        ['undefined properties', undefined, false, false],
+        ['no properties', [], false, false],
+        ['person property only', [personProperty], false, false],
+        ['cohort property only', [cohortProperty], false, false],
+        ['flag dependency only', [flagDependency], true, true],
+        ['flag dependency + person property', [flagDependency, personProperty], true, false],
+        ['flag dependency + empty property', [flagDependency, emptyProperty], true, true],
+        ['empty property only', [emptyProperty], false, false],
+    ])('%s', (_name, properties, hasFlagDependency, onlyFlagDependencies) => {
+        expect(conditionHasFlagDependency(properties)).toBe(hasFlagDependency)
+        expect(conditionOnlyFlagDependencies(properties)).toBe(onlyFlagDependencies)
+    })
+})

--- a/frontend/src/scenes/feature-flags/releaseConditionEstimateUtils.ts
+++ b/frontend/src/scenes/feature-flags/releaseConditionEstimateUtils.ts
@@ -2,6 +2,8 @@ import { isEmptyProperty, isFlagPropertyFilter } from 'lib/components/PropertyFi
 
 import { AnyPropertyFilter } from '~/types'
 
+import { FLAG_DEPENDENCY_ESTIMATE_TOOLTIP, MATCHING_ESTIMATE_TOOLTIP } from './constants'
+
 // The blast-radius estimate can't evaluate flag-dependency filters (they're resolved per
 // user at serve time), so it treats them as matching everyone. These helpers let the UI
 // detect that case and avoid showing a misleadingly large "Filters match" number.
@@ -15,4 +17,21 @@ export function conditionHasFlagDependency(properties?: AnyPropertyFilter[] | nu
 export function conditionOnlyFlagDependencies(properties?: AnyPropertyFilter[] | null): boolean {
     const meaningful = (properties ?? []).filter((property) => !isEmptyProperty(property))
     return meaningful.length > 0 && meaningful.every(isFlagPropertyFilter)
+}
+
+/**
+ * How to label the "Filters match" estimate. When a flag dependency is mixed with other filters the
+ * estimate is an upper bound, so we prefix "at most" and swap in the flag-dependency tooltip.
+ */
+export function getEstimateLabelParts(properties?: AnyPropertyFilter[] | null): {
+    hasFlagDependency: boolean
+    atMostPrefix: string
+    tooltip: JSX.Element
+} {
+    const hasFlagDependency = conditionHasFlagDependency(properties)
+    return {
+        hasFlagDependency,
+        atMostPrefix: hasFlagDependency ? 'at most ' : '',
+        tooltip: hasFlagDependency ? FLAG_DEPENDENCY_ESTIMATE_TOOLTIP : MATCHING_ESTIMATE_TOOLTIP,
+    }
 }

--- a/frontend/src/scenes/feature-flags/releaseConditionEstimateUtils.ts
+++ b/frontend/src/scenes/feature-flags/releaseConditionEstimateUtils.ts
@@ -1,0 +1,18 @@
+import { isEmptyProperty, isFlagPropertyFilter } from 'lib/components/PropertyFilters/utils'
+
+import { AnyPropertyFilter } from '~/types'
+
+// The blast-radius estimate can't evaluate flag-dependency filters (they're resolved per
+// user at serve time), so it treats them as matching everyone. These helpers let the UI
+// detect that case and avoid showing a misleadingly large "Filters match" number.
+
+/** Does this condition include a flag-dependency filter the blast-radius estimate can't evaluate? */
+export function conditionHasFlagDependency(properties?: AnyPropertyFilter[] | null): boolean {
+    return !!properties?.some(isFlagPropertyFilter)
+}
+
+/** Are all of a condition's non-empty filters flag dependencies? If so the estimate is just "everyone". */
+export function conditionOnlyFlagDependencies(properties?: AnyPropertyFilter[] | null): boolean {
+    const meaningful = (properties ?? []).filter((property) => !isEmptyProperty(property))
+    return meaningful.length > 0 && meaningful.every(isFlagPropertyFilter)
+}


### PR DESCRIPTION
## Problem

Someone editing a feature flag whose release condition depends on another flag saw a match estimate of nearly their entire user base, so the flag looked like it would roll out to everyone when far fewer users actually get it.

- The "Filters match ~N users" estimate cannot evaluate a flag-dependency filter (`flag_evaluates_to`).
- Such a filter compiles to a neutral `TRUE` in HogQL (`posthog/hogql/property.py`), because flag dependencies are resolved per user at serve time.
- So a condition whose only filter is a flag dependency counts every person, not the users the dependency actually selects.

## Changes

- Detect flag-dependency filters in a condition and stop showing the misleading count.
- Hide the number when the flag dependency is the only filter, and show a short caveat with a tooltip.
- Label the number "at most" when a flag dependency is mixed with person or cohort filters, since the estimate is then an upper bound.
- Fixed all three render sites: the condition body and the collapsed condition header in the collapsible editor, and the legacy component used by experiments and surveys.
- No backend change. The neutral `TRUE` is a correct upper bound, and per-user flag evaluation cannot be expressed in the HogQL estimate cheaply, so this is a presentation fix.

Rendered text, flag dependency as the only filter:

```
before   beta-banner evaluates to variant   (100% · 500,000 users)
         Filters match: ~500,000 users
         Rollout will be to ~500,000 users - 100%

after    beta-banner evaluates to variant   (100%)
         Depends on another feature flag, so the match estimate isn't shown.
```

> [!NOTE]
> No browser screenshot: this sandbox has no running dev stack, and the deeply nested editor has no Storybook story. The before/after above is the rendered DOM asserted by the new render test.

## How did you test this code?

Automated only. I (the agent) did not test in a browser.

- `releaseConditionEstimateUtils.test.ts` covers the predicates (flag-dep-only, mixed, person or cohort only, empty). Catches a regression where the UI stops recognizing a flag-dependency filter.
- `FeatureFlagReleaseConditions.flagDependencyEstimate.test.tsx` renders the editor and asserts the caveat shows, the large count is absent, and mixed conditions render "at most". Catches the misleading number returning to the UI. This test is how I found the second render site, the collapsed header.
- Ran the feature-flags release-condition Jest suites, plus oxlint and oxfmt, clean.
- Not run: the app and backend suites (no backend change). Whole-repo `tsc` reports pre-existing errors in unrelated products because the `@posthog/quill` workspace is not built in this checkout; the changed files type-check clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tools: PostHog Code (Claude Opus 4.8).
- Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.
- This started from a support question where a flag's usage differed from its match estimate. I root-caused it to the flag-dependency neutralization in `property_to_expr`, chose a frontend presentation fix over changing the estimate, then used the render test to find and fix the collapsed-header site as well.
- Provenance: the investigation began from a customer support question, but every committed value (flag key, ids, email, counts) is invented, not transcribed. No customer names or real identifiers are included.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
