### PR TITLE
fix(attio): surface a clear error for a non-ASCII API key

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/attio/attio.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/attio/attio.py
@@ -124,6 +124,14 @@ def get_resource(name: str) -> EndpointResource:
 
 def validate_credentials(api_key: str) -> tuple[bool, str | None]:
     """Validate Attio API credentials by making a test request."""
+    # A non-ASCII key can't be encoded into the Authorization header (requests uses latin-1),
+    # which would otherwise surface a raw UnicodeEncodeError to the user.
+    if not api_key.isascii():
+        return (
+            False,
+            "Your Attio API key contains an unsupported character (for example an invisible one pasted "
+            "from another app). Retype it by hand and try again.",
+        )
     try:
         res = make_tracked_session().get(
             "https://api.attio.com/v2/self",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/attio/tests/test_attio.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/attio/tests/test_attio.py
@@ -1,0 +1,14 @@
+from products.warehouse_sources.backend.temporal.data_imports.sources.attio.attio import validate_credentials
+
+
+class TestValidateCredentials:
+    def test_non_ascii_key_returns_actionable_message_without_leaking_encoding_error(self):
+        # A non-latin-1 key can't be encoded into the Authorization header; the raw
+        # UnicodeEncodeError ("'latin-1' codec can't encode ... ordinal not in range(256)")
+        # must never surface to the user.
+        valid, msg = validate_credentials("bad中key")
+
+        assert valid is False
+        assert "Retype it by hand" in (msg or "")
+        assert "latin-1" not in (msg or "")
+        assert "ordinal not in range" not in (msg or "")


### PR DESCRIPTION
## Problem

- Someone connecting an Attio source who pastes an API key with a non-ASCII character saw a raw Python error (`'latin-1' codec can't encode ... ordinal not in range(256)`) and had nothing to act on.
- The key goes into the `Authorization` header, which `requests` encodes as latin-1, so a non-ASCII character (often an invisible one pasted from another app) raises `UnicodeEncodeError`.
- `validate_credentials` caught the exception but returned `str(e)`, so the raw codec message reached the wizard.

## Changes

- `validate_credentials` now rejects a non-ASCII key before the request and returns an actionable message telling the user to retype it by hand.

## How did you test this code?

- New unit test: a non-ASCII key returns the friendly message, and the raw `latin-1` / `ordinal not in range` text never appears. Catches a regression back to leaking the codec error.
- Not run: the full warehouse-sources suite and any live Attio call, because this path needs no network once the key is rejected.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: no user-facing behavior beyond the error text changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored by Claude (PostHog Desktop) while triaging data-warehouse source-creation failures.
- Skills invoked: /writing-tests, /writing-user-facing-copy, /writing-code-comments, /writing-pr-descriptions.
- Public artifact: no customer values appear here. The error shape is described generically; the failing key was never copied into code, tests, or this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
