### PR TITLE
fix(notebooks): parse markdown component blocks in linear time

### DIFF
--- a/products/notebooks/backend/test/test_sharing.py
+++ b/products/notebooks/backend/test/test_sharing.py
@@ -12,6 +12,7 @@ from posthog.models import SharingConfiguration
 from products.notebooks.backend.models import Notebook
 from products.notebooks.backend.util import (
     MAX_MARKDOWN_COMPONENT_BLOCK_CHARS,
+    _parse_markdown_component_props,
     extract_inline_query_nodes,
     extract_referenced_insight_short_ids,
     filter_notebook_content_for_sharing,
@@ -390,6 +391,26 @@ class TestFilterNotebookContentForSharing(TestCase):
         self.assertEqual(original, snapshot)
 
 
+class _SliceCountingStr(str):
+    """A string that reports how many characters slicing has copied out of it and its slices."""
+
+    def __new__(cls, value: str, counter: list[int] | None = None) -> "_SliceCountingStr":
+        instance = super().__new__(cls, value)
+        instance._counter = [0] if counter is None else counter
+        return instance
+
+    @property
+    def copied_chars(self) -> int:
+        return self._counter[0]
+
+    def __getitem__(self, key: Any) -> Any:
+        result = str.__getitem__(self, key)
+        if not isinstance(key, slice):
+            return result
+        self._counter[0] += len(result)
+        return _SliceCountingStr(result, self._counter)
+
+
 class TestMarkdownComponentBlockParsing(TestCase):
     def _filtered_markdown(self, markdown: str) -> Any:
         return filter_notebook_content_for_sharing(_markdown_doc(markdown))["content"][0]["attrs"]["markdown"]
@@ -429,6 +450,16 @@ class TestMarkdownComponentBlockParsing(TestCase):
     def test_oversized_unsupported_block_is_still_redacted(self) -> None:
         code = "SECRET" * MAX_MARKDOWN_COMPONENT_BLOCK_CHARS
         self.assertEqual(self._filtered_markdown(f'<Python code="{code}" />'), "<Python />")
+
+    def test_prop_parsing_does_not_copy_the_block_once_per_prop(self) -> None:
+        block = _SliceCountingStr("<Image " + " ".join(f"p{index}" for index in range(2000)) + " />")
+
+        props = _parse_markdown_component_props(block)
+
+        self.assertEqual(len(props), 2000)
+        # One copy separates the props from the tag; a per-prop copy would make this quadratic, and
+        # anonymous share rendering parses every block in a stored notebook.
+        self.assertLessEqual(block.copied_chars, 2 * len(block))
 
 
 class TestNotebookSharingConfiguration(APIBaseTest):

--- a/products/notebooks/backend/test/test_sharing.py
+++ b/products/notebooks/backend/test/test_sharing.py
@@ -394,6 +394,8 @@ class TestFilterNotebookContentForSharing(TestCase):
 class _SliceCountingStr(str):
     """A string that reports how many characters slicing has copied out of it and its slices."""
 
+    _counter: list[int]
+
     def __new__(cls, value: str, counter: list[int] | None = None) -> "_SliceCountingStr":
         instance = super().__new__(cls, value)
         instance._counter = [0] if counter is None else counter

--- a/products/notebooks/backend/test/test_sharing.py
+++ b/products/notebooks/backend/test/test_sharing.py
@@ -11,6 +11,7 @@ from posthog.models import SharingConfiguration
 
 from products.notebooks.backend.models import Notebook
 from products.notebooks.backend.util import (
+    MAX_MARKDOWN_COMPONENT_BLOCK_CHARS,
     extract_inline_query_nodes,
     extract_referenced_insight_short_ids,
     filter_notebook_content_for_sharing,
@@ -387,6 +388,47 @@ class TestFilterNotebookContentForSharing(TestCase):
         snapshot = {"type": "doc", "content": [{"type": "ph-python", "attrs": {"code": "SECRET"}}]}
         filter_notebook_content_for_sharing(original)
         self.assertEqual(original, snapshot)
+
+
+class TestMarkdownComponentBlockParsing(TestCase):
+    def _filtered_markdown(self, markdown: str) -> Any:
+        return filter_notebook_content_for_sharing(_markdown_doc(markdown))["content"][0]["attrs"]["markdown"]
+
+    @parameterized.expand(
+        [
+            ("paired_tag", '<Comment ref="r-1">hello there</Comment>', '<Comment ref="r-1" />'),
+            (
+                "angle_bracket_inside_quoted_prop",
+                '<Image alt="a > b" src="https://example.com/a.png" />',
+                '<Image alt="a > b" src="https://example.com/a.png" />',
+            ),
+            (
+                "self_close_inside_quoted_prop",
+                '<Image alt="a /> b" src="https://example.com/a.png" />',
+                '<Image alt="a /> b" src="https://example.com/a.png" />',
+            ),
+            ("angle_bracket_inside_paired_tag_prop", '<Comment ref="a>b">x</Comment>', "<Comment />"),
+            ("content_after_closing_tag", '<Comment ref="r-1">hi</Comment> trailing', "<Comment />"),
+            (
+                "multiline_self_closing",
+                '<Query title="t"\n  query={{"kind":"HogQLQuery","query":"select 1"}}\n/>',
+                '<Query query={{"kind":"HogQLQuery","query":"select 1"}} title="t" />',
+            ),
+            ("multiline_paired", '<Comment ref="r-2">\nline one\nline two\n</Comment>', '<Comment ref="r-2" />'),
+            ("multiline_open_tag", '<Comment ref="r-3"\n>\nbody\n</Comment>', '<Comment ref="r-3" />'),
+            ("unterminated_block", '<Image alt="a"\nstill going', '<Image alt="a"\nstill going'),
+        ]
+    )
+    def test_component_block_shapes(self, _name: str, markdown: str, expected: str) -> None:
+        self.assertEqual(self._filtered_markdown(markdown), expected)
+
+    def test_props_of_an_oversized_block_are_not_parsed(self) -> None:
+        alt = "a" * MAX_MARKDOWN_COMPONENT_BLOCK_CHARS
+        self.assertEqual(self._filtered_markdown(f'<Image alt="{alt}" src="https://example.com/a.png" />'), "<Image />")
+
+    def test_oversized_unsupported_block_is_still_redacted(self) -> None:
+        code = "SECRET" * MAX_MARKDOWN_COMPONENT_BLOCK_CHARS
+        self.assertEqual(self._filtered_markdown(f'<Python code="{code}" />'), "<Python />")
 
 
 class TestNotebookSharingConfiguration(APIBaseTest):

--- a/products/notebooks/backend/util.py
+++ b/products/notebooks/backend/util.py
@@ -62,8 +62,13 @@ _SHARED_NOTEBOOK_MARKDOWN_COMPONENT_PROP_TYPES: dict[str, dict[str, type | tuple
     },
 }
 
+# The editor never emits a single component block anywhere near this large; the biggest real ones
+# hold a query JSON or a SQL cell's code. Over the cap a block parses to no props, so the sharing
+# filter emits a bare `<Tag />` instead of anything derived from the block's source.
+MAX_MARKDOWN_COMPONENT_BLOCK_CHARS = 1_000_000
+
 _MARKDOWN_COMPONENT_START_REGEX = re.compile(r"^<[A-Z][A-Za-z0-9]*(\s|>|/)")
-_MARKDOWN_COMPONENT_TAG_REGEX = re.compile(r"^<([A-Z][A-Za-z0-9]*)([\s\S]*?)(?:/>|>[\s\S]*</\1>)$")
+_MARKDOWN_COMPONENT_TAG_NAME_REGEX = re.compile(r"^<([A-Z][A-Za-z0-9]*)")
 _MARKDOWN_COMPONENT_PROP_NAME_REGEX = re.compile(r"^([A-Za-z_][A-Za-z0-9_-]*)")
 _MARKDOWN_COMPONENT_RAW_PROP_VALUE_REGEX = re.compile(r"^([^\s/>]+)")
 _MARKDOWN_COMPONENT_NUMBER_REGEX = re.compile(r"^-?\d+(\.\d+)?$")
@@ -371,18 +376,23 @@ def _read_markdown_component_block(lines: list[str], line_index: int) -> tuple[s
     if not _MARKDOWN_COMPONENT_START_REGEX.match(first_line):
         return None
 
-    tag_match = re.match(r"^<([A-Z][A-Za-z0-9]*)", first_line)
+    tag_match = _MARKDOWN_COMPONENT_TAG_NAME_REGEX.match(first_line)
     tag_name = tag_match.group(1) if tag_match else None
     if not tag_name:
         return None
 
+    closing_tag = f"</{tag_name}>"
     raw_lines: list[str] = []
     next_line_index = line_index
     found_terminator = False
     while next_line_index < len(lines) and (next_line_index == line_index or lines[next_line_index].strip()):
-        raw_lines.append(lines[next_line_index])
-        raw = "\n".join(raw_lines).strip()
-        if raw.endswith("/>") or f"</{tag_name}>" in raw:
+        line = lines[next_line_index]
+        raw_lines.append(line)
+        # The terminator is decidable from the line just added, so the block is scanned once
+        # rather than re-joined and re-searched per line. Every appended line is non-blank, so
+        # the joined block ends where this line ends; and a closing tag holds no whitespace or
+        # newline, so it cannot straddle a join or be created by stripping the block's edges.
+        if line.rstrip().endswith("/>") or closing_tag in line:
             found_terminator = True
             break
         next_line_index += 1
@@ -393,13 +403,41 @@ def _read_markdown_component_block(lines: list[str], line_index: int) -> tuple[s
     return tag_name, "\n".join(raw_lines).strip(), next_line_index + 1
 
 
+def _read_markdown_component_prop_source(raw: str) -> str | None:
+    """Return the source holding a component block's props, or None if `raw` is not one block.
+
+    The props run from the end of the tag name to the block's terminator. A block terminates
+    either by self-closing (`<Tag … />`) or by pairing (`<Tag …>…</Tag>`), and a tag name always
+    starts with a letter, so a block that ends in `</Tag>` can never also end in `/>`. That makes
+    the two shapes mutually exclusive and lets each be resolved with a single scan.
+    """
+    if len(raw) > MAX_MARKDOWN_COMPONENT_BLOCK_CHARS:
+        return None
+
+    tag_match = _MARKDOWN_COMPONENT_TAG_NAME_REGEX.match(raw)
+    if not tag_match:
+        return None
+    props_start = tag_match.end()
+
+    if raw.endswith("/>"):
+        return raw[props_start:-2] if props_start <= len(raw) - 2 else None
+
+    closing_tag = f"</{tag_match.group(1)}>"
+    if not raw.endswith(closing_tag):
+        return None
+
+    props_end = raw.find(">", props_start)
+    if props_end < 0 or props_end + 1 > len(raw) - len(closing_tag):
+        return None
+    return raw[props_start:props_end]
+
+
 def _parse_markdown_component_props(raw: str) -> dict[str, Any]:
-    match = _MARKDOWN_COMPONENT_TAG_REGEX.match(raw)
-    if not match:
+    source = _read_markdown_component_prop_source(raw)
+    if source is None:
         return {}
 
     props: dict[str, Any] = {}
-    source = match.group(2) or ""
     index = 0
     while index < len(source):
         while index < len(source) and source[index].isspace():

--- a/products/notebooks/backend/util.py
+++ b/products/notebooks/backend/util.py
@@ -69,8 +69,10 @@ MAX_MARKDOWN_COMPONENT_BLOCK_CHARS = 1_000_000
 
 _MARKDOWN_COMPONENT_START_REGEX = re.compile(r"^<[A-Z][A-Za-z0-9]*(\s|>|/)")
 _MARKDOWN_COMPONENT_TAG_NAME_REGEX = re.compile(r"^<([A-Z][A-Za-z0-9]*)")
-_MARKDOWN_COMPONENT_PROP_NAME_REGEX = re.compile(r"^([A-Za-z_][A-Za-z0-9_-]*)")
-_MARKDOWN_COMPONENT_RAW_PROP_VALUE_REGEX = re.compile(r"^([^\s/>]+)")
+# Anchored by the `pos` argument of `.match()` rather than by `^`, so the prop loop can scan from
+# an offset instead of slicing a fresh suffix per prop. `^` would never match at a non-zero `pos`.
+_MARKDOWN_COMPONENT_PROP_NAME_REGEX = re.compile(r"([A-Za-z_][A-Za-z0-9_-]*)")
+_MARKDOWN_COMPONENT_RAW_PROP_VALUE_REGEX = re.compile(r"([^\s/>]+)")
 _MARKDOWN_COMPONENT_NUMBER_REGEX = re.compile(r"^-?\d+(\.\d+)?$")
 
 
@@ -445,12 +447,12 @@ def _parse_markdown_component_props(raw: str) -> dict[str, Any]:
         if index >= len(source):
             break
 
-        name_match = _MARKDOWN_COMPONENT_PROP_NAME_REGEX.match(source[index:])
+        name_match = _MARKDOWN_COMPONENT_PROP_NAME_REGEX.match(source, index)
         if not name_match:
             break
 
         name = name_match.group(1)
-        index += len(name)
+        index = name_match.end()
         while index < len(source) and source[index].isspace():
             index += 1
 
@@ -502,9 +504,10 @@ def _read_markdown_component_prop_value(source: str, index: int) -> tuple[Any, i
         value, next_index = balanced
         return _parse_markdown_expression_value(value), next_index
 
-    raw_match = _MARKDOWN_COMPONENT_RAW_PROP_VALUE_REGEX.match(source[index:])
-    raw = raw_match.group(1) if raw_match else ""
-    return _parse_markdown_expression_value(raw), index + len(raw)
+    raw_match = _MARKDOWN_COMPONENT_RAW_PROP_VALUE_REGEX.match(source, index)
+    if not raw_match:
+        return _parse_markdown_expression_value(""), index
+    return _parse_markdown_expression_value(raw_match.group(1)), raw_match.end()
 
 
 def _read_balanced_markdown_expression(source: str, index: int) -> tuple[str, int] | None:


### PR DESCRIPTION
## Problem

- One request for a shared notebook link can hold a request worker for minutes of CPU. Anyone with the link can repeat it.
- The anonymous shared-notebook render parses the notebook's markdown twice, in `posthog/api/sharing.py`.
- Both parsers cost time quadratic in the length of a single markdown component block.
- Nothing bounds notebook content, so one block can reach the 20 MB `DATA_UPLOAD_MAX_MEMORY_SIZE` ceiling.
- The notebook save path parses the same content, and the publish gate parses the old and the new content on every edit.

I measured the render locally, at block sizes an attacker can store today. CI does not measure this.

| Stored markdown | Before | After |
| --- | --- | --- |
| 64 KB, one component block | 4.8 s | under 1 ms |
| 488 KB, one unterminated block | 283 ms | 2.8 ms |
| 20 MB, either shape | minutes, extrapolated from the curve | under 120 ms |

Review caught a third input shape the first version of this branch left quadratic: one block holding
many short props, such as `<Query a b c ... />`. The block reader was linear, but the prop loop still
matched against `source[index:]`, so each prop copied the rest of the block. That shape reaches the
same anonymous render, so the finding stayed open until the second commit.

| Stored markdown, many short props in each block | First version of this branch | Now |
| --- | --- | --- |
| 1 MB | 3.3 s | 181 ms |
| 4 MB | 13.2 s | 704 ms |
| 20 MB | about 66 s, extrapolated | 3.5 s |

Cost is now proportional to stored size for every shape I measured.

## Changes

- `_parse_markdown_component_props` reads a block's props with one scan, replacing a backtracking regex.
- The prop loop matches from an offset rather than from a fresh suffix copy, which needs the two prop
  patterns to drop their leading `^`, because `^` never matches at a non-zero `pos`.
- A block ends either self-closing or paired. A tag name always starts with a letter, so a block ending in `</Tag>` never also ends in `/>`. That is what makes one scan exact.
- `_read_markdown_component_block` decides its terminator from the line it just read, instead of re-joining and re-searching the whole block on every line.
- A single component block over 1 MB now parses to no props.

I did not cap stored notebook content, for three reasons.

- Parsing cost is now proportional to stored size, so the amplification this finding depended on is gone.
- The residual worst case ships a response as large as the work it causes, which makes it egress-bound rather than an amplifier.
- A cap has to cover three `validate_content` methods plus `aupdate_notebook_content` and `aupsert_notebook`, or it is theater. It would also reject saves on any notebook already over the line. That belongs in its own change, with product input on the value.

> [!NOTE]
> The 1 MB block cap is a backstop behind the linear parse, not the fix. It has two visible effects. A `<Query>` block over the cap yields no props, so the shared viewer renders it without its precomputed result. An over-cap `<SQLV2>`, `<PythonV2>`, or `<Query>` block also loses its `nodeId`, so `extract_cells` drops it from the cell state and the dependency graph. A pasted large data literal in a Python cell is the plausible way to reach that.

Two follow-ups I left out to keep this diff tight.

- `frontend/src/lib/components/MarkdownNotebook/markdown.ts` carries the same regex. The threat model there is a viewer's own tab.
- A component prop holding deeply nested JSON raises an uncaught `RecursionError` on the shared render, which returns a 500. That is a different failure mode and needs its own test.

## How did you test this code?

I (actually Claude) wrote the cap test first and confirmed it failed against the old parser before changing it.

- `test_props_of_an_oversized_block_are_not_parsed` catches a regression that drops the block cap.
- `test_oversized_unsupported_block_is_still_redacted` catches the tempting wrong fix. Capping inside the block reader would make an over-cap `<Python code="...">` block fall through to the viewer as raw text.
- `test_prop_parsing_does_not_copy_the_block_once_per_prop` counts the characters slicing copies out of
  the block, so it catches a return to the suffix copy without a wall-clock assertion.
- `test_component_block_shapes` pins nine block shapes the rewrite could silently change. It covers the paired form, an angle bracket inside a self-closing prop, an angle bracket inside a paired prop, `/>` inside a quoted prop, content after a closing tag, three multi-line layouts, and an unterminated block. No existing test covered any of them. Every expected value matches what the old parser returned.

Not checked: I could not sample real notebook sizes, so I reasoned the 1 MB block cap from the shape the editor emits. I ran no manual browser testing.

<details>
<summary>Suites I ran locally</summary>

- `products/notebooks/backend/test/` (whole directory)
- `posthog/api/test/test_sharing.py`, `test_sharing_access_token_security.py`, `test_share_password_api.py`

Three tests in the sharing suites fail with `TemplateDoesNotExist: exporter.html`. They fail the same way on `master` in this worktree, which has no frontend build.

</details>

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior, API, or setting changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code wrote this branch. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

The task named only the props regex. I confirmed it with a timing probe, then found the block reader was independently quadratic. It is reachable from the same anonymous path with a different input, so fixing only the regex would have left the finding open. Both are in this diff.

The block cap sits in `_parse_markdown_component_props` rather than in `_read_markdown_component_block`. The reader looked like the better choke point, but rejecting a block there makes its raw source pass through the sharing filter unredacted. One of the new tests pins that.

I used timing probes to confirm the finding and to size the result. I did not commit them, because a wall-clock assertion is flaky in CI.

