### PR TITLE
fix(conversations): reuse the team validator for project updates

### DIFF
--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -585,15 +585,6 @@ class ProjectBackwardCompatSerializer(
             return value
         return [domain for domain in value if domain]
 
-    def validate_conversations_settings(self, value: dict | None) -> dict | None:
-        if value is None:
-            return value
-        # Filter out None values from widget_domains if present
-        if "widget_domains" in value and value["widget_domains"] is not None:
-            value["widget_domains"] = [domain for domain in value["widget_domains"] if domain]
-            validate_authorized_url_wildcards(value["widget_domains"])
-        return value
-
     class Meta:
         model = Project
         fields = (
@@ -1031,6 +1022,12 @@ class ProjectBackwardCompatSerializer(
 
     def validate_proactive_tasks_enabled(self, value: bool | None) -> bool | None:
         return TeamSerializer.validate_proactive_tasks_enabled(cast(TeamSerializer, self), value)
+
+    # Delegate rather than reimplement: this blob holds server-managed credentials (the widget
+    # public token, the Slack bot token) that TeamSerializer strips from user input, and a partial
+    # copy here silently reopens whichever strips it leaves out.
+    def validate_conversations_settings(self, value: dict | None) -> dict | None:
+        return TeamSerializer.validate_conversations_settings(cast(TeamSerializer, self), value)
 
     def validate(self, attrs: Any) -> Any:
         attrs = validate_team_attrs(attrs, self.context["view"], self.instance)

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -1548,6 +1548,9 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
             "teams_channel_id",
             "teams_channel_name",
             "teams_channels",
+            "github_enabled",
+            "github_integration_id",
+            "github_repos",
         ):
             value.pop(managed_key, None)
         # Normalize multi-channel list: must be a list of non-empty strings, deduped, capped at 50

--- a/posthog/api/test/test_project.py
+++ b/posthog/api/test/test_project.py
@@ -646,6 +646,9 @@ class TestProjectAPI(team_api_test_factory()):  # type: ignore
             ("slack_enabled", True),
             ("email_enabled", True),
             ("teams_tenant_id", "tenant-of-another-team"),
+            ("github_enabled", True),
+            ("github_integration_id", 12345),
+            ("github_repos", ["acme/private-infra"]),
         ]
     )
     def test_conversations_settings_server_managed_keys_are_not_writable(self, key, injected_value):

--- a/posthog/api/test/test_project.py
+++ b/posthog/api/test/test_project.py
@@ -639,6 +639,43 @@ class TestProjectAPI(team_api_test_factory()):  # type: ignore
         self.assertEqual(settings["widget_greeting_text"], "Hello!")
         self.assertEqual(settings["widget_color"], "#ff0000")
 
