### PR TITLE
fix(security): address post-merge findings on leaked-key revocation

### DIFF
--- a/frontend/src/generated/core/api.ts
+++ b/frontend/src/generated/core/api.ts
@@ -2300,7 +2300,7 @@ export const getRevokeLeakedKeyCreateUrl = () => {
 }
 
 /**
- * Public, unauthenticated endpoint for self-service revocation of a leaked PostHog personal API key, project secret API key, or OAuth access/refresh token. If the token is live it is revoked immediately and the owner is notified by email.
+ * Public, unauthenticated endpoint for self-service revocation of a leaked PostHog personal API key, project secret API key, or OAuth access/refresh token. If the token matches a real credential, it is revoked immediately and the owner is notified by email. This includes an expired OAuth access token: the paired refresh token it protects may still be live.
  *
  * This endpoint only checks the region it is running on. `"found": false` does not guarantee the token is safe. If you're not sure which region issued it, check both: https://app.posthog.com/api/revoke_leaked_key and https://eu.posthog.com/api/revoke_leaked_key.
  * @summary Report and revoke a leaked PostHog API key or token

--- a/frontend/src/generated/core/api.zod.ts
+++ b/frontend/src/generated/core/api.zod.ts
@@ -917,7 +917,7 @@ export const SessionRecordingsSharingRefreshCreateBody = /* @__PURE__ */ zod
     .describe('Mixin for serializers to add user access control fields')
 
 /**
- * Public, unauthenticated endpoint for self-service revocation of a leaked PostHog personal API key, project secret API key, or OAuth access/refresh token. If the token is live it is revoked immediately and the owner is notified by email.
+ * Public, unauthenticated endpoint for self-service revocation of a leaked PostHog personal API key, project secret API key, or OAuth access/refresh token. If the token matches a real credential, it is revoked immediately and the owner is notified by email. This includes an expired OAuth access token: the paired refresh token it protects may still be live.
  *
  * This endpoint only checks the region it is running on. `"found": false` does not guarantee the token is safe. If you're not sure which region issued it, check both: https://app.posthog.com/api/revoke_leaked_key and https://eu.posthog.com/api/revoke_leaked_key.
  * @summary Report and revoke a leaked PostHog API key or token

--- a/posthog/api/github.py
+++ b/posthog/api/github.py
@@ -237,7 +237,7 @@ class SecretAlert(APIView):
 
             if item["type"] == GITHUB_TYPE_FOR_PERSONAL_API_KEY:
                 more_info = f"This key was detected by GitHub at {item['url']}."
-                revocation = revoke_leaked_secret(token, CANONICAL_PERSONAL_API_KEY, more_info, trusted=True)
+                revocation = revoke_leaked_secret(token, CANONICAL_PERSONAL_API_KEY, more_info)
                 local_found = revocation.found
 
                 pending_events.append(
@@ -256,7 +256,7 @@ class SecretAlert(APIView):
 
             elif item["type"] == GITHUB_TYPE_FOR_SECURE_API_KEY:
                 more_info = f"This key was detected by GitHub at {item['url']}."
-                revocation = revoke_leaked_secret(token, CANONICAL_PROJECT_SECRET_API_KEY, more_info, trusted=True)
+                revocation = revoke_leaked_secret(token, CANONICAL_PROJECT_SECRET_API_KEY, more_info)
                 local_found = revocation.found
                 key_kind = "project_secret_api_key" if revocation.found else None
 
@@ -287,7 +287,7 @@ class SecretAlert(APIView):
 
             elif item["type"] == GITHUB_TYPE_FOR_OAUTH_ACCESS_TOKEN:
                 more_info = f"This token was detected by GitHub at {item['url']}."
-                revocation = revoke_leaked_secret(token, CANONICAL_OAUTH_ACCESS_TOKEN, more_info, trusted=True)
+                revocation = revoke_leaked_secret(token, CANONICAL_OAUTH_ACCESS_TOKEN, more_info)
                 local_found = revocation.found
 
                 pending_events.append(
@@ -306,7 +306,7 @@ class SecretAlert(APIView):
 
             elif item["type"] == GITHUB_TYPE_FOR_OAUTH_REFRESH_TOKEN:
                 more_info = f"This token was detected by GitHub at {item['url']}."
-                revocation = revoke_leaked_secret(token, CANONICAL_OAUTH_REFRESH_TOKEN, more_info, trusted=True)
+                revocation = revoke_leaked_secret(token, CANONICAL_OAUTH_REFRESH_TOKEN, more_info)
                 local_found = revocation.found
 
                 pending_events.append(

--- a/posthog/api/github.py
+++ b/posthog/api/github.py
@@ -237,7 +237,7 @@ class SecretAlert(APIView):
 
             if item["type"] == GITHUB_TYPE_FOR_PERSONAL_API_KEY:
                 more_info = f"This key was detected by GitHub at {item['url']}."
-                revocation = revoke_leaked_secret(token, CANONICAL_PERSONAL_API_KEY, more_info)
+                revocation = revoke_leaked_secret(token, CANONICAL_PERSONAL_API_KEY, more_info, trusted=True)
                 local_found = revocation.found
 
                 pending_events.append(
@@ -256,7 +256,7 @@ class SecretAlert(APIView):
 
             elif item["type"] == GITHUB_TYPE_FOR_SECURE_API_KEY:
                 more_info = f"This key was detected by GitHub at {item['url']}."
-                revocation = revoke_leaked_secret(token, CANONICAL_PROJECT_SECRET_API_KEY, more_info)
+                revocation = revoke_leaked_secret(token, CANONICAL_PROJECT_SECRET_API_KEY, more_info, trusted=True)
                 local_found = revocation.found
                 key_kind = "project_secret_api_key" if revocation.found else None
 
@@ -287,7 +287,7 @@ class SecretAlert(APIView):
 
             elif item["type"] == GITHUB_TYPE_FOR_OAUTH_ACCESS_TOKEN:
                 more_info = f"This token was detected by GitHub at {item['url']}."
-                revocation = revoke_leaked_secret(token, CANONICAL_OAUTH_ACCESS_TOKEN, more_info)
+                revocation = revoke_leaked_secret(token, CANONICAL_OAUTH_ACCESS_TOKEN, more_info, trusted=True)
                 local_found = revocation.found
 
                 pending_events.append(
@@ -306,7 +306,7 @@ class SecretAlert(APIView):
 
             elif item["type"] == GITHUB_TYPE_FOR_OAUTH_REFRESH_TOKEN:
                 more_info = f"This token was detected by GitHub at {item['url']}."
-                revocation = revoke_leaked_secret(token, CANONICAL_OAUTH_REFRESH_TOKEN, more_info)
+                revocation = revoke_leaked_secret(token, CANONICAL_OAUTH_REFRESH_TOKEN, more_info, trusted=True)
                 local_found = revocation.found
 
                 pending_events.append(

--- a/posthog/api/leaked_key.py
+++ b/posthog/api/leaked_key.py
@@ -50,7 +50,9 @@ class LeakedKeyReportResponseSerializer(serializers.Serializer):
 class PublicLeakedKeyReport(APIView):
     """
     Public, unauthenticated self-service endpoint: submit a leaked PostHog token and,
-    if it's live, it's revoked immediately and the owner is notified. Safety relies on
+    if it matches a real credential, it's revoked immediately and the owner is
+    notified — even if the submitted OAuth access token has itself already expired,
+    since the paired refresh token it protects may still be live. Safety relies on
     possession of the plaintext token, not a signature — see secret_revocation.py.
 
     Region-local only, no cross-region relay: a "found": false result does not rule
@@ -78,7 +80,9 @@ class PublicLeakedKeyReport(APIView):
         description=(
             "Public, unauthenticated endpoint for self-service revocation of a leaked PostHog "
             "personal API key, project secret API key, or OAuth access/refresh token. If the "
-            "token is live it is revoked immediately and the owner is notified by email.\n\n"
+            "token matches a real credential, it is revoked immediately and the owner is "
+            "notified by email. This includes an expired OAuth access token: the paired "
+            "refresh token it protects may still be live.\n\n"
             'This endpoint only checks the region it is running on. `"found": false` does not '
             "guarantee the token is safe. If you're not sure which region issued it, check "
             "both: https://app.posthog.com/api/revoke_leaked_key and "

--- a/posthog/api/leaked_key.py
+++ b/posthog/api/leaked_key.py
@@ -94,20 +94,27 @@ class PublicLeakedKeyReport(APIView):
         # Unlike github_secret_alert, no token_prefix/token_suffix here: GitHub already
         # confirmed the string is a real PostHog-shaped secret before that event fires,
         # but this endpoint's callers are the whole internet, and people will paste
-        # things that aren't PostHog keys at all. token_sha256 alone is enough for
-        # dedup/monitoring without persisting fragments of third-party secrets.
+        # things that aren't PostHog keys at all.
+        properties: dict[str, str | int | bool | None] = {
+            "found": result.found,
+            "type": result.key_type,
+            "token_length": len(token),
+            # With no cross-region relay, this is the only signal showing whether
+            # callers in one region are reporting keys the other region issued.
+            "region": get_instance_region(),
+        }
+        if result.found:
+            # Only hash a token once it matched a real PostHog credential: those are
+            # high-entropy and this hash isn't practically reversible. For the common
+            # case of a caller pasting something that isn't a PostHog secret at all, an
+            # unsalted SHA-256 of a low-entropy string (a password, a short token) is
+            # dictionary/rainbow-table reversible, so we don't persist a recoverable
+            # copy of a third party's actual secret.
+            properties["token_sha256"] = sha256(token.encode("utf-8")).hexdigest()
         posthoganalytics.capture(
             distinct_id=None,
             event="public_leaked_key_report",
-            properties={
-                "found": result.found,
-                "type": result.key_type,
-                "token_length": len(token),
-                "token_sha256": sha256(token.encode("utf-8")).hexdigest(),
-                # With no cross-region relay, this is the only signal showing whether
-                # callers in one region are reporting keys the other region issued.
-                "region": get_instance_region(),
-            },
+            properties=properties,
         )
 
         return Response({"found": result.found, "type": result.key_type})

--- a/posthog/api/secret_revocation.py
+++ b/posthog/api/secret_revocation.py
@@ -31,7 +31,7 @@ class RevocationResult:
         return self.key_type is not None
 
 
-def _revoke_personal_api_key(token: str, more_info: str) -> bool:
+def _revoke_personal_api_key(token: str, more_info: str, *, trusted: bool) -> bool:
     key_lookup = find_personal_api_key(token)
     if key_lookup is None:
         return False
@@ -43,7 +43,7 @@ def _revoke_personal_api_key(token: str, more_info: str) -> bool:
     return True
 
 
-def _revoke_project_secret_api_key(token: str, more_info: str) -> bool:
+def _revoke_project_secret_api_key(token: str, more_info: str, *, trusted: bool) -> bool:
     project_secret_api_key = find_project_secret_api_key(token)
     if project_secret_api_key is None:
         return False
@@ -51,14 +51,20 @@ def _revoke_project_secret_api_key(token: str, more_info: str) -> bool:
     return True
 
 
-def _revoke_oauth_token(token: str, more_info: str, *, kind: Literal["access", "refresh"]) -> bool:
+def _revoke_oauth_token(token: str, more_info: str, *, kind: Literal["access", "refresh"], trusted: bool) -> bool:
     if kind == "access":
         access_token = find_oauth_access_token(token)
-        # An expired access token no longer authenticates, so possessing one doesn't
-        # give its holder the "already has full use of this credential" standing this
-        # endpoint's lack of a signature check relies on. Without this, anyone who once
-        # saw a since-expired token could still force-revoke the holder's live session.
-        if access_token is None or access_token.is_expired():
+        if access_token is None:
+            return False
+        # An expired access token no longer authenticates, so an anonymous possessor of
+        # one doesn't have the "already has full use of this credential" standing the
+        # public endpoint's lack of a signature check relies on - without this, anyone
+        # who once saw a since-expired token could force-revoke the holder's live
+        # session. A trusted, signed report (github.py) doesn't rest on that possession
+        # argument - GitHub independently verified the exposure - so it still revokes
+        # the paired refresh token and notifies the owner even if the access token
+        # itself has since expired and needs no revocation of its own.
+        if not trusted and access_token.is_expired():
             return False
         # Scoped to this one access/refresh token pair, not every session the user has
         # with the application - a leaked-token report is evidence about that one
@@ -76,12 +82,12 @@ def _revoke_oauth_token(token: str, more_info: str, *, kind: Literal["access", "
     return True
 
 
-def _revoke_oauth_access_token(token: str, more_info: str) -> bool:
-    return _revoke_oauth_token(token, more_info, kind="access")
+def _revoke_oauth_access_token(token: str, more_info: str, *, trusted: bool) -> bool:
+    return _revoke_oauth_token(token, more_info, kind="access", trusted=trusted)
 
 
-def _revoke_oauth_refresh_token(token: str, more_info: str) -> bool:
-    return _revoke_oauth_token(token, more_info, kind="refresh")
+def _revoke_oauth_refresh_token(token: str, more_info: str, *, trusted: bool) -> bool:
+    return _revoke_oauth_token(token, more_info, kind="refresh", trusted=trusted)
 
 
 _REVOKERS = {
@@ -155,13 +161,24 @@ def _detect_canonical_type(token: str) -> str | None:
     return None
 
 
-def revoke_leaked_secret(token: str, key_type: str | None, more_info: str) -> RevocationResult:
+def revoke_leaked_secret(
+    token: str, key_type: str | None, more_info: str, *, trusted: bool = False
+) -> RevocationResult:
     """Look up `token` as a leaked credential and revoke+notify on a match.
 
     If `key_type` is one of the CANONICAL_* constants, only that lookup runs.
     If `key_type` is None, the token's prefix determines which single lookup runs.
+
+    `trusted` should be True only when the report's authenticity is independently
+    verified before this function runs (e.g. GitHub's signed webhook). It only affects
+    OAuth access tokens: an expired one is otherwise treated as not found, since mere
+    possession of a dead token shouldn't grant an anonymous caller the power to
+    force-revoke a live session - a signed report doesn't rest on that possession
+    argument, so it still acts on an expired match. Defaults to False, the safer,
+    more restrictive behavior, so a caller that forgets to pass it gets the anonymous
+    (public-endpoint) semantics rather than the trusted ones.
     """
     resolved_type = key_type if key_type is not None else _detect_canonical_type(token)
-    if resolved_type is not None and _REVOKERS[resolved_type](token, more_info):
+    if resolved_type is not None and _REVOKERS[resolved_type](token, more_info, trusted=trusted):
         return RevocationResult(key_type=resolved_type)
     return RevocationResult(key_type=None)

--- a/posthog/api/secret_revocation.py
+++ b/posthog/api/secret_revocation.py
@@ -31,7 +31,7 @@ class RevocationResult:
         return self.key_type is not None
 
 
-def _revoke_personal_api_key(token: str, more_info: str, *, trusted: bool) -> bool:
+def _revoke_personal_api_key(token: str, more_info: str) -> bool:
     key_lookup = find_personal_api_key(token)
     if key_lookup is None:
         return False
@@ -43,7 +43,7 @@ def _revoke_personal_api_key(token: str, more_info: str, *, trusted: bool) -> bo
     return True
 
 
-def _revoke_project_secret_api_key(token: str, more_info: str, *, trusted: bool) -> bool:
+def _revoke_project_secret_api_key(token: str, more_info: str) -> bool:
     project_secret_api_key = find_project_secret_api_key(token)
     if project_secret_api_key is None:
         return False
@@ -51,20 +51,19 @@ def _revoke_project_secret_api_key(token: str, more_info: str, *, trusted: bool)
     return True
 
 
-def _revoke_oauth_token(token: str, more_info: str, *, kind: Literal["access", "refresh"], trusted: bool) -> bool:
+def _revoke_oauth_token(token: str, more_info: str, *, kind: Literal["access", "refresh"]) -> bool:
+    # Deliberately no expiry check on the access-token match: an already-expired token
+    # can't authenticate on its own, but revoking still matters if the same exposure
+    # also affects the paired refresh token (up to 30 days live). Gating this on
+    # expiry would only block that revocation, not close any capability - both this
+    # endpoint and github.py's webhook are triggerable by anyone holding a copy of a
+    # token, dead or alive (a public GitHub commit gets scanned and reported the same
+    # as an anonymous POST here), so there is no less-exposed path to gate in favor of.
+    # The only real consequence of a match either way is forcing a re-authentication,
+    # not a confidentiality or integrity loss.
     if kind == "access":
         access_token = find_oauth_access_token(token)
         if access_token is None:
-            return False
-        # An expired access token no longer authenticates, so an anonymous possessor of
-        # one doesn't have the "already has full use of this credential" standing the
-        # public endpoint's lack of a signature check relies on - without this, anyone
-        # who once saw a since-expired token could force-revoke the holder's live
-        # session. A trusted, signed report (github.py) doesn't rest on that possession
-        # argument - GitHub independently verified the exposure - so it still revokes
-        # the paired refresh token and notifies the owner even if the access token
-        # itself has since expired and needs no revocation of its own.
-        if not trusted and access_token.is_expired():
             return False
         # Scoped to this one access/refresh token pair, not every session the user has
         # with the application - a leaked-token report is evidence about that one
@@ -82,12 +81,12 @@ def _revoke_oauth_token(token: str, more_info: str, *, kind: Literal["access", "
     return True
 
 
-def _revoke_oauth_access_token(token: str, more_info: str, *, trusted: bool) -> bool:
-    return _revoke_oauth_token(token, more_info, kind="access", trusted=trusted)
+def _revoke_oauth_access_token(token: str, more_info: str) -> bool:
+    return _revoke_oauth_token(token, more_info, kind="access")
 
 
-def _revoke_oauth_refresh_token(token: str, more_info: str, *, trusted: bool) -> bool:
-    return _revoke_oauth_token(token, more_info, kind="refresh", trusted=trusted)
+def _revoke_oauth_refresh_token(token: str, more_info: str) -> bool:
+    return _revoke_oauth_token(token, more_info, kind="refresh")
 
 
 _REVOKERS = {
@@ -161,24 +160,13 @@ def _detect_canonical_type(token: str) -> str | None:
     return None
 
 
-def revoke_leaked_secret(
-    token: str, key_type: str | None, more_info: str, *, trusted: bool = False
-) -> RevocationResult:
+def revoke_leaked_secret(token: str, key_type: str | None, more_info: str) -> RevocationResult:
     """Look up `token` as a leaked credential and revoke+notify on a match.
 
     If `key_type` is one of the CANONICAL_* constants, only that lookup runs.
     If `key_type` is None, the token's prefix determines which single lookup runs.
-
-    `trusted` should be True only when the report's authenticity is independently
-    verified before this function runs (e.g. GitHub's signed webhook). It only affects
-    OAuth access tokens: an expired one is otherwise treated as not found, since mere
-    possession of a dead token shouldn't grant an anonymous caller the power to
-    force-revoke a live session - a signed report doesn't rest on that possession
-    argument, so it still acts on an expired match. Defaults to False, the safer,
-    more restrictive behavior, so a caller that forgets to pass it gets the anonymous
-    (public-endpoint) semantics rather than the trusted ones.
     """
     resolved_type = key_type if key_type is not None else _detect_canonical_type(token)
-    if resolved_type is not None and _REVOKERS[resolved_type](token, more_info, trusted=trusted):
+    if resolved_type is not None and _REVOKERS[resolved_type](token, more_info):
         return RevocationResult(key_type=resolved_type)
     return RevocationResult(key_type=None)

--- a/posthog/api/test/test_github.py
+++ b/posthog/api/test/test_github.py
@@ -1034,11 +1034,11 @@ class TestOAuthTokenSecretAlert(APIBaseTest):
     @patch("posthog.api.github.verify_github_signature")
     @patch("posthog.api.secret_revocation.send_oauth_token_exposed")
     def test_expired_oauth_access_token_report_still_revokes_and_notifies(self, mock_send_email, mock_verify):
-        # GitHub's report is a signed, independently-verified claim, not a possession
-        # claim - unlike the anonymous public endpoint, a report for an already-expired
-        # access token still revokes the paired refresh token and notifies the owner.
-        # GitHub's scan-to-report latency for historical commits routinely exceeds the
-        # access token's own lifetime, so this is the common case, not an edge case.
+        # An already-expired access token can't authenticate on its own, but revoking
+        # still matters if the same exposure also affects the longer-lived paired
+        # refresh token - and GitHub's scan-to-report latency for historical commits
+        # routinely exceeds the access token's own lifetime, so a report for an
+        # already-expired token is the common case here, not an edge case.
         mock_verify.return_value = None
 
         oauth_app = self._create_oauth_app()

--- a/posthog/api/test/test_github.py
+++ b/posthog/api/test/test_github.py
@@ -1033,6 +1033,58 @@ class TestOAuthTokenSecretAlert(APIBaseTest):
 
     @patch("posthog.api.github.verify_github_signature")
     @patch("posthog.api.secret_revocation.send_oauth_token_exposed")
+    def test_expired_oauth_access_token_report_still_revokes_and_notifies(self, mock_send_email, mock_verify):
+        # GitHub's report is a signed, independently-verified claim, not a possession
+        # claim - unlike the anonymous public endpoint, a report for an already-expired
+        # access token still revokes the paired refresh token and notifies the owner.
+        # GitHub's scan-to-report latency for historical commits routinely exceeds the
+        # access token's own lifetime, so this is the common case, not an edge case.
+        mock_verify.return_value = None
+
+        oauth_app = self._create_oauth_app()
+        token = "pha_expired_access_token_github_alert"
+        access_token = OAuthAccessToken.objects.create(
+            user=self.user,
+            application=oauth_app,
+            token=token,
+            expires=timezone.now() - timedelta(hours=1),
+            scope="openid profile",
+        )
+        access_token_id = access_token.id
+        refresh_token = OAuthRefreshToken.objects.create(
+            user=self.user,
+            application=oauth_app,
+            token="phr_live_session_for_expired_access",
+            access_token=access_token,
+        )
+
+        response = self.client.post(
+            "/api/alerts/github",
+            data=json.dumps(
+                [
+                    {
+                        "token": token,
+                        "type": GITHUB_TYPE_FOR_OAUTH_ACCESS_TOKEN,
+                        "url": "https://github.com/test/repo/blob/main/secrets.txt",
+                        "source": "github",
+                    }
+                ]
+            ),
+            content_type="application/json",
+            headers={"github-public-key-identifier": "test_kid", "github-public-key-signature": "test_sig"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data[0]["label"], "true_positive")
+
+        self.assertFalse(OAuthAccessToken.objects.filter(id=access_token_id).exists())
+        refresh_token.refresh_from_db()
+        self.assertIsNotNone(refresh_token.revoked)
+        mock_send_email.assert_called_once()
+
+    @patch("posthog.api.github.verify_github_signature")
+    @patch("posthog.api.secret_revocation.send_oauth_token_exposed")
     def test_oauth_refresh_token_found_and_revoked(self, mock_send_email, mock_verify):
         mock_verify.return_value = None
 

--- a/posthog/api/test/test_leaked_key.py
+++ b/posthog/api/test/test_leaked_key.py
@@ -317,6 +317,36 @@ class TestPublicLeakedKeyReport(APIBaseTest):
         self.assertFalse(OAuthAccessToken.objects.filter(id=first_access_token.id).exists())
         self.assertFalse(OAuthAccessToken.objects.filter(id=second_access_token.id).exists())
 
+    @patch("posthog.api.secret_revocation.send_personal_api_key_exposed")
+    @patch("posthog.api.leaked_key.posthoganalytics.capture")
+    def test_analytics_capture_includes_token_hash_only_when_found(
+        self, mock_capture: MagicMock, mock_send_personal_api_key_exposed: MagicMock
+    ) -> None:
+        # A real PostHog key is high-entropy, so hashing it is safe to persist. An
+        # unrecognized string might be a low-entropy third-party secret pasted by
+        # mistake (a password, a short token) - an unsalted SHA-256 of that is
+        # dictionary/rainbow-table reversible, so it must not be persisted.
+        token = generate_random_token_personal()
+        PersonalAPIKey.objects.create(
+            user=self.user,
+            label="leaked",
+            secure_value=hash_key_value(token),
+            mask_value=mask_key_value(token),
+            scopes=["*"],
+        )
+
+        self._post(token)
+        found_properties = mock_capture.call_args.kwargs["properties"]
+        self.assertTrue(found_properties["found"])
+        self.assertIn("token_sha256", found_properties)
+
+        mock_capture.reset_mock()
+
+        self._post("not-a-posthog-key-at-all")
+        not_found_properties = mock_capture.call_args.kwargs["properties"]
+        self.assertFalse(not_found_properties["found"])
+        self.assertNotIn("token_sha256", not_found_properties)
+
     def test_blank_token_returns_400(self) -> None:
         response = self._post("")
 

--- a/posthog/api/test/test_leaked_key.py
+++ b/posthog/api/test/test_leaked_key.py
@@ -204,32 +204,37 @@ class TestPublicLeakedKeyReport(APIBaseTest):
         self.team.refresh_from_db()
         self.assertEqual(self.team.secret_api_token, token)
 
-    def test_expired_oauth_access_token_does_not_revoke_the_live_session(self) -> None:
-        # An expired access token authenticates nothing, so possessing one grants no
-        # capability beyond what the endpoint's "possession = already usable" argument
-        # relies on. It must not be able to force-revoke a session its holder can no
-        # longer use.
+    def test_expired_oauth_access_token_still_revokes_the_paired_refresh_token(self) -> None:
+        # An expired access token can't authenticate on its own, but revoking still
+        # matters: if the same exposure also affects the longer-lived paired refresh
+        # token (up to 30 days), that's the only way to close it. Gating this on
+        # expiry wouldn't close any capability either way - this endpoint and
+        # github.py's webhook are both triggerable by anyone holding a copy of a
+        # token, dead or alive (a public GitHub commit gets scanned and reported the
+        # same as an anonymous POST here) - so there's no less-exposed path to prefer.
         oauth_app = self._create_oauth_app()
         expired_token = "pha_expired_leaked_access_token"
-        OAuthAccessToken.objects.create(
+        access_token = OAuthAccessToken.objects.create(
             user=self.user,
             application=oauth_app,
             token=expired_token,
             expires=timezone.now() - timedelta(hours=1),
             scope="openid profile",
         )
-        live_refresh_token = OAuthRefreshToken.objects.create(
+        refresh_token = OAuthRefreshToken.objects.create(
             user=self.user,
             application=oauth_app,
-            token="phr_live_session_refresh_token",
+            token="phr_session_paired_with_expired_access",
+            access_token=access_token,
         )
 
         response = self._post(expired_token)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json(), {"found": False, "type": None})
-        live_refresh_token.refresh_from_db()
-        self.assertIsNone(live_refresh_token.revoked)
+        self.assertEqual(response.json(), {"found": True, "type": CANONICAL_OAUTH_ACCESS_TOKEN})
+        self.assertFalse(OAuthAccessToken.objects.filter(id=access_token.id).exists())
+        refresh_token.refresh_from_db()
+        self.assertIsNotNone(refresh_token.revoked)
 
     def test_oauth_access_token_revocation_does_not_touch_other_sessions_with_same_app(self) -> None:
         # A leaked token is evidence about that one token, not the user's other sessions

--- a/posthog/models/oauth.py
+++ b/posthog/models/oauth.py
@@ -687,10 +687,14 @@ def revoke_oauth_session(
             refresh_token.revoked = now
             refresh_token.save(update_fields=["revoked"])
     else:
-        # Revoke refresh tokens before deleting access tokens, in one transaction, so a
-        # mid-way failure can't leave a refresh token live after its access token is
-        # already gone (same reasoning as revoke_application_sessions below).
+        # Same ordering as revoke_application_sessions below, for the same two reasons:
+        # grants deleted first so this blocks on a racing code exchange's grant-row lock
+        # instead of missing tokens it mints; refresh revoked before access deleted so a
+        # mid-way failure can't leave a refresh token live after its access token is gone.
         with transaction.atomic():
+            # Delete all grants for this user+application
+            OAuthGrant.objects.filter(user=user, application=application).delete()
+
             # Revoke all refresh tokens for this user+application
             OAuthRefreshToken.objects.filter(user=user, application=application, revoked__isnull=True).update(
                 revoked=now
@@ -698,9 +702,6 @@ def revoke_oauth_session(
 
             # Delete all access tokens for this user+application
             OAuthAccessToken.objects.filter(user=user, application=application).delete()
-
-            # Delete all grants for this user+application
-            OAuthGrant.objects.filter(user=user, application=application).delete()
 
 
 def _refresh_token_may_have_untracked_access_tokens(refresh_token: OAuthRefreshToken) -> bool:

--- a/posthog/models/oauth.py
+++ b/posthog/models/oauth.py
@@ -687,14 +687,20 @@ def revoke_oauth_session(
             refresh_token.revoked = now
             refresh_token.save(update_fields=["revoked"])
     else:
-        # Delete all access tokens for this user+application
-        OAuthAccessToken.objects.filter(user=user, application=application).delete()
+        # Revoke refresh tokens before deleting access tokens, in one transaction, so a
+        # mid-way failure can't leave a refresh token live after its access token is
+        # already gone (same reasoning as revoke_application_sessions below).
+        with transaction.atomic():
+            # Revoke all refresh tokens for this user+application
+            OAuthRefreshToken.objects.filter(user=user, application=application, revoked__isnull=True).update(
+                revoked=now
+            )
 
-        # Revoke all refresh tokens for this user+application
-        OAuthRefreshToken.objects.filter(user=user, application=application, revoked__isnull=True).update(revoked=now)
+            # Delete all access tokens for this user+application
+            OAuthAccessToken.objects.filter(user=user, application=application).delete()
 
-        # Delete all grants for this user+application
-        OAuthGrant.objects.filter(user=user, application=application).delete()
+            # Delete all grants for this user+application
+            OAuthGrant.objects.filter(user=user, application=application).delete()
 
 
 def _refresh_token_may_have_untracked_access_tokens(refresh_token: OAuthRefreshToken) -> bool:
@@ -737,10 +743,15 @@ def revoke_oauth_token_session(
         # posthog/api/oauth/views.py - and callers that create a refresh token before
         # its access token don't always back-fill refresh_token.access_token either), so
         # check both directions instead of trusting one.
-        OAuthRefreshToken.objects.filter(
-            Q(access_token=access_token) | Q(pk=access_token.source_refresh_token_id), revoked__isnull=True
-        ).update(revoked=now)
-        access_token.delete()
+        #
+        # Revoke the refresh token before deleting the access token, in one transaction,
+        # so a mid-way failure can't leave the refresh token live after its access token
+        # is already gone (same reasoning as revoke_application_sessions below).
+        with transaction.atomic():
+            OAuthRefreshToken.objects.filter(
+                Q(access_token=access_token) | Q(pk=access_token.source_refresh_token_id), revoked__isnull=True
+            ).update(revoked=now)
+            access_token.delete()
     elif refresh_token:
         if _refresh_token_may_have_untracked_access_tokens(refresh_token):
             # A leaked non-rotating refresh token can have minted any number of access
@@ -750,11 +761,15 @@ def revoke_oauth_token_session(
             # sweep revoke_token already uses for this exact case via RFC 7009.
             revoke_oauth_session(refresh_token=refresh_token)
             return
-        OAuthAccessToken.objects.filter(
-            Q(pk=refresh_token.access_token_id) | Q(source_refresh_token=refresh_token)
-        ).delete()
-        refresh_token.revoked = now
-        refresh_token.save(update_fields=["revoked"])
+        # Revoke before deleting the linked access token(s), in one transaction, so a
+        # mid-way failure can't leave this refresh token live (and able to mint a new
+        # access token) after its access token is already gone.
+        with transaction.atomic():
+            refresh_token.revoked = now
+            refresh_token.save(update_fields=["revoked"])
+            OAuthAccessToken.objects.filter(
+                Q(pk=refresh_token.access_token_id) | Q(source_refresh_token=refresh_token)
+            ).delete()
 
 
 def revoke_application_sessions(application: "OAuthApplication") -> None:


### PR DESCRIPTION
## Problem

- Since PR #81587 merged, both OAuth-access-token revocation paths (GitHub's signed secret-scanning webhook and the public leaked-key endpoint) silently stopped revoking or notifying on an already-expired token. GitHub's scan-to-report latency for historical commits routinely exceeds the token's 1-hour lifetime, so most real GitHub reports arrive for an already-expired token, which the shared revocation path now treats as a no-op.
- The public leaked-key endpoint hashes and permanently stores every submitted string in PostHog's own analytics, including strings that never matched a PostHog credential. An unsalted SHA-256 of a low-entropy third-party secret (a password, a short token pasted by mistake) is dictionary/rainbow-table reversible by anyone with query access to that data.
- `revoke_oauth_token_session`'s two writes aren't wrapped in a transaction, and one branch does them in the wrong order. A failure between the two writes can leave the reported credential still functionally live.

Not related to issue #81623, a separate, larger follow-up (schema migration for the DCR/CIMD case) that this PR doesn't touch.

## Changes

- Removes the expiry check on OAuth access-token matches entirely, for both paths. An already-expired access token can't authenticate on its own, but revoking still matters if the same exposure also affects the paired refresh token (live for up to 30 days) - and neither path is meaningfully less exposed to a possession-only attacker than the other, since a public GitHub commit gets scanned and reported the same as an anonymous POST to the public endpoint. The only consequence of a match, expired or not, is forcing a legitimate user to re-authenticate, not a confidentiality or integrity loss.
- The public endpoint only includes `token_sha256` in its analytics event once the token matched a real PostHog credential - those are high-entropy and the hash isn't practically reversible. Not persisted at all for the common case of a caller pasting something that isn't a PostHog secret.
- Wraps both branches of `revoke_oauth_token_session` in `transaction.atomic()`, and reorders the refresh-token branch to revoke the refresh token before deleting its access token(s) - matching the pattern the sibling `revoke_application_sessions` already documents and uses. Applied the identical fix to the pre-existing `revoke_oauth_session`, which had the same gap.
- `revoke_oauth_session`'s transaction deleted grants last; reordered to delete grants first, matching `revoke_application_sessions`, so the revoke blocks on a racing authorization-code exchange's grant-row lock instead of missing tokens it mints. This closes one sub-case of a broader concurrent-mint race - see "Known limitation" below for what's still open.
- Updated the public endpoint's docstring and OpenAPI description, both left stale by the expiry-check removal: a matched OAuth access token now states plainly that it still triggers revocation and notification even if the token itself has already expired.

## Known limitation (not fixed here)

Neither `revoke_oauth_session` nor `revoke_oauth_token_session` fully serializes against a concurrent, in-flight token refresh or code exchange. DOT validates a presented refresh token in autocommit, before any lock - if a revoke commits in the gap between that validation and the racing request's own mint transaction, the mint can still succeed and produce tokens the revoke never touched. `revoke_application_sessions` closes this for its app-wide scope with a `sessions_revoked_at` stamp the mint path checks inside its own transaction; neither of the single-session functions has an equivalent, since reusing the app-wide field would over-revoke every session for the app, contradicting their whole reason for existing. A correct fix needs a new per-session revocation marker, which is schema work beyond this PR's scope.

## How did you test this code?

- Added `test_expired_oauth_access_token_report_still_revokes_and_notifies` in `test_github.py` and `test_expired_oauth_access_token_still_revokes_the_paired_refresh_token` in `test_leaked_key.py`: an expired access token, reported through either path, still revokes its paired refresh token (and, on the GitHub path, notifies the owner). No prior test covered an expired token on either path.
- Added `test_analytics_capture_includes_token_hash_only_when_found` in `test_leaked_key.py`: asserts `token_sha256` is present for a matched key and absent for an unrecognized one.
- Ran `test_github.py`, `test_leaked_key.py`, `test_oauth.py`, `test_connected_apps.py`, `test_views.py` locally: 148 passed (plus 10 pre-existing failures in `test_views.py` unrelated to this change - `TemplateDoesNotExist: index.html`, caused by no built frontend in this dev environment, reproduces identically on `origin/master`).
- Ran `ruff check`, `ruff format --check`, and `uv run mypy --cache-fine-grained` on the touched files: clean.
- Not checked: transaction-atomicity under an actual mid-write failure (connection drop, deadlock) - relying on Django's `transaction.atomic()` primitive rather than fault-injection testing.
- No new tests for the grant-ordering reorder or the docs update: the reorder doesn't change observable behavior outside the race window described above (existing tests already cover the non-race outcome), and a docs-only change has nothing to assert against.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior changes beyond restoring the pre-#81587 behavior on both revocation paths.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude Code) found and fixed these after PR #81587 (public leaked-key revocation) merged and picked up further automated review comments from posthog's review bot on the merged commit. Tom asked me to assess each before acting; I verified all three against the actual code on `master` rather than trusting the bot's framing, then implemented fixes for all three plus one bonus fix (`revoke_oauth_session`'s identical atomicity gap, not itself flagged, but the same bug sitting next to the one that was).

Tom pushed back twice on the GitHub-webhook finding, and both changed the design. First: does it matter that the access token itself was already expired? Revoking a dead token has no security value on its own - what matters is the paired refresh token (live for up to 30 days) and the owner notification, both lost regardless of the dead token's own state. That shaped an initial fix: gate the expiry check only on the anonymous public endpoint, treat GitHub's signed webhook as trusted enough to skip it.

Second, sharper challenge: is GitHub's path actually less exposed to the public than the anonymous endpoint? No - GitHub's signature only proves the report came from GitHub's scanning infrastructure, not that the reporter is the token's legitimate owner. Anyone can commit a token they merely once saw to a public repo and let GitHub's scanner report it, reaching the identical "possession of a dead token" scenario through an extra hop. That distinction added a narrower path to the same outcome, not real protection, so the fix became full unification: no expiry gate on either path, matching the behavior both had before any of this changed.

A third review round on this PR itself caught the grant-ordering gap and the stale docs above, both fixed, plus a second instance of the concurrent-mint race already noted as a known limitation - the bot's own adjudication reached the same conclusion I had: real, but schema work beyond this PR, not a blocker. Flagging to Tom for how he wants that tracked rather than filing an issue unilaterally.

Skills invoked: `/writing-tests` before adding the two new tests, `/writing-user-facing-copy` before editing the endpoint's docstring and OpenAPI description, `/writing-pr-descriptions` for this body.

Nothing in this PR, its commits, or this description carries material from the session that is not already public in this repository.


