### PR TITLE
fix(activity-logs): derive available filters from the caller's queryset

### DIFF
--- a/posthog/api/advanced_activity_logs/field_discovery.py
+++ b/posthog/api/advanced_activity_logs/field_discovery.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 from typing import Any, TypedDict
 
 from django.db import connection
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 from django.utils import timezone
 
 from posthog.models.activity_logging.activity_log import ActivityLog, Change
@@ -27,12 +27,23 @@ class AdvancedActivityLogFieldDiscovery:
 
     `team_id` narrows every query and the cache key to a single project. It stays `None` for the
     organization-wide callers (the org-scoped endpoint and the background cache task), which are
-    allowed to see across projects.
+    allowed to see across projects. `include_org_scoped` widens a project's scope to the
+    organization-scoped rows that project's feed also shows, matching
+    `apply_organization_scoped_filter`. `user_id` identifies the caller a cached entry belongs to,
+    and stays `None` for the background task, which computes with no caller.
     """
 
-    def __init__(self, organization_id: UUIDT, team_id: int | None = None):
+    def __init__(
+        self,
+        organization_id: UUIDT,
+        team_id: int | None = None,
+        include_org_scoped: bool = False,
+        user_id: int | None = None,
+    ):
         self.organization_id = organization_id
         self.team_id = team_id
+        self.include_org_scoped = include_org_scoped
+        self.user_id = user_id
 
     def get_available_filters(self, base_queryset: QuerySet) -> dict[str, Any]:
         # The filter options themselves come from the caller's authorized queryset below, so they can
@@ -44,7 +55,11 @@ class AdvancedActivityLogFieldDiscovery:
         record_count = self._get_record_count()
 
         if record_count > SMALL_ORG_THRESHOLD:
-            cached = get_cached_fields(str(self.organization_id), self.team_id)
+            cached = get_cached_fields(str(self.organization_id), self.team_id, self.user_id)
+            if cached is None and self.team_id is None:
+                # The background task computes one organization-wide entry with no caller attached.
+                # Only an organization-wide caller may read it, and that route is admin-gated.
+                cached = get_cached_fields(str(self.organization_id))
             if cached:
                 return cached
             return {
@@ -60,7 +75,7 @@ class AdvancedActivityLogFieldDiscovery:
             "detail_fields": detail_fields,
         }
 
-        cache_fields(str(self.organization_id), result, record_count, self.team_id)
+        cache_fields(str(self.organization_id), result, record_count, self.team_id, self.user_id)
         return result
 
     def _get_static_filters(self, queryset: QuerySet) -> dict[str, list[dict[str, str]]]:
@@ -133,7 +148,8 @@ class AdvancedActivityLogFieldDiscovery:
         params: list[Any] = [str(self.organization_id)]
         team_clause = ""
         if self.team_id is not None:
-            team_clause = "AND team_id = %s"
+            # Mirrors `_get_base_queryset`, so sampling covers the same rows the count sizes.
+            team_clause = "AND (team_id = %s OR team_id IS NULL)" if self.include_org_scoped else "AND team_id = %s"
             params.append(self.team_id)
         params.extend([limit, offset])
 
@@ -171,7 +187,7 @@ class AdvancedActivityLogFieldDiscovery:
         batch_fields = self._extract_fields_from_records(records)
         batch_converted = self._convert_to_discovery_format(batch_fields)
 
-        existing_cache = get_cached_fields(str(self.organization_id), self.team_id)
+        existing_cache = get_cached_fields(str(self.organization_id), self.team_id, self.user_id)
         if existing_cache and "detail_fields" in existing_cache:
             current_detail_fields = existing_cache["detail_fields"]
             self._merge_fields_into_result(current_detail_fields, batch_converted)
@@ -201,13 +217,17 @@ class AdvancedActivityLogFieldDiscovery:
         }
 
         record_count = self._get_record_count()
-        cache_fields(str(self.organization_id), cache_data, record_count, self.team_id)
+        cache_fields(str(self.organization_id), cache_data, record_count, self.team_id, self.user_id)
 
     def _get_base_queryset(self) -> QuerySet:
         queryset = ActivityLog.objects.filter(organization_id=self.organization_id)
-        if self.team_id is not None:
-            queryset = queryset.filter(team_id=self.team_id)
-        return queryset
+        if self.team_id is None:
+            return queryset
+        if self.include_org_scoped:
+            return queryset.filter(
+                Q(team_id=self.team_id) | Q(team_id__isnull=True, organization_id=self.organization_id)
+            )
+        return queryset.filter(team_id=self.team_id)
 
     def _merge_fields_into_result(self, result: DetailFieldsResult, fields: list[tuple[str, str, list[str]]]) -> None:
         for scope, field_name, field_types in fields:

--- a/posthog/api/advanced_activity_logs/field_discovery.py
+++ b/posthog/api/advanced_activity_logs/field_discovery.py
@@ -23,14 +23,28 @@ DetailFieldsResult = dict[str, ScopeFields]
 
 
 class AdvancedActivityLogFieldDiscovery:
-    def __init__(self, organization_id: UUIDT):
+    """Derives the filter options an activity log caller may choose from.
+
+    `team_id` narrows every query and the cache key to a single project. It stays `None` for the
+    organization-wide callers (the org-scoped endpoint and the background cache task), which are
+    allowed to see across projects.
+    """
+
+    def __init__(self, organization_id: UUIDT, team_id: int | None = None):
         self.organization_id = organization_id
+        self.team_id = team_id
 
     def get_available_filters(self, base_queryset: QuerySet) -> dict[str, Any]:
-        record_count = self._get_org_record_count()
+        # The filter options themselves come from the caller's authorized queryset below, so they can
+        # never name a project, scope, or actor whose rows that caller cannot read. This count only
+        # chooses between the cached and the live branch, so it stays on the plain scoped count:
+        # counting the authorized queryset instead would evaluate the visibility, loop and canvas
+        # exclusions (JSON predicates on `detail`) over every row, on the organization-wide request
+        # this branch exists to keep cheap.
+        record_count = self._get_record_count()
 
         if record_count > SMALL_ORG_THRESHOLD:
-            cached = get_cached_fields(str(self.organization_id))
+            cached = get_cached_fields(str(self.organization_id), self.team_id)
             if cached:
                 return cached
             return {
@@ -39,14 +53,14 @@ class AdvancedActivityLogFieldDiscovery:
             }
 
         static_filters = self._get_static_filters(base_queryset)
-        detail_fields = self._analyze_detail_fields_memory()
+        detail_fields = self._analyze_detail_fields_memory(base_queryset)
 
         result = {
             "static_filters": static_filters,
             "detail_fields": detail_fields,
         }
 
-        cache_fields(str(self.organization_id), result, record_count)
+        cache_fields(str(self.organization_id), result, record_count, self.team_id)
         return result
 
     def _get_static_filters(self, queryset: QuerySet) -> dict[str, list[dict[str, str]]]:
@@ -89,8 +103,8 @@ class AdvancedActivityLogFieldDiscovery:
         clients = set(clients_query)
         return [{"value": client} for client in sorted(c for c in clients if c)]
 
-    def _analyze_detail_fields_memory(self) -> DetailFieldsResult:
-        fields = self._discover_fields_memory(batch_size=BATCH_SIZE, use_sampling=False)
+    def _analyze_detail_fields_memory(self, base_queryset: QuerySet) -> DetailFieldsResult:
+        fields = self._discover_fields_memory(base_queryset, batch_size=BATCH_SIZE)
         converted_fields = self._convert_to_discovery_format(fields)
 
         result: DetailFieldsResult = {}
@@ -101,12 +115,12 @@ class AdvancedActivityLogFieldDiscovery:
 
         return result
 
-    def _get_org_record_count(self) -> int:
-        return ActivityLog.objects.filter(organization_id=self.organization_id).count()
+    def _get_record_count(self) -> int:
+        return self._get_base_queryset().count()
 
     def get_activity_logs_queryset(self, hours_back: int | None = None) -> QuerySet:
         """Get the base queryset for activity logs, optionally filtered by time."""
-        queryset = ActivityLog.objects.filter(organization_id=self.organization_id, detail__isnull=False)
+        queryset = self._get_base_queryset().filter(detail__isnull=False)
 
         if hours_back is not None:
             cutoff_time = timezone.now() - timedelta(hours=hours_back)
@@ -116,17 +130,25 @@ class AdvancedActivityLogFieldDiscovery:
 
     def get_sampled_records(self, limit: int, offset: int = 0) -> list[dict]:
         """Get sampled records using SQL TABLESAMPLE for large datasets."""
+        params: list[Any] = [str(self.organization_id)]
+        team_clause = ""
+        if self.team_id is not None:
+            team_clause = "AND team_id = %s"
+            params.append(self.team_id)
+        params.extend([limit, offset])
+
         query = f"""
             SELECT scope, detail
             FROM posthog_activitylog TABLESAMPLE SYSTEM ({SAMPLING_PERCENTAGE})
             WHERE organization_id = %s
