### PR TITLE
fix(replay-vision): word the scanner cost estimate as conditional in a draft

### DIFF
--- a/products/replay_vision/frontend/components/NoBillingLimitNote.tsx
+++ b/products/replay_vision/frontend/components/NoBillingLimitNote.tsx
@@ -9,16 +9,24 @@ import { formatCreditCount } from '../utils/credits'
 interface Props {
     /** Projected monthly credits across every enabled scanner. */
     projectedCredits: number
+    /** The total counts a scanner that isn't running yet, so the projection is conditional on enabling it. */
+    draft?: boolean
 }
 
 /**
  * Uncapped orgs get no meter and no exhaustion guard, so the spend surfaces stand in for both:
  * the projection on its own line, then the same status-plus-way-out shape as `QuotaExhaustedNote`.
  */
-export function NoBillingLimitNote({ projectedCredits }: Props): JSX.Element {
+export function NoBillingLimitNote({ projectedCredits, draft = false }: Props): JSX.Element {
     return (
         <div className="space-y-1 text-xs text-muted">
-            <div>Enabled scanners are projected to use ~{formatCreditCount(projectedCredits)}/month.</div>
+            <div>
+                {draft
+                    ? `With this scanner enabled, your scanners would use ~${formatCreditCount(
+                          projectedCredits
+                      )}/month.`
+                    : `Enabled scanners are projected to use ~${formatCreditCount(projectedCredits)}/month.`}
+            </div>
             {/* One colour throughout, so the link is underlined instead of accented to stay discoverable. */}
             <div className="text-danger">
                 No billing limit set. Spend is uncapped.{' '}

--- a/products/replay_vision/frontend/components/QuotaImminentBanner.tsx
+++ b/products/replay_vision/frontend/components/QuotaImminentBanner.tsx
@@ -10,9 +10,14 @@ interface Props {
     capReachDate: dayjs.Dayjs
     /** Free-plan orgs have no limit to raise; they need billing instead. */
     onFreePlan: boolean
+    /**
+     * What the reader would have to do for this projection to start applying, e.g. `create this scanner`.
+     * Set only when the projection counts a scanner that isn't running yet, so the banner asks rather than warns.
+     */
+    draftAction?: string | null
 }
 
-export function QuotaImminentBanner({ capReachDate, onFreePlan }: Props): JSX.Element {
+export function QuotaImminentBanner({ capReachDate, onFreePlan, draftAction = null }: Props): JSX.Element {
     // Calendar days off the rendered date, so the two can't disagree.
     const days = capReachDate.startOf('day').diff(dayjs().startOf('day'), 'day')
     const timing = days <= 0 ? 'today' : `in ${pluralize(days, 'day')} (${capReachDate.format('MMMM D')})`
@@ -26,7 +31,16 @@ export function QuotaImminentBanner({ capReachDate, onFreePlan }: Props): JSX.El
             }}
         >
             <span className="text-xs">
-                Enabled scanners are on track to {outcome} {timing}. Lower the sampling rate to slow spend.
+                {draftAction ? (
+                    <>
+                        If you {draftAction}, your scanners would {outcome} {timing}.
+                    </>
+                ) : (
+                    <>
+                        Enabled scanners are on track to {outcome} {timing}.
+                    </>
+                )}{' '}
+                Lower the sampling rate to slow spend.
             </span>
         </LemonBanner>
     )

--- a/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.stories.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.stories.tsx
@@ -566,6 +566,19 @@ export const ScannerEditorTriggers: StoryObj = {
     parameters: { pageUrl: urls.replayVisionScannerTriggers(summarizerScanner.id) },
 }
 
+// A scanner that doesn't exist yet, sized against a quota its projection would overshoot. The estimate card is the
+// loudest spend surface in the product, so this pins the wording for the state where nothing is being spent.
+export const ScannerEditorTriggersDraft: StoryObj = {
+    parameters: { pageUrl: urls.replayVisionScannerTriggers('new') },
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/projects/:team_id/vision/quota/': { ...quota, credits_used: 8200, remaining: 1800 },
+            },
+        }),
+    ],
+}
+
 export const ActionEditorAlert: StoryObj = {
     parameters: {
         pageUrl: urls.replayVisionActionNew(summarizerScanner.id, 'alert'),

--- a/products/replay_vision/frontend/replay_scanners/components/QuotaStatusLine.test.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/QuotaStatusLine.test.tsx
@@ -19,6 +19,27 @@ describe('QuotaStatusLine', () => {
     it.each([
         { name: 'renders nothing below danger', projection: { ...base, status: 'warning' as const }, text: null },
         {
+            // A draft scanner spends nothing yet, so the overshoot is conditional on enabling it. Stating it as a
+            // projection in flight reads as spend already happening, which is what sent one user to their billing page.
+            name: 'conditional reach date for a draft scanner',
+            projection: { ...base, status: 'danger' as const, usedPct: 80, capReachDate: dayjs('2026-07-21') },
+            draft: true,
+            text: 'Would reach your spend limit on July 21',
+        },
+        {
+            name: 'conditional overshoot for a draft scanner with no reach date',
+            projection: { ...base, status: 'danger' as const, usedPct: 80 },
+            draft: true,
+            text: 'Would exceed the monthly spend limit',
+        },
+        {
+            // Spend already on the clock is a fact regardless of the draft, so this one must not go conditional.
+            name: 'reached stays stated as fact for a draft scanner',
+            projection: { ...base, exhausted: true, usedPct: 100 },
+            draft: true,
+            text: 'Spend limit reached',
+        },
+        {
             name: 'reached when the backend blocks spend',
             projection: { ...base, exhausted: true, usedPct: 100 },
             text: 'Spend limit reached',
@@ -35,8 +56,8 @@ describe('QuotaStatusLine', () => {
             projection: { ...base, status: 'danger' as const, usedPct: 80, capReachDate: dayjs('2026-07-21') },
             text: 'July 21',
         },
-    ])('$name', ({ projection, text }) => {
-        const { container } = render(<QuotaStatusLine projection={projection} onFreePlan={false} />)
+    ])('$name', ({ projection, text, draft }) => {
+        const { container } = render(<QuotaStatusLine projection={projection} onFreePlan={false} draft={draft} />)
 
         if (text === null) {
             expect(container.textContent).toBe('')

--- a/products/replay_vision/frontend/replay_scanners/components/QuotaStatusLine.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/QuotaStatusLine.tsx
@@ -4,15 +4,20 @@ interface Props {
     projection: QuotaProjection
     /** Free-plan orgs run out of credits; everyone else hits a spend limit they chose. */
     onFreePlan: boolean
+    /**
+     * The projection includes a scanner that isn't running, so the overshoot is conditional on enabling it.
+     * Only the forward-looking messages change mood; spend already on the clock stays stated as fact.
+     */
+    draft?: boolean
 }
 
 /** Red warning when the allocation is exhausted or projected to overshoot; renders nothing otherwise. */
-export function QuotaStatusLine({ projection, onFreePlan }: Props): JSX.Element | null {
-    const message = statusMessage(projection, onFreePlan)
+export function QuotaStatusLine({ projection, onFreePlan, draft = false }: Props): JSX.Element | null {
+    const message = statusMessage(projection, onFreePlan, draft)
     return message ? <span className="text-danger">{message}</span> : null
 }
 
-function statusMessage(projection: QuotaProjection, onFreePlan: boolean): JSX.Element | string | null {
+function statusMessage(projection: QuotaProjection, onFreePlan: boolean, draft: boolean): JSX.Element | string | null {
     if (projection.exhausted) {
         return onFreePlan ? 'Free credits used up' : 'Spend limit reached'
     }
@@ -26,11 +31,21 @@ function statusMessage(projection: QuotaProjection, onFreePlan: boolean): JSX.El
     }
     if (projection.capReachDate) {
         const date = <strong>{projection.capReachDate.format('MMMM D')}</strong>
+        if (draft) {
+            return onFreePlan ? (
+                <>Would use up your free credits on {date}</>
+            ) : (
+                <>Would reach your spend limit on {date}</>
+            )
+        }
         return onFreePlan ? (
             <>Free credits projected to run out on {date}</>
         ) : (
             <>Spend limit projected to be reached on {date}</>
         )
+    }
+    if (draft) {
+        return onFreePlan ? 'Would use up your free credits' : 'Would exceed the monthly spend limit'
     }
     return onFreePlan ? 'Projected to use up the free credits' : 'Projected to exceed the monthly spend limit'
 }

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerQuotaForecast.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerQuotaForecast.tsx
@@ -25,7 +25,7 @@ interface Props {
 }
 
 export function ScannerQuotaForecast({ scannerId }: Props): JSX.Element | null {
-    const { scanner, scannerEstimate, scannerEstimateLoading, scannerEstimateError } = useValues(
+    const { scanner, isNew, scannerEstimate, scannerEstimateLoading, scannerEstimateError } = useValues(
         replayScannerLogic({ id: scannerId })
     )
     const {
@@ -39,6 +39,11 @@ export function ScannerQuotaForecast({ scannerId }: Props): JSX.Element | null {
     if (!scanner) {
         return null
     }
+
+    // An unsaved scanner, or a saved one that is switched off, spends nothing yet. Its estimate still lands in the
+    // fleet projection below, so every line that reads as a statement about live spend has to say "would" instead.
+    const notRunning = isNew || !scanner.enabled
+    const draftAction = isNew ? 'create this scanner' : 'turn this scanner on'
 
     const samplingRatio = Math.max(0, Math.min(scanner.sampling_rate, 1))
     // The estimate already applies the quality filter and sampling rate backend-side.
@@ -72,7 +77,7 @@ export function ScannerQuotaForecast({ scannerId }: Props): JSX.Element | null {
         },
         {
             key: 'this-scanner',
-            label: 'Projected (this scanner)',
+            label: notRunning ? 'This scanner, if enabled' : 'Projected (this scanner)',
             credits: projectedCredits ?? 0,
             kind: 'monthly-rate',
             // The model resolves this to the card's status colour, which depends on the projection it is part of.
@@ -97,7 +102,8 @@ export function ScannerQuotaForecast({ scannerId }: Props): JSX.Element | null {
                 Spent this period: <strong>{formatCreditCount(used)}</strong>
             </div>
             <div>
-                Projected from this scanner: <strong>~{formatCreditCount(projectedCredits ?? 0)}/month</strong>
+                {notRunning ? 'From this scanner, if enabled' : 'Projected from this scanner'}:{' '}
+                <strong>~{formatCreditCount(projectedCredits ?? 0)}/month</strong>
             </div>
             <div>
                 Projected from other scanners: <strong>~{formatCreditCount(othersMonthly)}/month</strong>
@@ -124,7 +130,7 @@ export function ScannerQuotaForecast({ scannerId }: Props): JSX.Element | null {
     return (
         <LemonCard hoverEffect={false} className="p-3 space-y-2">
             <div className="flex items-baseline justify-between gap-3">
-                <LemonLabel>Estimated cost</LemonLabel>
+                <LemonLabel>{notRunning ? 'Estimated cost once enabled' : 'Estimated cost'}</LemonLabel>
                 {hasCap && projectedCredits !== null && (
                     <Tooltip title={breakdown}>
                         <span className={`text-xs tabular-nums ${styles.text}`}>
@@ -159,17 +165,25 @@ export function ScannerQuotaForecast({ scannerId }: Props): JSX.Element | null {
                 {/* The exhausted note and the imminent banner below carry this status, so don't say it twice. */}
                 {hasCap && !projection.exhausted && imminentDays === null && (
                     <span className="text-xs tabular-nums">
-                        <QuotaStatusLine projection={projection} onFreePlan={onFreePlan} />
+                        <QuotaStatusLine projection={projection} onFreePlan={onFreePlan} draft={notRunning} />
                     </span>
                 )}
             </div>
+
+            {notRunning && projectedCredits !== null && (
+                <div className="text-xs text-muted">
+                    {isNew
+                        ? 'This scanner is a draft. Nothing is scanned or charged until you create it.'
+                        : 'This scanner is off. Nothing is scanned or charged until you turn it on.'}
+                </div>
+            )}
 
             {/* `hasCap` is also false while quota is still loading, so require a resolved snapshot before
                 telling anyone their billing limit is missing. */}
             {quota !== null && !hasCap && projectedCredits !== null && (
                 <Tooltip title={breakdown}>
                     <div>
-                        <NoBillingLimitNote projectedCredits={newFleetMonthly} />
+                        <NoBillingLimitNote projectedCredits={newFleetMonthly} draft={notRunning} />
                     </div>
                 </Tooltip>
             )}
@@ -177,7 +191,11 @@ export function ScannerQuotaForecast({ scannerId }: Props): JSX.Element | null {
             {hasCap && projection.exhausted && <QuotaExhaustedNote onFreePlan={onFreePlan} />}
 
             {imminentDays !== null && projection.capReachDate && (
-                <QuotaImminentBanner capReachDate={projection.capReachDate} onFreePlan={onFreePlan} />
+                <QuotaImminentBanner
+                    capReachDate={projection.capReachDate}
+                    onFreePlan={onFreePlan}
+                    draftAction={notRunning ? draftAction : null}
+                />
             )}
 
             {hasCap && projectedCredits !== null && (
@@ -186,9 +204,9 @@ export function ScannerQuotaForecast({ scannerId }: Props): JSX.Element | null {
                         <div>
                             <QuotaMeter
                                 model={model}
-                                label={`Projected ${periodEndPct}% of the monthly spend limit by ${
-                                    resetsOn ?? 'period end'
-                                }`}
+                                label={`${
+                                    notRunning ? 'Would reach' : 'Projected'
+                                } ${periodEndPct}% of the monthly spend limit by ${resetsOn ?? 'period end'}`}
                             />
                         </div>
                     </Tooltip>


### PR DESCRIPTION
## Problem

Someone setting up their first Replay Vision scanner is told, in a warning banner, that spend is about to hit their limit before they have created anything.

- The estimate card on the "Scan conditions" step counts the scanner being edited as part of the enabled fleet.
- It then describes the total in the present tense: "Enabled scanners are on track to hit your monthly Vision spend limit in 4 days (August 11)".
- The banner carries a "Raise your billing limit" button, so the reader's next stop is billing.
- A user with no scanners has nothing enabled, so the sentence describes spend that cannot be happening.
- The header already says "Estimated cost". The louder lines under it do not agree with it.

## Changes

- Every forward-looking line on the card goes conditional while the scanner is unsaved, or saved and switched off.
- The header reads "Estimated cost once enabled", above a muted line: "This scanner is a draft. Nothing is scanned or charged until you create it."
- "Spend limit projected to be reached on August 11" becomes "Would reach your spend limit on August 11".
- The banner asks instead of warning: "If you create this scanner, your scanners would hit your monthly Vision spend limit in 4 days (August 11)".
- Spend already incurred stays factual. "Spend limit reached" and "Monthly spend limit exceeded" are true whatever the draft does, so they keep their wording.
- A saved scanner that is enabled keeps every existing string. Editing a disabled one says "turn this scanner on" rather than "create this scanner".
- The three child components take an optional flag and default to today's copy, so the usage tab is untouched.

The projection math, the thresholds and the danger styling are unchanged. Softening the styling would have hidden a real cost from someone who is about to commit to it.

> [!NOTE]
> The breakdown that separates this scanner from the rest of the fleet is a hover-only tooltip on the percentage badge and the meter. A click on either does nothing. Left for a follow-up.

## How did you test this code?

I (actually the PostHog Slack app, on Claude) verified this locally.

- Added a `ScannerEditorTriggersDraft` story: a new scanner against a quota near its cap. I rendered it in Storybook and read the card end to end.
- The existing `ScannerEditorTriggers` story covers a saved, enabled scanner. Its wording is unchanged, which is the regression I most wanted to see.
- Added three cases to `QuotaStatusLine.test.tsx`. Two cover the draft branch, which had no coverage. The third pins "Spend limit reached" as factual, so a later change cannot make incurred spend read as conditional.
- Ran the replay_vision Jest suites and frontend lint.
- Not checked: the flow against a real organization, the free-plan variants in a browser, and screenshot upload, which needs tooling this sandbox does not have. Reviewers can open the new story instead.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). A PostHog employee directed this from Slack. I could not verify their GitHub handle from that thread, so I left the PR unassigned rather than guess one.

- Written by the PostHog Slack app running Claude, from a [Slack thread](https://posthog.slack.com/archives/C0AK12ENNSK/p1786094016730969?thread_ts=1786094016.730969&cid=C0AK12ENNSK).
- Skills invoked: `/writing-user-facing-copy`, `/writing-pr-descriptions`, `/exploring-replay-vision-observations`.
- I started from the wrong diagnosis. I assumed the cost figure itself was being read as a charge. Reading `ScannerQuotaForecast.tsx` showed the header is already explicit, and that the problem is the present-tense sub-copy counting a draft as part of the enabled fleet. That moved the change from the figure to the three notes under it.
- Public artifact: this PR describes a wording problem in the UI. No session material, customer data, or usage numbers are in the diff or in this description. The new story reuses the mock quota already in the file.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AK12ENNSK/p1786094016730969?thread_ts=1786094016.730969&cid=C0AK12ENNSK)*
