### PR TITLE
chore(desktop): remove the posthog-code-comments feature flag gate

### DIFF
--- a/products/desktop/packages/shared/src/flags.ts
+++ b/products/desktop/packages/shared/src/flags.ts
@@ -51,8 +51,5 @@ export const STAGED_UPDATES_FLAG = "posthog-desktop-staged-updates";
  * surfaces (see docs/ANNOUNCEMENTS.md).
  */
 export const ANNOUNCEMENTS_FLAG = "posthog-desktop-announcements";
-/** Gates anchored comments across task, artifact, and Activity surfaces. */
-export const COMMENTS_FLAG = "posthog-code-comments";
-
 /** Gates the PR-refund action in the inbox (matches the web SIGNALS_PR_REFUNDS flag). */
 export const SIGNALS_PR_REFUNDS_FLAG = "signals-pr-refunds";

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityHoverCard.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityHoverCard.test.tsx
@@ -9,7 +9,6 @@ const mocks = vi.hoisted(() => ({
   isFetchingNextPage: false,
   items: [] as TaskActivityItem[],
   markRead: vi.fn(),
-  commentsEnabled: true,
 }));
 
 vi.mock("@posthog/quill", () => ({
@@ -85,9 +84,6 @@ vi.mock("@posthog/ui/features/canvas/hooks/useTaskActivity", () => ({
     fetchNextPage: mocks.fetchNextPage,
   }),
 }));
-vi.mock("@posthog/ui/features/sessions/useCommentsEnabled", () => ({
-  useCommentsEnabled: () => mocks.commentsEnabled,
-}));
 vi.mock("@posthog/ui/primitives/hooks/useInView", () => ({
   useInView: () => [vi.fn(), true],
 }));
@@ -102,7 +98,6 @@ describe("ActivityHoverCard", () => {
     mocks.hasNextPage = true;
     mocks.isFetchingNextPage = false;
     mocks.items = [];
-    mocks.commentsEnabled = true;
     useActivityFilterStore.setState({ unreadsOnly: false });
   });
 
@@ -141,31 +136,6 @@ describe("ActivityHoverCard", () => {
         activity_id: "activity-1",
       },
     ]);
