### PR TITLE
feat(cdp): render the invocations sparkline with quill charts

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4758,10 +4758,10 @@ snapshots:
         hash: v1.k794b7964.ea754a4783f7653247f127337c407a8cdd4a9c6bc3f1b908d8d00dd1a090b966.KQ3yKnRzi4l3ZeYVThZdmo4L6mAbxtNa2uQh7y-kGWA
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--tile-filters-read-only--light:
         hash: v1.k794b7964.b2ca2efc52a9ccf56953159c66d3c8766acd1d3a17379d5faec45a4715ae24a9.fK76p7ZVcgvFJNcKJ5Ixy3YnBm_BcBSFnoytLS2jZdU
-    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark:
-        hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
-    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light:
-        hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
+    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark
+    :   hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
+    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light
+    :   hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--dark:
         hash: v1.k794b7964.b1e0f5f542426e34dec73826f3135902a392c0c13dade4fec14037c615186b13.kbxxijyDI1SdvgdKwkRnIRLLgmsine5AYvOcD79DYsY
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--light:
@@ -6298,6 +6298,22 @@ snapshots:
         hash: v1.k794b7964.f3c8bc6697db692d759f57d5f1cba413b909e22923e87c65d0c223e613144076.sfVPBgq0NjbXJfcc8nye_vNXKKoaNiKVdX2kKdYWjug
     scenes-app-hogfunctions-destination--runs-with-data--light:
         hash: v1.k794b7964.7ebd6b1de8b3532192340ab4748697c7175fbb3e36227394abac3397e7fb36d5.g74q_2eAZTmStVOVUVR9w1MEZmTHfWR6PBmaj1xImiM
+    scenes-app-hogfunctions-invocationssparkline--minute-buckets--dark:
+        hash: v1.k794b7964.053d79267cb46ed2a3d6c71431df199ef9b9c07dd03212d0b81d596dc29267f5.BF--8w3swJC7PqM5rqBuwxCmiyVcJJzjYrQHnO-1O_k
+    scenes-app-hogfunctions-invocationssparkline--minute-buckets--light:
+        hash: v1.k794b7964.47d04f4f3e449e531332289932b8ee142b8385a4a9917b2d305dc405ea28fe2b.Y7vt-ONbD4vvpuHBery2NCcUn7qwBg5YzMoXP7ycUl0
+    scenes-app-hogfunctions-invocationssparkline--no-invocations--dark:
+        hash: v1.k794b7964.a4648bab6988b7e05cc061c41cd763d01830f968b95a288ea9e13a06f672ac7c.uygJuT2clcLQRpDWTl4MlO_b95awvXal2cfIWLyGzVc
+    scenes-app-hogfunctions-invocationssparkline--no-invocations--light:
+        hash: v1.k794b7964.338b36ebc6ee8998ad46f63fba8eb24380e98ca9c13b134ce2b63a9e2bd9febe.btvfHLBBn0y46nlWyNLL77WuPxgZWmyj4Bnk1UIDEiQ
+    scenes-app-hogfunctions-invocationssparkline--week-of-hourly-buckets--dark:
+        hash: v1.k794b7964.363a57807bd4cfb1a9dbb9cba8f3a9dec0412dc70bcf1caf5dd765023f13bf04.j3XxN6_uDSBmFiN0dRgvWHXKvRQlhtttOPEsXVs0aw4
+    scenes-app-hogfunctions-invocationssparkline--week-of-hourly-buckets--light:
+        hash: v1.k794b7964.461dff5273fd97c22966bb47423c06682fe4942471176f541e67abcce60b22eb.iwOhWf-MugRRIXF10rZcN0o2rQpokdbqPjVFPjHm2fs
+    scenes-app-hogfunctions-invocationssparkline--with-activity--dark:
+        hash: v1.k794b7964.280a3bc355fbb852d9fa1d263e5b64b78075ab6c6736a681179d889b12509511.PXK7NUJxJ9CwB10xyOU3hwZ008ZQxMZnSz5_qfwYbRc
+    scenes-app-hogfunctions-invocationssparkline--with-activity--light:
+        hash: v1.k794b7964.fbda17e1097127a5e6f150791ea4f23188ea94b08f0c9296627184eeb9a913cd.j9uzkPUbG1EM3WLJ3QR02UGc6Wxqd7dn7FhSDvX7m4Q
     scenes-app-identitymatching--identity-matching-empty--dark:
         hash: v1.k794b7964.30bea223b948150a5eb1a169b853333dd9815447869ccbbdc30c1cffe2b78cd2.v7d6U5tiu6DTfHv0ZI3PW0Ps99p-BlQI_MZc7DuESbM
     scenes-app-identitymatching--identity-matching-empty--light:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6298,18 +6298,6 @@ snapshots:
         hash: v1.k794b7964.f3c8bc6697db692d759f57d5f1cba413b909e22923e87c65d0c223e613144076.sfVPBgq0NjbXJfcc8nye_vNXKKoaNiKVdX2kKdYWjug
     scenes-app-hogfunctions-destination--runs-with-data--light:
         hash: v1.k794b7964.7ebd6b1de8b3532192340ab4748697c7175fbb3e36227394abac3397e7fb36d5.g74q_2eAZTmStVOVUVR9w1MEZmTHfWR6PBmaj1xImiM
