### PR TITLE
fix(desktop): keep the dock badge visible and show the unread count

### DIFF
--- a/products/desktop/apps/code/src/main/platform-adapters/electron-notifier.ts
+++ b/products/desktop/apps/code/src/main/platform-adapters/electron-notifier.ts
@@ -1,3 +1,4 @@
+import { formatDockBadge } from "@posthog/core/notification/dockBadge";
 import { MAIN_WINDOW_SERVICE } from "@posthog/platform/main-window";
 import type { INotifier, NotifyOptions } from "@posthog/platform/notifier";
 import { app, Notification } from "electron";
@@ -39,13 +40,16 @@ export class ElectronNotifier implements INotifier {
     notification.show();
   }
 
-  public setUnreadIndicator(on: boolean): void {
-    if (on) {
-      app.dock?.setBadge("•");
-    } else {
-      app.dock?.setBadge("");
+  public setUnreadCount(count: number): void {
+    // `app.dock` is macOS-only; Windows and Linux signal through flashFrame.
+    app.dock?.setBadge(formatDockBadge(count));
+    if (count === 0) {
       this.mainWindow.getBrowserWindow()?.flashFrame(false);
     }
+  }
+
+  public clearAttention(): void {
+    this.mainWindow.getBrowserWindow()?.flashFrame(false);
   }
 
   public requestAttention(): void {

--- a/products/desktop/apps/code/src/renderer/desktop-services.ts
+++ b/products/desktop/apps/code/src/renderer/desktop-services.ts
@@ -291,10 +291,12 @@ container.bind<INotifications>(NOTIFICATIONS_SERVICE).toConstantValue({
       notificationsLog.error("Failed to send notification", err);
     });
   },
-  showUnreadIndicator: () => {
-    hostTrpcClient.notification.showDockBadge.mutate().catch((err) => {
-      notificationsLog.error("Failed to show unread indicator", err);
-    });
+  setUnreadCount: (count) => {
+    hostTrpcClient.notification.setDockBadgeCount
+      .mutate({ count })
+      .catch((err) => {
+        notificationsLog.error("Failed to set dock badge count", err);
+      });
   },
   requestAttention: () => {
     hostTrpcClient.notification.bounceDock.mutate().catch((err) => {

--- a/products/desktop/apps/web/src/web-notifications.ts
+++ b/products/desktop/apps/web/src/web-notifications.ts
@@ -50,11 +50,16 @@ export const webNotifications: INotifications = {
 
   // Web equivalent of a dock badge: the Badging API (installed PWAs). No-op
   // where unsupported.
-  showUnreadIndicator(): void {
-    const setAppBadge = (
-      navigator as Navigator & { setAppBadge?: () => Promise<void> }
-    ).setAppBadge;
-    void setAppBadge?.call(navigator).catch(() => {});
+  setUnreadCount(count: number): void {
+    const nav = navigator as Navigator & {
+      setAppBadge?: (count?: number) => Promise<void>;
+      clearAppBadge?: () => Promise<void>;
+    };
+    if (count > 0) {
+      void nav.setAppBadge?.call(nav, count).catch(() => {});
+    } else {
+      void nav.clearAppBadge?.call(nav).catch(() => {});
+    }
   },
 
   // No browser equivalent of bouncing a dock icon.

--- a/products/desktop/packages/core/src/notification/dockBadge.test.ts
+++ b/products/desktop/packages/core/src/notification/dockBadge.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { formatDockBadge } from "./dockBadge";
+
+describe("formatDockBadge", () => {
+  it.each([
+    ["clears at zero", 0, ""],
+    ["clears below zero", -3, ""],
+    ["clears when not finite", Number.NaN, ""],
+    ["shows a single item", 1, "1"],
+    ["shows the cap exactly", 99, "99"],
+    ["caps above the limit", 100, "99+"],
+    ["truncates a fraction", 2.7, "2"],
+  ])("%s", (_label, count, expected) => {
+    expect(formatDockBadge(count)).toBe(expected);
+  });
+});

--- a/products/desktop/packages/core/src/notification/dockBadge.ts
+++ b/products/desktop/packages/core/src/notification/dockBadge.ts
@@ -1,0 +1,16 @@
+/** Above this, the badge reads "99+" so a long numeral can't stretch the tile. */
+const MAX_DOCK_BADGE_COUNT = 99;
+
+/**
+ * The badge label for a count, where "" clears it.
+ *
+ * The count arrives from the renderer over tRPC, so it is only trustworthy as
+ * far as the zod schema: a fractional or non-finite value must render as
+ * something sane rather than reaching `setBadge` as "NaN".
+ */
+export function formatDockBadge(count: number): string {
+  if (!Number.isFinite(count)) return "";
+  const whole = Math.floor(count);
+  if (whole <= 0) return "";
+  return whole > MAX_DOCK_BADGE_COUNT ? `${MAX_DOCK_BADGE_COUNT}+` : `${whole}`;
+}

--- a/products/desktop/packages/core/src/notification/notification.test.ts
+++ b/products/desktop/packages/core/src/notification/notification.test.ts
@@ -21,7 +21,8 @@ function createDeps(supported = true) {
     notify: vi.fn((options: NotifyOptions) => {
       lastNotify = options;
     }),
-    setUnreadIndicator: vi.fn(),
+    setUnreadCount: vi.fn(),
+    clearAttention: vi.fn(),
     requestAttention: vi.fn(),
   };
 
@@ -102,28 +103,40 @@ describe("NotificationService.send", () => {
 });
 
 describe("NotificationService dock badge", () => {
-  it("sets the unread indicator once and is idempotent", () => {
+  it("forwards a changed count and drops a repeat of the same one", () => {
     const { service, notifier } = createDeps();
 
-    service.showDockBadge();
-    service.showDockBadge();
+    service.setUnreadCount(3);
+    service.setUnreadCount(3);
+    service.setUnreadCount(0);
 
-    expect(notifier.setUnreadIndicator).toHaveBeenCalledTimes(1);
-    expect(notifier.setUnreadIndicator).toHaveBeenCalledWith(true);
+    expect(notifier.setUnreadCount).toHaveBeenCalledTimes(2);
+    expect(notifier.setUnreadCount).toHaveBeenNthCalledWith(1, 3);
+    expect(notifier.setUnreadCount).toHaveBeenNthCalledWith(2, 0);
   });
 
-  it("clears the badge on window focus only when a badge is set", () => {
+  it.each([
+    ["negative", -1, 0],
+    ["non-finite", Number.NaN, 0],
+    ["fractional", 2.7, 2],
+  ])("coerces a %s count", (_label, input, expected) => {
+    const { service, notifier } = createDeps();
+
+    service.setUnreadCount(input);
+
+    expect(notifier.setUnreadCount).toHaveBeenCalledWith(expected);
+  });
+
+  it("stops the attention flash on focus without changing the count", () => {
     const { service, notifier, getFocusHandler } = createDeps();
     service.init();
+    service.setUnreadCount(3);
 
     getFocusHandler()?.();
-    expect(notifier.setUnreadIndicator).not.toHaveBeenCalled();
 
-    service.showDockBadge();
-    vi.mocked(notifier.setUnreadIndicator).mockClear();
-
-    getFocusHandler()?.();
-    expect(notifier.setUnreadIndicator).toHaveBeenCalledWith(false);
+    expect(notifier.clearAttention).toHaveBeenCalled();
+    expect(notifier.setUnreadCount).toHaveBeenCalledTimes(1);
+    expect(notifier.setUnreadCount).toHaveBeenCalledWith(3);
   });
 
   it("requests attention when bouncing the dock", () => {

--- a/products/desktop/packages/core/src/notification/notification.ts
+++ b/products/desktop/packages/core/src/notification/notification.ts
@@ -15,7 +15,7 @@ import type { OpenTargetLinkService } from "../links/open-target-link";
 
 @injectable()
 export class NotificationService {
-  private hasBadge = false;
+  private lastCount: number | null = null;
   private readonly log: ScopedLogger;
 
   constructor(
@@ -33,7 +33,9 @@ export class NotificationService {
 
   @postConstruct()
   init(): void {
-    this.mainWindow.onFocus(() => this.clearDockBadge());
+    // Focus answers an attention signal, so drop the taskbar flash, but leave
+    // the count alone: looking at the window does not deal with the work.
+    this.mainWindow.onFocus(() => this.notifier.clearAttention());
   }
 
   send(
@@ -74,22 +76,23 @@ export class NotificationService {
     this.log.info("Notification sent", { title, body, silent, target });
   }
 
-  showDockBadge(): void {
-    if (this.hasBadge) return;
-    this.hasBadge = true;
-    this.notifier.setUnreadIndicator(true);
-    this.log.info("Dock badge shown");
+  /**
+   * Mirror how many items await the user onto the dock badge.
+   *
+   * The renderer pushes this on every change, including React re-renders that
+   * recompute the same number, so unchanged counts are dropped rather than
+   * re-issued to the OS.
+   */
+  setUnreadCount(count: number): void {
+    const next = Number.isFinite(count) ? Math.max(0, Math.floor(count)) : 0;
+    if (this.lastCount === next) return;
+    this.lastCount = next;
+    this.notifier.setUnreadCount(next);
+    this.log.info("Dock badge count set", { count: next });
   }
 
   bounceDock(): void {
     this.notifier.requestAttention();
     this.log.info("Dock bounce triggered");
-  }
-
-  private clearDockBadge(): void {
-    if (!this.hasBadge) return;
-    this.hasBadge = false;
-    this.notifier.setUnreadIndicator(false);
-    this.log.info("Dock badge cleared");
   }
 }

--- a/products/desktop/packages/host-router/src/routers/notification.router.ts
+++ b/products/desktop/packages/host-router/src/routers/notification.router.ts
@@ -33,11 +33,13 @@ export const notificationRouter = router({
         .get<NotificationService>(NOTIFICATION_SERVICE)
         .send(input.title, input.body, input.silent, input.target),
     ),
-  showDockBadge: publicProcedure.mutation(({ ctx }) =>
-    ctx.container
-      .get<NotificationService>(NOTIFICATION_SERVICE)
-      .showDockBadge(),
-  ),
+  setDockBadgeCount: publicProcedure
+    .input(z.object({ count: z.number().int().min(0) }))
+    .mutation(({ ctx, input }) =>
+      ctx.container
+        .get<NotificationService>(NOTIFICATION_SERVICE)
+        .setUnreadCount(input.count),
+    ),
   bounceDock: publicProcedure.mutation(({ ctx }) =>
     ctx.container.get<NotificationService>(NOTIFICATION_SERVICE).bounceDock(),
   ),

--- a/products/desktop/packages/platform/src/notifications.ts
+++ b/products/desktop/packages/platform/src/notifications.ts
@@ -15,7 +15,8 @@ export interface NotificationOptions {
 
 export interface INotifications {
   notify(options: NotificationOptions): void;
-  showUnreadIndicator(): void;
+  /** Mirror the number of items awaiting the user onto the host's app badge. */
+  setUnreadCount(count: number): void;
   requestAttention(): void;
 }
 

--- a/products/desktop/packages/platform/src/notifier.ts
+++ b/products/desktop/packages/platform/src/notifier.ts
@@ -8,7 +8,18 @@ export interface NotifyOptions {
 export interface INotifier {
   isSupported(): boolean;
   notify(options: NotifyOptions): void;
-  setUnreadIndicator(on: boolean): void;
+  /**
+   * How many items are waiting on the user, where 0 clears the indicator.
+   * Called whenever the count changes rather than when an event fires, so the
+   * badge still shows work that arrived while the app was focused.
+   */
+  setUnreadCount(count: number): void;
+  /**
+   * Stop a pending attention signal, such as a flashing taskbar frame, without
+   * touching the unread count. Called when the window regains focus, because
+   * being looked at answers "over here" but does not mean the work was handled.
+   */
+  clearAttention(): void;
   requestAttention(): void;
 }
 

--- a/products/desktop/packages/ui/src/features/notifications/notifications.test.ts
+++ b/products/desktop/packages/ui/src/features/notifications/notifications.test.ts
@@ -38,7 +38,7 @@ function makeBus(overrides?: {
   activeTarget?: NotificationTarget;
 }) {
   const notify = vi.fn();
-  const showUnreadIndicator = vi.fn();
+  const setUnreadCount = vi.fn();
   const requestAttention = vi.fn();
   const play = vi.mocked(playCompletionSound);
   play.mockClear();
@@ -64,12 +64,12 @@ function makeBus(overrides?: {
   };
 
   const bus = new NotificationBus(
-    { notify, showUnreadIndicator, requestAttention },
+    { notify, setUnreadCount, requestAttention },
     settingsPort,
     viewPort,
   );
 
-  return { bus, notify, showUnreadIndicator, requestAttention, play };
+  return { bus, notify, setUnreadCount, requestAttention, play };
 }
 
 describe("NotificationBus tier routing (via notifyPermissionRequest)", () => {
@@ -168,15 +168,16 @@ describe("notifyPromptComplete", () => {
 });
 
 describe("native tier settings gating (app unfocused)", () => {
-  it("skips the OS notification when desktopNotifications is off, still dings dock", () => {
-    const { bus, notify, showUnreadIndicator, requestAttention } = makeBus({
+  it("skips the OS notification when desktopNotifications is off, still bounces the dock", () => {
+    const { bus, notify, setUnreadCount, requestAttention } = makeBus({
       hasFocus: false,
       settings: { desktopNotifications: false },
     });
     bus.notifyPermissionRequest("My task", TASK_ID);
     expect(notify).not.toHaveBeenCalled();
-    expect(showUnreadIndicator).toHaveBeenCalledTimes(1);
     expect(requestAttention).toHaveBeenCalledTimes(1);
+    // The badge tracks unread activity instead, so an event must not write it.
+    expect(setUnreadCount).not.toHaveBeenCalled();
   });
 
   it("marks the OS notification silent when a custom sound plays", () => {

--- a/products/desktop/packages/ui/src/features/notifications/notifications.ts
+++ b/products/desktop/packages/ui/src/features/notifications/notifications.ts
@@ -122,8 +122,9 @@ export class NotificationBus {
         target: descriptor.target,
       });
     }
-    if (settings.dockBadgeNotifications)
-      this.notifications.showUnreadIndicator();
+    // The badge isn't set here: it mirrors the unread activity count through
+    // DockBadgeSync, so writing it from an event too would race that value.
+    // Bounce stays, being a momentary signal rather than state.
     if (settings.dockBounceNotifications) this.notifications.requestAttention();
   }
 

--- a/products/desktop/packages/ui/src/features/notifications/useDockBadgeSync.test.tsx
+++ b/products/desktop/packages/ui/src/features/notifications/useDockBadgeSync.test.tsx
@@ -1,0 +1,59 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  unreadCount: 0,
+  notifications: { setUnreadCount: vi.fn() },
+}));
+
+vi.mock("@posthog/ui/features/canvas/hooks/useTaskActivity", () => ({
+  useTaskActivity: () => ({ unreadCount: mocks.unreadCount }),
+}));
+
+vi.mock("@posthog/di/react", () => ({
+  useServiceOptional: () => mocks.notifications,
+}));
+
+import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
+import { useDockBadgeSync } from "./useDockBadgeSync";
+
+describe("useDockBadgeSync", () => {
+  beforeEach(() => {
+    mocks.notifications = { setUnreadCount: vi.fn() };
+    mocks.unreadCount = 0;
+    useSettingsStore.setState({ dockBadgeNotifications: true });
+  });
+
+  it("pushes the count, then zero once it drops so the badge can clear", () => {
+    mocks.unreadCount = 5;
+    const { rerender } = renderHook(() => useDockBadgeSync());
+    expect(mocks.notifications.setUnreadCount).toHaveBeenCalledWith(5);
+
+    mocks.unreadCount = 0;
+    rerender();
+
+    expect(mocks.notifications.setUnreadCount).toHaveBeenLastCalledWith(0);
+  });
+
+  it("pushes zero while the setting is off, and the count again once back on", () => {
+    mocks.unreadCount = 5;
+    useSettingsStore.setState({ dockBadgeNotifications: false });
+    renderHook(() => useDockBadgeSync());
+    expect(mocks.notifications.setUnreadCount).toHaveBeenCalledWith(0);
+
+    act(() => {
+      useSettingsStore.setState({ dockBadgeNotifications: true });
+    });
+
+    expect(mocks.notifications.setUnreadCount).toHaveBeenLastCalledWith(5);
+  });
+
+  it("clears the badge on unmount, so signing out leaves no stale count", () => {
+    mocks.unreadCount = 5;
+    const { unmount } = renderHook(() => useDockBadgeSync());
+
+    unmount();
+
+    expect(mocks.notifications.setUnreadCount).toHaveBeenLastCalledWith(0);
+  });
+});

--- a/products/desktop/packages/ui/src/features/notifications/useDockBadgeSync.ts
+++ b/products/desktop/packages/ui/src/features/notifications/useDockBadgeSync.ts
@@ -1,0 +1,51 @@
+import { useServiceOptional } from "@posthog/di/react";
+import {
+  type INotifications,
+  NOTIFICATIONS_SERVICE,
+} from "@posthog/platform/notifications";
+import { useTaskActivity } from "@posthog/ui/features/canvas/hooks/useTaskActivity";
+import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
+import { useEffect } from "react";
+
+/**
+ * Mirrors the unread task-activity count onto the host's app badge (the macOS
+ * dock tile, or the Badging API on web).
+ *
+ * The badge tracks the count rather than reacting to notification events,
+ * because `NotificationBus` decides where a notification goes from whether the
+ * app was focused at the instant it fired. Anything that arrived while the user
+ * was looking at the app never reached the dock under that rule, which is why
+ * the badge was effectively invisible.
+ */
+export function useDockBadgeSync(): void {
+  const { unreadCount } = useTaskActivity();
+  const enabled = useSettingsStore((s) => s.dockBadgeNotifications);
+  // Optional so hosts that bind no notifier (or a test container) no-op instead
+  // of throwing at the top of the app tree.
+  const notifications = useServiceOptional<INotifications>(
+    NOTIFICATIONS_SERVICE,
+  );
+  const count = enabled ? unreadCount : 0;
+
+  useEffect(() => {
+    notifications?.setUnreadCount(count);
+  }, [notifications, count]);
+
+  useEffect(
+    () => () => {
+      // Signing out unmounts this, and a stale number on the dock would outlive
+      // the session it came from.
+      notifications?.setUnreadCount(0);
+    },
+    [notifications],
+  );
+}
+
+// Renders nothing; exists to own the only task-activity subscription that is
+// guaranteed to be alive. The sidebar's Activity row unmounts on the settings
+// route, when the user hides that row, and when project-bluebird is off, so the
+// badge cannot depend on it.
+export function DockBadgeSync(): null {
+  useDockBadgeSync();
+  return null;
+}

--- a/products/desktop/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
@@ -828,16 +828,26 @@ function NotificationTestHarness({
       {localWorkspaces && (
         <SettingRow
           label="Dock badge"
-          description="Adds the unread dot to the dock icon (clears on next focus)."
+          description="Puts a 3 on the dock icon. The real badge counts unread activity, so it returns to that count on the next change."
         >
-          <Button
-            variant="soft"
-            size="1"
-            onClick={() => notifications?.showUnreadIndicator()}
-            disabled={nativeUnavailable}
-          >
-            Show
-          </Button>
+          <div className="flex gap-2">
+            <Button
+              variant="soft"
+              size="1"
+              onClick={() => notifications?.setUnreadCount(3)}
+              disabled={nativeUnavailable}
+            >
+              Show
+            </Button>
+            <Button
+              variant="soft"
+              size="1"
+              onClick={() => notifications?.setUnreadCount(0)}
+              disabled={nativeUnavailable}
+            >
+              Clear
+            </Button>
+          </div>
         </SettingRow>
       )}
 

--- a/products/desktop/packages/ui/src/shell/App.tsx
+++ b/products/desktop/packages/ui/src/shell/App.tsx
@@ -16,6 +16,7 @@ import { useIsOrgAdmin } from "@posthog/ui/features/auth/useOrgRole";
 import { CanvasGenerationToaster } from "@posthog/ui/features/canvas/freeform/useCanvasGenerationToasts";
 import { AddDirectoryDialog } from "@posthog/ui/features/folder-picker/AddDirectoryDialog";
 import { ErrorDetailsDialog } from "@posthog/ui/features/notifications/ErrorDetailsDialog";
+import { DockBadgeSync } from "@posthog/ui/features/notifications/useDockBadgeSync";
 import { OnboardingFlow } from "@posthog/ui/features/onboarding/components/OnboardingFlow";
 import { useOnboardingStore } from "@posthog/ui/features/onboarding/onboardingStore";
 import { SettingsDialog } from "@posthog/ui/features/settings/SettingsDialog";
@@ -218,6 +219,10 @@ function App({ devToolbar }: AppProps) {
             across every route (not just the canvas space). Renders null. */}
         <CanvasGenerationToaster />
         <PendingPromptRecovery />
+        {/* Keeps the dock badge in step with unread activity. Sibling of the
+            router because the settings route drops the app chrome, and the
+            sidebar row feeding the same count is one the user can hide. */}
+        <DockBadgeSync />
       </motion.div>
     );
   };


### PR DESCRIPTION
## Problem

The dock badge is a fire-once dot that the next window focus erases, so it is gone by the time you look at the dock.

- The badge is set when a task finishes or asks for input, and `onFocus` is the only code path that clears it.
- Switching back to the app is what clears it, so it rarely survives long enough to read.
- Local desktop logs over six days show 12 `Dock badge shown` lines, each matched by a `Dock badge cleared`. Median gap: 30.6 seconds. Shortest: 0.3 seconds.
- A `hasBadge` latch also stops it re-showing for a state it already signalled.
- The badge carries `"•"`, so it never says how much is waiting.

> [!NOTE]
> The report that started this was "I have never seen the dock badge". That turned out to be macOS notifications being disabled for the app, which suppresses the badge at the OS layer. `app.dock.setBadge` is still called in that state and still logs, so the logs above show calls rather than rendered badges. The behavior in this PR is a defect on its own merits, for anyone whose badges are allowed, but it is not the cause of that report.

## Changes

> [!NOTE]
> Sixteen files, but the change is wide rather than deep. Eight of them move 13 lines or fewer. The spread is one mechanical rename, `setUnreadIndicator(boolean)` to `setUnreadCount(number)`, across three host implementations and two test fakes. The new logic is two files, `useDockBadgeSync.ts` and `dockBadge.ts`.

- The dock badge now shows the number of unread activity items, and stays up until that number reaches zero.
- `DockBadgeSync` mirrors the task-activity `unread_count` onto the host app badge.
- It mounts beside the router in `App.tsx`, not in the sidebar. The sidebar's Activity row unmounts on the settings route, when the user hides that row, and when `project-bluebird` is off, so a subscription there would freeze the badge. Hoisting it also fixes `taskActivity.contribution.ts` dropping its optimistic unread bump in those same cases.
- `onFocus` now calls `clearAttention()`, which stops the Windows and Linux taskbar flash without touching the count. Removing the focus handler outright would leave that frame flashing until unread hit zero.
- `NotificationBus.notify` no longer writes the badge. Two writers on one badge have no ordering guarantee between their mutations, so a `1` could flicker over a `7`. Dock bounce stays there, being a momentary signal rather than state.
- `INotifier.setUnreadIndicator(boolean)` becomes `setUnreadCount(number)`, and `INotifications.showUnreadIndicator()` becomes `setUnreadCount(number)`. Renamed rather than added, so no boolean path survives alongside the count.
- `apps/web` gains a real count through the Badging API instead of an argument-less `setAppBadge`.
- The count is capped at `99+` by `formatDockBadge`, which also absorbs a fractional or non-finite value before it reaches `setBadge`.

> [!NOTE]
> Environment image builds and canvas generation stop badging the dock, because neither writes an activity row. Both keep their OS notification and optional dock bounce. The badge now means unread activity, so it stays clickable through to something.

The settings test button sets a literal `3` and gains a Clear button, since focus no longer clears the badge.

## How did you test this code?

I (actually Claude) ran these locally:

- `pnpm typecheck`, all packages.
- `@posthog/core` and `@posthog/ui` suites in full.
- `pnpm boundaries` and `biome check` over the changed files.
- `knip`, which flagged one unused export I then made module-local.

**Not verified: the badge rendering on a real dock.** This sandbox cannot run Electron, so no manual pass happened. The reporter's logs do show `app.dock.setBadge` reaching macOS today, so the OS path itself is known to work.

New tests and the regression each catches:

- `dockBadge.test.ts`: a zero or negative count must clear the badge rather than render `"0"`, and a non-finite one must not reach `setBadge` as `"NaN"`.
- `notification.test.ts`: focus must stop the flash without changing the count. This is the bug being fixed, and the previous test asserted the opposite.
- `useDockBadgeSync.test.tsx`: the count must reach the badge and drop to `0` when it clears, turning the setting off must push `0`, and unmounting on sign-out must not leave a stale number.

<details>
<summary>Suites with pre-existing failures in this sandbox</summary>

`workspace-server` and `apps/code` have failing tests here. I stashed the change and confirmed the baseline is identical, same files and same counts. They need better-sqlite3 native bindings and a network binary download, both from postinstall steps that failed in this sandbox.

</details>

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (PostHog Code) working from a report that the dock badge had never been seen.

The session first mapped the notification path, then diagnosed the cause. I initially blamed the focus-at-event-time routing in `routeNotification`, on the theory that the badge rarely fired. The desktop logs corrected that: it fires regularly and the clear-on-focus is what hides it. The plan changed to match before any code was written.

One planned step was dropped. I had proposed marking a task's activity read when its detail view opens, believing nothing did. `TaskDetail.tsx` already does, with a better rationale than mine, and I had missed it by truncating a grep. I also confirmed in the backend facade that `mark_task_activity_read` runs only from the explicit endpoint, so the docstring claiming the server converges on any route is wrong.

I cut two cases from `useDockBadgeSync.test.tsx` after review feedback that the diff looked large: a re-render assertion the service-level dedupe test already covers, and an unbound-notifier case that only exercised optional chaining.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/writing-pr-descriptions`. I read `/sending-notifications` and skipped it as backend-only.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*


