### PR TITLE
chore(ci): filter the backend, frontend, and rust suites on the pushed commits

### DIFF
--- a/.github/actions/paths-filter/README.md
+++ b/.github/actions/paths-filter/README.md
@@ -108,6 +108,16 @@ Enable this on suites where that trade is worth the runner time, and keep the me
 Detection is per invocation,
 so a workflow can gate cheap jobs on the push delta
 while a second step keeps the whole-pull-request `*_files` lists that test selection and lint scoping need.
+`ci-backend.yml` is the reference for that split:
+its `filter` step reports the push delta and drives the gate booleans,
+its `whole_pr` step reports the full diff and drives `migrations_files` and `product_yamls_files`.
+A list narrowed to one push would make a check validate a subset of the pull request and still report green.
+
+Selection that walks an import graph — snob, `jest --findRelatedTests`, the Rust affected-crate computation —
+must keep diffing the whole pull request against its base branch.
+Those selectors are monotone on the full diff: every run covers everything the pull request touches.
+Scope one to a push delta and coverage decays with each push,
+because a later push's run selects nothing for an earlier push's files.
 
 ## Rebuilding after source changes
 

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -92,20 +92,24 @@ jobs:
             || startsWith(github.head_ref, 'trunk-merge/')
             || !contains(github.event.pull_request.labels.*.name, 'no-ci')
         name: Determine need to run backend and migration checks
-        # Set job outputs to values from filter step
+        # Set job outputs to values from filter step. Booleans that gate whole jobs come
+        # from the push-delta `filter` step; the lists that scope work inside a job come
+        # from the whole-pull-request `whole_pr` step. Read both steps before moving one.
         outputs:
             backend: ${{ steps.filter.outputs.backend || 'true' }}
+            # Lists the pushed commits' files, not the pull request's. Unconsumed today —
+            # anything that scopes a check to it would validate a subset and report green.
             backend_files: ${{ steps.filter.outputs.backend_files }}
             migrations: ${{ steps.filter.outputs.migrations || 'true' }}
-            migrations_files: ${{ steps.filter.outputs.migrations_files }}
+            migrations_files: ${{ steps.whole_pr.outputs.migrations_files }}
             migrations_any: ${{ steps.filter.outputs.migrations_any || 'true' }}
             persons_sql: ${{ steps.filter.outputs.persons_sql || 'true' }}
             tasks_temporal: ${{ steps.filter.outputs.tasks_temporal || 'true' }}
             openapi_types: ${{ steps.filter.outputs.openapi_types || 'true' }}
             legacy: ${{ steps.filter.outputs.legacy || 'true' }}
             schema: ${{ steps.filter.outputs.schema || 'true' }}
-            product_yamls: ${{ steps.filter.outputs.product_yamls || 'false' }}
-            product_yamls_files: ${{ steps.filter.outputs.product_yamls_files }}
+            product_yamls: ${{ steps.whole_pr.outputs.product_yamls || 'false' }}
+            product_yamls_files: ${{ steps.whole_pr.outputs.product_yamls_files }}
             timing_scripts: ${{ steps.filter.outputs.timing_scripts }}
         steps:
             # For pull requests it's not necessary to checkout the code, but we
@@ -131,6 +135,17 @@ jobs:
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
                   list-files: 'escape'
+                  # Filter on the pushed commits rather than the whole pull request, so a
+                  # follow-up push touching no backend code doesn't boot Postgres and
+                  # ClickHouse for the Django matrices and the migration checks again.
+                  # Only the gate booleans above read this step — the `whole_pr` step below
+                  # keeps the file lists on the full diff.
+                  # Pull request runs cancel in progress, so an earlier push's run can be
+                  # cancelled while this one filters itself out — the merge queue's full diff
+                  # against master is what still catches that, so its own runs must keep
+                  # filtering on the whole pull request.
+                  # See .github/actions/paths-filter/README.md.
+                  since-last-push: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
                   filters: |
                       backend:
                         # Avoid running backend tests for irrelevant changes
@@ -290,15 +305,6 @@ jobs:
                         - '.github/scripts/turbo-discover.js'
                       tasks_temporal:
                         - 'products/tasks/backend/temporal/**/*'