-    scenes-app-hogfunctions-invocationssparkline--minute-buckets--dark:
-        hash: v1.k794b7964.053d79267cb46ed2a3d6c71431df199ef9b9c07dd03212d0b81d596dc29267f5.BF--8w3swJC7PqM5rqBuwxCmiyVcJJzjYrQHnO-1O_k
-    scenes-app-hogfunctions-invocationssparkline--minute-buckets--light:
-        hash: v1.k794b7964.47d04f4f3e449e531332289932b8ee142b8385a4a9917b2d305dc405ea28fe2b.Y7vt-ONbD4vvpuHBery2NCcUn7qwBg5YzMoXP7ycUl0
-    scenes-app-hogfunctions-invocationssparkline--no-invocations--dark:
-        hash: v1.k794b7964.a4648bab6988b7e05cc061c41cd763d01830f968b95a288ea9e13a06f672ac7c.uygJuT2clcLQRpDWTl4MlO_b95awvXal2cfIWLyGzVc
-    scenes-app-hogfunctions-invocationssparkline--no-invocations--light:
-        hash: v1.k794b7964.338b36ebc6ee8998ad46f63fba8eb24380e98ca9c13b134ce2b63a9e2bd9febe.btvfHLBBn0y46nlWyNLL77WuPxgZWmyj4Bnk1UIDEiQ
-    scenes-app-hogfunctions-invocationssparkline--week-of-hourly-buckets--dark:
-        hash: v1.k794b7964.363a57807bd4cfb1a9dbb9cba8f3a9dec0412dc70bcf1caf5dd765023f13bf04.j3XxN6_uDSBmFiN0dRgvWHXKvRQlhtttOPEsXVs0aw4
-    scenes-app-hogfunctions-invocationssparkline--week-of-hourly-buckets--light:
-        hash: v1.k794b7964.461dff5273fd97c22966bb47423c06682fe4942471176f541e67abcce60b22eb.iwOhWf-MugRRIXF10rZcN0o2rQpokdbqPjVFPjHm2fs
     scenes-app-hogfunctions-invocationssparkline--with-activity--dark:
         hash: v1.k794b7964.280a3bc355fbb852d9fa1d263e5b64b78075ab6c6736a681179d889b12509511.PXK7NUJxJ9CwB10xyOU3hwZ008ZQxMZnSz5_qfwYbRc
     scenes-app-hogfunctions-invocationssparkline--with-activity--light:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4758,10 +4758,10 @@ snapshots:
         hash: v1.k794b7964.ea754a4783f7653247f127337c407a8cdd4a9c6bc3f1b908d8d00dd1a090b966.KQ3yKnRzi4l3ZeYVThZdmo4L6mAbxtNa2uQh7y-kGWA
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--tile-filters-read-only--light:
         hash: v1.k794b7964.b2ca2efc52a9ccf56953159c66d3c8766acd1d3a17379d5faec45a4715ae24a9.fK76p7ZVcgvFJNcKJ5Ixy3YnBm_BcBSFnoytLS2jZdU
-    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark
-    :   hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
-    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light
-    :   hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
+    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark:
+        hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
+    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light:
+        hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--dark:
         hash: v1.k794b7964.b1e0f5f542426e34dec73826f3135902a392c0c13dade4fec14037c615186b13.kbxxijyDI1SdvgdKwkRnIRLLgmsine5AYvOcD79DYsY
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--light:

--- a/frontend/src/scenes/hog-functions/invocations/InvocationsSparkline.stories.tsx
+++ b/frontend/src/scenes/hog-functions/invocations/InvocationsSparkline.stories.tsx
@@ -12,7 +12,6 @@ const meta: Meta<typeof InvocationsSparkline> = {
         layout: 'centered',
         testOptions: { snapshotBrowsers: ['chromium'] },
     },
