### PR TITLE
feat(cdp): add a Salesforce lookup step

### DIFF
--- a/posthog/cdp/templates/__init__.py
+++ b/posthog/cdp/templates/__init__.py
@@ -74,6 +74,7 @@ from .rudderstack.template_rudderstack import (
 )
 from .salesforce.template_salesforce import (
     template_create as salesforce_create,
+    template_lookup as salesforce_lookup,
     template_update as salesforce_update,
 )
 from .sendgrid.template_sendgrid import (
@@ -127,6 +128,7 @@ HOG_FUNCTION_TEMPLATES = [
     reddit_pixel,
     rudderstack,
     salesforce_create,
+    salesforce_lookup,
     salesforce_update,
     sendgrid,
     snapchat_pixel,

--- a/posthog/cdp/templates/salesforce/template_salesforce.py
+++ b/posthog/cdp/templates/salesforce/template_salesforce.py
@@ -250,9 +250,15 @@ let assertApiName := (value, label, pattern) -> {
   }
 }
 
+// Backslash goes first, otherwise the sequences introduced below get escaped a second time.
 let escapeSoql := (value) -> {
   let escaped := replaceAll(value, '\\', '\\\\')
   escaped := replaceAll(escaped, '\'', '\\\'')
+  escaped := replaceAll(escaped, '\n', '\\n')
+  escaped := replaceAll(escaped, '\r', '\\r')
+  escaped := replaceAll(escaped, '\t', '\\t')
+  escaped := replaceAll(escaped, '\b', '\\b')
+  escaped := replaceAll(escaped, '\f', '\\f')
   return escaped
 }
 

--- a/posthog/cdp/templates/salesforce/template_salesforce.py
+++ b/posthog/cdp/templates/salesforce/template_salesforce.py
@@ -300,8 +300,9 @@ for (let rawField in splitByString(',', inputs.fields ?? '')) {
 let selectList := arrayStringConcat(selected, ', ')
 let escapedValue := escapeSoql(matchValue)
 
-// Two rows are enough to tell a unique match from an ambiguous one, and keep the
-// result inside the size limit for workflow variables.
+// Two rows are enough to tell a unique match from an ambiguous one. This bounds the
+// row count only. One long field still exceeds the workflow variable limit, which is
+// why the returned fields are listed explicitly rather than selected wholesale.
 let soql := f'SELECT {selectList} FROM {object} WHERE {matchField} = \'{escapedValue}\' LIMIT 2'
 let queryString := encodeForUrl(soql)
 
@@ -362,7 +363,7 @@ return {
             "key": "fields",
             "type": "string",
             "label": "Fields to return",
-            "description": "Comma separated fields to return on the matched record. `Id` is always included. Keep the list short, because workflow variables have a size limit.",
+            "description": "Comma separated fields to return on the matched record. `Id` is always included. Workflow variables share a 5 KB limit, so avoid long text fields here, or set a result path on the output variable to store only what you need.",
             "default": "Id",
             "secret": False,
             "required": False,

--- a/posthog/cdp/templates/salesforce/template_salesforce.py
+++ b/posthog/cdp/templates/salesforce/template_salesforce.py
@@ -233,6 +233,145 @@ return empty(res.body) ? {'success': true} : res.body
 )
 
 
+template_lookup: HogFunctionTemplateDC = HogFunctionTemplateDC(
+    status="beta",
+    free=False,
+    type="destination",
+    id="template-salesforce-lookup",
+    name="Salesforce",
+    description="Look up an object in Salesforce",
+    icon_url="/static/services/salesforce.png",
+    category=["CRM", "Customer Success"],
+    code_language="hog",
+    code=r"""
+let assertApiName := (value, label, pattern) -> {
+  if (not match(value, pattern)) {
+    throw Error(f'{label} \'{value}\' is not a valid Salesforce API name. Use letters, numbers, and underscores.')
+  }
+}
+
+let escapeSoql := (value) -> {
+  let escaped := replaceAll(value, '\\', '\\\\')
+  escaped := replaceAll(escaped, '\'', '\\\'')
+  return escaped
+}
+
+// The query travels in the URL, so percent-encode anything that would end the query
+// string or change its meaning. Percent signs go first, otherwise the replacements
+// below get encoded a second time.
+let encodeForUrl := (value) -> {
+  let encoded := replaceAll(value, '%', '%25')
+  encoded := replaceAll(encoded, ' ', '%20')
+  encoded := replaceAll(encoded, '"', '%22')
+  encoded := replaceAll(encoded, '#', '%23')
+  encoded := replaceAll(encoded, '&', '%26')
+  encoded := replaceAll(encoded, '\'', '%27')
+  encoded := replaceAll(encoded, '+', '%2B')
+  encoded := replaceAll(encoded, ',', '%2C')
+  encoded := replaceAll(encoded, '/', '%2F')
+  encoded := replaceAll(encoded, '<', '%3C')
+  encoded := replaceAll(encoded, '=', '%3D')
+  encoded := replaceAll(encoded, '>', '%3E')
+  encoded := replaceAll(encoded, '?', '%3F')
+  encoded := replaceAll(encoded, '\\', '%5C')
+  return encoded
+}
+
+let object := trim(inputs.object)
+let matchField := trim(inputs.match_field)
+let matchValue := trim(inputs.match_value)
+
+if (empty(matchValue)) {
+  throw Error('Salesforce lookup has no value to match on. The property mapped to the match value was empty when this ran. Check that it is set before this step.')
+}
+
+assertApiName(object, 'Object', '^[A-Za-z0-9_]+$')
+assertApiName(matchField, 'Match field', '^[A-Za-z0-9_]+$')
+
+let selected := ['Id']
+for (let rawField in splitByString(',', inputs.fields ?? '')) {
+  let field := trim(rawField)
+  if (notEmpty(field) and not has(selected, field)) {
+    assertApiName(field, 'Field', '^[A-Za-z0-9_.]+$')
+    selected := arrayPushBack(selected, field)
+  }
+}
+
+let selectList := arrayStringConcat(selected, ', ')
+let escapedValue := escapeSoql(matchValue)
+
+// Two rows are enough to tell a unique match from an ambiguous one, and keep the
+// result inside the size limit for workflow variables.
+let soql := f'SELECT {selectList} FROM {object} WHERE {matchField} = \'{escapedValue}\' LIMIT 2'
+let queryString := encodeForUrl(soql)
+
+let res := fetch(f'{inputs.oauth.instance_url}/services/data/v61.0/query/?q={queryString}', {
+  'method': 'GET',
+  'headers': {
+    'Authorization': f'Bearer {inputs.oauth.access_token}',
+    'Content-Type': 'application/json'
+  }
+});
+
+if (res.status >= 400) {
+  throw Error(f'Salesforce lookup on {object} failed with status {res.status}: {res.body}');
+}
+
+let records := res.body?.records ?? []
+let found := length(records) > 0
+
+print(f'Salesforce lookup on {object} matched {length(records)} record(s)')
+
+return {
+  'found': found,
+  'multiple': length(records) > 1,
+  'id': found ? records[1].Id : null,
+  'record': found ? records[1] : null
+}
+""".strip(),
+    inputs_schema=[
+        common_inputs["oauth"],
+        {
+            "key": "object",
+            "type": "string",
+            "label": "Object",
+            "description": "The Salesforce object to search, such as `Lead` or `Contact`.",
+            "default": "Lead",
+            "secret": False,
+            "required": True,
+        },
+        {
+            "key": "match_field",
+            "type": "string",
+            "label": "Match field",
+            "description": "The field to match on, such as `Email`. Unlike the update step, this does not have to be an External ID field.",
+            "default": "Email",
+            "secret": False,
+            "required": True,
+        },
+        {
+            "key": "match_value",
+            "type": "string",
+            "label": "Match value",
+            "description": "The value to match. The step fails if this is empty, so map it to a property that is set by the time the step runs.",
+            "default": "{person.properties.email}",
+            "secret": False,
+            "required": True,
+        },
+        {
+            "key": "fields",
+            "type": "string",
+            "label": "Fields to return",
+            "description": "Comma separated fields to return on the matched record. `Id` is always included. Keep the list short, because workflow variables have a size limit.",
+            "default": "Id",
+            "secret": False,
+            "required": False,
+        },
+    ],
+    filters=common_filters,
+)
+
+
 class TemplatSalesforceMigrator(HogFunctionTemplateMigrator):
     plugin_url = "https://github.com/PostHog/posthog-plugin-replicator"
 

--- a/posthog/cdp/templates/salesforce/test_template_salesforce.py
+++ b/posthog/cdp/templates/salesforce/test_template_salesforce.py
@@ -7,6 +7,7 @@ from posthog.cdp.templates.helpers import BaseHogFunctionTemplateTest
 from posthog.cdp.templates.salesforce.template_salesforce import (
     TemplatSalesforceMigrator,
     template_create as template_salesforce_create,
+    template_lookup as template_salesforce_lookup,
     template_update as template_salesforce_update,
 )
 
@@ -159,6 +160,92 @@ class TestTemplateSalesforceUpdate(BaseHogFunctionTemplateTest):
     def test_reports_success_when_salesforce_returns_no_body(self, _name: str, status: int, body: dict | None):
         self.mock_fetch_response = lambda *args: {"status": status, "body": body}  # type: ignore
         assert self.run_function(self._inputs(path="Lead/00Q1")).result == {"success": True}
+
+
+class TestTemplateSalesforceLookup(BaseHogFunctionTemplateTest):
+    template = template_salesforce_lookup
+
+    def _inputs(self, **kwargs):
+        inputs = {
+            "oauth": {
+                "instance_url": "https://example.my.salesforce.com",
+                "access_token": "oauth-1234",
+            },
+            "object": "Lead",
+            "match_field": "Email",
+            "match_value": "example@posthog.com",
+            "fields": "Id",
+        }
+        inputs.update(kwargs)
+        return inputs
+
+    def _respond(self, records):
+        self.mock_fetch_response = lambda *args: {"status": 200, "body": {"records": records}}  # type: ignore
+
+    def _query(self):
+        return self.get_mock_fetch_calls()[0][0].split("?q=")[1]
+
+    def test_queries_salesforce_and_returns_the_match(self):
+        self._respond([{"Id": "00Q1", "Status": "Open"}])
+        result = self.run_function(self._inputs(fields="Id, Status")).result
+        url, options = self.get_mock_fetch_calls()[0]
+        assert url == (
+            "https://example.my.salesforce.com/services/data/v61.0/query/"
+            "?q=SELECT%20Id%2C%20Status%20FROM%20Lead%20WHERE%20Email%20%3D%20%27example@posthog.com%27%20LIMIT%202"
+        )
+        assert options["method"] == "GET"
+        assert result == {
+            "found": True,
+            "multiple": False,
+            "id": "00Q1",
+            "record": {"Id": "00Q1", "Status": "Open"},
+        }
+
+    @parameterized.expand(
+        [
+            ("single quote", "x' OR Name != '", "%27x%5C%27%20OR%20Name%20!%3D%20%5C%27%27"),
+            ("plus addressing", "a+b@posthog.com", "%27a%2Bb@posthog.com%27"),
+            ("backslash", "a\\b@posthog.com", "%27a%5C%5Cb@posthog.com%27"),
+        ]
+    )
+    def test_escapes_the_match_value(self, _name: str, match_value: str, expected: str):
+        self._respond([])
+        self.run_function(self._inputs(match_value=match_value))
+        assert expected in self._query()
+
+    def test_returns_not_found_instead_of_failing(self):
+        self._respond([])
+        assert self.run_function(self._inputs()).result == {
+            "found": False,
+            "multiple": False,
+            "id": None,
+            "record": None,
+        }
+
+    def test_flags_more_than_one_match(self):
+        self._respond([{"Id": "00Q1"}, {"Id": "00Q2"}])
+        result = self.run_function(self._inputs()).result
+        assert result["multiple"] is True
+        assert result["id"] == "00Q1"
+
+    def test_rejects_empty_match_value(self):
+        with pytest.raises(UncaughtHogVMException) as e:
+            self.run_function(self._inputs(match_value=""))
+        assert "no value to match on" in str(e.value)
+        assert self.get_mock_fetch_calls() == []
+
+    @parameterized.expand(
+        [
+            ("object", {"object": "Lead WHERE Id != null"}),
+            ("match field", {"match_field": "Email'"}),
+            ("returned field", {"fields": "Id, Name FROM User"}),
+        ]
+    )
+    def test_rejects_invalid_api_names(self, _name: str, override: dict):
+        with pytest.raises(UncaughtHogVMException) as e:
+            self.run_function(self._inputs(**override))
+        assert "is not a valid Salesforce API name" in str(e.value)
+        assert self.get_mock_fetch_calls() == []
 
 
 class TestTemplateMigration(BaseTest):

--- a/posthog/cdp/templates/salesforce/test_template_salesforce.py
+++ b/posthog/cdp/templates/salesforce/test_template_salesforce.py
@@ -206,6 +206,7 @@ class TestTemplateSalesforceLookup(BaseHogFunctionTemplateTest):
             ("single quote", "x' OR Name != '", "%27x%5C%27%20OR%20Name%20!%3D%20%5C%27%27"),
             ("plus addressing", "a+b@posthog.com", "%27a%2Bb@posthog.com%27"),
             ("backslash", "a\\b@posthog.com", "%27a%5C%5Cb@posthog.com%27"),
+            ("embedded newline", "a@\nb.com", "%27a@%5Cnb.com%27"),
         ]
     )
     def test_escapes_the_match_value(self, _name: str, match_value: str, expected: str):


