### PR TITLE
feat(insights): show stale results while an insight refreshes

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/ComputationTimeWithRefresh.tsx
+++ b/frontend/src/queries/nodes/InsightViz/ComputationTimeWithRefresh.tsx
@@ -4,6 +4,7 @@ import { Link, Tooltip } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
 import { usePeriodicRerender } from 'lib/hooks/usePeriodicRerender'
+import { Spinner } from 'lib/lemon-ui/Spinner'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
@@ -17,7 +18,7 @@ export function ComputationTimeWithRefresh({ disableRefresh }: { disableRefresh?
     const { lastRefresh, response, query } = useValues(dataNodeLogic)
 
     const { insightProps } = useValues(insightLogic)
-    const { getInsightRefreshButtonDisabledReason } = useValues(insightDataLogic(insightProps))
+    const { getInsightRefreshButtonDisabledReason, insightDataLoading } = useValues(insightDataLogic(insightProps))
     const { loadData } = useActions(insightDataLogic(insightProps))
     const disabledReason = getInsightRefreshButtonDisabledReason()
 
@@ -37,21 +38,28 @@ export function ComputationTimeWithRefresh({ disableRefresh }: { disableRefresh?
             {!disableRefresh && (
                 <>
                     <span className="px-1">•</span>
-                    <Tooltip
-                        title={
-                            canBypassRefreshDisabled && disabledReason
-                                ? `${disabledReason} (you can bypass this due to dev env / staff permissions)`
-                                : undefined
-                        }
-                    >
-                        <Link
-                            onClick={() => loadData(shouldQueryBeAsync(query) ? 'force_async' : 'force_blocking')}
-                            className={disabledReason ? 'opacity-50' : ''}
-                            disabledReason={canBypassRefreshDisabled ? '' : disabledReason}
+                    {insightDataLoading ? (
+                        <span className="flex items-center gap-1.5">
+                            <Spinner textColored />
+                            Refreshing
+                        </span>
+                    ) : (
+                        <Tooltip
+                            title={
+                                canBypassRefreshDisabled && disabledReason
+                                    ? `${disabledReason} (you can bypass this due to dev env / staff permissions)`
+                                    : undefined
+                            }
                         >
-                            Refresh
-                        </Link>
-                    </Tooltip>
+                            <Link
+                                onClick={() => loadData(shouldQueryBeAsync(query) ? 'force_async' : 'force_blocking')}
+                                className={disabledReason ? 'opacity-50' : ''}
+                                disabledReason={canBypassRefreshDisabled ? '' : disabledReason}
+                            >
+                                Refresh
+                            </Link>
+                        </Tooltip>
+                    )}
                 </>
             )}
         </div>

--- a/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
@@ -5,7 +5,6 @@ import { LemonButton } from '@posthog/lemon-ui'
 
 import { ExportButton } from 'lib/components/ExportButton/ExportButton'
 import { InsightLegend } from 'lib/components/InsightLegend/InsightLegend'
-import { LoadingBar } from 'lib/lemon-ui/LoadingBar'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { Funnel } from 'scenes/funnels/Funnel'
@@ -182,7 +181,6 @@ export function InsightVizDisplay({
     // Empty states that completely replace the graph
     const BlockingEmptyState = (() => {
         if (insightDataLoading) {
-            // Stale results stay visible during reloads; the top bar and "Refreshing" note signal it
             if (hasRenderableResults) {
                 return null
             }
@@ -510,7 +508,6 @@ export function InsightVizDisplay({
             <div
                 className={clsx(
                     `InsightVizDisplay InsightVizDisplay--type-${activeView.toLowerCase()}`,
-                    'relative',
                     !embedded && 'border rounded bg-surface-primary'
                 )}
                 data-attr="insights-graph"
@@ -519,13 +516,6 @@ export function InsightVizDisplay({
                 {!embedded && <HideWeekendsDeprecationNotice insightProps={insightProps} />}
                 {showingResults && (
                     <>
-                        {insightDataLoading && hasRenderableResults && (
-                            <LoadingBar
-                                loadId={queryId}
-                                wrapperClassName="absolute top-0 inset-x-0 z-10 my-0 max-w-none"
-                                className="!h-1"
-                            />
-                        )}
                         {!embedded &&
                             ((isFunnels && hasFunnelResults) ||
                                 isPaths ||

--- a/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
@@ -5,6 +5,7 @@ import { LemonButton } from '@posthog/lemon-ui'
 
 import { ExportButton } from 'lib/components/ExportButton/ExportButton'
 import { InsightLegend } from 'lib/components/InsightLegend/InsightLegend'
+import { LoadingBar } from 'lib/lemon-ui/LoadingBar'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { Funnel } from 'scenes/funnels/Funnel'
@@ -157,6 +158,7 @@ export function InsightVizDisplay({
         supportsDisplay,
         samplingFactor,
         insightDataLoading,
+        hasRenderableResults,
         erroredQueryId,
         timedOutQueryId,
         vizSpecificOptions,
@@ -180,6 +182,10 @@ export function InsightVizDisplay({
     // Empty states that completely replace the graph
     const BlockingEmptyState = (() => {
         if (insightDataLoading) {
+            // Stale results stay visible during reloads; the top bar and "Refreshing" note signal it
+            if (hasRenderableResults) {
+                return null
+            }
             return (
                 <InsightLoadingState
                     queryId={queryId}
@@ -504,6 +510,7 @@ export function InsightVizDisplay({
             <div
                 className={clsx(
                     `InsightVizDisplay InsightVizDisplay--type-${activeView.toLowerCase()}`,
+                    'relative',
                     !embedded && 'border rounded bg-surface-primary'
                 )}
                 data-attr="insights-graph"
@@ -512,6 +519,13 @@ export function InsightVizDisplay({
                 {!embedded && <HideWeekendsDeprecationNotice insightProps={insightProps} />}
                 {showingResults && (
                     <>
+                        {insightDataLoading && hasRenderableResults && (
+                            <LoadingBar
+                                loadId={queryId}
+                                wrapperClassName="absolute top-0 inset-x-0 z-10 my-0 max-w-none"
+                                className="!h-1"
+                            />
+                        )}
                         {!embedded &&
                             ((isFunnels && hasFunnelResults) ||
                                 isPaths ||

--- a/frontend/src/scenes/insights/insightVizDataLogic.test.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.test.ts
@@ -884,6 +884,23 @@ describe('insightVizDataLogic', () => {
         })
     })
 
+    describe('hasRenderableResults', () => {
+        it('tracks whether the loaded response contains results', async () => {
+            await expectLogic(builtInsightVizDataLogic).toMatchValues({ hasRenderableResults: false })
+
+            await expectLogic(builtInsightVizDataLogic, () => {
+                builtInsightDataLogic.actions.loadDataSuccess({ result: funnelResult.result })
+            }).toMatchValues({ hasRenderableResults: true })
+
+            await expectLogic(builtInsightVizDataLogic, () => {
+                builtInsightDataLogic.actions.loadDataSuccess({
+                    cache_key: 'cache_1_abc',
+                    query_status: { id: 'cache_1_abc', complete: false },
+                } as Record<string, any>)
+            }).toMatchValues({ hasRenderableResults: false })
+        })
+    })
+
     describe('isSingleSeriesOutput', () => {
         it('returns true for single series without breakdown', () => {
             expectLogic(builtInsightVizDataLogic, () => {

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -202,6 +202,7 @@ export interface insightVizDataLogicValues {
     hasFormula: boolean
     hasLegend: boolean
     hasOnlyDataWarehouseSeries: boolean
+    hasRenderableResults: boolean
     insightFilter: InsightFilter | null | undefined
     interval: IntervalType | null | undefined
     isAllEventsQuery: boolean
@@ -1197,6 +1198,7 @@ export interface insightVizDataLogicMeta {
         validationError: (insightDataError: Record<string, any> | null) => string | null
         validationErrorCode: (insightDataError: Record<string, any> | null) => string | null
         timezone: (insightData: Record<string, any>) => any
+        hasRenderableResults: (insightData: Record<string, any>) => boolean
         allEventNames: (
             querySource:
                 | FunnelsQuery
@@ -2432,6 +2434,11 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
         ],
 
         timezone: [(s) => [s.insightData], (insightData: Record<string, any>) => insightData?.timezone || 'UTC'],
+
+        hasRenderableResults: [
+            (s) => [s.insightData],
+            (insightData: Record<string, any>): boolean => insightData?.result != null || insightData?.results != null,
+        ],
 
         // all events used in the insight (useful for fetching only relevant property definitions)
         allEventNames: [


### PR DESCRIPTION
## Problem

Opening a saved insight whose cached results are stale replaces the chart with a loading bar until the query recomputes, even though the stale results already reached the browser. Dashboards keep the stale tile visible with a refreshing note; the standalone insight page blanked instead.

## Changes

- While an insight reloads with previous results in hand, the chart, results table, and metadata row stay visible.
- The metadata row swaps the Refresh link for a spinner with "Refreshing", which also closes the double-submit path during a load.
- The blocking loading state still appears when there are no results to show (cold cache).
- Query edits in edit mode keep the previous chart visible, matching dashboard behavior on filter changes.
- Mechanism: `InsightVizDisplay` blanks only when loading and the new `hasRenderableResults` selector is false.
- The early null return in the loading branch also stops stale error and timeout states from replacing the chart mid-reload.

Refreshing a stale insight, the chart stays visible with the "Refreshing" note:
![refresh-stale](https://raw.githubusercontent.com/PostHog/pr-assets/69153880c5b21216a3d8400b62c8f407dae5e41f/2026/08/09288f16-9742-457e-bc40-6dd8a509c154.png)

Cold cache, the blocking loading state is unchanged:
![cold-cache](https://raw.githubusercontent.com/PostHog/pr-assets/0ee5c9a606888b86f0701186445833c232d239bb/2026/08/27f294a5-055b-4291-9f0f-37e507644893.png)

Editing the query (date range changed to last 30 days), the previous chart stays visible:
![edit-reload](https://raw.githubusercontent.com/PostHog/pr-assets/42d2ee1acd19763dad1348462d8ab81bcb22c60b/2026/08/93926fec-db78-4552-989f-43df264fe40f.png)

## How did you test this code?

- New jest test on `hasRenderableResults` catches the gate flipping wrong, which would blank the chart again while stale results exist.
- I (actually Claude) verified the three states above in the local dev app via Playwright with delayed query responses. The screenshots are from the current revision.
- The dashboard-tile check (no doubled indicator) is from an earlier run; dashboards bypass this code path.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No shipped doc covers insight loading states.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built in a Claude Code session using subagent-per-task execution with per-task reviews and a final whole-branch review.
- Repo skills invoked: /writing-tests, /writing-user-facing-copy, /writing-code-comments, /writing-pr-descriptions.
- Design decision: display-only change. The backend already returns stale results alongside an incomplete query status, and the previous results are already in kea state during reloads, so no transport changes were needed.
- Per human direction: always show the last results, including after query edits, and drop the earlier thin top bar since the "Refreshing" note is enough.
