### PR TITLE
chore(devex): probe Docker Hub credentials in Dagster CI

### DIFF
--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -300,12 +300,77 @@ jobs:
                   [ -d "data" ] && docker run --rm -v "$(pwd)/data:/data" alpine sh -c "rm -rf /data/seaweedfs /data/minio" || true
               continue-on-error: true
 
+            # TEMPORARY: diagnosing Docker Hub "unauthenticated pull rate limit" failures.
+            # Prints which rate-limit bucket the CI credentials land in. Never prints the
+            # credentials themselves, nor the derived JWT (a live bearer token, unmasked).
+            # Remove together with the two probe steps below once the root cause is fixed.
+            - name: 'PROBE: credential shape and rate-limit bucket'
+              continue-on-error: true
+              run: |
+                  set -euo pipefail
+                  IMG=library/postgres; TAG=15.12-alpine
+                  echo "DOCKERHUB_USER (a var, not a secret): '${DOCKERHUB_USERNAME:-<unset>}'"
+                  if [ -z "${DOCKERHUB_TOKEN:-}" ]; then
+                      echo "DOCKERHUB_TOKEN: UNSET - that alone would explain anonymous pulls"
+                      exit 0
+                  fi
+                  echo "DOCKERHUB_TOKEN: set, length ${#DOCKERHUB_TOKEN}"
+                  case "$DOCKERHUB_TOKEN" in
+                      dckr_oat_*) echo "token type: organization access token (dckr_oat_)" ;;
+                      dckr_pat_*) echo "token type: PERSONAL access token (dckr_pat_) - org entitlement may not apply" ;;
+                      *)          echo "token type: unrecognized prefix (legacy password?)" ;;
+                  esac
+                  echo "--- anonymous baseline for this runner's egress IP ---"
+                  ANON=$(curl -sS "https://auth.docker.io/token?service=registry.docker.io&scope=repository:$IMG:pull" | jq -r '.token // empty')
+                  curl -sS -I -H "Authorization: Bearer $ANON" \
+                      -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+                      "https://registry-1.docker.io/v2/$IMG/manifests/$TAG" \
+                      | grep -iE '^HTTP|ratelimit' || echo "(no ratelimit headers)"
+                  echo "--- same request, authenticated with the CI credentials ---"
+                  RESP=$(curl -sS -u "${DOCKERHUB_USERNAME}:${DOCKERHUB_TOKEN}" \
+                      "https://auth.docker.io/token?service=registry.docker.io&scope=repository:$IMG:pull")
+                  AUTHED=$(printf '%s' "$RESP" | jq -r '.token // empty')
+                  if [ -z "$AUTHED" ]; then
+                      echo "AUTH FAILED - no token returned:"
+                      printf '%s' "$RESP" | jq -r '.details // .errors // "unparseable"'
+                      exit 0
+                  fi
+                  echo "auth ok (jwt length ${#AUTHED})"
+                  curl -sS -I -H "Authorization: Bearer $AUTHED" \
+                      -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+                      "https://registry-1.docker.io/v2/$IMG/manifests/$TAG" \
+                      | grep -iE '^HTTP|ratelimit' || echo "(no ratelimit headers)"
+                  echo
+                  echo "Entitled looks like: 'docker-ratelimit-source: posthog' and NO ratelimit-limit header."
+                  echo "Anonymous looks like: an IP source and 'ratelimit-limit: 100;w=3600'."
+
             - name: Log in to Docker Hub
               if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
               uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
               with:
                   username: ${{ vars.DOCKERHUB_USER }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            # TEMPORARY: if login lands somewhere docker compose does not read, pulls go out anonymous.
+            - name: 'PROBE: credential store docker compose will actually read'
+              continue-on-error: true
+              run: |
+                  set -euo pipefail
+                  echo "HOME=$HOME  DOCKER_CONFIG=${DOCKER_CONFIG:-<unset>}"
+                  CONFIG="${DOCKER_CONFIG:-$HOME/.docker}/config.json"
+                  echo "config path: $CONFIG"
+                  if [ ! -f "$CONFIG" ]; then
+                      echo "NO CONFIG FILE - login did not persist where compose will look"
+                      exit 0
+                  fi
+                  # Keys only. Never dump 'auths' values: base64 of user:token, and unmasked.
+                  echo "--- registries with stored auth ---"
+                  jq -r '.auths // {} | keys[]' "$CONFIG"
+                  jq -r '{credsStore: (.credsStore // "<none>"), credHelpers: (.credHelpers // {})}' "$CONFIG"
+                  echo "--- does an explicit authenticated pull work here? ---"
+                  docker pull postgres:15.12-alpine >/dev/null 2>&1 \
+                      && echo "docker pull postgres:15.12-alpine: OK" \
+                      || echo "docker pull postgres:15.12-alpine: FAILED"
 
             - name: Start stack with Docker Compose
               env:

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -371,6 +371,16 @@ jobs:
                   docker pull postgres:15.12-alpine >/dev/null 2>&1 \
                       && echo "docker pull postgres:15.12-alpine: OK" \
                       || echo "docker pull postgres:15.12-alpine: FAILED"
+                  # The stored depot.dev registry auth suggests pulls are proxied through a
+                  # pull-through mirror. A mirror fetches upstream under its own identity, so
+                  # our Docker Hub credential would never reach Docker Hub on a cache miss.
+                  echo "--- daemon registry config (mirrors?) ---"
+                  docker info --format '{{json .RegistryConfig}}' 2>/dev/null | jq . || echo "(docker info failed)"
+                  echo "--- /etc/docker/daemon.json ---"
+                  cat /etc/docker/daemon.json 2>/dev/null || echo "(absent)"
+                  echo "--- who serves a cold pull? ---"
+                  docker rmi postgres:15.12-alpine >/dev/null 2>&1 || true
+                  docker pull postgres:15.12-alpine 2>&1 | tail -5
 
             - name: Start stack with Docker Compose
               env:


### PR DESCRIPTION
## Problem

Backend CI and Dagster CI have been failing since around 12:14 UTC today with `toomanyrequests: You have reached your unauthenticated pull rate limit` when Compose pulls the dev stack. At peak this hit roughly 45% of Backend CI jobs, against a baseline of zero for the previous 30 days.

The Docker Hub org subscription is active. A manually tested org access token returns `docker-ratelimit-source: posthog` with no rate-limit header at all for every image the dev stack needs — postgres, redis, zookeeper, clickhouse-server, redpanda, seaweedfs, alpine. So the entitlement is fine.

The failing pulls are landing in the anonymous bucket instead, which is 100 pulls per hour per IP. Depot runners share egress IPs and CI runs several thousand jobs an hour, each cold job pulling around 7 Docker Hub images, so that bucket empties immediately. That is why restoring the subscription changed nothing: those pulls never reach the account.

What is still unknown is *why* the credential does not apply, and there are only two candidates left. Either the CI secret does not carry the org entitlement, or `docker login` succeeds but stores the credential somewhere Compose does not read. `Login Succeeded` appears in every failing log, so the logs alone cannot tell these apart.

## Changes

Two temporary probe steps around the existing login step in the Dagster job — the smallest of the two affected workflows, and it triggers off its own workflow file.

- Before login: prints the token's type prefix and length, then the same manifest request twice, anonymous and authenticated, so the rate-limit headers show which bucket the CI credentials land in.
- After login: prints `HOME`, `DOCKER_CONFIG`, the registry keys stored in `config.json`, and any credential helper, then tries one explicit `docker pull`.

Both are `continue-on-error`, so they cannot turn the job red.

Neither the credentials nor the derived JWT are ever printed. The JWT matters here — it is a live bearer token and GitHub does not mask it. Only its length is logged. Stored `auths` values are base64 of `user:token`, so only the keys are printed, never the values.

Remove this commit once the root cause is fixed.

## How did you test this code?

Not run locally — it only produces signal on a depot runner with the real repository secrets, which is the whole point of the probe. Validated the YAML parses and `hogli lint:workflows` passes across all 124 workflows.

The equivalent probe was run by hand against Docker Hub with a throwaway org token, which is where the `docker-ratelimit-source: posthog` and `ratelimit-limit: 100;w=3600` figures above come from.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Skills invoked: `/diagnosing-ci-and-merge-bottlenecks` to size the incident, `/authoring-ci-workflows` for the workflow conventions.

Prevalence came from the engineering analytics warehouse. Worth noting for future incidents: `engineering_analytics_ci_failures` only fingerprints app-level test exceptions, so infra failures like this one return zero rows there and look like nothing is wrong. The signal is in the per-step JSON on `github_workflow_jobs` instead.

The first attempt at this was a standalone probe workflow, which was the wrong shape — it would have exercised a synthetic path rather than the one that actually breaks. Folding the probes into the real Dagster job keeps the runner class, step ordering, and env identical to the failing jobs.

Separately, the `Clean up data directories with container permissions` step runs `docker run alpine` before the login step, so that pull is always anonymous. Minor, but it spends the shared per-IP budget for free. Not changed here.

The durable fix is likely mirroring those seven Docker Hub base images to ghcr, since the `ghcr.io/posthog/*` images in the same Compose file never failed once during this incident. That is a separate PR.
