### PR TITLE
fix(data-warehouse): treat a progressing repartition rewrite as progress

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
@@ -518,11 +518,17 @@ def _handle_budget_exceeded(
     """Record a rewrite that ran out of one activity's budget, distinguishing progress from a stall.
 
     Checkpoint/resume lets a table too large to rewrite in one activity converge across runs (see
-    `RepartitionBudgetExceededError`), so an attempt that advanced the checkpoint is forward progress,
-    not a failure: counting it against the finite `MAX_REPARTITION_ATTEMPTS` would abandon a table that
-    simply needs more than three budgets mid-convergence and leave it un-repartitioned. Only an attempt
-    that wrote no new rows since the last checkpoint is stuck; that one falls through to
-    `_handle_failure` so a rewrite which genuinely can't advance in one budget still gives up.
+    `RepartitionBudgetExceededError`), so an attempt that streamed new rows is forward progress, not a
+    failure: counting it against the finite `MAX_REPARTITION_ATTEMPTS` would abandon a table that simply
+    needs more than three budgets mid-convergence and leave it un-repartitioned. Only an attempt that
+    committed no new rows before the budget ran out is stuck; that one falls through to `_handle_failure`
+    so a rewrite which genuinely can't advance in one budget still gives up.
+
+    Progress is read from `error.rows_written` — the rows this attempt actually streamed and committed —
+    not from the persisted checkpoint. The checkpoint can be absent (the post-budget row count that
+    persists it hit a transient read error) or freshly rebuilt from row 0 (live changed between attempts,
+    so the prior checkpoint was discarded), and in both cases a large, genuinely-progressing rewrite
+    would read as a stall against a zero-or-stale baseline and burn an attempt it did not earn.
 
     Returns the metric outcome: "superseded" when a newer attempt owns the claim, "progressing" when
     the rewrite advanced, otherwise whatever `_handle_failure` returns.
@@ -534,22 +540,20 @@ def _handle_budget_exceeded(
         return "superseded"
 
     pending = schema.repartition_pending or pending or {}
-    rows_written = int((schema.repartition_rewrite or {}).get("rows_written", 0))
-    high_water = int(pending.get("rewrite_high_water", 0))
-    if rows_written > high_water:
-        # Forward progress this attempt: keep the checkpoint, record the new high-water mark, and reset
-        # the failure counter — a rewrite still advancing is not the doomed one the cap exists to stop.
-        # The next run resumes from the checkpoint rather than re-streaming from row 0.
-        schema.set_repartition_pending({**pending, "attempts": 0, "rewrite_high_water": rows_written})
+    if error.rows_written > 0:
+        # Forward progress this attempt: keep the checkpoint and reset the failure counter — a rewrite
+        # still advancing is not the doomed one the cap exists to stop. The next run resumes from the
+        # checkpoint (when one persisted) rather than re-streaming from row 0.
+        schema.set_repartition_pending({**pending, "attempts": 0})
         logger.info(
-            f"repartition: over budget but rewrite advanced to {rows_written} rows, resuming next run",
-            rows_written=rows_written,
+            f"repartition: over budget but rewrite advanced by {error.rows_written} rows, resuming next run",
+            rows_written=error.rows_written,
         )
         _capture_stood_down(schema, inputs, trigger_reason, "rewrite_progressing", logger)
         return "progressing"
 
-    # No new rows since the last checkpoint: the rewrite can't make headway inside one budget, so count
-    # it as a real failed attempt and let `MAX_REPARTITION_ATTEMPTS` eventually give up on it.
+    # No new rows committed before the budget ran out: the rewrite can't make headway inside one budget,
+    # so count it as a real failed attempt and let `MAX_REPARTITION_ATTEMPTS` eventually give up on it.
     return _handle_failure(inputs, schema, pending, trigger_reason, error, claim_token, logger)
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
@@ -217,16 +217,18 @@ class TestBudgetExhaustion:
         _mock_capture_event: MagicMock,
         _mock_capture_exception: MagicMock,
     ) -> None:
-        # A rewrite that wrote no new rows since the last checkpoint (rows_written == high_water) is
-        # stuck, so budget exhaustion counts as a real failed attempt.
+        # A rewrite that committed no new rows before the budget ran out (error carries rows_written=0)
+        # is stuck, so budget exhaustion counts as a real failed attempt. A persisted checkpoint that
+        # still holds rows from an earlier attempt must not mask that stall — progress is judged by what
+        # this attempt streamed, not by the checkpoint's size.
         schema = _schema(
             name="public.usages",
             s3_folder_name="usages",
-            pending={**PENDING_TARGET, "attempts": prior_attempts, "rewrite_high_water": 12},
+            pending={**PENDING_TARGET, "attempts": prior_attempts},
             rewrite={"rows_written": 12},
         )
         mock_schema_model.objects.select_related.return_value.get.return_value = schema
-        mock_repartition.side_effect = RepartitionBudgetExceededError("out of budget")
+        mock_repartition.side_effect = RepartitionBudgetExceededError("out of budget", rows_written=0)
 
         _maybe_repartition_table(
             RepartitionActivityInputs(team_id=TEAM_ID, schema_id=SCHEMA_ID, job_id=JOB_ID, source_id=SOURCE_ID),
@@ -246,7 +248,18 @@ class TestBudgetExhaustion:
             schema.stamp_last_repartition_at.assert_not_called()
             schema.clear_repartition_rewrite.assert_not_called()
 
-    @parameterized.expand([("first_attempt", 0, 0), ("last_attempt_before_give_up", 2, 100)])
+    @parameterized.expand(
+        [
+            # A checkpoint that never persisted (the post-budget row count hit a transient read error)
+            # leaves no `repartition_rewrite`; the rows this attempt streamed are still forward progress.
+            ("checkpoint_did_not_persist", 0, None, None),
+            # A checkpoint rebuilt from row 0 (live changed between attempts, so the prior one was
+            # discarded) sits far below a `rewrite_high_water` left over from the discarded temp. Judged
+            # against that stale baseline the attempt reads as a stall; judged by what it streamed it is
+            # progress — and this is the last attempt before the cap, so a misjudgement gives up terminally.
+            ("stale_high_water_after_discard", 2, {"rows_written": 5}, 100_000),
+        ]
+    )
     @patch(f"{MODULE}.capture_exception")
     @patch(f"{MODULE}.capture_repartition_event")
     @patch(f"{MODULE}.HeartbeaterSync")
@@ -259,7 +272,8 @@ class TestBudgetExhaustion:
         self,
         _name: str,
         prior_attempts: int,
-        prior_high_water: int,
+        rewrite: dict | None,
+        stale_high_water: int | None,
         mock_schema_model: MagicMock,
         _mock_job_model: MagicMock,
         _mock_enabled: MagicMock,
@@ -269,18 +283,16 @@ class TestBudgetExhaustion:
         mock_capture_event: MagicMock,
         _mock_capture_exception: MagicMock,
     ) -> None:
-        # The checkpoint advanced (rows_written > high_water), so a table too large for one budget is
-        # converging across runs. It must never give up — even sitting at the last attempt before the
-        # cap — and must reset the failure counter and record the new high-water mark so the next run
-        # resumes rather than re-streaming from row 0.
-        schema = _schema(
-            name="public.usages",
-            s3_folder_name="usages",
-            pending={**PENDING_TARGET, "attempts": prior_attempts, "rewrite_high_water": prior_high_water},
-            rewrite={"rows_written": prior_high_water + 500},
-        )
+        # This attempt streamed new rows, so a table too large for one budget is converging across runs.
+        # It must never give up — even sitting at the last attempt before the cap — and must reset the
+        # failure counter, regardless of whether a checkpoint persisted or the recorded high-water mark
+        # is stale from a discarded temp.
+        pending = {**PENDING_TARGET, "attempts": prior_attempts}
+        if stale_high_water is not None:
+            pending["rewrite_high_water"] = stale_high_water
+        schema = _schema(name="public.usages", s3_folder_name="usages", pending=pending, rewrite=rewrite)
         mock_schema_model.objects.select_related.return_value.get.return_value = schema
-        mock_repartition.side_effect = RepartitionBudgetExceededError("out of budget")
+        mock_repartition.side_effect = RepartitionBudgetExceededError("out of budget", rows_written=500)
 
         _maybe_repartition_table(
             RepartitionActivityInputs(team_id=TEAM_ID, schema_id=SCHEMA_ID, job_id=JOB_ID, source_id=SOURCE_ID),
@@ -290,9 +302,7 @@ class TestBudgetExhaustion:
         schema.clear_repartition_pending.assert_not_called()
         schema.clear_repartition_rewrite.assert_not_called()
         schema.stamp_last_repartition_at.assert_not_called()
-        updated = schema.set_repartition_pending.call_args.args[0]
-        assert updated["attempts"] == 0
-        assert updated["rewrite_high_water"] == prior_high_water + 500
+        assert schema.set_repartition_pending.call_args.args[0]["attempts"] == 0
         emitted = [c.args[0] for c in mock_capture_event.call_args_list]
         assert "warehouse_repartition_failed" not in emitted
         assert "warehouse_repartition_skipped" in emitted


### PR DESCRIPTION
## Problem

- A data-warehouse table too large to repartition in one activity budget converges across runs. An over-budget attempt that streamed new rows should stand down as progress, not a failure.
- Such an attempt was instead recorded as a failed repartition even after streaming hundreds of millions of rows, burning one of the three allowed attempts.
- After three of these the pipeline gives up and leaves the table on its old layout, so the table keeps failing to sync.

The give-up path was reached with `error_type = RepartitionBudgetExceededError`, `final = false`, on a proactive-threshold rewrite that had already written a large row count.

## Changes

- Judge forward progress by the rows the attempt actually streamed, carried on `RepartitionBudgetExceededError.rows_written`, not the persisted checkpoint's size.
- An attempt that committed any new rows resets the failure counter and stands down as `progressing`. Only one that committed none counts toward the give-up cap.
- Drop the now-unused `rewrite_high_water` bookkeeping.

Why the old check misfired, both independent of the row count actually written:

- The checkpoint is absent when the post-budget row count hits a transient read error, so the comparison saw zero rows.
- The `rewrite_high_water` baseline is not reset when the checkpoint is discarded and rebuilt from row 0 (which happens when the live table changes between attempts), so a fresh rewrite is measured against a stale, larger mark.

The rows carried on the error come straight from the streaming loop, so they hold in both cases.

## How did you test this code?

- Updated the two budget-exhaustion unit tests in `test_repartition_table.py` to the new contract.
- The progressing test now covers the two regressions this fixes: a checkpoint that never persisted, and a stale high-water mark after a discarded checkpoint. Both stream new rows and must not burn an attempt. Under the old check each burned one and, at the cap, gave up terminally.
- The stalled test now asserts an attempt that committed no new rows (`rows_written = 0`) still burns an attempt and gives up with a cooldown, and that a leftover checkpoint does not mask that stall.
- Not run: the database-backed repartition suites (`test_repartition_controller.py`), because this sandbox has no Postgres.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (actually Claude) investigated a `warehouse_repartition_failed` event for the `RepartitionBudgetExceededError` mode, traced the emit path from `_handle_budget_exceeded` through `repartition_table_in_place`, and found the progress-vs-stall check keyed on state that can be missing or stale. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`. Considered resetting `rewrite_high_water` at each checkpoint-discard site instead, but keying progress on the rows the attempt streamed removes the shared-state coupling and also covers the missing-checkpoint case, so it is the smaller, more robust fix.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
