### PR TITLE
fix(gladly): fail report syncs on a header missing the key columns

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gladly/gladly.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gladly/gladly.py
@@ -49,6 +49,23 @@ class GladlyRetryableError(Exception):
     pass
 
 
+class GladlyReportHeaderError(Exception):
+    """A report body whose header is missing the columns the stream is keyed on.
+
+    A body that isn't the promised CSV still parses: its first line becomes the
+    header, so the rows come out carrying junk columns or nothing but the injected
+    `_row_id`, and the sync then fails much later with a misleading complaint about
+    the incremental field. Stop at the source instead. Keep the message matching
+    the entry in the source's non-retryable errors.
+    """
+
+    def __init__(self, metric_set: str, missing: list[str], present: list[str]) -> None:
+        super().__init__(
+            f"Gladly report is missing required columns {missing} for metricSet={metric_set}. "
+            f"Columns returned: {present!r:.300}"
+        )
+
+
 class _ResponseByteStream(io.RawIOBase):
     """Read a streaming response body through ``iter_content`` as a binary file.
 
@@ -142,6 +159,23 @@ def _normalize_report_column(name: str) -> str:
     declared primary key and incremental field aligned with the data.
     """
     return re.sub(r"[^a-z0-9]+", "_", name.strip().lower()).strip("_")
+
+
+def _report_csv_lines(stream: io.TextIOBase) -> Iterator[str]:
+    """Yield the report body with any blank lines before the header removed.
+
+    csv.DictReader takes the first line it reads as the header, so a leading blank
+    line becomes a single empty field name and every real column is then dropped
+    from the rows that follow. Lines keep their terminators, so csv still
+    reassembles values that contain a newline inside quotes.
+    """
+    header_seen = False
+    for line in stream:
+        if not header_seen:
+            if not line.strip():
+                continue
+            header_seen = True
+        yield line
 
 
 def _report_row_id(row: dict[str, Any]) -> str:
@@ -384,6 +418,11 @@ def _report_rows(
         logger=logger,
     )
     inject_row_id = config.primary_key == REPORT_ROW_ID_COLUMN
+    # The columns the stream is keyed on. An injected `_row_id` is built from the row
+    # rather than read from the report, so it is never required of the header.
+    required_columns = {incremental_field["field"] for incremental_field in config.incremental_fields}
+    if not inject_row_id:
+        required_columns.add(config.primary_key)
 
     is_first_request = True
     while window_start <= today:
