### PR TITLE
feat(hogql): Add new system tables for batch exports

### DIFF
--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -161,6 +161,107 @@ batch_exports: PostgresTable = PostgresTable(
     },
 )
 
+batch_export_on_demands: PostgresTable = PostgresTable(
+    name="batch_export_on_demands",
+    postgres_table_name="posthog_batchexportondemand",
+    access_scope="batch_export",
+    description="Batch exports triggered on demand rather than on a schedule; one row per on-demand export.",
+    fields={
+        "id": StringDatabaseField(name="id", description="On-demand batch export UUID."),
+        "team_id": IntegerDatabaseField(name="team_id"),
+        "destination_id": StringDatabaseField(
+            name="destination_id", description="Identifier of the destination config the export writes to."
+        ),
+        "source_id": StringDatabaseField(
+            name="source_id",
+            nullable=True,
+            description="Source of the data to export, if any; when set, takes precedence over model.",
+        ),
+        "model": StringDatabaseField(
+            name="model",
+            nullable=True,
+            description="Data model exported, e.g. 'events', 'persons', 'sessions' or 'hogql'.",
+        ),
+        "filters": StringJSONDatabaseField(
+            name="filters", nullable=True, description="Filters applied to the exported data."
+        ),
+        "_deleted": BooleanDatabaseField(name="deleted", hidden=True),
+        "deleted": ExpressionField(name="deleted", expr=ast.Call(name="toInt", args=[ast.Field(chain=["_deleted"])])),
+        "created_at": DateTimeDatabaseField(
+            name="created_at", description="When the on-demand batch export was created."
+        ),
+        "last_updated_at": DateTimeDatabaseField(
+            name="last_updated_at", description="When the on-demand batch export was last updated."
+        ),
+    },
+)
+
+
+class _BatchExportRunsTable(PostgresTable, DANGEROUS_NoTeamIdCheckTable):
+    predicates: list[Expr] = [
+        parse_expr(
+            "batch_export_id IN (SELECT id FROM system.batch_exports)"
+            " OR batch_export_on_demand_id IN (SELECT id FROM system.batch_export_on_demands)"
+        )
+    ]
+
+
+batch_export_runs: _BatchExportRunsTable = _BatchExportRunsTable(
+    name="batch_export_runs",
+    postgres_table_name="posthog_batchexportrun",
+    access_scope="batch_export",
+    description="Batch export run history; one row per run.",
+    fields={
+        "id": StringDatabaseField(name="id", description="Run UUID."),
+        "batch_export_id": StringDatabaseField(
+            name="batch_export_id",
+            nullable=True,
+            description="Batch export this run belongs to; joins to batch_exports.id. May be NULL if the run corresponds to an on-demand batch export.",
+        ),
+        "batch_export_on_demand_id": StringDatabaseField(
+            name="batch_export_on_demand_id",
+            nullable=True,
+            description="On-demand batch export this run belongs to; joins to batch_export_on_demands.id. May be NULL if the run corresponds to a regularly scheduled batch export.",
+        ),
+        "backfill_id": StringDatabaseField(
+            name="backfill_id",
+            nullable=True,
+            description="Backfill this run belongs to, if any; joins to batch_export_backfills.id.",
+        ),
+        "data_interval_start": DateTimeDatabaseField(
+            name="data_interval_start",
+            nullable=True,
+            description="Start of the time range covered by the run (NULL means no lower bound).",
+        ),
+        "data_interval_end": DateTimeDatabaseField(
+            name="data_interval_end",
+            nullable=False,
+            description="End of the time range covered by the run",
+        ),
+        "status": StringDatabaseField(
+            name="status", description="Run status, e.g. Running, Completed, Failed, Cancelled."
+        ),
+        "created_at": DateTimeDatabaseField(name="created_at", description="When the run was created."),
+        "finished_at": DateTimeDatabaseField(
+            name="finished_at", nullable=True, description="When the run finished; NULL while still running."
+        ),
+        "last_updated_at": DateTimeDatabaseField(
+            name="last_updated_at", description="When the run row was last updated."
+        ),
+        "records_completed": IntegerDatabaseField(
+            name="records_completed",
+            nullable=True,
+            description="Total number of records exported (NULL while still running or if the run failed).",
+        ),
+        "bytes_exported": IntegerDatabaseField(
+            name="bytes_exported",
+            nullable=True,
+            description="Total number of bytes exported (NULL while still running or if the run failed).",
+        ),
+    },
+)
+
+
 alerts: PostgresTable = PostgresTable(
     name="alerts",
     postgres_table_name="posthog_alertconfiguration",
@@ -2635,6 +2736,8 @@ class SystemTables(TableNode):
         "alerts": TableNode(name="alerts", table=alerts),
         "annotations": TableNode(name="annotations", table=annotations),
         "batch_export_backfills": TableNode(name="batch_export_backfills", table=batch_export_backfills),
+        "batch_export_on_demands": TableNode(name="batch_export_on_demands", table=batch_export_on_demands),
+        "batch_export_runs": TableNode(name="batch_export_runs", table=batch_export_runs),
         "batch_exports": TableNode(name="batch_exports", table=batch_exports),
         "business_knowledge_chunks": TableNode(name="business_knowledge_chunks", table=business_knowledge_chunks),
         "business_knowledge_documents": TableNode(

--- a/posthog/hogql/database/schema/test/test_system_tables.py
+++ b/posthog/hogql/database/schema/test/test_system_tables.py
@@ -109,6 +109,9 @@ TEAM_ID_FILTER_PATTERNS = {
     "_account_tagged_items": "system__accounts.team_id",
     # The custom property tables declare their real team_id column, so the standard direct
     # guard applies (and is pushed into the federated read).
+    # Runs have no team_id column; isolation is enforced via a predicate scoping through the
+    # run's parent (scheduled or on-demand batch export)
+    "batch_export_runs": "system__batch_exports.team_id",
     # Same shape, scoped through system.support_tickets instead
     "_ticket_tagged_items": "system__support_tickets.team_id",
     "_ticket_assignments": "system__support_tickets.team_id",
@@ -194,6 +197,33 @@ def _create_batch_export_backfill(team: Team, label: str):
         team=team, name=f"export_for_backfill_{label}", destination=destination, interval="hour"
     )
     return BatchExportBackfill.objects.create(team=team, batch_export=batch_export, status="Running")
+
+
+def _create_batch_export_run(team: Team, label: str):
+    from products.batch_exports.backend.models.batch_export import BatchExport, BatchExportDestination, BatchExportRun
+
+    destination = BatchExportDestination.objects.create(type="S3", config={})
+    batch_export = BatchExport.objects.create(
+        team=team, name=f"export_for_run_{label}", destination=destination, interval="hour"
+    )
+    return BatchExportRun.objects.create(batch_export=batch_export, status="Running", data_interval_end=timezone.now())
+
+
+def _create_batch_export_on_demand(team: Team, label: str):
+    from products.batch_exports.backend.models.batch_export import BatchExportDestination, BatchExportOnDemand
+
+    destination = BatchExportDestination.objects.create(type="S3", config={})
+    with team_scope(team.pk):
+        return BatchExportOnDemand.objects.create(team=team, destination=destination)
+
+
+def _create_batch_export_run_on_demand(team: Team, label: str):
+    from products.batch_exports.backend.models.batch_export import BatchExportRun
+
+    on_demand = _create_batch_export_on_demand(team, label)
+    return BatchExportRun.objects.create(
+        batch_export_on_demand=on_demand, status="Running", data_interval_end=timezone.now()
+    )
 
 
 def _create_alert(team: Team, label: str) -> AlertConfiguration:
@@ -769,6 +799,10 @@ SYSTEM_TABLE_FACTORIES = [
     ("alerts", _create_alert),
     ("annotations", _create_annotation),
     ("batch_export_backfills", _create_batch_export_backfill),
+    ("batch_export_on_demands", _create_batch_export_on_demand),
+    ("batch_export_runs", _create_batch_export_run),
+    # A run parented by an on-demand export exercises the other branch of the runs table's scoping predicate
+    ("batch_export_runs", _create_batch_export_run_on_demand),
     ("batch_exports", _create_batch_export),
     ("business_knowledge_chunks", _create_business_knowledge_chunk),
     ("business_knowledge_documents", _create_business_knowledge_document),

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -3514,6 +3514,224 @@
           "row_count": null,
           "type": "system"
       },
+      "system.batch_export_on_demands": {
+          "certification": null,
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "destination_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "destination_id",
+                  "id": null,
+                  "name": "destination_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "source_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "source_id",
+                  "id": null,
+                  "name": "source_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "model": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "model",
+                  "id": null,
+                  "name": "model",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "filters": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "filters",
+                  "id": null,
+                  "name": "filters",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "json"
+              },
+              "deleted": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "deleted",
+                  "id": null,
+                  "name": "deleted",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "last_updated_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "last_updated_at",
+                  "id": null,
+                  "name": "last_updated_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.batch_export_on_demands",
+          "name": "system.batch_export_on_demands",
+          "row_count": null,
+          "type": "system"
+      },
+      "system.batch_export_runs": {
+          "certification": null,
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "batch_export_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "batch_export_id",
+                  "id": null,
+                  "name": "batch_export_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "batch_export_on_demand_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "batch_export_on_demand_id",
+                  "id": null,
+                  "name": "batch_export_on_demand_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "backfill_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "backfill_id",
+                  "id": null,
+                  "name": "backfill_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "data_interval_start": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "data_interval_start",
+                  "id": null,
+                  "name": "data_interval_start",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "data_interval_end": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "data_interval_end",
+                  "id": null,
+                  "name": "data_interval_end",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "status": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "status",
+                  "id": null,
+                  "name": "status",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "finished_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "finished_at",
+                  "id": null,
+                  "name": "finished_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "last_updated_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "last_updated_at",
+                  "id": null,
+                  "name": "last_updated_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "records_completed": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "records_completed",
+                  "id": null,
+                  "name": "records_completed",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "bytes_exported": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "bytes_exported",
+                  "id": null,
+                  "name": "bytes_exported",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              }
+          },
+          "id": "system.batch_export_runs",
+          "name": "system.batch_export_runs",
+          "row_count": null,
+          "type": "system"
+      },
       "system.batch_exports": {
           "certification": null,
           "fields": {
@@ -13403,6 +13621,224 @@
           },
           "id": "system.batch_export_backfills",
           "name": "system.batch_export_backfills",
+          "row_count": null,
+          "type": "system"
+      },
+      "system.batch_export_on_demands": {
+          "certification": null,
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "destination_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "destination_id",
+                  "id": null,
+                  "name": "destination_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "source_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "source_id",
+                  "id": null,
+                  "name": "source_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "model": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "model",
+                  "id": null,
+                  "name": "model",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "filters": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "filters",
+                  "id": null,
+                  "name": "filters",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "json"
+              },
+              "deleted": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "deleted",
+                  "id": null,
+                  "name": "deleted",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "last_updated_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "last_updated_at",
+                  "id": null,
+                  "name": "last_updated_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              }
+          },
+          "id": "system.batch_export_on_demands",
+          "name": "system.batch_export_on_demands",
+          "row_count": null,
+          "type": "system"
+      },
+      "system.batch_export_runs": {
+          "certification": null,
+          "fields": {
+              "id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "id",
+                  "id": null,
+                  "name": "id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "batch_export_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "batch_export_id",
+                  "id": null,
+                  "name": "batch_export_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "batch_export_on_demand_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "batch_export_on_demand_id",
+                  "id": null,
+                  "name": "batch_export_on_demand_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "backfill_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "backfill_id",
+                  "id": null,
+                  "name": "backfill_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "data_interval_start": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "data_interval_start",
+                  "id": null,
+                  "name": "data_interval_start",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "data_interval_end": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "data_interval_end",
+                  "id": null,
+                  "name": "data_interval_end",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "status": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "status",
+                  "id": null,
+                  "name": "status",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "created_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_at",
+                  "id": null,
+                  "name": "created_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "finished_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "finished_at",
+                  "id": null,
+                  "name": "finished_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "last_updated_at": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "last_updated_at",
+                  "id": null,
+                  "name": "last_updated_at",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "records_completed": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "records_completed",
+                  "id": null,
+                  "name": "records_completed",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "bytes_exported": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "bytes_exported",
+                  "id": null,
+                  "name": "bytes_exported",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              }
+          },
+          "id": "system.batch_export_runs",
+          "name": "system.batch_export_runs",
           "row_count": null,
           "type": "system"
       },


### PR DESCRIPTION


<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

We don't expose batch export data via system tables for users. So, users can't query, e.g., the status of a run.
<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Similarly to existing backfills table, this adds a runs table and a batch export on demand. Extended system tables tests to cover it.

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added unit tests.
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Maybe? if there is a page about hogql system tables yeah.

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Had the robot review + add some tests. Maybe it overstepped it's welcome? Happy to yank all of that off if it's deemed not worth it.
<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->
