### PR TITLE
feat(security): add public self-service leaked API key revocation

### DIFF
--- a/frontend/src/generated/core/api.schemas.ts
+++ b/frontend/src/generated/core/api.schemas.ts
@@ -3845,6 +3845,42 @@ export interface BulkUpdateTagsResponseApi {
     skipped: BulkUpdateTagsErrorApi[]
 }
 
+export interface LeakedKeyReportApi {
+    /**
+     * The leaked PostHog personal API key, project secret API key, or OAuth access/refresh token to revoke.
+     * @maxLength 200
+     */
+    token: string
+}
+
+/**
+ * * `personal_api_key` - personal_api_key
+ * * `project_secret_api_key` - project_secret_api_key
+ * * `oauth_access_token` - oauth_access_token
+ * * `oauth_refresh_token` - oauth_refresh_token
+ */
+export type LeakedKeyReportResponseTypeEnumApi =
+    (typeof LeakedKeyReportResponseTypeEnumApi)[keyof typeof LeakedKeyReportResponseTypeEnumApi]
+
+export const LeakedKeyReportResponseTypeEnumApi = {
+    PersonalApiKey: 'personal_api_key',
+    ProjectSecretApiKey: 'project_secret_api_key',
+    OauthAccessToken: 'oauth_access_token',
+    OauthRefreshToken: 'oauth_refresh_token',
+} as const
+
+export interface LeakedKeyReportResponseApi {
+    /** Whether a matching PostHog key or token was found and revoked. */
+    found: boolean
+    /** The type of key that was found and revoked, or null if no match was found.
+     *
+     * * `personal_api_key` - personal_api_key
+     * * `project_secret_api_key` - project_secret_api_key
+     * * `oauth_access_token` - oauth_access_token
+     * * `oauth_refresh_token` - oauth_refresh_token */
+    type: LeakedKeyReportResponseTypeEnumApi | null
+}
+
 /**
  * * `disabled` - disabled
  * * `toolbar` - toolbar

--- a/frontend/src/generated/core/api.ts
+++ b/frontend/src/generated/core/api.ts
@@ -2302,7 +2302,7 @@ export const getRevokeLeakedKeyCreateUrl = () => {
 /**
  * Public, unauthenticated endpoint for self-service revocation of a leaked PostHog personal API key, project secret API key, or OAuth access/refresh token. If the token is live it is revoked immediately and the owner is notified by email.
  *
- * This endpoint only checks the region it is running on. `"found": false` does not guarantee the token is safe. If you're not sure which region issued it, also try the other region's endpoint: https://app.posthog.com/api/revoke_leaked_key or https://eu.posthog.com/api/revoke_leaked_key.
+ * This endpoint only checks the region it is running on. `"found": false` does not guarantee the token is safe. If you're not sure which region issued it, check both: https://app.posthog.com/api/revoke_leaked_key and https://eu.posthog.com/api/revoke_leaked_key.
  * @summary Report and revoke a leaked PostHog API key or token
  */
 export const revokeLeakedKeyCreate = async (

--- a/frontend/src/generated/core/api.ts
+++ b/frontend/src/generated/core/api.ts
@@ -31,6 +31,8 @@ import type {
     IdentityProviderConfigApi,
     IdentityProviderConfigsListParams,
     InvitesListParams,
+    LeakedKeyReportApi,
+    LeakedKeyReportResponseApi,
     OauthApplicationsListParams,
     OnboardingSkipRequestApi,
     OrganizationDomainApi,
@@ -2290,6 +2292,28 @@ export const sessionRecordingsSharingRefreshCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(sharingConfigurationApi),
+    })
+}
+
+export const getRevokeLeakedKeyCreateUrl = () => {
+    return `/api/revoke_leaked_key/`
+}
+
+/**
+ * Public, unauthenticated endpoint for self-service revocation of a leaked PostHog personal API key, project secret API key, or OAuth access/refresh token. If the token is live it is revoked immediately and the owner is notified by email.
+ *
+ * This endpoint only checks the region it is running on. `"found": false` does not guarantee the token is safe. If you're not sure which region issued it, also try the other region's endpoint: https://app.posthog.com/api/revoke_leaked_key or https://eu.posthog.com/api/revoke_leaked_key.
+ * @summary Report and revoke a leaked PostHog API key or token
+ */
+export const revokeLeakedKeyCreate = async (
+    leakedKeyReportApi: LeakedKeyReportApi,
+    options?: RequestInit
+): Promise<LeakedKeyReportResponseApi> => {
+    return apiMutator<LeakedKeyReportResponseApi>(getRevokeLeakedKeyCreateUrl(), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(leakedKeyReportApi),
     })
 }
 

--- a/frontend/src/generated/core/api.zod.ts
+++ b/frontend/src/generated/core/api.zod.ts
@@ -919,7 +919,7 @@ export const SessionRecordingsSharingRefreshCreateBody = /* @__PURE__ */ zod
 /**
  * Public, unauthenticated endpoint for self-service revocation of a leaked PostHog personal API key, project secret API key, or OAuth access/refresh token. If the token is live it is revoked immediately and the owner is notified by email.
  *
- * This endpoint only checks the region it is running on. `"found": false` does not guarantee the token is safe. If you're not sure which region issued it, also try the other region's endpoint: https://app.posthog.com/api/revoke_leaked_key or https://eu.posthog.com/api/revoke_leaked_key.
+ * This endpoint only checks the region it is running on. `"found": false` does not guarantee the token is safe. If you're not sure which region issued it, check both: https://app.posthog.com/api/revoke_leaked_key and https://eu.posthog.com/api/revoke_leaked_key.
  * @summary Report and revoke a leaked PostHog API key or token
  */
 export const revokeLeakedKeyCreateBodyTokenMax = 200

--- a/frontend/src/generated/core/api.zod.ts
+++ b/frontend/src/generated/core/api.zod.ts
@@ -917,6 +917,23 @@ export const SessionRecordingsSharingRefreshCreateBody = /* @__PURE__ */ zod
     .describe('Mixin for serializers to add user access control fields')
 
 /**
+ * Public, unauthenticated endpoint for self-service revocation of a leaked PostHog personal API key, project secret API key, or OAuth access/refresh token. If the token is live it is revoked immediately and the owner is notified by email.
+ *
+ * This endpoint only checks the region it is running on. `"found": false` does not guarantee the token is safe. If you're not sure which region issued it, also try the other region's endpoint: https://app.posthog.com/api/revoke_leaked_key or https://eu.posthog.com/api/revoke_leaked_key.
+ * @summary Report and revoke a leaked PostHog API key or token
+ */
+export const revokeLeakedKeyCreateBodyTokenMax = 200
+
+export const RevokeLeakedKeyCreateBody = /* @__PURE__ */ zod.object({
+    token: zod
+        .string()
+        .max(revokeLeakedKeyCreateBodyTokenMax)
+        .describe(
+            'The leaked PostHog personal API key, project secret API key, or OAuth access\/refresh token to revoke.'
+        ),
+})
+
+/**
  * Replace the authenticated user's profile and settings. Pass `@me` as the UUID to update the authenticated user. Prefer the PATCH endpoint for partial updates — PUT requires every writable field to be provided.
  */
 export const usersUpdateBodyFirstNameMax = 150

--- a/posthog/api/documentation.py
+++ b/posthog/api/documentation.py
@@ -743,11 +743,19 @@ def preprocess_exclude_path_format(endpoints, **kwargs):
     for path, path_regex, method, callback in endpoints:
         if getattr(callback.cls, "param_derived_from_user_current_team", None):
             continue
-        if not hasattr(callback.cls, "scope_object") or getattr(callback.cls, "hide_api_docs", False):
+        has_scope_object = hasattr(callback.cls, "scope_object")
+        # A view with no scope_object is normally excluded - the schema is built around
+        # team/org-scoped resources. include_in_api_docs is the explicit opt-in for a
+        # deliberately unscoped view (e.g. a public, unauthenticated endpoint) that still
+        # wants to appear in the docs.
+        if not has_scope_object and not getattr(callback.cls, "include_in_api_docs", False):
             continue
-        scope = callback.cls.scope_object
-        if scope == "INTERNAL" and not include_internal:
+        if getattr(callback.cls, "hide_api_docs", False):
             continue
+        if has_scope_object:
+            scope = callback.cls.scope_object
+            if scope == "INTERNAL" and not include_internal:
+                continue
 
         included.append((path, path_regex, method, callback))
         suffix = _extract_root_suffix(_PROJECTS_PREFIX_RE, path)

--- a/posthog/api/github.py
+++ b/posthog/api/github.py
@@ -18,19 +18,17 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from posthog.api.personal_api_key import PersonalAPIKeySerializer
-from posthog.api.project_secret_api_key import roll_project_secret_api_key_and_notify
+from posthog.api.secret_revocation import (
+    CANONICAL_OAUTH_ACCESS_TOKEN,
+    CANONICAL_OAUTH_REFRESH_TOKEN,
+    CANONICAL_PERSONAL_API_KEY,
+    CANONICAL_PROJECT_SECRET_API_KEY,
+    revoke_leaked_secret,
+)
 from posthog.models import Team
-from posthog.models.oauth import find_oauth_access_token, find_oauth_refresh_token, revoke_oauth_session
-from posthog.models.personal_api_key import find_personal_api_key
-from posthog.models.project_secret_api_key import find_project_secret_api_key
 from posthog.models.utils import mask_key_value
 from posthog.redis import get_client
-from posthog.tasks.email import (
-    send_feature_flags_secure_api_key_exposed,
-    send_oauth_token_exposed,
-    send_personal_api_key_exposed,
-)
+from posthog.tasks.email import send_feature_flags_secure_api_key_exposed
 from posthog.utils import get_instance_region
 
 logger = structlog.get_logger(__name__)
@@ -238,8 +236,9 @@ class SecretAlert(APIView):
             local_found = False
 
             if item["type"] == GITHUB_TYPE_FOR_PERSONAL_API_KEY:
-                key_lookup = find_personal_api_key(token)
-                local_found = key_lookup is not None
+                more_info = f"This key was detected by GitHub at {item['url']}."
+                revocation = revoke_leaked_secret(token, CANONICAL_PERSONAL_API_KEY, more_info)
+                local_found = revocation.found
 
                 pending_events.append(
                     {
@@ -252,36 +251,20 @@ class SecretAlert(APIView):
                     }
                 )
 
-                if key_lookup is not None:
+                if revocation.found:
                     result["label"] = "true_positive"
-                    more_info = f"This key was detected by GitHub at {item['url']}."
-
-                    key, _ = key_lookup
-                    old_mask_value = key.mask_value
-
-                    serializer = PersonalAPIKeySerializer(instance=key)
-                    serializer.roll(key)
-                    send_personal_api_key_exposed(key.user.id, key.id, old_mask_value, more_info)
 
             elif item["type"] == GITHUB_TYPE_FOR_SECURE_API_KEY:
-                key_kind = None
+                more_info = f"This key was detected by GitHub at {item['url']}."
+                revocation = revoke_leaked_secret(token, CANONICAL_PROJECT_SECRET_API_KEY, more_info)
+                local_found = revocation.found
+                key_kind = "project_secret_api_key" if revocation.found else None
 
