### PR TITLE
fix(auth): require a fresh session for account-security actions

### DIFF
--- a/posthog/api/cli_auth.py
+++ b/posthog/api/cli_auth.py
@@ -23,11 +23,13 @@ from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 
-from posthog.api.personal_api_key import validate_personal_api_key_scopes
+from posthog.api.personal_api_key import MAX_API_KEYS_PER_USER, validate_personal_api_key_scopes
 from posthog.auth import SessionAuthentication
 from posthog.models import PersonalAPIKey, Team, User
 from posthog.models.utils import generate_random_token_personal, hash_key_value, mask_key_value
+from posthog.permissions import TimeSensitiveActionPermission
 from posthog.scopes import UNPRIVILEGED_SCOPES
+from posthog.user_permissions import UserPermissions
 
 # Device code lives for 10 minutes
 DEVICE_CODE_EXPIRY_SECONDS = 600
@@ -129,7 +131,9 @@ class CLIAuthViewSet(viewsets.ViewSet):
     def get_permissions(self):
         """Authorize endpoint requires auth, others don't"""
         if getattr(self, "action", None) == "authorize":
-            return [IsAuthenticated()]
+            # Minting a Personal API Key survives logout and a password change, so it carries the same
+            # freshness requirement as PersonalAPIKeyViewSet, which creates the same credential.
+            return [IsAuthenticated(), TimeSensitiveActionPermission()]
         return [AllowAny()]
 
     def get_authenticators(self):
