### PR TITLE
feat(logs): add a version placeholder to mined log patterns

### DIFF
--- a/products/logs/backend/log_patterns.py
+++ b/products/logs/backend/log_patterns.py
@@ -25,6 +25,11 @@ _MASKING_INSTRUCTIONS = [
     # tail and head of a longer dotted run such as "1.2.3.4.5", and only a "." that carries
     # on the run blocks the match, so a sentence-final address still masks.
     MaskingInstruction(r"(?<![A-Za-z]/)(?<![\w.])\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(?!\w)(?!\.\d)", "ip"),
+    # Dotted version numbers ("Chrome/139.0.0.0", "HTTP/1.1") otherwise split into one <num>
+    # per part, which buries the literal content of a user-agent or protocol template. The
+    # "/" is required: it separates a version from a plain decimal such as "duration=1.5".
+    # Runs after ip so an address in a URL is already masked and cannot look like a version.
+    MaskingInstruction(r"(?<=/)\d+(?:\.\d+){1,3}", "version"),
     MaskingInstruction(r"\b0x[0-9a-fA-F]+\b", "hex"),
     MaskingInstruction(r"\b[0-9a-fA-F]{16,}\b", "hex"),
     MaskingInstruction(r"\b\d+\b", "num"),
@@ -42,6 +47,7 @@ _PLACEHOLDER_PATTERNS = {
     "<timestamp>": r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?(?:Z|[+-]\d{2}:?\d{2})?",
     "<uuid>": r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
     "<ip>": r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}",
+    "<version>": r"\d+(?:\.\d+){1,3}",
     "<hex>": r"(?:0x[0-9a-fA-F]+|[0-9a-fA-F]{16,})",
 }
 _PLACEHOLDER_RE = re.compile("|".join(re.escape(p) for p in _PLACEHOLDER_PATTERNS))

--- a/products/logs/backend/log_patterns.py
+++ b/products/logs/backend/log_patterns.py
@@ -28,8 +28,10 @@ _MASKING_INSTRUCTIONS = [
     # Dotted version numbers ("Chrome/139.0.0.0", "HTTP/1.1") otherwise split into one <num>
     # per part, which buries the literal content of a user-agent or protocol template. The
     # "/" is required: it separates a version from a plain decimal such as "duration=1.5".
+    # The part count is unbounded so a longer release such as "build/1.2.3.4.5" collapses
+    # whole, instead of leaving a "<version>.<num>" tail on a template of its own.
     # Runs after ip so an address in a URL is already masked and cannot look like a version.
-    MaskingInstruction(r"(?<=/)\d+(?:\.\d+){1,3}", "version"),
+    MaskingInstruction(r"(?<=/)\d+(?:\.\d+)+", "version"),
     MaskingInstruction(r"\b0x[0-9a-fA-F]+\b", "hex"),
     MaskingInstruction(r"\b[0-9a-fA-F]{16,}\b", "hex"),
     MaskingInstruction(r"\b\d+\b", "num"),
@@ -47,7 +49,7 @@ _PLACEHOLDER_PATTERNS = {
     "<timestamp>": r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?(?:Z|[+-]\d{2}:?\d{2})?",
     "<uuid>": r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
     "<ip>": r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}",
-    "<version>": r"\d+(?:\.\d+){1,3}",
+    "<version>": r"\d+(?:\.\d+)+",
     "<hex>": r"(?:0x[0-9a-fA-F]+|[0-9a-fA-F]{16,})",
 }
 _PLACEHOLDER_RE = re.compile("|".join(re.escape(p) for p in _PLACEHOLDER_PATTERNS))

