### PR TITLE
fix(postgres): align read schema to the columns actually returned

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/arrow_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/arrow_utils.py
@@ -580,6 +580,23 @@ def table_from_py_list(table_data: list[Any], schema: Optional[pa.Schema] = None
     return table_from_iterator(iter(table_data), schema=schema)
 
 
+def restrict_schema_to_columns(schema: pa.Schema, column_names: Sequence[str]) -> pa.Schema:
+    """Drop fields from `schema` that aren't among `column_names`.
+
+    `pa.Table.from_pydict` raises an opaque KeyError ("The passed mapping doesn't contain the
+    following field(s) of the schema: ...") when the provided schema declares a column the row
+    mapping lacks. A SQL source builds its Arrow schema from columns discovered during setup, but
+    the streaming read can return a strict subset — e.g. a column dropped at the source, or the
+    table recreated with a narrower shape, between discovery and the read. Restricting the schema
+    to the columns the query actually returned lets the batch build; extra columns present in the
+    rows but not the schema are still handled by `_process_batch`, which appends them.
+    """
+    present = set(column_names)
+    if all(name in present for name in schema.names):
+        return schema
+    return pa.schema([field for field in schema if field.name in present])
+
+
 def build_pyarrow_decimal_type(precision: int, scale: int) -> pa.Decimal128Type | pa.Decimal256Type:
     if precision <= 38:
         return pa.decimal128(precision, scale)

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_utils.py
@@ -32,6 +32,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arr
     observe_and_project_table,
     observed_schema_metadata_columns,
     raise_on_nullability_drift,
+    restrict_schema_to_columns,
     source_uses_delta_write_column_selection,
     table_from_py_list,
 )
@@ -337,6 +338,31 @@ def test_table_from_py_list_schema_missing_temporal_column(value, expected_type)
 
     assert table.schema.field("ts").type == expected_type
     assert table.column("ts").to_pylist() == [value]
