### PR TITLE
fix(desktop): reuse conversation builds across task switches

### DIFF
--- a/products/desktop/packages/ui/src/features/sessions/components/ConversationView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ConversationView.tsx
@@ -147,7 +147,7 @@ export function ConversationView({
     lastTurnInfo,
     isCompacting,
     completedToolCallCount,
-  } = useConversationItems(taskId ?? "", events, isPromptPending, {
+  } = useConversationItems(taskId, events, isPromptPending, {
     showDebugLogs,
   });
 

--- a/products/desktop/packages/ui/src/features/sessions/components/ConversationView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ConversationView.tsx
@@ -147,7 +147,7 @@ export function ConversationView({
     lastTurnInfo,
     isCompacting,
     completedToolCallCount,
-  } = useConversationItems(events, isPromptPending, {
+  } = useConversationItems(taskId ?? "", events, isPromptPending, {
     showDebugLogs,
   });
 

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -1312,9 +1312,14 @@ export function ChatThread({ events, ...props }: ChatThreadProps) {
 
 export function AcpChatThread({ events, ...props }: AcpChatThreadProps) {
   const showDebugLogs = useSettingsStore((state) => state.debugLogsCloudRuns);
-  const { items } = useConversationItems(events, props.isPromptPending, {
-    showDebugLogs,
-  });
+  const { items } = useConversationItems(
+    props.taskId ?? "",
+    events,
+    props.isPromptPending,
+    {
+      showDebugLogs,
+    },
+  );
 
   return (
     <ChatThreadRenderer

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -1313,7 +1313,7 @@ export function ChatThread({ events, ...props }: ChatThreadProps) {
 export function AcpChatThread({ events, ...props }: AcpChatThreadProps) {
   const showDebugLogs = useSettingsStore((state) => state.debugLogsCloudRuns);
   const { items } = useConversationItems(
-    props.taskId ?? "",
+    props.taskId,
     events,
     props.isPromptPending,
     {

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThreadFooter.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThreadFooter.tsx
@@ -40,9 +40,14 @@ export function ChatThreadFooter({
   hasPendingPermission,
 }: ChatThreadFooterProps) {
   const showDebugLogs = useSettingsStore((s) => s.debugLogsCloudRuns);
-  const eventFooterState = useConversationItems(events, isPromptPending, {
-    showDebugLogs,
-  });
+  const eventFooterState = useConversationItems(
+    taskId ?? "",
+    events,
+    isPromptPending,
+    {
+      showDebugLogs,
+    },
+  );
   const lastTurnInfo =
     footerState?.lastTurnInfo ?? eventFooterState.lastTurnInfo;
   const isCompacting =

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThreadFooter.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThreadFooter.tsx
@@ -41,7 +41,7 @@ export function ChatThreadFooter({
 }: ChatThreadFooterProps) {
   const showDebugLogs = useSettingsStore((s) => s.debugLogsCloudRuns);
   const eventFooterState = useConversationItems(
-    taskId ?? "",
+    taskId,
     events,
     isPromptPending,
     {

--- a/products/desktop/packages/ui/src/features/sessions/hooks/useConversationItems.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/hooks/useConversationItems.test.tsx
@@ -1,0 +1,92 @@
+import type { AcpMessage } from "@posthog/shared";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  MAX_CACHED_CONVERSATIONS,
+  useConversationItems,
+} from "./useConversationItems";
+
+function userPromptMsg(ts: number, id: number, text: string): AcpMessage {
+  return {
+    type: "acp_message",
+    ts,
+    message: {
+      jsonrpc: "2.0",
+      id,
+      method: "session/prompt",
+      params: { prompt: [{ type: "text", text }] },
+    },
+  };
+}
+
+function promptResponseMsg(ts: number, id: number): AcpMessage {
+  return {
+    type: "acp_message",
+    ts,
+    message: { jsonrpc: "2.0", id, result: { stopReason: "end_turn" } },
+  };
+}
+
+function conversation(text: string): AcpMessage[] {
+  return [userPromptMsg(1, 1, text), promptResponseMsg(2, 1)];
+}
+
+interface HookProps {
+  conversationKey: string;
+  events: AcpMessage[];
+}
+
+function renderConversationItems(initialProps: HookProps) {
+  return renderHook(
+    ({ conversationKey, events }: HookProps) =>
+      useConversationItems(conversationKey, events, false),
+    { initialProps },
+  );
+}
+
+describe("useConversationItems", () => {
+  it("returns the cached result when switching back to a conversation", () => {
+    const eventsA = conversation("a");
+    const eventsB = conversation("b");
+    const { result, rerender } = renderConversationItems({
+      conversationKey: "a",
+      events: eventsA,
+    });
+    const builtForA = result.current;
+    expect(builtForA.items.length).toBeGreaterThan(0);
+
+    rerender({ conversationKey: "b", events: eventsB });
+    expect(result.current).not.toBe(builtForA);
+
+    rerender({ conversationKey: "a", events: eventsA });
+    expect(result.current).toBe(builtForA);
+  });
+
+  it("rebuilds when a conversation's events change identity", () => {
+    const eventsA = conversation("a");
+    const { result, rerender } = renderConversationItems({
+      conversationKey: "a",
+      events: eventsA,
+    });
+    const builtForA = result.current;
+
+    rerender({ conversationKey: "a", events: [...eventsA] });
+    expect(result.current).not.toBe(builtForA);
+  });
+
+  it("evicts the least recently used conversation past the cap", () => {
+    const eventsA = conversation("a");
+    const { result, rerender } = renderConversationItems({
+      conversationKey: "a",
+      events: eventsA,
+    });
+    const builtForA = result.current;
+
+    for (let i = 0; i < MAX_CACHED_CONVERSATIONS; i++) {
+      rerender({ conversationKey: `other-${i}`, events: conversation(`${i}`) });
+    }
+
+    rerender({ conversationKey: "a", events: eventsA });
+    expect(result.current).not.toBe(builtForA);
+  });
+});

--- a/products/desktop/packages/ui/src/features/sessions/hooks/useConversationItems.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/hooks/useConversationItems.test.tsx
@@ -1,7 +1,9 @@
 import type { AcpMessage } from "@posthog/shared";
 import { renderHook } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { StrictMode } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
+  clearConversationItemCaches,
   MAX_CACHED_CONVERSATIONS,
   useConversationItems,
 } from "./useConversationItems";
@@ -32,7 +34,7 @@ function conversation(text: string): AcpMessage[] {
 }
 
 interface HookProps {
-  conversationKey: string;
+  conversationKey: string | undefined;
   events: AcpMessage[];
 }
 
@@ -40,11 +42,15 @@ function renderConversationItems(initialProps: HookProps) {
   return renderHook(
     ({ conversationKey, events }: HookProps) =>
       useConversationItems(conversationKey, events, false),
-    { initialProps },
+    { initialProps, wrapper: StrictMode },
   );
 }
 
 describe("useConversationItems", () => {
+  beforeEach(() => {
+    clearConversationItemCaches();
+  });
+
   it("returns the cached result when switching back to a conversation", () => {
     const eventsA = conversation("a");
     const eventsB = conversation("b");
@@ -72,6 +78,60 @@ describe("useConversationItems", () => {
 
     rerender({ conversationKey: "a", events: [...eventsA] });
     expect(result.current).not.toBe(builtForA);
+  });
+
+  it("shares one build between instances of the same conversation", () => {
+    const events = conversation("a");
+    const first = renderConversationItems({
+      conversationKey: "a",
+      events,
+    });
+    const second = renderConversationItems({
+      conversationKey: "a",
+      events,
+    });
+
+    expect(second.result.current).toBe(first.result.current);
+
+    first.unmount();
+    second.unmount();
+  });
+
+  it("keeps un-keyed instances isolated from each other", () => {
+    const events = conversation("a");
+    const first = renderConversationItems({
+      conversationKey: undefined,
+      events,
+    });
+    const second = renderConversationItems({
+      conversationKey: undefined,
+      events,
+    });
+
+    expect(second.result.current).not.toBe(first.result.current);
+
+    first.unmount();
+    second.unmount();
+  });
+
+  it("keeps a recently used conversation past the cap", () => {
+    const eventsA = conversation("a");
+    const { result, rerender } = renderConversationItems({
+      conversationKey: "a",
+      events: eventsA,
+    });
+    const builtForA = result.current;
+
+    for (let i = 0; i < MAX_CACHED_CONVERSATIONS - 1; i++) {
+      rerender({ conversationKey: `other-${i}`, events: conversation(`${i}`) });
+    }
+    rerender({ conversationKey: "a", events: eventsA });
+    expect(result.current).toBe(builtForA);
+
+    rerender({ conversationKey: "extra-1", events: conversation("x1") });
+    rerender({ conversationKey: "extra-2", events: conversation("x2") });
+    rerender({ conversationKey: "a", events: eventsA });
+    expect(result.current).toBe(builtForA);
   });
 
   it("evicts the least recently used conversation past the cap", () => {

--- a/products/desktop/packages/ui/src/features/sessions/hooks/useConversationItems.ts
+++ b/products/desktop/packages/ui/src/features/sessions/hooks/useConversationItems.ts
@@ -14,29 +14,53 @@ interface Cache {
   result: BuildResult | null;
 }
 
+export const MAX_CACHED_CONVERSATIONS = 8;
+
+function createCache(): Cache {
+  return {
+    impl: createIncrementalConversationBuilder(),
+    events: null,
+    pending: null,
+    debug: undefined,
+    result: null,
+  };
+}
+
 /**
  * Builds conversation items incrementally — each event is parsed once and
  * completed turns are reused by reference, so a streamed token costs work
- * proportional to the active turn rather than the whole thread. The persistent
- * builder lives in a ref; results are memoized on the (events, pending, debug)
- * triple so unrelated re-renders don't re-derive.
+ * proportional to the active turn rather than the whole thread. Builders and
+ * results are kept per conversation in an LRU-bounded map, so switching tasks
+ * and back returns the cached result instead of re-parsing the whole thread.
+ * Results are memoized on the (events, pending, debug) triple so unrelated
+ * re-renders don't re-derive.
  */
 export function useConversationItems(
+  conversationKey: string,
   events: AcpMessage[],
   isPromptPending: boolean | null,
   options?: BuildConversationOptions,
 ): BuildResult {
-  const ref = useRef<Cache | null>(null);
-  if (!ref.current) {
-    ref.current = {
-      impl: createIncrementalConversationBuilder(),
-      events: null,
-      pending: null,
-      debug: undefined,
-      result: null,
-    };
+  const cachesRef = useRef<Map<string, Cache> | null>(null);
+  if (!cachesRef.current) {
+    cachesRef.current = new Map();
   }
-  const cache = ref.current;
+  const caches = cachesRef.current;
+
+  let cache = caches.get(conversationKey);
+  if (cache) {
+    caches.delete(conversationKey);
+  } else {
+    cache = createCache();
+  }
+  caches.set(conversationKey, cache);
+  if (caches.size > MAX_CACHED_CONVERSATIONS) {
+    const oldest = caches.keys().next().value;
+    if (oldest !== undefined) {
+      caches.delete(oldest);
+    }
+  }
+
   const debug = options?.showDebugLogs;
 
   if (

--- a/products/desktop/packages/ui/src/features/sessions/hooks/useConversationItems.ts
+++ b/products/desktop/packages/ui/src/features/sessions/hooks/useConversationItems.ts
@@ -1,3 +1,4 @@
+import { MAX_CONNECTED_SESSIONS } from "@posthog/core/sessions/sessionEviction";
 import type { AcpMessage } from "@posthog/shared";
 import type {
   BuildConversationOptions,
@@ -14,7 +15,13 @@ interface Cache {
   result: BuildResult | null;
 }
 
-export const MAX_CACHED_CONVERSATIONS = 8;
+export const MAX_CACHED_CONVERSATIONS = MAX_CONNECTED_SESSIONS;
+
+const sharedCaches = new Map<string, Cache>();
+
+export function clearConversationItemCaches(): void {
+  sharedCaches.clear();
+}
 
 function createCache(): Cache {
   return {
@@ -26,37 +33,48 @@ function createCache(): Cache {
   };
 }
 
+function sharedCacheFor(conversationKey: string): Cache {
+  let cache = sharedCaches.get(conversationKey);
+  if (cache) {
+    sharedCaches.delete(conversationKey);
+  } else {
+    cache = createCache();
+  }
+  sharedCaches.set(conversationKey, cache);
+  if (sharedCaches.size > MAX_CACHED_CONVERSATIONS) {
+    const oldest = sharedCaches.keys().next().value;
+    if (oldest !== undefined) {
+      sharedCaches.delete(oldest);
+    }
+  }
+  return cache;
+}
+
 /**
  * Builds conversation items incrementally — each event is parsed once and
  * completed turns are reused by reference, so a streamed token costs work
- * proportional to the active turn rather than the whole thread. Persistent
- * builders live in a ref; results are memoized on the (events, pending, debug)
- * triple so unrelated re-renders don't re-derive.
+ * proportional to the active turn rather than the whole thread. Keyed builders
+ * live in a shared LRU, so every consumer of one conversation reuses one
+ * build and revisiting a recent conversation skips the re-parse; un-keyed
+ * callers get a private single-slot cache. Results are memoized on the
+ * (events, pending, debug) triple so unrelated re-renders don't re-derive.
  */
 export function useConversationItems(
-  conversationKey: string,
+  conversationKey: string | undefined,
   events: AcpMessage[],
   isPromptPending: boolean | null,
   options?: BuildConversationOptions,
 ): BuildResult {
-  const cachesRef = useRef<Map<string, Cache> | null>(null);
-  if (!cachesRef.current) {
-    cachesRef.current = new Map();
-  }
-  const caches = cachesRef.current;
+  const localCacheRef = useRef<Cache | null>(null);
 
-  let cache = caches.get(conversationKey);
-  if (cache) {
-    caches.delete(conversationKey);
+  let cache: Cache;
+  if (conversationKey) {
+    cache = sharedCacheFor(conversationKey);
   } else {
-    cache = createCache();
-  }
-  caches.set(conversationKey, cache);
-  if (caches.size > MAX_CACHED_CONVERSATIONS) {
-    const oldest = caches.keys().next().value;
-    if (oldest !== undefined) {
-      caches.delete(oldest);
+    if (!localCacheRef.current) {
+      localCacheRef.current = createCache();
     }
+    cache = localCacheRef.current;
   }
 
   const debug = options?.showDebugLogs;

--- a/products/desktop/packages/ui/src/features/sessions/hooks/useConversationItems.ts
+++ b/products/desktop/packages/ui/src/features/sessions/hooks/useConversationItems.ts
@@ -29,11 +29,9 @@ function createCache(): Cache {
 /**
  * Builds conversation items incrementally — each event is parsed once and
  * completed turns are reused by reference, so a streamed token costs work
- * proportional to the active turn rather than the whole thread. Builders and
- * results are kept per conversation in an LRU-bounded map, so switching tasks
- * and back returns the cached result instead of re-parsing the whole thread.
- * Results are memoized on the (events, pending, debug) triple so unrelated
- * re-renders don't re-derive.
+ * proportional to the active turn rather than the whole thread. Persistent
+ * builders live in a ref; results are memoized on the (events, pending, debug)
+ * triple so unrelated re-renders don't re-derive.
  */
 export function useConversationItems(
   conversationKey: string,


### PR DESCRIPTION
## Problem

Switching tasks re-parses the whole chat transcript on the main thread, even when switching straight back to a task you just viewed. Long threads block the UI for hundreds of ms per switch.

## Changes

- Conversation builds are cached per task in a shared LRU (capped to the session limit), so revisiting a recent task reuses the built thread.
- The thread and its footer now share one build instead of each parsing the same events.
- Conversations without a task id keep a private single-slot cache, so unrelated agent chats can't collide.

## How did you test this code?

- Hook tests (StrictMode): revisits reuse the build, instances share it, un-keyed instances stay isolated, LRU keeps recently used entries and evicts past the cap.
- Full sessions Vitest suite and `pnpm typecheck`.

