### PR TITLE
fix(insights): exclude leading partial bucket with incomplete periods toggle

### DIFF
--- a/frontend/src/lib/components/DateFilter/DateFilterExclusionsControl.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilterExclusionsControl.tsx
@@ -80,7 +80,7 @@ export function DateFilterExclusionsControl({
             <PopoverContent side="right" align="end" {...panelProps} className="w-64 gap-0 p-0">
                 {showIncomplete && (
                     <div className="flex items-center justify-between gap-2 px-3 py-2.5">
-                        <Label htmlFor="date-filter-exclude-incomplete">Incomplete period</Label>
+                        <Label htmlFor="date-filter-exclude-incomplete">Incomplete periods</Label>
                         <Switch
                             id="date-filter-exclude-incomplete"
                             size="sm"

--- a/frontend/src/lib/components/DateFilter/LemonDateFilterExclusions.tsx
+++ b/frontend/src/lib/components/DateFilter/LemonDateFilterExclusions.tsx
@@ -48,7 +48,7 @@ export function LemonDateFilterExclusions({
                         <div className="px-3 py-2.5">
                             <LemonSwitch
                                 fullWidth
-                                label="Incomplete period"
+                                label="Incomplete periods"
                                 checked={exclusions.incomplete}
                                 onChange={(incomplete) => onChange({ ...exclusions, incomplete })}
                                 data-attr="date-filter-exclude-incomplete-periods"

--- a/frontend/src/queries/nodes/InsightViz/InsightResultMetadata.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightResultMetadata.tsx
@@ -45,7 +45,7 @@ export const InsightResultMetadata = ({
             {dateRange?.excludeIncompletePeriods ? (
                 <span className="text-secondary">
                     <span className="mx-1">•</span>
-                    Incomplete period excluded
+                    Incomplete periods excluded
                 </span>
             ) : null}
         </>

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -783,6 +783,21 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual("2020-01-14", response.results[0]["days"][-1])
 
+    def test_exclude_incomplete_periods_drops_leading_partial_bucket(self):
+        self._create_test_events()
+
+        # 2020-01-19 is a Sunday (default week start), so -13d starts mid-week on Jan 6: the
+        # partial Jan 6-11 bucket is dropped alongside the current week, leaving Jan 12-18 only
+        with freeze_time("2020-01-19T12:00:00Z"):
+            query = TrendsQuery(
+                series=[EventsNode(event="$pageview")],
+                dateRange=DateRange(date_from="-13d", excludeIncompletePeriods=True),
+                interval=IntervalType.WEEK,
+            )
+            response = TrendsQueryRunner(team=self.team, query=query).calculate()
+
+        self.assertEqual(["2020-01-12"], response.results[0]["days"])
+
     def test_trends_days(self):
         self._create_test_events()
 

--- a/posthog/hogql_queries/utils/query_date_range.py
+++ b/posthog/hogql_queries/utils/query_date_range.py
@@ -131,12 +131,34 @@ class QueryDateRange:
         clipped = current_interval_start - timedelta(microseconds=1)
         # The base implementation is called explicitly: subclasses redefine date_from() in terms of
         # date_to() (e.g. the previous-period range), which would recurse, and the clip must be
-        # evaluated against the current range's own start regardless.
-        if clipped < QueryDateRange.date_from(self):
+        # evaluated against the current range's own start regardless. The unclipped start is used
+        # because the start clip is itself defined in terms of date_to().
+        if clipped < QueryDateRange._date_from_unclipped(self):
             # No complete interval in range: keep the partial current one rather than inverting the
             # range (mirrors alerts never dropping the only data point).
             return date_to
         return clipped
+
+    def _clip_incomplete_period_start(self, date_from: datetime) -> datetime:
+        """Advance date_from to the next interval boundary when the range starts mid-interval, so
+        the leading partial bucket is excluded too (DateRange.excludeIncompletePeriods) — e.g.
+        "Last 180 days" by week starts mid-week and would otherwise chart a few-day first bucket."""
+        if not (self._date_range and self._date_range.excludeIncompletePeriods):
+            return date_from
+        if self._interval_count != 1:
+            # Multi-unit buckets don't sit on single-interval boundaries, so a clip here would
+            # truncate the leading bucket mid-bucket instead of excluding it.
+            return date_from
+        aligned = self.align_with_interval(date_from)
+        if aligned >= date_from:
+            return date_from
+        advanced = aligned + self.interval_relativedelta()
+        # Explicit base call for the same recursion reasons as in _clip_incomplete_period.
+        if advanced > QueryDateRange.date_to(self):
+            # No complete interval in range: keep the partial leading one rather than inverting the
+            # range (mirrors alerts never dropping the only data point).
+            return date_from
+        return advanced
 
     def get_earliest_timestamp(self) -> datetime:
         if self._earliest_timestamp_fallback:
@@ -148,6 +170,9 @@ class QueryDateRange:
         return get_earliest_timestamp_unfiltered(self._team)
 
     def date_from(self) -> datetime:
+        return self._clip_incomplete_period_start(self._date_from_unclipped())
+
+    def _date_from_unclipped(self) -> datetime:
         date_from: datetime
         if self._date_range and self._date_range.date_from == "all":
             date_from = self.get_earliest_timestamp()

--- a/posthog/hogql_queries/utils/test/test_query_date_range.py
+++ b/posthog/hogql_queries/utils/test/test_query_date_range.py
@@ -166,18 +166,19 @@ class TestQueryDateRange(APIBaseTest):
         [
             # now is 2021-08-25T10:00Z (a Wednesday): a relative date_from landing mid-interval is
             # advanced to the next boundary, so the leading bucket is a complete one
-            ("day_already_aligned", IntervalType.DAY, "-7d", "2021-08-18T00:00:00Z"),
-            ("week_sunday_start", IntervalType.WEEK, "-30d", "2021-08-01T00:00:00Z"),
-            ("week_monday_start", IntervalType.WEEK, "-33d", "2021-07-26T00:00:00Z"),
-            ("month", IntervalType.MONTH, "-3m", "2021-06-01T00:00:00Z"),
-            ("quarter", IntervalType.QUARTER, "-2y", "2019-10-01T00:00:00Z"),
-            ("year", IntervalType.YEAR, "-3y", "2019-01-01T00:00:00Z"),
+            ("day_already_aligned", IntervalType.DAY, "-7d", "2021-08-18T00:00:00Z", WeekStartDay.SUNDAY),
+            ("week_sunday_start", IntervalType.WEEK, "-30d", "2021-08-01T00:00:00Z", WeekStartDay.SUNDAY),
+            ("week_monday_start", IntervalType.WEEK, "-33d", "2021-07-26T00:00:00Z", WeekStartDay.MONDAY),
+            ("month", IntervalType.MONTH, "-3m", "2021-06-01T00:00:00Z", WeekStartDay.SUNDAY),
+            ("quarter", IntervalType.QUARTER, "-2y", "2019-10-01T00:00:00Z", WeekStartDay.SUNDAY),
+            ("year", IntervalType.YEAR, "-3y", "2019-01-01T00:00:00Z", WeekStartDay.SUNDAY),
         ]
     )
-    def test_exclude_incomplete_periods_clips_date_from(self, _name, interval, date_from, expected_date_from):
+    def test_exclude_incomplete_periods_clips_date_from(
+        self, _name, interval, date_from, expected_date_from, week_start_day
+    ):
         now = parser.isoparse("2021-08-25T10:00:00.000Z")
-        if interval == IntervalType.WEEK and "monday" in _name:
-            self.team.week_start_day = WeekStartDay.MONDAY
+        self.team.week_start_day = week_start_day
         query_date_range = QueryDateRange(
             team=self.team,
             date_range=DateRange(date_from=date_from, excludeIncompletePeriods=True),

--- a/posthog/hogql_queries/utils/test/test_query_date_range.py
+++ b/posthog/hogql_queries/utils/test/test_query_date_range.py
@@ -162,6 +162,63 @@ class TestQueryDateRange(APIBaseTest):
         )
         self.assertEqual(query_date_range.date_to(), parser.isoparse(expected_date_to))
 
+    @parameterized.expand(
+        [
+            # now is 2021-08-25T10:00Z (a Wednesday): a relative date_from landing mid-interval is
+            # advanced to the next boundary, so the leading bucket is a complete one
+            ("day_already_aligned", IntervalType.DAY, "-7d", "2021-08-18T00:00:00Z"),
+            ("week_sunday_start", IntervalType.WEEK, "-30d", "2021-08-01T00:00:00Z"),
+            ("week_monday_start", IntervalType.WEEK, "-33d", "2021-07-26T00:00:00Z"),
+            ("month", IntervalType.MONTH, "-3m", "2021-06-01T00:00:00Z"),
+            ("quarter", IntervalType.QUARTER, "-2y", "2019-10-01T00:00:00Z"),
+            ("year", IntervalType.YEAR, "-3y", "2019-01-01T00:00:00Z"),
+        ]
+    )
+    def test_exclude_incomplete_periods_clips_date_from(self, _name, interval, date_from, expected_date_from):
+        now = parser.isoparse("2021-08-25T10:00:00.000Z")
+        if interval == IntervalType.WEEK and "monday" in _name:
+            self.team.week_start_day = WeekStartDay.MONDAY
+        query_date_range = QueryDateRange(
+            team=self.team,
+            date_range=DateRange(date_from=date_from, excludeIncompletePeriods=True),
+            interval=interval,
+            now=now,
+        )
+        self.assertEqual(query_date_range.date_from(), parser.isoparse(expected_date_from))
+
+    def test_exclude_incomplete_periods_clips_explicit_historical_date_from(self):
+        # A fixed historical range starting mid-week still gets its leading partial bucket dropped.
+        now = parser.isoparse("2021-08-25T10:00:00.000Z")
+        query_date_range = QueryDateRange(
+            team=self.team,
+            date_range=DateRange(date_from="2021-06-15", date_to="2021-08-01", excludeIncompletePeriods=True),
+            interval=IntervalType.WEEK,
+            now=now,
+        )
+        self.assertEqual(query_date_range.date_from(), parser.isoparse("2021-06-20T00:00:00Z"))
+
+    @parameterized.expand(
+        [
+            # A range without a single complete interval must keep the partial leading bucket
+            # rather than being clipped into an empty or inverted range.
+            ("range_within_current_month", "-3d", IntervalType.MONTH, None, "2021-08-22T00:00:00Z"),
+            # Multi-unit buckets don't sit on single-interval boundaries: the flag is a no-op there.
+            ("multi_unit_interval", "-1d", IntervalType.HOUR, 2, "2021-08-24T10:00:00Z"),
+        ]
+    )
+    def test_exclude_incomplete_periods_date_from_no_op_edge_cases(
+        self, _name, date_from, interval, interval_count, expected_date_from
+    ):
+        now = parser.isoparse("2021-08-25T10:00:00.000Z")
+        query_date_range = QueryDateRange(
+            team=self.team,
+            date_range=DateRange(date_from=date_from, excludeIncompletePeriods=True),
+            interval=interval,
+            interval_count=interval_count,
+            now=now,
+        )
+        self.assertEqual(query_date_range.date_from(), parser.isoparse(expected_date_from))
+
     def test_exclude_incomplete_periods_clips_explicit_date_to_in_current_period(self):
         # explicitDate=True skips date_to padding, but excludeIncompletePeriods still clips
         # when the explicit date_to falls inside the incomplete current period.


### PR DESCRIPTION
## Problem

With the incomplete periods toggle on, a trends insight whose date range starts mid-interval (for example "Last 180 days" grouped by week) still charts a partial first bucket. That bucket covers only a few days, so the line starts with a misleading dip. The toggle already drops the partial bucket at the end of the range, but not the one at the start.

## Changes

- `QueryDateRange.date_from()` now advances a mid-interval start to the next interval boundary when `excludeIncompletePeriods` is set, so the first bucket is a complete one.
- The start clip uses the same guards as the existing end clip: it is a no-op for multi-unit buckets, and it keeps the partial bucket when the range contains no complete interval at all.
- Compare-to-previous-period and compare-to ranges mirror the clipped current range, so both periods stay aligned.
- The toggle label and the insight metadata note now read "Incomplete periods", since both ends can be excluded.

Before: "Last 180 days" by week starts with a 3-day bucket showing a fraction of a normal week's count. After: the range starts at the first full week.

## How did you test this code?

- New unit tests in `test_query_date_range.py` cover the start clip for day/week/month/quarter/year intervals, both week start days, an explicit historical range, and the no-op guards (multi-unit buckets, range shorter than one interval).
- New trends runner test asserts the leading partial week is dropped alongside the current week.
- Ran the incomplete-period suites in `test_query_date_range.py` (23 passed), the two trends runner incomplete-period tests, and `test_query_previous_period_date_range.py` locally.
- Repo-wide `mypy --cache-fine-grained .` passes.
- I did not verify the change in a running browser session.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — the toggle is not yet documented under `docs/`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code in a PostHog Desktop cloud task. Skills invoked: /writing-user-facing-copy, /writing-pr-descriptions, /writing-tests (repo rules read from `.agents/skills/`). The alternative of extending the range backward to include the full first interval was rejected: it would silently query outside the selected range, while dropping the partial bucket matches what the toggle already does at the end.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