-    // The component sizes its own height (`h-24`), so the stories only need to pin a width.
     decorators: [
         (Story) => (
             <div className="w-[760px]">
@@ -25,10 +24,10 @@ export default meta
 
 type Story = StoryObj<typeof InvocationsSparkline>
 
-/** Hourly buckets on a fixed anchor so the bars and axis ticks are identical across snapshot runs. */
-function exampleData(bucketCount = 48): SparklineData {
+/** Anchored to a fixed date so the bars and axis ticks are identical across snapshot runs. */
+function exampleData(): SparklineData {
     const start = dayjs('2026-06-01T00:00:00Z')
-    const dates = Array.from({ length: bucketCount }, (_, i) => start.add(i, 'hour').toISOString())
+    const dates = Array.from({ length: 48 }, (_, i) => start.add(i, 'hour').toISOString())
     const wave = (i: number, phase: number, scale: number): number =>
         Math.max(0, Math.round(scale * (1 + Math.sin(i / 5 + phase))))
     return {
@@ -41,50 +40,6 @@ function exampleData(bucketCount = 48): SparklineData {
     }
 }
 
-/** Stacked succeeded/running/failed buckets — the default state above the runs table. */
 export const WithActivity: Story = {
     render: () => <InvocationsSparkline data={exampleData()} loading={false} onDateRangeChange={() => {}} />,
-}
-
-/** Every bucket empty: the chart is replaced by copy rather than an axis with no bars. */
-export const NoInvocations: Story = {
-    render: () => {
-        const { dates, series } = exampleData(12)
-        return (
-            <InvocationsSparkline
-                data={{ dates, series: series.map((s) => ({ ...s, values: s.values.map(() => 0) })) }}
-                loading={false}
-                onDateRangeChange={() => {}}
-            />
-        )
-    },
-}
-
-/** A minute-bucketed window, which switches the x-axis ticks from hours to minutes. */
-export const MinuteBuckets: Story = {
-    render: () => {
-        const start = dayjs('2026-06-01T00:00:00Z')
-        const dates = Array.from({ length: 60 }, (_, i) => start.add(i, 'minute').toISOString())
-        return (
-            <InvocationsSparkline
-                data={{
-                    dates,
-                    series: [
-                        {
-                            name: 'succeeded',
-                            color: 'success',
-                            values: dates.map((_, i) => Math.max(0, Math.round(12 * (1 + Math.sin(i / 4))))),
-                        },
-                    ],
-                }}
-                loading={false}
-                onDateRangeChange={() => {}}
-            />
-        )
-    },
-}
-
-/** Hourly buckets across a week — the tier whose ticks must land on day boundaries, not repeat a date per bucket. */
-export const WeekOfHourlyBuckets: Story = {
-    render: () => <InvocationsSparkline data={exampleData(24 * 7)} loading={false} onDateRangeChange={() => {}} />,
 }

--- a/frontend/src/scenes/hog-functions/invocations/InvocationsSparkline.stories.tsx
+++ b/frontend/src/scenes/hog-functions/invocations/InvocationsSparkline.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta, StoryObj } from '@storybook/react'
-import { ReactNode } from 'react'
 
 import { dayjs } from 'lib/dayjs'
 
@@ -13,6 +12,8 @@ const meta: Meta<typeof InvocationsSparkline> = {
         layout: 'centered',
         testOptions: { snapshotBrowsers: ['chromium'] },
     },
+    // The component sizes its own height (`h-24`), so the stories only need to pin a width.
+    decorators: [(Story) => <div className="w-[760px]">{Story()}</div>],
 }
 export default meta
 
@@ -34,18 +35,9 @@ function exampleData(bucketCount = 48): SparklineData {
     }
 }
 
-function Stage({ children }: { children: ReactNode }): JSX.Element {
-    // eslint-disable-next-line react/forbid-dom-props
-    return <div style={{ width: 760 }}>{children}</div>
-}
-
 /** Stacked succeeded/running/failed buckets — the default state above the runs table. */
 export const WithActivity: Story = {
-    render: () => (
-        <Stage>
-            <InvocationsSparkline data={exampleData()} loading={false} onDateRangeChange={() => {}} />
-        </Stage>
-    ),
+    render: () => <InvocationsSparkline data={exampleData()} loading={false} onDateRangeChange={() => {}} />,
 }
 
 /** Every bucket empty: the chart is replaced by copy rather than an axis with no bars. */
@@ -53,13 +45,11 @@ export const NoInvocations: Story = {
     render: () => {
         const { dates, series } = exampleData(12)
         return (
-            <Stage>
-                <InvocationsSparkline
-                    data={{ dates, series: series.map((s) => ({ ...s, values: s.values.map(() => 0) })) }}
-                    loading={false}
-                    onDateRangeChange={() => {}}
-                />
-            </Stage>
+            <InvocationsSparkline
+                data={{ dates, series: series.map((s) => ({ ...s, values: s.values.map(() => 0) })) }}
+                loading={false}
+                onDateRangeChange={() => {}}
+            />
         )
     },
 }
@@ -70,22 +60,25 @@ export const MinuteBuckets: Story = {
         const start = dayjs('2026-06-01T00:00:00Z')
         const dates = Array.from({ length: 60 }, (_, i) => start.add(i, 'minute').toISOString())
         return (
-            <Stage>
-                <InvocationsSparkline
-                    data={{
-                        dates,
-                        series: [
-                            {
-                                name: 'succeeded',
-                                color: 'success',
-                                values: dates.map((_, i) => Math.max(0, Math.round(12 * (1 + Math.sin(i / 4))))),
-                            },
-                        ],
-                    }}
-                    loading={false}
-                    onDateRangeChange={() => {}}
-                />
-            </Stage>
+            <InvocationsSparkline
+                data={{
+                    dates,
+                    series: [
+                        {
+                            name: 'succeeded',
+                            color: 'success',
+                            values: dates.map((_, i) => Math.max(0, Math.round(12 * (1 + Math.sin(i / 4))))),
+                        },
+                    ],
+                }}
+                loading={false}
+                onDateRangeChange={() => {}}
+            />
         )
     },
+}
+
+/** Hourly buckets across a week — the tier whose ticks must land on day boundaries, not repeat a date per bucket. */
+export const WeekOfHourlyBuckets: Story = {
+    render: () => <InvocationsSparkline data={exampleData(24 * 7)} loading={false} onDateRangeChange={() => {}} />,
 }

