### PR TITLE
fix(retention): drop entity matchers from the first-ever scan filter

### DIFF
--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -427,9 +427,23 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             filters.append(self.runner._group_actor_filter())
         filters.extend(self._cohort_breakdown_filters())
 
+        if self.is_first_ever_occurrence and self._return_names_within_start_names():
+            # The return branch's rows are a subset of the start branch's, so OR-ing the
+            # window-bounded return branch in admits nothing new. The start branch alone is the
+            # whole filter, which is exactly the flat name filter the legacy shape scans with.
+            filters.append(start_branch)
+            return filters
+
         return_branch = self._first_time_role_branch(self.return_event, "return") or self.events_timestamp_filter()
         filters.append(ast.Or(exprs=[start_branch, return_branch]))
         return filters
+
+    def _return_names_within_start_names(self) -> bool:
+        start_names = self.runner.get_events_for_entity(self.start_event)
+        return_names = self.runner.get_events_for_entity(self.return_event)
+        if None in start_names or None in return_names:
+            return False
+        return set(return_names) <= set(start_names)
 
     def _first_time_role_branch(
         self, entity: RetentionEntity, query_kind: Literal["start", "return"]
@@ -441,9 +455,18 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         event_name_filter = self.runner.event_name_filter([entity])
         if event_name_filter is not None:
             exprs.append(event_name_filter)
-        predicate = self._arm_scan_predicate(entity, query_kind)
-        if not (isinstance(predicate, ast.Constant) and predicate.value is True):
-            exprs.append(predicate)
+        # First-ever branches filter by event name only. Every aggregate condition re-checks the
+        # full entity matcher anyway, and ClickHouse does not share expression results between the
+        # WHERE stage and the aggregation stage, so a property or action-step matcher here is
+        # evaluated per row a second time. That costs far more CPU than the rows it removes save,
+        # while the names and the window bound already carry all the granule pruning the branch
+        # provides. The legacy first-ever shape scans with just the name filter for the same
+        # reason. First-time-matching keeps the full matcher because the legacy shape filters on
+        # it per row too, so it is cost parity there.
+        if not self.is_first_ever_occurrence:
+            predicate = self._arm_scan_predicate(entity, query_kind)
+            if not (isinstance(predicate, ast.Constant) and predicate.value is True):
+                exprs.append(predicate)
         if not exprs:
             return None
         if query_kind == "return":

--- a/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_query_runner.ambr
+++ b/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_query_runner.ambr
@@ -1314,6 +1314,186 @@
                         use_hive_partitioning=0
   '''
 # ---
+# name: TestRetention.test_retention_first_ever_single_scan_filters_by_event_name_only
+  '''
+  SELECT actor_activity.start_interval_index AS start_event_matching_interval,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         count(DISTINCT actor_activity.actor_id) AS count
+  FROM
+    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
+            if(has(arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(and(equals(events.event, 'act_a'), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), '%/dash%'), 0)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _start_event_timestamps, toStartOfInterval(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'act_a'), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), '%/dash%'), 0))), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'act_a'), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), '%/dash%'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'act_a'), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), '%/dash%'), 0))), NULL), toIntervalDay(1))), _start_event_timestamps, []) AS start_event_timestamps,
+            arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 5)) AS date_range,
+            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(and(equals(events.event, 'act_a'), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), '%/dash%'), 0)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
+            arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(ifNull(equals(_start_event_timestamps[1], interval_date), isNull(_start_event_timestamps[1])
+                                                                                                                                                 and isNull(interval_date)), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
+            arrayJoin(arrayConcat(if(ifNull(equals(start_event_timestamps[1], date_range[plus(start_interval_index, 1)]), isNull(start_event_timestamps[1])
+                                            and isNull(date_range[plus(start_interval_index, 1)])), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 5), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
+     FROM events
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), in(events.event, tuple('act_a')))
+     GROUP BY actor_id
+     HAVING 1) AS actor_activity
+  GROUP BY start_event_matching_interval,
+           intervals_from_base
+  ORDER BY start_event_matching_interval ASC,
+           intervals_from_base ASC
+  LIMIT 100000 SETTINGS readonly=2,
+                        max_execution_time=600,
+                        allow_experimental_object_type=1,
+                        max_ast_elements=4000000,
+                        max_expanded_ast_elements=4000000,
+                        max_bytes_before_external_group_by=23622320128,
+                        transform_null_in=1,
+                        optimize_min_equality_disjunction_chain_length=4294967295,
+                        optimize_rewrite_aggregate_function_with_if=0,
+                        optimize_min_inequality_conjunction_chain_length=4294967295,
+                        allow_experimental_join_condition=1,
+                        use_hive_partitioning=0
+  '''
+# ---
+# name: TestRetention.test_retention_first_ever_single_scan_filters_by_event_name_only.1
+  '''
+  SELECT actor_activity.start_interval_index AS start_event_matching_interval,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         count(DISTINCT actor_activity.actor_id) AS count
+  FROM
+    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
+            if(and(greaterOrEquals(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'act_a'), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), '%/dash%'), 0))), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'act_a'), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), '%/dash%'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'act_a'), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), '%/dash%'), 0))), NULL), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'act_a'), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), '%/dash%'), 0))), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'act_a'), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), '%/dash%'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'act_a'), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), '%/dash%'), 0))), NULL), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), [toTimeZone(toStartOfInterval(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'act_a'), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), '%/dash%'), 0))), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'act_a'), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), '%/dash%'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'act_a'), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), '%/dash%'), 0))), NULL), toIntervalDay(1)), 'UTC')], []) AS start_event_timestamps,
+            arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 5)) AS date_range,
+            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(and(equals(events.event, 'act_a'), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), '%/dash%'), 0)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
+            arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(ifNull(equals(_start_event_timestamps[1], interval_date), isNull(_start_event_timestamps[1])
+                                                                                                                                                 and isNull(interval_date)), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
+            arrayJoin(arrayConcat(if(ifNull(equals(start_event_timestamps[1], date_range[plus(start_interval_index, 1)]), isNull(start_event_timestamps[1])
+                                            and isNull(date_range[plus(start_interval_index, 1)])), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 5), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
+     FROM events
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), in(events.event, tuple('act_a')))
+     GROUP BY actor_id
+     HAVING 1) AS actor_activity
+  GROUP BY start_event_matching_interval,
+           intervals_from_base
+  ORDER BY start_event_matching_interval ASC,
+           intervals_from_base ASC
+  LIMIT 100000 SETTINGS readonly=2,
+                        max_execution_time=600,
+                        allow_experimental_object_type=1,
+                        max_ast_elements=4000000,
+                        max_expanded_ast_elements=4000000,
+                        max_bytes_before_external_group_by=23622320128,
+                        transform_null_in=1,
+                        optimize_min_equality_disjunction_chain_length=4294967295,
+                        optimize_rewrite_aggregate_function_with_if=0,
+                        optimize_min_inequality_conjunction_chain_length=4294967295,
+                        allow_experimental_join_condition=1,
+                        use_hive_partitioning=0
+  '''
+# ---
+# name: TestRetention.test_retention_first_ever_single_scan_filters_by_event_name_only.2
+  '''
+  SELECT actor_activity.start_interval_index AS start_event_matching_interval,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         actor_activity.breakdown_value AS breakdown_value,
+         count(DISTINCT actor_activity.actor_id) AS count
+  FROM
+    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
+            if(has(arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'signup'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS _start_event_timestamps, toStartOfInterval(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'signup')), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'signup'))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'signup')), NULL), toIntervalDay(1))), _start_event_timestamps, []) AS start_event_timestamps,
+            arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 5)) AS date_range,
+            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'act_a'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
+            arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(ifNull(equals(_start_event_timestamps[1], interval_date), isNull(_start_event_timestamps[1])
+                                                                                                                                                 and isNull(interval_date)), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
+            arrayJoin(arrayConcat(if(ifNull(equals(start_event_timestamps[1], date_range[plus(start_interval_index, 1)]), isNull(start_event_timestamps[1])
+                                            and isNull(date_range[plus(start_interval_index, 1)])), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 5), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base,
+            argMinIf(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'plan'), ''), 'null'), '^"|"$', '')), ''), toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'signup')) AS breakdown_value
+     FROM events
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), in(events.event, tuple('act_a', 'signup')))
+     GROUP BY actor_id
+     HAVING 1) AS actor_activity
+  GROUP BY start_event_matching_interval,
+           intervals_from_base,
+           breakdown_value
+  ORDER BY breakdown_value ASC,
+           start_event_matching_interval ASC,
+           intervals_from_base ASC
+  LIMIT 100000 SETTINGS readonly=2,
+                        max_execution_time=600,
+                        allow_experimental_object_type=1,
+                        max_ast_elements=4000000,
+                        max_expanded_ast_elements=4000000,
+                        max_bytes_before_external_group_by=23622320128,
+                        transform_null_in=1,
+                        optimize_min_equality_disjunction_chain_length=4294967295,
+                        optimize_rewrite_aggregate_function_with_if=0,
+                        optimize_min_inequality_conjunction_chain_length=4294967295,
+                        allow_experimental_join_condition=1,
+                        use_hive_partitioning=0
+  '''
+# ---
+# name: TestRetention.test_retention_first_ever_single_scan_filters_by_event_name_only.3
+  '''
+  SELECT actor_activity.start_interval_index AS start_event_matching_interval,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         actor_activity.breakdown_value AS breakdown_value,
+         count(DISTINCT actor_activity.actor_id) AS count
+  FROM
+    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
+            if(and(greaterOrEquals(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'signup')), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'signup'))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'signup')), NULL), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'signup')), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'signup'))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'signup')), NULL), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), [toTimeZone(toStartOfInterval(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'signup')), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'signup'))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'signup')), NULL), toIntervalDay(1)), 'UTC')], []) AS start_event_timestamps,
+            arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 5)) AS date_range,
+            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'act_a'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
+            arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(ifNull(equals(_start_event_timestamps[1], interval_date), isNull(_start_event_timestamps[1])
+                                                                                                                                                 and isNull(interval_date)), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
+            arrayJoin(arrayConcat(if(ifNull(equals(start_event_timestamps[1], date_range[plus(start_interval_index, 1)]), isNull(start_event_timestamps[1])
+                                            and isNull(date_range[plus(start_interval_index, 1)])), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 5), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base,
+            argMinIf(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'plan'), ''), 'null'), '^"|"$', '')), ''), toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'signup')) AS breakdown_value
+     FROM events
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), or(in(events.event, tuple('signup')), and(in(events.event, tuple('act_a')), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))))))
+     GROUP BY actor_id
+     HAVING 1) AS actor_activity
+  GROUP BY start_event_matching_interval,
+           intervals_from_base,
+           breakdown_value
+  ORDER BY breakdown_value ASC,
+           start_event_matching_interval ASC,
+           intervals_from_base ASC
+  LIMIT 100000 SETTINGS readonly=2,
+                        max_execution_time=600,
+                        allow_experimental_object_type=1,
+                        max_ast_elements=4000000,
+                        max_expanded_ast_elements=4000000,
+                        max_bytes_before_external_group_by=23622320128,
+                        transform_null_in=1,
+                        optimize_min_equality_disjunction_chain_length=4294967295,
+                        optimize_rewrite_aggregate_function_with_if=0,
+                        optimize_min_inequality_conjunction_chain_length=4294967295,
+                        allow_experimental_join_condition=1,
+                        use_hive_partitioning=0
+  '''
+# ---
 # name: TestRetention.test_retention_first_time_vs_first_ever_occurrence
   '''
   SELECT actor_activity.start_interval_index AS start_event_matching_interval,

