### PR TITLE
fix(data-warehouse): treat pausing/unpausing an already-gone schedule as a no-op

### DIFF
--- a/products/data_warehouse/backend/logic/data_load/service.py
+++ b/products/data_warehouse/backend/logic/data_load/service.py
@@ -231,17 +231,35 @@ async def a_external_data_workflow_exists(id: str) -> bool:
 
 def pause_external_data_schedule(id: str):
     temporal = sync_connect()
-    pause_schedule(temporal, schedule_id=id)
+    try:
+        pause_schedule(temporal, schedule_id=id)
+    except temporalio.service.RPCError as e:
+        # Swallow error if schedule does not exist already
+        if e.status == temporalio.service.RPCStatusCode.NOT_FOUND:
+            return
+        raise
 
 
 def unpause_external_data_schedule(id: str):
     temporal = sync_connect()
-    unpause_schedule(temporal, schedule_id=id)
+    try:
+        unpause_schedule(temporal, schedule_id=id)
+    except temporalio.service.RPCError as e:
+        # Swallow error if schedule does not exist already
+        if e.status == temporalio.service.RPCStatusCode.NOT_FOUND:
+            return
+        raise
 
 
 async def a_unpause_external_data_schedule(id: str):
     temporal = await async_connect()
-    await a_unpause_schedule(temporal, schedule_id=id)
+    try:
+        await a_unpause_schedule(temporal, schedule_id=id)
+    except temporalio.service.RPCError as e:
+        # Swallow error if schedule does not exist already
+        if e.status == temporalio.service.RPCStatusCode.NOT_FOUND:
+            return
+        raise
 
 
 def delete_external_data_schedule(schedule_id: str):

--- a/products/data_warehouse/backend/logic/data_load/test/test_service.py
+++ b/products/data_warehouse/backend/logic/data_load/test/test_service.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest_asyncio
 from asgiref.sync import async_to_sync, sync_to_async
+from parameterized import parameterized
 from temporalio.client import (
     Client as TemporalClient,
     ScheduleActionStartWorkflow,
@@ -25,11 +26,14 @@ from products.data_warehouse.backend.logic.data_load.service import (
     _get_cdc_extraction_schedule_id,
     _get_discover_schemas_schedule_id,
     _jitter_timedelta,
+    a_unpause_external_data_schedule,
     bulk_sync_cdc_extraction_schedules,
     bulk_update_external_data_job_schedules,
     cdc_min_interval,
     get_discover_schemas_schedule,
     get_sync_schedule,
+    pause_external_data_schedule,
+    unpause_external_data_schedule,
 )
 from products.warehouse_sources.backend.facade.models import ExternalDataSchema, ExternalDataSource
 
@@ -455,3 +459,54 @@ def test_bulk_update_edj_mixed_skip_fail_and_success():
     assert [sid for sid, _ in failures] == [str(broken.id)]
     assert create_mock.call_count == 0
     assert update_mock.call_count == 3
+
+
+# --- pause/unpause: a schedule whose backing workflow already completed (e.g. deleted by a
+# racing request) must be treated as already-paused/unpaused, not as a failure ---
+
+
+@parameterized.expand(
+    [
+        ("pause", "pause_schedule", pause_external_data_schedule),
+        ("unpause", "unpause_schedule", unpause_external_data_schedule),
+    ]
+)
+def test_pause_unpause_swallows_not_found_rpc_error(_name, patched_fn_name, service_fn):
+    with (
+        patch(f"{SERVICE}.sync_connect"),
+        patch(f"{SERVICE}.{patched_fn_name}", side_effect=_not_found()),
+    ):
+        service_fn("some-schedule-id")  # must not raise
+
+
+@parameterized.expand(
+    [
+        ("pause", "pause_schedule", pause_external_data_schedule),
+        ("unpause", "unpause_schedule", unpause_external_data_schedule),
+    ]
+)
+def test_pause_unpause_reraises_other_rpc_errors(_name, patched_fn_name, service_fn):
+    with (
+        patch(f"{SERVICE}.sync_connect"),
+        patch(f"{SERVICE}.{patched_fn_name}", side_effect=RPCError("unavailable", RPCStatusCode.UNAVAILABLE, b"")),
+        pytest.raises(RPCError),
+    ):
+        service_fn("some-schedule-id")
+
+
+def test_a_unpause_swallows_not_found_rpc_error():
+    with (
+        patch(f"{SERVICE}.async_connect", AsyncMock(return_value=MagicMock())),
+        patch(f"{SERVICE}.a_unpause_schedule", AsyncMock(side_effect=_not_found())),
+    ):
+        async_to_sync(a_unpause_external_data_schedule)("some-schedule-id")  # must not raise
+
+
+def test_a_unpause_reraises_other_rpc_errors():
+    other_rpc = RPCError("unavailable", RPCStatusCode.UNAVAILABLE, b"")
+    with (
+        patch(f"{SERVICE}.async_connect", AsyncMock(return_value=MagicMock())),
+        patch(f"{SERVICE}.a_unpause_schedule", AsyncMock(side_effect=other_rpc)),
+        pytest.raises(RPCError),
+    ):
+        async_to_sync(a_unpause_external_data_schedule)("some-schedule-id")


### PR DESCRIPTION
## Problem

A data warehouse schema sync toggle can crash instead of applying, surfaced by [error tracking](https://us.posthog.com/project/2/error_tracking/019ff653-e3ca-7852-b13a-490bac3ca92d).

The stack trace shows an `RPCError: workflow execution already completed` (gRPC `NOT_FOUND`) raised from `handle.pause()`, reached via `update_should_sync` -> `pause_external_data_schedule`. `update_should_sync` checks `external_data_workflow_exists` first, but the schedule's backing workflow can complete or be deleted between that check and the pause/unpause call, so the RPC then fails.

## Changes

- `pause_external_data_schedule`, `unpause_external_data_schedule`, and `a_unpause_external_data_schedule` now swallow `RPCError` when its status is `NOT_FOUND`, treating an already-gone schedule as already paused/unpaused.
- This matches the existing pattern in `delete_external_data_schedule` / `a_delete_external_data_schedule` in the same file, which already handle this race for deletes.
- Any other RPC error status still propagates and fails the caller as before.

## How did you test this code?

Added parameterized tests in `test_service.py`:
- `test_pause_unpause_swallows_not_found_rpc_error` - a `NOT_FOUND` RPCError from the underlying schedule call no longer raises, for both pause and unpause.
- `test_pause_unpause_reraises_other_rpc_errors` - a non-`NOT_FOUND` RPCError still raises, so the fix doesn't hide real failures.
- `test_a_unpause_swallows_not_found_rpc_error` / `test_a_unpause_reraises_other_rpc_errors` - same coverage for the async unpause path.

Ran the new tests and the rest of `test_service.py` locally, plus `ruff` and a repo-wide `mypy` - all clean. Not run: the full CI suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal error-handling fix, no documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged via PostHog error tracking (issue linked above): pulled the stack trace, exception type, and a representative event, then traced the call path from the interceptor in `posthog/temporal/common/posthog_client.py` down to `pause_external_data_schedule`. Found the existing `NOT_FOUND`-swallowing precedent for `delete_external_data_schedule` in the same file and applied the same pattern to pause/unpause. Invoked `/writing-tests` before adding the regression tests and `/writing-pr-descriptions` before writing this body. No duplicate open human-authored PR found (searched by exception type, message phrase, function names, and module path, excluding the automation bot; also checked the maintainer's own open PRs).