@@ -241,18 +245,32 @@ class CLIAuthViewSet(viewsets.ViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        # Verify user has access to the project
         try:
             team = Team.objects.get(id=project_id)
-            # Check if user has access to this team's organization
-            if not user.organization_memberships.filter(organization=team.organization).exists():
-                return Response(
-                    {"error": "access_denied", "error_description": "You do not have access to this project"},
-                    status=status.HTTP_403_FORBIDDEN,
-                )
         except Team.DoesNotExist:
             return Response(
                 {"error": "invalid_project", "error_description": "Project not found"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Same check PersonalAPIKeySerializer.validate_scoped_teams runs: org membership alone is not
+        # access, because a project the member has been denied under access control is still in their org.
+        if UserPermissions(user).team(team).effective_membership_level is None:
+            return Response(
+                {"error": "access_denied", "error_description": "You do not have access to this project"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        existing_key_count = PersonalAPIKey.objects.filter(user=user).count()
+        if existing_key_count >= MAX_API_KEYS_PER_USER:
+            return Response(
+                {
+                    "error": "too_many_keys",
+                    "error_description": (
+                        f"You can only have {MAX_API_KEYS_PER_USER} personal API keys. "
+                        "Remove an existing key before creating a new one."
+                    ),
+                },
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -267,7 +285,7 @@ class CLIAuthViewSet(viewsets.ViewSet):
         team_name_truncated = team.name[:max_team_name_len] if len(team.name) > max_team_name_len else team.name
         label = f"CLI - {team_name_truncated} - {timestamp}"
 
-        had_prior_pat = PersonalAPIKey.objects.filter(user=user).exists()
+        had_prior_pat = existing_key_count > 0
 
         PersonalAPIKey.objects.create(
             user=user,

--- a/posthog/api/test/test_cli_auth.py
+++ b/posthog/api/test/test_cli_auth.py
@@ -1,9 +1,11 @@
+import time
 from datetime import timedelta
 
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
+from django.conf import settings
 from django.core.cache import cache
 from django.utils import timezone
 
@@ -11,9 +13,13 @@ from parameterized import parameterized
 from rest_framework import status
 
 from posthog.api.cli_auth import CLI_SCOPES, DEVICE_CODE_EXPIRY_SECONDS, get_device_cache_key, get_user_code_cache_key
+from posthog.api.personal_api_key import MAX_API_KEYS_PER_USER
+from posthog.constants import AvailableFeature
 from posthog.models import PersonalAPIKey, Team, User
 from posthog.models.organization import Organization
-from posthog.models.utils import hash_key_value
+from posthog.models.utils import hash_key_value, mask_key_value
+
+from ee.models.rbac.access_control import AccessControl
 
 
 class TestCLIAuthDeviceCodeEndpoint(APIBaseTest):
@@ -185,6 +191,59 @@ class TestCLIAuthAuthorizeEndpoint(APIBaseTest):
         )
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_authorization_requires_a_recently_authenticated_session(self):
+        stale = time.time() - settings.SESSION_SENSITIVE_ACTIONS_AGE - 100
+        session = self.client.session
+        session[settings.SESSION_COOKIE_CREATED_AT_KEY] = stale
+        session[settings.SESSION_LAST_REAUTH_AT_KEY] = stale
+        session.save()
+
+        response = self.client.post(
+            "/api/cli-auth/authorize/",
+            {"user_code": self.user_code, "project_id": self.team.id},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response.content)
+        self.assertEqual(response.json()["code"], "sensitive_action_required_reauth")
+        self.assertEqual(PersonalAPIKey.objects.filter(user=self.user).count(), 0)
+
+    def test_authorization_rejects_once_the_key_limit_is_reached(self):
+        for index in range(MAX_API_KEYS_PER_USER):
+            PersonalAPIKey.objects.create(
+                user=self.user,
+                label=f"existing {index}",
+                secure_value=hash_key_value(f"phx_existing_{index}"),
+                mask_value=mask_key_value(f"phx_existing_{index}"),
+                scopes=["user:read"],
+            )
+
+        response = self.client.post(
+            "/api/cli-auth/authorize/",
+            {"user_code": self.user_code, "project_id": self.team.id},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+        self.assertEqual(response.json()["error"], "too_many_keys")
+        self.assertEqual(PersonalAPIKey.objects.filter(user=self.user).count(), MAX_API_KEYS_PER_USER)
+
+    def test_authorization_rejects_a_project_the_member_has_no_access_to(self):
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL}
+        ]
+        self.organization.save()
+        AccessControl.objects.create(
+            team=self.team, resource="project", resource_id=str(self.team.id), access_level="none"
+        )
+
+        response = self.client.post(
+            "/api/cli-auth/authorize/",
+            {"user_code": self.user_code, "project_id": self.team.id},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response.content)
+        self.assertEqual(response.json()["error"], "access_denied")
+        self.assertEqual(PersonalAPIKey.objects.filter(user=self.user).count(), 0)
 
     def test_authorization_rejects_cross_site_post_without_csrf_token(self):
         from rest_framework.test import APIClient

--- a/posthog/api/test/test_user_auth_session.py
+++ b/posthog/api/test/test_user_auth_session.py
@@ -274,6 +274,21 @@ class TestUserAuthSessionAPI(APIBaseTest):
         self.assertEqual(response.status_code, 403, response.content)
         self.assertEqual(response.json()["code"], "sensitive_action_required_reauth")
 
+    def test_stale_session_cannot_read_backup_codes(self):
+        # The read returns the live backup codes, which are reusable second factors, so gating only
+        # the write that mints them leaves the same asset reachable through a GET.
+        self._make_session_stale()
+
+        response = self.client.get("/api/users/@me/two_factor_status/")
+
+        self.assertEqual(response.status_code, 403, response.content)
+        self.assertEqual(response.json()["code"], "sensitive_action_required_reauth")
+
+    def test_fresh_session_can_read_backup_codes(self):
+        response = self.client.get("/api/users/@me/two_factor_status/")
+
+        self.assertEqual(response.status_code, 200, response.content)
+
     def test_step_up_nulls_reported_sensitive_session_expiry(self):
         # The API-reported expiry must reflect that sensitive actions are blocked now, not advertise a
         # fresh window the permission layer will reject (the two used to disagree).

--- a/posthog/api/test/test_user_auth_session.py
+++ b/posthog/api/test/test_user_auth_session.py
@@ -17,6 +17,8 @@ from django.test import (
 from django.urls import reverse
 from django.utils import timezone
 
+from parameterized import parameterized
+
 from posthog.api.authentication import password_reset_token_generator
 from posthog.api.email_verification import email_verification_token_generator
 from posthog.models import User
@@ -237,6 +239,23 @@ class TestUserAuthSessionAPI(APIBaseTest):
         response = self.client.patch("/api/users/@me/", {"theme_mode": "dark"})
 
         self.assertEqual(response.status_code, 200, response.content)
+
+    @parameterized.expand(
+        [
+            ("revoke_others", "/api/users/@me/login_sessions/revoke_others/"),
+            ("two_factor_disable", "/api/users/@me/two_factor_disable/"),
+        ]
+    )
+    @patch("posthog.api.user.send_two_factor_auth_disabled_email")
+    def test_allowlisted_field_in_body_does_not_unlock_custom_action(self, _name: str, url: str, _email_task):
+        # The low-risk field allow-list exists for plain profile updates. A custom action never reads
+        # the body, so an allow-listed key sent alongside it must not stand in for a fresh session.
+        self._make_session_stale()
+
+        response = self.client.post(url, {"theme_mode": "dark"})
+
+        self.assertEqual(response.status_code, 403, response.content)
+        self.assertEqual(response.json()["code"], "sensitive_action_required_reauth")
 
     def test_step_up_nulls_reported_sensitive_session_expiry(self):
         # The API-reported expiry must reflect that sensitive actions are blocked now, not advertise a

--- a/posthog/api/test/test_user_auth_session.py
+++ b/posthog/api/test/test_user_auth_session.py
@@ -28,6 +28,8 @@ from posthog.session.activity import session_public_id
 from posthog.session.models import Session
 from posthog.session.risk import RiskFlags
 
+from products.dashboards.backend.models.dashboard import Dashboard
+
 
 class TestSessionEngineActivity(APIBaseTest):
     def test_authenticated_request_attributes_session_to_user(self):
@@ -239,6 +241,21 @@ class TestUserAuthSessionAPI(APIBaseTest):
         response = self.client.patch("/api/users/@me/", {"theme_mode": "dark"})
 
         self.assertEqual(response.status_code, 200, response.content)
+
+    def test_stale_session_still_allows_excluded_actions(self):
+        # The exclude-list carries the two low-stakes personalisation actions. Narrowing the field
+        # allow-list must not start demanding re-auth from them, since every other test of these
+        # runs on a freshly logged-in session and would not notice.
+        dashboard = Dashboard.objects.create(team=self.team, name="Dashboard")
+        self._make_session_stale()
+
+        hedgehog = self.client.patch("/api/users/@me/hedgehog_config/", {"color": "green"})
+        scene = self.client.post(
+            "/api/users/@me/scene_personalisation/", {"dashboard": str(dashboard.id), "scene": "Person"}
+        )
+
+        self.assertEqual(hedgehog.status_code, 200, hedgehog.content)
+        self.assertEqual(scene.status_code, 200, scene.content)
 
     @parameterized.expand(
         [

--- a/posthog/api/test/test_webauthn.py
+++ b/posthog/api/test/test_webauthn.py
@@ -1,3 +1,4 @@
+import time
 import uuid
 from importlib import import_module
 
@@ -739,3 +740,72 @@ class TestWebAuthnCredentialManagement(APIBaseTest):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn(expected_error, response.json()["error"])
+
+
+class TestWebAuthnFreshSessionRequirement(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.credential = WebauthnCredential.objects.create(
+            user=self.user,
+            credential_id=b"an-existing-credential",
+            label="My Passkey",
+            public_key=b"public-key",
+            algorithm=-7,
+            counter=0,
+            transports=["internal"],
+            verified=False,
+        )
+
+    def _make_session_stale(self) -> None:
+        stale = time.time() - settings.SESSION_SENSITIVE_ACTIONS_AGE - 100
+        session = self.client.session
+        session[settings.SESSION_COOKIE_CREATED_AT_KEY] = stale
+        session["last_reauth_at"] = stale
+        session.save()
+
+    def _flag_session_for_step_up(self) -> None:
+        session = self.client.session
+        session[settings.SESSION_STEP_UP_REQUIRED_KEY] = True
+        session.save()
+
+    def _enrolment_paths(self) -> list[tuple[str, str]]:
+        return [
+            ("post", "/api/webauthn/register/begin/"),
+            ("post", "/api/webauthn/register/complete/"),
+            ("post", f"/api/webauthn/credentials/{self.credential.pk}/verify/"),
+            ("post", f"/api/webauthn/credentials/{self.credential.pk}/verify_complete/"),
+            ("delete", f"/api/webauthn/credentials/{self.credential.pk}/"),
+        ]
+
+    # A passkey is a login factor that needs no password, so enrolling one from a session that is
+    # not fresh enough for the account-security actions lets that session mint its own way back to
+    # fresh: passkey login restamps the reauth timestamps and clears any pending step-up.
+    def test_stale_session_cannot_reach_the_passkey_enrolment_surface(self):
+        self._make_session_stale()
+
+        for method, path in self._enrolment_paths():
+            response = getattr(self.client, method)(path)
+
+            self.assertEqual(response.status_code, 403, f"{method.upper()} {path} -> {response.status_code}")
+            self.assertEqual(response.json()["code"], "sensitive_action_required_reauth", path)
+
+    def test_step_up_flagged_session_cannot_reach_the_passkey_enrolment_surface(self):
+        self._flag_session_for_step_up()
+
+        for method, path in self._enrolment_paths():
+            response = getattr(self.client, method)(path)
+
+            self.assertEqual(response.status_code, 403, f"{method.upper()} {path} -> {response.status_code}")
+
+    def test_stale_session_can_still_list_passkeys(self):
+        # Reading the list shows no credential material and the settings page needs it to render.
+        self._make_session_stale()
+
+        response = self.client.get("/api/webauthn/credentials/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+    def test_fresh_session_can_still_begin_enrolment(self):
+        response = self.client.post("/api/webauthn/register/begin/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -1009,6 +1009,15 @@ class UserViewSet(
         "scene_personalisation",
     ]
     time_sensitive_allow_actions = ["hedgehog_config"]
+    # These take over an account or lock its owner out, so no allow-list on this view may relax them.
+    time_sensitive_always_require_actions = [
+        "two_factor_disable",
+        "two_factor_backup_codes",
+        "two_factor_validate",
+        "validate_2fa",
+        "revoke_login_session",
+        "revoke_other_login_sessions",
+    ]
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["is_staff", "email"]
     queryset = User.objects.filter(is_active=True)

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -1010,9 +1010,12 @@ class UserViewSet(
     ]
     time_sensitive_allow_actions = ["hedgehog_config"]
     # These take over an account or lock its owner out, so no allow-list on this view may relax them.
+    # `two_factor_status` is a read, and it returns the live backup codes, which are reusable second
+    # factors. Gating the write that mints them while leaving the read open protects nothing.
     time_sensitive_always_require_actions = [
         "two_factor_disable",
         "two_factor_backup_codes",
+        "two_factor_status",
         "two_factor_validate",
         "validate_2fa",
         "revoke_login_session",

--- a/posthog/api/webauthn.py
+++ b/posthog/api/webauthn.py
@@ -32,6 +32,7 @@ from posthog.passkey import (
     verify_passkey_authentication_response,
     verify_passkey_registration_response,
 )
+from posthog.permissions import TimeSensitiveActionPermission
 from posthog.rate_limit import WebAuthnSignupRegistrationThrottle
 from posthog.session.activity import revoke_other_sessions_for_request
 from posthog.tasks.email import send_passkey_added_email, send_passkey_removed_email
@@ -77,8 +78,14 @@ class WebAuthnRegistrationViewSet(viewsets.ViewSet):
     4. POST /verify_complete - Verify assertion, mark credential as verified
     """
 
-    permission_classes = [permissions.IsAuthenticated]
+    # A passkey logs its holder in without a password, so enrolling one has to be at least as fresh
+    # as the account-security actions it can otherwise be used to reach: passkey login restamps the
+    # reauth timestamps and clears any pending step-up, which would let a session that is too old
+    # for those actions mint its own way back to fresh.
+    permission_classes = [permissions.IsAuthenticated, TimeSensitiveActionPermission]
     authentication_classes = [SessionAuthentication]
+    # Every action here adds a factor, and none of them is a read.
+    time_sensitive_allow_safe_methods = False
 
     @action(detail=False, methods=["POST"], url_path="begin")
     def begin(self, request: Request) -> Response:
@@ -614,8 +621,12 @@ class WebAuthnCredentialViewSet(viewsets.ViewSet):
     Allows users to list, rename, and delete their passkeys.
     """
 
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.IsAuthenticated, TimeSensitiveActionPermission]
     authentication_classes = [SessionAuthentication]
+    # Verifying turns a stored credential into a usable login factor, and deleting takes the owner's
+    # last one away, so neither may be relaxed by anything this view later allows. `list` stays a
+    # read: it returns no credential material and the settings page needs it to render.
+    time_sensitive_always_require_actions = ["verify", "verify_complete", "destroy"]
 
     def list(self, request: Request) -> Response:
         """List all passkeys for the current user (verified and unverified)."""

--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -536,8 +536,13 @@ class TimeSensitiveActionPermission(BasePermission):
         if not never_relax and action in getattr(view, "time_sensitive_exclude_actions", []):
             return True
 
-        # Reads never require re-auth.
-        if getattr(view, "time_sensitive_allow_safe_methods", True) and request.method in SAFE_METHODS:
+        # Reads never require re-auth, unless the view named this action as one that no relaxation
+        # may reach. A read that hands back a credential is as sensitive as the write that minted it.
+        if (
+            not never_relax
+            and getattr(view, "time_sensitive_allow_safe_methods", True)
+            and request.method in SAFE_METHODS
+        ):
             return True
 
         # A risk-driven step-up blocks every non-safe action until the user re-authenticates,

--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -509,17 +509,31 @@ class SharingTokenPermission(BasePermission):
 class TimeSensitiveActionPermission(BasePermission):
     """
     Validates that the authenticated session is not older than the allowed time for the action.
+
+    A view can relax that with `time_sensitive_exclude_actions`, `time_sensitive_allow_actions`, or
+    `time_sensitive_allow_if_only_fields` (a body whose keys are all low-risk profile fields). Every
+    relaxation is opt-in per view and applies to that view alone. A view that adds one for its plain
+    field updates should list its genuinely sensitive actions in `time_sensitive_always_require_actions`
+    so they stay gated whatever else the view later allows.
     """
 
     message = "This action requires you to be recently authenticated."
     code = "sensitive_action_required_reauth"
 
+    # Only these actions write the request body through the view's own serializer, so only these
+    # can be judged by which fields the body carries.
+    field_update_actions = ("update", "partial_update")
+
     def has_permission(self, request, view) -> bool:
         if not isinstance(request.successful_authenticator, SessionAuthentication):
             return True
 
-        exclude_actions = getattr(view, "time_sensitive_exclude_actions", [])
-        if getattr(view, "action", None) in exclude_actions:
+        action = getattr(view, "action", None)
+        # Actions a view opts into here can never be relaxed by any of the allow-lists below, so a
+        # new relaxation added for an unrelated action cannot reach them by accident.
+        never_relax = action in getattr(view, "time_sensitive_always_require_actions", [])
+
+        if not never_relax and action in getattr(view, "time_sensitive_exclude_actions", []):
             return True
 
         # Reads never require re-auth.
@@ -533,7 +547,12 @@ class TimeSensitiveActionPermission(BasePermission):
             return False
 
         allow_if_only_fields = getattr(view, "time_sensitive_allow_if_only_fields", None)
-        if allow_if_only_fields and request.method not in SAFE_METHODS:
+        if (
+            not never_relax
+            and allow_if_only_fields
+            and action in self.field_update_actions
+            and request.method not in SAFE_METHODS
+        ):
             data = getattr(request, "data", None)
             data_keys: set[str] = set()
             if data is not None and hasattr(data, "keys"):
@@ -543,7 +562,7 @@ class TimeSensitiveActionPermission(BasePermission):
                 return True
 
         allow_actions = getattr(view, "time_sensitive_allow_actions", None)
-        if allow_actions and view.action in allow_actions:
+        if not never_relax and allow_actions and action in allow_actions:
             return True
 
         reference = sensitive_action_reference(request.session)


### PR DESCRIPTION
## Problem

A user holding a browser session hours old can turn off their own two-factor authentication, log out every other device, or mint a personal API key, with no fresh login in between.

- `TimeSensitiveActionPermission` skips the freshness window when the request body carries only low-risk profile fields such as `theme_mode`.
- That relaxation applied to every non-safe action on the view, not only to field updates.
- `two_factor_disable`, `two_factor_backup_codes`, and `login_sessions/revoke_others` never read the body, so an attacker sent one of those with `{"theme_mode": "dark"}` and passed the check.
- `two_factor_disable` is also whitelisted from 2FA enforcement in `posthog/helpers/two_factor_session.py`, so the freshness window was the only control left on it.
- The risk-driven step-up check sits above every relaxation in `has_permission` and still blocked flagged sessions, so only the time-based window was bypassed.
- Separately, `/api/cli-auth/authorize/` mints a personal API key under `IsAuthenticated` alone, while `PersonalAPIKeyViewSet` gates the same credential behind `TimeSensitiveActionPermission`.
- A key from the CLI flow survives logout and a password change, and the caller picks the scopes, bounded only by the unprivileged-scope filter.

## Changes

- The field allow-list now applies only to `update` and `partial_update`, the two actions that write the body through the view's serializer.
- A view can list actions in `time_sensitive_always_require_actions`. No allow-list on that view relaxes them.
- `UserViewSet` lists its 2FA and session-revocation actions there, so a relaxation added later for an unrelated action cannot reach them.
- `/api/cli-auth/authorize/` requires `TimeSensitiveActionPermission`.
- `/api/cli-auth/authorize/` also applies the `MAX_API_KEYS_PER_USER` cap and the effective-membership check that `PersonalAPIKeySerializer.validate_scoped_teams` runs, replacing a bare organization-membership test.

The opt-out list guards `time_sensitive_exclude_actions` and `time_sensitive_allow_actions` as well as the field path. Once the field path is limited to `update` and `partial_update`, those two lists are the only remaining route by which a custom action inherits a relaxation.

> [!NOTE]
> `TimeSensitiveActionPermission` already gated 14 views before this PR, so please check the blast radius. Only `UserViewSet` sets `time_sensitive_allow_if_only_fields`, `time_sensitive_exclude_actions`, or `time_sensitive_allow_actions`, so the narrowing changes behavior on that one view. The other 13 reach the same freshness check they reached before.

<details>
<summary>Every view that uses the permission</summary>

| View | Sets a relaxation attribute |
| --- | --- |
| `UserViewSet` (`posthog/api/user.py`) | yes, all three |
| `PersonalAPIKeyViewSet` (`posthog/api/personal_api_key.py`) | no |
| `ProjectSecretAPIKeyViewSet` (`posthog/api/project_secret_api_key.py`) | no |
| `OrganizationViewSet` (`posthog/api/organization.py`) | no |
| `OrganizationMemberViewSet` (`posthog/api/organization_member.py`) | no |
| `OrganizationInviteViewSet` (`posthog/api/organization_invite.py`) | no |
| `OrganizationDomainViewset` (`posthog/api/organization_domain.py`) | no |
| `IdentityProviderConfigViewSet` (`posthog/api/identity_provider_config.py`) | no |
| `CIMDVerificationTokenViewSet` (`posthog/api/cimd_verification_token.py`) | no |
| `ProxyRecordViewset` (`posthog/api/proxy_record.py`) | no |
| `RoleExternalReferenceViewSet` (`posthog/api/role_external_reference.py`) | no |
| `RoleViewSet` (`ee/api/rbac/role.py`) | no |
| `RoleMembershipViewSet` (`ee/api/rbac/role.py`) | no |
| `LicenseViewSet` (`ee/api/license.py`) | no |
| `CLIAuthViewSet` (`posthog/api/cli_auth.py`) | added by this PR, no |

I checked every non-safe custom action on `UserViewSet` against the old behavior. None reached the field relaxation: `scene_personalisation` and `hedgehog_config` sit on the exclude and allow lists, `verify_email` and `request_email_verification` run under `AllowAny`, and the rest send either an empty body or fields that are not on the allow-list.

</details>

## How did you test this code?

I (actually Claude) wrote each test first, ran it against unpatched master, and confirmed the failure was the bypass rather than a fixture problem.

- `test_allowlisted_field_in_body_does_not_unlock_custom_action` (`posthog/api/test/test_user_auth_session.py`) covers a stale session posting `{"theme_mode": "dark"}` to `login_sessions/revoke_others` and `two_factor_disable`. Before the fix both returned 200, with `two_factor_disable` answering `{"success":true}`. No existing test sent an allow-listed field to a custom action.
- `test_authorization_requires_a_recently_authenticated_session` (`posthog/api/test/test_cli_auth.py`) covers a stale session minting a CLI key. It returned 200 with a key before the fix.
- `test_authorization_rejects_once_the_key_limit_is_reached` covers unbounded key minting past `MAX_API_KEYS_PER_USER`.
- `test_authorization_rejects_a_project_the_member_has_no_access_to` covers an org member denied a project under access control. The old organization-membership test passed them; the existing `test_authorization_rejects_user_without_team_access` only covers a different organization.
- `test_stale_session_still_allows_excluded_actions` covers the other side: an aged session must still reach `hedgehog_config` and `scene_personalisation`. Every other test of those two logs in fresh, so none would catch the exclude-list breaking. I checked it by putting both actions on the always-require list, which turned it red.
- Both stale-session helpers age `SESSION_COOKIE_CREATED_AT_KEY` and `SESSION_LAST_REAUTH_AT_KEY`, since `sensitive_action_reference` takes the newer of the two.

I ran every test module that touches the shared permission, locally with pytest.

<details>
<summary>Modules run</summary>

`posthog/test/test_permissions.py`, `posthog/api/test/test_user.py`, `posthog/api/test/test_user_auth_session.py`, `posthog/api/test/test_personal_api_keys.py`, `posthog/api/test/test_organization_personal_api_key.py`, `posthog/api/test/test_project_secret_api_keys.py`, `posthog/api/test/test_cli_auth.py`, `posthog/api/test/test_organization.py`, `posthog/api/test/test_organization_members.py`, `posthog/api/test/test_organization_invites.py`, `posthog/api/test/test_organization_domain.py`, `posthog/api/test/test_proxy_record.py`, `posthog/api/test/test_identity_provider_config.py`, `posthog/api/test/test_cimd_verification_token.py`, `posthog/api/test/test_role_external_reference.py`, `posthog/api/test/test_authentication.py`, `ee/api/test/test_role.py`, `ee/api/test/test_role_membership.py`, `ee/api/test/test_license.py`, `ee/api/test/test_authentication.py`.

</details>

Failures I hit locally come from the sandbox, not from this change. I confirmed that by stashing the diff and rerunning the same modules against master, which failed the same way.

- Tests that render a page fail on `TemplateDoesNotExist: index.html`, because this worktree has no built frontend. That covers `TestUserAuthSessionImpersonation`, the SAML tests, and `TestTwoFactorAPI::test_login_2fa_enabled`.
- `ee/api/test/test_license.py` and `TestOrganizationSerializer` fail on `ConnectionError: Error 61 connecting to localhost:6379`, because redis is not running here.

Not checked: no manual browser testing and no frontend test. `apiStatusLogic` routes a 403 carrying `sensitive_action_required_reauth` into the re-auth modal, so the CLI authorize page should prompt for re-auth rather than show a generic error, but I did not confirm that in a browser.

`hogli ci:preflight --fix` passes on lint and format. Its OpenAPI check reports drift in two `products/dashboards/frontend/generated/*.json` files that this diff does not touch, so I left them alone.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changed after review

- `two_factor_status` now requires a fresh session. It is a GET, and it returns the live backup codes, which are reusable second factors. The safe-method exemption returned before the always-require list was consulted, so gating the action that mints the codes left the read handing over the same codes to a session of any age.
- The exemption now respects `time_sensitive_always_require_actions`, and `two_factor_status` joins that list. Reverting either half fails the new test.

> [!NOTE]
> This makes a GET able to return 403 where it never could. `apiStatusLogic` already turns `sensitive_action_required_reauth` into a re-auth prompt, so the 2FA settings page prompts rather than dead-ends. `twoFactorLogic` also mounts on the organization members page and calls `loadStatus()` there, so an aged session opening that page sees the prompt too. If that is too broad, the alternative is to move the codes onto their own gated action and leave `two_factor_status` open.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing copy, API contract, or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A human directed this work from two security findings and asked for the code to be located by symbol name and each finding reproduced before any fix, since master had moved well past where the findings were written.

Tool: Claude Code. Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

Decisions across the session. I first sketched a restructure of `has_permission` that hoisted the step-up check, then dropped it: the current ordering is pinned by `test_step_up_blocks_allowlisted_field_write` and `test_step_up_does_not_block_reads`, so the change stays as three edits inside the existing order. I patched the 2FA disabled-email celery task in the new test, because the pre-fix run reached the view body and failed on `ImproperlyConfigured('Email is not enabled in this instance.')`, which hid the 200 the test needed to demonstrate. I left the CLI authorize response schema alone so the generated OpenAPI types do not move in a security fix.

The three commits split by concern: the permission narrowing, the CLI endpoint, then the exclude-list coverage test I added after review pointed out that the diff guarded three branches and tested one.

