### PR TITLE
fix(decagon): send a required start bound on admin_logs full walks

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/decagon.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/decagon.py
@@ -38,6 +38,11 @@ TIMESTAMP_FILTER_BY_FIELD: dict[str, str] = {
     "last_message_at": "last_message_time",
 }
 
+# Fallback window value for endpoints whose incremental bound is mandatory. Used when a
+# walk has no natural window (a full refresh, or an incremental sync's first run), so it
+# fetches full history instead of omitting the param the endpoint requires.
+_EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
+
 
 class DecagonRetryableError(Exception):
     pass
@@ -192,6 +197,12 @@ def get_rows(
                 # that same second after the walk read it is the rarer failure, and a full
                 # refresh trues the table up.
                 window_value += 1
+
+    if window_value is None and config.incremental_param and config.incremental_param_required:
+        # No prior state and no watermark left the window unset, but this endpoint 400s
+        # on a request that omits the bound entirely. The epoch keeps a full walk honest
+        # (every row is included) while still satisfying the requirement.
+        window_value = _incremental_window_value(config, _EPOCH)
 
     @retry(
         retry=retry_if_exception_type((DecagonRetryableError, requests.ReadTimeout, requests.ConnectionError)),

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/settings.py
@@ -55,6 +55,11 @@ class DecagonEndpointConfig:
     # sync should be advertised for it.
     incremental_param: Optional[str] = None
     incremental_param_format: IncrementalParamFormat = "epoch_seconds"
+    # Whether the endpoint 400s on a request that omits incremental_param entirely (as
+    # opposed to treating it as an optional filter). A full refresh, or the first run of
+    # an incremental sync, has no window to send; when this is set, the walker falls back
+    # to the epoch so every such request still carries a bound.
+    incremental_param_required: bool = False
     # Param selecting which timestamp the bounds apply to (/conversation/export only).
     timestamp_filter_param: Optional[str] = None
     # Static query params always sent.
@@ -221,6 +226,9 @@ DECAGON_ENDPOINTS: dict[str, DecagonEndpointConfig] = {
         partition_key="created_at",
         incremental_param="start",
         incremental_param_format="iso8601",
+        # Unlike the exports, this endpoint 400s ("At least one of start or end dates is
+        # required") on a bare request, so a full walk cannot omit the bound.
+        incremental_param_required=True,
         # Ordering is undocumented for this endpoint; desc is the safe declaration (see
         # the field comment).
         sort_mode="desc",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/tests/test_decagon.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/tests/test_decagon.py
@@ -611,6 +611,27 @@ class TestTags:
 
 
 class TestAdminLogs:
+    @parameterized.expand(
+        [
+            ("full_refresh", {}),
+            (
+                "first_incremental_run_without_watermark",
+                {"should_use_incremental_field": True, "incremental_field": "created_at"},
+            ),
+        ]
+    )
+    def test_walk_without_a_watermark_still_sends_the_required_start_bound(
+        self, _name: str, incremental_kwargs: dict[str, Any]
+    ) -> None:
+        # /admin_log/get 400s ("At least one of start or end dates is required") on a bare
+        # request, so a full refresh or an incremental sync's first run must not omit it.
+        manager = _fresh_manager()
+        responses = [_make_response({"admin_logs": [{"id": "a1"}], "total": 1})]
+        sent_params, batches = _drive_rows(manager, responses, endpoint="admin_logs", **incremental_kwargs)
+
+        assert sent_params == [{"offset": "0", "limit": "100", "start": "1970-01-01T00:00:00+00:00"}]
+        assert [len(b) for b in batches] == [1]
+
     def test_incremental_walk_sends_iso_start_and_pages_on_offset(self) -> None:
         # `start` takes a different value format from the exports' epoch min_timestamp;
         # sending an epoch here is the cross-endpoint confusion the spec warns about.


### PR DESCRIPTION
## Problem

Every first sync of the Decagon `admin_logs` table fails with a `400 Bad Request`, whether it is a full refresh or the first run of an incremental sync. Decagon's error tracking issue: https://us.posthog.com/project/2/error_tracking/019ff2f8-4808-78e3-b2e3-5a79d3d3097e

Decagon's `/admin_log/get` endpoint rejects any request that omits both `start` and `end` ("At least one of start or end dates is required"). The connector only sends `start` once an incremental watermark exists, so a walk with no prior watermark sends neither and the request 400s before a single row syncs.

## Changes

- Add `incremental_param_required` to `DecagonEndpointConfig`, set for `admin_logs`, marking that its bound cannot be omitted.
- When a walk has no watermark (full refresh, or an incremental sync's first run) and the endpoint requires a bound, default the window to the Unix epoch so the request still carries `start` and the walk still returns full history.
- Other endpoints (`conversations`, `agent_assist_actions`) are unaffected: their bound stays optional.

## How did you test this code?

Added 2 parameterized cases to `TestAdminLogs` in `test_decagon.py`, covering a full refresh and an incremental sync's first run without a watermark — both previously sent a bare `{"offset": "0", "limit": "100"}`, which is exactly the request Decagon 400s on.

Ran locally:
- `pytest products/warehouse_sources/backend/temporal/data_imports/sources/decagon/tests/` — 63 passed
- `ruff check`/`ruff format` on the changed files — clean
- `uv run mypy --cache-fine-grained .` (repo-wide) — clean

Not run: a live call against Decagon's API (no test credentials in this environment); the fix is inferred from the 400 response body captured in production logs for this error.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing config or docs changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking MCP tools (issue details, sampled events, stack trace) and the `query-logs` tool, which surfaced the underlying Decagon response body (`"At least one of start or end dates is required"`) that pinned the root cause. Skills invoked: `/writing-tests` before adding the regression test, `/writing-pr-descriptions` before writing this body.