### PR TITLE
fix(data-warehouse): classify one-shot source setup errors

### DIFF
--- a/products/warehouse_sources/backend/presentation/views/external_data_source.py
+++ b/products/warehouse_sources/backend/presentation/views/external_data_source.py
@@ -3239,8 +3239,13 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 data={"message": f"Source type '{source_type}' does not support one-shot setup."},
             )
         except Exception as e:
-            capture_exception(e, {"source_type": source_type, "team_id": self.team_id})
-            return Response(status=status.HTTP_400_BAD_REQUEST, data={"message": str(e)})
+            # Credentials validated above can still fail here — `get_schemas` opens its own
+            # connection — so classify via the source's non-retryable-error map, same as `create`,
+            # `database_schema`, and `refresh_schemas`, instead of surfacing the raw driver error.
+            error_message, is_expected_source_error = _classify_refresh_schemas_error(source, e)
+            if not is_expected_source_error:
+                capture_exception(e, {"source_type": source_type, "team_id": self.team_id})
+            return Response(status=status.HTTP_400_BAD_REQUEST, data={"message": error_message})
 
         if not source_schemas:
             return Response(

--- a/products/warehouse_sources/backend/tests/api/test_external_data_source.py
+++ b/products/warehouse_sources/backend/tests/api/test_external_data_source.py
@@ -11429,6 +11429,34 @@ class TestExternalDataSourceSetup(APIBaseTest):
         mock_capture_exception.assert_not_called()
         assert not ExternalDataSource.objects.filter(team=self.team).exists()
 
+    @patch("products.warehouse_sources.backend.presentation.views.external_data_source.capture_exception")
+    @patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.stripe.source.StripeSource.validate_credentials",
+        return_value=(True, None),
+    )
+    def test_setup_classifies_schema_discovery_error_instead_of_leaking_raw(
+        self, _mock_validate, mock_capture_exception
+    ):
+        # Credentials pass the earlier gate, but `get_schemas` opens its own connection and can still
+        # fail (e.g. the key expired in between). One-shot setup must classify via the source's
+        # non-retryable-error map, same as the `create` path, not surface the raw driver error.
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.stripe.source.StripeSource.get_schemas",
+            side_effect=Exception("Expired API Key provided"),
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.pk}/external_data_sources/setup/",
+                data={
+                    "source_type": "Stripe",
+                    "prefix": "stripe_setup_error",
+                    "payload": {"auth_method": {"selection": "api_key", "stripe_secret_key": "sk_test_123"}},
+                },
+            )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        assert response.json()["message"] == "Your Stripe API key has expired. Please create a new key and reconnect."
+        mock_capture_exception.assert_not_called()
+        assert not ExternalDataSource.objects.filter(team=self.team).exists()
+
     def test_create_rejects_source_without_schema_discovery_without_persisting(self):
         # AmazonS3 is an unreleased scaffold with no get_schemas. Creating it must 400 and leave no
         # row behind — otherwise get_schemas raises NotImplementedError as an uncaught 500 after the


### PR DESCRIPTION
## Problem

- Someone setting up a data warehouse source through one-shot setup (the AI-assisted / MCP path) saw a raw database driver error when schema discovery failed, with nothing telling them what to fix.
- The `setup` endpoint returned `str(e)` on any `get_schemas` failure, while the interactive create, `database_schema`, and `refresh_schemas` paths all classify the same failure through `_classify_refresh_schemas_error`.

## Changes

- Route the `setup` endpoint's schema-discovery failure through `_classify_refresh_schemas_error`, matching the three sibling paths.
- Show the source's curated message (for example an expired-key or connection-refused hint) instead of the raw driver text.
- Capture only unexpected errors to error tracking; expected, classified failures stop adding noise.

## How did you test this code?

- Added `test_setup_classifies_schema_discovery_error_instead_of_leaking_raw`: a Stripe one-shot setup whose schema discovery raises "Expired API Key provided" now returns the curated message and does not capture the exception. It catches a regression where `setup` reverts to raw `str(e)` or loses the classifier wiring. No existing test covered the setup path's generic-exception branch, only its `NotImplementedError` branch and the create path's classification.
- Ran the new test and the sibling `test_setup_rejects_source_without_schema_discovery` against a freshly built test database: both pass.
- Not run: the broader warehouse suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- I (actually Claude) made this change while triaging data warehouse onboarding friction from session summaries; the recurring theme was unclear errors on failed source connections.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- The fix reuses the existing `_classify_refresh_schemas_error` classifier rather than adding new per-connector strings, so it inherits every source's curated messages and stays consistent with the create and refresh paths.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
