### PR TITLE
chore(replay): rebuild the anonymizer addon when its core crate changes

### DIFF
--- a/rust/replay-anonymizer-node/turbo.json
+++ b/rust/replay-anonymizer-node/turbo.json
@@ -1,0 +1,34 @@
+{
+    "$schema": "https://turbo.build/schema.json",
+    "extends": ["//"],
+    "tasks": {
+        // The scrub logic lives in the sibling `posthog-replay-anonymizer` crate, which turbo
+        // cannot see: it is a cargo path dependency, not a workspace package, so `^build` does
+        // not reach it and the root task's package-relative `src` covers only the Neon shim.
+        // Without these globs the addon's hash is unchanged by a core-crate edit and turbo
+        // replays a stale `index.node`.
+        "build": {
+            "inputs": [
+                "src",
+                "Cargo.toml",
+                "$TURBO_ROOT$/rust/replay-anonymizer/src/**",
+                "$TURBO_ROOT$/rust/replay-anonymizer/Cargo.toml",
+                "$TURBO_ROOT$/rust/Cargo.toml",
+                "$TURBO_ROOT$/rust/Cargo.lock"
+            ]
+        },
+        // `pnpm test` here runs `cargo test` over both crates, so the core crate's own tests and
+        // shared fixtures are inputs too.
+        "test": {
+            "inputs": [
+                "src",
+                "Cargo.toml",
+                "$TURBO_ROOT$/rust/replay-anonymizer/src/**",
+                "$TURBO_ROOT$/rust/replay-anonymizer/tests/**",
+                "$TURBO_ROOT$/rust/replay-anonymizer/Cargo.toml",
+                "$TURBO_ROOT$/rust/Cargo.toml",
+                "$TURBO_ROOT$/rust/Cargo.lock"
+            ]
+        }
+    }
+}

--- a/rust/replay-anonymizer-node/turbo.json
+++ b/rust/replay-anonymizer-node/turbo.json
@@ -2,11 +2,6 @@
     "$schema": "https://turbo.build/schema.json",
     "extends": ["//"],
     "tasks": {
-        // The scrub logic lives in the sibling `posthog-replay-anonymizer` crate, which turbo
-        // cannot see: it is a cargo path dependency, not a workspace package, so `^build` does
-        // not reach it and the root task's package-relative `src` covers only the Neon shim.
-        // Without these globs the addon's hash is unchanged by a core-crate edit and turbo
-        // replays a stale `index.node`.
         "build": {
             "inputs": [
                 "src",
@@ -17,8 +12,6 @@
                 "$TURBO_ROOT$/rust/Cargo.lock"
             ]
         },
-        // `pnpm test` here runs `cargo test` over both crates, so the core crate's own tests and
-        // shared fixtures are inputs too.
         "test": {
             "inputs": [
                 "src",


### PR DESCRIPTION
## Problem

Anyone who builds the Node ingestion workers with a warm turbo cache runs a stale session-replay anonymizer: their edits to the scrub logic are not compiled into `index.node`.

- [#71648](https://github.com/PostHog/posthog/pull/71648) split the crate and moved the scrub logic from `rust/replay-anonymizer-node/src` into `rust/replay-anonymizer/`.
- Turbo's `build` inputs are package relative: `src` and `Cargo.toml`. After the split those cover only the Neon shim, four files.
- Turbo cannot follow a cargo path dependency. `dependsOn: ["^build"]` walks workspace packages, and the core crate is not one.
- So the task inputs no longer change when the scrub logic changes, and turbo replays the cached `index.node` and `dist`.

The GitHub Actions path filters are correct. The split updated `ci-nodejs.yml`, `ci-nodejs-container.yml` and `ci-rust.yml`, and I confirmed on [PR #73862](https://github.com/PostHog/posthog/pull/73862), a core-crate-only change, that the Rust tests and the node image build both ran. CI runners also start with an empty turbo cache, so CI compiles the addon every time. This bug lives in warm caches: local development, `hogli start`, and the `turbo build --affected` report in `ci-turbo.yml`.

## Changes

- A new `rust/replay-anonymizer-node/turbo.json` adds `rust/replay-anonymizer/src/**` and its `Cargo.toml` to the `build` inputs.
- The `test` inputs also list the core crate's `tests/**`, because `pnpm test` runs `cargo test` over both crates and the JSON fixtures live there.
- Both tasks take `rust/Cargo.toml` and `rust/Cargo.lock`. The package manifest declares `workspace = true` deps, so a version bump is invisible without them.
- The config overrides `inputs` only. `outputs`, `cache`, `dependsOn` and `env` still come from the root config.

Globs rather than a build script: turbo resolves them at hash time, so a new file in the core crate is covered without anyone remembering to list it.

The file is plain JSON. Turbo reads `turbo.json` as JSONC and the root config uses comments, but nothing is lost by staying parseable everywhere.

> [!NOTE]
> `@posthog/cyclotron` and `@posthog/hogvm-node` have the same defect for the same reason. [#82412](https://github.com/PostHog/posthog/pull/82412) fixes those.

## How did you test this code?

I ran the `build` and `test` tasks under `--filter=@posthog/replay-anonymizer --no-daemon --dry-run=json`, comparing the resolved input set on a clean tree against one with a comment appended to `rust/replay-anonymizer/src/text.rs`. `edit_invisible=True` means turbo cannot see the edit.

```
WITHOUT-CONFIG @posthog/replay-anonymizer build  inputs=4   edit_invisible=True
WITHOUT-CONFIG @posthog/replay-anonymizer test   inputs=4   edit_invisible=True
WITH-CONFIG    @posthog/replay-anonymizer build  inputs=36  edit_invisible=False
WITH-CONFIG    @posthog/replay-anonymizer test   inputs=50  edit_invisible=False
```

The two `True` rows are the bug.

An earlier version of this section compared task hashes instead. Do not trust hashes here: `turbo --dry-run` returns `hashOfExternalDependencies` as an empty string on roughly one run in six in my sandbox, which moves the hash on an unchanged tree. The input map is stable across repeats, so the table above uses it. The conclusion did not change.

Not run: a real `turbo build` of the addon. A cold cache compiles it either way, so it cannot distinguish the two states.

No tests added. A guard asserting that every npm-publishing Rust crate declares its path dependencies is worth a follow-up once #82412 lands.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, model claude-opus-5, via Claude Code) audited every reference to the two crates after @robbie-c reported that the addon looked like it had stopped being rebuilt. The starting hypothesis was a missed workflow `paths` entry. That turned out to be wrong: all three workflows were updated in the split PR, and the container build ran on a core-crate-only PR. The turbo inputs were the thing the split missed.

The config first carried explanatory comments, matching the root `turbo.json`. @robbie-c asked for them gone, so the second commit removes them.

Skills invoked: `/writing-pr-descriptions`.

Environment note: `hogli` needed `uv` upgraded and Python 3.13.13 installed before it would run in this sandbox. `hogli ci:preflight --fix` then passed with no findings.
