### PR TITLE
fix(desktop): prevent archive/suspend from deleting parent directory of adopted external worktrees

### DIFF
--- a/products/desktop/packages/workspace-server/src/services/archive/archive.integration.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/archive/archive.integration.test.ts
@@ -133,6 +133,7 @@ async function withTestContext(
   };
   const workspaceSettings = {
     getWorktreeLocation: () => testWorktreeBasePath,
+    getAllWorktreeLocations: () => [testWorktreeBasePath],
   };
   const scopedLogger = {
     debug: vi.fn(),
@@ -351,6 +352,7 @@ describe("ArchiveService integration", () => {
         const archived = await ctx.service.archiveTask(ctx.archiveInput());
 
         expect(await pathExists(worktreePath)).toBe(false);
+        expect(await pathExists(path.dirname(worktreePath))).toBe(false);
         expect(ctx.archiveRepo.findAll()).toHaveLength(1);
         expect(archived.checkpointId).toBeTruthy();
 
@@ -481,6 +483,42 @@ describe("ArchiveService integration", () => {
 
         expect(archived.checkpointId).toBeTruthy();
         expect(await pathExists(legacyPath)).toBe(false);
+      }));
+
+    it("archive leaves the parent directory of an adopted external worktree intact", () =>
+      withTestContext({}, async (ctx) => {
+        const externalParent = await fs.mkdtemp(
+          path.join(os.tmpdir(), "external-parent-"),
+        );
+        try {
+          const externalWorktreePath = path.join(externalParent, "adopted-wt");
+          ctx.git(`worktree add "${externalWorktreePath}" HEAD --detach`);
+          await fs.writeFile(
+            path.join(externalParent, "sibling.txt"),
+            "keep me",
+          );
+
+          const workspace = ctx.workspaceRepo.create({
+            taskId: TASK_ID,
+            repositoryId: ctx.repoId,
+            mode: "worktree",
+          });
+          ctx.worktreeRepo.create({
+            workspaceId: workspace.id,
+            name: "adopted-wt",
+            path: externalWorktreePath,
+          });
+
+          await ctx.service.archiveTask(ctx.archiveInput());
+
+          expect(await pathExists(externalWorktreePath)).toBe(false);
+          expect(await pathExists(externalParent)).toBe(true);
+          expect(
+            await pathExists(path.join(externalParent, "sibling.txt")),
+          ).toBe(true);
+        } finally {
+          await fs.rm(externalParent, { recursive: true, force: true });
+        }
       }));
 
     it("archive succeeds when worktree was deleted externally", () =>

--- a/products/desktop/packages/workspace-server/src/services/archive/archive.ts
+++ b/products/desktop/packages/workspace-server/src/services/archive/archive.ts
@@ -50,7 +50,10 @@ import {
   captureWorktreeCheckpoint,
   restoreWorktreeFromCheckpoint,
 } from "../worktree-checkpoint/worktree-checkpoint";
-import { deriveWorktreePath as deriveWorktreePathFromBase } from "../worktree-path/worktree-path";
+import {
+  deriveWorktreePath as deriveWorktreePathFromBase,
+  isWorktreePathManaged,
+} from "../worktree-path/worktree-path";
 import { getCurrentBranchName } from "../worktree-query/worktree-query";
 import { recoverArchiveDetailsFromLogs } from "./archive-recovery";
 import { ARCHIVE_FILE_WATCHER, ARCHIVE_SESSION_CANCELLER } from "./identifiers";
@@ -306,11 +309,13 @@ export class ArchiveService {
                 logger: this.log,
               });
               await manager.deleteWorktree(worktreePath);
-              const worktreeBasePath =
-                this.workspaceSettings.getWorktreeLocation();
-              const parentDir = path.dirname(worktreePath);
-              if (worktreePath.startsWith(worktreeBasePath)) {
-                await forceRemove(parentDir);
+              if (
+                isWorktreePathManaged(
+                  worktreePath,
+                  this.workspaceSettings.getAllWorktreeLocations(),
+                )
+              ) {
+                await forceRemove(path.dirname(worktreePath));
               }
             } catch (error) {
               this.log.warn(
@@ -465,11 +470,13 @@ export class ArchiveService {
                 restoredWorktreeName,
               );
               await manager.deleteWorktree(worktreePath);
-              const worktreeBasePath =
-                this.workspaceSettings.getWorktreeLocation();
-              const parentDir = path.dirname(worktreePath);
-              if (worktreePath.startsWith(worktreeBasePath)) {
-                await forceRemove(parentDir);
+              if (
+                isWorktreePathManaged(
+                  worktreePath,
+                  this.workspaceSettings.getAllWorktreeLocations(),
+                )
+              ) {
+                await forceRemove(path.dirname(worktreePath));
               }
             }
           },

--- a/products/desktop/packages/workspace-server/src/services/archive/archive.ts
+++ b/products/desktop/packages/workspace-server/src/services/archive/archive.ts
@@ -306,8 +306,16 @@ export class ArchiveService {
                 logger: this.log,
               });
               await manager.deleteWorktree(worktreePath);
+              const worktreeBasePath = this.workspaceSettings.getWorktreeLocation();
               const parentDir = path.dirname(worktreePath);
-              await forceRemove(parentDir);
+              // Only remove the parent directory for app-managed worktrees
+              // (those inside the worktree base path). Adopted external worktrees
+              // have their parent outside the managed base, and removing it would
+              // recursively delete the parent directory containing the main repo
+              // and sibling worktrees (see #81530).
+              if (worktreePath.startsWith(worktreeBasePath)) {
+                await forceRemove(parentDir);
+              }
             } catch (error) {
               this.log.warn(
                 `Failed to remove worktree at ${worktreePath}; archiving anyway (on-disk worktree may need manual cleanup)`,
@@ -461,8 +469,11 @@ export class ArchiveService {
                 restoredWorktreeName,
               );
               await manager.deleteWorktree(worktreePath);
+              const worktreeBasePath = this.workspaceSettings.getWorktreeLocation();
               const parentDir = path.dirname(worktreePath);
-              await forceRemove(parentDir);
+              if (worktreePath.startsWith(worktreeBasePath)) {
+                await forceRemove(parentDir);
+              }
             }
           },
         );