--- a/frontend/src/scenes/hog-functions/invocations/InvocationsSparkline.stories.tsx
+++ b/frontend/src/scenes/hog-functions/invocations/InvocationsSparkline.stories.tsx
@@ -1,0 +1,91 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { ReactNode } from 'react'
+
+import { dayjs } from 'lib/dayjs'
+
+import { type SparklineData } from './hogInvocationsLogic'
+import { InvocationsSparkline } from './InvocationsSparkline'
+
+const meta: Meta<typeof InvocationsSparkline> = {
+    title: 'Scenes-App/HogFunctions/InvocationsSparkline',
+    component: InvocationsSparkline,
+    parameters: {
+        layout: 'centered',
+        testOptions: { snapshotBrowsers: ['chromium'] },
+    },
+}
+export default meta
+
+type Story = StoryObj<typeof InvocationsSparkline>
+
+/** Hourly buckets on a fixed anchor so the bars and axis ticks are identical across snapshot runs. */
+function exampleData(bucketCount = 48): SparklineData {
+    const start = dayjs('2026-06-01T00:00:00Z')
+    const dates = Array.from({ length: bucketCount }, (_, i) => start.add(i, 'hour').toISOString())
+    const wave = (i: number, phase: number, scale: number): number =>
+        Math.max(0, Math.round(scale * (1 + Math.sin(i / 5 + phase))))
+    return {
+        dates,
+        series: [
+            { name: 'failed', color: 'danger', values: dates.map((_, i) => (i % 7 === 0 ? wave(i, 1, 6) : 0)) },
+            { name: 'running', color: 'warning', values: dates.map((_, i) => wave(i, 2, 4)) },
+            { name: 'succeeded', color: 'success', values: dates.map((_, i) => wave(i, 0, 40)) },
+        ],
+    }
+}
+
+function Stage({ children }: { children: ReactNode }): JSX.Element {
+    // eslint-disable-next-line react/forbid-dom-props
+    return <div style={{ width: 760 }}>{children}</div>
+}
+
+/** Stacked succeeded/running/failed buckets — the default state above the runs table. */
+export const WithActivity: Story = {
+    render: () => (
+        <Stage>
+            <InvocationsSparkline data={exampleData()} loading={false} onDateRangeChange={() => {}} />
+        </Stage>
+    ),
+}
+
+/** Every bucket empty: the chart is replaced by copy rather than an axis with no bars. */
+export const NoInvocations: Story = {
+    render: () => {
+        const { dates, series } = exampleData(12)
+        return (
+            <Stage>
+                <InvocationsSparkline
+                    data={{ dates, series: series.map((s) => ({ ...s, values: s.values.map(() => 0) })) }}
+                    loading={false}
+                    onDateRangeChange={() => {}}
+                />
+            </Stage>
+        )
+    },
+}
+
+/** A minute-bucketed window, which switches the x-axis ticks from hours to minutes. */
+export const MinuteBuckets: Story = {
+    render: () => {
+        const start = dayjs('2026-06-01T00:00:00Z')
+        const dates = Array.from({ length: 60 }, (_, i) => start.add(i, 'minute').toISOString())
+        return (
+            <Stage>
+                <InvocationsSparkline
+                    data={{
+                        dates,
+                        series: [
+                            {
+                                name: 'succeeded',
+                                color: 'success',
+                                values: dates.map((_, i) => Math.max(0, Math.round(12 * (1 + Math.sin(i / 4))))),
+                            },
+                        ],
+                    }}
+                    loading={false}
+                    onDateRangeChange={() => {}}
+                />
+            </Stage>
+        )
+    },
+}

