### PR TITLE
fix(warehouse): paginate the DoIt report listing

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/doit/doit.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/doit/doit.py
@@ -2,6 +2,7 @@ import hashlib
 import datetime
 from dataclasses import dataclass
 from typing import Any, Optional
+from urllib.parse import urlencode
 
 import pyarrow as pa
 import structlog
@@ -37,6 +38,13 @@ REPORT_TIMEOUT_SECONDS = (DOIT_CONNECT_TIMEOUT_SECONDS, 300)
 
 # Key under a schema's persisted `schema_metadata` holding the DoIt report id.
 REPORT_ID_METADATA_KEY = "report_id"
+
+DOIT_REPORTS_URL = "https://api.doit.com/analytics/v1/reports"
+
+# The listing endpoint paginates at 50 reports per page by default, signalling more pages via a
+# `pageToken` in the response body. The cap is a safety valve against a server that keeps returning
+# tokens forever; at 50 reports per page it allows 10,000 reports.
+DOIT_REPORTS_MAX_PAGES = 200
 
 DOIT_INCREMENTAL_FIELDS: list[IncrementalField] = [
     {
@@ -87,18 +95,41 @@ def doit_list_reports(config: DoItSourceConfig, logger: Optional[FilteringBoundL
     if logger is None:
         logger = structlog.get_logger(__name__)
 
-    res = make_tracked_session(retry=DOIT_RETRY).get(
-        "https://api.doit.com/analytics/v1/reports",
-        headers={"Authorization": f"Bearer {config.api_key}"},
-        timeout=LIST_REPORTS_TIMEOUT_SECONDS,
-    )
+    session = make_tracked_session(retry=DOIT_RETRY)
 
-    # `DOIT_RETRY` sets `raise_on_status=False`, so a 5xx that outlives the retries lands here as a
-    # normal response; without this guard it surfaces as a JSON/key error with the status code lost.
-    if res.status_code != 200:
-        raise Exception(f"Request to list reports failed with status: {res.status_code}. With body: {res.text}")
+    reports: list[dict[str, Any]] = []
+    page_token: Optional[str] = None
+    for _ in range(DOIT_REPORTS_MAX_PAGES):
+        url = DOIT_REPORTS_URL
+        if page_token:
+            url = f"{DOIT_REPORTS_URL}?{urlencode({'pageToken': page_token})}"
 
-    reports = res.json()["reports"]
+        res = session.get(
+            url,
+            headers={"Authorization": f"Bearer {config.api_key}"},
+            timeout=LIST_REPORTS_TIMEOUT_SECONDS,
+        )
+
+        # `DOIT_RETRY` sets `raise_on_status=False`, so a 5xx that outlives the retries lands here as
+        # a normal response; without this guard it surfaces as a JSON/key error with the status code
+        # lost.
+        if res.status_code != 200:
+            raise Exception(f"Request to list reports failed with status: {res.status_code}. With body: {res.text}")
+
+        payload = res.json()
+        reports.extend(payload.get("reports") or [])
+
+        next_token = payload.get("pageToken")
+        # Treat an echoed token as the last page so a misbehaving server can't loop us.
+        if not next_token or next_token == page_token:
+            break
+        page_token = next_token
+    else:
+        logger.warning(
+            "DoIt report listing hit the page cap; the report list may be truncated",
+            max_pages=DOIT_REPORTS_MAX_PAGES,
+            reports_seen=len(reports),
+        )
 
     result = []
     for report in reports:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/doit/tests/test_doit_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/doit/tests/test_doit_source.py
@@ -3,12 +3,17 @@ from unittest.mock import MagicMock, patch
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import DEFAULT_RETRY
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.typings import SourceInputs
-from products.warehouse_sources.backend.temporal.data_imports.sources.doit.doit import DOIT_RETRY, DoItReport
+from products.warehouse_sources.backend.temporal.data_imports.sources.doit.doit import (
+    DOIT_RETRY,
+    DoItReport,
+    doit_list_reports,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.doit.source import DoItSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.doit import DoItSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 _SOURCE_MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.doit.source"
+_DOIT_MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.doit.doit"
 
 CONFIG = DoItSourceConfig(api_key="key")
 
@@ -58,3 +63,42 @@ class TestDoItSource:
 
     def test_doit_retry_preserves_default_statuses(self):
         assert set(DEFAULT_RETRY.status_forcelist or ()).issubset(set(DOIT_RETRY.status_forcelist or ()))
+
+
+def _reports_response(reports: list[dict], page_token: str | None = None) -> MagicMock:
+    res = MagicMock()
+    res.status_code = 200
+    body: dict = {"reports": reports}
+    if page_token is not None:
+        body["pageToken"] = page_token
+    res.json.return_value = body
+    return res
+
+
+class TestDoItListReportsPagination:
+    def test_follows_page_tokens_until_exhausted(self):
+        session = MagicMock()
+        session.get.side_effect = [
+            _reports_response([{"id": "r1", "reportName": "First"}], page_token="tok-2"),
+            _reports_response([{"id": "r2", "reportName": "Second"}]),
+        ]
+
+        with patch(f"{_DOIT_MODULE}.make_tracked_session", return_value=session):
+            reports = doit_list_reports(CONFIG)
+
+        assert [r.id for r in reports] == ["r1", "r2"]
+        assert session.get.call_count == 2
+        assert "pageToken=tok-2" in session.get.call_args_list[1].args[0]
+
+    def test_stops_when_the_server_echoes_the_same_page_token(self):
+        session = MagicMock()
+        session.get.side_effect = [
+            _reports_response([{"id": "r1", "reportName": "First"}], page_token="tok"),
+            _reports_response([{"id": "r2", "reportName": "Second"}], page_token="tok"),
+        ]
+
+        with patch(f"{_DOIT_MODULE}.make_tracked_session", return_value=session):
+            reports = doit_list_reports(CONFIG)
+
+        assert [r.id for r in reports] == ["r1", "r2"]
+        assert session.get.call_count == 2


### PR DESCRIPTION
## Problem

A DoIt account with more than 50 reports only sees the first 50 as syncable tables.
"Pull new schemas" reports success ("all 50 table(s) already tracked") while silently missing the rest.

DoIt's `GET /analytics/v1/reports` endpoint paginates at 50 reports per page by default and signals more pages via a `pageToken` in the response body.
`doit_list_reports` fetched a single page and never followed the token.

## Changes

- `doit_list_reports` now follows `pageToken` across pages on one tracked session, accumulating all reports.
- A cap of 200 pages (~10,000 reports) guards against a server that returns tokens forever; hitting it logs a structured warning.
- An echoed token (same token returned twice) ends the loop, so a misbehaving server cannot hang a sync worker.

This fixes schema discovery and the name-based report lookup fallback in `resolve_report_id`.
Syncs for schemas with a stamped `report_id` were already unaffected, since they resolve by id without listing.

## How did you test this code?

- Two new tests in `test_doit_source.py`: one catches a regression back to a single unpaginated fetch (the bug this PR fixes), one catches removal of the echoed-token guard.
- Ran the full DoIt test file locally; not run: the broader warehouse suites, which CI covers.
- Not verified against the live DoIt API; the pagination contract comes from the [DoIt API reference](https://developer.doit.com/reference/listreports).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - no user-facing parameter or table changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code.
Skills invoked: /implementing-warehouse-sources, /writing-tests, /writing-pr-descriptions.
Investigation started from a user report of "all 50 schemas have been loaded" on schema refresh; traced the 50 to DoIt's default page size rather than a PostHog-side cap.
