### PR TITLE
fix(github): tell users to connect an account, not reconnect

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/source.py
@@ -293,7 +293,7 @@ If automatic creation failed with a permissions error, the fix depends on how yo
             "This installation has been suspended": "Your GitHub App installation has been suspended. Re-enable it from your GitHub organization's installed GitHub Apps settings, then reconnect your GitHub account.",
             # Deterministic credential/config errors from _get_access_token and OAuthMixin.
             # These never resolve on retry — the source needs reconfiguring or reconnecting.
-            "Missing GitHub integration ID": "No GitHub account is connected. Please reconnect your GitHub account.",
+            "Missing GitHub integration ID": "No GitHub account is connected. Connect a GitHub account and try again.",
             "Missing personal access token": "GitHub personal access token is not configured. Please update the source configuration.",
             "No repositories configured": "No repositories are selected for this source. Please update the source configuration.",
             "resolve to the same warehouse table": "Two selected repositories resolve to the same warehouse table. Please remove or rename one.",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_source_class.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_source_class.py
@@ -236,7 +236,7 @@ class TestGithubSource:
         result = self.source.get_endpoint_permissions(config, self.team_id, ["teams", "team_members", "issues"])
 
         assert result["issues"] is None
-        assert result["teams"] == "No GitHub account is connected. Please reconnect your GitHub account."
+        assert result["teams"] == "No GitHub account is connected. Connect a GitHub account and try again."
         assert result["team_members"] == result["teams"]
 
     @pytest.mark.parametrize(
@@ -447,7 +447,7 @@ class TestGithubSource:
     @pytest.mark.parametrize(
         "selection,expected_message",
         [
-            ("oauth", "No GitHub account is connected. Please reconnect your GitHub account."),
+            ("oauth", "No GitHub account is connected. Connect a GitHub account and try again."),
             ("pat", "GitHub personal access token is not configured. Please update the source configuration."),
         ],
     )


### PR DESCRIPTION
## Problem

- Someone setting up a GitHub source who has not connected a GitHub account was told "No GitHub account is connected. Please reconnect your GitHub account." "Reconnect" implies a connection they never made, so it points at the wrong action.
- This was the most common GitHub source-creation failure on the day I triaged these.
- The message maps from the internal `Missing GitHub integration ID` error, which fires on the OAuth path when no integration is selected.

## Changes

- The message now reads "No GitHub account is connected. Connect a GitHub account and try again." It works whether or not the user connected before.

> [!NOTE]
> This corrects the copy, not the flow. Users reach this state because the setup form on the OAuth path lets them proceed before connecting an account. Blocking that earlier is a separate frontend change that needs product review and in-app verification, so it is out of scope here.

## How did you test this code?

- Updated the two existing tests that assert this exact string (`get_endpoint_permissions` per-table reason, and the `validate_credentials` OAuth case). They guard that the friendly copy, not the internal `Missing ...` developer string, reaches the wizard.
- Not run: the database-backed warehouse-sources suites, because this change is a string in a static error map.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: no documented workflow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored by Claude (PostHog Desktop) while triaging data-warehouse source-creation failures.
- Skills invoked: /writing-tests, /writing-user-facing-copy, /writing-code-comments, /writing-pr-descriptions.
- Public artifact: no customer values appear here.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