@@ -408,8 +447,20 @@ def _report_rows(
         text_stream = io.TextIOWrapper(
             io.BufferedReader(_ResponseByteStream(response, REPORT_CHUNK_BYTES)), encoding="utf-8-sig", newline=""
         )
-        reader = csv.DictReader(text_stream)
+        reader = csv.DictReader(_report_csv_lines(text_stream))
         columns = {name: _normalize_report_column(name) for name in reader.fieldnames or []}
+        present = sorted({column for column in columns.values() if column})
+        missing = sorted(required_columns.difference(present))
+        # An empty body has no header at all and is a legitimately empty window, so only
+        # a header that parsed and came back wrong is a contract break. Log it before
+        # raising: the exception message is replaced by user guidance on the way to the
+        # customer, so this is the only place the real shape is recorded.
+        if reader.fieldnames and missing:
+            logger.error(
+                f"Gladly: {config.name} report window {window_start} - {window_end} returned a header "
+                f"missing {missing}. Header row: {reader.fieldnames!r:.500}"
+            )
+            raise GladlyReportHeaderError(metric_set, missing, present)
 
         row_count = 0
         chunk: list[dict[str, Any]] = []

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gladly/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gladly/source.py
@@ -67,17 +67,23 @@ class GladlySource(ResumableSource[GladlySourceConfig, GladlyResumeConfig]):
         return {
             "401 Client Error: Unauthorized for url": "Gladly authentication failed. Please check your agent email and API token.",
             "403 Client Error: Forbidden for url": "Gladly denied access. Please check that the agent has the API User permission.",
+            # Raised by `_report_rows` when a report header is missing the columns the stream is
+            # keyed on. Gladly returns the same body for that window on a retry, so stop and tell
+            # the customer rather than replaying it.
+            "Gladly report is missing required columns": (
+                "Gladly returned a report without the columns this table syncs on, so there was no "
+                "data to sync. Re-enable the sync to try again, and contact support if it keeps happening."
+            ),
         }
 
     def get_retryable_errors(self) -> set[str]:
-        # `_report_rows` reads the report CSV straight off `response.raw` (see gladly.py) rather
-        # than through `iter_content`, so a stall in Gladly's report generation past
-        # REQUEST_TIMEOUT_SECONDS raises the bare urllib3 read-timeout while streaming rows —
-        # after `generate_report`'s own retry-on-`requests.ReadTimeout` has already returned a
-        # response, so it isn't caught there either. Temporal's activity retry regenerates the
-        # report and re-streams it; the resumable window state means only the in-flight window is
-        # redone, deduped on merge, so this is self-recovering rather than a tracked-exception-worthy
-        # failure.
+        # `_report_rows` streams the report CSV while it yields rows (see gladly.py), so a stall in
+        # Gladly's report generation past REQUEST_TIMEOUT_SECONDS raises the bare urllib3
+        # read-timeout mid-stream, after `generate_report`'s own retry-on-`requests.ReadTimeout` has
+        # already returned a response, so it isn't caught there either. Temporal's activity retry
+        # regenerates the report and re-streams it; the resumable window state means only the
+        # in-flight window is redone, deduped on merge, so this is self-recovering rather than a
+        # tracked-exception-worthy failure.
         return {"Read timed out"}
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gladly/tests/test_gladly.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gladly/tests/test_gladly.py
@@ -12,6 +12,7 @@ import requests
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.gladly.gladly import (
     CHUNK_SIZE,
+    GladlyReportHeaderError,
     GladlyResumeConfig,
     GladlyRetryableError,
     _base_url,
@@ -635,7 +636,11 @@ class TestGetReportRows:
     @freeze_time("2024-03-15T10:00:00Z")
     @mock.patch(f"{_MODULE}.make_tracked_session")
     def test_large_report_windows_are_chunked(self, mock_session):
-        csv_text = "Conversation ID\n" + "\n".join(f"conv-{i}" for i in range(CHUNK_SIZE + 1)) + "\n"
+        csv_text = (
+            "Timestamp,Conversation ID\n"
+            + "\n".join(f"2024-03-15T09:00:00.000Z,conv-{i}" for i in range(CHUNK_SIZE + 1))
+            + "\n"
+        )
         mock_session.return_value.post.side_effect = [_csv_response(csv_text)]
 
         manager = _make_manager(GladlyResumeConfig(last_report_window_end="2024-03-15"))
@@ -647,13 +652,59 @@ class TestGetReportRows:
     @mock.patch(f"{_MODULE}.REPORT_ROW_WARNING_THRESHOLD", 2)
     @mock.patch(f"{_MODULE}.make_tracked_session")
     def test_windows_near_the_report_row_cap_log_a_truncation_warning(self, mock_session):
-        mock_session.return_value.post.side_effect = [_csv_response("Conversation ID\nconv-1\nconv-2\n")]
+        mock_session.return_value.post.side_effect = [
+            _csv_response(
+                "Timestamp,Conversation ID\n2024-03-15T09:00:00.000Z,conv-1\n2024-03-15T10:00:00.000Z,conv-2\n"
+            )
+        ]
 
         manager = _make_manager(GladlyResumeConfig(last_report_window_end="2024-03-15"))
         logger = mock.MagicMock()
         list(get_rows("myorg", "agent@x.com", "token", "conversation_timestamps", logger, manager))
 
         logger.warning.assert_called_once()
+
+    @freeze_time("2024-03-15T10:00:00Z")
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_blank_lines_before_the_header_do_not_erase_the_columns(self, mock_session):
+        mock_session.return_value.post.side_effect = [
+            _csv_response("\r\n\r\nTimestamp,Contact ID\r\n2024-03-15T09:00:00.000Z,ct-1\r\n")
+        ]
+
+        manager = _make_manager(GladlyResumeConfig(last_report_window_end="2024-03-15"))
+        batches = list(get_rows("myorg", "agent@x.com", "token", "contact_timestamps", mock.MagicMock(), manager))
+
+        flat = [row for batch in batches for row in batch]
+        assert [(row["timestamp"], row["contact_id"]) for row in flat] == [("2024-03-15T09:00:00.000Z", "ct-1")]
+
+    @freeze_time("2024-03-15T10:00:00Z")
+    @pytest.mark.parametrize(
+        "endpoint,body",
+        [
+            ("contact_timestamps", '[\n{"timestamp":"2024-03-15T09:00:00.000Z"}\n]\n'),
+            ("contact_timestamps", "<html>\n<body>\nGladly is unavailable\n</body>\n</html>\n"),
+            ("contact_timestamps", "Event Type,Contact ID\nCONTACT/STARTED,ct-1\n"),
+            ("conversations", "Conversation ID,Status\nconv-1,OPEN\n"),
+        ],
+        ids=["json_body", "html_body", "cursor_column_renamed", "primary_key_column_renamed"],
+    )
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_a_report_missing_the_columns_it_syncs_on_fails_at_the_source(self, mock_session, endpoint, body):
+        mock_session.return_value.post.side_effect = [_csv_response(body)]
+
+        manager = _make_manager(GladlyResumeConfig(last_report_window_end="2024-03-15"))
+        with pytest.raises(GladlyReportHeaderError, match="missing required columns"):
+            list(get_rows("myorg", "agent@x.com", "token", endpoint, mock.MagicMock(), manager))
+
+    @freeze_time("2024-03-15T10:00:00Z")
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_a_whitespace_only_body_is_treated_as_an_empty_window(self, mock_session):
+        mock_session.return_value.post.side_effect = [_csv_response("\r\n")]
+
+        manager = _make_manager(GladlyResumeConfig(last_report_window_end="2024-03-15"))
+        batches = list(get_rows("myorg", "agent@x.com", "token", "contact_timestamps", mock.MagicMock(), manager))
+
+        assert batches == []
 
 
 class TestGladlySourceResponse:


### PR DESCRIPTION
## Problem

A Gladly report table stops syncing, and the error tells the customer to pick a different incremental field. No valid choice exists.

- A report body that is not the promised CSV still parses. `csv.DictReader` takes its first line as the header.
- `_normalize_report_column` maps that line to an empty name, so the row loop drops every column.
- The rows reach the pipeline carrying only the injected `_row_id`. `get_incremental_field_value` then fails, and its message lists no usable column.
- A leading blank line in an otherwise valid report CSV produces the same result.

## Changes

- `_report_rows` now requires the columns the stream is keyed on: the incremental cursor, plus the primary key when the endpoint does not inject `_row_id`. A header missing them raises `GladlyReportHeaderError`.
- A guard that rejects only a header with zero usable columns is not enough. An HTML error page yields one junk column named `html` and passes that test.
- `_report_csv_lines` drops blank lines before the header, so a leading blank line no longer erases every column.
- The source logs the header row before it raises. A registered non-retryable message replaces the exception text downstream, so this is the only record of the real shape.
- `GladlySource.get_non_retryable_errors` registers the new message, so the schema pauses with guidance instead of replaying the same body.
- A comment in `get_retryable_errors` still described reading off `response.raw`. #80717 replaced that with `iter_content`, so I corrected it.

## How did you test this code?

Automated tests only. I ran the Gladly suite and `pipelines/common/test/test_load.py` locally.

- New: a leading blank line keeps the real columns. Catches a regression where the skip is removed and rows carry only `_row_id` again.
- New: four parameterized cases where the header lacks a key column (JSON body, HTML body, renamed cursor, renamed primary key). Catches a regression where a malformed body syncs column-less rows and fails downstream.
- New: a whitespace-only body stays an empty window. The blank-line skip changes `fieldnames` from `[]` to `None` for that input, so this locks the empty-window path.
- Changed: two existing fixtures used a header without `Timestamp`. The new guard correctly rejects them, so the fixtures now carry the cursor column.
- Not checked: I could not call the Gladly API, so I do not know which malformed body shape a real report returns. The new log line records it on the next failure.
- Not run: mypy. `ci:preflight` reported it as advisory for this diff.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tool: Claude Code (Opus 5). Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.

The work started from a report sync that failed in production. No customer material reaches this diff. I wrote every test fixture from the report's documented column list, with the failing sync's data closed.

The first version of the guard rejected only a header where every column normalized away. An HTML body defeated it in test, because `<html>` normalizes to a valid column name. The guard then became the required-column check that shipped.
