### PR TITLE
feat(aio): remember tab timeframe

### DIFF
--- a/frontend/src/lib/logic/persistence.test.ts
+++ b/frontend/src/lib/logic/persistence.test.ts
@@ -1,0 +1,24 @@
+import { getCurrentTeamId } from 'lib/utils/getAppContext'
+
+import { buildTeamScopedPersistenceConfig, buildTeamScopedStorageConfig } from './persistence'
+
+jest.mock('lib/utils/getAppContext')
+
+const mockGetCurrentTeamId = getCurrentTeamId as jest.MockedFunction<typeof getCurrentTeamId>
+
+describe('team-scoped persistence', () => {
+    beforeEach(() => {
+        mockGetCurrentTeamId.mockReset()
+    })
+
+    it.each([
+        ['prefix config', () => buildTeamScopedPersistenceConfig('filters__')],
+        ['storage config', () => buildTeamScopedStorageConfig('filters')],
+    ])('fails closed without a project ID for %s', (_, buildConfig) => {
+        mockGetCurrentTeamId.mockImplementation(() => {
+            throw new Error('Project ID is not known.')
+        })
+
+        expect(buildConfig).toThrow('Project ID is not known.')
+    })
+})

--- a/frontend/src/lib/logic/persistence.ts
+++ b/frontend/src/lib/logic/persistence.ts
@@ -1,4 +1,4 @@
-import { getCurrentTeamIdOrNone } from 'lib/utils/getAppContext'
+import { getCurrentTeamId } from 'lib/utils/getAppContext'
 
 interface TeamScopedPersistenceConfig {
     persist: true
@@ -11,8 +11,7 @@ interface TeamScopedStorageConfig {
 }
 
 const getTeamStoragePrefix = (): string => {
-    const teamId = getCurrentTeamIdOrNone()
-    return teamId ? `${teamId}__` : ''
+    return `${getCurrentTeamId()}__`
 }
 
 export const buildTeamScopedPersistenceConfig = (prefix: string = ''): TeamScopedPersistenceConfig => ({

--- a/frontend/src/lib/logic/persistence.ts
+++ b/frontend/src/lib/logic/persistence.ts
@@ -1,0 +1,26 @@
+import { getCurrentTeamIdOrNone } from 'lib/utils/getAppContext'
+
+interface TeamScopedPersistenceConfig {
+    persist: true
+    prefix: string
+}
+
+interface TeamScopedStorageConfig {
+    persist: true
+    storageKey: string
+}
+
+const getTeamStoragePrefix = (): string => {
+    const teamId = getCurrentTeamIdOrNone()
+    return teamId ? `${teamId}__` : ''
+}
+
+export const buildTeamScopedPersistenceConfig = (prefix: string = ''): TeamScopedPersistenceConfig => ({
+    persist: true,
+    prefix: `${getTeamStoragePrefix()}${prefix}`,
+})
+
+export const buildTeamScopedStorageConfig = (storageKey: string): TeamScopedStorageConfig => ({
+    persist: true,
+    storageKey: `${getTeamStoragePrefix()}${storageKey}`,
+})

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeLLMTrace.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeLLMTrace.tsx
@@ -45,12 +45,12 @@ const Component = (props: NotebookNodeProps<NotebookNodeLLMTraceAttributes>): JS
 const ContextualTraceList = ({ attributes }: NotebookNodeProps<NotebookNodeLLMTraceAttributes>): JSX.Element | null => {
     const { expanded, notebookLogic } = useValues(notebookNodeLogic)
     const { setMenuItems } = useActions(notebookNodeLogic)
-    const { groupKey, groupTypeIndex, personId, tabId } = attributes
+    const { groupKey, groupTypeIndex, nodeId, personId, tabId } = attributes
     const group = groupKey && groupTypeIndex !== undefined ? { groupKey, groupTypeIndex } : undefined
     const logicKey = getLogicKey({ groupKey, personId, tabId })
 
-    const sharedLogic = aiObservabilitySharedLogic({ logicKey, personId, group })
-    const tracesLogic = aiObservabilityTracesTabLogic({ personId, group })
+    const sharedLogic = aiObservabilitySharedLogic({ logicKey: nodeId, personId, group })
+    const tracesLogic = aiObservabilityTracesTabLogic({ logicKey: nodeId, personId, group })
     const { setDates, setShouldFilterTestAccounts, setPropertyFilters } = useActions(sharedLogic)
     const { setTracesQuery } = useActions(tracesLogic)
     const { tracesQuery } = useValues(tracesLogic)
@@ -109,7 +109,7 @@ const ContextualSettings = ({
     const { personId, groupKey, groupTypeIndex, nodeId } = attributes
     const group = groupKey && groupTypeIndex !== undefined ? { groupKey, groupTypeIndex } : undefined
     const sharedLogic = aiObservabilitySharedLogic({ logicKey: nodeId, personId, group })
-    const tracesLogic = aiObservabilityTracesTabLogic({ personId, group })
+    const tracesLogic = aiObservabilityTracesTabLogic({ logicKey: nodeId, personId, group })
     const { setDates, setPropertyFilters } = useActions(sharedLogic)
     const { setTracesQuery } = useActions(tracesLogic)
     const { tracesQuery } = useValues(tracesLogic)

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsLogic.ts
@@ -206,8 +206,6 @@ export interface DateFilterState extends DateRange {
     interval: IntervalType
 }
 
-const persistConfig = buildTeamScopedPersistenceConfig()
-
 const INITIAL_DATE_FROM = '-7d' as string | null
 const INITIAL_DATE_TO = null as string | null
 const INITIAL_INTERVAL = getDefaultInterval(INITIAL_DATE_FROM, INITIAL_DATE_TO)
@@ -623,161 +621,169 @@ export const marketingAnalyticsLogic = kea<marketingAnalyticsLogicType>([
         setDrillDownLevel: (level: MarketingAnalyticsDrillDownLevel) => ({ level }),
         setInitialized: true,
     }),
-    reducers({
-        activeTab: [
-            MarketingAnalyticsTab.DASHBOARD as MarketingAnalyticsTab,
-            {
-                setActiveTab: (_, { tab }) => tab,
-            },
-        ],
-        initialized: [
-            false,
-            {
-                setInitialized: () => true,
-            },
-        ],
-        draftConversionGoal: [
-            null as ConversionGoalFilter | null,
-            {
-                setDraftConversionGoal: (_, { goal }) => goal,
-            },
-        ],
-        conversionGoalInput: [
-            {
-                ...defaultConversionGoalFilter,
-                conversion_goal_id: uuid(),
-                conversion_goal_name: '',
-            } as ConversionGoalFilter,
-            {
-                setConversionGoalInput: (_, { goal }) => goal,
-            },
-        ],
-        compareFilter: [
-            { compare: true } as CompareFilter,
-            persistConfig,
-            {
-                setCompareFilter: (_, { compareFilter }) => compareFilter,
-                syncFromUrl: (state, { params }) => {
-                    if (params.compare === undefined && params.compare_to === undefined) {
-                        return state
-                    }
-                    return {
-                        ...state,
-                        ...(params.compare !== undefined ? { compare: params.compare } : {}),
-                        ...(params.compare_to !== undefined ? { compare_to: params.compare_to } : {}),
-                    }
+    reducers(() => {
+        const persistConfig = buildTeamScopedPersistenceConfig()
+
+        return {
+            activeTab: [
+                MarketingAnalyticsTab.DASHBOARD as MarketingAnalyticsTab,
+                {
+                    setActiveTab: (_, { tab }) => tab,
                 },
-            },
-        ],
-        integrationFilter: [
-            { integrationSourceIds: [] } as IntegrationFilter,
-            persistConfig,
-            {
-                setIntegrationFilter: (_, { integrationFilter }) => integrationFilter,
-                syncFromUrl: (state, { params }) =>
-                    params.integrationSourceIds ? { integrationSourceIds: params.integrationSourceIds } : state,
-            },
-        ],
-        dateFilter: [
-            {
-                dateFrom: INITIAL_DATE_FROM,
-                dateTo: INITIAL_DATE_TO,
-                interval: INITIAL_INTERVAL,
-            },
-            persistConfig,
-            {
-                setDates: (_, { dateFrom, dateTo }) => {
-                    if (dateTo && !isValidRelativeOrAbsoluteDate(dateTo)) {
-                        dateTo = INITIAL_DATE_TO
-                    }
-                    if (dateFrom && !isValidRelativeOrAbsoluteDate(dateFrom)) {
-                        dateFrom = INITIAL_DATE_FROM
-                    }
-                    return {
-                        dateFrom,
-                        dateTo,
-                        interval: getDefaultInterval(dateFrom, dateTo),
-                    }
+            ],
+            initialized: [
+                false,
+                {
+                    setInitialized: () => true,
                 },
-                setDateInterval: (state, { interval }) => {
-                    const { dateFrom, dateTo } = updateDatesWithInterval(interval, state.dateFrom, state.dateTo)
-                    return {
-                        dateFrom,
-                        dateTo,
-                        interval,
-                    }
+            ],
+            draftConversionGoal: [
+                null as ConversionGoalFilter | null,
+                {
+                    setDraftConversionGoal: (_, { goal }) => goal,
                 },
-                setDatesAndInterval: (_, { dateFrom, dateTo, interval }) => {
-                    if (!dateFrom && !dateTo) {
-                        dateFrom = INITIAL_DATE_FROM
-                        dateTo = INITIAL_DATE_TO
-                    }
-                    if (dateTo && !isValidRelativeOrAbsoluteDate(dateTo)) {
-                        dateTo = INITIAL_DATE_TO
-                    }
-                    if (dateFrom && !isValidRelativeOrAbsoluteDate(dateFrom)) {
-                        dateFrom = INITIAL_DATE_FROM
-                    }
-                    return {
-                        dateFrom,
-                        dateTo,
-                        interval: interval || getDefaultInterval(dateFrom, dateTo),
-                    }
+            ],
+            conversionGoalInput: [
+                {
+                    ...defaultConversionGoalFilter,
+                    conversion_goal_id: uuid(),
+                    conversion_goal_name: '',
+                } as ConversionGoalFilter,
+                {
+                    setConversionGoalInput: (_, { goal }) => goal,
                 },
-                syncFromUrl: (state, { params }) => {
-                    if (params.dateFrom === undefined && params.dateTo === undefined && params.interval === undefined) {
-                        return state
-                    }
-                    const dateFrom = params.dateFrom ?? state.dateFrom
-                    const dateTo = params.dateTo ?? state.dateTo
-                    const interval = params.interval ?? state.interval
-                    return { dateFrom, dateTo, interval }
+            ],
+            compareFilter: [
+                { compare: true } as CompareFilter,
+                persistConfig,
+                {
+                    setCompareFilter: (_, { compareFilter }) => compareFilter,
+                    syncFromUrl: (state, { params }) => {
+                        if (params.compare === undefined && params.compare_to === undefined) {
+                            return state
+                        }
+                        return {
+                            ...state,
+                            ...(params.compare !== undefined ? { compare: params.compare } : {}),
+                            ...(params.compare_to !== undefined ? { compare_to: params.compare_to } : {}),
+                        }
+                    },
                 },
-            },
-        ],
-        columnConfigModalVisible: [
-            false,
-            {
-                showColumnConfigModal: () => true,
-                hideColumnConfigModal: () => false,
-            },
-        ],
-        conversionGoalModalVisible: [
-            false,
-            {
-                showConversionGoalModal: () => true,
-                hideConversionGoalModal: () => false,
-            },
-        ],
-        chartDisplayType: [
-            ChartDisplayType.ActionsAreaGraph as ChartDisplayType,
-            persistConfig,
-            {
-                setChartDisplayType: (_, { chartDisplayType }) => chartDisplayType,
-                syncFromUrl: (state, { params }) =>
-                    params.chartDisplayType !== undefined ? params.chartDisplayType : state,
-            },
-        ],
-        tileColumnSelection: [
-            MarketingAnalyticsColumnsSchemaNames.Cost as validColumnsForTiles,
-            persistConfig,
-            {
-                setTileColumnSelection: (_, { column }) => column,
-                syncFromUrl: (state, { params }) =>
-                    params.tileColumnSelection !== undefined
-                        ? (params.tileColumnSelection as validColumnsForTiles)
-                        : state,
-            },
-        ],
-        _drillDownLevel: [
-            MarketingAnalyticsDrillDownLevel.Campaign as MarketingAnalyticsDrillDownLevel,
-            persistConfig,
-            {
-                setDrillDownLevel: (_, { level }) => level,
-                syncFromUrl: (state, { params }) =>
-                    params.drillDownLevel !== undefined ? params.drillDownLevel : state,
-            },
-        ],
+            ],
+            integrationFilter: [
+                { integrationSourceIds: [] } as IntegrationFilter,
+                persistConfig,
+                {
+                    setIntegrationFilter: (_, { integrationFilter }) => integrationFilter,
+                    syncFromUrl: (state, { params }) =>
+                        params.integrationSourceIds ? { integrationSourceIds: params.integrationSourceIds } : state,
+                },
+            ],
+            dateFilter: [
+                {
+                    dateFrom: INITIAL_DATE_FROM,
+                    dateTo: INITIAL_DATE_TO,
+                    interval: INITIAL_INTERVAL,
+                },
+                persistConfig,
+                {
+                    setDates: (_, { dateFrom, dateTo }) => {
+                        if (dateTo && !isValidRelativeOrAbsoluteDate(dateTo)) {
+                            dateTo = INITIAL_DATE_TO
+                        }
+                        if (dateFrom && !isValidRelativeOrAbsoluteDate(dateFrom)) {
+                            dateFrom = INITIAL_DATE_FROM
+                        }
+                        return {
+                            dateFrom,
+                            dateTo,
+                            interval: getDefaultInterval(dateFrom, dateTo),
+                        }
+                    },
+                    setDateInterval: (state, { interval }) => {
+                        const { dateFrom, dateTo } = updateDatesWithInterval(interval, state.dateFrom, state.dateTo)
+                        return {
+                            dateFrom,
+                            dateTo,
+                            interval,
+                        }
+                    },
+                    setDatesAndInterval: (_, { dateFrom, dateTo, interval }) => {
+                        if (!dateFrom && !dateTo) {
+                            dateFrom = INITIAL_DATE_FROM
+                            dateTo = INITIAL_DATE_TO
+                        }
+                        if (dateTo && !isValidRelativeOrAbsoluteDate(dateTo)) {
+                            dateTo = INITIAL_DATE_TO
+                        }
+                        if (dateFrom && !isValidRelativeOrAbsoluteDate(dateFrom)) {
+                            dateFrom = INITIAL_DATE_FROM
+                        }
+                        return {
+                            dateFrom,
+                            dateTo,
+                            interval: interval || getDefaultInterval(dateFrom, dateTo),
+                        }
+                    },
+                    syncFromUrl: (state, { params }) => {
+                        if (
+                            params.dateFrom === undefined &&
+                            params.dateTo === undefined &&
+                            params.interval === undefined
+                        ) {
+                            return state
+                        }
+                        const dateFrom = params.dateFrom ?? state.dateFrom
+                        const dateTo = params.dateTo ?? state.dateTo
+                        const interval = params.interval ?? state.interval
+                        return { dateFrom, dateTo, interval }
+                    },
+                },
+            ],
+            columnConfigModalVisible: [
+                false,
+                {
+                    showColumnConfigModal: () => true,
+                    hideColumnConfigModal: () => false,
+                },
+            ],
+            conversionGoalModalVisible: [
+                false,
+                {
+                    showConversionGoalModal: () => true,
+                    hideConversionGoalModal: () => false,
+                },
+            ],
+            chartDisplayType: [
+                ChartDisplayType.ActionsAreaGraph as ChartDisplayType,
+                persistConfig,
+                {
+                    setChartDisplayType: (_, { chartDisplayType }) => chartDisplayType,
+                    syncFromUrl: (state, { params }) =>
+                        params.chartDisplayType !== undefined ? params.chartDisplayType : state,
+                },
+            ],
+            tileColumnSelection: [
+                MarketingAnalyticsColumnsSchemaNames.Cost as validColumnsForTiles,
+                persistConfig,
+                {
+                    setTileColumnSelection: (_, { column }) => column,
+                    syncFromUrl: (state, { params }) =>
+                        params.tileColumnSelection !== undefined
+                            ? (params.tileColumnSelection as validColumnsForTiles)
+                            : state,
+                },
+            ],
+            _drillDownLevel: [
+                MarketingAnalyticsDrillDownLevel.Campaign as MarketingAnalyticsDrillDownLevel,
+                persistConfig,
+                {
+                    setDrillDownLevel: (_, { level }) => level,
+                    syncFromUrl: (state, { params }) =>
+                        params.drillDownLevel !== undefined ? params.drillDownLevel : state,
+                },
+            ],
+        }
     }),
     selectors({
         drillDownLevel: [

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsLogic.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsLogic.ts
@@ -3,6 +3,7 @@ import { actionToUrl } from 'kea-router'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { buildTeamScopedPersistenceConfig } from 'lib/logic/persistence'
 import { getDefaultInterval, isValidRelativeOrAbsoluteDate, updateDatesWithInterval } from 'lib/utils/dateFilters'
 import { uuid } from 'lib/utils/dom'
 import { teamLogic } from 'scenes/teamLogic'
@@ -205,8 +206,7 @@ export interface DateFilterState extends DateRange {
     interval: IntervalType
 }
 
-const teamId = window.POSTHOG_APP_CONTEXT?.current_team?.id
-const persistConfig = { persist: true, prefix: `${teamId}__` }
+const persistConfig = buildTeamScopedPersistenceConfig()
 
 const INITIAL_DATE_FROM = '-7d' as string | null
 const INITIAL_DATE_TO = null as string | null

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -28,11 +28,11 @@ import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Link } from 'lib/lemon-ui/Link/Link'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { buildTeamScopedPersistenceConfig } from 'lib/logic/persistence'
 import { trackedActionToUrl } from 'lib/logic/scenes/trackedActionToUrl'
 import { getDefaultInterval, isValidRelativeOrAbsoluteDate } from 'lib/utils/dateFilters'
 import { isDefinitionStale } from 'lib/utils/definitions'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
-import { getCurrentTeamId } from 'lib/utils/getAppContext'
 import { UnexpectedNeverError, isNotNil } from 'lib/utils/guards'
 import { objectsEqual } from 'lib/utils/objects'
 import { addProductIntentForCrossSell } from 'lib/utils/product-intents'
@@ -851,12 +851,12 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
         },
     })),
     reducers(() => {
-        const persistConfig = { persist: true, prefix: `${getCurrentTeamId()}__` }
+        const persistConfig = buildTeamScopedPersistenceConfig()
         // The precompute toggle changed from opt-in (default `false`) to a tri-state where
         // `null` means "use the team default". Legacy users persisted the old `false`, which
         // would now read as an explicit opt-out. A versioned prefix orphans that stale value so
         // they rehydrate `null` and the backend's per-team default applies.
-        const precomputePersistConfig = { persist: true, prefix: `${getCurrentTeamId()}__precompute_optout_v2__` }
+        const precomputePersistConfig = buildTeamScopedPersistenceConfig('precompute_optout_v2__')
         return {
             surveyModalPath: [
                 null as string | null,

--- a/products/ai_observability/frontend/aiObservabilityLogic.test.ts
+++ b/products/ai_observability/frontend/aiObservabilityLogic.test.ts
@@ -619,6 +619,37 @@ describe('AI observability persisted preferences', () => {
         secondLogic.unmount()
     })
 
+    it('keeps notebook date filters separate from the saved scene timeframe', () => {
+        const savedSceneLogic = aiObservabilitySharedLogic()
+        savedSceneLogic.mount()
+        savedSceneLogic.actions.setDates('-30d', null)
+        savedSceneLogic.unmount()
+
+        const notebookLogic = aiObservabilitySharedLogic({ logicKey: 'notebook-node' })
+        notebookLogic.mount()
+        expect(notebookLogic.values.dateFilter).toEqual({ dateFrom: '-1h', dateTo: null })
+        notebookLogic.actions.setDates('-7d', null)
+        notebookLogic.unmount()
+
+        const remountedSceneLogic = aiObservabilitySharedLogic()
+        remountedSceneLogic.mount()
+        expect(remountedSceneLogic.values.dateFilter).toEqual({ dateFrom: '-30d', dateTo: null })
+        remountedSceneLogic.unmount()
+    })
+
+    it('drops invalid URL dates without replacing the saved scene timeframe', () => {
+        router.actions.push(urls.aiObservabilityTraces())
+        const logic = aiObservabilitySharedLogic()
+        logic.mount()
+        logic.actions.setDates('-30d', null)
+
+        router.actions.push(urls.aiObservabilityTraces(), { date_from: 'not-a-date' })
+
+        expect(logic.values.dateFilter).toEqual({ dateFrom: '-30d', dateTo: null })
+        expect(router.values.searchParams.date_from).toBe('-30d')
+        logic.unmount()
+    })
+
     it('persists selected dashboard across remount', () => {
         const firstLogic = aiObservabilityDashboardLogic()
         firstLogic.mount()

--- a/products/ai_observability/frontend/aiObservabilityLogic.test.ts
+++ b/products/ai_observability/frontend/aiObservabilityLogic.test.ts
@@ -84,6 +84,7 @@ describe('aiObservabilitySharedLogic', () => {
     let logic: ReturnType<typeof aiObservabilitySharedLogic.build>
 
     beforeEach(() => {
+        window.localStorage.clear()
         initKeaTests()
         sceneLogic.mount()
         router.actions.push(urls.aiObservabilityTraces())
@@ -158,8 +159,7 @@ describe('aiObservabilitySharedLogic', () => {
         expect(router.values.searchParams).toEqual({ review_search: 'abc' })
     })
 
-    it('should reset filters when switching tabs without params', () => {
-        // Set some filters first
+    it('should reset non-date filters when switching tabs without params', () => {
         logic.actions.setPropertyFilters([
             {
                 type: PropertyFilterType.Event,
@@ -172,15 +172,13 @@ describe('aiObservabilitySharedLogic', () => {
         logic.actions.setShouldFilterTestAccounts(true)
         logic.actions.setSearchQuery('walrus')
 
-        // Navigate to another tab without params
         router.actions.push(urls.aiObservabilityGenerations())
 
-        // Should reset to defaults
         expectLogic(logic).toMatchValues({
             propertyFilters: [],
             dateFilter: {
-                dateFrom: '-1h',
-                dateTo: null,
+                dateFrom: '-30d',
+                dateTo: '-1d',
             },
             shouldFilterTestAccounts: false,
             searchQuery: '',
@@ -222,6 +220,33 @@ describe('aiObservabilitySharedLogic', () => {
             dashboardDateFilter: { dateFrom: '-30d', dateTo: null },
             dashboardDateOverride: false,
             dashboardExternalDateFilters: { date_from: undefined, date_to: undefined },
+        })
+    })
+
+    it('keeps dashboard dates while restoring shared filters from the URL', () => {
+        router.actions.push(urls.aiObservabilityDashboard(), {
+            date_from: '-30d',
+            filters: [
+                {
+                    type: PropertyFilterType.Event,
+                    key: '$ai_model',
+                    value: 'example-model',
+                    operator: PropertyOperator.Exact,
+                },
+            ],
+        })
+
+        expect(router.values.searchParams.date_from).toBe('-30d')
+        expectLogic(logic).toMatchValues({
+            dashboardDateFilter: { dateFrom: '-30d', dateTo: null },
+            propertyFilters: [
+                {
+                    type: PropertyFilterType.Event,
+                    key: '$ai_model',
+                    value: 'example-model',
+                    operator: PropertyOperator.Exact,
+                },
+            ],
         })
     })
 
@@ -570,6 +595,26 @@ describe('AI observability persisted preferences', () => {
         secondLogic.mount()
 
         expect(secondLogic.values.showInputOutputColumns).toBe(false)
+
+        secondLogic.unmount()
+    })
+
+    it('restores persisted event dates on clean tabs and lets URL dates override them', () => {
+        router.actions.push(urls.aiObservabilityTraces())
+        const firstLogic = aiObservabilitySharedLogic()
+        firstLogic.mount()
+        firstLogic.actions.setDates('-30d', '-1d')
+        firstLogic.unmount()
+
+        router.actions.push(urls.aiObservabilityGenerations())
+        const secondLogic = aiObservabilitySharedLogic()
+        secondLogic.mount()
+
+        expect(secondLogic.values.dateFilter).toEqual({ dateFrom: '-30d', dateTo: '-1d' })
+
+        router.actions.push(urls.aiObservabilityTraces(), { date_from: '-7d' })
+
+        expect(secondLogic.values.dateFilter).toEqual({ dateFrom: '-7d', dateTo: null })
 
         secondLogic.unmount()
     })

--- a/products/ai_observability/frontend/aiObservabilitySharedLogic.ts
+++ b/products/ai_observability/frontend/aiObservabilitySharedLogic.ts
@@ -20,6 +20,7 @@ import type { ProductSetupStatus } from 'lib/components/ProductEmptyState/types'
 import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { trackedActionToUrl } from 'lib/logic/scenes/trackedActionToUrl'
+import { isValidRelativeOrAbsoluteDate } from 'lib/utils/dateFilters'
 import { objectsEqual } from 'lib/utils/objects'
 import { projectLogic } from 'scenes/projectLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
@@ -274,7 +275,7 @@ export type aiObservabilitySharedLogicType = MakeLogicType<
 export const aiObservabilitySharedLogic = kea<aiObservabilitySharedLogicType>([
     path(['products', 'ai_observability', 'frontend', 'aiObservabilitySharedLogic']),
     props({} as AIObservabilitySharedLogicProps),
-    key((props: AIObservabilitySharedLogicProps) => `${props?.personId || 'aiObservabilityScene'}`),
+    key((props: AIObservabilitySharedLogicProps) => props.logicKey || props.personId || 'aiObservabilityScene'),
     connect(() => ({
         // Mount the parser-recipe logic so a team's custom recipes reach the trace-rendering
         // normalizer on any AI observability page, not just the settings scene.
@@ -319,18 +320,29 @@ export const aiObservabilitySharedLogic = kea<aiObservabilitySharedLogicType>([
         applyUrlState: (state: ApplyUrlStatePayload) => state,
     }),
 
-    reducers({
-        dateFilter: [
-            {
-                dateFrom: INITIAL_EVENTS_DATE_FROM,
-                dateTo: INITIAL_DATE_TO,
-            },
-            buildAiObservabilityStorageConfig('events.dateFilter'),
-            {
-                setDates: (_, { dateFrom, dateTo }) => ({ dateFrom, dateTo }),
-                applyUrlState: (_, { dateFrom, dateTo }) => ({ dateFrom, dateTo }),
-            },
-        ],
+    reducers(({ props }) => ({
+        dateFilter: props.logicKey
+            ? [
+                  {
+                      dateFrom: INITIAL_EVENTS_DATE_FROM,
+                      dateTo: INITIAL_DATE_TO,
+                  },
+                  {
+                      setDates: (_, { dateFrom, dateTo }) => ({ dateFrom, dateTo }),
+                      applyUrlState: (_, { dateFrom, dateTo }) => ({ dateFrom, dateTo }),
+                  },
+              ]
+            : [
+                  {
+                      dateFrom: INITIAL_EVENTS_DATE_FROM,
+                      dateTo: INITIAL_DATE_TO,
+                  },
+                  buildAiObservabilityStorageConfig('events.dateFilter'),
+                  {
+                      setDates: (_, { dateFrom, dateTo }) => ({ dateFrom, dateTo }),
+                      applyUrlState: (_, { dateFrom, dateTo }) => ({ dateFrom, dateTo }),
+                  },
+              ],
 
         dashboardDateFilter: [
             {
@@ -394,7 +406,7 @@ export const aiObservabilitySharedLogic = kea<aiObservabilitySharedLogicType>([
                 applyUrlState: (state, { searchQuery }) => searchQuery ?? state,
             },
         ],
-    }),
+    })),
 
     loaders(() => ({
         hasSentAiEvent: {
@@ -506,8 +518,20 @@ export const aiObservabilitySharedLogic = kea<aiObservabilitySharedLogicType>([
             const { filters, date_from, date_to, filter_test_accounts, trace_search } = searchParams
 
             const parsedFilters = isAnyPropertyFilters(filters) ? filters : []
-            const hasDateFromOverride = applyEventDateParams && typeof date_from === 'string' && date_from.length > 0
-            const hasDateToOverride = applyEventDateParams && typeof date_to === 'string' && date_to.length > 0
+            const hasDateFromParam = applyEventDateParams && typeof date_from === 'string' && date_from.length > 0
+            const hasDateToParam = applyEventDateParams && typeof date_to === 'string' && date_to.length > 0
+            const hasDateFromOverride =
+                applyEventDateParams &&
+                typeof date_from === 'string' &&
+                date_from.length > 0 &&
+                isValidRelativeOrAbsoluteDate(date_from)
+            const hasDateToOverride =
+                applyEventDateParams &&
+                typeof date_to === 'string' &&
+                date_to.length > 0 &&
+                isValidRelativeOrAbsoluteDate(date_to)
+            const hasInvalidDateParam =
+                (hasDateFromParam && !hasDateFromOverride) || (hasDateToParam && !hasDateToOverride)
             const hasDateOverride = hasDateFromOverride || hasDateToOverride
             const newDateFrom = hasDateOverride
                 ? hasDateFromOverride
@@ -529,7 +553,7 @@ export const aiObservabilitySharedLogic = kea<aiObservabilitySharedLogicType>([
             const testAccountsChanged = filterTestAccountsValue !== values.shouldFilterTestAccounts
             const searchQueryChanged = newSearchQuery !== values.searchQuery
 
-            if (filtersChanged || datesChanged || testAccountsChanged || searchQueryChanged) {
+            if (filtersChanged || datesChanged || testAccountsChanged || searchQueryChanged || hasInvalidDateParam) {
                 // Dispatch a single batched action so actionToUrl produces one URL
                 // change instead of up to 3 separate ones. The actionToUrl handler
                 // for applyUrlState rewrites the shared params and drops stale

--- a/products/ai_observability/frontend/aiObservabilitySharedLogic.ts
+++ b/products/ai_observability/frontend/aiObservabilitySharedLogic.ts
@@ -36,6 +36,7 @@ import type { FeatureFlagsSet } from '../../../frontend/src/lib/logic/featureFla
 import type { ProductIntentProperties } from '../../../frontend/src/lib/utils/product-intents'
 import type { UserType } from '../../../frontend/src/types'
 import { AI_OBSERVABILITY_CLUSTER_URL_PATTERN } from './clusters/constants'
+import { buildAiObservabilityStorageConfig } from './preferenceStorage'
 import { parserRecipesLogic } from './settings/parserRecipesLogic'
 import { hasRecentAIEvents } from './utils/aiEvents'
 
@@ -324,6 +325,7 @@ export const aiObservabilitySharedLogic = kea<aiObservabilitySharedLogicType>([
                 dateFrom: INITIAL_EVENTS_DATE_FROM,
                 dateTo: INITIAL_DATE_TO,
             },
+            buildAiObservabilityStorageConfig('events.dateFilter'),
             {
                 setDates: (_, { dateFrom, dateTo }) => ({ dateFrom, dateTo }),
                 applyUrlState: (_, { dateFrom, dateTo }) => ({ dateFrom, dateTo }),
@@ -500,12 +502,23 @@ export const aiObservabilitySharedLogic = kea<aiObservabilitySharedLogicType>([
     }),
 
     urlToAction(({ actions, values, cache }) => {
-        function applySearchParams(searchParams: Record<string, unknown>): void {
+        function applySearchParams(searchParams: Record<string, unknown>, applyEventDateParams: boolean = true): void {
             const { filters, date_from, date_to, filter_test_accounts, trace_search } = searchParams
 
             const parsedFilters = isAnyPropertyFilters(filters) ? filters : []
-            const newDateFrom = (date_from as string | null) || INITIAL_EVENTS_DATE_FROM
-            const newDateTo = (date_to as string | null) || INITIAL_DATE_TO
+            const hasDateFromOverride = applyEventDateParams && typeof date_from === 'string' && date_from.length > 0
+            const hasDateToOverride = applyEventDateParams && typeof date_to === 'string' && date_to.length > 0
+            const hasDateOverride = hasDateFromOverride || hasDateToOverride
+            const newDateFrom = hasDateOverride
+                ? hasDateFromOverride
+                    ? date_from
+                    : INITIAL_EVENTS_DATE_FROM
+                : values.dateFilter.dateFrom
+            const newDateTo = hasDateOverride
+                ? hasDateToOverride
+                    ? date_to
+                    : INITIAL_DATE_TO
+                : values.dateFilter.dateTo
             const filterTestAccountsValue = [true, 'true', 1, '1'].includes(
                 filter_test_accounts as string | number | boolean
             )
@@ -566,7 +579,7 @@ export const aiObservabilitySharedLogic = kea<aiObservabilitySharedLogicType>([
         }
 
         function applyDashboard(searchParams: Record<string, unknown>): void {
-            applySearchParams(searchParams)
+            applySearchParams(searchParams, false)
 
             const hasDateOverride =
                 typeof searchParams.date_from === 'string' || typeof searchParams.date_to === 'string'
@@ -635,14 +648,26 @@ export const aiObservabilitySharedLogic = kea<aiObservabilitySharedLogicType>([
             return { ...passthroughSearchParams(), filters, date_from, date_to, filter_test_accounts, trace_search }
         }
 
+        function dateSearchParams(dateFrom: string | null, dateTo: string | null): Record<string, unknown> {
+            if (router.values.location.pathname.endsWith(urls.aiObservabilityDashboard())) {
+                return {
+                    date_from: router.values.searchParams.date_from,
+                    date_to: router.values.searchParams.date_to,
+                }
+            }
+            return {
+                date_from: dateFrom === INITIAL_EVENTS_DATE_FROM ? undefined : dateFrom || undefined,
+                date_to: dateTo || undefined,
+            }
+        }
+
         return {
             applyUrlState: ({ propertyFilters, dateFrom, dateTo, shouldFilterTestAccounts, searchQuery }) => [
                 router.values.location.pathname,
                 {
                     ...passthroughSearchParams(),
                     filters: propertyFilters.length > 0 ? propertyFilters : undefined,
-                    date_from: dateFrom === INITIAL_EVENTS_DATE_FROM ? undefined : dateFrom || undefined,
-                    date_to: dateTo || undefined,
+                    ...dateSearchParams(dateFrom, dateTo),
                     filter_test_accounts: shouldFilterTestAccounts ? 'true' : undefined,
                     trace_search:
                         (searchQuery ?? (router.values.searchParams.trace_search as string | undefined)) || undefined,

--- a/products/ai_observability/frontend/aiObservabilitySharedLogic.ts
+++ b/products/ai_observability/frontend/aiObservabilitySharedLogic.ts
@@ -321,28 +321,20 @@ export const aiObservabilitySharedLogic = kea<aiObservabilitySharedLogicType>([
     }),
 
     reducers(({ props }) => ({
-        dateFilter: props.logicKey
-            ? [
-                  {
-                      dateFrom: INITIAL_EVENTS_DATE_FROM,
-                      dateTo: INITIAL_DATE_TO,
-                  },
-                  {
-                      setDates: (_, { dateFrom, dateTo }) => ({ dateFrom, dateTo }),
-                      applyUrlState: (_, { dateFrom, dateTo }) => ({ dateFrom, dateTo }),
-                  },
-              ]
-            : [
-                  {
-                      dateFrom: INITIAL_EVENTS_DATE_FROM,
-                      dateTo: INITIAL_DATE_TO,
-                  },
-                  buildAiObservabilityStorageConfig('events.dateFilter'),
-                  {
-                      setDates: (_, { dateFrom, dateTo }) => ({ dateFrom, dateTo }),
-                      applyUrlState: (_, { dateFrom, dateTo }) => ({ dateFrom, dateTo }),
-                  },
-              ],
+        dateFilter: [
+            {
+                dateFrom: INITIAL_EVENTS_DATE_FROM,
+                dateTo: INITIAL_DATE_TO,
+            },
+            {
+                ...buildAiObservabilityStorageConfig('events.dateFilter'),
+                persist: !props.logicKey,
+            },
+            {
+                setDates: (_, { dateFrom, dateTo }) => ({ dateFrom, dateTo }),
+                applyUrlState: (_, { dateFrom, dateTo }) => ({ dateFrom, dateTo }),
+            },
+        ],
 
         dashboardDateFilter: [
             {

--- a/products/ai_observability/frontend/preferenceStorage.ts
+++ b/products/ai_observability/frontend/preferenceStorage.ts
@@ -1,16 +1,5 @@
-import { getCurrentTeamIdOrNone } from 'lib/utils/getAppContext'
+import { buildTeamScopedStorageConfig } from 'lib/logic/persistence'
 
-interface AIObservabilityPreferenceStorageConfig {
-    persist: true
+export const buildAiObservabilityStorageConfig = (
     storageKey: string
-}
-
-export function buildAiObservabilityStorageConfig(storageKey: string): AIObservabilityPreferenceStorageConfig {
-    const teamId = getCurrentTeamIdOrNone()
-    const teamPrefix = teamId ? `${teamId}__` : ''
-
-    return {
-        persist: true,
-        storageKey: `${teamPrefix}ai_observability.${storageKey}`,
-    }
-}
+): ReturnType<typeof buildTeamScopedStorageConfig> => buildTeamScopedStorageConfig(`ai_observability.${storageKey}`)

--- a/products/ai_observability/frontend/tabs/aiObservabilityTracesTabLogic.ts
+++ b/products/ai_observability/frontend/tabs/aiObservabilityTracesTabLogic.ts
@@ -15,6 +15,7 @@ import { buildAiObservabilityStorageConfig } from '../preferenceStorage'
 import { LLM_TRACES_PAGE_SIZE } from '../utils'
 
 export interface AIObservabilityTracesTabLogicProps {
+    logicKey?: string
     personId?: string
     group?: {
         groupKey: string
@@ -89,11 +90,11 @@ export type aiObservabilityTracesTabLogicType = MakeLogicType<
 
 export const aiObservabilityTracesTabLogic = kea<aiObservabilityTracesTabLogicType>([
     path(['products', 'ai_observability', 'frontend', 'tabs', 'aiObservabilityTracesTabLogic']),
-    key((props: AIObservabilityTracesTabLogicProps) => props?.personId || 'aiObservabilityScene'),
+    key((props: AIObservabilityTracesTabLogicProps) => props.logicKey || props.personId || 'aiObservabilityScene'),
     props({} as AIObservabilityTracesTabLogicProps),
     connect((props: AIObservabilityTracesTabLogicProps) => ({
         values: [
-            aiObservabilitySharedLogic({ personId: props.personId, group: props.group }),
+            aiObservabilitySharedLogic({ logicKey: props.logicKey, personId: props.personId, group: props.group }),
             ['dateFilter', 'shouldFilterTestAccounts', 'shouldFilterSupportTraces', 'propertyFilters', 'searchQuery'],
             groupsModel,
             ['groupsTaxonomicTypes'],


### PR DESCRIPTION
## Problem

AI Observability tabs reset to Last hour when users reopen a clean tab URL after selecting a longer timeframe.

The dashboard range added in #81819 applies only to the selected dashboard.

## Changes

- AI Observability remembers the shared event-tab timeframe for each project.
- Notebook trace nodes keep isolated date state and cannot overwrite the saved project timeframe.
- Explicit valid URL dates remain authoritative for shared links.
- Invalid URL dates fall back to the saved project timeframe.
- The shared persistence helper requires a project ID, which prevents unscoped storage keys.
- Dashboard dates remain independent from event-tab dates.
- The helper backs Web Analytics, Marketing Analytics, and AI Observability.

**Before:** Traces is set to Last 7 days.

![AI observability Traces set to Last 7 days](https://raw.githubusercontent.com/PostHog/pr-assets/b720b6227849f2b162dd2b28e418100ee2444982/2026/08/1ad0af49-a0e0-4a73-9063-3166b719773a.png)

**After:** Traces still shows Last 7 days after visiting Generations and reopening the clean Traces URL without `date_from`.

![AI observability Traces still on Last 7 days after clean return](https://raw.githubusercontent.com/PostHog/pr-assets/7e3f8d781363a6dd51c41949950403f36765ecfa/2026/08/9de59b4c-ad36-4d86-94e8-375b23e08db9.png)

## How did you test this code?

- Ran the AI Observability, Web Analytics, and persistence logic suites.
- Added regressions for notebook isolation, missing project IDs, invalid URL dates, clean tab visits, URL overrides, and dashboard isolation.
- Verified persistence manually by leaving Traces and reopening its clean URL.
- Ran frontend formatting, targeted linting, and the staged-file checks.
- Frontend CI passed typechecking, formatting, and all 8 Jest shards.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs change. This extends existing filter behavior without adding UI or setup steps.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and tested this change under human direction. Skills invoked: `/posthog-support-answer`, `/playwright`, `/writing-tests`, `/writing-code-comments`, `/gh-address-comments`, `/gh-fix-ci`, and `/writing-pr-descriptions`.

The session included private customer context. The PR contains only product behavior and invented test values.



