### PR TITLE
feat(replay): nudge users toward the visited page filter

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6280,6 +6280,10 @@ snapshots:
         hash: v1.k794b7964.976b4bc71204d3fdd7d22bc696a779a418376dfa7d6fc74cf50ebc5023c672b9.gyNSfDI5sGG3Hamw70N9MALDuDtbPb3jeSZzD9-IC5g
     replay-tabs-home-failure--not-found--light:
         hash: v1.k794b7964.68ea14164788313df082ab6a0376077a82369dbdb3365ce8427640ad453aa9d6.laeHUCIfmZ8CHubdHCTK_PaLsSGS3XkBTsQRSma6qoE
+    replay-tabs-home-filters-banner--page-filter-nudge--dark:
+        hash: v1.k794b7964.33db55efe063b4a0e5cf7399851c5e16172fd4b78dda3587881c7e58974e9507.6F1xl1LtKP40SgXwQBJF6ZZ65QMLRIXKXm1c5EzgCCE
+    replay-tabs-home-filters-banner--page-filter-nudge--light:
+        hash: v1.k794b7964.63bf390f520ab045439f3b5e7fc148517a4cd49a956f984dfb568d414ac4fd03.M4ZZ0EydB1dbBv-yull_buDmcAN0BjTaY9xoP8-LxlE
     replay-tabs-home-filters-banner--product-analytics-over-limit--dark:
         hash: v1.k794b7964.6419b76d333a64f252a9fe748e5126f24a45c5ef281ee5f244bee651d8732d5b.uq-8FJ0MflN3hPv_ZAsPCd6wVw2NpRKB_UZUBKyLOb8
     replay-tabs-home-filters-banner--product-analytics-over-limit--light:

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.stories.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.stories.tsx
@@ -86,3 +86,20 @@ export const ScannerCrossSell: Story = {
         testOptions: { waitForSelector: '[data-attr="replay-save-filters-as-scanner"]' },
     },
 }
