### PR TITLE
feat(desktop): keep polling for updates after one is staged

### DIFF
--- a/products/desktop/apps/code/src/main/index.ts
+++ b/products/desktop/apps/code/src/main/index.ts
@@ -438,10 +438,6 @@ app.whenReady().then(async () => {
 
   if (process.env.POSTHOG_E2E_UPDATE_FEED) {
     const updates = container.get<UpdatesService>(UPDATES_SERVICE);
-    // Pin the re-staging rollout on: the packaged e2e app boots posthog with
-    // an anonymous user whose flags would otherwise sync this off mid-test.
-    updates.setStagedUpdatesEnabled(true);
-    updates.setStagedUpdatesEnabled = () => {};
     Object.assign(globalThis, {
       __e2eUpdates: {
         check: () => updates.checkForUpdates(),

--- a/products/desktop/apps/code/src/renderer/platform-adapters/updates.ts
+++ b/products/desktop/apps/code/src/renderer/platform-adapters/updates.ts
@@ -6,7 +6,6 @@ import {
   updateStore,
 } from "@posthog/core/updates/updateStore";
 import { resolveService } from "@posthog/di/container";
-import { STAGED_UPDATES_FLAG } from "@posthog/shared";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import {
   UPDATES_CLIENT,
@@ -14,7 +13,6 @@ import {
 } from "@posthog/ui/features/updates/updatesClient";
 import { toast } from "@posthog/ui/primitives/toast";
 import { logger } from "@posthog/ui/shell/logger";
-import { posthogFeatureFlags } from "@posthog/ui/shell/posthogAnalyticsImpl";
 import { hostTrpcClient } from "@renderer/trpc/client";
 
 const log = logger.scope("updates-host");
@@ -129,25 +127,6 @@ function syncAutoDownload(enabled: boolean): void {
       log.error("Failed to sync auto-download preference", { error }),
     );
 }
-
-// Bridge the staged-updates rollout flag to the core updater; the service
-// defaults to off until posthog flags load and this sync lands.
-let lastSyncedStagedUpdates: boolean | null = null;
-function syncStagedUpdates(): void {
-  const enabled = posthogFeatureFlags.isEnabled(STAGED_UPDATES_FLAG);
-  if (enabled === lastSyncedStagedUpdates) return;
-  lastSyncedStagedUpdates = enabled;
-  void hostTrpcClient.updates.setStagedUpdates
-    .mutate({ enabled })
-    .catch((error: unknown) => {
-      // Forget the failed sync so the next flags-loaded callback retries it.
-      if (lastSyncedStagedUpdates === enabled) {
-        lastSyncedStagedUpdates = null;
-      }
-      log.error("Failed to sync staged-updates flag", { error });
-    });
-}
-posthogFeatureFlags.onFlagsLoaded(syncStagedUpdates);
 
 function onSettingsReady(): void {
   syncAutoDownload(useSettingsStore.getState().downloadUpdatesAutomatically);

--- a/products/desktop/packages/core/src/updates/updates.test.ts
+++ b/products/desktop/packages/core/src/updates/updates.test.ts
@@ -488,7 +488,6 @@ describe("UpdatesService", () => {
 
     it("rejects install while a newer update is re-downloading", async () => {
       await initializeService(service);
-      service.setStagedUpdatesEnabled(true);
       service.setAutoDownloadEnabled(true);
 
       updaterHandlers.updateDownloaded?.("v2.0.0");
@@ -556,7 +555,6 @@ describe("UpdatesService", () => {
     });
 
     it("ignores update-not-available once an update is already downloaded", () => {
-      service.setStagedUpdatesEnabled(true);
       // Simulate update already downloaded
       const downloadedHandler = updaterHandlers.updateDownloaded;
       if (downloadedHandler) {
@@ -746,10 +744,6 @@ describe("UpdatesService", () => {
   });
 
   describe("available update guards", () => {
-    beforeEach(() => {
-      service.setStagedUpdatesEnabled(true);
-    });
-
     it("background-checks without clearing the banner on periodic checks while available", async () => {
       await initializeService(service);
 
@@ -1063,10 +1057,6 @@ describe("UpdatesService", () => {
   });
 
   describe("periodic update checks", () => {
-    beforeEach(() => {
-      service.setStagedUpdatesEnabled(true);
-    });
-
     it("performs initial check on setup", async () => {
       await initializeService(service);
 
@@ -1149,10 +1139,6 @@ describe("UpdatesService", () => {
   });
 
   describe("staged update guards", () => {
-    beforeEach(() => {
-      service.setStagedUpdatesEnabled(true);
-    });
-
     it("background-checks on periodic checks without disturbing the staged update", async () => {
       await initializeService(service);
 
@@ -1567,108 +1553,6 @@ describe("UpdatesService", () => {
     });
   });
 
-  describe("staged updates rollout flag", () => {
-    it("stops the periodic interval once an update is staged while off", async () => {
-      await initializeService(service);
-
-      updaterHandlers.updateDownloaded?.("v2.0.0");
-      mockUpdater.check.mockClear();
-
-      await vi.advanceTimersByTimeAsync(60 * 60 * 1000 * 3);
-
-      expect(mockUpdater.check).not.toHaveBeenCalled();
-      expect(service.hasUpdateReady).toBe(true);
-    });
-
-    it.each([
-      [
-        "ready",
-        () => updaterHandlers.updateDownloaded?.("v2.0.0"),
-        "check skipped because update is already staged",
-      ],
-      [
-        "available",
-        () =>
-          updaterHandlers.updateAvailable?.({
-            version: "v2.0.0",
-            releaseNotes: null,
-          }),
-        "periodic check skipped because an update is already available",
-      ],
-    ])(
-      "skips periodic checks while %s without checking while off",
-      async (_state, arrange, reason) => {
-        await initializeService(service);
-        arrange();
-
-        mockUpdater.check.mockClear();
-        mockLog.info.mockClear();
-
-        const result = service.checkForUpdates("periodic");
-
-        expect(result).toEqual({ success: true });
-        expect(mockUpdater.check).not.toHaveBeenCalled();
-        expect(mockLog.info).toHaveBeenCalledWith(
-          "Update state transition",
-          expect.objectContaining({ reason }),
-        );
-      },
-    );
-
-    it("ignores update-available while an update is staged while off", async () => {
-      await initializeService(service);
-      service.setAutoDownloadEnabled(true);
-
-      updaterHandlers.updateDownloaded?.("v2.0.0");
-
-      mockUpdater.download.mockClear();
-      updaterHandlers.updateAvailable?.({
-        version: "v3.0.0",
-        releaseNotes: null,
-      });
-
-      expect(mockUpdater.download).not.toHaveBeenCalled();
-      expect(service.getStatus()).toEqual({
-        checking: false,
-        updateReady: true,
-        installing: false,
-        version: "v2.0.0",
-      });
-    });
-
-    it("keeps the staged version when a later download event arrives while off", async () => {
-      await initializeService(service);
-
-      const readyHandler = vi.fn();
-      service.on(UpdatesEvent.Ready, readyHandler);
-      updaterHandlers.updateDownloaded?.("v2.0.0");
-      readyHandler.mockClear();
-
-      updaterHandlers.updateDownloaded?.("v3.0.0");
-
-      expect(readyHandler).not.toHaveBeenCalled();
-      expect(service.getStatus()).toEqual({
-        checking: false,
-        updateReady: true,
-        installing: false,
-        version: "v2.0.0",
-      });
-    });
-
-    it("resumes polling when the flag turns on after an update is staged", async () => {
-      await initializeService(service);
-
-      updaterHandlers.updateDownloaded?.("v2.0.0");
-      mockUpdater.check.mockClear();
-
-      service.setStagedUpdatesEnabled(true);
-      await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
-
-      expect(mockUpdater.check).toHaveBeenCalledTimes(1);
-      expect(service.hasUpdateReady).toBe(true);
-    });
-  });
-
   describe("transition logging", () => {
     it("logs state transitions with source and state metadata", () => {
       service.checkForUpdates("user");
@@ -1687,7 +1571,6 @@ describe("UpdatesService", () => {
 
     it("logs background checks after an update is staged", async () => {
       await initializeService(service);
-      service.setStagedUpdatesEnabled(true);
       updaterHandlers.updateDownloaded?.("v2.0.0");
 
       mockLog.info.mockClear();
@@ -1755,7 +1638,6 @@ describe("UpdatesService", () => {
 
     it("keeps the staged state when a background check throws synchronously", async () => {
       await initializeService(service);
-      service.setStagedUpdatesEnabled(true);
       updaterHandlers.updateDownloaded?.("v2.0.0");
 
       const statusHandler = vi.fn();

--- a/products/desktop/packages/core/src/updates/updates.ts
+++ b/products/desktop/packages/core/src/updates/updates.ts
@@ -97,7 +97,6 @@ export class UpdatesService extends TypedEventEmitter<UpdatesEvents> {
   private availableInfo: UpdateAvailableInfo | null = null;
   private downloadProgress: UpdateDownloadProgress | null = null;
   private autoDownloadEnabled = false;
-  private stagedUpdatesEnabled = false;
   private lastProgressEmit = 0;
   private activeDownload: Promise<void> | null = null;
 
@@ -136,25 +135,6 @@ export class UpdatesService extends TypedEventEmitter<UpdatesEvents> {
 
     if (enabled && this.state === "available") {
       this.requestDownload();
-    }
-  }
-
-  // Synced from the posthog-desktop-staged-updates rollout flag; off keeps
-  // the legacy flow where polling stops once an update is staged.
-  setStagedUpdatesEnabled(enabled: boolean): void {
-    if (enabled === this.stagedUpdatesEnabled) {
-      return;
-    }
-    this.stagedUpdatesEnabled = enabled;
-    this.log.info("Staged-updates rollout flag updated", { enabled });
-
-    // The flag arrives async after boot; if a staged download already stopped
-    // the legacy interval, restart it so background checks resume.
-    if (enabled && this.initialized && this.checkIntervalId === null) {
-      this.checkIntervalId = setInterval(
-        () => this.checkForUpdates("periodic"),
-        UpdatesService.CHECK_INTERVAL_MS,
-      );
     }
   }
 
@@ -249,17 +229,6 @@ export class UpdatesService extends TypedEventEmitter<UpdatesEvents> {
       source === "periodic" &&
       (this.state === "ready" || this.state === "available")
     ) {
-      if (!this.stagedUpdatesEnabled) {
-        this.logStateTransition(this.state, {
-          source,
-          skippedBecauseUpdateStaged: this.state === "ready",
-          reason:
-            this.state === "ready"
-              ? "check skipped because update is already staged"
-              : "periodic check skipped because an update is already available",
-        });
-        return { success: true };
-      }
       return this.performBackgroundCheck(source);
     }
 
@@ -454,16 +423,6 @@ export class UpdatesService extends TypedEventEmitter<UpdatesEvents> {
       return;
     }
 
-    if (this.state === "ready" && !this.stagedUpdatesEnabled) {
-      this.log.info(
-        "Ignoring update-available because an update is already staged",
-        {
-          downloadedVersion: this.downloadedVersion,
-        },
-      );
-      return;
-    }
-
     // Strictly newer only: a manifest rollback must not downgrade what is
     // already staged, regardless of state — an offer accepted while
     // "available" or "downloading" would still re-stage over the download.
@@ -570,9 +529,7 @@ export class UpdatesService extends TypedEventEmitter<UpdatesEvents> {
 
     if (
       this.state === "installing" ||
-      (this.state === "ready" &&
-        (!this.stagedUpdatesEnabled ||
-          (version ?? null) === this.downloadedVersion))
+      (this.state === "ready" && (version ?? null) === this.downloadedVersion)
     ) {
       this.log.info("Ignoring duplicate update-downloaded event", {
         existingVersion: this.downloadedVersion,
@@ -586,9 +543,6 @@ export class UpdatesService extends TypedEventEmitter<UpdatesEvents> {
       reason: "update downloaded",
       incomingVersion: version ?? null,
     });
-    if (!this.stagedUpdatesEnabled) {
-      this.clearCheckInterval();
-    }
     this.emitStatus(this.stagedStatusPayload());
 
     this.log.info("Update downloaded, awaiting user confirmation", {

--- a/products/desktop/packages/host-router/src/routers/updates.router.ts
+++ b/products/desktop/packages/host-router/src/routers/updates.router.ts
@@ -54,14 +54,6 @@ export const updatesRouter = router({
         .setAutoDownloadEnabled(input.enabled);
     }),
 
-  setStagedUpdates: publicProcedure
-    .input(z.object({ enabled: z.boolean() }))
-    .mutation(({ ctx, input }) => {
-      ctx.container
-        .get<UpdatesService>(UPDATES_SERVICE)
-        .setStagedUpdatesEnabled(input.enabled);
-    }),
-
   onReady: subscribe(UpdatesEvent.Ready),
   onStatus: subscribe(UpdatesEvent.Status),
   onCheckFromMenu: subscribe(UpdatesEvent.CheckFromMenu),

--- a/products/desktop/packages/shared/src/flags.ts
+++ b/products/desktop/packages/shared/src/flags.ts
@@ -39,12 +39,6 @@ export const MCP_GATEWAY_FLAG = "mcp-gateway";
 /** Per-task estimated cost readout in the context usage indicator. */
 export const TASK_COST_FLAG = "posthog-code-task-cost";
 /**
- * Rollout gate for re-staging desktop updates: keep polling after an update
- * is staged and replace it when the feed offers a newer version. Off keeps
- * the legacy stop-polling-once-staged behavior.
- */
-export const STAGED_UPDATES_FLAG = "posthog-desktop-staged-updates";
-/**
  * Remote in-app announcements. The flag's JSON payload carries the
  * announcements (schema: `announcements.ts`); rollout % arms the system.
  * All broad announcements go through this — do not add ad-hoc promo


### PR DESCRIPTION
## Problem

- Desktop users stop receiving new releases once an update is offered or staged: the app halts its hourly check until the next relaunch.
- The fixed behavior (keep polling, re-stage strictly newer versions) exists but sits behind the `posthog-desktop-staged-updates` flag, which defaults off until PostHog flags load. Anonymous and keyless sessions never turn it on.

## Changes

- The updater now always keeps its hourly check running while an update is available or staged, and re-stages a strictly newer version.
- Removes the flag constant, the `setStagedUpdatesEnabled` service method, the `updates.setStagedUpdates` tRPC procedure and the renderer flag sync.
- Removes the e2e pin in `apps/code/src/main/index.ts` that forced the flag on for packaged update tests.
- The `posthog-desktop-staged-updates` flag can be deleted in PostHog once this ships.

No visual changes.

## How did you test this code?

- Ran the `@posthog/core` and `@posthog/host-router` Vitest suites and `pnpm typecheck` from `products/desktop` locally.
- Deleted the flag-off unit tests with the legacy path they covered. The existing staged-update guards (keep polling, re-stage newer, ignore rollback) now exercise the default path, so no new tests.
- Not run locally: the packaged update-chain Playwright suite, which needs a packaged build.