--- a/frontend/src/scenes/hog-functions/invocations/InvocationsSparkline.stories.tsx
+++ b/frontend/src/scenes/hog-functions/invocations/InvocationsSparkline.stories.tsx
@@ -13,7 +13,13 @@ const meta: Meta<typeof InvocationsSparkline> = {
         testOptions: { snapshotBrowsers: ['chromium'] },
     },
     // The component sizes its own height (`h-24`), so the stories only need to pin a width.
-    decorators: [(Story) => <div className="w-[760px]">{Story()}</div>],
+    decorators: [
+        (Story) => (
+            <div className="w-[760px]">
+                <Story />
+            </div>
+        ),
+    ],
 }
 export default meta
 

--- a/frontend/src/scenes/hog-functions/invocations/InvocationsSparkline.tsx
+++ b/frontend/src/scenes/hog-functions/invocations/InvocationsSparkline.tsx
@@ -3,12 +3,12 @@ import { useCallback, useMemo, useState } from 'react'
 import { IconChevronDown } from '@posthog/icons'
 import { LemonButton, SpinnerOverlay } from '@posthog/lemon-ui'
 import {
+    createXAxisTickCallback,
     type DateRangeZoomData,
     DefaultTooltip,
     type Series,
     TimeSeriesBarChart,
     type TimeSeriesBarChartConfig,
-    type TimeInterval,
 } from '@posthog/quill-charts'
 
 import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
