### PR TITLE
feat(journeys): draw the journey grid as a proportional sankey

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4730,10 +4730,10 @@ snapshots:
         hash: v1.k794b7964.ea754a4783f7653247f127337c407a8cdd4a9c6bc3f1b908d8d00dd1a090b966.KQ3yKnRzi4l3ZeYVThZdmo4L6mAbxtNa2uQh7y-kGWA
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--tile-filters-read-only--light:
         hash: v1.k794b7964.b2ca2efc52a9ccf56953159c66d3c8766acd1d3a17379d5faec45a4715ae24a9.fK76p7ZVcgvFJNcKJ5Ixy3YnBm_BcBSFnoytLS2jZdU
-    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark
-    :   hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
-    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light
-    :   hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
+    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark:
+        hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
+    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light:
+        hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--dark:
         hash: v1.k794b7964.b1e0f5f542426e34dec73826f3135902a392c0c13dade4fec14037c615186b13.kbxxijyDI1SdvgdKwkRnIRLLgmsine5AYvOcD79DYsY
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--light:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -2668,6 +2668,14 @@ snapshots:
         hash: v1.k794b7964.cc64ca6ab10ef0f936dd479fb6a76716fd5935b3dee59833377c03cb3e36569a.kVka0mzCaVBMto0uHpEx5cTwdVDK0wlESIquSCaBrjk
     insights-insightstable--sql-breakdown--light:
         hash: v1.k794b7964.710a5fa22da7eff24e97e754426977214d9cdb9fd0252415534110bc7d9bbf95.EmqhUt-YOAWJV1nbFZ2BA-Let9QcaeDgslu9bcPR_mE
+    insights-journeys-journeygrid--anchored--dark:
+        hash: v1.k794b7964.d960a6965fe0b701f77dc4cf3f1c668aa6c19f5369e5e4aaa5423a7158474deb.DVpy9fBOuJdH6MLVhfwTvQ1o2va4L7JaUwIpTqcGkRA
+    insights-journeys-journeygrid--anchored--light:
+        hash: v1.k794b7964.ab4a24132cd2d415118a5774326bafba3c0b2d4fae5e5b570da87455533622e9.tPiEyEEmflVExg0bWR8fYc8BzqZrg2y1R_MhCFUI5Pw
+    insights-journeys-journeygrid--anchored-with-chain-highlight--dark:
+        hash: v1.k794b7964.c43b6a6002a1ef2b9030a352ca4840e137fd436de0409060f4c4a97ee740b43d.GCVkRokuWvEmIuwR2cxsJGcIbNIGjN-7qfskI1Zap_8
+    insights-journeys-journeygrid--anchored-with-chain-highlight--light:
+        hash: v1.k794b7964.3c25339f2d35ecfb164f4c2d10f656af32dadc9fb61738f1615ca0472c68b362.DNXsvy-7s5WAmO8ITB50rk5n2SuIl2H4wQnZ7L_QFwk
     insights-metric--default--dark:
         hash: v1.k794b7964.bdc893ac78b0c99cb12fe2d3fa70346f932cccab0ae49df0d8e47e4740224266.KsZ8mkjoktS-Fzlo_tl1EQBX5t3-L0MWAbrR6yO2yCo
     insights-metric--default--light:
@@ -4722,10 +4730,10 @@ snapshots:
         hash: v1.k794b7964.ea754a4783f7653247f127337c407a8cdd4a9c6bc3f1b908d8d00dd1a090b966.KQ3yKnRzi4l3ZeYVThZdmo4L6mAbxtNa2uQh7y-kGWA
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--tile-filters-read-only--light:
         hash: v1.k794b7964.b2ca2efc52a9ccf56953159c66d3c8766acd1d3a17379d5faec45a4715ae24a9.fK76p7ZVcgvFJNcKJ5Ixy3YnBm_BcBSFnoytLS2jZdU
-    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark:
-        hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
-    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light:
-        hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
+    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark
+    :   hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
+    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light
+    :   hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--dark:
         hash: v1.k794b7964.b1e0f5f542426e34dec73826f3135902a392c0c13dade4fec14037c615186b13.kbxxijyDI1SdvgdKwkRnIRLLgmsine5AYvOcD79DYsY
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--light:

