### PR TITLE
feat(surveys): add project-level default survey wait period

### DIFF
--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -129,7 +129,7 @@ import {
     ReplayNetworkHeadersPayloads,
 } from './environment/SessionRecordingSettings'
 import { SessionSummariesSettings } from './environment/SessionSummariesSettings'
-import { SurveyDefaultAppearance, SurveyEnableToggle } from './environment/SurveySettings'
+import { SurveyDefaultAppearance, SurveyDefaultWaitPeriod, SurveyEnableToggle } from './environment/SurveySettings'
 import { TeamAccessControl } from './environment/TeamAccessControl'
 import {
     TeamAuthorizedURLs,
@@ -1286,6 +1286,15 @@ export const SETTINGS_MAP: SettingSection[] = [
                 docsUrl: 'https://posthog.com/docs/surveys/creating-surveys#customizing-the-look-and-feel',
                 component: <SurveyDefaultAppearance />,
                 keywords: ['appearance', 'style', 'theme', 'customization', 'popup'],
+            },
+            {
+                id: 'surveys-default-wait-period',
+                title: 'Default survey wait period',
+                description:
+                    'New surveys start with this wait period, so they skip anyone who has already seen a survey recently. Individual surveys can override it.',
+                docsUrl: 'https://posthog.com/docs/surveys/creating-surveys#display-conditions',
+                component: <SurveyDefaultWaitPeriod />,
+                keywords: ['wait', 'period', 'frequency', 'delay', 'fatigue', 'display', 'conditions'],
             },
         ],
     },

--- a/frontend/src/scenes/settings/environment/SurveySettings.tsx
+++ b/frontend/src/scenes/settings/environment/SurveySettings.tsx
@@ -1,1 +1,1 @@
-export { SurveyEnableToggle, SurveyDefaultAppearance } from 'scenes/surveys/SurveySettings'
+export { SurveyEnableToggle, SurveyDefaultAppearance, SurveyDefaultWaitPeriod } from 'scenes/surveys/SurveySettings'

--- a/frontend/src/scenes/settings/types.ts
+++ b/frontend/src/scenes/settings/types.ts
@@ -257,6 +257,7 @@ export type SettingId =
     | 'snippet'
     | 'snippet-v2'
     | 'surveys-default-appearance'
+    | 'surveys-default-wait-period'
     | 'surveys-interface'
     | 'theme'
     | 'user-delete'

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -67,7 +67,12 @@ import {
 import { SurveyBranchingFlowModal } from './branching-flow/SurveyBranchingFlowModal'
 import { SurveyPublicContentNotice } from './components/SurveyPublicContentNotice'
 import { SurveyUrlAudienceEstimate } from './components/SurveyUrlAudienceEstimate'
-import { SURVEY_TYPE_LABEL_MAP, SurveyMatchTypeLabels, defaultSurveyFieldValues } from './constants'
+import {
+    DEFAULT_SURVEY_WAIT_PERIOD_IN_DAYS,
+    SURVEY_TYPE_LABEL_MAP,
+    SurveyMatchTypeLabels,
+    defaultSurveyFieldValues,
+} from './constants'
 import { COMMON_LANGUAGES, getBaseLanguage, getSurveyLanguageName } from './language'
 import { SurveyAPIEditor } from './SurveyAPIEditor'
 import { SurveyAppearancePreview } from './SurveyAppearancePreview'
@@ -1720,7 +1725,7 @@ export default function SurveyEdit({ id }: { id: string }): JSX.Element {
                                                                                               seenSurveyWaitPeriodInDays:
                                                                                                   checked
                                                                                                       ? value?.seenSurveyWaitPeriodInDays ||
-                                                                                                        30
+                                                                                                        DEFAULT_SURVEY_WAIT_PERIOD_IN_DAYS
                                                                                                       : null,
                                                                                           })
                                                                                       }}

--- a/frontend/src/scenes/surveys/SurveySettings.tsx
+++ b/frontend/src/scenes/surveys/SurveySettings.tsx
@@ -3,7 +3,7 @@ import { DeepPartialMap, ValidationErrorType } from 'kea-forms'
 import { useState } from 'react'
 
 import { IconGear } from '@posthog/icons'
-import { LemonBanner, LemonButton, LemonSwitch, Link } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonCheckbox, LemonInput, LemonSwitch, Link } from '@posthog/lemon-ui'
 
 import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
 import { TeamMembershipLevel } from 'lib/constants'
@@ -14,7 +14,7 @@ import { teamLogic } from 'scenes/teamLogic'
 
 import { SurveyAppearance } from '~/types'
 
-import { NEW_SURVEY, defaultSurveyAppearance } from './constants'
+import { DEFAULT_SURVEY_WAIT_PERIOD_IN_DAYS, NEW_SURVEY, defaultSurveyAppearance } from './constants'
 import { Customization } from './survey-appearance/SurveyCustomization'
 import { SurveyAppearancePreview } from './SurveyAppearancePreview'
 
