### PR TITLE
fix(mcp): stop gating notebooks-delete-cell behind a confirmation

### DIFF
--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -7385,7 +7385,7 @@
         "required_scopes": ["notebook:write"],
         "feature_flag": "revamped-py-notebooks",
         "annotations": {
-            "destructiveHint": true,
+            "destructiveHint": false,
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": false

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -340,7 +340,7 @@
         "required_scopes": ["notebook:write"],
         "feature_flag": "revamped-py-notebooks",
         "annotations": {
-            "destructiveHint": true,
+            "destructiveHint": false,
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": false


### PR DESCRIPTION
## Problem

An agent that deletes a notebook cell through the PostHog agent CLI gets refused and has to repeat the same call with `--confirm`.

- The tool catalog marks `notebooks-delete-cell` with `destructiveHint: true`.
- The exec `call` gate rejects any tool with that annotation until the caller passes `--confirm`.
- The gate protects nothing here. `notebook-edit` rewrites or drops every cell in the same notebook, and it carries `destructiveHint: false`.
- The delete already reports its own blast radius: the response lists the cells that referenced the deleted cell's dataframe.

## Changes

- I (actually Claude) set `destructiveHint: false` on `notebooks-delete-cell` in `services/mcp/schema/tool-definitions.json`.
- I mirrored the same value into `tool-definitions-all.json`, which `scripts/generate-tools.ts` builds by copying that entry.
- The annotation is the only source of the gate, so this removes the confirmation for every caller: the agent CLI, the MCP server, and the dry-run output.
- The catalog holds exactly one delete-cell tool, so no feature-flag variant needs the same edit. The legacy notebook flow deletes cells through `notebook-edit`, which was never gated.

## How did you test this code?

- I ran the MCP unit suites for the tool catalog, tool filtering, notebook cell tools, and the exec gate locally. They pass.
- I added no test. The change is one annotation value, and the exec gate already has a test that drives it from a mock tool.
- Not run: `hogli build:openapi`. The preflight advisory fires on any change under the MCP tool config, and the regeneration needs the dev stack. I checked the generator by hand instead: it merges the handwritten entry into `tool-definitions-all.json` unchanged, and both files now hold the same entry.
- No UI change, so no screenshot.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Sinan asked me to remove the confirmation prompt on the markdown-notebook delete-cell tool, and to cover every delete-cell tool if the catalog held more than one. I searched the repo for delete-cell tool names and found one: `notebooks-delete-cell`.

I considered exempting the tool name inside the exec gate. I chose the annotation instead, because the gate reads only `tool.annotations.destructiveHint`, and a name list in `exec.ts` would hide the tool's real policy from the catalog.

Tools: Claude Code (Opus 5). Skills invoked: `/writing-pr-descriptions`.
