### PR TITLE
feat(desktop): show the unread count on the dock badge

### DIFF
--- a/products/desktop/apps/code/src/main/platform-adapters/electron-notifier.ts
+++ b/products/desktop/apps/code/src/main/platform-adapters/electron-notifier.ts
@@ -39,13 +39,16 @@ export class ElectronNotifier implements INotifier {
     notification.show();
   }
 
-  public setUnreadIndicator(on: boolean): void {
-    if (on) {
-      app.dock?.setBadge("•");
-    } else {
-      app.dock?.setBadge("");
+  public setUnreadCount(count: number): void {
+    // `app.dock` is macOS-only; Windows and Linux signal through flashFrame.
+    app.dock?.setBadge(count > 0 ? String(count) : "");
+    if (count === 0) {
       this.mainWindow.getBrowserWindow()?.flashFrame(false);
     }
+  }
+
+  public clearAttention(): void {
+    this.mainWindow.getBrowserWindow()?.flashFrame(false);
   }
 
   public requestAttention(): void {

--- a/products/desktop/apps/code/src/renderer/desktop-services.ts
+++ b/products/desktop/apps/code/src/renderer/desktop-services.ts
@@ -291,10 +291,12 @@ container.bind<INotifications>(NOTIFICATIONS_SERVICE).toConstantValue({
       notificationsLog.error("Failed to send notification", err);
     });
   },
-  showUnreadIndicator: () => {
-    hostTrpcClient.notification.showDockBadge.mutate().catch((err) => {
-      notificationsLog.error("Failed to show unread indicator", err);
-    });
+  setUnreadCount: (count) => {
+    hostTrpcClient.notification.setDockBadgeCount
+      .mutate({ count })
+      .catch((err) => {
+        notificationsLog.error("Failed to set dock badge count", err);
+      });
   },
   requestAttention: () => {
     hostTrpcClient.notification.bounceDock.mutate().catch((err) => {

--- a/products/desktop/apps/web/src/web-notifications.ts
+++ b/products/desktop/apps/web/src/web-notifications.ts
@@ -50,11 +50,16 @@ export const webNotifications: INotifications = {
 
   // Web equivalent of a dock badge: the Badging API (installed PWAs). No-op
   // where unsupported.
-  showUnreadIndicator(): void {
-    const setAppBadge = (
-      navigator as Navigator & { setAppBadge?: () => Promise<void> }
-    ).setAppBadge;
-    void setAppBadge?.call(navigator).catch(() => {});
+  setUnreadCount(count: number): void {
+    const nav = navigator as Navigator & {
+      setAppBadge?: (count?: number) => Promise<void>;
+      clearAppBadge?: () => Promise<void>;
+    };
+    if (count > 0) {
+      void nav.setAppBadge?.call(nav, count).catch(() => {});
+    } else {
+      void nav.clearAppBadge?.call(nav).catch(() => {});
+    }
   },
 
   // No browser equivalent of bouncing a dock icon.

--- a/products/desktop/packages/core/src/notification/notification.test.ts
+++ b/products/desktop/packages/core/src/notification/notification.test.ts
@@ -21,7 +21,8 @@ function createDeps(supported = true) {
     notify: vi.fn((options: NotifyOptions) => {
       lastNotify = options;
     }),
-    setUnreadIndicator: vi.fn(),
+    setUnreadCount: vi.fn(),
+    clearAttention: vi.fn(),
     requestAttention: vi.fn(),
   };
 
@@ -102,28 +103,40 @@ describe("NotificationService.send", () => {
 });
 
 describe("NotificationService dock badge", () => {
-  it("sets the unread indicator once and is idempotent", () => {
+  it("forwards a changed count and drops a repeat of the same one", () => {
     const { service, notifier } = createDeps();
 
-    service.showDockBadge();
-    service.showDockBadge();
+    service.setUnreadCount(3);
+    service.setUnreadCount(3);
+    service.setUnreadCount(0);
 
-    expect(notifier.setUnreadIndicator).toHaveBeenCalledTimes(1);
-    expect(notifier.setUnreadIndicator).toHaveBeenCalledWith(true);
+    expect(notifier.setUnreadCount).toHaveBeenCalledTimes(2);
+    expect(notifier.setUnreadCount).toHaveBeenNthCalledWith(1, 3);
+    expect(notifier.setUnreadCount).toHaveBeenNthCalledWith(2, 0);
   });
 
-  it("clears the badge on window focus only when a badge is set", () => {
+  it.each([
+    ["negative", -1, 0],
+    ["non-finite", Number.NaN, 0],
+    ["fractional", 2.7, 2],
+  ])("coerces a %s count", (_label, input, expected) => {
+    const { service, notifier } = createDeps();
+
+    service.setUnreadCount(input);
+
+    expect(notifier.setUnreadCount).toHaveBeenCalledWith(expected);
+  });
+
+  it("stops the attention flash on focus without changing the count", () => {
     const { service, notifier, getFocusHandler } = createDeps();
     service.init();
+    service.setUnreadCount(3);
 
     getFocusHandler()?.();
-    expect(notifier.setUnreadIndicator).not.toHaveBeenCalled();
 
-    service.showDockBadge();
-    vi.mocked(notifier.setUnreadIndicator).mockClear();
-
-    getFocusHandler()?.();
-    expect(notifier.setUnreadIndicator).toHaveBeenCalledWith(false);
+    expect(notifier.clearAttention).toHaveBeenCalled();
+    expect(notifier.setUnreadCount).toHaveBeenCalledTimes(1);
+    expect(notifier.setUnreadCount).toHaveBeenCalledWith(3);
   });
 
   it("requests attention when bouncing the dock", () => {

--- a/products/desktop/packages/core/src/notification/notification.ts
+++ b/products/desktop/packages/core/src/notification/notification.ts
@@ -15,7 +15,7 @@ import type { OpenTargetLinkService } from "../links/open-target-link";
 
 @injectable()
 export class NotificationService {
-  private hasBadge = false;
+  private lastCount: number | null = null;
   private readonly log: ScopedLogger;
 
   constructor(
@@ -33,7 +33,9 @@ export class NotificationService {
 
   @postConstruct()
   init(): void {
-    this.mainWindow.onFocus(() => this.clearDockBadge());
+    // Focus answers an attention signal, so drop the taskbar flash, but leave
+    // the count alone: looking at the window does not deal with the work.
+    this.mainWindow.onFocus(() => this.notifier.clearAttention());
   }
 
   send(
@@ -74,22 +76,23 @@ export class NotificationService {
     this.log.info("Notification sent", { title, body, silent, target });
   }
 
-  showDockBadge(): void {
-    if (this.hasBadge) return;
-    this.hasBadge = true;
-    this.notifier.setUnreadIndicator(true);
-    this.log.info("Dock badge shown");
+  /**
+   * Mirror how many items await the user onto the dock badge.
+   *
+   * The renderer pushes this on every change, including React re-renders that
+   * recompute the same number, so unchanged counts are dropped rather than
+   * re-issued to the OS.
+   */
+  setUnreadCount(count: number): void {
+    const next = Number.isFinite(count) ? Math.max(0, Math.floor(count)) : 0;
+    if (this.lastCount === next) return;
+    this.lastCount = next;
+    this.notifier.setUnreadCount(next);
+    this.log.info("Dock badge count set", { count: next });
   }
 
   bounceDock(): void {
     this.notifier.requestAttention();
     this.log.info("Dock bounce triggered");
-  }
-
-  private clearDockBadge(): void {
-    if (!this.hasBadge) return;
-    this.hasBadge = false;
-    this.notifier.setUnreadIndicator(false);
-    this.log.info("Dock badge cleared");
   }
 }

--- a/products/desktop/packages/host-router/src/routers/notification.router.ts
+++ b/products/desktop/packages/host-router/src/routers/notification.router.ts
@@ -33,11 +33,13 @@ export const notificationRouter = router({
         .get<NotificationService>(NOTIFICATION_SERVICE)
         .send(input.title, input.body, input.silent, input.target),
     ),
-  showDockBadge: publicProcedure.mutation(({ ctx }) =>
-    ctx.container
-      .get<NotificationService>(NOTIFICATION_SERVICE)
-      .showDockBadge(),
-  ),
+  setDockBadgeCount: publicProcedure
+    .input(z.object({ count: z.number().int().min(0) }))
+    .mutation(({ ctx, input }) =>
+      ctx.container
+        .get<NotificationService>(NOTIFICATION_SERVICE)
+        .setUnreadCount(input.count),
+    ),
   bounceDock: publicProcedure.mutation(({ ctx }) =>
     ctx.container.get<NotificationService>(NOTIFICATION_SERVICE).bounceDock(),
   ),

--- a/products/desktop/packages/platform/src/notifications.ts
+++ b/products/desktop/packages/platform/src/notifications.ts
@@ -15,7 +15,8 @@ export interface NotificationOptions {
 
 export interface INotifications {
   notify(options: NotificationOptions): void;
-  showUnreadIndicator(): void;
+  /** Mirror the number of items awaiting the user onto the host's app badge. */
+  setUnreadCount(count: number): void;
   requestAttention(): void;
 }
 

--- a/products/desktop/packages/platform/src/notifier.ts
+++ b/products/desktop/packages/platform/src/notifier.ts
@@ -8,7 +8,18 @@ export interface NotifyOptions {
 export interface INotifier {
   isSupported(): boolean;
   notify(options: NotifyOptions): void;
-  setUnreadIndicator(on: boolean): void;
+  /**
+   * How many items are waiting on the user, where 0 clears the indicator.
+   * Called whenever the count changes rather than when an event fires, so the
+   * badge still shows work that arrived while the app was focused.
+   */
+  setUnreadCount(count: number): void;
+  /**
+   * Stop a pending attention signal, such as a flashing taskbar frame, without
+   * touching the unread count. Called when the window regains focus, because
+   * being looked at answers "over here" but does not mean the work was handled.
+   */
+  clearAttention(): void;
   requestAttention(): void;
 }
 

--- a/products/desktop/packages/ui/src/features/notifications/notifications.test.ts
+++ b/products/desktop/packages/ui/src/features/notifications/notifications.test.ts
@@ -38,7 +38,7 @@ function makeBus(overrides?: {
   activeTarget?: NotificationTarget;
 }) {
   const notify = vi.fn();
-  const showUnreadIndicator = vi.fn();
+  const setUnreadCount = vi.fn();
   const requestAttention = vi.fn();
   const play = vi.mocked(playCompletionSound);
   play.mockClear();
@@ -64,12 +64,12 @@ function makeBus(overrides?: {
   };
 
   const bus = new NotificationBus(
-    { notify, showUnreadIndicator, requestAttention },
+    { notify, setUnreadCount, requestAttention },
     settingsPort,
     viewPort,
   );
 
-  return { bus, notify, showUnreadIndicator, requestAttention, play };
+  return { bus, notify, setUnreadCount, requestAttention, play };
 }
 
 describe("NotificationBus tier routing (via notifyPermissionRequest)", () => {
@@ -168,15 +168,16 @@ describe("notifyPromptComplete", () => {
 });
 
 describe("native tier settings gating (app unfocused)", () => {
-  it("skips the OS notification when desktopNotifications is off, still dings dock", () => {
-    const { bus, notify, showUnreadIndicator, requestAttention } = makeBus({
+  it("skips the OS notification when desktopNotifications is off, still bounces the dock", () => {
+    const { bus, notify, setUnreadCount, requestAttention } = makeBus({
       hasFocus: false,
       settings: { desktopNotifications: false },
     });
     bus.notifyPermissionRequest("My task", TASK_ID);
     expect(notify).not.toHaveBeenCalled();
-    expect(showUnreadIndicator).toHaveBeenCalledTimes(1);
     expect(requestAttention).toHaveBeenCalledTimes(1);
+    // The badge tracks unread activity instead, so an event must not write it.
+    expect(setUnreadCount).not.toHaveBeenCalled();
   });
 
   it("marks the OS notification silent when a custom sound plays", () => {

--- a/products/desktop/packages/ui/src/features/notifications/notifications.ts
+++ b/products/desktop/packages/ui/src/features/notifications/notifications.ts
@@ -122,8 +122,9 @@ export class NotificationBus {
         target: descriptor.target,
       });
     }
-    if (settings.dockBadgeNotifications)
-      this.notifications.showUnreadIndicator();
+    // The badge isn't set here: it mirrors the unread activity count through
+    // DockBadgeSync, so writing it from an event too would race that value.
+    // Bounce stays, being a momentary signal rather than state.
     if (settings.dockBounceNotifications) this.notifications.requestAttention();
   }
 

--- a/products/desktop/packages/ui/src/features/notifications/useDockBadgeSync.test.tsx
+++ b/products/desktop/packages/ui/src/features/notifications/useDockBadgeSync.test.tsx
@@ -1,0 +1,59 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  unreadCount: 0,
+  notifications: { setUnreadCount: vi.fn() },
+}));
+
+vi.mock("@posthog/ui/features/canvas/hooks/useTaskActivity", () => ({
+  useTaskActivity: () => ({ unreadCount: mocks.unreadCount }),
+}));
+
+vi.mock("@posthog/di/react", () => ({
+  useServiceOptional: () => mocks.notifications,
+}));
+
+import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
+import { useDockBadgeSync } from "./useDockBadgeSync";
+
+describe("useDockBadgeSync", () => {
+  beforeEach(() => {
+    mocks.notifications = { setUnreadCount: vi.fn() };
+    mocks.unreadCount = 0;
+    useSettingsStore.setState({ dockBadgeNotifications: true });
+  });
+
+  it("pushes the count, then zero once it drops so the badge can clear", () => {
+    mocks.unreadCount = 5;
+    const { rerender } = renderHook(() => useDockBadgeSync());
+    expect(mocks.notifications.setUnreadCount).toHaveBeenCalledWith(5);
+
+    mocks.unreadCount = 0;
+    rerender();
+
+    expect(mocks.notifications.setUnreadCount).toHaveBeenLastCalledWith(0);
+  });
+
+  it("pushes zero while the setting is off, and the count again once back on", () => {
+    mocks.unreadCount = 5;
+    useSettingsStore.setState({ dockBadgeNotifications: false });
+    renderHook(() => useDockBadgeSync());
+    expect(mocks.notifications.setUnreadCount).toHaveBeenCalledWith(0);
+
+    act(() => {
+      useSettingsStore.setState({ dockBadgeNotifications: true });
+    });
+
+    expect(mocks.notifications.setUnreadCount).toHaveBeenLastCalledWith(5);
+  });
+
+  it("clears the badge on unmount, so signing out leaves no stale count", () => {
+    mocks.unreadCount = 5;
+    const { unmount } = renderHook(() => useDockBadgeSync());
+
+    unmount();
+
+    expect(mocks.notifications.setUnreadCount).toHaveBeenLastCalledWith(0);
+  });
+});

--- a/products/desktop/packages/ui/src/features/notifications/useDockBadgeSync.ts
+++ b/products/desktop/packages/ui/src/features/notifications/useDockBadgeSync.ts
@@ -1,0 +1,51 @@
+import { useServiceOptional } from "@posthog/di/react";
+import {
+  type INotifications,
+  NOTIFICATIONS_SERVICE,
+} from "@posthog/platform/notifications";
+import { useTaskActivity } from "@posthog/ui/features/canvas/hooks/useTaskActivity";
+import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
+import { useEffect } from "react";
+
+/**
+ * Mirrors the unread task-activity count onto the host's app badge (the macOS
+ * dock tile, or the Badging API on web).
+ *
+ * The badge tracks the count rather than reacting to notification events,
+ * because `NotificationBus` decides where a notification goes from whether the
+ * app was focused at the instant it fired. Anything that arrived while the user
+ * was looking at the app never reached the dock under that rule, which is why
+ * the badge was effectively invisible.
+ */
+export function useDockBadgeSync(): void {
+  const { unreadCount } = useTaskActivity();
+  const enabled = useSettingsStore((s) => s.dockBadgeNotifications);
+  // Optional so hosts that bind no notifier (or a test container) no-op instead
+  // of throwing at the top of the app tree.
+  const notifications = useServiceOptional<INotifications>(
+    NOTIFICATIONS_SERVICE,
+  );
+  const count = enabled ? unreadCount : 0;
+
+  useEffect(() => {
+    notifications?.setUnreadCount(count);
+  }, [notifications, count]);
+
+  useEffect(
+    () => () => {
+      // Signing out unmounts this, and a stale number on the dock would outlive
+      // the session it came from.
+      notifications?.setUnreadCount(0);
+    },
+    [notifications],
+  );
+}
+
+// Renders nothing; exists to own the only task-activity subscription that is
+// guaranteed to be alive. The sidebar's Activity row unmounts on the settings
+// route, when the user hides that row, and when project-bluebird is off, so the
+// badge cannot depend on it.
+export function DockBadgeSync(): null {
+  useDockBadgeSync();
+  return null;
+}

--- a/products/desktop/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
@@ -828,16 +828,26 @@ function NotificationTestHarness({
       {localWorkspaces && (
         <SettingRow
           label="Dock badge"
-          description="Adds the unread dot to the dock icon (clears on next focus)."
+          description="Puts a 3 on the dock icon. The real badge counts unread activity, so it returns to that count on the next change."
         >
-          <Button
-            variant="soft"
-            size="1"
-            onClick={() => notifications?.showUnreadIndicator()}
-            disabled={nativeUnavailable}
-          >
-            Show
-          </Button>
+          <div className="flex gap-2">
+            <Button
+              variant="soft"
+              size="1"
+              onClick={() => notifications?.setUnreadCount(3)}
+              disabled={nativeUnavailable}
+            >
+              Show
+            </Button>
+            <Button
+              variant="soft"
+              size="1"
+              onClick={() => notifications?.setUnreadCount(0)}
+              disabled={nativeUnavailable}
+            >
+              Clear
+            </Button>
+          </div>
         </SettingRow>
       )}
 

--- a/products/desktop/packages/ui/src/shell/App.tsx
+++ b/products/desktop/packages/ui/src/shell/App.tsx
@@ -16,6 +16,7 @@ import { useIsOrgAdmin } from "@posthog/ui/features/auth/useOrgRole";
 import { CanvasGenerationToaster } from "@posthog/ui/features/canvas/freeform/useCanvasGenerationToasts";
 import { AddDirectoryDialog } from "@posthog/ui/features/folder-picker/AddDirectoryDialog";
 import { ErrorDetailsDialog } from "@posthog/ui/features/notifications/ErrorDetailsDialog";
+import { DockBadgeSync } from "@posthog/ui/features/notifications/useDockBadgeSync";
 import { OnboardingFlow } from "@posthog/ui/features/onboarding/components/OnboardingFlow";
 import { useOnboardingStore } from "@posthog/ui/features/onboarding/onboardingStore";
 import { SettingsDialog } from "@posthog/ui/features/settings/SettingsDialog";
@@ -218,6 +219,10 @@ function App({ devToolbar }: AppProps) {
             across every route (not just the canvas space). Renders null. */}
         <CanvasGenerationToaster />
         <PendingPromptRecovery />
+        {/* Keeps the dock badge in step with unread activity. Sibling of the
+            router because the settings route drops the app chrome, and the
+            sidebar row feeding the same count is one the user can hide. */}
+        <DockBadgeSync />
       </motion.div>
     );
   };


### PR DESCRIPTION
## Problem

The dock badge tells you something is waiting, but never how much.

- It draws the bullet character `"•"`, which is the only value ever passed to `setBadge`.
- Your dock already shows counts from other apps, so a dot reads as less informative than its neighbors.
- The badge also clears on the next window focus, so switching to the app to look at it is what removes it.

## Changes

- The dock badge shows the number of unread activity items, the same count the sidebar Activity row tracks.
- `DockBadgeSync` mirrors that count onto the host app badge, and it mounts beside the router in `App.tsx`.
- It does not mount in the sidebar, because the Activity row unmounts on the settings route, when the user hides that row, and when `project-bluebird` is off. A subscription there would freeze the badge.
- Clearing on focus goes away, which the count forces rather than chooses: focus was the only path that cleared the badge, so a count-driven badge would otherwise stick forever. It now clears when the count reaches zero.
- `clearAttention()` keeps the Windows and Linux taskbar flash reset that focus was also doing.
- `NotificationBus.notify` no longer writes the badge. Two writers on one badge have no ordering guarantee, so a `1` could overwrite a `7`. Dock bounce stays, being a momentary signal rather than state.
- `INotifier.setUnreadIndicator(boolean)` becomes `setUnreadCount(number)`, and `INotifications.showUnreadIndicator()` becomes `setUnreadCount(number)`.
- `apps/web` gains a real count through the Badging API instead of an argument-less `setAppBadge`.

> [!NOTE]
> Fourteen files, but the change is wide rather than deep. The spread is that one method rename reaching three host implementations, two test fakes, and a dev button. The new logic is one file, `useDockBadgeSync.ts`.

Environment image builds and canvas generation stop badging the dock, since neither writes an activity row. Both keep their OS notification and optional dock bounce.

No screenshot: the visible change is a numeral replacing a dot on the macOS dock tile, which I cannot capture from this sandbox.

## How did you test this code?

I (actually Claude) ran locally: `pnpm typecheck` across all packages, the `@posthog/core` and `@posthog/ui` notification suites, `pnpm boundaries`, `knip`, and `biome check` over the 14 changed files.

**Not verified: the badge rendering on a dock.** This sandbox cannot run Electron, so no manual pass happened. Worth confirming a numeral appears and survives clicking into the app before this leaves draft.

New and changed tests:

- `notification.test.ts`: focus must stop the taskbar flash without changing the count. The previous test asserted the opposite, so it locks in the behavior change.
- `notification.test.ts`: a negative or fractional count must not reach `setBadge` as `"-1"` or `"2.7"`. The dev button and any future caller bypass the router's zod guard.
- `useDockBadgeSync.test.tsx`: the count must reach the badge and fall to `0` when it clears, turning the setting off must push `0`, and unmounting on sign-out must not leave a stale number.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (PostHog Code).

This replaces #82116, which I closed. That PR argued the badge was effectively invisible and cited desktop log lines as evidence it fired but vanished. The reporter's macOS notification permission was off, which suppresses the badge at the OS layer, and `app.dock.setBadge` still logs in that state. So those log lines showed calls rather than rendered badges, and I had read a call site as an outcome. This PR drops that argument and stands on the narrower point that a dot carries no count.

Also dropped from #82116: a `formatDockBadge` helper with a `99+` cap and its test file. The router's zod schema and the service's coercion already guarantee a non-negative integer, so the adapter needs only `String(count)`. macOS handles a long numeral itself.

One separate defect this turned up, not fixed here: `NotificationsSettings.tsx` detects denied OS notification permission and greys out the Push notifications toggle, but leaves Dock badge and Bounce dock icon switched on, still promising a badge that cannot appear.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
