### PR TITLE
fix(alerts): cap concurrent alert evaluations

### DIFF
--- a/posthog/temporal/alerts/__init__.py
+++ b/posthog/temporal/alerts/__init__.py
@@ -1,5 +1,6 @@
 from posthog.temporal.alerts.activities import (
     cleanup_alert_checks,
+    enqueue_alert_checks,
     evaluate_alert,
     notify_alert,
     prepare_alert,
@@ -7,6 +8,7 @@ from posthog.temporal.alerts.activities import (
     run_investigation_safety_net,
 )
 from posthog.temporal.alerts.workflows import (
+    AlertEvaluationDispatcherWorkflow,
     CheckAlertWorkflow,
     CleanupAlertChecksWorkflow,
     RunInvestigationSafetyNetWorkflow,
@@ -15,6 +17,7 @@ from posthog.temporal.alerts.workflows import (
 
 WORKFLOWS = [
     ScheduleDueAlertChecksWorkflow,
+    AlertEvaluationDispatcherWorkflow,
     CheckAlertWorkflow,
     RunInvestigationSafetyNetWorkflow,
     CleanupAlertChecksWorkflow,
@@ -27,4 +30,5 @@ ACTIVITIES = [
     notify_alert,
     run_investigation_safety_net,
     cleanup_alert_checks,
+    enqueue_alert_checks,
 ]

--- a/posthog/temporal/alerts/activities.py
+++ b/posthog/temporal/alerts/activities.py
@@ -2,6 +2,7 @@ import traceback
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 
+from django.conf import settings
 from django.db import transaction
 from django.db.models import Case, F, IntegerField, Q, Value, When
 
@@ -36,6 +37,7 @@ from posthog.tasks.alerts.utils import (
 from posthog.temporal.alerts.investigation import claim_investigation_slot, should_trigger_investigation
 from posthog.temporal.alerts.types import (
     AlertInfo,
+    EnqueueAlertChecksActivityInputs,
     EvaluateAlertActivityInputs,
     EvaluateAlertResult,
     NotifyAlertActivityInputs,
@@ -44,6 +46,7 @@ from posthog.temporal.alerts.types import (
     PrepareAlertResult,
     SkipReason,
 )
+from posthog.temporal.common.client import async_connect
 from posthog.temporal.common.heartbeat import Heartbeater
 
 from products.alerts.backend.evaluation import check_alert_for_insight
@@ -86,15 +89,17 @@ async def retrieve_due_alerts() -> list[AlertInfo]:
             )
             .filter(Q(snoozed_until__isnull=True) | Q(snoozed_until__lt=now))
             .filter(insight__deleted=False)
+            .select_related("team")
             .annotate(_interval_order=calculation_interval_order)
             .order_by("_interval_order", F("next_check_at").asc(nulls_first=True))
-            .only("id", "team_id", "calculation_interval", "insight_id")
+            .only("id", "team_id", "team__organization_id", "calculation_interval", "insight_id")
         )
 
         return [
             AlertInfo(
                 alert_id=str(a.id),
                 team_id=a.team_id,
+                organization_id=str(a.team.organization_id),
                 distinct_id=str(a.id),
                 calculation_interval=a.calculation_interval,
                 insight_id=a.insight_id,
@@ -104,6 +109,21 @@ async def retrieve_due_alerts() -> list[AlertInfo]:
 
     async with Heartbeater():
         return await get_alerts()
+
+
+@temporalio.activity.defn
+async def enqueue_alert_checks(inputs: EnqueueAlertChecksActivityInputs) -> None:
+    if not inputs.alerts:
+        return
+
+    client = await async_connect()
+    await client.start_workflow(
+        "alert-evaluation-dispatcher",
+        id="alert-evaluation-dispatcher",
+        task_queue=settings.ANALYTICS_PLATFORM_TASK_QUEUE,
+        start_signal="enqueue_alerts",
+        start_signal_args=[inputs.alerts],
+    )
 
 
 @temporalio.activity.defn

--- a/posthog/temporal/alerts/schedule.py
+++ b/posthog/temporal/alerts/schedule.py
@@ -27,7 +27,7 @@ async def create_schedule_due_alert_checks_schedule(client: Client) -> None:
             execution_timeout=dt.timedelta(minutes=10),
         ),
         spec=ScheduleSpec(cron_expressions=["*/1 * * * *"]),
-        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.ALLOW_ALL),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
     )
 
     if await a_schedule_exists(client, SCHEDULE_ID):

--- a/posthog/temporal/alerts/types.py
+++ b/posthog/temporal/alerts/types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 from enum import StrEnum
 
@@ -26,9 +28,22 @@ class SkipReason(StrEnum):
 class AlertInfo:
     alert_id: str
     team_id: int
+    organization_id: str
     distinct_id: str
     calculation_interval: str | None
     insight_id: int
+
+
+@dataclasses.dataclass(frozen=True)
+class EnqueueAlertChecksActivityInputs:
+    alerts: list[AlertInfo]
+
+
+@dataclasses.dataclass(frozen=True)
+class AlertEvaluationDispatcherInputs:
+    pending_by_organization: dict[str, list[CheckAlertWorkflowInputs]] | None = None
+    pending_alert_ids: list[str] | None = None
+    organization_cursor: int = 0
 
 
 @dataclasses.dataclass(frozen=True)

--- a/posthog/temporal/alerts/workflows.py
+++ b/posthog/temporal/alerts/workflows.py
@@ -115,11 +115,11 @@ class AlertEvaluationDispatcherWorkflow(PostHogWorkflow):
             self._pending_or_in_flight_alert_ids.add(alert.alert_id)
 
     @temporalio.workflow.run
-    async def run(self, inputs: AlertEvaluationDispatcherInputs | None = None) -> None:
-        if inputs:
-            self._pending_by_organization = inputs.pending_by_organization or {}
-            self._pending_or_in_flight_alert_ids = set(inputs.pending_alert_ids or [])
-            self._organization_cursor = inputs.organization_cursor
+    async def run(self, dispatcher_inputs: AlertEvaluationDispatcherInputs | None = None) -> None:
+        if dispatcher_inputs:
+            self._pending_by_organization = dispatcher_inputs.pending_by_organization or {}
+            self._pending_or_in_flight_alert_ids = set(dispatcher_inputs.pending_alert_ids or [])
+            self._organization_cursor = dispatcher_inputs.organization_cursor
 
         while True:
             await temporalio.workflow.wait_condition(

--- a/posthog/temporal/alerts/workflows.py
+++ b/posthog/temporal/alerts/workflows.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 import temporalio.common
 import temporalio.workflow
-from temporalio.exceptions import ApplicationError, WorkflowAlreadyStartedError
+from temporalio.exceptions import WorkflowAlreadyStartedError
 
 from posthog.schema import AlertState
 
@@ -13,6 +13,7 @@ from posthog.slo.context import JsonValue
 from posthog.slo.types import SloArea, SloConfig, SloOperation
 from posthog.temporal.alerts.activities import (
     cleanup_alert_checks,
+    enqueue_alert_checks,
     evaluate_alert,
     notify_alert,
     prepare_alert,
@@ -21,7 +22,10 @@ from posthog.temporal.alerts.activities import (
 )
 from posthog.temporal.alerts.retry_policy import ALERT_NOTIFY_RETRY_POLICY, ALERT_PREPARE_RETRY_POLICY, alert_timeouts
 from posthog.temporal.alerts.types import (
+    AlertEvaluationDispatcherInputs,
+    AlertInfo,
     CheckAlertWorkflowInputs,
+    EnqueueAlertChecksActivityInputs,
     EvaluateAlertActivityInputs,
     NotifyAlertActivityInputs,
     PrepareAction,
@@ -53,65 +57,133 @@ class ScheduleDueAlertChecksWorkflow(PostHogWorkflow):
             ),
         )
 
-        # Fan-out child workflows — one per alert. Deterministic ID prevents
-        # duplicate checks when schedule runs overlap; Temporal guarantees no
-        # two open workflows can share the same ID, so a still-running child
-        # rejects the duplicate start.
-        tasks = []
+        await temporalio.workflow.execute_activity(
+            enqueue_alert_checks,
+            EnqueueAlertChecksActivityInputs(alerts=alerts),
+            start_to_close_timeout=dt.timedelta(minutes=1),
+            retry_policy=temporalio.common.RetryPolicy(
+                initial_interval=dt.timedelta(seconds=5),
+                maximum_interval=dt.timedelta(minutes=1),
+                maximum_attempts=3,
+            ),
+        )
+
+
+MAX_CONCURRENT_ALERT_CHECKS = 10
+
+
+@temporalio.workflow.defn(name="alert-evaluation-dispatcher")
+class AlertEvaluationDispatcherWorkflow(PostHogWorkflow):
+    def __init__(self) -> None:
+        self._pending_by_organization: dict[str, list[CheckAlertWorkflowInputs]] = {}
+        self._pending_or_in_flight_alert_ids: set[str] = set()
+        self._in_flight_alert_ids: set[str] = set()
+        self._organization_cursor = 0
+
+    @staticmethod
+    def parse_inputs(inputs: list[str]) -> None:
+        return None
+
+    @temporalio.workflow.signal
+    def enqueue_alerts(self, alerts: list[AlertInfo]) -> None:
         for alert in alerts:
+            if alert.alert_id in self._pending_or_in_flight_alert_ids:
+                continue
+
             slo_properties: dict[str, JsonValue] = {
                 "alert_type": "insight",
                 "calculation_interval": alert.calculation_interval,
                 "insight_id": alert.insight_id,
             }
-            task = temporalio.workflow.execute_child_workflow(
-                CheckAlertWorkflow.run,
-                CheckAlertWorkflowInputs(
-                    alert_id=alert.alert_id,
+            inputs = CheckAlertWorkflowInputs(
+                alert_id=alert.alert_id,
+                team_id=alert.team_id,
+                distinct_id=alert.distinct_id,
+                calculation_interval=alert.calculation_interval,
+                insight_id=alert.insight_id,
+                slo=SloConfig(
+                    operation=SloOperation.ALERT_CHECK,
+                    area=SloArea.ANALYTIC_PLATFORM,
                     team_id=alert.team_id,
+                    resource_id=alert.alert_id,
                     distinct_id=alert.distinct_id,
-                    calculation_interval=alert.calculation_interval,
-                    insight_id=alert.insight_id,
-                    slo=SloConfig(
-                        operation=SloOperation.ALERT_CHECK,
-                        area=SloArea.ANALYTIC_PLATFORM,
-                        team_id=alert.team_id,
-                        resource_id=alert.alert_id,
-                        distinct_id=alert.distinct_id,
-                        start_properties=slo_properties.copy(),
-                        completion_properties=slo_properties.copy(),
-                    ),
+                    start_properties=slo_properties.copy(),
+                    completion_properties=slo_properties.copy(),
                 ),
-                id=f"check-alert-{alert.alert_id}",
-                parent_close_policy=temporalio.workflow.ParentClosePolicy.ABANDON,
-                execution_timeout=alert_timeouts(alert.calculation_interval).workflow_execution,
             )
-            tasks.append(task)
+            self._pending_by_organization.setdefault(alert.organization_id, []).append(inputs)
+            self._pending_or_in_flight_alert_ids.add(alert.alert_id)
 
-        if tasks:
-            results = await asyncio.gather(*tasks, return_exceptions=True)
-            failed_ids = []
-            for alert, result in zip(alerts, results):
-                if isinstance(result, BaseException):
-                    if isinstance(result, WorkflowAlreadyStartedError):
-                        # Previous schedule run's child still processing this
-                        # alert — not a failure, just skip it.
-                        temporalio.workflow.logger.info(
-                            "check_alert.already_running",
-                            extra={"alert_id": alert.alert_id},
-                        )
-                    else:
-                        failed_ids.append(alert.alert_id)
-                        temporalio.workflow.logger.warning(
-                            "check_alert.child_workflow_error",
-                            extra={"alert_id": alert.alert_id, "error": str(result)},
-                        )
+    @temporalio.workflow.run
+    async def run(self, inputs: AlertEvaluationDispatcherInputs | None = None) -> None:
+        if inputs:
+            self._pending_by_organization = inputs.pending_by_organization or {}
+            self._pending_or_in_flight_alert_ids = set(inputs.pending_alert_ids or [])
+            self._organization_cursor = inputs.organization_cursor
 
-            if failed_ids:
-                raise ApplicationError(
-                    f"Alert checks failed for IDs: {failed_ids}",
-                    non_retryable=True,
+        while True:
+            await temporalio.workflow.wait_condition(
+                lambda: self._can_dispatch() or temporalio.workflow.info().is_continue_as_new_suggested()
+            )
+            if temporalio.workflow.info().is_continue_as_new_suggested():
+                await temporalio.workflow.wait_condition(lambda: not self._in_flight_alert_ids)
+                await temporalio.workflow.wait_condition(temporalio.workflow.all_handlers_finished)
+                temporalio.workflow.continue_as_new(
+                    AlertEvaluationDispatcherInputs(
+                        pending_by_organization=self._pending_by_organization,
+                        pending_alert_ids=sorted(self._pending_or_in_flight_alert_ids),
+                        organization_cursor=self._organization_cursor,
+                    )
                 )
+
+            while self._can_dispatch():
+                inputs = self._next_alert()
+                if inputs is None:
+                    break
+
+                self._in_flight_alert_ids.add(inputs.alert_id)
+                try:
+                    handle = await temporalio.workflow.start_child_workflow(
+                        CheckAlertWorkflow.run,
+                        inputs,
+                        id=f"check-alert-{inputs.alert_id}",
+                        parent_close_policy=temporalio.workflow.ParentClosePolicy.ABANDON,
+                        execution_timeout=alert_timeouts(inputs.calculation_interval).workflow_execution,
+                    )
+                except WorkflowAlreadyStartedError:
+                    temporalio.workflow.logger.info("check_alert.already_running", extra={"alert_id": inputs.alert_id})
+                    self._complete_alert_check(inputs.alert_id)
+                    continue
+                asyncio.create_task(self._wait_for_alert_check(inputs.alert_id, handle))
+
+    def _can_dispatch(self) -> bool:
+        return bool(self._pending_by_organization) and len(self._in_flight_alert_ids) < MAX_CONCURRENT_ALERT_CHECKS
+
+    def _next_alert(self) -> CheckAlertWorkflowInputs | None:
+        organization_ids = list(self._pending_by_organization)
+        if not organization_ids:
+            return None
+
+        organization_id = organization_ids[self._organization_cursor % len(organization_ids)]
+        self._organization_cursor = (self._organization_cursor + 1) % len(organization_ids)
+        inputs = self._pending_by_organization[organization_id].pop(0)
+        if not self._pending_by_organization[organization_id]:
+            del self._pending_by_organization[organization_id]
+        return inputs
+
+    async def _wait_for_alert_check(self, alert_id: str, handle: temporalio.workflow.ChildWorkflowHandle) -> None:
+        try:
+            await handle
+        except WorkflowAlreadyStartedError:
+            temporalio.workflow.logger.info("check_alert.already_running", extra={"alert_id": alert_id})
+        except Exception:
+            temporalio.workflow.logger.exception("check_alert.child_workflow_error", extra={"alert_id": alert_id})
+        finally:
+            self._complete_alert_check(alert_id)
+
+    def _complete_alert_check(self, alert_id: str) -> None:
+        self._in_flight_alert_ids.discard(alert_id)
+        self._pending_or_in_flight_alert_ids.discard(alert_id)
 
 
 @temporalio.workflow.defn(name="check-alert")

--- a/posthog/temporal/tests/test_alerts_workflows.py
+++ b/posthog/temporal/tests/test_alerts_workflows.py
@@ -27,8 +27,17 @@ from posthog.slo.types import SloArea, SloConfig, SloOperation, SloOutcome
 from posthog.tasks.alerts.utils import AlertEvaluationResult
 from posthog.temporal.alerts.activities import evaluate_alert, notify_alert, prepare_alert
 from posthog.temporal.alerts.schedule import create_schedule_due_alert_checks_schedule
-from posthog.temporal.alerts.types import AlertInfo, CheckAlertWorkflowInputs, SkipReason
-from posthog.temporal.alerts.workflows import CheckAlertWorkflow, ScheduleDueAlertChecksWorkflow
+from posthog.temporal.alerts.types import (
+    AlertInfo,
+    CheckAlertWorkflowInputs,
+    EnqueueAlertChecksActivityInputs,
+    SkipReason,
+)
+from posthog.temporal.alerts.workflows import (
+    AlertEvaluationDispatcherWorkflow,
+    CheckAlertWorkflow,
+    ScheduleDueAlertChecksWorkflow,
+)
 from posthog.temporal.common.slo_interceptor import SloInterceptor
 
 from products.alerts.backend.models.alert import AlertCheck, AlertConfiguration, Threshold
@@ -38,10 +47,11 @@ CHECK_ALERT_ACTIVITIES: list[Callable[..., Any]] = [prepare_alert, evaluate_aler
 
 
 @pytest.mark.asyncio
-async def test_schedule_due_alert_checks_adds_shared_slo_context() -> None:
+async def test_schedule_due_alert_checks_enqueues_due_alerts() -> None:
     alert = AlertInfo(
         alert_id="alert-1",
         team_id=42,
+        organization_id="org-1",
         distinct_id="user-1",
         calculation_interval=AlertCalculationInterval.DAILY.value,
         insight_id=123,
@@ -50,31 +60,30 @@ async def test_schedule_due_alert_checks_adds_shared_slo_context() -> None:
     with (
         patch(
             "posthog.temporal.alerts.workflows.temporalio.workflow.execute_activity",
-            new=AsyncMock(return_value=[alert]),
-        ),
-        patch(
-            "posthog.temporal.alerts.workflows.temporalio.workflow.execute_child_workflow", new=AsyncMock()
-        ) as execute_child,
+            new=AsyncMock(side_effect=[[alert], None]),
+        ) as execute_activity,
     ):
         await ScheduleDueAlertChecksWorkflow().run()
 
-    inputs = execute_child.call_args.args[1]
-    assert isinstance(inputs, CheckAlertWorkflowInputs)
-    assert inputs.slo is not None
-    assert inputs.slo.operation == SloOperation.ALERT_CHECK
-    assert inputs.slo.area == SloArea.ANALYTIC_PLATFORM
-    assert inputs.slo.team_id == 42
-    assert inputs.slo.resource_id == "alert-1"
-    assert inputs.slo.distinct_id == "user-1"
-    assert inputs.slo.start_properties == {
-        "alert_type": "insight",
-        "calculation_interval": AlertCalculationInterval.DAILY.value,
-        "insight_id": 123,
-    }
-    assert inputs.slo.completion_properties == inputs.slo.start_properties
+    inputs = execute_activity.call_args_list[1].args[1]
+    assert isinstance(inputs, EnqueueAlertChecksActivityInputs)
+    assert inputs.alerts == [alert]
 
-    inputs.slo.completion_properties["alert_state"] = AlertState.FIRING
-    assert "alert_state" not in inputs.slo.start_properties
+
+def test_alert_evaluation_dispatcher_round_robins_organizations_and_deduplicates_alerts() -> None:
+    dispatcher = AlertEvaluationDispatcherWorkflow()
+    dispatcher.enqueue_alerts(
+        [
+            AlertInfo("alert-1", 1, "org-1", "alert-1", AlertCalculationInterval.DAILY.value, 1),
+            AlertInfo("alert-2", 1, "org-1", "alert-2", AlertCalculationInterval.DAILY.value, 2),
+            AlertInfo("alert-3", 2, "org-2", "alert-3", AlertCalculationInterval.DAILY.value, 3),
+            AlertInfo("alert-1", 1, "org-1", "alert-1", AlertCalculationInterval.DAILY.value, 1),
+        ]
+    )
+
+    dispatched = [dispatcher._next_alert(), dispatcher._next_alert(), dispatcher._next_alert()]
+
+    assert [alert.alert_id if alert else None for alert in dispatched] == ["alert-1", "alert-3", "alert-2"]
 
 
 def test_schedule_is_registered_in_init_schedules():


### PR DESCRIPTION
## Problem

Alert evaluations can start together and exhaust an organization's query capacity.

## Changes

- Queue due checks in one durable Temporal dispatcher.
- Dispatch checks round-robin across organizations with ten concurrent slots.
- Deduplicate queued checks and preserve pending state during workflow continuation.
- **Why:** Queueing avoids failed alert checks while retaining parallel evaluation.

## How did you test this code?

- Ran targeted workflow tests for schedule enqueueing and organization round-robin dispatch. These guard against skipped queueing, duplicate checks, and unfair dispatch.
- Ran Ruff and repo-wide MyPy.
- Not run: database-backed alert workflow tests.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. This changes internal scheduling behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Created with PostHog Slack app. Used the repository workflow guidance and the `/writing-tests` and `/writing-pr-descriptions` skills.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09ALCCKESZ/p1786587444900989?thread_ts=1786587444.900989&cid=C09ALCCKESZ)*