### PR TITLE
fix(desktop/notifications): show the real unread count on the dock badge

### DIFF
--- a/products/desktop/apps/code/src/main/platform-adapters/electron-notifier.ts
+++ b/products/desktop/apps/code/src/main/platform-adapters/electron-notifier.ts
@@ -39,11 +39,9 @@ export class ElectronNotifier implements INotifier {
     notification.show();
   }
 
-  public setUnreadIndicator(on: boolean): void {
-    if (on) {
-      app.dock?.setBadge("•");
-    } else {
-      app.dock?.setBadge("");
+  public setBadgeCount(count: number): void {
+    app.setBadgeCount(count);
+    if (count === 0) {
       this.mainWindow.getBrowserWindow()?.flashFrame(false);
     }
   }

--- a/products/desktop/apps/code/src/renderer/desktop-services.ts
+++ b/products/desktop/apps/code/src/renderer/desktop-services.ts
@@ -291,9 +291,9 @@ container.bind<INotifications>(NOTIFICATIONS_SERVICE).toConstantValue({
       notificationsLog.error("Failed to send notification", err);
     });
   },
-  showUnreadIndicator: () => {
-    hostTrpcClient.notification.showDockBadge.mutate().catch((err) => {
-      notificationsLog.error("Failed to show unread indicator", err);
+  setBadgeCount: (count) => {
+    hostTrpcClient.notification.setBadgeCount.mutate({ count }).catch((err) => {
+      notificationsLog.error("Failed to set badge count", err);
     });
   },
   requestAttention: () => {

--- a/products/desktop/apps/web/src/web-notifications.ts
+++ b/products/desktop/apps/web/src/web-notifications.ts
@@ -50,11 +50,16 @@ export const webNotifications: INotifications = {
 
   // Web equivalent of a dock badge: the Badging API (installed PWAs). No-op
   // where unsupported.
-  showUnreadIndicator(): void {
-    const setAppBadge = (
-      navigator as Navigator & { setAppBadge?: () => Promise<void> }
-    ).setAppBadge;
-    void setAppBadge?.call(navigator).catch(() => {});
+  setBadgeCount(count: number): void {
+    const nav = navigator as Navigator & {
+      setAppBadge?: (count?: number) => Promise<void>;
+      clearAppBadge?: () => Promise<void>;
+    };
+    if (count > 0) {
+      void nav.setAppBadge?.(count).catch(() => {});
+    } else {
+      void nav.clearAppBadge?.().catch(() => {});
+    }
   },
 
   // No browser equivalent of bouncing a dock icon.

--- a/products/desktop/packages/core/src/notification/notification.test.ts
+++ b/products/desktop/packages/core/src/notification/notification.test.ts
@@ -14,21 +14,17 @@ function makeLogger() {
 
 function createDeps(supported = true) {
   let lastNotify: NotifyOptions | undefined;
-  let focusHandler: (() => void) | undefined;
 
   const notifier: INotifier = {
     isSupported: vi.fn(() => supported),
     notify: vi.fn((options: NotifyOptions) => {
       lastNotify = options;
     }),
-    setUnreadIndicator: vi.fn(),
+    setBadgeCount: vi.fn(),
     requestAttention: vi.fn(),
   };
 
   const mainWindow = {
-    onFocus: vi.fn((handler: () => void) => {
-      focusHandler = handler;
-    }),
     isMinimized: vi.fn(() => false),
     restore: vi.fn(),
     focus: vi.fn(),
@@ -49,7 +45,6 @@ function createDeps(supported = true) {
     mainWindow,
     openTargetLink,
     getLastNotify: () => lastNotify,
-    getFocusHandler: () => focusHandler,
   };
 }
 
@@ -102,29 +97,14 @@ describe("NotificationService.send", () => {
 });
 
 describe("NotificationService dock badge", () => {
-  it("sets the unread indicator once and is idempotent", () => {
-    const { service, notifier } = createDeps();
-
-    service.showDockBadge();
-    service.showDockBadge();
-
-    expect(notifier.setUnreadIndicator).toHaveBeenCalledTimes(1);
-    expect(notifier.setUnreadIndicator).toHaveBeenCalledWith(true);
-  });
-
-  it("clears the badge on window focus only when a badge is set", () => {
-    const { service, notifier, getFocusHandler } = createDeps();
-    service.init();
-
-    getFocusHandler()?.();
-    expect(notifier.setUnreadIndicator).not.toHaveBeenCalled();
-
-    service.showDockBadge();
-    vi.mocked(notifier.setUnreadIndicator).mockClear();
-
-    getFocusHandler()?.();
-    expect(notifier.setUnreadIndicator).toHaveBeenCalledWith(false);
-  });
+  it.each([0, 1, 42])(
+    "forwards the badge count to the notifier unchanged (%i)",
+    (count) => {
+      const { service, notifier } = createDeps();
+      service.setBadgeCount(count);
+      expect(notifier.setBadgeCount).toHaveBeenCalledWith(count);
+    },
+  );
 
   it("requests attention when bouncing the dock", () => {
     const { service, notifier } = createDeps();

--- a/products/desktop/packages/core/src/notification/notification.ts
+++ b/products/desktop/packages/core/src/notification/notification.ts
@@ -9,13 +9,12 @@ import {
 } from "@posthog/platform/main-window";
 import type { NotificationTarget } from "@posthog/platform/notifications";
 import { type INotifier, NOTIFIER_SERVICE } from "@posthog/platform/notifier";
-import { inject, injectable, postConstruct } from "inversify";
+import { inject, injectable } from "inversify";
 import { OPEN_TARGET_LINK_SERVICE } from "../links/identifiers";
 import type { OpenTargetLinkService } from "../links/open-target-link";
 
 @injectable()
 export class NotificationService {
-  private hasBadge = false;
   private readonly log: ScopedLogger;
 
   constructor(
@@ -29,11 +28,6 @@ export class NotificationService {
     logger: RootLogger,
   ) {
     this.log = logger.scope("notification");
-  }
-
-  @postConstruct()
-  init(): void {
-    this.mainWindow.onFocus(() => this.clearDockBadge());
   }
 
   send(
@@ -74,22 +68,15 @@ export class NotificationService {
     this.log.info("Notification sent", { title, body, silent, target });
   }
 
-  showDockBadge(): void {
-    if (this.hasBadge) return;
-    this.hasBadge = true;
-    this.notifier.setUnreadIndicator(true);
-    this.log.info("Dock badge shown");
+  // `count` is the caller's source of truth (e.g. the renderer's unread task
+  // activity count) — this is a thin forward, not a running tally.
+  setBadgeCount(count: number): void {
+    this.notifier.setBadgeCount(count);
+    this.log.info("Dock badge count set", { count });
   }
 
   bounceDock(): void {
     this.notifier.requestAttention();
     this.log.info("Dock bounce triggered");
-  }
-
-  private clearDockBadge(): void {
-    if (!this.hasBadge) return;
-    this.hasBadge = false;
-    this.notifier.setUnreadIndicator(false);
-    this.log.info("Dock badge cleared");
   }
 }

--- a/products/desktop/packages/host-router/src/routers/notification.router.ts
+++ b/products/desktop/packages/host-router/src/routers/notification.router.ts
@@ -33,11 +33,13 @@ export const notificationRouter = router({
         .get<NotificationService>(NOTIFICATION_SERVICE)
         .send(input.title, input.body, input.silent, input.target),
     ),
-  showDockBadge: publicProcedure.mutation(({ ctx }) =>
-    ctx.container
-      .get<NotificationService>(NOTIFICATION_SERVICE)
-      .showDockBadge(),
-  ),
+  setBadgeCount: publicProcedure
+    .input(z.object({ count: z.number() }))
+    .mutation(({ ctx, input }) =>
+      ctx.container
+        .get<NotificationService>(NOTIFICATION_SERVICE)
+        .setBadgeCount(input.count),
+    ),
   bounceDock: publicProcedure.mutation(({ ctx }) =>
     ctx.container.get<NotificationService>(NOTIFICATION_SERVICE).bounceDock(),
   ),

--- a/products/desktop/packages/platform/src/notifications.ts
+++ b/products/desktop/packages/platform/src/notifications.ts
@@ -15,7 +15,7 @@ export interface NotificationOptions {
 
 export interface INotifications {
   notify(options: NotificationOptions): void;
-  showUnreadIndicator(): void;
+  setBadgeCount(count: number): void;
   requestAttention(): void;
 }
 

--- a/products/desktop/packages/platform/src/notifier.ts
+++ b/products/desktop/packages/platform/src/notifier.ts
@@ -8,7 +8,7 @@ export interface NotifyOptions {
 export interface INotifier {
   isSupported(): boolean;
   notify(options: NotifyOptions): void;
-  setUnreadIndicator(on: boolean): void;
+  setBadgeCount(count: number): void;
   requestAttention(): void;
 }
 

--- a/products/desktop/packages/ui/src/features/canvas/task-activity/dockBadge.contribution.test.ts
+++ b/products/desktop/packages/ui/src/features/canvas/task-activity/dockBadge.contribution.test.ts
@@ -1,0 +1,131 @@
+import type { INotifications } from "@posthog/platform/notifications";
+import type { TaskActivityPage } from "@posthog/shared/domain-types";
+import type {
+  INotificationSettings,
+  NotificationSettings,
+} from "@posthog/ui/features/notifications/identifiers";
+import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
+import { registerRendererStateStorage } from "@posthog/ui/shell/rendererStorage";
+import { type InfiniteData, QueryClient } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DockBadgeContribution } from "./dockBadge.contribution";
+import { TASK_ACTIVITY_QUERY_KEY } from "./taskActivityQuery";
+
+registerRendererStateStorage({
+  getItem: vi.fn().mockResolvedValue(null),
+  setItem: vi.fn().mockResolvedValue(undefined),
+  removeItem: vi.fn().mockResolvedValue(undefined),
+});
+
+function page(unreadCount: number): InfiniteData<TaskActivityPage> {
+  return {
+    pages: [{ results: [], unread_count: unreadCount }],
+    pageParams: [undefined],
+  };
+}
+
+// Mirrors the real host adapters (desktop-services.ts, web-notifications.ts):
+// dockBadgeNotifications is read live off the shared store, not a snapshot,
+// so tests can exercise the contribution's store subscription the same way
+// production settings toggles do.
+function makeSettings(): INotificationSettings {
+  const settings: Omit<NotificationSettings, "dockBadgeNotifications"> = {
+    desktopNotifications: true,
+    dockBounceNotifications: true,
+    completionSound: "meep",
+    completionVolume: 80,
+    scaleSoundWithTaskLength: false,
+    customSounds: [],
+  };
+  return {
+    get: () => ({
+      ...settings,
+      dockBadgeNotifications:
+        useSettingsStore.getState().dockBadgeNotifications,
+    }),
+  };
+}
+
+describe("DockBadgeContribution", () => {
+  let queryClient: QueryClient;
+  let notifications: INotifications;
+
+  beforeEach(() => {
+    queryClient = new QueryClient();
+    notifications = {
+      notify: vi.fn(),
+      setBadgeCount: vi.fn(),
+      requestAttention: vi.fn(),
+    };
+    useSettingsStore.setState({ dockBadgeNotifications: true });
+  });
+
+  it("pushes the cached unread count on start", () => {
+    queryClient.setQueryData(TASK_ACTIVITY_QUERY_KEY, page(3));
+
+    new DockBadgeContribution(
+      queryClient,
+      notifications,
+      makeSettings(),
+    ).start();
+
+    expect(notifications.setBadgeCount).toHaveBeenCalledWith(3);
+  });
+
+  it("pushes 0 when dock badge notifications are disabled, regardless of unread count", () => {
+    queryClient.setQueryData(TASK_ACTIVITY_QUERY_KEY, page(5));
+    useSettingsStore.setState({ dockBadgeNotifications: false });
+
+    new DockBadgeContribution(
+      queryClient,
+      notifications,
+      makeSettings(),
+    ).start();
+
+    expect(notifications.setBadgeCount).toHaveBeenCalledWith(0);
+  });
+
+  it("resyncs when the dockBadgeNotifications setting changes, not just on cache updates", () => {
+    queryClient.setQueryData(TASK_ACTIVITY_QUERY_KEY, page(3));
+    new DockBadgeContribution(
+      queryClient,
+      notifications,
+      makeSettings(),
+    ).start();
+    vi.mocked(notifications.setBadgeCount).mockClear();
+
+    useSettingsStore.setState({ dockBadgeNotifications: false });
+    expect(notifications.setBadgeCount).toHaveBeenCalledWith(0);
+
+    useSettingsStore.setState({ dockBadgeNotifications: true });
+    expect(notifications.setBadgeCount).toHaveBeenCalledWith(3);
+  });
+
+  it("updates the badge when the unread count changes after start", () => {
+    queryClient.setQueryData(TASK_ACTIVITY_QUERY_KEY, page(1));
+    new DockBadgeContribution(
+      queryClient,
+      notifications,
+      makeSettings(),
+    ).start();
+    vi.mocked(notifications.setBadgeCount).mockClear();
+
+    queryClient.setQueryData(TASK_ACTIVITY_QUERY_KEY, page(4));
+
+    expect(notifications.setBadgeCount).toHaveBeenCalledWith(4);
+  });
+
+  it("does not push again when the count hasn't changed", () => {
+    queryClient.setQueryData(TASK_ACTIVITY_QUERY_KEY, page(2));
+    new DockBadgeContribution(
+      queryClient,
+      notifications,
+      makeSettings(),
+    ).start();
+    vi.mocked(notifications.setBadgeCount).mockClear();
+
+    queryClient.setQueryData(TASK_ACTIVITY_QUERY_KEY, page(2));
+
+    expect(notifications.setBadgeCount).not.toHaveBeenCalled();
+  });
+});

--- a/products/desktop/packages/ui/src/features/canvas/task-activity/dockBadge.contribution.ts
+++ b/products/desktop/packages/ui/src/features/canvas/task-activity/dockBadge.contribution.ts
@@ -13,9 +13,11 @@ import {
   IMPERATIVE_QUERY_CLIENT,
   type ImperativeQueryClient,
 } from "@posthog/ui/shell/queryClient";
-import type { InfiniteData } from "@tanstack/react-query";
+import { hashKey, type InfiniteData } from "@tanstack/react-query";
 import { inject, injectable } from "inversify";
 import { TASK_ACTIVITY_QUERY_KEY } from "./taskActivityQuery";
+
+const TASK_ACTIVITY_QUERY_HASH = hashKey(TASK_ACTIVITY_QUERY_KEY);
 
 // Keeps the native dock/taskbar badge equal to the same unread count the
 // sidebar Activity badge shows, so the two never disagree. Reads the cache
@@ -36,11 +38,13 @@ export class DockBadgeContribution implements Contribution {
 
   start(): void {
     this.sync();
-    // Not filtered to the task-activity key: query identity is keyed by value
-    // (see TaskActivityContribution.apply's `find`), not by array reference,
-    // so a subscribe-time reference check on `event.query.queryKey` would be
-    // fragile. `sync` itself is a cheap cache lookup plus a number compare.
-    this.queryClient.getQueryCache().subscribe(() => this.sync());
+    // queryHash compares by value (unlike the queryKey array reference), so
+    // this only reacts to the task-activity query instead of scanning the
+    // whole cache on every unrelated query event in the app.
+    this.queryClient.getQueryCache().subscribe((event) => {
+      if (event.query.queryHash !== TASK_ACTIVITY_QUERY_HASH) return;
+      this.sync();
+    });
     // INotificationSettings only exposes a snapshot getter, with no way to
     // learn a setting changed, so toggling "dock badge notifications" here
     // wouldn't otherwise resync until the next unrelated cache write.
@@ -52,10 +56,9 @@ export class DockBadgeContribution implements Contribution {
   }
 
   private sync(): void {
-    const query = this.queryClient.getQueryCache().find({
-      queryKey: TASK_ACTIVITY_QUERY_KEY,
-      exact: true,
-    });
+    const query = this.queryClient
+      .getQueryCache()
+      .get(TASK_ACTIVITY_QUERY_HASH);
     const data = query?.state.data as
       | InfiniteData<TaskActivityPage>
       | undefined;

--- a/products/desktop/packages/ui/src/features/canvas/task-activity/dockBadge.contribution.ts
+++ b/products/desktop/packages/ui/src/features/canvas/task-activity/dockBadge.contribution.ts
@@ -1,0 +1,69 @@
+import type { Contribution } from "@posthog/di/contribution";
+import {
+  type INotifications,
+  NOTIFICATIONS_SERVICE,
+} from "@posthog/platform/notifications";
+import type { TaskActivityPage } from "@posthog/shared/domain-types";
+import {
+  type INotificationSettings,
+  NOTIFICATION_SETTINGS_PROVIDER,
+} from "@posthog/ui/features/notifications/identifiers";
+import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
+import {
+  IMPERATIVE_QUERY_CLIENT,
+  type ImperativeQueryClient,
+} from "@posthog/ui/shell/queryClient";
+import type { InfiniteData } from "@tanstack/react-query";
+import { inject, injectable } from "inversify";
+import { TASK_ACTIVITY_QUERY_KEY } from "./taskActivityQuery";
+
+// Keeps the native dock/taskbar badge equal to the same unread count the
+// sidebar Activity badge shows, so the two never disagree. Reads the cache
+// directly (rather than reacting to individual notify() calls) because the
+// count also has to fall as items are read, not just rise as they arrive.
+@injectable()
+export class DockBadgeContribution implements Contribution {
+  private lastPushedCount: number | undefined;
+
+  constructor(
+    @inject(IMPERATIVE_QUERY_CLIENT)
+    private readonly queryClient: ImperativeQueryClient,
+    @inject(NOTIFICATIONS_SERVICE)
+    private readonly notifications: INotifications,
+    @inject(NOTIFICATION_SETTINGS_PROVIDER)
+    private readonly settings: INotificationSettings,
+  ) {}
+
+  start(): void {
+    this.sync();
+    // Not filtered to the task-activity key: query identity is keyed by value
+    // (see TaskActivityContribution.apply's `find`), not by array reference,
+    // so a subscribe-time reference check on `event.query.queryKey` would be
+    // fragile. `sync` itself is a cheap cache lookup plus a number compare.
+    this.queryClient.getQueryCache().subscribe(() => this.sync());
+    // INotificationSettings only exposes a snapshot getter, with no way to
+    // learn a setting changed, so toggling "dock badge notifications" here
+    // wouldn't otherwise resync until the next unrelated cache write.
+    useSettingsStore.subscribe((state, prev) => {
+      if (state.dockBadgeNotifications !== prev.dockBadgeNotifications) {
+        this.sync();
+      }
+    });
+  }
+
+  private sync(): void {
+    const query = this.queryClient.getQueryCache().find({
+      queryKey: TASK_ACTIVITY_QUERY_KEY,
+      exact: true,
+    });
+    const data = query?.state.data as
+      | InfiniteData<TaskActivityPage>
+      | undefined;
+    const count = this.settings.get().dockBadgeNotifications
+      ? (data?.pages[0]?.unread_count ?? 0)
+      : 0;
+    if (count === this.lastPushedCount) return;
+    this.lastPushedCount = count;
+    this.notifications.setBadgeCount(count);
+  }
+}

--- a/products/desktop/packages/ui/src/features/canvas/task-activity/taskActivity.module.ts
+++ b/products/desktop/packages/ui/src/features/canvas/task-activity/taskActivity.module.ts
@@ -1,8 +1,11 @@
 import { CONTRIBUTION } from "@posthog/di/contribution";
 import { ContainerModule } from "inversify";
+import { DockBadgeContribution } from "./dockBadge.contribution";
 import { TaskActivityContribution } from "./taskActivity.contribution";
 
 export const taskActivityUiModule = new ContainerModule(({ bind }) => {
   bind(TaskActivityContribution).toSelf().inSingletonScope();
   bind(CONTRIBUTION).toService(TaskActivityContribution);
+  bind(DockBadgeContribution).toSelf().inSingletonScope();
+  bind(CONTRIBUTION).toService(DockBadgeContribution);
 });

--- a/products/desktop/packages/ui/src/features/notifications/notifications.test.ts
+++ b/products/desktop/packages/ui/src/features/notifications/notifications.test.ts
@@ -38,7 +38,7 @@ function makeBus(overrides?: {
   activeTarget?: NotificationTarget;
 }) {
   const notify = vi.fn();
-  const showUnreadIndicator = vi.fn();
+  const setBadgeCount = vi.fn();
   const requestAttention = vi.fn();
   const play = vi.mocked(playCompletionSound);
   play.mockClear();
@@ -64,12 +64,12 @@ function makeBus(overrides?: {
   };
 
   const bus = new NotificationBus(
-    { notify, showUnreadIndicator, requestAttention },
+    { notify, setBadgeCount, requestAttention },
     settingsPort,
     viewPort,
   );
 
-  return { bus, notify, showUnreadIndicator, requestAttention, play };
+  return { bus, notify, requestAttention, play };
 }
 
 describe("NotificationBus tier routing (via notifyPermissionRequest)", () => {
@@ -168,14 +168,13 @@ describe("notifyPromptComplete", () => {
 });
 
 describe("native tier settings gating (app unfocused)", () => {
-  it("skips the OS notification when desktopNotifications is off, still dings dock", () => {
-    const { bus, notify, showUnreadIndicator, requestAttention } = makeBus({
+  it("skips the OS notification when desktopNotifications is off, still bounces the dock", () => {
+    const { bus, notify, requestAttention } = makeBus({
       hasFocus: false,
       settings: { desktopNotifications: false },
     });
     bus.notifyPermissionRequest("My task", TASK_ID);
     expect(notify).not.toHaveBeenCalled();
-    expect(showUnreadIndicator).toHaveBeenCalledTimes(1);
     expect(requestAttention).toHaveBeenCalledTimes(1);
   });
 

--- a/products/desktop/packages/ui/src/features/notifications/notifications.ts
+++ b/products/desktop/packages/ui/src/features/notifications/notifications.ts
@@ -122,8 +122,8 @@ export class NotificationBus {
         target: descriptor.target,
       });
     }
-    if (settings.dockBadgeNotifications)
-      this.notifications.showUnreadIndicator();
+    // The dock/taskbar badge count is driven by DockBadgeContribution, which
+    // mirrors the real unread task-activity count; this bus never sets it.
     if (settings.dockBounceNotifications) this.notifications.requestAttention();
   }
 

--- a/products/desktop/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
@@ -848,12 +848,6 @@ function TestSection({
                     Notification that opens the latest task
                   </DropdownMenuItem>
                   <DropdownMenuItem
-                    onClick={() => notifications?.setBadgeCount(1)}
-                    disabled={nativeUnavailable}
-                  >
-                    Dock badge
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
                     onClick={() => notifications?.requestAttention()}
                     disabled={nativeUnavailable}
                   >

--- a/products/desktop/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
@@ -848,7 +848,7 @@ function TestSection({
                     Notification that opens the latest task
                   </DropdownMenuItem>
                   <DropdownMenuItem
-                    onClick={() => notifications?.showUnreadIndicator()}
+                    onClick={() => notifications?.setBadgeCount(1)}
                     disabled={nativeUnavailable}
                   >
                     Dock badge


### PR DESCRIPTION
## Problem

The desktop app's dock icon (macOS) shows a badge when a task needs input or finishes, but it's a static dot. A user can't tell how many things are waiting without opening the app, and the number doesn't match the unread count already shown on the sidebar Activity badge.

## Changes

- The dock badge now shows the real unread task-activity count, the same number the sidebar Activity badge shows, instead of a fixed dot.
- `INotifications.setBadgeCount(count)` replaces `showUnreadIndicator()` on the shared platform interface, threaded through to Electron's `app.setBadgeCount()` and the web host's Badging API.
- A new `DockBadgeContribution` keeps the dock badge and the Activity badge reading the same query-cache entry, so they can't drift apart, and reacts immediately when the "dock badge notifications" setting is toggled.
- `NotificationService` (main process) dropped its own running counter and focus-based clearing; the renderer's real count is now the single source of truth.

> [!NOTE]
> Scope is the native OS dock/taskbar badge only. The sidebar Activity dot has a separate, known bug (`SidebarCountBadge.tsx` ignores its own `count` prop) that was intentionally left out of this PR.

## How did you test this code?

Automated only, run locally:
- `vitest run notification` in `packages/core` (9 tests, including forwarding the badge count unchanged).
- `vitest run dockBadge taskActivity notifications` in `packages/ui` (13 tests, including a regression test for the settings-toggle case and dedup on unchanged counts).
- `tsc --noEmit` on `packages/platform`, `packages/core`, `packages/ui`, `apps/code`, `apps/web`: clean for every file this PR touches (some unrelated pre-existing errors remain in `@posthog/agent`-dependent files in this checkout, confirmed present without this diff too).
- Not run: manual verification of the actual Dock icon on macOS, since this sandbox has no GUI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via PostHog Desktop) implemented this from a conversation with the PR assignee. The design went through two iterations: the first pass made the dock badge a locally-incrementing counter reset on window focus, but the user asked whether it should match the Activity tab's count, which it did not. I redesigned it to share the same query-cache entry instead.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `code-review` (self-review against this repo's `AGENTS.md` and the spec above, which caught a real bug — the settings toggle wasn't live-reactive — fixed before this PR), `/writing-pr-descriptions`.