+            {team_clause}
             AND detail IS NOT NULL
             ORDER BY created_at DESC
             LIMIT %s OFFSET %s
         """
 
         with connection.cursor() as cursor:
-            cursor.execute(query, [str(self.organization_id), limit, offset])
+            cursor.execute(query, params)
             records = []
             for row in cursor.fetchall():
                 scope, detail = row
@@ -149,7 +171,7 @@ class AdvancedActivityLogFieldDiscovery:
         batch_fields = self._extract_fields_from_records(records)
         batch_converted = self._convert_to_discovery_format(batch_fields)
 
-        existing_cache = get_cached_fields(str(self.organization_id))
+        existing_cache = get_cached_fields(str(self.organization_id), self.team_id)
         if existing_cache and "detail_fields" in existing_cache:
             current_detail_fields = existing_cache["detail_fields"]
             self._merge_fields_into_result(current_detail_fields, batch_converted)
@@ -178,11 +200,14 @@ class AdvancedActivityLogFieldDiscovery:
             "detail_fields": current_detail_fields,
         }
 
-        record_count = self._get_org_record_count()
-        cache_fields(str(self.organization_id), cache_data, record_count)
+        record_count = self._get_record_count()
+        cache_fields(str(self.organization_id), cache_data, record_count, self.team_id)
 
-    def _get_base_queryset(self):
-        return ActivityLog.objects.filter(organization_id=self.organization_id)
+    def _get_base_queryset(self) -> QuerySet:
+        queryset = ActivityLog.objects.filter(organization_id=self.organization_id)
+        if self.team_id is not None:
+            queryset = queryset.filter(team_id=self.team_id)
+        return queryset
 
     def _merge_fields_into_result(self, result: DetailFieldsResult, fields: list[tuple[str, str, list[str]]]) -> None:
         for scope, field_name, field_types in fields:
@@ -218,22 +243,18 @@ class AdvancedActivityLogFieldDiscovery:
         return result
 
     def _discover_fields_memory(
-        self, batch_size: int = 10000, use_sampling: bool = True
+        self, base_queryset: QuerySet, batch_size: int = BATCH_SIZE
     ) -> dict[str, set[tuple[str, str]]]:
         all_fields: dict[str, set[tuple[str, str]]] = {}
-        total_records = self._get_record_count_for_memory()
+        # The caller's queryset carries select_related for the list serializer, which values() cannot use.
+        detail_queryset = base_queryset.select_related(None).filter(detail__isnull=False)
+        total_records = detail_queryset.count()
 
         if total_records == 0:
             return all_fields
 
-        if use_sampling:
-            sampled_records = int(total_records * (SAMPLING_PERCENTAGE / 100))
-            records_to_process = sampled_records
-        else:
-            records_to_process = total_records
-
-        for offset in range(0, records_to_process, batch_size):
-            batch_fields = self._process_batch_memory(offset, batch_size, use_sampling)
+        for offset in range(0, total_records, batch_size):
+            batch_fields = self._process_batch_memory(detail_queryset, offset, batch_size)
             self._merge_fields_memory(all_fields, batch_fields)
             del batch_fields
             gc.collect()
@@ -261,16 +282,12 @@ class AdvancedActivityLogFieldDiscovery:
         return batch_fields
 
     def _process_batch_memory(
-        self, offset: int, limit: int, use_sampling: bool = True
+        self, detail_queryset: QuerySet, offset: int, limit: int
     ) -> dict[str, set[tuple[str, str]]]:
-        """Legacy method for backward compatibility."""
-        if use_sampling:
-            records = self.get_sampled_records(limit, offset)
-        else:
-            records = [
-                {"scope": record["scope"], "detail": record["detail"]}
-                for record in self.get_activity_logs_queryset().values("scope", "detail")[offset : offset + limit]
-            ]
+        records = [
+            {"scope": record["scope"], "detail": record["detail"]}
+            for record in detail_queryset.values("scope", "detail")[offset : offset + limit]
+        ]
 
         return self._extract_fields_from_records(records)
 
@@ -328,9 +345,6 @@ class AdvancedActivityLogFieldDiscovery:
             if scope not in all_fields:
                 all_fields[scope] = set()
             all_fields[scope].update(fields)
-
-    def _get_record_count_for_memory(self) -> int:
-        return ActivityLog.objects.filter(organization_id=self.organization_id, detail__isnull=False).count()
 
     def _convert_to_discovery_format(self, fields: dict[str, set[tuple[str, str]]]) -> list[tuple[str, str, list[str]]]:
         result = []

--- a/posthog/api/advanced_activity_logs/field_discovery.py
+++ b/posthog/api/advanced_activity_logs/field_discovery.py
@@ -57,8 +57,12 @@ class AdvancedActivityLogFieldDiscovery:
         if record_count > SMALL_ORG_THRESHOLD:
             cached = get_cached_fields(str(self.organization_id), self.team_id, self.user_id)
             if cached is None and self.team_id is None:
-                # The background task computes one organization-wide entry with no caller attached.
-                # Only an organization-wide caller may read it, and that route is admin-gated.
+                # The background task computes one organization-wide entry with no caller attached,
+                # so only an organization-wide caller reads it. That entry can still name another
+                # user's personal loop or canvas, which `restrict_loop_activity_for_org` and
+                # `restrict_canvas_activity_for_org` exist to prevent. Admin gating does not settle
+                # that, and dropping the fallback would leave a large organization with no filters,
+                # so it stays as the pre-existing behavior rather than as a decision made here.
                 cached = get_cached_fields(str(self.organization_id))
             if cached:
                 return cached

--- a/posthog/api/advanced_activity_logs/field_discovery.py
+++ b/posthog/api/advanced_activity_logs/field_discovery.py
@@ -55,7 +55,7 @@ class AdvancedActivityLogFieldDiscovery:
         record_count = self._get_record_count()
 
         if record_count > SMALL_ORG_THRESHOLD:
-            cached = get_cached_fields(str(self.organization_id), self.team_id, self.user_id)
+            cached = get_cached_fields(str(self.organization_id), self.team_id, self.user_id, self.include_org_scoped)
             if cached is None and self.team_id is None:
                 # The background task computes one organization-wide entry with no caller attached,
                 # so only an organization-wide caller reads it. That entry can still name another
@@ -79,7 +79,9 @@ class AdvancedActivityLogFieldDiscovery:
             "detail_fields": detail_fields,
         }
 
-        cache_fields(str(self.organization_id), result, record_count, self.team_id, self.user_id)
+        cache_fields(
+            str(self.organization_id), result, record_count, self.team_id, self.user_id, self.include_org_scoped
+        )
         return result
 
     def _get_static_filters(self, queryset: QuerySet) -> dict[str, list[dict[str, str]]]:
@@ -191,7 +193,9 @@ class AdvancedActivityLogFieldDiscovery:
         batch_fields = self._extract_fields_from_records(records)
         batch_converted = self._convert_to_discovery_format(batch_fields)
 
-        existing_cache = get_cached_fields(str(self.organization_id), self.team_id, self.user_id)
+        existing_cache = get_cached_fields(
+            str(self.organization_id), self.team_id, self.user_id, self.include_org_scoped
+        )
         if existing_cache and "detail_fields" in existing_cache:
             current_detail_fields = existing_cache["detail_fields"]
             self._merge_fields_into_result(current_detail_fields, batch_converted)
@@ -221,7 +225,9 @@ class AdvancedActivityLogFieldDiscovery:
         }
 
         record_count = self._get_record_count()
-        cache_fields(str(self.organization_id), cache_data, record_count, self.team_id, self.user_id)
+        cache_fields(
+            str(self.organization_id), cache_data, record_count, self.team_id, self.user_id, self.include_org_scoped
+        )
 
     def _get_base_queryset(self) -> QuerySet:
         queryset = ActivityLog.objects.filter(organization_id=self.organization_id)

--- a/posthog/api/advanced_activity_logs/fields_cache.py
+++ b/posthog/api/advanced_activity_logs/fields_cache.py
@@ -7,21 +7,30 @@ from posthog.redis import get_client
 from .constants import CACHE_KEY_PREFIX, CACHE_TTL_SECONDS, SMALL_ORG_THRESHOLD
 
 
-def _get_cache_key(organization_id: str, team_id: Optional[int] = None) -> str:
+def _get_cache_key(organization_id: str, team_id: Optional[int] = None, user_id: Optional[int] = None) -> str:
     """Discovery results are cached at the scope they were computed for.
 
     A project-scoped entry may only contain that project's metadata, so it cannot share a key with
