### PR TITLE
fix(file-system): constrain file tree href targets

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/menus/BrowserLikeMenuItems.test.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/menus/BrowserLikeMenuItems.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render } from '@testing-library/react'
+
+import { DropdownMenuItem } from 'lib/ui/DropdownMenu/DropdownMenu'
+
+import { BrowserLikeMenuItems } from './BrowserLikeMenuItems'
+
+describe('BrowserLikeMenuItems', () => {
+    // Radix menu items throw outside a menu root, and the guard under test doesn't need one.
+    function TestMenuItem({
+        onClick,
+        'data-attr': dataAttr,
+    }: {
+        onClick?: (event: React.MouseEvent) => void
+        'data-attr'?: string
+    }): JSX.Element {
+        return <button type="button" data-attr={dataAttr} onClick={onClick} />
+    }
+
+    function clickOpenLink(href: string): void {
+        const { container } = render(
+            <BrowserLikeMenuItems MenuItem={TestMenuItem as unknown as typeof DropdownMenuItem} href={href} />
+        )
+        fireEvent.click(container.querySelector('[data-attr="tree-item-menu-open-link-button"]')!)
+    }
+
+    let openSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        openSpy = jest.spyOn(window, 'open').mockImplementation(() => null)
+    })
+
+    afterEach(() => {
+        openSpy.mockRestore()
+    })
+
+    it.each([
+        ['javascript:alert(document.cookie)'],
+        ['JaVaScRiPt:alert(1)'],
+        ['java\tscript:alert(1)'],
+        ['  javascript:alert(1)'],
+        ['vbscript:msgbox(1)'],
+        ['data:text/html,<script>alert(1)</script>'],
+        ['//evil.example.com/x'],
+        // Browsers read a leading `/\` the same way they read `//`.
+        ['/\\evil.example.com/x'],
+        ['https://evil.example.com/x'],
+    ])('does not open %s', (href) => {
+        clickOpenLink(href)
+
+        expect(openSpy).not.toHaveBeenCalled()
+    })
+
+    it.each([['/insights/abc123'], ['http://localhost/project/1/insights']])('opens %s', (href) => {
+        clickOpenLink(href)
+
+        expect(openSpy).toHaveBeenCalledWith(href, '_blank')
+    })
+})

--- a/frontend/src/layout/panel-layout/ProjectTree/menus/BrowserLikeMenuItems.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/menus/BrowserLikeMenuItems.tsx
@@ -1,6 +1,7 @@
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { DropdownMenuItem } from 'lib/ui/DropdownMenu/DropdownMenu'
+import { isTrustedPostHogUrl } from 'lib/utils/trustedUrl'
 
 import { CustomMenuProps } from '../types'
 
