### PR TITLE
fix(mcp-analytics): compact large numbers in the tool report

### DIFF
--- a/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
@@ -29,7 +29,6 @@ import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { TZLabel } from 'lib/components/TZLabel'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
-import { humanFriendlyNumber } from 'lib/utils/numbers'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -40,7 +39,7 @@ import type { MCPToolFailureOccurrenceItem } from '~/queries/schema/schema-gener
 import { SceneExport } from '~/scenes/sceneTypes'
 
 import { ToolDetailIntentsSection } from './clustering/ToolDetailIntentsSection'
-import { formatMs, formatMsAsSeconds } from './dashboard/formatters'
+import { formatMs, formatMsAsSeconds, formatNumber } from './dashboard/formatters'
 import { HarnessLogo, HarnessPill } from './dashboard/harness'
 import { MetricTile } from './dashboard/MetricTile'
 import { mcpAnalyticsFeaturePreviewGate } from './featurePreviewGate'
@@ -112,7 +111,7 @@ interface ResultColumn {
 
 const neighborColumns: ResultColumn[] = [
     { header: 'Tool', expand: true, render: (r) => <span className="font-mono">{String(r[0] ?? '')}</span> },
-    { header: 'In same conversation', align: 'right', render: (r) => humanFriendlyNumber(Number(r[1] ?? 0)) },
+    { header: 'In same conversation', align: 'right', render: (r) => formatNumber(Number(r[1] ?? 0)) },
 ]
 
 // Card-wrapped quill table matching the dashboard table cards.
@@ -259,7 +258,7 @@ function StatTiles({
         {
             label: 'Calls',
             value: calls,
-            formatValue: humanFriendlyNumber,
+            formatValue: formatNumber,
             data: spark(daily.calls),
             color: theme.colors[0],
             goodDirection: 'up',
@@ -291,7 +290,7 @@ function StatTiles({
         {
             label: 'Users',
             value: summary?.users ?? 0,
-            formatValue: humanFriendlyNumber,
+            formatValue: formatNumber,
             data: spark(daily.users),
             color: theme.colors[0],
             goodDirection: 'up',
@@ -299,7 +298,7 @@ function StatTiles({
         {
             label: 'Sessions',
             value: summary?.conversations ?? 0,
-            formatValue: humanFriendlyNumber,
+            formatValue: formatNumber,
             data: spark(daily.sessions),
             color: theme.colors[6],
             goodDirection: 'up',
@@ -341,8 +340,7 @@ function IntentCoverageTag({
     return (
         <Tooltip title="Share of calls where $mcp_intent was captured. Inferred intents are server fallbacks; context_parameter intents come from the client.">
             <span className="text-[11px] text-secondary">
-                {humanFriendlyNumber(coverage.with_intent)} of {humanFriendlyNumber(coverage.total)} calls captured
-                intent ({pct}%)
+                {formatNumber(coverage.with_intent)} of {formatNumber(coverage.total)} calls captured intent ({pct}%)
             </span>
         </Tooltip>
     )
@@ -656,18 +654,18 @@ function MCPAnalyticsToolDetailContent({ toolName }: { toolName: string }): JSX.
                             {
                                 header: 'Calls',
                                 align: 'right',
-                                render: (r) => humanFriendlyNumber(Number(r[1] ?? 0)),
+                                render: (r) => formatNumber(Number(r[1] ?? 0)),
                             },
                             {
                                 header: 'Errors',
                                 align: 'right',
-                                render: (r) => humanFriendlyNumber(Number(r[2] ?? 0)),
+                                render: (r) => formatNumber(Number(r[2] ?? 0)),
                             },
                             { header: 'Error rate', align: 'right', render: (r) => `${Number(r[3] ?? 0)}%` },
                             {
                                 header: 'Sessions',
                                 align: 'right',
-                                render: (r) => humanFriendlyNumber(Number(r[4] ?? 0)),
+                                render: (r) => formatNumber(Number(r[4] ?? 0)),
                             },
                         ]}
                     />
@@ -680,12 +678,12 @@ function MCPAnalyticsToolDetailContent({ toolName }: { toolName: string }): JSX.
                             {
                                 header: 'Calls',
                                 align: 'right',
-                                render: (r) => humanFriendlyNumber(Number(r[1] ?? 0)),
+                                render: (r) => formatNumber(Number(r[1] ?? 0)),
                             },
                             {
                                 header: 'Errors',
                                 align: 'right',
-                                render: (r) => humanFriendlyNumber(Number(r[2] ?? 0)),
+                                render: (r) => formatNumber(Number(r[2] ?? 0)),
                             },
                             { header: 'Error rate', align: 'right', render: (r) => `${Number(r[3] ?? 0)}%` },
                             {
@@ -717,7 +715,7 @@ function MCPAnalyticsToolDetailContent({ toolName }: { toolName: string }): JSX.
                         {
                             header: 'Occurrences',
                             align: 'right',
-                            render: (r) => humanFriendlyNumber(Number(r[1] ?? 0)),
+                            render: (r) => formatNumber(Number(r[1] ?? 0)),
                         },
                         { header: 'Last seen', render: (r) => <TZLabel time={String(r[2])} /> },
                         {


### PR DESCRIPTION
## Problem

Someone opening the full tool report for a busy tool reads counts in full, like `1,204,873` calls. The number outgrows its stat tile and the right-aligned table columns, so the layout stretches and wraps on narrow windows.

Every other MCP analytics surface already compacts these counts: the dashboard KPI tiles, the harness donut, and the tool quality table all use the shared `formatNumber` helper. The report was the one surface left on the comma-grouped formatter.

## Changes

- The report formats counts with `formatNumber` from `dashboard/formatters`, the helper the dashboard tiles use.
- Covered: the Calls, Users and Sessions tiles, the intent coverage line, and the count columns in the by harness, top users, failures and related tools tables.
- Latency, error rate and percentage values keep their current formatting.

| Value | Before | After |
| --- | --- | --- |
| 412 | 412 | 412 |
| 41,096 | 41,096 | 41.1K |
| 4,951,882 | 4,951,882 | 4.95M |

Counts under 1,000 render unchanged, so small tools look the same as they do today.

No screenshot: this scene has no Storybook story, and I had no project with MCP data to render it against. The table above is the whole visible difference.

## How did you test this code?

- No tests changed. The change swaps one pure formatter for another with the same signature, and no existing test asserts the report's number strings.
- I ran oxfmt and oxlint on the changed file, and the frontend TypeScript check after building the nested quill workspace. The check reports no error in `products/mcp_analytics`; the remaining errors come from the unbuilt `@posthog/hogvm` package and predate this branch.
- Not done: I did not open the report in a browser.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually the PostHog Slack app, running Claude Code) made this change from a request in a [Slack thread](https://posthog.slack.com/archives/C0B3E1Y576X/p1786520706882419).

- Skills invoked: `/writing-pr-descriptions`.
- One judgment call on scope: `formatNumber` also fits `clustering/ToolIntentDetail`, which renders the "Intents served" panel on this report. I left it alone because the clustering tab shares that component, and widening the change would touch a surface nobody asked about.
- The report's tables now match the tool quality table, which already compacts without a tooltip carrying the exact value. If reviewers want the exact count on hover, that belongs in both places.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B3E1Y576X/p1786520706882419)*
