### PR TITLE
fix(replay): guard tagless custom snapshots and non-numeric web vitals

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemEvent.stories.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemEvent.stories.tsx
@@ -226,6 +226,35 @@ export const WebVitalsEvent: Story = {
     },
 }
 
+// captured web vitals properties reach us with a missing or non-numeric `value`, so the
+// metric name and rating have to render on their own
+export const WebVitalsEventWithUnusableValues: Story = {
+    render: renderBasic as any,
+    args: {
+        item: makeItem(
+            {},
+            { event: '$web_vitals' },
+            {
+                $lib: 'web',
+                $current_url: 'http://localhost:8000/project/1/activity/explore',
+                $web_vitals_INP_event: {
+                    name: 'INP',
+                    rating: 'good',
+                    id: 'v4-1719484470693-6845621238957',
+                    timestamp: 1719484490693,
+                },
+                $web_vitals_CLS_event: {
+                    name: 'CLS',
+                    value: '0.106',
+                    rating: 'needs-improvement',
+                    id: 'v4-1719484470710-6118725051157',
+                    timestamp: 1719484490693,
+                },
+            }
+        ),
+    },
+}
+
 export const GroupIdentifyEvent: Story = {
     render: renderBasic as any,
     args: {

--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemEvent.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemEvent.tsx
@@ -21,7 +21,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ceilMsToClosestSecond } from 'lib/utils/durations'
 import { autoCaptureEventToDescription } from 'lib/utils/events'
 import { getPrimaryPropertyForEvent } from 'lib/utils/events'
-import { isString } from 'lib/utils/guards'
+import { isNumber, isString } from 'lib/utils/guards'
 import { capitalizeFirstLetter } from 'lib/utils/strings'
 import { insightUrlForEvent } from 'scenes/insights/utils'
 import { urls } from 'scenes/urls'
@@ -51,7 +51,8 @@ function WebVitalEventSummary({ event }: { event: Record<string, any> }): JSX.El
                     titleSuffix=""
                     value={
                         <>
-                            {event.rating}: {event.value.toFixed(2)}
+                            {event.rating}
+                            {isNumber(event.value) ? `: ${event.value.toFixed(2)}` : ''}
                         </>
                     }
                 />

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.test.ts
@@ -1,5 +1,7 @@
 import { expectLogic } from 'kea-test-utils'
 
+import { RecordingSnapshot } from '@posthog/replay-shared'
+
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import {
@@ -220,6 +222,23 @@ describe('playerInspectorLogic', () => {
                     },
                 ],
             })
+        })
+    })
+
+    describe('custom snapshots', () => {
+        const customSnapshot = (timestamp: number, data: Record<string, any>): RecordingSnapshot =>
+            ({ type: 5, timestamp, windowId: 1, data }) as unknown as RecordingSnapshot
+
+        it('derives doctor items from tagged custom snapshots and skips untagged ones', () => {
+            dataLogic.actions.setProcessedSnapshots([
+                customSnapshot(1691755416097, { tag: '$session_options', payload: {} }),
+                customSnapshot(1691755417097, { payload: { without: 'a tag' } }),
+            ])
+
+            expect(logic.values.processedSnapshotData.doctorEvents.map((item) => item.tag)).toEqual([
+                'session options',
+                'count of snapshot types by window',
+            ])
         })
     })
 

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -31,6 +31,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ceilMsToClosestSecond } from 'lib/utils/durations'
 import { eventToDescription } from 'lib/utils/events'
 import { createFuse } from 'lib/utils/fuseSearch'
+import { isString } from 'lib/utils/guards'
 import { humanizeBytes } from 'lib/utils/numbers'
 import { toParams } from 'lib/utils/url'
 import { getText } from 'scenes/comments/Comment'
