### PR TITLE
fix(flags): stop shipping unevaluable flag targeting to local evaluation

### DIFF
--- a/products/feature_flags/backend/flags_cache.py
+++ b/products/feature_flags/backend/flags_cache.py
@@ -810,13 +810,14 @@ def _compare_flag_fields(db_flag: dict, cached_flag: dict, *, tolerate_blanked_f
     tolerate. See plans/verify-flags-cache-loose-comparison.md.
 
     ``tolerate_blanked_filters`` exempts ``filters`` when both sides agree the flag
-    is unevaluable. Only the ``flags.json`` writers blank those filters, and entries
+    is unevaluable. The ``flags.json`` writers blank those filters, and entries
     predating that still hold the full blob while the two writers deploy
     independently, so the blob and ``{"groups": []}`` both occur and the matcher
     ignores either one. It is opt-in because ``local_evaluation`` shares this
-    function for ``flags_with_cohorts.json``, which has a single writer and no
-    blanking: there any ``filters`` difference is real drift worth repairing. A
-    disagreement about ``active`` itself is reported in both modes.
+    function for ``flags_with_cohorts.json``, which blanks too but has a single
+    writer: there a full blob is either real drift or an entry predating the
+    blanking, and repairing it is what we want either way. A disagreement about
+    ``active`` itself is reported in both modes.
     """
     field_diffs = []
 

--- a/products/feature_flags/backend/local_evaluation.py
+++ b/products/feature_flags/backend/local_evaluation.py
@@ -54,7 +54,9 @@ from products.cohorts.backend.models.util import get_nested_cohort_ids
 from products.experiments.backend.models.experiment import Experiment, live_experiment_exists
 from products.feature_flags.backend.cache_keys import EU_CROSS_REGION_MIRROR_CACHE_KEY
 from products.feature_flags.backend.flags_cache import (
+    _blank_inactive_filters,
     _compare_flag_fields,
+    _is_unevaluable,
     get_team_ids_with_recently_updated_flags,
     get_teams_with_flags_queryset,
 )
@@ -630,7 +632,10 @@ def _get_flags_response_for_local_evaluation_batch(teams: list[Team]) -> dict[in
     for flag in all_flags:
         flag._evaluation_tag_names = flag.evaluation_tag_names_agg or []
         flag._has_experiment = flag.has_experiment_agg
-        referenced_cohort_ids.update(_extract_cohort_ids_from_filters(flag.filters or {}))
+        # A cohort only an unevaluable flag references can never reach the response, so loading
+        # it and walking its nested dependencies below is wasted work.
+        if not _is_unevaluable({"active": flag.active, "deleted": flag.deleted}):
+            referenced_cohort_ids.update(_extract_cohort_ids_from_filters(flag.filters or {}))
 
     # Load only the referenced cohorts and resolve nested dependencies
     # iteratively. Each iteration loads newly discovered nested cohort IDs
@@ -685,42 +690,51 @@ def _get_flags_response_for_local_evaluation_batch(teams: list[Team]) -> dict[in
 
         for feature_flag in team_flags_iter:
             try:
-                filters = feature_flag.get_filters()
+                flag_data = EvaluationFeatureFlagSerializer(feature_flag, context={}).data
 
-                # Pre-populate cache with empty entries for any referenced cohort_id
-                # not already loaded, so get_cohort_ids doesn't make fallback DB queries
-                # for deleted or cross-team cohorts.
-                for cid in _extract_cohort_ids_from_filters(filters):
-                    if cid not in seen_cohorts_cache:
-                        seen_cohorts_cache[cid] = ""
+                # An SDK skips a flag it cannot evaluate before it reads the filters, so the
+                # cohorts behind that targeting would ship for nothing. The targeting itself is
+                # dropped after the loop.
+                if not _is_unevaluable(flag_data):
+                    filters = feature_flag.get_filters()
 
-                cohort_ids = feature_flag.get_cohort_ids(
-                    using_database=DATABASE_FOR_LOCAL_EVALUATION,
-                    seen_cohorts_cache=seen_cohorts_cache,
-                )
+                    # Pre-populate cache with empty entries for any referenced cohort_id
+                    # not already loaded, so get_cohort_ids doesn't make fallback DB queries
+                    # for deleted or cross-team cohorts.
+                    for cid in _extract_cohort_ids_from_filters(filters):
+                        if cid not in seen_cohorts_cache:
+                            seen_cohorts_cache[cid] = ""
 
-                flags_data.append(EvaluationFeatureFlagSerializer(feature_flag, context={}).data)
+                    cohort_ids = feature_flag.get_cohort_ids(
+                        using_database=DATABASE_FOR_LOCAL_EVALUATION,
+                        seen_cohorts_cache=seen_cohorts_cache,
+                    )
 
-                for cohort_id in cohort_ids:
-                    str_id = str(cohort_id)
-                    if str_id not in cohorts:
-                        cohort = project_cohorts.get(cohort_id)
-                        if cohort is not None and not cohort.is_static:
-                            try:
-                                cohorts[str_id] = cohort.properties.to_dict()
-                            except Exception:
-                                logger.error(
-                                    "Error processing cohort properties",
-                                    extra={"cohort_id": cohort_id},
-                                    exc_info=True,
-                                )
+                    for cohort_id in cohort_ids:
+                        str_id = str(cohort_id)
+                        if str_id not in cohorts:
+                            cohort = project_cohorts.get(cohort_id)
+                            if cohort is not None and not cohort.is_static:
+                                try:
+                                    cohorts[str_id] = cohort.properties.to_dict()
+                                except Exception:
+                                    logger.error(
+                                        "Error processing cohort properties",
+                                        extra={"cohort_id": cohort_id},
+                                        exc_info=True,
+                                    )
 
+                flags_data.append(flag_data)
                 flag_id_to_key[str(feature_flag.id)] = feature_flag.key
 
             except Exception:
                 logger.error("Error processing feature flag", extra={"flag_id": feature_flag.pk}, exc_info=True)
                 FLAG_PROCESSING_ERROR_COUNTER.inc()
                 continue
+
+        # The same blanking the flags hypercache applies, for the same reason: the matcher
+        # skips these flags before it reads filters, so the targeting is unreachable weight.
+        _blank_inactive_filters(flags_data)
 
         response_data = _local_eval_response(
             flags=flags_data,

--- a/products/feature_flags/backend/test/test_local_evaluation.py
+++ b/products/feature_flags/backend/test/test_local_evaluation.py
@@ -1097,6 +1097,38 @@ class TestLocalEvaluationBatch(BaseTest):
         assert str(referenced_cohort.pk) in results[team.id]["cohorts"]
         assert str(unreferenced_cohort.pk) not in results[team.id]["cohorts"]
 
+    @parameterized.expand(
+        [
+            ("active", {}, True),
+            ("disabled", {"active": False}, False),
+        ]
+    )
+    def test_batch_blanks_targeting_and_skips_cohorts_of_flags_an_sdk_cannot_evaluate(
+        self, name: str, flag_state: dict, evaluable: bool
+    ) -> None:
+        # The entry itself has to stay either way: a live flag depending on this one resolves it
+        # to false, and dropping it collapses that dependency chain instead.
+        team = self._create_team_with_project(f"Blanking Team {name}")
+        cohort = Cohort.objects.create(
+            team=team,
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [{"type": "OR", "values": [{"key": "email", "value": "a@a.com", "type": "person"}]}],
+                }
+            },
+            name=f"cohort-of-{name}-flag",
+        )
+        targeting = {"groups": [{"properties": [{"key": "id", "type": "cohort", "value": cohort.pk}]}]}
+        flag = FeatureFlag.objects.create(team=team, key=f"{name}-flag", filters=targeting, **flag_state)
+
+        results = _get_flags_response_for_local_evaluation_batch([team])
+
+        by_key = {f["key"]: f for f in results[team.id]["flags"]}
+        assert flag.key in by_key
+        assert by_key[flag.key]["filters"] == (targeting if evaluable else {"groups": []})
+        assert (str(cohort.pk) in results[team.id]["cohorts"]) is evaluable
+
     def test_batch_static_cohort_excluded(self):
         """Static cohorts cannot be locally evaluated and should not appear in the response."""
         team = self._create_team_with_project("Static Cohort Team")


### PR DESCRIPTION
## Problem

An SDK doing local evaluation downloads the targeting rules and cohort definitions of every disabled and archived flag on the team, then never reads them.

The SDK sees `active: false` and skips the flag before it looks at `filters`. The flags hypercache already knows this: `_blank_inactive_filters` empties those filters so they stop taking up room in Redis, S3, and the service's memory. The local-evaluation payload never got the same treatment.

The waste grows on its own. Every finished experiment leaves one archived flag behind, and each one keeps a full copy of its targeting plus every cohort it references in the response.

## Changes

- Local evaluation now blanks the filters of any flag the SDK cannot evaluate, calling the same `_blank_inactive_filters` the hypercache uses.
- Cohorts referenced only by those flags no longer load into the payload.
- The bulk cohort preload skips them too, so building the payload stops walking their nested cohort trees.
- The flag entry itself stays, so a live flag that depends on an unevaluable one still resolves it to false.

Sharing the helper matters beyond avoiding duplication: `flags_cache` documents that the empty value must byte-match Rust's empty `FlagFilters`, whose `groups` field serializes unconditionally. That constraint now lives in one place.

> [!NOTE]
> `archived` never reaches an SDK. The `archived_flag_must_be_disabled` constraint makes every archived flag inactive, so archived flags travel as ordinary disabled ones and the `active` check covers them.

## How did you test this code?

One parameterized test in `TestLocalEvaluationBatch`, over an active and a disabled flag that each target a cohort. It asserts three things per case: the flag entry survives, its filters are blanked only when unevaluable, and its cohort reaches the response only when evaluable.

I verified the assertions fail against the unfixed code. The blanking is pinned on its own. The two cohort guards turn out to be redundant for the payload, since either alone keeps the cohort out, so that assertion catches the feature being removed rather than each guard.

The preload skip has no payload effect at all, only fewer queries while building it, so no test pins it.

Not checked: no SDK ran against this payload, and I have no production measurement of how much smaller it gets. The claim that SDKs ignore these filters rests on `active` and `deleted` being in the payload and on the hypercache having shipped the same behavior.

`_compare_flag_fields` keeps repairing a full blob it finds in a cached entry. During rollout that rewrites pre-blanking entries, which is the outcome we want; its docstring said local evaluation never blanks, and this corrects it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. `docs/internal/feature-flags/hypercache-system.md` documents this behavior for the hypercache and needs no change for local evaluation to match it.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude wrote the code through PostHog Code. Phil directed the work.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/simplify`.

This started as a review comment on #81616, which flagged that archived flags no longer count toward the per-team cap while still sitting in evaluation payloads. The first two candidate fixes were a second row ceiling and dropping archived flags from the payloads entirely. Phil asked why the payloads carry them at all, which turned up the real answer: the hypercache already drops the targeting and only local evaluation still ships it. That made the ceiling unnecessary and this the smaller, lower-risk change.

A `/simplify` pass then replaced a copied empty-filters literal with the shared helper, found that the bulk preload still loaded cohorts this change had made unreachable, and cut a test case that exercised no distinct branch.