--- a/products/product_analytics/frontend/insights/journeys/JourneyGrid.stories.tsx
+++ b/products/product_analytics/frontend/insights/journeys/JourneyGrid.stories.tsx
@@ -1,0 +1,158 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { PathsV2Results } from '~/queries/schema/schema-general'
+
+import { JourneyGrid } from './JourneyGrid'
+import { buildJourneyGridModel, chainCardKey, journeyItemKey, journeyRibbonKey } from './journeyGridModel'
+
+const item = (event: string, label?: string): { event: string; label?: string } =>
+    label === undefined ? { event } : { event, label }
+
+const signUp = item('signed_up')
+const dashboardView = item('$pageview', '/dashboard')
+const pricingView = item('$pageview', '/pricing')
+const ordersView = item('$pageview', '/orders')
+const productViewed = item('product_viewed')
+const productAdded = item('product_added')
+const checkoutStarted = item('checkout_started')
+const purchaseCompleted = item('purchase_completed')
+
+// Drop-offs register at the journey's last reached step, so each column's drop-off count is a
+// subset of that column's population (matching the runner's drop_off_elements semantics).
+const MOCK_RESULTS: PathsV2Results = {
+    steps: [
+        { stepIndex: 0, rows: [{ item: signUp, count: 8240 }], otherCount: 0, dropOffCount: 2340 },
+        {
+            stepIndex: 1,
+            rows: [
+                { item: dashboardView, count: 2140 },
+                { item: productViewed, count: 1350 },
+                { item: checkoutStarted, count: 950 },
+                { item: pricingView, count: 640 },
+            ],
+            otherCount: 820,
+            dropOffCount: 2335,
+        },
+        {
+            stepIndex: 2,
+            rows: [
+                { item: productAdded, count: 1400 },
+                { item: checkoutStarted, count: 820 },
+                { item: ordersView, count: 615 },
+            ],
+            otherCount: 690,
+            dropOffCount: 1915,
+        },
+        {
+            stepIndex: 3,
+            rows: [
+                { item: purchaseCompleted, count: 880 },
+                { item: productAdded, count: 320 },
+            ],
+            otherCount: 410,
+            dropOffCount: 1320,
+        },
+    ],
+    edges: [
+        { stepIndex: 0, source: signUp, target: dashboardView, count: 2140 },
+        { stepIndex: 0, source: signUp, target: productViewed, count: 1350 },
+        { stepIndex: 0, source: signUp, target: checkoutStarted, count: 950 },
+        { stepIndex: 0, source: signUp, target: pricingView, count: 640 },
+        { stepIndex: 0, source: signUp, target: null, count: 820 },
+        { stepIndex: 1, source: dashboardView, target: productAdded, count: 700 },
+        { stepIndex: 1, source: dashboardView, target: checkoutStarted, count: 260 },
+        { stepIndex: 1, source: dashboardView, target: ordersView, count: 210 },
+        { stepIndex: 1, source: dashboardView, target: null, count: 240 },
+        { stepIndex: 1, source: productViewed, target: productAdded, count: 520 },
+        { stepIndex: 1, source: productViewed, target: checkoutStarted, count: 180 },
+        { stepIndex: 1, source: productViewed, target: null, count: 160 },
+        { stepIndex: 1, source: checkoutStarted, target: productAdded, count: 120 },
+        { stepIndex: 1, source: checkoutStarted, target: checkoutStarted, count: 250 },
+        { stepIndex: 1, source: checkoutStarted, target: ordersView, count: 230 },
+        { stepIndex: 1, source: checkoutStarted, target: null, count: 120 },
+        { stepIndex: 1, source: pricingView, target: productAdded, count: 60 },
+        { stepIndex: 1, source: pricingView, target: checkoutStarted, count: 130 },
+        { stepIndex: 1, source: pricingView, target: ordersView, count: 105 },
+        { stepIndex: 1, source: pricingView, target: null, count: 60 },
+        { stepIndex: 1, source: null, target: ordersView, count: 70 },
+        { stepIndex: 1, source: null, target: null, count: 110 },
+        { stepIndex: 2, source: productAdded, target: purchaseCompleted, count: 560 },
+        { stepIndex: 2, source: productAdded, target: productAdded, count: 180 },
+        { stepIndex: 2, source: productAdded, target: null, count: 170 },
+        { stepIndex: 2, source: checkoutStarted, target: purchaseCompleted, count: 300 },
+        { stepIndex: 2, source: checkoutStarted, target: productAdded, count: 60 },
+        { stepIndex: 2, source: checkoutStarted, target: null, count: 90 },
+        { stepIndex: 2, source: ordersView, target: purchaseCompleted, count: 20 },
+        { stepIndex: 2, source: ordersView, target: productAdded, count: 60 },
+        { stepIndex: 2, source: ordersView, target: null, count: 80 },
+        { stepIndex: 2, source: null, target: productAdded, count: 20 },
+        { stepIndex: 2, source: null, target: null, count: 70 },
+    ],
+    prefixes: [
+        { items: [signUp], count: 8240 },
+        { items: [signUp, productViewed], count: 1350 },
+        { items: [signUp, productViewed, productAdded], count: 520 },
+        { items: [signUp, productViewed, productAdded, purchaseCompleted], count: 210 },
+    ],
+}
+
+const meta: Meta<typeof JourneyGrid> = {
+    title: 'Insights/Journeys/JourneyGrid',
+    component: JourneyGrid,
+    parameters: {
+        layout: 'fullscreen',
+        viewMode: 'story',
+        mockDate: '2024-01-15',
+    },
+}
+export default meta
+
+type Story = StoryObj<typeof JourneyGrid>
+
+export const Anchored: Story = {
+    render: () => (
+        <JourneyGrid
+            model={buildJourneyGridModel(MOCK_RESULTS)}
+            isAnchored
+            nodeColor="#1d4aff"
+            onCardClick={() => {}}
+            onRibbonClick={() => {}}
+        />
+    ),
+}
+
+export const AnchoredWithChainHighlight: Story = {
+    render: () => {
+        const chain = [signUp, productViewed, productAdded, purchaseCompleted]
+        const counts = [8240, 1350, 520, 210]
+        const totals = [8240, 5900, 3525, 1610]
+        return (
+            <JourneyGrid
+                model={buildJourneyGridModel(MOCK_RESULTS)}
+                isAnchored
+                nodeColor="#1d4aff"
+                chainHighlight={{
+                    chain,
+                    countByCardKey: Object.fromEntries(
+                        chain.map((chainItem, position) => [chainCardKey(position, chainItem), counts[position]])
+                    ),
+                    fractionByCardKey: Object.fromEntries(
+                        chain.map((chainItem, position) => [
+                            chainCardKey(position, chainItem),
+                            counts[position] / totals[position],
+                        ])
+                    ),
+                    ribbonKeys: new Set(
+                        chain
+                            .slice(1)
+                            .map((chainItem, position) =>
+                                journeyRibbonKey(position, journeyItemKey(chain[position]), journeyItemKey(chainItem))
+                            )
+                    ),
+                }}
+                onCardClick={() => {}}
+                onRibbonClick={() => {}}
+            />
+        )
+    },
+}

