### PR TITLE
fix(postgres): guard host validation for configs without an ssh tunnel

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/planetscale_postgres/test_planetscale_postgres_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/planetscale_postgres/test_planetscale_postgres_source.py
@@ -115,6 +115,26 @@ def test_database_host_is_passed_through_to_postgres():
     assert error is None
 
 
+def test_validate_credentials_handles_a_config_without_an_ssh_tunnel_field():
+    # The generated PlanetScale config carries no `ssh_tunnel` field (there is no tunnel to
+    # configure), so the inherited Postgres validation must not assume the attribute exists.
+    planetscale_config = PlanetScalePostgresSourceConfig(
+        host=_DIRECT_HOST,
+        database="postgres",
+        user="postgres.xxxxxxxxxx",
+        password="pscale_pw_xxxxxxxx",
+        port=5432,
+    )
+    assert not hasattr(planetscale_config, "ssh_tunnel")
+
+    with mock.patch.object(PostgresSource, "is_database_host_valid", return_value=(False, "host error")) as host_valid:
+        success, error = PlanetScalePostgresSource().validate_credentials(planetscale_config, team_id=1)
+
+    assert success is False
+    assert error == "host error"
+    assert host_valid.call_args.kwargs["using_ssh_tunnel"] is False
+
+
 @pytest.mark.parametrize("port", [6432, "6432"])
 def test_cdc_on_the_psbouncer_port_fails_without_connecting(port):
     # PSBouncer accepts normal connections, so the generic prerequisite checks would pass while

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/planetscale_postgres/test_planetscale_postgres_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/planetscale_postgres/test_planetscale_postgres_source.py
@@ -128,7 +128,9 @@ def test_validate_credentials_handles_a_config_without_an_ssh_tunnel_field():
     assert not hasattr(planetscale_config, "ssh_tunnel")
 
     with mock.patch.object(PostgresSource, "is_database_host_valid", return_value=(False, "host error")) as host_valid:
-        success, error = PlanetScalePostgresSource().validate_credentials(planetscale_config, team_id=1)
+        # The signature annotates PostgresSourceConfig, but the pipeline hands this source its own
+        # generated config at runtime — the exact mismatch that surfaced the missing attribute.
+        success, error = PlanetScalePostgresSource().validate_credentials(planetscale_config, team_id=1)  # type: ignore[arg-type]
 
     assert success is False
     assert error == "host error"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -1104,7 +1104,7 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
             return False, _HOST_IS_URL_ERROR
 
         valid_host, host_errors = self.is_database_host_valid(
-            config.host, team_id, using_ssh_tunnel=config.ssh_tunnel.enabled if config.ssh_tunnel else False
+            config.host, team_id, using_ssh_tunnel=self.ssh_tunnel_enabled(config)
         )
         if not valid_host:
             return valid_host, host_errors


### PR DESCRIPTION
## Problem

- A user validating PlanetScale Postgres credentials saw the check crash instead of returning a result.
- PlanetScale Postgres reuses the Postgres source, but its generated config has no `ssh_tunnel` field (there is no tunnel to configure).
- The inherited `validate_credentials` read `config.ssh_tunnel.enabled` directly, raising `AttributeError: 'PlanetScalePostgresSourceConfig' object has no attribute 'ssh_tunnel'`.
- Error tracking issue: https://us.posthog.com/project/2/error_tracking/019ff8e8-ce6e-76a3-aa5d-bb17389ee6c0

## Changes

- Host validation now resolves the SSH-tunnel setting through the mixin's `ssh_tunnel_enabled` helper, which reads it via `getattr` and returns `False` when the field is absent.
- This is a code bug, not a user or upstream condition, so `NonRetryableErrors` was not touched.
- The sibling call on the line above (`ssh_tunnel_is_valid`) already guarded with `hasattr`; this was the one unguarded access.

## How did you test this code?

- Added `test_validate_credentials_handles_a_config_without_an_ssh_tunnel_field`, which runs the real inherited validation against a `PlanetScalePostgresSourceConfig`. Existing tests all mocked `PostgresSource.validate_credentials`, so the crashing line never ran.
- Confirmed the new test reproduces the `AttributeError` with the fix reverted and passes with it.
- Ran the `planetscale_postgres` source test module locally.
- Not run: the wider warehouse suites; CI covers those.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored by Claude Code triaging a live error-tracking issue for the Postgres data-warehouse import source.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Confirmed the failure originates in this source's own code path (`postgres/source.py:validate_credentials`, inherited by `PlanetScalePostgresSource`) before making any change, and searched for human-authored duplicate PRs (none found).
