### PR TITLE
chore(rust): rebuild the node addons when their path dependencies change

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -62,6 +62,11 @@ jobs:
                         # its Rust tests; a rust-side change (incl. the shared fixtures) must run it.
                         - 'rust/replay-anonymizer/**'
                         - 'rust/replay-anonymizer-node/**'
+                        # These native addons are built by Turbo before Node.js tests. Their Rust
+                        # dependencies are not part of the ingestion consumer's targeted e2e set.
+                        - 'rust/cyclotron-core/**'
+                        - 'rust/cyclotron-node/**'
+                        - 'rust/common/hogvm/**'
                         - '**/crosslang/**'
                         # The clientwarnings consumer e2e replays capture's warning envelope from
                         # this shared fixture. Without it the rust filter below decides, and it only

--- a/rust/common/hogvm/node/turbo.json
+++ b/rust/common/hogvm/node/turbo.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "https://turbo.build/schema.json",
+    "extends": ["//"],
+    "tasks": {
+        "build": {
+            "inputs": [
+                "src",
+                "build.rs",
+                "Cargo.toml",
+                "Cargo.lock",
+                "$TURBO_ROOT$/rust/common/hogvm/src/**",
+                "$TURBO_ROOT$/rust/common/hogvm/Cargo.toml",
+                "$TURBO_ROOT$/rust/Cargo.toml"
+            ]
+        },
+        "test": {
+            "inputs": [
+                "src",
+                "build.rs",
+                "Cargo.toml",
+                "Cargo.lock",
+                "$TURBO_ROOT$/rust/common/hogvm/src/**",
+                "$TURBO_ROOT$/rust/common/hogvm/Cargo.toml",
+                "$TURBO_ROOT$/rust/Cargo.toml"
+            ]
+        }
+    }
+}

