### PR TITLE
fix(desktop): auto-retry the run stream on a 401

### DIFF
--- a/products/desktop/packages/core/src/cloud-task/cloud-task-engine.ts
+++ b/products/desktop/packages/core/src/cloud-task/cloud-task-engine.ts
@@ -317,10 +317,6 @@ function createStreamStatusError(status: number): CloudTaskStreamError {
           title: "Cloud authentication expired",
           message: "Please reauthenticate and retry the cloud run stream.",
           retryable: true,
-          // Every reconnect re-authenticates (authenticatedFetch refreshes the session token, the
-          // proxy leg re-mints its read token), so a 401 from a deploy window or an auth blip
-          // heals itself on a later attempt. The bounded reconnect budget turns a persistent 401
-          // into this banner instead of a single failed attempt doing so.
           autoRetry: true,
         },
         status,
@@ -1554,8 +1550,7 @@ export class CloudTaskEngine extends TypedEventEmitter<CloudTaskEvents> {
       }
 
       // Proxy-leg 401: the read token expired or its signing key rotated. Re-resolve to mint a
-      // fresh token (or route back to Django) instead of failing. A Django-leg 401 falls through
-      // to the reconnect budget below and re-authenticates on every attempt.
+      // fresh token (or route back to Django) instead of failing.
       const unauthorizedWatcher = this.watchers.get(key);
       if (
         error instanceof CloudTaskStreamError &&

--- a/products/desktop/packages/core/src/cloud-task/cloud-task-engine.ts
+++ b/products/desktop/packages/core/src/cloud-task/cloud-task-engine.ts
@@ -317,7 +317,11 @@ function createStreamStatusError(status: number): CloudTaskStreamError {
           title: "Cloud authentication expired",
           message: "Please reauthenticate and retry the cloud run stream.",
           retryable: true,
-          autoRetry: false,
+          // Every reconnect re-authenticates (authenticatedFetch refreshes the session token, the
+          // proxy leg re-mints its read token), so a 401 from a deploy window or an auth blip
+          // heals itself on a later attempt. The bounded reconnect budget turns a persistent 401
+          // into this banner instead of a single failed attempt doing so.
+          autoRetry: true,
         },
         status,
       );
@@ -1550,7 +1554,8 @@ export class CloudTaskEngine extends TypedEventEmitter<CloudTaskEvents> {
       }
 
       // Proxy-leg 401: the read token expired or its signing key rotated. Re-resolve to mint a
