### PR TITLE
fix(temporalio): ride out transport-cancellation RPC errors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/temporalio.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/temporalio.py
@@ -81,7 +81,12 @@ _RETRYABLE_RPC_STATUSES = frozenset(
 # single read (ListWorkflowExecutions / GetWorkflowExecutionHistory), not the server rejecting the
 # request. It's the client-side analog of the DEADLINE_EXCEEDED case above, so ride it out too.
 # Match the phrase rather than the whole CANCELLED status so a genuine cancellation still surfaces.
-_RETRYABLE_RPC_MESSAGES = ("h2 protocol error", "Timeout expired")
+#
+# tonic also surfaces status CANCELLED with the message "operation was canceled" when the
+# underlying transport connection is closed mid-request (a known upstream pattern, e.g.
+# temporalio/sdk-core#807) — another connection blip, not an intentional cancellation. Match the
+# phrase, not the whole status, for the same reason as above.
+_RETRYABLE_RPC_MESSAGES = ("h2 protocol error", "Timeout expired", "operation was canceled")
 
 
 def _is_retryable_rpc_error(error: RPCError) -> bool:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/test_temporalio.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/test_temporalio.py
@@ -124,6 +124,9 @@ class TestTransientRPCRetry:
             # tonic cancels a call that outruns the client's RPC deadline with status CANCELLED and
             # message "Timeout expired" — a client-side timeout that must be ridden out, not raised.
             ("Timeout expired", RPCStatusCode.CANCELLED),
+            # A transport connection closed mid-request also surfaces as CANCELLED, with message
+            # "operation was canceled" — a connection blip, not a real cancellation.
+            ("operation was canceled", RPCStatusCode.CANCELLED),
             # A DNS resolution blip surfaces as UNAVAILABLE — a connection-level failure that must
             # be ridden out rather than failing the whole import activity.
             ("dns error", RPCStatusCode.UNAVAILABLE),
@@ -177,7 +180,8 @@ class TestTransientRPCRetry:
             ("workflow execution not found for", RPCStatusCode.NOT_FOUND),
             # UNKNOWN alone must not be retried — only UNKNOWN carrying a transport signature is.
             ("internal server error", RPCStatusCode.UNKNOWN),
-            # CANCELLED alone must not be retried — only the "Timeout expired" phrase qualifies.
+            # CANCELLED alone must not be retried — only the "Timeout expired" and "operation was
+            # canceled" phrases qualify.
             ("Cancelled by caller", RPCStatusCode.CANCELLED),
         ],
     )


### PR DESCRIPTION
## Problem

A data warehouse import from the TemporalIO source failed on a single transient error instead of riding it out, surfaced by [error tracking](https://us.posthog.com/project/2/error_tracking/019ff5c3-593b-74c0-a35b-23c0103e50eb).

The stack trace shows an `RPCError: operation was canceled` (gRPC status `CANCELLED`) raised from `handle.fetch_history()` while paginating workflow histories. This status/message pair is a known upstream pattern (see [temporalio/sdk-core#807](https://github.com/temporalio/sdk-core/issues/807)) where the transport connection closes mid-request - a connection blip, not an intentional cancellation.

## Changes

- Added `"operation was canceled"` to the retryable RPC message list in `temporalio.py`, alongside the existing `"h2 protocol error"` and `"Timeout expired"` phrases this file already rides out in-process rather than failing the whole import activity.
- Matches on the message phrase rather than the whole `CANCELLED` status, so a genuine cancellation (e.g. `"Cancelled by caller"`) still surfaces and fails the activity as before.

## How did you test this code?

Extended the existing parameterized `TestTransientRPCRetry` cases in `test_temporalio.py`:
- Added an `("operation was canceled", RPCStatusCode.CANCELLED)` case to `test_rides_out_transient_error` - catches a regression where this connection blip fails the whole import instead of being ridden out.
- Ran the full `test_temporalio.py` suite locally: 46 passed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal retry classification only, no user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged via PostHog error tracking (issue linked above): pulled the stack trace and a representative event, confirmed the raise site is inside `products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/temporalio.py`, then used `WebSearch` to confirm `RPCError: operation was canceled` with status `CANCELLED` is a known upstream transport-cancellation pattern rather than a genuine cancellation or a user/credential problem. Invoked `/writing-tests` before extending the test file and `/writing-pr-descriptions` before writing this body. No duplicate open PR found for this error (searched by exception type, message phrase, and module path, excluding the automation bot).