-                project_secret_api_key = find_project_secret_api_key(token)
-                if project_secret_api_key is not None:
-                    local_found = True
-                    key_kind = "project_secret_api_key"
-                    result["label"] = "true_positive"
-
-                    more_info = f"This key was detected by GitHub at {item['url']}."
-                    roll_project_secret_api_key_and_notify(project_secret_api_key, more_info)
-                else:
+                if not revocation.found:
                     try:
                         team = Team.objects.get(Q(secret_api_token=token) | Q(secret_api_token_backup=token))
                         local_found = True
                         key_kind = "team_secret_token"
-                        result["label"] = "true_positive"
-
-                        more_info = f"This key was detected by GitHub at {item['url']}."
                         send_feature_flags_secure_api_key_exposed(team.id, mask_key_value(token), more_info)
 
                     except Team.DoesNotExist:
@@ -299,9 +282,13 @@ class SecretAlert(APIView):
                     }
                 )
 
+                if local_found:
+                    result["label"] = "true_positive"
+
             elif item["type"] == GITHUB_TYPE_FOR_OAUTH_ACCESS_TOKEN:
-                access_token = find_oauth_access_token(token)
-                local_found = access_token is not None
+                more_info = f"This token was detected by GitHub at {item['url']}."
+                revocation = revoke_leaked_secret(token, CANONICAL_OAUTH_ACCESS_TOKEN, more_info)
+                local_found = revocation.found
 
                 pending_events.append(
                     {
@@ -314,19 +301,13 @@ class SecretAlert(APIView):
                     }
                 )
 
-                if access_token is not None:
+                if revocation.found:
                     result["label"] = "true_positive"
-                    more_info = f"This token was detected by GitHub at {item['url']}."
-
-                    user = access_token.user
-                    revoke_oauth_session(access_token=access_token)
-
-                    if user:
-                        send_oauth_token_exposed(user.id, "access", mask_key_value(token), more_info)
 
             elif item["type"] == GITHUB_TYPE_FOR_OAUTH_REFRESH_TOKEN:
-                refresh_token = find_oauth_refresh_token(token)
-                local_found = refresh_token is not None
+                more_info = f"This token was detected by GitHub at {item['url']}."
+                revocation = revoke_leaked_secret(token, CANONICAL_OAUTH_REFRESH_TOKEN, more_info)
+                local_found = revocation.found
 
                 pending_events.append(
                     {
@@ -339,15 +320,8 @@ class SecretAlert(APIView):
                     }
                 )
 
-                if refresh_token is not None:
+                if revocation.found:
                     result["label"] = "true_positive"
-                    more_info = f"This token was detected by GitHub at {item['url']}."
-
-                    user = refresh_token.user
-                    revoke_oauth_session(refresh_token=refresh_token)
-
-                    if user:
-                        send_oauth_token_exposed(user.id, "refresh", mask_key_value(token), more_info)
 
             else:
                 raise ValidationError(detail="Unexpected alert type")

--- a/posthog/api/leaked_key.py
+++ b/posthog/api/leaked_key.py
@@ -1,0 +1,99 @@
+from hashlib import sha256
+
+import posthoganalytics
+from drf_spectacular.utils import OpenApiResponse
+from rest_framework import serializers
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from posthog.api.mixins import ValidatedRequest, validated_request
+from posthog.api.secret_revocation import (
+    CANONICAL_OAUTH_ACCESS_TOKEN,
+    CANONICAL_OAUTH_REFRESH_TOKEN,
+    CANONICAL_PERSONAL_API_KEY,
+    CANONICAL_PROJECT_SECRET_API_KEY,
+    revoke_leaked_secret,
+)
+from posthog.rate_limit import LeakedKeyReportThrottle
+
+PUBLIC_REPORT_MORE_INFO = "This key was reported as leaked via PostHog's public key-revocation API."
+
+
+class LeakedKeyReportSerializer(serializers.Serializer):
+    token = serializers.CharField(
+        help_text="The leaked PostHog personal API key, project secret API key, or OAuth access/refresh token to revoke.",
+    )
+
+
+class LeakedKeyReportResponseSerializer(serializers.Serializer):
+    found = serializers.BooleanField(
+        help_text="Whether a matching PostHog key or token was found and revoked.",
+    )
+    type = serializers.ChoiceField(
+        choices=[
+            CANONICAL_PERSONAL_API_KEY,
+            CANONICAL_PROJECT_SECRET_API_KEY,
+            CANONICAL_OAUTH_ACCESS_TOKEN,
+            CANONICAL_OAUTH_REFRESH_TOKEN,
+        ],
+        allow_null=True,
+        help_text="The type of key that was found and revoked, or null if no match was found.",
+    )
+
+
+class PublicLeakedKeyReport(APIView):
+    """
+    Public, unauthenticated self-service endpoint: submit a leaked PostHog token and,
+    if it's live, it's revoked immediately and the owner is notified. Safety relies on
+    possession of the plaintext token, not a signature — see secret_revocation.py.
+
+    Region-local only, no cross-region relay: a "found": false result does not rule
+    out the token being live in the other region. See the endpoint description below.
+    """
+
+    authentication_classes = []
+    permission_classes = [AllowAny]
+    throttle_classes = [LeakedKeyReportThrottle]
+
+    @validated_request(
+        request_serializer=LeakedKeyReportSerializer,
+        responses={
+            200: OpenApiResponse(response=LeakedKeyReportResponseSerializer, description="Lookup result."),
+            400: OpenApiResponse(description="Missing or blank token."),
+            429: OpenApiResponse(description="Too many requests from this IP."),
+        },
+        summary="Report and revoke a leaked PostHog API key or token",
+        description=(
+            "Public, unauthenticated endpoint for self-service revocation of a leaked PostHog "
+            "personal API key, project secret API key, or OAuth access/refresh token. If the "
+            "token is live it is revoked immediately and the owner is notified by email.\n\n"
+            'This endpoint only checks the region it is running on. `"found": false` does not '
+            "guarantee the token is safe — if you're not sure which region issued it, also try "
+            "the other region's endpoint: https://app.posthog.com/api/alerts/leaked_key or "
+            "https://eu.posthog.com/api/alerts/leaked_key."
+        ),
+        extensions={"x-product": "core"},
+    )
+    def post(self, request: ValidatedRequest) -> Response:
+        token = request.validated_data["token"]
+
+        result = revoke_leaked_secret(token, key_type=None, more_info=PUBLIC_REPORT_MORE_INFO)
+
+        # Unlike github_secret_alert, no token_prefix/token_suffix here: GitHub already
+        # confirmed the string is a real PostHog-shaped secret before that event fires,
+        # but this endpoint's callers are the whole internet, and people will paste
+        # things that aren't PostHog keys at all. token_sha256 alone is enough for
+        # dedup/monitoring without persisting fragments of third-party secrets.
+        posthoganalytics.capture(
+            distinct_id=None,
+            event="public_leaked_key_report",
+            properties={
+                "found": result.found,
+                "type": result.key_type,
+                "token_length": len(token),
+                "token_sha256": sha256(token.encode("utf-8")).hexdigest(),
+            },
+        )
+
+        return Response({"found": result.found, "type": result.key_type})

--- a/posthog/api/leaked_key.py
+++ b/posthog/api/leaked_key.py
@@ -80,8 +80,8 @@ class PublicLeakedKeyReport(APIView):
             "personal API key, project secret API key, or OAuth access/refresh token. If the "
             "token is live it is revoked immediately and the owner is notified by email.\n\n"
             'This endpoint only checks the region it is running on. `"found": false` does not '
-            "guarantee the token is safe. If you're not sure which region issued it, also try "
-            "the other region's endpoint: https://app.posthog.com/api/revoke_leaked_key or "
+            "guarantee the token is safe. If you're not sure which region issued it, check "
+            "both: https://app.posthog.com/api/revoke_leaked_key and "
             "https://eu.posthog.com/api/revoke_leaked_key."
         ),
         extensions={"x-product": "core"},

--- a/posthog/api/leaked_key.py
+++ b/posthog/api/leaked_key.py
@@ -3,6 +3,7 @@ from hashlib import sha256
 import posthoganalytics
 from drf_spectacular.utils import OpenApiResponse
 from rest_framework import serializers
+from rest_framework.parsers import JSONParser
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -16,12 +17,16 @@ from posthog.api.secret_revocation import (
     revoke_leaked_secret,
 )
 from posthog.rate_limit import LeakedKeyReportThrottle
+from posthog.utils import get_instance_region
 
 PUBLIC_REPORT_MORE_INFO = "This key was reported as leaked via PostHog's public key-revocation API."
 
 
 class LeakedKeyReportSerializer(serializers.Serializer):
     token = serializers.CharField(
+        # The longest key we issue is 51 characters. The cap rejects an oversized body
+        # before any hashing or lookup work happens.
+        max_length=200,
         help_text="The leaked PostHog personal API key, project secret API key, or OAuth access/refresh token to revoke.",
     )
 
@@ -55,12 +60,18 @@ class PublicLeakedKeyReport(APIView):
     authentication_classes = []
     permission_classes = [AllowAny]
     throttle_classes = [LeakedKeyReportThrottle]
+    parser_classes = [JSONParser]
+
+    # No scope_object: this endpoint is intentionally public and unscoped, not tied to
+    # a team/org resource, so APIScopePermission's scope model doesn't apply here. It
+    # opts into the public API docs directly instead.
+    include_in_api_docs = True
 
     @validated_request(
         request_serializer=LeakedKeyReportSerializer,
         responses={
             200: OpenApiResponse(response=LeakedKeyReportResponseSerializer, description="Lookup result."),
-            400: OpenApiResponse(description="Missing or blank token."),
+            400: OpenApiResponse(description="The token is missing, blank, or longer than 200 characters."),
             429: OpenApiResponse(description="Too many requests from this IP."),
         },
         summary="Report and revoke a leaked PostHog API key or token",
@@ -69,9 +80,9 @@ class PublicLeakedKeyReport(APIView):
             "personal API key, project secret API key, or OAuth access/refresh token. If the "
             "token is live it is revoked immediately and the owner is notified by email.\n\n"
             'This endpoint only checks the region it is running on. `"found": false` does not '
-            "guarantee the token is safe — if you're not sure which region issued it, also try "
-            "the other region's endpoint: https://app.posthog.com/api/alerts/leaked_key or "
-            "https://eu.posthog.com/api/alerts/leaked_key."
+            "guarantee the token is safe. If you're not sure which region issued it, also try "
+            "the other region's endpoint: https://app.posthog.com/api/revoke_leaked_key or "
+            "https://eu.posthog.com/api/revoke_leaked_key."
         ),
         extensions={"x-product": "core"},
     )
@@ -93,6 +104,9 @@ class PublicLeakedKeyReport(APIView):
                 "type": result.key_type,
                 "token_length": len(token),
                 "token_sha256": sha256(token.encode("utf-8")).hexdigest(),
+                # With no cross-region relay, this is the only signal showing whether
+                # callers in one region are reporting keys the other region issued.
+                "region": get_instance_region(),
             },
         )
 

