### PR TITLE
fix(desktop): square the activity tab underline ends

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.tsx
@@ -56,18 +56,20 @@ function ActivityHeader({
         {/* Nothing spells out "Activity" any more, so the strip carries the name.
             The list fills the row's 32px and drops quill's 3px inset so the
             line-variant indicator (bottom: 0 of the list) lands on the row's
-            bottom border, the way the left pane's tabs underline does. */}
+            bottom border, the way the left pane's tabs underline does.
+            The z-10 lifts the indicator above the active trigger, whose
+            opaque rounded background (quill: trigger z-1, indicator z-0)
+            otherwise covers the underline's top edge and leaves its ends
+            poking out as rounded-looking nubs. The underscores are escaped
+            because Tailwind turns bare underscores in arbitrary variants
+            into spaces, so the unescaped form matches nothing. */}
         <TabsList
           variant="line"
           aria-label="Activity"
-          className="h-[31px] gap-0.5 p-0"
+          className="h-[31px] gap-0.5 p-0 [&_.quill-tabs\_\_indicator]:z-10"
         >
           {ACTIVITY_TABS.map((t) => (
-            <TabsTrigger
-              key={t.key}
-              value={t.key}
-              className="rounded-none px-2.5"
-            >
+            <TabsTrigger key={t.key} value={t.key} className="px-2.5">
               <span className="font-medium text-[13px]">{t.label}</span>
             </TabsTrigger>
           ))}

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.tsx
@@ -63,7 +63,11 @@ function ActivityHeader({
           className="h-[31px] gap-0.5 p-0"
         >
           {ACTIVITY_TABS.map((t) => (
-            <TabsTrigger key={t.key} value={t.key} className="px-2.5">
+            <TabsTrigger
+              key={t.key}
+              value={t.key}
+              className="rounded-none px-2.5"
+            >
               <span className="font-medium text-[13px]">{t.label}</span>
             </TabsTrigger>
           ))}


### PR DESCRIPTION
## Problem

The active activity tab's underline (Timeline, Artifacts, Comments) shows rounded-looking nubs at both ends.

- The active tab trigger paints an opaque rounded background one z-level above the underline indicator and clips its top edge.
- At the trigger's rounded corners the clip recedes, so the underline's ends poke out taller than its middle.

## Changes

- The tab list raises the indicator's z-index above the trigger, so the underline paints its full square shape.
- The override escapes the underscores in `[&_.quill-tabs\_\_indicator]` because Tailwind turns bare underscores in arbitrary variants into spaces, which made the earlier attempts compile to a selector that matches nothing.
- Reverted the `rounded-none` trigger class from the first commit; the underline is a separate element, so it had no effect.

Before (the nubs, magnified):

![Activity tabs before square corners](https://raw.githubusercontent.com/PostHog/pr-assets/7c24389a201087f0d6c1c4a1fedfe7bf77c13c4f/2026/08/fb383303-d7cc-494f-ba8f-22a9f71c78d0.png)

> [!NOTE]
> `InboxTabBar.tsx` uses the same unescaped variant for its indicator transition overrides, so those rules have never applied. Left untouched here because fixing them changes the inbox tab animation.

## How did you test this code?

- Verified the compiled Tailwind output of the escaped variant produces `.quill-tabs__indicator { z-index: 10 }` (the unescaped form compiles to the dead selector `.quill-tabs  indicator`).
- Reproduced the clipping against the shipped `@posthog/quill` CSS in a standalone page and confirmed the z-index lift removes it.
- The human driver verified the fix visually in the running dev app.
- Ran `@posthog/ui` typecheck and Biome.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Styling fix only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Claude Fable 5) diagnosed and fixed this after two earlier attempts changed nothing on screen. Pixel-level analysis of screenshots located the clipping, and the shipped production bundle's CSS exposed the underscore-mangling bug that killed the earlier overrides. Skills invoked: /writing-code-comments, /writing-pr-descriptions.