### PR TITLE
chore(cdp): cut the invocations sparkline to one story and trim comments

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6262,18 +6262,6 @@ snapshots:
         hash: v1.k794b7964.f3c8bc6697db692d759f57d5f1cba413b909e22923e87c65d0c223e613144076.sfVPBgq0NjbXJfcc8nye_vNXKKoaNiKVdX2kKdYWjug
     scenes-app-hogfunctions-destination--runs-with-data--light:
         hash: v1.k794b7964.7ebd6b1de8b3532192340ab4748697c7175fbb3e36227394abac3397e7fb36d5.g74q_2eAZTmStVOVUVR9w1MEZmTHfWR6PBmaj1xImiM
-    scenes-app-hogfunctions-invocationssparkline--minute-buckets--dark:
-        hash: v1.k794b7964.053d79267cb46ed2a3d6c71431df199ef9b9c07dd03212d0b81d596dc29267f5.BF--8w3swJC7PqM5rqBuwxCmiyVcJJzjYrQHnO-1O_k
-    scenes-app-hogfunctions-invocationssparkline--minute-buckets--light:
-        hash: v1.k794b7964.47d04f4f3e449e531332289932b8ee142b8385a4a9917b2d305dc405ea28fe2b.Y7vt-ONbD4vvpuHBery2NCcUn7qwBg5YzMoXP7ycUl0
-    scenes-app-hogfunctions-invocationssparkline--no-invocations--dark:
-        hash: v1.k794b7964.a4648bab6988b7e05cc061c41cd763d01830f968b95a288ea9e13a06f672ac7c.uygJuT2clcLQRpDWTl4MlO_b95awvXal2cfIWLyGzVc
-    scenes-app-hogfunctions-invocationssparkline--no-invocations--light:
-        hash: v1.k794b7964.338b36ebc6ee8998ad46f63fba8eb24380e98ca9c13b134ce2b63a9e2bd9febe.btvfHLBBn0y46nlWyNLL77WuPxgZWmyj4Bnk1UIDEiQ
-    scenes-app-hogfunctions-invocationssparkline--week-of-hourly-buckets--dark:
-        hash: v1.k794b7964.363a57807bd4cfb1a9dbb9cba8f3a9dec0412dc70bcf1caf5dd765023f13bf04.j3XxN6_uDSBmFiN0dRgvWHXKvRQlhtttOPEsXVs0aw4
-    scenes-app-hogfunctions-invocationssparkline--week-of-hourly-buckets--light:
-        hash: v1.k794b7964.461dff5273fd97c22966bb47423c06682fe4942471176f541e67abcce60b22eb.iwOhWf-MugRRIXF10rZcN0o2rQpokdbqPjVFPjHm2fs
     scenes-app-hogfunctions-invocationssparkline--with-activity--dark:
         hash: v1.k794b7964.280a3bc355fbb852d9fa1d263e5b64b78075ab6c6736a681179d889b12509511.PXK7NUJxJ9CwB10xyOU3hwZ008ZQxMZnSz5_qfwYbRc
     scenes-app-hogfunctions-invocationssparkline--with-activity--light:

--- a/frontend/src/scenes/hog-functions/invocations/InvocationsSparkline.stories.tsx
+++ b/frontend/src/scenes/hog-functions/invocations/InvocationsSparkline.stories.tsx
@@ -12,7 +12,6 @@ const meta: Meta<typeof InvocationsSparkline> = {
         layout: 'centered',
         testOptions: { snapshotBrowsers: ['chromium'] },
     },
