### PR TITLE
feat(desktop): add workspace modes to quick search

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteNewTask.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteNewTask.tsx
@@ -155,6 +155,7 @@ export function WebsiteNewTask({ channelId }: { channelId: string }) {
           initialCloudRepository={view.initialCloudRepository}
           initialModel={view.initialModel}
           initialMode={view.initialMode}
+          initialWorkspaceMode={view.initialWorkspaceMode}
           reportAssociation={view.reportAssociation}
           suggestions={CHANNEL_TASK_SUGGESTIONS}
           onSuggestionSelect={(label) =>

--- a/products/desktop/packages/ui/src/features/command/CommandMenu.tsx
+++ b/products/desktop/packages/ui/src/features/command/CommandMenu.tsx
@@ -1,10 +1,13 @@
 import {
   ArchiveIcon,
+  ArrowsSplit,
   CaretLeftIcon,
   CaretRightIcon,
   ChartLine,
+  Cloud,
   EnvelopeSimple,
   GitDiffIcon,
+  Laptop,
   SquaresFourIcon,
 } from "@phosphor-icons/react";
 import { workspaceIdSet } from "@posthog/core/command-center/eligibility";
@@ -63,6 +66,7 @@ import {
 import { TaskIcon } from "@posthog/ui/features/sidebar/components/items/TaskIcon";
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import { useTaskPrStatus } from "@posthog/ui/features/sidebar/useTaskPrStatus";
+import { useCloudModeEnabled } from "@posthog/ui/features/task-detail/hooks/useCloudModeEnabled";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
 import { useWorkspaces } from "@posthog/ui/features/workspace/useWorkspace";
 import { LoopIcon } from "@posthog/ui/primitives/LoopIcon";
@@ -80,6 +84,7 @@ import { openTask, openTaskInput } from "@posthog/ui/router/useOpenTask";
 import { track } from "@posthog/ui/shell/analytics";
 import { showLogFolder } from "@posthog/ui/shell/openExternal";
 import { useThemeStore } from "@posthog/ui/shell/themeStore";
+import { useHostCapabilities } from "@posthog/ui/shell/useHostCapabilities";
 import {
   DesktopIcon,
   FileTextIcon,
@@ -154,6 +159,8 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
     (state) => state.getReviewMode,
   );
   const { data: tasks = [] } = useTasks();
+  const { localWorkspaces } = useHostCapabilities();
+  const cloudModeEnabled = useCloudModeEnabled();
   const archivedTaskIds = useArchivedTaskIds();
   const { data: workspaces, isFetched: workspacesFetched } = useWorkspaces();
   const provisioningTaskIds = useProvisioningStore(
@@ -379,6 +386,49 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
           openTaskInput();
         },
       },
+      ...(localWorkspaces
+        ? [
+            {
+              id: "new-local-task",
+              label: "New local task",
+              keywords: "create workspace local",
+              icon: <Laptop size={12} className="text-gray-11" />,
+              action: "new-task" as CommandMenuAction,
+              onRun: () => {
+                closeSettingsDialog();
+                openTaskInput({ initialWorkspaceMode: "local" });
+              },
+            },
+            {
+              id: "new-worktree-task",
+              label: "New worktree task",
+              keywords: "create workspace worktree",
+              icon: (
+                <ArrowsSplit size={12} className="rotate-270 text-gray-11" />
+              ),
+              action: "new-task" as CommandMenuAction,
+              onRun: () => {
+                closeSettingsDialog();
+                openTaskInput({ initialWorkspaceMode: "worktree" });
+              },
+            },
+          ]
+        : []),
+      ...(cloudModeEnabled
+        ? [
+            {
+              id: "new-cloud-task",
+              label: "New cloud task",
+              keywords: "create workspace cloud",
+              icon: <Cloud size={12} className="text-gray-11" />,
+              action: "new-task" as CommandMenuAction,
+              onRun: () => {
+                closeSettingsDialog();
+                openTaskInput({ initialWorkspaceMode: "cloud" });
+              },
+            },
+          ]
+        : []),
     ];
 
     if (canSearchFiles) {
@@ -487,6 +537,8 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
     canSearchFiles,
     openFilePicker,
     loopsEnabled,
+    localWorkspaces,
+    cloudModeEnabled,
   ]);
 
   const taskSections = useMemo<CommandSection[]>(() => {

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -109,7 +109,10 @@ import {
 import { usePreviewConfig } from "../hooks/usePreviewConfig";
 import { useTaskCreation } from "../hooks/useTaskCreation";
 import { useWarmTask } from "../hooks/useWarmTask";
-import { resolveWorkspaceModePreference } from "../hooks/workspaceModePreference";
+import {
+  resolveInitialWorkspaceMode,
+  resolveWorkspaceModePreference,
+} from "../hooks/workspaceModePreference";
 import { ChannelContextChip } from "./ChannelContextChip";
 import { CloudGithubMissingNotice } from "./CloudGithubMissingNotice";
 import { NewTaskSuggestions } from "./ContinueCliSessions";
@@ -127,6 +130,7 @@ interface TaskInputProps {
   initialCloudRepository?: string;
   initialModel?: string;
   initialMode?: string;
+  initialWorkspaceMode?: WorkspaceMode;
   reportAssociation?: TaskInputReportAssociation;
   /** Optional channel CONTEXT.md, appended to the initial prompt as background. */
   channelContext?: string;
@@ -184,6 +188,7 @@ export function TaskInput({
   initialCloudRepository,
   initialModel,
   initialMode,
+  initialWorkspaceMode,
   reportAssociation,
   channelContext,
   channelName,
@@ -415,6 +420,11 @@ export function TaskInput({
   // Force cloud mode on cloud-only hosts (web).
   const { localWorkspaces } = useHostCapabilities();
   const cloudModeEnabled = useCloudModeEnabled();
+  const resolvedInitialWorkspaceMode = resolveInitialWorkspaceMode({
+    mode: initialWorkspaceMode,
+    localWorkspaces,
+    cloudModeEnabled,
+  });
   const piHarnessEnabled = useFeatureFlag("pi-harness");
   const flagsLoaded = useFeatureFlagsLoaded();
   const reposReady = areReposReady({
@@ -435,6 +445,7 @@ export function TaskInput({
 
   const [workspaceMode, setWorkspaceModeState] = useState<WorkspaceMode>(() => {
     if (initialCloudRepository) return "cloud";
+    if (resolvedInitialWorkspaceMode) return resolvedInitialWorkspaceMode;
     if (!localWorkspaces) return "cloud";
     return resolveWorkspaceModePreference({
       preferredMode: lastUsedWorkspaceMode || DEFAULT_WORKSPACE_MODE,
@@ -452,10 +463,13 @@ export function TaskInput({
     (hasGithubIntegration || !isLoadingRepos);
 
   const didResolveWorkspaceModeRef = useRef(false);
+  const appliedWorkspaceModeRequestIdRef = useRef<string | undefined>(
+    undefined,
+  );
   useEffect(() => {
     if (didResolveWorkspaceModeRef.current) return;
     if (!settingsHydrated) return;
-    if (initialCloudRepository) {
+    if (initialCloudRepository || resolvedInitialWorkspaceMode) {
       didResolveWorkspaceModeRef.current = true;
       return;
     }
@@ -475,12 +489,22 @@ export function TaskInput({
     settingsHydrated,
     lastUsedWorkspaceMode,
     initialCloudRepository,
+    resolvedInitialWorkspaceMode,
     localWorkspaces,
     cloudSignalsSettled,
     cloudModeEnabled,
     hasGithubIntegration,
     lastUsedLocalWorkspaceMode,
   ]);
+
+  useEffect(() => {
+    if (!resolvedInitialWorkspaceMode || initialCloudRepository) return;
+    if (appliedWorkspaceModeRequestIdRef.current === initialPromptKey) return;
+
+    didResolveWorkspaceModeRef.current = true;
+    appliedWorkspaceModeRequestIdRef.current = initialPromptKey;
+    setWorkspaceModeState(resolvedInitialWorkspaceMode);
+  }, [resolvedInitialWorkspaceMode, initialCloudRepository, initialPromptKey]);
 
   const setWorkspaceMode = (mode: WorkspaceMode) => {
     didResolveWorkspaceModeRef.current = true;

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/workspaceModePreference.test.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/workspaceModePreference.test.ts
@@ -6,12 +6,13 @@ import {
 
 describe("resolveInitialWorkspaceMode", () => {
   it.each([
+    [undefined, true, true, null],
     ["local", true, false, "local"],
     ["worktree", true, false, "worktree"],
     ["cloud", false, true, "cloud"],
-    ["local", false, true, undefined],
-    ["worktree", false, true, undefined],
-    ["cloud", true, false, undefined],
+    ["local", false, true, null],
+    ["worktree", false, true, null],
+    ["cloud", true, false, null],
   ] as const)(
     "resolves %s with local workspaces %s and cloud enabled %s to %s",
     (mode, localWorkspaces, cloudModeEnabled, expected) => {

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/workspaceModePreference.test.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/workspaceModePreference.test.ts
@@ -1,5 +1,30 @@
 import { describe, expect, it } from "vitest";
-import { resolveWorkspaceModePreference } from "./workspaceModePreference";
+import {
+  resolveInitialWorkspaceMode,
+  resolveWorkspaceModePreference,
+} from "./workspaceModePreference";
+
+describe("resolveInitialWorkspaceMode", () => {
+  it.each([
+    ["local", true, false, "local"],
+    ["worktree", true, false, "worktree"],
+    ["cloud", false, true, "cloud"],
+    ["local", false, true, undefined],
+    ["worktree", false, true, undefined],
+    ["cloud", true, false, undefined],
+  ] as const)(
+    "resolves %s with local workspaces %s and cloud enabled %s to %s",
+    (mode, localWorkspaces, cloudModeEnabled, expected) => {
+      expect(
+        resolveInitialWorkspaceMode({
+          mode,
+          localWorkspaces,
+          cloudModeEnabled,
+        }),
+      ).toBe(expected);
+    },
+  );
+});
 
 describe("resolveWorkspaceModePreference", () => {
   it.each([

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/workspaceModePreference.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/workspaceModePreference.ts
@@ -18,10 +18,10 @@ export function resolveInitialWorkspaceMode({
   mode,
   localWorkspaces,
   cloudModeEnabled,
-}: InitialWorkspaceModeInput): WorkspaceMode | undefined {
-  if (!mode) return undefined;
-  if (mode === "cloud") return cloudModeEnabled ? mode : undefined;
-  return localWorkspaces ? mode : undefined;
+}: InitialWorkspaceModeInput): WorkspaceMode | null {
+  if (!mode) return null;
+  if (mode === "cloud") return cloudModeEnabled ? mode : null;
+  return localWorkspaces ? mode : null;
 }
 
 // Cloud is only honoured when it works out of the box (flag on + GitHub

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/workspaceModePreference.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/workspaceModePreference.ts
@@ -8,6 +8,22 @@ export interface WorkspaceModePreferenceInput {
   lastUsedLocalWorkspaceMode: LocalWorkspaceMode;
 }
 
+export interface InitialWorkspaceModeInput {
+  mode: WorkspaceMode | undefined;
+  localWorkspaces: boolean;
+  cloudModeEnabled: boolean;
+}
+
+export function resolveInitialWorkspaceMode({
+  mode,
+  localWorkspaces,
+  cloudModeEnabled,
+}: InitialWorkspaceModeInput): WorkspaceMode | undefined {
+  if (!mode) return undefined;
+  if (mode === "cloud") return cloudModeEnabled ? mode : undefined;
+  return localWorkspaces ? mode : undefined;
+}
+
 // Cloud is only honoured when it works out of the box (flag on + GitHub
 // connected); otherwise the preference falls back to the last local mode so
 // users never start behind a connect-GitHub prompt.

--- a/products/desktop/packages/ui/src/features/task-detail/stores/taskInputPrefillStore.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/stores/taskInputPrefillStore.ts
@@ -1,3 +1,4 @@
+import type { WorkspaceMode } from "@posthog/shared";
 import { create } from "zustand";
 
 export interface TaskInputReportAssociation {
@@ -14,6 +15,7 @@ export interface TaskInputPrefill {
   initialCloudRepository?: string;
   initialModel?: string;
   initialMode?: string;
+  initialWorkspaceMode?: WorkspaceMode;
   folderRunEnvironment?: "local" | "cloud";
   reportAssociation?: TaskInputReportAssociation;
 }

--- a/products/desktop/packages/ui/src/router/routes/code/index.tsx
+++ b/products/desktop/packages/ui/src/router/routes/code/index.tsx
@@ -16,6 +16,7 @@ function CodeIndexRoute() {
       initialCloudRepository={view.initialCloudRepository}
       initialModel={view.initialModel}
       initialMode={view.initialMode}
+      initialWorkspaceMode={view.initialWorkspaceMode}
       reportAssociation={view.reportAssociation}
     />
   );

--- a/products/desktop/packages/ui/src/router/routes/website/new.tsx
+++ b/products/desktop/packages/ui/src/router/routes/website/new.tsx
@@ -21,6 +21,7 @@ function WebsiteNewTaskRoute() {
       initialCloudRepository={view.initialCloudRepository}
       initialModel={view.initialModel}
       initialMode={view.initialMode}
+      initialWorkspaceMode={view.initialWorkspaceMode}
       reportAssociation={view.reportAssociation}
       suggestions={CHANNEL_TASK_SUGGESTIONS}
     />

--- a/products/desktop/packages/ui/src/router/useAppView.ts
+++ b/products/desktop/packages/ui/src/router/useAppView.ts
@@ -1,3 +1,4 @@
+import type { WorkspaceMode } from "@posthog/shared";
 import {
   type TaskInputReportAssociation,
   useTaskInputPrefillStore,
@@ -32,6 +33,7 @@ export interface AppView {
   initialCloudRepository?: string;
   initialModel?: string;
   initialMode?: string;
+  initialWorkspaceMode?: WorkspaceMode;
   folderRunEnvironment?: "local" | "cloud";
   reportAssociation?: TaskInputReportAssociation;
 }
@@ -151,6 +153,7 @@ export function useAppView(): AppView {
         initialCloudRepository: prefill.initialCloudRepository,
         initialModel: prefill.initialModel,
         initialMode: prefill.initialMode,
+        initialWorkspaceMode: prefill.initialWorkspaceMode,
         folderRunEnvironment: prefill.folderRunEnvironment,
         reportAssociation: prefill.reportAssociation,
         taskInputRequestId: prefill.requestId,

--- a/products/desktop/packages/ui/src/router/useOpenTask.test.ts
+++ b/products/desktop/packages/ui/src/router/useOpenTask.test.ts
@@ -100,6 +100,18 @@ describe("openTaskInput channel scoping", () => {
     expect(prefill.initialPrompt).toBeUndefined();
     expect(prefill.requestId).not.toBe(stale);
   });
+
+  it("refreshes the prefill when selecting the same workspace mode twice", () => {
+    openTaskInput({ initialWorkspaceMode: "cloud" });
+    const firstRequestId =
+      useTaskInputPrefillStore.getState().prefill.requestId;
+
+    openTaskInput({ initialWorkspaceMode: "cloud" });
+
+    const { prefill } = useTaskInputPrefillStore.getState();
+    expect(prefill.initialWorkspaceMode).toBe("cloud");
+    expect(prefill.requestId).not.toBe(firstRequestId);
+  });
 });
 
 describe("taskInputPrefillStore.consumePrompt", () => {

--- a/products/desktop/packages/ui/src/router/useOpenTask.ts
+++ b/products/desktop/packages/ui/src/router/useOpenTask.ts
@@ -1,5 +1,5 @@
 import { resolveService, resolveServiceOptional } from "@posthog/di/container";
-import { ANALYTICS_EVENTS } from "@posthog/shared";
+import { ANALYTICS_EVENTS, type WorkspaceMode } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import { useCurrentChannelStore } from "@posthog/ui/features/canvas/stores/currentChannelStore";
 import {
@@ -74,6 +74,7 @@ export interface TaskInputNavigationOptions {
   initialCloudRepository?: string;
   initialModel?: string;
   initialMode?: string;
+  initialWorkspaceMode?: WorkspaceMode;
   /**
    * Environment ("local" | "cloud") of the folder's most recent visible run,
    * used to prefill the workspace mode when starting a task scoped to a folder.
@@ -113,6 +114,7 @@ export function openTaskInput(
     !!options.initialCloudRepository ||
     !!options.initialModel ||
     !!options.initialMode ||
+    !!options.initialWorkspaceMode ||
     !!options.reportAssociation;
 
   useTaskInputPrefillStore.setState({
@@ -123,6 +125,7 @@ export function openTaskInput(
       initialCloudRepository: options.initialCloudRepository,
       initialModel: options.initialModel,
       initialMode: options.initialMode,
+      initialWorkspaceMode: options.initialWorkspaceMode,
       folderRunEnvironment: options.folderRunEnvironment,
       reportAssociation: options.reportAssociation,
       requestId: hasTransientState


### PR DESCRIPTION
## Problem

- Quick search opens a new task, but users cannot choose its workspace mode before the composer opens.
- The saved workspace preference can differ from the mode a user needs for the next task.

## Changes

- Add quick-search actions for local, worktree, and cloud tasks when each mode is available.
- Prefill the selected mode through every new-task route.
- Update an already-open composer for each new-task request.
- Keep cloud repository prefills in cloud mode.
- Reject unavailable mode prefills from shared callers.

<img width="1576" height="270" alt="CleanShot 2026-08-12 at 18 22 02@2x" src="https://github.com/user-attachments/assets/c3b76243-fe45-48c5-97dd-8a32b0bd31ef" />


## How did you test this code?

- The workspace-mode tests cover supported and unsupported host capabilities.
- The routing test covers selecting the same mode twice for an already-open composer.
- The Desktop UI typecheck is blocked by existing DOMWindow errors in `artifactHtmlCommentBridge.test.ts`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No matching user documentation exists for this Desktop quick-search workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex implemented the change after the task request.
- Skills used: `writing-user-facing-copy`, `writing-ui-components`, `qa-team`, and `writing-pr-descriptions`.
- QA found capability and conflicting-prefill cases. Codex fixed both.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*