-                      product_yamls:
-                        # Validates owner team slugs against PostHog/posthog collaborator teams,
-                        # and lints the distributed owners.yaml files (schema, conflicts, dead
-                        # globs, coverage). Costs one GitHub API call; gated here so we only pay
-                        # it when ownership actually changes. Drives the validate-product-yamls job.
-                        - 'products/*/product.yaml'
-                        - '**/owners.yaml'
-                        # Resolver changes must re-run the owners.yaml lint too.
-                        - 'tools/owners/**'
                       openapi_types:
                         # Generated OpenAPI types - validate they match schema
                         - 'frontend/src/generated/**/*'
@@ -325,6 +331,40 @@ jobs:
                         # Exec command reference templates - feed generate-exec-docs.ts
                         - 'services/mcp/src/templates/sections/**/*'
                         - 'services/mcp/schema/exec-command-reference.md'
+
+            # A second pass over the whole pull request, for the outputs that scope work
+            # inside a job instead of gating whether it runs: the migration safety check
+            # validates `migrations_files`, and the owners lint reads `product_yamls_files`.
+            # Scoped to the pushed commits, both would check a subset of the pull request
+            # and still report green — a push that adds no migration would validate none of
+            # the ones the pull request already carries.
+            - uses: ./.github/actions/paths-filter
+              id: whole_pr
+              if: github.event_name != 'push'
+              with:
+                  token: ${{ steps.app-token.outputs.token || github.token }}
+                  list-files: 'escape'
+                  filters: |
+                      # Duplicated from the step above, which needs the boolean on the push
+                      # delta to gate check-migrations. One run reports one basis, so a
+                      # filter needed on both bases is declared on both. Keep them in step.
+                      migrations:
+                        - 'docker/clickhouse/**'
+                        - 'posthog/migrations/*.py'
+                        - 'products/*/backend/migrations/*.py'
+                        - 'products/*/migrations/*.py'  # Legacy structure
+                      # Validates owner team slugs against PostHog/posthog collaborator teams,
+                      # and lints the distributed owners.yaml files (schema, conflicts, dead
+                      # globs, coverage). Costs one GitHub API call; gated here so we only pay
+                      # it when ownership actually changes. Drives the validate-product-yamls job.
+                      # Whole-pull-request on both the gate and the list: the lint is cheap and
+                      # scopes itself to the list, so narrowing it buys little and risks a
+                      # green run that linted none of the pull request's owners.yaml changes.
+                      product_yamls:
+                        - 'products/*/product.yaml'
+                        - '**/owners.yaml'
+                        # Resolver changes must re-run the owners.yaml lint too.
+                        - 'tools/owners/**'
 
     detect-snapshot-mode:
         name: Detect snapshot mode

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -77,6 +77,15 @@ jobs:
               if: github.event_name != 'push' # Run all tests on master push
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
+                  # Filter on the pushed commits rather than the whole pull request. The
+                  # includes below reach '**/*.md' and '**/*.yml', so almost any follow-up
+                  # push re-runs jest, tsc, and format against a diff they already covered.
+                  # Pull request runs cancel in progress, so an earlier push's run can be
+                  # cancelled while this one filters itself out — the merge queue's full diff
+                  # against master is what still catches that, so its own runs must keep
+                  # filtering on the whole pull request.
+                  # See .github/actions/paths-filter/README.md.
+                  since-last-push: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
                   filters: |
                       frontend:
                         # Avoid running frontend tests for irrelevant changes
@@ -181,6 +190,10 @@ jobs:
               if: github.event_name != 'push'
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
+                  # The gate ANDs this with the filter above, so both must read the same
+                  # diff. On the whole pull request this one would keep reporting true from
+                  # an earlier push's non-workspace files, cancelling out the narrowing.
+                  since-last-push: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
                   filters: ${{ runner.temp }}/frontend-exclude.yml
 
     # Pick which jest tests to run on draft PRs by passing changed files to

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -45,6 +45,14 @@ jobs:
               if: github.event_name != 'push' # Run all tests on master push
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
+                  # Filter on the pushed commits rather than the whole pull request, so a
+                  # follow-up push touching no Rust doesn't rebuild and retest the affected
+                  # crates again. Pull request runs cancel in progress, so an earlier push's
+                  # run can be cancelled while this one filters itself out — the merge
+                  # queue's full diff against master is what still catches that, so its own
+                  # runs must keep filtering on the whole pull request.
+                  # See .github/actions/paths-filter/README.md.
+                  since-last-push: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
                   filters: |
                       rust:
                         # Avoid running rust tests for irrelevant changes


