### PR TITLE
fix(personhog): deliver the merge event's writes when the saga aborts

### DIFF
--- a/nodejs/src/common/generated/personhog/personhog/identity/v1/identity_pb.ts
+++ b/nodejs/src/common/generated/personhog/personhog/identity/v1/identity_pb.ts
@@ -535,7 +535,8 @@ export type MergePersonsResponse = Message<'personhog.identity.v1.MergePersonsRe
     /**
      * The surviving person's document. Authoritative (the folded document
      * the leader produced) when a merge ran; the resolved person otherwise.
-     * Absent when the operation aborted without merging anything.
+     * An aborted operation still answers the person the event's writes were
+     * delivered to; absent only when the target no longer resolves.
      *
      * @generated from field: optional personhog.types.v1.Person survivor = 2;
      */

--- a/proto/personhog/identity/v1/identity.proto
+++ b/proto/personhog/identity/v1/identity.proto
@@ -189,7 +189,8 @@ message MergePersonsResponse {
   string op_id = 1;
   // The surviving person's document. Authoritative (the folded document
   // the leader produced) when a merge ran; the resolved person otherwise.
-  // Absent when the operation aborted without merging anything.
+  // An aborted operation still answers the person the event's writes were
+  // delivered to; absent only when the target no longer resolves.
   optional personhog.types.v1.Person survivor = 2;
   // One result per requested source, same order as the request.
   repeated MergeSourceResult results = 3;

--- a/rust/personhog-identity/src/service/merge.rs
+++ b/rust/personhog-identity/src/service/merge.rs
@@ -85,7 +85,8 @@ impl MergeEntrance {
             }
             let frozen = row.request.clone();
             let row = self.ops.execute(op_id, row.team_id, &frozen).await?;
-            return merge_response(&row);
+            let delivered = self.deliver_aborted_writes(&request, &row).await?;
+            return merge_response(&row, delivered);
         }
 
         // Classify: resolve everything once on the primary, settle what
