### PR TITLE
chore(ci): make semgrep security scans diff-aware via semgrep ci

### DIFF
--- a/.agents/security.md
+++ b/.agents/security.md
@@ -100,7 +100,7 @@ queryset.filter(name__icontains=value)  # SAFE
 **Do not add new `pickle` usage.**
 Unpickling bytes that any other process could influence is arbitrary code execution — the pickle stream can name any importable callable and pass it arguments.
 This applies to the equivalents too: `cPickle`, `cloudpickle`, `dill`, `marshal`, `shelve`, `joblib`, `pandas.read_pickle`, and `numpy.load(..., allow_pickle=True)`.
-CI already fails on new pickle: the `avoid-pickle` rule from the `p/security-audit` Semgrep pack runs with `--error` (see `.github/workflows/ci-security.yaml`), so introducing one is a hard stop, not a warning.
+CI already fails on new pickle: the `avoid-pickle` rule from the `p/security-audit` Semgrep pack runs as a blocking rule in the diff-aware `semgrep ci` jobs (see `.github/workflows/ci-security.yaml`), so introducing one is a hard stop, not a warning.
 Pickle can also appear without the word `pickle`: Django's default cache backend (`cache.set` / `cache.get`) pickles values transparently, so treat the cache as a pickle boundary and only store JSON-serializable values in it.
 
 **Use JSON instead.**

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,6 +25,8 @@ posthog/hogql/database/test/__snapshots__/test_database.ambr
 # Being open source brings us unwanted problems because Github Actions are untrusted and inherently unsafe
 # so we have to be extra careful with changes here. Let's have the security team own these checks.
 .github/workflows/ci-security.yaml @PostHog/team-security
+# The composite action ci-security.yaml runs its blocking scans through — same ownership, or the scans could be weakened without security review.
+.github/actions/semgrep-ci/ @PostHog/team-security
 .github/workflows/codeql.yml @PostHog/team-security
 
 # This workflow runs on the `pull_request_target` event so that it can run without needing a GitHub org member to explicitly approve it.

--- a/.github/actions/semgrep-ci/action.yml
+++ b/.github/actions/semgrep-ci/action.yml
@@ -1,0 +1,48 @@
+name: Semgrep diff-aware scan
+description: >
+    Run `semgrep ci` in the digest-pinned Semgrep image. On pull requests semgrep
+    resolves the merge-base with the base branch itself (GH_TOKEN fast path, then
+    deepening fetches) and reports only findings the PR introduces; on pushes there
+    is no baseline, so it runs a full scan. Runs logged out: nothing is uploaded to
+    semgrep.dev, and any finding fails the step via the exit code.
+
+inputs:
+    image:
+        description: Digest-pinned semgrep/semgrep Docker image
+        required: true
+    args:
+        description: >
+            Arguments for `semgrep ci` (--config, --include/--exclude, --exclude-rule,
+            --jobs, ...). Split on whitespace, so values must not contain spaces or
+            quotes. Anchor --include/--exclude patterns with a leading slash
+            (--include /bin); unanchored patterns also match same-named nested
+            directories anywhere in the tree.
+        required: true
+
+runs:
+    using: composite
+    steps:
+        - name: Run semgrep ci
+          shell: bash
+          env:
+              SEMGREP_ARGS: ${{ inputs.args }}
+              SEMGREP_IMAGE: ${{ inputs.image }}
+              # Lets semgrep resolve the PR merge-base with one API call instead of
+              # deepening fetches (cli/src/semgrep/meta.py GithubMeta._find_branchoff_point)
+              GH_TOKEN: ${{ github.token }}
+          # GithubMeta reads the GITHUB_* vars and the event payload to detect the
+          # PR context; the baseline git operations need the checkout's persisted
+          # auth from .git/config, and safe.directory because the workspace is
+          # owned by the runner user while the container runs as root.
+          run: |
+              docker run --rm \
+                -v "$GITHUB_WORKSPACE:/src" -w /src \
+                -v "$GITHUB_EVENT_PATH:/github-event.json:ro" \
+                -e SEMGREP_ENABLE_VERSION_CHECK=false \
+                -e GITHUB_ACTIONS -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH=/github-event.json \
+                -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_API_URL \
+                -e GITHUB_SHA -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_RUN_ID \
+                -e GITHUB_REPOSITORY_ID -e GITHUB_REPOSITORY_OWNER_ID \
+                -e GH_TOKEN \
+                "$SEMGREP_IMAGE" \
+                sh -c "git config --global --add safe.directory /src && exec semgrep ci --metrics=off --verbose --timeout 300 $SEMGREP_ARGS"

