### PR TITLE
fix(desktop): refresh comment activity notifications

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/hooks/useTaskActivity.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useTaskActivity.test.tsx
@@ -98,7 +98,21 @@ describe("task activity hooks", () => {
     });
   });
 
-  it("refreshes activity when the app regains focus", async () => {
+  it.each([
+    [
+      "the app regains focus",
+      (): void => {
+        act(() => focusManager.setFocused(false));
+        act(() => focusManager.setFocused(true));
+      },
+    ],
+    [
+      "an Activity surface opens",
+      (): void => {
+        renderHook(() => useTaskActivity(), { wrapper });
+      },
+    ],
+  ])("refreshes activity when %s", async (_name, refresh) => {
     mockClient.getTaskActivity
       .mockResolvedValueOnce({ results: [], unread_count: 0 })
       .mockResolvedValueOnce({
@@ -117,8 +131,7 @@ describe("task activity hooks", () => {
     );
     expect(hook.result.current.items).toEqual([]);
 
-    act(() => focusManager.setFocused(false));
-    act(() => focusManager.setFocused(true));
+    refresh();
 
     await waitFor(() =>
       expect(hook.result.current.items[0]).toMatchObject({

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useTaskActivity.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useTaskActivity.test.tsx
@@ -2,10 +2,14 @@ import type {
   TaskActivity,
   TaskActivityPage,
 } from "@posthog/shared/domain-types";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  focusManager,
+  QueryClient,
+  QueryClientProvider,
+} from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockClient = vi.hoisted(() => ({
   getTaskActivity: vi.fn(),
@@ -50,6 +54,11 @@ describe("task activity hooks", () => {
     });
   });
 
+  afterEach(() => {
+    queryClient.clear();
+    focusManager.setFocused(undefined);
+  });
+
   it("loads every activity page", async () => {
     mockClient.getTaskActivity
       .mockResolvedValueOnce({
@@ -87,6 +96,38 @@ describe("task activity hooks", () => {
       before: "2026-07-01T10:00:00Z",
       beforeId: "activity-1",
     });
+  });
+
+  it("refreshes activity when the app regains focus", async () => {
+    mockClient.getTaskActivity
+      .mockResolvedValueOnce({ results: [], unread_count: 0 })
+      .mockResolvedValueOnce({
+        results: [
+          activity({
+            id: "comment-activity-1",
+            latest_comment_id: "comment-1",
+          }),
+        ],
+        unread_count: 1,
+      });
+
+    const hook = renderHook(() => useTaskActivity(), { wrapper });
+    await waitFor(() =>
+      expect(mockClient.getTaskActivity).toHaveBeenCalledOnce(),
+    );
+    expect(hook.result.current.items).toEqual([]);
+
+    act(() => focusManager.setFocused(false));
+    act(() => focusManager.setFocused(true));
+
+    await waitFor(() =>
+      expect(hook.result.current.items[0]).toMatchObject({
+        id: "comment-activity-1",
+        commentId: "comment-1",
+      }),
+    );
+    expect(mockClient.getTaskActivity).toHaveBeenCalledTimes(2);
+    expect(hook.result.current.unreadCount).toBe(1);
   });
 
   it("does not optimistically clear activity newer than the marker", async () => {

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useTaskActivity.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useTaskActivity.ts
@@ -11,6 +11,8 @@ import { TASK_ACTIVITY_QUERY_KEY } from "../task-activity/taskActivityQuery";
 
 export { TASK_ACTIVITY_QUERY_KEY } from "../task-activity/taskActivityQuery";
 
+const TASK_ACTIVITY_REFETCH_INTERVAL_MS = 60_000;
+
 /**
  * Task lifecycle and comment activity for the current user, newest first. Task
  * lifecycle rows collapse per task while comment notifications remain separate.
@@ -40,7 +42,9 @@ export function useTaskActivity(options?: { enabled?: boolean }): {
         ? { before: page.next_before, beforeId: page.next_before_id }
         : undefined,
     enabled: !!client && (options?.enabled ?? true),
-    staleTime: Number.POSITIVE_INFINITY,
+    staleTime: TASK_ACTIVITY_REFETCH_INTERVAL_MS,
+    refetchInterval: TASK_ACTIVITY_REFETCH_INTERVAL_MS,
+    refetchOnWindowFocus: "always",
     meta: AUTH_SCOPED_QUERY_META,
   });
   const items = useMemo(

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useTaskActivity.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useTaskActivity.ts
@@ -44,6 +44,7 @@ export function useTaskActivity(options?: { enabled?: boolean }): {
     enabled: !!client && (options?.enabled ?? true),
     staleTime: TASK_ACTIVITY_REFETCH_INTERVAL_MS,
     refetchInterval: TASK_ACTIVITY_REFETCH_INTERVAL_MS,
+    refetchOnMount: "always",
     refetchOnWindowFocus: "always",
     meta: AUTH_SCOPED_QUERY_META,
   });


### PR DESCRIPTION
## Problem

Desktop users can receive a comment mention in Slack while the Activity feed remains unchanged.

The server stores the Activity row before it queues Slack delivery. The desktop cache treated the feed as fresh forever and received no signal for remote comments.

## Changes

- The Activity feed refreshes when the app regains focus.
- The hover panel and Activity page refresh when they open.
- The Activity feed refreshes every 60 seconds while the app stays open.
- The cache stays fresh for one refresh interval to avoid duplicate requests when Activity surfaces mount.
- This change has no visual difference, so it needs no screenshot.

## How did you test this code?

- Added hook cases that catch stale comments after focus returns or an Activity surface opens.
- Ran the full `@posthog/ui` test suite.
- Ran the `@posthog/ui` TypeScript check and desktop Biome checks.
- Ran `hogli ci:preflight --fix`.
- Not run: manual Electron verification.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This fix does not change a documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

An OpenAI coding agent used GitHub CLI and the PostHog MCP. Skills invoked: `/working-with-task-comments`, `/writing-tests`, `/writing-pr-descriptions`, and `/writing-simplified-technical-english`.

The committed test data uses invented identifiers and content.
