### PR TITLE
fix(cymbal): support semver suppression rule comparisons

### DIFF
--- a/rust/common/hogvm/src/context.rs
+++ b/rust/common/hogvm/src/context.rs
@@ -45,8 +45,8 @@ pub struct ExecutionContext {
     pub max_stack_depth: usize,
     pub max_heap_size: usize,
     pub max_steps: usize,
-    /// Opt-in comparison semantics. `false` (the default) is the legacy/reference behavior shared by
-    /// every existing consumer (e.g. `cymbal`): ordering ops require numeric operands and `Eq`
+    /// Opt-in comparison semantics. `false` (the default) is the strict behavior shared by
+    /// consumers such as `cymbal`: ordering ops accept numbers and numeric arrays, while `Eq`
     /// compares temporals structurally. `true` makes ordering coerce across types and order temporals
     /// by epoch, and `Eq` compare two temporals by epoch — the ClickHouse/Python-TS-aligned semantics
     /// the realtime-cohort evaluator needs. Set via [`ExecutionContext::with_coercing_comparisons`].
@@ -151,8 +151,8 @@ impl ExecutionContext {
     }
 
     /// Opt into coercing comparison semantics (cross-type ordering coercion + epoch ordering/equality
-    /// of temporals). Off by default; only the realtime-cohort evaluator opts in, so existing
-    /// consumers like `cymbal` keep the legacy strict behavior. See [`Self::coerce_comparisons`].
+    /// of temporals). Off by default; only the realtime-cohort evaluator opts in, so consumers like
+    /// `cymbal` keep strict behavior. See [`Self::coerce_comparisons`].
     pub fn with_coercing_comparisons(mut self) -> Self {
         self.coerce_comparisons = true;
         self

--- a/rust/common/hogvm/src/values.rs
+++ b/rust/common/hogvm/src/values.rs
@@ -407,8 +407,9 @@ impl HogLiteral {
 /// OPT-IN ONLY: this is reached exclusively from the coercing `compare_op` path, which the VM takes
 /// only when the context sets [`ExecutionContext::with_coercing_comparisons`](crate::ExecutionContext::with_coercing_comparisons)
 /// — today just the realtime-cohort evaluator. Every other shared-crate consumer (e.g. `cymbal`)
-/// keeps the legacy path where a non-number operand errors, so this coercion does NOT change their
-/// behavior. The semantics here match the Python/TS reference VMs (and ClickHouse for temporals).
+/// keeps the strict path where operands other than numbers and numeric arrays error, so this coercion
+/// does NOT change their behavior. The semantics here match the Python/TS reference VMs (and
+/// ClickHouse for temporals).
 ///
 /// 1. If *both* operands are temporal ([`HogLiteral::as_temporal_seconds`]) they are ordered by
 ///    epoch seconds to match ClickHouse and the Python/TS reference VMs; see the [`crate::stl`]

--- a/rust/common/hogvm/src/vm.rs
+++ b/rust/common/hogvm/src/vm.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
 use std::cell::RefCell;
+use std::cmp::Ordering;
 use std::rc::Rc;
 
 use indexmap::IndexMap;
@@ -929,26 +930,31 @@ impl<'a> HogVM<'a> {
         self.push_stack(HogLiteral::Boolean(matched ^ negate))
     }
 
-    /// `Gt`/`GtEq`/`Lt`/`LtEq` arm. The default (legacy) path requires numeric operands and errors
-    /// otherwise — the behavior `cymbal` and every other existing shared-crate consumer relies on
-    /// (a non-number operand erroring is what lets cymbal auto-disable a malformed rule). Only when
-    /// the context opts into coercing comparisons (the realtime-cohort evaluator, via
-    /// [`ExecutionContext::with_coercing_comparisons`](crate::ExecutionContext::with_coercing_comparisons))
-    /// does a non-`Number` operand reach [`compare_values`]' coercion instead of erroring. `a` is the
+    /// `Gt`/`GtEq`/`Lt`/`LtEq` arm. The default path accepts numbers and lexicographically ordered
+    /// numeric arrays. `sortableSemver` returns a numeric array, so server-side property filters need
+    /// this narrow array case even when they retain strict comparison semantics. Other non-number
+    /// operands still error, which lets cymbal auto-disable malformed rules. Only when the context
+    /// opts into coercing comparisons does a non-number operand reach [`compare_values`]. `a` is the
     /// top of the stack.
     fn compare_op(&mut self, op: NumOp) -> Result<(), VmError> {
-        if !self.context.coerce_comparisons {
-            // Legacy/reference path: both operands must be `Number` or this errors.
-            let (a, b): (Num, Num) = (self.pop_stack_as()?, self.pop_stack_as()?);
-            return self.push_stack(Num::binary_op(op, &a, &b)?);
-        }
         let a = self.pop_stack()?;
         let b = self.pop_stack()?;
         // Scope the immutable heap borrows so the result is owned before the `&mut self` push.
         let result = {
             let a_lit = a.deref(&self.heap)?;
             let b_lit = b.deref(&self.heap)?;
-            compare_values(op, a_lit, b_lit, &self.heap)?
+            if self.context.coerce_comparisons {
+                compare_values(op, a_lit, b_lit, &self.heap)?
+            } else if let (HogLiteral::Array(a_values), HogLiteral::Array(b_values)) =
+                (a_lit, b_lit)
+            {
+                let ordering = compare_numeric_arrays(a_values, b_values, &self.heap)?;
+                HogLiteral::Boolean(ordering_matches(op, ordering))
+            } else {
+                let a_num: &Num = a_lit.try_as()?;
+                let b_num: &Num = b_lit.try_as()?;
+                Num::binary_op(op, a_num, b_num)?
+            }
         };
         self.push_stack(result)
     }
@@ -1520,6 +1526,36 @@ fn failure(error: VmError, vm: Option<&HogVM>, step: usize) -> VmFailure {
         ip: vm.map_or(0, |vm| vm.ip),
         stack: vm.map_or(Vec::new(), |vm| vm.stack.clone()),
         step,
+    }
+}
+
+fn compare_numeric_arrays(
+    a: &[HogValue],
+    b: &[HogValue],
+    heap: &VmHeap,
+) -> Result<Ordering, VmError> {
+    for value in a.iter().chain(b) {
+        let _: &Num = value.deref(heap)?.try_as()?;
+    }
+
+    for (a_value, b_value) in a.iter().zip(b) {
+        let a_num: &Num = a_value.deref(heap)?.try_as()?;
+        let b_num: &Num = b_value.deref(heap)?.try_as()?;
+        let ordering = a_num.compare(b_num);
+        if ordering != Ordering::Equal {
+            return Ok(ordering);
+        }
+    }
+    Ok(a.len().cmp(&b.len()))
+}
+
+fn ordering_matches(op: NumOp, ordering: Ordering) -> bool {
+    match op {
+        NumOp::Gt => ordering.is_gt(),
+        NumOp::Gte => ordering.is_ge(),
+        NumOp::Lt => ordering.is_lt(),
+        NumOp::Lte => ordering.is_le(),
+        _ => unreachable!("ordering comparison requires a comparison operation"),
     }
 }
 

--- a/rust/common/hogvm/tests/numeric_coercion.rs
+++ b/rust/common/hogvm/tests/numeric_coercion.rs
@@ -17,6 +17,7 @@ const OP_STRING: i64 = 32;
 const OP_INTEGER: i64 = 33;
 const OP_FLOAT: i64 = 34;
 const OP_RETURN: i64 = 38;
+const OP_ARRAY: i64 = 43;
 
 /// `left <op> right`. The compiler emits operands as `[right…, left…, op]`.
 fn compare(left: &[Value], right: &[Value], op: i64) -> Vec<Value> {
@@ -54,6 +55,12 @@ fn string(s: &str) -> Vec<Value> {
 
 fn boolean(b: bool) -> Vec<Value> {
     vec![json!(if b { OP_TRUE } else { OP_FALSE })]
+}
+
+fn array(values: &[Vec<Value>]) -> Vec<Value> {
+    let mut bytecode = values.iter().flatten().cloned().collect::<Vec<_>>();
+    bytecode.extend([json!(OP_ARRAY), json!(values.len())]);
+    bytecode
 }
 
 #[test]
@@ -211,6 +218,23 @@ fn legacy_default_keeps_strict_comparisons_for_other_consumers() {
         run_legacy(compare(&boolean(true), &int(0), OP_GT)).is_err(),
         "bool vs number must error on the legacy path, not coerce",
     );
+    for (label, left, right) in [
+        (
+            "shared numeric prefix",
+            array(&[int(1), string("invalid")]),
+            array(&[int(1)]),
+        ),
+        (
+            "different numeric prefix",
+            array(&[int(2), string("invalid")]),
+            array(&[int(1)]),
+        ),
+    ] {
+        assert!(
+            run_legacy(compare(&left, &right, OP_GT)).is_err(),
+            "a nonnumeric array suffix must error after a {label}",
+        );
+    }
     // Pure numeric comparisons are identical on both paths.
     assert_eq!(
         run_legacy(compare(&int(20), &int(10), OP_GT)).unwrap(),

--- a/rust/common/hogvm/tests/stl.rs
+++ b/rust/common/hogvm/tests/stl.rs
@@ -8,6 +8,12 @@ use serde_json::{json, Value};
 
 // Opcode numeric values (mirror common/hogvm/python/operation.py).
 const OP_CALL_GLOBAL: i64 = 2;
+const OP_EQ: i64 = 11;
+const OP_NOT_EQ: i64 = 12;
+const OP_GT: i64 = 13;
+const OP_GT_EQ: i64 = 14;
+const OP_LT: i64 = 15;
+const OP_LT_EQ: i64 = 16;
 const OP_STRING: i64 = 32;
 const OP_INTEGER: i64 = 33;
 const OP_RETURN: i64 = 38;
@@ -54,6 +60,33 @@ fn collection(op: i64, elems: &[Vec<Value>]) -> Vec<Value> {
 /// Single-string-arg native returning a string — the shape most STL functions take.
 fn call_str(name: &str, arg: &str) -> Value {
     run(call(name, &[str_lit(arg)]))
+}
+
+#[test]
+fn sortable_semver_arrays_support_every_comparison_operation() {
+    // Tilde, caret, and wildcard ranges compile to a lower-bound GT_EQ and an upper-bound LT.
+    let cases = [
+        ("equals", OP_EQ, "1.2.3", "1.2.3", true),
+        ("equals", OP_EQ, "1.2.3", "1.2.4", false),
+        ("not equals", OP_NOT_EQ, "1.2.3", "1.2.4", true),
+        ("not equals", OP_NOT_EQ, "1.2.3", "1.2.3", false),
+        ("greater than", OP_GT, "2.0.0", "1.9.9", true),
+        ("greater than", OP_GT, "1.9.9", "2.0.0", false),
+        ("greater than or equal", OP_GT_EQ, "2.0.0", "2.0.0", true),
+        ("greater than or equal", OP_GT_EQ, "1.9.9", "2.0.0", false),
+        ("less than", OP_LT, "2.9.0", "2.10.0", true),
+        ("less than", OP_LT, "2.10.0", "2.10.0", false),
+        ("less than or equal", OP_LT_EQ, "2.10.0", "2.10.0", true),
+        ("less than or equal", OP_LT_EQ, "2.10.1", "2.10.0", false),
+    ];
+
+    for (label, operation, left, right, expected) in cases {
+        let mut comparison = call("sortableSemver", &[str_lit(right)]);
+        comparison.extend(call("sortableSemver", &[str_lit(left)]));
+        comparison.push(json!(operation));
+
+        assert_eq!(run(comparison), json!(expected), "{left} {label} {right}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Problem

Cymbal disables valid suppression rules when they use a semantic-version ordering operator.

`sortableSemver` returns numeric arrays. Strict Rust HogVM ordering accepted only scalar numbers, so Cymbal stored an evaluation error and disabled the rule.

## Changes

- Rust HogVM now compares numeric arrays component by component.
- Rust validates every element before comparison, including suffixes outside the shared prefix.
- Malformed arrays still fail Cymbal's strict checks and disable the affected rule.
- The regression matrix covers equality, inequality, all four ordering operations, and multi-digit components.
- Tilde, caret, and wildcard ranges use the covered lower-bound and upper-bound operations.
- This is the Rust layer of a two-PR stack. TypeScript alignment follows in the next layer.

## How did you test this code?

- `cargo test --manifest-path rust/common/hogvm/Cargo.toml`
- `cargo clippy --manifest-path rust/common/hogvm/Cargo.toml --all-targets -- -D warnings`
- `SQLX_OFFLINE=true cargo test --manifest-path rust/cymbal/Cargo.toml modes::processing::rules::suppression --lib`
- `cargo fmt --manifest-path rust/common/hogvm/Cargo.toml -- --check`
- `./bin/hogli ci:preflight --strict`
- Not run: the database-backed Cymbal integration tests.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This fix restores documented suppression-rule behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I used the pi coding agent with GPT-5.6, the Rust toolchain, and GitHub CLI. This environment did not provide a shareable session URL.

Skills invoked: `/stacking-prs`, `/writing-tests`, `/writing-pr-descriptions`, `suppressing-noisy-errors`, and `writing-simplified-technical-english`.

I kept Cymbal's strict validation instead of enabling broad cross-type coercion. The committed test versions are invented and contain no user-provided values.