@@ -21,6 +22,11 @@ export function BrowserLikeMenuItems({
                 asChild
                 onClick={(e) => {
                     e.stopPropagation()
+                    // `href` is server-supplied for tree and shortcut rows, and window.open honors
+                    // whatever scheme it is handed, unlike Link which rewrites its target.
+                    if (!isTrustedPostHogUrl(href)) {
+                        return
+                    }
                     window.open(href, '_blank')
                     onClick?.()
                 }}

--- a/posthog/api/file_system/file_system.py
+++ b/posthog/api/file_system/file_system.py
@@ -73,6 +73,27 @@ MAX_META_BYTES = 1_000_000
 RECENTS_SEARCH_SCAN_LIMIT = 200
 
 
+# Browsers drop C0 controls and DEL from anywhere in a URL, so `java<TAB>script:` navigates as
+# `javascript:`. An href has to be judged on what the browser will resolve, not the stored bytes.
+HREF_IGNORED_CHARS = dict.fromkeys([*range(0x00, 0x20), 0x7F])
+
+# A leading `//` (or `/\`, which browsers read the same way) is a protocol-relative URL to another
+# host rather than an app path, so it doesn't count as relative.
+HREF_ALLOWED_PREFIX = re.compile(r"^(?:/(?![/\\])|https?://)", re.IGNORECASE)
+
+
+def validate_file_system_href(href: Optional[str]) -> Optional[str]:
+    """Keep a caller-supplied href to targets the app can navigate to. A row is readable by everyone
+    in the project and its href reaches raw navigation in the tree menu, so the scheme cannot be
+    left open."""
+    if not href:
+        return href
+    normalized = href.translate(HREF_IGNORED_CHARS).strip()
+    if not HREF_ALLOWED_PREFIX.match(normalized):
+        raise serializers.ValidationError("Href must start with '/' or be an http(s) URL.")
+    return normalized
+
+
 def validate_file_system_path(path: Any) -> str:
     """Bound a caller-supplied path before it reaches the per-segment folder creation loop, which
     costs one existence check plus one insert per segment and autocommits each one."""
@@ -116,6 +137,9 @@ class FileSystemSerializer(FileSystemAccessLevelSerializerMixin, serializers.Mod
 
     def validate_path(self, path: str) -> str:
         return validate_file_system_path(path)
+
+    def validate_href(self, href: Optional[str]) -> Optional[str]:
+        return validate_file_system_href(href)
 
     def validate_meta(self, meta: Any) -> dict[str, Any]:
         # Readers treat `meta` as an object, so anything else stored here breaks every listing that

--- a/posthog/api/file_system/file_system_shortcut.py
+++ b/posthog/api/file_system/file_system_shortcut.py
@@ -1,4 +1,4 @@
-from typing import Any, cast
+from typing import Any, Optional, cast
 
 from django.db import transaction
 from django.db.models import Case, Q, QuerySet, When
@@ -11,6 +11,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from posthog.api.file_system.access_levels import FileSystemAccessLevelSerializerMixin
+from posthog.api.file_system.file_system import validate_file_system_href
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.models import User
 from posthog.models.file_system.constants import DEFAULT_SURFACE, surface_q
@@ -44,6 +45,9 @@ class FileSystemShortcutSerializer(FileSystemAccessLevelSerializerMixin, seriali
             },
             "order": {"help_text": "Display order within the user's shortcut list, ascending."},
         }
+
+    def validate_href(self, href: Optional[str]) -> Optional[str]:
+        return validate_file_system_href(href)
 
     def update(self, instance: FileSystemShortcut, validated_data: dict[str, Any]) -> FileSystemShortcut:
         instance.team_id = self.context["team_id"]

--- a/posthog/api/file_system/test/test_file_system.py
+++ b/posthog/api/file_system/test/test_file_system.py
@@ -2377,6 +2377,15 @@ class TestFileSystemSerializerInputValidation(SimpleTestCase):
             ("meta_too_large", {"path": "a", "type": "doc", "meta": {"k": "x" * (MAX_META_BYTES + 1)}}, "meta"),
             ("path_too_long", {"path": "x" * (MAX_PATH_LENGTH + 1), "type": "doc"}, "path"),
             ("path_too_many_segments", {"path": "/".join(["s"] * (MAX_PATH_SEGMENTS + 1)), "type": "doc"}, "path"),
+            ("href_javascript", {"path": "a", "type": "link", "href": "javascript:alert(1)"}, "href"),
+            ("href_javascript_uppercase", {"path": "a", "type": "link", "href": "JaVaScRiPt:alert(1)"}, "href"),
+            ("href_javascript_tab_in_scheme", {"path": "a", "type": "link", "href": "java\tscript:alert(1)"}, "href"),
+            ("href_javascript_leading_space", {"path": "a", "type": "link", "href": "  javascript:alert(1)"}, "href"),
+            ("href_vbscript", {"path": "a", "type": "link", "href": "vbscript:msgbox(1)"}, "href"),
+            ("href_data_uri", {"path": "a", "type": "link", "href": "data:text/html,<script>x</script>"}, "href"),
+            ("href_protocol_relative", {"path": "a", "type": "link", "href": "//evil.example.com/x"}, "href"),
+            ("href_backslash_relative", {"path": "a", "type": "link", "href": "/\\evil.example.com/x"}, "href"),
+            ("href_scheme_relative", {"path": "a", "type": "link", "href": "insights/abc123"}, "href"),
         ]
     )
     def test_rejects_out_of_bounds_input(self, _name: str, payload: dict[str, Any], field: str) -> None:
@@ -2391,6 +2400,12 @@ class TestFileSystemSerializerInputValidation(SimpleTestCase):
             ("meta_absent", {"path": "a/b", "type": "doc"}),
             ("meta_empty", {"path": "a/b", "type": "doc", "meta": {}}),
             ("path_at_segment_limit", {"path": "/".join(["s"] * MAX_PATH_SEGMENTS), "type": "doc"}),
+            ("href_app_path", {"path": "a/b", "type": "link", "href": "/insights/abc123?tab=1#x"}),
+            ("href_root", {"path": "a/b", "type": "link", "href": "/"}),
+            ("href_absolute_https", {"path": "a/b", "type": "link", "href": "https://app.example.com/x"}),
+            ("href_absolute_http", {"path": "a/b", "type": "link", "href": "http://app.example.com/x"}),
+            ("href_empty", {"path": "a/b", "type": "link", "href": ""}),
+            ("href_null", {"path": "a/b", "type": "link", "href": None}),
         ]
     )
     def test_accepts_in_bounds_input(self, _name: str, payload: dict[str, Any]) -> None:
@@ -2408,6 +2423,12 @@ class TestFileSystemInputValidationAPI(APIBaseTest):
 
     def test_create_with_too_many_path_segments_is_rejected_and_writes_nothing(self):
         response = self.client.post(self.url, {"path": "/".join(["s"] * (MAX_PATH_SEGMENTS + 1)), "type": "doc"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.json())
+        self.assertEqual(FileSystem.objects.filter(team=self.team).count(), 0)
+
+    def test_create_with_a_script_href_is_rejected_and_writes_nothing(self):
+        response = self.client.post(self.url, {"path": "Trap", "type": "link", "href": "javascript:alert(1)"})
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.json())
         self.assertEqual(FileSystem.objects.filter(team=self.team).count(), 0)

