### PR TITLE
fix(personhog): stop batch delete sagas deadlocking with the writer

### DIFF
--- a/rust/personhog-identity/src/lifecycle/delete.rs
+++ b/rust/personhog-identity/src/lifecycle/delete.rs
@@ -498,6 +498,32 @@ async fn unmap(pool: &PgPool, tables: &IdentityTables, op: &OpRow) -> Result<(),
     .await?;
     victims.sort_unstable();
 
+    // Take every row lock this transaction will need up front, in id order,
+    // before the multi-row updates below. Those statements acquire locks in
+    // whatever order the query plan visits rows, and the writer's flush
+    // upsert spans overlapping persons in one statement — uncontrolled
+    // order on either side is a deadlock cycle waiting for load. Sorted
+    // acquisition on both sides (the writer sorts its flush batches the
+    // same way) makes a cycle impossible.
+    let lock_persons_sql = format!(
+        "SELECT id FROM {person_table} WHERE team_id = $1 AND id = ANY($2) ORDER BY id FOR UPDATE",
+        person_table = tables.person,
+    );
+    sqlx::query(&lock_persons_sql)
+        .bind(team_id)
+        .bind(&victims)
+        .execute(&mut *tx)
+        .await?;
+    let lock_pdi_sql = format!(
+        "SELECT id FROM {pdi_table} WHERE team_id = $1 AND person_id = ANY($2) ORDER BY id FOR UPDATE",
+        pdi_table = tables.person_distinct_id,
+    );
+    sqlx::query(&lock_pdi_sql)
+        .bind(team_id)
+        .bind(&victims)
+        .execute(&mut *tx)
+        .await?;
+
     let tombstone_pdi_sql = format!(
         r#"
         UPDATE {pdi_table}

--- a/rust/personhog-identity/src/lifecycle/engine.rs
+++ b/rust/personhog-identity/src/lifecycle/engine.rs
@@ -39,6 +39,11 @@ const OPS_PARKED: &str = "personhog_lifecycle_ops_parked";
 /// How many abandoned ops one sweep pass will pick up.
 const SWEEP_BATCH_SIZE: i64 = 100;
 
+/// Pause before re-driving a step that lost a database conflict. Long
+/// enough for the competing statement (typically a writer flush) to finish;
+/// the execute deadline still bounds the total retry time.
+const DB_CONFLICT_BACKOFF: Duration = Duration::from_millis(50);
+
 pub type Tx<'a> = sqlx::Transaction<'a, sqlx::Postgres>;
 
 #[derive(Debug, thiserror::Error)]
@@ -76,6 +81,18 @@ impl SagaError {
         } else {
             SagaError::Leader(Box::new(status))
         }
+    }
+
+    /// A database conflict Postgres asks callers to retry: deadlock victim
+    /// (40P01), serialization failure (40001), or a cancelled statement
+    /// (57014, the statement timeout under lock contention). Steps commit
+    /// their work and their step advance together, so re-driving one is
+    /// always safe — the engine retries these instead of surfacing them.
+    pub fn is_db_conflict(&self) -> bool {
+        let SagaError::Db(sqlx::Error::Database(db)) = self else {
+            return false;
+        };
+        matches!(db.code().as_deref(), Some("40P01" | "40001" | "57014"))
     }
 }
 
