### PR TITLE
chore(ci): bump cargo-shear to 1.13.4

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -796,7 +796,7 @@ jobs:
               # (which records cargo-shear as installed) but not the binary itself, so
               # without --force binstall short-circuits ("already installed") and the
               # next step fails with `error: no such command: shear`.
-              run: cargo binstall --no-confirm --force cargo-shear@1.1.12
+              run: cargo binstall --no-confirm --force cargo-shear@1.13.4
 
             - name: Run cargo shear
               run: cargo shear

--- a/rust/personhog-replica/Cargo.toml
+++ b/rust/personhog-replica/Cargo.toml
@@ -19,7 +19,6 @@ futures = { workspace = true }
 axum = { workspace = true }
 chrono = { workspace = true }
 envconfig = { workspace = true }
-rand = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true }
@@ -29,6 +28,7 @@ tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
+rand = { workspace = true }
 rstest = "0.26"
 tokio = { workspace = true, features = ["test-util"] }
 tokio-stream = "0.1"

--- a/rust/personhog-router/Cargo.toml
+++ b/rust/personhog-router/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 [dependencies]
 personhog-common = { path = "../personhog-common" }
 personhog-coordination = { path = "../personhog-coordination" }
-personhog-proto = { path = "../personhog-proto" }
 assignment-coordination = { path = "../common/assignment-coordination" }
 k8s-awareness = { path = "../common/k8s-awareness" }
 common-alloc = { path = "../common/alloc" }
@@ -27,7 +26,6 @@ http = { workspace = true }
 http-body = "1"
 http-body-util = "0.1"
 metrics = { workspace = true }
-prost = { workspace = true }
 rand = { workspace = true }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 tokio = { workspace = true }
@@ -40,6 +38,7 @@ tracing-subscriber = { workspace = true }
 [dev-dependencies]
 dashmap = { workspace = true }
 flate2 = { workspace = true }
+personhog-proto = { path = "../personhog-proto" }
 prost = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }

--- a/rust/personhog-writer/Cargo.toml
+++ b/rust/personhog-writer/Cargo.toml
@@ -20,7 +20,6 @@ futures = { workspace = true }
 metrics = { workspace = true }
 prost = { workspace = true }
 rdkafka = { workspace = true }
-serde_json = { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
@@ -30,6 +29,7 @@ uuid = { workspace = true }
 [dev-dependencies]
 health = { path = "../common/health" }
 personhog-common = { path = "../personhog-common" }
+serde_json = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 
 [lints]


### PR DESCRIPTION
## Problem

- The Rust lint job fails whenever the cargo-shear 1.1.12 release-binary download hiccups: binstall falls back to building from source, and that build is now broken because 1.1.12 requires the yanked `cargo-util-schemas 0.7.3` ([failing run](https://github.com/PostHog/posthog/actions/runs/31629454844/job/94224362302)).
- The fallback failure is deterministic, so every download blip turns into a red lint job until the pin moves.

## Changes

- Bump the `cargo binstall` pin in ci-rust.yml from 1.1.12 to 1.13.4 (current latest).
- 1.13.4 adds a misplaced-dependency check; move the four dependencies it flags (only used by dev targets) to `[dev-dependencies]`: `rand` in personhog-replica, `personhog-proto` and `prost` in personhog-router, `serde_json` in personhog-writer.
- 1.13.4 also warns about unlinked or empty files in capture, cymbal, and cohort-stream-processor. Warnings do not fail the run (exit code 0), so those are left for their owning teams.

Unrebased PRs are unaffected: pull_request runs check out the PR merged with master, so the Cargo.toml fixes travel with the workflow change.

## How did you test this code?

- I ran cargo-shear 1.13.4 locally against the workspace: 0 errors, 3 file warnings, exit code 0.
- `cargo check --all-features` and `cargo clippy --all-targets` pass for the three touched crates, which proves no non-dev target used the moved dependencies.
- `bin/hogli lint:workflows` passes. Not run: the crates' test suites; moving a dependency between Cargo.toml sections cannot change runtime behavior, and clippy compiled all test targets.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code. Skills invoked: /authoring-ci-workflows, /writing-pr-descriptions.
- Found while investigating a lint failure on #82123; that run was re-triggered separately since its download failure was transient.
