### PR TITLE
fix(notebooks): cap frame materialize retries at 3 attempts

### DIFF
--- a/products/notebooks/backend/temporal/frame_materialize.py
+++ b/products/notebooks/backend/temporal/frame_materialize.py
@@ -900,7 +900,7 @@ def materialize_frame(inputs: FrameMaterializeInputs) -> str:
             # Post-write verification failed: the object is missing or predates this write
             # (see stat_frame). Retryable — a transient object-store blip should re-run — but
             # log it, because a deterministic cause (CH wrote to a store the app can't read,
-            # endpoint/bucket skew) would otherwise re-scan the whale silently up to 10 times.
+            # endpoint/bucket skew) would otherwise re-scan the whale silently on every attempt.
             logger.warning(
                 "notebook_frame_materialize_object_unverified",
                 team_id=inputs.team_id,
@@ -1011,10 +1011,10 @@ class NotebookFrameMaterializeWorkflow(PostHogWorkflow):
                     initial_interval=dt.timedelta(seconds=5),
                     backoff_coefficient=2.0,
                     maximum_interval=dt.timedelta(seconds=30),
-                    # Bound the storm. A transient mid-stream tear re-runs the entire scan, and
-                    # schedule_to_close only caps that for queries slow enough to fill the
-                    # window, so a fast query could otherwise repeat its scan on every attempt.
-                    # The deterministic failures are already non-retryable in the activity.
+                    # Bound the storm. A transient failure re-runs the entire scan on either
+                    # transport, and schedule_to_close only caps that for queries slow enough to
+                    # fill the window, so a fast query could otherwise repeat its scan on every
+                    # attempt. The deterministic failures are already non-retryable in the activity.
                     maximum_attempts=3,
                 ),
             )

--- a/products/notebooks/backend/temporal/frame_materialize.py
+++ b/products/notebooks/backend/temporal/frame_materialize.py
@@ -1004,14 +1004,18 @@ class NotebookFrameMaterializeWorkflow(PostHogWorkflow):
                 # the job fails with a clear error instead of piling onto ClickHouse.
                 schedule_to_close_timeout=dt.timedelta(minutes=10),
                 retry_policy=common.RetryPolicy(
-                    initial_interval=dt.timedelta(seconds=1),
+                    # Slot exhaustion raises before the activity touches ClickHouse, so this
+                    # backoff is the only queue a blocked job gets. The intervals are wide
+                    # enough that a job blocked behind a short frame still gets a turn inside
+                    # the small attempt budget below.
+                    initial_interval=dt.timedelta(seconds=5),
                     backoff_coefficient=2.0,
-                    maximum_interval=dt.timedelta(seconds=10),
-                    # Bound the storm: a deterministically-failing heavy query (e.g. a
-                    # mid-stream resource overrun that can't be caught up front) must not
-                    # re-execute for the full schedule_to_close window. Matches the Celery
-                    # async path's max_retries=10.
-                    maximum_attempts=10,
+                    maximum_interval=dt.timedelta(seconds=30),
+                    # Bound the storm. A transient mid-stream tear re-runs the entire scan, and
+                    # schedule_to_close only caps that for queries slow enough to fill the
+                    # window, so a fast query could otherwise repeat its scan on every attempt.
+                    # The deterministic failures are already non-retryable in the activity.
+                    maximum_attempts=3,
                 ),
             )
         except Exception:

--- a/products/notebooks/backend/test/test_frame_materialize.py
+++ b/products/notebooks/backend/test/test_frame_materialize.py
@@ -2,13 +2,17 @@ import io
 import uuid
 from types import SimpleNamespace
 
+import pytest
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
 from django.conf import settings
 
 from parameterized import parameterized
-from temporalio import exceptions
+from temporalio import activity, exceptions
+from temporalio.client import WorkflowFailureError
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from posthog.schema import QueryStatus
 
