### PR TITLE
perf(warehouse): load source registry entries on demand

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/__init__.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/__init__.py
@@ -45,17 +45,19 @@ def load_all_sources() -> None:
             _load_source(module_path)
 
 
-def load_source(source_type: ExternalDataSourceType) -> None:
+def load_source(source_type: ExternalDataSourceType) -> bool:
     """Import just the module that registers ``source_type`` with ``SourceRegistry``.
 
     Same failure isolation as ``load_all_sources``: a module that can't be imported is
-    reported and skipped, so the caller observes the type as unregistered. A type with no
-    mapped module is skipped silently, matching how a bulk load leaves an unknown type
-    unregistered.
+    reported and skipped, so the caller observes the type as unregistered. Returns whether an
+    import was attempted; ``False`` means the value has no mapped module (an unknown or
+    retired type), which a bulk load would likewise leave unregistered.
     """
     module_path = _module_paths_by_source_type().get(source_type)
-    if module_path is not None:
-        _load_source(module_path)
+    if module_path is None:
+        return False
+    _load_source(module_path)
+    return True
 
 
 def _bulk_load() -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/__init__.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/__init__.py
@@ -1,4 +1,5 @@
 import importlib
+from functools import cache
 from pathlib import Path
 from typing import Any
 
@@ -6,11 +7,19 @@ import structlog
 
 from posthog.exceptions_capture import capture_exception
 
+from products.warehouse_sources.backend.types import ExternalDataSourceType
+
 from .common.registry import SourceRegistry
 
-__all__ = ["SourceRegistry", "load_all_sources"]
+__all__ = ["SourceRegistry", "load_all_sources", "load_source"]
 
 logger = structlog.get_logger(__name__)
+
+# Source types whose module directory `_normalize` cannot derive from the enum value. When a
+# new source's enum value and directory name stop normalizing to the same key, map the type
+# to its directory here; `test_every_source_type_maps_to_exactly_one_source_module` fails
+# until every type resolves.
+_SOURCE_MODULE_OVERRIDES: dict[ExternalDataSourceType, str] = {}
 
 
 def load_all_sources() -> None:
@@ -36,8 +45,26 @@ def load_all_sources() -> None:
             _load_source(module_path)
 
 
+def load_source(source_type: ExternalDataSourceType) -> None:
+    """Import just the module that registers ``source_type`` with ``SourceRegistry``.
+
+    Same failure isolation as ``load_all_sources``: a module that can't be imported is
+    reported and skipped, so the caller observes the type as unregistered. A type with no
+    mapped module is skipped silently, matching how a bulk load leaves an unknown type
+    unregistered.
+    """
+    module_path = _module_paths_by_source_type().get(source_type)
+    if module_path is not None:
+        _load_source(module_path)
+
+
 def _bulk_load() -> None:
     from . import _load_all  # noqa: F401, PLC0415
+
+
+def _source_module_dirs() -> list[str]:
+    package_dir = Path(__path__[0])
+    return sorted(source.parent.name for source in package_dir.glob("*/source.py"))
 
 
 def _source_module_paths() -> list[str]:
