### PR TITLE
chore(owners): assign quill and the shared UI libs to platform-ux

### DIFF
--- a/owners.yaml
+++ b/owners.yaml
@@ -18,6 +18,8 @@ teams:
     # Metrics and Traces") absorbed logs, and #team-apm is where it lives.
     logs:
         slack: '#team-apm'
+    platform-ux:
+        slack: '#team-platform-ux'
     team-data-stack:
         slack: '#group-data-stack'
     # PostHog Desktop's channel kept the name it was created under.
@@ -63,8 +65,14 @@ rules:
       owners: team-ai-observability
     - match: '/docs/published/handbook/engineering/developing-locally.md'
       owners: team-devex
+    - match:
+          - '/frontend/src/lib/lemon-ui/'
+          - '/frontend/src/lib/ui/'
+      owners: platform-ux
     - match: '/nodejs/tests/'
       owners: team-ingestion
+    - match: '/packages/quill/'
+      owners: [platform-ux, '@sampennington']
     - match: '/posthog/helpers/email_utils.py'
       owners: team-platform-features
     - match: '/posthog/management/commands/find_enum_collisions.py'


### PR DESCRIPTION
## Problem

DevEx gets tagged for review on quill pull requests, such as [adding a scatter chart](https://github.com/PostHog/posthog/pull/81127).
The root `owners.yaml` routes every `AGENTS.md` and `CLAUDE.md` at any depth to `team-devex`, so editing a chart component's agent doc is enough to fire it.

That rule is a catch-all so ownership-policy and agent-tooling files never go out unassigned.
Nothing in quill has an owner, so on a quill pull request the catch-all is the only rule that matches.
`frontend/src/lib/lemon-ui` and `frontend/src/lib/ui` are unowned too, and their pull requests go out with no reviewer suggested at all.

## Changes

- `packages/quill/` routes to `platform-ux`, plus Sam Pennington as an individual owner.
- `frontend/src/lib/lemon-ui/` and `frontend/src/lib/ui/` route to `platform-ux`.
- The `teams:` registry maps `platform-ux` to `#team-platform-ux`. The derived channel would be `#platform-ux`, which does not exist.
- Assignment stays non-blocking. `.github/CODEOWNERS` is untouched.

Contribution over the last 12 months, from the commits and reviews APIs, bots excluded:

| Surface | Pull requests | Top committer | Top approver |
| --- | --- | --- | --- |
| `packages/quill` | 190 | sampennington (85) | sampennington (20) |
| `frontend/src/lib/lemon-ui` | 368 | pauldambra (56) | adamleithp (45) |
| `frontend/src/lib/ui` | 58 | adamleithp (33) | mariusandra (19) |

I put all three boundaries in the root file rather than in per-directory `owners.yaml` files.
The per-directory version was my first attempt, and `owners:fmt` scored it at 387 against a canonical 324.
To reach that canonical layout it wanted a new `frontend/src/owners.yaml` absorbing two files other teams own.
The root rules score 318, which is what master scores today, so this adds no drift and touches nobody else's file.

> [!NOTE]
> lemon-ui is the widest of the three and `platform-ux` currently has one member, so this routes roughly 370 pull requests a year to one person.
> Both owners should agree before this leaves draft.

## How did you test this code?

No tests added. This is data the resolver reads, and its behavior is covered by `tools/owners/tests`.

Verified locally against the resolver:

- `owners:who` returns `platform-ux` for all four surfaces, and `#team-platform-ux` as the channel.
- `owners:fmt` reports the layout canonical at cost 318.
- `owners:lint` passes, with the 4 warnings master already carries.
- `ci:preflight` reports nothing triggered.

Not checked: whether either owner accepts the assignment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) traced the devex review request on the scatter chart pull request back to the unanchored `AGENTS.md` rule, then pulled commit and approval counts from the GitHub API to work out who the real owners are. The local clone is shallow, so the first counts I produced covered five weeks rather than a year and understated quill by roughly 4x.

Skills invoked: `/establishing-code-ownership`, `/writing-pr-descriptions`.

Two decisions changed during the session. Individual owners belong in `owners.yaml`, not `CODEOWNERS`, which is blocking, security-owned, and explicitly discouraged. And placement moved from per-directory files to root rules once `owners:fmt` showed the per-directory version was the drift.
