### PR TITLE
fix(feature-flags): match $feature_interaction in enriched analytics query

### DIFF
--- a/posthog/test/test_feature_flag_analytics.py
+++ b/posthog/test/test_feature_flag_analytics.py
@@ -934,6 +934,12 @@ class TestEnrichedAnalytics(BaseTest):
             key="beta-feature3",
             created_by=self.user,
         )
+        f5 = FeatureFlag.objects.create(
+            team=self.team,
+            name="Beta feature",
+            key="beta-feature4",
+            created_by=self.user,
+        )
 
         # create usage dashboard for f1 and f3
         _create_usage_dashboard(f1, self.user)
@@ -960,6 +966,14 @@ class TestEnrichedAnalytics(BaseTest):
             distinct_id="test3",
             event="$feature_view",
             properties={"feature_flag": "test_flag"},
+            timestamp="2021-01-12T12:00:10Z",
+        )
+        # out of bounds for f5 - should not set has_enriched_analytics
+        _create_event(
+            team=self.team,
+            distinct_id="test8",
+            event="$feature_view",
+            properties={"feature_flag": "beta-feature4"},
             timestamp="2021-01-12T12:00:10Z",
         )
         # different flag
@@ -1006,11 +1020,13 @@ class TestEnrichedAnalytics(BaseTest):
         f2.refresh_from_db()
         f3.refresh_from_db()
         f4.refresh_from_db()
+        f5.refresh_from_db()
 
         self.assertEqual(f1.has_enriched_analytics, True)
         self.assertEqual(f2.has_enriched_analytics, True)
         self.assertEqual(f3.has_enriched_analytics, False)
         self.assertEqual(f4.has_enriched_analytics, False)
+        self.assertEqual(f5.has_enriched_analytics, False)
 
         # now try deleting a usage dashboard. It should not delete the feature flag
         assert f1.usage_dashboard is not None
@@ -1038,7 +1054,7 @@ class TestEnrichedAnalytics(BaseTest):
 
     def test_find_flags_with_enriched_analytics_via_feature_interaction_only(self):
         # A flag that only ever receives $feature_interaction (no $feature_view) should still be
