### PR TITLE
feat(signals): add pr refund labels to inbox ranking dataset

### DIFF
--- a/products/signals/dags/inbox_ranking/README.md
+++ b/products/signals/dags/inbox_ranking/README.md
@@ -54,7 +54,7 @@ All reads route to the offline cluster replicas on Cloud (`etl_workload()`), car
 
 - Backfill any day range from the Dagster UI; partitions start 2026-04-01 (the label epoch). Every asset sits in the `inbox_ranking_etl` pool so concurrent partitions don't each start their own fleet-wide embeddings scan — the pool's limit is a Dagster deployment setting, provisioned with the bucket.
 - Failures alert `#alerts-self-driving` (owner `team-self-driving`); assets retry twice with a 60s delay before failing a run. A UI-launched materialization runs under Dagster's implicit `__ASSET_JOB`, which carries no owner tag, so alert routing falls back to matching the `inbox_report_` asset-name prefix.
-- The job is capped at 3h via `dagster/max_runtime` — the six label streams run sequentially, each allowed up to 600s, and the join and S3 writes come after them.
+- The job is capped at 3h via `dagster/max_runtime` — the seven label streams run sequentially, each allowed up to 600s, and the join and S3 writes come after them.
 
 ### Deletion and retention
 

--- a/products/signals/dags/inbox_ranking/dataset/dag.py
+++ b/products/signals/dags/inbox_ranking/dataset/dag.py
@@ -73,7 +73,7 @@ from products.signals.dags.inbox_ranking.dataset.queries import (
     valid_report_uuids,
 )
 
-FEATURE_SCHEMA_VERSION = 1
+FEATURE_SCHEMA_VERSION = 2
 
 # Statuses a report can be authored straight into and still be in the inbox (`create_scout_report`
 # and `create_custom_agent_ready_report`), which is how a report reaches the spine without a
