### PR TITLE
fix(conversations): only warn about a missing support widget on support surfaces

### DIFF
--- a/products/conversations/frontend/components/SidePanel/sidepanelTicketsLogic.test.ts
+++ b/products/conversations/frontend/components/SidePanel/sidepanelTicketsLogic.test.ts
@@ -392,12 +392,20 @@ describe('sidepanelTicketsLogic', () => {
     })
 
     // The panel already shows free plans the community and upgrade options, and they have no email
-    // channel, so warning them the chat failed would offer support they don't actually get.
+    // channel, so warning them the chat failed would offer support they don't actually get. The
+    // unread badge also mounts this logic on every page, so outside a support surface the toast
+    // would interrupt unrelated work (and block clicks under the toast container) for anyone whose
+    // ad blocker keeps the widget from loading.
     it.each([
-        ['warns an entitled plan', 'paid', true],
-        ['stays quiet on a free plan', 'free', false],
-    ])('when the widget never loads, %s', async (_case, subscriptionLevel, expectWarning) => {
+        ['warns an entitled plan on the support panel', 'paid', true, true],
+        ['stays quiet on a free plan', 'free', true, false],
+        ['stays quiet outside support surfaces', 'paid', false, false],
+    ])('when the widget never loads, %s', async (_case, subscriptionLevel, onSupportPanel, expectWarning) => {
         const errorToast = jest.spyOn(lemonToast, 'error').mockReturnValue('' as never)
+        if (onSupportPanel) {
+            sidePanelStateLogic.mount()
+            sidePanelStateLogic.actions.openSidePanel(SidePanelTab.Support)
+        }
         logic = sidepanelTicketsLogic.build()
         logic.mount()
         await expectLogic(logic).toFinishAllListeners()
@@ -425,7 +433,7 @@ describe('sidepanelTicketsLogic', () => {
             ([event]) => event === 'support widget load failed'
         )
         expect(loadFailures).toHaveLength(1)
-        expect(loadFailures[0][1]).toMatchObject({ can_create_ticket: expectWarning })
+        expect(loadFailures[0][1]).toMatchObject({ can_create_ticket: subscriptionLevel === 'paid' })
         expect(errorToast).toHaveBeenCalledTimes(expectWarning ? 1 : 0)
         errorToast.mockRestore()
     })

--- a/products/conversations/frontend/components/SidePanel/sidepanelTicketsLogic.ts
+++ b/products/conversations/frontend/components/SidePanel/sidepanelTicketsLogic.ts
@@ -473,22 +473,37 @@ export const sidepanelTicketsLogic = kea<sidepanelTicketsLogicType>([
                 if ((cache.conversationsRetries ?? 0) < 20) {
                     cache.conversationsRetries = (cache.conversationsRetries ?? 0) + 1
                     cache.conversationsRetryTimer = window.setTimeout(() => actions.loadTickets(), 500)
-                } else if (!cache.conversationsUnavailableWarned) {
-                    // Out of retries. Kept separate from the send-failure event because nothing was
-                    // submitted here, and recorded even when we stay quiet so the rate is measurable.
-                    cache.conversationsUnavailableWarned = true
+                    return
+                }
+                // Out of retries. Kept separate from the send-failure event because nothing was
+                // submitted here, and recorded even when we stay quiet so the rate is measurable.
+                if (!cache.conversationsUnavailableCaptured) {
+                    cache.conversationsUnavailableCaptured = true
                     captureSupportWidgetLoadFailed({
                         surface: 'side_panel_tickets',
                         reason: 'extension_missing',
                         can_create_ticket: values.canCreateTicket,
                     })
-                    // Only warn people who could act on it. A free plan has no email fallback, and the
-                    // panel already shows them the community and upgrade options, so a toast offering
-                    // to email us would promise a channel they don't get. Warn while entitlement is
-                    // still unresolved, matching how the composer opens rather than drop a message.
-                    if (values.canCreateTicket || !values.isBillingResolved) {
-                        warnSupportWidgetUnavailable()
-                    }
+                }
+                // This logic also mounts from the panel bar's unread badge, which renders on every
+                // page, so an unavailable widget (an ad blocker is enough) would otherwise raise a
+                // persistent error toast on surfaces that have nothing to do with support and block
+                // clicks on whatever sits under the toast container. Only warn while the person is
+                // actually on a support surface; opening one later re-runs loadTickets and warns then.
+                const onSupportSurface =
+                    (values.sidePanelOpen && values.selectedTab === SidePanelTab.Support) ||
+                    removeProjectIdIfPresent(router.values.location.pathname) === urls.myTickets()
+                // Only warn people who could act on it. A free plan has no email fallback, and the
+                // panel already shows them the community and upgrade options, so a toast offering
+                // to email us would promise a channel they don't get. Warn while entitlement is
+                // still unresolved, matching how the composer opens rather than drop a message.
+                if (
+                    !cache.conversationsUnavailableWarned &&
+                    onSupportSurface &&
+                    (values.canCreateTicket || !values.isBillingResolved)
+                ) {
+                    cache.conversationsUnavailableWarned = true
+                    warnSupportWidgetUnavailable()
                 }
                 return
             }


### PR DESCRIPTION
## Problem

- Since #81414, anyone whose browser cannot load the support chat widget (an ad blocker is enough) gets a permanent "We can't load the support chat" error toast on every page, not just on support surfaces.
- The toast never auto-closes, and the toast container blocks clicks on anything under the bottom-right corner, such as the insight side panel's "View source" toggle and "Delete insight" button.
- This fails two Playwright tests on master, where the widget never loads: `Deleting an insight from dashboard redirects back` and `View source toggle enters edit mode and shows query editor` ([failing run](https://github.com/PostHog/posthog/actions/runs/31674516851), see the `error-context.md` snapshots in its artifact).
- The Support tab's unread badge mounts `sidepanelTicketsLogic` on every page, and its `loadTickets` warns after 20 retries for the extension.

## Changes

- The retry-exhausted warning now fires only while the person is on a support surface: the Support side panel, or the my-tickets scene.
- Opening a support surface later re-runs `loadTickets`, so those visitors still get the warning.
- The `support widget load failed` telemetry still records unconditionally.
- User-initiated paths (composer send, support form submit) warn exactly as before.

## How did you test this code?

- Extended the existing widget-never-loads cases in `sidepanelTicketsLogic.test.ts`. The new "stays quiet outside support surfaces" case catches the toast firing from the every-page badge mount again.
- Not run: the two Playwright tests, because they need the full dev stack. Both were green before #81414 landed, and the fix removes the only permanent toast in the failing runs' DOM snapshots.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Fable 5). Skills invoked: /fixing-flaky-tests, /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- Root-caused from the failing CI run's `error-context.md` DOM snapshot, which shows the persistent support toast intercepting the click, then dated the trigger to #81414 via the file's commit history.
- Considered a test-side workaround (dismissing toasts before side panel clicks) and rejected it: the blocked clicks reproduce for real users, so the fix belongs in the product.