@@ -306,7 +307,9 @@ export function computeDisplayGroups(items: InspectorListItem[], groupSimilar: b
 }
 
 function _isCustomSnapshot(x: unknown): x is customEvent {
-    return (x as customEvent).type === 5
+    // rrweb types `data.tag` as a required string, but captured snapshots reach us without it,
+    // and every consumer below reads the tag as one
+    return (x as customEvent).type === 5 && isString((x as customEvent).data?.tag)
 }
 
 function _isPluginSnapshot(x: unknown): x is pluginEvent {


### PR DESCRIPTION
## Problem

Opening a recording can replace the whole session replay page with the "An error has occurred" panel, for any project whose recordings contain one malformed field.
Two separate unguarded reads in the replay inspector throw during render:

- A `type: 5` rrweb custom event arriving with `data` but no `data.tag` crashes the `processedSnapshotData` selector in `niceify` — [error tracking issue 019fdf1d](https://us.posthog.com/project/2/error_tracking/019fdf1d-4f84-7ab1-b721-2eec626744d2) (19 occurrences / 6 sessions / 3 users since 2026-08-07).
- A `$web_vitals_*_event` property whose `value` is missing or not a number crashes `WebVitalEventSummary` — [error tracking issue 019f190a](https://us.posthog.com/project/2/error_tracking/019f190a-da54-7511-8b3f-d8a24dd3e6a5), still open, which is the non-numeric half of the same line.

Nothing under `frontend/src/scenes/session-recordings/` has its own `ErrorBoundary`, so the nearest one is the scene-level boundary in `scenes/App.tsx`.
That is what turns a single bad field into a blank page rather than one odd inspector row.

The two errors race: the first needs snapshots loaded, the second needs the events list, so which one a user hits depends on timing.
Neither is a frontend regression — `playerInspectorLogic.ts` last changed 2026-07-31, six days before the first error appeared.

## Changes

- `_isCustomSnapshot` now requires `data.tag` to be a string, not just `type === 5`. It asserts `x is customEvent`, which told TypeScript the tag was a string while nothing checked it at runtime.
- `WebVitalEventSummary` renders the metric name and rating on their own when `value` is not a number, instead of calling `toFixed` on it.
- Both reuse the existing `isString` / `isNumber` guards from `lib/utils/guards`.

Tightening the predicate rather than guarding at the two call sites is deliberate: it is the single gate for every `data.tag` read in the file, so it also covers `snapshotDescription`, `getPayloadFor`, and the `key:` template literals that would otherwise emit `-doctor-undefined`.
A tagless snapshot is now described as `Custom` instead of `Custom: undefined`, and it still lands in `snapshotCounts`, so it stays visible in the inspector's doctor tab rather than disappearing.

Scope is deliberately just these two guards. Worth a follow-up: the missing boundary below the scene level is what makes any future unguarded read here a full-page failure.

## How did you test this code?

Automated, run locally:

- New `playerInspectorLogic` test feeds a tagged and an untagged `type: 5` snapshot through `processedSnapshotData`. It catches a revert of the predicate: with the fix reverted it fails with the exact production error, `TypeError: Cannot read properties of undefined (reading 'replace')` at `niceify`. No existing test fed a custom event through this selector at all.
- New `WebVitalsEventWithUnusableValues` story covers the missing and non-numeric `value` cases, extending the existing `WebVitalsEvent` story rather than adding a render test for a one-line ternary.
- `src/scenes/session-recordings` Jest suite passes.

Not done: no manual browser check — I could not run the app in this environment, so the claim that the scene now renders rests on the reverted-fix reproduction above, not on observing the page.

`typescript:check` reports pre-existing errors from the unbuilt nested `@posthog/quill` workspace; none are in the changed files, and both functions touched are module-private so they cannot affect other files' types.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with PostHog Code (Claude Opus 4.5) while debugging a support ticket that reported the replay page dying on load.
The ticket supplied only minified stack traces; the frames were resolved by pulling the symbolicated traces from error tracking in project 2, which is also where the affected-user counts above come from.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

Two decisions worth flagging for review:

- The first instinct was to hunt down where the tagless snapshot is produced. Every synthesis site in the frontend and `common/replay-shared` (`process-all-snapshots.ts`, `chrome-extension-stripping.ts`, the mobile transformer) always sets a tag, so the malformed event arrives from captured data and the frontend has to tolerate it regardless.
- An `ErrorBoundary` around the inspector was considered and dropped to keep this to the confirmed crash sites.

No material from the originating ticket appears in this PR. The test fixtures were written from the two property shapes that had to be exercised — a `type: 5` event with no `tag`, and a web vitals property with no usable `value` — and the story reuses the placeholder values already in the neighbouring story.