@@ -133,6 +133,57 @@ export function SurveyDefaultAppearance(): JSX.Element {
                     </div>
                 )}
             </div>
+        </div>
+    )
+}
+
+export function SurveyDefaultWaitPeriod(): JSX.Element {
+    const { currentTeam, currentTeamLoading } = useValues(teamLogic)
+    const { updateCurrentTeam } = useActions(teamLogic)
+
+    const restrictedReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
+    })
+
+    const savedWaitPeriod = currentTeam?.survey_config?.seenSurveyWaitPeriodInDays ?? null
+    const [waitPeriod, setWaitPeriod] = useState<number | null>(savedWaitPeriod)
+
+    return (
+        <div className="flex flex-col gap-2 items-start">
+            <div className="flex flex-wrap gap-2 items-center text-sm">
+                <LemonCheckbox
+                    checked={waitPeriod !== null}
+                    onChange={(checked) => setWaitPeriod(checked ? DEFAULT_SURVEY_WAIT_PERIOD_IN_DAYS : null)}
+                    label="Don't show a new survey if another one was shown to the user in the last"
+                    disabledReason={restrictedReason}
+                />
+                <LemonInput
+                    type="number"
+                    size="xsmall"
+                    min={1}
+                    value={waitPeriod ?? undefined}
+                    onChange={(value) => setWaitPeriod(value && value > 0 ? value : null)}
+                    className="w-16 tabular-nums"
+                    disabledReason={restrictedReason}
+                />
+                <span className="text-secondary">days.</span>
+            </div>
+            <LemonButton
+                type="primary"
+                onClick={() =>
+                    updateCurrentTeam({
+                        survey_config: {
+                            ...currentTeam?.survey_config,
+                            seenSurveyWaitPeriodInDays: waitPeriod,
+                        },
+                    })
+                }
+                loading={currentTeamLoading}
+                disabledReason={restrictedReason ?? (waitPeriod === savedWaitPeriod ? 'No changes to save' : undefined)}
+            >
+                Save wait period
+            </LemonButton>
         </div>
     )
 }

--- a/frontend/src/scenes/surveys/constants.tsx
+++ b/frontend/src/scenes/surveys/constants.tsx
@@ -68,6 +68,9 @@ export const SurveyMatchTypeLabels = {
     [SurveyMatchType.NotRegex]: allOperatorsMapping[SurveyMatchType.NotRegex],
 }
 
