### PR TITLE
feat(data-warehouse): point to destinations when no source matches

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/SourceCatalog.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/SourceCatalog.tsx
@@ -6,6 +6,7 @@ import { LemonButton, LemonInput, LemonModal, LemonTag, LemonTextArea, Link } fr
 
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { getAccessControlDisabledReason } from 'lib/utils/accessControlUtils'
+import { urls } from 'scenes/urls'
 
 import { ExternalDataSourceType } from '~/queries/schema/schema-general'
 import { AccessControlLevel, AccessControlResourceType } from '~/types'
@@ -172,27 +173,36 @@ export function SourceCatalog({ allowedSources }: SourceCatalogProps): JSX.Eleme
                     autoFocus
                 />
 
-                {filteredItems.length === 0 &&
-                    (hasCrossCategoryMatches ? (
+                {filteredItems.length === 0 && (
+                    <div className="flex flex-col gap-1">
+                        {hasCrossCategoryMatches ? (
+                            <div className="text-muted text-sm">
+                                No sources match "{search.trim()}" in {selectedCategory}.{' '}
+                                <Link onClick={() => setSelectedCategory('all')}>Search all categories</Link> or request
+                                one below.
+                            </div>
+                        ) : (
+                            <div className="text-muted text-sm">
+                                No sources match.{' '}
+                                <Link
+                                    onClick={() => {
+                                        setSearch('')
+                                        setSelectedCategory('all')
+                                    }}
+                                >
+                                    Clear filters
+                                </Link>{' '}
+                                or request one below.
+                            </div>
+                        )}
+                        {/* Sources bring data into PostHog; users after an export (e.g. searching
+                            "webhook") land here by mistake, so point them at destinations. */}
                         <div className="text-muted text-sm">
-                            No sources match "{search.trim()}" in {selectedCategory}.{' '}
-                            <Link onClick={() => setSelectedCategory('all')}>Search all categories</Link> or request one
-                            below.
+                            Trying to send data out to another tool?{' '}
+                            <Link to={urls.destinations()}>Set up a destination</Link>.
                         </div>
-                    ) : (
-                        <div className="text-muted text-sm">
-                            No sources match.{' '}
-                            <Link
-                                onClick={() => {
-                                    setSearch('')
-                                    setSelectedCategory('all')
-                                }}
-                            >
-                                Clear filters
-                            </Link>{' '}
-                            or request one below.
-                        </div>
-                    ))}
+                    </div>
+                )}
 
                 <div className="grid grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-3">
                     {filteredItems.map((item) => (


### PR DESCRIPTION
## Problem

A user setting up a new data warehouse source searches the source catalog and finds no match, so the catalog shows an empty state. Some of those users are looking to send data *out* of PostHog (for example, searching "webhook"), which is a destination, not a source. The empty state only offered "request a source", dead-ending them on the wrong workflow.

## Changes

- Add a line to the source catalog empty state: "Trying to send data out to another tool? Set up a destination." linking to the destinations page.
- Keep the existing "no sources match" and cross-category messages unchanged; the new line renders alongside them whenever there are no results.

No screenshot: the change is one static line of muted helper text plus a link in the existing empty state.

## How did you test this code?

- Ran oxlint and oxfmt on the touched file: clean.
- I (Claude) could not run the project typecheck to completion in this sandbox because the `@posthog/quill` workspace is not built here, which fails unrelated files; no error referenced this file.
- No automated test asserts the empty-state copy, so none was added for a single static string.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (Claude Code). The change came from reviewing anonymized data-warehouse onboarding session summaries, which showed users repeatedly searching the source catalog for export/webhook integrations that are destinations. Skills invoked: `/writing-user-facing-copy` (empty-state copy) and `/writing-pr-descriptions` (this body). No customer data, names, or session content is included in the diff or this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
