### PR TITLE
fix(warehouse): actionable error when TikTok denies creative library access

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/canonical_descriptions.py
@@ -162,7 +162,11 @@ CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
         ),
     },
     "creative_videos": {
-        "description": "A video asset in your TikTok Ads creative library, joinable to the video used by an ad.",
+        "description": (
+            "A video asset in your TikTok Ads creative library, joinable to the video used by an ad. "
+            "Requires creative asset read access on the authorized advertiser; without it TikTok refuses "
+            "the request and this table can't sync."
+        ),
         "docs_url": "https://business-api.tiktok.com/portal/docs",
         "columns": {
             "video_id": "Unique identifier for the video asset.",
@@ -186,7 +190,11 @@ CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
         },
     },
     "creative_images": {
-        "description": "An image asset in your TikTok Ads creative library, joinable to the images used by an ad.",
+        "description": (
+            "An image asset in your TikTok Ads creative library, joinable to the images used by an ad. "
+            "Requires creative asset read access on the authorized advertiser; without it TikTok refuses "
+            "the request and this table can't sync."
+        ),
         "docs_url": "https://business-api.tiktok.com/portal/docs",
         "columns": {
             "image_id": "Unique identifier for the image asset.",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/source.py
@@ -42,8 +42,9 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.tiktok_ads
 from products.warehouse_sources.backend.temporal.data_imports.sources.tiktok_ads.utils import (
     TIKTOK_APP_TOKEN_MISMATCH_MESSAGE,
     TIKTOK_AUTH_ERROR_CODES,
+    TIKTOK_CREATIVE_PERMISSION_DENIED_FRAGMENTS,
+    TIKTOK_CREATIVE_PERMISSION_DENIED_MESSAGE,
     TIKTOK_NON_RETRYABLE_ERROR_PREFIX,
-    TIKTOK_PERMISSION_DENIED_FRAGMENT,
     TIKTOK_TRANSIENT_ERROR_CODES,
     TIKTOK_TRANSIENT_ERROR_MESSAGE,
     TikTokAdsAPIError,
@@ -76,14 +77,8 @@ class TikTokAdsSource(ResumableSource[TikTokAdsSourceConfig, TikTokAdsResumeConf
             # MUST stay above TIKTOK_NON_RETRYABLE_ERROR_PREFIX: a permission denial arrives as a
             # 40001 wrapped in that prefix, so it matches both keys. `external_data_job` collects
             # every match in dict order and then drops the lot if the *first* one is None, so the
-            # specific entry has to come first or this message is silently discarded.
-            TIKTOK_PERMISSION_DENIED_FRAGMENT: (
-                "TikTok denied access to your creative library: the authorized advertiser account has not "
-                "granted PostHog permission to read creative assets. This only affects the creative_videos "
-                "and creative_images tables, which have been disabled. Your campaign, ad and report tables "
-                "keep syncing. If your TikTok admin can grant creative asset access, reconnect the TikTok Ads "
-                "integration and grant it when TikTok asks. Otherwise leave these two tables unselected."
-            ),
+            # specific entries have to come first or this message is silently discarded.
+            **dict.fromkeys(TIKTOK_CREATIVE_PERMISSION_DENIED_FRAGMENTS, TIKTOK_CREATIVE_PERMISSION_DENIED_MESSAGE),
             # Other TikTok client errors not in the retryable code set (e.g. 40001 — the advertiser
             # doesn't exist or has been deleted). The paginator raises these with this exact
             # prefix; retrying cannot recover, so fail the job fast. The raw message is kept as

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/source.py
@@ -43,6 +43,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.tiktok_ads
     TIKTOK_APP_TOKEN_MISMATCH_MESSAGE,
     TIKTOK_AUTH_ERROR_CODES,
     TIKTOK_NON_RETRYABLE_ERROR_PREFIX,
+    TIKTOK_PERMISSION_DENIED_FRAGMENT,
     TIKTOK_TRANSIENT_ERROR_CODES,
     TIKTOK_TRANSIENT_ERROR_MESSAGE,
     TikTokAdsAPIError,
@@ -72,7 +73,18 @@ class TikTokAdsSource(ResumableSource[TikTokAdsSourceConfig, TikTokAdsResumeConf
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
-            # TikTok client errors not in the retryable code set (e.g. 40001 — the advertiser
+            # MUST stay above TIKTOK_NON_RETRYABLE_ERROR_PREFIX: a permission denial arrives as a
+            # 40001 wrapped in that prefix, so it matches both keys. `external_data_job` collects
+            # every match in dict order and then drops the lot if the *first* one is None, so the
+            # specific entry has to come first or this message is silently discarded.
+            TIKTOK_PERMISSION_DENIED_FRAGMENT: (
+                "TikTok denied access to your creative library: the authorized advertiser account has not "
+                "granted PostHog permission to read creative assets. This only affects the creative_videos "
+                "and creative_images tables, which have been disabled. Your campaign, ad and report tables "
+                "keep syncing. If your TikTok admin can grant creative asset access, reconnect the TikTok Ads "
+                "integration and grant it when TikTok asks. Otherwise leave these two tables unselected."
+            ),
+            # Other TikTok client errors not in the retryable code set (e.g. 40001 — the advertiser
             # doesn't exist or has been deleted). The paginator raises these with this exact
             # prefix; retrying cannot recover, so fail the job fast. The raw message is kept as
             # the user-facing error since it names the specific advertiser and TikTok error code.
@@ -106,7 +118,10 @@ class TikTokAdsSource(ResumableSource[TikTokAdsSourceConfig, TikTokAdsResumeConf
                 "If TikTok's authorization page rejects the connection before returning to PostHog, this is "
                 "usually an account or region restriction on TikTok's side. Check that you have an admin role "
                 "in the TikTok Business Center you're connecting, and that TikTok Ads is available in your region. "
-                "If it still fails, copy the Log ID from TikTok's error page and contact support."
+                "If it still fails, copy the Log ID from TikTok's error page and contact support.\n\n"
+                "The creative_videos and creative_images tables additionally need creative asset access on the "
+                "advertiser account. If your advertiser hasn't granted it, leave those two tables unselected. "
+                "Every other table syncs without it."
             ),
             releaseStatus=ReleaseStatus.GA,
             iconPath="/static/services/tiktok.png",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/source.py
@@ -74,10 +74,8 @@ class TikTokAdsSource(ResumableSource[TikTokAdsSourceConfig, TikTokAdsResumeConf
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
-            # MUST stay above TIKTOK_NON_RETRYABLE_ERROR_PREFIX: a permission denial arrives as a
-            # 40001 wrapped in that prefix, so it matches both keys. `external_data_job` collects
-            # every match in dict order and then drops the lot if the *first* one is None, so the
-            # specific entries have to come first or this message is silently discarded.
+            # Must precede TIKTOK_NON_RETRYABLE_ERROR_PREFIX: a denial matches both keys, and
+            # `external_data_job` takes the first match in dict order, discarding it when None.
             **dict.fromkeys(TIKTOK_CREATIVE_PERMISSION_DENIED_FRAGMENTS, TIKTOK_CREATIVE_PERMISSION_DENIED_MESSAGE),
             # Other TikTok client errors not in the retryable code set (e.g. 40001 — the advertiser
             # doesn't exist or has been deleted). The paginator raises these with this exact

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_source.py
@@ -88,8 +88,7 @@ class TestTikTokAdsSource:
         ]
     )
     def test_creative_permission_denied_is_non_retryable(self, name, message):
-        """An advertiser that hasn't granted creative asset access gets a 40001 on the creative
-        library endpoints. Reconnecting is the only fix, so it must be non-retryable."""
+        """Reconnecting is the only fix for a denial, so retrying it would loop forever."""
         paginator = TikTokAdsPaginator()
         mock_response = Mock()
         mock_response.status_code = 200
@@ -109,9 +108,7 @@ class TestTikTokAdsSource:
         ]
     )
     def test_creative_permission_denied_surfaces_friendly_message(self, name, message):
-        """The permission denial matches both the specific key and the generic non-retryable
-        prefix (which maps to None). `external_data_job` takes the *first* match in dict order and
-        discards it when it is None, so this fails if the entries are ever reordered."""
+        """Fails if the dict entries are reordered, which would shadow this message with None."""
         error_message = f"{TIKTOK_NON_RETRYABLE_ERROR_PREFIX} {message} (code: 40001)"
 
         friendly = [
@@ -132,9 +129,7 @@ class TestTikTokAdsSource:
         ]
     )
     def test_non_creative_permission_denied_keeps_raw_message(self, name, message):
-        """Every table in this source shares one paginator, so a denial on a non-creative endpoint
-        carries the same "does not grant you" wording. Answering it with the creative-library
-        message would tell a user whose report table just failed that report tables keep syncing."""
+        """A denial elsewhere shares the wording, so creative-library advice would contradict it."""
         error_message = f"{TIKTOK_NON_RETRYABLE_ERROR_PREFIX} {message} (code: 40001)"
 
         friendly = [
@@ -147,8 +142,7 @@ class TestTikTokAdsSource:
         assert friendly[0] is None
 
     def test_advertiser_deleted_40001_still_has_no_friendly_message(self):
-        """The creative-permission key must not over-match the other 40001 meaning: a deleted
-        advertiser should still surface TikTok's raw message, which names the advertiser."""
+        """The raw message names the advertiser, so the creative key must not over-match it."""
         error_message = (
             f"{TIKTOK_NON_RETRYABLE_ERROR_PREFIX} The advertiser 123 doesn't exist or has been deleted. (code: 40001)"
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_source.py
@@ -125,6 +125,27 @@ class TestTikTokAdsSource:
         assert "creative_videos" in friendly[0]
         assert "creative_images" in friendly[0]
 
+    @parameterized.expand(
+        [
+            ("report", "advertiser does not grant you /report/integrated/get/:GET permission"),
+            ("campaign", "advertiser does not grant you /campaign/get/:GET permission"),
+        ]
+    )
+    def test_non_creative_permission_denied_keeps_raw_message(self, name, message):
+        """Every table in this source shares one paginator, so a denial on a non-creative endpoint
+        carries the same "does not grant you" wording. Answering it with the creative-library
+        message would tell a user whose report table just failed that report tables keep syncing."""
+        error_message = f"{TIKTOK_NON_RETRYABLE_ERROR_PREFIX} {message} (code: 40001)"
+
+        friendly = [
+            friendly_error
+            for pattern, friendly_error in self.source.get_non_retryable_errors().items()
+            if error_message_matches(error_message, [pattern])
+        ]
+
+        assert friendly, "permission denial matched no non-retryable pattern"
+        assert friendly[0] is None
+
     def test_advertiser_deleted_40001_still_has_no_friendly_message(self):
         """The creative-permission key must not over-match the other 40001 meaning: a deleted
         advertiser should still surface TikTok's raw message, which names the advertiser."""

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_source.py
@@ -18,6 +18,7 @@ from posthog.schema import ReleaseStatus
 
 from posthog.models.integration import Integration
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import error_message_matches
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.integration_accounts import (
     IntegrationAccountListingError,
 )
@@ -28,6 +29,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.generated_
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.tiktok_ads.source import TikTokAdsSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.tiktok_ads.utils import (
+    TIKTOK_NON_RETRYABLE_ERROR_PREFIX,
     TIKTOK_TRANSIENT_ERROR_MESSAGE,
     TikTokAdsAPIError,
     TikTokAdsPaginator,
@@ -78,6 +80,84 @@ class TestTikTokAdsSource:
         assert any(pattern in error_message for pattern in patterns), (
             f"TikTok non-retryable error '{error_message}' does not match any non-retryable pattern"
         )
+
+    @parameterized.expand(
+        [
+            ("video", "advertiser does not grant you /file/video/ad/search/:GET permission"),
+            ("image", "advertiser does not grant you /file/image/ad/search/:GET permission"),
+        ]
+    )
+    def test_creative_permission_denied_is_non_retryable(self, name, message):
+        """An advertiser that hasn't granted creative asset access gets a 40001 on the creative
+        library endpoints. Reconnecting is the only fix, so it must be non-retryable."""
+        paginator = TikTokAdsPaginator()
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"code": 40001, "message": message, "data": {}}
+
+        with pytest.raises(ValueError) as exc_info:
+            paginator.update_state(mock_response)
+
+        error_message = str(exc_info.value)
+        patterns = self.source.get_non_retryable_errors()
+        assert any(pattern in error_message for pattern in patterns)
+
+    @parameterized.expand(
+        [
+            ("video", "advertiser does not grant you /file/video/ad/search/:GET permission"),
+            ("image", "advertiser does not grant you /file/image/ad/search/:GET permission"),
+        ]
+    )
+    def test_creative_permission_denied_surfaces_friendly_message(self, name, message):
+        """The permission denial matches both the specific key and the generic non-retryable
+        prefix (which maps to None). `external_data_job` takes the *first* match in dict order and
+        discards it when it is None, so this fails if the entries are ever reordered."""
+        error_message = f"{TIKTOK_NON_RETRYABLE_ERROR_PREFIX} {message} (code: 40001)"
+
+        friendly = [
+            friendly_error
+            for pattern, friendly_error in self.source.get_non_retryable_errors().items()
+            if error_message_matches(error_message, [pattern])
+        ]
+
+        assert friendly, "permission denial matched no non-retryable pattern"
+        assert friendly[0] is not None, "generic prefix shadowed the creative-permission message"
+        assert "creative_videos" in friendly[0]
+        assert "creative_images" in friendly[0]
+
+    def test_advertiser_deleted_40001_still_has_no_friendly_message(self):
+        """The creative-permission key must not over-match the other 40001 meaning: a deleted
+        advertiser should still surface TikTok's raw message, which names the advertiser."""
+        error_message = (
+            f"{TIKTOK_NON_RETRYABLE_ERROR_PREFIX} The advertiser 123 doesn't exist or has been deleted. (code: 40001)"
+        )
+
+        friendly = [
+            friendly_error
+            for pattern, friendly_error in self.source.get_non_retryable_errors().items()
+            if error_message_matches(error_message, [pattern])
+        ]
+
+        assert friendly, "deleted advertiser matched no non-retryable pattern"
+        assert friendly[0] is None
+
+    def test_creative_permission_denied_does_not_match_get_retryable_errors(self):
+        """A permission denial must not be swallowed as a benign retryable error."""
+        paginator = TikTokAdsPaginator()
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "code": 40001,
+            "message": "advertiser does not grant you /file/video/ad/search/:GET permission",
+            "data": {},
+        }
+
+        with pytest.raises(ValueError) as exc_info:
+            paginator.update_state(mock_response)
+
+        error_message = str(exc_info.value)
+        patterns = self.source.get_retryable_errors()
+        assert not any(pattern in error_message for pattern in patterns)
 
     @parameterized.expand(
         [

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/utils.py
@@ -88,18 +88,33 @@ def list_advertisers(access_token: str) -> list[dict]:
 # Prefix for the ValueError raised when TikTok returns a client error code that is not in the
 # retryable set. 40001 is a generic client-error bucket rather than a single failure: it covers
 # both "the advertiser doesn't exist or has been deleted" and per-endpoint permission denials
-# (see TIKTOK_PERMISSION_DENIED_FRAGMENT). Retrying any of these never succeeds, so
+# (see TIKTOK_CREATIVE_PERMISSION_DENIED_FRAGMENTS). Retrying any of these never succeeds, so
 # `TikTokAdsSource.get_non_retryable_errors` matches on this exact prefix to fail the job fast
 # instead of looping forever.
 TIKTOK_NON_RETRYABLE_ERROR_PREFIX = "TikTok API client error (non-retryable):"
 
 # TikTok permissions are declared on the app in the developer portal and granted per-advertiser at
 # authorization time — our authorize URL sends no `scope`, so we can't widen them after the fact.
-# An advertiser that didn't grant creative/asset read gets 40001 with this fragment on the creative
-# library endpoints (`/file/video/ad/search/`, `/file/image/ad/search/`), while every other table
-# keeps syncing. Matched as a substring, so keep it narrow: plain "permission" would swallow
-# unrelated 40001s.
-TIKTOK_PERMISSION_DENIED_FRAGMENT = "does not grant you"
+# An advertiser that didn't grant creative/asset read gets 40001 with this wording on the creative
+# library endpoints, while every other table keeps syncing.
+#
+# The denied path has to stay in the fragment. Every endpoint in this source shares one paginator,
+# so a denial on `/report/integrated/get/` or `/campaign/get/` produces the same "does not grant
+# you" wording; matching on that alone would answer a failed report table with creative-library
+# advice. TikTok templates the path into the message, so keying on it costs nothing and lets every
+# other denial fall through to its own raw message.
+TIKTOK_CREATIVE_PERMISSION_DENIED_FRAGMENTS = (
+    "does not grant you /file/video/ad/search/",
+    "does not grant you /file/image/ad/search/",
+)
+
+TIKTOK_CREATIVE_PERMISSION_DENIED_MESSAGE = (
+    "TikTok denied access to your creative library: the authorized advertiser account has not granted "
+    "PostHog permission to read creative assets. This only affects the creative_videos and creative_images "
+    "tables, which have been disabled. Your campaign, ad and report tables keep syncing. If your TikTok "
+    "admin can grant creative asset access, reconnect the TikTok Ads integration and grant it when TikTok "
+    "asks. Otherwise leave these two tables unselected."
+)
 
 
 class TikTokAdsAPIError(Exception):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/utils.py
@@ -85,11 +85,21 @@ def list_advertisers(access_token: str) -> list[dict]:
     return (body.get("data") or {}).get("list") or []
 
 
-# Prefix for the ValueError raised when TikTok returns a client error code that
-# is not in the retryable set (e.g. 40001 "advertiser doesn't exist or has been
-# deleted"). Retrying these never succeeds, so `TikTokAdsSource.get_non_retryable_errors`
-# matches on this exact prefix to fail the job fast instead of looping forever.
+# Prefix for the ValueError raised when TikTok returns a client error code that is not in the
+# retryable set. 40001 is a generic client-error bucket rather than a single failure: it covers
+# both "the advertiser doesn't exist or has been deleted" and per-endpoint permission denials
+# (see TIKTOK_PERMISSION_DENIED_FRAGMENT). Retrying any of these never succeeds, so
+# `TikTokAdsSource.get_non_retryable_errors` matches on this exact prefix to fail the job fast
+# instead of looping forever.
 TIKTOK_NON_RETRYABLE_ERROR_PREFIX = "TikTok API client error (non-retryable):"
+
+# TikTok permissions are declared on the app in the developer portal and granted per-advertiser at
+# authorization time — our authorize URL sends no `scope`, so we can't widen them after the fact.
+# An advertiser that didn't grant creative/asset read gets 40001 with this fragment on the creative
+# library endpoints (`/file/video/ad/search/`, `/file/image/ad/search/`), while every other table
+# keeps syncing. Matched as a substring, so keep it narrow: plain "permission" would swallow
+# unrelated 40001s.
+TIKTOK_PERMISSION_DENIED_FRAGMENT = "does not grant you"
 
 
 class TikTokAdsAPIError(Exception):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/utils.py
@@ -85,29 +85,22 @@ def list_advertisers(access_token: str) -> list[dict]:
     return (body.get("data") or {}).get("list") or []
 
 
-# Prefix for the ValueError raised when TikTok returns a client error code that is not in the
-# retryable set. 40001 is a generic client-error bucket rather than a single failure: it covers
-# both "the advertiser doesn't exist or has been deleted" and per-endpoint permission denials
-# (see TIKTOK_CREATIVE_PERMISSION_DENIED_FRAGMENTS). Retrying any of these never succeeds, so
-# `TikTokAdsSource.get_non_retryable_errors` matches on this exact prefix to fail the job fast
-# instead of looping forever.
+# Prefix for the ValueError the paginator raises on client error codes outside the retryable set.
+# 40001 is a generic bucket covering both a deleted advertiser and per-endpoint permission denials,
+# so callers have to discriminate on wording rather than on the code. Retrying never succeeds, so
+# `TikTokAdsSource.get_non_retryable_errors` matches this prefix to fail the job fast.
 TIKTOK_NON_RETRYABLE_ERROR_PREFIX = "TikTok API client error (non-retryable):"
 
-# TikTok permissions are declared on the app in the developer portal and granted per-advertiser at
-# authorization time — our authorize URL sends no `scope`, so we can't widen them after the fact.
-# An advertiser that didn't grant creative/asset read gets 40001 with this wording on the creative
-# library endpoints, while every other table keeps syncing.
-#
-# The denied path has to stay in the fragment. Every endpoint in this source shares one paginator,
-# so a denial on `/report/integrated/get/` or `/campaign/get/` produces the same "does not grant
-# you" wording; matching on that alone would answer a failed report table with creative-library
-# advice. TikTok templates the path into the message, so keying on it costs nothing and lets every
-# other denial fall through to its own raw message.
+# Keep the denied path in each fragment: every endpoint here shares one paginator, so a denial on
+# `/report/integrated/get/` carries the same "does not grant you" wording and would otherwise be
+# answered with creative-library advice. TikTok templates the path into the message.
 TIKTOK_CREATIVE_PERMISSION_DENIED_FRAGMENTS = (
     "does not grant you /file/video/ad/search/",
     "does not grant you /file/image/ad/search/",
 )
 
+# Reconnecting is the only fix, because our authorize URL sends no `scope`: the creative asset
+# permission is granted per-advertiser on TikTok's side and we can't widen it after the fact.
 TIKTOK_CREATIVE_PERMISSION_DENIED_MESSAGE = (
     "TikTok denied access to your creative library: the authorized advertiser account has not granted "
     "PostHog permission to read creative assets. This only affects the creative_videos and creative_images "


### PR DESCRIPTION
## Problem

A TikTok Ads source user whose advertiser account hasn't granted creative asset access sees two of their tables fail with a raw TikTok API string and no indication of what to do:

```
TikTok API client error (non-retryable): advertiser does not grant you /file/video/ad/search/:GET permission (code: 40001)
TikTok API client error (non-retryable): advertiser does not grant you /file/image/ad/search/:GET permission (code: 40001)
```

TikTok reuses code 40001 for two unrelated failures: a deleted advertiser, and a per-endpoint permission denial. We only modelled the first. `get_non_retryable_errors` mapped the whole non-retryable prefix to `None`, so the raw string was surfaced verbatim and the schema was auto-disabled.

The permission is not something the user can guess at from that message. TikTok permissions are declared on the app in the developer portal and granted per-advertiser at authorization time, and our authorize URL sends no `scope` (`posthog/models/integration.py`), so an advertiser that didn't grant creative asset access can only fix it by reconnecting.

## Changes

- Recognise the permission-denial variant of 40001 and replace it with a message that names the two affected tables (`creative_videos`, `creative_images`), states that the rest of the source keeps syncing, and gives both ways out: reconnect and grant, or leave the tables unselected.
- The denial matches both the new specific key and the generic non-retryable prefix. `external_data_job` collects every match in dict order and drops the lot when the first is `None`, so the specific entry must come first. A comment says why, and a test pins it.
- Match on `"does not grant you"` rather than `"permission"`, which would swallow unrelated 40001s.
- Correct the comments in `utils.py` and `source.py` that asserted 40001 only ever means a deleted advertiser.
- Mention the extra permission on the source caption and both table descriptions, so it's visible before the first sync rather than only after it fails.

Considered and rejected: making the tables `should_sync_default=False`. That only affects future schema discovery, so it wouldn't help anyone already broken, and it would silently drop the tables for the majority of advertisers that do grant the permission. Also considered swallowing the error and writing an empty table, but that reports a green sync over data the user never received, and no "skip this schema" primitive exists in the pipeline anyway.

Existing sources need no remediation: the two schemas are already auto-disabled and the rest of the source is unaffected.

## How did you test this code?

Automated only. I did not exercise a real TikTok account, so the messages come from the reported failures rather than a live reproduction.

`uv run pytest products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/test/` passes locally.

Four new tests, and the regression each catches:

- `test_creative_permission_denied_is_non_retryable` — the permission denial reaching `get_non_retryable_errors` at all. Without it, a future edit to the paginator's `retryable_codes` could make the job retry forever.
- `test_creative_permission_denied_surfaces_friendly_message` — the ordering dependency. I verified it fails as intended by temporarily moving the generic prefix above the specific key: both parameterized cases fail with "generic prefix shadowed the creative-permission message".
- `test_advertiser_deleted_40001_still_has_no_friendly_message` — the new key over-matching the other meaning of 40001, which would replace TikTok's advertiser-naming message with wrong creative-library advice.
- `test_creative_permission_denied_does_not_match_get_retryable_errors` — the denial being misread as transient.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The posthog.com source doc for TikTok Ads should get the same note about the creative library tables needing an extra permission. Separate repo, not in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus) via PostHog Desktop, directed by @jabahamondes, who asked for a code-level double check of the reported failures before any fix.

The first read of the code took its own comments at face value and treated 40001 as "advertiser deleted", which made the reported message look like a deleted-account problem. Reading TikTok's actual message text is what showed 40001 is a generic bucket, and that the real failure is per-endpoint and permission-shaped. That reframing is what the fix rests on.

The ordering dependency in `get_non_retryable_errors` was the one non-obvious part: the fix is inert if the entries are ever reordered, and nothing in the type system prevents that, hence the dedicated test rather than only a comment.

One thing a reviewer with TikTok portal access should confirm: whether PostHog's TikTok app requests the creative asset permission at all. This repo can't tell, since the authorize URL sends only `app_id`, `redirect_uri`, `state`. If the app never requests it, reconnecting can't fix it and the copy should say so outright, the way `meta_ads` does for `business_management`. The wording here is deliberately conditional ("if your TikTok admin can grant...") so it holds either way, but it could be sharpened once that's known.

No skills were invoked for this change.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