@@ -184,6 +184,11 @@ LABEL_FIELDS: list[tuple[str, pa.DataType]] = [
     ("pr_merged_count", pa.int32()),
     ("first_pr_merged_at", _TIMESTAMP),
     ("pr_closed_count", pa.int32()),
+    ("refund_count", pa.int32()),
+    ("first_refunded_at", _TIMESTAMP),
+    ("refund_reason", pa.string()),
+    ("refund_billing_path", pa.string()),
+    ("refund_credits", pa.int64()),
 ]
 
 _LABELS_FIELDS: list[tuple[str, pa.DataType]] = [
@@ -694,7 +699,7 @@ inbox_ranking_dataset_job = dagster.define_asset_job(
     name="inbox_ranking_dataset_job",
     selection=[STATE_TABLE, EMBEDDINGS_TABLE, LABELS_TABLE, MODEL_DATA_TABLE],
     partitions_def=partition_def,
-    # The six label streams run sequentially and each may take its full 600s query timeout, so an
+    # The seven label streams run sequentially and each may take its full 600s query timeout, so an
     # hour left a slow-but-valid pass no room for the join, the S3 writes, or an asset retry — and
     # the label windows only grow, since they accumulate from LABELS_EPOCH.
     tags={**owner_tags, "dagster/max_runtime": str(3 * 60 * 60)},

--- a/products/signals/dags/inbox_ranking/dataset/queries.py
+++ b/products/signals/dags/inbox_ranking/dataset/queries.py
@@ -93,6 +93,14 @@ def valid_report_uuids(report_ids: set[str | None]) -> set[str]:
     return {canonical for report_id in report_ids if (canonical := canonical_report_uuid(report_id)) is not None}
 
 
+# Trust boundary for every label stream below: these are analytics events captured in the dogfood
+# project, not authoritative records, so a label attests that an event arrived and never that the
+# thing it describes happened. The authoritative rows (SignalReport, SignalReportRefund) sit in
+# per-region Postgres while this dag runs US-only, so sourcing labels from them would silently drop
+# every non-US report — the same constraint that makes cross-region reports label-only (README.md).
+# Weight a label by how it is produced: the status, pr and refund streams are server-emitted behind
+# authenticated endpoints, while impressions, opens, actions and feedback come from the clients.
+
 # The `Inbox report feedback` producer contract (products/signals/frontend/inbox/inboxAnalytics.ts emits
 # exactly these two). Applied to the labeled-id spine and the feedback stream alike, so an event
 # whose sentiment is missing or off-contract carries no label and can neither mint a label-only

--- a/products/signals/dags/inbox_ranking/dataset/queries.py
+++ b/products/signals/dags/inbox_ranking/dataset/queries.py
@@ -116,7 +116,8 @@ FROM (
         'Inbox report opened',
         'Inbox report action',
         'Inbox report feedback',
-        'signal_report_status_changed'
+        'signal_report_status_changed',
+        'signals_pr_refund_created'
     )
       AND (event != 'Inbox report feedback' OR {FEEDBACK_SENTIMENTS_SQL})
       AND timestamp >= toDateTime({{labels_epoch}}) AND timestamp < toDateTime({{snapshot_end}})
@@ -371,6 +372,34 @@ WHERE event = 'Inbox report feedback'
 GROUP BY report_id
 """
 
+REFUNDS_COLUMNS = (
+    "refund_count",
+    "first_refunded_at",
+    "refund_reason",
+    "refund_billing_path",
+    "refund_credits",
+)
+# The refund action is the strongest explicit negative PR-quality label: a human reviewed the
+# implementation PR and asked for the charge back. It is deliberately its own stream because the
+# status stream cannot recover it: a refunded merged-PR report stays `resolved` (see the refund
+# guard in products/signals/backend/views.py), so `dismissal_reason='refunded'` misses those.
+# The endpoint mints one refund per report ever and repeat calls do not re-emit, so uniq over
+# refund_id keeps the count honest under at-least-once analytics delivery.
+REFUNDS_SQL = """
+SELECT
+    toString(properties.report_id) AS report_id,
+    uniq(toString(properties.refund_id)) AS refund_count,
+    min(timestamp) AS first_refunded_at,
+    nullIf(argMax(toString(properties.reason), timestamp), '') AS refund_reason,
+    nullIf(argMax(toString(properties.billing_path), timestamp), '') AS refund_billing_path,
+    argMax(toInt(properties.credits), timestamp) AS refund_credits
+FROM events
+WHERE event = 'signals_pr_refund_created'
+  AND timestamp >= toDateTime({labels_epoch}) AND timestamp < toDateTime({snapshot_end})
+  AND toString(properties.report_id) != ''
+GROUP BY report_id
+"""
+
 LABEL_STREAMS: tuple[tuple[str, str, tuple[str, ...]], ...] = (
     ("impressions", IMPRESSIONS_SQL, IMPRESSIONS_COLUMNS),
     ("opens", OPENS_SQL, OPENS_COLUMNS),
@@ -378,6 +407,7 @@ LABEL_STREAMS: tuple[tuple[str, str, tuple[str, ...]], ...] = (
     ("feedback", FEEDBACK_SQL, FEEDBACK_COLUMNS),
     ("status_changes", STATUS_SQL, STATUS_COLUMNS),
     ("pr_events", PR_EVENTS_SQL, PR_COLUMNS),
+    ("refunds", REFUNDS_SQL, REFUNDS_COLUMNS),
 )
 
 # Every label column a report can have, with its no-events default. Streams overwrite their own
@@ -417,6 +447,11 @@ LABEL_DEFAULTS: dict[str, Any] = {
     "pr_merged_count": 0,
     "first_pr_merged_at": None,
     "pr_closed_count": 0,
+    "refund_count": 0,
+    "first_refunded_at": None,
+    "refund_reason": None,
+    "refund_billing_path": None,
+    "refund_credits": None,
 }
 
 _TIMESTAMP_LABEL_COLUMNS = frozenset(name for name in LABEL_DEFAULTS if name.endswith("_at"))


### PR DESCRIPTION
## Problem

- The inbox ranking dataset carries no refund outcome, so a ranking model cannot learn from the clearest negative signal a report gets: a person reviewed its implementation PR and asked for the charge back.
- Refunds dwarf the other explicit quality signal: 609 refunded reports since 2026-07-15, against 125 with thumbs feedback.
- The status stream cannot recover them. A refunded merged-PR report stays `resolved`, so `dismissal_reason='refunded'` misses 155 of the 600 refunded reports on the current snapshot.

## Changes

- Adds a seventh label stream over the `signals_pr_refund_created` event to the daily dataset dag.
- New nullable columns on `inbox_report_labels` and `inbox_report_model_data`: `refund_count`, `first_refunded_at`, `refund_reason`, `refund_billing_path`, `refund_credits`.
- The count dedupes on `refund_id` because analytics delivery is at-least-once and the endpoint mints one refund per report ever.
- The refund event joins the labeled-ids spine, so a refunded report gets a dataset row even where PR attribution missed it.
- `FEATURE_SCHEMA_VERSION` bumps 1 to 2, per the dag's additive-column rule.

## How did you test this code?

- Existing guards in `products/signals/dags/inbox_ranking/tests/` cover the new stream generically: row-width strict zip, stream columns within defaults, exact parquet-schema agreement. No new tests, because the stream reuses the merge path those tests already pin.
- I smoke-tested the stream SQL live against the dogfood project: one row per refunded report, reason and billing path populated.
- I confirmed the Dagster location imports under Django and ran repo-wide mypy.
- Not run: a real partition materialization. The next scheduled run exercises it, and a failed asset retries without touching earlier partitions.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- `products/signals/dags/inbox_ranking/README.md` stream count updated in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session directed by Andy: verified the refund event and its live volumes in the dogfood project via the PostHog MCP, then extended the dag.
- Skills invoked: `/phs inbox-ranking` (the feature's cross-session tracker; its label catalog and backlog were updated alongside this PR), `/writing-code-comments`, `/writing-tests` gate applied (no new tests), `/writing-pr-descriptions`.
- All numbers above come from live queries against PostHog's own dogfood project (internal inbox usage, no customer data).
- Session also found a residual gap tracked outside this PR: 67 refunded reports lack a `pr_created` label despite refunds requiring a billable PR.
