### PR TITLE
fix(events): parse element chains without ambiguous backtracking

### DIFF
--- a/posthog/models/element/element.py
+++ b/posthog/models/element/element.py
@@ -22,12 +22,37 @@ class Element(models.Model):
 
 parse_attributes_regex = re.compile(r"(?P<attribute>(?P<key>.*?)\=\"(?P<value>.*?[^\\])\")", re.MULTILINE)
 
-# Below splits all elements by ;, while ignoring escaped quotes and semicolons within quotes
-split_chain_regex = re.compile(r'(?:[^\s;"]|"(?:\\.|[^"])*")+')
+# Below splits all elements by ;, while ignoring escaped quotes and semicolons within quotes.
+# Every branch of the quoted-string alternation starts on a distinct character, so a given
+# input has exactly one parse. An alternation where two branches can both consume a backslash
+# forces the engine to enumerate every way of tiling a run of them, which costs exponential
+# time in the length of the run.
+split_chain_regex = re.compile(r'(?:[^\s;"]|"(?:[^"\\]|\\.|\\(?=\n))*\\?")+')
+
+# elements_chain is copied verbatim from the event's $elements_chain property, so its length
+# is controlled by whoever sent the event. Splitting is linear in the chain, but attribute
+# parsing grows faster than linearly with a single element's attribute run, so bound the input.
+# Elements are ordered target-first, so truncating drops the outermost ancestors rather than
+# the element that was actually interacted with.
+MAX_ELEMENTS_CHAIN_LENGTH = 16_384
 
 # Below splits the tag/classes from attributes
 # Needs a regex because classes can have : too
 split_class_attributes = re.compile(r"(.*?)($|:([a-zA-Z\-\_0-9]*=.*))")
+
+
+def _split_chain(chain: str) -> list[str]:
+    if len(chain) <= MAX_ELEMENTS_CHAIN_LENGTH:
+        return split_chain_regex.findall(chain)
+    # cutting at the last separator keeps the final element whole, so an over-long chain
+    # loses its outermost ancestors instead of gaining a fragment parsed as a real element.
+    # A separator sitting near the start means one enormous element follows it, and cutting
+    # there would throw away almost everything, so keep the raw window in that case.
+    truncated = chain[:MAX_ELEMENTS_CHAIN_LENGTH]
+    separator = truncated.rfind(";")
+    if separator > MAX_ELEMENTS_CHAIN_LENGTH // 2:
+        truncated = truncated[:separator]
+    return split_chain_regex.findall(truncated)
 
 
 def _escape(input: str) -> str:
@@ -63,7 +88,7 @@ def chain_to_elements(chain: str) -> list[Element]:
     Converts an elements chain string into a list of Element objects.
     """
     elements = []
-    for idx, el_string in enumerate(re.findall(split_chain_regex, chain)):
+    for idx, el_string in enumerate(_split_chain(chain)):
         el_string_split = re.findall(split_class_attributes, el_string)[0]
         attributes = re.finditer(parse_attributes_regex, el_string_split[2]) if len(el_string_split) > 2 else []
 
@@ -151,7 +176,7 @@ def chain_to_element_dicts(chain: str, attributes_filter: Callable[[str], bool] 
     map to matching keys (see build_attributes_filter).
     """
     element_dicts: list[dict] = []
-    for idx, el_string in enumerate(split_chain_regex.findall(chain)):
+    for idx, el_string in enumerate(_split_chain(chain)):
         el_string_match = split_class_attributes.search(el_string)
         tag_part = el_string_match.group(1) if el_string_match else ""
         attrs_part = el_string_match.group(3) if el_string_match else None

--- a/posthog/models/element/element.py
+++ b/posthog/models/element/element.py
@@ -20,7 +20,10 @@ class Element(models.Model):
     group = models.ForeignKey("ElementGroup", on_delete=models.CASCADE, null=True, blank=True)
 
 
-parse_attributes_regex = re.compile(r"(?P<attribute>(?P<key>.*?)\=\"(?P<value>.*?[^\\])\")", re.MULTILINE)
+# The key stops at `=` so a failed attempt ends at the next one. A key of `.*?` instead scans to the
+# end of the attribute run before failing, once per start position, which costs time quadratic in the
+# run's length on input that holds `=` without a following quote.
+parse_attributes_regex = re.compile(r'(?P<attribute>(?P<key>[^"=]*)="(?P<value>.*?[^\\])")', re.MULTILINE)
 
 # Below splits all elements by ;, while ignoring escaped quotes and semicolons within quotes.
 # Every branch of the quoted-string alternation starts on a distinct character, so a given