+/** Wait period we pre-fill when someone turns one on, either per survey or as the project default. */
+export const DEFAULT_SURVEY_WAIT_PERIOD_IN_DAYS = 30
+
 // Sync with posthog/constants.py
 export const defaultSurveyAppearance = {
     fontFamily: 'inherit',

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -132,6 +132,7 @@ import {
     DATE_FORMAT,
     type OpenEndedColumnMap,
     type SurveyQueryFilters,
+    applyTeamDefaultWaitPeriod,
     buildAggregateQuery,
     buildOpenEndedQuery,
     buildPartialResponsesFilter,
@@ -1669,6 +1670,10 @@ export const surveyLogic = kea<surveyLogicType>([
                         ...defaultSurveyAppearance,
                         ...teamLogic.values.currentTeam?.survey_config?.appearance,
                     }
+                    templatedSurvey.conditions = applyTeamDefaultWaitPeriod(
+                        templatedSurvey.conditions,
+                        teamLogic.values.currentTeam?.survey_config
+                    )
                     return templatedSurvey
                 }
 
@@ -1677,6 +1682,10 @@ export const surveyLogic = kea<surveyLogicType>([
                     ...defaultSurveyAppearance,
                     ...teamLogic.values.currentTeam?.survey_config?.appearance,
                 }
+                newSurvey.conditions = applyTeamDefaultWaitPeriod(
+                    newSurvey.conditions,
+                    teamLogic.values.currentTeam?.survey_config
+                )
 
                 return newSurvey
             },
@@ -3887,6 +3896,10 @@ export const surveyLogic = kea<surveyLogicType>([
                     ...defaultSurveyAppearance,
                     ...teamLogic.values.currentTeam?.survey_config?.appearance,
                 },
+                conditions: applyTeamDefaultWaitPeriod(
+                    NEW_SURVEY.conditions,
+                    teamLogic.values.currentTeam?.survey_config
+                ),
             } as NewSurvey | Survey,
             errors: ({ name, questions, appearance, type }) => {
                 const sanitizedAppearance = sanitizeSurveyAppearance(appearance)

--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -19,6 +19,7 @@ import {
 } from '~/types'
 
 import {
+    applyTeamDefaultWaitPeriod,
     buildSurveyExampleInvocationGlobals,
     buildPartialResponsesFilter,
     buildSurveyOptionalBooleanPropertyFilter,
@@ -442,6 +443,48 @@ describe('survey utils', () => {
             expect(result?.actions).toEqual({ values: [{ id: 123, name: 'test' }] })
             expect(result?.events).toEqual({ values: [{ name: 'test' }] })
             expect(result?.deviceTypes).toEqual(['mobile'])
+        })
+    })
+
+    describe('applyTeamDefaultWaitPeriod', () => {
+        it('seeds the project default onto conditions that have no wait period', () => {
+            expect(applyTeamDefaultWaitPeriod(null, { seenSurveyWaitPeriodInDays: 30 })).toEqual({
+                actions: null,
+                events: null,
+                seenSurveyWaitPeriodInDays: 30,
+            })
+            expect(
+                applyTeamDefaultWaitPeriod(
+                    { url: 'https://example.com', actions: null, events: null },
+                    {
+                        seenSurveyWaitPeriodInDays: 30,
+                    }
+                )
+            ).toEqual({
+                url: 'https://example.com',
+                actions: null,
+                events: null,
+                seenSurveyWaitPeriodInDays: 30,
+            })
+        })
+
+        it('keeps a wait period the survey already has', () => {
+            expect(
+                applyTeamDefaultWaitPeriod(
+                    { seenSurveyWaitPeriodInDays: 14, actions: null, events: null },
+                    {
+                        seenSurveyWaitPeriodInDays: 30,
+                    }
+                )
+            ).toEqual({ seenSurveyWaitPeriodInDays: 14, actions: null, events: null })
+        })
+
+        it.each([
+            ['no survey config', undefined],
+            ['no default set', {}],
+            ['default cleared', { seenSurveyWaitPeriodInDays: null }],
+        ])('leaves conditions untouched with %s', (_name, surveyConfig) => {
+            expect(applyTeamDefaultWaitPeriod(null, surveyConfig)).toBeNull()
         })
     })
 

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -37,6 +37,7 @@ import {
     SurveySchedule,
     SurveyStats,
     SurveyType,
+    TeamSurveyConfigType,
 } from '~/types'
 
 const sanitizeConfig = { ADD_ATTR: ['target'] }
@@ -267,6 +268,22 @@ export function sanitizeSurveyDisplayConditions(
     }
 
     return sanitized
+}
+
+/**
+ * Seeds a new survey's display conditions with the project's default wait period. A wait period already
+ * on the survey, such as one coming from a template, is left alone.
+ */
+export function applyTeamDefaultWaitPeriod(
+    displayConditions: SurveyDisplayConditions | null,
+    surveyConfig?: TeamSurveyConfigType | null
+): SurveyDisplayConditions | null {
+    const waitPeriod = surveyConfig?.seenSurveyWaitPeriodInDays
+    if (!waitPeriod || displayConditions?.seenSurveyWaitPeriodInDays) {
+        return displayConditions
+    }
+
+    return { actions: null, events: null, ...displayConditions, seenSurveyWaitPeriodInDays: waitPeriod }
 }
 
 export function sanitizeSurveyAppearance(

--- a/frontend/src/scenes/surveys/wizard/steps/WhenStep.tsx
+++ b/frontend/src/scenes/surveys/wizard/steps/WhenStep.tsx
@@ -7,7 +7,7 @@ import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { AddEventButton } from 'scenes/surveys/AddEventButton'
-import { MAX_ITERATION_COUNT } from 'scenes/surveys/constants'
+import { DEFAULT_SURVEY_WAIT_PERIOD_IN_DAYS, MAX_ITERATION_COUNT } from 'scenes/surveys/constants'
 import { doesSurveyRepeatOnEveryEvent } from 'scenes/surveys/utils'
 
 import {
@@ -351,7 +351,9 @@ export function WhenStep(): JSX.Element {
                 <div className="flex flex-wrap items-center gap-2 text-sm mt-5">
                     <LemonCheckbox
                         checked={seenSurveyWaitPeriodInDays != null}
-                        onChange={(checked) => setSeenSurveyWaitPeriod(checked ? 30 : null)}
+                        onChange={(checked) =>
+                            setSeenSurveyWaitPeriod(checked ? DEFAULT_SURVEY_WAIT_PERIOD_IN_DAYS : null)
+                        }
                         label="Don't show this survey if another one was shown to the user in the last"
                     />
                     <LemonInput

--- a/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
+++ b/frontend/src/scenes/surveys/wizard/surveyWizardLogic.ts
@@ -41,6 +41,7 @@ import {
 import type { NewSurvey } from '../constants'
 import { surveyLogic } from '../surveyLogic'
 import { surveysLogic } from '../surveysLogic'
+import { applyTeamDefaultWaitPeriod } from '../utils'
 
 export type WizardStep = 'template' | 'questions' | 'where' | 'when' | 'appearance' | 'success'
 
@@ -477,7 +478,10 @@ export const surveyWizardLogic = kea<surveyWizardLogicType>([
             actions.setSurveyValue('schedule', isOnce ? SurveySchedule.Once : SurveySchedule.Recurring)
             actions.setSurveyValue('iteration_count', isOnce ? 0 : 10)
             actions.setSurveyValue('iteration_frequency_days', isOnce ? 0 : frequencyToDays[frequencyValue])
-            actions.setSurveyValue('conditions', template.conditions ?? null)
+            actions.setSurveyValue(
+                'conditions',
+                applyTeamDefaultWaitPeriod(template.conditions ?? null, values.currentTeam?.survey_config)
+            )
 
             actions.reportSurveyTemplateClicked(template.templateType, SURVEY_CREATED_SOURCE.SURVEY_WIZARD)
 

--- a/frontend/src/scenes/team-activity/teamActivityDescriber.tsx
+++ b/frontend/src/scenes/team-activity/teamActivityDescriber.tsx
@@ -393,6 +393,14 @@ const TEAM_PROPERTIES_MAPPING: Record<keyof TeamType, (change: ActivityChange) =
             )
         }
 
+        if (before?.seenSurveyWaitPeriodInDays !== after?.seenSurveyWaitPeriodInDays) {
+            descriptions.push(
+                after?.seenSurveyWaitPeriodInDays
+                    ? `${preamble} default survey wait period was set to ${after.seenSurveyWaitPeriodInDays} days`
+                    : `${preamble} default survey wait period was removed`
+            )
+        }
+
         propertyChangeDesc('backgroundColor', (c) => c?.appearance?.backgroundColor)
         propertyChangeDesc('submitButtonColor', (c) => c?.appearance?.submitButtonColor)
         propertyChangeDesc('submitButtonTextColor', (c) => c?.appearance?.submitButtonTextColor)

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -736,6 +736,8 @@ export interface ProjectType extends ProjectBasicType {
 
 export interface TeamSurveyConfigType {
     appearance?: SurveyAppearance
+    /** Default wait period new surveys start with, in days. Null or absent means no wait period. */
+    seenSurveyWaitPeriodInDays?: number | null
 }
 
 export type SessionRecordingMaskingLevel = 'normal' | 'total-privacy' | 'free-love'


### PR DESCRIPTION
## Problem

- Teams that want every survey to leave a gap after the last one have to set the wait period by hand on each new survey, and it is easy to forget.
- Surveys settings already carry project defaults for appearance, but not for anything under display conditions.

## Changes

- Project settings gain "Default survey wait period" under Surveys. New surveys start with it, so they skip anyone who has seen a survey in the last N days.
- The default lives in `team.survey_config.seenSurveyWaitPeriodInDays`, next to the existing default appearance. No migration, since `survey_config` is already a JSON field.
- The editor and the wizard seed the value when a survey is created. A wait period the survey already has, such as one from a template, wins over the project default.
- Existing surveys are untouched. This is a creation-time default, matching how default appearance behaves.
- Saving the setting is recorded in the team activity log.
- Only project admins can change it, same restriction as the other survey defaults.
- The hardcoded 30-day pre-fill in the editor and the wizard now reads from one constant.

Screenshot: I could not run the app in this sandbox, so there is no hand-taken screenshot. The visual review run on this branch renders the new section at the bottom of the Surveys settings scene, and its diff is confined to that section.

## How did you test this code?

- Added `applyTeamDefaultWaitPeriod` cases in `frontend/src/scenes/surveys/utils.test.ts`. They catch a seeding change that would overwrite a template's own wait period, and one that would stop applying the project default.
- Ran the surveys, settings, and team-activity Jest suites locally, plus the repo typecheck. Typecheck reports pre-existing errors elsewhere from an unbuilt quill workspace; none in the files this PR touches.
- The visual review run has 4 changed snapshots, all the surveys settings stories, which is the intended diff. Its 3 other changed snapshots are error tracking sparkline stories that also changed on master today, so they are not from this branch.
- Not done: no manual click-through, and no backend tests, because the change is frontend only.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The wait period is documented on posthog.com, not in this repo, so nothing here to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via the PostHog Slack app) wrote this after a request in Slack for a project-level default wait period alongside the other survey defaults.

Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`, `/triaging-visual-review-runs`.

One decision worth flagging: the default applies when a survey is created, not when surveys are served to the SDK. Applying it at serve time would have been fewer lines and would have covered surveys created through the API, but it would also silently change the behavior of every existing survey with no wait period set. Surveys created through the API or by Max do not inherit the default, which is the same gap the default appearance has.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1786556176076789?thread_ts=1786556176.076789&cid=C0ACRAMJUAG)*
