### PR TITLE
fix(hogql): stop rejecting boolean branches beside property accesses

### DIFF
--- a/posthog/hogql/test/test_type_system.py
+++ b/posthog/hogql/test/test_type_system.py
@@ -187,6 +187,22 @@ class TestHogQLTypeSystem:
             assert exc_info.value.start is not None, query
             assert exc_info.value.end is not None, query
 
+    def test_resolver_allows_boolean_branches_beside_property_accesses(self) -> None:
+        # A property access reads as the parent JSON column's type whenever no property-definition
+        # metadata is loaded, so treating that as a real conflict rejects queries ClickHouse runs.
+        for query in (
+            "SELECT coalesce(properties.blocked, false) FROM events",
+            "SELECT ifNull(properties.blocked, false) FROM events",
+            "SELECT if(1, false, properties.blocked) FROM events",
+            "SELECT multiIf(1, false, 2, true, properties.blocked) FROM events",
+            "SELECT coalesce(properties.blocked, properties.plan = 'paid') FROM events",
+            "SELECT coalesce(person.properties.blocked, false) FROM events",
+        ):
+            node = cast(ast.SelectQuery, resolve_types(self._select(query), self.context, dialect="clickhouse"))
+            column_type = node.select[0].type
+            assert column_type is not None
+            assert column_type.resolve_constant_type(self.context) == ast.UnknownType(), query
+
     def test_resolver_poisons_only_unanalyzable_branches(self) -> None:
         # An unmapped function (throwIf) infers as unanalyzable, poisoning the unifying call's type...
         for query in ("SELECT ifNull(throwIf(0, 'x'), 1)", "SELECT if(1, throwIf(0, 'x'), 1)"):

