### PR TITLE
feat(desktop): move cloud artifacts into a composer popover

### DIFF
--- a/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.test.tsx
@@ -146,7 +146,7 @@ describe("CloudArtifactDownloads", () => {
     expect(screen.queryByText("handoff.pack")).not.toBeInTheDocument();
     expect(screen.queryByText("Edited by you")).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByText("Download"));
+    fireEvent.click(screen.getByLabelText("Download report.pdf"));
 
     await waitFor(() => expect(click).toHaveBeenCalledOnce());
     expect(fetchArtifact).toHaveBeenCalledWith(
@@ -187,7 +187,7 @@ describe("CloudArtifactDownloads", () => {
       openFiles();
 
       const downloadButtons = screen.getAllByRole("button", {
-        name: "Download",
+        name: /^Download /,
       });
       fireEvent.click(downloadButtons[0]);
 

--- a/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.test.tsx
@@ -142,9 +142,8 @@ describe("CloudArtifactDownloads", () => {
     openFiles();
 
     expect(screen.getByText("report.pdf")).toBeInTheDocument();
-    expect(screen.getByText("12 KB")).toBeInTheDocument();
+    expect(screen.getByText(/12 KB/)).toBeInTheDocument();
     expect(screen.queryByText("handoff.pack")).not.toBeInTheDocument();
-    expect(screen.queryByText("Edited by you")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByLabelText("Download report.pdf"));
 
@@ -224,9 +223,9 @@ describe("CloudArtifactDownloads", () => {
     renderDownloads();
     openFiles();
 
-    expect(screen.queryByText("Edited by you")).not.toBeInTheDocument();
     fireEvent.click(screen.getByLabelText("Choose a version of report.md"));
-    expect(screen.getByText(/Version 1 · Edited by you ·/)).toBeInTheDocument();
+    expect(screen.getByText(/^v1 · You ·/)).toBeInTheDocument();
+    expect(screen.getByText(/^v2 · Agent ·/)).toBeInTheDocument();
   });
 
   it("opens an artifact preview in a new tab", () => {
@@ -298,7 +297,7 @@ describe("CloudArtifactDownloads", () => {
     renderDownloads();
     openFiles();
 
-    expect(screen.getByText("1 KB")).toBeInTheDocument();
+    expect(screen.getByText(/1 KB$/)).toBeInTheDocument();
     fireEvent.click(screen.getByText("report.pdf"));
     expect(openArtifactTab).toHaveBeenCalledWith("task-1", {
       runId: "run-1",
@@ -330,12 +329,12 @@ describe("CloudArtifactDownloads", () => {
     renderDownloads();
     openFiles();
 
-    expect(screen.getByText("2 KB")).toBeInTheDocument();
+    expect(screen.getByText(/2 KB$/)).toBeInTheDocument();
 
     fireEvent.click(screen.getByLabelText("Choose a version of report.pdf"));
-    fireEvent.click(screen.getByText(/^Version 1/));
+    fireEvent.click(screen.getByText(/^v1 ·/));
 
-    expect(screen.getByText("1 KB")).toBeInTheDocument();
+    expect(screen.getByText(/1 KB$/)).toBeInTheDocument();
   });
 
   it("disables dismissal until every version has an id", () => {

--- a/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.test.tsx
@@ -88,6 +88,11 @@ function renderDownloads() {
   );
 }
 
+// Rows render inside a popover, so every row assertion opens it first.
+function openFiles() {
+  fireEvent.click(screen.getByRole("button", { name: /^Artifacts \(/ }));
+}
+
 describe("CloudArtifactDownloads", () => {
   beforeEach(() => {
     fetchedArtifacts = [
@@ -134,6 +139,7 @@ describe("CloudArtifactDownloads", () => {
       .mockImplementation(() => undefined);
 
     renderDownloads();
+    openFiles();
 
     expect(screen.getByText("report.pdf")).toBeInTheDocument();
     expect(screen.getByText("12 KB")).toBeInTheDocument();
@@ -178,6 +184,7 @@ describe("CloudArtifactDownloads", () => {
           <CloudArtifactDownloads taskId="task-1" task={task} />
         </Theme>,
       );
+      openFiles();
 
       const downloadButtons = screen.getAllByRole("button", {
         name: "Download",
@@ -215,6 +222,7 @@ describe("CloudArtifactDownloads", () => {
     ];
 
     renderDownloads();
+    openFiles();
 
     expect(screen.queryByText("Edited by you")).not.toBeInTheDocument();
     fireEvent.click(screen.getByLabelText("Choose a version of report.md"));
@@ -223,6 +231,7 @@ describe("CloudArtifactDownloads", () => {
 
   it("opens an artifact preview in a new tab", () => {
     renderDownloads();
+    openFiles();
 
     fireEvent.click(screen.getByText("report.pdf"));
 
@@ -252,10 +261,11 @@ describe("CloudArtifactDownloads", () => {
 
     renderDownloads();
 
-    expect(screen.getAllByText("report.pdf")).toHaveLength(1);
     expect(
-      screen.getByRole("button", { name: "Files (1)" }),
+      screen.getByRole("button", { name: "Artifacts (1)" }),
     ).toBeInTheDocument();
+    openFiles();
+    expect(screen.getAllByText("report.pdf")).toHaveLength(1);
 
     fireEvent.click(screen.getByText("report.pdf"));
 
@@ -286,6 +296,7 @@ describe("CloudArtifactDownloads", () => {
     ];
 
     renderDownloads();
+    openFiles();
 
     expect(screen.getByText("1 KB")).toBeInTheDocument();
     fireEvent.click(screen.getByText("report.pdf"));
@@ -317,6 +328,7 @@ describe("CloudArtifactDownloads", () => {
     ];
 
     renderDownloads();
+    openFiles();
 
     expect(screen.getByText("2 KB")).toBeInTheDocument();
 
@@ -342,6 +354,7 @@ describe("CloudArtifactDownloads", () => {
     ];
 
     renderDownloads();
+    openFiles();
 
     const dismiss = screen.getByLabelText("Dismiss report.pdf");
     expect(dismiss).toHaveAttribute("aria-disabled", "true");
@@ -377,6 +390,7 @@ describe("CloudArtifactDownloads", () => {
     });
 
     renderDownloads();
+    openFiles();
 
     fireEvent.click(screen.getByLabelText("Dismiss report.pdf"));
 
@@ -420,6 +434,7 @@ describe("CloudArtifactDownloads", () => {
     ]);
 
     const { rerender } = renderDownloads();
+    openFiles();
 
     fireEvent.click(screen.getByLabelText("Dismiss report.pdf"));
     await waitFor(() =>
@@ -457,11 +472,9 @@ describe("CloudArtifactDownloads", () => {
     ];
 
     renderDownloads();
+    openFiles();
 
     expect(screen.queryByText("report.pdf")).not.toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Files (0)" }),
-    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByText("Show 1 dismissed"));
 
@@ -517,73 +530,13 @@ describe("CloudArtifactDownloads", () => {
     );
   });
 
-  it("starts expanded and collapses when the header is clicked", () => {
-    renderDownloads();
-
-    const trigger = screen.getByRole("button", { name: "Files (1)" });
-    expect(trigger).toHaveAttribute("aria-expanded", "true");
-    expect(screen.getByText("report.pdf")).toBeVisible();
-
-    fireEvent.click(trigger);
-
-    expect(trigger).toHaveAttribute("aria-expanded", "false");
-    expect(screen.queryByText("report.pdf")).not.toBeInTheDocument();
-
-    fireEvent.click(trigger);
-
-    expect(trigger).toHaveAttribute("aria-expanded", "true");
-    expect(screen.getByText("report.pdf")).toBeVisible();
-  });
-
-  it("expands when the visible file list changes", () => {
-    const { rerender } = renderDownloads();
-
-    fireEvent.click(screen.getByRole("button", { name: "Files (1)" }));
-    expect(screen.queryByText("report.pdf")).not.toBeInTheDocument();
-
-    fetchedArtifacts = [
-      ...(fetchedArtifacts ?? []),
-      {
-        id: "output-2",
-        name: "summary.txt",
-        type: "output",
-        storage_path: "tasks/run-1/summary.txt",
-      },
-    ];
-    rerender(
-      <Theme>
-        <CloudArtifactDownloads taskId="task-1" task={task} />
-      </Theme>,
-    );
-
-    expect(screen.getByRole("button", { name: "Files (2)" })).toHaveAttribute(
-      "aria-expanded",
-      "true",
-    );
-    expect(screen.getByText("summary.txt")).toBeVisible();
-  });
-
-  it("stays collapsed when a refetch returns the same files", () => {
-    const { rerender } = renderDownloads();
-
-    fireEvent.click(screen.getByRole("button", { name: "Files (1)" }));
-    fetchedArtifacts = [...(fetchedArtifacts ?? [])];
-    rerender(
-      <Theme>
-        <CloudArtifactDownloads taskId="task-1" task={task} />
-      </Theme>,
-    );
-
-    const trigger = screen.getByRole("button", { name: "Files (1)" });
-    expect(trigger).toHaveAttribute("aria-expanded", "false");
-    fireEvent.click(trigger);
-  });
-
   it("treats a successful empty refresh as authoritative", () => {
     const { rerender } = renderDownloads();
 
-    fireEvent.click(screen.getByRole("button", { name: "Files (1)" }));
-    const artifacts = fetchedArtifacts;
+    expect(
+      screen.getByRole("button", { name: "Artifacts (1)" }),
+    ).toBeInTheDocument();
+
     fetchedArtifacts = [];
     rerender(
       <Theme>
@@ -591,42 +544,6 @@ describe("CloudArtifactDownloads", () => {
       </Theme>,
     );
 
-    expect(screen.queryByRole("button", { name: "Files (1)" })).toBeNull();
-
-    fetchedArtifacts = artifacts;
-    rerender(
-      <Theme>
-        <CloudArtifactDownloads taskId="task-1" task={task} />
-      </Theme>,
-    );
-
-    expect(screen.getByRole("button", { name: "Files (1)" })).toHaveAttribute(
-      "aria-expanded",
-      "true",
-    );
-  });
-
-  it("remembers collapse state per task", () => {
-    const { unmount } = renderDownloads();
-
-    fireEvent.click(screen.getByRole("button", { name: "Files (1)" }));
-    expect(screen.queryByText("report.pdf")).not.toBeInTheDocument();
-    unmount();
-
-    const artifacts = fetchedArtifacts;
-    fetchedArtifacts = undefined;
-    const { rerender } = renderDownloads();
-    fetchedArtifacts = artifacts;
-    rerender(
-      <Theme>
-        <CloudArtifactDownloads taskId="task-1" task={task} />
-      </Theme>,
-    );
-
-    expect(screen.getByRole("button", { name: "Files (1)" })).toHaveAttribute(
-      "aria-expanded",
-      "false",
-    );
-    expect(screen.queryByText("report.pdf")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^Artifacts \(/ })).toBeNull();
   });
 });

--- a/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.tsx
@@ -1,9 +1,8 @@
-import { CaretDown, DownloadSimple, Paperclip, X } from "@phosphor-icons/react";
+import { CaretDown, DownloadSimple, Package, X } from "@phosphor-icons/react";
 import {
   groupRunArtifactVersions,
   type RunArtifactVersions,
   runArtifactVersionKey,
-  runArtifactVersionLabel,
 } from "@posthog/core/canvas/runArtifactSchemas";
 import {
   SESSION_SERVICE,
@@ -19,9 +18,8 @@ import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-  Text,
 } from "@posthog/quill";
-import { formatRelativeTimeShort, type TaskRunArtifact } from "@posthog/shared";
+import { formatRelativeTimeLong, type TaskRunArtifact } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import {
   getAuthIdentity,
@@ -32,7 +30,6 @@ import { usePanelLayoutStore } from "@posthog/ui/features/panels/panelLayoutStor
 import { useSessionSelector } from "@posthog/ui/features/sessions/sessionStore";
 import { useArtifactDownload } from "@posthog/ui/features/sessions/useArtifactDownload";
 import { FileIcon } from "@posthog/ui/primitives/FileIcon";
-import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
 import { toast } from "@posthog/ui/primitives/toast";
 import { formatFileSize } from "@posthog/ui/utils/formatFileSize";
 import { useMutation, useQuery } from "@tanstack/react-query";
@@ -41,31 +38,42 @@ import { useCompletedArtifactUploads } from "./countArtifactUploads";
 
 type ArtifactGroup = RunArtifactVersions<TaskRunArtifact>;
 
-/**
- * The menu sits at the right edge of the thread, and its popup is capped at the space left
- * there and clips what does not fit, so the age is the compact form rather than the row's.
- */
-function wasEditedByCurrentUser(
+interface CurrentUser {
+  id?: number;
+  first_name?: string | null;
+}
+
+// Labels mirror the artifact pane (TaskArtifactsList) so the same file reads
+// the same way on both surfaces.
+function uploaderLabel(
   artifact: TaskRunArtifact,
-  currentUserId: number | undefined,
-): boolean {
-  return (
-    artifact.uploaded_by === "user" &&
-    currentUserId !== undefined &&
-    artifact.uploaded_by_user_id === currentUserId
-  );
+  currentUser: CurrentUser | undefined,
+): string {
+  if (artifact.uploaded_by !== "user") return "Agent";
+  if (
+    currentUser?.id !== undefined &&
+    artifact.uploaded_by_user_id === currentUser.id
+  ) {
+    return currentUser.first_name?.trim() || "You";
+  }
+  return "Teammate";
+}
+
+/** Compact one-based version label: v1 is oldest, v{total} is newest. */
+function versionShortLabel(index: number, total: number): string {
+  return `v${total - index}`;
 }
 
 function versionMenuLabel(
   artifact: TaskRunArtifact,
   index: number,
   total: number,
-  currentUserId: number | undefined,
+  currentUser: CurrentUser | undefined,
 ): string {
   return [
-    runArtifactVersionLabel(index, total),
-    wasEditedByCurrentUser(artifact, currentUserId) ? "Edited by you" : null,
-    artifact.uploaded_at ? formatRelativeTimeShort(artifact.uploaded_at) : null,
+    versionShortLabel(index, total),
+    uploaderLabel(artifact, currentUser),
+    artifact.uploaded_at ? formatRelativeTimeLong(artifact.uploaded_at) : null,
   ]
     .filter(Boolean)
     .join(" · ");
@@ -195,114 +203,170 @@ export function CloudArtifactDownloads({
     const canDownload = Boolean(selected.id);
     const canChangeDismissal = group.versions.every((version) => version.id);
 
+    const metaText = [
+      uploaderLabel(selected, currentUser),
+      selected.uploaded_at
+        ? formatRelativeTimeLong(selected.uploaded_at)
+        : null,
+      size,
+    ]
+      .filter(Boolean)
+      .join(" · ");
+
     return (
+      // Compact take on the artifact pane's ArtifactCard (TaskArtifactsList):
+      // role="button" because the version picker and trailing actions are real
+      // buttons and HTML forbids nesting those.
+      // biome-ignore lint/a11y/useSemanticElements: nested real buttons forbid a <button> card
       <div
         key={group.name}
-        className="flex min-w-0 items-center justify-between gap-2 rounded-md bg-background px-2 py-1.5"
-      >
-        <button
-          type="button"
-          className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left"
-          disabled={!canDownload}
-          onClick={() => {
-            if (!taskId || !selected.id) return;
+        role="button"
+        tabIndex={canDownload ? 0 : undefined}
+        aria-disabled={canDownload ? undefined : true}
+        aria-label={`View ${group.name}`}
+        className={`flex w-full items-center gap-2.5 rounded-lg border border-border bg-muted py-1.5 pr-1.5 pl-2 text-[13px] transition-colors ${
+          canDownload
+            ? "cursor-pointer hover:border-gray-6 hover:bg-gray-3"
+            : ""
+        }`}
+        onClick={() => {
+          if (!taskId || !selected.id) return;
+          openArtifactTab(taskId, {
+            runId,
+            artifactId: selected.id,
+            name: selected.name,
+          });
+        }}
+        onKeyDown={(event) => {
+          if (event.target !== event.currentTarget) return;
+          if (
+            canDownload &&
+            taskId &&
+            selected.id &&
+            (event.key === "Enter" || event.key === " ")
+          ) {
+            event.preventDefault();
             openArtifactTab(taskId, {
               runId,
               artifactId: selected.id,
               name: selected.name,
             });
-          }}
-        >
-          <FileIcon filename={selected.name} size={16} />
-          <Text className="truncate text-[13px]">{selected.name}</Text>
-          {size !== null && (
-            <Text className="shrink-0 text-[12px] text-gray-10">{size}</Text>
-          )}
-          {wasEditedByCurrentUser(selected, currentUser?.id) && (
-            <Text className="shrink-0 text-[12px] text-gray-10">
-              Edited by you
-            </Text>
-          )}
-          <RelativeTimestamp timestamp={selected.uploaded_at} />
-        </button>
-        {group.versions.length > 1 && (
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              render={
-                <Button
-                  size="sm"
-                  variant="outline"
-                  aria-label={`Choose a version of ${group.name}`}
-                >
-                  {runArtifactVersionLabel(
-                    selectedIndex,
-                    group.versions.length,
-                  )}
-                  <CaretDown size={12} />
-                </Button>
-              }
-            />
-            <DropdownMenuContent align="end">
-              {group.versions.map((version, index) => (
-                <DropdownMenuItem
-                  key={runArtifactVersionKey(version)}
-                  onClick={() =>
-                    setSelectedVersionByName((current) => ({
-                      ...current,
-                      [group.name]: runArtifactVersionKey(version),
-                    }))
-                  }
-                >
-                  {versionMenuLabel(
-                    version,
-                    index,
-                    group.versions.length,
-                    currentUser?.id,
-                  )}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        )}
-        {group.dismissed ? (
-          <Button
-            size="sm"
-            variant="outline"
-            disabled={dismissal.isPending || !canChangeDismissal}
-            onClick={() => dismissal.mutate({ group, dismissed: false })}
+          }
+        }}
+      >
+        <div className="relative flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-md bg-gray-4">
+          {/* The icon again, blown up and blurred: the tile tints itself with
+              the icon's own colors, so new icons never need a color mapping. */}
+          <div
+            aria-hidden
+            className="absolute inset-0 flex scale-[2.4] items-center justify-center opacity-40 blur-[9px] saturate-[1.8] dark:opacity-70"
           >
-            Restore
-          </Button>
-        ) : (
-          <>
+            <FileIcon filename={group.name} size={16} />
+          </div>
+          <div className="relative flex items-center justify-center">
+            <FileIcon filename={group.name} size={16} />
+          </div>
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="truncate font-medium">{group.name}</div>
+          <div className="flex items-center gap-1 whitespace-nowrap text-[12px] text-muted-foreground">
+            {metaText && <span className="truncate">{metaText}</span>}
+            {group.versions.length > 1 && (
+              <>
+                {metaText && <span>·</span>}
+                <DropdownMenu>
+                  <DropdownMenuTrigger
+                    render={
+                      <button
+                        type="button"
+                        aria-label={`Choose a version of ${group.name}`}
+                        onClick={(event) => event.stopPropagation()}
+                        className="flex shrink-0 cursor-pointer items-center gap-0.5 text-foreground"
+                      >
+                        {versionShortLabel(
+                          selectedIndex,
+                          group.versions.length,
+                        )}
+                        <CaretDown size={10} />
+                      </button>
+                    }
+                  />
+                  {/* w-max: the default popup width tracks the anchor, and this
+                      trigger is a couple of characters wide, so version labels
+                      would be cut off. */}
+                  <DropdownMenuContent align="start" className="w-max">
+                    {group.versions.map((version, index) => (
+                      <DropdownMenuItem
+                        key={runArtifactVersionKey(version)}
+                        onClick={() =>
+                          setSelectedVersionByName((current) => ({
+                            ...current,
+                            [group.name]: runArtifactVersionKey(version),
+                          }))
+                        }
+                      >
+                        {versionMenuLabel(
+                          version,
+                          index,
+                          group.versions.length,
+                          currentUser,
+                        )}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </>
+            )}
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          {group.dismissed ? (
             <Button
-              size="icon-sm"
+              size="sm"
               variant="outline"
-              aria-label={`Download ${group.name}`}
-              disabled={!canDownload || downloadingId !== null}
-              onClick={() => {
-                if (!taskId || !selected.id) return;
-                void download({
-                  taskId,
-                  runId,
-                  artifactId: selected.id,
-                  name: selected.name,
-                });
+              disabled={dismissal.isPending || !canChangeDismissal}
+              onClick={(event) => {
+                event.stopPropagation();
+                dismissal.mutate({ group, dismissed: false });
               }}
             >
-              <DownloadSimple size={14} />
+              Restore
             </Button>
-            <Button
-              size="icon-sm"
-              variant="outline"
-              aria-label={`Dismiss ${group.name}`}
-              disabled={dismissal.isPending || !canChangeDismissal}
-              onClick={() => dismissal.mutate({ group, dismissed: true })}
-            >
-              <X size={14} />
-            </Button>
-          </>
-        )}
+          ) : (
+            <>
+              <Button
+                size="icon-sm"
+                variant="default"
+                aria-label={`Download ${group.name}`}
+                disabled={!canDownload || downloadingId !== null}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  if (!taskId || !selected.id) return;
+                  void download({
+                    taskId,
+                    runId,
+                    artifactId: selected.id,
+                    name: selected.name,
+                  });
+                }}
+              >
+                <DownloadSimple size={14} />
+              </Button>
+              <Button
+                size="icon-sm"
+                variant="default"
+                aria-label={`Dismiss ${group.name}`}
+                disabled={dismissal.isPending || !canChangeDismissal}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  dismissal.mutate({ group, dismissed: true });
+                }}
+              >
+                <X size={14} />
+              </Button>
+            </>
+          )}
+        </div>
       </div>
     );
   };
@@ -318,7 +382,7 @@ export function CloudArtifactDownloads({
             className="relative"
             aria-label={`Artifacts (${visibleGroups.length})`}
           >
-            <Paperclip size={16} />
+            <Package size={16} />
             {visibleGroups.length > 0 && (
               <span className="-top-1 -right-1 absolute flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-primary px-0.5 font-semibold text-[9px] text-primary-foreground">
                 {visibleGroups.length}

--- a/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.tsx
@@ -1,17 +1,10 @@
-import { Collapsible } from "@base-ui/react/collapsible";
-import {
-  CaretDown,
-  CaretRight,
-  DownloadSimple,
-  X,
-} from "@phosphor-icons/react";
+import { CaretDown, DownloadSimple, Paperclip, X } from "@phosphor-icons/react";
 import {
   groupRunArtifactVersions,
   type RunArtifactVersions,
   runArtifactVersionKey,
   runArtifactVersionLabel,
 } from "@posthog/core/canvas/runArtifactSchemas";
-import { artifactFilesListKey } from "@posthog/core/sessions/artifactFilesListKey";
 import {
   SESSION_SERVICE,
   type SessionService,
@@ -23,6 +16,9 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
   Text,
 } from "@posthog/quill";
 import { formatRelativeTimeShort, type TaskRunArtifact } from "@posthog/shared";
@@ -34,17 +30,13 @@ import {
 import { useMeQuery } from "@posthog/ui/features/auth/useMeQuery";
 import { usePanelLayoutStore } from "@posthog/ui/features/panels/panelLayoutStore";
 import { useSessionSelector } from "@posthog/ui/features/sessions/sessionStore";
-import {
-  useArtifactFilesCollapsed,
-  useSessionViewActions,
-} from "@posthog/ui/features/sessions/sessionViewStore";
 import { useArtifactDownload } from "@posthog/ui/features/sessions/useArtifactDownload";
 import { FileIcon } from "@posthog/ui/primitives/FileIcon";
 import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
 import { toast } from "@posthog/ui/primitives/toast";
 import { formatFileSize } from "@posthog/ui/utils/formatFileSize";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useCompletedArtifactUploads } from "./countArtifactUploads";
 
 type ArtifactGroup = RunArtifactVersions<TaskRunArtifact>;
@@ -96,8 +88,6 @@ export function CloudArtifactDownloads({
     taskId,
     (session) => session?.cloudStatus,
   );
-  const { setArtifactFilesCollapsed, syncArtifactFilesListKey } =
-    useSessionViewActions();
   const authIdentity = useAuthStateValue(getAuthIdentity);
   const { download, downloadingId } = useArtifactDownload();
   const { data: currentUser } = useMeQuery();
@@ -149,19 +139,6 @@ export function CloudArtifactDownloads({
   );
   const visibleGroups = groups.filter((group) => !group.dismissed);
   const dismissedGroups = groups.filter((group) => group.dismissed);
-  const fileListKey = artifactManifest
-    ? artifactFilesListKey(
-        runId,
-        visibleGroups.map((group) => group.name),
-      )
-    : undefined;
-  const collapsed = useArtifactFilesCollapsed(taskId, fileListKey);
-
-  useEffect(() => {
-    if (taskId && fileListKey !== undefined) {
-      syncArtifactFilesListKey(taskId, fileListKey);
-    }
-  }, [fileListKey, syncArtifactFilesListKey, taskId]);
 
   const dismissal = useMutation({
     mutationFn: ({
@@ -331,25 +308,44 @@ export function CloudArtifactDownloads({
   };
 
   return (
-    // Base UI rather than quill's Collapsible: quill styles the root/trigger
-    // as a standalone disclosure row (hover/selected fills on the whole
-    // padded header), which reads as a misplaced selected block inside this
-    // already-bordered card — see ChannelsList for the same call.
-    <Collapsible.Root
-      open={!collapsed}
-      onOpenChange={(open) => {
-        if (taskId && fileListKey !== undefined) {
-          setArtifactFilesCollapsed(taskId, !open, fileListKey);
+    <Popover>
+      <PopoverTrigger
+        render={
+          <Button
+            type="button"
+            variant="default"
+            size="icon-sm"
+            className="relative"
+            aria-label={`Artifacts (${visibleGroups.length})`}
+          >
+            <Paperclip size={16} />
+            {visibleGroups.length > 0 && (
+              <span className="-top-1 -right-1 absolute flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-primary px-0.5 font-semibold text-[9px] text-primary-foreground">
+                {visibleGroups.length}
+              </span>
+            )}
+          </Button>
         }
-      }}
-      className="mb-3 rounded-lg border border-gray-4 bg-gray-2 p-3"
-    >
-      <Collapsible.Trigger className="flex w-full cursor-pointer items-center gap-1.5 text-left font-medium text-[13px]">
-        {collapsed ? <CaretRight size={12} /> : <CaretDown size={12} />}
-        Files ({visibleGroups.length})
-      </Collapsible.Trigger>
-      <Collapsible.Panel className="mt-2">
-        <div className="flex flex-col gap-1">
+      />
+      {/* quill's popup is a fixed 18rem; the rows carry name, size, age, and
+          actions, which need the width the old inline card had. */}
+      <PopoverContent
+        side="top"
+        align="end"
+        sideOffset={6}
+        className="w-[400px] max-w-[calc(100vw-2rem)] gap-2"
+      >
+        <div className="flex items-center justify-between">
+          <span className="font-medium text-[13px] text-foreground">
+            Artifacts
+          </span>
+          <span className="text-[12px] text-muted-foreground tabular-nums">
+            {visibleGroups.length === 1
+              ? "1 artifact"
+              : `${visibleGroups.length} artifacts`}
+          </span>
+        </div>
+        <div className="flex max-h-72 flex-col gap-1 overflow-y-auto">
           {visibleGroups.map(renderRow)}
           {showDismissed && dismissedGroups.map(renderRow)}
         </div>
@@ -357,7 +353,7 @@ export function CloudArtifactDownloads({
           <Button
             size="sm"
             variant="link-muted"
-            className="mt-1"
+            className="self-start"
             onClick={() => setShowDismissed((current) => !current)}
           >
             {showDismissed
@@ -365,7 +361,7 @@ export function CloudArtifactDownloads({
               : `Show ${dismissedGroups.length} dismissed`}
           </Button>
         )}
-      </Collapsible.Panel>
-    </Collapsible.Root>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/CloudArtifactDownloads.tsx
@@ -276,8 +276,9 @@ export function CloudArtifactDownloads({
         ) : (
           <>
             <Button
-              size="sm"
+              size="icon-sm"
               variant="outline"
+              aria-label={`Download ${group.name}`}
               disabled={!canDownload || downloadingId !== null}
               onClick={() => {
                 if (!taskId || !selected.id) return;
@@ -290,7 +291,6 @@ export function CloudArtifactDownloads({
               }}
             >
               <DownloadSimple size={14} />
-              {downloadingId === selected.id ? "Opening..." : "Download"}
             </Button>
             <Button
               size="icon-sm"

--- a/products/desktop/packages/ui/src/features/sessions/components/ConversationView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ConversationView.tsx
@@ -15,7 +15,6 @@ import type {
   ConversationItem,
   TurnContext,
 } from "@posthog/ui/features/sessions/components/buildConversationItems";
-import { CloudArtifactDownloads } from "@posthog/ui/features/sessions/components/CloudArtifactDownloads";
 import { ConversationSearchBar } from "@posthog/ui/features/sessions/components/ConversationSearchBar";
 import {
   PROMPT_RECALL_HINT_KEY,
@@ -476,7 +475,6 @@ export function ConversationView({
 
   const footer = (
     <div className={compact ? "pb-1" : "pb-16"}>
-      <CloudArtifactDownloads taskId={taskId} task={task} />
       <SessionFooter
         task={task}
         isPromptPending={isPromptPending}

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -23,6 +23,7 @@ import { useDraftStore } from "@posthog/ui/features/message-editor/draftStore";
 import { useAutoFocusOnTyping } from "@posthog/ui/features/message-editor/useAutoFocusOnTyping";
 import { resolveAndAttachDroppedFiles } from "@posthog/ui/features/message-editor/utils/persistFile";
 import { PermissionSelector } from "@posthog/ui/features/permissions/PermissionSelector";
+import { CloudArtifactDownloads } from "@posthog/ui/features/sessions/components/CloudArtifactDownloads";
 import {
   CloudStreamDisconnectedBanner,
   ConnectingToAgent,
@@ -852,7 +853,13 @@ export function SessionView({
                             ) : undefined
                           }
                           toolbarEndSlot={
-                            <ContextUsageIndicator usage={contextUsage} />
+                            <>
+                              <CloudArtifactDownloads
+                                taskId={taskId}
+                                task={task}
+                              />
+                              <ContextUsageIndicator usage={contextUsage} />
+                            </>
                           }
                           onToggleMessagingMode={toggleMessagingMode}
                           onAttachmentsChange={handleAttachmentsChange}

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -53,7 +53,6 @@ import type {
   BuildResult,
   ConversationItem,
 } from "@posthog/ui/features/sessions/components/buildConversationItems";
-import { CloudArtifactDownloads } from "@posthog/ui/features/sessions/components/CloudArtifactDownloads";
 import {
   ChatMarkdown,
   ChatStreamingMarkdown,
@@ -1438,7 +1437,6 @@ function ChatThreadRenderer({
 
   const footer = (
     <>
-      <CloudArtifactDownloads taskId={taskId} task={task} />
       <ChatThreadFooter
         events={footerEvents}
         isPromptPending={isPromptPending}

--- a/products/desktop/packages/ui/src/features/sessions/sessionViewStore.ts
+++ b/products/desktop/packages/ui/src/features/sessions/sessionViewStore.ts
@@ -17,10 +17,6 @@ interface SessionViewState {
    * resets to expanded on app restart.
    */
   queueCollapsedByTaskId: Record<string, boolean>;
-  artifactFilesCollapseByTaskId: Record<
-    string,
-    { collapsed: boolean; fileListKey: string }
-  >;
   /**
    * Thumbs rating given to an agent turn, keyed by turn id. Feedback is
    * analytics-only, so this exists purely to keep the chosen thumb lit —
@@ -37,12 +33,6 @@ interface SessionViewActions {
   setGroupOverride: (id: string, expanded: boolean) => void;
   clearGroupOverrides: () => void;
   setQueueCollapsed: (taskId: string, collapsed: boolean) => void;
-  setArtifactFilesCollapsed: (
-    taskId: string,
-    collapsed: boolean,
-    fileListKey: string,
-  ) => void;
-  syncArtifactFilesListKey: (taskId: string, fileListKey: string) => void;
   setTurnFeedback: (
     turnId: string,
     sentiment: AgentTurnFeedbackSentiment,
@@ -57,7 +47,6 @@ const useStore = create<SessionViewStore>((set) => ({
   showSearch: false,
   groupOverrides: {},
   queueCollapsedByTaskId: {},
-  artifactFilesCollapseByTaskId: {},
   turnFeedbackByTurnId: {},
   actions: {
     setShowRawLogs: (show) => set({ showRawLogs: show }),
@@ -84,24 +73,6 @@ const useStore = create<SessionViewStore>((set) => ({
           [taskId]: collapsed,
         },
       })),
-    setArtifactFilesCollapsed: (taskId, collapsed, fileListKey) =>
-      set((state) => ({
-        artifactFilesCollapseByTaskId: {
-          ...state.artifactFilesCollapseByTaskId,
-          [taskId]: { collapsed, fileListKey },
-        },
-      })),
-    syncArtifactFilesListKey: (taskId, fileListKey) =>
-      set((state) => {
-        const current = state.artifactFilesCollapseByTaskId[taskId];
-        if (!current || current.fileListKey === fileListKey) return state;
-        return {
-          artifactFilesCollapseByTaskId: {
-            ...state.artifactFilesCollapseByTaskId,
-            [taskId]: { collapsed: false, fileListKey },
-          },
-        };
-      }),
     setTurnFeedback: (turnId, sentiment) =>
       set((state) => ({
         turnFeedbackByTurnId: {
@@ -118,17 +89,6 @@ export const useShowSearch = () => useStore((s) => s.showSearch);
 export const useGroupOverrides = () => useStore((s) => s.groupOverrides);
 export const useQueueCollapsed = (taskId: string) =>
   useStore((s) => s.queueCollapsedByTaskId[taskId] ?? false);
-export const useArtifactFilesCollapsed = (
-  taskId: string | undefined,
-  fileListKey: string | undefined,
-) =>
-  useStore((s) =>
-    taskId === undefined
-      ? false
-      : (s.artifactFilesCollapseByTaskId[taskId]?.collapsed ?? false) &&
-        (fileListKey === undefined ||
-          s.artifactFilesCollapseByTaskId[taskId]?.fileListKey === fileListKey),
-  );
 export const useTurnFeedback = (turnId: string) =>
   useStore((s) => s.turnFeedbackByTurnId[turnId] ?? null);
 export const useSessionViewActions = () => useStore((s) => s.actions);


### PR DESCRIPTION
## Problem

Cloud task artifacts render as a "Files (N)" card pinned above the composer, which pushes the conversation up and takes a full-width block for something you only occasionally open.

## Changes

- The artifact list moves into a popover behind a Package icon button (with a count badge) in the composer toolbar, next to the context ring.
- The popover opens above, right-aligned, styled like the context breakdown popover.
- Rows follow the artifact pane's card recipe (`TaskArtifactsList`): a tinted icon tile, the file name over an "uploader · age · size" meta line with an inline vN version picker, and icon-only download and dismiss actions.
- The "Show N dismissed" toggle stays in the popover footer.
- The inline card above the thread footer is removed from both the chat thread and the legacy conversation view.
- The per-task collapse state in `sessionViewStore` only served the old card, so it goes too.

The real component, captured from Storybook with the run's artifact manifest as fixture data:

![artifacts-popover](https://raw.githubusercontent.com/PostHog/pr-assets/c965dd111adb70df74f1e1bcf8ec970395bc8b58/2026/08/1a70a6af-ca48-43c4-a99e-008573e748f1.gif)

<details>
<summary>Full-page screenshot</summary>

![real-open](https://raw.githubusercontent.com/PostHog/pr-assets/05f985dafadba6b0c42d9f0b31260b825f1ab276/2026/08/bd8807b9-e1ac-499f-9d51-5cd311d6a9cc.png)

</details>

## How did you test this code?

- Adapted `CloudArtifactDownloads.test.tsx` to open the popover before row assertions; download, dismissal, versioning, and manifest-refresh coverage is unchanged.
- Dropped the four collapse-persistence tests, since the collapse behavior no longer exists.
- Rendered the real component in Storybook via a throwaway story (headless Chromium) to capture the media above; the story is not committed.
- Not run: the Electron app against a live backend, so the media shows fixture artifacts rather than a real cloud run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.
- Session: mocked up the popover as HTML first, the user picked the trigger placement, popover style, and pane-matching row aesthetics across review rounds; each round was captured from Storybook.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
