### PR TITLE
fix(logs): mask ISO-8601 timestamps in pattern miner templates

### DIFF
--- a/products/logs/backend/log_patterns.py
+++ b/products/logs/backend/log_patterns.py
@@ -15,6 +15,9 @@ ERROR_SEVERITIES = {"error", "fatal"}
 # one cluster per distinct value. Order matters — Drain applies these in sequence, so
 # more-specific patterns (uuid, ip, hex) run before the catch-all number mask.
 _MASKING_INSTRUCTIONS = [
+    # Timestamp must precede the number catch-all: \b never matches between a digit and
+    # a letter, so "12T08" and "397557Z" in ISO-8601 bodies would survive \b\d+\b intact.
+    MaskingInstruction(r"\b\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?(?:Z|[+-]\d{2}:?\d{2})?", "timestamp"),
     MaskingInstruction(r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b", "uuid"),
     MaskingInstruction(r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b", "ip"),
     MaskingInstruction(r"\b0x[0-9a-fA-F]+\b", "hex"),
@@ -31,6 +34,7 @@ _WHITESPACE_RE = re.compile(r"\s+")
 _PLACEHOLDER_PATTERNS = {
     "<*>": r"\S+",
     "<num>": r"\d+",
+    "<timestamp>": r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?(?:Z|[+-]\d{2}:?\d{2})?",
     "<uuid>": r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
     "<ip>": r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}",
     "<hex>": r"(?:0x[0-9a-fA-F]+|[0-9a-fA-F]{16,})",

--- a/products/logs/backend/presentation/views/api.py
+++ b/products/logs/backend/presentation/views/api.py
@@ -760,7 +760,7 @@ class _LogPatternSerializer(serializers.Serializer):
     pattern = serializers.CharField(
         help_text=(
             'Mined log template with variable tokens masked, e.g. "Connected to <ip> in <num>ms". '
-            "Tokens: <uuid>, <ip>, <hex>, <num>, plus <*> for word positions Drain found to vary."
+            "Tokens: <timestamp>, <uuid>, <ip>, <hex>, <num>, plus <*> for word positions Drain found to vary."
         ),
     )
     count = serializers.IntegerField(

--- a/products/logs/backend/test/test_log_patterns.py
+++ b/products/logs/backend/test/test_log_patterns.py
@@ -5,7 +5,13 @@ from unittest import TestCase
 
 from parameterized import parameterized
 
-from products.logs.backend.log_patterns import LogSample, compile_match_regex, extract_match_literal, mine_patterns
+from products.logs.backend.log_patterns import (
+    LogSample,
+    compile_match_regex,
+    extract_match_literal,
+    mine_patterns,
+    pattern_fingerprint,
+)
 
 
 def _sample(
@@ -52,6 +58,33 @@ class TestMinePatterns(TestCase):
                 ],
                 "<uuid>",
                 "446655440000",
+            ),
+            (
+                "timestamp_iso_t",
+                [
+                    "job 2026-08-12T08:10:43.397557Z retried",
+                    "job 2026-08-13T09:11:44.123456Z retried",
+                ],
+                "<timestamp>",
+                "397557Z",
+            ),
+            (
+                "timestamp_space_separated",
+                [
+                    "job 2026-08-12 08:10:43.397557 retried",
+                    "job 2026-08-13 09:11:44.123456 retried",
+                ],
+                "<timestamp>",
+                "397557",
+            ),
+            (
+                "timestamp_utc_offset",
+                [
+                    "job 2026-08-12T08:10:43+00:00 retried",
+                    "job 2026-08-13T09:11:44+02:00 retried",
+                ],
+                "<timestamp>",
+                "12T08",
             ),
         ]
     )
@@ -152,6 +185,24 @@ class TestMinePatterns(TestCase):
         for example in patterns[0].examples:
             assert compiled.search(example.body)
 
+    def test_same_statement_on_different_dates_shares_fingerprint(self) -> None:
+        # The patterns diff compares fingerprints across two windows (default: one week
+        # apart). A timestamp fragment surviving masking becomes a literal run, so the
+        # same log statement would fingerprint differently and show up as a false
+        # new/gone pair.
+        monday = mine_patterns([_sample("2026-08-12T08:10:43.397557Z task_retrying attempt=3")])
+        week_later = mine_patterns([_sample("2026-08-19T09:04:17.112233Z task_retrying attempt=7")])
+
+        assert pattern_fingerprint(monday[0].pattern) == pattern_fingerprint(week_later[0].pattern)
+
+    def test_match_regex_matches_siblings_with_different_timestamps(self) -> None:
+        # An unmasked timestamp baked into match_regex narrows the "view matching logs"
+        # pivot to the single line the pattern was mined from.
+        patterns = mine_patterns([_sample("task_retrying at 2026-08-12T08:10:43.397557Z scheduled")])
+
+        assert patterns[0].match_regex is not None
+        assert re.search(patterns[0].match_regex, "task_retrying at 2026-08-19T14:02:11.000001Z scheduled")
+
 
 class TestCompileMatchRegex(TestCase):
     @parameterized.expand(
@@ -164,6 +215,7 @@ class TestCompileMatchRegex(TestCase):
             ("peer <ip> disconnected", "peer 10.32.243.94 disconnected"),
             ("token <hex> rejected", "token 0xdeadbeef rejected"),
             ("path /api/v1/users?id=<num> hit", "path /api/v1/users?id=42 hit"),
+            ("job <timestamp> finished", "job 2026-08-12T08:10:43.397557Z finished"),
         ]
     )
     def test_compiled_regex_matches_raw_bodies(self, template: str, raw_body: str) -> None:

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -1557,7 +1557,7 @@ export interface _LogPatternExampleApi {
 export type _LogPatternApiSeverityCounts = { [key: string]: number }
 
 export interface _LogPatternApi {
-    /** Mined log template with variable tokens masked, e.g. "Connected to <ip> in <num>ms". Tokens: <uuid>, <ip>, <hex>, <num>, plus <*> for word positions Drain found to vary. */
+    /** Mined log template with variable tokens masked, e.g. "Connected to <ip> in <num>ms". Tokens: <timestamp>, <uuid>, <ip>, <hex>, <num>, plus <*> for word positions Drain found to vary. */
     pattern: string
     /** Occurrences of this pattern within the sample. When `sampled` is true this is a sample count, not the full-window total — prefer `estimated_count` for display. */
     count: number

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -78851,7 +78851,7 @@ export namespace Schemas {
     }
 
     export interface _LogPattern {
-      /** Mined log template with variable tokens masked, e.g. "Connected to <ip> in <num>ms". Tokens: <uuid>, <ip>, <hex>, <num>, plus <*> for word positions Drain found to vary. */
+      /** Mined log template with variable tokens masked, e.g. "Connected to <ip> in <num>ms". Tokens: <timestamp>, <uuid>, <ip>, <hex>, <num>, plus <*> for word positions Drain found to vary. */
       pattern: string;
       /** Occurrences of this pattern within the sample. When `sampled` is true this is a sample count, not the full-window total — prefer `estimated_count` for display. */
       count: number;


### PR DESCRIPTION
## Problem

- The logs Patterns tab shows mined templates with raw timestamp fragments in them, like `<num>-<num>-12T08:<num>:<num>.397557Z`.
- The masker has no timestamp rule. The `\b\d+\b` catch-all cannot match a digit run that touches a letter, so `12` (before `T`) and `397557` (before `Z`) survive masking.
- A leaked date becomes a literal run in the template fingerprint, so the same log statement fingerprints differently across diff windows. The patterns diff then reports false "new" and "gone" pairs.
- The "View matching logs" pivot bakes the exact timestamp into `match_regex` and returns only the mined line.
- Fingerprint-unique templates cannot merge and burn slots against the 200-pattern cap.
- In one sampled production window, 17 of 119 mined templates (14%) carried a literal date or microsecond fragment.

## Changes

- Add a timestamp `MaskingInstruction` ahead of the `\b\d+\b` catch-all. It covers `T` and space separators, optional fractional seconds, and `Z` or numeric offsets.
- Mirror the expression as `<timestamp>` in `_PLACEHOLDER_PATTERNS`. It uses no lookaround and no backreferences because these patterns run in ClickHouse `match()`, which is RE2.
- Add `<timestamp>` to the pattern field `help_text` and regenerate the OpenAPI types.
- No frontend change: the pattern highlighter already matches any `<word>` token.

No visual change beyond templates now showing `<timestamp>` where raw fragments appeared.

## How did you test this code?

- New parameterized masking cases (`T`-separated, space-separated, UTC-offset) catch the fragment leak. All failed before the fix.
- A fingerprint test mines the same statement on two dates and asserts equal fingerprints. It guards the false diff pairs.
- A sibling-match test asserts the mined `match_regex` matches a line with a different timestamp. It guards the over-narrow pivot.
- Not run: the DB-backed suites (`test_patterns_api`, `test_patterns_query_runner`) — this environment has no dev-stack Postgres, and the setup errors pre-exist on the clean tree.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The patterns doc on posthog.com attributes this leak to low line counts, which is wrong. It needs a correction in that repo as a follow-up.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code from a prepared ticket spec, TDD style: the five new tests went red before the fix and green after.
- Skills invoked: /writing-tests, /improving-drf-endpoints, /code-review, /writing-pr-descriptions.
- The spec's optional follow-up (strip a leading timestamp from the body before mining) was intentionally not implemented.
- All committed test data is invented; no production log content appears in the diff.
