### PR TITLE
fix(instance-settings): bind the SMTP credential to its host

### DIFF
--- a/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
@@ -8,7 +8,7 @@ import { pluralize } from 'lib/utils/strings'
 import { SystemStatusRow } from '~/types'
 
 import { RenderMetricValue } from './RenderMetricValue'
-import { systemStatusLogic } from './systemStatusLogic'
+import { EMAIL_TRANSPORT_SETTINGS, systemStatusLogic } from './systemStatusLogic'
 
 interface ChangeRowInterface extends Pick<SystemStatusRow, 'value'> {
     oldValue?: boolean | string | number | number[] | null
@@ -62,7 +62,9 @@ export function InstanceConfigSaveModal({ onClose, isOpen }: { onClose: () => vo
     const isChangingEnabledEmailSettings =
         instanceConfigEditingState.EMAIL_ENABLED !== false &&
         Object.keys(instanceConfigEditingState).find((key) => key.startsWith('EMAIL'))
-    const isEnablingEmail = instanceConfigEditingState.EMAIL_ENABLED === true
+    const isChangingEmailTransport = Object.keys(instanceConfigEditingState).some((key) =>
+        EMAIL_TRANSPORT_SETTINGS.includes(key)
+    )
     const changeNoun = Object.keys(instanceConfigEditingState).length === 1 ? 'change' : 'changes'
 
     return (
@@ -88,10 +90,15 @@ export function InstanceConfigSaveModal({ onClose, isOpen }: { onClose: () => vo
             }
         >
             <div className="deprecated-space-y-2">
+                {isChangingEmailTransport && (
+                    <LemonBanner type="warning">
+                        Changing the mail host, port, or encryption clears the stored email password. Enter it again
+                        after saving, so it is never sent to a server you did not set it up for.
+                    </LemonBanner>
+                )}
                 {isChangingEnabledEmailSettings && (
                     <LemonBanner type="info">
-                        As you are changing email settings and {isEnablingEmail ? 'enabling email' : 'email is enabled'}
-                        , we'll attempt to send a test email so you can verify everything works.
+                        Saving does not send a test email. Use the send test email button once your changes are applied.
                     </LemonBanner>
                 )}
                 {Object.keys(instanceConfigEditingState).includes('RECORDINGS_PERFORMANCE_EVENTS_TTL_WEEKS') && (

--- a/frontend/src/scenes/instance/SystemStatus/InstanceConfigTab.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InstanceConfigTab.tsx
@@ -19,10 +19,20 @@ import { ConfigMode, systemStatusLogic } from './systemStatusLogic'
 
 export function InstanceConfigTab(): JSX.Element {
     const { configOptions, preflightLoading } = useValues(preflightLogic)
-    const { editableInstanceSettings, instanceSettingsLoading, instanceConfigMode, instanceConfigEditingState } =
-        useValues(systemStatusLogic)
-    const { loadInstanceSettings, setInstanceConfigMode, updateInstanceConfigValue, clearInstanceConfigEditing } =
-        useActions(systemStatusLogic)
+    const {
+        editableInstanceSettings,
+        instanceSettingsLoading,
+        instanceConfigMode,
+        instanceConfigEditingState,
+        testEmailSentLoading,
+    } = useValues(systemStatusLogic)
+    const {
+        loadInstanceSettings,
+        setInstanceConfigMode,
+        updateInstanceConfigValue,
+        clearInstanceConfigEditing,
+        sendTestEmail,
+    } = useActions(systemStatusLogic)
 
     useOnMountEffect(loadInstanceSettings)
 
@@ -118,6 +128,15 @@ export function InstanceConfigTab(): JSX.Element {
                 </div>
                 {instanceConfigMode === ConfigMode.View ? (
                     <>
+                        <LemonButton
+                            type="secondary"
+                            onClick={sendTestEmail}
+                            data-attr="instance-config-send-test-email-button"
+                            loading={testEmailSentLoading}
+                            disabledReason={testEmailSentLoading ? 'Sending' : undefined}
+                        >
+                            Send test email
+                        </LemonButton>
                         <LemonButton
                             type="primary"
                             onClick={() => setInstanceConfigMode(ConfigMode.Edit)}

--- a/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.test.ts
+++ b/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.test.ts
@@ -1,0 +1,50 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { systemStatusLogic } from './systemStatusLogic'
+
+describe('systemStatusLogic', () => {
+    let logic: ReturnType<typeof systemStatusLogic.build>
+    let patchedKeys: string[]
+
+    beforeEach(() => {
+        patchedKeys = []
+        initKeaTests()
+        eventUsageLogic.mount()
+        useMocks({
+            get: {
+                '/api/instance_status': () => [200, { results: [] }],
+                '/api/instance_settings': () => [200, { results: [] }],
+            },
+            patch: {
+                '/api/instance_settings/:key': ({ params }) => {
+                    patchedKeys.push(params.key as string)
+                    return [200, {}]
+                },
+            },
+        })
+        logic = systemStatusLogic()
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+    })
+
+    it('saves the email password after the mail host, so the host change cannot clear it', async () => {
+        logic.actions.updateInstanceConfigValue('EMAIL_HOST_PASSWORD', 'new-password')
+        logic.actions.updateInstanceConfigValue('EMAIL_HOST', 'smtp.elsewhere.example.com')
+        logic.actions.saveInstanceConfig()
+
+        await expectLogic(logic).toDispatchActions([
+            'increaseUpdatedInstanceConfigCount',
+            'increaseUpdatedInstanceConfigCount',
+        ])
+
+        expect(patchedKeys).toEqual(['EMAIL_HOST', 'EMAIL_HOST_PASSWORD'])
+    })
+})

--- a/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
+++ b/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
@@ -20,6 +20,14 @@ export enum ConfigMode {
 export type InstanceStatusTabName = 'overview' | 'metrics' | 'settings' | 'staff_users'
 
 /**
+ * Settings that decide which server the SMTP credentials are handed to. The backend clears the
+ * stored password whenever one of them changes, so the UI has to warn before that happens.
+ */
+export const EMAIL_TRANSPORT_SETTINGS = ['EMAIL_HOST', 'EMAIL_PORT', 'EMAIL_USE_TLS', 'EMAIL_USE_SSL']
+
+export const EMAIL_CREDENTIAL_SETTING = 'EMAIL_HOST_PASSWORD'
+
+/**
  * We allow the specific instance settings that can be edited via the /instance/status page.
  * Even if some settings are editable in the frontend according to the API, we may don't want to expose them here.
  * For example: async migrations settings are handled in their own page.
@@ -80,6 +88,8 @@ export interface systemStatusLogicValues {
     systemStatus: SystemStatus | null
     systemStatusLoading: boolean
     tab: InstanceStatusTabName
+    testEmailSent: boolean
+    testEmailSentLoading: boolean
     updatedInstanceConfigCount: number | null
 }
 
@@ -139,6 +149,21 @@ export interface systemStatusLogicActions {
     saveInstanceConfig: () => {
         value: true
     }
+    sendTestEmail: () => any
+    sendTestEmailFailure: (
+        error: string,
+        errorObject?: any
+    ) => {
+        error: string
+        errorObject?: any
+    }
+    sendTestEmailSuccess: (
+        testEmailSent: boolean,
+        payload?: any
+    ) => {
+        testEmailSent: boolean
+        payload?: any
+    }
     setInstanceConfigMode: (mode: ConfigMode) => {
         mode: ConfigMode
     }
@@ -189,6 +214,21 @@ export const systemStatusLogic = kea<systemStatusLogicType>([
         increaseUpdatedInstanceConfigCount: true,
     }),
     loaders(() => ({
+        testEmailSent: [
+            false,
+            {
+                sendTestEmail: async () => {
+                    try {
+                        await api.create('api/instance_settings/send_test_email')
+                        lemonToast.success('Test email sent. Check your inbox.')
+                        return true
+                    } catch (error: any) {
+                        lemonToast.error(error?.detail || 'Could not send the test email.')
+                        return false
+                    }
+                },
+            },
+        ],
         systemStatus: [
             null as SystemStatus | null,
             {
@@ -297,15 +337,23 @@ export const systemStatusLogic = kea<systemStatusLogicType>([
         },
         saveInstanceConfig: async (_, breakpoint) => {
             actions.setUpdatedInstanceConfigCount(0)
-            await Promise.all(
-                Object.entries(values.instanceConfigEditingState).map(async ([key, value]) => {
-                    await api.update(`api/instance_settings/${key}`, {
-                        value,
-                    })
-                    eventUsageLogic.actions.reportInstanceSettingChange(key, value)
-                    actions.increaseUpdatedInstanceConfigCount()
+            const saveSetting = async ([key, value]: [string, boolean | number | string]): Promise<void> => {
+                await api.update(`api/instance_settings/${key}`, {
+                    value,
                 })
-            )
+                eventUsageLogic.actions.reportInstanceSettingChange(key, value)
+                actions.increaseUpdatedInstanceConfigCount()
+            }
+
+            // The backend clears the stored password whenever a transport setting changes, so a
+            // password edited in the same save has to be written after everything else. Sending
+            // them together would let the clear land on the password the operator just entered.
+            const edits = Object.entries(values.instanceConfigEditingState)
+            const passwordEdits = edits.filter(([key]) => key === EMAIL_CREDENTIAL_SETTING)
+            const otherEdits = edits.filter(([key]) => key !== EMAIL_CREDENTIAL_SETTING)
+
+            await Promise.all(otherEdits.map(saveSetting))
+            await Promise.all(passwordEdits.map(saveSetting))
             await breakpoint(1000)
             if (values.updatedInstanceConfigCount === Object.keys(values.instanceConfigEditingState).length) {
                 actions.loadInstanceSettings()

--- a/posthog/api/instance_settings.py
+++ b/posthog/api/instance_settings.py
@@ -3,8 +3,11 @@ import json
 from typing import Any, Optional, Union, cast, get_args, get_origin
 
 import structlog
+from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import exceptions, mixins, permissions, serializers, viewsets
+from rest_framework.decorators import action
 from rest_framework.request import Request
+from rest_framework.response import Response
 
 from posthog.cloud_utils import is_cloud
 from posthog.email import is_email_available
@@ -29,6 +32,12 @@ logger = structlog.get_logger(__name__)
 
 REDACTED = "<redacted>"
 UNSET = "<unset>"
+
+# Settings that decide which server the SMTP credentials are handed to. The stored password was
+# entered for one destination, so changing any of these has to invalidate it rather than replay it
+# against a host its owner never approved.
+EMAIL_TRANSPORT_SETTINGS = frozenset({"EMAIL_HOST", "EMAIL_PORT", "EMAIL_USE_TLS", "EMAIL_USE_SSL"})
+EMAIL_CREDENTIAL_SETTING = "EMAIL_HOST_PASSWORD"
 
 
 def _redact_if_secret(key: str, value: Any) -> Any:
@@ -156,17 +165,16 @@ class InstanceSettingsSerializer(serializers.Serializer):
 
             sync_execute(UPDATE_PERFORMANCE_EVENTS_TABLE_TTL_SQL(), {"weeks": new_value_parsed})
 
+        # Clear before the new destination is stored, never after: a failure between the two writes
+        # would otherwise leave the instance pointing at the new host with the old password intact.
+        if instance.key in EMAIL_TRANSPORT_SETTINGS and before_value != new_value_parsed:
+            self._clear_email_credential(request)
+
         set_instance_setting_raw(instance.key, new_value_parsed)
         instance.value = new_value_parsed
 
         if request is not None:
             self._log_setting_change(request, instance.key, before_value, new_value_parsed)
-
-            if instance.key.startswith("EMAIL_"):
-                # Partial EMAIL_* updates (e.g. setting EMAIL_HOST_PASSWORD before EMAIL_HOST)
-                # would otherwise raise ImproperlyConfigured and fail the request with a 500.
-                if is_email_available(with_absolute_urls=True):
-                    send_canary_email.apply_async(kwargs={"user_email": request.user.email})
 
         if instance.key.startswith("ASYNC_MIGRATION") and not SKIP_ASYNC_MIGRATIONS_SETUP:
             from posthog.async_migrations.setup import setup_async_migrations
@@ -174,6 +182,16 @@ class InstanceSettingsSerializer(serializers.Serializer):
             setup_async_migrations()
 
         return instance
+
+    def _clear_email_credential(self, request: Optional[Request]) -> None:
+        before_value = get_instance_setting_raw(EMAIL_CREDENTIAL_SETTING)
+        if not before_value:
+            return
+
+        set_instance_setting_raw(EMAIL_CREDENTIAL_SETTING, "")
+
+        if request is not None:
+            self._log_setting_change(request, EMAIL_CREDENTIAL_SETTING, before_value, "")
 
     def _log_setting_change(self, request: Request, key: str, before_value: Any, new_value: Any) -> None:
         if before_value == new_value:
@@ -213,6 +231,10 @@ class InstanceSettingsSerializer(serializers.Serializer):
         )
 
 
+class SendTestEmailResponseSerializer(serializers.Serializer):
+    success = serializers.BooleanField(help_text="True when the test email was queued for delivery.")
+
+
 class InstanceSettingsViewset(
     viewsets.GenericViewSet,
     mixins.ListModelMixin,
@@ -222,6 +244,29 @@ class InstanceSettingsViewset(
     permission_classes = [permissions.IsAuthenticated, IsStaffUser]
     serializer_class = InstanceSettingsSerializer
     lookup_field = "key"
+
+    @extend_schema(
+        request=None,
+        responses={
+            200: SendTestEmailResponseSerializer,
+            400: OpenApiResponse(description="Email is not configured on this instance."),
+        },
+        extensions={"x-product": "core"},
+        description="Send a test email to the requesting user to check the instance's email configuration.",
+    )
+    @action(detail=False, methods=["POST"])
+    def send_test_email(self, request: Request) -> Response:
+        # A partially configured instance (e.g. EMAIL_HOST_PASSWORD set before EMAIL_HOST) makes
+        # EmailMessage raise ImproperlyConfigured, which would surface as a 500 instead of a 400.
+        if not is_email_available(with_absolute_urls=True):
+            raise serializers.ValidationError(
+                "Email is not set up on this instance. Add a mail host, turn on email, then try again.",
+                code="email_not_configured",
+            )
+
+        # IsAuthenticated + IsStaffUser permission classes guarantee this is a real User.
+        send_canary_email.apply_async(kwargs={"user_email": cast(User, request.user).email})
+        return Response({"success": True})
 
     def get_queryset(self):
         output = []

--- a/posthog/api/test/test_instance_settings.py
+++ b/posthog/api/test/test_instance_settings.py
@@ -209,8 +209,11 @@ class TestInstanceSettings(APIBaseTest):
                 f"/api/instance_settings/EMAIL_DEFAULT_FROM",
                 {"value": "hellohello@posthog.com"},
             )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["value"], "hellohello@posthog.com")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.json()["value"], "hellohello@posthog.com")
+
+            response = self.client.post("/api/instance_settings/send_test_email")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
 
         self.assertEqual(mail.outbox[0].from_email, "hellohello@posthog.com")
         self.assertEqual(mail.outbox[0].subject, "This is a test email of your PostHog instance")
@@ -471,3 +474,113 @@ class TestInstanceSettings(APIBaseTest):
         # The setting itself must still be persisted; only the audit row is skipped.
         self.assertEqual(get_instance_setting("AUTO_START_ASYNC_MIGRATIONS"), True)
         self.assertEqual(self._instance_setting_logs().count(), initial_count)
+
+
+TRANSPORT_CHANGES = [
+    ("host", "EMAIL_HOST", "smtp.elsewhere.example.com"),
+    ("port", "EMAIL_PORT", 2525),
+    ("use_tls", "EMAIL_USE_TLS", True),
+    ("use_ssl", "EMAIL_USE_SSL", True),
+]
+
+CONFIGURED_HOST = "smtp.relay.example.com"
+CONFIGURED_PASSWORD = "relay-password"
+
+
+class TestEmailCredentialBinding(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.user.is_staff = True
+        self.user.save()
+        set_instance_setting("EMAIL_ENABLED", True)
+        set_instance_setting("EMAIL_HOST", CONFIGURED_HOST)
+        set_instance_setting("EMAIL_HOST_PASSWORD", CONFIGURED_PASSWORD)
+
+    def _patch(self, key: str, value: object):
+        with self.settings(CELERY_TASK_ALWAYS_EAGER=True):
+            return self.client.patch(f"/api/instance_settings/{key}", {"value": value})
+
+    @parameterized.expand(TRANSPORT_CHANGES)
+    def test_changing_transport_clears_stored_password(self, _name: str, key: str, new_value: object):
+        response = self._patch(key, new_value)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        self.assertEqual(get_instance_setting("EMAIL_HOST_PASSWORD"), "")
+
+    @parameterized.expand(TRANSPORT_CHANGES)
+    def test_changing_transport_does_not_send_mail(self, _name: str, key: str, new_value: object):
+        response = self._patch(key, new_value)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        self.assertEqual(mail.outbox, [])
+
+    @parameterized.expand(TRANSPORT_CHANGES)
+    def test_no_op_transport_update_keeps_stored_password(self, _name: str, key: str, _new_value: object):
+        response = self._patch(key, get_instance_setting(key))
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        self.assertEqual(get_instance_setting("EMAIL_HOST_PASSWORD"), CONFIGURED_PASSWORD)
+
+    @parameterized.expand(
+        [
+            ("default_from", "EMAIL_DEFAULT_FROM", "noreply@example.com"),
+            ("host_user", "EMAIL_HOST_USER", "relay-user"),
+        ]
+    )
+    def test_non_transport_email_update_keeps_stored_password(self, _name: str, key: str, new_value: object):
+        response = self._patch(key, new_value)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        self.assertEqual(get_instance_setting("EMAIL_HOST_PASSWORD"), CONFIGURED_PASSWORD)
+
+    def test_clearing_the_password_is_logged_without_disclosing_it(self):
+        response = self._patch("EMAIL_HOST", "smtp.elsewhere.example.com")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        logs = ActivityLog.objects.filter(scope="InstanceSetting", item_id="EMAIL_HOST_PASSWORD")
+        self.assertEqual(logs.count(), 1)
+
+        log = logs.first()
+        assert log is not None
+        assert log.detail is not None
+        change = log.detail["changes"][0]
+        self.assertEqual(change["before"], REDACTED)
+        self.assertEqual(change["after"], UNSET)
+        self.assertNotIn(CONFIGURED_PASSWORD, json.dumps(log.detail))
+
+    def test_password_re_entered_after_a_host_change_is_kept(self):
+        response = self._patch("EMAIL_HOST", "smtp.elsewhere.example.com")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertEqual(get_instance_setting("EMAIL_HOST_PASSWORD"), "")
+
+        response = self._patch("EMAIL_HOST_PASSWORD", "new-password")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        self.assertEqual(get_instance_setting("EMAIL_HOST_PASSWORD"), "new-password")
+
+    def test_send_test_email_sends_mail(self):
+        with self.settings(CELERY_TASK_ALWAYS_EAGER=True):
+            response = self.client.post("/api/instance_settings/send_test_email")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, "This is a test email of your PostHog instance")
+
+    def test_send_test_email_rejects_unconfigured_instance(self):
+        set_instance_setting("EMAIL_HOST", "")
+
+        with self.settings(CELERY_TASK_ALWAYS_EAGER=True):
+            response = self.client.post("/api/instance_settings/send_test_email")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+
+        self.assertEqual(mail.outbox, [])
+
+    def test_send_test_email_is_staff_only(self):
+        self.user.is_staff = False
+        self.user.save()
+
+        with self.settings(CELERY_TASK_ALWAYS_EAGER=True):
+            response = self.client.post("/api/instance_settings/send_test_email")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response.content)
+
+        self.assertEqual(mail.outbox, [])


### PR DESCRIPTION
## Problem

A staff user on the instance configuration page can read the instance's SMTP password, which the product otherwise refuses to show them.

- `/api/instance_settings/` redacts `EMAIL_HOST_PASSWORD` to `*****` on read and to `<redacted>` in the activity log. It is write-only by design.
- Changing `EMAIL_HOST` left that password in place, and `posthog/email.py` builds its SMTP connection from instance settings at send time.
- So a staff user could point the host at a server they control and read the password off their own listener. `EMAIL_USE_TLS` is writable too, so the session can be forced to plaintext first.

The endpoint is staff-gated, so this is a staff user reaching a credential they are not meant to see, not an unauthenticated hole. It matters because the password usually belongs to a shared corporate relay, so it reaches past PostHog: whoever holds it can send mail as the organization's domain.

## Changes

> [!WARNING]
> **Operators must re-enter the email password after changing the mail host, port, or encryption.** Mail stays broken until they do. This is the point of the change: a password entered for one server is no longer usable against a server its owner never approved. The instance configuration page warns before the save and the UI writes the new password after the host, so changing both in one save keeps working.
>
> This includes turning TLS or SSL on for the host you already use. The password is cleared there too, even though the server did not change. That is the least intuitive case and the one to push back on if you want a narrower rule.
>
> On an instance configured by environment variable, the cleared value is written to the database, and a database row shadows the environment default. Redeploying with `EMAIL_HOST_PASSWORD` set will not restore mail. The password has to be entered in the UI.

- `InstanceSettingsSerializer.update` clears `EMAIL_HOST_PASSWORD` when `EMAIL_HOST`, `EMAIL_PORT`, `EMAIL_USE_TLS`, or `EMAIL_USE_SSL` changes.
- The clear runs before the new transport value is stored. A failure between the two writes then leaves the old host with no password, rather than the new host with the old password. There is no `ATOMIC_REQUESTS` here, so ordering is the guarantee.
- A no-op save does not clear anything. Neither do `EMAIL_HOST_USER` and `EMAIL_DEFAULT_FROM`, which do not move the destination.
- The clear is written to the activity log against `EMAIL_HOST_PASSWORD`, value redacted, so "mail stopped working" is traceable.
- Saving email settings no longer dispatches the test email by itself. `POST /api/instance_settings/send_test_email` does, behind a "Send test email" button on the instance configuration page.
- `systemStatusLogic.saveInstanceConfig` sends the password PATCH after the other settings. It used to send every edited key through one `Promise.all`, which would let the host's clear land on the password the operator had just typed, sometimes.

I rejected the smaller fix of only removing the automatic test email. It closes the trigger an attacker uses today, but the stored password still travels to whatever host is configured on the next legitimate send. Binding the credential to its host is what makes the password useless against an unapproved destination.

`EMAIL_HOST_USER` is deliberately not in the set. It does not change where the credentials go.

### UI

No screenshot: I could not run the app in this worktree. Three visible changes, all in `/instance/settings`:

- A "Send test email" button next to "Edit".
- A new warning in the save confirmation modal when a transport setting changes, naming the password clear.
- The old modal banner promising "we'll attempt to send a test email" is replaced, because saving no longer sends one.

## How did you test this code?

I wrote the two security tests first and confirmed they failed against master for the right reasons: the password survived as `relay-password` after the host changed, and the save put a canary message in `mail.outbox`.

Automated tests I ran, all with a mocked mail backend and no real SMTP:

- `posthog/api/test/test_instance_settings.py::TestEmailCredentialBinding`, 19 cases. Catches: the password surviving a transport change (parameterized over all four keys), the save auto-sending mail to the new host, a no-op save destroying a working password, the clear spreading to email settings that do not move the destination, the cleartext leaking into the activity log, and `send_test_email` 500ing or answering a non-staff caller.
- `frontend/src/scenes/instance/SystemStatus/systemStatusLogic.test.ts`, 1 case. Catches someone collapsing the two-phase save back into one `Promise.all`, which wipes a password entered alongside a host change. I checked this one bites: reverting the ordering fails it.
- `posthog/api/test/test_instance_settings.py` in full. `test_updating_email_settings` moved onto the new endpoint, since the behavior it asserted (a save sends mail) is the behavior this PR removes.
- `posthog/test/test_email.py`, `posthog/tasks/test/test_email.py`, `posthog/tasks/test/test_email_verification.py`. Two geoip-dependent failures and one error, identical on a clean `origin/master` worktree, so unrelated to this change.

Not checked: I did not run the app, so the three UI changes above are unverified visually. I did not exercise a real SMTP server.

`hogli build:openapi` produced no diff, so `send_test_email` does not reach the generated frontend types.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. `docs/published/handbook/engineering/developing-locally.md` is the only doc covering email, and it configures maildev through environment variables with an empty password. It does not describe the instance settings path this PR changes. The page the UI links to for instance settings lives outside this repository.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via Claude Code) wrote this from a description of the finding and an instruction to bind the credential to its host rather than just remove the automatic test email.

Skills invoked: `/writing-tests`, `/improving-drf-endpoints`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.

Two things changed during the session. I first cleared the password after writing the new transport value, then moved the clear ahead of it so a failure between the two writes fails safe. And I initially left `saveInstanceConfig` on its single `Promise.all`, which would have made "new host plus new password in one save" wipe the new password nondeterministically. That is the frontend ordering change and its logic test.

Nothing here draws on material outside this repository. The hostnames and passwords in the tests are invented and use `example.com`.
