### PR TITLE
fix(desktop): show discuss and scout runs in inbox report, resume PR-bearing tasks

### DIFF
--- a/products/desktop/packages/ui/src/features/inbox/hooks/useReportTasks.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useReportTasks.ts
@@ -31,13 +31,22 @@ function derivePurpose(taskRun: {
     if (taskRun.type === "implementation") {
       return { purpose: "implementation", purposeLabel: "Implementation" };
     }
-    // repo_selection runs are plumbing, not report work — never displayed (matches the
-    // pre-derivation behavior of only showing research/implementation).
-    return null;
+    if (taskRun.type === "scout") {
+      return { purpose: "other", purposeLabel: "Scout" };
+    }
+    // repo_selection runs are plumbing, not report work — never displayed.
+    if (taskRun.type === "repo_selection") {
+      return null;
+    }
+    // discussion and any other signals task run fall through to "other".
+    return {
+      purpose: "other",
+      purposeLabel: `Signals: ${humanizeIdentifier(taskRun.type)}`,
+    };
   }
   return {
     purpose: "other",
-    purposeLabel: `${humanizeIdentifier(taskRun.product)} — ${humanizeIdentifier(taskRun.type)}`,
+    purposeLabel: `${humanizeIdentifier(taskRun.product)}: ${humanizeIdentifier(taskRun.type)}`,
   };
 }
 
@@ -133,11 +142,14 @@ export function findContinuableImplementationTask(
   reportTasks: ReportTaskData[] | undefined,
 ): Task | null {
   if (!reportTasks) return null;
+  // The PR's existence is the signal that matters, not the task's purpose label:
+  // a Discuss or Scout run that already shipped a PR must count as continuable so
+  // re-engaging the report resumes that task instead of starting a duplicate.
+  const withPr = reportTasks.find((t) => getTaskPrUrl(t.task));
+  if (withPr) return withPr.task;
   const implementation = reportTasks.filter(
     (t) => t.purpose === "implementation",
   );
-  const withPr = implementation.find((t) => getTaskPrUrl(t.task));
-  if (withPr) return withPr.task;
   const running = implementation.find((t) => {
     const status = t.task.latest_run?.status;
     return status != null && !isTerminalStatus(status);


### PR DESCRIPTION
## Summary

Fixes #76347 — desktop and mobile Inbox hide Discuss/Scout runs from a report's Runs section, and a report whose only PR-bearing run is a Discuss task gets a duplicate implementation PR on re-engagement.

## Two bugs in `products/desktop/packages/ui/src/features/inbox/hooks/useReportTasks.ts`

### 1. `derivePurpose` drops discussion and scout runs

The `product === "signals"` branch returned `null` for **any** type that wasn't `research` or `implementation`, even though the comment only justified excluding `repo_selection`. Since `null` entries are filtered out of `reportTasks`, a report whose only work was a Discuss task showed an **empty Runs section on desktop/mobile** while web lists the run and its transcript.

Aligned with web's `deriveTaskPurpose` (`frontend/src/scenes/inbox/components/detail/artefactTypes.ts`):
- `scout` → `{ purpose: "other", purposeLabel: "Scout" }`
- anything else under `signals` except `repo_selection` → `{ purpose: "other", purposeLabel: "Signals: <type>" }` (covers `discussion`)
- only `repo_selection` stays hidden

### 2. `findContinuableImplementationTask` misses PR-bearing non-implementation runs

It only considered `purpose === "implementation"` tasks. A Discuss task that already shipped a PR was invisible to it: not in `reportTasks` at all (bug 1), and the report's `implementation_pr_url` is `null` for exactly this case (#76346). So on desktop the report looked untouched, `canCreateImplementationPr` still returned `true`, and re-engaging it started a **second implementation PR for work already done**.

The PR's existence is the signal that matters, not the run's label — so scan all `reportTasks` for a task with a `pr_url` first, and only fall back to running implementation tasks.

## Acceptance criteria

- [x] Desktop/mobile Runs sections list `discussion` and `scout` runs with the same labels web uses; `repo_selection` stays hidden
- [x] A report whose only PR-bearing run is a Discuss run resumes that task on re-engagement instead of starting a new implementation task