### PR TITLE
chore(journeys): add storybook stories for the journey grid

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4730,10 +4730,10 @@ snapshots:
         hash: v1.k794b7964.ea754a4783f7653247f127337c407a8cdd4a9c6bc3f1b908d8d00dd1a090b966.KQ3yKnRzi4l3ZeYVThZdmo4L6mAbxtNa2uQh7y-kGWA
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--tile-filters-read-only--light:
         hash: v1.k794b7964.b2ca2efc52a9ccf56953159c66d3c8766acd1d3a17379d5faec45a4715ae24a9.fK76p7ZVcgvFJNcKJ5Ixy3YnBm_BcBSFnoytLS2jZdU
-    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark
-    :   hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
-    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light
-    :   hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
+    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark:
+        hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
+    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light:
+        hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--dark:
         hash: v1.k794b7964.b1e0f5f542426e34dec73826f3135902a392c0c13dade4fec14037c615186b13.kbxxijyDI1SdvgdKwkRnIRLLgmsine5AYvOcD79DYsY
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--light:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -2668,6 +2668,14 @@ snapshots:
         hash: v1.k794b7964.cc64ca6ab10ef0f936dd479fb6a76716fd5935b3dee59833377c03cb3e36569a.kVka0mzCaVBMto0uHpEx5cTwdVDK0wlESIquSCaBrjk
     insights-insightstable--sql-breakdown--light:
         hash: v1.k794b7964.710a5fa22da7eff24e97e754426977214d9cdb9fd0252415534110bc7d9bbf95.EmqhUt-YOAWJV1nbFZ2BA-Let9QcaeDgslu9bcPR_mE
+    insights-journeys-journeygrid--anchored--dark:
+        hash: v1.k794b7964.d960a6965fe0b701f77dc4cf3f1c668aa6c19f5369e5e4aaa5423a7158474deb.DVpy9fBOuJdH6MLVhfwTvQ1o2va4L7JaUwIpTqcGkRA
+    insights-journeys-journeygrid--anchored--light:
+        hash: v1.k794b7964.ab4a24132cd2d415118a5774326bafba3c0b2d4fae5e5b570da87455533622e9.tPiEyEEmflVExg0bWR8fYc8BzqZrg2y1R_MhCFUI5Pw
+    insights-journeys-journeygrid--anchored-with-chain-highlight--dark:
+        hash: v1.k794b7964.c43b6a6002a1ef2b9030a352ca4840e137fd436de0409060f4c4a97ee740b43d.GCVkRokuWvEmIuwR2cxsJGcIbNIGjN-7qfskI1Zap_8
+    insights-journeys-journeygrid--anchored-with-chain-highlight--light:
+        hash: v1.k794b7964.3c25339f2d35ecfb164f4c2d10f656af32dadc9fb61738f1615ca0472c68b362.DNXsvy-7s5WAmO8ITB50rk5n2SuIl2H4wQnZ7L_QFwk
     insights-metric--default--dark:
         hash: v1.k794b7964.bdc893ac78b0c99cb12fe2d3fa70346f932cccab0ae49df0d8e47e4740224266.KsZ8mkjoktS-Fzlo_tl1EQBX5t3-L0MWAbrR6yO2yCo
     insights-metric--default--light:
@@ -4722,10 +4730,10 @@ snapshots:
         hash: v1.k794b7964.ea754a4783f7653247f127337c407a8cdd4a9c6bc3f1b908d8d00dd1a090b966.KQ3yKnRzi4l3ZeYVThZdmo4L6mAbxtNa2uQh7y-kGWA
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--tile-filters-read-only--light:
         hash: v1.k794b7964.b2ca2efc52a9ccf56953159c66d3c8766acd1d3a17379d5faec45a4715ae24a9.fK76p7ZVcgvFJNcKJ5Ixy3YnBm_BcBSFnoytLS2jZdU
-    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark:
-        hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
-    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light:
-        hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
+    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark
+    :   hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
+    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light
+    :   hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--dark:
         hash: v1.k794b7964.b1e0f5f542426e34dec73826f3135902a392c0c13dade4fec14037c615186b13.kbxxijyDI1SdvgdKwkRnIRLLgmsine5AYvOcD79DYsY
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--light:

--- a/products/product_analytics/frontend/insights/journeys/JourneyGrid.stories.tsx
+++ b/products/product_analytics/frontend/insights/journeys/JourneyGrid.stories.tsx
@@ -1,0 +1,158 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { PathsV2Results } from '~/queries/schema/schema-general'
+
+import { JourneyGrid } from './JourneyGrid'
+import { buildJourneyGridModel, chainCardKey, journeyItemKey, journeyRibbonKey } from './journeyGridModel'
+
+const item = (event: string, label?: string): { event: string; label?: string } =>
+    label === undefined ? { event } : { event, label }
+
+const signUp = item('signed_up')
+const dashboardView = item('$pageview', '/dashboard')
+const pricingView = item('$pageview', '/pricing')
+const ordersView = item('$pageview', '/orders')
+const productViewed = item('product_viewed')
+const productAdded = item('product_added')
+const checkoutStarted = item('checkout_started')
+const purchaseCompleted = item('purchase_completed')
+
+// Drop-offs register at the journey's last reached step, so each column's drop-off count is a
+// subset of that column's population (matching the runner's drop_off_elements semantics).
+const MOCK_RESULTS: PathsV2Results = {
+    steps: [
+        { stepIndex: 0, rows: [{ item: signUp, count: 8240 }], otherCount: 0, dropOffCount: 2340 },
+        {
+            stepIndex: 1,
+            rows: [
+                { item: dashboardView, count: 2140 },
+                { item: productViewed, count: 1350 },
+                { item: checkoutStarted, count: 950 },
+                { item: pricingView, count: 640 },
+            ],
+            otherCount: 820,
+            dropOffCount: 2335,
+        },
+        {
+            stepIndex: 2,
+            rows: [
+                { item: productAdded, count: 1400 },
+                { item: checkoutStarted, count: 820 },
+                { item: ordersView, count: 615 },
+            ],
+            otherCount: 690,
+            dropOffCount: 1915,
+        },
+        {
+            stepIndex: 3,
+            rows: [
+                { item: purchaseCompleted, count: 880 },
+                { item: productAdded, count: 320 },
+            ],
+            otherCount: 410,
+            dropOffCount: 1320,
+        },
+    ],
+    edges: [
+        { stepIndex: 0, source: signUp, target: dashboardView, count: 2140 },
+        { stepIndex: 0, source: signUp, target: productViewed, count: 1350 },
+        { stepIndex: 0, source: signUp, target: checkoutStarted, count: 950 },
+        { stepIndex: 0, source: signUp, target: pricingView, count: 640 },
+        { stepIndex: 0, source: signUp, target: null, count: 820 },
+        { stepIndex: 1, source: dashboardView, target: productAdded, count: 700 },
+        { stepIndex: 1, source: dashboardView, target: checkoutStarted, count: 260 },
+        { stepIndex: 1, source: dashboardView, target: ordersView, count: 210 },
+        { stepIndex: 1, source: dashboardView, target: null, count: 240 },
+        { stepIndex: 1, source: productViewed, target: productAdded, count: 520 },
+        { stepIndex: 1, source: productViewed, target: checkoutStarted, count: 180 },
+        { stepIndex: 1, source: productViewed, target: null, count: 160 },
+        { stepIndex: 1, source: checkoutStarted, target: productAdded, count: 120 },
+        { stepIndex: 1, source: checkoutStarted, target: checkoutStarted, count: 250 },
+        { stepIndex: 1, source: checkoutStarted, target: ordersView, count: 230 },
+        { stepIndex: 1, source: checkoutStarted, target: null, count: 120 },
+        { stepIndex: 1, source: pricingView, target: productAdded, count: 60 },
+        { stepIndex: 1, source: pricingView, target: checkoutStarted, count: 130 },
+        { stepIndex: 1, source: pricingView, target: ordersView, count: 105 },
+        { stepIndex: 1, source: pricingView, target: null, count: 60 },
+        { stepIndex: 1, source: null, target: ordersView, count: 70 },
+        { stepIndex: 1, source: null, target: null, count: 110 },
+        { stepIndex: 2, source: productAdded, target: purchaseCompleted, count: 560 },
+        { stepIndex: 2, source: productAdded, target: productAdded, count: 180 },
+        { stepIndex: 2, source: productAdded, target: null, count: 170 },
+        { stepIndex: 2, source: checkoutStarted, target: purchaseCompleted, count: 300 },
+        { stepIndex: 2, source: checkoutStarted, target: productAdded, count: 60 },
+        { stepIndex: 2, source: checkoutStarted, target: null, count: 90 },
+        { stepIndex: 2, source: ordersView, target: purchaseCompleted, count: 20 },
+        { stepIndex: 2, source: ordersView, target: productAdded, count: 60 },
+        { stepIndex: 2, source: ordersView, target: null, count: 80 },
+        { stepIndex: 2, source: null, target: productAdded, count: 20 },
+        { stepIndex: 2, source: null, target: null, count: 70 },
+    ],
+    prefixes: [
+        { items: [signUp], count: 8240 },
+        { items: [signUp, productViewed], count: 1350 },
+        { items: [signUp, productViewed, productAdded], count: 520 },
+        { items: [signUp, productViewed, productAdded, purchaseCompleted], count: 210 },
+    ],
+}
+
+const meta: Meta<typeof JourneyGrid> = {
+    title: 'Insights/Journeys/JourneyGrid',
+    component: JourneyGrid,
+    parameters: {
+        layout: 'fullscreen',
+        viewMode: 'story',
+        mockDate: '2024-01-15',
+    },
+}
+export default meta
+
+type Story = StoryObj<typeof JourneyGrid>
+
+export const Anchored: Story = {
+    render: () => (
+        <JourneyGrid
+            model={buildJourneyGridModel(MOCK_RESULTS)}
+            isAnchored
+            nodeColor="#1d4aff"
+            onCardClick={() => {}}
+            onRibbonClick={() => {}}
+        />
+    ),
+}
+
+export const AnchoredWithChainHighlight: Story = {
+    render: () => {
+        const chain = [signUp, productViewed, productAdded, purchaseCompleted]
+        const counts = [8240, 1350, 520, 210]
+        const totals = [8240, 5900, 3525, 1610]
+        return (
+            <JourneyGrid
+                model={buildJourneyGridModel(MOCK_RESULTS)}
+                isAnchored
+                nodeColor="#1d4aff"
+                chainHighlight={{
+                    chain,
+                    countByCardKey: Object.fromEntries(
+                        chain.map((chainItem, position) => [chainCardKey(position, chainItem), counts[position]])
+                    ),
+                    fractionByCardKey: Object.fromEntries(
+                        chain.map((chainItem, position) => [
+                            chainCardKey(position, chainItem),
+                            counts[position] / totals[position],
+                        ])
+                    ),
+                    ribbonKeys: new Set(
+                        chain
+                            .slice(1)
+                            .map((chainItem, position) =>
+                                journeyRibbonKey(position, journeyItemKey(chain[position]), journeyItemKey(chainItem))
+                            )
+                    ),
+                }}
+                onCardClick={() => {}}
+                onRibbonClick={() => {}}
+            />
+        )
+    },
+}