-  });
-
-  it("hides only comment-derived activity while comments are disabled", () => {
-    mocks.commentsEnabled = false;
-    mocks.items = [
-      {
-        id: "comment-activity",
-        taskId: "task-1",
-        activityAt: "2026-08-07T00:00:00Z",
-        activityKind: "mention",
-        commentId: "comment-1",
-        isUnread: true,
-      } as TaskActivityItem,
-      {
-        id: "task-activity",
-        taskId: "task-2",
-        activityAt: "2026-08-07T00:01:00Z",
-        activityKind: "mention",
-        isUnread: true,
-      } as TaskActivityItem,
-    ];
-
-    render(<ActivityHoverCard onClose={vi.fn()} />);
-
-    expect(screen.getAllByText("Activity row")).toHaveLength(1);
   });
 
   it("drops read activity while the unreads filter is on", () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityHoverCard.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityHoverCard.tsx
@@ -18,14 +18,12 @@ import { useBlockedTaskIds } from "@posthog/ui/features/canvas/hooks/useBlockedS
 import { useMarkTaskActivityRead } from "@posthog/ui/features/canvas/hooks/useMarkTaskActivityRead";
 import { useTaskActivity } from "@posthog/ui/features/canvas/hooks/useTaskActivity";
 import { useActivityFilterStore } from "@posthog/ui/features/canvas/stores/activityFilterStore";
-import { useCommentsEnabled } from "@posthog/ui/features/sessions/useCommentsEnabled";
 import { useInView } from "@posthog/ui/primitives/hooks/useInView";
 import { track } from "@posthog/ui/shell/analytics";
 import { useEffect, useState } from "react";
 import {
   activityReadPayload,
   getUnreadActivityItems,
-  getVisibleActivityItems,
   markLoadedReadLabel,
 } from "./activityFeed";
 
@@ -38,7 +36,6 @@ export function ActivityHoverCard({
   onClose,
   side = "right",
 }: ActivityHoverCardProps) {
-  const commentsEnabled = useCommentsEnabled();
   const client = useOptionalAuthenticatedClient();
   const { data: currentUser } = useCurrentUser({ client });
   const {
@@ -57,7 +54,7 @@ export function ActivityHoverCard({
     rootMargin: "100px 0px",
   });
   const unreadsOnly = useActivityFilterStore((state) => state.unreadsOnly);
-  const visibleItems = getVisibleActivityItems(items, commentsEnabled);
+  const visibleItems = items;
   const unreadItems = getUnreadActivityItems(visibleItems);
   const shownItems = unreadsOnly ? unreadItems : visibleItems;
   const { mutate: markTasksRead, isPending: isMarkingRead } =

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.test.tsx
@@ -58,12 +58,6 @@ vi.mock("@posthog/ui/shell/analytics", () => ({ track: vi.fn() }));
 import { useCommentNavigationStore } from "@posthog/ui/features/sessions/commentNavigationStore";
 import { ActivityPanel } from "./ActivityPanel";
 
-const commentsFlag = vi.hoisted(() => ({ enabled: true }));
-
-vi.mock("@posthog/ui/features/sessions/useCommentsEnabled", () => ({
-  useCommentsEnabled: () => commentsFlag.enabled,
-}));
-
 const task = { id: "task-1", title: "Ship it" } as unknown as Task;
 
 function renderPanel(taskId = "task-1") {
@@ -81,7 +75,6 @@ describe("ActivityPanel", () => {
   let scrollTo: MockInstance;
 
   beforeEach(() => {
-    commentsFlag.enabled = true;
     scrollTo = vi.spyOn(Element.prototype, "scrollTo");
     useCommentNavigationStore.setState({
       focusByTask: {},
@@ -103,13 +96,6 @@ describe("ActivityPanel", () => {
     expect(screen.getByText("comments body")).toBeTruthy();
     // The composer belongs to the conversation, not to a list of threads.
     expect(screen.queryByText("composer")).toBeNull();
-  });
-
-  it("hides the comments tab while comments are disabled", () => {
-    commentsFlag.enabled = false;
-    renderPanel();
-
-    expect(screen.queryByRole("tab", { name: "Comments" })).toBeNull();
   });
 
   // A thread picked on the artifact itself lands in this tab, so the pick has

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.tsx
@@ -18,7 +18,6 @@ import {
 import { useThreadConversation } from "@posthog/ui/features/canvas/hooks/useThreadConversation";
 import { useCommentNavigationStore } from "@posthog/ui/features/sessions/commentNavigationStore";
 import { buildConversationItems } from "@posthog/ui/features/sessions/components/buildConversationItems";
-import { useCommentsEnabled } from "@posthog/ui/features/sessions/useCommentsEnabled";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { track } from "@posthog/ui/shell/analytics";
 import { useQuery } from "@tanstack/react-query";
@@ -37,14 +36,12 @@ const ACTIVITY_TABS: readonly { key: ActivityTab; label: string }[] = [
  *  review toolbar, which are the same fixed height and border. */
 function ActivityHeader({
   tab,
-  commentsEnabled,
   onTabChange,
   onClose,
   onToggleCollapsed,
   onOpenFull,
 }: {
   tab: ActivityTab;
-  commentsEnabled: boolean;
   onTabChange: (tab: ActivityTab) => void;
   onClose?: () => void;
   onToggleCollapsed?: () => void;
@@ -65,9 +62,7 @@ function ActivityHeader({
           aria-label="Activity"
           className="h-[31px] gap-0.5 p-0"
         >
-          {ACTIVITY_TABS.filter(
-            (candidate) => commentsEnabled || candidate.key !== "comments",
-          ).map((t) => (
+          {ACTIVITY_TABS.map((t) => (
             <TabsTrigger key={t.key} value={t.key} className="px-2.5">
               <span className="font-medium text-[13px]">{t.label}</span>
             </TabsTrigger>
@@ -128,7 +123,6 @@ function ActivityConversation({
   canOpenInPlace?: boolean;
 }) {
   const taskId = task.id;
-  const commentsEnabled = useCommentsEnabled();
   const {
     timeline,
     agentStatus,
@@ -190,7 +184,6 @@ function ActivityConversation({
   );
   useEffect(() => {
     if (
-      commentsEnabled &&
       commentFocus?.openCommentsTab &&
       commentFocus.nonce !== seenFocus.current.get(taskId)
     ) {
@@ -198,10 +191,7 @@ function ActivityConversation({
       // Not handleTabChange: a programmatic switch isn't a user tab change.
       setTab("comments");
     }
-  }, [commentFocus, commentsEnabled, taskId]);
-  useEffect(() => {
-    if (!commentsEnabled && tab === "comments") setTab("timeline");
-  }, [commentsEnabled, tab]);
+  }, [commentFocus, taskId]);
   useEffect(() => {
     if (tab === "comments" && commentFocus?.openCommentsTab) {
       acknowledgeCommentsTabOpen(taskId, commentFocus.nonce);
@@ -252,7 +242,6 @@ function ActivityConversation({
     <div className="flex h-full min-w-0 flex-col bg-gray-1">
       <ActivityHeader
         tab={tab}
-        commentsEnabled={commentsEnabled}
         onTabChange={handleTabChange}
         onOpenFull={onOpenFull}
         onToggleCollapsed={onToggleCollapsed}

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityView.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityView.test.tsx
@@ -7,7 +7,6 @@ const navigation = vi.hoisted(() => ({
   toChannelTask: vi.fn(),
   toTaskDetail: vi.fn(),
 }));
-const commentsFlag = vi.hoisted(() => ({ enabled: true }));
 
 vi.mock("@posthog/ui/router/navigationBridge", () => ({
   navigateToChannelDashboard: navigation.toChannelDashboard,
@@ -18,10 +17,6 @@ vi.mock("@posthog/ui/shell/analytics", () => ({ track: vi.fn() }));
 
 import { useCommentNavigationStore } from "@posthog/ui/features/sessions/commentNavigationStore";
 import { ActivityRow, activityHeadline } from "./ActivityView";
-
-vi.mock("@posthog/ui/features/sessions/useCommentsEnabled", () => ({
-  useCommentsEnabled: () => commentsFlag.enabled,
-}));
 
 function item(overrides: Partial<TaskActivityItem>): TaskActivityItem {
   return {
@@ -44,7 +39,6 @@ const NO_BLOCKED_TASKS: ReadonlySet<string> = new Set();
 
 describe("activityHeadline", () => {
   beforeEach(() => {
-    commentsFlag.enabled = true;
     navigation.toChannelTask.mockReset();
     navigation.toChannelDashboard.mockReset();
     navigation.toTaskDetail.mockReset();
@@ -158,37 +152,5 @@ describe("activityHeadline", () => {
       openCommentsTab: true,
       intent: "navigate",
     });
-  });
-
-  it("does not open comment navigation while comments are disabled", () => {
-    commentsFlag.enabled = false;
-    const activity = item({
-      activityKind: "owned_item_comment",
-      channelId: "channel-1",
-      commentId: "comment-1",
-      commentTarget: { scope: "desktop_canvas", itemId: "canvas-1" },
-    });
-
-    render(
-      <ActivityRow
-        item={activity}
-        channelId="channel-1"
-        onOpen={vi.fn()}
-        onMarkRead={vi.fn()}
-        blockedTaskIds={NO_BLOCKED_TASKS}
-      />,
-    );
-    const activityButton = screen
-      .getByText("commented on your canvas")
-      .closest("button");
-    if (!activityButton) throw new Error("Expected activity row button");
-    fireEvent.click(activityButton);
-
-    expect(navigation.toChannelTask).toHaveBeenCalledWith(
-      "channel-1",
-      "task-1",
-    );
-    expect(navigation.toChannelDashboard).not.toHaveBeenCalled();
-    expect(useCommentNavigationStore.getState().focusByTask).toEqual({});
   });
 });

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityView.tsx
@@ -36,7 +36,6 @@ import { useThreadPanelStore } from "@posthog/ui/features/canvas/stores/threadPa
 import { copyChannelLink } from "@posthog/ui/features/canvas/utils/copyChannelLink";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
 import { useCommentNavigationStore } from "@posthog/ui/features/sessions/commentNavigationStore";
-import { useCommentsEnabled } from "@posthog/ui/features/sessions/useCommentsEnabled";
 import { DOT_TONE_VAR } from "@posthog/ui/features/sidebar/components/items/taskStatusVocabulary";
 import {
   PageHeader,
@@ -58,9 +57,7 @@ import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo } from "react";
 import {
   activityReadPayload,
-  activityUnreadTotalForLabel,
   getUnreadActivityItems,
-  getVisibleActivityItems,
   markLoadedReadLabel,
 } from "./activityFeed";
 
@@ -186,7 +183,6 @@ export function ActivityRow({
   onNavigate?: () => void;
   compact?: boolean;
 }) {
-  const commentsEnabled = useCommentsEnabled();
   const isAgentActivity =
     item.activityKind === "awaiting_input" ||
     item.activityKind === "completed" ||
@@ -209,17 +205,13 @@ export function ActivityRow({
       task_id: item.taskId,
     });
     onOpen(item);
-    if (commentsEnabled && item.commentId && item.commentTarget) {
+    if (item.commentId && item.commentTarget) {
       useCommentNavigationStore
         .getState()
         .requestCommentFocus(item.taskId, item.commentTarget, item.commentId);
     }
     onNavigate?.();
-    if (
-      commentsEnabled &&
-      channelId &&
-      item.commentTarget?.scope === "desktop_canvas"
-    ) {
+    if (channelId && item.commentTarget?.scope === "desktop_canvas") {
       useCanvasChatPanelStore.getState().openComments();
       navigateToChannelDashboard(channelId, item.commentTarget.itemId);
       return;
@@ -339,7 +331,6 @@ export function ActivityRow({
 // in, or messaged in — newest activity first. Rows clear as they are opened, not
 // when the page is; merely landing here shouldn't dismiss what you haven't read.
 export function ActivityView() {
-  const commentsEnabled = useCommentsEnabled();
   const spacesLayout = useChannelsLayout();
   const client = useOptionalAuthenticatedClient();
   const { data: currentUser } = useCurrentUser({ client });
@@ -355,22 +346,14 @@ export function ActivityView() {
   const blockedTaskIds = useBlockedTaskIds();
   const { mutate: markTasksRead, isPending: isMarkingRead } =
     useMarkTaskActivityRead();
-  const visibleItems = useMemo(
-    () => getVisibleActivityItems(items, commentsEnabled),
-    [commentsEnabled, items],
-  );
+  const visibleItems = items;
   const unreadItems = useMemo(
     () => getUnreadActivityItems(visibleItems),
     [visibleItems],
   );
   const unreadsOnly = useActivityFilterStore((state) => state.unreadsOnly);
   const shownItems = unreadsOnly ? unreadItems : visibleItems;
-  const visibleUnreadCount = activityUnreadTotalForLabel({
-    commentsEnabled,
-    unreadCount,
-    loadedVisibleUnread: unreadItems.length,
-    hasNextPage,
-  });
+  const visibleUnreadCount = unreadCount;
   // Opening a row is what marks it read. The server does the same when the task is
   // reached any other way, so the feed converges either way.
   const markRead = useCallback(

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskArtifactsList.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskArtifactsList.test.tsx
@@ -18,10 +18,6 @@ const mocks = vi.hoisted(() => ({
   taskRunsRefreshKeys: [] as number[],
 }));
 
-vi.mock("@posthog/ui/features/sessions/useCommentsEnabled", () => ({
-  useCommentsEnabled: () => true,
-}));
-
 vi.mock("@posthog/core/sessions/sessionService", () => ({
   SESSION_SERVICE: Symbol("SESSION_SERVICE"),
 }));

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskArtifactsList.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskArtifactsList.tsx
@@ -49,7 +49,6 @@ import { useCompletedArtifactUploads } from "@posthog/ui/features/sessions/compo
 import { useCommentsForTargetsQuery } from "@posthog/ui/features/sessions/components/useComments";
 import { useSessionSelector } from "@posthog/ui/features/sessions/sessionStore";
 import { useArtifactDownload } from "@posthog/ui/features/sessions/useArtifactDownload";
-import { useCommentsEnabled } from "@posthog/ui/features/sessions/useCommentsEnabled";
 import { FileIcon } from "@posthog/ui/primitives/FileIcon";
 import { openExternalUrl } from "@posthog/ui/shell/openExternal";
 import { formatFileSize } from "@posthog/ui/utils/formatFileSize";
@@ -410,7 +409,6 @@ export function TaskArtifactsList({
    *  open externally rather than into a review pane nobody is showing. */
   canOpenInPlace?: boolean;
 }) {
-  const commentsEnabled = useCommentsEnabled();
   // A finished upload_artifact tool call re-keys the runs query, so a file
   // the agent just delivered shows up now rather than on the next poll.
   const events = useSessionSelector(task.id, (session) => session?.events);
@@ -424,12 +422,8 @@ export function TaskArtifactsList({
   // One query for every row's badge, so N resources cost one request rather
   // than one per row. The threads themselves live in the Comments tab.
   const targets = useMemo(() => commentTargets(rows), [rows]);
-  const commentsQuery = useCommentsForTargetsQuery(targets, task.id, {
-    enabled: commentsEnabled,
-  });
-  const comments = commentsEnabled
-    ? (commentsQuery.data ?? EMPTY_COMMENTS)
-    : EMPTY_COMMENTS;
+  const commentsQuery = useCommentsForTargetsQuery(targets, task.id);
+  const comments = commentsQuery.data ?? EMPTY_COMMENTS;
   // Open threads only, so a row's badge agrees with what the Comments tab
   // shows on the same resource.
   const openCountByItem = useMemo(() => {

--- a/products/desktop/packages/ui/src/features/canvas/components/activityFeed.test.ts
+++ b/products/desktop/packages/ui/src/features/canvas/components/activityFeed.test.ts
@@ -1,36 +1,9 @@
-import type { TaskActivityItem } from "@posthog/core/canvas/taskActivity";
 import { describe, expect, it } from "vitest";
-import {
-  activityUnreadTotalForLabel,
-  getVisibleActivityItems,
-  markLoadedReadLabel,
-} from "./activityFeed";
+import { markLoadedReadLabel } from "./activityFeed";
 
 describe("activityFeed", () => {
-  it("hides comment activity without hiding existing task mentions", () => {
-    const taskMention = {
-      id: "task-mention",
-      activityKind: "mention",
-    } as TaskActivityItem;
-    const commentMention = {
-      id: "comment-mention",
-      activityKind: "mention",
-      commentId: "comment-1",
-    } as TaskActivityItem;
-
-    expect(
-      getVisibleActivityItems([taskMention, commentMention], false),
-    ).toEqual([taskMention]);
-  });
-
-  it("labels a partial read action as visible only", () => {
-    const total = activityUnreadTotalForLabel({
-      commentsEnabled: false,
-      unreadCount: 8,
-      loadedVisibleUnread: 3,
-      hasNextPage: true,
-    });
-
-    expect(markLoadedReadLabel(3, total)).toBe("Mark visible as read");
+  it('says "Mark visible as read" while unread activity stays on unloaded pages', () => {
+    expect(markLoadedReadLabel(3, 8)).toBe("Mark visible as read");
+    expect(markLoadedReadLabel(8, 8)).toBe("Mark all as read");
   });
 });

--- a/products/desktop/packages/ui/src/features/canvas/components/activityFeed.ts
+++ b/products/desktop/packages/ui/src/features/canvas/components/activityFeed.ts
@@ -6,13 +6,6 @@ export function getUnreadActivityItems(
   return items.filter((item) => item.isUnread);
 }
 
-export function getVisibleActivityItems(
-  items: TaskActivityItem[],
-  commentsEnabled: boolean,
-): TaskActivityItem[] {
-  return commentsEnabled ? items : items.filter((item) => !item.commentId);
-}
-
 export function activityReadPayload(items: TaskActivityItem[]) {
   return items.map((item) => ({
     task_id: item.taskId,
@@ -28,19 +21,4 @@ export function markLoadedReadLabel(
   return loadedUnreadCount === unreadCount
     ? "Mark all as read"
     : "Mark visible as read";
-}
-
-export function activityUnreadTotalForLabel({
-  commentsEnabled,
-  unreadCount,
-  loadedVisibleUnread,
-  hasNextPage,
-}: {
-  commentsEnabled: boolean;
-  unreadCount: number;
-  loadedVisibleUnread: number;
-  hasNextPage: boolean;
-}): number {
-  if (commentsEnabled) return unreadCount;
-  return loadedVisibleUnread + (hasNextPage ? 1 : 0);
 }

--- a/products/desktop/packages/ui/src/features/sessions/components/AnnotatedArtifactHtml.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/AnnotatedArtifactHtml.tsx
@@ -41,7 +41,6 @@ function isFrameRect(value: unknown): value is ArtifactHtmlFrameRect {
 export function AnnotatedArtifactHtml({
   html,
   name,
-  commentsEnabled,
   comments,
   activeThreadId,
   locateRequest,
@@ -52,7 +51,6 @@ export function AnnotatedArtifactHtml({
 }: {
   html: string;
   name: string;
-  commentsEnabled: boolean;
   comments: ResourceComment[];
   activeThreadId: string | null;
   locateRequest: CommentLocateRequest | null;
@@ -77,22 +75,12 @@ export function AnnotatedArtifactHtml({
   );
   const [selection, setSelection] = useState<EditorSelection | null>(null);
   const previewDocument = useMemo(
-    () =>
-      scriptedArtifactHtmlDocument(
-        html,
-        commentsEnabled ? channelRef.current : undefined,
-        initialTheme,
-      ),
-    [commentsEnabled, html, initialTheme],
+    () => scriptedArtifactHtmlDocument(html, channelRef.current, initialTheme),
+    [html, initialTheme],
   );
   const fallbackDocument = useMemo(
-    () =>
-      artifactHtmlDocument(
-        html,
-        commentsEnabled ? channelRef.current : undefined,
-        initialTheme,
-      ),
-    [commentsEnabled, html, initialTheme],
+    () => artifactHtmlDocument(html, channelRef.current, initialTheme),
+    [html, initialTheme],
   );
 
   const selectionOpen = selection !== null;
@@ -115,7 +103,6 @@ export function AnnotatedArtifactHtml({
   );
 
   const messages = useMemo(() => {
-    if (!commentsEnabled) return [];
     const next: Record<string, unknown>[] = [
       {
         marker: ARTIFACT_HTML_BRIDGE_MARKER,
@@ -147,7 +134,7 @@ export function AnnotatedArtifactHtml({
       });
     }
     return next;
-  }, [bridgeItems, commentsEnabled, locateRequest, selectionOpen, theme]);
+  }, [bridgeItems, locateRequest, selectionOpen, theme]);
 
   const receive = useCallback(
     (value: unknown, frameBox: ArtifactHtmlFrameRect) => {

--- a/products/desktop/packages/ui/src/features/sessions/components/ArtifactPreview.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ArtifactPreview.test.tsx
@@ -35,23 +35,17 @@ const artifactComments = vi.hoisted(() => ({
 }));
 const createComment = vi.hoisted(() => vi.fn());
 const useQuery = vi.hoisted(() => vi.fn());
-const commentsFlag = vi.hoisted(() => ({ enabled: true }));
 const taskRuns = vi.hoisted(() => ({
   data: [] as unknown[],
   isLoading: false,
   refreshRuns: vi.fn(),
 }));
-const orgMembersOptions = vi.hoisted(() => vi.fn());
 const artifactMocks = vi.hoisted(() => ({
   getCloudRunArtifacts: vi.fn(),
   getCloudAttachmentPreviewUrl: vi.fn(),
   uploadCloudRunArtifactVersion: vi.fn(),
   invalidateQueries: vi.fn(),
   openArtifactTab: vi.fn(),
-}));
-
-vi.mock("@posthog/ui/features/sessions/useCommentsEnabled", () => ({
-  useCommentsEnabled: () => commentsFlag.enabled,
 }));
 
 vi.mock("@posthog/core/sessions/sessionService", () => ({
@@ -89,10 +83,7 @@ vi.mock("@posthog/ui/features/canvas/hooks/useTaskRuns", () => ({
 }));
 
 vi.mock("@posthog/ui/features/canvas/hooks/useOrgMembers", () => ({
-  useOrgMembers: (options: { enabled?: boolean }) => {
-    orgMembersOptions(options);
-    return { members: [] };
-  },
+  useOrgMembers: () => ({ members: [] }),
 }));
 
 vi.mock("@posthog/ui/features/canvas/components/MentionComposer", () => ({
@@ -219,7 +210,6 @@ function textComment(): ResourceComment {
 
 describe("ArtifactPreview", () => {
   beforeEach(() => {
-    commentsFlag.enabled = true;
     auth.identity = "auth-1";
     useCommentNavigationStore.setState({
       focusByTask: {},
@@ -385,33 +375,6 @@ describe("ArtifactPreview", () => {
     expect(frame).toHaveAttribute("src", "blob:preview");
     expect(frame).toHaveAttribute("sandbox", "allow-scripts");
     expect(frame).toHaveAttribute("referrerpolicy", "no-referrer");
-  });
-
-  it("keeps comment controls and the HTML bridge out while comments are disabled", async () => {
-    commentsFlag.enabled = false;
-    useQuery.mockReturnValue({
-      data: { kind: "html", html: "<h1>Artifact content</h1>" },
-      isLoading: false,
-      isError: false,
-    });
-
-    render(
-      <ArtifactPreview
-        taskId="task-1"
-        runId="run-1"
-        artifactId="artifact-1"
-        name="report.html"
-      />,
-    );
-
-    expect(orgMembersOptions).toHaveBeenLastCalledWith({ enabled: false });
-
-    expect(screen.queryByText("Comment…")).toBeNull();
-    const documentBlob = vi.mocked(URL.createObjectURL).mock.calls[0]?.[0];
-    expect(documentBlob).toBeInstanceOf(Blob);
-    await expect(
-      new Response(documentBlob as Blob).text(),
-    ).resolves.not.toContain("__POSTHOG_ARTIFACT_COMMENT_BRIDGE__");
   });
 
   // Same zoom-and-annotate surface as a raster image: an <img> renders SVG in a

--- a/products/desktop/packages/ui/src/features/sessions/components/ArtifactPreview.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ArtifactPreview.tsx
@@ -26,7 +26,6 @@ import { useTaskRuns } from "@posthog/ui/features/canvas/hooks/useTaskRuns";
 import { usePanelLayoutStore } from "@posthog/ui/features/panels/panelLayoutStore";
 import { useCommentNavigationStore } from "@posthog/ui/features/sessions/commentNavigationStore";
 import { useSessionSelector } from "@posthog/ui/features/sessions/sessionStore";
-import { useCommentsEnabled } from "@posthog/ui/features/sessions/useCommentsEnabled";
 import {
   type ReactElement,
   useCallback,
@@ -95,7 +94,6 @@ export function ArtifactPreview({
   artifactId: string;
   name: string;
 }): ReactElement {
-  const commentsEnabled = useCommentsEnabled();
   const sessionService = useService<SessionService>(SESSION_SERVICE);
   const openArtifactTab = usePanelLayoutStore((state) => state.openArtifactTab);
   const [showRendered, setShowRendered] = useState(true);
@@ -159,10 +157,8 @@ export function ArtifactPreview({
     () => ({ scope: "task_artifact", itemId: displayedArtifactId }),
     [displayedArtifactId],
   );
-  const commentsQuery = useCommentsQuery(commentTarget, taskId, {
-    enabled: commentsEnabled,
-  });
-  const { members } = useOrgMembers({ enabled: commentsEnabled });
+  const commentsQuery = useCommentsQuery(commentTarget, taskId);
+  const { members } = useOrgMembers();
   const createComment = useCreateComment(commentTarget, taskId);
   const requestCommentFocus = useCommentNavigationStore(
     (state) => state.requestCommentFocus,
@@ -195,10 +191,8 @@ export function ArtifactPreview({
     authIdentity,
     openArtifactTab,
   });
-  const comments = commentsEnabled
-    ? (commentsQuery.data ?? EMPTY_COMMENTS)
-    : EMPTY_COMMENTS;
-  const commentLoadError = commentsEnabled && commentsQuery.isError && (
+  const comments = commentsQuery.data ?? EMPTY_COMMENTS;
+  const commentLoadError = commentsQuery.isError && (
     <div
       role="alert"
       className="shrink-0 border-amber-6 border-b bg-amber-2 px-3 py-2 text-amber-12 text-xs"
@@ -342,7 +336,6 @@ export function ArtifactPreview({
       versionNav={versionNav}
       taskId={taskId}
       commentTarget={commentTarget}
-      commentsEnabled={commentsEnabled}
       canEdit={editing.canEdit}
       beginEditing={editing.beginEditing}
       previewData={previewData}

--- a/products/desktop/packages/ui/src/features/sessions/components/ArtifactPreviewContent.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ArtifactPreviewContent.tsx
@@ -74,7 +74,6 @@ export function ArtifactPreviewContent({
   versionNav,
   taskId,
   commentTarget,
-  commentsEnabled,
   canEdit,
   beginEditing,
   previewData,
@@ -101,7 +100,6 @@ export function ArtifactPreviewContent({
   versionNav?: ReactNode;
   taskId: string;
   commentTarget: CommentTarget;
-  commentsEnabled: boolean;
   canEdit: boolean;
   beginEditing: () => void;
   previewData: PreviewData | undefined;
@@ -141,12 +139,10 @@ export function ArtifactPreviewContent({
           canEdit={canEdit}
           onEdit={beginEditing}
           actions={
-            commentsEnabled ? (
-              <ArtifactDocumentCommentAction
-                target={commentTarget}
-                taskId={taskId}
-              />
-            ) : undefined
+            <ArtifactDocumentCommentAction
+              target={commentTarget}
+              taskId={taskId}
+            />
           }
         />
         {commentLoadError}
@@ -161,20 +157,18 @@ export function ArtifactPreviewContent({
                 components={{ img: () => null }}
               />
             </div>
-            {commentsEnabled && (
-              <ArtifactTextAnnotations
-                artifactName={name}
-                rootRef={markdownRootRef}
-                containerRef={markdownContainerRef}
-                comments={annotationComments}
-                activeThreadId={focusedThreadId}
-                locateRequest={locateRequest}
-                members={members}
-                onActivateThread={activateThread}
-                onCreate={createAnchoredComment}
-                onResolutionsChange={onResolutionsChange}
-              />
-            )}
+            <ArtifactTextAnnotations
+              artifactName={name}
+              rootRef={markdownRootRef}
+              containerRef={markdownContainerRef}
+              comments={annotationComments}
+              activeThreadId={focusedThreadId}
+              locateRequest={locateRequest}
+              members={members}
+              onActivateThread={activateThread}
+              onCreate={createAnchoredComment}
+              onResolutionsChange={onResolutionsChange}
+            />
           </div>
         ) : (
           <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
@@ -201,12 +195,10 @@ export function ArtifactPreviewContent({
           canEdit={canEdit}
           onEdit={beginEditing}
           actions={
-            commentsEnabled ? (
-              <ArtifactDocumentCommentAction
-                target={commentTarget}
-                taskId={taskId}
-              />
-            ) : undefined
+            <ArtifactDocumentCommentAction
+              target={commentTarget}
+              taskId={taskId}
+            />
           }
         />
         {commentLoadError}
@@ -214,7 +206,6 @@ export function ArtifactPreviewContent({
           <AnnotatedArtifactHtml
             html={previewData.html}
             name={name}
-            commentsEnabled={commentsEnabled}
             comments={annotationComments}
             activeThreadId={focusedThreadId}
             locateRequest={locateRequest}
@@ -243,7 +234,7 @@ export function ArtifactPreviewContent({
     (isAllowedImageMimeType(previewData.type) ||
       previewData.type === SVG_MIME_TYPE)
   ) {
-    const imageActions = commentsEnabled ? (
+    const imageActions = (
       <div className="flex shrink-0 items-center gap-1">
         <ArtifactDocumentCommentAction target={commentTarget} taskId={taskId} />
         <Tooltip>
@@ -270,7 +261,7 @@ export function ArtifactPreviewContent({
           </TooltipContent>
         </Tooltip>
       </div>
-    ) : undefined;
+    );
     return (
       <div className="flex h-full flex-col overflow-hidden">
         <GenericArtifactHeader
@@ -286,7 +277,7 @@ export function ArtifactPreviewContent({
             comments={annotationComments}
             activeThreadId={focusedThreadId}
             locateRequest={locateRequest}
-            commenting={commentsEnabled && imageCommenting}
+            commenting={imageCommenting}
             members={members}
             onCommentingChange={setImageCommenting}
             onActivateThread={activateThread}
@@ -298,9 +289,9 @@ export function ArtifactPreviewContent({
     );
   }
 
-  const documentActions = commentsEnabled ? (
+  const documentActions = (
     <ArtifactDocumentCommentAction target={commentTarget} taskId={taskId} />
-  ) : undefined;
+  );
   return (
     <div className="flex h-full flex-col overflow-hidden">
       {editableKind === "plain-text" && artifactResult?.source !== undefined ? (

--- a/products/desktop/packages/ui/src/features/sessions/useCommentsEnabled.ts
+++ b/products/desktop/packages/ui/src/features/sessions/useCommentsEnabled.ts
@@ -1,6 +1,0 @@
-import { COMMENTS_FLAG } from "@posthog/shared";
-import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
-
-export function useCommentsEnabled(): boolean {
-  return useFeatureFlag(COMMENTS_FLAG);
-}


### PR DESCRIPTION
## Problem

Desktop task comments are fully released — \`posthog-code-comments\` sits at 100% rollout with no property filters. The flag check is a hardcoded \`true\` that still costs a hook call and conditional branches across the artifact and Activity surfaces; this removes it.

## Changes

- Delete \`COMMENTS_FLAG\` from \`packages/shared/src/flags.ts\` and delete the \`useCommentsEnabled\` hook, its only indirection.
- Ungate the five consumers: artifact previews load and render comments unconditionally, the Activity panel always shows the Comments tab, and comment-derived activity always navigates to the review target.
- Simplify \`activityFeed.ts\`: drop \`getVisibleActivityItems\` and \`activityUnreadTotalForLabel\`, which only existed to hide comment-derived rows in the feed while the flag was off.
- No visual or behavior change: every removed branch was the unreachable flag-off path.

## How did you test this code?

- Ran the \`@posthog/ui\` vitest suite (348 files) and \`tsc --noEmit\` for \`@posthog/ui\` and \`@posthog/shared\`; biome clean on all touched files.
- Test changes: removed the four flag-disabled cases and the \`useCommentsEnabled\` module mocks (the gated behavior they covered no longer exists). Slimmed \`activityFeed.test.ts\` to the surviving \`markLoadedReadLabel\` both-branch behavior — that helper is still shipped, and no other test asserts the label.
- Not checked: the running desktop app UI (headless Linux sandbox) — diff is a branch deletion on the always-live path.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

N/A — no docs reference this internal rollout flag.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (PostHog desktop cloud task) authored the change from a request to clean up the \`posthog-code-comments\` flag now that desktop comments are fully released. Skills invoked: \`cleaning-up-stale-feature-flags\` (fully-rolled-out flags → remove the check, keep the enabled path), \`writing-tests\`, \`writing-pr-descriptions\`. The flag is left enabled in PostHog; it can be archived once this ships. Public-artifact check: only the public flag key and rollout state from the task's own channel context are referenced; no session material reaches this PR.

One decision worth noting: \`useCommentsEnabled\` was deleted rather than flipped to \`() => true\` — it had no other callers or semantics beyond this flag, so the indirection went with it.