### PR DESCRIPTION
## Problem

A workflow can create and update Salesforce objects but cannot read one, so there is no way to check whether a record exists before acting on it.

- The update step only creates-if-missing by upserting on an External ID field, which an admin has to flag. `Email` is not one by default.
- The documented alternative is a generic webhook step, plus a second webhook step to mint a token, because the step cannot reuse the connected Salesforce integration.
- No Salesforce step returned a value, so a workflow could not read a Salesforce response into an output variable at all.

Stacked on #81705, which fixes the path guard on the existing steps. Origin: [support thread](https://posthog.slack.com/archives/C0B0ETED9MY/p1786388578552859?thread_ts=1786388578.552859&cid=C0B0ETED9MY).

## Changes

- New `template-salesforce-lookup` step, with inputs for object, match field, match value, and fields to return.
- The step returns `{found, multiple, id, record}`, so a conditional branch can read the result through an output variable.
- A lookup that matches nothing returns `found: false` and succeeds. Only a transport or permission failure throws, because "no record" is the answer the branch needs, not an error.
- The step builds the SOQL itself and escapes the match value, so an apostrophe in a person property cannot end the string literal or alter the query.
- Object, match field, and returned fields must match a Salesforce API name pattern, checked before the request.
- `LIMIT 2` separates a unique match from an ambiguous one. It bounds the row count only, so the returned fields stay an explicit list and the field description points at the result path for anything larger.
- An empty match value fails before the request, the same guard the create and update steps get in #81705.