+
+const withPageFilter = (values: Record<string, any>[]): Record<string, any> => ({
+    pageUrl: combineUrl(urls.replay(), {
+        showFilters: true,
+        filters: {
+            date_from: '-3d',
+            date_to: null,
+            filter_test_accounts: false,
+            duration: [{ type: 'recording', key: 'duration', value: 1, operator: 'gt' }],
+            filter_group: { type: 'AND', values: [{ type: 'AND', values }] },
+        },
+    }).url,
+})
+
+export const PageFilterNudge: Story = {
+    parameters: withPageFilter([{ type: 'event', key: '$current_url', operator: 'icontains', value: '/pricing' }]),
+}

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -22,6 +22,7 @@ import {
 } from '@posthog/icons'
 import {
     LemonBadge,
+    LemonBanner,
     LemonButton,
     LemonDivider,
     LemonInput,
@@ -56,7 +57,7 @@ import { getProjectEventExistence } from 'lib/utils/getAppContext'
 import { addProductIntentForCrossSell } from 'lib/utils/product-intents'
 import { TestAccountFilter } from 'scenes/insights/filters/TestAccountFilter'
 import { MaxTool } from 'scenes/max/MaxTool'
-import { TimestampFormatToLabel } from 'scenes/session-recordings/utils'
+import { TimestampFormatToLabel, hasPageFilter } from 'scenes/session-recordings/utils'
 import { urls } from 'scenes/urls'
 
 import { actionsModel } from '~/models/actionsModel'
@@ -1020,6 +1021,15 @@ export const ReplayFiltersTab = ({
                     </div>
                 </div>
             </UniversalFilters>
+
+            {hasPageFilter(filters) && (
+                <div className="px-2 mt-4">
+                    <LemonBanner type="info" dismissKey="replay-filters-page-filter-vs-visited-page">
+                        Filtering on a URL matches pageview events from anywhere in the session, including time the
+                        recording doesn't cover. "Visited page" only matches URLs captured in the video.
+                    </LemonBanner>
+                </div>
+            )}
 
             {!compactActions && (
                 <>

--- a/frontend/src/scenes/session-recordings/utils.test.ts
+++ b/frontend/src/scenes/session-recordings/utils.test.ts
@@ -1,7 +1,7 @@
 import { defaultQuickEmojis } from 'lib/lemon-ui/LemonTextArea/emojiUsageLogic'
-import { filtersFromUniversalFilterGroups, isSingleEmoji } from 'scenes/session-recordings/utils'
+import { filtersFromUniversalFilterGroups, hasPageFilter, isSingleEmoji } from 'scenes/session-recordings/utils'
 
-import { FilterLogicalOperator, RecordingUniversalFilters } from '~/types'
+import { FilterLogicalOperator, PropertyOperator, RecordingUniversalFilters } from '~/types'
 
 const withFilterGroup = (filterGroup: RecordingUniversalFilters['filter_group']): RecordingUniversalFilters => ({
     date_from: '-3d',
@@ -47,6 +47,53 @@ describe('session recording utils', () => {
             ],
         ])('returns all leaves for the %s', (_label, filterGroup, expected) => {
             expect(filtersFromUniversalFilterGroups(withFilterGroup(filterGroup))).toEqual(expected)
+        })
+    })
+
+    describe('hasPageFilter', () => {
+        const pageProperty = (
+            key: string,
+            operator: PropertyOperator = PropertyOperator.IContains,
+            value: any = '/pricing'
+        ): any => ({ type: 'event', key, operator, value })
+
+        const pageview = (properties: any[]): any => ({
+            id: '$pageview',
+            name: '$pageview',
+            type: 'events',
+            properties,
+        })
+
+        const group = (...values: any[]): RecordingUniversalFilters =>
+            withFilterGroup({
+                type: FilterLogicalOperator.And,
+                values: [{ type: FilterLogicalOperator.And, values }],
+            })
+
+        it.each([
+            ['shows the hint for a current URL property', [pageProperty('$current_url')], true],
+            ['shows the hint for a pathname property', [pageProperty('$pathname')], true],
+            ['shows the hint for a URL property scoping a pageview', [pageview([pageProperty('$current_url')])], true],
+            [
+                'shows the hint for a negated URL property',
+                [pageProperty('$current_url', PropertyOperator.NotIContains)],
+                true,
+            ],
+            // Nothing is typed yet, so there is no page to nudge about.
+            [
+                'stays quiet until a value is entered',
+                [pageProperty('$current_url', PropertyOperator.IContains, '')],
+                false,
+            ],
+            [
+                'stays quiet for an operator that takes no value',
+                [pageProperty('$current_url', PropertyOperator.IsSet, null)],
+                false,
+            ],
+            ['stays quiet for a bare pageview', [pageview([])], false],
+            ['stays quiet for an unrelated filter', [event('a')], false],
+        ])('%s', (_label, values, shows) => {
+            expect(hasPageFilter(group(...values))).toBe(shows)
         })
     })
 })

--- a/frontend/src/scenes/session-recordings/utils.ts
+++ b/frontend/src/scenes/session-recordings/utils.ts
@@ -1,7 +1,10 @@
 import emojiRegex from 'emoji-regex'
 
+import { isActionFilter, isEventFilter } from 'lib/components/UniversalFilters/utils'
+
 import {
     LegacyRecordingFilters,
+    PropertyOperator,
     RecordingUniversalFilters,
     type SessionRecordingMaskingConfig,
     type SessionRecordingMaskingLevel,
@@ -40,6 +43,28 @@ export const filtersFromUniversalFilterGroups = (filters: RecordingUniversalFilt
     }
     return flatten(filters.filter_group.values)
 }
+
+// The properties people reach for when they mean "show me sessions that visited this page".
+const PAGE_PROPERTY_KEYS = ['$current_url', '$pathname']
+
+type PageProperty = { key?: unknown; operator?: PropertyOperator; value?: any }
+
+const isPagePropertyFilter = (filter: PageProperty): boolean =>
+    PAGE_PROPERTY_KEYS.includes(filter.key as string) &&
+    !!filter.operator &&
+    filter.value != null &&
+    filter.value !== '' &&
+    !(Array.isArray(filter.value) && filter.value.length === 0)
+
+const pagePropertiesOf = (filter: UniversalFilterValue): PageProperty[] =>
+    isEventFilter(filter) || isActionFilter(filter) ? (filter.properties ?? []) : [filter]
+
+/**
+ * True when the filters express "sessions that visited page X". Those match pageview events from anywhere
+ * in the session, so they can match a moment the video never covers, unlike `visited_page`.
+ */
+export const hasPageFilter = (filters: RecordingUniversalFilters): boolean =>
+    filtersFromUniversalFilterGroups(filters).some((filter) => pagePropertiesOf(filter).some(isPagePropertyFilter))
 
 export const getMaskingLevelFromConfig = (config: SessionRecordingMaskingConfig): SessionRecordingMaskingLevel => {
     if (config.maskTextSelector === '*' && config.maskAllInputs && config.blockSelector === 'img') {


### PR DESCRIPTION
## Problem

Filtering session recordings by a URL returns recordings whose video never covers that URL, and the person only finds out after opening each one.

- "Current URL" and "Pathname" are event properties: they match pageview events from the whole session, then join to the recording on `session_id`. A recording often covers only a fraction of its session, because of replay triggers, sampling, or a linked flag.
- "Visited page" reads `all_urls`, which ingestion builds from the URLs captured in the video, so it cannot match a moment the recording never saw.
- Nothing in the filter panel said which of the two is video-backed.

Related: #78856 warns about the same mismatch inside the player. This steers people away from hitting it in the filters.

## Changes

- The replay filter panel now shows a dismissible banner when a filter uses a `$current_url` or `$pathname` property. It says URL filters match pageviews from anywhere in the session, and points to "Visited page" for video-backed matching.
- `hasPageFilter` in `utils.ts` detects those filters, including a URL property scoping a pageview or action, and stays quiet until a value is entered.

This is frontend only and additive. Backend query behavior is unchanged.

### Screenshots

The banner is the only visible change. The `PageFilterNudge` story in `RecordingsUniversalFiltersEmbed.stories.tsx` renders it; I did not capture a static image from this environment, and the visual-regression job generates the baseline on first run.

## How did you test this code?

- Added 8 parameterized `hasPageFilter` cases to `utils.test.ts`. They guard that the banner shows for a URL property (including one scoping a pageview, and a negated one) and stays hidden for an empty value, a value-less operator, a bare pageview, and an unrelated filter.
- Ran the frontend typecheck and the touched Jest suite locally; both pass.
- Not run: backend suites, because this PR changes no backend code.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This branch was reconciled onto master. Master shipped an equivalent, more complete visited-page negation fix (#91418) after the branch diverged, so the branch's now-superseded backend commits were dropped. What remains is the frontend nudge, which was the crux of the PR. The banner and its `hasPageFilter` helper carry over unchanged; only the backend and its tests were removed.

Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.
