### PR TITLE
fix(github): stop transient upstream 5xx from minting error-tracking issues

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/source.py
@@ -307,7 +307,11 @@ If automatic creation failed with a permissions error, the fix depends on how yo
         # A GitHubRateLimitError that survives _fetch_page's own rate-limit-aware tenacity retry
         # still gets picked up by Temporal's activity retry; classify it as retryable so it's
         # logged as a warning rather than tracked as an exception. Mirrors Stripe's equivalent case.
-        return {"GitHub API rate limit exceeded"}
+        #
+        # A GithubRetryableError (any transient upstream 5xx) that survives the same tenacity retry
+        # gets the same treatment — a GitHub-side outage, not something reconnecting or reconfiguring
+        # the source can fix.
+        return {"GitHub API rate limit exceeded", "Github API error (retryable)"}
 
     def get_oauth_accounts(
         self, integration_id: int, team_id: int, search: str | None = None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_source_class.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_source_class.py
@@ -129,6 +129,15 @@ class TestGithubSource:
         retryable_errors = self.source.get_retryable_errors()
         assert error_message_matches(observed_error, retryable_errors)
 
+    def test_transient_5xx_error_is_retryable_not_non_retryable(self):
+        # A GithubRetryableError (any transient upstream 5xx) that exhausts _fetch_page's tenacity
+        # retry must stay retryable, so a GitHub-side outage doesn't disable the source.
+        observed_error = "Github API error (retryable): status=503, url=https://api.github.com/repos/o/r/issues"
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert not any(key in observed_error for key in non_retryable_errors)
+        retryable_errors = self.source.get_retryable_errors()
+        assert error_message_matches(observed_error, retryable_errors)
+
     @pytest.mark.parametrize(
         "raised_message,expected_key",
         [


### PR DESCRIPTION
## Problem

The GitHub warehouse source mints an error-tracking issue for every transient upstream outage, even though the sync already recovers on its own.

`_fetch_page` raises `GithubRetryableError` on any `>= 500` response and retries it internally with backoff. When those internal retries exhaust (e.g. a repeated `503`), the error escapes to `_handle_import_error`, which falls through to its default branch: log as an exception and re-raise. Temporal then retries the whole activity, which usually recovers, but the error tracking issue was already created – see [this issue](https://us.posthog.com/project/2/error_tracking/019ff6b9-9452-7641-9854-fcb9be71dfa4), triggered by a `status=500` from `GET /repos/{owner}/{repo}/issues`.

This is a GitHub-side hiccup, not something a customer can fix by reconnecting or reconfiguring, so it shouldn't page anyone or show up as an open issue.

## Changes

- Add the `GithubRetryableError` message prefix to `GithubSource.get_retryable_errors()`, alongside the existing rate-limit entry.
- `_handle_import_error` already logs anything in that set as a warning and re-raises for Temporal to retry, instead of capturing it as an exception – this is the same mechanism the Stripe source uses for its own transient 5xx wording.
- No change to `get_non_retryable_errors()`: this is a self-healing infrastructure error, not a credential or config problem.

## How did you test this code?

Added `test_transient_5xx_error_is_retryable_not_non_retryable`, mirroring the existing rate-limit test: it asserts the exhausted-retry message matches `get_retryable_errors()` and none of `get_non_retryable_errors()`. Catches the regression where a future edit drops or narrows the match and transient 5xx errors start minting error-tracking issues again.

Ran locally: `pytest products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_source_class.py` (88 passed), `ruff check`/`ruff format`, and `mypy` on `source.py` (all clean).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None – no user-facing or documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated from the linked error tracking issue (`GithubRetryableError`, `status=500`). Confirmed the stack trace originates in `_fetch_page` inside this source's own code, then traced how the error is classified in `_handle_import_error` and why it fell through to the exception-logging default. Chose to extend the existing `get_retryable_errors()` message-matching mechanism (already used for GitHub rate limits and by the Stripe source for its own transient 5xx wording) rather than reintroduce a since-superseded `get_transient_retryable_errors()` approach from an earlier, now-stale bot attempt at the same problem (#71777) – the current `_handle_import_error` already has a working, generic path for this. Invoked `/writing-tests` and `/writing-pr-descriptions` while producing this PR.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*