Structured inputs rather than a raw SOQL field: the match value comes from person data, so a raw query field would interpolate user input straight into SOQL. A raw-query escape hatch can follow if someone needs `LIKE` or a date range.

> [!NOTE]
> The step percent-encodes the query with an explicit character list instead of `encodeURIComponent`, which the TypeScript and Rust hog VMs have but the Python one does not. Closing that gap belongs in its own PR against the shared VM, not here.

I did not add the new template to `frontend/src/mocks/fixtures/_hogFunctionTemplatesDestinations.json`. That fixture is a captured snapshot that already omits `template-kudosity-sms` and `template-userlist` from master, so it does not track template additions. #81705 edits it only because it carried a copy of the bug being fixed.

## How did you test this code?

Added six tests to `test_template_salesforce.py`:

- Query construction and return shape. Catches a break in either contract, and the return shape is what output variables read.
- Match value escaping, over a single quote, plus addressing, and a backslash. The quote case catches SOQL injection through a person property. The plus case catches a dropped `%2B`, which silently turns `a+b@x.com` into `a b@x.com` and returns no match.
- Empty match value. Same regression as #81705, on the new step.
- No match returns `found: false` without throwing. Catches a change that turns a miss into a step failure and breaks branching.
- Two matches set `multiple`. Catches an ambiguous match being treated as unique.
- Invalid API names in the object, match field, and returned fields. Catches a bypass of the identifier check.

I ran the Salesforce tests and `test_cdp_templates.py`, which compiles every template, against a local Postgres and ClickHouse.

Not checked: no request reached a real Salesforce org, so the SOQL is validated against the [escape-sequence reference](https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select_quotedstringescapes.htm) and the [query resource](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_query.htm) rather than a live response. I also did not open the step in the workflow editor.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None in this repo. The destination reference lives on posthog.com.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via PostHog Desktop) wrote this. A PostHog engineer chose the structured-input design over raw SOQL and over a combined mode. Assigned to the engineer who directed it, resolved from the authenticated `gh api user` identity rather than inferred from a display name.

Skills invoked: `/writing-user-facing-copy` for the input descriptions and error strings, `/writing-tests` for the test gate, `/stacking-prs` for the stack, `/writing-pr-descriptions` for this body.

Two constraints shaped the implementation. The hog VM used by the template test harness lacks `encodeURIComponent`, so the encoding is explicit. And a step only populates an output variable if its hog code returns a value, which is why the return shape is a deliberate contract rather than the raw response body.

Public artifact: this work started from a customer support thread. No material from that thread is in the diff, the tests, the commit message, or this description. The test data is invented.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