--- a/products/product_analytics/frontend/insights/journeys/JourneyGrid.tsx
+++ b/products/product_analytics/frontend/insights/journeys/JourneyGrid.tsx
@@ -2,11 +2,17 @@ import { useMemo } from 'react'
 
 import { Tooltip } from '@posthog/lemon-ui'
 
-import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
 import { percentage } from 'lib/utils/numbers'
 import { humanFriendlyNumber } from 'lib/utils/numbers'
 import { midEllipsis, pluralize } from 'lib/utils/strings'
 
+import {
+    BAR_WIDTH,
+    COLUMN_PITCH,
+    JourneyLayoutRow,
+    LABEL_BLOCK_HEIGHT,
+    buildJourneyGridLayout,
+} from './journeyGridLayout'
 import {
     JourneyChainHighlight,
     JourneyGridModel,
@@ -16,35 +22,11 @@ import {
     ribbonPath,
 } from './journeyGridModel'
 
-const CARD_WIDTH = 224
-const COLUMN_GAP = 104
-const CARD_HEIGHT = 66
-const ROW_GAP = 14
-const HEADER_HEIGHT = 28
-const PORT_TOP_OFFSET = 6
-const PORT_GAP = 2
-const MAX_RIBBON_THICKNESS = 36
-const MIN_RIBBON_THICKNESS = 2
-const MAX_LABEL_CHARS = 30
-const RIBBON_OPACITY = 0.15
-const RIBBON_OPACITY_ON_CHAIN = 0.4
-const RIBBON_OPACITY_DIMMED = 0.06
-
-interface CardGeometry {
-    row: JourneyGridRow
-    stepIndex: number
-    x: number
-    y: number
-}
-
-interface RibbonGeometry {
-    ribbon: JourneyGridRibbon
-    thickness: number
-    fromX: number
-    fromY: number
-    toX: number
-    toY: number
-}
+const MAX_LABEL_CHARS = 34
+const LABEL_WIDTH = COLUMN_PITCH - 24
+const RIBBON_OPACITY = 0.18
+const RIBBON_OPACITY_ON_CHAIN = 0.5
+const RIBBON_OPACITY_DIMMED = 0.05
 
 function cardKey(stepIndex: number, rowKey: string): string {
     return `${stepIndex}:${rowKey}`
@@ -71,59 +53,7 @@ export function JourneyGrid({
     onRibbonHover?: (ribbon: JourneyGridRibbon) => void
     onGridLeave?: () => void
 }): JSX.Element {
-    const { cards, ribbons, chartWidth, chartHeight } = useMemo(() => {
-        const cardByKey = new Map<string, CardGeometry>()
-        const cards: CardGeometry[] = []
-        let maxCardBottom = 0
-        model.columns.forEach((column, columnIndex) => {
-            let y = HEADER_HEIGHT
-            for (const row of column.rows) {
-                const card = { row, stepIndex: column.stepIndex, x: columnIndex * (CARD_WIDTH + COLUMN_GAP), y }
-                cardByKey.set(cardKey(column.stepIndex, row.key), card)
-                cards.push(card)
-                y += CARD_HEIGHT + ROW_GAP
-            }
-            maxCardBottom = Math.max(maxCardBottom, y - ROW_GAP)
-        })
-
-        const thicknessFor = (count: number): number =>
-            Math.max(MIN_RIBBON_THICKNESS, (count / Math.max(model.maxRibbonCount, 1)) * MAX_RIBBON_THICKNESS)
-
-        // Resolve each ribbon's cards once, then stack the ports on each card side in the vertical
-        // order of the connected cards, so ribbons out of one card never cross at the card edge.
-        const resolvedRibbons = model.ribbons.flatMap((ribbon) => {
-            const sourceCardKey = cardKey(ribbon.sourceStep, ribbon.sourceKey)
-            const targetCardKey = cardKey(ribbon.sourceStep + 1, ribbon.targetKey)
-            const source = cardByKey.get(sourceCardKey)
-            const target = cardByKey.get(targetCardKey)
-            return source && target ? [{ ribbon, source, target, sourceCardKey, targetCardKey }] : []
-        })
-        resolvedRibbons.sort((a, b) => a.source.y - b.source.y || a.target.y - b.target.y)
-
-        const outCursor = new Map<string, number>()
-        const inCursor = new Map<string, number>()
-        const ribbons: RibbonGeometry[] = resolvedRibbons.map(
-            ({ ribbon, source, target, sourceCardKey, targetCardKey }) => {
-                const thickness = thicknessFor(ribbon.count)
-                const fromY = source.y + PORT_TOP_OFFSET + (outCursor.get(sourceCardKey) ?? 0)
-                const toY = target.y + PORT_TOP_OFFSET + (inCursor.get(targetCardKey) ?? 0)
-                outCursor.set(sourceCardKey, (outCursor.get(sourceCardKey) ?? 0) + thickness + PORT_GAP)
-                inCursor.set(targetCardKey, (inCursor.get(targetCardKey) ?? 0) + thickness + PORT_GAP)
-                return {
-                    ribbon,
-                    thickness,
-                    fromX: source.x + CARD_WIDTH,
-                    fromY,
-                    toX: target.x,
-                    toY,
-                }
-            }
-        )
-
-        const chartWidth = model.columns.length * (CARD_WIDTH + COLUMN_GAP) - COLUMN_GAP
-        const chartHeight = maxCardBottom + 16
-        return { cards, ribbons, chartWidth, chartHeight }
-    }, [model])
+    const layout = useMemo(() => buildJourneyGridLayout(model), [model])
 
     const ribbonOpacity = (ribbon: JourneyGridRibbon): number => {
         if (!chainHighlight) {
@@ -135,9 +65,9 @@ export function JourneyGrid({
     return (
         <div className="overflow-auto p-4" data-attr="journey-grid" onMouseLeave={onGridLeave}>
             {/* eslint-disable-next-line react/forbid-dom-props */}
-            <div className="relative" style={{ width: chartWidth, height: chartHeight }}>
-                <svg width={chartWidth} height={chartHeight} className="absolute inset-0 pointer-events-none">
-                    {ribbons.map(({ ribbon, thickness, fromX, fromY, toX, toY }) => (
+            <div className="relative" style={{ width: layout.width, height: layout.height }}>
+                <svg width={layout.width} height={layout.height} className="absolute inset-0 pointer-events-none">
+                    {layout.ribbons.map(({ ribbon, fromX, fromY, fromThickness, toX, toY, toThickness }) => (
                         <Tooltip
                             key={ribbon.key}
                             title={
@@ -153,14 +83,14 @@ export function JourneyGrid({
                             }
                         >
                             <path
-                                d={ribbonPath(fromX, fromY, thickness, toX, toY, thickness)}
+                                d={ribbonPath(fromX, fromY, fromThickness, toX, toY, toThickness)}
                                 fill={nodeColor}
                                 opacity={ribbonOpacity(ribbon)}
                                 // The transparent stroke widens the hover target without changing the
                                 // drawn shape, so hair-thin ribbons can still be hovered for a tooltip.
                                 stroke="transparent"
                                 strokeWidth={8}
-                                className={`pointer-events-auto hover:opacity-40 transition-opacity ${
+                                className={`pointer-events-auto hover:opacity-50 transition-opacity ${
                                     onRibbonClick ? 'cursor-pointer' : ''
                                 }`}
                                 data-attr="journey-grid-ribbon"
@@ -198,31 +128,29 @@ export function JourneyGrid({
                         key={`header-${column.stepIndex}`}
                         className="absolute text-xs font-semibold text-secondary"
                         // eslint-disable-next-line react/forbid-dom-props
-                        style={{ left: columnIndex * (CARD_WIDTH + COLUMN_GAP), top: 0, width: CARD_WIDTH }}
+                        style={{ left: columnIndex * COLUMN_PITCH, top: 0, width: LABEL_WIDTH }}
                     >
                         Step {column.stepIndex + 1}
                     </div>
                 ))}
 
-                {cards.map(({ row, stepIndex, x, y }) => (
-                    <JourneyCard
-                        key={cardKey(stepIndex, row.key)}
-                        row={row}
-                        x={x}
-                        y={y}
+                {layout.rows.map((layoutRow) => (
+                    <JourneyNode
+                        key={cardKey(layoutRow.stepIndex, layoutRow.row.key)}
+                        layoutRow={layoutRow}
                         isAnchored={isAnchored}
                         nodeColor={nodeColor}
                         chainCount={
-                            chainHighlight ? chainHighlight.countByCardKey[cardKey(stepIndex, row.key)] : undefined
-                        }
-                        chainFraction={
-                            chainHighlight ? chainHighlight.fractionByCardKey[cardKey(stepIndex, row.key)] : undefined
+                            chainHighlight
+                                ? chainHighlight.countByCardKey[cardKey(layoutRow.stepIndex, layoutRow.row.key)]
+                                : undefined
                         }
                         dimmed={
-                            !!chainHighlight && chainHighlight.countByCardKey[cardKey(stepIndex, row.key)] === undefined
+                            !!chainHighlight &&
+                            chainHighlight.countByCardKey[cardKey(layoutRow.stepIndex, layoutRow.row.key)] === undefined
                         }
-                        onClick={onCardClick ? () => onCardClick(stepIndex, row) : undefined}
-                        onMouseEnter={onCardHover ? () => onCardHover(stepIndex, row) : undefined}
+                        onClick={onCardClick ? () => onCardClick(layoutRow.stepIndex, layoutRow.row) : undefined}
+                        onMouseEnter={onCardHover ? () => onCardHover(layoutRow.stepIndex, layoutRow.row) : undefined}
                     />
                 ))}
             </div>
@@ -230,10 +158,10 @@ export function JourneyGrid({
     )
 }
 
-const CARD_STYLES: Record<JourneyGridRowKind, { container: string; text: string; dataAttr: string }> = {
-    item: { container: 'border bg-surface-primary', text: '', dataAttr: 'journey-grid-node' },
-    other: { container: 'border border-dashed bg-surface-primary', text: '', dataAttr: 'journey-grid-other-row' },
-    dropOff: { container: 'border border-transparent', text: 'text-secondary', dataAttr: 'journey-grid-drop-off-row' },
+const NODE_DATA_ATTRS: Record<JourneyGridRowKind, string> = {
+    item: 'journey-grid-node',
+    other: 'journey-grid-other-row',
+    dropOff: 'journey-grid-drop-off-row',
 }
 
 function dropOffTooltip(isAnchored: boolean): string {
@@ -247,62 +175,49 @@ function dropOffTooltip(isAnchored: boolean): string {
     )
 }
 
-function JourneyCard({
-    row,
-    x,
-    y,
+function JourneyNode({
+    layoutRow,
     isAnchored,
     nodeColor,
     chainCount,
-    chainFraction,
     dimmed,
     onClick,
     onMouseEnter,
 }: {
-    row: JourneyGridRow
-    x: number
-    y: number
+    layoutRow: JourneyLayoutRow
     isAnchored: boolean
     nodeColor: string
-    /** The active chain's count for this card; set only while the card is on the hovered chain. */
+    /** The active chain's count for this node; set only while the node is on the hovered chain. */
     chainCount?: number
-    /** The chain count's share of the column total, so the bar describes the number shown above it. */
-    chainFraction?: number
     dimmed?: boolean
     onClick?: () => void
     onMouseEnter?: () => void
 }): JSX.Element {
-    const styles = CARD_STYLES[row.kind]
+    const { row, x, labelY, barHeight } = layoutRow
+    const isDropOff = row.kind === 'dropOff'
     const onChain = chainCount !== undefined
-    const tooltip =
-        row.kind === 'dropOff' ? (
-            dropOffTooltip(isAnchored)
-        ) : row.kind === 'other' ? (
-            'Less common steps at this position, grouped together.'
-        ) : (
-            <>
-                {row.label}
-                {row.item?.label != null && <span className="text-muted"> ({row.item.event})</span>}
-            </>
-        )
+    const tooltip = isDropOff ? (
+        dropOffTooltip(isAnchored)
+    ) : row.kind === 'other' ? (
+        'Less common steps at this position, grouped together.'
+    ) : (
+        <>
+            {row.label}
+            {row.item?.label != null && <span className="text-muted"> ({row.item.event})</span>}
+        </>
+    )
 
     return (
-        // The whole card is the tooltip trigger — a label-only trigger makes the tooltip vanish
-        // as soon as the pointer moves onto the count or progress bar within the card.
+        // The whole node is the tooltip trigger — a label-only trigger makes the tooltip vanish
+        // as soon as the pointer moves onto the count or bar within the node.
         <Tooltip title={tooltip}>
             <div
-                className={`absolute rounded px-2 py-1.5 transition-opacity ${styles.container} ${
-                    onClick ? 'cursor-pointer' : ''
-                } ${dimmed ? 'opacity-40' : ''}`}
+                className={`absolute transition-opacity ${onClick ? 'cursor-pointer' : ''} ${
+                    dimmed ? 'opacity-40' : ''
+                }`}
                 // eslint-disable-next-line react/forbid-dom-props
-                style={{
-                    left: x,
-                    top: y,
-                    width: CARD_WIDTH,
-                    height: CARD_HEIGHT,
-                    ...(onChain ? { boxShadow: `0 0 0 2px ${nodeColor}` } : {}),
-                }}
-                data-attr={styles.dataAttr}
+                style={{ left: x, top: labelY, width: LABEL_WIDTH }}
+                data-attr={NODE_DATA_ATTRS[row.kind]}
                 role={onClick ? 'button' : undefined}
                 tabIndex={onClick ? 0 : undefined}
                 onClick={onClick}
@@ -318,23 +233,35 @@ function JourneyCard({
                         : undefined
                 }
             >
-                <div className={`text-xs font-semibold truncate ${styles.text}`}>
-                    {midEllipsis(row.label, MAX_LABEL_CHARS)}
+                {/* Fixed-height label block: the layout attaches ribbons at labelY + LABEL_BLOCK_HEIGHT,
+                    so the bar's top must not drift with text flow. */}
+                {/* eslint-disable-next-line react/forbid-dom-props */}
+                <div className="overflow-hidden" style={{ height: isDropOff ? undefined : LABEL_BLOCK_HEIGHT }}>
+                    <div className={`text-xs font-semibold truncate ${isDropOff ? 'text-secondary' : ''}`}>
+                        {midEllipsis(row.label, MAX_LABEL_CHARS)}
+                    </div>
+                    <div className="flex items-baseline gap-1.5">
+                        <span className={`text-sm font-semibold ${isDropOff ? 'text-secondary' : ''}`}>
+                            {humanFriendlyNumber(onChain ? chainCount : row.count)}
+                        </span>
+                        {!onChain && <span className="text-xs text-secondary">{percentage(row.fraction, 1)}</span>}
+                        {onChain && <span className="text-xs text-secondary">on this path</span>}
+                    </div>
                 </div>
-                <div className="flex items-baseline gap-1.5 mt-0.5">
-                    <span className={`text-sm font-semibold ${styles.text}`}>
-                        {humanFriendlyNumber(onChain ? chainCount : row.count)}
-                    </span>
-                    {!onChain && <span className="text-xs text-secondary">{percentage(row.fraction, 1)}</span>}
-                    {onChain && <span className="text-xs text-secondary">on this path</span>}
-                </div>
-                {row.kind !== 'dropOff' && (
-                    <LemonProgress
-                        percent={Math.max(2, (onChain ? (chainFraction ?? 0) : row.fraction) * 100)}
-                        strokeColor={row.kind === 'other' ? 'var(--color-gray-400)' : nodeColor}
-                        bgColor="var(--color-fill-secondary)"
-                        smoothing={false}
-                        className="mt-1"
+                {!isDropOff && (
+                    <div
+                        className="rounded"
+                        // eslint-disable-next-line react/forbid-dom-props
+                        style={{
+                            width: BAR_WIDTH,
+                            height: barHeight,
+                            backgroundColor: row.kind === 'other' ? 'var(--color-gray-400)' : nodeColor,
+                            ...(onChain
+                                ? {
+                                      boxShadow: `0 0 0 2px var(--color-bg-surface-primary), 0 0 0 4px ${nodeColor}`,
+                                  }
+                                : {}),
+                        }}
                     />
                 )}
             </div>

--- a/products/product_analytics/frontend/insights/journeys/journeyGridLayout.test.ts
+++ b/products/product_analytics/frontend/insights/journeys/journeyGridLayout.test.ts
@@ -1,0 +1,110 @@
+import { PathsV2Results } from '~/queries/schema/schema-general'
+
+import {
+    BAR_HEIGHT_BUDGET,
+    LABEL_BLOCK_HEIGHT,
+    MIN_BAR_HEIGHT,
+    MIN_RIBBON_THICKNESS,
+    buildJourneyGridLayout,
+} from './journeyGridLayout'
+import { buildJourneyGridModel } from './journeyGridModel'
+
+const item = (event: string): { event: string } => ({ event })
+
+const results: PathsV2Results = {
+    steps: [
+        { stepIndex: 0, rows: [{ item: item('a'), count: 1000 }], otherCount: 0, dropOffCount: 200 },
+        {
+            stepIndex: 1,
+            rows: [
+                { item: item('b'), count: 500 },
+                { item: item('c'), count: 250 },
+                { item: item('d'), count: 1 },
+            ],
+            otherCount: 49,
+            dropOffCount: 800,
+        },
+    ],
+    edges: [
+        { stepIndex: 0, source: item('a'), target: item('b'), count: 500 },
+        { stepIndex: 0, source: item('a'), target: item('c'), count: 250 },
+        { stepIndex: 0, source: item('a'), target: item('d'), count: 1 },
+        { stepIndex: 0, source: item('a'), target: null, count: 49 },
+    ],
+    prefixes: [],
+}
+
+describe('buildJourneyGridLayout', () => {
+    it('sizes bars from one shared px-per-actor scale, with the largest column filling the budget', () => {
+        const layout = buildJourneyGridLayout(buildJourneyGridModel(results))
+
+        const barOf = (stepIndex: number, event: string): number =>
+            layout.rows.find((r) => r.stepIndex === stepIndex && r.row.label === event)!.barHeight
+
+        expect(barOf(0, 'a')).toBeCloseTo(BAR_HEIGHT_BUDGET)
+        // Cross-column comparability: half the actors means half the bar height, on the same scale
+        expect(barOf(1, 'b')).toBeCloseTo(BAR_HEIGHT_BUDGET / 2)
+        expect(barOf(1, 'c')).toBeCloseTo(BAR_HEIGHT_BUDGET / 4)
+    })
+
+    it('clamps tiny counts to visible minimum bar and ribbon sizes', () => {
+        const layout = buildJourneyGridLayout(buildJourneyGridModel(results))
+
+        const tinyRow = layout.rows.find((r) => r.row.label === 'd')!
+        expect(tinyRow.barHeight).toEqual(MIN_BAR_HEIGHT)
+        const tinyRibbon = layout.ribbons.find((r) => r.ribbon.targetKey === tinyRow.row.key)!
+        expect(tinyRibbon.toThickness).toBeGreaterThanOrEqual(MIN_RIBBON_THICKNESS)
+    })
+
+    it('tiles each bar edge contiguously without spilling past the bar bottom', () => {
+        const layout = buildJourneyGridLayout(buildJourneyGridModel(results))
+
+        const source = layout.rows.find((r) => r.stepIndex === 0 && r.row.label === 'a')!
+        const outbound = layout.ribbons.filter((r) => r.ribbon.sourceStep === 0).sort((a, b) => a.fromY - b.fromY)
+        expect(outbound[0].fromY).toEqual(source.barY)
+        let cursor = source.barY
+        for (const band of outbound) {
+            expect(band.fromY).toBeCloseTo(cursor)
+            cursor += band.fromThickness
+        }
+        expect(cursor).toBeLessThanOrEqual(source.barY + source.barHeight + 1e-6)
+    })
+
+    it('squeezes inflated bands to fit when minimum thicknesses overflow a tiny bar', () => {
+        const sources = ['a', 'b', 'c', 'd', 'e']
+        const manyIntoTiny: PathsV2Results = {
+            steps: [
+                {
+                    stepIndex: 0,
+                    rows: sources.map((event) => ({ item: item(event), count: 300 })),
+                    otherCount: 0,
+                    dropOffCount: 0,
+                },
+                { stepIndex: 1, rows: [{ item: item('z'), count: 5 }], otherCount: 1495, dropOffCount: 0 },
+            ],
+            edges: sources.flatMap((event) => [
+                { stepIndex: 0, source: item(event), target: item('z'), count: 1 },
+                { stepIndex: 0, source: item(event), target: null, count: 299 },
+            ]),
+            prefixes: [],
+        }
+        const layout = buildJourneyGridLayout(buildJourneyGridModel(manyIntoTiny))
+
+        const target = layout.rows.find((r) => r.stepIndex === 1 && r.row.label === 'z')!
+        const inbound = layout.ribbons.filter((r) => r.ribbon.targetKey === target.row.key)
+        const totalIn = inbound.reduce((sum, band) => sum + band.toThickness, 0)
+        expect(target.barHeight).toEqual(MIN_BAR_HEIGHT)
+        expect(totalIn).toBeLessThanOrEqual(target.barHeight + 1e-6)
+    })
+
+    it('renders drop-off rows as text-only blocks with no bar and no ribbon endpoints', () => {
+        const layout = buildJourneyGridLayout(buildJourneyGridModel(results))
+
+        const dropOffs = layout.rows.filter((r) => r.row.kind === 'dropOff')
+        expect(dropOffs).toHaveLength(2)
+        expect(dropOffs.every((r) => r.barHeight === 0)).toBe(true)
+        // A drop-off row sits below the previous row's bar, offset by the label block, never overlapping
+        const source = layout.rows.find((r) => r.stepIndex === 0 && r.row.label === 'a')!
+        expect(dropOffs[0].labelY).toBeGreaterThanOrEqual(source.labelY + LABEL_BLOCK_HEIGHT + source.barHeight)
+    })
+})

--- a/products/product_analytics/frontend/insights/journeys/journeyGridLayout.ts
+++ b/products/product_analytics/frontend/insights/journeys/journeyGridLayout.ts
@@ -1,0 +1,138 @@
+import { JourneyGridModel, JourneyGridRibbon, JourneyGridRow } from './journeyGridModel'
+
+// One shared px-per-actor scale drives both bar heights and ribbon thicknesses, so flows
+// visually conserve: a node's out-ribbons tile its bar edge instead of floating beside it.
+export const COLUMN_PITCH = 280
+export const BAR_WIDTH = 88
+export const LABEL_BLOCK_HEIGHT = 40
+export const DROP_OFF_BLOCK_HEIGHT = 36
+export const ROW_GAP = 20
+export const HEADER_HEIGHT = 28
+/** Height budget for the tallest column's bars; smaller columns scale down from it. */
+export const BAR_HEIGHT_BUDGET = 420
+export const MIN_BAR_HEIGHT = 6
+export const MIN_RIBBON_THICKNESS = 1.5
+
+export interface JourneyLayoutRow {
+    row: JourneyGridRow
+    stepIndex: number
+    /** Column left edge; the label block and bar both start here. */
+    x: number
+    /** Label block top. */
+    labelY: number
+    /** Bar top; equals labelY + LABEL_BLOCK_HEIGHT. Unused for drop-off rows. */
+    barY: number
+    /** 0 for drop-off rows, which render as text only. */
+    barHeight: number
+}
+
+export interface JourneyLayoutRibbon {
+    ribbon: JourneyGridRibbon
+    fromX: number
+    fromY: number
+    /** Band thickness at the source bar's edge. */
+    fromThickness: number
+    toX: number
+    toY: number
+    /** Band thickness at the target bar's edge; differs from the source end when squeezed. */
+    toThickness: number
+}
+
+export interface JourneyGridLayout {
+    rows: JourneyLayoutRow[]
+    ribbons: JourneyLayoutRibbon[]
+    width: number
+    height: number
+}
+
+function rowKey(stepIndex: number, key: string): string {
+    return `${stepIndex}:${key}`
+}
+
+export function buildJourneyGridLayout(model: JourneyGridModel): JourneyGridLayout {
+    // Drop-off counts overlap the column's other rows (a journey ending at a step is also counted
+    // at that step), so they stay out of the actor sum that sets the scale.
+    let maxColumnActors = 0
+    for (const column of model.columns) {
+        const actors = column.rows.reduce((sum, row) => (row.kind === 'dropOff' ? sum : sum + row.count), 0)
+        maxColumnActors = Math.max(maxColumnActors, actors)
+    }
+    const scale = maxColumnActors > 0 ? BAR_HEIGHT_BUDGET / maxColumnActors : 0
+
+    const rowByKey = new Map<string, JourneyLayoutRow>()
+    const rows: JourneyLayoutRow[] = []
+    let height = 0
+    model.columns.forEach((column, columnIndex) => {
+        let y = HEADER_HEIGHT
+        for (const row of column.rows) {
+            const barHeight = row.kind === 'dropOff' ? 0 : Math.max(MIN_BAR_HEIGHT, row.count * scale)
+            const layoutRow: JourneyLayoutRow = {
+                row,
+                stepIndex: column.stepIndex,
+                x: columnIndex * COLUMN_PITCH,
+                labelY: y,
+                barY: y + LABEL_BLOCK_HEIGHT,
+                barHeight,
+            }
+            rowByKey.set(rowKey(column.stepIndex, row.key), layoutRow)
+            rows.push(layoutRow)
+            y += (row.kind === 'dropOff' ? DROP_OFF_BLOCK_HEIGHT : LABEL_BLOCK_HEIGHT + barHeight) + ROW_GAP
+        }
+        height = Math.max(height, y - ROW_GAP)
+    })
+
+    // Stack the ports on each bar edge in the vertical order of the connected bars, so ribbons
+    // out of one bar never cross at the edge. Ports are contiguous, tiling the edge like a sankey.
+    const resolved = model.ribbons.flatMap((ribbon) => {
+        const source = rowByKey.get(rowKey(ribbon.sourceStep, ribbon.sourceKey))
+        const target = rowByKey.get(rowKey(ribbon.sourceStep + 1, ribbon.targetKey))
+        return source && target && source.row.kind !== 'dropOff' && target.row.kind !== 'dropOff'
+            ? [{ ribbon, source, target }]
+            : []
+    })
+    resolved.sort((a, b) => a.source.barY - b.source.barY || a.target.barY - b.target.barY)
+
+    const baseThickness = (ribbon: JourneyGridRibbon): number => Math.max(MIN_RIBBON_THICKNESS, ribbon.count * scale)
+
+    // In open mode an actor with several journeys can appear on more than one edge of a node, and
+    // minimum thicknesses inflate hair-thin bands, so a bar's ports can sum past its height;
+    // squeeze that end's bands proportionally to keep them tiling within the edge.
+    const outTotal = new Map<string, number>()
+    const inTotal = new Map<string, number>()
+    for (const { ribbon } of resolved) {
+        const thickness = baseThickness(ribbon)
+        const sourceKey = rowKey(ribbon.sourceStep, ribbon.sourceKey)
+        const targetKey = rowKey(ribbon.sourceStep + 1, ribbon.targetKey)
+        outTotal.set(sourceKey, (outTotal.get(sourceKey) ?? 0) + thickness)
+        inTotal.set(targetKey, (inTotal.get(targetKey) ?? 0) + thickness)
+    }
+    const squeeze = (total: number | undefined, barHeight: number): number =>
+        total && total > barHeight ? barHeight / total : 1
+
+    const outCursor = new Map<string, number>()
+    const inCursor = new Map<string, number>()
+    const ribbons: JourneyLayoutRibbon[] = resolved.map(({ ribbon, source, target }) => {
+        const sourceKey = rowKey(ribbon.sourceStep, ribbon.sourceKey)
+        const targetKey = rowKey(ribbon.sourceStep + 1, ribbon.targetKey)
+        const base = baseThickness(ribbon)
+        const fromThickness = base * squeeze(outTotal.get(sourceKey), source.barHeight)
+        const toThickness = base * squeeze(inTotal.get(targetKey), target.barHeight)
+        const fromY = source.barY + (outCursor.get(sourceKey) ?? 0)
+        const toY = target.barY + (inCursor.get(targetKey) ?? 0)
+        outCursor.set(sourceKey, (outCursor.get(sourceKey) ?? 0) + fromThickness)
+        inCursor.set(targetKey, (inCursor.get(targetKey) ?? 0) + toThickness)
+        return {
+            ribbon,
+            fromX: source.x + BAR_WIDTH,
+            fromY,
+            fromThickness,
+            toX: target.x,
+            toY,
+            toThickness,
+        }
+    })
+
+    const labelWidth = COLUMN_PITCH - 24
+    const width = model.columns.length > 0 ? (model.columns.length - 1) * COLUMN_PITCH + labelWidth : 0
+    return { rows, ribbons, width, height: height + 16 }
+}


### PR DESCRIPTION
## TL;DR (eli5)

The journeys chart now works like a river map: wide streams mean many people, narrow streams mean few. Before, every box was the same size and you had to read the numbers to know where people went.

## Problem

The journeys insight drew every step as a fixed 224×66 card, so a step with 8,000 people looked identical to one with 300. Ribbons were capped at 36px, attached near the card top, and squeezed through a 104px gutter, so the flow read as decorative spaghetti rather than a chart.

Stacked on [#81977](https://github.com/PostHog/posthog/pull/81977), which added the Storybook stories used to render the before/after below.

## Changes

- One px-per-actor scale drives both bar heights and ribbon thicknesses, so a bar's out-ribbons tile its edge and flows visually conserve. The unfilled part of a bar edge is the drop-off.
- Labels move above the bars (Mixpanel-style split of text block and mark), which frees the bars to encode magnitude and widens the ribbon field from 104px to 192px.
- Drop-off stays a text-only row: its count overlaps the column's other rows, so a bar would double-count.
- The layout is a pure function in `journeyGridLayout.ts`; interaction (tooltips, persons modal clicks, keyboard, hover chain highlight) is unchanged.

Before → after (rest state):

![before](https://raw.githubusercontent.com/PostHog/pr-assets/6d5c6a7f1ea50d53cab13711f866f658089e5db2/2026/08/815dd29f-f19f-445a-a537-ad34f2614d35.png)

![journeys_current](https://raw.githubusercontent.com/PostHog/pr-assets/43a6ac856a0f8ea62f23b405eca67f0e99d8280e/2026/08/747e7898-249d-40e0-9ecd-10b5c6f21348.png)

Hover chain highlight:

![journeys_chain](https://raw.githubusercontent.com/PostHog/pr-assets/732f136584450230d8585e3c310a1a71fba6a764/2026/08/a2f83329-9e0a-469c-b9ec-d5d2d20aeedb.png)

Dark mode:

![journeys_dark](https://raw.githubusercontent.com/PostHog/pr-assets/5fc78ee27f6fe3a9da7aa05d682405dca917866f/2026/08/f4b6bb94-02e8-46dc-96d1-192f43169580.png)

## How did you test this code?

- New unit tests on the pure layout: cross-column proportionality, ribbons tiling a bar edge without spilling, min-size clamps for tiny counts, band squeezing when minimums overflow a tiny bar, and drop-off staying text-only. No existing test covered geometry.
- Existing `journeyGridModel` tests still pass; the model is untouched.
- Rendered both stories in light and dark in a local Storybook (screenshots above).
- `pnpm --filter=@posthog/frontend typescript:check` passed.
- Not run: the visual regression suite; this PR intentionally changes the two snapshots added in [#81977](https://github.com/PostHog/posthog/pull/81977).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (cloud task) implemented this after a gap assessment against competing flow views; the user asked for the fix as a stacked PR.
- Skills invoked: /stacking-prs, /writing-tests, /writing-code-comments, /writing-pr-descriptions, /triaging-visual-review-runs.
- The fixture data is invented; the driver's GitHub handle is unknown to this session, so the PR is unassigned.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