--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -39,6 +39,7 @@ jobs:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   clean: false
+                  persist-credentials: false
             - name: Force all scans for oversized pull requests
               id: oversized
               if: github.event_name == 'pull_request' && github.event.pull_request.changed_files > 3000
@@ -50,6 +51,8 @@ jobs:
               with:
                   client-id: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_APP_ID }}
                   private-key: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY }}
+                  # paths-filter only calls pulls.listFiles
+                  permission-pull-requests: read
             - uses: ./.github/actions/paths-filter
               id: filter
               if: github.event_name != 'push' && steps.oversized.outputs.force_all != 'true'
@@ -391,6 +394,8 @@ jobs:
 
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
 
             # Pass 1: print WARNING-severity findings. No --error — this step
             # does not fail CI. Backlogs from migration-in-progress rules show
@@ -445,6 +450,8 @@ jobs:
 
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
 
             - name: Test custom Semgrep rules
               run: |
@@ -477,6 +484,8 @@ jobs:
 
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
 
             - name: Run Semgrep (desktop, universal security packs)
               run: |

--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -149,26 +149,27 @@ jobs:
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Run Semgrep
-              run: |
-                  docker run --rm -v "${{ github.workspace }}:/src" -w /src \
-                    -e SEMGREP_ENABLE_VERSION_CHECK=false \
-                    ${{ env.SEMGREP_IMAGE }} \
-                    semgrep \
-                      --config "p/python" \
-                      --config "p/owasp-top-ten" \
-                      --config "p/security-audit" \
-                      --config "p/trailofbits" \
-                      --config ".semgrep/rules/security" \
-                      --exclude-rule trailofbits.generic.redis-unencrypted-transport.redis-unencrypted-transport \
-                      --exclude-rule "python.django.security.audit.csrf-exempt.no-csrf-exempt" \
-                      --exclude-rule "generic.html-templates.security.var-in-href.var-in-href" \
-                      --exclude "products/desktop" \
-                      --error \
-                      --metrics=off \
-                      --verbose \
-                      --jobs 4 \
-                      --timeout 300 \
-                      bin/ common/ ee/ posthog/ products/ services/llm-gateway/ services/stripe-mock/
+              uses: ./.github/actions/semgrep-ci
+              with:
+                  image: ${{ env.SEMGREP_IMAGE }}
+                  args: >-
+                      --config p/python
+                      --config p/owasp-top-ten
+                      --config p/security-audit
+                      --config p/trailofbits
+                      --config .semgrep/rules/security
+                      --exclude-rule trailofbits.generic.redis-unencrypted-transport.redis-unencrypted-transport
+                      --exclude-rule python.django.security.audit.csrf-exempt.no-csrf-exempt
+                      --exclude-rule generic.html-templates.security.var-in-href.var-in-href
+                      --include /bin
+                      --include /common
+                      --include /ee
+                      --include /posthog
+                      --include /products
+                      --include /services/llm-gateway
+                      --include /services/stripe-mock
+                      --exclude products/desktop
+                      --jobs 4
 
     semgrep-go:
         needs: changes
