### PR TITLE
fix(data-imports): classify retried connection drops as retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -41,7 +41,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.c
     drop_slot_and_publication,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres import (
+    _CONNECTION_DROPPED_ERROR_SUBSTRINGS,
     _CONNECTION_LIMIT_ERROR_SUBSTRINGS,
+    _POOLER_CONNECTION_DROPPED_ERROR_SUBSTRINGS,
+    _SERVER_STARTING_UP_ERROR_SUBSTRINGS,
     _SSH_HANDSHAKE_EOF_ERROR,
     XMIN_AS_INCREMENTAL_FIELD_ERROR,
     PostgresImplementation,
@@ -788,40 +791,36 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
 
     def get_retryable_errors(self) -> set[str]:
         # `get_rows` already retries a mid-stream drop in-process (reconnect, or fall back to
-        # offset chunking) — see `_CONNECTION_DROPPED_ERROR_SUBSTRINGS` in postgres.py. It only
-        # reaches here once that in-process handling gives up (e.g. a full-table scan can't safely
-        # resume once rows have been yielded, since OFFSET has no stable ORDER BY to resume from).
+        # offset chunking) — see `_CONNECTION_DROPPED_ERROR_SUBSTRINGS` /
+        # `_POOLER_CONNECTION_DROPPED_ERROR_SUBSTRINGS` in postgres.py. It only reaches here once
+        # that in-process handling gives up (e.g. a full-table scan can't safely resume once rows
+        # have been yielded, since OFFSET has no stable ORDER BY to resume from, or the drop
+        # recurs on every reconnect attempt within `_connect_with_dropped_retry`'s bounded budget).
         # Temporal then retries the whole activity and the failure is transient and
         # self-recovering, so classify it here too — otherwise `_handle_import_error` logs it at
         # `exception` on every occurrence, flooding error tracking with a self-recovering failure
-        # (e.g. a cloud provider terminating a backend for maintenance or failover).
-        # "the database system is shutting down" is the connect-time sibling of the same restart: a
-        # smart/fast shutdown refuses new connections while the source is going down, which the
-        # offset-chunking reconnect also retries in-process (`_SERVER_STARTING_UP_ERROR_SUBSTRINGS`
-        # in postgres.py) — this is the same whole-activity-retry fallback for when that budget is
-        # exhausted (e.g. a longer maintenance window).
+        # (e.g. a cloud provider terminating a backend for maintenance/failover, or a pooler whose
+        # connection pool stays saturated longer than the in-process retry budget).
+        #
+        # `_SERVER_STARTING_UP_ERROR_SUBSTRINGS` covers the connect-time siblings of the same class:
+        # a primary/standby booting, replaying WAL after a crash, or a smart/fast shutdown refusing
+        # new connections while the source is going down — all retried in-process by the
+        # offset-chunking reconnect, same exhausted-budget fallback as above.
         #
         # `_CONNECTION_LIMIT_ERROR_SUBSTRINGS` (e.g. "remaining connection slots are reserved") is a
         # connect-time capacity refusal already retried in-process by `_connect_with_dropped_retry` /
         # `_is_dropped_or_connection_limit`. A slot frees the moment another connection closes, so a
         # sustained shortage that outlasts that budget is still transient — the same
-        # reaches-here-only-after-internal-retries-exhaust case as the two entries above.
+        # reaches-here-only-after-internal-retries-exhaust case as the other entries.
         #
-        # A mid-stream or connect-time connection drop ("server closed the connection unexpectedly",
-        # the SSL-flavoured "SSL connection has been closed unexpectedly") is retried in-process by
-        # `_connect_with_dropped_retry` / the offset-chunking fallback (both keyed on
-        # `_CONNECTION_DROPPED_ERROR_SUBSTRINGS` in postgres.py). Once that budget is exhausted the
-        # raw psycopg `OperationalError` reaches `_handle_import_error`, which — without a match here
-        # — logs it at `exception` and reports it to error tracking on every occurrence, even though
-        # Temporal retries the whole activity and the drop is transient and self-recovering (a pooler
-        # idle cull, failover, or network blip). Classify it retryable so it logs as a warning
-        # instead. These stay clear of `get_non_retryable_errors` deliberately (see the note there),
-        # so the sync keeps retrying rather than being disabled.
+        # Reusing the actual substring tuples postgres.py retries on (rather than a hand-picked
+        # subset) keeps this in sync as new transient classes are added there — a substring added
+        # to one of those tuples without a matching update here would otherwise keep reporting a
+        # self-recovering failure to error tracking on every occurrence.
         return {
-            "terminating connection due to",
-            "the database system is shutting down",
-            "server closed the connection unexpectedly",
-            "SSL connection has been closed unexpectedly",
+            *_CONNECTION_DROPPED_ERROR_SUBSTRINGS,
+            *_POOLER_CONNECTION_DROPPED_ERROR_SUBSTRINGS,
+            *_SERVER_STARTING_UP_ERROR_SUBSTRINGS,
             *_CONNECTION_LIMIT_ERROR_SUBSTRINGS,
         }
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1331,6 +1331,32 @@ class TestPostgresSourceRetryableErrors:
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert not is_non_retryable, f"Connection-limit error should not be non-retryable: {error_msg}"
 
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            # psycopg's own message when libpq finds the socket already gone (e.g. the setup
+            # commit at the end of `get_connection`). `_connect_with_dropped_retry` already
+            # retries this in-process on the read/sync connect path; this is the
+            # whole-activity-retry fallback for when a sustained outage (e.g. a saturated pooler)
+            # outlasts that bounded budget.
+            "the connection is lost",
+            "OperationalError: the connection is lost",
+            # Supavisor's transaction-mode pooler checkout timeout, surfaced as a generic XX000
+            # InternalError_ rather than the libpq/PgBouncer wordings above.
+            "(ECHECKOUTTIMEOUT) unable to check out connection from the pool after 60000ms in Transaction mode",
+        ],
+    )
+    def test_connection_dropped_is_classified_retryable(self, source, error_msg):
+        retryable = source.get_retryable_errors()
+        is_retryable = any(pattern.lower() in error_msg.lower() for pattern in retryable)
+        assert is_retryable, f"Connection-dropped error should be classified retryable: {error_msg}"
+
+    def test_connection_dropped_is_not_also_non_retryable(self, source):
+        error_msg = "the connection is lost"
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert not is_non_retryable, f"Connection-dropped error should not be non-retryable: {error_msg}"
+
 
 def _raise_eof() -> None:
     # Indirection so the `yield` below stays reachable under mypy's warn_unreachable — at runtime