--- a/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
@@ -5226,6 +5226,79 @@ class TestRetention(RetentionBaseQueryVariantComparisonMixin, ClickhouseTestMixi
             expected_first_ever_counts,
         )
 
+    @snapshot_clickhouse_queries
+    def test_retention_first_ever_single_scan_filters_by_event_name_only(self):
+        # Pins the single-scan WHERE shape for first-ever retention: event-name filters only, no
+        # property or action-step matchers. ClickHouse evaluates WHERE matchers per row separately
+        # from the aggregate conditions that already check them, which makes large scans materially
+        # slower; a reintroduction shows up as a snapshot diff.
+        _create_person(team_id=self.team.pk, distinct_ids=["person1"])
+        _create_person(team_id=self.team.pk, distinct_ids=["person2"])
+        _create_events(
+            self.team,
+            [
+                ("person1", _date(0), {"$current_url": "https://example.com/dash"}),
+                ("person1", _date(2), {"$current_url": "https://example.com/dash"}),
+                # person2's first act_a misses the URL step, so first-ever excludes them
+                ("person2", _date(0), {"$current_url": "https://example.com/other"}),
+            ],
+            event="act_a",
+        )
+        _create_events(
+            self.team,
+            [("person1", _date(0), {"plan": "pro"}), ("person2", _date(1), {"plan": "free"})],
+            event="signup",
+        )
+        flush_persons_and_events()
+
+        action = Action.objects.create(
+            team=self.team,
+            name="act_a on dash",
+            steps_json=[{"event": "act_a", "url": "/dash", "url_matching": "contains"}],
+        )
+
+        # Same entity on both sides: the WHERE collapses to the flat event-name filter.
+        result_same_action = self.run_query(
+            query={
+                "dateRange": {"date_from": _date(0), "date_to": _date(4)},
+                "retentionFilter": {
+                    "retentionType": "retention_first_ever_occurrence",
+                    "totalIntervals": 5,
+                    "targetEntity": {"id": action.id, "type": TREND_FILTER_TYPE_ACTIONS},
+                    "returningEntity": {"id": action.id, "type": TREND_FILTER_TYPE_ACTIONS},
+                },
+            }
+        )
+        self.assertEqual(
+            pluck(result_same_action, "values", "count"),
+            [
+                [1, 0, 1, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+            ],
+        )
+
+        # Different entities plus a breakdown (which forces the single scan): the WHERE keeps the
+        # per-role name branches with the window bound on the return side, still matcher-free.
+        result_diff_breakdown = self.run_query(
+            query={
+                "dateRange": {"date_from": _date(0), "date_to": _date(4)},
+                "retentionFilter": {
+                    "retentionType": "retention_first_ever_occurrence",
+                    "totalIntervals": 5,
+                    "targetEntity": {"id": "signup", "type": "events"},
+                    "returningEntity": {"id": "act_a", "type": "events"},
+                },
+                "breakdownFilter": {"breakdowns": [{"type": "hogql", "property": "properties.plan"}]},
+            }
+        )
+        pro_rows = [r for r in result_diff_breakdown if r.get("breakdown_value") == "pro"]
+        free_rows = [r for r in result_diff_breakdown if r.get("breakdown_value") == "free"]
+        self.assertEqual(pluck(pro_rows, "values", "count")[0], [1, 0, 1, 0, 0])
+        self.assertEqual(pluck(free_rows, "values", "count")[1], [1, 0, 0, 0, 0])
+
     def test_cohort_filter_optimization_with_property_filter(self):
         """Test that cohort filters in properties trigger LEFTJOIN optimization"""
         cohort = Cohort.objects.create(


### PR DESCRIPTION
## TL;DR

Retention's new query builder asked ClickHouse the same expensive question twice per event row: "does this row match the action/property filters?" once while filtering the scan, and once while aggregating. The old builder only asks during aggregation. This PR makes the new builder do the same, which removes a ~20% slowdown on "first ever" retention insights.

**Why:** this slowdown is the last blocker for ramping the `retention-fixed-interval-base-query-dwh-variant` flag past dogfooding and deleting the legacy query path. Refs [#64819](https://github.com/PostHog/posthog/pull/64819).

## Problem

Teams on the DWH query variant get first-ever retention results ~20% slower than on the legacy query, on identical data, with identical bytes read.

- The variant's single-scan WHERE carries the full entity matchers (action step URL/property conditions, entity property filters).
- ClickHouse does not share expression results between the WHERE stage and the aggregation stage, so those matchers run a second time on every scanned row.
- The legacy query scans first-ever with the event-name filter only; every aggregate condition re-checks the matcher anyway.
- First-time-matching shapes were unaffected because the legacy query also filters on matchers per row there.

## Changes

- First-ever role branches in `_single_scan_filters` now filter by event name only; the return branch keeps its window bound.
- When the return entity's event names are a subset of the start entity's, the OR collapses to the flat name filter, so the WHERE is identical to the legacy query's.
- First-time-matching branches are unchanged, as is the two-arm scan (its arm predicates feed the role tags and must stay).
- Rejected alternative: hoisting the repeated first-ever anchor expression. Controlled benchmarks showed no effect, and `EXPLAIN actions=1` shows ClickHouse dedupes the repeated `minIf` mentions into one aggregate state.

## How did you test this code?

- Local benchmark on 20M synthetic events (dev ClickHouse, interleaved runs, medians from `system.query_log`): worst shape (first-ever, same action with property steps, weekly) went from 1.45x legacy wall time to 1.05x; the same shape with a breakdown went from 1.32x to 1.01x; a different-entity breakdown shape kept the variant's existing byte-pruning win.
- Attribution used hybrid queries (variant SELECT with legacy WHERE and vice versa): the WHERE matchers accounted for the whole regression.
- New snapshot test `test_retention_first_ever_single_scan_filters_by_event_name_only` pins both fixed WHERE shapes (flat collapse, names-only OR) and asserts result correctness. It catches a reintroduction of matchers into the scan filter, which no existing snapshot covered.
- Ran the full `test_retention_query_runner.py` and `test_retention_first_time_anchor.py` suites locally; the variant-comparison mixin in every test asserts legacy and variant results stay equal.
- Not run: repo-wide mypy and the DWH retention suites (this path is only reachable when both entities are events, but CI runs them).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None (internal query generation, no user-facing behavior change).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). The driver's GitHub handle isn't verifiable from this session, so the PR is unassigned; driver, please self-assign.

- Authored by Claude Code (cloud task) as part of the retention DWH-variant rollout perf gate.
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- Session flow: reproduced the production regression on synthetic data, attributed it to the scan filter via hybrid SQL benchmarks, ruled out the repeated-anchor hypothesis with EXPLAIN and controlled pairs, then fixed the branch construction. All benchmark data is invented synthetic data; no customer data is committed.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