@@ -192,22 +193,17 @@ jobs:
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Run Semgrep
-              run: |
-                  docker run --rm -v "${{ github.workspace }}:/src" -w /src \
-                    -e SEMGREP_ENABLE_VERSION_CHECK=false \
-                    ${{ env.SEMGREP_IMAGE }} \
-                    semgrep \
-                      --config "p/golang" \
-                      --config "p/owasp-top-ten" \
-                      --config "p/security-audit" \
-                      --config "p/trailofbits" \
-                      --config "r/go.lang.security" \
-                      --exclude-rule go.lang.security.audit.xss.no-fprintf-to-responsewriter.no-fprintf-to-responsewriter \
-                      --error \
-                      --metrics=off \
-                      --verbose \
-                      --timeout 300 \
-                      livestream/
+              uses: ./.github/actions/semgrep-ci
+              with:
+                  image: ${{ env.SEMGREP_IMAGE }}
+                  args: >-
+                      --config p/golang
+                      --config p/owasp-top-ten
+                      --config p/security-audit
+                      --config p/trailofbits
+                      --config r/go.lang.security
+                      --exclude-rule go.lang.security.audit.xss.no-fprintf-to-responsewriter.no-fprintf-to-responsewriter
+                      --include /livestream
 
     semgrep-rust:
         needs: changes
@@ -231,24 +227,20 @@ jobs:
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Run Semgrep
-              run: |
-                  docker run --rm -v "${{ github.workspace }}:/src" -w /src \
-                    -e SEMGREP_ENABLE_VERSION_CHECK=false \
-                    ${{ env.SEMGREP_IMAGE }} \
-                    semgrep \
-                      --config "p/rust" \
-                      --config "p/owasp-top-ten" \
-                      --config "p/security-audit" \
-                      --config "p/trailofbits" \
-                      --config "r/rust.lang.security" \
-                      --exclude-rule trailofbits.generic.curl-unencrypted-url.curl-unencrypted-url \
-                      --exclude-rule trailofbits.generic.redis-unencrypted-transport.redis-unencrypted-transport \
-                      --exclude-rule trailofbits.rs.panic-in-function-returning-result.panic-in-function-returning-result \
-                      --error \
-                      --metrics=off \
-                      --verbose \
-                      --timeout 300 \
-                      cli/ rust/
+              uses: ./.github/actions/semgrep-ci
+              with:
+                  image: ${{ env.SEMGREP_IMAGE }}
+                  args: >-
+                      --config p/rust
+                      --config p/owasp-top-ten
+                      --config p/security-audit
+                      --config p/trailofbits
+                      --config r/rust.lang.security
+                      --exclude-rule trailofbits.generic.curl-unencrypted-url.curl-unencrypted-url
+                      --exclude-rule trailofbits.generic.redis-unencrypted-transport.redis-unencrypted-transport
+                      --exclude-rule trailofbits.rs.panic-in-function-returning-result.panic-in-function-returning-result
+                      --include /cli
+                      --include /rust
 
     semgrep-js:
         needs: changes
@@ -272,21 +264,22 @@ jobs:
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Run Semgrep
-              run: |
-                  docker run --rm -v "${{ github.workspace }}:/src" -w /src \
-                    -e SEMGREP_ENABLE_VERSION_CHECK=false \
-                    ${{ env.SEMGREP_IMAGE }} \
-                    semgrep \
-                      --config ".semgrep/rules/security" \
-                      --config "p/javascript" \
-                      --config "p/owasp-top-ten" \
-                      --config "p/security-audit" \
-                      --config "p/trailofbits" \
-                      --error \
-                      --metrics=off \
-                      --verbose \
-                      --timeout 300 \
-                      frontend/ nodejs/ services/agent-proxy/ services/integration-service/ services/mcp/ services/oauth-proxy/ services/stripe-app/
+              uses: ./.github/actions/semgrep-ci
+              with:
+                  image: ${{ env.SEMGREP_IMAGE }}
+                  args: >-
+                      --config .semgrep/rules/security
+                      --config p/javascript
+                      --config p/owasp-top-ten
+                      --config p/security-audit
+                      --config p/trailofbits
+                      --include /frontend
+                      --include /nodejs
+                      --include /services/agent-proxy
+                      --include /services/integration-service
+                      --include /services/mcp
+                      --include /services/oauth-proxy
+                      --include /services/stripe-app
 
     semgrep-products-frontend:
         needs: changes
@@ -314,17 +307,12 @@ jobs:
             # require-iframe-sandbox, ...) live in semgrep-js. When more
             # product-specific rules land, extend the --config list explicitly.
             - name: Run Semgrep
