### PR TITLE
refactor(marketing-analytics): drop the retention capabilities nothing emits

### DIFF
--- a/products/marketing_analytics/backend/api.py
+++ b/products/marketing_analytics/backend/api.py
@@ -800,7 +800,7 @@ class SuggestionSerializer(serializers.Serializer):
     )
     unlocks = serializers.ListField(
         child=serializers.CharField(),
-        help_text="Capabilities this unblocks: cost, attribution, roas, cac, retention_by_channel, ltv_by_channel",
+        help_text="Capabilities this unblocks: cost, attribution, roas, cac",
     )
     # DRF has no discriminated-union field and fighting drf-spectacular for one isn't
     # worth it. The shape is the `ApplyOp` union in `services/setup_types.py`, which is
@@ -832,7 +832,7 @@ class SuggestionSerializer(serializers.Serializer):
 
 
 class CapabilityReadinessSerializer(serializers.Serializer):
-    capability = serializers.CharField(help_text="cost/attribution/roas/cac/retention_by_channel/ltv_by_channel")
+    capability = serializers.CharField(help_text="cost/attribution/roas/cac")
     status = serializers.CharField(help_text="unlocked/partial/blocked")
     explanation = serializers.CharField(help_text="Why it's in that state, in plain English")
     blocked_by = serializers.ListField(

--- a/products/marketing_analytics/backend/services/setup_types.py
+++ b/products/marketing_analytics/backend/services/setup_types.py
@@ -27,22 +27,23 @@ class SuggestionKind(StrEnum):
     FIX_CONVERSION_GOAL = "fix_conversion_goal"
     MARK_GOAL_AS_REVENUE = "mark_goal_as_revenue"
     MARK_GOAL_AS_CUSTOMER = "mark_goal_as_customer"
-    SET_ACTIVITY_EVENT = "set_activity_event"
-    SET_SIGNUP_EVENT = "set_signup_event"
-    SET_PAYMENT_EVENT = "set_payment_event"
-    SET_SUBSCRIPTION_EVENT = "set_subscription_event"
 
 
 class Capability(StrEnum):
     """What a working setup buys you. Every suggestion says which of these it
-    unlocks, so the UI can answer "why should I care?" without extra copy."""
+    unlocks, so the UI can answer "why should I care?" without extra copy.
+
+    Retention and LTV by channel are deliberately absent. Both need
+    `customer_analytics_config.activity_event` and friends, which belong to Customer
+    analytics — a different product, a different model, and fields whose own
+    project-admin checks `apply_setup_ops` already refuses to write. Marketing analytics
+    supplies the attribution side; the setup for the other half lives with the other
+    half."""
 
     COST = "cost"
     ATTRIBUTION = "attribution"
     ROAS = "roas"
     CAC = "cac"
-    RETENTION_BY_CHANNEL = "retention_by_channel"
-    LTV_BY_CHANNEL = "ltv_by_channel"
 
 
 class ReadinessStatus(StrEnum):
@@ -100,12 +101,6 @@ UNBLOCKS: dict[SuggestionKind, frozenset[SuggestionKind]] = {
         {
             SuggestionKind.MARK_GOAL_AS_REVENUE,
             SuggestionKind.MARK_GOAL_AS_CUSTOMER,
-        }
-    ),
-    SuggestionKind.SET_ACTIVITY_EVENT: frozenset(
-        {
-            SuggestionKind.SET_PAYMENT_EVENT,
-            SuggestionKind.SET_SUBSCRIPTION_EVENT,
         }
     ),
 }

--- a/products/marketing_analytics/backend/services/setup_types.py
+++ b/products/marketing_analytics/backend/services/setup_types.py
@@ -31,14 +31,7 @@ class SuggestionKind(StrEnum):
 
 class Capability(StrEnum):
     """What a working setup buys you. Every suggestion says which of these it
-    unlocks, so the UI can answer "why should I care?" without extra copy.
-
-    Retention and LTV by channel are deliberately absent. Both need
-    `customer_analytics_config.activity_event` and friends, which belong to Customer
-    analytics — a different product, a different model, and fields whose own
-    project-admin checks `apply_setup_ops` already refuses to write. Marketing analytics
-    supplies the attribution side; the setup for the other half lives with the other
-    half."""
+    unlocks, so the UI can answer "why should I care?" without extra copy."""
 
     COST = "cost"
     ATTRIBUTION = "attribution"

--- a/products/marketing_analytics/frontend/generated/api.schemas.ts
+++ b/products/marketing_analytics/frontend/generated/api.schemas.ts
@@ -1513,7 +1513,7 @@ export interface SuggestionApi {
     title: string
     /** The concrete numbers behind the suggestion, so a user can sanity-check it without taking it on faith */
     evidence: string
-    /** Capabilities this unblocks: cost, attribution, roas, cac, retention_by_channel, ltv_by_channel */
+    /** Capabilities this unblocks: cost, attribution, roas, cac */
     unlocks: string[]
     /** The operation that applies this suggestion, or null when there's nothing to automate. An object with an 'op' discriminator — see the ApplyOp union in setup_types. Pass it verbatim to apply_setup_ops; never hand-craft one. */
     apply: unknown
@@ -1545,7 +1545,7 @@ export interface SuggestionApi {
 }
 
 export interface CapabilityReadinessApi {
-    /** cost/attribution/roas/cac/retention_by_channel/ltv_by_channel */
+    /** cost/attribution/roas/cac */
     capability: string
     /** unlocked/partial/blocked */
     status: string

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -14805,7 +14805,7 @@ export namespace Schemas {
     }
 
     export interface CapabilityReadiness {
-      /** cost/attribution/roas/cac/retention_by_channel/ltv_by_channel */
+      /** cost/attribution/roas/cac */
       capability: string;
       /** unlocked/partial/blocked */
       status: string;
@@ -68897,7 +68897,7 @@ export namespace Schemas {
       title: string;
       /** The concrete numbers behind the suggestion, so a user can sanity-check it without taking it on faith */
       evidence: string;
-      /** Capabilities this unblocks: cost, attribution, roas, cac, retention_by_channel, ltv_by_channel */
+      /** Capabilities this unblocks: cost, attribution, roas, cac */
       unlocks: string[];
       /** The operation that applies this suggestion, or null when there's nothing to automate. An object with an 'op' discriminator — see the ApplyOp union in setup_types. Pass it verbatim to apply_setup_ops; never hand-craft one. */
       apply: unknown;


### PR DESCRIPTION
## What

`Capability` carried `RETENTION_BY_CHANNEL` and `LTV_BY_CHANNEL`, and `SuggestionKind` carried four `set_*_event` kinds. Nothing produces any of them — the readiness block has always returned four capabilities. Also removes the `UNBLOCKS` entry wiring two of the dead kinds together, and two `help_text` strings that advertised them.

## Why they don't belong here

They need `customer_analytics_config.activity_event` / `signup_event` / `payment_event` / `subscription_event` — `TeamCustomerAnalyticsConfig`, not `marketing_analytics_config`. Different product, different model.

`apply_setup_ops` already reached this conclusion from the other direction:

```python
_UNIMPLEMENTED_OPS = frozenset({"set_source_column_mapping", "set_customer_analytics_event"})
# "...needs work that belongs with their own features — the project-admin check its fields carry"
```

Those fields carry `field_access_control(..., "project", "admin")` from another product, so the write path refuses them. The capability enum kept promising what the write path declines to do.

Retention-by-channel is real and worth having — it's `RetentionQueryRunner` broken down by `utm_source`. But it needs *two* products configured, and marketing analytics only owns one half. Setting the other product's events from this tab was the part that was wrong.

## Why remove rather than comment

An enum value with no producer is what leads the next person to write the branch that handles it and never runs. This stack has already found two of those: a `secondary_apply` field the serializer never sends, with a modal button behind it, and five navigate ops the backend doesn't emit. Same shape, same fix.

If retention setup gets built, the capability comes back with a producer attached.

## Verification

`products/marketing_analytics/backend/`: 1188 passed. ruff and mypy clean. Nothing outside the two files references the removed names — the only remaining hits are in `frontend/generated/`, which CI regenerates.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*