### PR TITLE
fix(data-imports): strip leaked exception class name from non-retryable sync error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
@@ -871,7 +871,10 @@ class ExternalDataJobWorkflow(PostHogWorkflow):
             elif isinstance(e.cause, exceptions.ApplicationError) and e.cause.type == "NonRetryableException":
                 update_inputs.status = ExternalDataJob.Status.FAILED
                 update_inputs.internal_error = str(e.cause.cause)
-                update_inputs.latest_error = str(e.cause.cause)
+                # `_customer_facing_error` here too (like the else branch): a non-retryable error whose
+                # friendly mapping is None keeps its raw message, and the finalization activity won't
+                # overwrite it — so `str(e.cause.cause)` would leak the wrapped exception class name.
+                update_inputs.latest_error = _customer_facing_error(e.cause.cause)
                 raise
             else:
                 # Handle other activity errors normally


### PR DESCRIPTION
## Problem

- A data warehouse sync that fails with a non-retryable error shows the customer an internal Python class name in front of the error. A GitHub grant denial reads `GithubAccessDeniedError: GitHub can't read this table: ...` in the sync's error message, where the customer should see only the sentence.
- The workflow's `NonRetryableException` branch set `latest_error` to `str(e.cause.cause)`, which Temporal renders as `<ClassName>: <message>`.
- When a source maps an error to a `None` friendly message (keep the raw, already-actionable text), the finalization step never overwrites `latest_error`, so the leaked class name is what gets stored and shown.

## Changes

- The `NonRetryableException` branch now routes `latest_error` through `_customer_facing_error`, the same helper the sibling `else` branch already uses, so the customer sees the message without the class-name prefix.
- `internal_error` still records the full class-prefixed string for debugging.
- This is a value change inside the workflow's error handler, not a change to its activity or child-workflow sequence, so it does not affect Temporal replay determinism.

## How did you test this code?

- `_customer_facing_error` already has unit tests asserting it strips a leaked class name for a `RESTClientRetryableError` and a driver `OperationalError` (`tests/test_external_data_job_activities.py::TestCustomerFacingError`). This change routes the non-retryable branch through that same tested helper.
- Ran `ruff check` and `ruff format --check` on the changed file: clean.
- Not run: the Temporal workflow and end-to-end sync suites, which need a live stack (Postgres, object storage) this sandbox lacks.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: internal error-surfacing change, no API or documented-workflow change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Found while triaging a day of data warehouse sync failures. The same underlying error surfaced both with and without a class-name prefix depending on which failure branch stored it; the prefixed form is this branch. Retryable exhaustion already goes through `_customer_facing_error` (the `else` branch), so only the non-retryable branch still leaked.
- Tools: Claude Code. Skills invoked: `/writing-pr-descriptions`, `/writing-code-comments`.