--- a/rust/cyclotron-node/turbo.json
+++ b/rust/cyclotron-node/turbo.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "https://turbo.build/schema.json",
+    "extends": ["//"],
+    "tasks": {
+        "build": {
+            "inputs": [
+                "src",
+                "Cargo.toml",
+                "$TURBO_ROOT$/rust/cyclotron-core/src/**",
+                "$TURBO_ROOT$/rust/cyclotron-core/.sqlx/**",
+                "$TURBO_ROOT$/rust/cyclotron-core/Cargo.toml",
+                "$TURBO_ROOT$/rust/common/compression/src/**",
+                "$TURBO_ROOT$/rust/common/compression/Cargo.toml",
+                "$TURBO_ROOT$/rust/common/metrics/src/**",
+                "$TURBO_ROOT$/rust/common/metrics/Cargo.toml",
+                "$TURBO_ROOT$/rust/Cargo.toml",
+                "$TURBO_ROOT$/rust/Cargo.lock"
+            ]
+        },
+        "test": {
+            "inputs": [
+                "src",
+                "Cargo.toml",
+                "$TURBO_ROOT$/rust/cyclotron-core/src/**",
+                "$TURBO_ROOT$/rust/cyclotron-core/.sqlx/**",
+                "$TURBO_ROOT$/rust/cyclotron-core/Cargo.toml",
+                "$TURBO_ROOT$/rust/common/compression/src/**",
+                "$TURBO_ROOT$/rust/common/compression/Cargo.toml",
+                "$TURBO_ROOT$/rust/common/metrics/src/**",
+                "$TURBO_ROOT$/rust/common/metrics/Cargo.toml",
+                "$TURBO_ROOT$/rust/Cargo.toml",
+                "$TURBO_ROOT$/rust/Cargo.lock"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
## Problem

You edit `cyclotron-core` or the `hogvm` crate. You rebuild with a warm turbo cache. Turbo gives you the old `index.node`. That binary does not contain your change.

- Turbo hashes each package's own `src` and `Cargo.toml`.
- `@posthog/cyclotron` reaches 8 files that way. `@posthog/hogvm-node` reaches 7 files.
- Both packages compile Rust code outside those directories. They reach that code through cargo path dependencies.
- Turbo cannot follow a path dependency. `dependsOn: ["^build"]` walks workspace packages only. A cargo crate is not a workspace package.
- The input set does not change when the dependency crate changes. Turbo then replays the cached artifact.

This PR follows [#82410](https://github.com/PostHog/posthog/pull/82410). That PR fixed the same defect for `@posthog/replay-anonymizer`. A crate split caused the defect there. These two packages always had it.

CI does not have this problem. Runners start with an empty turbo cache. They compile the addons every time. The defect appears only with a warm cache, so it affects local development and `hogli start`.

## Changes

This PR adds two package configs. Each config lists the crates that its addon compiles.

`rust/cyclotron-node/turbo.json` covers the full path closure. It does not stop at the direct dependency:

```
cyclotron-node -> cyclotron-core -> common/compression
                                 -> common/metrics
```

The config also takes `rust/cyclotron-core/.sqlx/**`. The sqlx macros compile those 16 offline query files into the binary. A change to one query changes the artifact.

`rust/common/hogvm/node/turbo.json` covers the `hogvm` crate. This package declares its own `[workspace]`. It therefore takes its own `Cargo.lock` and not `rust/Cargo.lock`. The config also adds `build.rs`, because the root config's `src` glob does not match that file.

Both configs override `inputs` only. `outputs`, `cache`, `dependsOn` and `env` still come from the root config.

Neither config takes the `tests/**` directory of a dependency crate. `pnpm test` runs `cargo test` from the package directory. That command tests one package.

## How did you test this code?

I ran the `build` and `test` tasks for each package. I used `--filter`, `--no-daemon` and `--dry-run=json`. I compared the resolved input set on a clean tree against the input set after I appended a comment to a dependency crate. `edit_invisible=True` means that turbo cannot see the edit.

```
WITH-CONFIG    @posthog/cyclotron     build  inputs=45  edit_invisible=False
WITH-CONFIG    @posthog/cyclotron     test   inputs=45  edit_invisible=False
WITH-CONFIG    @posthog/hogvm-node    build  inputs=27  edit_invisible=False
WITH-CONFIG    @posthog/hogvm-node    test   inputs=27  edit_invisible=False
WITHOUT-CONFIG @posthog/cyclotron     build  inputs=8   edit_invisible=True
WITHOUT-CONFIG @posthog/cyclotron     test   inputs=8   edit_invisible=True
WITHOUT-CONFIG @posthog/hogvm-node    build  inputs=7   edit_invisible=True
WITHOUT-CONFIG @posthog/hogvm-node    test   inputs=7   edit_invisible=True
```

The four `True` rows show the defect. The probe edited `rust/cyclotron-core/src/lib.rs` and `rust/common/hogvm/src/vm.rs`.

The evidence is the input set and not the task hash. `turbo --dry-run` returns `hashOfExternalDependencies` as an empty string on approximately one run in six in my sandbox. That empty value moves the hash on an unchanged tree. The input set stays the same across repeated runs.

I did not run a real `turbo build`. A cold cache compiles the addon in both states, so that test cannot separate them.

I added no tests. A guard test can check that every Rust crate with an npm package declares its path dependencies. That test becomes possible after this PR and #82410 merge. It is worth a follow-up.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, model claude-opus-5, via Claude Code) wrote this PR. @robbie-c asked me to extend the #82410 fix to these two packages.

I read each manifest and derived the path closure from it. I did not copy the anonymizer config. That method found three differences: the transitive `common/*` crates under cyclotron-core, the `.sqlx` offline data, and the separate cargo workspace of hogvm-node.

I measured the defect with task hashes first. Those hashes were non-deterministic in this sandbox. I changed the evidence to the input set.

Skills invoked: `/writing-pr-descriptions`, and the ASD-STE100 skill from https://github.com/robbie-c/asd-ste100-skill. The STE skill shapes the English in this description: active voice, simple tenses, one fact per sentence, and one term per concept.

I branched from `eca44dbf3`. That commit was the master tip at the time. I checked master again before I pushed. `hogli ci:preflight --fix` reported no findings.