--- a/posthog/hogql/test/test_type_system.py
+++ b/posthog/hogql/test/test_type_system.py
@@ -12,6 +12,7 @@ from posthog.hogql.errors import QueryError
 from posthog.hogql.functions.mapping import find_hogql_function
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import print_prepared_ast
+from posthog.hogql.property_metadata import PropertyMetadata
 from posthog.hogql.resolver import resolve_types
 from posthog.hogql.transforms.type_aware_simplification import simplify_redundant_type_operations
 from posthog.hogql.type_diagnostics import (
@@ -202,6 +203,11 @@ class TestHogQLTypeSystem:
             column_type = node.select[0].type
             assert column_type is not None
             assert column_type.resolve_constant_type(self.context) == ast.UnknownType(), query
+
+        # A loaded property definition types the property confidently enough to conflict with the
+        # boolean branch, so only the property-access check keeps this query from being rejected.
+        self.context.property_metadata = PropertyMetadata(event_properties={"signup": {"type": "DateTime"}})
+        self._assert_first_column_type("SELECT coalesce(properties.signup, false) FROM events", ast.UnknownType())
 
     def test_resolver_poisons_only_unanalyzable_branches(self) -> None:
         # An unmapped function (throwIf) infers as unanalyzable, poisoning the unifying call's type...

--- a/posthog/hogql/type_system.py
+++ b/posthog/hogql/type_system.py
@@ -742,7 +742,11 @@ def _branch_type_is_untrustworthy(branch_type: ast.ConstantType, expr: Optional[
     resolver frequently does not have loaded - it then falls back to the JSON type of the parent
     `properties` column, regardless of what the property actually holds. The printer resolves the
     physical read separately, so `coalesce(properties.blocked, false)` reaches ClickHouse with two
-    compatible branches even though inference reports JSON and Boolean."""
+    compatible branches even though inference reports JSON and Boolean.
+
+    Every property access is skipped, not only the metadata-missing fallback: a loaded property
+    definition types the property from the values seen so far, which is still a guess about what a
+    given row holds, so it is no safer to raise on than the JSON fallback."""
     if runtime_type_from_constant_type(branch_type).family in _UNTRUSTWORTHY_BRANCH_FAMILIES:
         return True
     while isinstance(expr, ast.Alias):

--- a/posthog/hogql/type_system.py
+++ b/posthog/hogql/type_system.py
@@ -164,6 +164,11 @@ DATETIME_RUNTIME_TYPE = RuntimeType(family="datetime")
 # Families least_common_runtime_type() already unifies with boolean (bool literals read as 0/1).
 _BOOLEAN_COMPATIBLE_FAMILIES: frozenset[RuntimeTypeFamily] = frozenset({"boolean", "integer", "float", "decimal"})
 
+# JSON is what a property access falls back to when no property-definition metadata is available,
+# and it also covers native JSON/Dynamic columns. Either way the family says nothing about the type
+# ClickHouse ends up with, so a mismatch against it is never trustworthy enough to raise on.
+_UNTRUSTWORTHY_BRANCH_FAMILIES: frozenset[RuntimeTypeFamily] = frozenset({"json"})
+
 
 _INTEGER_RE = re.compile(r"^(U?Int)(8|16|32|64|128|256)$", re.IGNORECASE)
 _FLOAT_RE = re.compile(r"^Float(32|64)$", re.IGNORECASE)
@@ -730,6 +735,21 @@ def least_common_supertype(types: Sequence[ast.ConstantType], dialect: HogQLDial
     return constant_type_from_runtime_type(least_common_runtime_type(runtime_types, dialect=dialect))
 
 
+def _branch_type_is_untrustworthy(branch_type: ast.ConstantType, expr: Optional[ast.Expr]) -> bool:
+    """Whether a branch's inferred type is too weak a signal to raise a user-facing error over.
+
+    A property access (`properties.blocked`) is typed from property-definition metadata, which the
+    resolver frequently does not have loaded - it then falls back to the JSON type of the parent
+    `properties` column, regardless of what the property actually holds. The printer resolves the
+    physical read separately, so `coalesce(properties.blocked, false)` reaches ClickHouse with two
+    compatible branches even though inference reports JSON and Boolean."""
+    if runtime_type_from_constant_type(branch_type).family in _UNTRUSTWORTHY_BRANCH_FAMILIES:
+        return True
+    while isinstance(expr, ast.Alias):
+        expr = expr.expr
+    return expr is not None and isinstance(expr.type, ast.PropertyType)
+
+
 def _branch_supertype_or_raise(
     branch_types: list[ast.ConstantType],
     branch_args: Sequence[Optional[ast.Expr]],
@@ -744,7 +764,9 @@ def _branch_supertype_or_raise(
     rather than raising on every family combination with no explicit unification rule: many
     generated queries elsewhere in the codebase mix families (e.g. DateTime with a String
     placeholder, JSON with a String default) that silently degrade to UnknownType today and work
-    fine against ClickHouse, so raising there would be a false positive."""
+    fine against ClickHouse, so raising there would be a false positive. Branches whose inferred
+    type is a guess rather than a fact are skipped for the same reason - see
+    _branch_type_is_untrustworthy."""
     result = least_common_supertype(branch_types, dialect=dialect)
     if not isinstance(result, ast.UnknownType) or result.unanalyzable:
         return result
@@ -754,6 +776,8 @@ def _branch_supertype_or_raise(
         if not isinstance(branch_type, ast.UnknownType)
     ]
     if len(known) < 2:
+        return result
+    if any(_branch_type_is_untrustworthy(branch_type, expr) for branch_type, expr in known):
         return result
     families = {runtime_type_from_constant_type(branch_type).family for branch_type, _ in known}
     if "boolean" not in families or not (families - _BOOLEAN_COMPATIBLE_FAMILIES):


### PR DESCRIPTION
User reported insights crashing, traced it to this. 

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019ff0b2-a498-7fd1-9e45-4ae8a17c9e4c

## Problem

- Saved SQL insights and dashboards started failing validation on 2026-08-11 with `Cannot find a common type between \`coalesce\` branches of type Boolean and JSON`, across many teams and on both `coalesce` and `ifNull`.
- The failures are false positives: the same queries ran fine before, and ClickHouse's own `NO_COMMON_TYPE` volume did not move when these appeared, so nothing shifted from a runtime error to a validation error — the errors are net new.
- A property access resolves to the parent `properties` column's JSON type whenever property-definition metadata isn't loaded, whatever the property actually holds (`PropertyType.resolve_constant_type`). The printer lowers the physical read separately, so `coalesce(properties.blocked, false)` reaches ClickHouse with two compatible branches while inference reports JSON and Boolean.
- `_branch_supertype_or_raise` (added in [#77046](https://github.com/PostHog/posthog/pull/77046)) raises on any boolean-vs-non-numeric pair, so that inference guess became a hard error at validation time. It reaches every surface that validates HogQL: insight refresh, cache warming, and Max's query tools.
- Error tracking: [coalesce](https://us.posthog.com/project/2/error_tracking/019ff0b2-a498-7fd1-9e45-4ae8a17c9e4c), [ifNull](https://us.posthog.com/project/2/error_tracking/019ff077-1611-7051-aae3-d3e78c847cfd), both first seen the day #77046 shipped and still active.

## Changes

- `if`/`ifNull`/`multiIf`/`coalesce` no longer raise when a branch's inferred type is a guess rather than a fact — they degrade to `UnknownType` as they did before #77046.
- A branch counts as untrustworthy when its family is JSON, or when the expression resolves to a `PropertyType`. Both are the "no metadata, fall back to the parent column" path; the second also covers a property typed `String` by metadata that mixes with a boolean.
- The case #77046 was written for still raises: real columns and literals with genuinely incompatible types, e.g. `if(is_prior_customer, false, won_date)`.
- Deliberately not a revert. The original error message is a real improvement over ClickHouse's positionless `NO_COMMON_TYPE`, so this keeps it and narrows what triggers it.

## How did you test this code?

- Added `test_resolver_allows_boolean_branches_beside_property_accesses` in `posthog/hogql/test/test_type_system.py`, covering all four functions with a property-access branch beside a boolean branch. It catches a re-broadening of the raise, which is exactly the regression that shipped: without the fix, all six queries in it throw.
- `#77046`'s own `test_resolver_raises_on_incompatible_branch_types` still passes unchanged, which is the guard against over-narrowing.
- Ran `uv run pytest posthog/hogql/test/test_type_system.py` and `uv run mypy --cache-fine-grained .` (clean, repo-wide).
- Not verified: no Postgres or ClickHouse in this sandbox, so nothing was run end to end against a real query, and the printed SQL for these expressions was not inspected. The claim that ClickHouse accepts them rests on the error-volume comparison above, not on a local execution.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal type-inference behavior, no documented surface changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude via the PostHog Slack app, from a support report of broken dashboard visualizations. Invoked `/writing-tests` and `/writing-pr-descriptions`.
- Diagnosis order: found the error string in `type_system.py`, traced it to #77046 merged the day before, then used error tracking to confirm the regression shape — the new `QueryError` volume is additive on top of a flat ClickHouse `NO_COMMON_TYPE` baseline, so these queries used to succeed. Stack frames on the exception events pointed at `hogql_query_runner` under cache warming, i.e. users' own saved SQL rather than a generated query.
- Reproduced locally without a database by resolving `SELECT coalesce(properties.foo, false) FROM events` against a bare `Database()`, which raises, and by confirming `coalesce(properties.foo, 'x')` does not — that asymmetry is what pinned the trigger to the boolean pairing rather than to property typing in general.
- Considered reverting #77046 outright. Kept its error instead, since the message and source span are genuinely better than what ClickHouse returns, and only the trigger condition was wrong.
- No customer data, ticket contents, or conversation text is included in this PR.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C045L1VEG87/p1786539271266459?thread_ts=1786539271.266459&cid=C045L1VEG87)*