@@ -336,6 +353,7 @@ impl Engine {
                 // counter climbing for one op_type/kind, not as generic
                 // retry noise. Alert on it — a wedged op can hold fences.
                 let kind = match &err {
+                    SagaError::Db(_) if err.is_db_conflict() => "db_conflict",
                     SagaError::Db(_) => "db",
                     SagaError::Leader(_) => "leader",
                     SagaError::LeaderRefused(_) => "leader_refused",
@@ -352,6 +370,23 @@ impl Engine {
                     ],
                     1,
                 );
+                if err.is_db_conflict() {
+                    // Concurrent multi-row writers (a writer flush, another
+                    // saga) can deadlock or time out against a step's
+                    // transaction; the loser rolls back whole and the step
+                    // is safe to repeat. Keep the lease and re-drive after a
+                    // pause instead of surfacing an error the caller would
+                    // retry anyway; the execute deadline bounds the loop.
+                    tracing::warn!(
+                        op_id = %op_id,
+                        op_type = %row.op_type,
+                        step = %row.step,
+                        error = %err,
+                        "lifecycle step lost a database conflict; retrying"
+                    );
+                    tokio::time::sleep(DB_CONFLICT_BACKOFF).await;
+                    continue;
+                }
                 if let SagaError::LeaderRefused(status) = &err {
                     // Retrying a refusal cannot succeed, and the sweeper
                     // looping on it would hold this op's fences forever.

--- a/rust/personhog-identity/tests/lifecycle_engine_tests.rs
+++ b/rust/personhog-identity/tests/lifecycle_engine_tests.rs
@@ -658,3 +658,112 @@ async fn resume_does_not_unpark() {
 
     ctx.cleanup().await.expect("cleanup");
 }
+
+/// A concocted Postgres error carrying just a SQLSTATE, so tests can hand
+/// the engine the exact errors Postgres emits for lock conflicts without
+/// manufacturing a real deadlock.
+#[derive(Debug)]
+struct FakePgError(&'static str);
+
+impl std::fmt::Display for FakePgError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "fake database error ({})", self.0)
+    }
+}
+
+impl std::error::Error for FakePgError {}
+
+impl sqlx::error::DatabaseError for FakePgError {
+    fn message(&self) -> &str {
+        "fake database error"
+    }
+
+    fn code(&self) -> Option<std::borrow::Cow<'_, str>> {
+        Some(std::borrow::Cow::Borrowed(self.0))
+    }
+
+    fn as_error(&self) -> &(dyn std::error::Error + Send + Sync + 'static) {
+        self
+    }
+
+    fn as_error_mut(&mut self) -> &mut (dyn std::error::Error + Send + Sync + 'static) {
+        self
+    }
+
+    fn into_error(self: Box<Self>) -> Box<dyn std::error::Error + Send + Sync + 'static> {
+        self
+    }
+
+    fn kind(&self) -> sqlx::error::ErrorKind {
+        sqlx::error::ErrorKind::Other
+    }
+}
+
+fn db_error(code: &'static str) -> SagaError {
+    SagaError::Db(sqlx::Error::Database(Box::new(FakePgError(code))))
+}
+
+#[test]
+fn database_conflicts_classify_as_retriable() {
+    for code in ["40P01", "40001", "57014"] {
+        assert!(db_error(code).is_db_conflict(), "{code} must be a conflict");
+    }
+    assert!(
+        !db_error("23505").is_db_conflict(),
+        "a unique violation is not a conflict"
+    );
+    assert!(!SagaError::Busy.is_db_conflict());
+}
+
+/// Driver whose first step loses a deadlock; every later attempt behaves
+/// like [`DummyDriver`].
+struct DeadlockOnceDriver {
+    inner: DummyDriver,
+    deadlocked: AtomicUsize,
+}
+
+#[async_trait]
+impl OpDriver for DeadlockOnceDriver {
+    fn op_type(&self) -> &'static str {
+        "merge"
+    }
+
+    fn initial_step(&self) -> &'static str {
+        "started"
+    }
+
+    async fn run_step(&self, pool: &PgPool, op: &OpRow) -> Result<(), SagaError> {
+        if self.deadlocked.fetch_add(1, Ordering::SeqCst) == 0 {
+            return Err(db_error("40P01"));
+        }
+        self.inner.run_step(pool, op).await
+    }
+}
+
+#[tokio::test]
+async fn a_step_that_loses_a_database_conflict_is_retried_not_surfaced() {
+    let ctx = TestContext::new().await;
+    let engine = ctx.engine();
+    let driver = DeadlockOnceDriver {
+        inner: DummyDriver::new(),
+        deadlocked: AtomicUsize::new(0),
+    };
+    let op_id = Uuid::now_v7();
+
+    let row = engine
+        .execute(&driver, op_id, ctx.team_id, &json!({"work": 1}))
+        .await
+        .expect("the conflict is retried inside the engine, not surfaced");
+
+    assert_eq!(row.step, STEP_COMPLETED);
+    assert_eq!(
+        driver.inner.steps_run.load(Ordering::SeqCst),
+        2,
+        "both real steps ran after the deadlocked attempt"
+    );
+    let (_, attempt, _, completed) = op_row(&ctx, op_id).await;
+    assert!(completed);
+    assert_eq!(attempt, 1, "the retry re-drives under the original claim");
+
+    ctx.cleanup().await.expect("cleanup");
+}

