### PR TITLE
fix(aio): constrain self-driving evals table width

### DIFF
--- a/products/ai_observability/frontend/selfDriving/AIObservabilitySelfDriving.tsx
+++ b/products/ai_observability/frontend/selfDriving/AIObservabilitySelfDriving.tsx
@@ -82,6 +82,7 @@ export function AIObservabilitySelfDriving(): JSX.Element {
         {
             title: 'Name',
             key: 'name',
+            width: '40%',
             render: (_, evaluation) => (
                 <div className="flex min-w-0 flex-col">
                     <span className="truncate font-semibold">{evaluation.name}</span>
@@ -126,6 +127,21 @@ export function AIObservabilitySelfDriving(): JSX.Element {
                 const lastGeneratedAt = evaluationReportsByEvaluationId[evaluation.id]?.last_generated_at
                 return lastGeneratedAt ? <TZLabel time={lastGeneratedAt} /> : 'Never'
             },
+        },
+        {
+            key: 'actions',
+            width: 72,
+            align: 'right',
+            render: (_, evaluation) => (
+                <LemonButton
+                    type="secondary"
+                    size="small"
+                    to={evaluationEditUrl(evaluation.id)}
+                    data-attr="edit-ai-observability-evaluation"
+                >
+                    Edit
+                </LemonButton>
+            ),
         },
     ]
 
@@ -284,6 +300,7 @@ export function AIObservabilitySelfDriving(): JSX.Element {
                         dataSource={evaluations}
                         loading={evaluationReportsLoading}
                         loadingSkeletonRows={2}
+                        tableLayout="fixed"
                         rowKey="id"
                         nouns={['eval', 'evals']}
                         data-attr="ai-observability-evaluations-table"
@@ -296,16 +313,6 @@ export function AIObservabilitySelfDriving(): JSX.Element {
                                 router.actions.push(evaluationEditUrl(evaluation.id))
                             },
                         })}
-                        rowActions={(evaluation) => (
-                            <LemonButton
-                                type="secondary"
-                                size="small"
-                                to={evaluationEditUrl(evaluation.id)}
-                                data-attr="edit-ai-observability-evaluation"
-                            >
-                                Edit
-                            </LemonButton>
-                        )}
                     />
                 )}
             </section>


### PR DESCRIPTION
## Problem

People reviewing self-driving evals can encounter a horizontally scrolling page when an eval description is long.

## Changes

- The evals table uses a fixed layout and reserves 40% of its width for names and descriptions.
- The Edit action uses a fixed-width column, keeping it visible within the table.

![ai-observability-evals-table-fixed](https://raw.githubusercontent.com/PostHog/pr-assets/35a3529a478ae9dcaaf8e9daa57fd6a89a98587c/2026/08/6c2a5987-bf37-42e2-8bba-f040a15d391b.png)

## How did you test this code?

- Ran the focused self-driving component tests and frontend TypeScript validation.
- Verified a 2,375-character synthetic description at 1280×900 without document or table overflow.
- Confirmed the Edit action remains visible and the description truncates in a local browser.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This corrects an existing table layout without changing documented behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex implemented the fix and used browser automation for local visual verification.
- Skills invoked: `/llma-git-workflow`, `/posthog-efficient-validation`, `/run-posthog`, `/running-ci-preflight`, `/writing-pr-descriptions`, `/create-pr`, and Browser control.
- The screenshot uses an invented local evaluation. No customer or session-derived data appears in the committed artifacts.
