### PR TITLE
feat(onboarding): install-step copy, live verification, and manual path

### DIFF
--- a/frontend/src/scenes/onboarding/legacy/sdks/RealtimeCheckIndicator.tsx
+++ b/frontend/src/scenes/onboarding/legacy/sdks/RealtimeCheckIndicator.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from 'react'
+
 import { IconCheck, IconWarning } from '@posthog/icons'
 
 import { type AdblockDetectionResult } from './hooks/useAdblockDetection'
@@ -7,13 +9,27 @@ import { OnboardingLiveEvents } from './OnboardingLiveEvents'
 export type RealtimeCheckIndicatorProps = {
     teamPropertyToVerify: string
     listeningForName?: string
+    /** Drop the "Verify installation" label where space is tight and the chip explains itself. */
+    hideLabel?: boolean
+    /** Fires once when verification flips from waiting to complete. Already-complete mounts don't fire. */
+    onComplete?: () => void
 }
 
 export function RealtimeCheckIndicator({
     teamPropertyToVerify,
     listeningForName = 'event',
+    hideLabel = false,
+    onComplete,
 }: RealtimeCheckIndicatorProps): JSX.Element {
     const installationComplete = useInstallationComplete(teamPropertyToVerify)
+    const wasComplete = useRef(installationComplete)
+    useEffect(() => {
+        if (installationComplete && !wasComplete.current) {
+            onComplete?.()
+        }
+        wasComplete.current = installationComplete
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [installationComplete])
 
     return (
         <div className="flex items-center gap-3">
@@ -27,7 +43,7 @@ export function RealtimeCheckIndicator({
                 </div>
             ) : (
                 <div className="flex flex-row gap-3 items-center">
-                    <div className="font-medium">Verify installation</div>
+                    {!hideLabel && <div className="font-medium">Verify installation</div>}
                     <div className="flex items-center gap-2 px-2 py-1 border border-accent rounded-sm">
                         <div className="relative flex items-center justify-center">
                             <div className="absolute w-3 h-3 border-2 border-accent rounded-full animate-ping" />

--- a/frontend/src/scenes/onboarding/legacy/sdks/RealtimeCheckIndicator.tsx
+++ b/frontend/src/scenes/onboarding/legacy/sdks/RealtimeCheckIndicator.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef } from 'react'
 
 import { IconCheck, IconWarning } from '@posthog/icons'
 
+import { cn } from 'lib/utils/css-classes'
+
 import { type AdblockDetectionResult } from './hooks/useAdblockDetection'
 import { useInstallationComplete } from './hooks/useInstallationComplete'
 import { OnboardingLiveEvents } from './OnboardingLiveEvents'
@@ -9,8 +11,8 @@ import { OnboardingLiveEvents } from './OnboardingLiveEvents'
 export type RealtimeCheckIndicatorProps = {
     teamPropertyToVerify: string
     listeningForName?: string
-    /** Drop the "Verify installation" label where space is tight and the chip explains itself. */
-    hideLabel?: boolean
+    /** Compact presentation for tight headers: no "Verify installation" label, no chip border. */
+    minimal?: boolean
     /** Fires once when verification flips from waiting to complete. Already-complete mounts don't fire. */
     onComplete?: () => void
 }
@@ -18,7 +20,7 @@ export type RealtimeCheckIndicatorProps = {
 export function RealtimeCheckIndicator({
     teamPropertyToVerify,
     listeningForName = 'event',
-    hideLabel = false,
+    minimal = false,
     onComplete,
 }: RealtimeCheckIndicatorProps): JSX.Element {
     const installationComplete = useInstallationComplete(teamPropertyToVerify)
@@ -43,8 +45,13 @@ export function RealtimeCheckIndicator({
                 </div>
             ) : (
                 <div className="flex flex-row gap-3 items-center">
-                    {!hideLabel && <div className="font-medium">Verify installation</div>}
-                    <div className="flex items-center gap-2 px-2 py-1 border border-accent rounded-sm">
+                    {!minimal && <div className="font-medium">Verify installation</div>}
+                    <div
+                        className={cn(
+                            'flex items-center gap-2 px-2 py-1',
+                            !minimal && 'border border-accent rounded-sm'
+                        )}
+                    >
                         <div className="relative flex items-center justify-center">
                             <div className="absolute w-3 h-3 border-2 border-accent rounded-full animate-ping" />
                             <div className="w-2 h-2 bg-accent rounded-full" />

--- a/frontend/src/scenes/onboarding/onboardingEventUsageLogic.ts
+++ b/frontend/src/scenes/onboarding/onboardingEventUsageLogic.ts
@@ -76,11 +76,15 @@ export interface onboardingEventUsageLogicActions {
     reportOnboardingGoalSelected: (goal: string) => {
         goal: string
     }
-    reportOnboardingInstallModeSelected: (mode: 'cloud' | 'local') => {
-        mode: 'cloud' | 'local'
+    reportOnboardingInstallModeSelected: (mode: 'cloud' | 'local' | 'manual') => {
+        mode: 'cloud' | 'local' | 'manual'
     }
+    reportOnboardingInstallVerified: () => {}
     reportOnboardingPlanSelected: (plan: 'free' | 'pay_as_you_go') => {
         plan: 'free' | 'pay_as_you_go'
+    }
+    reportOnboardingSelfDrivingExplainerClicked: (stepKey: SelfDrivingOnboardingStepId) => {
+        stepKey: SelfDrivingOnboardingStepId
     }
     reportOnboardingStepViewed: (stepId: SelfDrivingOnboardingStepId) => {
         stepId: SelfDrivingOnboardingStepId
@@ -164,7 +168,9 @@ export const onboardingEventUsageLogic = kea<onboardingEventUsageLogicType>([
             recommendedProducts,
             properties,
         }),
-        reportOnboardingInstallModeSelected: (mode: 'cloud' | 'local') => ({ mode }),
+        reportOnboardingInstallModeSelected: (mode: 'cloud' | 'local' | 'manual') => ({ mode }),
+        reportOnboardingSelfDrivingExplainerClicked: (stepKey: SelfDrivingOnboardingStepId) => ({ stepKey }),
+        reportOnboardingInstallVerified: () => ({}),
         reportOnboardingPlanSelected: (plan: 'free' | 'pay_as_you_go') => ({ plan }),
         reportOnboardingCloudRunQueued: (props: { taskId: string; runId: string; repository: string }) => props,
         reportOnboardingCloudRunCompleted: (props: {
@@ -221,6 +227,18 @@ export const onboardingEventUsageLogic = kea<onboardingEventUsageLogicType>([
             posthog.capture('onboarding install mode selected', {
                 mode,
                 ...wizardSyncEventProps(values.featureFlags),
+            })
+        },
+        reportOnboardingSelfDrivingExplainerClicked: ({ stepKey }) => {
+            posthog.capture('onboarding self-driving explainer clicked', {
+                step_key: stepKey,
+                ...SELF_DRIVING_ONBOARDING_EVENT_PROPS,
+            })
+        },
+        reportOnboardingInstallVerified: () => {
+            posthog.capture('onboarding installation verified', {
+                step_key: 'install',
+                ...SELF_DRIVING_ONBOARDING_EVENT_PROPS,
             })
         },
         reportOnboardingPlanSelected: ({ plan }) => {

--- a/frontend/src/scenes/onboarding/self-driving/SelfDrivingOnboardingFlow.tsx
+++ b/frontend/src/scenes/onboarding/self-driving/SelfDrivingOnboardingFlow.tsx
@@ -229,7 +229,7 @@ export function SelfDrivingOnboardingFlow(): JSX.Element {
                         {step.id === 'install' && (
                             <RealtimeCheckIndicator
                                 teamPropertyToVerify="ingested_event"
-                                hideLabel
+                                minimal
                                 onComplete={reportOnboardingInstallVerified}
                             />
                         )}

--- a/frontend/src/scenes/onboarding/self-driving/SelfDrivingOnboardingFlow.tsx
+++ b/frontend/src/scenes/onboarding/self-driving/SelfDrivingOnboardingFlow.tsx
@@ -10,6 +10,7 @@ import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { cn } from 'lib/utils/css-classes'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
+import { RealtimeCheckIndicator } from '../legacy/sdks/RealtimeCheckIndicator'
 import {
     onboardingEventUsageLogic,
     SELF_DRIVING_ONBOARDING_EVENT_PROPS,
@@ -19,6 +20,7 @@ import { resolveSetup } from '../shared/useCases'
 import type { OnboardingExtraStepId, OnboardingUseCaseKey } from '../shared/useCases'
 import { wizardSyncUiLogic } from '../shared/wizard-sync/wizardSyncUiLogic'
 import { InstallationTrackerGate } from './components/InstallationTracker'
+import { ManualSetupButton } from './components/SelfDrivingInstallOptions'
 import { onboardingLogic } from './onboardingLogic'
 import { RoughMark } from './RoughMark'
 import { AIObservabilityStep } from './steps/AIObservabilityStep'
@@ -111,7 +113,7 @@ export function SelfDrivingOnboardingFlow(): JSX.Element {
     const { isCompleting } = useValues(onboardingLogic)
     const { reportOnboardingStarted, reportOnboardingStepCompleted, reportOnboardingStepSkipped } =
         useActions(eventUsageLogic)
-    const { reportOnboardingStepViewed } = useActions(onboardingEventUsageLogic)
+    const { reportOnboardingStepViewed, reportOnboardingInstallVerified } = useActions(onboardingEventUsageLogic)
     // The step list depends on the declared use case (persisted, so a refresh keeps the
     // conditional steps in place).
     const { selectedUseCase } = useValues(useCaseSelectionLogic)
@@ -191,7 +193,9 @@ export function SelfDrivingOnboardingFlow(): JSX.Element {
             {/* Pinned header: back button + progress share one row. Equal-width side slots keep the
                 progress dots centered in the card regardless of whether the back button is shown. */}
             <div className="shrink-0 flex flex-col items-center gap-4">
-                <div className="flex items-center gap-2 w-full">
+                {/* The dots are absolutely centered so uneven side content (back button vs the
+                    verification chip or run pill) can never shift them off the card's midline. */}
+                <div className="relative flex items-center justify-between gap-2 w-full min-h-8">
                     <div className="w-8 shrink-0 flex justify-start">
                         {!isFirst && (
                             <LemonButton
@@ -204,7 +208,7 @@ export function SelfDrivingOnboardingFlow(): JSX.Element {
                         )}
                     </div>
                     <div
-                        className="flex-1 flex items-center justify-center gap-1.5"
+                        className="absolute left-1/2 -translate-x-1/2 flex items-center gap-1.5"
                         role="group"
                         aria-label={`Step ${stepIndex + 1} of ${steps.length}`}
                     >
@@ -217,9 +221,18 @@ export function SelfDrivingOnboardingFlow(): JSX.Element {
                             />
                         ))}
                     </div>
-                    <div className="min-w-8 shrink-0 flex justify-end">
-                        {/* Past the install step, the run keeps a quiet presence up here; on the
-                            install step itself the tracker lives in the content. */}
+                    <div className="shrink-0 flex justify-end">
+                        {/* On the install step, live verification: flips when the team's first event
+                            lands, whichever install path produced it. Past the install step, the run
+                            keeps a quiet presence up here; on the install step itself the tracker
+                            lives in the content. */}
+                        {step.id === 'install' && (
+                            <RealtimeCheckIndicator
+                                teamPropertyToVerify="ingested_event"
+                                hideLabel
+                                onComplete={reportOnboardingInstallVerified}
+                            />
+                        )}
                         {stepIndex > steps.findIndex((s) => s.id === 'install') && <InstallationTrackerGate />}
                     </div>
                 </div>
@@ -256,15 +269,18 @@ export function SelfDrivingOnboardingFlow(): JSX.Element {
                         <span />
                     )}
                     {!step.hideContinue && (
-                        <LemonButton
-                            type="primary"
-                            status="alt"
-                            sideIcon={<IconArrowRight />}
-                            onClick={completeStep}
-                            loading={isLast && isCompleting}
-                        >
-                            {isLast ? 'Finish' : isFirst ? 'Get started' : 'Continue'}
-                        </LemonButton>
+                        <div className="flex items-center gap-2">
+                            {step.id === 'install' && <ManualSetupButton />}
+                            <LemonButton
+                                type="primary"
+                                status="alt"
+                                sideIcon={<IconArrowRight />}
+                                onClick={completeStep}
+                                loading={isLast && isCompleting}
+                            >
+                                {isLast ? 'Finish' : isFirst ? 'Get started' : 'Continue'}
+                            </LemonButton>
+                        </div>
                     )}
                 </div>
             )}

--- a/frontend/src/scenes/onboarding/self-driving/components/SelfDrivingInstallOptions.tsx
+++ b/frontend/src/scenes/onboarding/self-driving/components/SelfDrivingInstallOptions.tsx
@@ -10,6 +10,7 @@ import { useLocalWizardRunActive } from 'scenes/onboarding/shared/wizard-sync/ho
 import { WizardCommandBlock } from 'scenes/onboarding/shared/wizard-sync/WizardCommandBlock'
 import { WizardInstallOptions } from 'scenes/onboarding/shared/wizard-sync/WizardInstallOptions'
 import { SELF_DRIVING_WORKFLOW_ID } from 'scenes/onboarding/shared/wizard-sync/workflows'
+import { urls } from 'scenes/urls'
 
 import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
 
@@ -43,9 +44,9 @@ function ProductsBeingInstalled(): JSX.Element {
 
 /** What the self-driving run wires up, so the command isn't a leap of faith. */
 const WIZARD_SETS_UP = [
+    'Installs the SDK and wires up event capture',
     'Connects GitHub so agents can open pull requests',
-    'Chooses signal sources and scouts to watch',
-    'Sends findings to the Inbox',
+    'Sets up scouts that send findings to your Inbox',
 ]
 
 // The self-driving run is interactive: it asks about your issue tracker, walks you through the
@@ -54,7 +55,8 @@ const WIZARD_SETS_UP = [
 // being left to the experiment flag.
 export function SelfDrivingInstallOptions({ onContinue }: { onContinue: () => void }): JSX.Element {
     const { isCloudOrDev } = useWizardCommand()
-    const { reportOnboardingInstallModeSelected } = useActions(onboardingEventUsageLogic)
+    const { reportOnboardingInstallModeSelected, reportOnboardingSelfDrivingExplainerClicked } =
+        useActions(onboardingEventUsageLogic)
     // Once the CLI registers a run, the command block and its caption give way to the tracker -
     // the command has been run, so repeating it is noise.
     const isRunActive = useLocalWizardRunActive(SELF_DRIVING_WORKFLOW_ID)
@@ -78,8 +80,16 @@ export function SelfDrivingInstallOptions({ onContinue }: { onContinue: () => vo
     return (
         <div className="flex flex-col gap-4">
             <p className="text-sm text-muted text-center m-0">
-                Run this command in your project. The setup agent connects GitHub, chooses signal sources, and
-                configures scouts.
+                Run this command in your project. The setup agent detects your framework, installs the SDK, and starts
+                capturing events.{' '}
+                <Link
+                    to="https://posthog.com/self-driving"
+                    target="_blank"
+                    onClick={() => reportOnboardingSelfDrivingExplainerClicked('install')}
+                    data-attr="self-driving-explainer-link"
+                >
+                    What is self-driving?
+                </Link>
             </p>
             <WizardInstallOptions
                 hideHog
@@ -94,20 +104,40 @@ export function SelfDrivingInstallOptions({ onContinue }: { onContinue: () => vo
                             <WizardCommandBlock
                                 hideHog
                                 subcommand="self-driving"
-                                description="Takes about ten minutes. It'll ask you a few things along the way."
+                                description="About ten minutes: a few questions up front, then the agent does the rest."
                             />
                         )}
                         <ProductsBeingInstalled />
                     </div>
                 }
             />
-            <CheckList
-                size="xs"
-                items={WIZARD_SETS_UP.map((line) => ({
-                    icon: <IconCheckCircle />,
-                    content: <span className="text-muted">{line}</span>,
-                }))}
-            />
+            <div className="flex justify-center">
+                <CheckList
+                    size="xs"
+                    items={WIZARD_SETS_UP.map((line) => ({
+                        icon: <IconCheckCircle />,
+                        content: <span className="text-muted">{line}</span>,
+                    }))}
+                />
+            </div>
         </div>
+    )
+}
+
+/** The manual escape hatch, rendered by the flow footer next to Continue on the install step. */
+export function ManualSetupButton(): JSX.Element {
+    const { reportOnboardingInstallModeSelected } = useActions(onboardingEventUsageLogic)
+    // New tab so the step, and its verification, stays open while they follow the instructions.
+    return (
+        <LemonButton
+            type="tertiary"
+            size="small"
+            to={urls.settings('environment-details', 'snippet')}
+            targetBlank
+            onClick={() => reportOnboardingInstallModeSelected('manual')}
+            data-attr="self-driving-manual-setup"
+        >
+            Need to set up manually?
+        </LemonButton>
     )
 }

--- a/frontend/src/scenes/onboarding/self-driving/components/SelfDrivingInstallOptions.tsx
+++ b/frontend/src/scenes/onboarding/self-driving/components/SelfDrivingInstallOptions.tsx
@@ -1,8 +1,15 @@
 import { useActions, useValues } from 'kea'
+import { useEffect, useState } from 'react'
 
 import { IconCheckCircle } from '@posthog/icons'
-import { LemonButton, Link } from '@posthog/lemon-ui'
+import { LemonButton, LemonModal, Link } from '@posthog/lemon-ui'
 
+import { useAdblockDetection } from 'scenes/onboarding/legacy/sdks/hooks/useAdblockDetection'
+import { useInstallationComplete } from 'scenes/onboarding/legacy/sdks/hooks/useInstallationComplete'
+import { SDKGrid } from 'scenes/onboarding/legacy/sdks/OnboardingInstallStep/SDKGrid'
+import { SDKInstructionsModal } from 'scenes/onboarding/legacy/sdks/OnboardingInstallStep/SDKInstructionsModal'
+import { ProductAnalyticsSDKInstructions } from 'scenes/onboarding/legacy/sdks/product-analytics/ProductAnalyticsSDKInstructions'
+import { sdksLogic } from 'scenes/onboarding/legacy/sdks/sdksLogic'
 import { onboardingEventUsageLogic } from 'scenes/onboarding/onboardingEventUsageLogic'
 import { CheckList } from 'scenes/onboarding/shared/components/CheckList'
 import { useWizardCommand } from 'scenes/onboarding/shared/useWizardCommand'
@@ -10,9 +17,10 @@ import { useLocalWizardRunActive } from 'scenes/onboarding/shared/wizard-sync/ho
 import { WizardCommandBlock } from 'scenes/onboarding/shared/wizard-sync/WizardCommandBlock'
 import { WizardInstallOptions } from 'scenes/onboarding/shared/wizard-sync/WizardInstallOptions'
 import { SELF_DRIVING_WORKFLOW_ID } from 'scenes/onboarding/shared/wizard-sync/workflows'
-import { urls } from 'scenes/urls'
+import { teamLogic } from 'scenes/teamLogic'
 
 import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
+import { type SDK } from '~/types'
 
 import { DOCS_URL_BY_PRODUCT_PATH, ONBOARDING_TOOLS, resolveSetup, toolIconType } from '../../shared/useCases'
 import { useCaseSelectionLogic } from '../useCaseSelectionLogic'
@@ -85,6 +93,7 @@ export function SelfDrivingInstallOptions({ onContinue }: { onContinue: () => vo
                 <Link
                     to="https://posthog.com/self-driving"
                     target="_blank"
+                    targetBlankIcon={false}
                     onClick={() => reportOnboardingSelfDrivingExplainerClicked('install')}
                     data-attr="self-driving-explainer-link"
                 >
@@ -124,20 +133,76 @@ export function SelfDrivingInstallOptions({ onContinue }: { onContinue: () => vo
     )
 }
 
-/** The manual escape hatch, rendered by the flow footer next to Continue on the install step. */
+/**
+ * The manual escape hatch, rendered by the flow footer next to Continue on the install step.
+ * Opens the legacy manual-setup dialog: the SDK grid, then per-SDK instructions. Picking an SDK
+ * closes the grid and opens the instructions; closing the instructions reopens the grid.
+ */
 export function ManualSetupButton(): JSX.Element {
     const { reportOnboardingInstallModeSelected } = useActions(onboardingEventUsageLogic)
-    // New tab so the step, and its verification, stays open while they follow the instructions.
+    const { setAvailableSDKInstructionsMap, selectSDK, setSearchTerm, setSelectedTag } = useActions(sdksLogic)
+    const { filteredSDKs, selectedSDK, tags, searchTerm, selectedTag } = useValues(sdksLogic)
+    const { currentTeam } = useValues(teamLogic)
+    const installationComplete = useInstallationComplete('ingested_event')
+    const adblockResult = useAdblockDetection()
+    const [gridOpen, setGridOpen] = useState(false)
+    const [instructionsOpen, setInstructionsOpen] = useState(false)
+
+    // The same map the legacy default flow shows: one install covers the core web products.
+    useEffect(() => {
+        setAvailableSDKInstructionsMap(ProductAnalyticsSDKInstructions)
+    }, [setAvailableSDKInstructionsMap])
+
+    const handleSDKClick = (sdk: SDK): void => {
+        selectSDK(sdk)
+        setGridOpen(false)
+        setInstructionsOpen(true)
+    }
+
     return (
-        <LemonButton
-            type="tertiary"
-            size="small"
-            to={urls.settings('environment-details', 'snippet')}
-            targetBlank
-            onClick={() => reportOnboardingInstallModeSelected('manual')}
-            data-attr="self-driving-manual-setup"
-        >
-            Need to set up manually?
-        </LemonButton>
+        <>
+            <LemonButton
+                type="tertiary"
+                size="small"
+                onClick={() => {
+                    reportOnboardingInstallModeSelected('manual')
+                    setGridOpen(true)
+                }}
+                data-attr="self-driving-manual-setup"
+            >
+                Set up manually
+            </LemonButton>
+            <LemonModal isOpen={gridOpen} onClose={() => setGridOpen(false)} title="Manual SDK setup" width="80vw">
+                <div className="p-4">
+                    <SDKGrid
+                        filteredSDKs={filteredSDKs ?? []}
+                        searchTerm={searchTerm}
+                        selectedTag={selectedTag}
+                        tags={tags}
+                        onSDKClick={handleSDKClick}
+                        onSearchChange={setSearchTerm}
+                        onTagChange={setSelectedTag}
+                        currentTeam={currentTeam}
+                        showTopControls
+                        installationComplete={installationComplete}
+                        showTopSkipButton={false}
+                    />
+                </div>
+            </LemonModal>
+            {selectedSDK && (
+                <SDKInstructionsModal
+                    isOpen={instructionsOpen && !gridOpen}
+                    onClose={() => {
+                        setInstructionsOpen(false)
+                        setGridOpen(true)
+                    }}
+                    sdk={selectedSDK}
+                    sdkInstructionMap={ProductAnalyticsSDKInstructions}
+                    adblockResult={adblockResult}
+                    verifyingProperty="ingested_event"
+                    verifyingName="event"
+                />
+            )}
+        </>
     )
 }


### PR DESCRIPTION
## Problem

- New users in the self-driving onboarding pass the install step in seconds and do not run the setup command.
- They install by hand instead: they copy the project token from settings and paste a snippet, and the flow does not see it.
- The step copy does not say that the command installs the SDK. It promises GitHub and scouts only.
- The step gives no manual option and no signal when events arrive.

## Changes

- The copy now leads with the install: "The setup agent detects your framework, installs the SDK, and starts capturing events."
- The subtitle ends with an inline "What is self-driving?" link to https://posthog.com/self-driving.
- The card header shows a live indicator without a border or label. "Waiting for events" changes to "Installation complete" when the team ingests its first event, from any install path.
- The footer adds "Set up manually" next to Continue. It opens the legacy manual setup dialog: the SDK grid, then the instructions for the selected SDK, with the same verification.
- The indicator reuses `RealtimeCheckIndicator` from the legacy flow, with new `minimal` and `onComplete` props. The legacy surfaces keep their current look.
- New analytics: mode `manual` on `onboarding install mode selected`, plus `onboarding self-driving explainer clicked` and `onboarding installation verified`. The verified event fires once, on the change to complete, not on already-complete mounts.
- The progress dots now center absolutely, so header content cannot move them.

> [!NOTE]
> This changes the self-driving arm of the running onboarding experiment. Conversion comparisons across this deploy reflect different copy and layout.

| Before | After (waiting) | After (verified) |
| --- | --- | --- |
| ![before](https://raw.githubusercontent.com/PostHog/pr-assets/93b54f5e6d85059469523ac77d7286c5b1f9e728/2026/08/71a8446a-fa6c-407e-aa2c-dcc00223d42a.jpg) | ![after-waiting](https://raw.githubusercontent.com/PostHog/pr-assets/70237b4e9701f7512e84567e1209c20674704197/2026/08/484045bf-70d9-4b37-9598-c78ec29d928e.jpg) | ![after-complete](https://raw.githubusercontent.com/PostHog/pr-assets/fa660eab7c508d0c6f83aa0dd612dbbad7e165ee/2026/08/8fa10f5a-f512-4bc3-a478-f517de2a9145.jpg) |

The manual setup dialog, opened from the footer:

![manual-dialog](https://raw.githubusercontent.com/PostHog/pr-assets/36691bc791d9947ccf03235b54bd847396279654/2026/08/4b0c6b74-a04d-4ea7-872b-3f442f357a08.jpg)

## How did you test this code?

- I viewed the step in the local dev app in both indicator states. The screenshots above show it.
- I opened the manual dialog, selected Next.js, and saw the nested instructions modal with its verification footer.
- I flipped `posthog_team.ingested_event` in local Postgres to show each state, and sent one event through local capture to see the indicator change live.
- I ran the jest suites under `frontend/src/scenes/onboarding/self-driving/`, the full TypeScript check, and lint.
- Not added: a unit test for the `onComplete` transition. I checked that behavior in the dev app only.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: Claude Code. Skills invoked: `/writing-user-facing-copy`, `/writing-pr-descriptions`, `/asd-ste100`, plus the self-driving positioning guide for the copy.
- The human directed the layout across iterations: the indicator moved to the header and lost its label and border, the manual button moved to the footer row and now opens the legacy dialog instead of linking to settings, the explainer became an inline link, and the checklist and dots became centered.
- Motivation: early reads of the onboarding experiment show self-driving users who skip the command and install by hand from the settings token page.
- The screenshots come from the local dev app. The data in them is synthetic.