--- a/products/desktop/packages/workspace-server/src/services/archive/archive.ts
+++ b/products/desktop/packages/workspace-server/src/services/archive/archive.ts
@@ -306,13 +306,9 @@ export class ArchiveService {
                 logger: this.log,
               });
               await manager.deleteWorktree(worktreePath);
-              const worktreeBasePath = this.workspaceSettings.getWorktreeLocation();
+              const worktreeBasePath =
+                this.workspaceSettings.getWorktreeLocation();
               const parentDir = path.dirname(worktreePath);
-              // Only remove the parent directory for app-managed worktrees
-              // (those inside the worktree base path). Adopted external worktrees
-              // have their parent outside the managed base, and removing it would
-              // recursively delete the parent directory containing the main repo
-              // and sibling worktrees (see #81530).
               if (worktreePath.startsWith(worktreeBasePath)) {
                 await forceRemove(parentDir);
               }
@@ -469,7 +465,8 @@ export class ArchiveService {
                 restoredWorktreeName,
               );
               await manager.deleteWorktree(worktreePath);
-              const worktreeBasePath = this.workspaceSettings.getWorktreeLocation();
+              const worktreeBasePath =
+                this.workspaceSettings.getWorktreeLocation();
               const parentDir = path.dirname(worktreePath);
               if (worktreePath.startsWith(worktreeBasePath)) {
                 await forceRemove(parentDir);

--- a/products/desktop/packages/workspace-server/src/services/suspension/suspension.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/suspension/suspension.test.ts
@@ -1,6 +1,10 @@
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetAutoSuspendEnabled = vi.hoisted(() => vi.fn(() => true));
+const mockGetAllWorktreeLocations = vi.hoisted(() =>
+  vi.fn(() => ["/tmp/worktrees"]),
+);
 const mockGetMaxActiveWorktrees = vi.hoisted(() => vi.fn(() => 5));
 const mockGetAutoSuspendAfterDays = vi.hoisted(() => vi.fn(() => 7));
 const mockCaptureRun = vi.hoisted(() => vi.fn(() => ({ success: true })));
@@ -50,6 +54,7 @@ vi.mock("node:fs/promises", () => {
   return { default: fns, ...fns };
 });
 
+import { rm } from "node:fs/promises";
 import type { IWorkspaceSettings } from "@posthog/platform/workspace-settings";
 import { createMockArchiveRepository } from "@posthog/workspace-server/db/repositories/archive-repository.mock";
 import { createMockRepositoryRepository } from "@posthog/workspace-server/db/repositories/repository-repository.mock";
@@ -84,7 +89,7 @@ function createMocks() {
     setMaxActiveWorktrees: vi.fn(),
     setAutoSuspendAfterDays: vi.fn(),
     getWorktreeLocation: () => "/tmp/worktrees",
-    getAllWorktreeLocations: () => ["/tmp/worktrees"],
+    getAllWorktreeLocations: mockGetAllWorktreeLocations,
     setWorktreeLocation: vi.fn(),
   } as unknown as IWorkspaceSettings;
   const logger = {
@@ -134,6 +139,7 @@ function makeService(mocks: ReturnType<typeof createMocks>) {
 function seedWorktreeWorkspace(
   mocks: ReturnType<typeof createMocks>,
   overrides: Partial<Workspace> = {},
+  worktreePath?: string,
 ) {
   const ws = mocks.workspaceRepo.create({
     taskId: overrides.taskId ?? "task-1",
@@ -150,7 +156,7 @@ function seedWorktreeWorkspace(
   mocks.worktreeRepo.create({
     workspaceId: resolved.id,
     name: `wt-${resolved.taskId}`,
-    path: `/tmp/worktrees/wt-${resolved.taskId}/repo`,
+    path: worktreePath ?? `/tmp/worktrees/wt-${resolved.taskId}/repo`,
   });
   return resolved;
 }
@@ -164,6 +170,7 @@ describe("SuspensionService", () => {
     mockGetAutoSuspendEnabled.mockImplementation(() => true);
     mockGetMaxActiveWorktrees.mockImplementation(() => 5);
     mockGetAutoSuspendAfterDays.mockImplementation(() => 7);
+    mockGetAllWorktreeLocations.mockImplementation(() => ["/tmp/worktrees"]);
     mocks = createMocks();
     service = makeService(mocks);
   });
@@ -318,6 +325,49 @@ describe("SuspensionService", () => {
         expect(suspended[0].reason).toBe("inactivity");
       },
     );
+  });
+
+  describe("worktree cleanup on suspend", () => {
+    it.each([
+      {
+        label: "removes the parent directory of a managed worktree",
+        worktreePath: "/tmp/worktrees/wt-task-1/repo",
+        locations: ["/tmp/worktrees"],
+        removesParent: true,
+      },
+      {
+        label: "removes the parent directory under a legacy location",
+        worktreePath: "/tmp/legacy-worktrees/wt-task-1/repo",
+        locations: ["/tmp/worktrees", "/tmp/legacy-worktrees"],
+        removesParent: true,
+      },
+      {
+        label: "leaves the parent directory of an adopted external worktree",
+        worktreePath: "/repos/external-checkouts/wt-task-1/repo",
+        locations: ["/tmp/worktrees"],
+        removesParent: false,
+      },
+      {
+        label: "leaves a sibling directory sharing the base path prefix",
+        worktreePath: "/tmp/worktrees-old/wt-task-1/repo",
+        locations: ["/tmp/worktrees"],
+        removesParent: false,
+      },
+    ])("$label", async ({ worktreePath, locations, removesParent }) => {
+      mockGetAllWorktreeLocations.mockReturnValue(locations);
+      seedWorktreeWorkspace(mocks, {}, worktreePath);
+
+      await service.suspendTask("task-1", "manual");
+
+      if (removesParent) {
+        expect(vi.mocked(rm)).toHaveBeenCalledWith(
+          path.dirname(worktreePath),
+          expect.objectContaining({ recursive: true }),
+        );
+      } else {
+        expect(vi.mocked(rm)).not.toHaveBeenCalled();
+      }
+    });
   });
 
   describe("withRollback", () => {

--- a/products/desktop/packages/workspace-server/src/services/suspension/suspension.ts
+++ b/products/desktop/packages/workspace-server/src/services/suspension/suspension.ts
@@ -38,7 +38,10 @@ import {
   captureWorktreeCheckpoint,
   restoreWorktreeFromCheckpoint,
 } from "../worktree-checkpoint/worktree-checkpoint";
-import { deriveWorktreePath as deriveWorktreePathFromBase } from "../worktree-path/worktree-path";
+import {
+  deriveWorktreePath as deriveWorktreePathFromBase,
+  isWorktreePathManaged,
+} from "../worktree-path/worktree-path";
 import { getCurrentBranchName } from "../worktree-query/worktree-query";
 import {
   SUSPENSION_FILE_WATCHER,
@@ -317,10 +320,13 @@ export class SuspensionService extends TypedEventEmitter<SuspensionServiceEvents
   ): Promise<void> {
     const manager = this.createWorktreeManager(folderPath);
     await manager.deleteWorktree(worktreePath);
-    const worktreeBasePath = this.workspaceSettings.getWorktreeLocation();
-    const parentDir = path.dirname(worktreePath);
-    if (worktreePath.startsWith(worktreeBasePath)) {
-      await forceRemove(parentDir);
+    if (
+      isWorktreePathManaged(
+        worktreePath,
+        this.workspaceSettings.getAllWorktreeLocations(),
+      )
+    ) {
+      await forceRemove(path.dirname(worktreePath));
     }
   }
 

--- a/products/desktop/packages/workspace-server/src/services/suspension/suspension.ts
+++ b/products/desktop/packages/workspace-server/src/services/suspension/suspension.ts
@@ -317,7 +317,15 @@ export class SuspensionService extends TypedEventEmitter<SuspensionServiceEvents
   ): Promise<void> {
     const manager = this.createWorktreeManager(folderPath);
     await manager.deleteWorktree(worktreePath);
-    await forceRemove(path.dirname(worktreePath));
+    const worktreeBasePath = this.workspaceSettings.getWorktreeLocation();
+    const parentDir = path.dirname(worktreePath);
+    // Only remove the parent directory for app-managed worktrees (those inside
+    // the worktree base path). Adopted external worktrees have their parent
+    // outside the managed base, and removing it would recursively delete the
+    // parent directory containing the main repo and sibling worktrees (#81530).
+    if (worktreePath.startsWith(worktreeBasePath)) {
+      await forceRemove(parentDir);
+    }
   }
 
   private async killTaskProcesses(

--- a/products/desktop/packages/workspace-server/src/services/suspension/suspension.ts
+++ b/products/desktop/packages/workspace-server/src/services/suspension/suspension.ts
@@ -319,10 +319,6 @@ export class SuspensionService extends TypedEventEmitter<SuspensionServiceEvents
     await manager.deleteWorktree(worktreePath);
     const worktreeBasePath = this.workspaceSettings.getWorktreeLocation();
     const parentDir = path.dirname(worktreePath);
-    // Only remove the parent directory for app-managed worktrees (those inside
-    // the worktree base path). Adopted external worktrees have their parent
-    // outside the managed base, and removing it would recursively delete the
-    // parent directory containing the main repo and sibling worktrees (#81530).
     if (worktreePath.startsWith(worktreeBasePath)) {
       await forceRemove(parentDir);
     }

--- a/products/desktop/packages/workspace-server/src/services/worktree-path/worktree-path.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/worktree-path/worktree-path.test.ts
@@ -2,7 +2,7 @@ import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { deriveWorktreePath } from "./worktree-path";
+import { deriveWorktreePath, isWorktreePathManaged } from "./worktree-path";
 
 const REPO = "/repos/posthog";
 const REPO_NAME = "posthog";
@@ -55,5 +55,57 @@ describe("deriveWorktreePath", () => {
     expect(deriveWorktreePath(tmpDir, "/a/b/other-repo", "feat")).toBe(
       path.join(tmpDir, "feat", "other-repo"),
     );
+  });
+});
+
+describe("isWorktreePathManaged", () => {
+  const BASE = path.resolve("/data/worktrees");
+  const LEGACY = path.resolve("/data/legacy-worktrees");
+
+  it.each([
+    {
+      label: "path inside the base",
+      candidate: path.join(BASE, "wt", "repo"),
+      bases: [BASE],
+      expected: true,
+    },
+    {
+      label: "path equal to the base",
+      candidate: BASE,
+      bases: [BASE],
+      expected: true,
+    },
+    {
+      label: "path inside a legacy base",
+      candidate: path.join(LEGACY, "wt", "repo"),
+      bases: [BASE, LEGACY],
+      expected: true,
+    },
+    {
+      label: "path outside every base",
+      candidate: path.resolve("/repos/checkout/wt"),
+      bases: [BASE, LEGACY],
+      expected: false,
+    },
+    {
+      label: "sibling directory sharing the base as a string prefix",
+      candidate: path.resolve("/data/worktrees-old/wt/repo"),
+      bases: [BASE],
+      expected: false,
+    },
+    {
+      label: "base with a trailing separator",
+      candidate: path.join(BASE, "wt", "repo"),
+      bases: [BASE + path.sep],
+      expected: true,
+    },
+    {
+      label: "unnormalized dot segments in the path",
+      candidate: [BASE, "..", "worktrees", "wt"].join(path.sep),
+      bases: [BASE],
+      expected: true,
+    },
+  ])("$label -> $expected", ({ candidate, bases, expected }) => {
+    expect(isWorktreePathManaged(candidate, bases)).toBe(expected);
   });
 });

--- a/products/desktop/packages/workspace-server/src/services/worktree-path/worktree-path.ts
+++ b/products/desktop/packages/workspace-server/src/services/worktree-path/worktree-path.ts
@@ -20,3 +20,14 @@ export function deriveWorktreePath(
   if (fs.existsSync(legacyFormatPath)) return legacyFormatPath;
   return newFormatPath;
 }
+
+export function isWorktreePathManaged(
+  worktreePath: string,
+  worktreeBasePaths: string[],
+): boolean {
+  const resolved = path.resolve(worktreePath);
+  return worktreeBasePaths.some((basePath) => {
+    const base = path.resolve(basePath);
+    return resolved === base || resolved.startsWith(base + path.sep);
+  });
+}


### PR DESCRIPTION
## Problem

Archiving or suspending a task whose worktree was adopted from outside the app deletes the worktree's parent directory. That parent can be the user's own code folder, holding the main repo and sibling checkouts.

- After deleting a worktree, archive and suspension always ran `forceRemove(path.dirname(worktreePath))`.
- That is safe only for app-managed worktrees, whose parent is a per-task container under the worktree base.

Fixes #81530

## Changes

- Cleanup removes the parent directory only when the worktree lives under an app-managed worktree location.
- A new `isWorktreePathManaged` helper resolves both paths and requires a separator boundary, so a sibling folder like `worktrees-old` cannot match the base `worktrees` as a string prefix.
- The helper checks every configured location (`getAllWorktreeLocations()`), so worktrees under a legacy location still get their parent cleaned up.
- All three cleanup sites (archive, unarchive rollback, suspension) share the helper.

No frontend changes, so no screenshots.

## How did you test this code?

- Unit cases for `isWorktreePathManaged` cover containment, legacy bases, trailing separators, dot segments and prefix-sibling rejection. The prefix-sibling case fails against a raw `startsWith` guard.
- Suspension unit tests assert the parent directory is removed for managed and legacy-location worktrees and left alone for adopted external and prefix-sibling paths.
- An archive integration test archives a real adopted worktree outside the base and asserts the parent directory and a sibling file survive. It fails against the unguarded code.
- Ran the vitest suites for the three touched services locally. Not run: the rest of the desktop suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- The original guard is from the PR author. A multi-agent review of the branch found the string-prefix collision, the legacy-location gap and the missing test coverage.
- Claude Code, directed by the assignee, pushed two follow-up commits: one strips narration comments, one extracts the hardened helper and adds the tests.
- Skills invoked: /writing-code-comments, /writing-tests, /writing-pr-descriptions.
