### PR TITLE
fix(desktop): dismiss mission control overlay on focus

### DIFF
--- a/products/desktop/apps/code/src/main/platform-adapters/electron-mission-control.test.ts
+++ b/products/desktop/apps/code/src/main/platform-adapters/electron-mission-control.test.ts
@@ -127,6 +127,21 @@ describe("MissionControlService", () => {
     expect(service.getState().active).toBe(false);
   });
 
+  it("refreshes immediately when the app regains focus", () => {
+    const { state, impl } = fakeSampler([MISSION_CONTROL_BACKING]);
+    sampler.create.mockReturnValue(impl);
+    const service = new MissionControlService();
+
+    service.arm();
+    vi.advanceTimersByTime(250);
+    expect(service.getState().active).toBe(true);
+
+    state.windows = [];
+    service.refresh();
+
+    expect(service.getState().active).toBe(false);
+  });
+
   it("never touches the window list while the setting is off", () => {
     settings.enabled = false;
     const { state, impl } = fakeSampler([MISSION_CONTROL_BACKING]);

--- a/products/desktop/apps/code/src/main/platform-adapters/electron-mission-control.ts
+++ b/products/desktop/apps/code/src/main/platform-adapters/electron-mission-control.ts
@@ -75,6 +75,11 @@ export class MissionControlService extends TypedEventEmitter<MissionControlServi
     this.timer = setInterval(() => this.poll(), POLL_INTERVAL_MS);
   }
 
+  refresh(): void {
+    if (!this.enabled || !this.resolveSampler()) return;
+    this.poll();
+  }
+
   disarm(): void {
     this.clearTimer();
     this.setActive(false);

--- a/products/desktop/apps/code/src/main/window.ts
+++ b/products/desktop/apps/code/src/main/window.ts
@@ -326,6 +326,7 @@ export function createWindow(): void {
   );
   mainWindow.on("show", () => missionControl.arm());
   mainWindow.on("restore", () => missionControl.arm());
+  mainWindow.on("focus", () => missionControl.refresh());
   mainWindow.on("hide", () => missionControl.disarm());
   mainWindow.on("minimize", () => missionControl.disarm());
   mainWindow.on("closed", () => missionControl.disarm());


### PR DESCRIPTION
## Problem

Returning to PostHog Code from Mission Control can leave the overlay visible for up to 250 ms.

**Why:** The delayed dismissal makes the app feel unresponsive when users resume work.

## Changes

- The app samples Mission Control state immediately when its window regains focus.
- Polling remains as the entry detector because macOS exposes no reliable public Mission Control enter or exit notification.
- No screenshot: the overlay appearance is unchanged.

## How did you test this code?

- Added a regression test that verifies focus-driven refresh dismisses the overlay before the next poll.
- Ran the focused Mission Control test suite, Code typecheck, and Biome checks.
- Not tested manually on macOS in this Linux environment.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and verified this change through PostHog Desktop. Skills invoked: /i-have-adhd, /posthog-desktop, and /writing-pr-descriptions.

No private session material appears in the public artifacts.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*