### PR TITLE
feat(ai-research): tell a broken image fetch lane apart from an idle one

### DIFF
--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/metrics.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/metrics.ts
@@ -81,14 +81,6 @@ export class ImageFetchConsumerMetrics {
         help: 'Age of a URL when this lane reached it, measured from capture rather than from produce. The tail against the configured age limit says how much of a backlog would be dropped rather than fetched',
         buckets: [1, 10, 60, 300, 900, 3600, 6 * 3600, 24 * 3600],
     })
-    /**
-     * Poll batches, split by whether Kafka returned anything.
-     *
-     * The one metric that separates a broken lane from an idle one. Every other number here is zero
-     * when the topic is missing, when the producer is off, and when traffic is genuinely quiet, and
-     * the phase 0 decision rests on telling those apart. A flat total means this lane is not polling
-     * at all. A climbing total with `empty="true"` means it polls and the topic holds nothing.
-     */
     private static readonly polls = new Counter({
         name: 'ml_image_fetch_consumer_polls_total',
         help: 'Poll batches, by whether Kafka returned records. A flat total means the lane is not polling; a climbing total with empty="true" means it polls and the topic is empty. Zero on every other metric cannot tell those apart',

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/metrics.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/metrics.ts
@@ -81,6 +81,19 @@ export class ImageFetchConsumerMetrics {
         help: 'Age of a URL when this lane reached it, measured from capture rather than from produce. The tail against the configured age limit says how much of a backlog would be dropped rather than fetched',
         buckets: [1, 10, 60, 300, 900, 3600, 6 * 3600, 24 * 3600],
     })
+    /**
+     * Poll batches, split by whether Kafka returned anything.
+     *
+     * The one metric that separates a broken lane from an idle one. Every other number here is zero
+     * when the topic is missing, when the producer is off, and when traffic is genuinely quiet, and
+     * the phase 0 decision rests on telling those apart. A flat total means this lane is not polling
+     * at all. A climbing total with `empty="true"` means it polls and the topic holds nothing.
+     */
+    private static readonly polls = new Counter({
+        name: 'ml_image_fetch_consumer_polls_total',
+        help: 'Poll batches, by whether Kafka returned records. A flat total means the lane is not polling; a climbing total with empty="true" means it polls and the topic is empty. Zero on every other metric cannot tell those apart',
+        labelNames: ['empty'],
+    })
     private static readonly dryRun = new Gauge({
         name: 'ml_image_fetch_consumer_dry_run',
         help: '1 while the lane sends no outbound request, 0 once fetching is enabled. Every other metric of this lane means something different either side of this value',
@@ -88,6 +101,9 @@ export class ImageFetchConsumerMetrics {
 
     public static setDryRun(enabled: boolean): void {
         this.dryRun.set(enabled ? 1 : 0)
+    }
+    public static incPoll(empty: boolean): void {
+        this.polls.labels(String(empty)).inc()
     }
     public static incFetchable(count: number): void {
         this.fetchable.inc(count)

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/url-fetch-consumer.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/url-fetch-consumer.test.ts
@@ -1,4 +1,5 @@
 import { Message } from 'node-rdkafka'
+import { register } from 'prom-client'
 
 import { UrlFetchConsumer } from './url-fetch-consumer'
 import { SightingStore, sightingKey } from './url-sightings'
@@ -105,6 +106,37 @@ describe('UrlFetchConsumer', () => {
         expect(() => new UrlFetchConsumer(sightings, { maxAgeMs, dedupMaxRefs: 10, dryRun: true })).toThrow(
             'SESSION_RECORDING_ML_IMAGE_FETCH_MAX_AGE_MS'
         )
+    })
+
+    /** Reads a sample by its exported name. A histogram is registered under its base name, and its
+     *  count sample carries the `_count` suffix in metricName rather than in the metric's name. */
+    async function metric(exportedName: string, labels: Record<string, string> = {}): Promise<number> {
+        for (const m of await register.getMetricsAsJSON()) {
+            for (const v of m.values as { value: number; labels: Record<string, unknown>; metricName?: string }[]) {
+                if ((v.metricName ?? m.name) !== exportedName) {
+                    continue
+                }
+                if (Object.entries(labels).every(([key, value]) => String(v.labels[key]) === value)) {
+                    return v.value
+                }
+            }
+        }
+        return 0
+    }
+
+    it('counts an empty poll and leaves the batch histograms alone', async () => {
+        // The poll counter is the only thing separating a lane reading a topic that does not exist
+        // from one reading an empty topic: every other metric is zero in both cases. The batch
+        // histograms have to stay out of it, or an idle lane reports a steady stream of batches
+        // carrying no sites and drags the distribution the budget is sized from down to zero.
+        const pollsBefore = await metric('ml_image_fetch_consumer_polls_total', { empty: 'true' })
+        const batchesBefore = await metric('ml_image_fetch_consumer_domains_per_batch_count')
+
+        await consumer.handleBatch([], NOW)
+
+        expect(await metric('ml_image_fetch_consumer_polls_total', { empty: 'true' })).toBe(pollsBefore + 1)
+        expect(await metric('ml_image_fetch_consumer_domains_per_batch_count')).toBe(batchesBefore)
+        expect(sightings.reads).toBe(0)
     })
 
     it('writes one ledger entry per URL it would fetch', async () => {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/url-fetch-consumer.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/url-fetch-consumer.test.ts
@@ -108,8 +108,8 @@ describe('UrlFetchConsumer', () => {
         )
     })
 
-    /** Reads a sample by its exported name. A histogram is registered under its base name, and its
-     *  count sample carries the `_count` suffix in metricName rather than in the metric's name. */
+    /** prom-client registers a histogram under its base name and puts the `_count` suffix in
+     *  metricName, so matching on the metric's own name silently finds nothing. */
     async function metric(exportedName: string, labels: Record<string, string> = {}): Promise<number> {
         for (const m of await register.getMetricsAsJSON()) {
             for (const v of m.values as { value: number; labels: Record<string, unknown>; metricName?: string }[]) {
@@ -125,10 +125,8 @@ describe('UrlFetchConsumer', () => {
     }
 
     it('counts an empty poll and leaves the batch histograms alone', async () => {
-        // The poll counter is the only thing separating a lane reading a topic that does not exist
-        // from one reading an empty topic: every other metric is zero in both cases. The batch
-        // histograms have to stay out of it, or an idle lane reports a steady stream of batches
-        // carrying no sites and drags the distribution the budget is sized from down to zero.
+        // An idle lane must not add batches that carry no sites, because the per-site budget is
+        // sized from that distribution.
         const pollsBefore = await metric('ml_image_fetch_consumer_polls_total', { empty: 'true' })
         const batchesBefore = await metric('ml_image_fetch_consumer_domains_per_batch_count')
 

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/url-fetch-consumer.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/url-fetch-consumer.ts
@@ -50,6 +50,7 @@ export class UrlFetchConsumer {
         // from the present, which would make the duration meaningless.
         const startedAt = process.hrtime.bigint()
         ImageFetchConsumerMetrics.incPoll(messages.length === 0)
+        // Before the batch histograms, so an idle lane does not report batches that carry no sites.
         if (messages.length === 0) {
             return
         }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/url-fetch-consumer.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/url-fetch-consumer.ts
@@ -49,6 +49,10 @@ export class UrlFetchConsumer {
         // Wall clock, not the caller's nowMs: nowMs dates the URLs and a test is free to set it far
         // from the present, which would make the duration meaningless.
         const startedAt = process.hrtime.bigint()
+        ImageFetchConsumerMetrics.incPoll(messages.length === 0)
+        if (messages.length === 0) {
+            return
+        }
         const drops = new Map<UrlDropReason, number>()
         const countDrop = (reason: UrlDropReason, count = 1): void => {
             drops.set(reason, (drops.get(reason) ?? 0) + count)

--- a/nodejs/src/servers/ingestion-session-replay-ml-image-fetch-server.ts
+++ b/nodejs/src/servers/ingestion-session-replay-ml-image-fetch-server.ts
@@ -34,9 +34,7 @@ export function buildImageFetchConsumerConfig(config: IngestionSessionReplayMlMi
         groupId: config.SESSION_RECORDING_ML_IMAGE_FETCH_GROUP_ID,
         autoCommit: true,
         autoOffsetStore: true,
-        // So an empty poll still reaches the consumer and moves the poll counter. Without it a lane
-        // reading a topic that does not exist looks the same as one reading a topic with nothing on
-        // it: healthy pods, no lag, and every metric at zero.
+        // An empty poll reaches the consumer, which counts it. See ml_image_fetch_consumer_polls_total.
         callEachBatchWhenEmpty: true,
         fetchBatchSize: config.SESSION_RECORDING_ML_IMAGE_FETCH_BATCH_SIZE,
     }

--- a/nodejs/src/servers/ingestion-session-replay-ml-image-fetch-server.ts
+++ b/nodejs/src/servers/ingestion-session-replay-ml-image-fetch-server.ts
@@ -34,6 +34,10 @@ export function buildImageFetchConsumerConfig(config: IngestionSessionReplayMlMi
         groupId: config.SESSION_RECORDING_ML_IMAGE_FETCH_GROUP_ID,
         autoCommit: true,
         autoOffsetStore: true,
+        // So an empty poll still reaches the consumer and moves the poll counter. Without it a lane
+        // reading a topic that does not exist looks the same as one reading a topic with nothing on
+        // it: healthy pods, no lag, and every metric at zero.
+        callEachBatchWhenEmpty: true,
         fetchBatchSize: config.SESSION_RECORDING_ML_IMAGE_FETCH_BATCH_SIZE,
     }
 }


### PR DESCRIPTION
## Problem

Somebody reading the phase 0 dashboard cannot tell a broken lane from a quiet one, and phase 0 is the measurement that decides whether the image fetcher gets built.

Every metric in the lane reads zero in three different situations: the topic does not exist, the mirror's producer flag is off, and traffic is genuinely quiet. The pods are healthy in all three, and consumer lag is zero in all three, because a consumer subscribed to a topic with nothing on it looks exactly like one subscribed to a topic that is not there.

Follows [#81188](https://github.com/PostHog/posthog/pull/81188), which added the lane.

## Changes

- The consumer now receives empty polls and counts them, through `callEachBatchWhenEmpty`.
- `ml_image_fetch_consumer_polls_total{empty}` is the discriminator. A flat total means the lane is not polling at all. A climbing total with `empty="true"` means it polls and the topic holds nothing.
- An empty poll returns before the batch histograms. An idle lane would otherwise report a steady stream of batches carrying no sites, which drags down the distribution the per-site request budget is sized from.

The lane still does no work on an empty poll: it touches neither Redis nor the pod cache.

I did not add a startup assertion that the topic exists. `getMetadata` for a named topic creates it on some brokers, which is the failure this lane most needs to avoid, so the counter is the safer signal.

## How did you test this code?

One new test, plus the 30 already there. It reads the exported metrics rather than the consumer's return value, because the behaviour worth pinning is what an operator sees.

I mutation-tested it, and the first version had no teeth. My metric lookup matched on the metric name, but prom-client registers a histogram under its base name and puts the `_count` suffix in `metricName`, so both reads returned 0 and the assertion compared 0 to 0. After fixing the lookup, removing the early return fails the test, and removing the counter increment fails it.

Not run: anything against a real broker. Whether `callEachBatchWhenEmpty` yields empty batches at the rate I expect is unverified here.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude Opus 5) wrote this, directed by Robbie. Skills invoked: `/qa-team`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/asd-ste100`.

A `/qa-team` review across the open deployment PRs raised this. The finding I acted on was that the lane fails closed on nothing: a missing topic leaves healthy pods, zero lag, and zero on every counter, which is indistinguishable from success with no traffic.

Public artifact: nothing here comes from a customer conversation, a ticket, or a log.
