### PR TITLE
feat(logs): improve alert creation controls

### DIFF
--- a/products/logs/frontend/components/LogsAlerting/LogsAlertCreateModal.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertCreateModal.tsx
@@ -142,37 +142,35 @@ function LogsAlertReview({
         : 'No notification destinations'
 
     return (
-        <div className="max-w-2xl">
-            <AlertWizardReview
-                notice={
-                    pendingNotifications.length === 0 ? (
-                        <LemonBanner type="warning">
-                            This alert will run without notifications. Go back to Notify to add a destination.
-                        </LemonBanner>
-                    ) : undefined
-                }
-                items={[
-                    { label: 'Name', value: alertForm.name },
-                    { label: 'Severity', value: severity },
-                    { label: 'Service', value: services },
-                    {
-                        label: 'Attributes',
-                        value: attributeCount
-                            ? `${attributeCount} attribute filter${attributeCount === 1 ? '' : 's'}`
-                            : 'None',
-                    },
-                    {
-                        label: 'Fires when',
-                        value: `log count is ${alertForm.thresholdOperator} ${alertForm.thresholdCount} in ${alertForm.windowMinutes} minutes`,
-                    },
-                    {
-                        label: 'Noise reduction',
-                        value: `${alertForm.datapointsToAlarm} of ${alertForm.evaluationPeriods} checks must match`,
-                    },
-                    { label: 'Notification cooldown', value: `${alertForm.cooldownMinutes} minutes` },
-                    { label: 'Notifies', value: notificationSummary },
-                ]}
-            />
-        </div>
+        <AlertWizardReview
+            notice={
+                pendingNotifications.length === 0 ? (
+                    <LemonBanner type="warning">
+                        This alert will run without notifications. Go back to Notify to add a destination.
+                    </LemonBanner>
+                ) : undefined
+            }
+            items={[
+                { label: 'Name', value: alertForm.name },
+                { label: 'Severity', value: severity },
+                { label: 'Service', value: services },
+                {
+                    label: 'Attributes',
+                    value: attributeCount
+                        ? `${attributeCount} attribute filter${attributeCount === 1 ? '' : 's'}`
+                        : 'None',
+                },
+                {
+                    label: 'Fires when',
+                    value: `log count is ${alertForm.thresholdOperator} ${alertForm.thresholdCount} in ${alertForm.windowMinutes} minutes`,
+                },
+                {
+                    label: 'Noise reduction',
+                    value: `${alertForm.datapointsToAlarm} of ${alertForm.evaluationPeriods} checks must match`,
+                },
+                { label: 'Notification cooldown', value: `${alertForm.cooldownMinutes} minutes` },
+                { label: 'Notifies', value: notificationSummary },
+            ]}
+        />
     )
 }

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertCreateModal.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertCreateModal.tsx
@@ -102,7 +102,7 @@ function buildLogsAlertWizardSteps({
             title: 'Set trigger',
             description: 'Set the log count that fires the alert and reduce notification noise if needed.',
             content: (
-                <div className="max-w-2xl space-y-6">
+                <div className="space-y-6">
                     <LogsAlertTrigger />
                     <LogsAlertSimulation embedded />
                 </div>

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertForm.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertForm.tsx
@@ -134,6 +134,7 @@ export function LogsAlertFilters({ filterError }: { filterError?: string }): JSX
                     <SeverityLevelsFilter
                         value={alertForm.severityLevels}
                         onChange={(levels) => setAlertFormValue('severityLevels', levels)}
+                        showBulkActions
                     />
                 </LemonField>
                 <LemonField.Pure label="Service">

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertSimulation.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertSimulation.tsx
@@ -261,6 +261,27 @@ function SimulationResults({ result }: { result: LogsAlertSimulateResponseApi })
     )
 }
 
+function SimulationPlaceholder(): JSX.Element {
+    return (
+        <div className="relative h-56 overflow-hidden rounded border border-dashed border-border bg-bg-light">
+            <div aria-hidden className="space-y-4 p-4 opacity-60">
+                <LemonSkeleton className="h-32" />
+                <div className="flex gap-6">
+                    <LemonSkeleton className="h-8 w-16" repeat={3} />
+                </div>
+            </div>
+            <div className="absolute inset-0 flex items-center justify-center bg-bg-light/80 p-4 text-center">
+                <div>
+                    <div className="text-sm font-medium">Select a time range, then run a simulation</div>
+                    <p className="m-0 mt-1 text-xs text-secondary">
+                        Historical log counts and alert outcomes will appear here.
+                    </p>
+                </div>
+            </div>
+        </div>
+    )
+}
+
 export function LogsAlertSimulation({ embedded = false }: { embedded?: boolean }): JSX.Element {
     const { simulationResult, simulationResultLoading, simulationDateFrom } = useValues(logsAlertFormLogic)
     const { simulateAlert, setSimulationDateFrom } = useActions(logsAlertFormLogic)
@@ -294,12 +315,7 @@ export function LogsAlertSimulation({ embedded = false }: { embedded?: boolean }
 
             {simulationResult && <SimulationResults result={simulationResult} />}
 
-            {!simulationResult && !simulationResultLoading && (
-                <div className="py-4 text-secondary text-sm">
-                    Select a time range and click "Run simulation" to preview how this alert would behave on historical
-                    data.
-                </div>
-            )}
+            {!simulationResult && !simulationResultLoading && <SimulationPlaceholder />}
         </div>
     )
 

--- a/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertFormLogic.test.ts
+++ b/products/logs/frontend/components/LogsAlerting/__tests__/logsAlertFormLogic.test.ts
@@ -13,7 +13,7 @@ import {
     LogsAlertConfigurationStateEnumApi,
 } from 'products/logs/frontend/generated/api.schemas'
 
-import { LogsAlertFormType, logsAlertFormLogic } from '../logsAlertFormLogic'
+import { buildFormDefaults, LogsAlertFormType, logsAlertFormLogic } from '../logsAlertFormLogic'
 
 jest.mock('products/logs/frontend/generated/api', () => ({
     logsAlertsCreate: jest.fn(),
@@ -456,6 +456,12 @@ describe('logsAlertFormLogic', () => {
             expect(logic.values.alertForm.severityLevels).toEqual(['error'])
         })
 
+        it('allows existing alerts without filters', () => {
+            const existingAlertWithoutFilters = { ...MOCK_ALERT, filters: null } as unknown as LogsAlertConfigurationApi
+
+            expect(buildFormDefaults(existingAlertWithoutFilters).severityLevels).toEqual([])
+        })
+
         it('pre-populates numeric fields from existing alert', () => {
             expect(logic.values.alertForm.thresholdCount).toBe(MOCK_ALERT.threshold_count)
             expect(logic.values.alertForm.windowMinutes).toBe(MOCK_ALERT.window_minutes)
@@ -503,7 +509,7 @@ describe('logsAlertFormLogic', () => {
 
             expect(logic.values.alertForm).toMatchObject({
                 name: '',
-                severityLevels: [],
+                severityLevels: ['trace', 'debug', 'info', 'warn', 'error', 'fatal'],
                 serviceNames: [],
                 thresholdOperator: 'above',
                 thresholdCount: 100,

--- a/products/logs/frontend/components/LogsAlerting/logsAlertFormLogic.ts
+++ b/products/logs/frontend/components/LogsAlerting/logsAlertFormLogic.ts
@@ -35,6 +35,8 @@ const EMPTY_FILTER_GROUP: UniversalFiltersGroup = {
     values: [],
 }
 
+const DEFAULT_SEVERITY_LEVELS: LogMessage['severity_text'][] = ['trace', 'debug', 'info', 'warn', 'error', 'fatal']
+
 export interface LogsAlertFormType {
     name: string
     severityLevels: LogMessage['severity_text'][]
@@ -70,11 +72,14 @@ function saveErrorMessage(error: ApiError): string {
 }
 
 export function buildFormDefaults(alert: LogsAlertConfigurationApi | null): LogsAlertFormType {
+    const filters = (alert?.filters ?? {}) as Record<string, unknown>
+
     return {
         name: alert?.name ?? '',
-        severityLevels:
-            ((alert?.filters as Record<string, unknown>)?.severityLevels as LogMessage['severity_text'][]) ?? [],
-        serviceNames: ((alert?.filters as Record<string, unknown>)?.serviceNames as string[]) ?? [],
+        severityLevels: alert
+            ? ((filters.severityLevels as LogMessage['severity_text'][]) ?? [])
+            : DEFAULT_SEVERITY_LEVELS,
+        serviceNames: (filters.serviceNames as string[]) ?? [],
         filterGroup: extractFilterGroup(alert),
         thresholdOperator: alert?.threshold_operator ?? LogsAlertThresholdOperatorEnumApi.Above,
         thresholdCount: alert?.threshold_count ?? 100,

--- a/products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsFilter.test.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsFilter.test.tsx
@@ -1,0 +1,33 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import { SeverityLevelsFilter } from './SeverityLevelsFilter'
+
+describe('SeverityLevelsFilter', () => {
+    afterEach(cleanup)
+
+    it('selects every severity level from the alert bulk action', () => {
+        const onChange = jest.fn()
+        render(<SeverityLevelsFilter value={['error']} onChange={onChange} showBulkActions />)
+
+        fireEvent.click(screen.getByTestId('logs-severity-filter'))
+        fireEvent.click(screen.getByTestId('logs-severity-select-all'))
+
+        expect(onChange).toHaveBeenCalledWith(['trace', 'debug', 'info', 'warn', 'error', 'fatal'])
+    })
+
+    it('clears every severity level from the alert bulk action', () => {
+        const onChange = jest.fn()
+        render(
+            <SeverityLevelsFilter
+                value={['trace', 'debug', 'info', 'warn', 'error', 'fatal']}
+                onChange={onChange}
+                showBulkActions
+            />
+        )
+
+        fireEvent.click(screen.getByTestId('logs-severity-filter'))
+        fireEvent.click(screen.getByTestId('logs-severity-clear-all'))
+
+        expect(onChange).toHaveBeenCalledWith([])
+    })
+})

--- a/products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsFilter.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/SeverityLevelsFilter.tsx
@@ -15,14 +15,43 @@ const SEVERITY_OPTIONS: { key: LogMessage['severity_text']; label: string }[] = 
 interface SeverityLevelsFilterProps {
     value: LogMessage['severity_text'][]
     onChange: (levels: LogMessage['severity_text'][]) => void
+    showBulkActions?: boolean
 }
 
-export const SeverityLevelsFilter = ({ value, onChange }: SeverityLevelsFilterProps): JSX.Element => {
+export const SeverityLevelsFilter = ({
+    value,
+    onChange,
+    showBulkActions = false,
+}: SeverityLevelsFilterProps): JSX.Element => {
+    const allSelected = SEVERITY_OPTIONS.every((option) => value.includes(option.key))
+
     return (
         <LemonDropdown
             closeOnClickInside={false}
             overlay={
                 <div className="space-y-px p-1">
+                    {showBulkActions && (
+                        <div className="flex gap-1 px-1 pb-1">
+                            <LemonButton
+                                type="tertiary"
+                                size="xsmall"
+                                onClick={() => onChange(SEVERITY_OPTIONS.map((option) => option.key))}
+                                disabledReason={allSelected ? 'All severity levels are selected' : undefined}
+                                data-attr="logs-severity-select-all"
+                            >
+                                Select all
+                            </LemonButton>
+                            <LemonButton
+                                type="tertiary"
+                                size="xsmall"
+                                onClick={() => onChange([])}
+                                disabledReason={value.length === 0 ? 'No severity levels are selected' : undefined}
+                                data-attr="logs-severity-clear-all"
+                            >
+                                Clear all
+                            </LemonButton>
+                        </div>
+                    )}
                     {SEVERITY_OPTIONS.map((option) => (
                         <LemonButton
                             key={option.key}


### PR DESCRIPTION
## Problem

- Log-alert creators cannot quickly select or clear every severity level.
- The simulation preview and wizard steps leave unused modal space.

## Changes

<img width="956" height="722" alt="CleanShot 2026-08-12 at 13 15 16@2x" src="https://github.com/user-attachments/assets/ccbd9cc2-f6ba-46bb-8a95-d6514174f3c9" />
<img width="1750" height="766" alt="CleanShot 2026-08-12 at 13 15 22@2x" src="https://github.com/user-attachments/assets/03d83ff2-8501-47b7-b885-fd924edd3458" />


- Preselect every severity level for new log alerts.
- Add Select all and Clear all controls to the alert severity picker.
- Show a simulation placeholder until a user runs a preview.
- Let the trigger and review steps use the full modal width.
- Preserve existing alerts that have no saved filters.

## How did you test this code?

- Focused tests cover severity bulk actions and alert defaults without saved filters.
- Checked lint, formatting, and deterministic CI preflight rules.
- Not run: manual visual review in a local browser.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No documentation update. This change adds controls within the existing alert workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex implemented user-directed log-alert editor improvements.
- Skills: authoring-log-alerts, writing-user-facing-copy, qa-team, writing-pr-descriptions.
- QA identified compatibility and empty-state guidance issues. This PR includes fixes for both.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*