-        # detected as enriched, because the docs present the two events as interchangeable triggers.
+        # detected as enriched, since the generated usage dashboard charts both events.
         flag = FeatureFlag.objects.create(
             team=self.team,
             name="Interaction only feature",

--- a/posthog/test/test_feature_flag_analytics.py
+++ b/posthog/test/test_feature_flag_analytics.py
@@ -1036,6 +1036,34 @@ class TestEnrichedAnalytics(BaseTest):
         self.assertEqual(f1.has_enriched_analytics, True)
         self.assertEqual(f1.usage_dashboard, None)
 
+    def test_find_flags_with_enriched_analytics_via_feature_interaction_only(self):
+        # A flag that only ever receives $feature_interaction (no $feature_view) should still be
+        # detected as enriched — the docs present the two events as interchangeable triggers.
+        flag = FeatureFlag.objects.create(
+            team=self.team,
+            name="Interaction only feature",
+            key="interaction-only-flag",
+            created_by=self.user,
+        )
+
+        _create_event(
+            team=self.team,
+            distinct_id="test",
+            event="$feature_interaction",
+            properties={"feature_flag": "interaction-only-flag"},
+            timestamp="2021-01-01T12:00:00Z",
+        )
+
+        flush_persons_and_events()
+
+        start = datetime.datetime(2021, 1, 1, 0, 0, 0)
+        end = datetime.datetime(2021, 1, 2, 0, 0, 0)
+
+        find_flags_with_enriched_analytics(start, end)
+
+        flag.refresh_from_db()
+        self.assertEqual(flag.has_enriched_analytics, True)
+
 
 class TestFindFlagsWithEnrichedAnalyticsTask(BaseTest):
     @patch("products.feature_flags.backend.flag_analytics.find_flags_with_enriched_analytics")

--- a/posthog/test/test_feature_flag_analytics.py
+++ b/posthog/test/test_feature_flag_analytics.py
@@ -1038,7 +1038,7 @@ class TestEnrichedAnalytics(BaseTest):
 
     def test_find_flags_with_enriched_analytics_via_feature_interaction_only(self):
         # A flag that only ever receives $feature_interaction (no $feature_view) should still be
-        # detected as enriched — the docs present the two events as interchangeable triggers.
+        # detected as enriched, because the docs present the two events as interchangeable triggers.
         flag = FeatureFlag.objects.create(
             team=self.team,
             name="Interaction only feature",

--- a/products/feature_flags/backend/flag_analytics.py
+++ b/products/feature_flags/backend/flag_analytics.py
@@ -245,7 +245,7 @@ def _build_enriched_analytics_query() -> str:
         SELECT team_id, {_enriched_flag_key_expr_sql()} as flag_key
         FROM events
         PREWHERE event IN ('$feature_view', '$feature_interaction')
-        WHERE timestamp between %(begin)s AND %(end)s
+        AND timestamp between %(begin)s AND %(end)s
         GROUP BY team_id, flag_key
     """
 

--- a/products/feature_flags/backend/flag_analytics.py
+++ b/products/feature_flags/backend/flag_analytics.py
@@ -244,7 +244,8 @@ def _build_enriched_analytics_query() -> str:
     return f"""
         SELECT team_id, {_enriched_flag_key_expr_sql()} as flag_key
         FROM events
-        WHERE timestamp between %(begin)s AND %(end)s AND event IN ('$feature_view', '$feature_interaction')
+        PREWHERE event IN ('$feature_view', '$feature_interaction')
+        WHERE timestamp between %(begin)s AND %(end)s
         GROUP BY team_id, flag_key
     """
 

--- a/products/feature_flags/backend/flag_analytics.py
+++ b/products/feature_flags/backend/flag_analytics.py
@@ -244,7 +244,7 @@ def _build_enriched_analytics_query() -> str:
     return f"""
         SELECT team_id, {_enriched_flag_key_expr_sql()} as flag_key
         FROM events
-        WHERE timestamp between %(begin)s AND %(end)s AND event = '$feature_view'
+        WHERE timestamp between %(begin)s AND %(end)s AND event IN ('$feature_view', '$feature_interaction')
         GROUP BY team_id, flag_key
     """
 


### PR DESCRIPTION
## Problem

Docs (posthog.com/docs/libraries/js/usage#enriched-flag-analytics) present `$feature_view` and `$feature_interaction` as interchangeable triggers for unlocking two extra charts on a feature flag's Usage tab ("Feature viewed total volume" and "Feature interaction total volume").

In practice, only `$feature_view` actually unlocks them. `find_flags_with_enriched_analytics` in `products/feature_flags/backend/flag_analytics.py` only queries for `event = '$feature_view'`, so a flag that sends `$feature_interaction` but never `$feature_view` never gets `has_enriched_analytics` set — even though it's sending exactly what the docs describe as half the feature.

Closes #81545

## Changes

One-line fix in `_build_enriched_analytics_query()`: match both events, not just `$feature_view`.

```diff
- WHERE timestamp between %(begin)s AND %(end)s AND event = '$feature_view'
+ WHERE timestamp between %(begin)s AND %(end)s AND event IN ('$feature_view', '$feature_interaction')
```

Both events share the same `feature_flag` property (confirmed against the docs), so no other query changes are needed. The query already groups by `team_id, flag_key`, so a flag sending both event types doesn't get double-processed.

> [!NOTE]
> This only fixes the `has_enriched_analytics` flag-setting job. I didn't audit whether the chart-rendering queries themselves have any similar restriction — that's a separate code path and out of scope here.

## How did you test this code?

Added `test_find_flags_with_enriched_analytics_via_feature_interaction_only`, covering a flag that only ever receives `$feature_interaction` (never `$feature_view`) — confirms `has_enriched_analytics` correctly becomes `True`. Ran the full `TestEnrichedAnalytics` suite locally (7 passed, no regressions).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?