### PR TITLE
fix(messaging): let API keys read the suppression list, with person:read

### DIFF
--- a/products/messaging/backend/api/message_suppression.py
+++ b/products/messaging/backend/api/message_suppression.py
@@ -96,7 +96,8 @@ class MessageSuppressionViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
 
     scope_object = "hog_flow"
     # Custom actions must declare their write status so TeamAndOrgViewSetMixin's AccessControlPermission
-    # checks hog_flow:write on the mutating endpoints; the default 'suppressions' list stays a read.
+    # checks hog_flow:write on the mutating endpoints. `suppressions` is scoped by its own
+    # `required_scopes` instead, since it needs person:read on top of the workflow scope.
     scope_object_write_actions = ["add_suppression", "remove_suppression"]
     serializer_class = _FallbackSerializer
 
@@ -108,7 +109,12 @@ class MessageSuppressionViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         responses={200: PaginatedMessageSuppressionSerializer},
         summary="List suppressed email addresses for the team",
     )
-    @action(detail=False, methods=["get"])
+    # The rows carry recipient email addresses and their SMTP diagnostics, so reading them is
+    # person-data access on top of workflow read — same rationale as the `assets` and
+    # `user_blast_radius` actions on HogFlowViewSet. Without `person:read` a workflow-only token
+    # could enumerate who a team emails, and probe whether a given address is known by paging for
+    # it. The UI uses session auth, which skips scope checks, so the suppression list is unaffected.
+    @action(detail=False, methods=["get"], required_scopes=["hog_flow:read", "person:read"])
     def suppressions(self, request: Request, **kwargs: Any) -> Response:
         """List suppressed recipients for the team, most recently updated first."""
         # Resource-level check: `AccessControlPermission` only guarantees the caller has some

--- a/products/messaging/backend/api/test/test_message_suppression.py
+++ b/products/messaging/backend/api/test/test_message_suppression.py
@@ -2,6 +2,11 @@ from posthog.test.base import APIBaseTest
 
 from django.test import SimpleTestCase
 
+from parameterized import parameterized
+
+from posthog.models.personal_api_key import PersonalAPIKey
+from posthog.models.utils import generate_random_token_personal, hash_key_value
+
 from products.messaging.backend.api.message_suppression import MessageSuppressionViewSet
 from products.messaging.backend.models.message_suppression import MessageSuppression, SuppressionSource
 
@@ -22,6 +27,43 @@ class TestMessageSuppressionViewSetScope(SimpleTestCase):
             "add_suppression",
             "remove_suppression",
         }
+
+
+class TestSuppressionListPersonalAPIKeyAccess(APIBaseTest):
+    """
+    Guards the token scopes on the read action. It needs both hog_flow:read and person:read, so
+    neither alone opens up the recipient addresses and SMTP diagnostics the rows carry. Session auth
+    skips scope checks entirely, so only a token exercises this.
+    """
+
+    def _key(self, scopes: list[str]) -> str:
+        value = generate_random_token_personal()
+        PersonalAPIKey.objects.create(
+            label="Test",
+            user=self.user,
+            secure_value=hash_key_value(value),
+            scopes=scopes,
+        )
+        return value
+
+    @parameterized.expand(
+        [
+            (["hog_flow:read", "person:read"], 200),
+            (["hog_flow:read"], 403),
+            (["person:read"], 403),
+        ]
+    )
+    def test_suppressions_read_requires_both_scopes(self, scopes: list[str], expected_status: int) -> None:
+        self.client.logout()
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/messaging_suppressions/suppressions/",
+            HTTP_AUTHORIZATION=f"Bearer {self._key(scopes)}",
+        )
+
+        assert response.status_code == expected_status, response.json()
+        if expected_status == 200:
+            assert set(response.json()) == {"count", "next", "previous", "results"}
 
 
 class TestRemoveSuppressionResetsSource(APIBaseTest):


### PR DESCRIPTION
## Problem

A user with a valid personal API key cannot read their team's email suppression list. `GET /api/projects/:id/messaging_suppressions/suppressions/` returns 403 for every personal API key and OAuth token, whatever scopes it carries.