### PR DESCRIPTION
## TL;DR (eli5)

The journeys chart now renders in Storybook with fake data. Anyone can see it, and change how it looks, without starting the app or seeding paths data.

## Problem

Visual work on the journeys insight has no render target. Seeing the chart requires a running app plus seeded paths data, and there is no visual regression coverage for it.

The chart's looks lag competing flow views, so iteration on it is coming. This PR adds the harness for that; it changes no product code.

## Changes

- Adds two `JourneyGrid` stories: the rest state and the hover chain-highlight state.
- The fixture is invented e-commerce data shaped to the runner's semantics: drop-offs register at the journey's last reached step, so column percentages stay honest.

Rest state:

![journeys_current](https://raw.githubusercontent.com/PostHog/pr-assets/6d5c6a7f1ea50d53cab13711f866f658089e5db2/2026/08/815dd29f-f19f-445a-a537-ad34f2614d35.png)

Hover chain-highlight state:

![journeys_chain](https://raw.githubusercontent.com/PostHog/pr-assets/532a4cc264987f49663b788bd03fce78bea16b28/2026/08/20140dc5-f38d-4b0d-9a36-6c20dfaa7597.png)

## How did you test this code?

- Rendered both stories in a local Storybook; the screenshots above come from that run.
- `pnpm --filter=@posthog/frontend typescript:check` passed.
- Not run: the visual regression suite; CI generates the snapshots for new stories.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (cloud task) wrote the stories while assessing how the journeys insight looks against competing flow views.
- Skills invoked: /writing-pr-descriptions.
- The fixture is invented; no numbers or text from the session context are transcribed. The driver's GitHub handle is unknown to this session, so the PR is unassigned.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