-              run: |
-                  docker run --rm -v "${{ github.workspace }}:/src" -w /src \
-                    -e SEMGREP_ENABLE_VERSION_CHECK=false \
-                    ${{ env.SEMGREP_IMAGE }} \
-                    semgrep \
-                      --config ".semgrep/rules/security/prefer-codegen-api.yaml" \
-                      --error \
-                      --metrics=off \
-                      --verbose \
-                      --timeout 300 \
-                      products/
+              uses: ./.github/actions/semgrep-ci
+              with:
+                  image: ${{ env.SEMGREP_IMAGE }}
+                  args: >-
+                      --config .semgrep/rules/security/prefer-codegen-api.yaml
+                      --include /products
 
     # scans GitHub Actions and other repo-wide config
     semgrep-general:
@@ -352,37 +340,31 @@ jobs:
 
             # exclude all directories already scanned by other jobs
             - name: Run Semgrep
-              run: |
-                  docker run --rm -v "${{ github.workspace }}:/src" -w /src \
-                    -e SEMGREP_ENABLE_VERSION_CHECK=false \
-                    ${{ env.SEMGREP_IMAGE }} \
-                    semgrep \
-                      --config "p/owasp-top-ten" \
-                      --config "p/security-audit" \
-                      --config "p/trailofbits" \
-                      --config "p/github-actions" \
-                      --exclude-rule dockerfile.security.no-sudo-in-dockerfile.no-sudo-in-dockerfile \
-                      --exclude-rule trailofbits.generic.redis-unencrypted-transport.redis-unencrypted-transport \
-                      --exclude-rule trailofbits.yaml.docker-compose.port-all-interfaces.port-all-interfaces \
-                      --exclude-rule yaml.github-actions.security.audit.unsafe-add-mask-workflow-command.unsafe-add-mask-workflow-command \
-                      --error \
-                      --metrics=off \
-                      --verbose \
-                      --jobs 4 \
-                      --timeout 300 \
-                      --exclude ./cli/ \
-                      --exclude ./common/ \
-                      --exclude ./ee/ \
-                      --exclude ./frontend/ \
-                      --exclude ./livestream/ \
-                      --exclude ./nodejs/ \
-                      --exclude ./posthog/ \
-                      --exclude ./products/ \
-                      --exclude ./rust/ \
-                      --exclude ./.semgrep/ \
-                      --exclude ./docs/ \
-                      --exclude ./services/ \
-                      .
+              uses: ./.github/actions/semgrep-ci
+              with:
+                  image: ${{ env.SEMGREP_IMAGE }}
+                  args: >-
+                      --config p/owasp-top-ten
+                      --config p/security-audit
+                      --config p/trailofbits
+                      --config p/github-actions
+                      --exclude-rule dockerfile.security.no-sudo-in-dockerfile.no-sudo-in-dockerfile
+                      --exclude-rule trailofbits.generic.redis-unencrypted-transport.redis-unencrypted-transport
+                      --exclude-rule trailofbits.yaml.docker-compose.port-all-interfaces.port-all-interfaces
+                      --exclude-rule yaml.github-actions.security.audit.unsafe-add-mask-workflow-command.unsafe-add-mask-workflow-command
+                      --exclude /cli
+                      --exclude /common
+                      --exclude /ee
+                      --exclude /frontend
+                      --exclude /livestream
+                      --exclude /nodejs
+                      --exclude /posthog
+                      --exclude /products
+                      --exclude /rust
+                      --exclude /.semgrep
+                      --exclude /docs
+                      --exclude /services
+                      --jobs 4
 
     # Devex / hygiene rules. Two passes:
     #   - WARNING-severity rules print findings without failing the job

--- a/tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
@@ -779,8 +779,9 @@ class TestSemgrepServicesCoverageCheck:
     def test_reads_composite_action_with_args(self, tmp_path: Path) -> None:
         # The real jobs pass scan targets through the semgrep-ci composite
         # action's `args` input, as `--include /services/<name>` with no
