### PR TITLE
fix(data-imports): scope table size save to stop false url_pattern rejections

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/calculate_table_size.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/calculate_table_size.py
@@ -74,6 +74,10 @@ def calculate_table_size_activity(inputs: CalculateTableSizeActivityInputs) -> N
     job.save(update_fields=["storage_delta_mib", "updated_at"])
 
     table.size_in_s3_mib = total_mib
-    table.save()
+    # Scoped to the field this activity actually changes: an unscoped save() compares this
+    # possibly-stale in-memory url_pattern (table was loaded before the potentially long
+    # get_size_of_folder() call above) against the row's current DB value, and a credential-less
+    # table with no other change in flight trips the url_pattern guard on that false mismatch.
+    table.save(update_fields=["size_in_s3_mib", "updated_at"])
 
     logger.debug("Table model updated")

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_calculate_table_size.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_calculate_table_size.py
@@ -1,0 +1,65 @@
+import pytest
+from unittest.mock import patch
+
+from posthog.models import Organization, Team
+
+from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
+from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.models.table import DataWarehouseTable
+from products.warehouse_sources.backend.temporal.data_imports.workflow_activities import calculate_table_size as calc
+from products.warehouse_sources.backend.temporal.data_imports.workflow_activities.calculate_table_size import (
+    CalculateTableSizeActivityInputs,
+    calculate_table_size_activity,
+)
+
+
+def _team() -> Team:
+    return Team.objects.create(organization=Organization.objects.create(name="org"), name="t")
+
+
+def _schema_table_job(team: Team) -> tuple[ExternalDataSchema, DataWarehouseTable, ExternalDataJob]:
+    table = DataWarehouseTable(
+        name="stripe_charge",
+        format="Parquet",
+        team=team,
+        url_pattern="https://posthog-owned.example/team/stripe_charge",
+    )
+    table.save(internally_computed_url_pattern=True)
+    source = ExternalDataSource.objects.create(source_id="src", connection_id="conn", team=team, source_type="Stripe")
+    schema = ExternalDataSchema.objects.create(name="Charge", team=team, source=source, table=table)
+    job = ExternalDataJob.objects.create(
+        team=team, pipeline=source, schema=schema, status=ExternalDataJob.Status.COMPLETED
+    )
+    return schema, table, job
+
+
+# transaction=True: the activity calls close_old_connections(), which breaks the atomic wrapper
+# a plain django_db test relies on for rollback (same reason test_compute_table_statistics.py's
+# activity-level test class uses it).
+@pytest.mark.django_db(transaction=True)
+class TestCalculateTableSizeActivity:
+    def test_survives_a_concurrent_url_pattern_change_on_a_credential_less_table(self) -> None:
+        # This activity only ever intends to update size_in_s3_mib. It loads the table before
+        # get_size_of_folder() (an S3 listing that can take a while), so a sync elsewhere in the
+        # same window can legitimately rewrite the table's url_pattern in the DB before this
+        # activity's own save runs. An unscoped save() here used to compare this stale in-memory
+        # url_pattern against the row's now-current DB value and reject the save as a
+        # client-supplied URL change, even though nothing about this activity touches url_pattern.
+        team = _team()
+        schema, table, job = _schema_table_job(team)
+
+        def _slow_listing(_folder: str) -> float:
+            DataWarehouseTable.objects.filter(pk=table.pk).update(
+                url_pattern="https://posthog-owned.example/team/stripe_charge_repartitioned"
+            )
+            return 12.5
+
+        with patch.object(calc, "get_size_of_folder", side_effect=_slow_listing):
+            calculate_table_size_activity(
+                CalculateTableSizeActivityInputs(team_id=team.id, schema_id=str(schema.id), job_id=str(job.id))
+            )
+
+        table.refresh_from_db()
+        assert table.size_in_s3_mib == 12.5
+        assert table.url_pattern == "https://posthog-owned.example/team/stripe_charge_repartitioned"


### PR DESCRIPTION
## Problem

A post-import data-warehouse sync activity can fail with a validation error on a table that has no stored credential, even though nothing about the sync touched that table's URL. This was caught by [error tracking](https://us.posthog.com/project/2/error_tracking/019ff83b-2adb-73a0-ab5a-3e410009fd2a).

`calculate_table_size_activity` (`products/warehouse_sources/backend/temporal/data_imports/workflow_activities/calculate_table_size.py`) loads the table row, lists its S3 folder to compute a size (which can take a while), then saves the table with an unscoped `save()`.

## Changes

- Scope that save to `update_fields=["size_in_s3_mib", "updated_at"]`, the only fields this activity changes.
- An unscoped save compares the table's in-memory `url_pattern`, loaded before the S3 listing, against whatever the DB currently holds. If another sync legitimately rewrote `url_pattern` on the same credential-less table in that window, the two no longer match, and `DataWarehouseTable._reject_client_supplied_url_pattern_change` raises even though this activity never assigns `url_pattern`.
- Scoping the save skips that guard's DB read entirely (it early-exits when `url_pattern` isn't in `update_fields`), matching the existing pattern in `pipeline_sync.py`.

## How did you test this code?

- Added `test_calculate_table_size.py`, reproducing the race: the mocked S3 listing rewrites the table's `url_pattern` in the DB mid-activity (simulating a concurrent sync), then asserts the activity completes and persists the new size instead of raising.
- Confirmed the test fails with the exact production error (`ValidationError` from `table.py`'s `_reject_client_supplied_url_pattern_change`) against the old code, and passes with the fix.
- Ran the full `test_table.py` and `workflow_activities/tests/` suites locally: 173 passed.
- Not run: a live Temporal worker end-to-end pass (this fix only changes an activity's local save scoping).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal pipeline bug fix, no documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking issue by Claude Code. Read the exception's stack trace and sample event properties via the PostHog MCP tools, traced the call path from `calculate_table_size_activity` into `DataWarehouseTable.save()`, and identified the save-scoping gap as the root cause (not a source-specific issue). Invoked `/writing-tests` before adding the regression test and `/writing-pr-descriptions` before writing this body. Verified the fix by temporarily reverting it and confirming the new test reproduces the original `ValidationError`.