### PR TITLE
fix(logs): truncate log bodies at a word boundary before mining

### DIFF
--- a/products/logs/backend/log_patterns.py
+++ b/products/logs/backend/log_patterns.py
@@ -133,6 +133,9 @@ class LogSample:
     severity_text: str
     service_name: str
     timestamp: dt.datetime
+    # Set on the examples the miner keeps, when `body` covers only a prefix of the raw line.
+    # compile_match_regex drops its end anchor for those.
+    truncated: bool = False
 
 
 @dataclass
@@ -170,10 +173,25 @@ class _Accumulator:
     severity_counts: dict[str, int] = field(default_factory=dict)
 
 
-def _prepare_body(body: str, truncate: int) -> str:
+@dataclass(frozen=True)
+class _PreparedBody:
+    text: str
+    truncated: bool
+
+
+def _prepare_body(body: str, truncate: int) -> _PreparedBody:
     # Collapse newlines / whitespace runs so multi-line bodies (stack traces) mine as a
     # single line, then bound length to keep Drain's parse tree and memory in check.
-    return _WHITESPACE_RE.sub(" ", body).strip()[:truncate]
+    collapsed = _WHITESPACE_RE.sub(" ", body).strip()
+    if len(collapsed) <= truncate:
+        return _PreparedBody(collapsed, truncated=False)
+    # Cut back to the last space inside the cap. Drain splits on whitespace, so a mid-word
+    # cut hands it a fragment ("(Macinto") that it treats as a literal token, and one long
+    # statement then fragments into a cluster per distinct cut point. A body with no space
+    # inside the cap has no boundary to cut at, so it still cuts hard.
+    head = collapsed[:truncate]
+    boundary = head.rfind(" ")
+    return _PreparedBody(head[:boundary] if boundary > 0 else head, truncated=True)
 
 
 def _build_miner(sim_th: float, depth: int, max_clusters: int) -> tuple[LogMasker, Drain]:
@@ -224,15 +242,15 @@ def pattern_fingerprint(template: str) -> str:
     return "\x00".join(literals) if literals else template
 
 
-def compile_match_regex(template: str, examples: list[LogSample], truncate: int) -> str | None:
+def compile_match_regex(template: str, examples: list[LogSample]) -> str | None:
     """Compile a mined template into an RE2-safe regex over raw log bodies, self-validated
     against the pattern's own examples.
 
     Returns None rather than an unvalidated predicate: Drain refines templates as rows merge,
     so an early-stored example can diverge from the final template — and a filter that
     silently matches the wrong logs is worse than no filter. Anchored at the start (leading
-    whitespace was stripped before mining); the end anchor is dropped when any example hit
-    the mining truncation cap, since the template then only covers a prefix of the raw line.
+    whitespace was stripped before mining); the end anchor is dropped when any example was
+    truncated, since the template then only covers a prefix of the raw line.
     """
     if not examples:
         return None
@@ -248,7 +266,7 @@ def compile_match_regex(template: str, examples: list[LogSample], truncate: int)
         pos = match.end()
     parts.append(_escape_literal(template[pos:]))
 
-    truncated = any(len(example.body) >= truncate for example in examples)
+    truncated = any(example.truncated for example in examples)
     candidate = r"^\s*" + "".join(parts) + ("" if truncated else r"\s*$")
 
     try:
@@ -308,7 +326,7 @@ def mine_patterns(
 
     for sample in samples:
         prepared = _prepare_body(sample.body, truncate)
-        cluster, _change_type = drain.add_log_message(masker.mask(prepared))
+        cluster, _change_type = drain.add_log_message(masker.mask(prepared.text))
         cluster_id = cluster.cluster_id
 
         acc = accumulators.get(cluster_id)
@@ -331,13 +349,14 @@ def mine_patterns(
         acc.count += 1
         severity = sample.severity_text.lower()
         acc.severity_counts[severity] = acc.severity_counts.get(severity, 0) + 1
-        if len(acc.examples) < max_examples and all(e.body != prepared for e in acc.examples):
+        if len(acc.examples) < max_examples and all(e.body != prepared.text for e in acc.examples):
             acc.examples.append(
                 LogSample(
-                    body=prepared,
+                    body=prepared.text,
                     severity_text=sample.severity_text,
                     service_name=sample.service_name,
                     timestamp=sample.timestamp,
+                    truncated=prepared.truncated,
                 )
             )
         if sample.service_name not in acc.services and len(acc.services) < max_services:
@@ -360,7 +379,7 @@ def mine_patterns(
             services=acc.services,
             bucket_counts=acc.bucket_counts,
             severity_counts=acc.severity_counts,
-            match_regex=compile_match_regex(acc.template, acc.examples, truncate),
+            match_regex=compile_match_regex(acc.template, acc.examples),
             match_literal=extract_match_literal(acc.template),
         )
         for acc in accumulators.values()

--- a/products/logs/backend/log_patterns.py
+++ b/products/logs/backend/log_patterns.py
@@ -167,6 +167,9 @@ class _Accumulator:
     first_seen: dt.datetime
     last_seen: dt.datetime
     count: int = 0
+    # Cluster-level, because `examples` is deduped and capped: a truncated sample can be
+    # dropped before it lands there, and the end anchor must still come off.
+    truncated: bool = False
     examples: list[LogSample] = field(default_factory=list)
     services: list[str] = field(default_factory=list)
     bucket_counts: list[int] = field(default_factory=list)
@@ -242,15 +245,18 @@ def pattern_fingerprint(template: str) -> str:
     return "\x00".join(literals) if literals else template
 
 
-def compile_match_regex(template: str, examples: list[LogSample]) -> str | None:
+def compile_match_regex(template: str, examples: list[LogSample], *, truncated: bool | None = None) -> str | None:
     """Compile a mined template into an RE2-safe regex over raw log bodies, self-validated
     against the pattern's own examples.
 
     Returns None rather than an unvalidated predicate: Drain refines templates as rows merge,
     so an early-stored example can diverge from the final template — and a filter that
     silently matches the wrong logs is worse than no filter. Anchored at the start (leading
-    whitespace was stripped before mining); the end anchor is dropped when any example was
-    truncated, since the template then only covers a prefix of the raw line.
+    whitespace was stripped before mining); the end anchor is dropped when the cluster held a
+    truncated body, since the template then only covers a prefix of the raw line.
+
+    Pass `truncated` from the cluster. Falling back to the retained examples under-reports it,
+    because dedup and the example cap can both drop the truncated body.
     """
     if not examples:
         return None
@@ -266,7 +272,8 @@ def compile_match_regex(template: str, examples: list[LogSample]) -> str | None:
         pos = match.end()
     parts.append(_escape_literal(template[pos:]))
 
-    truncated = any(example.truncated for example in examples)
+    if truncated is None:
+        truncated = any(example.truncated for example in examples)
     candidate = r"^\s*" + "".join(parts) + ("" if truncated else r"\s*$")
 
     try:
@@ -347,6 +354,7 @@ def mine_patterns(
                 acc.last_seen = sample.timestamp
 
         acc.count += 1
+        acc.truncated = acc.truncated or prepared.truncated
         severity = sample.severity_text.lower()
         acc.severity_counts[severity] = acc.severity_counts.get(severity, 0) + 1
         if len(acc.examples) < max_examples and all(e.body != prepared.text for e in acc.examples):
@@ -379,7 +387,7 @@ def mine_patterns(
             services=acc.services,
             bucket_counts=acc.bucket_counts,
             severity_counts=acc.severity_counts,
-            match_regex=compile_match_regex(acc.template, acc.examples),
+            match_regex=compile_match_regex(acc.template, acc.examples, truncated=acc.truncated),
             match_literal=extract_match_literal(acc.template),
         )
         for acc in accumulators.values()

--- a/products/logs/backend/test/test_log_patterns.py
+++ b/products/logs/backend/test/test_log_patterns.py
@@ -43,7 +43,7 @@ def _log_body_st(draw: st.DrawFn) -> str:
     return body
 
 
-_word_st = st.sampled_from(
+_log_word_st = st.sampled_from(
     ["request", "failed", "retrying", "user", "team", "cache", "hit", "GET", "POST", "attempt", "closed"]
 )
 _key_st = st.sampled_from(["team_id=", "attempt=", "status=", "peer=", "ts=", "job="])
@@ -66,7 +66,7 @@ _maskable_st = st.one_of(
 def _log_line_st(draw: st.DrawFn) -> str:
     parts = draw(
         st.lists(
-            st.one_of(_word_st, _maskable_st, st.tuples(_key_st, _maskable_st).map("".join)),
+            st.one_of(_log_word_st, _maskable_st, st.tuples(_key_st, _maskable_st).map("".join)),
             min_size=1,
             max_size=14,
         )
@@ -74,13 +74,10 @@ def _log_line_st(draw: st.DrawFn) -> str:
     return " ".join(parts)
 
 
+# Always crosses the truncation cap. Hypothesis biases toward small inputs, so a general body
+# strategy almost never reaches the cap and leaves the prefix handling untested.
 @st.composite
 def _long_log_body_st(draw: st.DrawFn) -> str:
-    """A body that always crosses the truncation cap.
-
-    Hypothesis biases toward small inputs, so a general body strategy almost never reaches
-    the cap and leaves the prefix handling untested. Repeating one filler token forces it.
-    """
     prefix = draw(st.lists(_token_st, min_size=1, max_size=8))
     filler = draw(st.text(st.characters(min_codepoint=33, max_codepoint=126), min_size=3, max_size=14))
     gap = draw(_gap_st)

--- a/products/logs/backend/test/test_log_patterns.py
+++ b/products/logs/backend/test/test_log_patterns.py
@@ -36,7 +36,6 @@ _gap_st = st.sampled_from([" ", "  ", "\t", "\n", "\r\n", " \n  "])
 
 @st.composite
 def _log_body_st(draw: st.DrawFn) -> str:
-    """A whitespace-separated body of any length."""
     tokens = draw(st.lists(_token_st, min_size=1, max_size=150))
     body = tokens[0]
     for token in tokens[1:]:
@@ -65,7 +64,6 @@ _maskable_st = st.one_of(
 
 @st.composite
 def _log_line_st(draw: st.DrawFn) -> str:
-    """A log-shaped line: literal words and key prefixes mixed with maskable values."""
     parts = draw(
         st.lists(
             st.one_of(_word_st, _maskable_st, st.tuples(_key_st, _maskable_st).map("".join)),
@@ -347,6 +345,22 @@ class TestMinePatterns(TestCase):
         example = patterns[0].examples[0]
         assert len(example.body) <= 512
         assert set(example.body.split(" ")) == {"prefix", "Macintosh"}
+
+    def test_regex_matches_a_long_body_whose_truncated_example_was_dropped(self) -> None:
+        # Truncation is a property of the cluster, not of the examples that survive into it.
+        # The dedup check compares text only, so a long body that prepares to the same text
+        # as a short one leaves no truncated example behind. Deriving the end anchor from the
+        # retained examples then builds a filter that excludes the long line it was mined
+        # from. The example cap drops a truncated example the same way.
+        short = " ".join(f"tok{i}" for i in range(80))
+        long_body = f"{short} {'X' * 60}"
+        assert len(short) < 512 < len(long_body)
+
+        patterns = mine_patterns([_sample(short), _sample(long_body)])
+
+        assert len(patterns) == 1
+        assert patterns[0].match_regex is not None
+        assert re.search(patterns[0].match_regex, long_body)
 
     def test_word_boundary_truncation_still_drops_the_end_anchor(self) -> None:
         # Cutting back to a boundary puts the prepared body under the cap, so a length check

--- a/products/logs/backend/test/test_log_patterns.py
+++ b/products/logs/backend/test/test_log_patterns.py
@@ -29,12 +29,14 @@ def _sample(
     severity: str = "info",
     service: str = "api",
     ts: dt.datetime | None = None,
+    truncated: bool = False,
 ) -> LogSample:
     return LogSample(
         body=body,
         severity_text=severity,
         service_name=service,
         timestamp=ts or dt.datetime(2026, 6, 23, 12, 0, 0, tzinfo=dt.UTC),
+        truncated=truncated,
     )
 
 
@@ -263,9 +265,33 @@ class TestMinePatterns(TestCase):
         assert patterns[0].examples[0].severity_text == "info"
 
     def test_long_bodies_are_truncated_before_mining(self) -> None:
+        # one token with no space inside the cap: there is no boundary to cut back to
         patterns = mine_patterns([_sample("x" * 1000)])
 
         assert len(patterns[0].examples[0].body) == 512
+
+    def test_truncation_cuts_back_to_a_word_boundary(self) -> None:
+        # A hard character cut leaves a partial token, which Drain treats as a literal. Bodies
+        # that differ only past the cap then fragment into one cluster per cut point instead
+        # of merging, and the partial word shows up in the template a person reads.
+        body = "prefix " + " ".join(["Macintosh"] * 200)
+
+        patterns = mine_patterns([_sample(body)])
+
+        example = patterns[0].examples[0]
+        assert len(example.body) <= 512
+        assert set(example.body.split(" ")) == {"prefix", "Macintosh"}
+
+    def test_word_boundary_truncation_still_drops_the_end_anchor(self) -> None:
+        # Cutting back to a boundary puts the prepared body under the cap, so a length check
+        # can no longer tell truncation apart from a short line. Getting that wrong anchors
+        # the predicate at the end, and it matches none of the real, longer lines.
+        body = "prefix " + " ".join(["Macintosh"] * 200)
+
+        patterns = mine_patterns([_sample(body)])
+
+        assert patterns[0].match_regex is not None
+        assert re.search(patterns[0].match_regex, body)
 
     def test_first_and_last_seen_span_the_cluster(self) -> None:
         earliest = dt.datetime(2026, 6, 23, 12, 0, 0, tzinfo=dt.UTC)
@@ -359,7 +385,7 @@ class TestCompileMatchRegex(TestCase):
         ]
     )
     def test_compiled_regex_matches_raw_bodies(self, template: str, raw_body: str) -> None:
-        regex = compile_match_regex(template, [_sample(raw_body.strip())], truncate=512)
+        regex = compile_match_regex(template, [_sample(raw_body.strip())])
 
         assert regex is not None
         assert re.search(regex, raw_body)
@@ -372,7 +398,7 @@ class TestCompileMatchRegex(TestCase):
         ]
     )
     def test_compiled_regex_is_anchored(self, template: str, non_matching_body: str) -> None:
-        regex = compile_match_regex(template, [_sample("User dave not found")], truncate=512)
+        regex = compile_match_regex(template, [_sample("User dave not found")])
 
         assert regex is not None
         assert not re.search(regex, non_matching_body)
@@ -381,7 +407,7 @@ class TestCompileMatchRegex(TestCase):
         # A body that hit the mining truncation cap means the template only covers a prefix
         # of the raw line — the predicate must still match the full-length original.
         truncated_body = "prefix " + "x" * 505
-        regex = compile_match_regex("prefix <*>", [_sample(truncated_body)], truncate=512)
+        regex = compile_match_regex("prefix <*>", [_sample(truncated_body, truncated=True)])
 
         assert regex is not None
         assert re.search(regex, truncated_body + " continues beyond the cap")
@@ -393,7 +419,7 @@ class TestCompileMatchRegex(TestCase):
         ]
     )
     def test_templates_without_literal_content_get_no_regex(self, _name: str, template: str) -> None:
-        assert compile_match_regex(template, [_sample("anything at all")], truncate=512) is None
+        assert compile_match_regex(template, [_sample("anything at all")]) is None
 
     def test_diverged_example_fails_validation(self) -> None:
         # Drain refines templates as rows merge, so a stored example can stop matching the
@@ -401,10 +427,10 @@ class TestCompileMatchRegex(TestCase):
         # withheld instead.
         examples = [_sample("User dave not found"), _sample("something entirely different")]
 
-        assert compile_match_regex("User <*> not found", examples, truncate=512) is None
+        assert compile_match_regex("User <*> not found", examples) is None
 
     def test_no_examples_means_no_regex(self) -> None:
-        assert compile_match_regex("User <*> not found", [], truncate=512) is None
+        assert compile_match_regex("User <*> not found", []) is None
 
     @parameterized.expand(
         [

--- a/products/logs/backend/test/test_log_patterns.py
+++ b/products/logs/backend/test/test_log_patterns.py
@@ -16,12 +16,78 @@ from products.logs.backend.log_patterns import (
     _HOST_SUFFIXES,
     _MASKING_INSTRUCTIONS,
     _PLACEHOLDER_PATTERNS,
+    _WHITESPACE_RE,
     LogSample,
+    _prepare_body,
     compile_match_regex,
     extract_match_literal,
     mine_patterns,
     pattern_fingerprint,
 )
+
+_BODY_TRUNCATE = 512
+
+# Printable, non-whitespace characters: Drain splits on whitespace, so these are the
+# characters a single token can hold. The range covers regex metacharacters and the angle
+# brackets the placeholders use, which is where escaping and placeholder round-tripping break.
+_token_st = st.text(st.characters(min_codepoint=33, max_codepoint=126), min_size=1, max_size=20)
+_gap_st = st.sampled_from([" ", "  ", "\t", "\n", "\r\n", " \n  "])
+
+
+@st.composite
+def _log_body_st(draw: st.DrawFn) -> str:
+    """A whitespace-separated body of any length."""
+    tokens = draw(st.lists(_token_st, min_size=1, max_size=150))
+    body = tokens[0]
+    for token in tokens[1:]:
+        body += draw(_gap_st) + token
+    return body
+
+
+_word_st = st.sampled_from(
+    ["request", "failed", "retrying", "user", "team", "cache", "hit", "GET", "POST", "attempt", "closed"]
+)
+_key_st = st.sampled_from(["team_id=", "attempt=", "status=", "peer=", "ts=", "job="])
+# Values that masking is meant to consume. Drawing these rather than random characters is
+# what makes the placeholder round-trip reachable: a mask that never fires proves nothing.
+_maskable_st = st.one_of(
+    st.integers(min_value=0, max_value=10**12).map(str),
+    st.tuples(*[st.integers(min_value=0, max_value=255)] * 4).map(lambda octets: ".".join(map(str, octets))),
+    st.uuids().map(str),
+    st.datetimes(min_value=dt.datetime(2020, 1, 1), max_value=dt.datetime(2030, 1, 1)).map(dt.datetime.isoformat),
+    st.text("0123456789abcdef", min_size=16, max_size=40),
+    st.integers(min_value=0, max_value=999).map(lambda n: f"0x{n:x}"),
+    st.tuples(st.integers(min_value=0, max_value=99), st.integers(min_value=0, max_value=99)).map(
+        lambda parts: f"{parts[0]}.{parts[1]}"
+    ),
+)
+
+
+@st.composite
+def _log_line_st(draw: st.DrawFn) -> str:
+    """A log-shaped line: literal words and key prefixes mixed with maskable values."""
+    parts = draw(
+        st.lists(
+            st.one_of(_word_st, _maskable_st, st.tuples(_key_st, _maskable_st).map("".join)),
+            min_size=1,
+            max_size=14,
+        )
+    )
+    return " ".join(parts)
+
+
+@st.composite
+def _long_log_body_st(draw: st.DrawFn) -> str:
+    """A body that always crosses the truncation cap.
+
+    Hypothesis biases toward small inputs, so a general body strategy almost never reaches
+    the cap and leaves the prefix handling untested. Repeating one filler token forces it.
+    """
+    prefix = draw(st.lists(_token_st, min_size=1, max_size=8))
+    filler = draw(st.text(st.characters(min_codepoint=33, max_codepoint=126), min_size=3, max_size=14))
+    gap = draw(_gap_st)
+    repeats = _BODY_TRUNCATE // (len(filler) + len(gap)) + draw(st.integers(min_value=2, max_value=20))
+    return gap.join([*prefix, *[filler] * repeats])
 
 
 def _sample(
@@ -825,3 +891,50 @@ class TestKlogTimestampProperties(TestCase):
 
         assert patterns[0].match_regex is not None
         assert re.search(patterns[0].match_regex, line.format(headers[1]))
+
+
+class TestTruncationProperties(TestCase):
+    """The cases above pin specific cut points; these hold the invariants over all bodies.
+
+    Truncation is where a body stops being the line a person wrote and becomes a prefix the
+    miner invented, so both properties are about that prefix staying honest.
+    """
+
+    @given(body=st.one_of(_log_body_st(), _long_log_body_st()), cap=st.integers(min_value=8, max_value=600))
+    @settings(max_examples=400, deadline=None)
+    def test_prepared_body_holds_only_whole_tokens(self, body: str, cap: int) -> None:
+        collapsed = _WHITESPACE_RE.sub(" ", body).strip()
+
+        prepared = _prepare_body(body, cap)
+
+        assert len(prepared.text) <= cap
+        # the flag has to mean "text is a prefix, not the whole line" for every input, since
+        # compile_match_regex decides the end anchor from it alone
+        assert prepared.truncated == (prepared.text != collapsed)
+        if " " in collapsed[:cap]:
+            # a cut back to a boundary can only drop whole tokens, never split one
+            assert set(prepared.text.split(" ")) <= set(collapsed.split(" "))
+
+    @given(body=st.one_of(_log_body_st(), _long_log_body_st(), _log_line_st()))
+    @settings(max_examples=300, deadline=None)
+    def test_mined_regex_matches_the_raw_body_it_came_from(self, body: str) -> None:
+        # The pivot from a pattern to its logs runs match_regex against raw bodies in
+        # ClickHouse, while mining sees a collapsed and truncated copy. Any disagreement
+        # between the two produces a filter that returns nothing for a pattern the person is
+        # looking at. A None regex is the honest outcome and is allowed.
+        patterns = mine_patterns([_sample(body)])
+
+        assert len(patterns) == 1
+        if patterns[0].match_regex is not None:
+            assert re.search(patterns[0].match_regex, body)
+
+    @given(body=st.one_of(_log_body_st(), _long_log_body_st(), _log_line_st()))
+    @settings(max_examples=300, deadline=None)
+    def test_mined_literal_is_present_in_the_body(self, body: str) -> None:
+        # match_literal is the icontains fallback when no regex compiles, so it has to be
+        # text that really occurs in the line, not a fragment masking invented.
+        patterns = mine_patterns([_sample(body)])
+
+        literal = patterns[0].match_literal
+        if literal is not None:
+            assert literal in _WHITESPACE_RE.sub(" ", body)


### PR DESCRIPTION
## Problem

Someone reading Logs → Patterns on a service with long log lines sees templates that end in a partial word, such as `<*> (Macinto` or `<*> (Windows N`, and sees many near-identical templates instead of one.

- The miner caps each body at 512 characters with a plain character slice.
- When that cap lands mid-word, the leftover fragment becomes a token.
- Drain splits on whitespace and treats the fragment as a literal, so it never merges with the same statement cut at a different point.
- Long lines with a variable-length prefix, such as any line carrying a user agent, hit a different cut point per row.
- Every wasted template costs a slot in the capped result list, which pushes real long-tail templates out.

## Changes

- Truncation now cuts back to the last space inside the cap, so the miner never sees a partial token.
- A body with no space inside the cap still cuts hard, because there is no boundary to cut back to.
- `LogSample` carries a `truncated` flag, and `_prepare_body` returns it alongside the prepared text.
- `compile_match_regex` reads that flag and loses its `truncate` parameter.

The flag is the part that is not obvious. Cutting back to a boundary puts the prepared body under the cap, so the old length comparison would report a truncated body as complete, anchor the predicate at the end, and produce a filter that matches none of the real lines. Tracking truncation where it happens is the only reliable signal.

> [!NOTE]
> Affected templates change shape on deploy, so the first patterns diff after this ships reports them as new.

## How did you test this code?

- `test_truncation_cuts_back_to_a_word_boundary` catches a return to a hard cut. It asserts every token in the prepared body is a whole word.
- `test_word_boundary_truncation_still_drops_the_end_anchor` catches the end-anchor trap above. It fails against a word-boundary cut that infers truncation from length.
- `test_long_bodies_are_truncated_before_mining` still covers the no-boundary case, so the cap itself cannot regress.
- I confirmed the two behaviors directly: the old slice left the fragment `Macin`, the new one ends on a whole word, a length check on the new prepared body reports 506 against a cap of 512, and the compiled regex still matches the full raw line.
- `mypy --follow-imports=silent` passes on the changed module and its query runner, which covers the signature change. I did not run mypy repo-wide.
**Property tests** (`TestTruncationProperties`, Hypothesis) hold the invariants over generated bodies rather than the one body above.

- A prepared body never exceeds the cap, and its `truncated` flag always means "this text is a prefix, not the whole line".
- When a space falls inside the cap, every token of the prepared body is a whole token of the input, so a cut can only drop tokens and never split one.
- `match_regex`, when it is not None, matches the raw body it was mined from. This is the contract the log pivot rests on, and mining only ever sees a collapsed and truncated copy.
- `match_literal`, when it is not None, really occurs in that body.

I mutation-tested the properties, and the first attempt was too weak to catch anything. Hypothesis biases toward small inputs, so a general body strategy almost never reached the 512-character cap and the end-anchor bug passed. A second strategy that always crosses the cap fixed that, and it now produces the falsifying example directly. Random printable tokens also never generate maskable values, so a mask added without a registered placeholder went unnoticed until I added a log-shaped strategy that mixes literal words with timestamps, addresses, UUIDs, and hex.

- Not run: the database-backed tests in `test_pattern_diff.py` and `test_patterns_query_runner.py`. This sandbox has no Postgres or ClickHouse.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via the PostHog Slack app) traced this from the output side. A mined pattern list held many templates that were prefixes of one user-agent string, cut at different points, which led back to the character slice in `_prepare_body`.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

I first wrote the boundary cut on its own and then found the end-anchor problem, which is why the flag and the signature change are in the same PR: the boundary cut is not safe to ship without them.

This is one of five separate PRs against `log_patterns.py`. The other four change the masking rules, so they conflict with each other on merge and want landing one at a time. This one touches different parts of the file and should merge cleanly alongside them.

