### PR TITLE
fix(hogvm): align TypeScript semver comparisons

### DIFF
--- a/common/hogvm/typescript/src/__tests__/execute.test.ts
+++ b/common/hogvm/typescript/src/__tests__/execute.test.ts
@@ -111,6 +111,39 @@ describe('hogvm execute', () => {
         expect(execSync(['_h', op.NULL, op.INTEGER, 1, op.NOT_EQ], options)).toBe(true)
     })
 
+    test('sortable semver arrays use numeric component ordering', () => {
+        const sortableSemver = (version: string): any[] => [op.STRING, version, op.CALL_GLOBAL, 'sortableSemver', 1]
+        const options = {
+            external: {
+                regex: {
+                    extract: (regex: string, value: string): string => {
+                        const match = new RegExp(regex).exec(value)
+                        return match?.[1] ?? match?.[0] ?? ''
+                    },
+                },
+            },
+        }
+        const compareSemver = (left: string, right: string, operation: op): boolean =>
+            execSync(['_H', 1, ...sortableSemver(right), ...sortableSemver(left), operation], options)
+
+        for (const [operation, left, right, expected] of [
+            [op.EQ, '1.2.3', '1.2.3', true],
+            [op.EQ, '1.2.3', '1.2.4', false],
+            [op.NOT_EQ, '1.2.3', '1.2.4', true],
+            [op.NOT_EQ, '1.2.3', '1.2.3', false],
+            [op.GT, '2.0.0', '1.9.9', true],
+            [op.GT, '1.9.9', '2.0.0', false],
+            [op.GT_EQ, '2.0.0', '2.0.0', true],
+            [op.GT_EQ, '1.9.9', '2.0.0', false],
+            [op.LT, '2.9.0', '2.10.0', true],
+            [op.LT, '2.10.0', '2.10.0', false],
+            [op.LT_EQ, '2.10.0', '2.10.0', true],
+            [op.LT_EQ, '2.10.1', '2.10.0', false],
+        ] as const) {
+            expect(compareSemver(left, right, operation)).toBe(expected)
+        }
+    })
+
     test('error handling', async () => {
         const globals = { properties: { foo: 'bar' } }
         const options = { globals }

--- a/common/hogvm/typescript/src/execute.ts
+++ b/common/hogvm/typescript/src/execute.ts
@@ -32,6 +32,55 @@ import {
     unifyComparisonTypes,
 } from './utils'
 
+function compareValues(left: any, right: any, operation: Operation): boolean {
+    ;[left, right] = unifyComparisonTypes(left, right)
+
+    if (Array.isArray(left) && Array.isArray(right) && left.every(Number.isFinite) && right.every(Number.isFinite)) {
+        let ordering = 0
+        for (let i = 0; i < Math.min(left.length, right.length); i++) {
+            if (left[i] !== right[i]) {
+                ordering = left[i] < right[i] ? -1 : 1
+                break
+            }
+        }
+        if (ordering === 0) {
+            ordering = Math.sign(left.length - right.length)
+        }
+
+        switch (operation) {
+            case Operation.EQ:
+                return ordering === 0
+            case Operation.NOT_EQ:
+                return ordering !== 0
+            case Operation.GT:
+                return ordering > 0
+            case Operation.GT_EQ:
+                return ordering >= 0
+            case Operation.LT:
+                return ordering < 0
+            case Operation.LT_EQ:
+                return ordering <= 0
+        }
+    }
+
+    switch (operation) {
+        case Operation.EQ:
+            return left === right
+        case Operation.NOT_EQ:
+            return left !== right
+        case Operation.GT:
+            return left > right
+        case Operation.GT_EQ:
+            return left >= right
+        case Operation.LT:
+            return left < right
+        case Operation.LT_EQ:
+            return left <= right
+        default:
+            throw new HogVMException(`Invalid comparison operation: ${operation}`)
+    }
+}
+
 export function execSync(bytecode: any[] | VMState | Bytecodes, options?: ExecOptions): any {
     const response = exec(bytecode, options)
     if (response.finished) {
@@ -409,28 +458,22 @@ export function exec(input: any[] | VMState | Bytecodes, options?: ExecOptions):
                     pushStack(Number(popStack()) % Number(popStack()))
                     break
                 case Operation.EQ:
-                    ;[temp, temp2] = unifyComparisonTypes(popStack(), popStack())
-                    pushStack(temp === temp2)
+                    pushStack(compareValues(popStack(), popStack(), Operation.EQ))
                     break
                 case Operation.NOT_EQ:
-                    ;[temp, temp2] = unifyComparisonTypes(popStack(), popStack())
-                    pushStack(temp !== temp2)
+                    pushStack(compareValues(popStack(), popStack(), Operation.NOT_EQ))
                     break
                 case Operation.GT:
-                    ;[temp, temp2] = unifyComparisonTypes(popStack(), popStack())
-                    pushStack(temp > temp2)
+                    pushStack(compareValues(popStack(), popStack(), Operation.GT))
                     break
                 case Operation.GT_EQ:
-                    ;[temp, temp2] = unifyComparisonTypes(popStack(), popStack())
-                    pushStack(temp >= temp2)
+                    pushStack(compareValues(popStack(), popStack(), Operation.GT_EQ))
                     break
                 case Operation.LT:
-                    ;[temp, temp2] = unifyComparisonTypes(popStack(), popStack())
-                    pushStack(temp < temp2)
+                    pushStack(compareValues(popStack(), popStack(), Operation.LT))
                     break
                 case Operation.LT_EQ:
-                    ;[temp, temp2] = unifyComparisonTypes(popStack(), popStack())
-                    pushStack(temp <= temp2)
+                    pushStack(compareValues(popStack(), popStack(), Operation.LT_EQ))
                     break
                 case Operation.LIKE:
                     pushStack(like(popStack(), popStack(), false, options?.external?.regex?.match))


### PR DESCRIPTION
## Problem

The TypeScript HogVM misorders semantic versions with multi-digit components and treats equal version arrays as unequal.

`sortableSemver` returns numeric arrays. JavaScript converts those arrays to strings for ordering and compares separate arrays by reference for equality.

## Changes

- TypeScript HogVM now compares finite numeric arrays component by component.
- Valid semver comparisons now match Python and the Rust behavior from the preceding PR.
- Existing JavaScript comparison behavior remains unchanged for other value types.
- The regression matrix covers equality, inequality, all four ordering operations, and multi-digit components.
- This is the TypeScript layer of the stack and depends on the Rust layer in #81731.

## How did you test this code?

- `pnpm --filter=@posthog/hogvm test`
- `pnpm --filter=@posthog/hogvm typecheck`
- `pnpm --filter=@posthog/hogvm build:compile`
- `pnpm exec oxfmt --check common/hogvm/typescript/src/execute.ts common/hogvm/typescript/src/__tests__/execute.test.ts`
- `./bin/hogli ci:preflight --strict`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This fix aligns existing semver behavior across runtimes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I used the pi coding agent with GPT-5.6, the TypeScript toolchain, and GitHub CLI. This environment did not provide a shareable session URL.

Skills invoked: `/stacking-prs`, `/writing-tests`, `/writing-pr-descriptions`, and `writing-simplified-technical-english`.

The committed test versions are invented and contain no user-provided values.