--- a/products/logs/backend/test/test_log_patterns.py
+++ b/products/logs/backend/test/test_log_patterns.py
@@ -368,7 +368,9 @@ _product_st = st.text("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", mi
 _scheme_st = st.sampled_from(["http", "https"])
 
 
-_version_st = st.lists(st.integers(min_value=0, max_value=9999), min_size=2, max_size=4).map(
+# Up to six parts, past the four a browser build uses: a bounded mask consumes the first four
+# of a longer release and leaves the rest as <num>, which is a template of its own again.
+_version_st = st.lists(st.integers(min_value=0, max_value=9999), min_size=2, max_size=6).map(
     lambda parts: ".".join(map(str, parts))
 )
 _decimal_context_st = st.sampled_from(["duration_ms=", "ratio=", "load ", "p95="])
@@ -563,7 +565,7 @@ class TestVersionMaskProperties(TestCase):
     def test_any_version_after_a_product_name_collapses_to_one_placeholder(self, product: str, version: str) -> None:
         patterns = mine_patterns([_sample(f"agent {product}/{version} connected")])
 
-        # exact template: two to four parts become one placeholder, not one <num> per part
+        # exact template: however many parts, one placeholder, not one <num> per part
         assert patterns[0].pattern == f"agent {product}/<version> connected"
 
     @given(context=_decimal_context_st, whole=st.integers(min_value=0, max_value=9999), frac=st.integers(0, 999))

--- a/products/logs/backend/test/test_log_patterns.py
+++ b/products/logs/backend/test/test_log_patterns.py
@@ -102,6 +102,18 @@ class TestMinePatterns(TestCase):
                 "397557",
             ),
             (
+                "version_after_product",
+                ["agent Chrome/139.0.0.0 connected", "agent Chrome/140.0.7.1 connected"],
+                "<version>",
+                "139",
+            ),
+            (
+                "protocol_version",
+                ["served HTTP/1.1 request", "served HTTP/2.0 request"],
+                "<version>",
+                "1.1",
+            ),
+            (
                 "timestamp_utc_offset",
                 [
                     "job 2026-08-12T08:10:43+00:00 retried",
@@ -136,6 +148,20 @@ class TestMinePatterns(TestCase):
         patterns = mine_patterns([_sample(line)])
 
         assert "<ip>" not in patterns[0].pattern
+
+    @parameterized.expand(
+        [
+            ("decimal_metric", "request took duration=1.5 seconds"),
+            ("numeric_path_segment", "POST /api/projects/2/query/ returned 200"),
+            ("module_version", "loaded python3.13 runtime"),
+        ]
+    )
+    def test_plain_decimals_are_not_masked_as_versions(self, _name: str, line: str) -> None:
+        # The "/" requirement is what separates a version from a measurement. Masking a
+        # latency or a ratio as <version> hides the number a reader came for.
+        patterns = mine_patterns([_sample(line)])
+
+        assert "<version>" not in patterns[0].pattern
 
     def test_error_count_includes_only_error_and_fatal(self) -> None:
         samples = [
@@ -253,6 +279,7 @@ class TestCompileMatchRegex(TestCase):
             ("request <uuid> failed", "request 93fce79d-6926-4b08-8fa5-00ffd8e65f4e failed"),
             ("peer <ip> disconnected", "peer 10.32.243.94 disconnected"),
             ("token <hex> rejected", "token 0xdeadbeef rejected"),
+            ("agent Chrome/<version> connected", "agent Chrome/139.0.0.0 connected"),
             ("path /api/v1/users?id=<num> hit", "path /api/v1/users?id=42 hit"),
             ("job <timestamp> finished", "job 2026-08-12T08:10:43.397557Z finished"),
         ]

--- a/products/logs/backend/test/test_log_patterns.py
+++ b/products/logs/backend/test/test_log_patterns.py
@@ -368,7 +368,14 @@ _product_st = st.text("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", mi
 _scheme_st = st.sampled_from(["http", "https"])
 
 
-_variable_token_st = st.one_of(_uuid_st, _hex_0x_st, _hex_bare_st, _num_st, _timestamp_st(), _ipv4_st)
+_version_st = st.lists(st.integers(min_value=0, max_value=9999), min_size=2, max_size=4).map(
+    lambda parts: ".".join(map(str, parts))
+)
+_decimal_context_st = st.sampled_from(["duration_ms=", "ratio=", "load ", "p95="])
+_slash_version_st = st.tuples(_product_st, _version_st).map(lambda t: f"{t[0]}/{t[1]}")
+_variable_token_st = st.one_of(
+    _uuid_st, _hex_0x_st, _hex_bare_st, _num_st, _timestamp_st(), _ipv4_st, _slash_version_st
+)
 
 
 class TestMaskingProperties(TestCase):
@@ -448,6 +455,9 @@ _five_octet_st = st.tuples(*[st.integers(min_value=0, max_value=255)] * 5).map(
     lambda octets: ".".join(map(str, octets))
 )
 _versioned_quad_st = st.tuples(_product_st, _ipv4_st).map(lambda t: f"{t[0]}/{t[1]}")
+_plain_decimal_st = st.tuples(st.integers(min_value=0, max_value=9999), st.integers(min_value=0, max_value=999)).map(
+    lambda t: f"{t[0]}.{t[1]}"
+)
 # One row per (masked kind, confusable neighbor). Both halves of the row matter: the mask
 # has to tell the pair apart, and so does the pivot regex the mask produces. A single
 # union-of-everything property dilutes each pair to a fraction of the example budget, so
@@ -461,6 +471,7 @@ _CONFUSABLE_PAIRS = [
     ("hex_vs_letter_only_hex", st.one_of(_hex_0x_st, _hex_bare_st), _letter_hex_st),
     ("ip_vs_five_octets", _ipv4_st, _five_octet_st),
     ("ip_vs_versioned_quad", _ipv4_st, _versioned_quad_st),
+    ("version_vs_plain_decimal", _slash_version_st, _plain_decimal_st),
 ]
 
 
@@ -538,3 +549,40 @@ class TestIpMaskProperties(TestCase):
 
         assert "<ip>" in patterns[0].pattern
         assert address not in patterns[0].pattern
+
+
+class TestVersionMaskProperties(TestCase):
+    """The cases above pin browser and protocol versions; these hold the rule over all parts.
+
+    The mask trades on one character. Everything after a slash is a version, everything else
+    keeps its number, so both properties test that line rather than a handful of versions.
+    """
+
+    @given(product=_product_st, version=_version_st)
+    @settings(max_examples=400, deadline=None)
+    def test_any_version_after_a_product_name_collapses_to_one_placeholder(self, product: str, version: str) -> None:
+        patterns = mine_patterns([_sample(f"agent {product}/{version} connected")])
+
+        # exact template: two to four parts become one placeholder, not one <num> per part
+        assert patterns[0].pattern == f"agent {product}/<version> connected"
+
+    @given(context=_decimal_context_st, whole=st.integers(min_value=0, max_value=9999), frac=st.integers(0, 999))
+    @settings(max_examples=400, deadline=None)
+    def test_decimals_outside_a_path_keep_their_number(self, context: str, whole: int, frac: int) -> None:
+        # Latencies, ratios, and load averages are decimals too. Reading one as a version
+        # would hide the measurement the person opened the pattern for.
+        patterns = mine_patterns([_sample(f"request {context}{whole}.{frac} done")])
+
+        assert "<version>" not in patterns[0].pattern
+
+    @given(product=_product_st, version_a=_version_st, version_b=_version_st)
+    @settings(max_examples=300, deadline=None)
+    def test_lines_differing_only_by_version_share_a_fingerprint(
+        self, product: str, version_a: str, version_b: str
+    ) -> None:
+        # This is what the mask is for: one template per client, not one per release.
+        line = f"agent {product}/{{}} connected"
+        first = mine_patterns([_sample(line.format(version_a))])
+        second = mine_patterns([_sample(line.format(version_b))])
+
+        assert pattern_fingerprint(first[0].pattern) == pattern_fingerprint(second[0].pattern)


### PR DESCRIPTION
## Problem

Someone reading Logs → Patterns sees a user-agent template spelled `Mozilla/<num>.<num> ... AppleWebKit/<num>.<num> ... Chrome/<num>.<num>.<num>.<num>`, where the placeholders outnumber the words.

- Masking has no version placeholder, so each part of a dotted version becomes its own `<num>`.
- User-agent, protocol, and client-version lines carry several versions each.
- The literal content that identifies the statement gets buried in placeholder noise.

This builds on #82021, which stops the IP mask from claiming those same version strings. Merge that first.

## Changes

- Dotted versions after a `/` now mask to `<version>`, so `Chrome/139.0.0.0` reads `Chrome/<version>`.
- The `/` is required, which is what separates a version from a measurement: `duration=1.5` keeps its number.
- The instruction runs after `<ip>`, so an address in a URL masks as an address first and cannot be read as a version.
- The placeholder accepts any number of parts, so a two-part protocol version and a five-part build both collapse whole. A bound left the tail of a longer release as `<version>.<num>`, on a template of its own.
- `<version>` gets a match_regex fragment, so the "view matching logs" pivot still works on these templates.

## How did you test this code?

- 2 masking cases (`version_after_product`, `protocol_version`) catch a regression that drops the instruction or narrows it to four-part versions only.
- Versions of two to six parts all mine to `agent Chrome/<version> connected`, which is the property below.
- `test_plain_decimals_are_not_masked_as_versions` — 3 cases catch dropping the `/` requirement, which would swallow latencies, ratios, and numeric path segments.
- The `ipv4_in_url` case from #82021 is the ordering guard. It fails if this instruction moves ahead of the IP mask.
- 1 `compile_match_regex` case catches a missing `<version>` fragment, which would silently withhold the log pivot.
- I ran the miner over a full browser user-agent line and an Envoy access line and read the resulting templates.
**Property tests** (`TestVersionMaskProperties`, Hypothesis) hold the rule over all version parts rather than the two versions above.

- Any version of two to six parts after a product name collapses to one placeholder, asserted as full template equality.
- Any decimal in a latency, ratio, or load context keeps its number.
- Two lines differing only by version share a fingerprint, which is one template per client instead of one per release.
- Product names are drawn ending in a letter, because the IP mask's guard keys on that character. A name ending in a digit leaves a four-part version looking like an address, which is a real limit of this design rather than a gap in the test.

I mutation-tested the properties. Dropping the instruction fails the collapse property, dropping the slash requirement fails the decimal property, and moving the instruction ahead of the IP mask fails the `ipv4_in_url` case from #82021, which is the ordering claim above. Putting the four-part bound back fails the collapse property and the fingerprint property, on a five-part version.

- Not run: the database-backed tests in `test_pattern_diff.py`. This sandbox has no Postgres.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via the PostHog Slack app) found this while auditing which value classes the pattern miner leaves untemplated. Versions were the most common one after hostnames.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

The ordering against the IP mask is the part worth a second look. Masking versions first looks simpler and reads better, but `http://10.0.0.1/` then mines as a version, so this instruction has to run second and depends on the guard in #82021.

This is one of five separate PRs against the same two blocks in `log_patterns.py`, so they conflict with each other on merge and want landing one at a time. This one is stacked on #82021 rather than on master.


