### PR TITLE
fix(data-imports): stop reporting transient App Store Connect 5xx/429 as unhandled errors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/source.py
@@ -121,10 +121,17 @@ Sales and subscription reports also need your vendor number (App Store Connect â
 
     def get_retryable_errors(self) -> set[str]:
         # `_get` has no retry loop of its own â€” it relies on the tracked session's urllib3 adapter
-        # to retry a connection failure or read timeout. Once that budget is exhausted, Temporal
-        # retries the whole activity, so this is transient and self-recovering. The host is fixed
-        # (never user input), so matching on it doesn't risk swallowing an unrelated failure.
-        return {"HTTPSConnectionPool(host='api.appstoreconnect.apple.com'"}
+        # to retry a connection failure, read timeout, or 429/5xx response. Once that budget is
+        # exhausted, Temporal retries the whole activity, so this is transient and self-recovering.
+        # The host is fixed (never user input), so matching on it doesn't risk swallowing an
+        # unrelated failure. `requests.Response.raise_for_status` derives "Server Error"/"Client
+        # Error" prefixes from the status code alone, not the vendor's reason text, so they're
+        # stable to match on (see mailchimp/convex sources for the same pattern).
+        return {
+            "HTTPSConnectionPool(host='api.appstoreconnect.apple.com'",
+            "Server Error",
+            "429 Client Error",
+        }
 
     def get_schemas(
         self,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/tests/test_app_store_connect_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/tests/test_app_store_connect_source.py
@@ -217,6 +217,14 @@ class TestAppStoreConnectSource:
                 "read_timeout",
                 "HTTPSConnectionPool(host='api.appstoreconnect.apple.com', port=443): Read timed out. (read timeout=60)",
             ),
+            (
+                "server_error",
+                "500 Server Error: Internal Server Error for url: https://api.appstoreconnect.apple.com/v1/salesReports?filter%5Bfrequency%5D=DAILY",
+            ),
+            (
+                "rate_limited",
+                "429 Client Error: Too Many Requests for url: https://api.appstoreconnect.apple.com/v1/salesReports",
+            ),
         ]
     )
     def test_retryable_errors_match_transient_network_failures(self, _name: str, observed_error: str) -> None:


### PR DESCRIPTION
## Problem

An App Store Connect sync that hits a transient 500 or 429 from Apple's sales-report API reports an unhandled exception to error tracking, even though the request already exhausted its retry budget and Temporal would retry the sync on its own.

## Changes

- `AppStoreConnectSource.get_retryable_errors()` only matched connection-level failures (a fixed connection-pool host string), not an HTTP-level 5xx/429 that survives the tracked session's urllib3 retry adapter and reaches `raise_for_status()`.
- Added `"Server Error"` and `"429 Client Error"` entries, matching the pattern already used by the Mailchimp and Convex sources — `requests.Response.raise_for_status()` derives these prefixes from the status code alone, not the vendor's reason text, so they're stable to match on.
- Once matched, the error is logged as a warning and re-raised for Temporal's activity-level retry, instead of being reported as a defect.

## How did you test this code?

Added 2 cases to the existing `test_retryable_errors_match_transient_network_failures` parameterized test (a 500 and a 429 for the sales-report endpoint) — guards the two new entries in `get_retryable_errors()`.

Ran locally: `pytest products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/tests/test_app_store_connect_source.py` — 27 passed.
Not run: the full CI suite (relies on CI to confirm).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated a live PostHog error-tracking issue (`HTTPError` from `products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/app_store_connect.py`) via the PostHog MCP error-tracking tools, then traced the call chain into `AppStoreConnectSource.get_retryable_errors()` to find the missing entries. Compared against the Mailchimp and Convex sources, which already handle this class of transient error the same way.