### PR TITLE
feat(home): add unified work table across pinned spaces

### DIFF
--- a/products/desktop/packages/core/src/home/homeFilters.test.ts
+++ b/products/desktop/packages/core/src/home/homeFilters.test.ts
@@ -1,0 +1,220 @@
+import type { UserBasic } from "@posthog/shared/domain-types";
+import { describe, expect, it } from "vitest";
+import {
+  filterHomeRows,
+  groupHomeRows,
+  type HomeFilters,
+  homeFacets,
+  NO_HOME_FILTERS,
+  sortHomeRows,
+  toggleHomeFilter,
+} from "./homeFilters";
+import type { HomeRow } from "./homeRows";
+
+const ADA: UserBasic = {
+  id: 1,
+  uuid: "ada-uuid",
+  email: "ada@example.com",
+  first_name: "Ada",
+  last_name: "Lovelace",
+};
+
+function row(overrides: Partial<HomeRow> = {}): HomeRow {
+  return {
+    key: overrides.id ? `session:${overrides.id}` : "session:row-1",
+    kind: "session",
+    id: "row-1",
+    title: "Fix the export",
+    status: "in_progress",
+    reference: "#128",
+    spaceId: "space-1",
+    spaceName: "ux-platform",
+    projectId: "project-1",
+    projectName: "Onboarding",
+    assignee: ADA,
+    createdAt: 10,
+    updatedAt: 20,
+    pinned: false,
+    environment: "cloud",
+    source: null,
+    task: null,
+    ...overrides,
+  };
+}
+
+function filters(overrides: Partial<HomeFilters> = {}): HomeFilters {
+  return { ...NO_HOME_FILTERS, ...overrides };
+}
+
+describe("home filters", () => {
+  it("keeps every row while no facet is set", () => {
+    const rows = [row({ id: "a" }), row({ id: "b", status: "done" })];
+
+    expect(
+      filterHomeRows(rows, { query: "", filters: NO_HOME_FILTERS }),
+    ).toHaveLength(2);
+  });
+
+  it.each<[string, Partial<HomeFilters>, string[]]>([
+    ["status", { statuses: ["done"] }, ["done-row"]],
+    ["kind", { kinds: ["canvas"] }, ["canvas-row"]],
+    ["space", { spaceIds: ["space-2"] }, ["other-space-row"]],
+    ["project", { projectIds: ["project-2"] }, ["other-project-row"]],
+    ["assignee", { assigneeUuids: ["ada-uuid"] }, ["assigned-row"]],
+  ])("narrows on %s", (_facet, narrowed, expected) => {
+    const rows = [
+      row({ id: "done-row", status: "done", assignee: null, projectId: null }),
+      row({
+        id: "canvas-row",
+        kind: "canvas",
+        assignee: null,
+        projectId: null,
+      }),
+      row({
+        id: "other-space-row",
+        spaceId: "space-2",
+        assignee: null,
+        projectId: null,
+      }),
+      row({
+        id: "other-project-row",
+        projectId: "project-2",
+        projectName: "Billing",
+        assignee: null,
+      }),
+      row({
+        id: "assigned-row",
+        projectId: null,
+        status: "todo",
+        kind: "plan",
+      }),
+    ];
+
+    expect(
+      filterHomeRows(rows, { query: "", filters: filters(narrowed) })
+        .map((match) => match.id)
+        .sort(),
+    ).toEqual(expected);
+  });
+
+  it("excludes unassigned work when filtering by assignee", () => {
+    const rows = [
+      row({ id: "assigned" }),
+      row({ id: "nobody", assignee: null }),
+    ];
+
+    expect(
+      filterHomeRows(rows, {
+        query: "",
+        filters: filters({ assigneeUuids: ["ada-uuid"] }),
+      }).map((match) => match.id),
+    ).toEqual(["assigned"]);
+  });
+
+  it.each([
+    ["a title", "export"],
+    ["a project name", "onboard"],
+    ["a space name", "ux-plat"],
+    ["a reference", "#128"],
+  ])("searches %s", (_field, query) => {
+    expect(
+      filterHomeRows([row()], { query, filters: NO_HOME_FILTERS }),
+    ).toHaveLength(1);
+  });
+
+  it("adds and removes one value without disturbing the other facets", () => {
+    const withStatus = toggleHomeFilter(
+      filters({ kinds: ["canvas"] }),
+      "statuses",
+      "done",
+    );
+    expect(withStatus).toMatchObject({ statuses: ["done"], kinds: ["canvas"] });
+
+    expect(toggleHomeFilter(withStatus, "statuses", "done")).toMatchObject({
+      statuses: [],
+      kinds: ["canvas"],
+    });
+  });
+
+  it("floats pinned work above the chosen order", () => {
+    const rows = [
+      row({ id: "newest", updatedAt: 100 }),
+      row({ id: "pinned", updatedAt: 1, pinned: true }),
+    ];
+
+    expect(sortHomeRows(rows, "recent").map((match) => match.id)).toEqual([
+      "pinned",
+      "newest",
+    ]);
+  });
+});
+
+describe("home grouping", () => {
+  it("keeps statuses in their canonical order and drops the empty ones", () => {
+    const rows = [
+      row({ id: "done", status: "done" }),
+      row({ id: "failed", status: "failed" }),
+      row({ id: "running", status: "in_progress" }),
+    ];
+
+    expect(groupHomeRows(rows, "status").map((group) => group.key)).toEqual([
+      "failed",
+      "in_progress",
+      "done",
+    ]);
+  });
+
+  it.each<["project" | "assignee", Partial<HomeRow>, string]>([
+    ["project", { projectId: null, projectName: null }, "No project"],
+    ["assignee", { assignee: null }, "Unassigned"],
+  ])(
+    "puts work with no %s in its own group, last",
+    (groupBy, missing, label) => {
+      const groups = groupHomeRows(
+        [row({ id: "has-one" }), row({ id: "missing", ...missing })],
+        groupBy,
+      );
+
+      expect(groups.at(-1)).toMatchObject({ label, rows: [{ id: "missing" }] });
+    },
+  );
+
+  it("leads with the busiest group when grouping by space", () => {
+    const rows = [
+      row({ id: "a", spaceId: "quiet", spaceName: "quiet" }),
+      row({ id: "b", spaceId: "busy", spaceName: "busy" }),
+      row({ id: "c", spaceId: "busy", spaceName: "busy" }),
+    ];
+
+    expect(groupHomeRows(rows, "space").map((group) => group.label)).toEqual([
+      "#busy",
+      "#quiet",
+    ]);
+  });
+});
+
+describe("home facets", () => {
+  it("offers only the values present, with their counts", () => {
+    const rows = [
+      row({ id: "a", status: "done" }),
+      row({ id: "b", status: "done" }),
+      row({ id: "c", status: "failed" }),
+    ];
+
+    expect(homeFacets(rows).statuses).toEqual([
+      { value: "failed", label: "Failed", count: 1 },
+      { value: "done", label: "Done", count: 2 },
+    ]);
+  });
+
+  it("leaves unfiled work out of the project facet", () => {
+    const rows = [
+      row({ id: "a" }),
+      row({ id: "b", projectId: null, projectName: null }),
+    ];
+
+    expect(homeFacets(rows).projects).toEqual([
+      { value: "project-1", label: "Onboarding", count: 1 },
+    ]);
+  });
+});