-    the organization-wide entry the background task builds.
+    the organization-wide entry the background task builds. An entry a request computed carries the
+    caller too, because the queryset it was derived from applies that caller's visibility, loop and
+    canvas restrictions. Keying on the caller rather than on those restrictions individually means a
+    new restriction cannot be forgotten here. The background task attaches no caller, so its entry
+    keeps the bare organization key.
     """
-    if team_id is None:
-        return f"{CACHE_KEY_PREFIX}:{organization_id}"
-    return f"{CACHE_KEY_PREFIX}:{organization_id}:team:{team_id}"
+    key = f"{CACHE_KEY_PREFIX}:{organization_id}"
+    if team_id is not None:
+        key = f"{key}:team:{team_id}"
+    if user_id is not None:
+        key = f"{key}:user:{user_id}"
+    return key
 
 
-def get_cached_fields(organization_id: str, team_id: Optional[int] = None) -> Optional[dict]:
+def get_cached_fields(
+    organization_id: str, team_id: Optional[int] = None, user_id: Optional[int] = None
+) -> Optional[dict]:
     try:
         client = get_client()
-        key = _get_cache_key(organization_id, team_id)
+        key = _get_cache_key(organization_id, team_id, user_id)
         json_data = client.get(key)
 
         if not json_data:
@@ -33,10 +42,16 @@ def get_cached_fields(organization_id: str, team_id: Optional[int] = None) -> Op
         return None
 
 
-def cache_fields(organization_id: str, fields_data: dict, record_count: int, team_id: Optional[int] = None) -> None:
+def cache_fields(
+    organization_id: str,
+    fields_data: dict,
+    record_count: int,
+    team_id: Optional[int] = None,
+    user_id: Optional[int] = None,
+) -> None:
     try:
         client = get_client()
-        key = _get_cache_key(organization_id, team_id)
+        key = _get_cache_key(organization_id, team_id, user_id)
         json_data = json.dumps(fields_data, default=str)
 
         if record_count > SMALL_ORG_THRESHOLD:
@@ -49,11 +64,11 @@ def cache_fields(organization_id: str, fields_data: dict, record_count: int, tea
         capture_exception(e)
 
 
-def delete_cached_fields(organization_id: str, team_id: Optional[int] = None) -> bool:
-    """Delete cached fields for an organization, or for one project within it"""
+def delete_cached_fields(organization_id: str, team_id: Optional[int] = None, user_id: Optional[int] = None) -> bool:
+    """Delete cached fields for an organization, or for one project or caller within it"""
     try:
         client = get_client()
-        key = _get_cache_key(organization_id, team_id)
+        key = _get_cache_key(organization_id, team_id, user_id)
         return bool(client.delete(key))
     except Exception as e:
         capture_exception(e)

--- a/posthog/api/advanced_activity_logs/fields_cache.py
+++ b/posthog/api/advanced_activity_logs/fields_cache.py
@@ -7,7 +7,12 @@ from posthog.redis import get_client
 from .constants import CACHE_KEY_PREFIX, CACHE_TTL_SECONDS, SMALL_ORG_THRESHOLD
 
 
-def _get_cache_key(organization_id: str, team_id: Optional[int] = None, user_id: Optional[int] = None) -> str:
+def _get_cache_key(
+    organization_id: str,
+    team_id: Optional[int] = None,
+    user_id: Optional[int] = None,
+    include_org_scoped: bool = False,
+) -> str:
     """Discovery results are cached at the scope they were computed for.
 
     A project-scoped entry may only contain that project's metadata, so it cannot share a key with