+    @parameterized.expand(
+        [
+            ("widget_public_token", "token_belonging_to_another_team"),
+            ("slack_bot_token", "xoxb-not-a-real-token"),
+            ("slack_enabled", True),
+            ("email_enabled", True),
+            ("teams_tenant_id", "tenant-of-another-team"),
+        ]
+    )
+    def test_conversations_settings_server_managed_keys_are_not_writable(self, key, injected_value):
+        self.team.conversations_settings = {"widget_greeting_text": "Hello!"}
+        self.team.save()
+
+        response = self.client.patch(
+            f"/api/projects/{self.project.id}/",
+            {"conversations_settings": {key: injected_value, "widget_color": "#ff0000"}},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.team.refresh_from_db()
+        settings = self.team.conversations_settings
+        self.assertNotEqual(settings.get(key), injected_value)
+        self.assertEqual(settings["widget_color"], "#ff0000")
+
+    def test_conversations_settings_patch_cannot_replace_existing_widget_token(self):
+        self.team.conversations_settings = {"widget_public_token": "this_teams_own_token"}
+        self.team.save()
+
+        response = self.client.patch(
+            f"/api/projects/{self.project.id}/",
+            {"conversations_settings": {"widget_public_token": "token_belonging_to_another_team"}},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.team.refresh_from_db()
+        self.assertEqual(self.team.conversations_settings["widget_public_token"], "this_teams_own_token")
+
     def test_enabling_conversations_auto_generates_token(self):
         self.team.conversations_enabled = False
         self.team.conversations_settings = None

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -976,9 +976,14 @@ class WidgetAuthentication(authentication.BaseAuthentication):
         Team = apps.get_model(app_label="posthog", model_name="Team")
         try:
             team = Team.objects.get(conversations_settings__widget_public_token=token, conversations_enabled=True)
+        except Team.DoesNotExist:
+            raise AuthenticationFailed("Invalid token or conversations not enabled")
         # An ambiguous match identifies no team any more than a miss does, so it fails the same way
         # rather than authenticating the request as whichever colliding team the database returned.
-        except (Team.DoesNotExist, Team.MultipleObjectsReturned):
+        # It is logged separately because a bad token is routine and duplicate tokens are not: they
+        # disable the widget for every team holding one until an operator clears the duplicate.
+        except Team.MultipleObjectsReturned:
+            structlog_logger.exception("widget_public_token matches more than one team")
             raise AuthenticationFailed("Invalid token or conversations not enabled")
 
         return (None, team)

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -973,10 +973,12 @@ class WidgetAuthentication(authentication.BaseAuthentication):
         if not token:
             return None  # Let other authenticators try
 
+        Team = apps.get_model(app_label="posthog", model_name="Team")
         try:
-            Team = apps.get_model(app_label="posthog", model_name="Team")
             team = Team.objects.get(conversations_settings__widget_public_token=token, conversations_enabled=True)
-        except Team.DoesNotExist:
+        # An ambiguous match identifies no team any more than a miss does, so it fails the same way
+        # rather than authenticating the request as whichever colliding team the database returned.
+        except (Team.DoesNotExist, Team.MultipleObjectsReturned):
             raise AuthenticationFailed("Invalid token or conversations not enabled")
 
         return (None, team)

--- a/products/conversations/backend/api/tests/test_widget.py
+++ b/products/conversations/backend/api/tests/test_widget.py
@@ -7,9 +7,13 @@ from django.test import SimpleTestCase
 
 from parameterized import parameterized
 from rest_framework import status
-from rest_framework.test import APIClient
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.request import Request
+from rest_framework.test import APIClient, APIRequestFactory
 
+from posthog.auth import WidgetAuthentication
 from posthog.models.comment import Comment
+from posthog.models.team import Team
 
 from products.conversations.backend.api.serializers import WidgetMessageSerializer
 from products.conversations.backend.models import SigningSecret, Ticket
@@ -64,6 +68,19 @@ class TestWidgetAPI(BaseTest):
             **self._get_headers(),
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_authentication_fails_closed_when_two_teams_share_a_token(self):
+        Team.objects.create(
+            organization=self.organization,
+            name="Team sharing the token",
+            conversations_enabled=True,
+            conversations_settings={"widget_public_token": self.widget_token},
+        )
+
+        request = APIRequestFactory().post("/api/conversations/v1/widget/message", **self._get_headers())
+
+        with self.assertRaises(AuthenticationFailed):
+            WidgetAuthentication().authenticate(Request(request))
 
     def test_create_message_creates_ticket(self):
         response = self.client.post(


### PR DESCRIPTION
## Problem

- A project admin can stop another team's support widget from authenticating, and it stays broken until someone rotates that team's token.
- `widget_public_token` is the only credential the public conversations widget carries.
- Every team serves its own token unauthenticated in its remote config, so the value is readable by anyone.
- `PATCH /api/projects/<id>/` merged a caller-supplied `widget_public_token` straight into the stored settings blob.
- `WidgetAuthentication` resolves the team with `Team.objects.get(conversations_settings__widget_public_token=...)`.
- Two rows carrying the same token raise `MultipleObjectsReturned`, and the surrounding handler only catches `DoesNotExist`.

The write happened because the validator existed twice.
`TeamSerializer.validate_conversations_settings` strips the server-managed keys from user input.
`ProjectBackwardCompatSerializer` reimplemented a subset of that validator and left the strips out.

## Changes

- `ProjectBackwardCompatSerializer.validate_conversations_settings` delegates to `TeamSerializer`, like the 15 validators above it. The duplicate body is deleted.
- The project endpoint now strips the Slack, email and Teams integration keys too. The copy never covered them.
- `WidgetAuthentication` treats an ambiguous token match as an authentication failure instead of a server error.

I chose delegation over re-adding the strip list because a second copy is what caused this.
Falling behind again now requires deleting a call, not forgetting a key.

> [!NOTE]
> This PR adds no unique index on `conversations_settings->>'widget_public_token'`. That index is defense in depth, and it is a deliberate follow-up rather than an oversight. The serializer change closes the write path on its own, and leaving the migration out keeps this PR quick to review and land.

I checked the other writers first. The project serializer was the only path that merged an arbitrary caller-supplied blob.

## How did you test this code?

Before the fix the project cases stored the injected value, and the authenticator case raised `Team.MultipleObjectsReturned` out of `authenticate()`.

- `test_conversations_settings_server_managed_keys_are_not_writable` covers 5 keys. It catches a project-endpoint write to any server-managed key in the blob. No existing test exercised this endpoint's strips.
- `test_conversations_settings_patch_cannot_replace_existing_widget_token` catches an overwrite of a team's own token, which the parameterized cases miss because they start from a blob without one.
- `test_authentication_fails_closed_when_two_teams_share_a_token` catches the uncaught `MultipleObjectsReturned`. It calls the authenticator directly, because the test client re-raises instead of returning a 500.

I did not exercise this against a running stack or a browser.
Local Redis was down in this worktree, so some tests in these modules fail on an unmodified checkout as well.
I ran each failing set against a clean tree and confirmed the same ones fail without my change.

<details>
<summary>Commands and results</summary>

```
pytest posthog/api/test/test_project.py posthog/api/test/test_team.py \
       posthog/api/test/test_team_project_parity.py posthog/api/test/test_team_project_differential.py
  3 failed, 523 passed   (same 3 fail on a clean tree: Redis ConnectionError)

pytest products/conversations/backend/api/tests/test_widget.py \
       products/conversations/backend/api/tests/test_restore.py \
       posthog/api/test/test_product_enablement.py posthog/models/test/test_remote_config.py
  18 failed, 138 passed  (clean tree: 18 failed, 137 passed. Redis ConnectionError and 429s)

pytest posthog/api/test/test_authentication.py
  1 failed, 158 passed, 1 error   (both pre-exist: TemplateDoesNotExist: index.html)
```

</details>

## Changed after review

- The managed-key tuple also strips `github_enabled`, `github_integration_id` and `github_repos`. Those keys are written only by the GitHub setup endpoints, which require organization admin, while the settings blob PATCH is gated on project admin. An ordinary organization member holds project admin by default when the team has no explicit access-control row.
- An ambiguous widget token logs separately from a bad one. Both fail the same way to the caller, but a duplicate token is a data-integrity condition an operator has to clear.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing surface or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via Claude Code on Opus 5) made this change.
Skills invoked: `/writing-tests`, `/improving-drf-endpoints`, `/writing-code-comments`, `/writing-pr-descriptions`.

The finding arrived as two separate reports, one per serializer line. They are one defect, so this is one PR.
Line numbers in the report were stale, so I located the code by symbol and reproduced the finding before changing anything. Both halves reproduced.

Deferring the unique index depends on there being no other write path, so I enumerated them before making that call.
`TeamSerializer` already strips the key, `posthog/api/product_enablement.py` only fills it when absent, `Team.generate_conversations_public_token_and_save` generates it, and the conversations product's Slack, Teams, GitHub and email settings writers each assign named keys.

Nothing in this diff, its fixtures, or this description carries material from the session that is not already in this repository. The tokens in the tests are invented strings.

