### PR TITLE
fix(canvas): stop treating desktop OAuth grants as sandbox tokens

### DIFF
--- a/products/canvas/backend/presentation/views.py
+++ b/products/canvas/backend/presentation/views.py
@@ -888,10 +888,19 @@ class CanvasViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
     @staticmethod
     def _is_sandbox_authenticated(request: Request) -> bool:
-        """True when the request bears an OAuth token minted under a sandbox app —
-        the credential a task sandbox (via the MCP server) calls this API with."""
+        """True when the request bears an OAuth token minted for a task sandbox —
+        the credential a task sandbox (via the MCP server) calls this API with.
+
+        The token's bound ``sandbox_task_id`` is the discriminator, not the application:
+        the sandbox apps also issue the desktop app's interactive grants, so matching on
+        client id alone treats every desktop user as a sandbox with no task to scope to.
+        Only the server sets ``sandbox_task_id``, so a consent-flow grant never carries it.
+        """
         authenticator = request.successful_authenticator
         if not isinstance(authenticator, OAuthAccessTokenAuthentication):
             return False
-        application = authenticator.access_token.application
+        access_token = authenticator.access_token
+        if access_token.sandbox_task_id is None:
+            return False
+        application = access_token.application
         return application is not None and application.client_id in SANDBOX_OAUTH_APP_CLIENT_IDS

--- a/products/canvas/backend/presentation/views.py
+++ b/products/canvas/backend/presentation/views.py
@@ -891,16 +891,17 @@ class CanvasViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         """True when the request bears an OAuth token minted for a task sandbox —
         the credential a task sandbox (via the MCP server) calls this API with.
 
-        The token's bound ``sandbox_task_id`` is the discriminator, not the application:
-        the sandbox apps also issue the desktop app's interactive grants, so matching on
-        client id alone treats every desktop user as a sandbox with no task to scope to.
-        Only the server sets ``sandbox_task_id``, so a consent-flow grant never carries it.
+        The sandbox apps also issue the desktop app's interactive grants, so the application
+        alone does not prove sandbox origin. Server-minted tokens carry either a task binding
+        or the internal provenance scope. An unbound server token must still fail closed rather
+        than inherit its user's Canvas visibility.
         """
         authenticator = request.successful_authenticator
         if not isinstance(authenticator, OAuthAccessTokenAuthentication):
             return False
         access_token = authenticator.access_token
-        if access_token.sandbox_task_id is None:
+        scopes = set((access_token.scope or "").split())
+        if access_token.sandbox_task_id is None and "internal_run:read" not in scopes:
             return False
         application = access_token.application
         return application is not None and application.client_id in SANDBOX_OAUTH_APP_CLIENT_IDS

--- a/products/canvas/backend/tests/test_canvas_oauth.py
+++ b/products/canvas/backend/tests/test_canvas_oauth.py
@@ -10,6 +10,7 @@ from posthog.models.oauth import OAuthAccessToken, OAuthApplication
 from posthog.models.scoping import team_scope
 from posthog.temporal.oauth import ARRAY_APP_CLIENT_ID_DEV
 
+from products.canvas.backend.models import Canvas
 from products.tasks.backend.models import Channel, Task
 
 
@@ -43,29 +44,38 @@ class TestCanvasOAuthAccess(APIBaseTest):
         )
         return token.token
 
-    def _list_canvases(self, scope: str) -> int:
+    def _list_canvases(self, scope: str, client_id: str | None = None):
         with team_scope(self.team.id):
             channel = Channel.objects.create(team=self.team, name="general")
-        token = self._bearer(scope)
+            Canvas.objects.create(team=self.team, channel=channel, name="Signups", created_by=self.user)
+        token = self._bearer(scope, client_id=client_id)
         self.client.logout()