-    // The component sizes its own height (`h-24`), so the stories only need to pin a width.
     decorators: [
         (Story) => (
             <div className="w-[760px]">
@@ -25,10 +24,10 @@ export default meta
 
 type Story = StoryObj<typeof InvocationsSparkline>
 
-/** Hourly buckets on a fixed anchor so the bars and axis ticks are identical across snapshot runs. */
-function exampleData(bucketCount = 48): SparklineData {
+/** Anchored to a fixed date so the bars and axis ticks are identical across snapshot runs. */
+function exampleData(): SparklineData {
     const start = dayjs('2026-06-01T00:00:00Z')
-    const dates = Array.from({ length: bucketCount }, (_, i) => start.add(i, 'hour').toISOString())
+    const dates = Array.from({ length: 48 }, (_, i) => start.add(i, 'hour').toISOString())
     const wave = (i: number, phase: number, scale: number): number =>
         Math.max(0, Math.round(scale * (1 + Math.sin(i / 5 + phase))))
     return {
@@ -41,50 +40,6 @@ function exampleData(bucketCount = 48): SparklineData {
     }
 }
 
-/** Stacked succeeded/running/failed buckets — the default state above the runs table. */
 export const WithActivity: Story = {
     render: () => <InvocationsSparkline data={exampleData()} loading={false} onDateRangeChange={() => {}} />,
-}
-
-/** Every bucket empty: the chart is replaced by copy rather than an axis with no bars. */
-export const NoInvocations: Story = {
-    render: () => {
-        const { dates, series } = exampleData(12)
-        return (
-            <InvocationsSparkline
-                data={{ dates, series: series.map((s) => ({ ...s, values: s.values.map(() => 0) })) }}
-                loading={false}
-                onDateRangeChange={() => {}}
-            />
-        )
-    },
-}
-
-/** A minute-bucketed window, which switches the x-axis ticks from hours to minutes. */
-export const MinuteBuckets: Story = {
-    render: () => {
-        const start = dayjs('2026-06-01T00:00:00Z')
-        const dates = Array.from({ length: 60 }, (_, i) => start.add(i, 'minute').toISOString())
-        return (
-            <InvocationsSparkline
-                data={{
-                    dates,
-                    series: [
-                        {
-                            name: 'succeeded',
-                            color: 'success',
-                            values: dates.map((_, i) => Math.max(0, Math.round(12 * (1 + Math.sin(i / 4))))),
-                        },
-                    ],
-                }}
-                loading={false}
-                onDateRangeChange={() => {}}
-            />
-        )
-    },
-}
-
-/** Hourly buckets across a week — the tier whose ticks must land on day boundaries, not repeat a date per bucket. */
-export const WeekOfHourlyBuckets: Story = {
-    render: () => <InvocationsSparkline data={exampleData(24 * 7)} loading={false} onDateRangeChange={() => {}} />,
 }

--- a/frontend/src/scenes/hog-functions/invocations/InvocationsSparkline.tsx
+++ b/frontend/src/scenes/hog-functions/invocations/InvocationsSparkline.tsx
@@ -48,22 +48,16 @@ export function InvocationsSparkline({
     const theme = useChartTheme()
     const config = useChartConfig<TimeSeriesBarChartConfig>(
         () => ({
-            // The runs table below renders timestamps in local time, so the axis should agree. The interval
-            // is left to quill, which reads it off consecutive labels — the span disagrees with the
-            // logic's bucket tier, and it is the interval that picks the tick mode.
             xAxis: { tickFormatter: createXAxisTickCallback({ allDays: dates, timezone: dayjs.tz.guess() }) },
         }),
         [dates]
     )
 
-    // Wired directly rather than through `useDateRangeZoom`, which gates on the insight drag-to-zoom
-    // rollout flag: here the drag is the primary way to narrow the runs list, not an opt-in extra.
     const onDateRangeZoom = useCallback(
         ({ startIndex, endIndex }: DateRangeZoomData): void => {
             const from = dates[startIndex]
-            // `+1` so the selection end aligns with the *next* bucket boundary,
-            // mirroring how the logs sparkline emits ranges. If we hit past
-            // the end of the buckets, leave dateTo undefined (= "up to now").
+            // +1 ends the range at the next bucket boundary; past the last bucket leaves dateTo
+            // undefined, which the runs list reads as "up to now".
             const to = dates[endIndex + 1]
             if (from) {
                 onDateRangeChange(from, to)
@@ -88,7 +82,7 @@ export function InvocationsSparkline({
                 </LemonButton>
             </div>
             {!collapsed && (
-                // Quill charts fill a *flex* parent (their root is flex-1), so the sized container must be a flex column.
+                // Quill's chart root is flex-1, so the sized container has to be a flex column for h-24 to apply.
                 <div className="relative h-24 flex flex-col">
                     {hasAnyData ? (
                         <TimeSeriesBarChart


### PR DESCRIPTION
## Problem

A reviewer on [#81936](https://github.com/PostHog/posthog/pull/81936) reads four Storybook stories of the same component, and comments that mostly restate the line under them.

- Only the populated story shows something a reader cannot infer: the chart paints, stacks three series, and picks up the status colors. The empty, minute-bucketed and week-long variants re-shoot that component for cases the code already states.
- Each story also costs two snapshot identifiers and two chromium captures per CI run.

This PR targets #81936's branch, so the cleanup lands inside that PR rather than as a follow-up to master.

## Changes

- Keep `WithActivity` and delete the other three stories, along with their six now-orphaned baseline entries in `frontend/snapshots.yml`.
- Keep the two comments a reader cannot get from the code: why the range end is offset by one bucket, and why the sized container has to be a flex column.
- Delete the rest, including the three-line note above `xAxis` and the note above `onDateRangeZoom`.

The surviving story keeps the same 48 hourly buckets and the same fixed anchor, so its two baselines should stay valid and visual review should report no changed snapshot.

## How did you test this code?

No new tests. This PR only deletes stories and comments, so there is no behavior to cover.

- Ran `tsgo --noEmit` over both changed files, `oxlint` over the directory, and `oxfmt --check "**/*.{yaml,yml}"` to hold the yaml gate that the baseline auto-commit broke earlier on #81936.
- Not checked: I did not render Storybook, so the prediction above about the two surviving baselines is unverified. Visual review on this PR is the check.

No visible change to the shipped component. The stories are dev-only and the component diff is comments.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via Claude Code) made this change on request after reviewing #81936: cut the stories to the one that carries the most, then sweep the comments that added nothing.

Skills invoked: `/writing-code-comments` shaped which comments survived and removed the em-dashes from the two that did; `/writing-pr-descriptions` shaped this body.

Two decisions worth surfacing. I kept `WithActivity` over `WeekOfHourlyBuckets` even though the latter also exercises the day-boundary tick path behind the interval fix in #81936: at 48 buckets the bars are legible in a snapshot, at 168 they are a mush, and the tick behavior is already verified by executing `createXAxisTickCallback` across all four bucket tiers. I also left `WithActivity`'s fixture untouched so its baselines survive and no human has to approve a changed snapshot.

This is a stacked PR because `git_signed_commit` began refusing #81936's branch as the run's base branch part-way through the session, after accepting two commits on it.