--- a/posthog/api/secret_revocation.py
+++ b/posthog/api/secret_revocation.py
@@ -1,0 +1,115 @@
+from dataclasses import dataclass
+
+from posthog.api.personal_api_key import PersonalAPIKeySerializer
+from posthog.api.project_secret_api_key import roll_project_secret_api_key_and_notify
+from posthog.models.oauth import find_oauth_access_token, find_oauth_refresh_token, revoke_oauth_session
+from posthog.models.personal_api_key import find_personal_api_key
+from posthog.models.project_secret_api_key import find_project_secret_api_key
+from posthog.models.utils import (
+    OAUTH_ACCESS_TOKEN_PREFIX,
+    OAUTH_REFRESH_TOKEN_PREFIX,
+    PERSONAL_API_KEY_PREFIX,
+    SECRET_API_TOKEN_PREFIX,
+    mask_key_value,
+)
+from posthog.tasks.email import send_oauth_token_exposed, send_personal_api_key_exposed
+
+CANONICAL_PERSONAL_API_KEY = "personal_api_key"
+CANONICAL_PROJECT_SECRET_API_KEY = "project_secret_api_key"
+CANONICAL_OAUTH_ACCESS_TOKEN = "oauth_access_token"
+CANONICAL_OAUTH_REFRESH_TOKEN = "oauth_refresh_token"
+
+
+@dataclass(frozen=True, kw_only=True)
+class RevocationResult:
+    found: bool
+    key_type: str | None
+
+
+def _revoke_personal_api_key(token: str, more_info: str) -> bool:
+    key_lookup = find_personal_api_key(token)
+    if key_lookup is None:
+        return False
+    key, _ = key_lookup
+    old_mask_value = key.mask_value
+    serializer = PersonalAPIKeySerializer(instance=key)
+    serializer.roll(key)
+    send_personal_api_key_exposed(key.user.id, key.id, old_mask_value, more_info)
+    return True
+
+
+def _revoke_project_secret_api_key(token: str, more_info: str) -> bool:
+    project_secret_api_key = find_project_secret_api_key(token)
+    if project_secret_api_key is None:
+        return False
+    roll_project_secret_api_key_and_notify(project_secret_api_key, more_info)
+    return True
+
+
+def _revoke_oauth_access_token(token: str, more_info: str) -> bool:
+    access_token = find_oauth_access_token(token)
+    if access_token is None:
+        return False
+    user = access_token.user
+    revoke_oauth_session(access_token=access_token)
+    if user:
+        send_oauth_token_exposed(user.id, "access", mask_key_value(token), more_info)
+    return True
+
+
+def _revoke_oauth_refresh_token(token: str, more_info: str) -> bool:
+    refresh_token = find_oauth_refresh_token(token)
+    if refresh_token is None:
+        return False
+    user = refresh_token.user
+    revoke_oauth_session(refresh_token=refresh_token)
+    if user:
+        send_oauth_token_exposed(user.id, "refresh", mask_key_value(token), more_info)
+    return True
+
+
+_REVOKERS = {
+    CANONICAL_PERSONAL_API_KEY: _revoke_personal_api_key,
+    CANONICAL_PROJECT_SECRET_API_KEY: _revoke_project_secret_api_key,
+    CANONICAL_OAUTH_ACCESS_TOKEN: _revoke_oauth_access_token,
+    CANONICAL_OAUTH_REFRESH_TOKEN: _revoke_oauth_refresh_token,
+}
+
+# Every key type has a reserved prefix (posthog/models/utils.py) enforced at
+# generation time. Auto-detect uses it to run exactly one lookup instead of trying
+# every type in turn — a token matching no known prefix costs nothing beyond these
+# string comparisons, instead of paying for a personal-API-key lookup's SHA-256 +
+# two rounds of PBKDF2 (PERSONAL_API_KEY_MODES_TO_TRY) on every unrecognized string
+# an anonymous caller submits.
+#
+# Team-level secret tokens (Team.secret_api_token) share SECRET_API_TOKEN_PREFIX
+# with project secret API keys but are deliberately not in this map: unlike these
+# four, a match there can't be auto-rotated on the spot
+# (Team.rotate_secret_token_and_save needs a user to attribute the rotation to), so
+# github.py handles that case itself as a fallback rather than through this shared,
+# type-agnostic path.
+_PREFIX_TO_CANONICAL_TYPE = {
+    PERSONAL_API_KEY_PREFIX: CANONICAL_PERSONAL_API_KEY,
+    SECRET_API_TOKEN_PREFIX: CANONICAL_PROJECT_SECRET_API_KEY,
+    OAUTH_ACCESS_TOKEN_PREFIX: CANONICAL_OAUTH_ACCESS_TOKEN,
+    OAUTH_REFRESH_TOKEN_PREFIX: CANONICAL_OAUTH_REFRESH_TOKEN,
+}
+
+
+def _detect_canonical_type(token: str) -> str | None:
+    for prefix, canonical_type in _PREFIX_TO_CANONICAL_TYPE.items():
+        if token.startswith(prefix):
+            return canonical_type
+    return None
+
+
+def revoke_leaked_secret(token: str, key_type: str | None, more_info: str) -> RevocationResult:
+    """Look up `token` as a leaked credential and revoke+notify on a match.
+
+    If `key_type` is one of the CANONICAL_* constants, only that lookup runs.
+    If `key_type` is None, the token's prefix determines which single lookup runs.
+    """
+    resolved_type = key_type if key_type is not None else _detect_canonical_type(token)
+    if resolved_type is not None and _REVOKERS[resolved_type](token, more_info):
+        return RevocationResult(found=True, key_type=resolved_type)
+    return RevocationResult(found=False, key_type=None)

--- a/posthog/api/secret_revocation.py
+++ b/posthog/api/secret_revocation.py
@@ -54,7 +54,11 @@ def _revoke_project_secret_api_key(token: str, more_info: str) -> bool:
 def _revoke_oauth_token(token: str, more_info: str, *, kind: Literal["access", "refresh"]) -> bool:
     if kind == "access":
         access_token = find_oauth_access_token(token)
-        if access_token is None:
+        # An expired access token no longer authenticates, so possessing one doesn't
+        # give its holder the "already has full use of this credential" standing this
+        # endpoint's lack of a signature check relies on. Without this, anyone who once
+        # saw a since-expired token could still force-revoke the holder's live session.
+        if access_token is None or access_token.is_expired():
             return False
         revoke_oauth_session(access_token=access_token)
         user = access_token.user

--- a/posthog/api/secret_revocation.py
+++ b/posthog/api/secret_revocation.py
@@ -4,7 +4,7 @@ from typing import Literal
 from posthog.api.personal_api_key import PersonalAPIKeySerializer
 from posthog.api.project_secret_api_key import roll_project_secret_api_key_and_notify
 from posthog.dataclasses import frozen