+
+
+def test_restrict_schema_to_columns_drops_fields_absent_from_the_read():
+    # A SQL source's discovered schema can declare a column the streaming read no longer returns
+    # (dropped at the source, or the table recreated with a narrower shape, between discovery and
+    # the read). `from_pydict` crashes with an opaque KeyError in that case, so the read path first
+    # restricts the schema to the columns it actually got back.
+    schema = pa.schema(
+        cast(Any, [pa.field("id", pa.int64()), pa.field("name", pa.string()), pa.field("dropped", pa.string())])
+    )
+    rows = [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}]
+
+    with pytest.raises(KeyError):
+        table_from_py_list(rows, schema)
+
+    restricted = restrict_schema_to_columns(schema, ["id", "name"])
+    assert restricted.names == ["id", "name"]
+    assert restricted.field("id").type == pa.int64()
+
+    table = table_from_py_list(rows, restricted)
+    assert table.schema.names == ["id", "name"]
+    assert table.column("id").to_pylist() == [1, 2]
+
+    # When every schema field is present the schema is returned unchanged (common case).
+    assert restrict_schema_to_columns(restricted, ["id", "name"]) is restricted
 
 
 @pytest.mark.parametrize(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/partitioned_tables.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/partitioned_tables.py
@@ -14,6 +14,7 @@ from structlog.types import FilteringBoundLogger
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arrow_utils import (
     QueryTimeoutException,
+    restrict_schema_to_columns,
     table_from_iterator,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.partitioning import (
@@ -440,12 +441,13 @@ def iterate_date_windows(
                     logger.debug(f"window query lo={lo} hi={hi}: {query.as_string()}")
                     cur.execute(query)
                     columns = [c.name for c in cur.description or []]
+                    window_schema = restrict_schema_to_columns(arrow_schema, columns)
                     while True:
                         rows = cur.fetchmany(chunk_size)
                         if not rows:
                             break
                         rows_this_window += len(rows)
-                        yield table_from_iterator((dict(zip(columns, r)) for r in rows), arrow_schema)
+                        yield table_from_iterator((dict(zip(columns, r)) for r in rows), window_schema)
         except psycopg.errors.QueryCanceled:
             qc_retries += 1
             if qc_retries > WINDOW_MAX_QUERY_CANCELED_RETRIES or window <= min_window:
@@ -626,12 +628,13 @@ def iterate_partitions(
                 logger.debug(f"partition query {child.schema}.{child.name}: {query.as_string()}")
                 cur.execute(query)
                 columns = [c.name for c in cur.description or []]
+                partition_schema = restrict_schema_to_columns(arrow_schema, columns)
                 while True:
                     rows = cur.fetchmany(chunk_size)
                     if not rows:
                         break
                     rows_this_partition += len(rows)
-                    yield table_from_iterator((dict(zip(columns, r)) for r in rows), arrow_schema)
+                    yield table_from_iterator((dict(zip(columns, r)) for r in rows), partition_schema)
 
         elapsed = clock() - p_start
         total_rows += rows_this_partition

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -45,6 +45,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arr
     QueryTimeoutException,
     TemporaryFileSizeExceedsLimitException,
     build_pyarrow_decimal_type,
+    restrict_schema_to_columns,
     table_from_iterator,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.consts import (
@@ -3524,7 +3525,10 @@ def postgres_source(
 
                             offset += len(rows)
 
-                            yield table_from_iterator((dict(zip(column_names, row)) for row in rows), arrow_schema)
+                            yield table_from_iterator(
+                                (dict(zip(column_names, row)) for row in rows),
+                                restrict_schema_to_columns(arrow_schema, column_names),
+                            )
 
                             successive_errors = 0
                             successive_conn_errors = 0
@@ -3723,6 +3727,7 @@ def postgres_source(
                             cursor.execute(query)
 
                             column_names = [column.name for column in cursor.description or []]
+                            read_schema = restrict_schema_to_columns(arrow_schema, column_names)
 
                             while True:
                                 rows = cursor.fetchmany(chunk_size)
@@ -3731,7 +3736,7 @@ def postgres_source(
 
                                 dicts = [dict(zip(column_names, row)) for row in rows]
                                 del rows
-                                yield table_from_iterator(iter(dicts), arrow_schema)
+                                yield table_from_iterator(iter(dicts), read_schema)
                                 offset += len(dicts)
                     return
                 except psycopg.errors.SerializationFailure as e:


### PR DESCRIPTION
## Problem

- A Postgres data-warehouse sync crashes when the table it reads returns fewer columns than PostHog discovered moments earlier, failing the customer's import.
- PostHog builds the Arrow schema for a table from the columns read during setup, then opens a separate connection to stream rows.
- If a column is dropped at the source, or the table is recreated with a narrower shape, between those two steps, the streaming read returns a strict subset of the discovered columns.
- `pa.Table.from_pydict` then raises an opaque `KeyError` ("the passed mapping doesn't contain the following field(s) of the schema") because the schema declares columns the row batch lacks.
- Seen in error tracking on a table whose wide, ELT-managed shape changed under an active sync: [issue 019ff610](https://us.posthog.com/project/2/error_tracking/019ff610-de29-7e51-bcf3-64a8244a1491).

## Changes

- Restrict the discovered schema to the columns each read actually returned, before building the Arrow batch.
- Apply it on every Postgres read path: server cursor, offset chunking, windowed, and per-partition.
- Extra columns present in the rows but not the schema are unchanged; `_process_batch` still appends them.
- The new `restrict_schema_to_columns` helper lives in `arrow_utils.py` next to `table_from_iterator`; no other source calls it, so their behavior is unchanged.

## How did you test this code?

- Added `test_restrict_schema_to_columns_drops_fields_absent_from_the_read`: it asserts `from_pydict` raises `KeyError` when a schema field is missing from the rows (the crash), then that restricting the schema builds the table with the columns present. No existing test covered a schema field absent from the batch.
- Ran that test locally (passes). Not run: the database-backed Postgres source suites, which need a live Postgres this sandbox lacks.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged from an error-tracking webhook by Claude (Opus 4.8) via the Claude Agent SDK. I (actually Claude) confirmed the failing frame chain (`get_rows` → `table_from_iterator` → `_process_batch` → `pa.Table.from_pydict`) is a genuine call path, not serialized log context.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Classified as a fixable bug rather than a non-retryable user/upstream error: the failure is our Arrow-building code assuming the read matches setup-time discovery, not a credential, config, or third-party condition. Chose to reconcile the schema to the live cursor columns rather than widen `NonRetryableErrors`.
