### PR TITLE
fix(surveys): preserve embedded background color

### DIFF
--- a/frontend/public/surveys/hosted-survey.css
+++ b/frontend/public/surveys/hosted-survey.css
@@ -653,7 +653,7 @@ body.PostHogHostedSurvey {
 
 html.embed-mode body.PostHogHostedSurvey {
     min-height: auto;
-    background: transparent;
+    background: var(--ph-survey-page-background);
 }
 
 html.embed-mode .PostHogHostedSurvey .main-container,


### PR DESCRIPTION
## Problem

People who embed a hosted survey with a dark background see the parent page color instead of their configured survey background.

Closes #81649

## Changes

- Embed mode now applies the hosted survey's configured page background.
- Existing iframe sizing, padding, and height messaging remain unchanged.

![Embedded survey with configured dark background](https://raw.githubusercontent.com/sidsri14/posthog/pr-assets-v2/posthog-81649-embedded-survey-after.png)

## How did you test this code?

- Chromium rendered the configured dark background at desktop and 390px widths.
- The 390px viewport had no horizontal overflow.
- Chromium preserved the default white background.
- Pinned Stylelint 15.11.0 passed on the stylesheet.
- Not run: the full PostHog stack because this is a sparse checkout.
- No test added: a source-scraping assertion violates the test policy, while a new browser suite is disproportionate for this CSS cascade.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex used the GitHub plugin and Playwright CLI. Session: `codex://threads/019f65b4-329b-71e0-883c-4288069d8eb7`.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, and the Playwright CLI skill.
- Browser verification replaced a brittle source-scraping test.