-from posthog.models.oauth import find_oauth_access_token, find_oauth_refresh_token, revoke_oauth_session
+from posthog.models.oauth import find_oauth_access_token, find_oauth_refresh_token, revoke_oauth_token_session
 from posthog.models.personal_api_key import find_personal_api_key
 from posthog.models.project_secret_api_key import find_project_secret_api_key
 from posthog.models.utils import (
@@ -60,13 +60,16 @@ def _revoke_oauth_token(token: str, more_info: str, *, kind: Literal["access", "
         # saw a since-expired token could still force-revoke the holder's live session.
         if access_token is None or access_token.is_expired():
             return False
-        revoke_oauth_session(access_token=access_token)
+        # Scoped to this one access/refresh token pair, not every session the user has
+        # with the application - a leaked-token report is evidence about that one
+        # token, not the user's other sessions. See revoke_oauth_token_session.
+        revoke_oauth_token_session(access_token=access_token)
         user = access_token.user
     else:
         refresh_token = find_oauth_refresh_token(token)
         if refresh_token is None:
             return False
-        revoke_oauth_session(refresh_token=refresh_token)
+        revoke_oauth_token_session(refresh_token=refresh_token)
         user = refresh_token.user
     if user:
         send_oauth_token_exposed(user.id, kind, mask_key_value(token), more_info)

--- a/posthog/api/secret_revocation.py
+++ b/posthog/api/secret_revocation.py
@@ -1,8 +1,9 @@
 import re
-from dataclasses import dataclass
+from typing import Literal
 
 from posthog.api.personal_api_key import PersonalAPIKeySerializer
 from posthog.api.project_secret_api_key import roll_project_secret_api_key_and_notify
+from posthog.dataclasses import frozen
 from posthog.models.oauth import find_oauth_access_token, find_oauth_refresh_token, revoke_oauth_session
 from posthog.models.personal_api_key import find_personal_api_key
 from posthog.models.project_secret_api_key import find_project_secret_api_key
@@ -21,10 +22,13 @@ CANONICAL_OAUTH_ACCESS_TOKEN = "oauth_access_token"
 CANONICAL_OAUTH_REFRESH_TOKEN = "oauth_refresh_token"
 
 
-@dataclass(frozen=True, kw_only=True)
+@frozen
 class RevocationResult:
-    found: bool
     key_type: str | None
+
+    @property
+    def found(self) -> bool:
+        return self.key_type is not None
 
 
 def _revoke_personal_api_key(token: str, more_info: str) -> bool:
@@ -47,26 +51,30 @@ def _revoke_project_secret_api_key(token: str, more_info: str) -> bool:
     return True
 
 
-def _revoke_oauth_access_token(token: str, more_info: str) -> bool:
-    access_token = find_oauth_access_token(token)
-    if access_token is None:
-        return False
-    user = access_token.user
-    revoke_oauth_session(access_token=access_token)
+def _revoke_oauth_token(token: str, more_info: str, *, kind: Literal["access", "refresh"]) -> bool:
+    if kind == "access":
+        access_token = find_oauth_access_token(token)
+        if access_token is None:
+            return False
+        revoke_oauth_session(access_token=access_token)
+        user = access_token.user
+    else:
+        refresh_token = find_oauth_refresh_token(token)
+        if refresh_token is None:
+            return False
+        revoke_oauth_session(refresh_token=refresh_token)
+        user = refresh_token.user
     if user:
-        send_oauth_token_exposed(user.id, "access", mask_key_value(token), more_info)
+        send_oauth_token_exposed(user.id, kind, mask_key_value(token), more_info)
     return True
+
+
+def _revoke_oauth_access_token(token: str, more_info: str) -> bool:
+    return _revoke_oauth_token(token, more_info, kind="access")
 
 
 def _revoke_oauth_refresh_token(token: str, more_info: str) -> bool:
-    refresh_token = find_oauth_refresh_token(token)
-    if refresh_token is None:
-        return False
-    user = refresh_token.user
-    revoke_oauth_session(refresh_token=refresh_token)
-    if user:
-        send_oauth_token_exposed(user.id, "refresh", mask_key_value(token), more_info)
-    return True
+    return _revoke_oauth_token(token, more_info, kind="refresh")
 
 
 _REVOKERS = {
@@ -87,9 +95,11 @@ _REVOKERS = {
 # none, so the map alone would leave the fleet's oldest keys unrevocable.
 # _looks_like_legacy_personal_api_key covers them by shape instead. That widens what
 # reaches the personal-key lookup — any 43-character URL-safe string qualifies,
-# including legacy unprefixed Team.api_token values, which simply miss — but the bound
-# still holds, since an arbitrary string has to match that exact length and alphabet
-# to cost anything at all.
+# including legacy unprefixed Team.api_token values, which simply miss. That shape
+# check only narrows *which* strings pay the expensive lookup, not how many times a
+# caller can pay it: on the public endpoint, a caller can construct a matching string
+# on purpose, so per-request cost is still bounded only by LeakedKeyReportThrottle's
+# per-IP rate limit, not by this check.
 #
 # Team-level secret tokens (Team.secret_api_token) share SECRET_API_TOKEN_PREFIX
 # with project secret API keys but are deliberately not in this map: unlike these
@@ -103,6 +113,15 @@ _PREFIX_TO_CANONICAL_TYPE = {
     OAUTH_ACCESS_TOKEN_PREFIX: CANONICAL_OAUTH_ACCESS_TOKEN,
     OAUTH_REFRESH_TOKEN_PREFIX: CANONICAL_OAUTH_REFRESH_TOKEN,
 }
+
+# The non-personal-key prefixes above, re-exported so other prefix-based key-type checks
+# (e.g. the admin key-search view in posthog/views.py) can stay in sync with this map
+# instead of re-listing the same three prefixes by hand.
+NON_PERSONAL_SECRET_PREFIXES = (
+    SECRET_API_TOKEN_PREFIX,
+    OAUTH_ACCESS_TOKEN_PREFIX,
+    OAUTH_REFRESH_TOKEN_PREFIX,
+)
 
 
 _LEGACY_PERSONAL_API_KEY_PATTERN = re.compile(r"^[A-Za-z0-9_-]{43}$")
@@ -137,5 +156,5 @@ def revoke_leaked_secret(token: str, key_type: str | None, more_info: str) -> Re
     """
     resolved_type = key_type if key_type is not None else _detect_canonical_type(token)
     if resolved_type is not None and _REVOKERS[resolved_type](token, more_info):
-        return RevocationResult(found=True, key_type=resolved_type)
-    return RevocationResult(found=False, key_type=None)
+        return RevocationResult(key_type=resolved_type)
+    return RevocationResult(key_type=None)

--- a/posthog/api/secret_revocation.py
+++ b/posthog/api/secret_revocation.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import dataclass
 
 from posthog.api.personal_api_key import PersonalAPIKeySerializer
@@ -75,12 +76,20 @@ _REVOKERS = {
     CANONICAL_OAUTH_REFRESH_TOKEN: _revoke_oauth_refresh_token,
 }
 
-# Every key type has a reserved prefix (posthog/models/utils.py) enforced at
-# generation time. Auto-detect uses it to run exactly one lookup instead of trying
+# Every key type issued today has a reserved prefix (posthog/models/utils.py) enforced
+# at generation time. Auto-detect uses it to run exactly one lookup instead of trying
 # every type in turn — a token matching no known prefix costs nothing beyond these
 # string comparisons, instead of paying for a personal-API-key lookup's SHA-256 +
 # two rounds of PBKDF2 (PERSONAL_API_KEY_MODES_TO_TRY) on every unrecognized string
 # an anonymous caller submits.
+#
+# Personal API keys are the one exception: those issued before the prefix existed have
+# none, so the map alone would leave the fleet's oldest keys unrevocable.
+# _looks_like_legacy_personal_api_key covers them by shape instead. That widens what
+# reaches the personal-key lookup — any 43-character URL-safe string qualifies,
+# including legacy unprefixed Team.api_token values, which simply miss — but the bound
+# still holds, since an arbitrary string has to match that exact length and alphabet
+# to cost anything at all.
 #
 # Team-level secret tokens (Team.secret_api_token) share SECRET_API_TOKEN_PREFIX
 # with project secret API keys but are deliberately not in this map: unlike these
@@ -96,10 +105,27 @@ _PREFIX_TO_CANONICAL_TYPE = {
 }
 
 
+_LEGACY_PERSONAL_API_KEY_PATTERN = re.compile(r"^[A-Za-z0-9_-]{43}$")
+
+
+def _looks_like_legacy_personal_api_key(token: str) -> bool:
+    """Personal API keys created before the phx_ prefix (2021-06-23, commit
+    6c9bb2db0fb) are bare secrets.token_urlsafe(32) output: exactly 43 URL-safe
+    base64 characters, no prefix. They're still valid today — PERSONAL_API_KEY_MODES_TO_TRY
+    exists specifically to authenticate them via their legacy hash. This exact
+    length+charset check keeps auto-detect's cost bound intact: only a token
+    matching this precise shape reaches the expensive personal-key lookup,
+    not every unrecognized string.
+    """
+    return bool(_LEGACY_PERSONAL_API_KEY_PATTERN.match(token))
+
+
 def _detect_canonical_type(token: str) -> str | None:
     for prefix, canonical_type in _PREFIX_TO_CANONICAL_TYPE.items():
         if token.startswith(prefix):
             return canonical_type
+    if _looks_like_legacy_personal_api_key(token):
+        return CANONICAL_PERSONAL_API_KEY
     return None
 
 

--- a/posthog/api/test/test_github.py
+++ b/posthog/api/test/test_github.py
@@ -312,7 +312,7 @@ dYtHUlWNMx0y6YwVG8nlBiJk2e0n+zpzs2WwszrnC7wfCqgU6rU3TkDvBQ==
         self.assertIn("Github-Public-Key-Identifier", str(data))
 
     @patch("posthog.api.github.verify_github_signature")
-    @patch("posthog.api.github.send_personal_api_key_exposed")
+    @patch("posthog.api.secret_revocation.send_personal_api_key_exposed")
     def test_secret_alert_finds_and_rolls_existing_personal_api_key(self, mock_send_email, mock_verify):
         """Test that an existing personal API key is found, rolled, and email is sent."""
         mock_verify.return_value = None
@@ -390,7 +390,7 @@ dYtHUlWNMx0y6YwVG8nlBiJk2e0n+zpzs2WwszrnC7wfCqgU6rU3TkDvBQ==
         self.assertEqual(data[0]["label"], "false_positive")
 
     @patch("posthog.api.github.verify_github_signature")
-    @patch("posthog.api.github.send_personal_api_key_exposed")
+    @patch("posthog.api.secret_revocation.send_personal_api_key_exposed")
     def test_secret_alert_finds_key_with_legacy_pbkdf2_hash(self, mock_send_email, mock_verify):
         """Test that keys stored with legacy PBKDF2 hash are still found."""
         mock_verify.return_value = None
@@ -987,7 +987,7 @@ class TestOAuthTokenSecretAlert(APIBaseTest):
         )
 
     @patch("posthog.api.github.verify_github_signature")
-    @patch("posthog.api.github.send_oauth_token_exposed")
+    @patch("posthog.api.secret_revocation.send_oauth_token_exposed")
     def test_oauth_access_token_found_and_revoked(self, mock_send_email, mock_verify):
         mock_verify.return_value = None
 
@@ -1032,7 +1032,7 @@ class TestOAuthTokenSecretAlert(APIBaseTest):
         self.assertEqual(call_args[0][1], "access")
 
     @patch("posthog.api.github.verify_github_signature")
-    @patch("posthog.api.github.send_oauth_token_exposed")
+    @patch("posthog.api.secret_revocation.send_oauth_token_exposed")
     def test_oauth_refresh_token_found_and_revoked(self, mock_send_email, mock_verify):
         mock_verify.return_value = None
 
@@ -1125,7 +1125,7 @@ class TestOAuthTokenSecretAlert(APIBaseTest):
         self.assertEqual(data[0]["label"], "false_positive")
 
     @patch("posthog.api.github.verify_github_signature")
-    @patch("posthog.api.github.send_oauth_token_exposed")
+    @patch("posthog.api.secret_revocation.send_oauth_token_exposed")
     def test_oauth_access_token_revocation_also_revokes_related_artifacts(self, mock_send_email, mock_verify):
         mock_verify.return_value = None
 
@@ -1187,7 +1187,7 @@ class TestOAuthTokenSecretAlert(APIBaseTest):
         self.assertFalse(OAuthGrant.objects.filter(id=grant_id).exists())
 
     @patch("posthog.api.github.verify_github_signature")
-    @patch("posthog.api.github.send_oauth_token_exposed")
+    @patch("posthog.api.secret_revocation.send_oauth_token_exposed")
     def test_oauth_refresh_token_revocation_also_revokes_related_artifacts(self, mock_send_email, mock_verify):
         mock_verify.return_value = None
 
@@ -1283,7 +1283,7 @@ class TestOAuthTokenSecretAlert(APIBaseTest):
         self.assertEqual(data[0]["label"], "false_positive")
 
     @patch("posthog.api.github.verify_github_signature")
-    @patch("posthog.api.github.send_oauth_token_exposed")
+    @patch("posthog.api.secret_revocation.send_oauth_token_exposed")
     def test_initial_access_token_revokes_paired_refresh_token(self, mock_send_email, mock_verify):
         """Initial access token (no source_refresh_token) should still revoke paired refresh token."""
         mock_verify.return_value = None
@@ -1354,7 +1354,7 @@ class TestOAuthTokenSecretAlert(APIBaseTest):
         self.assertFalse(OAuthGrant.objects.filter(id=grant_id).exists())
 
     @patch("posthog.api.github.verify_github_signature")
-    @patch("posthog.api.github.send_oauth_token_exposed")
+    @patch("posthog.api.secret_revocation.send_oauth_token_exposed")
     def test_initial_refresh_token_revokes_paired_access_token(self, mock_send_email, mock_verify):
         """Initial refresh token should still revoke paired access token."""
         mock_verify.return_value = None

--- a/posthog/api/test/test_github.py
+++ b/posthog/api/test/test_github.py
@@ -1126,7 +1126,7 @@ class TestOAuthTokenSecretAlert(APIBaseTest):
 
     @patch("posthog.api.github.verify_github_signature")
     @patch("posthog.api.secret_revocation.send_oauth_token_exposed")
-    def test_oauth_access_token_revocation_also_revokes_related_artifacts(self, mock_send_email, mock_verify):
+    def test_oauth_access_token_revocation_revokes_paired_refresh_token_not_grant(self, mock_send_email, mock_verify):
         mock_verify.return_value = None
 
         oauth_app = self._create_oauth_app()
@@ -1184,11 +1184,14 @@ class TestOAuthTokenSecretAlert(APIBaseTest):
         refresh_token.refresh_from_db()
         self.assertIsNotNone(refresh_token.revoked)
 
-        self.assertFalse(OAuthGrant.objects.filter(id=grant_id).exists())
+        # A leaked-token report is evidence about this one token, not the user's other
+        # sessions or in-flight authorizations - revoke_oauth_token_session only revokes
+        # the paired access/refresh token, not other grants for the same user+app.
+        self.assertTrue(OAuthGrant.objects.filter(id=grant_id).exists())
 
     @patch("posthog.api.github.verify_github_signature")
     @patch("posthog.api.secret_revocation.send_oauth_token_exposed")
-    def test_oauth_refresh_token_revocation_also_revokes_related_artifacts(self, mock_send_email, mock_verify):
+    def test_oauth_refresh_token_revocation_revokes_paired_access_token_not_grant(self, mock_send_email, mock_verify):
         mock_verify.return_value = None
 
         oauth_app = self._create_oauth_app()
@@ -1246,7 +1249,9 @@ class TestOAuthTokenSecretAlert(APIBaseTest):
 
         self.assertFalse(OAuthAccessToken.objects.filter(id=access_token_id).exists())
 
-        self.assertFalse(OAuthGrant.objects.filter(id=grant_id).exists())
+        # See the access-token variant above: the narrow revocation doesn't sweep other
+        # grants for the same user+app.
+        self.assertTrue(OAuthGrant.objects.filter(id=grant_id).exists())
 
     @patch("posthog.api.github.verify_github_signature")
     def test_revoked_oauth_refresh_token_returns_false_positive(self, mock_verify):
@@ -1350,8 +1355,9 @@ class TestOAuthTokenSecretAlert(APIBaseTest):
         refresh_token.refresh_from_db()
         self.assertIsNotNone(refresh_token.revoked)
 
-        # Grant should be deleted
-        self.assertFalse(OAuthGrant.objects.filter(id=grant_id).exists())
+        # Grant is untouched - it's not part of this token's session (see
+        # revoke_oauth_token_session's docstring)
+        self.assertTrue(OAuthGrant.objects.filter(id=grant_id).exists())
 
     @patch("posthog.api.github.verify_github_signature")
     @patch("posthog.api.secret_revocation.send_oauth_token_exposed")
@@ -1421,5 +1427,5 @@ class TestOAuthTokenSecretAlert(APIBaseTest):
         refresh_token.refresh_from_db()
         self.assertIsNotNone(refresh_token.revoked)
 
-        # Grant should be deleted
-        self.assertFalse(OAuthGrant.objects.filter(id=grant_id).exists())
+        # Grant is untouched - see the access-token variant above.
+        self.assertTrue(OAuthGrant.objects.filter(id=grant_id).exists())

--- a/posthog/api/test/test_leaked_key.py
+++ b/posthog/api/test/test_leaked_key.py
@@ -1,0 +1,153 @@
+import json
+from datetime import timedelta
+
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from django.utils import timezone
+
+from parameterized import parameterized
+from rest_framework import status
+
+from posthog.api.secret_revocation import (
+    CANONICAL_OAUTH_ACCESS_TOKEN,
+    CANONICAL_OAUTH_REFRESH_TOKEN,
+    CANONICAL_PERSONAL_API_KEY,
+    CANONICAL_PROJECT_SECRET_API_KEY,
+)
+from posthog.models import PersonalAPIKey
+from posthog.models.oauth import (
+    OAuthAccessToken,
+    OAuthApplication,
+    OAuthRefreshToken,
+    find_oauth_access_token,
+    find_oauth_refresh_token,
+)
+from posthog.models.personal_api_key import find_personal_api_key
+from posthog.models.project_secret_api_key import find_project_secret_api_key
+from posthog.models.utils import generate_random_token_personal, hash_key_value, mask_key_value
+from posthog.test.api_keys import create_project_secret_api_key
+
+
+class TestPublicLeakedKeyReport(APIBaseTest):
+    def _create_oauth_app(self) -> OAuthApplication:
+        return OAuthApplication.objects.create(
+            name="Test OAuth App",
+            client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="https://example.com/callback",
+            algorithm="RS256",
+            skip_authorization=False,
+            organization=self.organization,
+            user=self.user,
+        )
+
+    def _post(self, token: str):
+        return self.client.post(
+            "/api/alerts/leaked_key",
+            data=json.dumps({"token": token}),
+            content_type="application/json",
+        )
+
+    @parameterized.expand(
+        [
+            ("personal_api_key", CANONICAL_PERSONAL_API_KEY),
+            ("project_secret_api_key", CANONICAL_PROJECT_SECRET_API_KEY),
+            ("oauth_access_token", CANONICAL_OAUTH_ACCESS_TOKEN),
+            ("oauth_refresh_token", CANONICAL_OAUTH_REFRESH_TOKEN),
+        ]
+    )
+    @patch("posthog.api.project_secret_api_key.send_project_secret_api_key_exposed")
+    @patch("posthog.api.secret_revocation.send_oauth_token_exposed")
+    @patch("posthog.api.secret_revocation.send_personal_api_key_exposed")
+    def test_auto_detects_and_revokes_each_key_type(
+        self,
+        kind: str,
+        expected_type: str,
+        mock_send_personal_api_key_exposed,
+        mock_send_oauth_token_exposed,
+        mock_send_project_secret_api_key_exposed,
+    ) -> None:
+        if kind == "personal_api_key":
+            token = generate_random_token_personal()
+            PersonalAPIKey.objects.create(
+                user=self.user,
+                label="leaked",
+                secure_value=hash_key_value(token),
+                mask_value=mask_key_value(token),
+                scopes=["*"],
+            )
+
+            def still_present() -> bool:
+                return find_personal_api_key(token) is not None
+        elif kind == "project_secret_api_key":
+            _, token = create_project_secret_api_key(team=self.team, created_by=self.user)
+
+            def still_present() -> bool:
+                return find_project_secret_api_key(token) is not None
+        elif kind == "oauth_access_token":
+            oauth_app = self._create_oauth_app()
+            token = "pha_test_leaked_access_token"
+            OAuthAccessToken.objects.create(
+                user=self.user,
+                application=oauth_app,
+                token=token,
+                expires=timezone.now() + timedelta(hours=1),
+                scope="openid profile",
+            )
+
+            def still_present() -> bool:
+                return find_oauth_access_token(token) is not None
+        else:
+            oauth_app = self._create_oauth_app()
+            token = "phr_test_leaked_refresh_token"
+            OAuthRefreshToken.objects.create(user=self.user, application=oauth_app, token=token)
+
+            def still_present() -> bool:
+                return find_oauth_refresh_token(token) is not None
+
+        response = self._post(token)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"found": True, "type": expected_type})
+        self.assertFalse(still_present())
+
+    @parameterized.expand(
+        [
+            # Recognized prefix, but no such key exists — exercises the one lookup
+            # that runs and misses.
+            ("known_prefix_but_key_does_not_exist", "phx_this_is_not_a_real_key"),
+            # No PostHog key prefix at all — exercises _detect_canonical_type
+            # returning None and skipping every lookup entirely.
+            ("no_recognized_prefix_at_all", "not-a-posthog-key-at-all"),
+        ]
+    )
+    def test_unrecognized_token_is_not_found(self, _name: str, token: str) -> None:
+        response = self._post(token)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"found": False, "type": None})
+
+    def test_team_secret_token_is_not_auto_detected(self) -> None:
+        # Team.secret_api_token shares the "phs_" prefix with project secret API
+        # keys, but it's a different model (Team, not ProjectSecretAPIKey), so the
+        # single lookup the "phs_" prefix triggers (find_project_secret_api_key)
+        # naturally misses — it's intentionally excluded from auto-detect (see
+        # _PREFIX_TO_CANONICAL_TYPE in secret_revocation.py) since it can't be
+        # auto-rotated without a user to attribute the rotation to.
+        token = "phs_legacy_team_secret_token_for_public_endpoint_test"
+        self.team.secret_api_token = token
+        self.team.save()
+
+        response = self._post(token)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"found": False, "type": None})
+
+        self.team.refresh_from_db()
+        self.assertEqual(self.team.secret_api_token, token)
+
+    def test_blank_token_returns_400(self) -> None:
+        response = self._post("")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/posthog/api/test/test_leaked_key.py
+++ b/posthog/api/test/test_leaked_key.py
@@ -1,9 +1,10 @@
 import json
 import secrets
 from datetime import timedelta
+from typing import Any
 
 from posthog.test.base import APIBaseTest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.utils import timezone
 
@@ -50,7 +51,7 @@ class TestPublicLeakedKeyReport(APIBaseTest):
             user=self.user,
         )
 
-    def _post(self, token: str):
+    def _post(self, token: str) -> Any:
         return self.client.post(
             "/api/revoke_leaked_key",
             data=json.dumps({"token": token}),
@@ -73,9 +74,9 @@ class TestPublicLeakedKeyReport(APIBaseTest):
         self,
         kind: str,
         expected_type: str,
-        mock_send_personal_api_key_exposed,
-        mock_send_oauth_token_exposed,
-        mock_send_project_secret_api_key_exposed,
+        mock_send_personal_api_key_exposed: MagicMock,
+        mock_send_oauth_token_exposed: MagicMock,
+        mock_send_project_secret_api_key_exposed: MagicMock,
     ) -> None:
         if kind == "personal_api_key":
             token = generate_random_token_personal()

--- a/posthog/api/test/test_leaked_key.py
+++ b/posthog/api/test/test_leaked_key.py
@@ -231,6 +231,48 @@ class TestPublicLeakedKeyReport(APIBaseTest):
         live_refresh_token.refresh_from_db()
         self.assertIsNone(live_refresh_token.revoked)
 
+    def test_oauth_access_token_revocation_does_not_touch_other_sessions_with_same_app(self) -> None:
+        # A leaked token is evidence about that one token, not the user's other sessions
+        # with the same app (e.g. the same app authorized from a second device) - a
+        # report about one session must not revoke another.
+        oauth_app = self._create_oauth_app()
+
+        leaked_refresh_token = OAuthRefreshToken.objects.create(
+            user=self.user, application=oauth_app, token="phr_leaked_session_refresh"
+        )
+        leaked_access_token = OAuthAccessToken.objects.create(
+            user=self.user,
+            application=oauth_app,
+            token="pha_leaked_session_access",
+            expires=timezone.now() + timedelta(hours=1),
+            scope="openid profile",
+            source_refresh_token=leaked_refresh_token,
+        )
+
+        other_refresh_token = OAuthRefreshToken.objects.create(
+            user=self.user, application=oauth_app, token="phr_other_session_refresh"
+        )
+        other_access_token = OAuthAccessToken.objects.create(
+            user=self.user,
+            application=oauth_app,
+            token="pha_other_session_access",
+            expires=timezone.now() + timedelta(hours=1),
+            scope="openid profile",
+            source_refresh_token=other_refresh_token,
+        )
+
+        response = self._post("pha_leaked_session_access")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"found": True, "type": CANONICAL_OAUTH_ACCESS_TOKEN})
+        self.assertFalse(OAuthAccessToken.objects.filter(id=leaked_access_token.id).exists())
+        leaked_refresh_token.refresh_from_db()
+        self.assertIsNotNone(leaked_refresh_token.revoked)
+
+        self.assertTrue(OAuthAccessToken.objects.filter(id=other_access_token.id).exists())
+        other_refresh_token.refresh_from_db()
+        self.assertIsNone(other_refresh_token.revoked)
+
     def test_blank_token_returns_400(self) -> None:
         response = self._post("")
 

--- a/posthog/api/test/test_leaked_key.py
+++ b/posthog/api/test/test_leaked_key.py
@@ -1,4 +1,5 @@
 import json
+import secrets
 from datetime import timedelta
 
 from posthog.test.base import APIBaseTest
@@ -9,6 +10,7 @@ from django.utils import timezone
 from parameterized import parameterized
 from rest_framework import status
 
+from posthog.api.leaked_key import PUBLIC_REPORT_MORE_INFO
 from posthog.api.secret_revocation import (
     CANONICAL_OAUTH_ACCESS_TOKEN,
     CANONICAL_OAUTH_REFRESH_TOKEN,
@@ -23,9 +25,10 @@ from posthog.models.oauth import (
     find_oauth_access_token,
     find_oauth_refresh_token,
 )
-from posthog.models.personal_api_key import find_personal_api_key
+from posthog.models.personal_api_key import LEGACY_PERSONAL_API_KEY_SALT, find_personal_api_key
 from posthog.models.project_secret_api_key import find_project_secret_api_key
 from posthog.models.utils import generate_random_token_personal, hash_key_value, mask_key_value
+from posthog.rate_limit import LeakedKeyReportThrottle
 from posthog.test.api_keys import create_project_secret_api_key
 
 
@@ -49,7 +52,7 @@ class TestPublicLeakedKeyReport(APIBaseTest):
 
     def _post(self, token: str):
         return self.client.post(
-            "/api/alerts/leaked_key",
+            "/api/revoke_leaked_key",
             data=json.dumps({"token": token}),
             content_type="application/json",
         )
@@ -57,6 +60,7 @@ class TestPublicLeakedKeyReport(APIBaseTest):
     @parameterized.expand(
         [
             ("personal_api_key", CANONICAL_PERSONAL_API_KEY),
+            ("legacy_personal_api_key", CANONICAL_PERSONAL_API_KEY),
             ("project_secret_api_key", CANONICAL_PROJECT_SECRET_API_KEY),
             ("oauth_access_token", CANONICAL_OAUTH_ACCESS_TOKEN),
             ("oauth_refresh_token", CANONICAL_OAUTH_REFRESH_TOKEN),
@@ -75,7 +79,7 @@ class TestPublicLeakedKeyReport(APIBaseTest):
     ) -> None:
         if kind == "personal_api_key":
             token = generate_random_token_personal()
-            PersonalAPIKey.objects.create(
+            key = PersonalAPIKey.objects.create(
                 user=self.user,
                 label="leaked",
                 secure_value=hash_key_value(token),
@@ -85,11 +89,43 @@ class TestPublicLeakedKeyReport(APIBaseTest):
 
             def still_present() -> bool:
                 return find_personal_api_key(token) is not None
+
+            def assert_owner_notified() -> None:
+                mock_send_personal_api_key_exposed.assert_called_once_with(
+                    self.user.id, key.id, mask_key_value(token), PUBLIC_REPORT_MORE_INFO
+                )
+        elif kind == "legacy_personal_api_key":
+            # Keys issued before the phx_ prefix are bare secrets.token_urlsafe(32) output
+            # stored under the legacy PBKDF2 hash. They still authenticate, so they must
+            # still be revocable here.
+            token = secrets.token_urlsafe(32)
+            key = PersonalAPIKey.objects.create(
+                user=self.user,
+                label="leaked legacy",
+                secure_value=hash_key_value(
+                    token, mode="pbkdf2", legacy_salt=LEGACY_PERSONAL_API_KEY_SALT, iterations=260000
+                ),
+                mask_value=mask_key_value(token),
+                scopes=["*"],
+            )
+
+            def still_present() -> bool:
+                return find_personal_api_key(token) is not None
+
+            def assert_owner_notified() -> None:
+                mock_send_personal_api_key_exposed.assert_called_once_with(
+                    self.user.id, key.id, mask_key_value(token), PUBLIC_REPORT_MORE_INFO
+                )
         elif kind == "project_secret_api_key":
-            _, token = create_project_secret_api_key(team=self.team, created_by=self.user)
+            project_secret_api_key, token = create_project_secret_api_key(team=self.team, created_by=self.user)
 
             def still_present() -> bool:
                 return find_project_secret_api_key(token) is not None
+
+            def assert_owner_notified() -> None:
+                mock_send_project_secret_api_key_exposed.assert_called_once_with(
+                    self.team.id, project_secret_api_key.id, mask_key_value(token), PUBLIC_REPORT_MORE_INFO
+                )
         elif kind == "oauth_access_token":
             oauth_app = self._create_oauth_app()
             token = "pha_test_leaked_access_token"
@@ -103,6 +139,11 @@ class TestPublicLeakedKeyReport(APIBaseTest):
 
             def still_present() -> bool:
                 return find_oauth_access_token(token) is not None
+
+            def assert_owner_notified() -> None:
+                mock_send_oauth_token_exposed.assert_called_once_with(
+                    self.user.id, "access", mask_key_value(token), PUBLIC_REPORT_MORE_INFO
+                )
         else:
             oauth_app = self._create_oauth_app()
             token = "phr_test_leaked_refresh_token"
@@ -111,11 +152,17 @@ class TestPublicLeakedKeyReport(APIBaseTest):
             def still_present() -> bool:
                 return find_oauth_refresh_token(token) is not None
 
+            def assert_owner_notified() -> None:
+                mock_send_oauth_token_exposed.assert_called_once_with(
+                    self.user.id, "refresh", mask_key_value(token), PUBLIC_REPORT_MORE_INFO
+                )
+
         response = self._post(token)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), {"found": True, "type": expected_type})
         self.assertFalse(still_present())
+        assert_owner_notified()
 
     @parameterized.expand(
         [
@@ -125,6 +172,10 @@ class TestPublicLeakedKeyReport(APIBaseTest):
             # No PostHog key prefix at all — exercises _detect_canonical_type
             # returning None and skipping every lookup entirely.
             ("no_recognized_prefix_at_all", "not-a-posthog-key-at-all"),
+            # Matches the legacy unprefixed personal-key shape (43 URL-safe chars), so the
+            # personal-key lookup runs and misses. Guards the shape fallback against
+            # false positives.
+            ("legacy_shape_but_not_a_real_key", "x" * 43),
         ]
     )
     def test_unrecognized_token_is_not_found(self, _name: str, token: str) -> None:
@@ -156,3 +207,11 @@ class TestPublicLeakedKeyReport(APIBaseTest):
         response = self._post("")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_repeated_reports_from_one_ip_are_throttled(self) -> None:
+        with patch.object(LeakedKeyReportThrottle, "rate", "1/minute"):
+            first = self._post("phx_not_a_real_key")
+            second = self._post("phx_not_a_real_key")
+
+        self.assertEqual(first.status_code, status.HTTP_200_OK)
+        self.assertEqual(second.status_code, status.HTTP_429_TOO_MANY_REQUESTS)

--- a/posthog/api/test/test_leaked_key.py
+++ b/posthog/api/test/test_leaked_key.py
@@ -30,6 +30,11 @@ from posthog.test.api_keys import create_project_secret_api_key
 
 
 class TestPublicLeakedKeyReport(APIBaseTest):
+    # Every case must exercise the anonymous path this endpoint exists to serve. With the
+    # default force-login, dropping `authentication_classes`/`permission_classes` from the
+    # view would fall back to DRF's authenticated-only defaults and no test would notice.
+    CONFIG_AUTO_LOGIN = False
+
     def _create_oauth_app(self) -> OAuthApplication:
         return OAuthApplication.objects.create(
             name="Test OAuth App",

--- a/posthog/api/test/test_leaked_key.py
+++ b/posthog/api/test/test_leaked_key.py
@@ -204,6 +204,33 @@ class TestPublicLeakedKeyReport(APIBaseTest):
         self.team.refresh_from_db()
         self.assertEqual(self.team.secret_api_token, token)
 
+    def test_expired_oauth_access_token_does_not_revoke_the_live_session(self) -> None:
+        # An expired access token authenticates nothing, so possessing one grants no
+        # capability beyond what the endpoint's "possession = already usable" argument
+        # relies on. It must not be able to force-revoke a session its holder can no
+        # longer use.
+        oauth_app = self._create_oauth_app()
+        expired_token = "pha_expired_leaked_access_token"
+        OAuthAccessToken.objects.create(
+            user=self.user,
+            application=oauth_app,
+            token=expired_token,
+            expires=timezone.now() - timedelta(hours=1),
+            scope="openid profile",
+        )
+        live_refresh_token = OAuthRefreshToken.objects.create(
+            user=self.user,
+            application=oauth_app,
+            token="phr_live_session_refresh_token",
+        )
+
+        response = self._post(expired_token)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"found": False, "type": None})
+        live_refresh_token.refresh_from_db()
+        self.assertIsNone(live_refresh_token.revoked)
+
     def test_blank_token_returns_400(self) -> None:
         response = self._post("")
 

--- a/posthog/api/test/test_leaked_key.py
+++ b/posthog/api/test/test_leaked_key.py
@@ -273,6 +273,50 @@ class TestPublicLeakedKeyReport(APIBaseTest):
         other_refresh_token.refresh_from_db()
         self.assertIsNone(other_refresh_token.revoked)
 
+    def test_leaked_non_rotating_refresh_token_revokes_every_derived_access_token(self) -> None:
+        # DCR/CIMD clients get non-rotating refreshes: every refresh inserts a new access
+        # token row with no link back to the refresh token that minted it, instead of
+        # updating one row in place. Reporting the refresh token must still catch every
+        # access token it could have produced, not just whichever one (if any) happens to
+        # still be linked.
+        dcr_app = OAuthApplication.objects.create(
+            name="Test DCR App",
+            client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="https://example.com/callback",
+            algorithm="RS256",
+            skip_authorization=False,
+            organization=self.organization,
+            user=self.user,
+            is_dcr_client=True,
+        )
+        leaked_refresh_token = OAuthRefreshToken.objects.create(
+            user=self.user, application=dcr_app, token="phr_dcr_refresh_token"
+        )
+        first_access_token = OAuthAccessToken.objects.create(
+            user=self.user,
+            application=dcr_app,
+            token="pha_dcr_access_token_1",
+            expires=timezone.now() + timedelta(hours=1),
+            scope="openid profile",
+        )
+        second_access_token = OAuthAccessToken.objects.create(
+            user=self.user,
+            application=dcr_app,
+            token="pha_dcr_access_token_2",
+            expires=timezone.now() + timedelta(hours=1),
+            scope="openid profile",
+        )
+
+        response = self._post("phr_dcr_refresh_token")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"found": True, "type": CANONICAL_OAUTH_REFRESH_TOKEN})
+        leaked_refresh_token.refresh_from_db()
+        self.assertIsNotNone(leaked_refresh_token.revoked)
+        self.assertFalse(OAuthAccessToken.objects.filter(id=first_access_token.id).exists())
+        self.assertFalse(OAuthAccessToken.objects.filter(id=second_access_token.id).exists())
+
     def test_blank_token_returns_400(self) -> None:
         response = self._post("")
 

--- a/posthog/models/oauth.py
+++ b/posthog/models/oauth.py
@@ -697,6 +697,21 @@ def revoke_oauth_session(
         OAuthGrant.objects.filter(user=user, application=application).delete()
 
 
+def _refresh_token_may_have_untracked_access_tokens(refresh_token: OAuthRefreshToken) -> bool:
+    """True for a non-rotating refresh token (DCR/CIMD clients - see
+    OAuthTokenView._save_bearer_token in posthog/api/oauth/views.py), which inserts a new,
+    unlinked OAuthAccessToken row on every refresh instead of updating one access token in
+    place. Those rows carry no queryable link back to the refresh token that minted them
+    (source_refresh_token is left None specifically so sibling rows stay addressable), so
+    there's no way to enumerate every access token a given non-rotating refresh token could
+    have produced.
+    """
+    application = refresh_token.application
+    if application.is_dcr_client or application.is_cimd_client:
+        return True
+    return not oauth2_settings.ROTATE_REFRESH_TOKEN
+
+
 def revoke_oauth_token_session(
     access_token: OAuthAccessToken | None = None, refresh_token: OAuthRefreshToken | None = None
 ) -> None:
@@ -727,6 +742,14 @@ def revoke_oauth_token_session(
         ).update(revoked=now)
         access_token.delete()
     elif refresh_token:
+        if _refresh_token_may_have_untracked_access_tokens(refresh_token):
+            # A leaked non-rotating refresh token can have minted any number of access
+            # tokens with no durable link back to it (see
+            # _refresh_token_may_have_untracked_access_tokens), so a per-token revoke can't
+            # guarantee all of them are caught. Fall back to the same (user, application)
+            # sweep revoke_token already uses for this exact case via RFC 7009.
+            revoke_oauth_session(refresh_token=refresh_token)
+            return
         OAuthAccessToken.objects.filter(
             Q(pk=refresh_token.access_token_id) | Q(source_refresh_token=refresh_token)
         ).delete()

--- a/posthog/models/oauth.py
+++ b/posthog/models/oauth.py
@@ -655,7 +655,15 @@ def find_oauth_refresh_token(token: str) -> OAuthRefreshToken | None:
 def revoke_oauth_session(
     access_token: OAuthAccessToken | None = None, refresh_token: OAuthRefreshToken | None = None
 ) -> None:
-    """Revoke all OAuth artifacts related to a session (access token, refresh token, and grant)."""
+    """Revoke all OAuth artifacts for the token's (user, application) pair - every access
+    token, every refresh token, and every grant, not just the given one.
+
+    Use this where the user or client explicitly asked to disconnect the whole app
+    (connected_apps.py, RFC 7009 revoke_token) - there, sweeping every session for that
+    (user, application) is the correct, intentional scope. For a report that ONE specific
+    credential leaked, use revoke_oauth_token_session instead: a leaked token is evidence
+    about that one token, not about the user's other sessions with the app.
+    """
     from django.utils import timezone
 
     now = timezone.now()
@@ -687,6 +695,43 @@ def revoke_oauth_session(
 
         # Delete all grants for this user+application
         OAuthGrant.objects.filter(user=user, application=application).delete()
+
+
+def revoke_oauth_token_session(
+    access_token: OAuthAccessToken | None = None, refresh_token: OAuthRefreshToken | None = None
+) -> None:
+    """Revoke only the one access/refresh token pair the given token belongs to, not
+    every session the user has with the application.
+
+    Use this for a report that identifies ONE specific leaked credential (github.py, the
+    public leaked-key endpoint) - see revoke_oauth_session for where the broader sweep is
+    the correct, intentional scope instead.
+
+    Doesn't touch OAuthGrant: a grant is a single-use authorization code consumed at
+    token exchange, not part of an ongoing session, so there's no "this token's grant" to
+    revoke alongside it.
+    """
+    from django.utils import timezone
+
+    now = timezone.now()
+
+    if access_token:
+        # Neither direction of the access_token <-> refresh_token OneToOne is reliably
+        # populated on its own (our non-rotating _save_bearer_token branch leaves
+        # source_refresh_token None - see revoke_token's docstring in
+        # posthog/api/oauth/views.py - and callers that create a refresh token before
+        # its access token don't always back-fill refresh_token.access_token either), so
+        # check both directions instead of trusting one.
+        OAuthRefreshToken.objects.filter(
+            Q(access_token=access_token) | Q(pk=access_token.source_refresh_token_id), revoked__isnull=True
+        ).update(revoked=now)
+        access_token.delete()
+    elif refresh_token:
+        OAuthAccessToken.objects.filter(
+            Q(pk=refresh_token.access_token_id) | Q(source_refresh_token=refresh_token)
+        ).delete()
+        refresh_token.revoked = now
+        refresh_token.save(update_fields=["revoked"])
 
 
 def revoke_application_sessions(application: "OAuthApplication") -> None:

--- a/posthog/models/test/test_oauth.py
+++ b/posthog/models/test/test_oauth.py
@@ -553,6 +553,47 @@ class TestOAuthModels(TestCase):
         self.assertTrue(OAuthAccessToken.objects.filter(id=other_access_token.id).exists())
         self.assertTrue(OAuthGrant.objects.filter(id=grant.id).exists())
 
+    def test_revoke_oauth_token_session_sweeps_all_access_tokens_for_non_rotating_refresh(self):
+        # DCR/CIMD clients get non-rotating refreshes: _save_bearer_token inserts a new,
+        # unlinked OAuthAccessToken row per refresh instead of updating one in place, so
+        # source_refresh_token stays None on every one of them and there's no queryable
+        # link back to the refresh token that minted them. A per-token revoke can't find
+        # tokens it has no link to, so this must fall back to the full sweep instead.
+        app = OAuthApplication.objects.create(
+            name="DCR Non-Rotating Test App",
+            client_id="dcr_non_rotating_client_id",
+            client_secret="dcr_non_rotating_client_secret",
+            client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="https://example.com/callback",
+            organization=self.organization,
+            algorithm="RS256",
+            is_dcr_client=True,
+        )
+        refresh_token = OAuthRefreshToken.objects.create(application=app, user=self.user, token="dcr_refresh_1")
+        first_access_token = OAuthAccessToken.objects.create(
+            application=app, user=self.user, token="dcr_access_1", expires=timezone.now() + timedelta(minutes=5)
+        )
+        second_access_token = OAuthAccessToken.objects.create(
+            application=app, user=self.user, token="dcr_access_2", expires=timezone.now() + timedelta(minutes=5)
+        )
+        grant = OAuthGrant.objects.create(
+            application=app,
+            user=self.user,
+            code="dcr_grant_code",
+            code_challenge="challenge",
+            code_challenge_method="S256",
+            expires=timezone.now() + timedelta(minutes=5),
+        )
+
+        revoke_oauth_token_session(refresh_token=refresh_token)
+
+        self.assertFalse(OAuthAccessToken.objects.filter(id=first_access_token.id).exists())
+        self.assertFalse(OAuthAccessToken.objects.filter(id=second_access_token.id).exists())
+        self.assertFalse(OAuthGrant.objects.filter(id=grant.id).exists())
+        refresh_token.refresh_from_db()
+        self.assertIsNotNone(refresh_token.revoked)
+
     @freeze_time("2026-01-01 00:00:00")
     def test_revoke_application_sessions_revokes_across_all_users_and_leaves_other_apps(self):
         app = self._make_app("Narrowed App", "narrowed_client_id")

--- a/posthog/models/test/test_oauth.py
+++ b/posthog/models/test/test_oauth.py
@@ -19,6 +19,7 @@ from posthog.models.oauth import (
     normalize_cimd_url,
     revoke_application_sessions,
     revoke_oauth_session,
+    revoke_oauth_token_session,
 )
 from posthog.models.oauth_provisioning import ProvisioningConfig
 
@@ -507,6 +508,50 @@ class TestOAuthModels(TestCase):
         revoke_oauth_session(access_token=access_token)
 
         self.assertFalse(OAuthAccessToken.objects.filter(id=token_id).exists())
+
+    def test_revoke_oauth_token_session_revokes_only_the_paired_tokens(self):
+        app = OAuthApplication.objects.create(
+            name="Narrow Revoke Test App",
+            client_id="narrow_revoke_test_client_id",
+            client_secret="narrow_revoke_test_client_secret",
+            client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="https://example.com/callback",
+            organization=self.organization,
+            algorithm="RS256",
+        )
+        refresh_token = OAuthRefreshToken.objects.create(application=app, user=self.user, token="narrow_refresh_1")
+        access_token = OAuthAccessToken.objects.create(
+            application=app,
+            user=self.user,
+            token="narrow_access_1",
+            expires=timezone.now() + timedelta(minutes=5),
+            source_refresh_token=refresh_token,
+        )
+        # A second, unrelated session for the same user+application - must survive.
+        other_access_token = OAuthAccessToken.objects.create(
+            application=app,
+            user=self.user,
+            token="narrow_access_2",
+            expires=timezone.now() + timedelta(minutes=5),
+        )
+        grant = OAuthGrant.objects.create(
+            application=app,
+            user=self.user,
+            code="narrow_grant_code",
+            code_challenge="challenge",
+            code_challenge_method="S256",
+            expires=timezone.now() + timedelta(minutes=5),
+        )
+
+        revoke_oauth_token_session(access_token=access_token)
+
+        self.assertFalse(OAuthAccessToken.objects.filter(id=access_token.id).exists())
+        refresh_token.refresh_from_db()
+        self.assertIsNotNone(refresh_token.revoked)
+
+        self.assertTrue(OAuthAccessToken.objects.filter(id=other_access_token.id).exists())
+        self.assertTrue(OAuthGrant.objects.filter(id=grant.id).exists())
 
     @freeze_time("2026-01-01 00:00:00")
     def test_revoke_application_sessions_revokes_across_all_users_and_leaves_other_apps(self):

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -346,6 +346,19 @@ class WebAuthnSignupRegistrationThrottle(IPThrottle):
     rate = "10/minute"
 
 
+class LeakedKeyReportThrottle(IPThrottle):
+    """
+    Rate limit the public leaked-key revocation endpoint by IP address.
+
+    This isn't an authorization gate — guessing a valid high-entropy PostHog token
+    is computationally infeasible regardless of rate. It just bounds nuisance load
+    (hashing + DB lookups against garbage strings) from a single IP.
+    """
+
+    scope = "leaked_key_report"
+    rate = "10/minute"
+
+
 class SignupEmailPrecheckThrottle(IPThrottle):
     """
     Rate limit signup email precheck requests by IP.

--- a/posthog/test/test_rate_limit.py
+++ b/posthog/test/test_rate_limit.py
@@ -893,6 +893,29 @@ class TestAIObservabilitySummarizationRateThrottle(SimpleTestCase):
             self.assertFalse(throttle_class().allow_request(request, view))
 
 
+class TestLeakedKeyReportThrottle(SimpleTestCase):
+    def setUp(self) -> None:
+        cache.clear()
+
+    def tearDown(self) -> None:
+        cache.clear()
+
+    def test_scope_and_rate(self) -> None:
+        throttle = rate_limit.LeakedKeyReportThrottle()
+        self.assertEqual(throttle.scope, "leaked_key_report")
+        self.assertEqual(throttle.rate, "10/minute")
+
+    def test_limits_requests_per_ip(self) -> None:
+        request = Mock(headers={}, META={"REMOTE_ADDR": "203.0.113.5"})
+        other_request = Mock(headers={}, META={"REMOTE_ADDR": "203.0.113.6"})
+        view = Mock()
+
+        with patch.object(rate_limit.LeakedKeyReportThrottle, "rate", "1/minute"):
+            self.assertTrue(rate_limit.LeakedKeyReportThrottle().allow_request(request, view))
+            self.assertFalse(rate_limit.LeakedKeyReportThrottle().allow_request(request, view))
+            self.assertTrue(rate_limit.LeakedKeyReportThrottle().allow_request(other_request, view))
+
+
 class _PSAKTeamThrottleForTest(rate_limit.ProjectSecretApiKeyTeamRateThrottle):
     scope = "test_psak_team"
     rate = "100/minute"

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -20,6 +20,7 @@ from posthog.api import (
     api_not_found,
     authentication,
     github,
+    leaked_key,
     playwright_setup,
     report,
     router,
@@ -476,6 +477,7 @@ urlpatterns = [
     # api
     path("api/unsubscribe", unsubscribe.unsubscribe),
     path("api/alerts/github", github.SecretAlert.as_view()),
+    opt_slash_path("api/revoke_leaked_key", leaked_key.PublicLeakedKeyReport.as_view()),
     path(
         "api/legal_documents/pandadoc",
         csrf_exempt(legal_document_pandadoc_webhook),

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -26,6 +26,7 @@ import structlog
 from opentelemetry import trace
 
 from posthog.api.capture import capture_internal
+from posthog.api.secret_revocation import NON_PERSONAL_SECRET_PREFIXES
 from posthog.auth import AUTH_BRAND_COOKIE, apply_auth_brand_cookie, normalize_auth_brand
 from posthog.cloud_utils import is_cloud
 from posthog.email import is_email_available
@@ -467,12 +468,7 @@ def api_key_search_view(request: HttpRequest):
     personal_api_key_hash_mode = None
     # Legacy personal API keys predate the phx_ prefix, so any query without another known
     # prefix is also treated as a personal key candidate (matching authentication behavior).
-    non_personal_api_key_prefixes = (
-        SECRET_API_TOKEN_PREFIX,
-        OAUTH_ACCESS_TOKEN_PREFIX,
-        OAUTH_REFRESH_TOKEN_PREFIX,
-        PROJECT_API_TOKEN_PREFIX,
-    )
+    non_personal_api_key_prefixes = (*NON_PERSONAL_SECRET_PREFIXES, PROJECT_API_TOKEN_PREFIX)
     if query and not query.startswith(non_personal_api_key_prefixes):
         result = find_personal_api_key(query)
         if result is not None:

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -387,6 +387,9 @@ tools:
     reset-token-partial-update:
         operation: organizations_projects_reset_token_partial_update
         enabled: false
+    revoke-leaked-key-create:
+        operation: revoke_leaked_key_create
+        enabled: false
     rotate-secret-token-partial-update:
         operation: organizations_projects_rotate_secret_token_partial_update
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -42071,6 +42071,42 @@ export namespace Schemas {
       FullWidth: 'full_width',
     } as const;
 
+    export interface LeakedKeyReport {
+      /**
+         * The leaked PostHog personal API key, project secret API key, or OAuth access/refresh token to revoke.
+         * @maxLength 200
+         */
+      token: string;
+    }
+
+    /**
+     * * `personal_api_key` - personal_api_key
+     * * `project_secret_api_key` - project_secret_api_key
+     * * `oauth_access_token` - oauth_access_token
+     * * `oauth_refresh_token` - oauth_refresh_token
+     */
+    export type LeakedKeyReportResponseTypeEnum = typeof LeakedKeyReportResponseTypeEnum[keyof typeof LeakedKeyReportResponseTypeEnum];
+
+
+    export const LeakedKeyReportResponseTypeEnum = {
+      PersonalApiKey: 'personal_api_key',
+      ProjectSecretApiKey: 'project_secret_api_key',
+      OauthAccessToken: 'oauth_access_token',
+      OauthRefreshToken: 'oauth_refresh_token',
+    } as const;
+
+    export interface LeakedKeyReportResponse {
+      /** Whether a matching PostHog key or token was found and revoked. */
+      found: boolean;
+      /** The type of key that was found and revoked, or null if no match was found.
+       *
+       * * `personal_api_key` - personal_api_key
+       * * `project_secret_api_key` - project_secret_api_key
+       * * `oauth_access_token` - oauth_access_token
+       * * `oauth_refresh_token` - oauth_refresh_token */
+      type: LeakedKeyReportResponseTypeEnum | null;
+    }
+
     export interface LegalDocumentCreator {
       first_name: string;
       email: string;


### PR DESCRIPTION
A customer reached out asking if they could send us some API keys to revoke. We should give them a self service way to do this.

## Problem

- Someone who finds their own leaked PostHog API key (in a public repo, a log, a paste site) has no way to revoke it without logging into PostHog first.
- PostHog already revokes keys reported by GitHub's secret-scanning partner program (`posthog/api/github.py`), but that path only accepts GitHub's own signed reports, not a self-report from the person who found the leak.

## Changes

- Adds `POST /api/revoke_leaked_key`, a public, unauthenticated endpoint. It revokes a leaked personal API key, project secret API key, or OAuth access/refresh token on submission of the raw token, then emails the owner.
- Safety rests on possession of the plaintext token, not a signature: anyone holding the actual secret already has full use of it, so letting them revoke it grants no new capability, only a legitimate defensive action.
- Extracts the lookup/revoke/notify logic that `github.py`'s signed endpoint already had into a shared `posthog/api/secret_revocation.py` module. Both endpoints now call the same function.
- Detects the token type by its reserved prefix (`phx_`, `phs_`, `pha_`, `phr_`) instead of trying every type in turn, so an unrecognized string costs nothing beyond a few string comparisons rather than a personal-API-key lookup's SHA-256 and two rounds of PBKDF2.
- Falls back to a shape check (43 characters, URL-safe base64) for personal API keys issued before the `phx_` prefix existed (mid-2021). Those legacy keys are still valid today and needed the same coverage as prefixed ones.
- Rate-limits the endpoint to 10 requests/minute per IP.
- Does not relay a miss to the other region (US/EU). A relay would need a new authenticated cross-region call, and no signature exists here to build one on. The endpoint's description tells callers that a `false` result does not rule out the token being live in the other region, and names both endpoints.
- Appears in the generated OpenAPI schema and public API docs, unlike the GitHub-signed endpoint. drf-spectacular's schema hook normally requires a `scope_object`, which ties a view to PostHog's per-team/org API-key scope model — a fit for team-scoped resources, not this deliberately unscoped public endpoint. Adds a narrow `include_in_api_docs` opt-in to `preprocess_exclude_path_format` so a view can join the schema without that coupling.
- Rejects an expired OAuth access token instead of treating it as found. Possessing an expired token gives no functional use of the credential, so without this check, anyone who had ever seen a token that later expired could still force-revoke the owner's current, live session for that app.
- Scopes OAuth token revocation to the one reported access/refresh pair instead of every session the user has with the application. A leaked token is evidence about that one token, not the user's other sessions. This changes `github.py`'s existing behavior too, since it shares the same revocation path: a leaked-token report no longer sweeps the user's other grants or sessions for that app. The broader sweep stays available as `revoke_oauth_session` for the two flows where it's the correct, intentional scope: a user disconnecting an app (`connected_apps.py`) and an RFC 7009 revoke request (`oauth/views.py`).
- Falls back to that same broad sweep for one case the narrow scoping can't handle correctly: a non-rotating refresh token (DCR/CIMD clients) can mint any number of access tokens with no queryable link back to it, by design, so reporting the refresh token itself still needs the full sweep to catch all of them. This is a known, accepted, scoped-down limitation, not a full fix: it can still revoke another session on the same app for that one client population. The precise fix needs a schema change to the token-minting path, tracked separately in [#81623](https://github.com/PostHog/posthog/issues/81623) rather than folded into this PR.

## How did you test this code?

- Added tests in `test_leaked_key.py` covering: each of the four auto-detected token types actually being revoked (not just the response claiming so) and the owner notified with the correct arguments; the legacy unprefixed personal-key path; an unrecognized token and a token that only matches the legacy shape both returning not-found with no side effects; team-level secret tokens staying unreachable by design; an expired OAuth access token being rejected without touching the owner's live refresh token; a second, unrelated OAuth session for the same user and app surviving a leaked-token report; blank-token validation; and the throttle rejecting a second request.
- Added a model-level test for `revoke_oauth_token_session` in `test_oauth.py`, alongside `revoke_oauth_session`'s own tests, asserting an unrelated access token and grant both survive, plus a second test minting two access tokens from one non-rotating refresh token and asserting both are revoked when it's reported.
- Added an end-to-end test in `test_leaked_key.py` for the same non-rotating case: two access tokens minted from one DCR application's refresh token, reporting the refresh token through the public endpoint, both revoked.
- Updated four `test_github.py` assertions that asserted the old broad sweep of an unrelated grant to assert it survives instead, since narrowing the shared revocation path changes that behavior for the GitHub webhook too. Renamed two of those tests to describe what they now demonstrate.
- Ran the combined suite (`test_github.py`, `test_leaked_key.py`, `test_oauth.py`, `test_rate_limit.py`) locally on this branch: 181 passed, 1 failed. The failure (`test_does_not_rate_limit_capture_endpoints`, `TemplateDoesNotExist: index.html`) is unrelated to this change and reproduces identically on `origin/master` with none of this branch's commits applied, caused by no built frontend in this dev environment.
- Ran `ruff check`, `ruff format --check`, and `uv run mypy --cache-fine-grained .` on the touched files, and a full repo-wide `mypy` pass: clean (the only errors found are in unrelated pre-existing files this branch doesn't touch).
- Not checked: the endpoint against a real multi-region (US/EU) deployment.

## Automatic notifications

- [x] Publish to changelog?

## Docs update

None needed by hand. The endpoint documents itself: it's now in the generated OpenAPI schema, driven by the `help_text` and `description` already on its serializers and view (see Changes).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude Code) designed and implemented this with Tom driving the review checkpoints throughout. Skills invoked: `superpowers:brainstorming` and `superpowers:writing-plans` for design and planning, `superpowers:subagent-driven-development` for implementation (a fresh subagent per task, plus an independent reviewer subagent per task and one final whole-branch reviewer, each running adversarial verification against the diff), `/improving-drf-endpoints` and `/writing-tests` while authoring the endpoint and its tests, `superpowers:finishing-a-development-branch` and `/writing-pr-descriptions` for this handoff.

Seven decisions Tom made during review are worth flagging for reviewers:
- Whether legacy unprefixed personal API keys should be covered in this PR or deferred as a follow-up. He chose to include the shape-based fallback now (see Changes) rather than ship the endpoint with that population silently unrevocable.
- Whether the endpoint should relay a miss to the other region. He chose to document the gap rather than build a new cross-region authenticated call.
- The endpoint's path. It started as `/api/alerts/leaked_key`, next to the GitHub webhook route it shares logic with. Tom asked for alternatives since nothing here is an alert; he picked `/api/revoke_leaked_key`, matching the existing flat-route precedent (`api/unsubscribe`) over a `security/`-namespaced option.
- Whether an expired OAuth access token should still be able to force-revoke a live session. He chose to add the expiry check (see Changes) rather than leave it as-is.
- Whether the public endpoint should notify the owner when it detects a live Team-level `secret_api_token` it can't auto-rotate. He chose to leave this silent, matching the earlier decision to exclude team tokens from auto-detect entirely, rather than add a notification-only path for this one credential type.
- Whether a leaked OAuth token report should still revoke every session the user has with that application, or just the reported one. My recommendation was to narrow it, for both leak-reporting paths rather than only the public one, since the two differ in how they're authenticated but not in what they know about the blast radius of a report. Tom agreed and asked for it in this PR (see Changes).
- Whether to close the remaining DCR/CIMD gap in that narrowing with a schema migration in this PR, or ship the documented, scoped-down fallback and track the full fix separately. Tom chose to ship now and track separately ([#81623](https://github.com/PostHog/posthog/issues/81623)), rather than expand this PR into the token-minting path.

This branch also went through an independent `/code-review high` pass and picked up automated review comments from several bots once pushed (parameterai, veria-ai, greptile-apps, posthog's own review bot). I verified each against the code before acting: fixed the OAuth expiry gap and the OAuth session-scoping gap above, a `RevocationResult` dataclass that should have used the house `@frozen` decorator, a comment overclaiming a cost bound that a public caller can deliberately defeat, duplicated OAuth revoke functions, a redundant `found` field, missing test type annotations, and a description that read as if it assumed the caller was on the US region. Left unfixed as pre-existing and out of scope: `IPThrottle` trusting a caller-supplied `X-Forwarded-For` (affects many existing throttles, not new here). A duplicate-notification-email race on concurrent identical-token submissions was judged low severity and left as-is: the leaked credential still ends up revoked either way.

Two bots then re-reviewed the OAuth session-scoping commit itself and caught a real gap in it: narrowing revocation to one access/refresh pair broke coverage for non-rotating (DCR/CIMD) refresh tokens, which can mint access tokens with no durable link back to the refresh token. Fixed by falling back to the full sweep for that one case (see Changes) rather than leaving it as a known gap, since it undermined the correctness of a fix from earlier in this same review round.

A third round then flagged that this fallback itself reintroduces cross-session collateral damage, but only for that one client population. I confirmed there's no way to scope it more precisely with the current schema (`OAuthAccessToken.source_refresh_token` is a `OneToOneField`, so only one access token per refresh token can hold that back-reference, structurally). Filed [#81623](https://github.com/PostHog/posthog/issues/81623) for the real fix rather than expanding this PR into a token-minting schema change.

Nothing in this PR, its commits, or this description carries material from the session that is not already public in this repository.





