### PR TITLE
fix(slack-app): keep run footer links useful for every reader

### DIFF
--- a/posthog/temporal/ai/slack_app/activities/task_creation.py
+++ b/posthog/temporal/ai/slack_app/activities/task_creation.py
@@ -1081,6 +1081,7 @@ def _resume_task_with_new_run(
     user_text_prefix: str | None = None,
 ) -> bool:
     """Create a new run on the same task when a follow-up arrives after the previous run completed."""
+    from products.slack_app.backend.facade.run_preferences import resolve_run_preferences  # noqa: PLC0415
     from products.slack_app.backend.services.slack_messages import decode_slack_event_text  # noqa: PLC0415
     from products.slack_app.backend.slack_thread import SlackThreadContext
     from products.tasks.backend.facade import api as tasks_facade
@@ -1121,6 +1122,18 @@ def _resume_task_with_new_run(
         # have changed since the run this one continues.
         **_artifact_delivery_state_updates(integration),
     }
+
+    # `create_run` builds a fresh state, so a follow-up that says nothing about the model
+    # reaches the sandbox with none and the agent server picks its own — the thread then
+    # can't say what ran. Resolved again rather than carried over, like the keys above: a
+    # follow-up honours whatever the picker says now.
+    run_prefs = resolve_run_preferences(integration, slack_user_id)
+    if run_prefs.model:
+        extra_state["model"] = run_prefs.model
+    if run_prefs.runtime_adapter:
+        extra_state["runtime_adapter"] = run_prefs.runtime_adapter
+    if run_prefs.reasoning_effort:
+        extra_state["reasoning_effort"] = run_prefs.reasoning_effort
 
     previous_state = previous_run.state or {}
     if previous_state.get("slack_thread_url"):

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -1886,7 +1886,7 @@ def _resolve_tasks_state(
     from django.utils import timezone as django_timezone
 
     from products.slack_app.backend.models import SlackThreadTaskMapping
-    from products.slack_app.backend.services.slack_messages import DESKTOP_URL_SCHEME, viewer_has_code_access
+    from products.slack_app.backend.services.slack_messages import viewer_has_code_access
     from products.tasks.backend.facade import api as tasks_facade
 
     slack_team_id = integration.integration_id
@@ -1921,8 +1921,8 @@ def _resolve_tasks_state(
 
     site_url = (settings.SITE_URL or "").rstrip("/")
     # Both task links answer to the reader, the same check the reply footer's links use.
-    # The desktop one only resolves for someone who has the app, so it rides alongside
-    # the web one rather than instead of it.
+    # The desktop one goes through the `/code/task` web bridge, which opens the app when
+    # installed and offers a download when not, so it rides alongside the web one.
     can_open_code_links = viewer_has_code_access(integration, slack_user_id)
     now = django_timezone.now()
     all_items: list[TaskItem] = []
@@ -1937,7 +1937,7 @@ def _resolve_tasks_state(
         posthog_url = desktop_url = None
         if can_open_code_links:
             posthog_url = f"{site_url}/project/{t.team_id}/tasks/{t.id}"
-            desktop_url = f"{DESKTOP_URL_SCHEME}://task/{t.id}"
+            desktop_url = f"{site_url}/code/task/{t.id}"
         all_items.append(
             TaskItem(
                 title=t.title,

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -269,13 +269,15 @@ class TaskItem:
     """One row on the Tasks card."""
 
     title: str
-    posthog_url: str
     status: str | None  # TaskRun.Status value or None when there's no run yet
     repository: str | None
     pr_url: str | None
     thread_url: str | None
     updated_at_label: str
-    desktop_url: str | None = None  # omitted for viewers without PostHog Code access
+    # Both task links are omitted for a viewer without PostHog Code access, matching the
+    # reply footer: a task page they can't open is as much a dead end as the desktop app.
+    posthog_url: str | None = None
+    desktop_url: str | None = None
     error_message: str | None = None  # surfaced on row 2 in place of the normal meta line
 
 
@@ -1916,9 +1918,10 @@ def _resolve_tasks_state(
     mapping_by_task = {str(m["task_id"]): m for m in mappings}
 
     site_url = (settings.SITE_URL or "").rstrip("/")
-    # The desktop link only resolves for someone who has the app, so it is offered
-    # alongside the web one rather than instead of it.
-    show_desktop = viewer_has_code_access(integration, slack_user_id)
+    # Both task links answer to the reader, the same check the reply footer's links use.
+    # The desktop one only resolves for someone who has the app, so it rides alongside
+    # the web one rather than instead of it.
+    can_open_code_links = viewer_has_code_access(integration, slack_user_id)
     now = django_timezone.now()
     all_items: list[TaskItem] = []
     repos_seen: list[str] = []
@@ -1932,14 +1935,14 @@ def _resolve_tasks_state(
         all_items.append(
             TaskItem(
                 title=t.title,
-                posthog_url=f"{site_url}/project/{t.team_id}/tasks/{t.id}",
+                posthog_url=f"{site_url}/project/{t.team_id}/tasks/{t.id}" if can_open_code_links else None,
                 status=run.status if run else None,
                 repository=t.repository,
                 pr_url=pr_urls_by_task.get(str(t.id)),
                 thread_url=_slack_thread_permalink(mapping.get("channel", ""), mapping.get("thread_ts", "")),
                 updated_at_label=_format_relative(mapping.get("updated_at"), now=now),
                 error_message=run.error_message if run else None,
-                desktop_url=f"{DESKTOP_URL_SCHEME}://task/{t.id}" if show_desktop else None,
+                desktop_url=f"{DESKTOP_URL_SCHEME}://task/{t.id}" if can_open_code_links else None,
             )
         )
         if t.repository and t.repository not in seen_repo_set:

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -269,15 +269,17 @@ class TaskItem:
     """One row on the Tasks card."""
 
     title: str
+    # Both task links are `None` for a viewer without PostHog Code access, matching the
+    # reply footer: a task page they can't open is as much a dead end as the desktop app.
+    # Stated at every construction rather than defaulted, so a row can't lose its links
+    # by omission and render as plain text.
+    posthog_url: str | None
+    desktop_url: str | None
     status: str | None  # TaskRun.Status value or None when there's no run yet
     repository: str | None
     pr_url: str | None
     thread_url: str | None
     updated_at_label: str
-    # Both task links are omitted for a viewer without PostHog Code access, matching the
-    # reply footer: a task page they can't open is as much a dead end as the desktop app.
-    posthog_url: str | None = None
-    desktop_url: str | None = None
     error_message: str | None = None  # surfaced on row 2 in place of the normal meta line
 
 
@@ -1932,17 +1934,21 @@ def _resolve_tasks_state(
             continue
         run = runs_by_task.get(str(t.id))
         mapping: Mapping[str, Any] = mapping_by_task.get(str(t.id), {})
+        posthog_url = desktop_url = None
+        if can_open_code_links:
+            posthog_url = f"{site_url}/project/{t.team_id}/tasks/{t.id}"
+            desktop_url = f"{DESKTOP_URL_SCHEME}://task/{t.id}"
         all_items.append(
             TaskItem(
                 title=t.title,
-                posthog_url=f"{site_url}/project/{t.team_id}/tasks/{t.id}" if can_open_code_links else None,
+                posthog_url=posthog_url,
+                desktop_url=desktop_url,
                 status=run.status if run else None,
                 repository=t.repository,
                 pr_url=pr_urls_by_task.get(str(t.id)),
                 thread_url=_slack_thread_permalink(mapping.get("channel", ""), mapping.get("thread_ts", "")),
                 updated_at_label=_format_relative(mapping.get("updated_at"), now=now),
                 error_message=run.error_message if run else None,
-                desktop_url=f"{DESKTOP_URL_SCHEME}://task/{t.id}" if can_open_code_links else None,
             )
         )
         if t.repository and t.repository not in seen_repo_set:

--- a/products/slack_app/backend/services/slack_messages.py
+++ b/products/slack_app/backend/services/slack_messages.py
@@ -329,11 +329,6 @@ def invalidate_thread_messages_cache(integration_id: int, channel: str, thread_t
         )
 
 
-# The scheme a production desktop install registers. Dev builds register
-# `posthog-code-dev://` instead, which the server can't tell apart from here, so links
-# minted server-side always target the production build.
-DESKTOP_URL_SCHEME = "posthog-code"
-
 # Query param a link we compose can carry to tell our own unfurler to leave it alone
 # (honoured by `parse_posthog_resource_link`).
 UNFURL_OPT_OUT_PARAM = "unfurl"
@@ -386,9 +381,11 @@ def load_run_footer(run_id: str | UUID | None) -> RunFooter:
         state = parse_run_state(run.state)
         return RunFooter(
             task_url=_task_url(run.team_id, run.task_id, run.id),
-            # Task-scoped, matching the desktop app's own task route — the run id has no
-            # equivalent there.
-            desktop_url=f"{DESKTOP_URL_SCHEME}://task/{run.task_id}",
+            # The web bridge page, not the raw `posthog-code://` scheme: it redirects into the
+            # desktop app when installed and offers a download when not, so a reader without
+            # the app lands somewhere useful instead of a dead link. It also picks the right
+            # scheme (prod vs dev) client-side, which a server-minted scheme link can't.
+            desktop_url=_desktop_bridge_url(run.task_id),
             model=state.model,
             reasoning_effort=state.reasoning_effort,
         )
@@ -447,7 +444,17 @@ def app_home_url(integration: Integration) -> str | None:
 def _task_url(team_id: int, task_id: UUID, run_id: UUID) -> str:
     # `unfurl=false` asks our own link unfurler to leave this one alone: the footer already
     # says what the card would, right next to the link.
-    path = f"/project/{team_id}/tasks/{task_id}?runId={run_id}&{UNFURL_OPT_OUT_PARAM}=false"
+    return _public_url(f"/project/{team_id}/tasks/{task_id}?runId={run_id}&{UNFURL_OPT_OUT_PARAM}=false")
+
+
+def _desktop_bridge_url(task_id: UUID) -> str:
+    # `/code/task/<id>` is the public bridge scene (see `CodeTaskLink`), not the desktop
+    # app's own route. `unfurl=false` keeps our unfurler off it — the footer already names
+    # the run right beside the link.
+    return _public_url(f"/code/task/{task_id}?{UNFURL_OPT_OUT_PARAM}=false")
+
+
+def _public_url(path: str) -> str:
     # Mirrors the Slack onboarding links: in local dev the tunnel is what makes a link
     # posted into Slack actually reachable.
     if settings.DEBUG and settings.NGROK_URL:

--- a/products/slack_app/backend/services/slack_messages.py
+++ b/products/slack_app/backend/services/slack_messages.py
@@ -403,12 +403,7 @@ def reply_footer_block(footer: RunFooter, configure_url: str | None = None) -> d
     The answer itself is the message, so this is muted rather than competing with the
     prose. A run with no links and no pinned model contributes no segments and gets no
     trailing line at all.
-
-    "Configure" rides on run provenance rather than standing as a line of its own, so a
-    footer with nothing to say about the run takes it down too.
     """
-    if not footer.has_content():
-        return None
     segments: list[str] = []
     if footer.task_url:
         segments.append(f"<{footer.task_url}|View on web>")

--- a/products/slack_app/backend/services/slack_messages.py
+++ b/products/slack_app/backend/services/slack_messages.py
@@ -403,7 +403,12 @@ def reply_footer_block(footer: RunFooter, configure_url: str | None = None) -> d
     The answer itself is the message, so this is muted rather than competing with the
     prose. A run with no links and no pinned model contributes no segments and gets no
     trailing line at all.
+
+    "Configure" rides on run provenance rather than standing as a line of its own, so a
+    footer with nothing to say about the run takes it down too.
     """
+    if not footer.has_content():
+        return None
     segments: list[str] = []
     if footer.task_url:
         segments.append(f"<{footer.task_url}|View on web>")

--- a/products/slack_app/backend/slack_thread.py
+++ b/products/slack_app/backend/slack_thread.py
@@ -172,24 +172,44 @@ class SlackThreadHandler:
             self._code_access = viewer_has_code_access(self._get_integration(), self.actor_slack_user_id)
         return bool(self._code_access)
 
+    def reader_footer(self) -> RunFooter:
+        """`run_footer` as this reply's reader may see it, links withheld where they can't
+        open them.
+
+        The one place that answers this, so a card's buttons and the footer's links can't
+        disagree about the same reader. A footer carrying no links asks nothing, which
+        keeps a plain answer off the identity lookup behind the access check.
+        """
+        if not (self.run_footer.task_url or self.run_footer.desktop_url):
+            return self.run_footer
+        if self.viewer_can_open_code_links():
+            return self.run_footer
+        return replace(self.run_footer, task_url=None, desktop_url=None)
+
+    def reader_task_url(self) -> str | None:
+        """The task page this reply's reader may open, or `None` where they may not."""
+        return self.reader_footer().task_url
+
     def _footer_block(self, include_task_url: bool = True) -> dict[str, Any] | None:
         """This handler's footer, or `None` when the workspace isn't in the rollout.
 
         "Configure" points at the Home tab, so it only appears where that tab exists — a
         workspace outside the Home rollout would land on an empty one. The Home flag is
-        only consulted once there is actually a link to gate.
+        only consulted once there is actually something to gate.
         """
-        # A handler with nothing to describe can't produce a footer, so it never pays for
-        # the flag lookups. Configure alone, under a reply, isn't worth a line.
+        # Both guards below are about cost, not correctness: `reply_footer_block` decides
+        # what an empty footer renders as. This one skips the flag and identity lookups
+        # behind a footer that can't appear.
         if not self.run_footer.has_content():
             return None
         if not self.footer_enabled():
             return None
-        footer = self.run_footer if include_task_url else replace(self.run_footer, task_url=None)
-        if not self.viewer_can_open_code_links():
-            footer = replace(footer, task_url=None, desktop_url=None)
+        footer = self.reader_footer()
+        if not include_task_url:
+            footer = replace(footer, task_url=None)
         # Withholding the links can empty a footer that had content a moment ago: a run on
-        # the default model pins none, so the links were the whole line.
+        # the default model pins none, so the links were the whole line. Asking here saves
+        # the Home flag evaluation below.
         if not footer.has_content():
             return None
         integration = self._get_integration()

--- a/products/slack_app/backend/slack_thread.py
+++ b/products/slack_app/backend/slack_thread.py
@@ -197,9 +197,8 @@ class SlackThreadHandler:
         workspace outside the Home rollout would land on an empty one. The Home flag is
         only consulted once there is actually something to gate.
         """
-        # Both guards below are about cost, not correctness: `reply_footer_block` decides
-        # what an empty footer renders as. This one skips the flag and identity lookups
-        # behind a footer that can't appear.
+        # A handler with nothing to describe can't produce a footer, so it never pays for
+        # the flag lookups.
         if not self.run_footer.has_content():
             return None
         if not self.footer_enabled():
@@ -207,11 +206,6 @@ class SlackThreadHandler:
         footer = self.reader_footer()
         if not include_task_url:
             footer = replace(footer, task_url=None)
-        # Withholding the links can empty a footer that had content a moment ago: a run on
-        # the default model pins none, so the links were the whole line. Asking here saves
-        # the Home flag evaluation below.
-        if not footer.has_content():
-            return None
         integration = self._get_integration()
         configure_url = app_home_url(integration)
         if configure_url and not is_slack_app_home_enabled(integration):

--- a/products/slack_app/backend/slack_thread.py
+++ b/products/slack_app/backend/slack_thread.py
@@ -185,13 +185,17 @@ class SlackThreadHandler:
             return None
         if not self.footer_enabled():
             return None
+        footer = self.run_footer if include_task_url else replace(self.run_footer, task_url=None)
+        if not self.viewer_can_open_code_links():
+            footer = replace(footer, task_url=None, desktop_url=None)
+        # Withholding the links can empty a footer that had content a moment ago: a run on
+        # the default model pins none, so the links were the whole line.
+        if not footer.has_content():
+            return None
         integration = self._get_integration()
         configure_url = app_home_url(integration)
         if configure_url and not is_slack_app_home_enabled(integration):
             configure_url = None
-        footer = self.run_footer if include_task_url else replace(self.run_footer, task_url=None)
-        if not self.viewer_can_open_code_links():
-            footer = replace(footer, task_url=None, desktop_url=None)
         return reply_footer_block(footer, configure_url)
 
     def _get_bot_user_id(self) -> str | None:

--- a/products/slack_app/backend/tests/services/slack_messages/test_run_footer.py
+++ b/products/slack_app/backend/tests/services/slack_messages/test_run_footer.py
@@ -17,7 +17,7 @@ from products.slack_app.backend.services.slack_messages import (
 )
 
 TASK_URL = "https://us.posthog.com/project/1/tasks/2?runId=3&unfurl=false"
-DESKTOP_URL = "posthog-code://task/2"
+DESKTOP_URL = "https://us.posthog.com/code/task/2?unfurl=false"
 
 
 class TestRunFooter(SimpleTestCase):
@@ -71,7 +71,7 @@ class TestLoadRunFooter(SimpleTestCase):
 
         footer = load_run_footer("run-1")
 
-        assert footer.desktop_url == f"posthog-code://task/{task_id}"
+        assert f"/code/task/{task_id}" in (footer.desktop_url or "")
         assert f"/tasks/{task_id}" in (footer.task_url or "")
         assert footer.model == "claude-opus-5"
 

--- a/products/slack_app/backend/tests/services/slack_messages/test_run_footer.py
+++ b/products/slack_app/backend/tests/services/slack_messages/test_run_footer.py
@@ -37,6 +37,12 @@ class TestRunFooter(SimpleTestCase):
                 f"<{TASK_URL}|View on web> · <{DESKTOP_URL}|View on desktop>",
             ),
             ("model_without_effort", RunFooter(model="claude-opus-5"), None, "*Claude Opus 5*"),
+            (
+                "configure_only",
+                RunFooter(),
+                "slack://app?team=T1&id=A1&tab=home",
+                "<slack://app?team=T1&id=A1&tab=home|Configure>",
+            ),
         ]
     )
     def test_renders_present_segments_as_slack_links(
@@ -48,19 +54,10 @@ class TestRunFooter(SimpleTestCase):
 
         assert block == {"type": "context", "elements": [{"type": "mrkdwn", "text": expected}]}
 
-    @parameterized.expand(
-        [
-            ("nothing_at_all", None),
-            ("configure_alone", "slack://app?team=T1&id=A1&tab=home"),
-        ]
-    )
-    def test_contributes_no_block_when_there_is_nothing_to_say(self, _name: str, configure_url: str | None) -> None:
+    def test_contributes_no_block_when_there_is_nothing_to_say(self) -> None:
         # A context block with an empty `elements` list is rejected by Slack, which would
-        # fail the whole message post rather than just dropping the footer. Configure rides
-        # on run provenance, so it can't hold a line open by itself either: a run on the
-        # default model pins no model, and a reader who can't open the links has nothing
-        # left to read.
-        assert reply_footer_block(RunFooter(), configure_url) is None
+        # fail the whole message post rather than just dropping the footer.
+        assert reply_footer_block(RunFooter()) is None
 
 
 class TestLoadRunFooter(SimpleTestCase):

--- a/products/slack_app/backend/tests/services/slack_messages/test_run_footer.py
+++ b/products/slack_app/backend/tests/services/slack_messages/test_run_footer.py
@@ -37,12 +37,6 @@ class TestRunFooter(SimpleTestCase):
                 f"<{TASK_URL}|View on web> · <{DESKTOP_URL}|View on desktop>",
             ),
             ("model_without_effort", RunFooter(model="claude-opus-5"), None, "*Claude Opus 5*"),
-            (
-                "configure_only",
-                RunFooter(),
-                "slack://app?team=T1&id=A1&tab=home",
-                "<slack://app?team=T1&id=A1&tab=home|Configure>",
-            ),
         ]
     )
     def test_renders_present_segments_as_slack_links(
@@ -54,10 +48,19 @@ class TestRunFooter(SimpleTestCase):
 
         assert block == {"type": "context", "elements": [{"type": "mrkdwn", "text": expected}]}
 
-    def test_contributes_no_block_when_there_is_nothing_to_say(self) -> None:
+    @parameterized.expand(
+        [
+            ("nothing_at_all", None),
+            ("configure_alone", "slack://app?team=T1&id=A1&tab=home"),
+        ]
+    )
+    def test_contributes_no_block_when_there_is_nothing_to_say(self, _name: str, configure_url: str | None) -> None:
         # A context block with an empty `elements` list is rejected by Slack, which would
-        # fail the whole message post rather than just dropping the footer.
-        assert reply_footer_block(RunFooter()) is None
+        # fail the whole message post rather than just dropping the footer. Configure rides
+        # on run provenance, so it can't hold a line open by itself either: a run on the
+        # default model pins no model, and a reader who can't open the links has nothing
+        # left to read.
+        assert reply_footer_block(RunFooter(), configure_url) is None
 
 
 class TestLoadRunFooter(SimpleTestCase):

--- a/products/slack_app/backend/tests/services/test_slack_app_home.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home.py
@@ -699,7 +699,7 @@ class TestTasksCard:
         # The desktop link dead-ends for anyone without the app, so it rides alongside the
         # web one rather than replacing it.
         state = TasksState(
-            items=(self._item(desktop_url="posthog-code://task/abc"),),
+            items=(self._item(desktop_url="https://us.posthog.com/code/task/abc"),),
             has_any_tasks=True,
             page=0,
             total_pages=1,
@@ -709,7 +709,7 @@ class TestTasksCard:
         _, sub = self._task_items(view, expected_count=1)[0]
 
         assert "<https://app/project/1/tasks/abc|View on web>" in sub
-        assert "<posthog-code://task/abc|View on desktop>" in sub
+        assert "<https://us.posthog.com/code/task/abc|View on desktop>" in sub
 
     def test_both_task_links_are_withheld_from_a_viewer_without_code_access(self):
         # A task page is as much a dead end for them as the desktop app, so the pair goes

--- a/products/slack_app/backend/tests/services/test_slack_app_home.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home.py
@@ -693,18 +693,17 @@ class TestTasksCard:
         assert "<https://github.com/posthog/posthog/pull/123|PR>" in sub_rows[1]
         assert "_Updated 5m ago_" in sub_rows[1]
 
-    @pytest.mark.parametrize(
-        "desktop_url,expected",
-        [
-            ("posthog-code://task/abc", "<posthog-code://task/abc|View on desktop>"),
-            (None, None),
-        ],
-    )
-    def test_desktop_link_appears_only_for_a_viewer_who_can_open_it(self, desktop_url, expected):
-        # A `posthog-code://` link dead-ends for anyone without the app, so it rides
-        # alongside the web link rather than replacing it.
+    @pytest.mark.parametrize("can_open", [True, False])
+    def test_task_links_appear_only_for_a_viewer_who_can_open_them(self, can_open):
+        # Both links travel as a pair: a task page is as much a dead end for someone
+        # without PostHog Code access as a `posthog-code://` link is without the app.
+        links = (
+            {"posthog_url": "https://app/project/1/tasks/abc", "desktop_url": "posthog-code://task/abc"}
+            if can_open
+            else {"posthog_url": None, "desktop_url": None}
+        )
         state = TasksState(
-            items=(self._item(desktop_url=desktop_url),),
+            items=(self._item(**links),),
             has_any_tasks=True,
             page=0,
             total_pages=1,
@@ -713,11 +712,28 @@ class TestTasksCard:
         view = render_home_view(**self._kwargs(tasks_state=state))
         _, sub = self._task_items(view, expected_count=1)[0]
 
-        assert "<https://app/project/1/tasks/abc|View on web>" in sub
-        if expected:
-            assert expected in sub
+        if can_open:
+            assert "<https://app/project/1/tasks/abc|View on web>" in sub
+            assert "<posthog-code://task/abc|View on desktop>" in sub
         else:
+            assert "View on web" not in sub
             assert "View on desktop" not in sub
+
+    def test_title_is_plain_text_when_neither_thread_nor_task_link_is_available(self):
+        # A row with no Slack permalink normally falls back to the task page. Withhold
+        # that too and the title has nowhere to point, so it must not render a link.
+        state = TasksState(
+            items=(self._item(thread_url=None, posthog_url=None),),
+            has_any_tasks=True,
+            page=0,
+            total_pages=1,
+            total_filtered=1,
+        )
+        view = render_home_view(**self._kwargs(tasks_state=state))
+        text = _all_text(view)
+
+        assert "*Fix flaky retention test*" in text
+        assert "|Fix flaky retention test>" not in text
 
     def test_task_with_no_repo_or_pr_skips_those_meta_parts(self):
         state = TasksState(

--- a/products/slack_app/backend/tests/services/test_slack_app_home.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home.py
@@ -453,6 +453,7 @@ class TestRenderHomeView:
                     TaskItem(
                         title="Fix flaky retention test",
                         posthog_url="https://app/project/1/tasks/abc",
+                        desktop_url=None,
                         status="in_progress",
                         repository="posthog/posthog",
                         pr_url=None,
@@ -593,9 +594,10 @@ class TestTasksCard:
         return base
 
     def _item(self, **overrides) -> TaskItem:
-        defaults = {
+        defaults: dict[str, Any] = {
             "title": "Fix flaky retention test",
             "posthog_url": "https://app/project/1/tasks/abc",
+            "desktop_url": None,
             "status": "in_progress",
             "repository": "posthog/posthog",
             "pr_url": "https://github.com/posthog/posthog/pull/123",
@@ -693,17 +695,11 @@ class TestTasksCard:
         assert "<https://github.com/posthog/posthog/pull/123|PR>" in sub_rows[1]
         assert "_Updated 5m ago_" in sub_rows[1]
 
-    @pytest.mark.parametrize("can_open", [True, False])
-    def test_task_links_appear_only_for_a_viewer_who_can_open_them(self, can_open):
-        # Both links travel as a pair: a task page is as much a dead end for someone
-        # without PostHog Code access as a `posthog-code://` link is without the app.
-        links = (
-            {"posthog_url": "https://app/project/1/tasks/abc", "desktop_url": "posthog-code://task/abc"}
-            if can_open
-            else {"posthog_url": None, "desktop_url": None}
-        )
+    def test_both_task_links_render_for_a_viewer_who_can_open_them(self):
+        # The desktop link dead-ends for anyone without the app, so it rides alongside the
+        # web one rather than replacing it.
         state = TasksState(
-            items=(self._item(**links),),
+            items=(self._item(desktop_url="posthog-code://task/abc"),),
             has_any_tasks=True,
             page=0,
             total_pages=1,
@@ -712,12 +708,24 @@ class TestTasksCard:
         view = render_home_view(**self._kwargs(tasks_state=state))
         _, sub = self._task_items(view, expected_count=1)[0]
 
-        if can_open:
-            assert "<https://app/project/1/tasks/abc|View on web>" in sub
-            assert "<posthog-code://task/abc|View on desktop>" in sub
-        else:
-            assert "View on web" not in sub
-            assert "View on desktop" not in sub
+        assert "<https://app/project/1/tasks/abc|View on web>" in sub
+        assert "<posthog-code://task/abc|View on desktop>" in sub
+
+    def test_both_task_links_are_withheld_from_a_viewer_without_code_access(self):
+        # A task page is as much a dead end for them as the desktop app, so the pair goes
+        # together — the same rule the reply footer's links follow.
+        state = TasksState(
+            items=(self._item(posthog_url=None, desktop_url=None),),
+            has_any_tasks=True,
+            page=0,
+            total_pages=1,
+            total_filtered=1,
+        )
+        view = render_home_view(**self._kwargs(tasks_state=state))
+        _, sub = self._task_items(view, expected_count=1)[0]
+
+        assert "View on web" not in sub
+        assert "View on desktop" not in sub
 
     def test_title_is_plain_text_when_neither_thread_nor_task_link_is_available(self):
         # A row with no Slack permalink normally falls back to the task page. Withhold

--- a/products/slack_app/backend/tests/test_followup_forwarding.py
+++ b/products/slack_app/backend/tests/test_followup_forwarding.py
@@ -25,6 +25,7 @@ from posthog.temporal.ai.slack_app.helpers import safe_react
 
 from products.slack_app.backend.api import SlackUserContext
 from products.slack_app.backend.models import SlackThreadTaskMapping
+from products.slack_app.backend.services.run_preferences import SLACK_DEFAULT_MODEL
 
 
 def _make_inputs(integration_id: int, slack_team_id: str = "T_SLACK") -> PostHogCodeSlackMentionWorkflowInputs:
@@ -1015,6 +1016,27 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         assert new_run.state.get("initial_prompt_override") == "Bob: fix the tests"
         assert new_run.state["slack_actor_user_id"] == bob.id
         assert new_run.state["slack_actor_slack_user_id"] == "U_BOB"
+
+    @patch("products.tasks.backend.facade.temporal.execute_task_processing_workflow")
+    @patch("posthog.models.integration.SlackIntegration")
+    def test_a_resumed_run_carries_the_model_the_workspace_would_pick(self, mock_slack_cls, mock_execute_workflow):
+        # `create_run` builds a fresh state, so without this the follow-up reached the
+        # sandbox with no model and the agent server chose one we never recorded — leaving
+        # the thread's footer unable to name what ran.
+        self.task_run.status = self.TaskRun.Status.COMPLETED
+        self.task_run.save()
+        self._create_mapping()
+        mock_slack_cls.return_value = MagicMock()
+
+        inputs = _make_inputs(self.integration.id)
+        result = forward_posthog_code_followup_activity(
+            inputs, "C123", "1234.5678", "U_ALICE", "<@BOT> fix the tests", "1234.5679"
+        )
+
+        assert result is True
+        new_run = self.TaskRun.objects.get(id=mock_execute_workflow.call_args.kwargs["run_id"])
+        assert new_run.state["model"] == SLACK_DEFAULT_MODEL
+        assert new_run.state["runtime_adapter"]
 
     @patch("posthog.models.integration.SlackIntegration")
     def test_sandbox_not_ready_returns_true_with_message(self, mock_slack_cls):

--- a/products/slack_app/backend/tests/test_slack_thread.py
+++ b/products/slack_app/backend/tests/test_slack_thread.py
@@ -359,7 +359,7 @@ class TestReplyFooterGate(SimpleTestCase):
         mock_get_integration.return_value = Integration(config={"app_id": "A1"}, integration_id="T1")
         footer = RunFooter(
             task_url="https://app/project/1/tasks/t",
-            desktop_url="posthog-code://task/t",
+            desktop_url="https://us.posthog.com/code/task/t",
             model="claude-opus-5",
         )
 

--- a/products/slack_app/backend/tests/test_slack_thread.py
+++ b/products/slack_app/backend/tests/test_slack_thread.py
@@ -343,7 +343,7 @@ class TestReplyFooterGate(SimpleTestCase):
     @patch("products.slack_app.backend.slack_thread.is_slack_app_model_classifier_enabled", return_value=True)
     @patch.object(SlackThreadHandler, "_get_integration")
     @patch.object(SlackThreadHandler, "_get_client")
-    def test_a_run_on_the_default_model_drops_the_footer_with_its_links(
+    def test_a_default_model_run_posts_a_footer_only_when_its_links_are_open(
         self,
         _name: str,
         code_access: bool,

--- a/products/slack_app/backend/tests/test_slack_thread.py
+++ b/products/slack_app/backend/tests/test_slack_thread.py
@@ -338,34 +338,39 @@ class TestReplyFooterGate(SimpleTestCase):
         )
         return SlackThreadHandler(context, footer or RunFooter(model="claude-opus-5"))
 
-    @parameterized.expand([("withheld", False, False), ("granted", True, True)])
+    @parameterized.expand([("withheld", False), ("granted", True)])
     @patch("products.slack_app.backend.slack_thread.is_slack_app_home_enabled", return_value=True)
     @patch("products.slack_app.backend.slack_thread.is_slack_app_model_classifier_enabled", return_value=True)
     @patch.object(SlackThreadHandler, "_get_integration")
     @patch.object(SlackThreadHandler, "_get_client")
-    def test_a_default_model_run_posts_a_footer_only_when_its_links_are_open(
+    def test_withholding_the_links_still_leaves_the_model_and_configure(
         self,
         _name: str,
         code_access: bool,
-        expected: bool,
         mock_get_client,
         mock_get_integration,
         _mock_flag,
         _mock_home,
     ) -> None:
-        # A default-model run pins no model, so the links are the whole line. Withholding
-        # them left a footer reading just "Configure" under the answer.
+        # Whether this reader can open a task page changes which segments render, never
+        # whether the line appears: the model and the way to change it are theirs either way.
         mock_client = MagicMock()
         mock_get_client.return_value = mock_client
         mock_get_integration.return_value = Integration(config={"app_id": "A1"}, integration_id="T1")
-        links_only = RunFooter(task_url="https://app/project/1/tasks/t", desktop_url="posthog-code://task/t")
+        footer = RunFooter(
+            task_url="https://app/project/1/tasks/t",
+            desktop_url="posthog-code://task/t",
+            model="claude-opus-5",
+        )
 
         with patch.object(SlackThreadHandler, "viewer_can_open_code_links", return_value=code_access):
-            self._handler(links_only).post_thread_message("the answer", with_footer=True)
+            self._handler(footer).post_thread_message("the answer", with_footer=True)
 
-        kwargs = mock_client.chat_postMessage.call_args.kwargs
-        assert kwargs["text"] == "the answer"
-        assert bool(kwargs.get("blocks")) is expected
+        line = mock_client.chat_postMessage.call_args.kwargs["blocks"][-1]["elements"][0]["text"]
+        assert "*Claude Opus 5*" in line
+        assert "|Configure>" in line
+        assert ("View on web" in line) is code_access
+        assert ("View on desktop" in line) is code_access
 
     @parameterized.expand([("off", False, False), ("on", True, True)])
     @patch("products.slack_app.backend.slack_thread.is_slack_app_home_enabled", return_value=False)

--- a/products/slack_app/backend/tests/test_slack_thread.py
+++ b/products/slack_app/backend/tests/test_slack_thread.py
@@ -329,14 +329,43 @@ class TestPostPrOpenedReplyTarget(SimpleTestCase):
 
 
 class TestReplyFooterGate(SimpleTestCase):
-    def _handler(self) -> SlackThreadHandler:
+    def _handler(self, footer: RunFooter | None = None) -> SlackThreadHandler:
         context = SlackThreadContext(
             integration_id=1,
             channel="C001",
             thread_ts="1234.5678",
             mentioning_slack_user_id="U123",
         )
-        return SlackThreadHandler(context, RunFooter(model="claude-opus-5"))
+        return SlackThreadHandler(context, footer or RunFooter(model="claude-opus-5"))
+
+    @parameterized.expand([("withheld", False, False), ("granted", True, True)])
+    @patch("products.slack_app.backend.slack_thread.is_slack_app_home_enabled", return_value=True)
+    @patch("products.slack_app.backend.slack_thread.is_slack_app_model_classifier_enabled", return_value=True)
+    @patch.object(SlackThreadHandler, "_get_integration")
+    @patch.object(SlackThreadHandler, "_get_client")
+    def test_a_run_on_the_default_model_drops_the_footer_with_its_links(
+        self,
+        _name: str,
+        code_access: bool,
+        expected: bool,
+        mock_get_client,
+        mock_get_integration,
+        _mock_flag,
+        _mock_home,
+    ) -> None:
+        # A default-model run pins no model, so the links are the whole line. Withholding
+        # them left a footer reading just "Configure" under the answer.
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_get_integration.return_value = Integration(config={"app_id": "A1"}, integration_id="T1")
+        links_only = RunFooter(task_url="https://app/project/1/tasks/t", desktop_url="posthog-code://task/t")
+
+        with patch.object(SlackThreadHandler, "viewer_can_open_code_links", return_value=code_access):
+            self._handler(links_only).post_thread_message("the answer", with_footer=True)
+
+        kwargs = mock_client.chat_postMessage.call_args.kwargs
+        assert kwargs["text"] == "the answer"
+        assert bool(kwargs.get("blocks")) is expected
 
     @parameterized.expand([("off", False, False), ("on", True, True)])
     @patch("products.slack_app.backend.slack_thread.is_slack_app_home_enabled", return_value=False)

--- a/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
+++ b/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
@@ -100,7 +100,7 @@ def post_slack_update(input: PostSlackUpdateInput) -> None:
         footer = load_run_footer(task_run.id)
         handler = SlackThreadHandler(context, footer)
         # The buttons lead where the footer's links do, so they answer to the same reader.
-        task_url = footer.task_url if handler.viewer_can_open_code_links() else None
+        task_url = handler.reader_task_url()
         pr_url = (task_run.output or {}).get("pr_url")
 
         if input.sandbox_cleaned:

--- a/products/tasks/backend/tests/test_post_slack_update.py
+++ b/products/tasks/backend/tests/test_post_slack_update.py
@@ -34,8 +34,8 @@ class TestPostSlackUpdate(TestCase):
         )
         self._footer_patcher.start()
         self.addCleanup(self._footer_patcher.stop)
-        # These tests mock the handler's __init__, so the reader gate is patched on the
-        # class rather than resolved from a Slack identity.
+        # The gate is patched on the class so it answers without a Slack identity lookup;
+        # the deny-path test flips it to prove the url really hangs off this answer.
         self._access_patcher = patch.object(SlackThreadHandler, "viewer_can_open_code_links", return_value=True)
         self._access_patcher.start()
         self.addCleanup(self._access_patcher.stop)
@@ -65,10 +65,9 @@ class TestPostSlackUpdate(TestCase):
 
     @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
-    @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
     def test_completed_run_with_pr_routes_through_post_pr_opened(
-        self, mock_task_run_class, mock_handler_init, mock_update_reaction, mock_post_pr_opened
+        self, mock_task_run_class, mock_update_reaction, mock_post_pr_opened
     ):
         # Completed runs with a PR funnel through the single ``post_pr_opened``
         # template via the dedupe helper. ``post_completion`` is reserved for
@@ -87,10 +86,9 @@ class TestPostSlackUpdate(TestCase):
 
     @patch.object(SlackThreadHandler, "post_completion")
     @patch.object(SlackThreadHandler, "update_reaction")
-    @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
     def test_completed_run_without_pr_posts_task_completed(
-        self, mock_task_run_class, mock_handler_init, mock_update_reaction, mock_post_completion
+        self, mock_task_run_class, mock_update_reaction, mock_post_completion
     ):
         # ``post_completion`` is the no-PR terminal-state card.
         mock_run = self._make_mock_run(mock_task_run_class.Status.COMPLETED, output={})
@@ -103,11 +101,8 @@ class TestPostSlackUpdate(TestCase):
 
     @patch.object(SlackThreadHandler, "post_error")
     @patch.object(SlackThreadHandler, "update_reaction")
-    @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
-    def test_failed_run_updates_reaction_to_x(
-        self, mock_task_run_class, mock_handler_init, mock_update_reaction, mock_post_error
-    ):
+    def test_failed_run_updates_reaction_to_x(self, mock_task_run_class, mock_update_reaction, mock_post_error):
         mock_run = self._make_mock_run(
             mock_task_run_class.Status.FAILED,
             error_message="Something went wrong",
@@ -121,10 +116,9 @@ class TestPostSlackUpdate(TestCase):
 
     @patch.object(SlackThreadHandler, "post_cancelled")
     @patch.object(SlackThreadHandler, "update_reaction")
-    @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
     def test_cancelled_run_posts_cancelled_message(
-        self, mock_task_run_class, mock_handler_init, mock_update_reaction, mock_post_cancelled
+        self, mock_task_run_class, mock_update_reaction, mock_post_cancelled
     ):
         mock_run = self._make_mock_run(mock_task_run_class.Status.CANCELLED)
         mock_task_run_class.objects.select_related.return_value.get.return_value = mock_run
@@ -135,9 +129,8 @@ class TestPostSlackUpdate(TestCase):
         mock_post_cancelled.assert_called_once()
 
     @patch.object(SlackThreadHandler, "post_or_update_progress")
-    @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
-    def test_in_progress_run_posts_stage(self, mock_task_run_class, mock_handler_init, mock_post_progress):
+    def test_in_progress_run_posts_stage(self, mock_task_run_class, mock_post_progress):
         mock_run = self._make_mock_run(
             mock_task_run_class.Status.IN_PROGRESS,
             stage="Cloning repository",
@@ -155,12 +148,10 @@ class TestPostSlackUpdate(TestCase):
     @patch.object(SlackThreadHandler, "update_reaction")
     @patch.object(SlackThreadHandler, "post_or_update_progress")
     @patch.object(SlackThreadHandler, "post_pr_opened")
-    @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
     def test_in_progress_with_pr_keeps_eyes_reaction(
         self,
         mock_task_run_class,
-        mock_handler_init,
         _mock_post_pr_opened,
         mock_post_progress,
         mock_update_reaction,
@@ -191,7 +182,6 @@ class TestPostSlackUpdate(TestCase):
     @patch.object(SlackThreadHandler, "update_reaction")
     @patch.object(SlackThreadHandler, "post_or_update_progress")
     @patch.object(SlackThreadHandler, "post_pr_opened")
-    @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
     def test_in_progress_with_pr_tags_actor_then_mentioner(
         self,
@@ -199,7 +189,6 @@ class TestPostSlackUpdate(TestCase):
         run_state,
         expected_target,
         mock_task_run_class,
-        mock_handler_init,
         mock_post_pr_opened,
         mock_post_progress,
         mock_update_reaction,
@@ -246,13 +235,11 @@ class TestPostSlackUpdate(TestCase):
     @patch.object(SlackThreadHandler, "post_completion")
     @patch.object(SlackThreadHandler, "delete_progress")
     @patch.object(SlackThreadHandler, "update_reaction")
-    @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
     def test_timed_out_run_silently_deletes_progress(
         self,
         run_kwargs,
         mock_task_run_class,
-        mock_handler_init,
         mock_update_reaction,
         mock_delete_progress,
         mock_post_completion,
@@ -279,13 +266,11 @@ class TestPostSlackUpdate(TestCase):
     @patch.object(SlackThreadHandler, "post_error")
     @patch.object(SlackThreadHandler, "delete_progress")
     @patch.object(SlackThreadHandler, "update_reaction")
-    @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
     def test_failed_timeout_run_stays_quiet_instead_of_posting_an_error_card(
         self,
         run_kwargs,
         mock_task_run_class,
-        mock_handler_init,
         mock_update_reaction,
         mock_delete_progress,
         mock_post_error,
@@ -315,13 +300,11 @@ class TestPostSlackUpdate(TestCase):
     @patch.object(SlackThreadHandler, "post_error")
     @patch.object(SlackThreadHandler, "delete_progress")
     @patch.object(SlackThreadHandler, "update_reaction")
-    @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
     def test_failed_run_whose_message_mentions_a_timeout_still_posts_an_error_card(
         self,
         error_message,
         mock_task_run_class,
-        mock_handler_init,
         mock_update_reaction,
         mock_delete_progress,
         mock_post_error,
@@ -346,12 +329,10 @@ class TestPostSlackUpdate(TestCase):
 
     @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
-    @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
     def test_completed_pr_run_after_cleanup_posts_pr_opened_card(
         self,
         mock_task_run_class,
-        mock_handler_init,
         mock_update_reaction,
         mock_post_pr_opened,
     ):
@@ -382,12 +363,10 @@ class TestPostSlackUpdate(TestCase):
     @patch.object(SlackThreadHandler, "delete_progress")
     @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
-    @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
     def test_completed_run_does_not_repost_pr_when_already_announced(
         self,
         mock_task_run_class,
-        mock_handler_init,
         mock_update_reaction,
         mock_post_pr_opened,
         mock_delete_progress,
@@ -418,12 +397,10 @@ class TestPostSlackUpdate(TestCase):
     @patch.object(SlackThreadHandler, "delete_progress")
     @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
-    @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
     def test_run_does_not_repost_pr_a_sibling_run_already_announced(
         self,
         mock_task_run_class,
-        mock_handler_init,
         mock_update_reaction,
         mock_post_pr_opened,
         mock_delete_progress,
@@ -446,12 +423,10 @@ class TestPostSlackUpdate(TestCase):
 
     @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
-    @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
     def test_completed_run_with_new_pr_url_posts_card_even_if_old_url_notified(
         self,
         mock_task_run_class,
-        mock_handler_init,
         mock_update_reaction,
         mock_post_pr_opened,
     ):
@@ -479,12 +454,10 @@ class TestPostSlackUpdate(TestCase):
     @patch.object(SlackThreadHandler, "delete_progress")
     @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
-    @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
     def test_completed_pr_run_after_cleanup_does_not_repost_if_already_notified(
         self,
         mock_task_run_class,
-        mock_handler_init,
         mock_update_reaction,
         mock_post_pr_opened,
         mock_delete_progress,
@@ -511,12 +484,10 @@ class TestPostSlackUpdate(TestCase):
     @patch.object(SlackThreadHandler, "delete_progress")
     @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
-    @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
     def test_same_pr_url_with_notified_url_in_state_does_not_repost(
         self,
         mock_task_run_class,
-        mock_handler_init,
         mock_update_reaction,
         mock_post_pr_opened,
         mock_delete_progress,
@@ -545,12 +516,10 @@ class TestPostSlackUpdate(TestCase):
 
     @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
-    @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
     def test_different_pr_url_from_notified_url_posts_once(
         self,
         mock_task_run_class,
-        mock_handler_init,
         mock_update_reaction,
         mock_post_pr_opened,
     ):
@@ -585,12 +554,10 @@ class TestPostSlackUpdate(TestCase):
     @patch.object(SlackThreadHandler, "post_cancelled")
     @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
-    @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
     def test_user_without_posthog_code_access_omits_task_url(
         self,
         mock_task_run_class,
-        _mock_handler_init,
         _mock_update_reaction,
         mock_post_pr_opened,
         mock_post_cancelled,
@@ -668,12 +635,10 @@ class TestPostSlackUpdate(TestCase):
 
     @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
-    @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
     def test_cancelled_pr_run_after_cleanup_posts_pr_opened_card(
         self,
         mock_task_run_class,
-        mock_handler_init,
         mock_update_reaction,
         mock_post_pr_opened,
     ):


### PR DESCRIPTION
## Problem

The Slack reply footer and App Home task cards showed links that didn't work for everyone, and a couple of details were plain wrong:

- "View on web" showed on rows a reader couldn't actually open.
- "View on desktop" used a raw `posthog-code://` link that dead-ends without the desktop app.
- A follow-up run dropped the model, so the footer couldn't say what ran (and the run fell back to the agent server's default instead of the picker).
- A run on the default model could leave a footer reading just "Configure".

## Changes

- Both task links now come from one reader-access check, so the footer and the lifecycle-card buttons agree.
- "View on desktop" points at the `/code/task/<id>` web bridge (already on master), which opens the app or offers a download.
- A resumed run resolves run preferences like the first run does, so it honours the picker and the footer can name the model.
- Withholding the links changes which segments show, never whether the footer appears — model and Configure stay for every reader.

## How did you test this code?

Automated. Non-DB unit tests and mypy pass locally; the DB-backed tests and frontend typecheck/lint run on CI (no Postgres or frontend toolchain in the dev sandbox).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built from a Slack thread. The desktop-link change is backend-only — the `/code/task/:taskId` bridge scene already exists on master.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/D0AQWDXTB89/p1786563354803049?thread_ts=1786563354.803049&cid=D0AQWDXTB89)*
