### PR TITLE
feat(aio): filter traces by person from the single trace page

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4722,10 +4722,10 @@ snapshots:
         hash: v1.k794b7964.ea754a4783f7653247f127337c407a8cdd4a9c6bc3f1b908d8d00dd1a090b966.KQ3yKnRzi4l3ZeYVThZdmo4L6mAbxtNa2uQh7y-kGWA
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--tile-filters-read-only--light:
         hash: v1.k794b7964.b2ca2efc52a9ccf56953159c66d3c8766acd1d3a17379d5faec45a4715ae24a9.fK76p7ZVcgvFJNcKJ5Ixy3YnBm_BcBSFnoytLS2jZdU
-    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark
-    :   hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
-    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light
-    :   hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
+    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark:
+        hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
+    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light:
+        hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--dark:
         hash: v1.k794b7964.b1e0f5f542426e34dec73826f3135902a392c0c13dade4fec14037c615186b13.kbxxijyDI1SdvgdKwkRnIRLLgmsine5AYvOcD79DYsY
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--light:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4722,10 +4722,10 @@ snapshots:
         hash: v1.k794b7964.ea754a4783f7653247f127337c407a8cdd4a9c6bc3f1b908d8d00dd1a090b966.KQ3yKnRzi4l3ZeYVThZdmo4L6mAbxtNa2uQh7y-kGWA
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--tile-filters-read-only--light:
         hash: v1.k794b7964.b2ca2efc52a9ccf56953159c66d3c8766acd1d3a17379d5faec45a4715ae24a9.fK76p7ZVcgvFJNcKJ5Ixy3YnBm_BcBSFnoytLS2jZdU
-    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark:
-        hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
-    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light:
-        hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
+    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark
+    :   hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
+    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light
+    :   hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--dark:
         hash: v1.k794b7964.b1e0f5f542426e34dec73826f3135902a392c0c13dade4fec14037c615186b13.kbxxijyDI1SdvgdKwkRnIRLLgmsine5AYvOcD79DYsY
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--light:
@@ -5443,11 +5443,11 @@ snapshots:
     scenes-app-ai-observability-trace--full--light:
         hash: v1.k794b7964.ccfd240291b68c038036220ca359b4987c4ac7323a1e000037cc4ca5b82d8ec9.i9mrpnbsbZ1684VkG-73iX07RcINQT0AeFz9Dpcb9dA
     scenes-app-ai-observability-trace--full-specific-event--dark:
-        hash: v1.k794b7964.9e2b03887812835f8023784604140d29f446039730a7dc25b79e36cde1ed1b6d.QHqBYIGjK-VR1vwG9_SzRgH3BeHv6k00HcHn9RAnM10
+        hash: v1.k794b7964.e3496790d775f03b10ed1bc55489b53bd68a8f1d5bf4c36e92e7c58cba73c3cf.LADKqNV4wMSksDi7YyzIWu2l9bwlxk97FCwHADpTgKc
     scenes-app-ai-observability-trace--full-specific-event--light:
-        hash: v1.k794b7964.20c4c76745d353d2ad3ef1bd0b9804fb219f8e2f609e892e2cfdc5bf8718a235.4i9VZL_CH7pQefsi18fQOQtJh1f0jnk12bZBlZSSoCM
+        hash: v1.k794b7964.1ddd78a021ebd0cd3cea5ca666c614f58559072fe662f906a6088e55996c39f1.-Yz__8kqDKDJjJF22RHdo6Oc7bor-4yVH9B3QlcqUjU
     scenes-app-ai-observability-trace--without-content--dark:
-        hash: v1.k794b7964.43c0a5235771b6bdb554e89d09b43f6aa3603ed7ebe2e0d84858e0d2c15eb278.yNl0wPG__RV5KWRQSSk1AAiPFcFBXftZFMuYZ9uXZeY
+        hash: v1.k794b7964.065a9980470f35b7f51d4e5943b3990752fd4245f5537e67744683bc40e68f73.RrP5nFq9CZ--jD-uCfFALgQcsBQase6zp2D996rVI6k
     scenes-app-ai-observability-trace--without-content--light:
         hash: v1.k794b7964.cdee9ec2c6fded05ad4a583ba11574423b6fbe1685ec0c4c1f777e233845c467.87Jht5vUQnHMpxJ1KeqOIPgUtSlmqRwKAZhhEkgC2EM
     scenes-app-aigateway--empty--dark:

--- a/products/ai_observability/frontend/AIObservabilityTraceScene.tsx
+++ b/products/ai_observability/frontend/AIObservabilityTraceScene.tsx
@@ -14,6 +14,7 @@ import {
     IconComment,
     IconCopy,
     IconDownload,
+    IconFilter,
     IconMessage,
     IconPlay,
     IconPlus,
@@ -63,6 +64,7 @@ import { AccessControlLevel, AccessControlResourceType, SidePanelTab } from '~/t
 
 import type { BranchPRMatchApi } from 'products/engineering_analytics/frontend/generated/api.schemas'
 
+import { PersonData, getFilterIdentifier, getTracesUrlWithPersonFilter } from './aiObservabilityColumnRenderers'
 import { EnrichedTraceTreeNode, findNodeForEvent, aiObservabilityTraceDataLogic } from './aiObservabilityTraceDataLogic'
 import { DisplayOption, TraceViewMode, aiObservabilityTraceLogic } from './aiObservabilityTraceLogic'
 import { AttachedFeedbackPills } from './components/AttachedFeedbackPills'
@@ -604,6 +606,34 @@ function Chip({
     )
 }
 
+// Not built on top of Chip: the email needs its own popover click target, separate
+// from the filter button, so the whole tag can't share one tooltip trigger.
+function PersonChip({ person }: { person: PersonData }): JSX.Element {
+    const { push } = useActions(router)
+    const filterIdentifier = getFilterIdentifier(person)
+
+    return (
+        <LemonTag size="small" className="bg-surface-primary">
+            <span className="sr-only">Person</span>
+            <PersonDisplay withIcon="sm" person={person} />
+            {filterIdentifier && (
+                <Tooltip title={`View traces for ${filterIdentifier.value}`}>
+                    <LemonButton
+                        size="xsmall"
+                        icon={<IconFilter />}
+                        noPadding
+                        className="ml-0.5"
+                        onClick={(e) => {
+                            e.stopPropagation()
+                            push(getTracesUrlWithPersonFilter(filterIdentifier))
+                        }}
+                    />
+                </Tooltip>
+            )}
+        </LemonTag>
+    )
+}
+
 function UsageChip({ event }: { event: LLMTraceEvent | LLMTrace }): JSX.Element | null {
     const usage = formatLLMUsage(event)
     return usage ? (
@@ -1072,9 +1102,7 @@ function TraceMetadata({
 
     return (
         <header className="flex gap-1.5 flex-wrap">
-            <Chip title="Person">
-                <PersonDisplay withIcon="sm" person={personData} />
-            </Chip>
+            <PersonChip person={personData} />
             {trace.aiSessionId && (
                 <Chip title="AI Session ID - Click to view session details">
                     <Link to={getSessionUrl(trace.aiSessionId)} subtle>

--- a/products/ai_observability/frontend/AIObservabilityTraceScene.tsx
+++ b/products/ai_observability/frontend/AIObservabilityTraceScene.tsx
@@ -617,18 +617,18 @@ function PersonChip({ person }: { person: PersonData }): JSX.Element {
             <span className="sr-only">Person</span>
             <PersonDisplay withIcon="sm" person={person} />
             {filterIdentifier && (
-                <Tooltip title={`View traces for ${filterIdentifier.value}`}>
-                    <LemonButton
-                        size="xsmall"
-                        icon={<IconFilter />}
-                        noPadding
-                        className="ml-0.5"
-                        onClick={(e) => {
-                            e.stopPropagation()
-                            push(getTracesUrlWithPersonFilter(filterIdentifier))
-                        }}
-                    />
-                </Tooltip>
+                <LemonButton
+                    size="xsmall"
+                    icon={<IconFilter />}
+                    // A string tooltip also becomes the accessible name of this icon-only button
+                    tooltip={`View traces for ${filterIdentifier.value}`}
+                    noPadding
+                    className="ml-0.5"
+                    onClick={(e) => {
+                        e.stopPropagation()
+                        push(getTracesUrlWithPersonFilter(filterIdentifier))
+                    }}
+                />
             )}
         </LemonTag>
     )


### PR DESCRIPTION
## Problem

Someone looking at one LLM trace cannot get from the person on that trace to the rest of that person's traces. The traces list already has a filter icon next to each person, so the trace page reads as missing it.

## Changes

- The person chip on the single trace page now has a filter icon that opens the traces list filtered to that person.
- The name keeps its old behavior and opens the person popover. Only the icon navigates.
- The icon reuses the filter helpers the traces list and users tab already share, so the filter it builds is the same one (email, username, or distinct id).
- `PersonChip` is a new local component rather than the shared `Chip`. `Chip` wraps the whole tag in one tooltip trigger, which would stack a second tooltip over the icon's own.

Before:

![header-before](https://raw.githubusercontent.com/PostHog/pr-assets/e00e8d76262565a5ce765e34bdd6380548d7d2c8/2026/08/89773bd4-740b-43f5-a6a3-e73eba5f8177.png)

After:

![header-after](https://raw.githubusercontent.com/PostHog/pr-assets/0be87716a835a473b04ac0d7ff39d00be6066e1c/2026/08/590c0524-22e8-44f4-ba9c-d9f8e64624e2.png)

## How did you test this code?

No automated tests added. I (actually the PostHog Slack app) drove the `Scenes-App/AI observability/Trace` Storybook story in headless Chromium and checked three things:

- Chip heights on that header row measure 20px before and after the change, so the person chip still matches the usage and cost chips.
- Clicking the name opens the person popover and does not navigate.
- Hovering the icon shows one tooltip, "View traces for <identifier>", not a second stacked one.

Not checked: the navigation target itself. Storybook runs kea-router on a memory history, so the pushed URL is not observable there. The URL comes from `getTracesUrlWithPersonFilter`, which the users tab already uses unchanged.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually the PostHog Slack app) wrote this from a request in a Slack thread. Skills invoked: `/writing-pr-descriptions`, plus the repo frontend guides for LemonUI reuse.

The first attempt added the icon inside the shared `Chip`. Hovering the icon then showed both the chip's "Person" tooltip and the icon's own, because `Chip` makes the whole tag the tooltip trigger. Splitting it into `PersonChip` was what fixed that, and it also let the name keep its own click target.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1786538782034849)*