-        res = self.client.get(
+        return self.client.get(
             f"/api/projects/{self.team.id}/canvases/?channel={channel.id}&limit=200",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        return res.status_code
 
     def test_list_canvases_with_wildcard_oauth_token(self):
-        assert self._list_canvases("*") == 200
+        assert self._list_canvases("*").status_code == 200
 
     def test_list_canvases_with_canvas_read_oauth_token(self):
-        assert self._list_canvases("canvas:read") == 200
+        assert self._list_canvases("canvas:read").status_code == 200
 
     def test_list_canvases_denied_without_canvas_scope(self):
         # A token whose enumerated grant predates the canvas scope: other scopes
         # present, canvas absent. This is what a stale desktop session narrowed
         # to an app's scope ceiling looks like; the client's OAUTH_SCOPE_VERSION
         # bump exists to re-auth these.
-        assert self._list_canvases("task:read task:write dashboard:read") == 403
+        assert self._list_canvases("task:read task:write dashboard:read").status_code == 403
+
+    def test_list_canvases_with_an_interactive_desktop_grant(self):
+        # The desktop app's own grants come from the same OAuth apps that mint
+        # sandbox tokens, so treating a client-id match as sandbox origin empties
+        # every canvas list in the app: no bound task means nothing to scope to.
+        response = self._list_canvases("*", client_id=ARRAY_APP_CLIENT_ID_DEV)
+
+        assert response.status_code == 200
+        assert [row["name"] for row in response.json()["results"]] == ["Signups"]
 
     def _create_canvas(
         self,

--- a/products/canvas/backend/tests/test_canvas_oauth.py
+++ b/products/canvas/backend/tests/test_canvas_oauth.py
@@ -77,6 +77,15 @@ class TestCanvasOAuthAccess(APIBaseTest):
         assert response.status_code == 200
         assert [row["name"] for row in response.json()["results"]] == ["Signups"]
 
+    def test_list_canvases_with_an_unbound_server_minted_sandbox_token(self):
+        response = self._list_canvases(
+            "canvas:read internal_run:read",
+            client_id=ARRAY_APP_CLIENT_ID_DEV,
+        )
+
+        assert response.status_code == 200
+        assert response.json()["results"] == []
+
     def _create_canvas(
         self,
         *,


### PR DESCRIPTION
## Problem

Desktop users could not list, open, or create Canvases because the API classified their interactive OAuth grants as task sandboxes.

### History

1. [#80869](https://github.com/PostHog/posthog/pull/80869) added task-scoped Canvas authorization using the OAuth application client ID.
2. The Array OAuth application issues both interactive desktop grants and server-minted sandbox tokens. The client ID cannot distinguish them.
3. The first version of this PR used only `sandbox_task_id`. That restored desktop access but treated current unbound server tokens as human grants.
4. The final version also recognizes the server-only `internal_run:read` scope, so unbound server sandboxes fail closed.

## Changes

| Caller | Broken behavior | Final behavior |
|---|---|---|
| Interactive desktop grant | Treated as an unbound sandbox; lists were empty, retrieval returned 404, and creation returned 403 | Uses the user's normal space visibility |
| Task-bound sandbox | Limited to its task-linked Canvases | Remains limited to its task-linked Canvases |
| Unbound server sandbox | The first fix treated it as a human and exposed the token user's Canvas visibility | Recognized by `internal_run:read` and denied Canvas access |
| Forged, missing, or mismatched task header | Denied | Remains denied |

The OAuth client ID remains an additional check for both server-token paths.

## How did you test this code?

- Added an interactive Array-grant case that returns the user's Canvases.
- Added an unbound server-token case that returns no Canvases.
- Ran all 8 Canvas OAuth API tests and all 41 Canvas CRUD API tests locally.
- Ran a manual Django API matrix for list, retrieve, and create across interactive, unbound, bound, missing-header, and wrong-header tokens.
- Not run: live desktop sign-in.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually the PostHog Slack app, running Claude) investigated this from a Slack report that canvases had disappeared. This repo checkout is shallow, so I read the recent history through the GitHub API and traced the read path from the desktop client's `DashboardsService.list` down to `CanvasViewSet.safely_get_queryset`.

I first suspected the client, and ruled it out: the desktop code applies no filter that could empty the list, and the recent removal of the home-canvas concept left no client dependency behind. The backend gate is the only place the rows disappear.

The final check uses both server signals. `sandbox_task_id` scopes task agents, while `internal_run:read` keeps unbound server sandboxes fail closed. Interactive grants carry neither signal.

Skills invoked: `/security-audit`, `/review-hog-perspective-logic-correctness`, `/review-hog-perspective-contracts-security`, `/review-hog-validation-criteria`, `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, and `/writing-pr-descriptions`.




