### PR TITLE
fix(hypercache): avoid duplicate object storage captures

### DIFF
--- a/posthog/storage/hypercache.py
+++ b/posthog/storage/hypercache.py
@@ -289,9 +289,12 @@ class HyperCache:
             # Any storage-layer failure here (including a misconfigured S3 endpoint that
             # makes boto3 raise on client construction) must degrade to a cache miss and
             # fall through to load_fn, never bubble a 500 up to the request handler.
-            # ValueError also catches json.JSONDecodeError from a corrupt blob, so capture
-            # it — otherwise persistent corruption keeps missing silently as a plain hit_db.
-            capture_exception(e)
+            # ObjectStorage already logs and captures ObjectStorageError at its boundary.
+            # Do not capture its wrapper again here: that creates a second error-tracking
+            # event for every failed read. Other failures originate in this layer (for
+            # example JSONDecodeError from a corrupt blob), so capture those here.
+            if not isinstance(e, ObjectStorageError):
+                capture_exception(e)
 
         # NOTE: This only applies to the django version - the dedicated service will rely entirely on the cache
         try:

--- a/posthog/storage/test/test_hypercache.py
+++ b/posthog/storage/test/test_hypercache.py
@@ -112,21 +112,25 @@ class TestHyperCacheGetFromCache(HyperCacheTestBase):
 
     @parameterized.expand(
         [
-            ("value_error", ValueError("Invalid endpoint: https://${POSTHOG_DOMAIN}")),
-            ("object_storage_error", object_storage.ObjectStorageError("read failed")),
-            ("boto_core_error", BotoCoreError()),
-            ("client_error", ClientError({"Error": {"Code": "AccessDenied"}}, "GetObject")),
+            ("value_error", ValueError("Invalid endpoint: https://${POSTHOG_DOMAIN}"), True),
+            ("object_storage_error", object_storage.ObjectStorageError("read failed"), False),
+            ("boto_core_error", BotoCoreError(), True),
+            ("client_error", ClientError({"Error": {"Code": "AccessDenied"}}, "GetObject"), True),
         ]
     )
-    def test_get_from_cache_s3_exception_falls_back_to_db(self, _name, exception):
-        """A storage-layer failure on the S3 read must degrade to a cache miss, not a 500."""
+    def test_get_from_cache_s3_exception_falls_back_to_db(self, _name, exception, should_capture):
+        """S3 failures fall back to DB without recapturing errors reported by ObjectStorage."""
         self.hypercache.clear_cache(self.team_id, kinds=["redis"])
 
-        with patch.object(object_storage, "read", side_effect=exception):
+        with (
+            patch.object(object_storage, "read", side_effect=exception),
+            patch("posthog.storage.hypercache.capture_exception") as mock_capture,
+        ):
             result, source = self.hypercache.get_from_cache_with_source(self.team_id)
 
         assert result == {"default": "data"}
         assert source == "db"
+        assert mock_capture.called is should_capture
 
     def test_get_from_cache_corrupt_s3_payload_falls_back_to_db(self):
         """A malformed S3 blob (json.JSONDecodeError, a ValueError subclass) must degrade to a cache miss."""


### PR DESCRIPTION
## Problem

HyperCache's optional S3 tier catches `ObjectStorageError` and falls back to the database. The object-storage boundary already logs and captures the underlying failure before raising that wrapper, but HyperCache captured the wrapper again. One failed `GetObject` therefore produced two error-tracking events.

This amplified [error issue 019f8abf-5962-7b12-8344-cd99a22dc50c](https://us.posthog.com/error_tracking/019f8abf-5962-7b12-8344-cd99a22dc50c), where an `AccessDenied` read of `cache/teams/2/feature_flags/flags_with_cohorts.json` was handled and then reported again from `get_from_cache_with_source`.

## Changes

- Do not recapture `ObjectStorageError` in HyperCache because ObjectStorage owns reporting it.
- Continue capturing failures that originate in HyperCache or bypass the object-storage wrapper, including corrupt JSON, `BotoCoreError`, and raw `ClientError`.
- Test both reporting paths while preserving the DB fallback behavior.

This removes the duplicate wrapper issue without hiding the underlying object-storage permission error.

## Verification

- `uv run pytest posthog/storage/test/test_hypercache.py -q -k 'test_get_from_cache_s3_exception_falls_back_to_db'` (4 passed)
- `uv run ruff check posthog/storage/hypercache.py posthog/storage/test/test_hypercache.py`
- `uv run ruff format --check posthog/storage/hypercache.py posthog/storage/test/test_hypercache.py`

The full `TestHyperCacheGetFromCache` class also needs the local object-storage service. In this isolated runner, its integration cases fail to connect to `http://objectstorage:19000`; the targeted mocked cases pass.