- The response is `{"code": "permission_denied", "detail": "This action does not support personal API key access"}`.
- The read is a custom `@action` named `suppressions`, not `list`.
- `APIScopePermission` maps an action name to a required scope. An action it cannot map resolves to no scope, and the permission rejects it outright.
- The two POST actions work, because `scope_object_write_actions` declares them.
- Session auth returns before the scope check, so the app is unaffected and the gap stays hidden.

This reinstates #80759, which was reverted in #81483 so its review conversation could finish. That conversation is resolved here, so this PR carries the whole change rather than an increment on top of it.

## Changes

- Give the `suppressions` action `required_scopes=["hog_flow:read", "person:read"]`. `APIScopePermission` requires every listed scope, so a token missing either is rejected.
- Add a scope matrix test: both scopes pass, and each scope alone is rejected.

The reverted PR declared the action a plain read, reachable with `hog_flow:read` alone. Veria flagged that a workflow-scoped token could then read every suppressed address and the SMTP diagnostic from each bounce, and page the list to probe whether a given address is known. `HogFlowViewSet` already pairs `person:read` with `hog_flow:read` on `assets`, `invocation_results` and `user_blast_radius`, each for that same reason. This puts the suppression list on that existing convention.

Scoping the action this way makes an entry in `scope_object_read_actions` redundant, because `APIScopePermission` reads `required_scopes` first and returns. I left it out rather than keeping it as documentation, since omitting it also fails closed: if someone drops `required_scopes` later, the endpoint returns to 403 for every token instead of falling back to `hog_flow:read` alone, which is the exposure Veria raised.

> [!NOTE]
> The app is unaffected, because session auth skips scope checks. The MCP tool `messaging-suppressions-suppressions-retrieve` is `enabled: false`, so no tool changes behavior.

The two POST actions keep `hog_flow:write` alone. They take an address as input rather than returning one, so they disclose nothing about who a team messages.

## How did you test this code?

The parameterized matrix in `TestSuppressionListPersonalAPIKeyAccess` catches two regressions no existing test covered. Every other test in the file uses `APIBaseTest` session auth, which skips scope checks and passes either way.

- A token cannot reach the endpoint at all. I reproduced the reported 403 against the unfixed code.
- `hog_flow:read` alone reaches it. Against the reverted PR's code this case fails with `assert 200 == 403`, which is the exposure itself.
- `person:read` alone is rejected, so the change tightens the requirement rather than swapping it.

I probed the rejection reason with a throwaway test, then deleted it. The body is `API key missing required scope 'person:read'`, so the scope check produces the 403 rather than an unrelated gate. I also confirmed the endpoint works without an entry in `scope_object_read_actions`, rather than assuming `required_scopes` takes precedence.

<details>
<summary>Checks I ran locally</summary>

Both suppression suites and ruff, against a local dev stack. The pre-commit hook ran `lint:python:fix`, `format:python`, and `ty check`.

</details>

I did not test this against a browser or a deployed environment, and I did not exercise the OAuth token path, which shares the permission class. No OpenAPI regeneration: `PersonalAPIKeyScheme` reads the scopes when it builds the spec, and no generated artifact in the repo records them.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via PostHog Code) opened #80759, then picked up Veria's review comment after the revert landed. The branch is rebased onto post-revert master, so the diff now reinstates the fix and tightens the scope in one commit.

I checked the suggestion against the codebase before implementing it, since a bot flag is not on its own a reason to narrow an endpoint. The `hog_flow` plus `person:read` pairing turned out to be an established convention in `hog_flow.py` with the same written rationale. I used the `@action(required_scopes=...)` form rather than the `dangerously_get_required_scopes` hook that `hog_flow.py` uses, because this action serves one method and does not need method-aware scopes.

Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-pr-descriptions`.

One thing for a reviewer to weigh, which I did not change here. `MessagePreferencesViewSet` exposes recipient identifiers through `opt_outs` and `export_opt_outs_csv` under `hog_flow:read` alone, which looks like the same gap in the same product. I left it out to keep this PR to the reported issue, and because that endpoint is older and more likely to have callers. It is worth a decision either way, since leaving it means the stricter gate sits on the narrower endpoint while a bulk CSV export stays open.

The work drew only on this repository. No customer conversation, ticket, or log reached the diff or this description.