-        # trailing slash — those must count as coverage, and the boundary
-        # match must not let `/services/api` cover a `services/api-v2`.
+        # trailing slash — those must count as coverage. Excluded services and
+        # prefix matches must not: `--exclude /services/api-v2` is not
+        # coverage of api-v2, and `/services/api` does not cover it either.
         repo_root = tmp_path
         for service in ("api", "api-v2"):
             (repo_root / "services" / service).mkdir(parents=True)
@@ -803,6 +804,7 @@ class TestSemgrepServicesCoverageCheck:
                       args: >-
                         --config p/python
                         --include /services/api
+                        --exclude /services/api-v2
               semgrep-js:
                 runs-on: ubuntu-latest
                 timeout-minutes: 5

--- a/tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
@@ -776,6 +776,43 @@ class TestSemgrepServicesCoverageCheck:
         [issue] = SemgrepServicesCoverageCheck(repo_root=repo_root).run(_read_all(workflows_dir)).issues
         assert "services/worker/" in issue.message
 
+    def test_reads_composite_action_with_args(self, tmp_path: Path) -> None:
+        # The real jobs pass scan targets through the semgrep-ci composite
+        # action's `args` input, as `--include /services/<name>` with no
+        # trailing slash — those must count as coverage, and the boundary
+        # match must not let `/services/api` cover a `services/api-v2`.
+        repo_root = tmp_path
+        for service in ("api", "api-v2"):
+            (repo_root / "services" / service).mkdir(parents=True)
+        workflows_dir = repo_root / ".github" / "workflows"
+        workflows_dir.mkdir(parents=True)
+        _write(
+            workflows_dir,
+            "ci-security.yaml",
+            """
+            name: Security
+            on: [pull_request]
+            jobs:
+              semgrep-python:
+                runs-on: ubuntu-latest
+                timeout-minutes: 5
+                steps:
+                  - uses: ./.github/actions/semgrep-ci
+                    with:
+                      image: semgrep/semgrep:1.0.0
+                      args: >-
+                        --config p/python
+                        --include /services/api
+              semgrep-js:
+                runs-on: ubuntu-latest
+                timeout-minutes: 5
+                steps:
+                  - run: echo ok
+            """,
+        )
+        [issue] = SemgrepServicesCoverageCheck(repo_root=repo_root).run(_read_all(workflows_dir)).issues
+        assert "services/api-v2/" in issue.message
+
 
 # ---------------------------------------------------------------------------
 # CheckoutFullDepthCheck

--- a/tools/hogli-commands/hogli_commands/workflow_lint/checks/semgrep_services_coverage.py
+++ b/tools/hogli-commands/hogli_commands/workflow_lint/checks/semgrep_services_coverage.py
@@ -100,8 +100,8 @@ def _tracked_services(repo_root: Path, services_dir: Path) -> list[str]:
 
 
 def _covering_run_text(wf: Workflow) -> str:
-    # scan targets may live in `run:` text or in a composite action's `with:`
-    # values (e.g. the semgrep-ci action's `args`)
+    # scan targets may live in `run:` text or in a composite action's `args`
+    # input (the semgrep-ci action)
     parts: list[str] = []
     for job in wf.jobs:
         if job.name not in COVERING_JOBS:
@@ -110,5 +110,14 @@ def _covering_run_text(wf: Workflow) -> str:
             if step.run is not None:
                 parts.append(step.run)
             if step.with_ is not None:
-                parts.extend(value for value in step.with_.values() if isinstance(value, str))
+                args = step.with_.get("args")
+                if isinstance(args, str):
+                    parts.extend(_include_patterns(args))
     return "\n".join(parts)
+
+
+def _include_patterns(args: str) -> list[str]:
+    # Only `--include` values count as coverage: an `--exclude /services/<name>`
+    # or an unrelated input naming a service must not satisfy the check.
+    tokens = args.split()
+    return [value for flag, value in zip(tokens, tokens[1:]) if flag == "--include"]

--- a/tools/hogli-commands/hogli_commands/workflow_lint/checks/semgrep_services_coverage.py
+++ b/tools/hogli-commands/hogli_commands/workflow_lint/checks/semgrep_services_coverage.py
@@ -16,6 +16,7 @@ CI — which sees only tracked files — would never scan those.
 
 from __future__ import annotations
 