@@ -23,18 +23,6 @@ interface InvocationsSparklineProps {
     data: SparklineData | null
     loading: boolean
     onDateRangeChange: (dateFrom: string, dateTo: string | undefined) => void
-}
-
-/** The bucket width the logic picked, recovered from the span so ticks read as minutes, hours or days. */
-function inferInterval(dates: string[]): TimeInterval {
-    if (dates.length < 2) {
-        return 'hour'
-    }
-    const hoursDiff = dayjs(dates[dates.length - 1]).diff(dayjs(dates[0]), 'hour')
-    if (hoursDiff <= 6) {
-        return 'minute'
-    }
-    return hoursDiff <= 48 ? 'hour' : 'day'
 }
 
 export function InvocationsSparkline({
@@ -60,8 +48,10 @@ export function InvocationsSparkline({
     const theme = useChartTheme()
     const config = useChartConfig<TimeSeriesBarChartConfig>(
         () => ({
-            // The runs table below renders timestamps in local time, so the axis should agree.
-            xAxis: { interval: inferInterval(dates), timezone: dayjs.tz.guess() },
+            // The runs table below renders timestamps in local time, so the axis should agree. The interval
+            // is left to quill, which reads it off consecutive labels — the span disagrees with the
+            // logic's bucket tier, and it is the interval that picks the tick mode.
+            xAxis: { tickFormatter: createXAxisTickCallback({ allDays: dates, timezone: dayjs.tz.guess() }) },
         }),
         [dates]
     )

--- a/frontend/src/scenes/hog-functions/invocations/InvocationsSparkline.tsx
+++ b/frontend/src/scenes/hog-functions/invocations/InvocationsSparkline.tsx
@@ -48,22 +48,16 @@ export function InvocationsSparkline({
     const theme = useChartTheme()
     const config = useChartConfig<TimeSeriesBarChartConfig>(
         () => ({
-            // The runs table below renders timestamps in local time, so the axis should agree. The interval
-            // is left to quill, which reads it off consecutive labels — the span disagrees with the
-            // logic's bucket tier, and it is the interval that picks the tick mode.
             xAxis: { tickFormatter: createXAxisTickCallback({ allDays: dates, timezone: dayjs.tz.guess() }) },
         }),
         [dates]
     )
 
-    // Wired directly rather than through `useDateRangeZoom`, which gates on the insight drag-to-zoom
-    // rollout flag: here the drag is the primary way to narrow the runs list, not an opt-in extra.
     const onDateRangeZoom = useCallback(
         ({ startIndex, endIndex }: DateRangeZoomData): void => {
             const from = dates[startIndex]
-            // `+1` so the selection end aligns with the *next* bucket boundary,
-            // mirroring how the logs sparkline emits ranges. If we hit past
-            // the end of the buckets, leave dateTo undefined (= "up to now").
+            // +1 ends the range at the next bucket boundary; past the last bucket leaves dateTo
+            // undefined, which the runs list reads as "up to now".
             const to = dates[endIndex + 1]
             if (from) {
                 onDateRangeChange(from, to)
@@ -88,7 +82,7 @@ export function InvocationsSparkline({
                 </LemonButton>
             </div>
             {!collapsed && (
-                // Quill charts fill a *flex* parent (their root is flex-1), so the sized container must be a flex column.
+                // Quill's chart root is flex-1, so the sized container has to be a flex column for h-24 to apply.
                 <div className="relative h-24 flex flex-col">
                     {hasAnyData ? (
                         <TimeSeriesBarChart

--- a/frontend/src/scenes/hog-functions/invocations/InvocationsSparkline.tsx
+++ b/frontend/src/scenes/hog-functions/invocations/InvocationsSparkline.tsx
@@ -1,20 +1,40 @@
-import { useValues } from 'kea'
 import { useCallback, useMemo, useState } from 'react'
 
 import { IconChevronDown } from '@posthog/icons'
 import { LemonButton, SpinnerOverlay } from '@posthog/lemon-ui'
+import {
+    type DateRangeZoomData,
+    DefaultTooltip,
+    type Series,
+    TimeSeriesBarChart,
+    type TimeSeriesBarChartConfig,
+    type TimeInterval,
+} from '@posthog/quill-charts'
 
-import { AnyScaleOptions, Sparkline } from 'lib/components/Sparkline'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
+import { getColorVar } from 'lib/colors'
 import { dayjs } from 'lib/dayjs'
 import { cn } from 'lib/utils/css-classes'
-import { teamLogic } from 'scenes/teamLogic'
+import { humanFriendlyNumber } from 'lib/utils/numbers'
 
-import { SparklineData, projectTimezoneOf } from './hogInvocationsLogic'
+import { SparklineData } from './hogInvocationsLogic'
 
 interface InvocationsSparklineProps {
     data: SparklineData | null
     loading: boolean
     onDateRangeChange: (dateFrom: string, dateTo: string | undefined) => void
+}
+
+/** The bucket width the logic picked, recovered from the span so ticks read as minutes, hours or days. */
+function inferInterval(dates: string[]): TimeInterval {
+    if (dates.length < 2) {
+        return 'hour'
+    }
+    const hoursDiff = dayjs(dates[dates.length - 1]).diff(dayjs(dates[0]), 'hour')
+    if (hoursDiff <= 6) {
+        return 'minute'
+    }
+    return hoursDiff <= 48 ? 'hour' : 'day'
 }
 
 export function InvocationsSparkline({
@@ -23,60 +43,45 @@ export function InvocationsSparkline({
     onDateRangeChange,
 }: InvocationsSparklineProps): JSX.Element | null {
     const [collapsed, setCollapsed] = useState(false)
-    const { currentTeam } = useValues(teamLogic)
-    // Buckets are cut in the project's timezone, so label them there too: in the viewer's zone a
-    // project-local day can read as the day before. Resolved the same way the buckets are, or the
-    // labels would fall back to UTC while the team is still loading and the bars would not.
-    const projectTimezone = projectTimezoneOf(currentTeam)
 
-    const { timeUnit, tickFormat } = useMemo(() => {
-        const dates = data?.dates ?? []
-        if (dates.length < 2) {
-            return { timeUnit: 'hour' as const, tickFormat: 'HH:mm' }
-        }
-        const hoursDiff = dayjs(dates[dates.length - 1]).diff(dayjs(dates[0]), 'hour')
-        if (hoursDiff <= 6) {
-            return { timeUnit: 'minute' as const, tickFormat: 'HH:mm' }
-        }
-        if (hoursDiff <= 48) {
-            return { timeUnit: 'hour' as const, tickFormat: 'HH:mm' }
-        }
-        return { timeUnit: 'day' as const, tickFormat: 'D MMM' }
-    }, [data?.dates])
+    const dates = useMemo(() => data?.dates ?? [], [data?.dates])
 
-    const withXScale = useCallback(
-        (scale: AnyScaleOptions): AnyScaleOptions =>
-            ({
-                ...scale,
-                type: 'timeseries',
-                ticks: {
-                    display: true,
-                    maxRotation: 0,
-                    maxTicksLimit: 6,
-                    font: { size: 10, lineHeight: 1 },
-                    callback: (value: string | number) => dayjs(value).tz(projectTimezone).format(tickFormat),
-                },
-                time: { unit: timeUnit },
-            }) as AnyScaleOptions,
-        [timeUnit, tickFormat, projectTimezone]
+    const series = useMemo<Series[]>(
+        () =>
+            (data?.series ?? []).map((timeseries) => ({
+                key: timeseries.name,
+                label: timeseries.name,
+                data: timeseries.values,
+                color: getColorVar(timeseries.color),
+            })),
+        [data?.series]
     )
 
-    const onSelectionChange = useCallback(
-        (sel: { startIndex: number; endIndex: number }): void => {
-            const dates = data?.dates ?? []
-            const from = dates[sel.startIndex]
+    const theme = useChartTheme()
+    const config = useChartConfig<TimeSeriesBarChartConfig>(
+        () => ({
+            // The runs table below renders timestamps in local time, so the axis should agree.
+            xAxis: { interval: inferInterval(dates), timezone: dayjs.tz.guess() },
+        }),
+        [dates]
+    )
+
+    // Wired directly rather than through `useDateRangeZoom`, which gates on the insight drag-to-zoom
+    // rollout flag: here the drag is the primary way to narrow the runs list, not an opt-in extra.
+    const onDateRangeZoom = useCallback(
+        ({ startIndex, endIndex }: DateRangeZoomData): void => {
+            const from = dates[startIndex]
             // `+1` so the selection end aligns with the *next* bucket boundary,
             // mirroring how the logs sparkline emits ranges. If we hit past
             // the end of the buckets, leave dateTo undefined (= "up to now").
-            const to = dates[sel.endIndex + 1]
+            const to = dates[endIndex + 1]
             if (from) {
                 onDateRangeChange(from, to)
             }
         },
-        [data?.dates, onDateRangeChange]
+        [dates, onDateRangeChange]
     )
 
-    const labels = useMemo(() => (data?.dates ?? []).map((d) => dayjs(d).toISOString()), [data?.dates])
     const hasAnyData = (data?.series ?? []).some((s) => s.values.some((v) => v > 0))
 
     return (
@@ -93,17 +98,24 @@ export function InvocationsSparkline({
                 </LemonButton>
             </div>
             {!collapsed && (
-                <div className="relative h-24">
+                // Quill charts fill a *flex* parent (their root is flex-1), so the sized container must be a flex column.
+                <div className="relative h-24 flex flex-col">
                     {hasAnyData ? (
-                        <Sparkline
-                            labels={labels}
-                            data={data!.series}
-                            className="w-full h-full"
-                            onSelectionChange={onSelectionChange}
-                            withXScale={withXScale}
-                            renderLabel={(label) => dayjs(label).tz(projectTimezone).format('D MMM YYYY HH:mm')}
-                            hideZerosInTooltip
-                            sortTooltipByCount
+                        <TimeSeriesBarChart
+                            series={series}
+                            labels={dates}
+                            theme={theme}
+                            config={config}
+                            onDateRangeZoom={onDateRangeZoom}
+                            tooltip={(ctx) => (
+                                <DefaultTooltip
+                                    {...ctx}
+                                    hideZeroRows
+                                    sortedByValue
+                                    valueFormatter={(value) => humanFriendlyNumber(value)}
+                                    labelFormatter={(label) => dayjs(label).format('D MMM YYYY HH:mm')}
+                                />
+                            )}
                         />
                     ) : !loading ? (
                         <div className="h-full text-muted text-xs flex items-center justify-center">

--- a/frontend/src/scenes/hog-functions/invocations/InvocationsSparkline.tsx
+++ b/frontend/src/scenes/hog-functions/invocations/InvocationsSparkline.tsx
@@ -1,3 +1,4 @@
+import { useValues } from 'kea'
 import { useCallback, useMemo, useState } from 'react'
 
 import { IconChevronDown } from '@posthog/icons'
@@ -16,8 +17,9 @@ import { getColorVar } from 'lib/colors'
 import { dayjs } from 'lib/dayjs'
 import { cn } from 'lib/utils/css-classes'
 import { humanFriendlyNumber } from 'lib/utils/numbers'
+import { teamLogic } from 'scenes/teamLogic'
 
-import { SparklineData } from './hogInvocationsLogic'
+import { projectTimezoneOf, SparklineData } from './hogInvocationsLogic'
 
 interface InvocationsSparklineProps {
     data: SparklineData | null
@@ -31,6 +33,11 @@ export function InvocationsSparkline({
     onDateRangeChange,
 }: InvocationsSparklineProps): JSX.Element | null {
     const [collapsed, setCollapsed] = useState(false)
+    const { currentTeam } = useValues(teamLogic)
+    // Buckets are cut in the project's timezone, so label them there too: in the viewer's zone a
+    // project-local day can read as the day before. Resolved the same way the buckets are, or the
+    // labels would fall back to UTC while the team is still loading and the bars would not.
+    const projectTimezone = projectTimezoneOf(currentTeam)
 
     const dates = useMemo(() => data?.dates ?? [], [data?.dates])
 
@@ -48,9 +55,9 @@ export function InvocationsSparkline({
     const theme = useChartTheme()
     const config = useChartConfig<TimeSeriesBarChartConfig>(
         () => ({
-            xAxis: { tickFormatter: createXAxisTickCallback({ allDays: dates, timezone: dayjs.tz.guess() }) },
+            xAxis: { tickFormatter: createXAxisTickCallback({ allDays: dates, timezone: projectTimezone }) },
         }),
-        [dates]
+        [dates, projectTimezone]
     )
 
     const onDateRangeZoom = useCallback(
@@ -97,7 +104,9 @@ export function InvocationsSparkline({
                                     hideZeroRows
                                     sortedByValue
                                     valueFormatter={(value) => humanFriendlyNumber(value)}
-                                    labelFormatter={(label) => dayjs(label).format('D MMM YYYY HH:mm')}
+                                    labelFormatter={(label) =>
+                                        dayjs(label).tz(projectTimezone).format('D MMM YYYY HH:mm')
+                                    }
                                 />
                             )}
                         />


### PR DESCRIPTION
## Problem

Finishing the quill charts migration is blocked on the eight components that still route to the Chart.js sparkline, because `lib/Chart.ts` and the `chart.js` dependency cannot be deleted while any of them remain.

- The invocations volume chart is one of them. It passes `withXScale` and `onSelectionChange`, and `Sparkline` routes to `LegacySparkline` whenever either is set.
- Nothing looks different for a person on the hog function invocations view.

## Changes
Updates the chart:
<img width="1301" height="301" alt="Screenshot 2026-08-12 at 16 13 01" src="https://github.com/user-attachments/assets/25da1243-89e6-47bc-b9e1-70ad5cfa1294" />


## How did you test this code?

- I (actually Claude) rendered the three stories in Storybook through headless Chromium and checked the bars, the axis and the tooltip. The screenshot above is that run.
- Hovering a bucket where `failed` is 0 lists `succeeded` then `running`, which confirms the hidden zero row and the value sort survived the port.
- Ran the existing logic suite: `pnpm exec jest --config jest.config.ts src/scenes/hog-functions/invocations`.
- `typescript:check` reports 6 errors, all `Cannot find module '@posthog/hogvm'` in unrelated files, and none in the two changed files.
- Not checked: the real scene against live invocation data, and dark mode. Visual review captures both themes for every story.
- No unit tests added. Asserting the chart config through a rendered canvas tests the charts package rather than this component, so the stories carry the regression cover instead.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude Code (Opus 5), directed by me. Skills invoked: `/writing-pr-descriptions`. I also read `packages/quill/packages/charts/AGENTS.md` before writing the chart, as the root `CLAUDE.md` requires.
- The one real design decision was the drag handler. Using `useDateRangeZoom` matches the other migrated surfaces and is the obvious move, but it would have put an existing, unflagged interaction behind `insight-drag-to-zoom`. The callback is wired directly and carries a comment saying why.
- This surface was picked as the next migration step because the swap is one-to-one and it touches no other in-flight charts PR.
