### PR TITLE
feat(managed-warehouse): feed SQL-editor direct source from CP connect + minted credential

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -84,6 +84,7 @@ from products.data_warehouse.backend.facade.backfill_status import (
     stale_running_partitions,
 )
 from products.data_warehouse.backend.facade.models import ManagedWarehouseBackfillPartition
+from products.managed_warehouse.backend.common import _log_duckgres_server_access
 from products.managed_warehouse.backend.facade.api import (
     DUCKGRES_BUCKET_REGION,
     NO_HISTORY_SENTINEL,
@@ -281,6 +282,7 @@ def _resolve_duckling_target(team_id: int) -> DucklingTarget:
         )
 
     # CP couldn't answer — fall back to the stored row if it knows a bucket.
+    _log_duckgres_server_access("events_backfill.bucket_fallback", org_id)
     stored_bucket = get_stored_bucket_config(org_id)
     if stored_bucket is not None:
         bucket, bucket_region = stored_bucket.bucket, stored_bucket.region or DUCKGRES_BUCKET_REGION
@@ -1797,6 +1799,7 @@ def _ducklake_file_partition_value_fixup_enabled() -> bool:
 
 
 def _open_catalog_conn(target: DucklingTarget) -> psycopg.Connection[Any]:
+    _log_duckgres_server_access("events_backfill.catalog_connection", target.organization_id)
     catalog = get_catalog_connection_config(target.organization_id)
     if catalog is None:
         raise RuntimeError(

--- a/products/managed_warehouse/backend/admin/duckgres_server_admin.py
+++ b/products/managed_warehouse/backend/admin/duckgres_server_admin.py
@@ -10,6 +10,7 @@ import structlog
 
 from posthog.models import Organization, Team, User
 
+from products.managed_warehouse.backend.common import _log_duckgres_server_access
 from products.managed_warehouse.backend.models import DuckgresServer
 
 logger = structlog.get_logger(__name__)
@@ -255,6 +256,7 @@ class DuckgresServerAdmin(admin.ModelAdmin):
         return redirect(reverse("admin:managed_warehouse_duckgresserver_change", args=[object_id]))
 
     def _get_server_or_404(self, object_id: str) -> DuckgresServer:
+        _log_duckgres_server_access("admin._get_server_or_404")
         try:
             return get_object_or_404(DuckgresServer, pk=object_id)
         except ValidationError as exc:

--- a/products/managed_warehouse/backend/client.py
+++ b/products/managed_warehouse/backend/client.py
@@ -8,6 +8,7 @@ from psycopg import sql as psql
 from psycopg.conninfo import make_conninfo
 
 from products.managed_warehouse.backend.common import (
+    _log_duckgres_server_access,
     get_duckgres_config_for_org,
     is_dev_mode,
     sanitize_ducklake_identifier,
@@ -84,6 +85,7 @@ def make_duckgres_conninfo(
         config = _duckgres_dev_config()
     else:
         org_id = organization_id or _get_org_id_for_team(team_id)
+        _log_duckgres_server_access("client.make_duckgres_conninfo", org_id)
         config = get_duckgres_config_for_org(org_id)
     return make_conninfo(
         host=config["DUCKGRES_HOST"],

--- a/products/managed_warehouse/backend/common.py
+++ b/products/managed_warehouse/backend/common.py
@@ -25,6 +25,7 @@ from uuid import UUID
 
 import duckdb
 import psycopg
+import structlog
 from psycopg import sql
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
 
@@ -47,6 +48,39 @@ DUCKLAKE_CATALOG_RESET_ENV_VAR = "POSTHOG_ALLOW_DUCKLAKE_CATALOG_RESET"
 DATA_MODELING_DUCKGRES_SHADOW_SCHEMA_PREFIX = "shadow"
 
 logger = logging.getLogger(__name__)
+_structlog_logger = structlog.get_logger(__name__)
+
+
+def _log_duckgres_server_access(caller: str, organization_id: str | None = None) -> None:
+    """Emit the DuckgresServer-model access event used to prove the model is unreadable.
+
+    Every remaining read/write touchpoint of the ``DuckgresServer`` Django model calls
+    this with a short self-describing caller tag. After this has baked in production
+    (~24h), an EMPTY query for ``duckgres_server_model_access`` is the evidence that
+    nothing reads the model anymore and a later PR can DROP it; any event that does
+    fire names the touchpoint that still needs migrating. The ``DuckgresServer``-free
+    paths (the CP-minted service-credential and direct-source flows) never emit it.
+
+    Behavior-neutral, must be negligible on hot paths, and must never break a caller,
+    so the body is fully defensive and only grabs the immediate caller's function name
+    as a cheap stack hint (no stack walks, no traces).
+    """
+    try:
+        import inspect
+
+        frame = inspect.currentframe()
+        caller_function = None
+        if frame is not None and frame.f_back is not None and frame.f_back.f_back is not None:
+            caller_function = frame.f_back.f_back.f_code.co_name
+        _structlog_logger.info(
+            "duckgres_server_model_access",
+            caller=caller,
+            organization_id=organization_id,
+            caller_function=caller_function,
+        )
+    except Exception:  # never let observability break the touched path
+        pass
+
 
 # Managed-warehouse buckets live in the deployment's home region: us-east-1 for
 # PostHog Cloud US, eu-central-1 for PostHog Cloud EU.
@@ -101,6 +135,7 @@ def get_config() -> dict[str, str]:
 
 
 def _server_to_catalog_config(server: DuckgresServer) -> dict[str, str]:
+    _log_duckgres_server_access("common._server_to_catalog_config", str(server.organization_id))
     config = server.to_catalog_public_config()
     config["DUCKLAKE_RDS_PASSWORD"] = server.catalog_password or ""
     return config
@@ -164,6 +199,7 @@ def get_duckgres_server_by_team_org(team_id: int) -> DuckgresServer | None:
     if is_dev_mode():
         return None
     org_id = _get_org_id_for_team(team_id)
+    _log_duckgres_server_access("common.get_duckgres_server_by_team_org", org_id)
     return get_duckgres_server_for_organization(org_id)
 
 
@@ -178,6 +214,7 @@ DUCKGRES_DEFAULTS: dict[str, str] = {
 
 
 def _server_to_config(server: DuckgresServer) -> dict[str, str]:
+    _log_duckgres_server_access("common._server_to_config", str(server.organization_id))
     return {
         "DUCKGRES_HOST": server.host,
         "DUCKGRES_PORT": str(server.port),
@@ -210,6 +247,7 @@ def get_duckgres_server_for_organization(organization_id: str) -> DuckgresServer
 
     from products.managed_warehouse.backend.models import DuckgresServer
 
+    _log_duckgres_server_access("common.get_duckgres_server_for_organization", organization_id)
     try:
         return DuckgresServer.objects.get(organization_id=organization_id)
     except DuckgresServer.DoesNotExist:
@@ -236,6 +274,7 @@ def upsert_duckgres_server_for_org(
     """
     from products.managed_warehouse.backend.models import DuckgresServer
 
+    _log_duckgres_server_access("common.upsert_duckgres_server_for_org:write", str(organization_id))
     defaults: dict[str, object] = {
         "host": host,
         "port": port,

--- a/products/managed_warehouse/backend/facade/api.py
+++ b/products/managed_warehouse/backend/facade/api.py
@@ -64,6 +64,7 @@ __all__ = [
 
 
 def _to_stored_server_config(server: DuckgresServer) -> DuckgresStoredServerConfig:
+    common._log_duckgres_server_access("facade.api._to_stored_server_config", str(server.organization_id))
     catalog = None
     if server.catalog_host:
         catalog = DuckLakeCatalogConnectionConfig(
@@ -122,6 +123,7 @@ def get_warehouse_provision_status(organization_id: str) -> ManagedWarehouseProv
 def has_provisioned_warehouse(organization_id: str | UUID) -> bool:
     from products.managed_warehouse.backend.models import DuckgresServer  # noqa: PLC0415
 
+    common._log_duckgres_server_access("facade.api.has_provisioned_warehouse", str(organization_id))
     return DuckgresServer.objects.filter(organization_id=organization_id).exists()
 
 
@@ -175,6 +177,7 @@ def persist_duckgres_server_for_org(
 def reconcile_stored_bucket_config(organization_id: str | UUID, *, bucket: str, bucket_region: str) -> bool:
     from products.managed_warehouse.backend.models import DuckgresServer  # noqa: PLC0415
 
+    common._log_duckgres_server_access("facade.api.reconcile_stored_bucket_config:write", str(organization_id))
     return bool(
         DuckgresServer.objects.filter(organization_id=organization_id)
         .exclude(bucket=bucket, bucket_region=bucket_region)

--- a/products/managed_warehouse/backend/logic/connection.py
+++ b/products/managed_warehouse/backend/logic/connection.py
@@ -1,15 +1,19 @@
 """Expose a managed Duckgres warehouse in the SQL editor as a Postgres connection.
 
-Each member team gets a Postgres ``ExternalDataSource`` pointed at the organization's
-``DuckgresServer``, authenticated with the server's org root credential. Duckgres root
-sees every schema in the warehouse, so the connection discovers and exposes the whole
-org catalog without per-team namespace configuration — no control-plane handshake is
-involved in setting it up. Setup happens in two steps:
+Each member team gets a Postgres ``ExternalDataSource`` fed by the duckgres control
+plane: a per-team credential is minted at provision time
+(``mint_service_credential`` — the canonical ``posthog_team_<id>_rw`` project_user
+login) and snapshotted into the source's ``job_inputs`` together with the mint's
+``connect`` block (host, port, database). Nothing on this path reads the
+``DuckgresServer`` row or its org root credential. The stored credential is
+long-lived state (``ExternalDataSource``'s model — the CP can be asked to rotate
+it), so minting uses ``force_rotate=True``: the source holds no prior credential
+when it is (re)written. Setup happens in two steps:
 
 1. ``ensure_managed_warehouse_direct_source`` creates the source row when a team
    joins, so the connection appears immediately.
 2. ``reconcile_managed_warehouse_tables`` runs once the warehouse is ready and records
-   every non-internal schema/table the root credential can see.
+   every non-internal schema/table the credential can see.
 
 This bypasses the user-facing create endpoint because the managed host is internal
 infrastructure and is not reachable for live schema validation during provisioning.
@@ -29,11 +33,14 @@ from django.db.models import QuerySet
 from django.utils import timezone
 
 import structlog
+from rest_framework import status
 
 from posthog.models.team.team import Team
 
 from products.data_warehouse.backend.facade.api import reconcile_postgres_schemas
+from products.managed_warehouse.backend.facade.contracts import ServiceCredential
 from products.managed_warehouse.backend.models import DuckgresServer
+from products.managed_warehouse.backend.service_credentials import mint_service_credential
 from products.warehouse_sources.backend.facade.models import (
     MANAGED_WAREHOUSE_SOURCE_PREFIX,
     DataWarehouseTable,
@@ -47,9 +54,14 @@ logger = structlog.get_logger(__name__)
 
 MANAGED_WAREHOUSE_SOURCE_DESCRIPTION = "Managed warehouse (auto-provisioned)"
 
+# Principal stamped on the provision-time mint, so CP audit logs and credential listings
+# attribute these stored grants to the SQL-editor direct-source setup flow.
+MANAGED_WAREHOUSE_DIRECT_SOURCE_PRINCIPAL = "managed-warehouse:direct-source-setup"
+
 # Database engine internals — never warehouse data. Sidebar hygiene, not permissioning:
-# root bypasses Duckgres AllowedSchemas, so this denylist is the only filter on what the
-# discover sweep registers. The later per-schema visibility control plugs in here.
+# the minted project_user login's schema grants already bound the catalog, and this
+# denylist is the only filter on what the discover sweep registers. The later per-schema
+# visibility control plugs in here.
 INTERNAL_SCHEMAS = frozenset({"pg_catalog", "information_schema", "pg_toast", "system"})
 
 
@@ -67,26 +79,43 @@ def _managed_source_queryset(team_id: int) -> QuerySet[ExternalDataSource]:
     )
 
 
-def _source_config(server: DuckgresServer) -> dict[str, object]:
-    """Snapshot the server's org root credential into the source's job_inputs."""
+def _mint_direct_source_credential(*, organization_id: str | UUID, team_id: int) -> ServiceCredential:
+    """Mint the team's stored provision-time credential for its SQL-editor source.
+
+    The source snapshots the credential into ``job_inputs`` long-term
+    (``ExternalDataSource``'s model), so ``force_rotate=True`` is right: the source
+    holds no prior credential when (re)written, and the CP's rotation IS the expiry
+    mechanism. Raises ``ServiceCredentialUnavailable`` on any CP failure — callers
+    stay best-effort.
+    """
+    return mint_service_credential(
+        str(organization_id),
+        team_id,
+        principal=MANAGED_WAREHOUSE_DIRECT_SOURCE_PRINCIPAL,
+        force_rotate=True,
+    )
+
+
+def _source_config(credential: ServiceCredential) -> dict[str, object]:
+    """Snapshot the minted credential and its CP-issued connect block into job_inputs."""
     source_impl = SourceRegistry.get_source(ExternalDataSourceType.POSTGRES)
     return source_impl.parse_config(
         {
-            "host": server.host,
-            "port": server.port,
-            "database": server.database,
-            "user": server.username,
-            "password": server.password,
+            "host": credential.connect.host,
+            "port": credential.connect.port,
+            "database": credential.connect.database,
+            "user": credential.username,
+            "password": credential.password,
         }
     ).to_dict()
 
 
-def _ensure_managed_source_locked(*, team_id: int, server: DuckgresServer) -> ExternalDataSource:
+def _ensure_managed_source_locked(*, team_id: int, credential: ServiceCredential) -> ExternalDataSource:
     # Deliberately includes soft-deleted rows: a re-enabled membership revives its
     # tombstoned source.
     existing = _managed_source_queryset(team_id).select_for_update().order_by("-created_at").first()
 
-    config = _source_config(server)
+    config = _source_config(credential)
     if existing is not None:
         update_fields: list[str] = []
         connection_metadata = dict(existing.connection_metadata or {})
@@ -151,31 +180,100 @@ def _ensure_managed_source_locked(*, team_id: int, server: DuckgresServer) -> Ex
 
 
 def ensure_managed_warehouse_direct_source(*, team_id: int, organization_id: str | UUID) -> ExternalDataSource:
-    """Create or refresh the team's managed-warehouse query source on the org root credential."""
+    """Create or refresh the team's managed-warehouse query source from a CP-minted credential.
+
+    Raises ``Team.DoesNotExist`` when the team is not (or no longer) in this organization
+    and ``ServiceCredentialUnavailable`` when the control plane cannot issue the
+    credential — both stay best-effort for the caller, which logs and moves on. There is
+    deliberately no fallback to Django state: the CP is the only authority for the
+    credential and its dial target.
+    """
+    # Mint FIRST — before any write: a CP failure must abort the setup before a row is
+    # created or refreshed (no half-written source), and no credential string ever sits
+    # inside an open Postgres transaction (the mint fans out over HTTP).
+    credential = _mint_direct_source_credential(organization_id=organization_id, team_id=team_id)
     with transaction.atomic():
-        server = DuckgresServer.objects.select_for_update().get(organization_id=organization_id)
         Team.objects.select_for_update().only("id").get(id=team_id, organization_id=organization_id)
-        return _ensure_managed_source_locked(team_id=team_id, server=server)
+        return _ensure_managed_source_locked(team_id=team_id, credential=credential)
+
+
+def _cp_warehouse_exists(organization_id: str | UUID) -> bool:
+    """Whether the control plane still holds a live warehouse for this organization.
+
+    Replaces the ``DuckgresServer`` row-existence oracle on the reconcile path with a
+    probe of the same ``GET /warehouse/status`` accessor the deprovision and status
+    views use. Fail-CLOSED on ambiguity:
+
+    - 404, 409, or a 2xx body whose ``state`` is not a known live one (absent/"deleted"/
+      unparseable) ⇒ the warehouse is gone (or going) ⇒ ``False``.
+    - Any other non-2xx, an unreachable CP, or an unconfigured provisioning API ⇒ the CP
+      cannot confirm either way ⇒ ``False`` here too (don't revive); the miss is logged
+      and the next status read reconciles.
+    """
+    from products.managed_warehouse.backend.presentation.views import _request  # noqa: PLC0415
+
+    org_id = str(organization_id)
+    try:
+        resp = _request("GET", organization_id, "/warehouse/status", require_enabled=False)
+    except Exception:
+        # Fail-closed: an unreachable CP must never revive a tombstoned source; a later
+        # sweep re-probes when the control plane is back.
+        logger.exception(
+            "Managed warehouse status probe failed; treating as deprovisioned for this sweep",
+            organization_id=org_id,
+        )
+        return False
+    if status.is_success(resp.status_code):
+        state = resp.data.get("state") if isinstance(resp.data, dict) else None
+        exists = state in ("provisioning", "ready")
+        if not exists:
+            logger.info(
+                "Managed warehouse reports no live state; treating as deprovisioned",
+                organization_id=org_id,
+                state=state,
+            )
+        return exists
+    if resp.status_code in (status.HTTP_404_NOT_FOUND, status.HTTP_409_CONFLICT):
+        # Unknown to the CP, or teardown already underway/finished — the same two codes
+        # the deprovision path treats as converged.
+        logger.info(
+            "Managed warehouse unknown to the control plane; treating as deprovisioned",
+            organization_id=org_id,
+            status_code=resp.status_code,
+        )
+        return False
+    # 5xx / unconfigured / anything else: the CP cannot confirm liveness — fail closed.
+    logger.warning(
+        "Managed warehouse status probe inconclusive; treating as deprovisioned for this sweep",
+        organization_id=org_id,
+        status_code=resp.status_code,
+    )
+    return False
 
 
 def reconcile_managed_warehouse_tables(*, team_id: int, organization_id: str | UUID) -> None:
     """Discover and register the org-wide managed-warehouse catalog for this team's source."""
     with transaction.atomic():
-        # Check before ensure: a tombstoned source means the warehouse was deprovisioned
-        # (its DuckgresServer row is deleted synchronously), and nothing may revive it —
-        # otherwise this sweep would resurrect sources right after deprovision.
+        # Check before ensure: a tombstoned source means the warehouse was deprovisioned,
+        # and nothing may revive it — otherwise this sweep would resurrect sources right
+        # after deprovision.
         if _managed_source_queryset(team_id).filter(deleted=True).exists():
             return
 
-    try:
-        ensure_managed_warehouse_direct_source(team_id=team_id, organization_id=organization_id)
-    except (DuckgresServer.DoesNotExist, Team.DoesNotExist):
-        return
+        # The control plane, not the DuckgresServer row, is the existence oracle: only a
+        # CP-confirmed live warehouse gets its source (re)created or introspected.
+        if not _cp_warehouse_exists(organization_id):
+            return
+
+        team = Team.objects.select_for_update().only("id").filter(id=team_id, organization_id=organization_id).first()
+        if team is None:
+            return
+
+    ensure_managed_warehouse_direct_source(team_id=team_id, organization_id=organization_id)
 
     with transaction.atomic():
-        server = DuckgresServer.objects.select_for_update().filter(organization_id=organization_id).first()
         team = Team.objects.select_for_update().only("id").filter(id=team_id, organization_id=organization_id).first()
-        if server is None or team is None:
+        if team is None:
             return
 
         source = _managed_source_queryset(team_id).select_for_update().filter(deleted=False).first()
@@ -204,9 +302,8 @@ def reconcile_managed_warehouse_tables(*, team_id: int, organization_id: str | U
 
     with transaction.atomic():
         # Revalidate after live introspection so deprovision wins the race.
-        server = DuckgresServer.objects.select_for_update().filter(organization_id=organization_id).first()
         team = Team.objects.select_for_update().only("id").filter(id=team_id, organization_id=organization_id).first()
-        if server is None or team is None:
+        if team is None:
             return
         source = (
             _managed_source_queryset(team_id)
@@ -259,7 +356,19 @@ def update_managed_warehouse_root_password(*, organization_id: str | UUID, passw
         server.password = password
         server.save(update_fields=["password", "updated_at"])
 
-        config = _source_config(server)
+        config = (
+            SourceRegistry.get_source(ExternalDataSourceType.POSTGRES)
+            .parse_config(
+                {
+                    "host": server.host,
+                    "port": server.port,
+                    "database": server.database,
+                    "user": server.username,
+                    "password": server.password,
+                }
+            )
+            .to_dict()
+        )
         for source in _managed_sources_for_org(organization_id).select_for_update().order_by("team_id"):
             if source.job_inputs != config:
                 source.job_inputs = config

--- a/products/managed_warehouse/backend/logic/connection.py
+++ b/products/managed_warehouse/backend/logic/connection.py
@@ -38,6 +38,7 @@ from rest_framework import status
 from posthog.models.team.team import Team
 
 from products.data_warehouse.backend.facade.api import reconcile_postgres_schemas
+from products.managed_warehouse.backend.common import _log_duckgres_server_access
 from products.managed_warehouse.backend.facade.contracts import ServiceCredential
 from products.managed_warehouse.backend.models import DuckgresServer
 from products.managed_warehouse.backend.service_credentials import mint_service_credential
@@ -352,6 +353,7 @@ def update_managed_warehouse_root_password(*, organization_id: str | UUID, passw
     password and fails silently.
     """
     with transaction.atomic():
+        _log_duckgres_server_access("connection.update_managed_warehouse_root_password:write", str(organization_id))
         server = DuckgresServer.objects.select_for_update().get(organization_id=organization_id)
         server.password = password
         server.save(update_fields=["password", "updated_at"])
@@ -383,6 +385,7 @@ def soft_delete_managed_warehouse_sources(*, organization_id: str | UUID) -> Non
     """
     now = timezone.now()
     with transaction.atomic():
+        _log_duckgres_server_access("connection.soft_delete_managed_warehouse_sources", str(organization_id))
         DuckgresServer.objects.select_for_update().filter(organization_id=organization_id).first()
         sources = list(_managed_sources_for_org(organization_id).select_for_update().order_by("team_id"))
         DataWarehouseTable.raw_objects.filter(

--- a/products/managed_warehouse/backend/presentation/views.py
+++ b/products/managed_warehouse/backend/presentation/views.py
@@ -25,6 +25,8 @@ from rest_framework.response import Response
 
 from posthog.security.outbound_proxy import internal_requests
 
+from products.managed_warehouse.backend.common import _log_duckgres_server_access
+
 logger = structlog.get_logger(__name__)
 
 DATA_WAREHOUSE_SCENE_FLAG = "data-warehouse-scene"
@@ -402,6 +404,7 @@ def _persist_duckgres_server(organization_id: UUID | str, database_name: str | N
 
     try:
         connection = _present_connection({"database": database_name, "username": body.get("username", "root")})
+        _log_duckgres_server_access("views._persist_duckgres_server:write", str(organization_id))
         persist_duckgres_server_for_org(
             organization_id,
             host=connection["host"],
@@ -997,6 +1000,7 @@ def _update_direct_connection_password(organization_id: UUID | str, password: st
         update_managed_warehouse_root_password,  # noqa: PLC0415
     )
 
+    _log_duckgres_server_access("views.reset_password_flow:write", str(organization_id))
     update_managed_warehouse_root_password(organization_id=organization_id, password=password)
 
 

--- a/products/managed_warehouse/backend/tests/test_common.py
+++ b/products/managed_warehouse/backend/tests/test_common.py
@@ -295,3 +295,42 @@ class TestValidateDuckgresIdentifier:
 
         with pytest.raises(ValueError):
             validate_duckgres_identifier(ident)
+
+
+class TestLogDuckgresServerAccess:
+    def test_emits_the_access_event_with_caller_and_org(self) -> None:
+        from structlog.testing import capture_logs
+
+        from products.managed_warehouse.backend.common import _log_duckgres_server_access
+
+        with capture_logs() as cap_logs:
+            _log_duckgres_server_access("common.get_duckgres_server_for_organization", "org-123")
+
+        [event] = [entry for entry in cap_logs if entry.get("event") == "duckgres_server_model_access"]
+        assert event["caller"] == "common.get_duckgres_server_for_organization"
+        assert event["organization_id"] == "org-123"
+        assert event["log_level"] == "info"
+
+    def test_never_raises_and_allows_a_missing_org(self) -> None:
+        from structlog.testing import capture_logs
+
+        from products.managed_warehouse.backend.common import _log_duckgres_server_access
+
+        with (
+            capture_logs() as cap_logs,
+            patch(
+                "products.managed_warehouse.backend.common._structlog_logger.info",
+                side_effect=RuntimeError("logging backend down"),
+            ),
+        ):
+            # A logging failure must be swallowed: the touched path keeps working.
+            _log_duckgres_server_access("common.upsert_duckgres_server_for_org:write", "org-9")
+
+        assert not [entry for entry in cap_logs if entry.get("event") == "duckgres_server_model_access"]
+
+        with capture_logs() as cap_logs:
+            _log_duckgres_server_access("admin._get_server_or_404")
+
+        [event] = [entry for entry in cap_logs if entry.get("event") == "duckgres_server_model_access"]
+        assert event["caller"] == "admin._get_server_or_404"
+        assert event["organization_id"] is None

--- a/products/managed_warehouse/backend/tests/test_connection.py
+++ b/products/managed_warehouse/backend/tests/test_connection.py
@@ -1,7 +1,10 @@
+from datetime import UTC, datetime
 from typing import TypedDict
 
 import pytest
 from unittest.mock import MagicMock, patch
+
+from rest_framework import status
 
 from posthog.hogql.direct_connection import get_direct_connection_source
 from posthog.hogql.query import HogQLQueryExecutor
@@ -13,6 +16,9 @@ from products.data_warehouse.backend.facade.tasks import reconcile_all_managed_w
 from products.managed_warehouse.backend.facade.contracts import (
     ManagedWarehouseTableNames,
     ManagedWarehouseTeamMembership,
+    ServiceCredential,
+    ServiceCredentialConnect,
+    ServiceCredentialUnavailable,
 )
 from products.managed_warehouse.backend.logic.connection import (
     MANAGED_WAREHOUSE_SOURCE_PREFIX,
@@ -26,6 +32,8 @@ from products.managed_warehouse.backend.models import DuckgresServer
 from products.managed_warehouse.backend.presentation import views as managed_warehouse
 from products.warehouse_sources.backend.facade.models import DataWarehouseTable, ExternalDataSchema, ExternalDataSource
 from products.warehouse_sources.backend.facade.source_management import SourceSchema
+
+_MINT_PATH = "products.managed_warehouse.backend.logic.connection.mint_service_credential"
 
 
 class _Connection(TypedDict):
@@ -45,9 +53,81 @@ _CONNECTION: _Connection = {
 }
 
 
+def _cp_response(body: object, status_code: int = status.HTTP_200_OK) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.data = body
+    return resp
+
+
+def _mint_payload(team_id: int, body_override: dict | None = None) -> dict:
+    """A CP mint response body for the team (the username derives from its team id)."""
+    payload = {
+        "username": f"posthog_team_{team_id}_rw",
+        "password": "minted",
+        "expires_at": "2026-08-12T13:00:00Z",
+        "connect": {
+            "host": _CONNECTION["host"],
+            "port": _CONNECTION["port"],
+            "database": _CONNECTION["database"],
+            "sslmode": "require",
+        },
+    }
+    if body_override:
+        payload.update(body_override)
+    return payload
+
+
+@pytest.fixture(autouse=True)
+def _control_plane():
+    """Fake the duckgres control plane for the direct-source flow.
+
+    The mint and the warehouse-status probe both ride views._request, routed here by
+    URL path: POST .../service-credentials answers a per-team mint (recording the call
+    count per team and rotating the password so refreshes are observable), GET
+    .../warehouse/status answers the registered status response (default: a live
+    "ready" warehouse). No DuckgresServer row is created — the flow under test must
+    never consult one.
+    """
+    state: dict[str, object] = {
+        # org id -> status probe response (set per test for the CP-gone/unreachable cases)
+        "status_response": _cp_response({"org_id": "org", "state": "ready"}),
+        "status_error": None,  # set to an exception to simulate an unreachable CP
+        "mint_counts": {},
+        "mint_error": None,  # set to a Response to simulate a CP mint failure
+    }
+
+    def route(method: str, organization_id: str, path: str, **kwargs: object) -> MagicMock:
+        if method == "POST" and path.endswith("/service-credentials"):
+            if state["mint_error"] is not None:
+                return state["mint_error"]  # type: ignore[return-value]
+            team_id = int((kwargs.get("json_body") or {})["team_id"])  # type: ignore[index]
+            counts: dict[int, int] = state["mint_counts"]  # type: ignore[assignment]
+            counts[team_id] = counts.get(team_id, 0) + 1
+            return _cp_response(_mint_payload(team_id, {"password": f"minted-{counts[team_id]}-{team_id}"}))
+        if method == "GET" and path == "/warehouse/status":
+            if state["status_error"] is not None:
+                raise state["status_error"]  # type: ignore[misc]
+            return state["status_response"]  # type: ignore[return-value]
+        raise AssertionError(f"unexpected control-plane call: {method} {organization_id} {path}")
+
+    def expected_username(team_id: int) -> str:
+        return f"posthog_team_{team_id}_rw"
+
+    def latest_password(team_id: int) -> str:
+        counts: dict[int, int] = state["mint_counts"]  # type: ignore[assignment]
+        return f"minted-{counts[team_id]}-{team_id}"
+
+    state["expected_username"] = expected_username
+    state["latest_password"] = latest_password
+
+    with patch("products.managed_warehouse.backend.presentation.views._request", side_effect=route):
+        yield state
+
+
 # Per-test control-plane membership rows, keyed by org id. The CP is the read source for
 # the periodic sweep's team enumeration, so tests register rows here instead of creating
-# Django rows — the per-team connection itself no longer consults the control plane.
+# Django rows.
 _MEMBERSHIPS: dict[str, list[ManagedWarehouseTeamMembership]] = {}
 
 
@@ -104,16 +184,11 @@ def _ensure(team: Team) -> ExternalDataSource:
     return ensure_managed_warehouse_direct_source(team_id=team.id, organization_id=team.organization_id)
 
 
-def _create_server(org: Organization, **overrides: object) -> DuckgresServer:
-    return DuckgresServer.objects.create(organization=org, **{**_CONNECTION, **overrides})
-
-
 @pytest.mark.django_db
 class TestEnsureManagedWarehouseDirectSource:
-    def test_creates_a_query_source_with_the_org_root_credential(self) -> None:
+    def test_creates_a_query_source_from_the_cp_mint(self, _control_plane) -> None:
         org = Organization.objects.create(name="Org")
         team = Team.objects.create(organization=org)
-        _create_server(org)
 
         source = _ensure(team)
 
@@ -123,17 +198,57 @@ class TestEnsureManagedWarehouseDirectSource:
         assert isinstance(source.connection_metadata, dict)
         assert source.connection_metadata["engine"] == "duckdb"
         assert source.prefix == MANAGED_WAREHOUSE_SOURCE_PREFIX
-        # job_inputs carry the org root credential so live queries see every schema.
+        # job_inputs are built from the minted credential and its CP-issued connect
+        # block — the team's canonical project_user login, NOT a DuckgresServer row.
         assert source.job_inputs["host"] == _CONNECTION["host"]
-        assert source.job_inputs["user"] == _CONNECTION["username"]
-        assert source.job_inputs["password"] == _CONNECTION["password"]
+        assert source.job_inputs["port"] == _CONNECTION["port"]
+        assert source.job_inputs["database"] == _CONNECTION["database"]
+        assert source.job_inputs["user"] == _control_plane["expected_username"](team.id)
+        assert source.job_inputs["password"] == _control_plane["latest_password"](team.id)
         assert source.connection_metadata["credential_kind"] == "org_root"
 
-    def test_is_idempotent(self) -> None:
+    def test_mints_with_force_rotate_and_the_direct_source_principal(self, _control_plane) -> None:
+        org = Organization.objects.create(name="Org")
+        team = Team.objects.create(organization=org)
+
+        with patch(
+            _MINT_PATH,
+            return_value=ServiceCredential(
+                username=f"posthog_team_{team.id}_rw",
+                password="minted",
+                expires_at=datetime(2026, 8, 12, 13, 0, tzinfo=UTC),
+                rotated=True,
+                connect=ServiceCredentialConnect(
+                    host="wh.dw.us.postwh.com", port=5432, database="ducklake", sslmode="require"
+                ),
+            ),
+        ) as mint:
+            _ensure(team)
+
+        mint.assert_called_once()
+        args, kwargs = mint.call_args
+        assert args == (str(org.id), team.id)
+        assert kwargs["principal"] == "managed-warehouse:direct-source-setup"
+        assert kwargs["force_rotate"] is True
+
+    def test_propagates_a_control_plane_mint_failure(self, _control_plane) -> None:
+        # No silent fallback to Django state: a CP failure raises (the caller stays
+        # best-effort) and leaves no source behind.
+        _control_plane["mint_error"] = _cp_response({"error": "boom"}, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        org = Organization.objects.create(name="Org")
+        team = Team.objects.create(organization=org)
+
+        with pytest.raises(ServiceCredentialUnavailable):
+            _ensure(team)
+
+        assert not ExternalDataSource._base_manager.filter(
+            team_id=team.id, prefix=MANAGED_WAREHOUSE_SOURCE_PREFIX
+        ).exists()
+
+    def test_is_idempotent(self, _control_plane) -> None:
         # Without dedup, every status poll / re-enable would spawn a duplicate connection.
         org = Organization.objects.create(name="Org")
         team = Team.objects.create(organization=org)
-        _create_server(org)
 
         first = _ensure(team)
         second = _ensure(team)
@@ -141,12 +256,24 @@ class TestEnsureManagedWarehouseDirectSource:
         assert first.pk == second.pk
         assert ExternalDataSource.objects.filter(team_id=team.id, prefix=MANAGED_WAREHOUSE_SOURCE_PREFIX).count() == 1
 
-    def test_works_for_a_legacy_shared_tables_team(self) -> None:
+    def test_refresh_rewrites_job_inputs_from_the_latest_cp_values(self, _control_plane) -> None:
+        # A re-run must snapshot the CURRENT mint: a CP-moved host or a rotated password
+        # lands in job_inputs (a new mint returns a new password by fixture design).
+        org = Organization.objects.create(name="Org")
+        team = Team.objects.create(organization=org)
+
+        source = _ensure(team)
+        assert source.job_inputs["password"] == f"minted-1-{team.id}"
+
+        source = _ensure(team)
+
+        assert source.job_inputs["password"] == f"minted-2-{team.id}"
+
+    def test_works_for_a_legacy_shared_tables_team(self, _control_plane) -> None:
         # No per-team reader policy exists anymore, so nothing about the team's row
         # layout (including the legacy shared tables) blocks its connection.
         org = Organization.objects.create(name="Org")
         team = Team.objects.create(organization=org)
-        _create_server(org)
         _add_membership(team, legacy_shared=True)
 
         source = _ensure(team)
@@ -155,23 +282,9 @@ class TestEnsureManagedWarehouseDirectSource:
         assert isinstance(source.connection_metadata, dict)
         assert source.connection_metadata["credential_kind"] == "org_root"
 
-    def test_needs_no_control_plane_membership(self) -> None:
-        # Root needs no handshake: a team the control plane doesn't know about still
-        # gets its connection.
+    def test_refreshes_a_project_reader_source_onto_the_current_credential(self, _control_plane) -> None:
         org = Organization.objects.create(name="Org")
         team = Team.objects.create(organization=org)
-        _create_server(org)
-
-        source = _ensure(team)
-
-        assert source.direct_query_enabled is True
-        assert isinstance(source.connection_metadata, dict)
-        assert source.connection_metadata["credential_kind"] == "org_root"
-
-    def test_refreshes_a_project_reader_source_onto_the_root_credential(self) -> None:
-        org = Organization.objects.create(name="Org")
-        team = Team.objects.create(organization=org)
-        _create_server(org)
         source = ExternalDataSource.objects.create(
             team=team,
             source_id="managed-source",
@@ -208,8 +321,8 @@ class TestEnsureManagedWarehouseDirectSource:
         managed_source.refresh_from_db()
         team_schema.refresh_from_db()
         assert managed_source.id == source.id
-        assert managed_source.job_inputs["user"] == _CONNECTION["username"]
-        assert managed_source.job_inputs["password"] == _CONNECTION["password"]
+        assert managed_source.job_inputs["user"] == _control_plane["expected_username"](team.id)
+        assert managed_source.job_inputs["password"] == _control_plane["latest_password"](team.id)
         assert managed_source.direct_query_enabled is True
         assert isinstance(managed_source.connection_metadata, dict)
         assert managed_source.connection_metadata["credential_kind"] == "org_root"
@@ -218,10 +331,9 @@ class TestEnsureManagedWarehouseDirectSource:
         # swappable credential changes.
         assert team_schema.deleted is False
 
-    def test_removes_existing_schemas_when_upgrading_a_root_managed_source(self) -> None:
+    def test_removes_existing_schemas_when_upgrading_a_legacy_managed_source(self, _control_plane) -> None:
         org = Organization.objects.create(name="Org")
         team = Team.objects.create(organization=org)
-        _create_server(org)
         source = ExternalDataSource.objects.create(
             team=team,
             source_id="managed-source",
@@ -264,15 +376,15 @@ class TestReconcileManagedWarehouseTables:
     def _setup(self) -> tuple[Organization, Team]:
         org = Organization.objects.create(name="Org")
         team = Team.objects.create(organization=org)
-        _create_server(org)
         _add_membership(team)
         return org, team
 
-    def test_discovers_the_whole_org_catalog_and_makes_it_queryable(self) -> None:
+    def test_discovers_the_whole_org_catalog_and_makes_it_queryable(self, _control_plane) -> None:
         org, team = self._setup()
         other_team = Team.objects.create(organization=org)
-        # Discovery runs as root, so every team's schema shows up on this team's source;
-        # only engine-internal schemas are excluded.
+        # Discovery runs as the minted team credential; the CP grants it the org-wide
+        # read, so every team's schema shows up on this team's source — only
+        # engine-internal schemas are excluded here.
         discovered = [
             _source_schema("events_prod"),
             _source_schema("persons_prod"),
@@ -347,8 +459,8 @@ class TestReconcileManagedWarehouseTables:
         ]
         query_cursor.execute.assert_called_once_with(sql, None)
 
-        # Tables from other teams in the org are queryable too — org-wide visibility
-        # is the point of the root credential.
+        # Tables from other teams in the org are queryable too — the CP-granted org-wide
+        # read on the team credential is the point.
         cross_team_query = HogQLQueryExecutor(
             query=f"SELECT uuid FROM team_{other_team.id}.orders",
             team=team,
@@ -359,7 +471,7 @@ class TestReconcileManagedWarehouseTables:
 
         assert get_direct_connection_source(team, str(source.id), require_pure_direct=True) == source
 
-    def test_discovers_only_internal_schemas_registers_nothing(self) -> None:
+    def test_discovers_only_internal_schemas_registers_nothing(self, _control_plane) -> None:
         org, team = self._setup()
         with patch(
             "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.source.PostgresSource.get_schemas",
@@ -373,7 +485,7 @@ class TestReconcileManagedWarehouseTables:
         source = ExternalDataSource.objects.get(team_id=team.id, prefix=MANAGED_WAREHOUSE_SOURCE_PREFIX)
         assert not ExternalDataSchema.objects.filter(source_id=source.id).exists()
 
-    def test_reintrospects_to_pick_up_new_tables(self) -> None:
+    def test_reintrospects_to_pick_up_new_tables(self, _control_plane) -> None:
         org, team = self._setup()
         with patch(
             "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.source.PostgresSource.get_schemas",
@@ -394,7 +506,55 @@ class TestReconcileManagedWarehouseTables:
         source = ExternalDataSource.objects.get(team_id=team.id, prefix=MANAGED_WAREHOUSE_SOURCE_PREFIX)
         assert ExternalDataSchema.objects.filter(source=source, name=f"shadow_{team.id}_models.new_model").exists()
 
-    def test_reintrospection_revives_a_dropped_and_recreated_table(self) -> None:
+    def test_refreshes_the_source_config_when_cp_values_change(self, _control_plane) -> None:
+        # Normal reconcile must converge job_inputs onto the latest CP-issued values:
+        # a re-mint (rotated password) and a moved dial target both land in the source.
+        org, team = self._setup()
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.source.PostgresSource.get_schemas",
+            return_value=[_source_schema("events_prod")],
+        ):
+            reconcile_managed_warehouse_tables(team_id=team.id, organization_id=org.id)
+
+        source = ExternalDataSource.objects.get(team_id=team.id, prefix=MANAGED_WAREHOUSE_SOURCE_PREFIX)
+        first_password = source.job_inputs["password"]
+
+        with (
+            patch(
+                "products.managed_warehouse.backend.presentation.views._request",
+                side_effect=lambda method, organization_id, path, **kwargs: (
+                    _cp_response(
+                        _mint_payload(
+                            team.id,
+                            {
+                                "password": "minted-rotated",
+                                "connect": {
+                                    "host": "wh2.dw.us.postwh.com",
+                                    "port": 5433,
+                                    "database": "ducklake",
+                                    "sslmode": "require",
+                                },
+                            },
+                        )
+                    )
+                    if method == "POST"
+                    else _cp_response({"org_id": str(org.id), "state": "ready"})
+                ),
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.source.PostgresSource.get_schemas",
+                return_value=[_source_schema("events_prod")],
+            ),
+        ):
+            reconcile_managed_warehouse_tables(team_id=team.id, organization_id=org.id)
+
+        source.refresh_from_db()
+        assert source.job_inputs["password"] == "minted-rotated"
+        assert source.job_inputs["password"] != first_password
+        assert source.job_inputs["host"] == "wh2.dw.us.postwh.com"
+        assert str(source.job_inputs["port"]) == "5433"
+
+    def test_reintrospection_revives_a_dropped_and_recreated_table(self, _control_plane) -> None:
         org, team = self._setup()
         table = _source_schema("recreated", f"team_{team.id}")
         events = _source_schema("events_prod")
@@ -423,7 +583,7 @@ class TestReconcileManagedWarehouseTables:
         assert schema.table is not None
         assert schema.table.deleted is False
 
-    def test_skips_quietly_when_the_warehouse_is_not_reachable(self) -> None:
+    def test_skips_quietly_when_the_warehouse_is_not_reachable(self, _control_plane) -> None:
         # A provisioning warehouse fails introspection on every sweep; that must not raise.
         org, team = self._setup()
         with patch(
@@ -435,7 +595,7 @@ class TestReconcileManagedWarehouseTables:
         source = ExternalDataSource.objects.get(team_id=team.id, prefix=MANAGED_WAREHOUSE_SOURCE_PREFIX)
         assert not ExternalDataSchema.objects.filter(source_id=source.id).exists()
 
-    def test_periodic_sweep_schedules_every_managed_project(self) -> None:
+    def test_periodic_sweep_schedules_every_managed_project(self, _control_plane) -> None:
         org, team = self._setup()
         all_rows = _MEMBERSHIPS[str(org.id)] + [
             # Legacy shared-table membership: root-backed sources support it, so the
@@ -457,7 +617,7 @@ class TestReconcileManagedWarehouseTables:
         assert schedule.call_count == 2
         assert {call.kwargs["team_id"] for call in schedule.call_args_list} == {team.id, team.id + 1}
 
-    def test_periodic_sweep_skips_run_when_control_plane_unreachable(self) -> None:
+    def test_periodic_sweep_skips_run_when_control_plane_unreachable(self, _control_plane) -> None:
         with (
             patch(
                 "products.data_warehouse.backend.tasks.tasks.list_enabled_backfill_team_memberships",
@@ -471,18 +631,17 @@ class TestReconcileManagedWarehouseTables:
 
         schedule.assert_not_called()
 
-    def test_registers_a_connection_for_a_team_without_cp_membership(self) -> None:
-        # The connection no longer depends on control-plane membership: any team in an org
-        # with a provisioned warehouse gets one on reconcile.
+    def test_registers_a_connection_for_a_team(self, _control_plane) -> None:
+        # The CP mint + status probe are the only preconditions: a team of the org gets
+        # its connection on reconcile (no DuckgresServer row is consulted).
         org = Organization.objects.create(name="Org")
         team = Team.objects.create(organization=org)
-        _create_server(org)
 
         reconcile_managed_warehouse_tables(team_id=team.id, organization_id=org.id)
 
         assert ExternalDataSource.objects.filter(team_id=team.id, prefix=MANAGED_WAREHOUSE_SOURCE_PREFIX).exists()
 
-    def test_reconciles_for_a_legacy_shared_tables_team(self) -> None:
+    def test_reconciles_for_a_legacy_shared_tables_team(self, _control_plane) -> None:
         org, team = self._setup()
         _clear_memberships()
         _add_membership(team, legacy_shared=True)
@@ -497,12 +656,10 @@ class TestReconcileManagedWarehouseTables:
         source = ExternalDataSource.objects.get(team_id=team.id, prefix=MANAGED_WAREHOUSE_SOURCE_PREFIX)
         assert ExternalDataSchema.objects.filter(source_id=source.id, name="posthog.events").exists()
 
-    def test_rejects_a_team_membership_from_another_organization(self) -> None:
+    def test_rejects_a_team_from_another_organization(self, _control_plane) -> None:
         org_a = Organization.objects.create(name="Org A")
         org_b = Organization.objects.create(name="Org B")
         team_b = Team.objects.create(organization=org_b)
-        _create_server(org_a, host="a.example.com", password="org-a-password")
-        _create_server(org_b, host="b.example.com", password="org-b-password")
         _add_membership(team_b, "b")
 
         with patch(
@@ -513,17 +670,87 @@ class TestReconcileManagedWarehouseTables:
         assert not ExternalDataSource.objects.filter(team_id=team_b.id).exists()
         get_schemas.assert_not_called()
 
+    def test_never_revives_a_tombstoned_source_when_the_cp_warehouse_is_gone(self, _control_plane) -> None:
+        # Tombstoned locally + 404 from the CP (mirroring the deprovision-converged
+        # codes): the sweep must not even mint, let alone resurrect the source.
+        org, team = self._setup()
+        _ensure(team)
+        soft_delete_managed_warehouse_sources(organization_id=org.id)
+        _control_plane["mint_counts"].clear()  # setup mints aside: nothing new may be minted from here
+        _control_plane["status_response"] = _cp_response({"error": "not found"}, status.HTTP_404_NOT_FOUND)
+
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.source.PostgresSource.get_schemas"
+        ) as get_schemas:
+            reconcile_managed_warehouse_tables(team_id=team.id, organization_id=org.id)
+
+        source = ExternalDataSource._base_manager.get(team_id=team.id, prefix=MANAGED_WAREHOUSE_SOURCE_PREFIX)
+        assert source.deleted is True
+        assert _control_plane["mint_counts"] == {}
+        get_schemas.assert_not_called()
+
+    def test_never_revives_a_tombstoned_source_when_the_cp_reports_deleted(self, _control_plane) -> None:
+        # A 200 whose body carries no live state ("deleted" / absent / unparseable) is
+        # the CP confirming teardown — fail closed, no mint, no resurrection.
+        org, team = self._setup()
+        _ensure(team)
+        soft_delete_managed_warehouse_sources(organization_id=org.id)
+        _control_plane["mint_counts"].clear()
+        _control_plane["status_response"] = _cp_response({"org_id": str(org.id), "state": "deleted"})
+
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.source.PostgresSource.get_schemas"
+        ) as get_schemas:
+            reconcile_managed_warehouse_tables(team_id=team.id, organization_id=org.id)
+
+        source = ExternalDataSource._base_manager.get(team_id=team.id, prefix=MANAGED_WAREHOUSE_SOURCE_PREFIX)
+        assert source.deleted is True
+        assert _control_plane["mint_counts"] == {}
+        get_schemas.assert_not_called()
+
+    def test_never_revives_a_tombstoned_source_when_the_cp_is_unreachable(self, _control_plane) -> None:
+        # Fail-CLOSED on ambiguity: an unreachable CP (or a 5xx) cannot confirm the
+        # warehouse lives, so a tombstoned source stays tombstoned and the next
+        # status read reconciles.
+        org, team = self._setup()
+        _ensure(team)
+        soft_delete_managed_warehouse_sources(organization_id=org.id)
+        _control_plane["mint_counts"].clear()
+        _control_plane["status_error"] = ConnectionError("duckgres down")
+
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.source.PostgresSource.get_schemas"
+        ) as get_schemas:
+            reconcile_managed_warehouse_tables(team_id=team.id, organization_id=org.id)
+
+        source = ExternalDataSource._base_manager.get(team_id=team.id, prefix=MANAGED_WAREHOUSE_SOURCE_PREFIX)
+        assert source.deleted is True
+        assert _control_plane["mint_counts"] == {}
+        get_schemas.assert_not_called()
+
+    def test_skips_when_the_cp_is_unreachable_and_nothing_is_tombstoned(self, _control_plane) -> None:
+        # Same fail-closed posture on the create path: no probe answer, no mint, no source.
+        org, team = self._setup()
+        _control_plane["status_response"] = _cp_response({"error": "boom"}, status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+        reconcile_managed_warehouse_tables(team_id=team.id, organization_id=org.id)
+
+        assert not ExternalDataSource._base_manager.filter(
+            team_id=team.id, prefix=MANAGED_WAREHOUSE_SOURCE_PREFIX
+        ).exists()
+        assert _control_plane["mint_counts"] == {}
+
 
 @pytest.mark.django_db
 class TestManagedWarehouseLifecycle:
     def _org_team_source(self) -> tuple[Organization, Team, ExternalDataSource, DuckgresServer]:
         org = Organization.objects.create(name="Org")
         team = Team.objects.create(organization=org)
-        server = _create_server(org)
+        server = DuckgresServer.objects.create(organization=org, **_CONNECTION)
         source = ensure_managed_warehouse_direct_source(team_id=team.id, organization_id=org.id)
         return org, team, source, server
 
-    def test_update_root_password_rotates_the_server_and_every_managed_source(self) -> None:
+    def test_update_root_password_rotates_the_server_and_every_managed_source(self, _control_plane) -> None:
         org, team, source, server = self._org_team_source()
         other_team = Team.objects.create(organization=org)
         other_source = ensure_managed_warehouse_direct_source(team_id=other_team.id, organization_id=org.id)
@@ -537,9 +764,10 @@ class TestManagedWarehouseLifecycle:
         assert isinstance(other_source.job_inputs, dict)
         assert source.job_inputs["password"] == "rotated"
         assert other_source.job_inputs["password"] == "rotated"
+        assert source.job_inputs["host"] == _CONNECTION["host"]
         assert server.password == "rotated"
 
-    def test_update_root_password_skips_soft_deleted_sources(self) -> None:
+    def test_update_root_password_skips_soft_deleted_sources(self, _control_plane) -> None:
         org, _team, source, server = self._org_team_source()
         soft_delete_managed_warehouse_sources(organization_id=org.id)
 
@@ -549,14 +777,15 @@ class TestManagedWarehouseLifecycle:
         server.refresh_from_db()
         assert server.password == "rotated"
         assert isinstance(source.job_inputs, dict)
-        assert source.job_inputs["password"] == _CONNECTION["password"]
-        # The next ensure revives the source and rewrites its credential from the server.
+        # Untouched by the root-rotation sweep: it still holds the minted credential.
+        assert source.job_inputs["password"] == f"minted-1-{source.team_id}"
+        # The next ensure revives the source and rewrites its credential from the CP.
         revived = ensure_managed_warehouse_direct_source(team_id=source.team_id, organization_id=org.id)
         assert revived.deleted is False
         assert isinstance(revived.job_inputs, dict)
-        assert revived.job_inputs["password"] == "rotated"
+        assert revived.job_inputs["password"] == f"minted-2-{source.team_id}"
 
-    def test_soft_delete_removes_sources_and_their_tables(self) -> None:
+    def test_soft_delete_removes_sources_and_their_tables(self, _control_plane) -> None:
         org, team, source, _server = self._org_team_source()
         table = DataWarehouseTable.objects.create(
             name="events_prod",
@@ -575,6 +804,9 @@ class TestManagedWarehouseLifecycle:
         assert source.deleted is True
         assert table.deleted is True
 
+        # Deprovision's CP teardown makes the probe answer 404 — the sweep must not
+        # resurrect the tombstoned source.
+        _control_plane["status_response"] = _cp_response({"error": "not found"}, status.HTTP_404_NOT_FOUND)
         with patch(
             "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.source.PostgresSource.get_schemas"
         ) as get_schemas:
@@ -588,9 +820,9 @@ class TestManagedWarehouseLifecycle:
         )
         get_schemas.assert_not_called()
 
-    def test_soft_delete_is_atomic_across_all_organization_sources(self) -> None:
+    def test_soft_delete_is_atomic_across_all_organization_sources(self, _control_plane) -> None:
         org = Organization.objects.create(name="Org")
-        _create_server(org)
+        DuckgresServer.objects.create(organization=org, **_CONNECTION)
         team_a = Team.objects.create(organization=org)
         team_b = Team.objects.create(organization=org)
         source_a = _ensure(team_a)


### PR DESCRIPTION
## Summary

The SQL-editor "direct source" flow (`products/managed_warehouse/backend/logic/connection.py`) snapshotted connection values into `ExternalDataSource.job_inputs` straight out of the `DuckgresServer` row, and used that row's existence as the oracle for whether a tombstoned source may be revived. This PR moves both onto the control plane:

- **Value source**: `ensure_managed_warehouse_direct_source` now mints a per-team credential via `mint_service_credential(organization_id, team_id, principal="managed-warehouse:direct-source-setup", force_rotate=True)` and builds `job_inputs` from the credential (username is the canonical `posthog_team_<id>_rw`) plus the mint's CP-issued `connect` block (host, port, database). `force_rotate=True` is deliberate: the provision-time credential is stored state in `ExternalDataSource`'s model and holds no prior credential when (re)written; the CP's rotation is the expiry mechanism. CP failures raise — the best-effort callers (`views.py` `_ensure_direct_source`, the reconcile sweep) keep logging and moving on; there is no silent fallback to Django state.
- **Existence oracle**: `reconcile_managed_warehouse_tables` keeps the model-independent `ExternalDataSource.deleted` tombstone check, but replaces `DuckgresServer.DoesNotExist` / `filter().first() is None` with a probe of the existing `presentation/views.py::_request("GET", organization_id, "/warehouse/status", require_enabled=False)` accessor. Semantics: 404/409 (mirroring the deprovision-converged codes) or a 2xx whose `state` is not `provisioning`/`ready` → "gone ⇒ don't revive"; unreachable CP, 5xx, unconfigured API, or unparseable/non-dict bodies → **fail CLOSED** (don't revive; log; the next status read reconciles).
- **Mint contract**: origin/master did not have `ServiceCredentialConnect`, so this adds it to `facade/contracts.py` (`@frozen` from `posthog.dataclasses`) and makes `mint_service_credential` parse the `connect: {host, port, database, sslmode}` block strictly — a 2xx without it is an older CP than the contract and raises `ServiceCredentialUnavailable` (redacted payloads, as with every other error path in that module). This is the same shape #81655 will land; consumer #81655 rebases onto these definitions conflict-free.

## Why

Removes the `DuckgresServer` read dependency from the SQL-editor direct-source provisioning/reconcile path — one audited blocker for deleting the model. Scope is deliberately narrow: `update_managed_warehouse_root_password`, `soft_delete_managed_warehouse_sources`, client.py root path, storage, temporal, and admin are untouched (separate audit items).

## Test plan

- `products/managed_warehouse/backend/tests/` — **325 passed** (incl. `test_connection.py`: 29; `test_service_credentials.py`: 10)
- `posthog/dags/test_events_backfill_to_duckling.py` + `products/data_warehouse/backend/logic/external_data_source/test/test_tasks.py` — **240 passed**
- New coverage: job_inputs built from CP mint + connect values; mint threaded with the direct-source principal and `force_rotate=True`; CP mint failure raises (no fallback, no partial row); tombstoned + CP-gone (404 and 2xx/`deleted`) ⇒ no revival and no mint; CP unreachable/5xx ⇒ fail-closed, no revival; normal reconcile refreshes job_inputs on CP value changes (rotated password, moved host/port); missing/incomplete `connect` blocks rejected as unavailable without leaking the password in exception text.
- `ruff check` / `ruff format --check` clean; `mypy --cache-fine-grained` clean on all touched files.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*