--- a/posthog/models/element/element.py
+++ b/posthog/models/element/element.py
@@ -52,22 +52,21 @@ def iter_attributes(source: str) -> Iterator[tuple[str, str]]:
     run's length for an element that holds no `="` at all, which is a shape the sender controls.
     `str.find` jumps straight to the next candidate instead, so the whole run is read once.
     """
-    index = 0
+    # `key_start` is where the previous pair ended, and the key is everything from there. `search`
+    # runs ahead of it over `="` pairs that turn out to have no value, so that text lands in the key
+    # rather than being dropped, which is where the regex's leftmost match would have started too.
+    key_start = 0
+    search = 0
     while True:
-        equals = source.find('="', index)
+        equals = source.find('="', search)
         if equals < 0:
             return
-        # The key runs back to the previous attribute's closing quote, matching what the lazy
-        # key of the original single regex consumed.
-        key_start = equals
-        while key_start > index and source[key_start - 1] != '"':
-            key_start -= 1
         value_match = _ATTRIBUTE_VALUE_REGEX.match(source, equals + 2)
         if value_match is None:
-            index = equals + 2
+            search = equals + 2
             continue
         yield source[key_start:equals], value_match.group(1)
-        index = value_match.end()
+        key_start = search = value_match.end()
 
 
 def _split_chain(chain: str) -> list[str]:

--- a/posthog/models/element/element.py
+++ b/posthog/models/element/element.py
@@ -1,5 +1,5 @@
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
@@ -20,10 +20,10 @@ class Element(models.Model):
     group = models.ForeignKey("ElementGroup", on_delete=models.CASCADE, null=True, blank=True)
 
 
-# The key stops at `=` so a failed attempt ends at the next one. A key of `.*?` instead scans to the
-# end of the attribute run before failing, once per start position, which costs time quadratic in the
-# run's length on input that holds `=` without a following quote.
-parse_attributes_regex = re.compile(r'(?P<attribute>(?P<key>[^"=]*)="(?P<value>.*?[^\\])")', re.MULTILINE)
+# Matches one attribute's value, anchored where the caller found the opening quote. Unchanged from
+# the pattern the whole attribute used to be part of, so values parse exactly as before: the shortest
+# run whose last character is not a backslash, up to the closing quote.
+_ATTRIBUTE_VALUE_REGEX = re.compile(r'(.*?[^\\])"', re.MULTILINE)
 
 # Below splits all elements by ;, while ignoring escaped quotes and semicolons within quotes.
 # Every branch of the quoted-string alternation starts on a distinct character, so a given
@@ -42,6 +42,32 @@ MAX_ELEMENTS_CHAIN_LENGTH = 16_384
 # Below splits the tag/classes from attributes
 # Needs a regex because classes can have : too
 split_class_attributes = re.compile(r"(.*?)($|:([a-zA-Z\-\_0-9]*=.*))")
+
+
+def iter_attributes(source: str) -> Iterator[tuple[str, str]]:
+    """Yield each `key="value"` pair in an element's attribute run, left to right.
+
+    Written as a scan rather than one regex because a regex has to restart at every position when a
+    match fails, and each restart re-reads the rest of the run. That made the cost quadratic in the
+    run's length for an element that holds no `="` at all, which is a shape the sender controls.
+    `str.find` jumps straight to the next candidate instead, so the whole run is read once.
+    """
+    index = 0
+    while True:
+        equals = source.find('="', index)
+        if equals < 0:
+            return
+        # The key runs back to the previous attribute's closing quote, matching what the lazy
+        # key of the original single regex consumed.
+        key_start = equals
+        while key_start > index and source[key_start - 1] != '"':
+            key_start -= 1
+        value_match = _ATTRIBUTE_VALUE_REGEX.match(source, equals + 2)
+        if value_match is None:
+            index = equals + 2
+            continue
+        yield source[key_start:equals], value_match.group(1)
+        index = value_match.end()
 
 
 def _split_chain(chain: str) -> list[str]:
@@ -93,7 +119,7 @@ def chain_to_elements(chain: str) -> list[Element]:
     elements = []
     for idx, el_string in enumerate(_split_chain(chain)):
         el_string_split = re.findall(split_class_attributes, el_string)[0]
-        attributes = re.finditer(parse_attributes_regex, el_string_split[2]) if len(el_string_split) > 2 else []
+        attributes = iter_attributes(el_string_split[2]) if len(el_string_split) > 2 else []
 
         element = Element(order=idx)
 
@@ -103,20 +129,19 @@ def chain_to_elements(chain: str) -> list[Element]:
             if len(tag_and_class) > 1:
                 element.attr_class = [cl for cl in tag_and_class[1].split(".") if cl != ""]
 
-        for ii in attributes:
-            item = ii.groupdict()
-            if item["key"] == "href":
-                element.href = item["value"]
-            elif item["key"] == "nth-child":
-                element.nth_child = int(item["value"])
-            elif item["key"] == "nth-of-type":
-                element.nth_of_type = int(item["value"])
-            elif item["key"] == "text":
-                element.text = item["value"]
-            elif item["key"] == "attr_id":
-                element.attr_id = item["value"]
-            elif item["key"]:
-                element.attributes[item["key"]] = item["value"]
+        for key, value in attributes:
+            if key == "href":
+                element.href = value
+            elif key == "nth-child":
+                element.nth_child = int(value)
+            elif key == "nth-of-type":
+                element.nth_of_type = int(value)
+            elif key == "text":
+                element.text = value
+            elif key == "attr_id":
+                element.attr_id = value
+            elif key:
+                element.attributes[key] = value
 
         elements.append(element)
     return elements
@@ -203,9 +228,7 @@ def chain_to_element_dicts(chain: str, attributes_filter: Callable[[str], bool] 
                 element["attr_class"] = [cl for cl in tag_and_class[1].split(".") if cl != ""]
 
         if attrs_part:
-            for attribute_match in parse_attributes_regex.finditer(attrs_part):
-                key = attribute_match.group("key")
-                value = attribute_match.group("value")
+            for key, value in iter_attributes(attrs_part):
                 if key == "href":
                     element["href"] = value
                 elif key == "nth-child":

--- a/posthog/test/test_element_model.py
+++ b/posthog/test/test_element_model.py
@@ -188,6 +188,14 @@ class TestChainSplitting(SimpleTestCase):
         assert len(chain) <= MAX_ELEMENTS_CHAIN_LENGTH
         assert len(chain_to_elements(chain)) == segments
 
+    def test_an_attribute_key_stops_at_the_equals_sign(self) -> None:
+        # An attribute run holding `=` without a following quote is what makes the parse quadratic,
+        # and it stops being quadratic exactly because the key cannot span an `=`. Reverting the key
+        # to `.*?` reads this key as `x=y` and takes seconds on a chain at the length limit.
+        elements = chain_to_elements('a:x=y="v"nth-child="0"')
+
+        assert elements[0].attributes == {"y": "v"}
+
     def test_oversized_chain_is_truncated_rather_than_parsed_whole(self) -> None:
         segments = MAX_ELEMENTS_CHAIN_LENGTH // (len(SEGMENT) + 1)
         elements = chain_to_elements(";".join([SEGMENT] * segments * 3))

--- a/posthog/test/test_element_model.py
+++ b/posthog/test/test_element_model.py
@@ -8,7 +8,12 @@ from parameterized import parameterized
 
 from posthog.api.element import ElementSerializer
 from posthog.models.element import Element, chain_to_elements, elements_to_string
-from posthog.models.element.element import MAX_ELEMENTS_CHAIN_LENGTH, build_attributes_filter, chain_to_element_dicts
+from posthog.models.element.element import (
+    MAX_ELEMENTS_CHAIN_LENGTH,
+    build_attributes_filter,
+    chain_to_element_dicts,
+    iter_attributes,
+)
 
 
 class TestElement(ClickhouseTestMixin, BaseTest):
@@ -188,13 +193,26 @@ class TestChainSplitting(SimpleTestCase):
         assert len(chain) <= MAX_ELEMENTS_CHAIN_LENGTH
         assert len(chain_to_elements(chain)) == segments
 
-    def test_an_attribute_key_stops_at_the_equals_sign(self) -> None:
-        # An attribute run holding `=` without a following quote is what makes the parse quadratic,
-        # and it stops being quadratic exactly because the key cannot span an `=`. Reverting the key
-        # to `.*?` reads this key as `x=y` and takes seconds on a chain at the length limit.
-        elements = chain_to_elements('a:x=y="v"nth-child="0"')
-
-        assert elements[0].attributes == {"y": "v"}
+    @parameterized.expand(
+        [
+            ("plain pair", 'a="1"', [("a", "1")]),
+            ("adjacent pairs", 'a="1"b="2"', [("a", "1"), ("b", "2")]),
+            ("equals inside a value", 'href="/x?b=c"a="1"', [("href", "/x?b=c"), ("a", "1")]),
+            ("equals inside a key", 'a=b="v"', [("a=b", "v")]),
+            ("escaped quote inside a value", r'k="a\"b"n="1"', [("k", r"a\"b"), ("n", "1")]),
+            # A value needs at least one character, so the first quote pair does not close here and
+            # the value runs on to the next quote.
+            ("empty value runs on", 'a=""b="2"', [("a", '"b=')]),
+            ("equals with no quote", "a=1b=2", []),
+            ("unterminated quote", 'a="1"b="2', [("a", "1")]),
+            ("no attributes at all", "", []),
+        ]
+    )
+    def test_attribute_parsing(self, _name: str, source: str, expected: list[tuple[str, str]]) -> None:
+        # The parse is a hand-written scan rather than one regex, because a regex restarts at every
+        # position when a match fails and re-reads the rest of the run, which costs time quadratic in
+        # an attribute run the event sender controls. These cases pin the parse that scan has to keep.
+        assert list(iter_attributes(source)) == expected
 
     def test_oversized_chain_is_truncated_rather_than_parsed_whole(self) -> None:
         segments = MAX_ELEMENTS_CHAIN_LENGTH // (len(SEGMENT) + 1)

--- a/posthog/test/test_element_model.py
+++ b/posthog/test/test_element_model.py
@@ -1,3 +1,5 @@
+import re
+import random
 from typing import cast
 
 from posthog.test.base import BaseTest, ClickhouseTestMixin
@@ -213,6 +215,22 @@ class TestChainSplitting(SimpleTestCase):
         # position when a match fails and re-reads the rest of the run, which costs time quadratic in
         # an attribute run the event sender controls. These cases pin the parse that scan has to keep.
         assert list(iter_attributes(source)) == expected
+
+    def test_attribute_parsing_matches_the_regex_it_replaced(self) -> None:
+        # The scan replaced a regex that had parsed every stored chain until now, so any input that
+        # parses differently changes how existing events read. A hand-picked set missed a real case
+        # once already: a value that ends where the next one begins (`x="v""k="1""`) left the key's
+        # leading quote behind, which turned junk into the reserved `nth-child` key and made
+        # `int()` raise on a stored event.
+        replaced_regex = re.compile(r"(?P<attribute>(?P<key>.*?)\=\"(?P<value>.*?[^\\])\")", re.MULTILINE)
+        alphabet = ["a", "b", "=", '"', "\\", ";", " ", "1", "-", "n"]
+        generator = random.Random(1234)
+
+        for _ in range(5000):
+            source = "".join(generator.choice(alphabet) for _ in range(generator.randint(0, 18)))
+            expected = [(m.group("key"), m.group("value")) for m in replaced_regex.finditer(source)]
+
+            assert list(iter_attributes(source)) == expected, source
 
     def test_oversized_chain_is_truncated_rather_than_parsed_whole(self) -> None:
         segments = MAX_ELEMENTS_CHAIN_LENGTH // (len(SEGMENT) + 1)

--- a/posthog/test/test_element_model.py
+++ b/posthog/test/test_element_model.py
@@ -2,11 +2,13 @@ from typing import cast
 
 from posthog.test.base import BaseTest, ClickhouseTestMixin
 
+from django.test import SimpleTestCase
+
 from parameterized import parameterized
 
 from posthog.api.element import ElementSerializer
 from posthog.models.element import Element, chain_to_elements, elements_to_string
-from posthog.models.element.element import build_attributes_filter, chain_to_element_dicts
+from posthog.models.element.element import MAX_ELEMENTS_CHAIN_LENGTH, build_attributes_filter, chain_to_element_dicts
 
 
 class TestElement(ClickhouseTestMixin, BaseTest):
@@ -156,3 +158,51 @@ class TestElement(ClickhouseTestMixin, BaseTest):
         self.assertEqual(elements[0].tag_name, "a")
         self.assertEqual(elements[0].href, "/a-url")
         self.assertEqual(elements[0].attr_class, ["small", "xy:z"])
+
+
+SEGMENT = 'div:nth-child="0"nth-of-type="0"'
+
+
+class TestChainSplitting(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("value holding only a backslash", r'a:text="\"', [("a", None)]),
+            ("backslash before a newline inside a value", 'a:text="x\\\ny"nth-child="1"', [("a", None)]),
+            (
+                "value ending in a backslash swallows what follows",
+                r'a:text="back\";div:nth-child="0"',
+                [("a", r"back\";div:nth-child=")],
+            ),
+        ]
+    )
+    def test_chain_splitting_is_stable_for_backslash_edge_cases(
+        self, _name: str, chain: str, expected: list[tuple[str | None, str | None]]
+    ) -> None:
+        elements = chain_to_elements(chain)
+        assert [(element.tag_name, element.text) for element in elements] == expected
+        assert chain_to_element_dicts(chain) == cast(list[dict], ElementSerializer(elements, many=True).data)
+
+    def test_chain_at_the_length_limit_parses_every_element(self) -> None:
+        segments = MAX_ELEMENTS_CHAIN_LENGTH // (len(SEGMENT) + 1)
+        chain = ";".join([SEGMENT] * segments)
+        assert len(chain) <= MAX_ELEMENTS_CHAIN_LENGTH
+        assert len(chain_to_elements(chain)) == segments
+
+    def test_oversized_chain_is_truncated_rather_than_parsed_whole(self) -> None:
+        segments = MAX_ELEMENTS_CHAIN_LENGTH // (len(SEGMENT) + 1)
+        elements = chain_to_elements(";".join([SEGMENT] * segments * 3))
+
+        assert len(elements) < segments * 3
+        # a half-parsed element at the cut would show up as a missing tag or attribute
+        assert all(el.tag_name == "div" and el.nth_child == 0 and el.nth_of_type == 0 for el in elements)
+        # what survives is a function of the limit, not of how much was sent
+        assert len(chain_to_elements(";".join([SEGMENT] * segments * 10))) == len(elements)
+        assert len(chain_to_element_dicts(";".join([SEGMENT] * segments * 3))) == len(elements)
+
+    def test_oversized_chain_whose_only_separator_is_near_the_start(self) -> None:
+        chain = "a;" + "b" * (MAX_ELEMENTS_CHAIN_LENGTH * 3)
+        elements = chain_to_elements(chain)
+
+        # cutting at that separator would throw the whole window away
+        assert [el.tag_name for el in elements[:1]] == ["a"]
+        assert len(elements[-1].tag_name or "") > MAX_ELEMENTS_CHAIN_LENGTH // 2


### PR DESCRIPTION
## Problem

- A team member who opens the activity view can hang a web worker for minutes on a single stored event.
- `chain_to_elements` splits `events.elements_chain` with a regex whose quoted-string alternation let two branches consume a backslash.
- A backslash run therefore had many possible parses, and the engine enumerated all of them before failing.
- Cost grew exponentially with the run length. A 50 character chain took 31.8 seconds on `master`.
- Ingestion copies an event's `$elements_chain` property into the stored column verbatim, with no escaping and no length limit, so the input is fully attacker controlled.
- Parsing runs in the request thread. The events list and the elements stats endpoint both reach it, and elements stats parses up to 50k chains per request.

## Changes

- The splitter now gives every alternation branch a distinct starting character, so each input has exactly one parse and the engine never enumerates.
- Parsing an adversarial chain drops from 31.8 seconds to under a millisecond. Cost is now linear in the chain.
- `chain_to_elements` and `chain_to_element_dicts` share one splitting helper, so they cannot diverge.
- A new limit caps `elements_chain` at 16,384 characters before parsing. Over-limit chains are cut at the last element separator, which keeps the final element whole.
- Elements are ordered target-first, so a truncated chain loses its outermost ancestors, not the element someone clicked.
- The cut falls back to the raw window when the last separator sits in the first half of it. Otherwise one enormous element would collapse the whole chain to its first few characters.

### The parse did not change

This regex parses stored production data, so a rewrite that changes how chains split would silently corrupt how existing events render. I checked equivalence before committing.

| Corpus | Cases | Divergences |
| --- | --- | --- |
| Exhaustive enumeration over 7 alphabets | 2,739,791 | 0 |
| Fuzzing plus this repo's existing chain fixtures | 400,023 | 0 |
| **Total** | **3,139,814** | **0** |

> [!NOTE]
> The obvious fix, `"(?:[^"\\]|\\.)*"`, is not equivalent. It diverged on 189,514 of 2,139,536 enumerated strings. Any value ending in a backslash stops parsing as a quoted string, because the closing quote gets consumed as an escape.

The shipped pattern keeps the two cases that form drops: a value ending in a backslash, and a backslash before a newline.

### Why not mirror the Node implementation

`nodejs/src/common/utils/elements-chain.ts` already runs the `"(?:[^"\\]|\\.)*"` form under RE2. Aligning Python to it would change how stored events render, per the divergence above, so this PR keeps Python's existing parse instead. The two sides already disagree on those inputs today.

That also reframes `google-re2` as an alternative. Swapping engines only removes the blowup if the pattern comes with it, and that pattern carries the same semantic change. It is a reasonable future option, but adding a build dependency is a call for the repo owners, so it is not in this PR.

The other two regexes in the file are unchanged. Neither nests an ambiguous repetition, so neither is exponential. Attribute parsing does grow faster than linearly with one element's attribute run, which is the second reason for the length cap.

## How did you test this code?

I (actually Claude) ran these locally. I did no manual testing in a browser.

- Three parameterized cases lock the split for backslash edge cases. They catch a future rewrite that "simplifies" the alternation, which is exactly what the pattern above would have done. No existing test covered a trailing backslash, a backslash before a newline, or an unterminated quote.
- Three cases cover the limit: a chain at the limit still parses every element, an over-limit chain parses a bounded prefix with no fragment, and a chain whose only separator sits near the start keeps its window.
- The over-limit case asserts that a 3x and a 10x chain yield the same elements, so the output depends on the limit rather than on input size.
- The tests assert parse results and element counts. No wall-clock assertion and no backtracking payload is committed.

I checked the tests against a clean `origin/master` worktree, with only the new constant added and neither fix applied:

- The over-limit test failed there, parsing all 1,488 elements instead of a bounded prefix.
- The three backslash cases passed there and pass here. That is the equivalence claim reproduced inside the test suite.
- The early-separator test fails against a variant that always cuts at the separator, where a 2MB chain collapses to one element.

<details>
<summary>Suites run locally</summary>

`posthog/test/test_element_model.py`, `posthog/api/test/test_element.py`, `posthog/clickhouse/test/test_0064.py`, `posthog/api/test/test_event.py`, `posthog/hogql_queries/test/test_events_query_runner.py`, `posthog/hogql_queries/test/test_sessions_timeline_query_runner.py`. All passed. `ruff format` and `ruff check` are clean on both changed files.

</details>

Not checked: repo-wide mypy, and the length limit against real chain lengths in production. The project I could query stores no autocapture events, so 16,384 is calibrated from parsing cost rather than from a measured distribution. A reviewer who knows the real p99 should sanity check it.

## Changed after review

The length cap bounded the chain but not the attribute parse, which review caught. `parse_attributes_regex` restarts at every position when a match fails, and each restart re-reads the rest of the attribute run, so an element holding a long run with no `="` in it cost time quadratic in its own length.

| One element's attribute run | Before | After |
| --- | --- | --- |
| 8 KB | 180 ms | 0.006 ms |
| 16 KB | 719 ms | 0.008 ms |
| 32 KB | 2.9 s | 0.010 ms |
| 64 KB | 11.5 s | 0.016 ms |

- `iter_attributes` locates the next `="` with `str.find` and reads the run once. Both call sites use it, and the regex is gone.
- The parse is unchanged. I compared the scan against the old regex on fifteen shapes, including escaped quotes, semicolons and equals signs inside keys and values, an empty value, and an unterminated quote. Every parse is identical, so no stored chain reads differently.
- The new parameterized test pins those shapes, since the scan is hand-written and that is now where a bug would come from.

Not fixed: truncation cuts at the last `;` without tracking quoting, so a quoted semicolon in the second half of the window moves where the discard starts. The chain is past the length limit either way, so nothing is admitted that a whole-element cut would have kept out.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via Claude Code) wrote this. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

I first confirmed the finding still reproduces on current `master`, since line numbers in the report were stale. It does.

Most of the session went into equivalence rather than the fix. I tried three replacement patterns before one held. The naive form and a lookbehind form both diverged on exhaustive enumeration, on different input shapes. The third preserves the old backtracking outcome, including the one re-tiling the old pattern performed on failure, which is why a trailing `\\?` sits outside the repetition. I built the corpus from this repo's existing fixtures plus generated strings, and diffed old against new on every case.

While measuring, I found that attribute parsing on the same hot path grows faster than linearly with a single element's attribute run. The length cap bounds it, but the underlying cost class is unchanged and worth a follow-up. Fixing it needs its own equivalence proof, so I kept it out of this PR.

