### PR TITLE
fix(mysql): classify statement-timeout errors as a bad query plan

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
@@ -104,6 +104,14 @@ _LOST_CONNECTION_DURING_QUERY_CODE = 2013
 # resolves it.
 _OUT_OF_SORT_MEMORY_CODE = 1038
 
+# pymysql error code for "Query execution was interrupted, maximum statement
+# execution time exceeded" — the same bad plan (full scan + filesort over the
+# incremental field) seen from a third side: the server's own `max_execution_time`
+# cap kills the query outright before the filesort can finish. Forcing the
+# incremental-field index lets MySQL read rows in index order and skip the
+# filesort entirely, so the same FORCE INDEX fallback resolves it.
+_QUERY_EXECUTION_TIME_EXCEEDED_CODE = 3024
+
 # Raised in place of the raw pymysql 2013 when a lost-connection bad plan can't be dodged by the
 # FORCE INDEX fallback because the incremental field has no usable index. The un-indexed full-table
 # sort re-times-out on every run, so it's deterministic — distinct from a genuine transient mid-query
@@ -297,20 +305,22 @@ def _is_bad_plan_error(e: pymysql.err.OperationalError) -> bool:
     """Return True if the error is a symptom of MySQL filesorting the incremental
     `ORDER BY` instead of using an index — recoverable via the FORCE INDEX fallback.
 
-    Matches two codes, both signalling the optimizer picked a full scan + filesort
+    Matches three codes, all signalling the optimizer picked a full scan + filesort
     over the incremental field:
 
     - `2013` (lost connection during query): the filesort preparation outran a
       middlebox / server-side query timeout before any rows streamed back.
     - `1038` (out of sort memory): the filesort itself overran the server's
       `sort_buffer_size`.
+    - `3024` (query execution was interrupted): the server's own `max_execution_time`
+      cap killed the query before the filesort could finish.
 
     Forcing the incremental-field index makes MySQL read rows in index order and
-    skip the filesort, resolving both. Other `OperationalError`s (access denied,
+    skip the filesort, resolving all three. Other `OperationalError`s (access denied,
     table missing, etc.) should propagate untouched.
     """
     code = e.args[0] if e.args else None
-    return code in (_LOST_CONNECTION_DURING_QUERY_CODE, _OUT_OF_SORT_MEMORY_CODE)
+    return code in (_LOST_CONNECTION_DURING_QUERY_CODE, _OUT_OF_SORT_MEMORY_CODE, _QUERY_EXECUTION_TIME_EXCEEDED_CODE)
 
 
 # Number of times `connect` will open a fresh pymysql connection before giving up. Matches the
@@ -1566,8 +1576,9 @@ class MySQLImplementation(SQLSourceImplementation[MySQLSourceConfig, pymysql.Con
                     )
                     # A lost connection here recurs every run: with no usable index the incremental
                     # sort is unavoidable and re-times-out. Re-raise it as a deterministic error so
-                    # the schema is paused with guidance instead of looping. Out-of-sort-memory
-                    # (1038) is already classified by its own code, so leave it raw.
+                    # the schema is paused with guidance instead of looping. Out-of-sort-memory (1038)
+                    # and query-execution-time-exceeded (3024) already carry their own stable, locale-
+                    # independent codes, so leave those raw.
                     if e.args and e.args[0] == _LOST_CONNECTION_DURING_QUERY_CODE:
                         raise MySQLUnavoidableFilesortError() from e
                     raise

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -304,6 +304,15 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # locale-independent error code (the trailing message text is translated on non-English
             # servers) so it catches both the raw pymysql string and the wrapped `(1038, ...)` form.
             "(1038,": "Your MySQL/MariaDB server ran out of sort buffer memory while ordering this table by its incremental field (error 1038). We try to avoid the sort by forcing the incremental field's index, but this table has no usable index on that field. Add an index on the incremental field, raise the server's 'sort_buffer_size', or switch this table to a full re-sync, then resync.",
+            # MySQL/MariaDB error 3024 (ER_QUERY_TIMEOUT): the server's own `max_execution_time`
+            # cap killed the `ORDER BY <incremental_field>` query before the filesort could
+            # finish. We already try to dodge the sort with the in-activity FORCE INDEX fallback
+            # (see `_is_bad_plan_error`); this only escapes once that fallback can't apply — no
+            # usable index on the incremental field. Both `max_execution_time` and the missing
+            # index are static server-side state, so every retry filesorts the same rows and
+            # fails identically. Match the locale-independent error code (the trailing message
+            # text is translated on non-English servers).
+            "(3024,": "Your MySQL/MariaDB server's maximum statement execution time was exceeded while ordering this table by its incremental field (error 3024). We try to avoid the sort by forcing the incremental field's index, but this table has no usable index on that field. Add an index on the incremental field, raise the server's 'max_execution_time', or switch this table to a full re-sync, then resync.",
             # MySQL/MariaDB error 2013 (lost connection during query) that escapes the in-activity
             # FORCE INDEX fallback because the incremental field has no usable index (see
             # `MySQLUnavoidableFilesortError` in mysql.py). The un-indexed full-table sort re-times-out

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -916,6 +916,16 @@ class TestIsBadPlanError:
             pymysql.err.OperationalError(1038, "Out of sort memory, consider increasing server sort buffer size")
         )
 