--- a/rust/personhog-writer/src/pg.rs
+++ b/rust/personhog-writer/src/pg.rs
@@ -99,9 +99,16 @@ impl PgStore {
 /// must halt on. Nothing is ever dropped or substituted here — a silent
 /// repair would diverge PG from the cache and changelog.
 fn prepare_chunk(persons: &[Person]) -> Result<PreparedArrays<'_>, WriteError> {
-    let cap = persons.len();
-    let mut arrays = PreparedArrays::with_capacity(cap);
-    for person in persons {
+    // Bind order is lock order: the upsert acquires row locks in unnest
+    // order, so binding in conflict-key order gives every flush one global
+    // lock direction. Concurrent multi-row writers on overlapping persons
+    // (the delete saga's unmap, another flush) sort the same way, and
+    // sorted-vs-sorted acquisition cannot deadlock. Only the bind order
+    // changes — batch composition and ack accounting are untouched.
+    let mut sorted: Vec<&Person> = persons.iter().collect();
+    sorted.sort_unstable_by_key(|p| (p.team_id, p.id));
+    let mut arrays = PreparedArrays::with_capacity(sorted.len());
+    for person in sorted {
         push_person(&mut arrays, person)?;
     }
     Ok(arrays)
@@ -412,6 +419,22 @@ mod tests {
             version: 1,
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn prepare_chunk_binds_in_conflict_key_order() {
+        // Bind order is the upsert's lock order; a batch bound in buffer
+        // order deadlocks against concurrent sorted writers on overlapping
+        // rows.
+        let persons = [
+            person_with(5, 2),
+            person_with(3, 1),
+            person_with(4, 2),
+            person_with(1, 1),
+        ];
+        let arrays = prepare_chunk(&persons).expect("chunk prepares");
+        assert_eq!(arrays.team_ids, vec![1, 1, 2, 2]);
+        assert_eq!(arrays.ids, vec![1, 3, 4, 5]);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

- A DeletePersons call carrying a batch of victims can fail with a gRPC Internal error whenever the writer flushes updates to the same persons.
- In a synthetic dev load test (8 workers looping batched creates, property updates, then 100-person deletes), ~8% of batch delete sagas failed with Postgres deadlocks (40P01) or 5 s statement timeouts, in bursts aligned with writer flushes. Single-victim deletes never hit this.
- The saga's unmap transaction and the writer's flush upsert each lock overlapping person rows with multi-row statements, in orders neither controls, so they can wait on each other in a cycle.
- Correctness holds throughout: the deadlock loser rolls back whole and a retry with the same op_id finishes the op. The damage is caller-visible availability.

## Changes

- The saga engine retries a step that loses a database conflict (deadlock 40P01, serialization failure 40001, statement timeout 57014) under its held lease, instead of surfacing an error the caller would retry anyway. Steps commit their work and their step advance together, so re-driving one is safe by design; the execute deadline bounds the retry loop.
- The delete saga's unmap transaction takes its person and distinct-id row locks up front with `SELECT ... ORDER BY id FOR UPDATE`, so every saga walks rows in one direction.
- The writer binds its flush batches in (team_id, id) order. Bind order is the upsert's lock order, and sorted-vs-sorted acquisition cannot cycle. Batch composition and ack accounting are unchanged; the flush buffer already dedups by person.
- Retried conflicts are visible as a `db_conflict` kind on the existing step-failure counter.

## How did you test this code?

- New engine test: a driver whose first step fails with a fabricated 40P01 completes on retry, under the original claim (no re-claim). Red-checked: fails with the retry disabled.
- New engine test covers the retriable SQLSTATE set plus a non-retriable unique violation.
- New writer test pins the (team_id, id) bind order of flush batches. Red-checked against the unsorted code.
- Ran the full personhog-identity and personhog-writer suites locally against the persons test database.
- Not verified: a deterministic end-to-end saga-vs-writer deadlock reproduction. That needs a concurrent harness scenario, tracked as a follow-up to the delete-saga test plan.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Implemented by Claude Code from a root-cause writeup supplied by José (load test evidence, cause, and the three fixes in priority order).
- Skills invoked: /writing-tests, /reviewing-personhog-protocol, /writing-pr-descriptions.
- The retry classification reuses the step idempotence contract the engine already documents; no lease or protocol semantics changed. Lock ordering and the writer sort only change SQL acquisition order, not state.