-      // fresh token (or route back to Django) instead of failing. Django-leg 401 stays fatal below.
+      // fresh token (or route back to Django) instead of failing. A Django-leg 401 falls through
+      // to the reconnect budget below and re-authenticates on every attempt.
       const unauthorizedWatcher = this.watchers.get(key);
       if (
         error instanceof CloudTaskStreamError &&

--- a/products/desktop/packages/core/src/cloud-task/cloud-task.test.ts
+++ b/products/desktop/packages/core/src/cloud-task/cloud-task.test.ts
@@ -3101,7 +3101,7 @@ describe("CloudTaskEngine", () => {
     expect(mockNetFetch).toHaveBeenCalledTimes(3);
   });
 
-  it("fails a Django-leg watcher on a stream 401 without re-resolving the read target", async () => {
+  it("retries a Django-leg stream 401 and recovers without re-resolving the read target", async () => {
     vi.useFakeTimers();
 
     const updates: unknown[] = [];
@@ -3128,11 +3128,17 @@ describe("CloudTaskEngine", () => {
       );
     });
 
-    // A Django-leg 401 is fatal (autoRetry: false). The proxy re-resolve path is guarded on a
-    // non-null streamBaseUrl, so a Django leg must fail rather than re-mint a stream_token.
-    mockStreamFetch.mockImplementation(() =>
-      Promise.resolve(createJsonResponse({ detail: "expired" }, 401)),
-    );
+    // A deploy-window 401 on the Django leg: the next attempt re-authenticates and succeeds,
+    // so the watcher must recover without surfacing the auth banner.
+    const logFrame =
+      'id: 7\ndata: {"type":"notification","timestamp":"2026-01-01T00:00:02Z","notification":{"jsonrpc":"2.0","method":"_posthog/console","params":{"sessionId":"run-1","level":"info","message":"after recovery"}}}\n\n';
+    mockStreamFetch
+      .mockImplementationOnce(() =>
+        Promise.resolve(createJsonResponse({ detail: "expired" }, 401)),
+      )
+      .mockImplementation(() =>
+        Promise.resolve(createOpenSseResponse(logFrame)),
+      );
 
     service.watch({
       taskId: "task-1",
@@ -3147,10 +3153,58 @@ describe("CloudTaskEngine", () => {
           (u) =>
             typeof u === "object" &&
             u !== null &&
-            (u as { kind?: string }).kind === "error",
+            (u as { kind?: string }).kind === "logs",
         ),
       10_000,
     );
+
+    expect(mockStreamFetch.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(updates.some((u) => (u as { kind?: string }).kind === "error")).toBe(
+      false,
+    );
+    // The Django leg reconnects as itself: no stream_token re-mint on a 401.
+    expect(mockStreamTokenFetch.mock.calls.length).toBe(1);
+  });
+
+  it("surfaces the auth banner after persistent Django-leg 401s exhaust the reconnect budget", async () => {
+    vi.useFakeTimers();
+
+    const updates: unknown[] = [];
+    service.on(CloudTaskEvent.Update, (payload) => updates.push(payload));
+
+    mockNetFetch.mockImplementation((input: string | Request) => {
+      const url = typeof input === "string" ? input : input.url;
+      if (url.includes("/session_logs/")) {
+        return Promise.resolve(
+          createJsonResponse([], 200, { "X-Has-More": "false" }),
+        );
+      }
+      return Promise.resolve(
+        createJsonResponse({
+          id: "run-1",
+          status: "in_progress",
+          stage: null,
+          output: null,
+          error_message: null,
+          branch: "main",
+          updated_at: "2026-01-01T00:00:00Z",
+        }),
+      );
+    });
+
+    mockStreamFetch.mockImplementation(() =>
+      Promise.resolve(createJsonResponse({ detail: "expired" }, 401)),
+    );
+
+    service.watch({
+      taskId: "task-1",
+      runId: "run-1",
+      apiHost: "https://app.example.com",
+      teamId: 2,
+    });
+
+    await waitFor(() => mockStreamFetch.mock.calls.length >= 1, 10_000);
+    await vi.advanceTimersByTimeAsync(120_000);
 
     expect(updates).toContainEqual({
       taskId: "task-1",
@@ -3161,12 +3215,11 @@ describe("CloudTaskEngine", () => {
       retryable: true,
     });
 
-    // The Django leg did not re-resolve, and the fatal failure schedules no reconnect.
-    expect(mockStreamTokenFetch.mock.calls.length).toBe(1);
+    // The budget retried several times before failing, and a failed watcher stops for good.
+    expect(mockStreamFetch.mock.calls.length).toBeGreaterThan(2);
     const streamCallsAtFailure = mockStreamFetch.mock.calls.length;
-    await vi.advanceTimersByTimeAsync(10_000);
+    await vi.advanceTimersByTimeAsync(60_000);
     expect(mockStreamFetch.mock.calls.length).toBe(streamCallsAtFailure);
-    expect(mockStreamTokenFetch.mock.calls.length).toBe(1);
   });
 
   it("treats a 429 from stream_token as transient and retries the read-target resolution", async () => {

--- a/products/desktop/packages/core/src/cloud-task/cloud-task.test.ts
+++ b/products/desktop/packages/core/src/cloud-task/cloud-task.test.ts
@@ -3128,8 +3128,6 @@ describe("CloudTaskEngine", () => {
       );
     });
 
-    // A deploy-window 401 on the Django leg: the next attempt re-authenticates and succeeds,
-    // so the watcher must recover without surfacing the auth banner.
     const logFrame =
       'id: 7\ndata: {"type":"notification","timestamp":"2026-01-01T00:00:02Z","notification":{"jsonrpc":"2.0","method":"_posthog/console","params":{"sessionId":"run-1","level":"info","message":"after recovery"}}}\n\n';
     mockStreamFetch
@@ -3162,7 +3160,6 @@ describe("CloudTaskEngine", () => {
     expect(updates.some((u) => (u as { kind?: string }).kind === "error")).toBe(
       false,
     );
-    // The Django leg reconnects as itself: no stream_token re-mint on a 401.
     expect(mockStreamTokenFetch.mock.calls.length).toBe(1);
   });
 
@@ -3215,7 +3212,6 @@ describe("CloudTaskEngine", () => {
       retryable: true,
     });
 
-    // The budget retried several times before failing, and a failed watcher stops for good.
     expect(mockStreamFetch.mock.calls.length).toBeGreaterThan(2);
     const streamCallsAtFailure = mockStreamFetch.mock.calls.length;
     await vi.advanceTimersByTimeAsync(60_000);


### PR DESCRIPTION
## Problem

When the cloud run stream hits a 401, the watcher dies after one attempt. The view freezes until you refocus the window or click retry.

## Changes

- A stream 401 now retries through the existing bounded reconnect budget, re-authenticating on each attempt.
- If the 401 persists, the same auth banner shows once the budget runs out. 403, 404 and 406 still fail fast.

## How did you test this code?

- Engine tests: a transient 401 recovers, a persistent one ends in the banner with retries stopped.
- Full `@posthog/core` suite and `pnpm typecheck`.
