### PR TITLE
fix(desktop): stop MCP apps rendering blank under their own CSP

### DIFF
--- a/products/desktop/apps/mobile/src/features/mcp/sandbox/mcpAppCsp.test.ts
+++ b/products/desktop/apps/mobile/src/features/mcp/sandbox/mcpAppCsp.test.ts
@@ -12,6 +12,9 @@ describe("sanitizeDomain", () => {
     ["example.com", "example.com"],
     ["*.example.com", "*.example.com"],
     ["example.com:8080", "example.com:8080"],
+    // A stripped origin ('https:cdn.example.com') is an invalid source that a
+    // browser ignores, taking the whole domain's permission with it.
+    ["https://cdn.example.com", "https://cdn.example.com"],
     ["' unsafe-eval; script-src *;", "unsafe-evalscript-src*"],
     ['" onload=alert(1)', "onloadalert1"],
     ["example.com; frame-ancestors *", "example.comframe-ancestors*"],

--- a/products/desktop/apps/mobile/src/features/mcp/sandbox/mcpAppCsp.ts
+++ b/products/desktop/apps/mobile/src/features/mcp/sandbox/mcpAppCsp.ts
@@ -3,8 +3,12 @@ import type { McpUiResourceCsp } from "@modelcontextprotocol/ext-apps/app-bridge
 const DEFAULT_CSP =
   "default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; media-src 'self' data:; connect-src 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; base-uri 'none'";
 
+// Sources arrive as full origins (`https://mcp.us.posthog.com`), so `/` has to
+// survive: `https:mcp.us.posthog.com` is not a source expression, and a browser
+// drops the whole entry as invalid. Spaces, semicolons and quotes are still
+// stripped, which is what stops a declared domain from injecting a directive.
 export function sanitizeDomain(domain: string): string {
-  return domain.replace(/[^a-zA-Z0-9.*:-]/g, "");
+  return domain.replace(/[^a-zA-Z0-9.*:/-]/g, "");
 }
 
 export function buildCspString(csp?: McpUiResourceCsp): string {

--- a/products/desktop/packages/ui/src/features/mcp-apps/utils/mcp-app-csp.test.ts
+++ b/products/desktop/packages/ui/src/features/mcp-apps/utils/mcp-app-csp.test.ts
@@ -11,8 +11,15 @@ describe("sanitizeDomain", () => {
   it("passes through valid domains", () => {
     expect(sanitizeDomain("example.com")).toBe("example.com");
     expect(sanitizeDomain("*.example.com")).toBe("*.example.com");
-    // CSP domains don't include protocol slashes - slashes are stripped
     expect(sanitizeDomain("example.com:8080")).toBe("example.com:8080");
+  });
+
+  it("keeps a full origin intact", () => {
+    // Stripping the slashes here left 'https:cdn.example.com', which a browser
+    // rejects as an invalid source and ignores — blocking the whole domain.
+    expect(sanitizeDomain("https://cdn.example.com")).toBe(
+      "https://cdn.example.com",
+    );
   });
 
   it("strips injection characters", () => {

--- a/products/desktop/packages/ui/src/features/mcp-apps/utils/mcp-app-csp.ts
+++ b/products/desktop/packages/ui/src/features/mcp-apps/utils/mcp-app-csp.ts
@@ -17,8 +17,12 @@ import type { McpUiResourceCsp } from "@modelcontextprotocol/ext-apps/app-bridge
 const DEFAULT_CSP =
   "default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; media-src 'self' data:; connect-src 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; base-uri 'none'";
 
+// Sources arrive as full origins (`https://mcp.us.posthog.com`), so `/` has to
+// survive: `https:mcp.us.posthog.com` is not a source expression, and a browser
+// drops the whole entry as invalid. Spaces, semicolons and quotes are still
+// stripped, which is what stops a declared domain from injecting a directive.
 export function sanitizeDomain(domain: string): string {
-  return domain.replace(/[^a-zA-Z0-9.*:-]/g, "");
+  return domain.replace(/[^a-zA-Z0-9.*:/-]/g, "");
 }
 
 export function buildCspString(


### PR DESCRIPTION
## Problem

MCP apps in PostHog Desktop intermittently render as an empty panel — no chart, no error, nothing. It has been seen on insights and on experiment tools.

- An MCP server declares the domains its app loads from as full origins: `https://mcp.us.posthog.com`.
- `sanitizeDomain` allowed every character except `/`, so the frame's policy got `https:mcp.us.posthog.com`. That is not a source expression, so the browser reports an invalid source and ignores the entry.
- `script-src` and `style-src` then fall back to `'self'`, which matches nothing in a null-origin frame, and the app's own `styles.css` and `main.js` are blocked.

The devtools console shows it plainly, which is the only reason it was ever visible:

```text
The source list for the Content Security Policy directive 'script-src' contains an invalid source: 'https:mcp.us.posthog.com'. It will be ignored.
Loading the stylesheet '<URL>' violates the following Content Security Policy directive: "style-src 'self' 'unsafe-inline' https:mcp.us.posthog.com". The action has been blocked.
```

## Changes

- Allow `/` through `sanitizeDomain`, so a declared origin survives into the policy. One character in the character class, in both copies of the sanitizer — desktop and mobile.
- Spaces, semicolons and quotes are still stripped. That is the part that stops a declared domain from injecting a directive, and the existing injection tests still cover it.
- The desktop test asserted the stripping as intended, commented "CSP domains don't include protocol slashes". That assumption is what shipped the bug, so it is replaced by a case pinning the opposite.

ChatGPT was unaffected throughout, which is a hint at where the mistake sat: it reads the same domains from the `openai/widgetCSP` key and never passes them through this sanitizer.

## How did you test this code?

Ran the real sandbox proxy and the real `applyCspToHtml` output in headless Chromium, counting what the app actually managed to fetch. A blocked resource is never requested, so the asset server is the measurement:

| declared origin | assets fetched | app script ran |
| --- | --- | --- |
| slashes stripped (before) | none | no |
| left intact (after) | `styles.css`, `main.js` | yes |

The unit suites for both copies pass. Not checked: the packaged Electron app — this sandbox has no display, so the frame was exercised in Chromium instead, and no real MCP app was loaded end to end.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app, from a thread about blank MCP app panels in desktop. The diagnosis came from reading the CSP path and confirming it in a browser, not from the console output alone.

A companion change to report these violations to PostHog — so the next occurrence arrives as data rather than as a console line somebody happens to expand — was built and then closed unmerged as too large for what it bought: [#82300](https://github.com/PostHog/posthog/pull/82300). Worth knowing before adding reporting here: on Electron 42 a CSP delivered as a response header is enforced but never reported, so `report-uri` / `report-to` are not the shortcut they look like.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1786562247158569?thread_ts=1786562247.158569&cid=C0ACRAMJUAG)*