--- a/posthog/api/file_system/test/test_file_system_shortcut.py
+++ b/posthog/api/file_system/test/test_file_system_shortcut.py
@@ -36,6 +36,15 @@ class TestFileSystemShortcutAPI(APIBaseTest):
         self.assertEqual(response_data["path"], "Document.txt")
         self.assertEqual(response_data["type"], "doc-file")
 
+    def test_create_shortcut_with_a_script_href_is_rejected_and_writes_nothing(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/file_system_shortcut/",
+            {"path": "Trap", "type": "link", "href": "javascript:alert(1)"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.json())
+        self.assertEqual(FileSystemShortcut.objects.filter(team=self.team).count(), 0)
+
     def test_retrieve_shortcut(self):
         shortcut_obj = FileSystemShortcut.objects.create(
             team=self.team,


### PR DESCRIPTION
## Problem

A file tree row can carry a link target that is not an app page, and every project member gets that target when they use the row's context menu.

- Any project member can write a `FileSystem` or `FileSystemShortcut` row, and both serializers store `href` verbatim with no scheme check.
- The tree menu's "Open link in new browser tab" passes that stored `href` straight to `window.open`, which follows whatever scheme it is handed.
- The sibling navigation path is already guarded. `Link` rewrites its target, so `window.open` was the remaining raw call site.

## Changes

- `BrowserLikeMenuItems` now checks `isTrustedPostHogUrl` before it calls `window.open`.
- I reused that existing helper instead of a new one, because it resolves the target against the current origin the way the browser does.
- A new `validate_file_system_href` accepts a leading `/` or an `http(s)://` URL, and rejects everything else with a 400.
- `FileSystemSerializer` and `FileSystemShortcutSerializer` both call it, so either endpoint rejects the same values.
- The validator drops C0 controls and DEL before it matches, because browsers ignore those characters inside a URL.
- It also rejects a leading `//` or `/\`, which browsers read as another host rather than an app path.

The two ends close the same class of value but are not the same rule. The serializer still stores an off-origin `http(s)` URL, and the menu then refuses to open it. That asymmetry is deliberate, so the API stays usable for absolute app URLs while the menu opens only what the app serves.

`BrowserLikeMenuItems` is shared by three surfaces. The project tree menu and the ai-first browse tab both feed it a server-supplied `href`. The Max chat list feeds it an absolute app URL built in the client, which is why the serializer keeps `http(s)://` rather than relative paths alone.

> [!NOTE]
> Server-side writers still bypass this. `create_or_update_file` and `FileSystemRepresentation` set `href` on the model directly, so the validator does not run for them. Those values are product-generated, not caller-supplied.

Nothing looks different. One behavior changes: the ai-first browse tab passes `href` unguarded, so an entry with no `href` used to open a blank tab and now opens nothing. The tree menu already gated on a truthy `href`.

## How did you test this code?

Automated only. I (actually Claude) ran the suites below locally and did no manual browser testing.

- Backend cases live in `TestFileSystemSerializerInputValidation`, extending the existing parameterized reject and accept lists. They catch a serializer that stops validating `href`.
- Two endpoint cases, one per viewset, assert a 400 and that no row is written. They catch a viewset wired to a serializer that skips the check.
- `BrowserLikeMenuItems.test.tsx` clicks the menu item and asserts `window.open`. It catches the component opening a target the app would not route to.

<details>
<summary>What I ran</summary>

- `pytest posthog/api/file_system/ posthog/api/test/test_file_system.py posthog/models/file_system/`
- `jest src/layout/panel-layout src/lib/utils/trustedUrl.test.ts src/lib/lemon-ui/Link`
- `pnpm --filter=@posthog/frontend typescript:check`, which reports the same six pre-existing `@posthog/hogvm` module errors with and without this change
- `ruff format` and `ruff check` on `posthog/api/file_system/`

I confirmed both ends failed before the fix and pass after it.

</details>

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus). Skills invoked: `/writing-tests`, `/improving-drf-endpoints`, `/writing-code-comments`, `/writing-pr-descriptions`.

- I wrote the failing tests at both ends first, confirmed each failed for the right reason, then applied the fix.
- I checked all three `BrowserLikeMenuItems` call sites before choosing the predicate. The Max one passes an absolute URL, which ruled out a relative-only allowlist.
- I picked `isTrustedPostHogUrl` over exporting `hasDangerousScheme` from `Link.tsx`. An allowlist does not have to track new dangerous schemes as they appear.
- I did not add `help_text` to the `href` field, so the OpenAPI spec is unchanged and no codegen run is needed.