### PR DESCRIPTION
## Problem

A follow-up push on an open pull request re-runs the Django matrices, the jest and typecheck matrix, and the Rust crate tests, even when the push touches nothing they exercise.

- The base of this stack, #80712, gave the vendored paths-filter a `since-last-push` input, then opted in only `ci-e2e-playwright` and `ci-storybook`.
- I left these three out because their gates carry risks the two visual suites do not. This PR handles each of those risks.
- `ci-frontend`'s filter includes `**/*.md` and `**/*.yml`, so a docs-only push re-runs jest, tsc, and format.

## Changes

Three workflows opt in. The merge queue keeps the full diff everywhere, through `!startsWith(github.head_ref, 'trunk-merge/')`.

| Workflow | Reads the push delta | Stays on the whole pull request |
| --- | --- | --- |
| `ci-rust` | `rust` | The affected-crate computation, which diffs `pull_request.base.sha` |
| `ci-frontend` | `frontend`, `frontend_code`, `replay_shared`, and the derived workspace excludes | The jest selector, which diffs the base branch |
| `ci-backend` | The gate booleans, in the `filter` step | `migrations_files` and `product_yamls_files`, in a new `whole_pr` step |

- `ci-backend` needs two passes. A file list narrowed to one push would make the migration safety check and the owners lint validate a subset of the pull request, then report green.
- The concrete failure: push A adds a migration, push B changes a Python file. The gate opens on B, `migrations_files` is empty, and the check passes without reading A's migration.
- `migrations` is declared in both steps. The gate wants the push delta and the file list wants the full diff, and one run of the action reports one basis.
- `product_yamls` stays whole-pull-request on both the gate and the list. The lint costs one API call, so narrowing it buys little and risks a green run that linted nothing.
- `ci-frontend` narrows both of its filter steps. The gate ANDs them, so a whole-pull-request exclude step would cancel the narrowing out.
- Import-graph selection keeps diffing the whole pull request. Those selectors are monotone on the full diff, and scoping one to a push delta would decay coverage with each push.

> [!WARNING]
> Pull request runs cancel in progress. If push A touches Rust and push B touches only docs, A's job can be cancelled while B's run filters it out, so nothing tests A on the pull request. The merge queue's full diff against master is the gate that still catches it. This PR extends that trade from two visual suites to the unit-test suites, so a broken build can now surface in the queue rather than on the pull request.

## How did you test this code?

- `bin/hogli lint:workflows` passes all 8 checks across 124 workflows.
- `actionlint` under CI's `SHELLCHECK_OPTS=--severity=error` reports only the pre-existing `- parallel:` syntax complaints, which are present on the base branch too.
- I parsed each `changes` job with PyYAML and asserted which filters each step declares and which step every job output reads.
- Not verified: the `synchronize` path, for the same reason as #80712. It needs a second push to a real pull request.
- Not verified: any saving. The first measurable evidence is a docs-only push to this pull request.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`.github/actions/paths-filter/README.md` gains the two-step split, with `ci-backend` named as the reference, and the rule that import-graph selectors keep the full diff.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude Opus 5, in Claude Code) wrote this. @gantoine asked why #80712 stopped at two suites, then asked for all three, given a world where the merge queue is the only gate and a green pull request only buys entry to it. That premise is what makes the cancellation trade above acceptable here.

The design changed once during the session. My first plan duplicated the whole `backend` filter into a second step. I inverted it instead: the existing step narrows, and a small second step re-declares only the two filters whose file lists are consumed.

Two things I did not do, both worth their own PR:

- A rebase pulls master's own changes into the `before...after` comparison, because the merge base sits at the old master point. A docs-only pull request rebased onto a master carrying Rust changes would run the Rust suite it would otherwise skip. That over-reports, so it is safe, but it works against the goal. It affects #80712 as it stands.
- An amend-push gets no saving at all, because the three-dot comparison widens to the whole branch delta. How many `synchronize` events here are appends rather than force-pushes sets the ceiling on this whole idea, and I did not measure it.

Skills invoked: `/stacking-prs`, `/writing-code-comments`, `/writing-pr-descriptions`.

Everything in this diff comes from this repository. No session material reached the code or this description.