@@ -311,7 +315,7 @@ class TestFrameMaterializeCHWrites(APIBaseTest):
         [
             # Budget failures sync_execute rewraps as APIException subclasses (NOT
             # InternalCHQueryError) — the case the earlier hand-built InternalCHQueryError
-            # masked. Must be terminal, else the canonical whale failures retry 10x.
+            # masked. Must be terminal, else the canonical whale failures re-scan on every retry.
             ("memory_wrapped", _per_query_memory_error(), True, "materialization limits"),
             # "(total)" / "(for user)" memory pressure: the cluster was busy, not this query too
             # big, so the same query can succeed on retry. Finalizing it would both waste the
@@ -386,3 +390,57 @@ class TestFrameMaterializeCHWrites(APIBaseTest):
         status = manager.get_query_status()
         self.assertTrue(status.complete and status.error)
         self.assertIn("too large", status.error_message or "")
+
+
+@pytest.mark.asyncio
+async def test_exhausted_retries_stop_at_three_scans_and_finalize_the_status():
+    # A transient tear leaves the activity retryable, so nothing in the activity itself ends
+    # the job. Two things have to hold at the workflow level: the scan repeats a bounded
+    # number of times (each attempt re-runs the whole ClickHouse query), and the run still
+    # reaches a terminal state. Without the second one the kernel polls a never-completing
+    # status until its own deadline and reports a timeout instead of the real error.
+    attempts = 0
+    marked_failed = False
+
+    @activity.defn(name="notebook-frame-materialize")
+    async def tear_every_attempt(inputs: frame_materialize.FrameMaterializeInputs) -> str:
+        nonlocal attempts
+        attempts += 1
+        raise ObjectStorageError("stream torn mid-upload")
+
+    @activity.defn(name="notebook-frame-materialize-mark-failed")
+    async def mark_failed(inputs: frame_materialize.FrameMaterializeInputs) -> None:
+        nonlocal marked_failed
+        marked_failed = True
+
+    inputs = frame_materialize.FrameMaterializeInputs(
+        query_id="fm-retry-cap",
+        team_id=1,
+        notebook_short_id="nbfm001",
+        user_id=1,
+        query="select 1",
+        query_hash="abc123",
+        cache_key="notebook-frame:1:abc123",
+    )
+    task_queue = str(uuid.uuid4())
+
+    # Time skipping fast-forwards the retry backoff, so the policy's real intervals cost the
+    # suite nothing.
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=task_queue,
+            workflows=[frame_materialize.NotebookFrameMaterializeWorkflow],
+            activities=[tear_every_attempt, mark_failed],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            with pytest.raises(WorkflowFailureError):
+                await env.client.execute_workflow(
+                    frame_materialize.NotebookFrameMaterializeWorkflow.run,
+                    inputs,
+                    id=str(uuid.uuid4()),
+                    task_queue=task_queue,
+                )
+
+    assert attempts == 3
+    assert marked_failed


### PR DESCRIPTION
## Problem

- A notebook Python cell that keeps failing to fetch its data can re-run its ClickHouse query 10 times before it reports the error.
- The failure arrives after ClickHouse starts streaming, so each retry repeats the entire scan.
- The 10 minute `schedule_to_close_timeout` bounds the chain, but it only binds for slow queries. A query that finishes in seconds fits all 10 attempts.

## Changes

```diff
-initial_interval  = 1s
-maximum_interval  = 10s
-maximum_attempts  = 10
+initial_interval  = 5s
+maximum_interval  = 30s
+maximum_attempts  = 3
```

- The attempt cap bounds repeated scans at 3.
- Slot exhaustion raises before the activity touches ClickHouse, so the backoff is the only queue a blocked job gets.
- The wider intervals keep about 15 seconds of that queue. Cutting the attempts alone would leave 3 seconds.
- Only notebooks v2 reaches this workflow, for whole frame Python inputs behind the `notebooks-frame-store` flag.

> [!NOTE]
> A retry policy value is not part of the workflow's command sequence, so in flight executions replay safely and need no `workflow.patched()` gate.

## How did you test this code?

- One new test covers `NotebookFrameMaterializeWorkflow`, which had no test of any kind.
- It runs the workflow against an activity that tears on every attempt, then asserts the activity ran 3 times and the failure activity ran once.
- The second assertion guards the terminal state. Without it a run that exhausts its retries never finalizes, and the kernel polls a pending status until its own deadline and reports a timeout instead of the real error.
- I mutated the cap back to 10 and confirmed the test fails with `assert 10 == 3`.
- Temporal's time-skipping environment fast-forwards the backoff, so the test adds no wall clock time for the retry intervals.
- I ran the test file and ruff locally. I did not run mypy repo wide, and I did not exercise a live notebook run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The notebooks design docs describe the concurrency limiter and the retry classification, but they state no attempt count.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via Claude Code) made this change. Sinan asked whether the SQLV2 lanes really retry a failed query 10 times. Tracing it found two separate budgets: the Celery lane, whose retries fire before ClickHouse runs anything, and this Temporal lane, whose retries can repeat a finished scan. Only the second one needed capping.

We considered carrying a scan counter across attempts in Temporal heartbeat details, which would keep slot blocked attempts free while capping real scans at 3. Sinan chose the constant change plus a wider backoff, which buys most of the same protection in one line.

I first opened this without a test, on the grounds that asserting the constant would only mirror the diff. Greptile flagged the missing coverage, and the second look found a better target: the workflow's failure branch was untested, and testing it exercises the retry sequence as a side effect. The test asserts behavior at the workflow level rather than reading the policy object.

Skills invoked: `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.