@@ -45,8 +72,31 @@ def _source_module_paths() -> list[str]:
 
     A test asserts this stays in step with `_load_all`'s import list.
     """
-    package_dir = Path(__path__[0])
-    return sorted(f"{__name__}.{source.parent.name}.source" for source in package_dir.glob("*/source.py"))
+    return [f"{__name__}.{module_dir}.source" for module_dir in _source_module_dirs()]
+
+
+def _normalize(name: str) -> str:
+    # Enum values are CamelCase and source directories are snake_case, with word boundaries
+    # that don't line up mechanically ("TikTokAds" -> "tiktok_ads", "DoIt" -> "doit"). Case
+    # and underscores are the only differences, so stripping both pairs each enum value with
+    # its directory.
+    return name.lower().replace("_", "")
+
+
+@cache
+def _module_paths_by_source_type() -> dict[ExternalDataSourceType, str]:
+    """The module that registers each source type, derived from the directory layout.
+
+    Tests assert the result is a bijection between ``ExternalDataSourceType`` and the on-disk
+    catalog, and that each mapped module is where the registered source class really lives.
+    """
+    dirs_by_key = {_normalize(module_dir): module_dir for module_dir in _source_module_dirs()}
+    mapping: dict[ExternalDataSourceType, str] = {}
+    for source_type in ExternalDataSourceType:
+        module_dir = _SOURCE_MODULE_OVERRIDES.get(source_type) or dirs_by_key.get(_normalize(source_type.value))
+        if module_dir is not None:
+            mapping[source_type] = f"{__name__}.{module_dir}.source"
+    return mapping
 
 
 def _load_source(module_path: str) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/registry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/registry.py
@@ -12,6 +12,7 @@ class SourceRegistry:
 
     _sources: dict[ExternalDataSourceType, "AnySource"] = {}
     _loaded: bool = False
+    _attempted_types: set[ExternalDataSourceType] = set()
     _load_lock = threading.Lock()
 
     @classmethod
@@ -38,6 +39,27 @@ class SourceRegistry:
             cls._loaded = True
 
     @classmethod
+    def _ensure_source_loaded(cls, source_type: ExternalDataSourceType) -> None:
+        # Targeted twin of `_ensure_loaded` for single-type lookups: imports only the module
+        # that registers `source_type`, so asking for one source doesn't pay the cold import
+        # of the whole catalog and its vendor SDKs. `_loaded` stays False, which keeps the
+        # complete-catalog callers (`get_all_sources`, `get_registered_types`) bulk-loading
+        # on their first use. Shares `_load_lock` with the bulk path so the two can't
+        # interleave; the serialization is noise next to the import cost. `_attempted_types`
+        # mirrors the bulk loader's failure isolation: a module that fails to import is
+        # reported once by `load_source` and its type stays unregistered, rather than
+        # re-running the broken import on every lookup.
+        if cls._loaded or source_type in cls._sources:
+            return
+        with cls._load_lock:
+            if cls._loaded or source_type in cls._sources or source_type in cls._attempted_types:
+                return
+            from products.warehouse_sources.backend.temporal.data_imports.sources import load_source  # noqa: PLC0415
+
+            load_source(source_type)
+            cls._attempted_types.add(source_type)
+
+    @classmethod
     def register(cls, source_class: type["AnySource"]):
         source_class_instance = source_class()
         source_type = source_class_instance.source_type
@@ -50,7 +72,7 @@ class SourceRegistry:
     def get_source(cls, source_type: ExternalDataSourceType) -> "AnySource":
         """Get a source instance by type"""
 
-        cls._ensure_loaded()
+        cls._ensure_source_loaded(source_type)
         if source_type not in cls._sources:
             raise ValueError(f"Unknown source type: {source_type}")
         return cls._sources[source_type]
@@ -66,7 +88,7 @@ class SourceRegistry:
     def is_registered(cls, source_type: ExternalDataSourceType) -> bool:
         """Check if a source type is registered"""
 
-        cls._ensure_loaded()
+        cls._ensure_source_loaded(source_type)
         return source_type in cls._sources
 
     @classmethod

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/registry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/registry.py
@@ -48,7 +48,9 @@ class SourceRegistry:
         # interleave; the serialization is noise next to the import cost. `_attempted_types`
         # mirrors the bulk loader's failure isolation: a module that fails to import is
         # reported once by `load_source` and its type stays unregistered, rather than
-        # re-running the broken import on every lookup.
+        # re-running the broken import on every lookup. Only types that resolved to a module
+        # are cached, because lookups accept arbitrary values (callers pass raw model-field
+        # strings) and caching unresolvable ones would grow the set without bound.
         if cls._loaded or source_type in cls._sources:
             return
         with cls._load_lock:
@@ -56,8 +58,8 @@ class SourceRegistry:
                 return
             from products.warehouse_sources.backend.temporal.data_imports.sources import load_source  # noqa: PLC0415
 
-            load_source(source_type)
-            cls._attempted_types.add(source_type)
+            if load_source(source_type):
+                cls._attempted_types.add(source_type)
 
     @classmethod
     def register(cls, source_class: type["AnySource"]):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tests/test_all_sources_import.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tests/test_all_sources_import.py
@@ -1,7 +1,26 @@
-from products.warehouse_sources.backend.temporal.data_imports.sources import load_all_sources
+from products.warehouse_sources.backend.temporal.data_imports.sources import (
+    _module_paths_by_source_type,
+    load_all_sources,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 
 
 def test_load_all_sources_imports_every_source_module():
     # A stale import in any single source module breaks the whole registry load — every
     # source self-registers on import, so one bad path takes down imports for all sources.
     load_all_sources()
+
+
+def test_source_module_mapping_matches_where_each_registered_source_lives():
+    # `get_source` imports the mapped module and expects the type to be registered
+    # afterwards, so a mapping entry that resolves to any other module makes that type
+    # unloadable on the targeted path. Comparing against the registered class's defining
+    # module checks the mapping against where each source actually lives.
+    mapping = _module_paths_by_source_type()
+
+    mismatches = {
+        source_type: (mapping.get(source_type), type(source).__module__)
+        for source_type, source in SourceRegistry.get_all_sources().items()
+        if mapping.get(source_type) != type(source).__module__
+    }
+    assert mismatches == {}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tests/test_source_loading.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tests/test_source_loading.py
@@ -15,6 +15,11 @@ from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 _SOURCES = "products.warehouse_sources.backend.temporal.data_imports.sources"
 
+# The product-tests CI job runs pytest from products/warehouse_sources, and `python -c` puts
+# the current directory on sys.path, so subprocesses must be launched from the repo root for
+# `posthog.settings` to be importable.
+_REPO_ROOT = next(parent for parent in Path(__file__).parents if (parent / "manage.py").exists())
+
 
 def test_broken_source_module_does_not_block_the_rest_of_the_catalog():
     with (
@@ -84,6 +89,14 @@ assert SourceRegistry.is_registered(ExternalDataSourceType.MYSQL)
 assert SOURCES + ".mysql.source" in sys.modules, "is_registered did not load the requested source"
 assert SOURCES + "._load_all" not in sys.modules, "is_registered ran the full-catalog loader"
 
+try:
+    SourceRegistry.get_source("NotARealSourceType")
+except ValueError:
+    pass
+else:
+    raise AssertionError("expected ValueError for an unknown source type")
+assert "NotARealSourceType" not in SourceRegistry._attempted_types, "unresolvable values must not grow the attempt cache"
+
 with patch(SOURCES + ".load_source") as load_source:
     assert SourceRegistry.get_source(ExternalDataSourceType.POSTGRES) is postgres
     load_source.assert_not_called()
@@ -100,5 +113,6 @@ def test_get_source_imports_only_the_requested_source_module():
         capture_output=True,
         text=True,
         timeout=180,
+        cwd=_REPO_ROOT,
     )
     assert result.returncode == 0, f"targeted-load subprocess failed:\n{result.stderr[-4000:]}"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tests/test_source_loading.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tests/test_source_loading.py
@@ -1,9 +1,15 @@
 import ast
+import sys
+import subprocess
 from pathlib import Path
 
 from unittest.mock import patch
 
-from products.warehouse_sources.backend.temporal.data_imports.sources import _source_module_paths, load_all_sources
+from products.warehouse_sources.backend.temporal.data_imports.sources import (
+    _module_paths_by_source_type,
+    _source_module_paths,
+    load_all_sources,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -35,3 +41,64 @@ def test_per_source_fallback_covers_every_source_the_bulk_import_loads():
         for node in ast.walk(bulk_import_list)
         if isinstance(node, ast.ImportFrom) and node.module
     }
+
+
+def test_every_source_type_maps_to_exactly_one_source_module():
+    mapping = _module_paths_by_source_type()
+
+    assert set(mapping) == set(ExternalDataSourceType)
+    assert sorted(mapping.values()) == _source_module_paths()
+
+
+# Runs in a clean interpreter: pytest has long since imported source modules into this
+# process, so only a cold subprocess can observe which modules a targeted lookup pulls in.
+_TARGETED_LOAD_SCRIPT = f"""
+import os
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
+import django
+django.setup()
+
+import sys
+from unittest.mock import patch
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
+from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+SOURCES = "{_SOURCES}"
+for module in (SOURCES + "._load_all", SOURCES + ".postgres.source", SOURCES + ".stripe.source"):
+    assert module not in sys.modules, module + " already imported at django.setup(); no cold state to observe"
+
+postgres = SourceRegistry.get_source(ExternalDataSourceType.POSTGRES)
+assert type(postgres).__name__ == "PostgresSource", type(postgres).__name__
+assert type(postgres).__module__ == SOURCES + ".postgres.source", type(postgres).__module__
+assert SOURCES + ".postgres.source" in sys.modules
+assert SOURCES + "._load_all" not in sys.modules, "get_source ran the full-catalog loader"
+assert SOURCES + ".stripe.source" not in sys.modules, "get_source imported an unrelated source"
+
+stripe = SourceRegistry.get_source(ExternalDataSourceType.STRIPE)
+assert type(stripe).__name__ == "StripeSource", type(stripe).__name__
+assert SOURCES + ".stripe.source" in sys.modules
+assert SOURCES + "._load_all" not in sys.modules, "the second lookup ran the full-catalog loader"
+
+assert SourceRegistry.is_registered(ExternalDataSourceType.MYSQL)
+assert SOURCES + ".mysql.source" in sys.modules, "is_registered did not load the requested source"
+assert SOURCES + "._load_all" not in sys.modules, "is_registered ran the full-catalog loader"
+
+with patch(SOURCES + ".load_source") as load_source:
+    assert SourceRegistry.get_source(ExternalDataSourceType.POSTGRES) is postgres
+    load_source.assert_not_called()
+
+with patch(SOURCES + ".load_all_sources") as load_all_sources:
+    SourceRegistry.get_all_sources()
+    load_all_sources.assert_called_once()
+"""
+
+
+def test_get_source_imports_only_the_requested_source_module():
+    result = subprocess.run(
+        [sys.executable, "-c", _TARGETED_LOAD_SCRIPT],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert result.returncode == 0, f"targeted-load subprocess failed:\n{result.stderr[-4000:]}"


### PR DESCRIPTION
## Problem

- The first warehouse-source lookup in a process stalls while the whole catalog imports: ~1,300 source modules and their vendor SDKs for one requested source.
- Cold on a dev checkout, `SourceRegistry.get_source(POSTGRES)` took 8.7 s and imported 1,289 source modules; the postgres module alone accounts for 2.9 s.
- The registry already defers catalog loading to first use; this PR narrows first use from "everything" to the requested source.

## Changes

- `SourceRegistry.get_source` and `is_registered` import only the requested source's module; the rest of the catalog stays unimported.
- A new `load_source(source_type)` resolves each type's module by name normalization (lowercase, drop underscores), plus an explicit override table for future names that stop pairing up.
- Normalization beats the obvious camel-to-snake rule, which resolves 145 of the 1,289 types to the wrong directory ("TikTokAds" vs `tiktok_ads`, "DoIt" vs `doit`); tests hold the mapping to a bijection with the enum and the on-disk catalog.
- Complete-catalog callers (`get_all_sources`, `get_registered_types`, the Temporal worker prewarm) still call `load_all_sources()`, because each needs every source. The prewarm keeps importing every vendor SDK once per process at boot.
- A targeted load shares the existing double-checked load lock and never marks the catalog as loaded; repeated lookups return the registered instance without re-importing.
- Failure isolation is unchanged: a source module that fails to import is reported once and its type reads as unregistered, leaving other sources usable.
- Independent of #82137 (direct-Postgres phase timings); nothing here uses it.

## How did you test this code?

- A new cold-subprocess test drives the whole targeted path: `get_source(POSTGRES)` returns `PostgresSource` without importing `_load_all` or the stripe source. It then loads stripe separately, checks `is_registered(MYSQL)` loads only mysql, and checks a repeated lookup does not re-invoke the loader. Finally `get_all_sources` must still invoke the bulk loader. Catches a revert to whole-catalog loading, which no existing test observed.
- `test_every_source_type_maps_to_exactly_one_source_module` catches a new source whose enum value and directory stop pairing, which would otherwise surface as `Unknown source type` at runtime.
- `test_source_module_mapping_matches_where_each_registered_source_lives` (in the full-import test file, where the catalog load is already paid) catches a mapping entry that resolves to the wrong existing module.
- Ran `hogli test products/warehouse_sources/backend/temporal/data_imports/sources/tests/` (includes the unchanged broken-source fallback tests), `hogli ci:preflight --fix`, and repo-wide `uv run mypy --cache-fine-grained .`, all clean locally.
- Before/after, cold process (fresh interpreter, `django.setup()`, one `get_source(POSTGRES)`, count `sources.*.source` entries in `sys.modules`): 8.7 s and 1,289 source modules with `_load_all` imported, versus 2.9 s and 1 source module with no `_load_all`.
- Not covered by a new test: concurrent first access. The lock pattern is the existing double-checked `_load_lock`; a thread-race test would be nondeterministic, so the subprocess test asserts the observable invariants instead.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: no doc describes the registry's loading behavior.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored by Claude Code from a written task brief; the session ran tests and measurements in a cloud dev VM.
- Skills invoked: `/django-startup-time`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Considered a fully explicit 1,289-entry type-to-module table; chose derivation plus an override table so adding a source needs no mapping edit, with the bijection tests keeping it honest.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