--- a/products/desktop/packages/core/src/home/homeFilters.ts
+++ b/products/desktop/packages/core/src/home/homeFilters.ts
@@ -1,0 +1,316 @@
+import type { HomeRow } from "./homeRows";
+import {
+  HOME_STATUS_LABELS,
+  HOME_STATUS_ORDER,
+  HOME_WORK_KIND_LABELS,
+  type HomeStatus,
+  type HomeWorkKind,
+} from "./schemas";
+
+/**
+ * What the table is narrowed to. Each facet is a set of accepted values, and an
+ * empty set means "don't narrow on this" rather than "match nothing" — a filter
+ * nobody has touched should never hide a row.
+ */
+export interface HomeFilters {
+  statuses: readonly HomeStatus[];
+  kinds: readonly HomeWorkKind[];
+  spaceIds: readonly string[];
+  projectIds: readonly string[];
+  /** User uuids. Work with no assignee matches only when this is empty. */
+  assigneeUuids: readonly string[];
+}
+
+export const NO_HOME_FILTERS: HomeFilters = {
+  statuses: [],
+  kinds: [],
+  spaceIds: [],
+  projectIds: [],
+  assigneeUuids: [],
+};
+
+export type HomeGroupBy = "status" | "project" | "space" | "assignee" | "none";
+export type HomeSort = "recent" | "created" | "alpha" | "status";
+
+export const HOME_GROUP_BY_LABELS: Record<HomeGroupBy, string> = {
+  status: "Status",
+  project: "Project",
+  space: "Space",
+  assignee: "Assignee",
+  none: "Nothing",
+};
+
+export const HOME_SORT_LABELS: Record<HomeSort, string> = {
+  recent: "Last updated",
+  created: "Created",
+  alpha: "Title",
+  status: "Status",
+};
+
+/** How many filters are narrowing the table, which the filter button carries. */
+export function countHomeFilters(filters: HomeFilters): number {
+  return (
+    filters.statuses.length +
+    filters.kinds.length +
+    filters.spaceIds.length +
+    filters.projectIds.length +
+    filters.assigneeUuids.length
+  );
+}
+
+/** Add or remove one value of a facet, leaving the rest of the filters alone. */
+export function toggleHomeFilter<K extends keyof HomeFilters>(
+  filters: HomeFilters,
+  facet: K,
+  value: HomeFilters[K][number],
+): HomeFilters {
+  const current = filters[facet] as readonly string[];
+  const next = current.includes(value as string)
+    ? current.filter((entry) => entry !== value)
+    : [...current, value as string];
+  return { ...filters, [facet]: next };
+}
+
+function matches(accepted: readonly string[], value: string | null): boolean {
+  if (accepted.length === 0) return true;
+  return value != null && accepted.includes(value);
+}
+
+/**
+ * The rows a query and a set of filters leave. The query is matched against
+ * everything a reader can see on the row — title, project, space, reference —
+ * so typing a space name finds its work without opening the filter menu.
+ */
+export function filterHomeRows(
+  rows: readonly HomeRow[],
+  { query, filters }: { query: string; filters: HomeFilters },
+): HomeRow[] {
+  const needle = query.trim().toLowerCase();
+  return rows.filter((row) => {
+    if (!matches(filters.statuses, row.status)) return false;
+    if (!matches(filters.kinds, row.kind)) return false;
+    if (!matches(filters.spaceIds, row.spaceId)) return false;
+    if (!matches(filters.projectIds, row.projectId)) return false;
+    if (!matches(filters.assigneeUuids, row.assignee?.uuid ?? null)) {
+      return false;
+    }
+    if (!needle) return true;
+    return [row.title, row.projectName, row.spaceName, row.reference]
+      .filter((field): field is string => !!field)
+      .some((field) => field.toLowerCase().includes(needle));
+  });
+}
+
+const STATUS_RANK = new Map(
+  HOME_STATUS_ORDER.map((status, index) => [status, index]),
+);
+
+function statusRank(status: HomeStatus): number {
+  return STATUS_RANK.get(status) ?? HOME_STATUS_ORDER.length;
+}
+
+/**
+ * Pinned work first, then the chosen order. Pinning is the reader's own filing
+ * and outranks every sort, the same way it does in the space's session list.
+ */
+export function sortHomeRows(
+  rows: readonly HomeRow[],
+  sort: HomeSort,
+): HomeRow[] {
+  const compare = (a: HomeRow, b: HomeRow): number => {
+    if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
+    switch (sort) {
+      case "created":
+        return b.createdAt - a.createdAt;
+      case "alpha":
+        return a.title.localeCompare(b.title);
+      case "status": {
+        const byStatus = statusRank(a.status) - statusRank(b.status);
+        return byStatus === 0 ? b.updatedAt - a.updatedAt : byStatus;
+      }
+      default:
+        return b.updatedAt - a.updatedAt;
+    }
+  };
+  return [...rows].sort(compare);
+}
+
+/** One section of the table: a heading, and the rows filed under it. */
+export interface HomeGroup {
+  /** Stable across renders and across data refreshes — collapse state keys on it. */
+  key: string;
+  label: string;
+  rows: HomeRow[];
+}
+
+/** The heading a row falls under, or null when it has no value for the facet. */
+function groupKeyFor(
+  row: HomeRow,
+  groupBy: Exclude<HomeGroupBy, "none">,
+): { key: string; label: string } | null {
+  switch (groupBy) {
+    case "status":
+      return { key: row.status, label: HOME_STATUS_LABELS[row.status] };
+    case "project":
+      return row.projectId && row.projectName
+        ? { key: row.projectId, label: row.projectName }
+        : null;
+    case "space":
+      return { key: row.spaceId, label: `#${row.spaceName}` };
+    case "assignee":
+      return row.assignee
+        ? {
+            key: row.assignee.uuid,
+            label:
+              [row.assignee.first_name, row.assignee.last_name]
+                .filter(Boolean)
+                .join(" ") ||
+              row.assignee.email ||
+              "Unknown",
+          }
+        : null;
+  }
+}
+
+/**
+ * The heading for rows that have no value for the facet being grouped on:
+ * unfiled work, or work nobody has picked up. It sorts last, because it is the
+ * pile you deal with after the named ones. Exported because the table treats it
+ * differently from a real heading: there is no project to add work to.
+ */
+export const UNGROUPED_GROUP_KEY = "__ungrouped__";
+
+const UNGROUPED_LABELS: Record<Exclude<HomeGroupBy, "none">, string> = {
+  status: "No status",
+  project: "No project",
+  space: "No space",
+  assignee: "Unassigned",
+};
+
+/**
+ * Split rows into the table's sections. Grouping by status keeps every status
+ * in its canonical order and drops the empty ones; every other facet is ordered
+ * by how much work sits under it, so the busiest heading leads.
+ */
+export function groupHomeRows(
+  rows: readonly HomeRow[],
+  groupBy: HomeGroupBy,
+): HomeGroup[] {
+  if (groupBy === "none") {
+    return [{ key: "all", label: "All work", rows: [...rows] }];
+  }
+
+  const groups = new Map<string, HomeGroup>();
+  for (const row of rows) {
+    const target = groupKeyFor(row, groupBy) ?? {
+      key: UNGROUPED_GROUP_KEY,
+      label: UNGROUPED_LABELS[groupBy],
+    };
+    const existing = groups.get(target.key);
+    if (existing) {
+      existing.rows.push(row);
+    } else {
+      groups.set(target.key, { ...target, rows: [row] });
+    }
+  }
+
+  if (groupBy === "status") {
+    return HOME_STATUS_ORDER.map((status) => groups.get(status)).filter(
+      (group): group is HomeGroup => group != null,
+    );
+  }
+
+  return [...groups.values()].sort((a, b) => {
+    if (a.key === UNGROUPED_GROUP_KEY) return 1;
+    if (b.key === UNGROUPED_GROUP_KEY) return -1;
+    const byCount = b.rows.length - a.rows.length;
+    return byCount === 0 ? a.label.localeCompare(b.label) : byCount;
+  });
+}
+
+/** One offerable value of a facet, with how much work carries it. */
+export interface HomeFacetOption<T extends string = string> {
+  value: T;
+  label: string;
+  count: number;
+}
+
+export interface HomeFacets {
+  statuses: HomeFacetOption<HomeStatus>[];
+  kinds: HomeFacetOption<HomeWorkKind>[];
+  spaces: HomeFacetOption[];
+  projects: HomeFacetOption[];
+  assignees: HomeFacetOption[];
+}
+
+/**
+ * The facet values actually present in a set of rows, so the filter menu only
+ * offers what can match. Statuses and kinds keep their canonical order; the
+ * rest come back alphabetical, so the menu is stable between refreshes.
+ */
+export function homeFacets(rows: readonly HomeRow[]): HomeFacets {
+  const tally = <T extends string>(
+    pick: (row: HomeRow) => { value: T; label: string } | null,
+  ): Map<T, { label: string; count: number }> => {
+    const counts = new Map<T, { label: string; count: number }>();
+    for (const row of rows) {
+      const entry = pick(row);
+      if (!entry) continue;
+      const existing = counts.get(entry.value);
+      if (existing) existing.count += 1;
+      else counts.set(entry.value, { label: entry.label, count: 1 });
+    }
+    return counts;
+  };
+
+  const statusCounts = tally<HomeStatus>((row) => ({
+    value: row.status,
+    label: HOME_STATUS_LABELS[row.status],
+  }));
+  const kindCounts = tally<HomeWorkKind>((row) => ({
+    value: row.kind,
+    label: HOME_WORK_KIND_LABELS[row.kind],
+  }));
+  const alphabetical = <T extends string>(
+    counts: Map<T, { label: string; count: number }>,
+  ) =>
+    [...counts.entries()]
+      .map(([value, entry]) => ({ value, ...entry }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+
+  return {
+    statuses: HOME_STATUS_ORDER.flatMap((status) => {
+      const entry = statusCounts.get(status);
+      return entry ? [{ value: status, ...entry }] : [];
+    }),
+    kinds: (["session", "canvas", "plan", "todo"] as const).flatMap((kind) => {
+      const entry = kindCounts.get(kind);
+      return entry ? [{ value: kind, ...entry }] : [];
+    }),
+    spaces: alphabetical(
+      tally((row) => ({ value: row.spaceId, label: `#${row.spaceName}` })),
+    ),
+    projects: alphabetical(
+      tally((row) =>
+        row.projectId && row.projectName
+          ? { value: row.projectId, label: row.projectName }
+          : null,
+      ),
+    ),
+    assignees: alphabetical(
+      tally((row) => {
+        const assignee = row.assignee;
+        if (!assignee) return null;
+        return {
+          value: assignee.uuid,
+          label:
+            [assignee.first_name, assignee.last_name]
+              .filter(Boolean)
+              .join(" ") ||
+            assignee.email ||
+            "Unknown",
+        };
+      }),
+    ),
+  };
+}

--- a/products/desktop/packages/core/src/home/homeRows.test.ts
+++ b/products/desktop/packages/core/src/home/homeRows.test.ts
@@ -1,0 +1,217 @@
+import type {
+  Task,
+  TaskRunStatus,
+  UserBasic,
+} from "@posthog/shared/domain-types";
+import { describe, expect, it } from "vitest";
+import type { DashboardRecord } from "../canvas/dashboardSchemas";
+import {
+  buildHomeRows,
+  type HomeSpaceWork,
+  statusFromCanvas,
+  statusFromRun,
+} from "./homeRows";
+import type { HomeNote, HomeProject, HomeStatus } from "./schemas";
+
+const ADA: UserBasic = {
+  id: 1,
+  uuid: "ada-uuid",
+  email: "ada@example.com",
+  first_name: "Ada",
+};
+
+const NONE: ReadonlySet<string> = new Set();
+
+function task(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "task-1",
+    task_number: 128,
+    slug: "task-1",
+    title: "Fix the export",
+    description: "",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    created_by: ADA,
+    origin_product: "user_created",
+    ...overrides,
+  };
+}
+
+function canvas(overrides: Partial<DashboardRecord> = {}): DashboardRecord {
+  return {
+    id: "canvas-1",
+    channelId: "space-1",
+    name: "Retention",
+    templateId: "freeform",
+    context: "",
+    createdAt: 10,
+    updatedAt: 20,
+    ...overrides,
+  };
+}
+
+function project(overrides: Partial<HomeProject> = {}): HomeProject {
+  return {
+    id: "project-1",
+    spaceId: "space-1",
+    name: "Onboarding",
+    status: "in_progress",
+    lead: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+function note(overrides: Partial<HomeNote> = {}): HomeNote {
+  return {
+    id: "note-1",
+    projectId: "project-1",
+    kind: "todo",
+    title: "Write the migration",
+    body: "",
+    status: "todo",
+    assignee: null,
+    createdAt: 5,
+    updatedAt: 30,
+    ...overrides,
+  };
+}
+
+function spaceWork(overrides: Partial<HomeSpaceWork> = {}): HomeSpaceWork {
+  return {
+    space: { id: "space-1", name: "ux-platform", personal: false },
+    tasks: [],
+    canvases: [],
+    ...overrides,
+  };
+}
+
+type BuildInput = Parameters<typeof buildHomeRows>[0];
+
+function build(overrides: Partial<BuildInput> = {}) {
+  return buildHomeRows({
+    work: [],
+    projects: [],
+    notes: [],
+    filing: {},
+    archivedTaskIds: NONE,
+    pinnedTaskIds: NONE,
+    ...overrides,
+  });
+}
+
+describe("home rows", () => {
+  it.each<[TaskRunStatus | null | undefined, HomeStatus]>([
+    ["in_progress", "in_progress"],
+    ["queued", "todo"],
+    ["not_started", "todo"],
+    ["completed", "done"],
+    ["failed", "failed"],
+    ["cancelled", "canceled"],
+    [null, "backlog"],
+    [undefined, "backlog"],
+  ])("reads a %s run as %s", (runStatus, expected) => {
+    expect(statusFromRun(runStatus)).toBe(expected);
+  });
+
+  it.each<[string, HomeStatus, Partial<DashboardRecord>]>([
+    ["generating", "in_progress", { generationTaskId: "task-9" }],
+    ["published", "done", { publishedBuildId: "build-1" }],
+    ["never built", "todo", {}],
+    // A canvas being regenerated is in progress even though a build is live:
+    // the run in flight is the newer fact about it.
+    [
+      "regenerating",
+      "in_progress",
+      { generationTaskId: "task-9", publishedBuildId: "build-1" },
+    ],
+  ])("reads a %s canvas as %s", (_label, expected, overrides) => {
+    expect(statusFromCanvas(canvas(overrides))).toBe(expected);
+  });
+
+  it("keeps archived sessions out of the table", () => {
+    const rows = build({
+      work: [
+        spaceWork({
+          tasks: [task({ id: "kept" }), task({ id: "archived" })],
+        }),
+      ],
+      archivedTaskIds: new Set(["archived"]),
+    });
+
+    expect(rows.map((row) => row.id)).toEqual(["kept"]);
+  });
+
+  it("files work under the project it is filed to", () => {
+    const rows = build({
+      work: [
+        spaceWork({ tasks: [task({ id: "filed" }), task({ id: "loose" })] }),
+      ],
+      projects: [project()],
+      filing: { filed: "project-1" },
+    });
+
+    expect(
+      Object.fromEntries(rows.map((row) => [row.id, row.projectName])),
+    ).toEqual({ filed: "Onboarding", loose: null });
+  });
+
+  it("drops a filing that points at a project which no longer exists", () => {
+    const rows = build({
+      work: [spaceWork({ tasks: [task()] })],
+      projects: [],
+      filing: { "task-1": "deleted-project" },
+    });
+
+    expect(rows[0]?.projectId).toBeNull();
+  });
+
+  it("leaves out notes whose project sits outside the pinned spaces", () => {
+    const rows = build({
+      work: [spaceWork()],
+      projects: [project({ id: "elsewhere", spaceId: "space-2" })],
+      notes: [note({ projectId: "elsewhere" })],
+    });
+
+    expect(rows).toEqual([]);
+  });
+
+  it("gives a note its project's space", () => {
+    const rows = build({
+      work: [spaceWork()],
+      projects: [project()],
+      notes: [note()],
+    });
+
+    expect(rows[0]).toMatchObject({
+      kind: "todo",
+      spaceId: "space-1",
+      spaceName: "ux-platform",
+      projectName: "Onboarding",
+    });
+  });
+
+  it("orders every kind together by last activity", () => {
+    const rows = build({
+      work: [
+        spaceWork({
+          tasks: [task({ id: "old", updated_at: "2026-01-01T00:00:00Z" })],
+          canvases: [
+            canvas({ id: "newest", updatedAt: Date.parse("2026-06-01") }),
+          ],
+        }),
+      ],
+      projects: [project()],
+      notes: [note({ updatedAt: Date.parse("2026-03-01") })],
+    });
+
+    expect(rows.map((row) => row.id)).toEqual(["newest", "note-1", "old"]);
+  });
+
+  it("leaves a session that has never run unplaced rather than local", () => {
+    const rows = build({ work: [spaceWork({ tasks: [task()] })] });
+
+    expect(rows[0]?.environment).toBeNull();
+  });
+});

--- a/products/desktop/packages/core/src/home/homeRows.ts
+++ b/products/desktop/packages/core/src/home/homeRows.ts
@@ -1,0 +1,259 @@
+import type {
+  Task,
+  TaskRunStatus,
+  UserBasic,
+} from "@posthog/shared/domain-types";
+import type { DashboardRecord } from "../canvas/dashboardSchemas";
+import type {
+  HomeFiling,
+  HomeNote,
+  HomeProject,
+  HomeStatus,
+  HomeWorkKind,
+} from "./schemas";
+
+/** A space, trimmed to what the home table names it by. */
+export interface HomeSpace {
+  id: string;
+  name: string;
+  /** The private `#me` space, which reads differently from a shared one. */
+  personal: boolean;
+}
+
+/** One pinned space and the work the app already knows it holds. */
+export interface HomeSpaceWork {
+  space: HomeSpace;
+  tasks: readonly Task[];
+  canvases: readonly DashboardRecord[];
+}
+
+/**
+ * One line of the home table. Every kind of work flattens to this, so the table
+ * sorts, groups and filters over a single shape rather than branching per kind
+ * in the renderer.
+ */
+export interface HomeRow {
+  /** Unique across kinds — an id alone can collide between a note and a task. */
+  key: string;
+  kind: HomeWorkKind;
+  id: string;
+  title: string;
+  status: HomeStatus;
+  /** The dim leading label, e.g. a session's `#128`. Null when it has none. */
+  reference: string | null;
+  spaceId: string;
+  spaceName: string;
+  projectId: string | null;
+  projectName: string | null;
+  /**
+   * Who the work belongs to. For a session that is whoever started it — the
+   * agent runs on their behalf, so there is no second person to name.
+   */
+  assignee: UserBasic | null;
+  createdAt: number;
+  updatedAt: number;
+  pinned: boolean;
+  /** Where a session runs. Null for the kinds that don't run. */
+  environment: "local" | "cloud" | null;
+  /** The product that filed the session, when it wasn't started here. */
+  source: string | null;
+  /**
+   * The task behind a `session` row, null for every other kind. Rows need the
+   * whole record rather than a projection: opening a session hands it to the
+   * navigation seam, which provisions its workspace from fields the row itself
+   * has no reason to carry.
+   */
+  task: Task | null;
+}
+
+/**
+ * `origin_product` for a session started here rather than filed by another
+ * product. It's the default the backend stamps on, so it means "no source".
+ */
+const SELF_ORIGIN = "user_created";
+
+/**
+ * A run's status in the table's vocabulary. A session with no run at all has
+ * been written but never started, which is exactly what backlog means.
+ */
+export function statusFromRun(
+  status: TaskRunStatus | null | undefined,
+): HomeStatus {
+  switch (status) {
+    case "in_progress":
+      return "in_progress";
+    case "queued":
+    case "not_started":
+      return "todo";
+    case "completed":
+      return "done";
+    case "failed":
+      return "failed";
+    case "cancelled":
+      return "canceled";
+    default:
+      return "backlog";
+  }
+}
+
+/**
+ * A canvas's status is read off its build lifecycle rather than stored: a
+ * canvas being generated is in progress, one with a live build is finished
+ * work, and one that has never built is a name somebody reserved.
+ */
+export function statusFromCanvas(canvas: DashboardRecord): HomeStatus {
+  if (canvas.generationTaskId) return "in_progress";
+  return canvas.publishedBuildId ? "done" : "todo";
+}
+
+function taskReference(task: Task): string | null {
+  return task.task_number == null ? null : `#${task.task_number}`;
+}
+
+function rowFromTask(
+  task: Task,
+  space: HomeSpace,
+  project: HomeProject | null,
+  pinnedTaskIds: ReadonlySet<string>,
+): HomeRow {
+  return {
+    key: `session:${task.id}`,
+    kind: "session",
+    id: task.id,
+    title: task.title || "Untitled session",
+    status: statusFromRun(task.latest_run?.status),
+    reference: taskReference(task),
+    spaceId: space.id,
+    spaceName: space.name,
+    projectId: project?.id ?? null,
+    projectName: project?.name ?? null,
+    assignee: task.created_by ?? null,
+    createdAt: Date.parse(task.created_at) || 0,
+    updatedAt: Date.parse(task.updated_at) || 0,
+    pinned: pinnedTaskIds.has(task.id),
+    // A session that has never run is unplaced, not local: claiming a machine
+    // for it would put it under a filter it can't actually satisfy.
+    environment: task.latest_run
+      ? task.latest_run.environment === "cloud"
+        ? "cloud"
+        : "local"
+      : null,
+    source:
+      task.origin_product && task.origin_product !== SELF_ORIGIN
+        ? task.origin_product
+        : null,
+    task,
+  };
+}
+
+function rowFromCanvas(
+  canvas: DashboardRecord,
+  space: HomeSpace,
+  project: HomeProject | null,
+): HomeRow {
+  return {
+    key: `canvas:${canvas.id}`,
+    kind: "canvas",
+    id: canvas.id,
+    title: canvas.name,
+    status: statusFromCanvas(canvas),
+    reference: null,
+    spaceId: space.id,
+    spaceName: space.name,
+    projectId: project?.id ?? null,
+    projectName: project?.name ?? null,
+    // A canvas record carries only its author's name and uuid, so the avatar
+    // gets what it needs and nothing that would claim more than we know.
+    assignee: canvas.createdByUuid
+      ? {
+          id: 0,
+          uuid: canvas.createdByUuid,
+          email: "",
+          first_name: canvas.createdBy ?? "",
+        }
+      : null,
+    createdAt: canvas.createdAt,
+    updatedAt: canvas.updatedAt,
+    pinned: canvas.pinnedAt != null,
+    environment: null,
+    source: null,
+    task: null,
+  };
+}
+
+function rowFromNote(
+  note: HomeNote,
+  project: HomeProject,
+  space: HomeSpace,
+): HomeRow {
+  return {
+    key: `${note.kind}:${note.id}`,
+    kind: note.kind,
+    id: note.id,
+    title: note.title || (note.kind === "plan" ? "Untitled plan" : "Untitled"),
+    status: note.status,
+    reference: null,
+    spaceId: space.id,
+    spaceName: space.name,
+    projectId: project.id,
+    projectName: project.name,
+    assignee: note.assignee,
+    createdAt: note.createdAt,
+    updatedAt: note.updatedAt,
+    pinned: false,
+    environment: null,
+    source: null,
+    task: null,
+  };
+}
+
+/**
+ * Every piece of work across the pinned spaces, newest activity first.
+ *
+ * Notes are keyed off their project rather than a space, so a plan whose
+ * project sits in an unpinned space stays out — the table's promise is that it
+ * shows the pinned spaces and nothing else, and a project is only ever in one.
+ */
+export function buildHomeRows({
+  work,
+  projects,
+  notes,
+  filing,
+  archivedTaskIds,
+  pinnedTaskIds,
+}: {
+  work: readonly HomeSpaceWork[];
+  projects: readonly HomeProject[];
+  notes: readonly HomeNote[];
+  filing: HomeFiling;
+  archivedTaskIds: ReadonlySet<string>;
+  pinnedTaskIds: ReadonlySet<string>;
+}): HomeRow[] {
+  const projectById = new Map(projects.map((project) => [project.id, project]));
+  const spaceById = new Map(work.map(({ space }) => [space.id, space]));
+  const projectFor = (workId: string): HomeProject | null => {
+    const projectId = filing[workId];
+    return projectId ? (projectById.get(projectId) ?? null) : null;
+  };
+
+  const rows: HomeRow[] = [];
+
+  for (const { space, tasks, canvases } of work) {
+    for (const task of tasks) {
+      if (archivedTaskIds.has(task.id)) continue;
+      rows.push(rowFromTask(task, space, projectFor(task.id), pinnedTaskIds));
+    }
+    for (const canvas of canvases) {
+      rows.push(rowFromCanvas(canvas, space, projectFor(canvas.id)));
+    }
+  }
+
+  for (const note of notes) {
+    const project = projectById.get(note.projectId);
+    const space = project ? spaceById.get(project.spaceId) : undefined;
+    if (!project || !space) continue;
+    rows.push(rowFromNote(note, project, space));
+  }
+
+  return rows.sort((a, b) => b.updatedAt - a.updatedAt);
+}

--- a/products/desktop/packages/core/src/home/schemas.ts
+++ b/products/desktop/packages/core/src/home/schemas.ts
@@ -1,0 +1,131 @@
+import type { UserBasic } from "@posthog/shared/domain-types";
+import { z } from "zod";
+
+/**
+ * Where a piece of work stands, across every kind of work a project holds.
+ * Deliberately one vocabulary rather than per-kind ones: the home table's whole
+ * point is that a session, a canvas, a plan and a todo line up in the same
+ * column, so a reader can scan a space's work without translating between three
+ * sets of words.
+ *
+ * `failed` is ours, not Linear's. An agent run that died is the row a reader
+ * most needs to see, and folding it into `canceled` hides it among the work
+ * somebody deliberately stopped.
+ */
+export const homeStatusSchema = z.enum([
+  "backlog",
+  "todo",
+  "in_progress",
+  "done",
+  "failed",
+  "canceled",
+]);
+export type HomeStatus = z.infer<typeof homeStatusSchema>;
+
+/**
+ * Group order for the table: what wants attention first, what is finished last.
+ * Failures lead because they are the only status that asks the reader to do
+ * something they don't already know about.
+ */
+export const HOME_STATUS_ORDER: readonly HomeStatus[] = [
+  "failed",
+  "in_progress",
+  "todo",
+  "backlog",
+  "done",
+  "canceled",
+];
+
+export const HOME_STATUS_LABELS: Record<HomeStatus, string> = {
+  backlog: "Backlog",
+  todo: "Todo",
+  in_progress: "In progress",
+  done: "Done",
+  failed: "Failed",
+  canceled: "Canceled",
+};
+
+/** The four things a project holds. */
+export const homeWorkKindSchema = z.enum(["session", "canvas", "plan", "todo"]);
+export type HomeWorkKind = z.infer<typeof homeWorkKindSchema>;
+
+export const HOME_WORK_KIND_LABELS: Record<HomeWorkKind, string> = {
+  session: "Session",
+  canvas: "Canvas",
+  plan: "Plan",
+  todo: "Todo",
+};
+
+/**
+ * Enough of a `UserBasic` to draw an avatar and a name, stored on the records
+ * this app owns so a plan filed months ago still says who wrote it without a
+ * lookup against the org's member list.
+ */
+export const homeUserSchema = z.object({
+  id: z.number(),
+  uuid: z.string(),
+  email: z.string(),
+  first_name: z.string().optional(),
+  last_name: z.string().optional(),
+}) satisfies z.ZodType<UserBasic>;
+
+/**
+ * A project: the unit of work inside a space. It holds sessions and canvases
+ * that already exist in the space, plus plans and todos authored here.
+ *
+ * `spaceId` is a backend channel id — a project cannot exist outside a space,
+ * because the space is what decides who can see the work it gathers.
+ */
+export const homeProjectSchema = z.object({
+  id: z.string().min(1),
+  spaceId: z.string().min(1),
+  name: z.string().min(1),
+  status: homeStatusSchema,
+  /** Who is driving it; null while nobody has claimed it. */
+  lead: homeUserSchema.nullable(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+});
+export type HomeProject = z.infer<typeof homeProjectSchema>;
+
+/**
+ * A plan or a todo — the two kinds of work a project holds that are authored
+ * here rather than filed from something the backend already owns. Both are the
+ * same record because they differ only in how much prose they carry: a todo is
+ * a line, a plan is a document.
+ */
+export const homeNoteSchema = z.object({
+  id: z.string().min(1),
+  projectId: z.string().min(1),
+  kind: z.enum(["plan", "todo"]),
+  title: z.string(),
+  /** Markdown. Empty for a todo that is just its title. */
+  body: z.string(),
+  status: homeStatusSchema,
+  /** Whoever is carrying it; null until someone picks it up. */
+  assignee: homeUserSchema.nullable(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+});
+export type HomeNote = z.infer<typeof homeNoteSchema>;
+
+/**
+ * Which project a session or canvas belongs to, keyed by the work's own id.
+ * Filing is a client-side relation for now, so it is stored beside the projects
+ * rather than on the task or canvas record itself.
+ */
+export const homeFilingSchema = z.record(z.string(), z.string());
+export type HomeFiling = z.infer<typeof homeFilingSchema>;
+
+/**
+ * Everything the projects layer holds, as one persisted shape. Kept together
+ * because the three parts only make sense as a set: a note without its project
+ * has nowhere to live, and a filing pointing at a deleted project is a row that
+ * claims a parent it doesn't have.
+ */
+export const homeRegistrySchema = z.object({
+  projects: z.record(z.string(), homeProjectSchema),
+  notes: z.record(z.string(), homeNoteSchema),
+  filing: homeFilingSchema,
+});
+export type HomeRegistry = z.infer<typeof homeRegistrySchema>;

--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -258,6 +258,7 @@ export interface CommandMenuActionProperties {
 }
 
 export type SidebarNavItem =
+  | "home"
   | "new_task"
   | "search"
   | "inbox"

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelNav.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelNav.test.tsx
@@ -24,6 +24,7 @@ vi.mock("@posthog/ui/router/useAppView", () => ({
 }));
 vi.mock("@posthog/ui/router/navigationBridge", () => ({
   navigateToActivity: vi.fn(),
+  navigateToHome: vi.fn(),
   navigateToInbox: vi.fn(),
   navigateToWebsiteCommandCenter: vi.fn(),
 }));

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelNav.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelNav.tsx
@@ -2,6 +2,7 @@ import {
   BellIcon,
   EnvelopeSimple,
   GearSix,
+  HouseIcon,
   Lightning,
 } from "@phosphor-icons/react";
 import {
@@ -33,6 +34,7 @@ import { CountBadge } from "@posthog/ui/primitives/CountBadge";
 import { LoopIcon } from "@posthog/ui/primitives/LoopIcon";
 import {
   navigateToActivity,
+  navigateToHome,
   navigateToInbox,
   navigateToLoops,
   navigateToWebsiteCommandCenter,
@@ -200,6 +202,7 @@ export function ChannelNav() {
     action();
   };
 
+  const isHome = view.type === "home";
   const isInbox = view.type === "inbox";
   const isActivity = view.type === "activity";
   const isCommandCenter = view.type === "command-center";
@@ -212,6 +215,12 @@ export function ChannelNav() {
     // providers never share it.
     <TooltipProvider delay={400}>
       <div className="flex shrink-0 gap-2 p-2">
+        <NavIcon
+          icon={<HouseIcon size={16} weight={isHome ? "fill" : "regular"} />}
+          label="Home"
+          isActive={isHome}
+          onClick={withTrack("home", navigateToHome)}
+        />
         <NavIcon
           icon={
             <EnvelopeSimple size={16} weight={isInbox ? "fill" : "regular"} />

--- a/products/desktop/packages/ui/src/features/home/components/HomeStatusIcon.tsx
+++ b/products/desktop/packages/ui/src/features/home/components/HomeStatusIcon.tsx
@@ -1,0 +1,83 @@
+import {
+  CheckCircleIcon,
+  CircleDashedIcon,
+  CircleHalfIcon,
+  CircleIcon,
+  type Icon,
+  ProhibitInsetIcon,
+  WarningCircleIcon,
+} from "@phosphor-icons/react";
+import {
+  HOME_STATUS_LABELS,
+  type HomeStatus,
+} from "@posthog/core/home/schemas";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@posthog/quill";
+
+/**
+ * The glyph and colour each status wears, everywhere it appears: the row, the
+ * group heading, and the filter menu. One table keeps them from drifting apart,
+ * which is what makes the column scannable at a glance.
+ *
+ * Colours are the theme's step-11 tokens, the readable step for a glyph rather
+ * than a filled shape, matching the session dot vocabulary the sidebar uses.
+ */
+const STATUS_PRESENTATION: Record<
+  HomeStatus,
+  { icon: Icon; color: string; weight: "regular" | "fill" | "bold" }
+> = {
+  backlog: {
+    icon: CircleDashedIcon,
+    color: "var(--gray-10)",
+    weight: "regular",
+  },
+  todo: { icon: CircleIcon, color: "var(--gray-11)", weight: "regular" },
+  in_progress: {
+    icon: CircleHalfIcon,
+    color: "var(--primary)",
+    weight: "fill",
+  },
+  done: { icon: CheckCircleIcon, color: "var(--green-11)", weight: "fill" },
+  failed: { icon: WarningCircleIcon, color: "var(--red-11)", weight: "fill" },
+  canceled: {
+    icon: ProhibitInsetIcon,
+    color: "var(--gray-10)",
+    weight: "regular",
+  },
+};
+
+export function HomeStatusIcon({
+  status,
+  size = 15,
+  className,
+}: {
+  status: HomeStatus;
+  size?: number;
+  className?: string;
+}) {
+  const { icon: Glyph, color, weight } = STATUS_PRESENTATION[status];
+  return (
+    <Glyph
+      size={size}
+      weight={weight}
+      color={color}
+      className={className}
+      aria-hidden
+    />
+  );
+}
+
+/** The row's status cell: the glyph alone, with its name on hover. */
+export function HomeStatusCell({ status }: { status: HomeStatus }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span className="flex size-4 shrink-0 items-center justify-center">
+            <HomeStatusIcon status={status} />
+          </span>
+        }
+      />
+      <TooltipContent>{HOME_STATUS_LABELS[status]}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/products/desktop/packages/ui/src/features/home/components/HomeTable.tsx
+++ b/products/desktop/packages/ui/src/features/home/components/HomeTable.tsx
@@ -1,0 +1,149 @@
+import { CaretDownIcon, CaretRightIcon, PlusIcon } from "@phosphor-icons/react";
+import {
+  type HomeGroup,
+  UNGROUPED_GROUP_KEY,
+} from "@posthog/core/home/homeFilters";
+import {
+  Button,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@posthog/quill";
+import { HomeWorkRow } from "@posthog/ui/features/home/components/HomeWorkRow";
+import { ProjectMenu } from "@posthog/ui/features/home/components/ProjectMenu";
+import { useHomeViewStore } from "@posthog/ui/features/home/homeViewStore";
+import type { HomeRowActions } from "@posthog/ui/features/home/useHomeActions";
+import { memo } from "react";
+
+export interface HomeProjectOption {
+  id: string;
+  name: string;
+}
+
+/** No projects in this space, as one shared array so a memoized row holds. */
+const NO_PROJECTS: HomeProjectOption[] = [];
+
+function HomeGroupSectionInner({
+  group,
+  collapsed,
+  actions,
+  projectsBySpace,
+  showProject,
+  showSpace,
+  groupsAreProjects,
+  onAddToGroup,
+}: {
+  group: HomeGroup;
+  collapsed: boolean;
+  actions: HomeRowActions;
+  projectsBySpace: Map<string, HomeProjectOption[]>;
+  showProject: boolean;
+  showSpace: boolean;
+  /** Whether every heading names a project, which is what the header acts on. */
+  groupsAreProjects: boolean;
+  onAddToGroup: (group: HomeGroup) => void;
+}) {
+  const toggleGroup = useHomeViewStore((state) => state.toggleGroup);
+  const Caret = collapsed ? CaretRightIcon : CaretDownIcon;
+  // The unfiled pile is not a project, so there is nothing to add work to and
+  // nothing to rename or delete.
+  const isProject = groupsAreProjects && group.key !== UNGROUPED_GROUP_KEY;
+
+  return (
+    <section>
+      <div className="sticky top-0 z-10 flex h-8 items-center gap-2 border-(--gray-4) border-b bg-(--gray-2) px-3">
+        <button
+          type="button"
+          onClick={() => toggleGroup(group.key)}
+          aria-expanded={!collapsed}
+          className="flex min-w-0 items-center gap-1.5 font-medium text-(--gray-12) text-sm hover:text-(--foreground)"
+        >
+          <Caret size={12} className="shrink-0 text-(--gray-10)" aria-hidden />
+          <span className="truncate">{group.label}</span>
+          <span className="text-(--gray-10) tabular-nums">
+            {group.rows.length}
+          </span>
+        </button>
+        <div className="flex-1" />
+        {isProject ? (
+          <>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant="default"
+                    size="icon-sm"
+                    aria-label={`Add a todo to ${group.label}`}
+                    onClick={() => onAddToGroup(group)}
+                  >
+                    <PlusIcon size={14} />
+                  </Button>
+                }
+              />
+              <TooltipContent>Add a todo here</TooltipContent>
+            </Tooltip>
+            <ProjectMenu projectId={group.key} projectName={group.label} />
+          </>
+        ) : null}
+      </div>
+      {collapsed
+        ? null
+        : group.rows.map((row) => (
+            <HomeWorkRow
+              key={row.key}
+              row={row}
+              actions={actions}
+              projectOptions={projectsBySpace.get(row.spaceId) ?? NO_PROJECTS}
+              showProject={showProject}
+              showSpace={showSpace}
+            />
+          ))}
+    </section>
+  );
+}
+
+const HomeGroupSection = memo(HomeGroupSectionInner);
+
+/**
+ * The table itself: sections in the order the grouping put them, each a sticky
+ * heading over its rows. There is no header row. Every column but the title is
+ * a glyph or a chip that says what it is, and a header band over a list this
+ * dense costs more than it explains.
+ */
+export function HomeTable({
+  groups,
+  actions,
+  projectsBySpace,
+  showProject,
+  showSpace,
+  groupsAreProjects,
+  onAddToGroup,
+}: {
+  groups: HomeGroup[];
+  actions: HomeRowActions;
+  projectsBySpace: Map<string, HomeProjectOption[]>;
+  showProject: boolean;
+  showSpace: boolean;
+  groupsAreProjects: boolean;
+  onAddToGroup: (group: HomeGroup) => void;
+}) {
+  const collapsedGroups = useHomeViewStore((state) => state.collapsedGroups);
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      {groups.map((group) => (
+        <HomeGroupSection
+          key={group.key}
+          group={group}
+          collapsed={collapsedGroups[group.key] ?? false}
+          actions={actions}
+          projectsBySpace={projectsBySpace}
+          showProject={showProject}
+          showSpace={showSpace}
+          groupsAreProjects={groupsAreProjects}
+          onAddToGroup={onAddToGroup}
+        />
+      ))}
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/home/components/HomeToolbar.tsx
+++ b/products/desktop/packages/ui/src/features/home/components/HomeToolbar.tsx
@@ -1,0 +1,260 @@
+import {
+  ArrowsDownUpIcon,
+  FunnelIcon,
+  MagnifyingGlassIcon,
+  RowsIcon,
+  XIcon,
+} from "@phosphor-icons/react";
+import {
+  HOME_GROUP_BY_LABELS,
+  HOME_SORT_LABELS,
+  type HomeFacets,
+  type HomeGroupBy,
+  type HomeSort,
+} from "@posthog/core/home/homeFilters";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@posthog/quill";
+import { HomeStatusIcon } from "@posthog/ui/features/home/components/HomeStatusIcon";
+import { useHomeViewStore } from "@posthog/ui/features/home/homeViewStore";
+
+const GROUP_BY_OPTIONS: HomeGroupBy[] = [
+  "status",
+  "project",
+  "space",
+  "assignee",
+  "none",
+];
+
+const SORT_OPTIONS: HomeSort[] = ["recent", "created", "alpha", "status"];
+
+/**
+ * Search, the filter menu, and how the table is arranged. One bar, so the whole
+ * state of the table is readable without opening anything: the filter button
+ * carries the number of filters hiding rows behind it.
+ */
+export function HomeToolbar({
+  facets,
+  activeFilterCount,
+}: {
+  facets: HomeFacets;
+  activeFilterCount: number;
+}) {
+  const query = useHomeViewStore((state) => state.query);
+  const setQuery = useHomeViewStore((state) => state.setQuery);
+  const filters = useHomeViewStore((state) => state.filters);
+  const toggleFilter = useHomeViewStore((state) => state.toggleFilter);
+  const clearFilters = useHomeViewStore((state) => state.clearFilters);
+  const groupBy = useHomeViewStore((state) => state.groupBy);
+  const setGroupBy = useHomeViewStore((state) => state.setGroupBy);
+  const sort = useHomeViewStore((state) => state.sort);
+  const setSort = useHomeViewStore((state) => state.setSort);
+
+  return (
+    <div className="flex shrink-0 items-center gap-2 border-(--gray-4) border-b px-3 py-2">
+      <InputGroup className="max-w-64">
+        <InputGroupAddon>
+          <MagnifyingGlassIcon size={14} className="text-(--gray-10)" />
+        </InputGroupAddon>
+        <InputGroupInput
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search work"
+          aria-label="Search work"
+        />
+        {query ? (
+          <InputGroupAddon align="inline-end">
+            <Button
+              variant="default"
+              size="icon-xs"
+              aria-label="Clear search"
+              onClick={() => setQuery("")}
+            >
+              <XIcon size={12} />
+            </Button>
+          </InputGroupAddon>
+        ) : null}
+      </InputGroup>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              variant={activeFilterCount ? "outline" : "default"}
+              size="sm"
+            >
+              <FunnelIcon size={14} />
+              Filter
+              {activeFilterCount ? (
+                <span className="tabular-nums">{activeFilterCount}</span>
+              ) : null}
+            </Button>
+          }
+        />
+        <DropdownMenuContent
+          align="start"
+          className="max-h-96 min-w-56 overflow-y-auto"
+        >
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>Status</DropdownMenuLabel>
+            {facets.statuses.map((facet) => (
+              <DropdownMenuCheckboxItem
+                key={facet.value}
+                checked={filters.statuses.includes(facet.value)}
+                onCheckedChange={() => toggleFilter("statuses", facet.value)}
+              >
+                <HomeStatusIcon status={facet.value} size={14} />
+                <span className="whitespace-nowrap">{facet.label}</span>
+                <span className="ml-auto tabular-nums">{facet.count}</span>
+              </DropdownMenuCheckboxItem>
+            ))}
+          </DropdownMenuGroup>
+
+          <DropdownMenuSeparator />
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>Kind</DropdownMenuLabel>
+            {facets.kinds.map((facet) => (
+              <DropdownMenuCheckboxItem
+                key={facet.value}
+                checked={filters.kinds.includes(facet.value)}
+                onCheckedChange={() => toggleFilter("kinds", facet.value)}
+              >
+                <span className="whitespace-nowrap">{facet.label}</span>
+                <span className="ml-auto tabular-nums">{facet.count}</span>
+              </DropdownMenuCheckboxItem>
+            ))}
+          </DropdownMenuGroup>
+
+          <DropdownMenuSeparator />
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>Space</DropdownMenuLabel>
+            {facets.spaces.map((facet) => (
+              <DropdownMenuCheckboxItem
+                key={facet.value}
+                checked={filters.spaceIds.includes(facet.value)}
+                onCheckedChange={() => toggleFilter("spaceIds", facet.value)}
+              >
+                <span className="whitespace-nowrap">{facet.label}</span>
+                <span className="ml-auto tabular-nums">{facet.count}</span>
+              </DropdownMenuCheckboxItem>
+            ))}
+          </DropdownMenuGroup>
+
+          {facets.projects.length > 0 ? (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuGroup>
+                <DropdownMenuLabel>Project</DropdownMenuLabel>
+                {facets.projects.map((facet) => (
+                  <DropdownMenuCheckboxItem
+                    key={facet.value}
+                    checked={filters.projectIds.includes(facet.value)}
+                    onCheckedChange={() =>
+                      toggleFilter("projectIds", facet.value)
+                    }
+                  >
+                    <span className="whitespace-nowrap">{facet.label}</span>
+                    <span className="ml-auto tabular-nums">{facet.count}</span>
+                  </DropdownMenuCheckboxItem>
+                ))}
+              </DropdownMenuGroup>
+            </>
+          ) : null}
+
+          <DropdownMenuSeparator />
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>Started by</DropdownMenuLabel>
+            {facets.assignees.map((facet) => (
+              <DropdownMenuCheckboxItem
+                key={facet.value}
+                checked={filters.assigneeUuids.includes(facet.value)}
+                onCheckedChange={() =>
+                  toggleFilter("assigneeUuids", facet.value)
+                }
+              >
+                <span className="whitespace-nowrap">{facet.label}</span>
+                <span className="ml-auto tabular-nums">{facet.count}</span>
+              </DropdownMenuCheckboxItem>
+            ))}
+          </DropdownMenuGroup>
+
+          {activeFilterCount > 0 ? (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={clearFilters}>
+                Clear filters
+              </DropdownMenuItem>
+            </>
+          ) : null}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button variant="default" size="sm">
+              <RowsIcon size={14} />
+              {HOME_GROUP_BY_LABELS[groupBy]}
+            </Button>
+          }
+        />
+        <DropdownMenuContent align="start">
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>Group by</DropdownMenuLabel>
+            <DropdownMenuRadioGroup value={groupBy}>
+              {GROUP_BY_OPTIONS.map((option) => (
+                <DropdownMenuRadioItem
+                  key={option}
+                  value={option}
+                  onClick={() => setGroupBy(option)}
+                >
+                  {HOME_GROUP_BY_LABELS[option]}
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button variant="default" size="sm">
+              <ArrowsDownUpIcon size={14} />
+              {HOME_SORT_LABELS[sort]}
+            </Button>
+          }
+        />
+        <DropdownMenuContent align="start">
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>Sort by</DropdownMenuLabel>
+            <DropdownMenuRadioGroup value={sort}>
+              {SORT_OPTIONS.map((option) => (
+                <DropdownMenuRadioItem
+                  key={option}
+                  value={option}
+                  onClick={() => setSort(option)}
+                >
+                  {HOME_SORT_LABELS[option]}
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/home/components/HomeView.stories.tsx
+++ b/products/desktop/packages/ui/src/features/home/components/HomeView.stories.tsx
@@ -1,0 +1,254 @@
+import type { HomeRow } from "@posthog/core/home/homeRows";
+import type {
+  HomeNote,
+  HomeStatus,
+  HomeWorkKind,
+} from "@posthog/core/home/schemas";
+import type { UserBasic } from "@posthog/shared/domain-types";
+import { HomePage } from "@posthog/ui/features/home/components/HomeView";
+import { useHomeProjectsStore } from "@posthog/ui/features/home/homeProjectsStore";
+import { useHomeViewStore } from "@posthog/ui/features/home/homeViewStore";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const ADA: UserBasic = {
+  id: 1,
+  uuid: "ada",
+  email: "ada@example.com",
+  first_name: "Ada",
+  last_name: "Lovelace",
+};
+
+const GRACE: UserBasic = {
+  id: 2,
+  uuid: "grace",
+  email: "grace@example.com",
+  first_name: "Grace",
+  last_name: "Hopper",
+};
+
+const SPACES = [
+  { id: "space-ux", name: "ux-platform" },
+  { id: "space-growth", name: "growth" },
+  { id: "space-me", name: "me" },
+];
+
+const PROJECTS = [
+  { id: "project-nav", spaceId: "space-ux", name: "Navigation rebuild" },
+  { id: "project-signup", spaceId: "space-growth", name: "Signup funnel" },
+];
+
+const DAY = 86_400_000;
+// Fixed clock so the relative timestamps in the rows don't move between runs.
+const NOW = Date.parse("2026-08-12T12:00:00Z");
+
+let sequence = 0;
+
+/**
+ * The notes the plan and todo rows stand for. A note row on the table is a view
+ * of a record in the projects store, so the two have to carry the same id or
+ * opening the row finds nothing.
+ */
+const NOTES: HomeNote[] = [];
+
+function row(
+  title: string,
+  overrides: {
+    kind?: HomeWorkKind;
+    status?: HomeStatus;
+    spaceId?: string;
+    projectId?: string | null;
+    assignee?: UserBasic | null;
+    daysAgo?: number;
+    pinned?: boolean;
+    reference?: string | null;
+  } = {},
+): HomeRow {
+  sequence += 1;
+  const kind = overrides.kind ?? "session";
+  const spaceId = overrides.spaceId ?? "space-ux";
+  const project = PROJECTS.find((p) => p.id === overrides.projectId) ?? null;
+  const updatedAt = NOW - (overrides.daysAgo ?? 0) * DAY;
+  if ((kind === "plan" || kind === "todo") && project) {
+    NOTES.push({
+      id: String(sequence),
+      projectId: project.id,
+      kind,
+      title,
+      body:
+        kind === "plan"
+          ? "## Approach\n\nOne pass over the tree, then the keyboard paths."
+          : "",
+      status: overrides.status ?? "todo",
+      assignee: overrides.assignee === undefined ? ADA : overrides.assignee,
+      createdAt: updatedAt - DAY,
+      updatedAt,
+    });
+  }
+  return {
+    key: `${kind}:${sequence}`,
+    id: String(sequence),
+    kind,
+    title,
+    status: overrides.status ?? "todo",
+    reference:
+      overrides.reference ?? (kind === "session" ? `#${100 + sequence}` : null),
+    spaceId,
+    spaceName: SPACES.find((s) => s.id === spaceId)?.name ?? "unknown",
+    projectId: project?.id ?? null,
+    projectName: project?.name ?? null,
+    assignee: overrides.assignee === undefined ? ADA : overrides.assignee,
+    createdAt: updatedAt - DAY,
+    updatedAt,
+    pinned: overrides.pinned ?? false,
+    environment: kind === "session" ? "cloud" : null,
+    source: null,
+    task: null,
+  };
+}
+
+const ROWS: HomeRow[] = [
+  row("Rebuild the space switcher", {
+    status: "in_progress",
+    projectId: "project-nav",
+    pinned: true,
+  }),
+  row("Sidebar drops focus when a space collapses", {
+    status: "failed",
+    projectId: "project-nav",
+    assignee: GRACE,
+    daysAgo: 1,
+  }),
+  row("Navigation rebuild plan", {
+    kind: "plan",
+    status: "in_progress",
+    projectId: "project-nav",
+    daysAgo: 2,
+  }),
+  row("Audit every keyboard path through the tree", {
+    kind: "todo",
+    status: "todo",
+    projectId: "project-nav",
+    assignee: GRACE,
+    daysAgo: 2,
+  }),
+  row("Signup funnel by referrer", {
+    kind: "canvas",
+    status: "done",
+    spaceId: "space-growth",
+    projectId: "project-signup",
+    daysAgo: 3,
+  }),
+  row("Trim the onboarding checklist", {
+    status: "in_progress",
+    spaceId: "space-growth",
+    projectId: "project-signup",
+    assignee: GRACE,
+    daysAgo: 4,
+  }),
+  row("Add a retry to the invite email job", {
+    status: "done",
+    spaceId: "space-growth",
+    daysAgo: 5,
+  }),
+  row("Scratch: compare two caching strategies", {
+    status: "backlog",
+    spaceId: "space-me",
+    assignee: null,
+    daysAgo: 9,
+  }),
+  row("Drop the legacy exporter", {
+    status: "canceled",
+    spaceId: "space-me",
+    daysAgo: 21,
+  }),
+];
+
+/**
+ * Seeds the local projects registry and resets the view store, so each story
+ * renders the same table no matter what the last one left behind.
+ */
+function seedStores({
+  groupBy = "status" as const,
+}: {
+  groupBy?: "status" | "project" | "space";
+} = {}) {
+  useHomeProjectsStore.setState({
+    projects: Object.fromEntries(
+      PROJECTS.map((project) => [
+        project.id,
+        {
+          ...project,
+          status: "in_progress" as const,
+          lead: ADA,
+          createdAt: NOW,
+          updatedAt: NOW,
+        },
+      ]),
+    ),
+    notes: Object.fromEntries(NOTES.map((note) => [note.id, note])),
+    filing: {},
+  });
+  useHomeViewStore.setState({
+    query: "",
+    filters: {
+      statuses: [],
+      kinds: [],
+      spaceIds: [],
+      projectIds: [],
+      assigneeUuids: [],
+    },
+    groupBy,
+    sort: "recent",
+    collapsedGroups: {},
+  });
+}
+
+const meta = {
+  title: "Home/HomePage",
+  component: HomePage,
+  parameters: { layout: "fullscreen" },
+  args: {
+    spaces: SPACES,
+    rows: ROWS,
+    isLoading: false,
+    currentUser: ADA,
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-screen">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof HomePage>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const GroupedByStatus: Story = {
+  beforeEach: () => seedStores(),
+};
+
+export const GroupedByProject: Story = {
+  beforeEach: () => seedStores({ groupBy: "project" }),
+};
+
+export const GroupedBySpace: Story = {
+  beforeEach: () => seedStores({ groupBy: "space" }),
+};
+
+export const Loading: Story = {
+  args: { isLoading: true },
+  beforeEach: () => seedStores(),
+};
+
+export const NoPinnedSpaces: Story = {
+  args: { spaces: [], rows: [] },
+  beforeEach: () => seedStores(),
+};
+
+export const NoWorkYet: Story = {
+  args: { rows: [] },
+  beforeEach: () => seedStores(),
+};

--- a/products/desktop/packages/ui/src/features/home/components/HomeView.tsx
+++ b/products/desktop/packages/ui/src/features/home/components/HomeView.tsx
@@ -1,0 +1,326 @@
+import {
+  KanbanIcon,
+  NoteIcon,
+  PlusIcon,
+  StackIcon,
+} from "@phosphor-icons/react";
+import {
+  countHomeFilters,
+  filterHomeRows,
+  groupHomeRows,
+  type HomeGroup,
+  homeFacets,
+  sortHomeRows,
+} from "@posthog/core/home/homeFilters";
+import type { HomeRow } from "@posthog/core/home/homeRows";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+  Skeleton,
+} from "@posthog/quill";
+import type { UserBasic } from "@posthog/shared/domain-types";
+import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
+import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
+import {
+  type HomeProjectOption,
+  HomeTable,
+} from "@posthog/ui/features/home/components/HomeTable";
+import { HomeToolbar } from "@posthog/ui/features/home/components/HomeToolbar";
+import { NewProjectDialog } from "@posthog/ui/features/home/components/NewProjectDialog";
+import {
+  NoteDialog,
+  type NoteDialogTarget,
+} from "@posthog/ui/features/home/components/NoteDialog";
+import { useHomeProjectsStore } from "@posthog/ui/features/home/homeProjectsStore";
+import { useHomeViewStore } from "@posthog/ui/features/home/homeViewStore";
+import { useHomeActions } from "@posthog/ui/features/home/useHomeActions";
+import {
+  useHomeRows,
+  usePinnedSpaces,
+} from "@posthog/ui/features/home/useHomeWork";
+import { navigateToCanvas } from "@posthog/ui/router/navigationBridge";
+import { useCallback, useMemo, useState } from "react";
+
+/**
+ * The home page: every piece of work across the spaces this reader pinned, in
+ * one table.
+ *
+ * Fetching only. Everything the page draws lives in {@link HomePage}, which
+ * takes it all as props so the surface can be rendered without a backend.
+ */
+export function HomeView() {
+  const { spaces, isLoading: spacesLoading } = usePinnedSpaces();
+  const { rows, isLoading } = useHomeRows();
+  const client = useOptionalAuthenticatedClient();
+  const { data: currentUser } = useCurrentUser({ client });
+
+  const spaceOptions = useMemo(
+    () => spaces.map((space) => ({ id: space.id, name: space.name })),
+    [spaces],
+  );
+
+  return (
+    <HomePage
+      spaces={spaceOptions}
+      rows={rows}
+      isLoading={spacesLoading || isLoading}
+      currentUser={currentUser ?? null}
+    />
+  );
+}
+
+export interface HomePageSpace {
+  id: string;
+  name: string;
+}
+
+/**
+ * The table is the whole page. Its own chrome is one toolbar, because the point
+ * of the surface is to answer "what is happening" in a glance rather than to be
+ * navigated.
+ */
+export function HomePage({
+  spaces,
+  rows,
+  isLoading,
+  currentUser,
+}: {
+  spaces: HomePageSpace[];
+  rows: HomeRow[];
+  isLoading: boolean;
+  currentUser: UserBasic | null;
+}) {
+  const projects = useHomeProjectsStore((state) => state.projects);
+
+  const query = useHomeViewStore((state) => state.query);
+  const filters = useHomeViewStore((state) => state.filters);
+  const groupBy = useHomeViewStore((state) => state.groupBy);
+  const sort = useHomeViewStore((state) => state.sort);
+  const clearFilters = useHomeViewStore((state) => state.clearFilters);
+  const setQuery = useHomeViewStore((state) => state.setQuery);
+
+  const [projectDialogOpen, setProjectDialogOpen] = useState(false);
+  const [noteTarget, setNoteTarget] = useState<NoteDialogTarget | null>(null);
+
+  const openNote = useCallback(
+    (row: HomeRow) => setNoteTarget({ mode: "edit", noteId: row.id }),
+    [],
+  );
+  const actions = useHomeActions({ onOpenNote: openNote });
+
+  const facets = useMemo(() => homeFacets(rows), [rows]);
+  const visible = useMemo(
+    () => sortHomeRows(filterHomeRows(rows, { query, filters }), sort),
+    [rows, query, filters, sort],
+  );
+  const groups = useMemo(
+    () => groupHomeRows(visible, groupBy),
+    [visible, groupBy],
+  );
+
+  const spaceNameById = useMemo(
+    () => new Map(spaces.map((space) => [space.id, space.name])),
+    [spaces],
+  );
+
+  // One array per space, rebuilt only when the projects change, so a memoized
+  // row keeps its props across the table's polling refreshes.
+  const projectsBySpace = useMemo(() => {
+    const bySpace = new Map<string, HomeProjectOption[]>();
+    for (const project of Object.values(projects)) {
+      const existing = bySpace.get(project.spaceId);
+      const option = { id: project.id, name: project.name };
+      if (existing) existing.push(option);
+      else bySpace.set(project.spaceId, [option]);
+    }
+    return bySpace;
+  }, [projects]);
+
+  const projectOptions = useMemo(
+    () =>
+      Object.values(projects).map((project) => ({
+        id: project.id,
+        name: project.name,
+        spaceName: spaceNameById.get(project.spaceId) ?? "",
+      })),
+    [projects, spaceNameById],
+  );
+
+  // Only reachable from a project heading: under any other grouping there is no
+  // one project the new work would belong to.
+  const addToGroup = useCallback(
+    (group: HomeGroup) =>
+      setNoteTarget({ mode: "create", kind: "todo", projectId: group.key }),
+    [],
+  );
+
+  const activeFilterCount = countHomeFilters(filters);
+  const hasProjects = projectOptions.length > 0;
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <header className="flex shrink-0 items-center gap-2 px-4 pt-4 pb-2">
+        <h1 className="font-semibold text-(--gray-12) text-lg">Home</h1>
+        <span className="text-muted-foreground text-sm">
+          {spaces.length === 1
+            ? "1 pinned space"
+            : `${spaces.length} pinned spaces`}
+        </span>
+        <div className="flex-1" />
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <Button
+                variant="primary"
+                size="sm"
+                disabled={spaces.length === 0}
+              >
+                <PlusIcon size={14} />
+                New
+              </Button>
+            }
+          />
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => setProjectDialogOpen(true)}>
+              Project…
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            {/* A plan and a todo both live inside a project, so there is
+                nothing to file them under until one exists. */}
+            <DropdownMenuItem
+              disabled={!hasProjects}
+              onClick={() => setNoteTarget({ mode: "create", kind: "todo" })}
+            >
+              Todo…
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={!hasProjects}
+              onClick={() => setNoteTarget({ mode: "create", kind: "plan" })}
+            >
+              Plan…
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </header>
+
+      {spaces.length > 0 ? (
+        <HomeToolbar facets={facets} activeFilterCount={activeFilterCount} />
+      ) : null}
+
+      {isLoading ? (
+        <HomeTableSkeleton />
+      ) : spaces.length === 0 ? (
+        <NoPinnedSpaces />
+      ) : visible.length === 0 ? (
+        <NothingToShow
+          narrowed={activeFilterCount > 0 || query.length > 0}
+          onClear={() => {
+            clearFilters();
+            setQuery("");
+          }}
+        />
+      ) : (
+        <HomeTable
+          groups={groups}
+          actions={actions}
+          projectsBySpace={projectsBySpace}
+          showProject={groupBy !== "project"}
+          showSpace={groupBy !== "space"}
+          groupsAreProjects={groupBy === "project"}
+          onAddToGroup={addToGroup}
+        />
+      )}
+
+      <NewProjectDialog
+        open={projectDialogOpen}
+        onOpenChange={setProjectDialogOpen}
+        spaces={spaces}
+        currentUser={currentUser}
+      />
+      <NoteDialog
+        target={noteTarget}
+        onClose={() => setNoteTarget(null)}
+        projects={projectOptions}
+        currentUser={currentUser}
+      />
+    </div>
+  );
+}
+
+/** One placeholder per row the table will draw, so the page doesn't jump. */
+const SKELETON_ROWS = ["1", "2", "3", "4", "5", "6", "7", "8"];
+
+function HomeTableSkeleton() {
+  return (
+    <output aria-label="Loading work" className="flex flex-col gap-px p-3">
+      {SKELETON_ROWS.map((row) => (
+        <Skeleton key={row} className="h-9 w-full" />
+      ))}
+    </output>
+  );
+}
+
+function NoPinnedSpaces() {
+  return (
+    <Empty className="flex-1">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <StackIcon />
+        </EmptyMedia>
+        <EmptyTitle>No pinned spaces yet</EmptyTitle>
+        <EmptyDescription>
+          Home shows the work in the spaces you pin. Star a space to start
+          following it here.
+        </EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        <Button variant="primary" onClick={() => navigateToCanvas()}>
+          Browse spaces
+        </Button>
+      </EmptyContent>
+    </Empty>
+  );
+}
+
+function NothingToShow({
+  narrowed,
+  onClear,
+}: {
+  narrowed: boolean;
+  onClear: () => void;
+}) {
+  return (
+    <Empty className="flex-1">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          {narrowed ? <NoteIcon /> : <KanbanIcon />}
+        </EmptyMedia>
+        <EmptyTitle>
+          {narrowed ? "Nothing matches" : "Nothing here yet"}
+        </EmptyTitle>
+        <EmptyDescription>
+          {narrowed
+            ? "No work in your pinned spaces matches the search and filters."
+            : "Work started in your pinned spaces shows up here."}
+        </EmptyDescription>
+      </EmptyHeader>
+      {narrowed ? (
+        <EmptyContent>
+          <Button variant="outline" onClick={onClear}>
+            Clear search and filters
+          </Button>
+        </EmptyContent>
+      ) : null}
+    </Empty>
+  );
+}

--- a/products/desktop/packages/ui/src/features/home/components/HomeWorkRow.tsx
+++ b/products/desktop/packages/ui/src/features/home/components/HomeWorkRow.tsx
@@ -1,0 +1,209 @@
+import {
+  ChatCircleIcon,
+  DotsThreeIcon,
+  type Icon,
+  ListChecksIcon,
+  NoteIcon,
+  PushPinIcon,
+  ShapesIcon,
+} from "@phosphor-icons/react";
+import type { HomeRow } from "@posthog/core/home/homeRows";
+import {
+  HOME_STATUS_LABELS,
+  HOME_STATUS_ORDER,
+  HOME_WORK_KIND_LABELS,
+} from "@posthog/core/home/schemas";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@posthog/quill";
+import { formatRelativeTimeShort } from "@posthog/shared";
+import { UserAvatar } from "@posthog/ui/features/auth/UserAvatar";
+import {
+  HomeStatusCell,
+  HomeStatusIcon,
+} from "@posthog/ui/features/home/components/HomeStatusIcon";
+import type { HomeRowActions } from "@posthog/ui/features/home/useHomeActions";
+import { memo } from "react";
+
+/**
+ * The glyph that says what kind of work a row is. Sessions borrow the chat
+ * glyph they wear elsewhere in the app, canvases the shapes glyph the space's
+ * own list gives an unclassified canvas.
+ */
+const KIND_ICON: Record<HomeRow["kind"], Icon> = {
+  session: ChatCircleIcon,
+  canvas: ShapesIcon,
+  plan: NoteIcon,
+  todo: ListChecksIcon,
+};
+
+/** Dim, fixed-width trailing metadata, so the columns line up down the table. */
+const META_CLASS = "shrink-0 text-[11px] text-muted-foreground";
+
+function HomeWorkRowInner({
+  row,
+  actions,
+  projectOptions,
+  showProject,
+  showSpace,
+}: {
+  row: HomeRow;
+  actions: HomeRowActions;
+  /** Projects in this row's own space: work can only move within a space. */
+  projectOptions: { id: string; name: string }[];
+  /** False when the group heading above already names it. */
+  showProject: boolean;
+  showSpace: boolean;
+}) {
+  const KindIcon = KIND_ICON[row.kind];
+  // Plans and todos are the only work this app owns outright, so they are the
+  // only rows whose status and existence the menu can actually change.
+  const isNote = row.kind === "plan" || row.kind === "todo";
+
+  return (
+    <div className="group flex h-9 items-center gap-2 border-(--gray-4) border-b px-3 text-sm last:border-b-0 focus-within:bg-(--gray-2) hover:bg-(--gray-2)">
+      {/* A real button rather than a clickable row div: it is one tab stop that
+          Enter and Space already work on, and it lets the actions menu sit
+          beside it instead of nested inside another button. */}
+      <button
+        type="button"
+        onClick={() => actions.open(row)}
+        className="flex min-w-0 flex-1 items-center gap-2 text-left focus-visible:outline-none"
+      >
+        <HomeStatusCell status={row.status} />
+
+        <span className={`${META_CLASS} w-12 tabular-nums`}>
+          {row.reference ?? ""}
+        </span>
+
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <span className="flex size-4 shrink-0 items-center justify-center">
+                <KindIcon size={14} className="text-(--gray-10)" aria-hidden />
+              </span>
+            }
+          />
+          <TooltipContent>{HOME_WORK_KIND_LABELS[row.kind]}</TooltipContent>
+        </Tooltip>
+
+        <span className="min-w-0 flex-1 truncate">{row.title}</span>
+
+        {row.pinned ? (
+          <PushPinIcon
+            size={12}
+            weight="fill"
+            className="shrink-0 text-(--gray-10)"
+            aria-label="Pinned"
+          />
+        ) : null}
+
+        {showProject && row.projectName ? (
+          <span className="hidden max-w-40 shrink-0 truncate rounded-(--radius-2) bg-(--gray-3) px-1.5 py-0.5 text-(--gray-11) text-[11px] sm:block">
+            {row.projectName}
+          </span>
+        ) : null}
+
+        {showSpace ? (
+          <span
+            className={`${META_CLASS} hidden w-32 truncate text-right md:block`}
+          >
+            #{row.spaceName}
+          </span>
+        ) : null}
+
+        <span className="flex w-6 shrink-0 justify-center">
+          {row.assignee ? <UserAvatar user={row.assignee} size="xs" /> : null}
+        </span>
+
+        <span className={`${META_CLASS} w-10 text-right`}>
+          {formatRelativeTimeShort(row.updatedAt)}
+        </span>
+      </button>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              variant="default"
+              size="icon-sm"
+              aria-label={`Actions for ${row.title}`}
+              className="shrink-0 opacity-0 group-hover:opacity-100 data-[popup-open]:opacity-100"
+            >
+              <DotsThreeIcon size={16} />
+            </Button>
+          }
+        />
+        <DropdownMenuContent align="end">
+          {isNote ? (
+            <>
+              <DropdownMenuGroup>
+                <DropdownMenuLabel>Status</DropdownMenuLabel>
+                {HOME_STATUS_ORDER.map((status) => (
+                  <DropdownMenuItem
+                    key={status}
+                    onClick={() => actions.setNoteStatus(row, status)}
+                  >
+                    <HomeStatusIcon status={status} size={14} />
+                    {HOME_STATUS_LABELS[status]}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuGroup>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => actions.remove(row)}>
+                Delete
+              </DropdownMenuItem>
+            </>
+          ) : (
+            <>
+              <DropdownMenuGroup>
+                <DropdownMenuLabel>Move to project</DropdownMenuLabel>
+                {projectOptions.length === 0 ? (
+                  <DropdownMenuItem disabled>
+                    No projects in #{row.spaceName} yet
+                  </DropdownMenuItem>
+                ) : (
+                  projectOptions.map((project) => (
+                    <DropdownMenuItem
+                      key={project.id}
+                      onClick={() => actions.fileToProject(row, project.id)}
+                    >
+                      {project.name}
+                    </DropdownMenuItem>
+                  ))
+                )}
+              </DropdownMenuGroup>
+              {row.projectId ? (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onClick={() => actions.fileToProject(row, null)}
+                  >
+                    Remove from project
+                  </DropdownMenuItem>
+                </>
+              ) : null}
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
+/**
+ * Memoized because the table polls: every refresh hands the list new row
+ * objects, and a screenful of rows each carrying a dropdown, two tooltips and
+ * an avatar is enough re-render to show up as scroll jank.
+ */
+export const HomeWorkRow = memo(HomeWorkRowInner);

--- a/products/desktop/packages/ui/src/features/home/components/NewProjectDialog.tsx
+++ b/products/desktop/packages/ui/src/features/home/components/NewProjectDialog.tsx
@@ -1,0 +1,128 @@
+import {
+  Button,
+  Dialog,
+  DialogBody,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldLabel,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@posthog/quill";
+import type { UserBasic } from "@posthog/shared/domain-types";
+import { useHomeProjectsStore } from "@posthog/ui/features/home/homeProjectsStore";
+import { type FormEvent, useEffect, useId, useState } from "react";
+
+export interface NewProjectSpace {
+  id: string;
+  name: string;
+}
+
+/**
+ * Create a project inside one of the pinned spaces. The space is picked here
+ * and never changes afterwards: everything the project gathers is scoped by
+ * that space, so moving one would change who can see its work.
+ */
+export function NewProjectDialog({
+  open,
+  onOpenChange,
+  spaces,
+  defaultSpaceId,
+  currentUser,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  spaces: NewProjectSpace[];
+  defaultSpaceId?: string;
+  currentUser: UserBasic | null;
+}) {
+  const nameFieldId = useId();
+  const spaceFieldId = useId();
+  const createProject = useHomeProjectsStore((state) => state.createProject);
+  const [name, setName] = useState("");
+  const [spaceId, setSpaceId] = useState(defaultSpaceId ?? spaces[0]?.id ?? "");
+
+  // Reopening should start clean, and the space list may have loaded since the
+  // last time this mounted.
+  useEffect(() => {
+    if (!open) return;
+    setName("");
+    setSpaceId(defaultSpaceId ?? spaces[0]?.id ?? "");
+  }, [open, defaultSpaceId, spaces]);
+
+  const canCreate = name.trim().length > 0 && spaceId.length > 0;
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault();
+    if (!canCreate) return;
+    createProject({ spaceId, name: name.trim(), lead: currentUser });
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>New project</DialogTitle>
+          <DialogDescription>
+            A project gathers the plans, canvases, todos and sessions for one
+            piece of work.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={submit}>
+          <DialogBody viewportClassName="flex flex-col gap-3">
+            <Field>
+              <FieldLabel htmlFor={nameFieldId}>Name</FieldLabel>
+              <Input
+                id={nameFieldId}
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="Onboarding revamp"
+                autoFocus
+              />
+            </Field>
+            <Field>
+              <FieldLabel htmlFor={spaceFieldId}>Space</FieldLabel>
+              <Select
+                value={spaceId}
+                onValueChange={(value) => setSpaceId(String(value))}
+              >
+                <SelectTrigger id={spaceFieldId}>
+                  {/* The trigger shows the value it was given unless it is told
+                      how to read it, and a space's value is an opaque id. */}
+                  <SelectValue>
+                    {(value) => {
+                      const space = spaces.find((s) => s.id === value);
+                      return space ? `#${space.name}` : "Pick a space";
+                    }}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  {spaces.map((space) => (
+                    <SelectItem key={space.id} value={space.id}>
+                      #{space.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </Field>
+          </DialogBody>
+          <DialogFooter>
+            <DialogClose render={<Button variant="outline">Cancel</Button>} />
+            <Button type="submit" variant="primary" disabled={!canCreate}>
+              Create project
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/products/desktop/packages/ui/src/features/home/components/NoteDialog.tsx
+++ b/products/desktop/packages/ui/src/features/home/components/NoteDialog.tsx
@@ -1,0 +1,245 @@
+import type { HomeNote, HomeStatus } from "@posthog/core/home/schemas";
+import {
+  HOME_STATUS_LABELS,
+  HOME_STATUS_ORDER,
+} from "@posthog/core/home/schemas";
+import {
+  Button,
+  Dialog,
+  DialogBody,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldLabel,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Textarea,
+} from "@posthog/quill";
+import type { UserBasic } from "@posthog/shared/domain-types";
+import { HomeStatusIcon } from "@posthog/ui/features/home/components/HomeStatusIcon";
+import { useHomeProjectsStore } from "@posthog/ui/features/home/homeProjectsStore";
+import { type FormEvent, useEffect, useId, useState } from "react";
+
+export interface NoteDialogProject {
+  id: string;
+  name: string;
+  spaceName: string;
+}
+
+/**
+ * What the dialog is doing this time: writing a new plan or todo into a
+ * project, or opening one that already exists.
+ */
+export type NoteDialogTarget =
+  | { mode: "create"; kind: HomeNote["kind"]; projectId?: string }
+  | { mode: "edit"; noteId: string };
+
+const KIND_COPY: Record<HomeNote["kind"], { title: string; hint: string }> = {
+  plan: {
+    title: "New plan",
+    hint: "Write out the approach before anyone starts building.",
+  },
+  todo: {
+    title: "New todo",
+    hint: "One thing that needs doing, in a sentence.",
+  },
+};
+
+/**
+ * The editor for the two kinds of work this app owns outright. Everything else
+ * on the home table opens somewhere it already lives, so this is the only place
+ * a row's own contents can be written.
+ */
+export function NoteDialog({
+  target,
+  onClose,
+  projects,
+  currentUser,
+}: {
+  /** Null while nothing is open, which is also what closes the dialog. */
+  target: NoteDialogTarget | null;
+  onClose: () => void;
+  projects: NoteDialogProject[];
+  currentUser: UserBasic | null;
+}) {
+  const titleFieldId = useId();
+  const statusFieldId = useId();
+  const projectFieldId = useId();
+  const bodyFieldId = useId();
+  const notes = useHomeProjectsStore((state) => state.notes);
+  const createNote = useHomeProjectsStore((state) => state.createNote);
+  const updateNote = useHomeProjectsStore((state) => state.updateNote);
+  const deleteNote = useHomeProjectsStore((state) => state.deleteNote);
+
+  const existing =
+    target?.mode === "edit" ? (notes[target.noteId] ?? null) : null;
+  const kind =
+    existing?.kind ?? (target?.mode === "create" ? target.kind : "todo");
+  // Asked to open something that is no longer there: deleted in another window,
+  // or dropped by a schema change. Staying shut is the honest answer; falling
+  // through would offer a create form nobody asked for.
+  const open = target?.mode === "create" || existing != null;
+
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [status, setStatus] = useState<HomeStatus>("todo");
+  const [projectId, setProjectId] = useState("");
+
+  // Load the dialog's fields from whatever it was opened on, once per opening.
+  // The note is read off the store imperatively rather than from the subscribed
+  // copy, so saving does not hand this effect a new record and reset the form
+  // out from under whoever is still typing.
+  useEffect(() => {
+    if (!target) return;
+    if (target.mode === "edit") {
+      const note = useHomeProjectsStore.getState().notes[target.noteId];
+      setTitle(note?.title ?? "");
+      setBody(note?.body ?? "");
+      setStatus(note?.status ?? "todo");
+      setProjectId(note?.projectId ?? "");
+      return;
+    }
+    setTitle("");
+    setBody("");
+    setStatus("todo");
+    setProjectId(target.projectId ?? projects[0]?.id ?? "");
+  }, [target, projects]);
+
+  const canSave = title.trim().length > 0 && projectId.length > 0;
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault();
+    if (!canSave) return;
+    if (existing) {
+      updateNote(existing.id, { title: title.trim(), body, status });
+    } else {
+      createNote({
+        projectId,
+        kind,
+        title: title.trim(),
+        body,
+        assignee: currentUser,
+      });
+    }
+    onClose();
+  };
+
+  const remove = () => {
+    if (existing) deleteNote(existing.id);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            {existing ? title || "Untitled" : KIND_COPY[kind].title}
+          </DialogTitle>
+          {existing ? null : (
+            <DialogDescription>{KIND_COPY[kind].hint}</DialogDescription>
+          )}
+        </DialogHeader>
+        <form onSubmit={submit}>
+          <DialogBody viewportClassName="flex flex-col gap-3">
+            <Field>
+              <FieldLabel htmlFor={titleFieldId}>Title</FieldLabel>
+              <Input
+                id={titleFieldId}
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                placeholder={
+                  kind === "plan" ? "Rework the setup flow" : "Update the docs"
+                }
+                autoFocus
+              />
+            </Field>
+
+            {existing ? (
+              <Field>
+                <FieldLabel htmlFor={statusFieldId}>Status</FieldLabel>
+                <Select
+                  value={status}
+                  onValueChange={(value) => setStatus(value as HomeStatus)}
+                >
+                  <SelectTrigger id={statusFieldId}>
+                    <SelectValue>
+                      {(value) => HOME_STATUS_LABELS[value as HomeStatus]}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {HOME_STATUS_ORDER.map((option) => (
+                      <SelectItem key={option} value={option}>
+                        <HomeStatusIcon status={option} size={14} />
+                        {HOME_STATUS_LABELS[option]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </Field>
+            ) : (
+              <Field>
+                <FieldLabel htmlFor={projectFieldId}>Project</FieldLabel>
+                <Select
+                  value={projectId}
+                  onValueChange={(value) => setProjectId(String(value))}
+                >
+                  <SelectTrigger id={projectFieldId}>
+                    <SelectValue>
+                      {(value) =>
+                        projects.find((project) => project.id === value)
+                          ?.name ?? "Pick a project"
+                      }
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {projects.map((project) => (
+                      <SelectItem key={project.id} value={project.id}>
+                        {project.name}
+                        <span className="text-muted-foreground">
+                          #{project.spaceName}
+                        </span>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </Field>
+            )}
+
+            <Field>
+              <FieldLabel htmlFor={bodyFieldId}>
+                {kind === "plan" ? "Plan" : "Notes"}
+              </FieldLabel>
+              <Textarea
+                id={bodyFieldId}
+                value={body}
+                onChange={(event) => setBody(event.target.value)}
+                rows={kind === "plan" ? 10 : 4}
+                placeholder="Markdown"
+              />
+            </Field>
+          </DialogBody>
+          <DialogFooter>
+            {existing ? (
+              <Button variant="outline" type="button" onClick={remove}>
+                Delete
+              </Button>
+            ) : null}
+            <DialogClose render={<Button variant="outline">Cancel</Button>} />
+            <Button type="submit" variant="primary" disabled={!canSave}>
+              {existing ? "Save" : "Create"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/products/desktop/packages/ui/src/features/home/components/ProjectMenu.tsx
+++ b/products/desktop/packages/ui/src/features/home/components/ProjectMenu.tsx
@@ -1,0 +1,137 @@
+import { DotsThreeIcon } from "@phosphor-icons/react";
+import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Button,
+  Dialog,
+  DialogBody,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Field,
+  FieldLabel,
+  Input,
+} from "@posthog/quill";
+import { useHomeProjectsStore } from "@posthog/ui/features/home/homeProjectsStore";
+import { type FormEvent, useEffect, useId, useState } from "react";
+
+/**
+ * Rename or remove a project, from the heading its work sits under. Both live
+ * here rather than in the toolbar because a project is only ever named on the
+ * table once, and that is where the reader is already looking at it.
+ */
+export function ProjectMenu({
+  projectId,
+  projectName,
+}: {
+  projectId: string;
+  projectName: string;
+}) {
+  const nameFieldId = useId();
+  const renameProject = useHomeProjectsStore((state) => state.renameProject);
+  const deleteProject = useHomeProjectsStore((state) => state.deleteProject);
+  const [renaming, setRenaming] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [name, setName] = useState(projectName);
+
+  useEffect(() => {
+    if (renaming) setName(projectName);
+  }, [renaming, projectName]);
+
+  const submitRename = (event: FormEvent) => {
+    event.preventDefault();
+    if (!name.trim()) return;
+    renameProject(projectId, name);
+    setRenaming(false);
+  };
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              variant="default"
+              size="icon-sm"
+              aria-label={`Actions for ${projectName}`}
+            >
+              <DotsThreeIcon size={16} />
+            </Button>
+          }
+        />
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={() => setRenaming(true)}>
+            Rename…
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => setDeleting(true)}>
+            Delete project…
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog open={renaming} onOpenChange={setRenaming}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Rename project</DialogTitle>
+          </DialogHeader>
+          <form onSubmit={submitRename}>
+            <DialogBody>
+              <Field>
+                <FieldLabel htmlFor={nameFieldId}>Name</FieldLabel>
+                <Input
+                  id={nameFieldId}
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
+                  autoFocus
+                />
+              </Field>
+            </DialogBody>
+            <DialogFooter>
+              <DialogClose render={<Button variant="outline">Cancel</Button>} />
+              <Button type="submit" variant="primary" disabled={!name.trim()}>
+                Save
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={deleting} onOpenChange={setDeleting}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete {projectName}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              The plans and todos in this project go with it. Sessions and
+              canvases stay where they are, and lose their project.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogClose
+              render={<Button variant="outline">Cancel</Button>}
+            />
+            <Button
+              variant="destructive"
+              onClick={() => {
+                deleteProject(projectId);
+                setDeleting(false);
+              }}
+            >
+              Delete project
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/products/desktop/packages/ui/src/features/home/homeProjectsStore.ts
+++ b/products/desktop/packages/ui/src/features/home/homeProjectsStore.ts
@@ -1,0 +1,206 @@
+import type {
+  HomeFiling,
+  HomeNote,
+  HomeProject,
+  HomeStatus,
+} from "@posthog/core/home/schemas";
+import { homeRegistrySchema } from "@posthog/core/home/schemas";
+import type { UserBasic } from "@posthog/shared/domain-types";
+import { logger } from "@posthog/ui/shell/logger";
+import { electronStorage } from "@posthog/ui/shell/rendererStorage";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+const log = logger.scope("home-projects");
+
+/**
+ * Projects, the plans and todos they hold, and which project each session or
+ * canvas is filed under.
+ *
+ * Filing lives here rather than on the task and canvas records because a
+ * project has no backend yet: this is the reader's own arrangement of work the
+ * backend already owns, the same way pinning is. That also means it is
+ * per-device, and a project vanishing on another machine is expected for now.
+ */
+interface HomeProjectsState {
+  projects: Record<string, HomeProject>;
+  notes: Record<string, HomeNote>;
+  /** Session or canvas id, to the project it belongs to. */
+  filing: HomeFiling;
+
+  createProject: (input: {
+    spaceId: string;
+    name: string;
+    lead: UserBasic | null;
+  }) => HomeProject;
+  renameProject: (projectId: string, name: string) => void;
+  setProjectStatus: (projectId: string, status: HomeStatus) => void;
+  deleteProject: (projectId: string) => void;
+
+  createNote: (input: {
+    projectId: string;
+    kind: HomeNote["kind"];
+    title: string;
+    body?: string;
+    assignee: UserBasic | null;
+  }) => HomeNote | null;
+  updateNote: (
+    noteId: string,
+    patch: Partial<Pick<HomeNote, "title" | "body" | "status" | "assignee">>,
+  ) => void;
+  deleteNote: (noteId: string) => void;
+
+  /** File a session or canvas under a project, or pass null to unfile it. */
+  fileWork: (workId: string, projectId: string | null) => void;
+}
+
+/**
+ * Everything a project's contents point back at, removed together. A note whose
+ * project is gone has nowhere to render, and a filing pointing at a deleted
+ * project would leave rows claiming a parent that no longer exists.
+ */
+function withoutProject(
+  state: HomeProjectsState,
+  projectId: string,
+): Pick<HomeProjectsState, "projects" | "notes" | "filing"> {
+  const projects = { ...state.projects };
+  delete projects[projectId];
+  return {
+    projects,
+    notes: Object.fromEntries(
+      Object.entries(state.notes).filter(
+        ([, note]) => note.projectId !== projectId,
+      ),
+    ),
+    filing: Object.fromEntries(
+      Object.entries(state.filing).filter(([, id]) => id !== projectId),
+    ),
+  };
+}
+
+export const useHomeProjectsStore = create<HomeProjectsState>()(
+  persist(
+    (set, get) => ({
+      projects: {},
+      notes: {},
+      filing: {},
+
+      createProject: ({ spaceId, name, lead }) => {
+        const now = Date.now();
+        const project: HomeProject = {
+          id: crypto.randomUUID(),
+          spaceId,
+          name,
+          status: "todo",
+          lead,
+          createdAt: now,
+          updatedAt: now,
+        };
+        set((state) => ({
+          projects: { ...state.projects, [project.id]: project },
+        }));
+        return project;
+      },
+
+      renameProject: (projectId, name) =>
+        set((state) => {
+          const project = state.projects[projectId];
+          if (!project || !name.trim()) return state;
+          return {
+            projects: {
+              ...state.projects,
+              [projectId]: {
+                ...project,
+                name: name.trim(),
+                updatedAt: Date.now(),
+              },
+            },
+          };
+        }),
+
+      setProjectStatus: (projectId, status) =>
+        set((state) => {
+          const project = state.projects[projectId];
+          if (!project) return state;
+          return {
+            projects: {
+              ...state.projects,
+              [projectId]: { ...project, status, updatedAt: Date.now() },
+            },
+          };
+        }),
+
+      deleteProject: (projectId) =>
+        set((state) => withoutProject(state, projectId)),
+
+      createNote: ({ projectId, kind, title, body = "", assignee }) => {
+        if (!get().projects[projectId]) return null;
+        const now = Date.now();
+        const note: HomeNote = {
+          id: crypto.randomUUID(),
+          projectId,
+          kind,
+          title,
+          body,
+          status: "todo",
+          assignee,
+          createdAt: now,
+          updatedAt: now,
+        };
+        set((state) => ({ notes: { ...state.notes, [note.id]: note } }));
+        return note;
+      },
+
+      updateNote: (noteId, patch) =>
+        set((state) => {
+          const note = state.notes[noteId];
+          if (!note) return state;
+          return {
+            notes: {
+              ...state.notes,
+              [noteId]: { ...note, ...patch, updatedAt: Date.now() },
+            },
+          };
+        }),
+
+      deleteNote: (noteId) =>
+        set((state) => {
+          const notes = { ...state.notes };
+          delete notes[noteId];
+          return { notes };
+        }),
+
+      fileWork: (workId, projectId) =>
+        set((state) => {
+          const filing = { ...state.filing };
+          if (projectId) filing[workId] = projectId;
+          else delete filing[workId];
+          return { filing };
+        }),
+    }),
+    {
+      name: "home-projects",
+      storage: electronStorage,
+      partialize: ({ projects, notes, filing }) => ({
+        projects,
+        notes,
+        filing,
+      }),
+      // Validate on the way in rather than trusting the file: this shape is
+      // still moving, and a half-written record from an older build would
+      // otherwise crash the table on every render instead of once at boot.
+      merge: (persisted, current) => {
+        const parsed = homeRegistrySchema.safeParse(persisted);
+        if (!parsed.success) {
+          if (persisted != null) {
+            log.warn("Discarded unreadable saved projects", {
+              issues: parsed.error.issues.length,
+            });
+          }
+          return current;
+        }
+        return { ...current, ...parsed.data };
+      },
+    },
+  ),
+);

--- a/products/desktop/packages/ui/src/features/home/homeViewStore.ts
+++ b/products/desktop/packages/ui/src/features/home/homeViewStore.ts
@@ -1,0 +1,77 @@
+import type {
+  HomeFilters,
+  HomeGroupBy,
+  HomeSort,
+} from "@posthog/core/home/homeFilters";
+import {
+  NO_HOME_FILTERS,
+  toggleHomeFilter,
+} from "@posthog/core/home/homeFilters";
+import { electronStorage } from "@posthog/ui/shell/rendererStorage";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+/**
+ * How the home table is arranged right now. View state, so it lives here rather
+ * than beside the projects: it says nothing about the work, only about how this
+ * reader is looking at it.
+ *
+ * The search query is deliberately not persisted. A filter left on is state the
+ * table explains with a badge; a query restored from last week is a table that
+ * looks empty for no visible reason.
+ */
+interface HomeViewState {
+  query: string;
+  filters: HomeFilters;
+  groupBy: HomeGroupBy;
+  sort: HomeSort;
+  collapsedGroups: Record<string, boolean>;
+
+  setQuery: (query: string) => void;
+  toggleFilter: <K extends keyof HomeFilters>(
+    facet: K,
+    value: HomeFilters[K][number],
+  ) => void;
+  clearFilters: () => void;
+  setGroupBy: (groupBy: HomeGroupBy) => void;
+  setSort: (sort: HomeSort) => void;
+  toggleGroup: (key: string) => void;
+}
+
+export const useHomeViewStore = create<HomeViewState>()(
+  persist(
+    (set) => ({
+      query: "",
+      filters: NO_HOME_FILTERS,
+      groupBy: "status",
+      sort: "recent",
+      collapsedGroups: {},
+
+      setQuery: (query) => set({ query }),
+      toggleFilter: (facet, value) =>
+        set((state) => ({
+          filters: toggleHomeFilter(state.filters, facet, value),
+        })),
+      clearFilters: () => set({ filters: NO_HOME_FILTERS }),
+      setGroupBy: (groupBy) => set({ groupBy }),
+      setSort: (sort) => set({ sort }),
+      toggleGroup: (key) =>
+        set((state) => ({
+          collapsedGroups: {
+            ...state.collapsedGroups,
+            [key]: !state.collapsedGroups[key],
+          },
+        })),
+    }),
+    {
+      name: "home-view",
+      storage: electronStorage,
+      partialize: ({ filters, groupBy, sort, collapsedGroups }) => ({
+        filters,
+        groupBy,
+        sort,
+        collapsedGroups,
+      }),
+    },
+  ),
+);

--- a/products/desktop/packages/ui/src/features/home/useHomeActions.ts
+++ b/products/desktop/packages/ui/src/features/home/useHomeActions.ts
@@ -1,0 +1,78 @@
+import type { HomeRow } from "@posthog/core/home/homeRows";
+import type { HomeStatus } from "@posthog/core/home/schemas";
+import { useHomeProjectsStore } from "@posthog/ui/features/home/homeProjectsStore";
+import { navigateToChannelDashboard } from "@posthog/ui/router/navigationBridge";
+import { openTask } from "@posthog/ui/router/useOpenTask";
+import { logger } from "@posthog/ui/shell/logger";
+import { useCallback, useMemo } from "react";
+
+const log = logger.scope("home-actions");
+
+/**
+ * What a row can do. One object for the whole table rather than closures per
+ * row, so a poll that hands the list new row objects doesn't also hand every
+ * row new props and re-render the screen.
+ */
+export interface HomeRowActions {
+  open: (row: HomeRow) => void;
+  fileToProject: (row: HomeRow, projectId: string | null) => void;
+  /** Plans and todos only: the other kinds read their status off a run. */
+  setNoteStatus: (row: HomeRow, status: HomeStatus) => void;
+  remove: (row: HomeRow) => void;
+}
+
+/**
+ * Opening a row goes wherever that kind of work already lives: a session to its
+ * detail view inside its space, a canvas to the space's canvas view. A plan or
+ * a todo has no page of its own yet, so it opens in place through `onOpenNote`.
+ */
+export function useHomeActions({
+  onOpenNote,
+}: {
+  onOpenNote: (row: HomeRow) => void;
+}): HomeRowActions {
+  const fileWork = useHomeProjectsStore((state) => state.fileWork);
+  const updateNote = useHomeProjectsStore((state) => state.updateNote);
+  const deleteNote = useHomeProjectsStore((state) => state.deleteNote);
+
+  const open = useCallback(
+    (row: HomeRow) => {
+      switch (row.kind) {
+        case "session":
+          if (row.task) {
+            void openTask(row.task, { channelId: row.spaceId }).catch(
+              (error: unknown) =>
+                log.error("Failed to open session", { error }),
+            );
+          }
+          return;
+        case "canvas":
+          navigateToChannelDashboard(row.spaceId, row.id);
+          return;
+        default:
+          onOpenNote(row);
+      }
+    },
+    [onOpenNote],
+  );
+
+  const fileToProject = useCallback(
+    (row: HomeRow, projectId: string | null) => fileWork(row.id, projectId),
+    [fileWork],
+  );
+
+  const setNoteStatus = useCallback(
+    (row: HomeRow, status: HomeStatus) => updateNote(row.id, { status }),
+    [updateNote],
+  );
+
+  const remove = useCallback(
+    (row: HomeRow) => deleteNote(row.id),
+    [deleteNote],
+  );
+
+  return useMemo(
+    () => ({ open, fileToProject, setNoteStatus, remove }),
+    [open, fileToProject, setNoteStatus, remove],
+  );
+}

--- a/products/desktop/packages/ui/src/features/home/useHomeWork.ts
+++ b/products/desktop/packages/ui/src/features/home/useHomeWork.ts
@@ -1,0 +1,167 @@
+import type { DashboardRecord } from "@posthog/core/canvas/dashboardSchemas";
+import {
+  buildHomeRows,
+  type HomeRow,
+  type HomeSpaceWork,
+} from "@posthog/core/home/homeRows";
+import { useHostTRPC } from "@posthog/host-router/react";
+import type { Task } from "@posthog/shared/domain-types";
+import { useArchivedTaskIds } from "@posthog/ui/features/archive/useArchivedTaskIds";
+import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
+import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
+import {
+  SPACE_QUERY_GC_TIME_MS,
+  SPACE_QUERY_STALE_TIME_MS,
+} from "@posthog/ui/features/canvas/hooks/spaceQueryPolicy";
+import {
+  type Channel,
+  useChannels,
+} from "@posthog/ui/features/canvas/hooks/useChannels";
+import { useHomeProjectsStore } from "@posthog/ui/features/home/homeProjectsStore";
+import { usePinnedTasks } from "@posthog/ui/features/sidebar/usePinnedTasks";
+import { useQueries } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+/**
+ * How much of a space's history the table reaches back over. Far more than the
+ * sidebar tree's page, because this is the surface you scan a quarter's work
+ * on, and far short of everything, because a busy org would otherwise pull tens
+ * of thousands of task records to draw one screen.
+ */
+const TASKS_PER_SPACE = 100;
+
+/** Slower than a space's own feed: the home table is a glance, not a monitor. */
+const HOME_POLL_INTERVAL_MS = 30_000;
+
+const homeSpaceTasksQueryKey = (spaceId: string) =>
+  ["home-space-tasks", spaceId] as const;
+
+/**
+ * The spaces the table covers: the ones this reader pinned, plus their own
+ * private space, which is pinned by definition.
+ */
+export function usePinnedSpaces(): { spaces: Channel[]; isLoading: boolean } {
+  const { channels, isLoading } = useChannels();
+  const spaces = useMemo(
+    () =>
+      channels.filter(
+        (channel) => channel.starred || channel.channelType === "personal",
+      ),
+    [channels],
+  );
+  return { spaces, isLoading };
+}
+
+/** One list per space, and whether any space is still on its first fetch. */
+interface SpaceLists<T> {
+  lists: T[][];
+  pending: boolean;
+}
+
+// Module scope so `useQueries` can memoize on them: an inline combine is a new
+// function every render, which rebuilds every row on every render with it.
+function combineTaskPages(
+  queries: { data?: { tasks: Task[] }; isPending: boolean }[],
+): SpaceLists<Task> {
+  return {
+    lists: queries.map((query) => query.data?.tasks ?? []),
+    pending: queries.some((query) => query.isPending),
+  };
+}
+
+function combineCanvasLists(
+  queries: { data?: DashboardRecord[]; isPending: boolean }[],
+): SpaceLists<DashboardRecord> {
+  return {
+    lists: queries.map((query) => query.data ?? []),
+    pending: queries.some((query) => query.isPending),
+  };
+}
+
+/**
+ * Every pinned space's sessions and canvases, as one row per piece of work.
+ *
+ * The fan-out is one pair of queries per pinned space rather than a single flat
+ * list, because the flat tasks endpoint is capped and most of its rows carry no
+ * space at all, so it cannot answer "what is in these spaces".
+ */
+export function useHomeRows(): { rows: HomeRow[]; isLoading: boolean } {
+  const client = useOptionalAuthenticatedClient();
+  const trpc = useHostTRPC();
+  const { spaces, isLoading: spacesLoading } = usePinnedSpaces();
+  const archivedTaskIds = useArchivedTaskIds();
+  const { pinnedTaskIds } = usePinnedTasks();
+  const projects = useHomeProjectsStore((state) => state.projects);
+  const notes = useHomeProjectsStore((state) => state.notes);
+  const filing = useHomeProjectsStore((state) => state.filing);
+
+  const tasksPerSpace = useQueries({
+    queries: spaces.map((space) => ({
+      queryKey: homeSpaceTasksQueryKey(space.id),
+      queryFn: async () => {
+        if (!client) throw new Error("Not authenticated");
+        return await client.getTasksPage({
+          channel: space.id,
+          limit: TASKS_PER_SPACE,
+        });
+      },
+      enabled: !!client,
+      gcTime: SPACE_QUERY_GC_TIME_MS,
+      meta: AUTH_SCOPED_QUERY_META,
+      refetchInterval: HOME_POLL_INTERVAL_MS,
+      staleTime: SPACE_QUERY_STALE_TIME_MS,
+    })),
+    combine: combineTaskPages,
+  });
+
+  const canvasesPerSpace = useQueries({
+    queries: spaces.map((space) =>
+      trpc.dashboards.list.queryOptions(
+        { channelId: space.id },
+        {
+          gcTime: SPACE_QUERY_GC_TIME_MS,
+          meta: AUTH_SCOPED_QUERY_META,
+          refetchInterval: HOME_POLL_INTERVAL_MS,
+          staleTime: SPACE_QUERY_STALE_TIME_MS,
+        },
+      ),
+    ),
+    combine: combineCanvasLists,
+  });
+
+  const work = useMemo<HomeSpaceWork[]>(
+    () =>
+      spaces.map((space, index) => ({
+        space: {
+          id: space.id,
+          name: space.name,
+          personal: space.channelType === "personal",
+        },
+        tasks: tasksPerSpace.lists[index] ?? [],
+        canvases: canvasesPerSpace.lists[index] ?? [],
+      })),
+    [spaces, tasksPerSpace, canvasesPerSpace],
+  );
+
+  const rows = useMemo(
+    () =>
+      buildHomeRows({
+        work,
+        projects: Object.values(projects),
+        notes: Object.values(notes),
+        filing,
+        archivedTaskIds,
+        pinnedTaskIds,
+      }),
+    [work, projects, notes, filing, archivedTaskIds, pinnedTaskIds],
+  );
+
+  return {
+    rows,
+    // Loading until the spaces are known and every one of them has answered
+    // once. An empty table before that is "not asked yet", not "nothing here",
+    // and the two want very different screens.
+    isLoading:
+      spacesLoading || tasksPerSpace.pending || canvasesPerSpace.pending,
+  };
+}

--- a/products/desktop/packages/ui/src/features/sidebar/components/CustomizeSidebarDialog.test.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/CustomizeSidebarDialog.test.tsx
@@ -154,7 +154,7 @@ describe("CustomizeSidebarSettings", () => {
     useSidebarStore.setState({ navItemOrder: ["configure", "inbox"] });
     renderSettings();
 
-    expect(rowLabels().slice(0, 2)).toEqual(["Settings", "Inbox"]);
+    expect(rowLabels().slice(0, 3)).toEqual(["Home", "Settings", "Inbox"]);
   });
 
   it("previews on dragover and persists only on drop", () => {
@@ -163,13 +163,14 @@ describe("CustomizeSidebarSettings", () => {
     dragStart("loops");
     dragOver("loops", "inbox");
 
-    expect(rowLabels()[0]).toBe("Loops");
+    expect(rowLabels()[1]).toBe("Loops");
     expect(useSidebarStore.getState().navItemOrder).toEqual([]);
     expect(track).not.toHaveBeenCalled();
 
     dragEnd("loops");
 
     expect(useSidebarStore.getState().navItemOrder).toEqual([
+      "home",
       "loops",
       "inbox",
       "activity",
@@ -178,7 +179,7 @@ describe("CustomizeSidebarSettings", () => {
     ]);
     expect(track).toHaveBeenCalledWith(ANALYTICS_EVENTS.SIDEBAR_REORDERED, {
       item: "loops",
-      to_index: 0,
+      to_index: 1,
     });
   });
 
@@ -189,11 +190,11 @@ describe("CustomizeSidebarSettings", () => {
     dragOver("loops", "inbox");
     dragOver("loops", "inbox");
 
-    expect(rowLabels()[0]).toBe("Loops");
+    expect(rowLabels()[1]).toBe("Loops");
 
     dragEnd("loops");
 
-    expect(useSidebarStore.getState().navItemOrder[0]).toBe("loops");
+    expect(useSidebarStore.getState().navItemOrder[1]).toBe("loops");
   });
 
   it("a canceled drag drops the preview and leaves the store untouched", () => {
@@ -203,7 +204,7 @@ describe("CustomizeSidebarSettings", () => {
     dragOver("loops", "inbox");
     dragEnd("loops", { cancel: true });
 
-    expect(rowLabels()[0]).toBe("Inbox");
+    expect(rowLabels()[1]).toBe("Inbox");
     expect(useSidebarStore.getState().navItemOrder).toEqual([]);
     expect(track).not.toHaveBeenCalled();
   });
@@ -226,6 +227,6 @@ describe("CustomizeSidebarSettings", () => {
     await user.click(screen.getByRole("button", { name: "Reset" }));
 
     expect(useSidebarStore.getState().navItemOrder).toEqual([]);
-    expect(rowLabels()[0]).toBe("Inbox");
+    expect(rowLabels()[0]).toBe("Home");
   });
 });

--- a/products/desktop/packages/ui/src/features/sidebar/components/CustomizeSidebarDialog.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/CustomizeSidebarDialog.tsx
@@ -4,6 +4,7 @@ import {
   Bell,
   DotsSixVertical,
   EnvelopeSimple,
+  HouseIcon,
   SlidersHorizontal,
   SquaresFourIcon,
 } from "@phosphor-icons/react";
@@ -28,6 +29,7 @@ const ITEM_ICONS: Record<
   CustomizableNavItemId,
   React.ComponentType<{ size?: number | string }>
 > = {
+  home: HouseIcon,
   inbox: EnvelopeSimple,
   "command-center": SquaresFourIcon,
   activity: Bell,
@@ -72,7 +74,7 @@ export function CustomizeSidebarSettings() {
   const items = orderedNavItems(previewOrder ?? navItemOrder).filter(
     ({ id }) => {
       if (id === "loops") return loopsEnabled;
-      if (id === "activity") return bluebirdEnabled;
+      if (id === "activity" || id === "home") return bluebirdEnabled;
       return true;
     },
   );

--- a/products/desktop/packages/ui/src/features/sidebar/components/SidebarNavSection.test.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/SidebarNavSection.test.tsx
@@ -21,6 +21,7 @@ const {
   navigateToMcpServers,
   navigateToCommandCenter,
   navigateToActivity,
+  navigateToHome,
   openCommandMenu,
 } = vi.hoisted(() => ({
   track: vi.fn(),
@@ -31,6 +32,7 @@ const {
   navigateToMcpServers: vi.fn(),
   navigateToCommandCenter: vi.fn(),
   navigateToActivity: vi.fn(),
+  navigateToHome: vi.fn(),
   openCommandMenu: vi.fn(),
 }));
 
@@ -48,6 +50,7 @@ vi.mock("@posthog/ui/router/navigationBridge", () => ({
   navigateToActivity,
   navigateToAgents,
   navigateToCommandCenter,
+  navigateToHome,
   navigateToInbox,
   navigateToLoops: vi.fn(),
   navigateToMcpServers,
@@ -111,6 +114,7 @@ describe("SidebarNavSection", () => {
   });
 
   it.each([
+    ["home", "Home"],
     ["inbox", "Inbox"],
     ["command-center", "Command Center"],
     ["activity", "Activity"],
@@ -149,6 +153,15 @@ describe("SidebarNavSection", () => {
       ANALYTICS_EVENTS.SIDEBAR_NAV_ITEM_CLICKED,
       { item: "inbox", in_more: false, layout: "code" },
     );
+  });
+
+  it("navigates to the root route from Home", async () => {
+    const user = userEvent.setup();
+    renderNav();
+
+    await user.click(screen.getByRole("button", { name: /Home/ }));
+
+    expect(navigateToHome).toHaveBeenCalledTimes(1);
   });
 
   it("does not render the Channels mode toggle in navigation", () => {

--- a/products/desktop/packages/ui/src/features/sidebar/components/SidebarNavSection.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/SidebarNavSection.tsx
@@ -17,6 +17,7 @@ import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import {
   navigateToActivity,
   navigateToCommandCenter,
+  navigateToHome,
   navigateToInbox,
   navigateToLoops,
   navigateToWebsiteCommandCenter,
@@ -31,6 +32,7 @@ import type { ReactNode } from "react";
 import { ActivityItem } from "./items/ActivityItem";
 import { CommandCenterItem } from "./items/CommandCenterItem";
 import { ConfigureItem } from "./items/ConfigureItem";
+import { HomeItem } from "./items/HomeItem";
 import { InboxItem } from "./items/InboxItem";
 import { LoopsItem } from "./items/LoopsItem";
 import { NewTaskItem } from "./items/NewTaskItem";
@@ -83,8 +85,9 @@ export function SidebarNavSection({
 
   // Active flags are pure functions of the current view — mirror what
   // useSidebarData derives, without pulling in its task-loading.
-  const isHomeActive =
+  const isNewTaskActive =
     view.type === "task-input" || view.type === "task-pending";
+  const isHomeActive = view.type === "home";
   const isActivityActive = view.type === "activity";
   const isInboxActive = view.type === "inbox";
   const isLoopsActive = view.type === "loops";
@@ -134,6 +137,9 @@ export function SidebarNavSection({
     ),
   );
   const navItemAvailable: Record<CustomizableNavItemId, boolean> = {
+    // Home is the root route's bluebird view; off the flag that route only
+    // redirects into Code, so the row would lead nowhere.
+    home: bluebirdEnabled,
     inbox: true,
     "command-center": true,
     activity: bluebirdEnabled,
@@ -147,6 +153,13 @@ export function SidebarNavSection({
     CustomizableNavItemId,
     (depth: 0 | 1) => ReactNode
   > = {
+    home: (depth) => (
+      <HomeItem
+        depth={depth}
+        isActive={isHomeActive}
+        onClick={withNavTrack("home", navigateToHome, depth)}
+      />
+    ),
     inbox: (depth) => (
       <InboxItem
         depth={depth}
@@ -192,7 +205,7 @@ export function SidebarNavSection({
     <Flex direction="column" className="shrink-0 gap-px px-2 py-2">
       <Box mb="2">
         <NewTaskItem
-          isActive={isHomeActive}
+          isActive={isNewTaskActive}
           onClick={withNavTrack("new_task", goNewTask)}
         />
       </Box>

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/HomeItem.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/HomeItem.tsx
@@ -1,0 +1,20 @@
+import { HouseIcon } from "@phosphor-icons/react";
+import { SidebarItem } from "../SidebarItem";
+
+interface HomeItemProps {
+  isActive: boolean;
+  onClick: () => void;
+  depth?: number;
+}
+
+export function HomeItem({ isActive, onClick, depth = 0 }: HomeItemProps) {
+  return (
+    <SidebarItem
+      depth={depth}
+      icon={<HouseIcon size={16} weight={isActive ? "fill" : "regular"} />}
+      label="Home"
+      isActive={isActive}
+      onClick={onClick}
+    />
+  );
+}

--- a/products/desktop/packages/ui/src/features/sidebar/constants.test.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/constants.test.ts
@@ -46,6 +46,7 @@ describe("orderedNavItems", () => {
 
     expect(ids.indexOf("activity")).toBe(ids.indexOf("inbox") + 1);
     expect(ids.filter((id) => id !== "activity")).toEqual([
+      "home",
       "inbox",
       "loops",
       "command-center",
@@ -58,16 +59,18 @@ describe("orderedNavItems", () => {
       (item) => item.id,
     );
 
-    expect(ids[0]).toBe("inbox");
+    expect(ids[0]).toBe("home");
   });
 
   it("puts stored ids first and appends the rest in default order", () => {
-    const ids = orderedNavItems(["configure", "inbox"]).map((item) => item.id);
+    const ids = orderedNavItems(["home", "configure", "inbox"]).map(
+      (item) => item.id,
+    );
 
-    expect(ids.slice(0, 2)).toEqual(["configure", "inbox"]);
-    expect(ids.slice(2)).toEqual(
+    expect(ids.slice(0, 3)).toEqual(["home", "configure", "inbox"]);
+    expect(ids.slice(3)).toEqual(
       CUSTOMIZABLE_NAV_ITEM_IDS.filter(
-        (id) => id !== "configure" && id !== "inbox",
+        (id) => id !== "home" && id !== "configure" && id !== "inbox",
       ),
     );
   });
@@ -77,7 +80,9 @@ describe("moveNavItem", () => {
   it("moves an item backward to the target position", () => {
     const next = moveNavItem([], "loops", "inbox");
 
-    expect(next[0]).toBe("loops");
+    expect(next.indexOf("loops")).toBe(
+      CUSTOMIZABLE_NAV_ITEM_IDS.indexOf("inbox"),
+    );
     expect(next).toHaveLength(CUSTOMIZABLE_NAV_ITEM_IDS.length);
   });
 

--- a/products/desktop/packages/ui/src/features/sidebar/constants.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/constants.ts
@@ -11,6 +11,7 @@ export const SIDEBAR_MIN_WIDTH = 240;
 export const CHANNELS_SIDEBAR_MIN_WIDTH = 272;
 
 export const CUSTOMIZABLE_NAV_ITEMS = [
+  { id: "home", label: "Home", analyticsId: "home", defaultVisible: true },
   { id: "inbox", label: "Inbox", analyticsId: "inbox", defaultVisible: true },
   {
     id: "activity",

--- a/products/desktop/packages/ui/src/router/navigationBridge.ts
+++ b/products/desktop/packages/ui/src/router/navigationBridge.ts
@@ -15,6 +15,10 @@ import { getRouterOrNull } from "./routerRef";
 // (early boot, unit tests). These are renderer conveniences — they must never
 // throw just because the router singleton hasn't been created.
 
+export function navigateToHome(): void {
+  void getRouterOrNull()?.navigate({ to: "/" });
+}
+
 export function navigateToCode(): void {
   void getRouterOrNull()?.navigate({ to: "/code" });
 }

--- a/products/desktop/packages/ui/src/router/routes/index.tsx
+++ b/products/desktop/packages/ui/src/router/routes/index.tsx
@@ -1,7 +1,45 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { useBluebirdFlag } from "@posthog/ui/features/feature-flags/useBluebirdFlag";
+import { useFeatureFlagsLoaded } from "@posthog/ui/features/feature-flags/useFeatureFlagsLoaded";
+import { HomeView } from "@posthog/ui/features/home/components/HomeView";
+import { createFileRoute, Navigate } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
 
 export const Route = createFileRoute("/")({
-  beforeLoad: () => {
-    throw redirect({ to: "/code" });
-  },
+  component: IndexRoute,
 });
+
+/**
+ * How long the root route will wait for feature flags before deciding without
+ * them. Long enough to cover a normal flag fetch, short enough that a reader
+ * whose flags never arrive (offline, first run) still lands somewhere.
+ */
+const FLAG_WAIT_MS = 1_000;
+
+/** True once the flags have arrived, or once waiting for them stopped paying. */
+function useFlagsSettled(): boolean {
+  const loaded = useFeatureFlagsLoaded();
+  const [waited, setWaited] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setWaited(true), FLAG_WAIT_MS);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return loaded || waited;
+}
+
+/**
+ * The root route is Home for anyone on bluebird, and the old redirect into Code
+ * for everyone else.
+ *
+ * The decision waits for the flags rather than guessing. Redirecting first and
+ * correcting later would bounce a bluebird reader through Code on every cold
+ * start, and a redirect is not something a later render can take back.
+ */
+function IndexRoute() {
+  const settled = useFlagsSettled();
+  const bluebird = useBluebirdFlag();
+
+  if (!settled) return null;
+  return bluebird ? <HomeView /> : <Navigate to="/code" replace />;
+}

--- a/products/desktop/packages/ui/src/router/useAppView.ts
+++ b/products/desktop/packages/ui/src/router/useAppView.ts
@@ -7,6 +7,7 @@ import { useMemo } from "react";
 import { getCurrentMatches } from "./navigationBridge";
 
 export type AppViewType =
+  | "home"
   | "task-detail"
   | "task-pending"
   | "task-input"
@@ -43,6 +44,10 @@ function deriveFromMatches(matches: Match[]): AppView {
   if (!last) return { type: "task-input" };
 
   switch (last.routeId) {
+    // The root route renders Home on bluebird; off it, it redirects into Code
+    // before this view is read for anything user-visible.
+    case "/":
+      return { type: "home" };
     // Both the /code task detail and the channels-space task detail render the
     // same task-detail view, so consumers (active-state highlighting, archive's
     // navigate-away-if-active check) treat them identically.


### PR DESCRIPTION
## Problem

Users need a single surface to see all work across the spaces they care about — sessions, canvases, plans, and todos — without navigating between multiple views. The home page should answer "what is happening" at a glance by aggregating pinned spaces' work into one filterable, sortable, groupable table.

## Changes

Added a complete home page surface that unifies work across pinned spaces:

**Core data structures** (`products/desktop/packages/core/src/home/`):
- `schemas.ts`: Unified vocabulary for work status (`backlog`, `todo`, `in_progress`, `done`, `failed`, `canceled`) and kinds (`session`, `canvas`, `plan`, `todo`) that spans all work types
- `homeRows.ts`: Flattens sessions, canvases, plans, and todos into a single `HomeRow` shape for consistent table rendering; includes status mapping from task runs and canvas build state
- `homeFilters.ts`: Filtering, sorting, grouping, and facet extraction logic; supports filtering by status, kind, space, project, and assignee; sorting by recency, creation, title, or status; grouping by any of those dimensions

**UI components** (`products/desktop/packages/ui/src/features/home/components/`):
- `HomeView.tsx`: Data-fetching wrapper that loads pinned spaces and work, passes to `HomePage` for rendering
- `HomePage.tsx`: Main layout orchestrating the toolbar, table, and dialogs; manages view state (query, filters, grouping, sorting)
- `HomeToolbar.tsx`: Search input, filter menu with facet counts, and controls for grouping and sorting
- `HomeTable.tsx`: Groups rows by the chosen dimension and renders collapsible sections
- `HomeWorkRow.tsx`: Individual row with status indicator, reference, title, project/space/assignee metadata, and actions menu
- `HomeStatusIcon.tsx`: Consistent status glyph and color across the table
- `NoteDialog.tsx`: Editor for plans and todos (the two work kinds this app owns outright)
- `NewProjectDialog.tsx`: Create a project in a pinned space
- `ProjectMenu.tsx`: Rename or delete a project from its heading

**State management**:
- `homeProjectsStore.ts`: Zustand store for projects, notes, and filing (which session/canvas belongs to which project); persisted to local storage
- `homeViewStore.ts`: Zustand store for view state (search query, active filters, grouping, sorting, collapsed groups); persisted to local storage

**Hooks and actions**:
- `useHomeWork.ts`: Fetches pinned spaces and their tasks/canvases; polls for updates
- `useHomeActions.ts`: Handlers for opening work, filing to projects, changing note status, and removing work

**Stories and tests**:
- `HomeView.stories.tsx`: Storybook stories covering various row types, statuses, and table states
- `homeFilters.test.ts`: Unit tests for filtering, sorting, grouping, and facet extraction
- `homeRows.test.ts`: Unit tests for status mapping and row building from different work kinds

**Routing**:
- Updated `products/desktop/packages/ui/src/router/routes/index.tsx` to render `HomeView` at `/` when the home feature flag is enabled, replacing the redirect to `/code`

The table is the whole page — its chrome is one toolbar, because the point is to scan work at a glance rather than navigate. Pinned work appears first in every sort. Filtering is additive per facet (all selected statuses OR all selected kinds, etc.) and empty facets mean "don't narrow on this" rather than "match nothing." The search query matches against title, project, space, and reference. Projects are per-device and per-space; filing is the reader's own arrangement of work the backend already owns.

## How did you test this code?

- Added comprehensive unit tests for filtering, sorting, grouping, and facet extraction (`homeFilters.test.ts`, `homeRows.test.ts`)
- Added Storybook stories covering multiple row types, statuses, and table configurations (`HomeView.stories.tsx`)
- Existing integration tests for data fetching and state management pass

##

https://claude.ai/code/session_01L35eVMwXMCYvA8ehCCZQz2