### PR TITLE
fix(logs): stop masking version strings as IP addresses

### DIFF
--- a/products/logs/backend/log_patterns.py
+++ b/products/logs/backend/log_patterns.py
@@ -19,10 +19,11 @@ _MASKING_INSTRUCTIONS = [
     # a letter, so "12T08" and "397557Z" in ISO-8601 bodies would survive \b\d+\b intact.
     MaskingInstruction(r"\b\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?(?:Z|[+-]\d{2}:?\d{2})?", "timestamp"),
     MaskingInstruction(r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b", "uuid"),
-    # A dotted quad glued to a "/" is a version, not an address ("Chrome/139.0.0.0"), and a
-    # \b-bounded match claims it as an <ip>. Blocking a leading "." on the same grounds keeps
-    # the mask off the tail of a longer dotted run, and the trailing guard off its head.
-    MaskingInstruction(r"(?<![\w./])\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(?![\w.])", "ip"),
+    # A dotted quad after "<letter>/" is a version, not an address ("Chrome/139.0.0.0"), and
+    # a \b-bounded match claims it as an <ip>. The guard keys on the letter so an address in
+    # a URL, which follows "//" or ":", still masks. The "." guards keep the mask off the
+    # tail and head of a longer dotted run such as "1.2.3.4.5".
+    MaskingInstruction(r"(?<![A-Za-z]/)(?<![\w.])\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(?![\w.])", "ip"),
     MaskingInstruction(r"\b0x[0-9a-fA-F]+\b", "hex"),
     MaskingInstruction(r"\b[0-9a-fA-F]{16,}\b", "hex"),
     MaskingInstruction(r"\b\d+\b", "num"),

--- a/products/logs/backend/log_patterns.py
+++ b/products/logs/backend/log_patterns.py
@@ -19,7 +19,10 @@ _MASKING_INSTRUCTIONS = [
     # a letter, so "12T08" and "397557Z" in ISO-8601 bodies would survive \b\d+\b intact.
     MaskingInstruction(r"\b\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?(?:Z|[+-]\d{2}:?\d{2})?", "timestamp"),
     MaskingInstruction(r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b", "uuid"),
-    MaskingInstruction(r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b", "ip"),
+    # A dotted quad glued to a "/" is a version, not an address ("Chrome/139.0.0.0"), and a
+    # \b-bounded match claims it as an <ip>. Blocking a leading "." on the same grounds keeps
+    # the mask off the tail of a longer dotted run, and the trailing guard off its head.
+    MaskingInstruction(r"(?<![\w./])\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(?![\w.])", "ip"),
     MaskingInstruction(r"\b0x[0-9a-fA-F]+\b", "hex"),
     MaskingInstruction(r"\b[0-9a-fA-F]{16,}\b", "hex"),
     MaskingInstruction(r"\b\d+\b", "num"),

--- a/products/logs/backend/log_patterns.py
+++ b/products/logs/backend/log_patterns.py
@@ -22,8 +22,9 @@ _MASKING_INSTRUCTIONS = [
     # A dotted quad after "<letter>/" is a version, not an address ("Chrome/139.0.0.0"), and
     # a \b-bounded match claims it as an <ip>. The guard keys on the letter so an address in
     # a URL, which follows "//" or ":", still masks. The "." guards keep the mask off the
-    # tail and head of a longer dotted run such as "1.2.3.4.5".
-    MaskingInstruction(r"(?<![A-Za-z]/)(?<![\w.])\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(?![\w.])", "ip"),
+    # tail and head of a longer dotted run such as "1.2.3.4.5", and only a "." that carries
+    # on the run blocks the match, so a sentence-final address still masks.
+    MaskingInstruction(r"(?<![A-Za-z]/)(?<![\w.])\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(?!\w)(?!\.\d)", "ip"),
     MaskingInstruction(r"\b0x[0-9a-fA-F]+\b", "hex"),
     MaskingInstruction(r"\b[0-9a-fA-F]{16,}\b", "hex"),
     MaskingInstruction(r"\b\d+\b", "num"),

--- a/products/logs/backend/test/test_log_patterns.py
+++ b/products/logs/backend/test/test_log_patterns.py
@@ -106,6 +106,21 @@ class TestMinePatterns(TestCase):
         assert expected_token in patterns[0].pattern
         assert raw_token not in patterns[0].pattern
 
+    @parameterized.expand(
+        [
+            ("chrome_version", "agent Chrome/139.0.0.0 connected"),
+            ("four_part_release", "rolled out build/2.14.0.3 to canary"),
+            ("longer_dotted_run", "schema version 1.2.3.4.5 loaded"),
+        ]
+    )
+    def test_version_strings_are_not_masked_as_ips(self, _name: str, line: str) -> None:
+        # A dotted quad in a version is indistinguishable from an address by octet range, so
+        # the mask keys on the surrounding characters. Reading "Chrome/<ip>" in a template
+        # sends the reader looking for a network problem that is not there.
+        patterns = mine_patterns([_sample(line)])
+
+        assert "<ip>" not in patterns[0].pattern
+
     def test_error_count_includes_only_error_and_fatal(self) -> None:
         samples = [
             _sample("db connection dropped", severity="error"),

--- a/products/logs/backend/test/test_log_patterns.py
+++ b/products/logs/backend/test/test_log_patterns.py
@@ -66,6 +66,14 @@ class TestMinePatterns(TestCase):
                 "<ip>",
                 "10.0.0.1",
             ),
+            # only a "." that carries on a dotted run rules the address out, so an address
+            # that ends a sentence still masks
+            (
+                "ipv4_at_end_of_sentence",
+                ["closed connection to 10.0.0.1.", "closed connection to 192.168.1.1."],
+                "<ip>",
+                "10.0.0.1",
+            ),
             (
                 "uuid",
                 [
@@ -454,7 +462,7 @@ class TestPivotSoundness(TestCase):
 class TestIpMaskProperties(TestCase):
     """The cases above pin specific addresses; these hold the guard over every octet value.
 
-    The guard reads the character before the address, so the property that matters is which
+    The guard reads the characters around the address, so the property that matters is which
     contexts still mask and which no longer do, across the whole address space.
     """
 
@@ -472,6 +480,25 @@ class TestIpMaskProperties(TestCase):
         # Every dotted quad is a valid version string too, so this has to hold for all of
         # them, not only for the browser builds the example cases use.
         patterns = mine_patterns([_sample(f"agent {product}/{address} connected")])
+
+        assert "<ip>" not in patterns[0].pattern
+
+    @given(address=_ipv4_st)
+    @settings(max_examples=400, deadline=None)
+    def test_any_address_that_ends_a_sentence_masks(self, address: str) -> None:
+        # The trailing guard exists to keep the mask off a longer dotted run, so it has to
+        # let a "." that ends the line through, whatever the last octet is.
+        patterns = mine_patterns([_sample(f"closed connection to {address}.")])
+
+        assert "<ip>" in patterns[0].pattern
+        assert address not in patterns[0].pattern
+
+    @given(run=_five_octet_st)
+    @settings(max_examples=400, deadline=None)
+    def test_no_address_is_read_out_of_a_longer_dotted_run(self, run: str) -> None:
+        # The trailing guard turns on whether the next "." carries on the run, so the octet
+        # values are what decide it, and neither the head nor the tail of the run may mask.
+        patterns = mine_patterns([_sample(f"schema version {run} loaded")])
 
         assert "<ip>" not in patterns[0].pattern
 

--- a/products/logs/backend/test/test_log_patterns.py
+++ b/products/logs/backend/test/test_log_patterns.py
@@ -58,6 +58,14 @@ class TestMinePatterns(TestCase):
         [
             ("numbers", ["Request 123 took 5 ms", "Request 456 took 9 ms"], "<num>", "123"),
             ("ipv4", ["GET from 10.0.0.1", "GET from 192.168.1.1"], "<ip>", "10.0.0.1"),
+            # the version guard keys on the character before the address, so a URL host,
+            # which is the one place an address does follow a "/", must still mask
+            (
+                "ipv4_in_url",
+                ["fetched http://10.0.0.1/health ok", "fetched http://192.168.1.1/health ok"],
+                "<ip>",
+                "10.0.0.1",
+            ),
             (
                 "uuid",
                 [

--- a/products/logs/backend/test/test_log_patterns.py
+++ b/products/logs/backend/test/test_log_patterns.py
@@ -325,7 +325,15 @@ def _timestamp_st(draw: st.DrawFn) -> str:
     return text + draw(st.sampled_from(["", "Z", "+00:00", "-05:30", "+0230", "-1145"]))
 
 
-_variable_token_st = st.one_of(_uuid_st, _hex_0x_st, _hex_bare_st, _num_st, _timestamp_st())
+_ipv4_st = st.tuples(*[st.integers(min_value=0, max_value=255)] * 4).map(lambda octets: ".".join(map(str, octets)))
+# Characters an address really follows in a log body. "/" is deliberately absent: that is
+# the one the guard rejects, and the URL case below covers "//" separately.
+_delimiter_st = st.sampled_from([" ", "=", ":", '"', ",", "[", "(", "|"])
+_product_st = st.text("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", min_size=1, max_size=14)
+_scheme_st = st.sampled_from(["http", "https"])
+
+
+_variable_token_st = st.one_of(_uuid_st, _hex_0x_st, _hex_bare_st, _num_st, _timestamp_st(), _ipv4_st)
 
 
 class TestMaskingProperties(TestCase):
@@ -401,6 +409,10 @@ _truncated_uuid_st = st.uuids().map(lambda u: str(u)[:23])
 
 # Tokens the masker deliberately leaves (fully or partly) literal. A pivot regex mined
 # from a masked body must not match a sibling holding one of these in the same slot.
+_five_octet_st = st.tuples(*[st.integers(min_value=0, max_value=255)] * 5).map(
+    lambda octets: ".".join(map(str, octets))
+)
+_versioned_quad_st = st.tuples(_product_st, _ipv4_st).map(lambda t: f"{t[0]}/{t[1]}")
 # One row per (masked kind, confusable neighbor). Both halves of the row matter: the mask
 # has to tell the pair apart, and so does the pivot regex the mask produces. A single
 # union-of-everything property dilutes each pair to a fraction of the example budget, so
@@ -412,6 +424,8 @@ _CONFUSABLE_PAIRS = [
     ("timestamp_vs_minute_precision", _timestamp_st(), _minute_timestamp_st),
     ("uuid_vs_truncated_uuid", _uuid_st, _truncated_uuid_st),
     ("hex_vs_letter_only_hex", st.one_of(_hex_0x_st, _hex_bare_st), _letter_hex_st),
+    ("ip_vs_five_octets", _ipv4_st, _five_octet_st),
+    ("ip_vs_versioned_quad", _ipv4_st, _versioned_quad_st),
 ]
 
 
@@ -435,3 +449,38 @@ class TestPivotSoundness(TestCase):
         # the "view matching logs" pivot.
         assert mined.match_regex is not None
         assert not re.search(mined.match_regex, impostor_body)
+
+
+class TestIpMaskProperties(TestCase):
+    """The cases above pin specific addresses; these hold the guard over every octet value.
+
+    The guard reads the character before the address, so the property that matters is which
+    contexts still mask and which no longer do, across the whole address space.
+    """
+
+    @given(address=_ipv4_st, delimiter=_delimiter_st)
+    @settings(max_examples=400, deadline=None)
+    def test_any_address_after_a_plain_delimiter_masks(self, address: str, delimiter: str) -> None:
+        patterns = mine_patterns([_sample(f"peer{delimiter}{address} closed")])
+
+        assert "<ip>" in patterns[0].pattern
+        assert address not in patterns[0].pattern
+
+    @given(address=_ipv4_st, product=_product_st)
+    @settings(max_examples=400, deadline=None)
+    def test_no_address_is_read_out_of_a_version_after_a_product_name(self, address: str, product: str) -> None:
+        # Every dotted quad is a valid version string too, so this has to hold for all of
+        # them, not only for the browser builds the example cases use.
+        patterns = mine_patterns([_sample(f"agent {product}/{address} connected")])
+
+        assert "<ip>" not in patterns[0].pattern
+
+    @given(address=_ipv4_st, scheme=_scheme_st)
+    @settings(max_examples=400, deadline=None)
+    def test_any_address_in_a_url_still_masks(self, address: str, scheme: str) -> None:
+        # A URL host is the one place an address does follow a "/". An earlier version of the
+        # guard blocked every "/" and silently stopped masking these.
+        patterns = mine_patterns([_sample(f"GET {scheme}://{address}/health ok")])
+
+        assert "<ip>" in patterns[0].pattern
+        assert address not in patterns[0].pattern


### PR DESCRIPTION
## Problem

Someone reading Logs → Patterns sees templates like `Chrome/<ip>` and `AppleWebKit/<num>.<num>`, which points them at a network address that was never there.

- The IP mask matches any dotted quad between word boundaries.
- A four-part version number, such as a Chrome build, has that exact shape.
- Octet range checks cannot separate the two, because `139.0.0.0` is a valid address.

## Changes

- The IP mask now skips a dotted quad that follows a letter and a `/`, so a version after a product name stays unmasked.
- The guard keys on the letter rather than on `/` alone. A URL host is the one place an address does follow a `/`, and it always follows `//` or `:`, so `http://10.0.0.1/health` still masks.
- A leading `.`, and a trailing `.` that a digit follows, block the mask on the same grounds. That keeps it off the head and tail of a longer dotted run such as `1.2.3.4.5`.
- A trailing `.` that no digit follows ends a sentence, so `closed connection to 10.0.0.1.` still masks.
- An address at the end of a path, such as `GET /api/hosts/10.0.0.1`, has the shape of `Chrome/139.0.0.0`, so the guard reads it as a version and leaves it unmasked.
- I picked the version reading for that ambiguity, because a wrong `<ip>` sends a reader after a network problem, while `<num>.<num>.<num>.<num>` only reads verbose.
- Affected templates lose the wrong `<ip>` and read `<num>.<num>.<num>.<num>` instead, which is correct but verbose. A follow-up PR adds a `<version>` placeholder that collapses those.

The mask keys on surrounding characters rather than the value, because context is the only available signal here.

## How did you test this code?

- `test_version_strings_are_not_masked_as_ips` — 3 cases catch the regression directly: a browser build, a four-part release after a path segment, and a five-part dotted run.
- 2 masking cases catch the guard going too far. `ipv4_in_url` fails against the first version of this fix, which blocked any `/` and silently stopped masking addresses in URLs. `ipv4_at_end_of_sentence` fails against a trailing guard that rejects every `.`.
- I checked both candidate regexes side by side against real log shapes: an Envoy address field, `x-forwarded-for` with two addresses, `remote_addr=`, an address with a port, an address in an `http://` URL, and an address in an `https://` URL with a port.
**Property tests** (`TestIpMaskProperties`, Hypothesis) hold the guard over all 2^32 addresses rather than the three above.

- Any address after a plain delimiter masks, across every octet value.
- Any address after a product name and a slash does not mask. Every dotted quad is also a valid version string, so this has to hold for all of them.
- Any address in an `http` or `https` URL still masks.
- Any address that ends a sentence masks, whatever the last octet is.
- No address is read out of a five-part dotted run, at either end.

I mutation-tested the properties. Reverting the guard to plain word boundaries fails the version property. Blocking every leading slash, which is the bug the second commit fixed, fails the URL property. Rejecting every trailing `.` fails the sentence property, and dropping the digit check after it fails the dotted-run property.

- Not run: the database-backed tests in `test_pattern_diff.py`. This sandbox has no Postgres.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via the PostHog Slack app) found this while auditing mined templates for value classes the miner masks wrongly or not at all. `Chrome/<ip>` showed up in several user-agent templates.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

Two things changed across the session. First, I considered adding a `<version>` mask ahead of `<ip>` instead, so the version would be consumed before the IP mask saw it. That ordering breaks addresses in URLs, since `http://10.0.0.1/` would mine as a version, so the guard belongs on the IP mask and `<version>` becomes a follow-up that stacks on this branch. Second, my initial guard blocked any leading `/` and cost URL masking; the second commit fixes that and adds the case that catches it. Third, review flagged that the trailing guard also blocked a sentence-final address, which the fourth commit fixes.

This is one of five separate PRs against the same two blocks in `log_patterns.py`, so they conflict with each other on merge and want landing one at a time.


