### PR TITLE
fix(ci): survive Docker Hub pull rate limits

### DIFF
--- a/.agents/skills/debugging-ci-failures/SKILL.md
+++ b/.agents/skills/debugging-ci-failures/SKILL.md
@@ -121,6 +121,7 @@ explains the run's conclusion. Keep excerpts under 40 lines.
 | `manage.py migrate` error, `migrations:check` failure, missing migration | migration / schema  | `hogli migrations:check` locally                                   |
 | OpenAPI schema diff, generated API types out of sync                     | codegen drift       | `hogli build:openapi`                                              |
 | `Cannot connect`, `ECONNREFUSED`, OOM, runner killed, setup step timeout | infra / runner      | treat as transient; report, do not fix                             |
+| `toomanyrequests` / `unauthenticated pull rate limit` on a pull          | Docker Hub limit    | read the launch log tail; check whether the pull was authenticated |
 | `apt-get`, `uv sync`, `pnpm install`, docker pull, setup action failures | environment / setup | diff `.nvmrc`, `pyproject.toml`, `package.json`, Dockerfiles       |
 | `hogli lint:skills`, `hogli build:skills` failure                        | skills build        | run the same `hogli` command locally                               |
 | SDK compat check, `ci-survey-sdk-check`, cross-version failure           | SDK compatibility   | check SDK version matrix for the affected package                  |

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -818,6 +818,20 @@ jobs:
                   username: ${{ vars.DOCKERHUB_USER }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+            # The warehouse-sources shards start their own containers through
+            # testcontainers, which authenticates from DOCKER_AUTH_CONFIG rather than
+            # the credentials the login step wrote.
+            # https://testcontainers-python.readthedocs.io/en/latest/#private-docker-registry
+            - name: Authenticate testcontainers image pulls
+              if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+              env:
+                  DOCKERHUB_USER: ${{ vars.DOCKERHUB_USER }}
+                  DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+              run: |
+                  encoded=$(printf '%s:%s' "$DOCKERHUB_USER" "$DOCKERHUB_PASSWORD" | base64 -w 0)
+                  echo "::add-mask::$encoded"
+                  echo "DOCKER_AUTH_CONFIG={\"auths\":{\"https://index.docker.io/v1/\":{\"auth\":\"${encoded}\"}}}" >> "$GITHUB_ENV"
+
             - name: Start services
               env:
                   COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml

--- a/bin/ci-wait-for-docker
+++ b/bin/ci-wait-for-docker
@@ -4,7 +4,9 @@ set -euo pipefail
 # CI-only helper around Docker Compose startup and readiness checks.
 #
 # `launch` starts services with the current Compose context and returns
-# immediately when `--background` is used so the runner can do other work.
+# immediately when `--background` is used so the runner can do other work. It
+# keeps its output in a log file and retries registry rate limits with a longer
+# backoff than other startup failures get.
 # `wait` delegates readiness polling to bin/wait-for-docker. It waits for any
 # in-flight background `launch` for the same Compose context before starting
 # health timeouts and retries only when timed-out services never materialized
@@ -19,8 +21,14 @@ DEFAULT_COMPOSE_FILE="${REPO_ROOT}/docker-compose.dev.yml"
 WAIT_RETRIES="${WAIT_FOR_DOCKER_RETRIES:-1}"
 WAIT_RETRY_TIMEOUT="${WAIT_FOR_DOCKER_RETRY_TIMEOUT:-120}"
 COMPOSE_WAIT_TIMEOUT="${WAIT_FOR_COMPOSE_TIMEOUT:-600}"
-LAUNCH_RETRIES="${WAIT_FOR_DOCKER_LAUNCH_RETRIES:-1}"
+LAUNCH_RETRIES="${WAIT_FOR_DOCKER_LAUNCH_RETRIES:-3}"
 LAUNCH_RETRY_DELAY="${WAIT_FOR_DOCKER_LAUNCH_RETRY_DELAY:-5}"
+# Registry rejections outlast the seconds-long backoff that a flaky daemon needs,
+# because Docker Hub meters pulls over a six-hour window.
+# https://docs.docker.com/docker-hub/usage/pulls/
+LAUNCH_RATE_LIMIT_RETRY_DELAY="${WAIT_FOR_DOCKER_RATE_LIMIT_RETRY_DELAY:-60}"
+RATE_LIMIT_PATTERN='toomanyrequests|pull rate limit'
+LAUNCH_LOG_TAIL_LINES=40
 
 usage() {
     cat <<'EOF'
@@ -55,12 +63,52 @@ compose() {
     fi
 }
 
-background_launch_pid_file() {
+compose_state_key() {
     local compose_file="${COMPOSE_FILE:-$DEFAULT_COMPOSE_FILE}"
-    local state_key
 
-    state_key=$(printf '%s\n%s\n%s\n' "$REPO_ROOT" "$compose_file" "${COMPOSE_PROFILES:-}" | cksum | awk '{print $1}')
-    printf '%s/ci-wait-for-docker-%s.pid\n' "${TMPDIR:-/tmp}" "$state_key"
+    printf '%s\n%s\n%s\n' "$REPO_ROOT" "$compose_file" "${COMPOSE_PROFILES:-}" | cksum | awk '{print $1}'
+}
+
+background_launch_pid_file() {
+    printf '%s/ci-wait-for-docker-%s.pid\n' "${TMPDIR:-/tmp}" "$(compose_state_key)"
+}
+
+# A background launch writes to the "Start services" step, which has already been
+# closed by the time `wait` reports the failure, so keep a copy the wait step can
+# quote from.
+launch_log_file() {
+    printf '%s/ci-wait-for-docker-%s.log\n' "${TMPDIR:-/tmp}" "$(compose_state_key)"
+}
+
+launch_log_shows_rate_limit() {
+    local launch_log
+    launch_log="$(launch_log_file)"
+
+    [ -s "$launch_log" ] && grep -qiE "$RATE_LIMIT_PATTERN" "$launch_log"
+}
+
+report_launch_diagnostics() {
+    local launch_log
+    launch_log="$(launch_log_file)"
+
+    if [ ! -s "$launch_log" ]; then
+        return 0
+    fi
+
+    if launch_log_shows_rate_limit; then
+        cat <<'EOF'
+==========================================
+Docker Hub rate-limited this job's image pulls, so the services never started.
+Anonymous pulls are metered per runner egress IP, so a job can be rejected as
+unauthenticated even after `docker login` succeeded. Confirm the credentials
+reached the pull before writing this off as a flake.
+https://docs.docker.com/docker-hub/usage/pulls/
+==========================================
+EOF
+    fi
+
+    echo "Last ${LAUNCH_LOG_TAIL_LINES} lines of the Docker Compose launch log:"
+    tail -n "$LAUNCH_LOG_TAIL_LINES" "$launch_log"
 }
 
 read_background_launch_pid() {
@@ -148,6 +196,10 @@ compose_up() {
     fi
 }
 
+compose_up_logged() {
+    compose_up "$@" 2>&1 | tee -a "$(launch_log_file)"
+}
+
 missing_services() {
     local services=("$@")
     local missing=()
@@ -181,7 +233,7 @@ run_launch_once() {
             ;;
     esac
 
-    compose_up "$@"
+    compose_up_logged "$@"
 }
 
 run_launch() {
@@ -220,6 +272,7 @@ run_launch() {
     done
 
     launch_services=("$@")
+    : > "$(launch_log_file)"
 
     launch_runner() {
         local inner_attempt=1
@@ -236,8 +289,13 @@ run_launch() {
                 return 1
             fi
 
-            inner_sleep_time=$(( LAUNCH_RETRY_DELAY * 2 ** (inner_attempt - 1) ))
-            echo "Docker Compose launch failed (attempt ${inner_attempt}/${LAUNCH_RETRIES}), retrying in ${inner_sleep_time}s..."
+            if launch_log_shows_rate_limit; then
+                inner_sleep_time=$(( LAUNCH_RATE_LIMIT_RETRY_DELAY * inner_attempt ))
+                echo "Docker Hub rate-limited the image pull (attempt ${inner_attempt}/${LAUNCH_RETRIES}), retrying in ${inner_sleep_time}s..."
+            else
+                inner_sleep_time=$(( LAUNCH_RETRY_DELAY * 2 ** (inner_attempt - 1) ))
+                echo "Docker Compose launch failed (attempt ${inner_attempt}/${LAUNCH_RETRIES}), retrying in ${inner_sleep_time}s..."
+            fi
             sleep "$inner_sleep_time"
             inner_attempt=$(( inner_attempt + 1 ))
         done
@@ -262,6 +320,17 @@ run_launch() {
 }
 
 run_wait() {
+    local status=0
+
+    wait_for_services "$@" || status=$?
+    if [ "$status" -ne 0 ]; then
+        report_launch_diagnostics
+    fi
+
+    return "$status"
+}
+
+wait_for_services() {
     # Default: wait for core (db redis7 kafka clickhouse) plus any extras passed
     # as args — matches `bin/wait-for-docker`'s semantics so the two helpers stay
     # consistent. Pass `--only` as the first arg to wait ONLY for the listed
@@ -335,7 +404,7 @@ run_wait() {
 
         attempt=$(( attempt + 1 ))
         echo "Retry ${attempt}/${WAIT_RETRIES}: re-running docker compose up for missing services: ${missing[*]}"
-        if ! compose_up "${missing[@]}"; then
+        if ! compose_up_logged "${missing[@]}"; then
             echo "Retry ${attempt}/${WAIT_RETRIES} failed while starting: ${missing[*]}"
         fi
         current_timeout="$WAIT_RETRY_TIMEOUT"


### PR DESCRIPTION
## Problem

- Every backend CI job that starts containers failed for about an hour, so nothing could merge ([example run](https://github.com/PostHog/posthog/actions/runs/31596030004)).
- Docker Hub rejected the image pulls with `toomanyrequests: You have reached your unauthenticated pull rate limit`.
- The job reported that as `TIMEOUT: 300s waiting for clickhouse` five minutes later, in a different step, with the pull error nowhere in the failing step.
- The `warehouse-sources` shards hit the same limit through testcontainers, which pulls `mysql:9.2` without the credentials the login step wrote.
- Docker Hub meters anonymous pulls per runner egress IP over a six-hour window, so a job can be rejected as unauthenticated even after `docker login` succeeds ([Docker Hub usage docs](https://docs.docker.com/docker-hub/usage/pulls/)).

## Changes

- `bin/ci-wait-for-docker` keeps the compose launch output in a log file, because a background launch writes to a step that closes before `wait` reports the failure.
- The failing wait step prints the tail of that log, so the pull error appears where the job goes red.
- The wait step names Docker Hub rate limiting when the log shows it, and links the pull limit docs.
- A rate-limited launch retries three times with a 60 second base backoff, instead of the 5 second backoff other startup failures get.
- The product tests job exports `DOCKER_AUTH_CONFIG`, the [documented testcontainers credential channel](https://testcontainers-python.readthedocs.io/en/latest/#private-docker-registry), so `mysql:9.2` pulls with the Docker Hub account.
- Retry counts and delays stay overridable through the existing `WAIT_FOR_DOCKER_*` variables.

> [!NOTE]
> This does not explain why the compose pulls counted as unauthenticated in jobs where `Login Succeeded!` printed seconds earlier. Someone with Docker Hub org access should check the account plan and the token. The diagnostics here make the next occurrence readable from the failing step instead of requiring a hunt through an earlier one.

## How did you test this code?

- I stubbed `docker` to fail with the real `toomanyrequests` message, then ran `bin/ci-wait-for-docker launch` and `wait` against it. The launch backed off across three attempts and the wait printed the rate-limit block followed by the log tail.
- Not verified: a real Docker Hub 429, and the testcontainers pull. Neither reproduces in this sandbox. The `warehouse-sources` shards on this PR exercise the `DOCKER_AUTH_CONFIG` step.
- No new automated tests. The `bin/` shell helpers have no test harness in this repo, and building one for a single helper is a larger change than this fix.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Added the rate-limit signature to the `debugging-ci-failures` skill, so the next person classifying this failure reads the launch log instead of treating a readiness timeout as a runner flake.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually the PostHog Slack app, running Claude) wrote this from a Slack thread that started with a master-is-red alert. The requester is named in the linked thread; I left the PR unassigned rather than guess at their GitHub handle.

- Tools: `gh` CLI for run and job logs, Docker Hub and testcontainers documentation, a stubbed `docker` binary for local verification.
- Skills invoked: `/authoring-ci-workflows`, `/writing-code-comments`, `/writing-pr-descriptions`.
- I first read the failure as one problem and found two: a testcontainers pull that never carried credentials, and compose pulls that Docker Hub counted as anonymous despite a successful login. Only the first has a fix here.
- I considered moving the `docker run alpine` cleanup step ahead of the login step to remove one anonymous pull per job, then dropped it: `data/` does not exist on an ephemeral runner, so that step never pulls.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AS64N6DJL/p1786538300291949?thread_ts=1786538300.291949&cid=C0AS64N6DJL)*
