### PR TITLE
fix(experiments): show skeletons after metric changes

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -282,7 +282,7 @@ describe('experimentLogic', () => {
     describe('updateExperimentMetrics', () => {
         it('keeps existing results when saving the metric definitions fails', async () => {
             const existingResult = experimentMetricResultsSuccessJson.query_status
-                .results as CachedNewExperimentQueryResponse
+                .results as unknown as CachedNewExperimentQueryResponse
 
             logic.actions.setExperiment(experiment)
             logic.actions.setPrimaryMetricsResults([existingResult])

--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -279,6 +279,25 @@ describe('experimentLogic', () => {
         })
     })
 
+    describe('updateExperimentMetrics', () => {
+        it('keeps existing results when saving the metric definitions fails', async () => {
+            const existingResult = experimentMetricResultsSuccessJson.query_status
+                .results as CachedNewExperimentQueryResponse
+
+            logic.actions.setExperiment(experiment)
+            logic.actions.setPrimaryMetricsResults([existingResult])
+            logic.actions.setPrimaryMetricsResultsErrors([null])
+            jest.spyOn(api, 'update').mockRejectedValueOnce(new Error('network down'))
+
+            await expectLogic(logic, () => logic.actions.updateExperimentMetrics())
+                .toDispatchActions(['updateExperimentFailure'])
+                .toFinishAllListeners()
+
+            expect(logic.values.primaryMetricsResults).toEqual([existingResult])
+            expect(logic.values.primaryMetricsResultsErrors).toEqual([null])
+        })
+    })
+
     describe('currentRefresh tracking', () => {
         it('marks the refresh as in_progress while running and completed when it succeeds', async () => {
             logic.actions.setExperiment(experiment)

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -2720,10 +2720,30 @@ export const experimentLogic = kea<experimentLogicType>([
             }
         },
         updateExperimentMetrics: async () => {
-            // Metric results are positional. Once the metric list changes, keeping the previous arrays
+            actions.updateExperiment({
+                metrics: values.experiment.metrics,
+                metrics_secondary: values.experiment.metrics_secondary,
+                update_feature_flag_params: false,
+            })
+
+            // kea-loaders turns a rejected loader into a failure action, so awaiting its async action does
+            // not throw. Await the underlying queued request instead to keep the existing result caches when
+            // the save fails. The loader still owns error reporting and optimistic-concurrency recovery.
+            const updatePromise = cache.inflightUpdate?.promise
+            if (!updatePromise) {
+                return
+            }
+            try {
+                await updatePromise
+            } catch {
+                return
+            }
+
+            // Metric results are positional. Once the metric list has saved, keeping the previous arrays
             // around can briefly pair a result with the wrong metric (and gives no feedback while the
-            // updated results are computed). Clear both result stores up front so every metric in the
-            // optimistic, updated list renders its existing per-variant loading skeleton.
+            // updated results are computed). Clear both result stores so every metric in the updated list
+            // renders its existing per-variant loading skeleton. Do this only after a successful save: if
+            // the update fails, the previous experiment and its results remain valid and visible.
             actions.clearMetricsResults()
             const metricsLogic = experimentMetricsLogic({ experiment: values.experiment })
             metricsLogic.actions.setPrimaryMetricsResults([])
@@ -2731,11 +2751,6 @@ export const experimentLogic = kea<experimentLogicType>([
             metricsLogic.actions.setSecondaryMetricsResults([])
             metricsLogic.actions.setSecondaryMetricsResultsErrors([])
 
-            await asyncActions.updateExperiment({
-                metrics: values.experiment.metrics,
-                metrics_secondary: values.experiment.metrics_secondary,
-                update_feature_flag_params: false,
-            })
             // Reload results for added/edited metrics
             actions.refreshExperimentResults(true, 'config_change')
         },

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -2720,6 +2720,17 @@ export const experimentLogic = kea<experimentLogicType>([
             }
         },
         updateExperimentMetrics: async () => {
+            // Metric results are positional. Once the metric list changes, keeping the previous arrays
+            // around can briefly pair a result with the wrong metric (and gives no feedback while the
+            // updated results are computed). Clear both result stores up front so every metric in the
+            // optimistic, updated list renders its existing per-variant loading skeleton.
+            actions.clearMetricsResults()
+            const metricsLogic = experimentMetricsLogic({ experiment: values.experiment })
+            metricsLogic.actions.setPrimaryMetricsResults([])
+            metricsLogic.actions.setPrimaryMetricsResultsErrors([])
+            metricsLogic.actions.setSecondaryMetricsResults([])
+            metricsLogic.actions.setSecondaryMetricsResultsErrors([])
+
             await asyncActions.updateExperiment({
                 metrics: values.experiment.metrics,
                 metrics_secondary: values.experiment.metrics_secondary,


### PR DESCRIPTION
## Problem

People editing metrics on a running experiment see stale results with no loading feedback while the updated metrics recalculate.

Closes #82032

## Changes

- Clear positional metric results when metric definitions change.
- Render existing per-variant skeleton rows for the updated metric count until fresh results arrive.

### Loading

![Experiment metrics loading state](https://raw.githubusercontent.com/PostHog/pr-assets/d99ec7562a7df5c1a2e04e0d90860eb98b4ff1e3/2026/08/14b23eae-25c0-4991-a32e-93167684a2a0.png)

### Loaded

![Experiment metrics loaded state](https://raw.githubusercontent.com/PostHog/pr-assets/98bf7936ec3acc7d4c5e7e689e41e2d6e7b74855/2026/08/1c734646-5a83-4dee-b4d7-b4cde60c003a.png)

## How did you test this code?

- Formatting: `pnpm exec oxfmt --check frontend/src/scenes/experiments/experimentLogic.tsx`
- Focused tests: `pnpm exec jest src/scenes/experiments/experimentLogic.test.ts --runInBand --forceExit`
- Captured the multiple-metrics Storybook story with delayed result responses and after results loaded.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Codex. The change reuses the existing table skeleton UI and clears both metric result stores.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
