### PR TITLE
fix(query): scope response coalescing to the requesting principal

### DIFF
--- a/posthog/api/query_coalescer.py
+++ b/posthog/api/query_coalescer.py
@@ -270,7 +270,8 @@ _TEAM_ID_RE = re.compile(r"^/api/(?:environments|projects)/(\d+)/")
 
 # Detail routes are deliberately absent: a replayed response never reaches the view handler, so
 # `get_object()` and the object-level permission checks hanging off it never run for the follower.
-# `QueryCoalescingMixin` enforces the same rule per action.
+# `QueryCoalescingMixin` enforces the same rule per action, so a pattern added for a view that does
+# not mix it in gets no enforcement at all.
 _COALESCE_PATH_PATTERNS = [
     re.compile(r"^/api/(?:environments|projects)/\d+/query/$"),
     re.compile(r"^/api/(?:environments|projects)/\d+/insights/trend/$"),  # legacy endpoint

--- a/posthog/api/query_coalescer.py
+++ b/posthog/api/query_coalescer.py
@@ -23,6 +23,9 @@ from posthog import (
 
 logger = structlog.get_logger(__name__)
 
+COALESCED_RESPONSE_META_KEY = "_coalesced_response"
+DISQUALIFIED_META_KEY = "_coalescing_disqualified"
+
 LOCK_KEY_PREFIX = "http_qc"
 DONE_KEY_PREFIX = "http_qc_done"
 ERROR_KEY_PREFIX = "http_qc_err"
@@ -265,11 +268,13 @@ class QueryCoalescer:
 
 _TEAM_ID_RE = re.compile(r"^/api/(?:environments|projects)/(\d+)/")
 
+# Detail routes are deliberately absent: a replayed response never reaches the view handler, so
+# `get_object()` and the object-level permission checks hanging off it never run for the follower.
+# `QueryCoalescingMixin` enforces the same rule per action.
 _COALESCE_PATH_PATTERNS = [
     re.compile(r"^/api/(?:environments|projects)/\d+/query/$"),
     re.compile(r"^/api/(?:environments|projects)/\d+/insights/trend/$"),  # legacy endpoint
     re.compile(r"^/api/(?:environments|projects)/\d+/insights/funnel/$"),  # legacy endpoint
-    re.compile(r"^/api/(?:environments|projects)/\d+/insights/\d+/$"),
 ]
 
 
@@ -320,6 +325,11 @@ class QueryCoalescingMiddleware:
             # Force render DRF responses so we can capture the body
             if hasattr(response, "render") and callable(response.render):
                 response.render()
+            if request.META.get(DISQUALIFIED_META_KEY):
+                # The view has an object-level permission surface, so its body is not replayable.
+                # Signal rather than stay silent, so followers fall through now instead of waiting.
+                coalescer.signal_error()
+                return response
             content_type = response.get("Content-Type", "application/json")
             if response.status_code < 400 or response.status_code >= 500:
                 # Coalesce successes (2xx) and server errors (5xx).
@@ -351,7 +361,7 @@ class QueryCoalescingMiddleware:
             if data:
                 log.info("query_coalescing_middleware_follower_done")
                 # Attach cached response for the view mixin to gate behind permissions
-                request.META["_coalesced_response"] = data
+                request.META[COALESCED_RESPONSE_META_KEY] = data
                 return self.get_response(request)
             log.warning("query_coalescing_middleware_follower_done_read_failed")
 
@@ -376,6 +386,27 @@ class QueryCoalescingMiddleware:
     # Fields that are unique per request and should not affect coalescing
     _IGNORED_KEY_FIELDS = {"client_query_id", "session_id"}
 
+    # Credential material that tells one principal from another. A GET query string and a POST body
+    # are already hashed into the key, so these only add the axes the key would otherwise miss: the
+    # Authorization header, the sharing cookie, and query-string credentials on a POST, where the
+    # query string is not part of the key.
+    #
+    # Coalesced responses are principal-specific, because /query/ results are filtered by
+    # UserAccessControl and warehouse tables resolve per user. So an authenticator whose credential
+    # reaches none of these would let two principals share one rendered result. Keep in sync with
+    # the authenticators in TeamAndOrgViewSetMixin.get_authenticators.
+    _CREDENTIAL_QUERY_PARAMS = ("personal_api_key", "sharing_access_token")
+    _CREDENTIAL_COOKIES = ("posthog_sharing_token",)
+
+    @staticmethod
+    def _principal_fingerprint(request: HttpRequest) -> str:
+        user = getattr(request, "user", None)
+        user_id = user.pk if user is not None and user.is_authenticated else ""
+        parts = [str(user_id), request.META.get("HTTP_AUTHORIZATION", "")]
+        parts.extend(request.GET.get(param, "") for param in QueryCoalescingMiddleware._CREDENTIAL_QUERY_PARAMS)
+        parts.extend(request.COOKIES.get(cookie, "") for cookie in QueryCoalescingMiddleware._CREDENTIAL_COOKIES)
+        return "|".join(parts)
+
     @staticmethod
     def _compute_key(team_id: int, request: HttpRequest) -> str:
         if request.method == "GET":
@@ -393,7 +424,8 @@ class QueryCoalescingMiddleware:
             except ValueError:
                 normalized = request.body
 
-        raw = f"{team_id}:{request.method}:{request.path}:{normalized.decode()}"
+        principal = QueryCoalescingMiddleware._principal_fingerprint(request)
+        raw = f"{team_id}:{request.method}:{request.path}:{principal}:{normalized.decode()}"
         return hashlib.sha256(raw.encode()).hexdigest()
 
 
@@ -415,7 +447,12 @@ class QueryCoalescingMixin(_MixinBase):
     """
 
     def dispatch(self, request, *args, **kwargs):
-        coalesced = request.META.get("_coalesced_response")
+        if self._has_object_permission_surface(request):
+            request.META[DISQUALIFIED_META_KEY] = True
+            request.META.pop(COALESCED_RESPONSE_META_KEY, None)
+            return super().dispatch(request, *args, **kwargs)
+
+        coalesced = request.META.get(COALESCED_RESPONSE_META_KEY)
         if coalesced is None:
             return super().dispatch(request, *args, **kwargs)
 
@@ -438,3 +475,19 @@ class QueryCoalescingMixin(_MixinBase):
             status=coalesced["status"],
             content_type=coalesced.get("content_type", "application/json"),
         )
+
+    def _has_object_permission_surface(self, request) -> bool:
+        """Whether this action can reach `get_object()`, and with it `check_object_permissions`.
+
+        Neither runs for a replayed response, which would skip every object-level check PostHog
+        performs after `initial()`: `AccessControlPermission.has_object_permission` and the
+        sharing-token object check. Such an action has to execute for real.
+
+        Read per action rather than per view, because `QueryViewSet` declares
+        `sharing_enabled_actions` for `retrieve` while the coalesced action is `create`, which
+        reaches no object.
+        """
+        if getattr(self, "detail", False):
+            return True
+        action = (getattr(self, "action_map", None) or {}).get((request.method or "").lower(), "")
+        return action in getattr(self, "sharing_enabled_actions", [])

--- a/posthog/api/query_coalescer.py
+++ b/posthog/api/query_coalescer.py
@@ -457,6 +457,18 @@ class QueryCoalescingMixin(_MixinBase):
         if coalesced is None:
             return super().dispatch(request, *args, **kwargs)
 
+        try:
+            return self._replay_coalesced_response(request, coalesced, *args, **kwargs)
+        finally:
+            # This branch returns without reaching `TeamAndOrgViewSetMixin.dispatch`, whose finally
+            # releases the team scope `initial()` set. ContextVars are thread-local and the worker
+            # thread is reused, so a token left set here would scope the next request on this
+            # thread to this request's team. Views without that mixin set no scope to release.
+            release_team_scope = getattr(self, "_release_team_scope", None)
+            if release_team_scope is not None:
+                release_team_scope()
+
+    def _replay_coalesced_response(self, request, coalesced, *args, **kwargs):
         self.args = args
         self.kwargs = kwargs
         self.headers = self.default_response_headers

--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -1,4 +1,5 @@
 import sys
+from contextvars import Token
 from functools import cached_property, lru_cache
 from typing import TYPE_CHECKING, Any, Literal, Optional, cast
 from uuid import UUID
@@ -128,6 +129,9 @@ class RouterRegistry:
 # IMPORTANT: Almost all viewsets should inherit from this mixin. It should be the first thing it inherits from to ensure
 # that typing works as expected
 class TeamAndOrgViewSetMixin(_GenericViewSet):
+    # Set by `initial()` when it scopes the request to a team, and released in `dispatch()`.
+    _team_scope_token: Optional[Token[Optional[int]]] = None
+
     # This flag disables nested routing handling, reverting to the old request.user.team behavior
     # Allows for a smoother transition from the old flat API structure to the newer nested one
     param_derived_from_user_current_team: Optional[Literal["team_id", "project_id"]] = None

--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -182,10 +182,18 @@ class TeamAndOrgViewSetMixin(_GenericViewSet):
         try:
             return super().dispatch(request, *args, **kwargs)
         finally:
-            token = getattr(self, "_team_scope_token", None)
-            if token is not None:
-                reset_current_team_id(token)
-                self._team_scope_token = None
+            self._release_team_scope()
+
+    def _release_team_scope(self) -> None:
+        """Reset the team scope this request set, if it set one.
+
+        Idempotent, so a `dispatch` override that returns without reaching the wrapper above can
+        call it without having to know whether `initial()` ran.
+        """
+        token = getattr(self, "_team_scope_token", None)
+        if token is not None:
+            reset_current_team_id(token)
+            self._team_scope_token = None
 
     def initial(self, request, *args, **kwargs):
         """

--- a/posthog/api/test/test_query_coalescing.py
+++ b/posthog/api/test/test_query_coalescing.py
@@ -579,7 +579,11 @@ class TestQueryCoalescingKey(APIBaseTest):
                 del self.client.cookies[name]
 
     def test_key_is_stable_for_the_same_principal(self):
-        self.assertEqual(self._key_for(), self._key_for())
+        # The posthog-js cookie carries a session timestamp that moves between two requests from one
+        # page, so a key built from the whole cookie jar would coalesce nothing.
+        first = self._key_for(cookies={"ph_phc_test_posthog": "sesid_1"})
+        second = self._key_for(cookies={"ph_phc_test_posthog": "sesid_2"})
+        self.assertEqual(first, second)
 
     @parameterized.expand(
         [

--- a/posthog/api/test/test_query_coalescing.py
+++ b/posthog/api/test/test_query_coalescing.py
@@ -23,6 +23,7 @@ from posthog.api.query_coalescer import (
 )
 from posthog.constants import AvailableFeature
 from posthog.models.organization import OrganizationMembership
+from posthog.models.scoping import get_current_team_id
 
 from products.product_analytics.backend.models.insight import Insight
 
@@ -334,6 +335,28 @@ class TestQueryCoalescingMiddleware(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("test_event", response.json()["results"][0][0])
+
+    def test_replaying_a_response_leaves_no_team_scope_behind(self):
+        mock_coalescer = mock.MagicMock()
+        mock_coalescer.try_acquire.return_value = False
+        mock_coalescer._dry_run = False
+        mock_coalescer.wait_for_signal.return_value = CoalesceSignal.DONE
+        mock_coalescer.get_success_response.return_value = {
+            "status": 200,
+            "body": '{"results": []}',
+            "content_type": "application/json",
+        }
+
+        with (
+            mock.patch("posthog.api.query_coalescer.posthoganalytics.feature_enabled", return_value=True),
+            mock.patch("posthog.api.query_coalescer.QueryCoalescer", return_value=mock_coalescer),
+        ):
+            response = self.client.post(self._query_url(), self._query_payload())
+
+        self.assertEqual(response.status_code, 200)
+        # The worker thread is reused, so a scope left set here would silently scope the next
+        # request to this request's team instead of failing closed.
+        self.assertIsNone(get_current_team_id())
 
     def test_follower_falls_through_on_error_signal(self):
         _create_event(team=self.team, event="test_event", distinct_id="user1")

--- a/posthog/api/test/test_query_coalescing.py
+++ b/posthog/api/test/test_query_coalescing.py
@@ -1,3 +1,4 @@
+import re
 import time
 import threading
 from typing import Any
@@ -20,6 +21,12 @@ from posthog.api.query_coalescer import (
     QueryCoalescer,
     query_coalesce_counter,
 )
+from posthog.constants import AvailableFeature
+from posthog.models.organization import OrganizationMembership
+
+from products.product_analytics.backend.models.insight import Insight
+
+from ee.models.rbac.access_control import AccessControl
 
 
 class TestQueryCoalescer(TestCase):
@@ -480,7 +487,6 @@ class TestQueryCoalescingMiddleware(ClickhouseTestMixin, APIBaseTest):
             ("query", "/api/environments/{team_id}/query/"),
             ("insights_trend", "/api/environments/{team_id}/insights/trend/"),
             ("insights_funnel", "/api/environments/{team_id}/insights/funnel/"),
-            ("insights_pk", "/api/environments/{team_id}/insights/123/"),
         ]
     )
     def test_matching_paths_trigger_coalescing(self, _name, path_template):
@@ -494,3 +500,98 @@ class TestQueryCoalescingMiddleware(ClickhouseTestMixin, APIBaseTest):
         ):
             self.client.post(path, {"query": {"kind": "EventsQuery", "select": ["event"]}})
             mock_cls.assert_called_once()
+
+
+class TestQueryCoalescingObjectPermissions(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
+        ]
+        self.organization.save()
+
+        self.insight = Insight.objects.create(team=self.team, name="Restricted insight", created_by=self.user)
+        AccessControl.objects.create(
+            resource="insight", resource_id=self.insight.id, team=self.team, access_level="none"
+        )
+
+        self.denied_user = self._create_user("denied@posthog.com", level=OrganizationMembership.Level.MEMBER)
+        self.client.force_login(self.denied_user)
+        self.path = f"/api/projects/{self.team.pk}/insights/{self.insight.id}/"
+
+    def test_follower_cannot_replay_an_insight_it_has_no_object_access_to(self):
+        # Control: the object-level denial has to be real, otherwise the replay assertion is vacuous
+        self.assertEqual(self.client.get(self.path).status_code, 403)
+
+        leaked_body = '{"id": 1, "name": "Restricted insight", "result": [["leaked"]]}'
+        mock_coalescer = mock.MagicMock()
+        mock_coalescer.try_acquire.return_value = False
+        mock_coalescer._dry_run = False
+        mock_coalescer.wait_for_signal.return_value = CoalesceSignal.DONE
+        mock_coalescer.get_success_response.return_value = {
+            "status": 200,
+            "body": leaked_body,
+            "content_type": "application/json",
+        }
+
+        with (
+            mock.patch("posthog.api.query_coalescer.posthoganalytics.feature_enabled", return_value=True),
+            mock.patch("posthog.api.query_coalescer.QueryCoalescer", return_value=mock_coalescer),
+            mock.patch(
+                "posthog.api.query_coalescer._COALESCE_PATH_PATTERNS",
+                [re.compile(r"^/api/(?:environments|projects)/\d+/insights/\d+/$")],
+            ),
+        ):
+            response = self.client.get(self.path)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertNotIn("leaked", response.content.decode())
+
+    def test_insight_detail_path_is_not_coalesced(self):
+        with mock.patch("posthog.api.query_coalescer.QueryCoalescer") as mock_cls:
+            self.client.get(self.path)
+            mock_cls.assert_not_called()
+
+
+class TestQueryCoalescingKey(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.other_user = self._create_user("other@posthog.com", level=OrganizationMembership.Level.MEMBER)
+
+    def _key_for(self, *, query_string: str = "", cookies: dict[str, str] | None = None, **extra) -> str:
+        path = f"/api/environments/{self.team.id}/query/"
+        if query_string:
+            path = f"{path}?{query_string}"
+        for name, value in (cookies or {}).items():
+            self.client.cookies[name] = value
+
+        mock_coalescer = mock.MagicMock()
+        mock_coalescer.try_acquire.return_value = True
+        try:
+            with (
+                mock.patch("posthog.api.query_coalescer.posthoganalytics.feature_enabled", return_value=True),
+                mock.patch("posthog.api.query_coalescer.QueryCoalescer", return_value=mock_coalescer) as mock_cls,
+            ):
+                self.client.post(path, {"query": {"kind": "EventsQuery", "select": ["event"]}}, **extra)
+            return mock_cls.call_args.args[0]
+        finally:
+            for name in cookies or {}:
+                del self.client.cookies[name]
+
+    def test_key_is_stable_for_the_same_principal(self):
+        self.assertEqual(self._key_for(), self._key_for())
+
+    @parameterized.expand(
+        [
+            ("session_user", True, {}),
+            ("authorization_header", False, {"HTTP_AUTHORIZATION": "Bearer phx_coalescing_test_key"}),
+            ("personal_api_key_query_param", False, {"query_string": "personal_api_key=phx_coalescing_test_key"}),
+            ("sharing_access_token_query_param", False, {"query_string": "sharing_access_token=share_test_token"}),
+            ("sharing_password_cookie", False, {"cookies": {"posthog_sharing_token": "sharing_test_jwt"}}),
+        ]
+    )
+    def test_key_differs_when_the_principal_differs(self, _name, switch_user, variant):
+        baseline = self._key_for()
+        if switch_user:
+            self.client.force_login(self.other_user)
+        self.assertNotEqual(baseline, self._key_for(**variant))


### PR DESCRIPTION
## Problem

A project member who is denied an insight can be handed that insight's contents, rendered from another member's request.
The same holds for `POST /api/projects/{id}/query/`, where a member denied a warehouse table can receive an allowed member's result set.

- The HTTP query coalescer stores one request's response in Redis and replays it to concurrent identical requests.
- The replay runs only `self.initial()`, which is DRF's view-level check. The view handler never runs.
- So `get_object()` never runs, and neither does `check_object_permissions`. `AccessControlPermission.has_object_permission` and the sharing-token object check are both skipped.
- The coalescing key covered team, method, path and request body. It carried no user, no key or token identity, and no access-control state.
- `POST /query/` results are per principal. The runner filters on `UserAccessControl`, and warehouse tables resolve per user.
- The query runner's own cache partitions on `restricted_objects` and `restricted_resources` for exactly this reason. The coalescer sat in front of it as a second cache with none of that partitioning.
- The follower read path is gated by the `http-query-coalescing` flag. The leader store path runs regardless of the flag.

## Changes

**The key now identifies the principal.** `_compute_key` folds in a principal fingerprint:

- the session-resolved user id,
- the `Authorization` header, which carries personal API keys, OAuth tokens and sharing JWTs,
- the `posthog_sharing_token` cookie,
- `personal_api_key` and `sharing_access_token` from the query string.

The last two matter only for POST, because the key already hashes a GET query string and a POST body.

> [!NOTE]
> A wider key means fewer coalesced hits. Two users running the same query no longer share one execution. One user's own fan-out, such as a dashboard loading its tiles, still coalesces.

**The key does not carry the query cache's access-control fingerprint.** I considered porting `restricted_objects` and `restricted_resources` across, and rejected it:

- The fingerprint is a function of user, team and query. The key now pins all three, so it adds no isolation.
- The query cache needs it because that cache is keyed on the query, not on the user.
- The middleware could not build it anyway. It runs before DRF authenticates, so a personal-API-key request has no resolved `User` there.
- It would also cost a `blocked_resource_ids_by_scope` query on the hot path the coalescer exists to shorten.

**Actions with an object-level permission surface no longer coalesce**, whatever the key says:

- Detail routes leave `_COALESCE_PATH_PATTERNS`, so `GET /insights/{id}/` is no longer stored or replayed.
- `QueryCoalescingMixin` refuses a replay when `self.detail` is true, or when the action is in `sharing_enabled_actions`.
- A disqualified leader signals its followers instead of storing, so they fall through immediately rather than waiting out the timeout.

The rule reads per action rather than per view. `QueryViewSet` declares `sharing_enabled_actions` for `retrieve`, while the coalesced action is `create`, which reaches no object. A per-view rule would disable the endpoint the coalescer exists for.

> [!WARNING]
> The per-action rule lives in `QueryCoalescingMixin`. A pattern added for a view that does not mix it in gets no enforcement. Both current patterns route to views that do. The comment on `_COALESCE_PATH_PATTERNS` names this.

## How did you test this code?

I (actually Claude) wrote both tests before the fix and confirmed each failed as the vulnerability rather than as a fixture error.

Regressions the new tests catch, none of which an existing test covered:

- `test_follower_cannot_replay_an_insight_it_has_no_object_access_to`: a member denied an insight receives a replayed body for it. Before the fix the request returned 200 with the other member's insight. The test opens with a control assertion, that the same member gets 403 without coalescing, so the fixture cannot pass vacuously.
- `test_insight_detail_path_is_not_coalesced`: the leader stores an insight detail body, which happens regardless of the feature flag.
- `test_key_differs_when_the_principal_differs`: five credential axes that produced one shared key. Before the fix all five returned an identical digest.
- `test_key_is_stable_for_the_same_principal`: guards the hit rate. Two requests from one principal share a key even when the posthog-js cookie changes between them. I checked that it fails if the fingerprint widens to that cookie.

<details>
<summary>Local runs</summary>

```
.venv/bin/pytest posthog/api/test/test_query.py posthog/api/test/test_query_coalescing.py -q
97 passed

.venv/bin/pytest products/product_analytics/backend/api/test/test_insight.py -q
174 passed, 3 skipped
```

I removed the `insights_pk` row from `test_matching_paths_trigger_coalescing`, since it asserted the behavior this PR removes.

</details>

Not checked:

- The hit-rate effect is reasoned, not measured. I did not run a load test or read production coalescing metrics.
- Repo-wide mypy. This worktree has no venv of its own.
- No manual testing against a running app.

## Changed after review

- The replay branch releases the team scope it set. It returns without reaching `TeamAndOrgViewSetMixin.dispatch`, whose `finally` normally does that, and ContextVars are thread-local on a reused worker thread. The token stayed set, so the next request on that thread resolved to the replayed request's team instead of failing closed.
- The reset lives on the mixin that owns the token, as `_release_team_scope()`, so there is one implementation rather than two.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior, API surface or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code wrote this, working from a reported finding. Skills invoked: `/writing-tests`, `/improving-drf-endpoints`, `/writing-code-comments`, `/writing-pr-descriptions`.

Two decisions changed shape during the work.
The brief asked for the access-control fingerprint in the key. I left it out for the reasons under Changes.
The brief also asked me to disqualify any view declaring `sharing_enabled_actions`. Read per view, that disqualifies `QueryViewSet` and leaves the coalescer dead, so I made the rule per action.

One thing I found but did not fix: `QueryViewSet.create` branches on the `x-posthog-client: mcp` header, which mutates the query. Two requests with identical bodies and different values of that header share a key and can return differently shaped results. Both principals are authorized, so this is a correctness wrinkle rather than an exposure, and it predates this PR.