### PR DESCRIPTION
## Problem

A Postgres-backed sync (Supabase included, since it connects through the shared Postgres driver) reports a transient connection failure to error tracking, even though Temporal already retries the whole activity and the sync recovers on its own.

This surfaced from a real error-tracking issue: an `OperationalError: the connection is lost`, itself following a Supavisor pooler checkout timeout, after the source's in-process reconnect logic (`get_rows` / `offset_chunking` in `postgres.py`) exhausted its bounded retry budget.

## Changes

- `PostgresSource.get_retryable_errors()` listed a hand-picked, stale subset of the connection-drop wordings — it was missing `"the connection is lost"` and every Supavisor pooler-specific wording (e.g. `ECHECKOUTTIMEOUT`), so once the in-process retry budget was exhausted, these self-recovering failures were logged at `exception` level and reported to error tracking on every occurrence instead of as a warning.
- Reused the actual substring tuples `postgres.py`'s in-process retry logic already keys on (`_CONNECTION_DROPPED_ERROR_SUBSTRINGS`, `_POOLER_CONNECTION_DROPPED_ERROR_SUBSTRINGS`, `_SERVER_STARTING_UP_ERROR_SUBSTRINGS`, `_CONNECTION_LIMIT_ERROR_SUBSTRINGS`) instead of duplicating a subset by hand, so this fallback classification can't drift out of sync again as new transient wordings are added there.
- The sync itself still retries the same way (Temporal activity retry) — this only changes how the already-transient failure is logged/reported once the in-process budget is exhausted.

## How did you test this code?

- Added 3 parameterized cases to `TestPostgresSourceRetryableErrors` covering `"the connection is lost"` and the Supavisor `ECHECKOUTTIMEOUT` wording, plus a non-retryable disjointness check — guards the exact wording that triggered this fix.
- Ran `pytest products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py -k TestPostgresSourceRetryableErrors`: 14 passed.
- Ran `ruff check` and `ruff format --check` on both changed files: clean.
- Not run: the DB-backed tests in the same file (`TestGetPrimaryKeys`, `TestGetTable`, etc.) — this sandbox has no live Postgres instance, and they fail with `Connection refused` on master too, so this is a pre-existing environment gap rather than a regression from this change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal error-classification change, no user-facing behavior or API change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, triaging a PostHog error-tracking issue delivered by webhook.
- Skills invoked: `investigating-error-issue` (issue triage), `writing-tests`, `writing-pr-descriptions`.
- Traced the reported `OperationalError`/`InternalError_` exception chain to `get_rows` → `offset_chunking` → `get_connection` in `postgres.py`, confirmed the in-process retry logic already treats both wordings as transient, and found the gap in `get_retryable_errors()` that let the exhausted-retry error escape to error tracking as a reported exception instead of a warning.