@@ -16,21 +21,30 @@ def _get_cache_key(organization_id: str, team_id: Optional[int] = None, user_id:
     canvas restrictions. Keying on the caller rather than on those restrictions individually means a
     new restriction cannot be forgotten here. The background task attaches no caller, so its entry
     keeps the bare organization key.
+
+    `include_org_scoped` is in the key because an admin can turn that project setting off, which
+    narrows the caller's queryset without changing who the caller is. The remaining restrictions
+    stay bounded by the entry's TTL instead.
     """
     key = f"{CACHE_KEY_PREFIX}:{organization_id}"
     if team_id is not None:
         key = f"{key}:team:{team_id}"
     if user_id is not None:
         key = f"{key}:user:{user_id}"
+    if include_org_scoped:
+        key = f"{key}:orgscoped"
     return key
 
 
 def get_cached_fields(
-    organization_id: str, team_id: Optional[int] = None, user_id: Optional[int] = None
+    organization_id: str,
+    team_id: Optional[int] = None,
+    user_id: Optional[int] = None,
+    include_org_scoped: bool = False,
 ) -> Optional[dict]:
     try:
         client = get_client()
-        key = _get_cache_key(organization_id, team_id, user_id)
+        key = _get_cache_key(organization_id, team_id, user_id, include_org_scoped)
         json_data = client.get(key)
 
         if not json_data:
@@ -48,10 +62,11 @@ def cache_fields(
     record_count: int,
     team_id: Optional[int] = None,
     user_id: Optional[int] = None,
+    include_org_scoped: bool = False,
 ) -> None:
     try:
         client = get_client()
-        key = _get_cache_key(organization_id, team_id, user_id)
+        key = _get_cache_key(organization_id, team_id, user_id, include_org_scoped)
         json_data = json.dumps(fields_data, default=str)
 
         if record_count > SMALL_ORG_THRESHOLD:
@@ -64,11 +79,16 @@ def cache_fields(
         capture_exception(e)
 
 
-def delete_cached_fields(organization_id: str, team_id: Optional[int] = None, user_id: Optional[int] = None) -> bool:
+def delete_cached_fields(
+    organization_id: str,
+    team_id: Optional[int] = None,
+    user_id: Optional[int] = None,
+    include_org_scoped: bool = False,
+) -> bool:
     """Delete cached fields for an organization, or for one project or caller within it"""
     try:
         client = get_client()
-        key = _get_cache_key(organization_id, team_id, user_id)
+        key = _get_cache_key(organization_id, team_id, user_id, include_org_scoped)
         return bool(client.delete(key))
     except Exception as e:
         capture_exception(e)

--- a/posthog/api/advanced_activity_logs/fields_cache.py
+++ b/posthog/api/advanced_activity_logs/fields_cache.py
@@ -7,14 +7,21 @@ from posthog.redis import get_client
 from .constants import CACHE_KEY_PREFIX, CACHE_TTL_SECONDS, SMALL_ORG_THRESHOLD
 
 
-def _get_cache_key(organization_id: str) -> str:
-    return f"{CACHE_KEY_PREFIX}:{organization_id}"
+def _get_cache_key(organization_id: str, team_id: Optional[int] = None) -> str:
+    """Discovery results are cached at the scope they were computed for.
+
+    A project-scoped entry may only contain that project's metadata, so it cannot share a key with
+    the organization-wide entry the background task builds.
+    """
+    if team_id is None:
+        return f"{CACHE_KEY_PREFIX}:{organization_id}"
+    return f"{CACHE_KEY_PREFIX}:{organization_id}:team:{team_id}"
 
 
-def get_cached_fields(organization_id: str) -> Optional[dict]:
+def get_cached_fields(organization_id: str, team_id: Optional[int] = None) -> Optional[dict]:
     try:
         client = get_client()
-        key = _get_cache_key(organization_id)
+        key = _get_cache_key(organization_id, team_id)
         json_data = client.get(key)
 
         if not json_data:
@@ -26,10 +33,10 @@ def get_cached_fields(organization_id: str) -> Optional[dict]:
         return None
 
 
-def cache_fields(organization_id: str, fields_data: dict, record_count: int) -> None:
+def cache_fields(organization_id: str, fields_data: dict, record_count: int, team_id: Optional[int] = None) -> None:
     try:
         client = get_client()
-        key = _get_cache_key(organization_id)
+        key = _get_cache_key(organization_id, team_id)
         json_data = json.dumps(fields_data, default=str)
 
         if record_count > SMALL_ORG_THRESHOLD:
@@ -42,11 +49,11 @@ def cache_fields(organization_id: str, fields_data: dict, record_count: int) -> 
         capture_exception(e)
 
 
-def delete_cached_fields(organization_id: str) -> bool:
-    """Delete cached fields for an organization"""
+def delete_cached_fields(organization_id: str, team_id: Optional[int] = None) -> bool:
+    """Delete cached fields for an organization, or for one project within it"""
     try:
         client = get_client()
-        key = _get_cache_key(organization_id)
+        key = _get_cache_key(organization_id, team_id)
         return bool(client.delete(key))
     except Exception as e:
         capture_exception(e)

--- a/posthog/api/advanced_activity_logs/viewset.py
+++ b/posthog/api/advanced_activity_logs/viewset.py
@@ -576,10 +576,15 @@ class AdvancedActivityLogsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSe
             self._filter_manager = AdvancedActivityLogFilterManager()
         return self._filter_manager
 
+    def _field_discovery_team_id(self) -> Optional[int]:
+        return self.team_id
+
     @property
     def field_discovery(self) -> AdvancedActivityLogFieldDiscovery:
         if self._field_discovery is None:
-            self._field_discovery = AdvancedActivityLogFieldDiscovery(self.organization.id)
+            self._field_discovery = AdvancedActivityLogFieldDiscovery(
+                self.organization.id, team_id=self._field_discovery_team_id()
+            )
         return self._field_discovery
 
     def _make_filters_serializable(self, filters_data: dict) -> dict[str, Any]:
@@ -778,6 +783,11 @@ class OrganizationAdvancedActivityLogsViewSet(AdvancedActivityLogsViewSet):
         # parents_query_dict is {"organization_id": <uuid>} on this nested route, so let
         # TeamAndOrgViewSetMixin filter the queryset by organization_id automatically.
         return False
+
+    def _field_discovery_team_id(self) -> Optional[int]:
+        # This route is admin-gated and has no single team, so discovery stays organization-wide.
+        # `self.team_id` is not resolvable here either, because parents_query_dict carries no team_id.
+        return None
 
     def safely_get_queryset(self, queryset) -> QuerySet:
         queryset = queryset.select_related("user")

--- a/posthog/api/advanced_activity_logs/viewset.py
+++ b/posthog/api/advanced_activity_logs/viewset.py
@@ -582,8 +582,14 @@ class AdvancedActivityLogsViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSe
     @property
     def field_discovery(self) -> AdvancedActivityLogFieldDiscovery:
         if self._field_discovery is None:
+            team_id = self._field_discovery_team_id()
             self._field_discovery = AdvancedActivityLogFieldDiscovery(
-                self.organization.id, team_id=self._field_discovery_team_id()
+                self.organization.id,
+                team_id=team_id,
+                # `self.team` is only resolvable on the project route, and the org route is
+                # organization-wide already, so it needs no widening.
+                include_org_scoped=bool(self.team.receive_org_level_activity_logs) if team_id is not None else False,
+                user_id=getattr(self.request.user, "pk", None),
             )
         return self._field_discovery
 

--- a/posthog/api/test/test_activity_log.py
+++ b/posthog/api/test/test_activity_log.py
@@ -463,7 +463,10 @@ class TestAdvancedActivityLogsAvailableFiltersScoping(APIBaseTest):
         delete_cached_fields(str(self.organization.id))
         delete_cached_fields(str(self.organization.id), team_id=self.team.id)
         for user in (self.user, self.other_user):
-            delete_cached_fields(str(self.organization.id), team_id=self.team.id, user_id=user.pk)
+            for org_scoped in (False, True):
+                delete_cached_fields(
+                    str(self.organization.id), team_id=self.team.id, user_id=user.pk, include_org_scoped=org_scoped
+                )
 
     def _log(self, team_id: int | None, scope: str, activity: str, detail: dict, user: User) -> None:
         ActivityLog.objects.create(
@@ -520,6 +523,23 @@ class TestAdvancedActivityLogsAvailableFiltersScoping(APIBaseTest):
         assert res.status_code == status.HTTP_200_OK
         body = res.json()
         assert self._values(body, "scopes") == set()
+        assert body["detail_fields"] == {}
+
+    def test_turning_off_organization_scoped_reads_does_not_reuse_the_wider_cache(self) -> None:
+        # An admin can narrow a caller's queryset without changing who the caller is, so the caller
+        # alone does not identify what an entry was computed from.
+        self.team.receive_org_level_activity_logs = True
+        self.team.save()
+        self._log(None, "Organization", "updated", {"org_scoped_field": "o"}, self.user)
+        assert self._available_filters().status_code == status.HTTP_200_OK
+        assert "Organization" in self._available_filters().json()["detail_fields"]
+
+        self.team.receive_org_level_activity_logs = False
+        self.team.save()
+
+        with patch("posthog.api.advanced_activity_logs.field_discovery.SMALL_ORG_THRESHOLD", 0):
+            body = self._available_filters().json()
+
         assert body["detail_fields"] == {}
 
     def test_record_count_covers_the_organization_scoped_rows_the_project_can_read(self) -> None:

--- a/posthog/api/test/test_activity_log.py
+++ b/posthog/api/test/test_activity_log.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 from uuid import uuid4
 
 from freezegun import freeze_time
@@ -11,7 +11,9 @@ from django.utils import timezone
 
 from parameterized import parameterized
 from rest_framework import status
-from rest_framework.response import Response
+
+if TYPE_CHECKING:
+    from rest_framework.response import _MonkeyPatchedResponse
 
 from posthog.api.advanced_activity_logs.fields_cache import cache_fields, delete_cached_fields, get_cached_fields
 from posthog.constants import AvailableFeature
@@ -479,7 +481,7 @@ class TestAdvancedActivityLogsAvailableFiltersScoping(APIBaseTest):
             detail=detail,
         )
 
-    def _available_filters(self) -> Response:
+    def _available_filters(self) -> "_MonkeyPatchedResponse":
         return self.client.get(f"/api/projects/{self.team.id}/advanced_activity_logs/available_filters/")
 
     @staticmethod

--- a/posthog/api/test/test_activity_log.py
+++ b/posthog/api/test/test_activity_log.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 from parameterized import parameterized
 from rest_framework import status
 
+from posthog.api.advanced_activity_logs.fields_cache import cache_fields, delete_cached_fields, get_cached_fields
 from posthog.constants import AvailableFeature
 from posthog.models import Organization, OrganizationMembership, PersonalAPIKey, Team, User
 from posthog.models.activity_logging.activity_log import ActivityLog, Detail, log_activity
@@ -432,6 +433,106 @@ class TestOrganizationAdvancedActivityLogsAvailableFilters(APIBaseTest):
         assert {"FeatureFlag", "Insight"}.issubset(scopes)
         activities = {entry["value"] for entry in body["static_filters"]["activities"]}
         assert {"created", "updated"}.issubset(activities)
+
+
+class TestAdvancedActivityLogsAvailableFiltersScoping(APIBaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.user.is_staff = False
+        self.user.save()
+        self.organization.available_product_features = [{"key": AvailableFeature.AUDIT_LOGS, "name": "Activity logs"}]
+        self.organization.save()
+
+        self.other_team = Team.objects.create(organization=self.organization, name="Other project")
+        self.other_user = User.objects.create_and_join(
+            organization=self.organization,
+            email="other-project-actor@posthog.com",
+            password="",
+        )
+
+        self._log(self.team.id, "Dashboard", "created", {"project_a_field": "a"}, self.user)
+        self._log(self.other_team.id, "Insight", "deleted", {"project_b_field": "b"}, self.other_user)
+        # Restricted for non-staff by activity_visibility_restrictions, but inside this project.
+        self._log(self.team.id, "User", "created", {"restricted_field": "r"}, self.user)
+
+        self._clear_caches()
+        self.addCleanup(self._clear_caches)
+
+    def _clear_caches(self) -> None:
+        delete_cached_fields(str(self.organization.id))
+        delete_cached_fields(str(self.organization.id), team_id=self.team.id)
+
+    def _log(self, team_id: int, scope: str, activity: str, detail: dict, user: User) -> None:
+        ActivityLog.objects.create(
+            organization_id=self.organization.id,
+            team_id=team_id,
+            user=user,
+            scope=scope,
+            activity=activity,
+            item_id="item-1",
+            detail=detail,
+        )
+
+    def _available_filters(self) -> Any:
+        return self.client.get(f"/api/projects/{self.team.id}/advanced_activity_logs/available_filters/")
+
+    @staticmethod
+    def _values(body: dict, key: str) -> set[str]:
+        return {entry["value"] for entry in body["static_filters"][key]}
+
+    @staticmethod
+    def _detail_field_names(body: dict, scope: str) -> set[str]:
+        return {field["name"] for field in body["detail_fields"].get(scope, {}).get("fields", [])}
+
+    def test_available_filters_are_scoped_to_the_requested_project(self) -> None:
+        res = self._available_filters()
+
+        assert res.status_code == status.HTTP_200_OK
+        body = res.json()
+        assert self._values(body, "scopes") == {"Dashboard"}
+        assert self._values(body, "activities") == {"created"}
+        assert self._values(body, "users") == {str(self.user.uuid)}
+        assert self._detail_field_names(body, "Dashboard") == {"project_a_field"}
+        assert "Insight" not in body["detail_fields"]
+
+    def test_available_filters_are_cached_under_a_project_scoped_key(self) -> None:
+        assert self._available_filters().status_code == status.HTTP_200_OK
+
+        assert get_cached_fields(str(self.organization.id)) is None
+        cached = get_cached_fields(str(self.organization.id), team_id=self.team.id)
+        assert cached is not None
+        assert {entry["value"] for entry in cached["static_filters"]["scopes"]} == {"Dashboard"}
+
+    def test_available_filters_omit_detail_fields_of_restricted_scopes(self) -> None:
+        res = self._available_filters()
+
+        assert res.status_code == status.HTTP_200_OK
+        assert "User" not in res.json()["detail_fields"]
+
+    def test_available_filters_do_not_serve_the_organization_wide_cache(self) -> None:
+        cache_fields(
+            str(self.organization.id),
+            {
+                "static_filters": {
+                    "users": [{"value": str(self.other_user.uuid), "label": "Other"}],
+                    "scopes": [{"value": "Insight"}],
+                    "activities": [{"value": "deleted"}],
+                    "clients": [{"value": "other-project-client"}],
+                },
+                "detail_fields": {"Insight": {"fields": [{"name": "project_b_field", "types": ["string"]}]}},
+            },
+            record_count=0,
+        )
+
+        with patch("posthog.api.advanced_activity_logs.field_discovery.SMALL_ORG_THRESHOLD", 0):
+            res = self._available_filters()
+
+        assert res.status_code == status.HTTP_200_OK
+        body = res.json()
+        assert self._values(body, "scopes") == set()
+        assert self._values(body, "users") == set()
+        assert self._values(body, "clients") == set()
+        assert body["detail_fields"] == {}
 
 
 class TestActivityLogBearerAuthAttribution(APIBaseTest):

--- a/posthog/api/test/test_activity_log.py
+++ b/posthog/api/test/test_activity_log.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 
 from parameterized import parameterized
 from rest_framework import status
+from rest_framework.response import Response
 
 from posthog.api.advanced_activity_logs.fields_cache import cache_fields, delete_cached_fields, get_cached_fields
 from posthog.constants import AvailableFeature
@@ -461,8 +462,10 @@ class TestAdvancedActivityLogsAvailableFiltersScoping(APIBaseTest):
     def _clear_caches(self) -> None:
         delete_cached_fields(str(self.organization.id))
         delete_cached_fields(str(self.organization.id), team_id=self.team.id)
+        for user in (self.user, self.other_user):
+            delete_cached_fields(str(self.organization.id), team_id=self.team.id, user_id=user.pk)
 
-    def _log(self, team_id: int, scope: str, activity: str, detail: dict, user: User) -> None:
+    def _log(self, team_id: int | None, scope: str, activity: str, detail: dict, user: User) -> None:
         ActivityLog.objects.create(
             organization_id=self.organization.id,
             team_id=team_id,
@@ -473,7 +476,7 @@ class TestAdvancedActivityLogsAvailableFiltersScoping(APIBaseTest):
             detail=detail,
         )
 
-    def _available_filters(self) -> Any:
+    def _available_filters(self) -> Response:
         return self.client.get(f"/api/projects/{self.team.id}/advanced_activity_logs/available_filters/")
 
     @staticmethod
@@ -499,9 +502,38 @@ class TestAdvancedActivityLogsAvailableFiltersScoping(APIBaseTest):
         assert self._available_filters().status_code == status.HTTP_200_OK
 
         assert get_cached_fields(str(self.organization.id)) is None
-        cached = get_cached_fields(str(self.organization.id), team_id=self.team.id)
+        assert get_cached_fields(str(self.organization.id), team_id=self.team.id) is None
+        cached = get_cached_fields(str(self.organization.id), team_id=self.team.id, user_id=self.user.pk)
         assert cached is not None
         assert {entry["value"] for entry in cached["static_filters"]["scopes"]} == {"Dashboard"}
+
+    def test_available_filters_do_not_serve_another_members_cache(self) -> None:
+        assert self._available_filters().status_code == status.HTTP_200_OK
+
+        self.other_user.current_team = self.team
+        self.other_user.save()
+        self.client.force_login(self.other_user)
+
+        with patch("posthog.api.advanced_activity_logs.field_discovery.SMALL_ORG_THRESHOLD", 0):
+            res = self._available_filters()
+
+        assert res.status_code == status.HTTP_200_OK
+        body = res.json()
+        assert self._values(body, "scopes") == set()
+        assert body["detail_fields"] == {}
+
+    def test_record_count_covers_the_organization_scoped_rows_the_project_can_read(self) -> None:
+        self.team.receive_org_level_activity_logs = True
+        self.team.save()
+        self._log(None, "Organization", "updated", {"org_scoped_field": "o"}, self.user)
+
+        # Two project rows plus one organization-scoped row. A count that misses the last one stays
+        # at or below this threshold and takes the live branch the threshold exists to avoid.
+        with patch("posthog.api.advanced_activity_logs.field_discovery.SMALL_ORG_THRESHOLD", 2):
+            res = self._available_filters()
+
+        assert res.status_code == status.HTTP_200_OK
+        assert res.json()["detail_fields"] == {}
 
     def test_available_filters_omit_detail_fields_of_restricted_scopes(self) -> None:
         res = self._available_filters()

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -1653,7 +1653,7 @@ def refresh_activity_log_fields_cache(flush: bool = False, hours_back: int = 14)
         deleted = delete_cached_fields(str(org_id))
         logger.info(f"Flushed cache for org {org_id}: {deleted}")
 
-        record_count = discovery._get_org_record_count()
+        record_count = discovery._get_record_count()
         estimated_sampled_records = int(record_count * (SAMPLING_PERCENTAGE / 100))
         total_batches = (estimated_sampled_records + BATCH_SIZE - 1) // BATCH_SIZE
 


### PR DESCRIPTION
## Problem

A member of one project could read activity log metadata about every other project in the organization, through that project's own filter picker.

- `GET /api/projects/:id/advanced_activity_logs/available_filters/` described the whole organization instead of the project.
- Field discovery ran on `ActivityLog.objects.filter(organization_id=...)`, not on the queryset the viewset had already authorized.
- Detail field names logged in other projects showed up as `detail_fields` keys.
- Scopes the list endpoint hides from non-staff, such as `User`, also showed up as `detail_fields` keys, because the discovery path skipped `apply_activity_visibility_restrictions`.
- Above 20000 rows the endpoint returned the organization's cached blob verbatim, which carries actor uuids, names and emails, plus every scope, activity and client in the organization.
- The organization-scoped endpoint exposes the same data on purpose and requires admin or owner. The project route reached it with no such gate.

## Changes

- Field discovery now derives every filter option from the queryset the viewset authorized, so an option can never name a row the caller cannot read.
- `AdvancedActivityLogFieldDiscovery` takes an optional `team_id`, which keys the cache per project and filters the sampling SQL.
- The organization route passes `team_id=None` and keeps its current behavior.
- I pass the queryset rather than adding a `team_id` filter, because a project queryset with `receive_org_level_activity_logs` on legitimately includes organization-scoped rows.
- That queryset already carries the visibility, loop and canvas restrictions, so discovery inherits them instead of reapplying them.
- The record count that picks the cached branch stays a plain scoped `COUNT`. Counting the authorized queryset would run the loop and canvas JSON predicates over a whole organization, on the request this branch exists to keep cheap. The count only selects a branch, so it need not match the authorized scope exactly.
- The in-memory discovery path lost its unused sampling branch, so a request cannot reach the raw SQL sampler at all.
- No cache version bump is needed. The project route reads a key namespace that never existed before, so no pre-deploy organization blob is reachable from it, and the organization route reads the same key as before.

> [!WARNING]
> Members see fewer filter values than before. That is the fix working, not a regression.

> [!NOTE]
> Known limitation: a project whose own row count exceeds 20000 now gets an empty filter set, because nothing populates the per-project cache keys. The background refresh task builds organization keys only. I did not extend it. Rebuilding per project would multiply a job that already has a 2 hour limit by the number of projects in the organization. This needs a follow-up if a large project reports empty filters.

## How did you test this code?

New tests in `posthog/api/test/test_activity_log.py`, class `TestAdvancedActivityLogsAvailableFiltersScoping`. Each one fails before the fix and passes after it.

- Cross-project scoping catches discovery reverting to an organization-wide queryset. Before the fix it failed on a second project's scope key appearing in `detail_fields`.
- Restricted scopes catches `detail_fields` exposing a scope the list endpoint hides from non-staff.
- Warm cache catches the project route reading the organization-wide cache entry. It is the amplified variant, so it seeds a poisoned organization blob and lowers the threshold.
- Cache key catches the write side, which the other three miss. Dropping the project from the `cache_fields` call alone writes project data back onto the organization key, and only this test fails.

I ran the advanced activity logs package, `posthog/api/test/test_activity_log.py`, and the `available_filters` cases in `posthog/api/test/test_personal_api_keys.py`.

Not checked: no manual or browser testing, and no verification against a project large enough to take the cached branch.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changed after review

- The cache key carries the caller. The queryset it is derived from applies that caller's visibility, loop and canvas restrictions, so one member could populate an entry another member then read for the whole TTL. Keying on the caller rather than on each restriction means a restriction added later cannot be forgotten there.
- The threshold count covers the same rows the queryset reads. It filtered on `team_id` alone, while a project with `receive_org_level_activity_logs` also reads organization-scoped rows, so a project could stay on the live branch by holding its volume in rows the count ignored.

> [!NOTE]
> The organization-wide route still falls back to the entry the background task builds, which is computed with no caller. That entry can therefore name another user's personal loop or canvas metadata, which `restrict_loop_activity_for_org` and `restrict_canvas_activity_for_org` exist to prevent. The route is admin-gated and the behavior predates this branch, and dropping the fallback would leave large organizations with no filters at all. Recording it rather than changing it here.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The response schema is unchanged, and no documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via Claude Code) wrote this change under human direction. The finding was reported against an older revision, so I confirmed it still reproduced on current master before touching anything, then wrote the failing tests, then fixed.

Skills invoked: `/writing-tests`, `/improving-drf-endpoints`, `/writing-code-comments`, `/writing-pr-descriptions`.

Two decisions worth flagging for review. The count that selects the cached branch is now per project rather than per organization, because an organization-wide count would send every project in a large organization to a per-project cache key that nothing populates, emptying the filter picker for all of them. And a per-project cache entry is still computed under one user's visibility, so within the 12 hour TTL another user could be served it if the project later crosses the threshold. That matches how the organization key already behaved, on a smaller blast radius, so I left it.