+import re
 import subprocess
 from pathlib import Path
 
@@ -31,7 +32,7 @@ SECURITY_WORKFLOW_NAME = "ci-security.yaml"
 class SemgrepServicesCoverageCheck(WorkflowCheck):
     id = "WF004-semgrep-services-coverage"
     label = "semgrep services coverage"
-    description = f"every services/<name>/ appears in {' or '.join(COVERING_JOBS)} run-text in {SECURITY_WORKFLOW_NAME}"
+    description = f"every services/<name>/ appears in {' or '.join(COVERING_JOBS)} run or with-args text in {SECURITY_WORKFLOW_NAME}"
 
     def __init__(self, repo_root: Path | None = None) -> None:
         # Injected so tests can point at a fixture tree without monkeypatching env vars.
@@ -61,7 +62,9 @@ class SemgrepServicesCoverageCheck(WorkflowCheck):
 
         services = _tracked_services(self._repo_root, services_dir)
         for name in services:
-            if f"services/{name}/" not in run_text:
+            # boundary-delimited: matches `services/api/` run targets as well as
+            # `--include /services/api` args, but not `services/api-v2`
+            if not re.search(rf"services/{re.escape(name)}(?=[/\s]|$)", run_text):
                 result.issues.append(
                     Issue(
                         workflow=SECURITY_WORKFLOW_NAME,
@@ -97,6 +100,8 @@ def _tracked_services(repo_root: Path, services_dir: Path) -> list[str]:
 
 
 def _covering_run_text(wf: Workflow) -> str:
+    # scan targets may live in `run:` text or in a composite action's `with:`
+    # values (e.g. the semgrep-ci action's `args`)
     parts: list[str] = []
     for job in wf.jobs:
         if job.name not in COVERING_JOBS:
@@ -104,4 +109,6 @@ def _covering_run_text(wf: Workflow) -> str:
         for step in job.steps:
             if step.run is not None:
                 parts.append(step.run)
+            if step.with_ is not None:
+                parts.extend(value for value in step.with_.values() if isinstance(value, str))
     return "\n".join(parts)


### PR DESCRIPTION
## Problem

A new semgrep rule that matches existing code turns CI red on every open PR, not only on the code that a PR changes. Each security job scans its full directory list on each PR, so authors pay for findings they did not introduce.

## Changes

- The six blocking scan jobs (python, go, rust, js, products-frontend, general) now run `semgrep ci` through a new composite action.

| Event | Before | After |
| --- | --- | --- |
| `pull_request` | Full scan. Any finding fails. | Diff scan against the merge-base. Only new findings fail. |
| `push` to master | Full scan. | Full scan (unchanged). A rule with a backlog fails here, not on unrelated PRs. |

- On a pull request, semgrep resolves the merge-base itself: one GitHub API call with `GH_TOKEN`, then deepening fetches as a fallback.
- Positional scan targets became root-anchored `--include /dir` patterns. Unanchored patterns also match nested directories with the same name, so anchoring keeps the old scope.
- The devex and desktop jobs keep `semgrep scan`. They filter with `--severity`, and `semgrep ci` does not have that flag.
- The WF004 linter now reads scan targets from composite-action `with:` args, not only from `run:` text.
- The image stays digest-pinned. Note for future bumps: the logged-out path falls back from the OCaml binary to pysemgrep, and each flag must parse in both.

## How did you test this code?

- I listed the resolved targets of the old and new invocations for all six jobs with the pinned image (`--x-ls`). The sets are identical.
- I ran the exact composite command logged out on this repo. It exited 0 with the expected scope and metrics off.
- The new linter test guards two regressions: targets in `with:` args must count as service coverage, and `/services/api` must not cover `services/api-v2`.
- Not run: a real pull-request baseline scan, because it needs the Actions event context. The checks on this PR exercise that path.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- This PR updates the semgrep passage in `.agents/security.md`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude Code (Fable 5) in a local session. Felipe directed the work.