+    def test_matches_error_3024_query_execution_time_exceeded(self):
+        # The server's own max_execution_time cap killing the query is a third
+        # symptom of the same full-scan-and-filesort plan — the FORCE INDEX
+        # fallback resolves it too.
+        assert _is_bad_plan_error(
+            pymysql.err.OperationalError(
+                3024, "Query execution was interrupted, maximum statement execution time exceeded"
+            )
+        )
+
     @pytest.mark.parametrize(
         "code,message",
         [
@@ -2092,6 +2102,24 @@ class TestMySQLSourceNonRetryableErrors:
         non_retryable = source.get_non_retryable_errors()
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert is_non_retryable, f"Out-of-sort-memory error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            # Raw pymysql str(error) form (single-quoted tuple repr).
+            str(
+                pymysql.err.OperationalError(
+                    3024, "Query execution was interrupted, maximum statement execution time exceeded"
+                )
+            ),
+            # Temporal-wrapped form (double-quoted).
+            'OperationalError: (3024, "Query execution was interrupted, maximum statement execution time exceeded")',
+        ],
+    )
+    def test_query_execution_time_exceeded_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Query-execution-time-exceeded error should be non-retryable: {error_msg}"
 
     @pytest.mark.parametrize(
         "error_msg",


### PR DESCRIPTION
## Problem

An incremental MySQL sync that falls back to a full-table scan can get killed by the server's own statement-timeout cap (error 3024, "maximum statement execution time exceeded"). The source didn't recognize this as a bad query plan, so it kept retrying the identical doomed query instead of applying the FORCE INDEX recovery already built for the same failure mode.

Surfaced by a live [error tracking issue](https://us.posthog.com/project/2/error_tracking/019ff599-3154-7871-b842-ab09727a7645): `OperationalError(3024, ...)` raised from `_stream_with_optional_force_index` while streaming rows.

## Changes

- Extend `_is_bad_plan_error` to also match error 3024, alongside the existing 2013 (lost connection) and 1038 (out of sort memory) codes it already treats as full-scan-plus-filesort symptoms.
- Add a non-retryable entry for `(3024,` mirroring the existing `(1038,` one, so a table with no usable index on its incremental field pauses with actionable guidance instead of retrying forever.

## How did you test this code?

- Added `test_matches_error_3024_query_execution_time_exceeded` to `TestIsBadPlanError` — catches a regression where 3024 stops triggering the FORCE INDEX fallback.
- Added `test_query_execution_time_exceeded_is_non_retryable` to `TestMySQLSourceNonRetryableErrors` — catches a regression where an unavoidable 3024 timeout would retry forever instead of pausing the schema.
- Ran `products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py` locally (64 selected tests passed).
- Ran `ruff check`, `ruff format`, and `mypy` on the changed files; all clean.
- Not run: a live sync against a MySQL server actually configured with `max_execution_time` — no such environment available here.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing config or workflow changed, only internal retry classification.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via Claude Code using the PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to pull the full stack trace and confirm the failure originates in this source's code, then an Explore subagent to read `mysql.py`/`source.py` and find the precedent (Postgres already classifies its analogous statement-timeout error). Skills invoked: `/writing-tests` (extended existing parameterized cases rather than adding new test classes) and `/writing-pr-descriptions` for this body.

Searched open PRs (excluding the `posthog` bot) for a duplicate fix; found none. Checked the maintainer's own open PRs for this area — none touch `mysql.py`.