@@ -228,7 +229,51 @@ impl MergeEntrance {
             .map_err(|e| Status::internal(format!("failed to freeze inline results: {e}")))?;
 
         let row = self.ops.execute(op_id, request.team_id, &frozen).await?;
-        merge_response(&row)
+        let delivered = self.deliver_aborted_writes(&request, &row).await?;
+        merge_response(&row, delivered)
+    }
+
+    /// An aborted saga never folds, so the merge event's writes (its
+    /// $set/$set_once and the identified flip) would otherwise reach
+    /// nobody. Ingestion applies both to the target even when it refuses a
+    /// merge (person-merge-service.ts sets updateIsIdentified before it
+    /// looks at the source), so the RPC must too: deliver them against
+    /// whatever the target distinct id resolves to now. The frozen request
+    /// is not consulted for the person, because the op that caused the
+    /// abort may have settled the target away since. A push failure errors
+    /// the call rather than answering OK with lost writes; the retry
+    /// attaches to the aborted op and re-drives this delivery.
+    async fn deliver_aborted_writes(
+        &self,
+        request: &MergePersonsRequest,
+        row: &OpRow,
+    ) -> Result<Option<ProtoPerson>, Status> {
+        let aborted = row
+            .outcome
+            .as_ref()
+            .and_then(|o| o.get("aborted"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if !aborted {
+            return Ok(None);
+        }
+        let key = (request.team_id, request.target_distinct_id.clone());
+        let mut resolved = self
+            .storage
+            .resolve_distinct_ids(std::slice::from_ref(&key))
+            .await
+            .map_err(|e| Status::internal(format!("target re-resolution failed: {e}")))?;
+        // A target that no longer resolves was destroyed after the abort;
+        // the writes have no person to land on, and the caller's retry
+        // semantics (re-deliver the event) cover the gap.
+        let Some(survivor) = resolved.remove(&key) else {
+            return Ok(None);
+        };
+        // A saga only exists for legal resolved pairs, and ingestion marks
+        // the target identified for any legal pair regardless of the merge
+        // outcome, so the flip always accompanies the delivery.
+        let pushed = self.push_event_properties(request, &survivor, true).await?;
+        Ok(Some(pushed.unwrap_or_else(|| survivor.into())))
     }
 
     /// Apply the merge event's $set/$set_once and the identified flip to
@@ -440,10 +485,15 @@ fn survivor_to_proto(survivor: &Value, team_id: i64) -> ProtoPerson {
 
 /// Assemble the response for an op that ran the saga: inline outcomes from
 /// the frozen request, saga outcomes from the recorded terminal outcome,
-/// in the original request's source order.
+/// in the original request's source order. An aborted outcome records no
+/// survivor; `delivered` fills it with the person the aborted delivery
+/// wrote to, so the caller still learns the event's person.
 // See `MergeEntrance::handle` for why result_large_err is allowed.
 #[allow(clippy::result_large_err)]
-fn merge_response(row: &OpRow) -> Result<MergePersonsResponse, Status> {
+fn merge_response(
+    row: &OpRow,
+    delivered: Option<ProtoPerson>,
+) -> Result<MergePersonsResponse, Status> {
     let Some(outcome) = &row.outcome else {
         return Err(Status::internal(format!(
             "op {} is terminal but has no recorded outcome",
@@ -504,7 +554,8 @@ fn merge_response(row: &OpRow) -> Result<MergePersonsResponse, Status> {
         survivor: outcome
             .survivor
             .as_ref()
-            .map(|s| survivor_to_proto(s, row.team_id)),
+            .map(|s| survivor_to_proto(s, row.team_id))
+            .or(delivered),
         results,
     })
 }

--- a/rust/personhog-identity/tests/lifecycle_merge_tests.rs
+++ b/rust/personhog-identity/tests/lifecycle_merge_tests.rs
@@ -2123,10 +2123,10 @@ async fn a_move_limited_source_skips_while_the_rest_merge_through_the_rpc() {
 }
 
 #[tokio::test]
-async fn an_identified_source_aborts_through_the_rpc_with_no_survivor() {
+async fn an_identified_source_abort_still_delivers_the_events_writes() {
     let h = MergeHarness::new().await;
     let service = h.service();
-    let _target = h
+    let target = h
         .ctx
         .insert_person_with_distinct_id("rpc-ident-target")
         .await;
@@ -2137,20 +2137,24 @@ async fn an_identified_source_aborts_through_the_rpc_with_no_survivor() {
     h.set_person(source, r#"{"plan": "pro"}"#, 3, true).await;
 
     let op_id = Uuid::now_v7();
-    let request = rpc_request(
+    let mut request = rpc_request(
         h.ctx.team_id,
         "rpc-ident-target",
         &["rpc-ident-source"],
         op_id,
     );
+    request.event_set = serde_json::to_vec(&json!({"tier": "pro"})).unwrap();
     let response = service
         .merge_persons(Request::new(request.clone()))
         .await
         .expect("an aborted op still answers OK")
         .into_inner();
 
-    // The skip is an answer, not an error — and an aborted op carries no
-    // survivor document.
+    // The skip is an answer, not an error. The saga never folds, so the
+    // event's $set and the identified flip are delivered through the
+    // ordinary write surface instead, and the answer carries the person
+    // they landed on — the same person ingestion continues the event with
+    // when it refuses a merge.
     assert_eq!(
         rpc_outcomes(&response),
         vec![(
@@ -2158,24 +2162,96 @@ async fn an_identified_source_aborts_through_the_rpc_with_no_survivor() {
             MergeSourceOutcome::SkippedAlreadyIdentified
         )]
     );
-    assert!(response.survivor.is_none());
+    assert_eq!(response.survivor.as_ref().expect("survivor").id, target);
+    assert_eq!(
+        h.leader.calls(),
+        vec![LeaderCall::PropertyPush {
+            person_id: target,
+            is_identified: Some(true),
+        }]
+    );
     let (source_deleted, _, _) = h.person_state(source).await;
     assert!(!source_deleted);
 
     // The abort is recorded: a retry reproduces the answer instead of
-    // re-running classification.
+    // re-running classification, and re-drives the delivery (the same
+    // at-least-once semantics as the inline branch).
     let retry = service
         .merge_persons(Request::new(request))
         .await
         .expect("retry succeeds")
         .into_inner();
-    assert!(retry.survivor.is_none());
+    assert_eq!(retry.survivor.as_ref().expect("survivor").id, target);
     assert_eq!(
         rpc_outcomes(&retry),
         vec![(
             "rpc-ident-source".to_string(),
             MergeSourceOutcome::SkippedAlreadyIdentified
         )]
+    );
+    assert_eq!(h.leader.calls().len(), 2);
+
+    h.ctx.cleanup().await.expect("cleanup");
+}
+
+#[tokio::test]
+async fn a_failed_abort_delivery_errors_the_call_and_the_retry_delivers() {
+    let h = MergeHarness::new().await;
+    let service = h.service();
+    let target = h
+        .ctx
+        .insert_person_with_distinct_id("rpc-abort-fail-target")
+        .await;
+    let source = h
+        .ctx
+        .insert_person_with_distinct_id("rpc-abort-fail-source")
+        .await;
+    h.set_person(source, r#"{"plan": "pro"}"#, 3, true).await;
+    h.leader.fail_next(
+        Rpc::PropertyPush,
+        target,
+        Status::unavailable("leader unavailable"),
+    );
+
+    let op_id = Uuid::now_v7();
+    let mut request = rpc_request(
+        h.ctx.team_id,
+        "rpc-abort-fail-target",
+        &["rpc-abort-fail-source"],
+        op_id,
+    );
+    request.event_set = serde_json::to_vec(&json!({"tier": "pro"})).unwrap();
+
+    // OK means the event's writes are durable, so a failed delivery must
+    // surface as an error, never as an aborted answer with lost writes.
+    let status = service
+        .merge_persons(Request::new(request.clone()))
+        .await
+        .expect_err("a failed delivery fails the call");
+    assert_eq!(status.code(), Code::Unavailable);
+    let (step, _) = op_row_state(&h.ctx.pool, op_id).await;
+    assert_eq!(step, STEP_ABORTED);
+
+    // The retry attaches to the recorded abort and re-drives the delivery.
+    let retry = service
+        .merge_persons(Request::new(request))
+        .await
+        .expect("retry succeeds")
+        .into_inner();
+    assert_eq!(retry.survivor.as_ref().expect("survivor").id, target);
+    assert_eq!(
+        rpc_outcomes(&retry),
+        vec![(
+            "rpc-abort-fail-source".to_string(),
+            MergeSourceOutcome::SkippedAlreadyIdentified
+        )]
+    );
+    assert_eq!(
+        h.leader.calls(),
+        vec![LeaderCall::PropertyPush {
+            person_id: target,
+            is_identified: Some(true),
+        }]
     );
 
     h.ctx.cleanup().await.expect("cleanup");


### PR DESCRIPTION
## Problem

- An aborted merge saga (identified source, held target, every source fallen out) never folds, so the merge event's `$set`/`$set_once` and identified flip reached nobody. The inline branch pushes them and the fold carries them; the abort path dropped them. Raised in review on #79228.
- Ingestion applies both to the target even when it refuses a merge: `person-merge-service.ts` marks the target identified before it examines the source, and a refused merge falls through to the ordinary person update.

## Changes

- After a terminal aborted op row, the entrance re-resolves the target distinct id and pushes the event's writes through the leader.
- The frozen person id is not trusted for the delivery: the op that caused the abort may have settled the target away.
- The identified flip rides along on every abort delivery. A saga only exists for legal resolved pairs, and ingestion marks the target identified for any legal pair regardless of merge outcome.
- Aborted answers now carry the delivered person as survivor, the same person ingestion continues the event with. Absent only when the target no longer resolves.
- A failed push errors the call instead of answering OK with lost writes. The retry attaches to the recorded abort and re-drives the delivery, the same at-least-once shape as the inline branch.
- The survivor field's proto comment states the new contract; the Node stub regen carries only that comment.

## How did you test this code?

Two RPC tests:

- The identified-source abort test now asserts delivery: one leader push carrying the flip, survivor = target, and the retry re-driving the delivery. It previously asserted the absence of all three.
- New: a scripted push failure answers UNAVAILABLE with the abort recorded, and the retry attaches and delivers. Guards the "OK means the writes are durable" contract on the abort branch.

Ran `cargo test -p personhog-identity` (101 tests) and clippy `--all-targets` against a local persons Postgres. Not run here: the wider Rust CI matrix.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: pre-production service, contract documented in the proto.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code from a reviewer question on #79228. Node parity traced in `person-merge-service.ts`: `updateIsIdentified` is set before the source is examined, and a refused merge returns `needsPersonUpdate: true`.
- Skills invoked: /stacking-prs, /writing-pr-descriptions, /writing-tests, /writing-code-comments.
- The saga-level abort tests are untouched: delivery lives entirely in the entrance, after the op machinery returns the terminal row.
