### PR TITLE
feat(flags): reject usage dashboard generation for deleted flags

### DIFF
--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -3097,6 +3097,20 @@ class FeatureFlagViewSet(
 
         return response
 
+    @staticmethod
+    def _deleted_flag_rejection(feature_flag: FeatureFlag, restore_hint: str) -> Response | None:
+        """Dashboard-generating actions refuse soft-deleted flags: they would recreate the
+        auto-generated insights that the delete_feature_flag_usage_insights sweep deletes."""
+        if not feature_flag.deleted:
+            return None
+        return Response(
+            {
+                "success": False,
+                "error": f"This feature flag has been deleted. Restore it before {restore_hint}.",
+            },
+            status=400,
+        )
+
     # No UI surface calls this, since the Usage tab renders its charts inline. It exists for API
     # users who want a saved usage dashboard.
     @extend_schema(request=None)
@@ -3105,6 +3119,9 @@ class FeatureFlagViewSet(
         from products.dashboards.backend.models.dashboard import Dashboard
 
         feature_flag: FeatureFlag = self.get_object()
+        rejection = self._deleted_flag_rejection(feature_flag, "generating a usage dashboard")
+        if rejection is not None:
+            return rejection
         try:
             # The FK on the flag isn't cleared by a dashboard soft-delete, so look the id up
             # through the manager that excludes deleted rows rather than via the FK accessor,
@@ -3138,6 +3155,9 @@ class FeatureFlagViewSet(
     @action(methods=["POST"], detail=True)
     def enrich_usage_dashboard(self, request: request.Request, **kwargs):
         feature_flag: FeatureFlag = self.get_object()
+        rejection = self._deleted_flag_rejection(feature_flag, "enriching its usage dashboard")
+        if rejection is not None:
+            return rejection
         usage_dashboard = feature_flag.usage_dashboard
 
         if not usage_dashboard:

--- a/products/feature_flags/backend/api/test/test_feature_flag.py
+++ b/products/feature_flags/backend/api/test/test_feature_flag.py
@@ -5084,6 +5084,17 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         self.assertNotEqual(new_dashboard_id, deleted_dashboard_id)
         self.assertTrue(Dashboard.objects.filter(id=new_dashboard_id, deleted=False).exists())
 
+    @parameterized.expand(["dashboard", "enrich_usage_dashboard"])
+    def test_dashboard_generating_endpoints_reject_a_deleted_flag(self, endpoint: str) -> None:
+        flag = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="deleted-flag", deleted=True)
+
+        response = self.client.post(f"/api/projects/{self.team.id}/feature_flags/{flag.id}/{endpoint}")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("has been deleted", response.json()["error"])
+        flag.refresh_from_db()
+        self.assertIsNone(flag.usage_dashboard_id)
+
     @patch("products.feature_flags.backend.flag_analytics.CACHE_BUCKET_SIZE", 10)
     def test_local_evaluation_billing_analytics_for_regular_feature_flag_list(self):
         FeatureFlag.objects.all().delete()


### PR DESCRIPTION
## Problem

A soft-deleted feature flag can still get its usage dashboard and insights regenerated through the API.
The flag serves no traffic, so the dashboard only ever shows a flatline.
`POST .../dashboard` and `POST .../enrich_usage_dashboard` both regenerate it, undoing `delete_feature_flag_usage_insights`, the command that already soft-deletes those insights.

## Changes

- Both actions now return 400 for a soft-deleted flag, telling the caller to restore it first.
- A shared `_deleted_flag_rejection` helper backs both checks, so they share one rule instead of duplicating it.
- `create_static_cohort_for_flag`, the viewset's third detail-level POST action, stays unguarded: it snapshots historical events and touches no dashboard state.

## How did you test this code?

- Added `test_dashboard_generating_endpoints_reject_a_deleted_flag`, parameterized across both actions. It catches either endpoint recreating insights the cleanup sweep already removed.
- Ran it plus the viewset's existing dashboard and enrichment tests locally with `hogli test`. Not run: CI, which this PR's checks will cover.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The internal endpoint reference table only lists the route and a one-line summary, with no claim about deleted-flag behavior either way.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via PostHog Desktop) built this as a follow-up to a separate PR that sweeps auto-generated flag usage insights for soft-deleted flags.
Phil asked what a from-scratch version of these endpoints would do about deleted flags.
He approved building the guard as its own follow-up and reviewed the decisions below.

Skills invoked: `/improving-drf-endpoints` before editing the viewset, `/simplify` for a reuse and simplification pass on the diff, `/writing-pr-descriptions` for this description.

Decisions along the way:
- The guard started on `dashboard` alone. A `/simplify` finding showed `enrich_usage_dashboard` was an unguarded sibling that could recreate the same swept insights, so it became a shared helper applied to both.
- The test's setup moved from two API round trips (create, then soft-delete) to one ORM `create(..., deleted=True)` call, matching this file's convention for state that isn't itself under test.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*