### PR TITLE
feat(workflows): turn off unlayer ai features in the email editor

### DIFF
--- a/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
+++ b/frontend/src/scenes/hog-functions/email-templater/EmailTemplater.tsx
@@ -188,6 +188,10 @@ function DestinationEmailTemplaterForm({
                                             preview: true,
                                             imageEditor: true,
                                             stockImages: false,
+                                            // Unlayer's AI features (Magic Image, smart text, the AI
+                                            // assistant) default to on; they're third-party AI consuming
+                                            // paid credits from our Unlayer workspace, so keep them all off.
+                                            ai: false,
                                         },
                                     }}
                                 />
@@ -551,6 +555,10 @@ function NativeEmailTemplaterForm({
                                             preview: true,
                                             imageEditor: true,
                                             stockImages: false,
+                                            // Unlayer's AI features (Magic Image, smart text, the AI
+                                            // assistant) default to on; they're third-party AI consuming
+                                            // paid credits from our Unlayer workspace, so keep them all off.
+                                            ai: false,
                                         },
                                         projectId: unlayerEditorProjectId,
                                         customJS: [unsubscribeLinkToolCustomJs],


### PR DESCRIPTION
## Problem

The workflows email builder shows Unlayer's built-in AI features: a "Magic AI" image generator with sample images, smart text suggestions, and an AI assistant. We never opted into these; Unlayer enables them by default in the embedded editor. Each use draws paid AI credits from our Unlayer workspace. The editor is a cross-origin iframe, so we cannot see or support what they generate.

## Changes

- Set `features.ai: false` on both `EmailEditor` embeds: the workflow/destination email editor and the template editor.
- This removes Magic Image, smart text, smart headings, smart buttons, image alt text generation, and the AI assistant.
- The sample images in the Magic Image panel are not configurable, so off is the only lever ([Unlayer AI configuration docs](https://docs.unlayer.com/builder/ai-configuration)).

No screenshot: the AI panels render inside Unlayer's third-party iframe, and only against our paid Unlayer project in a live session.

## How did you test this code?

- The full frontend typecheck reports an identical error list with and without this change. The sandbox's pre-existing errors come from unbuilt local packages, none in this file.
- `unlayer-types` (pinned by `react-email-editor`) types `features.ai` as `boolean | {...}`, so the flag is valid config.
- Frontend lint/format and `hogli ci:preflight --fix` pass.
- Not run: a live editor session against the paid Unlayer project. The removal is verified against Unlayer's documented config, not visually.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: no docs reference the Unlayer AI features.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- I (Claude, in a PostHog Desktop session) first investigated whether the AI features see any use: in-editor activity is not measurable from PostHog analytics because the editor is a cross-origin iframe, and Unlayer meters AI usage in its own console.
- Skills invoked: /writing-code-comments, /writing-pr-descriptions.
- Scope started as `ai: { magicImage: false }` (image generator only) and widened to `ai: false` at the driver's direction.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
