### PR TITLE
fix(desktop): preserve prompts when resuming sessions

### DIFF
--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -3465,8 +3465,12 @@ describe("AgentServer HTTP Mode", () => {
       await s.start();
 
       const prompt = vi.fn(async () => ({ stopReason: "cancelled" }));
+      const updateTaskRun = vi.fn(async () => ({}));
       const internals = s as unknown as {
-        posthogAPI: { getTaskRun: ReturnType<typeof vi.fn> };
+        posthogAPI: {
+          getTaskRun: ReturnType<typeof vi.fn>;
+          updateTaskRun: typeof updateTaskRun;
+        };
         session: {
           clientConnection: { prompt: typeof prompt };
         };
@@ -3478,6 +3482,7 @@ describe("AgentServer HTTP Mode", () => {
       };
       internals.session.clientConnection.prompt = prompt;
       internals.nativeResume = { sessionId: "prior-session", warm: true };
+      internals.posthogAPI.updateTaskRun = updateTaskRun;
       vi.spyOn(internals.posthogAPI, "getTaskRun").mockResolvedValue(
         createTaskRun({
           id: "test-run-id",
@@ -3508,6 +3513,13 @@ describe("AgentServer HTTP Mode", () => {
       expect(promptBlocks).toEqual([
         { type: "text", text: "keep my follow-up" },
       ]);
+      expect(updateTaskRun).toHaveBeenCalledWith(
+        "test-task-id",
+        "test-run-id",
+        {
+          state_remove_keys: ["pending_user_message"],
+        },
+      );
     });
   });
 

--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -3683,6 +3683,7 @@ describe("AgentServer HTTP Mode", () => {
         const newSession = vi.fn(async () => ({ sessionId: "fresh-session" }));
 
         const internals = s as unknown as {
+          posthogAPI: { getTaskRun: ReturnType<typeof vi.fn> };
           session: {
             acpSessionId: string;
             clientConnection: {
@@ -3705,6 +3706,12 @@ describe("AgentServer HTTP Mode", () => {
         internals.session.clientConnection.prompt = prompt;
         internals.session.clientConnection.newSession = newSession;
         internals.nativeResume = { sessionId: "prior-session", warm: true };
+        vi.spyOn(internals.posthogAPI, "getTaskRun").mockResolvedValue(
+          createTaskRun({
+            id: "test-run-id",
+            state: { resume_from_run_id: "previous-run" },
+          }),
+        );
         internals.loadResumeState = vi.fn(async () => {
           internals.resumeState = {
             conversation: [

--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -3413,17 +3413,24 @@ describe("AgentServer HTTP Mode", () => {
         sessionId: "prior-session",
       };
 
-      await s.sendResumeMessage(
-        payload,
-        createTaskRun({
-          id: "test-run-id",
-          task: "test-task-id",
-          state: {
-            pending_user_message: "visible follow-up",
-            pending_user_message_ts: "123.456",
-          },
-        }),
-      );
+      const taskRun = createTaskRun({
+        id: "test-run-id",
+        task: "test-task-id",
+        state: {
+          pending_user_message: "visible follow-up",
+          pending_user_message_ts: "123.456",
+        },
+      });
+      vi.spyOn(
+        (
+          s as unknown as {
+            posthogAPI: { getTaskRun: ReturnType<typeof vi.fn> };
+          }
+        ).posthogAPI,
+        "getTaskRun",
+      ).mockResolvedValue(taskRun);
+
+      await s.sendResumeMessage(payload, taskRun);
 
       const [{ prompt: promptBlocks }] = prompt.mock.calls[0] as unknown as [
         { prompt: ContentBlock[] },
@@ -3451,6 +3458,56 @@ describe("AgentServer HTTP Mode", () => {
         type: "text",
         _meta: { ui: { hidden: true } },
       });
+    });
+
+    it("refetches the run before choosing a native resume prompt", async () => {
+      const s = createServer();
+      await s.start();
+
+      const prompt = vi.fn(async () => ({ stopReason: "cancelled" }));
+      const internals = s as unknown as {
+        posthogAPI: { getTaskRun: ReturnType<typeof vi.fn> };
+        session: {
+          clientConnection: { prompt: typeof prompt };
+        };
+        nativeResume: { sessionId: string; warm: boolean } | null;
+        sendResumeContinuation(
+          payload: JwtPayload,
+          taskRun: TaskRun | null,
+        ): Promise<void>;
+      };
+      internals.session.clientConnection.prompt = prompt;
+      internals.nativeResume = { sessionId: "prior-session", warm: true };
+      vi.spyOn(internals.posthogAPI, "getTaskRun").mockResolvedValue(
+        createTaskRun({
+          id: "test-run-id",
+          task: "test-task-id",
+          state: { pending_user_message: "keep my follow-up" },
+        }),
+      );
+
+      await internals.sendResumeContinuation(
+        {
+          task_id: "test-task-id",
+          run_id: "test-run-id",
+          team_id: 1,
+          user_id: 1,
+          distinct_id: "test-distinct-id",
+          mode: "interactive",
+        },
+        createTaskRun({
+          id: "test-run-id",
+          task: "test-task-id",
+          state: { resume_from_run_id: "previous-run" },
+        }),
+      );
+
+      const [{ prompt: promptBlocks }] = prompt.mock.calls[0] as unknown as [
+        { prompt: ContentBlock[] },
+      ];
+      expect(promptBlocks).toEqual([
+        { type: "text", text: "keep my follow-up" },
+      ]);
     });
   });
 

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -2299,7 +2299,11 @@ export class AgentServer {
 
       const checkpointApplied = await this.applyResumeGitCheckpoint(payload);
 
-      const pendingUserPrompt = await this.getPendingUserPrompt(taskRun);
+      const currentTaskRun = await this.refreshTaskRunForResume(
+        payload,
+        taskRun,
+      );
+      const pendingUserPrompt = await this.getPendingUserPrompt(currentTaskRun);
 
       const checkpointContext = checkpointApplied
         ? `The workspace environment (all files, packages, and code changes) has been fully restored from the latest checkpoint.`
@@ -2364,7 +2368,12 @@ export class AgentServer {
           ? false
           : await this.applyResumeGitCheckpoint(payload);
 
-        const pendingUserPrompt = await this.getPendingUserPrompt(taskRun);
+        const currentTaskRun = await this.refreshTaskRunForResume(
+          payload,
+          taskRun,
+        );
+        const pendingUserPrompt =
+          await this.getPendingUserPrompt(currentTaskRun);
         const prompt: ContentBlock[] = pendingUserPrompt?.prompt.length
           ? pendingUserPrompt.prompt
           : [
@@ -2389,6 +2398,22 @@ export class AgentServer {
       },
       { retryOnOversizedPrompt: true },
     );
+  }
+
+  private async refreshTaskRunForResume(
+    payload: JwtPayload,
+    fallback: TaskRun | null,
+  ): Promise<TaskRun | null> {
+    try {
+      return await this.posthogAPI.getTaskRun(payload.task_id, payload.run_id);
+    } catch (error) {
+      this.logger.debug("Failed to refresh task run before resume", {
+        taskId: payload.task_id,
+        runId: payload.run_id,
+        error,
+      });
+      return fallback;
+    }
   }
 
   /**

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -2291,6 +2291,7 @@ export class AgentServer {
   ): Promise<void> {
     if (!this.session || !this.resumeState) return;
     const resumeState = this.resumeState;
+    taskRun = await this.refreshTaskRunForResume(payload, taskRun);
 
     await this.runResumeTurn(payload, taskRun, "Resume message", async () => {
       const conversationSummary = formatConversationForResume(
@@ -2299,11 +2300,7 @@ export class AgentServer {
 
       const checkpointApplied = await this.applyResumeGitCheckpoint(payload);
 
-      const currentTaskRun = await this.refreshTaskRunForResume(
-        payload,
-        taskRun,
-      );
-      const pendingUserPrompt = await this.getPendingUserPrompt(currentTaskRun);
+      const pendingUserPrompt = await this.getPendingUserPrompt(taskRun);
 
       const checkpointContext = checkpointApplied
         ? `The workspace environment (all files, packages, and code changes) has been fully restored from the latest checkpoint.`
@@ -2358,6 +2355,7 @@ export class AgentServer {
     taskRun: TaskRun | null,
   ): Promise<void> {
     if (!this.session) return;
+    taskRun = await this.refreshTaskRunForResume(payload, taskRun);
 
     await this.runResumeTurn(
       payload,
@@ -2368,12 +2366,7 @@ export class AgentServer {
           ? false
           : await this.applyResumeGitCheckpoint(payload);
 
-        const currentTaskRun = await this.refreshTaskRunForResume(
-          payload,
-          taskRun,
-        );
-        const pendingUserPrompt =
-          await this.getPendingUserPrompt(currentTaskRun);
+        const pendingUserPrompt = await this.getPendingUserPrompt(taskRun);
         const prompt: ContentBlock[] = pendingUserPrompt?.prompt.length
           ? pendingUserPrompt.prompt
           : [


### PR DESCRIPTION
## Problem

People can lose a newly submitted prompt when Desktop restores an older session snapshot.

**Why:** A stale run snapshot can omit the new message and trigger a synthetic continuation instead.

## Changes

- Desktop refreshes the run before choosing the prompt for both native and summary resume paths.
- If the refresh fails, the existing run state remains available as a fallback.

## How did you test this code?

- Added a regression test for a stale snapshot followed by a newly submitted prompt.
- Ran the focused resume tests, agent typecheck, Biome, and CI preflight.
- The full agent suite has an unrelated existing filesystem-permission failure in a JSONL hydration test.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes. This restores the existing prompt behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex implemented and validated the fix.
- Skills invoked: `/posthog-desktop`, `/debugging-local-task-agent-runs`, `/writing-tests`, `/writing-user-facing-copy`, and `/writing-pr-descriptions`.
- The report supplied reproduction context. The committed test message is invented and contains no report data.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*