### PR TITLE
fix(data-imports): raise a clear error instead of an empty delta merge predicate

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_writer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_writer.py
@@ -13,6 +13,7 @@ import pyarrow.compute as pc
 from parameterized import parameterized
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arrow_utils import (
+    MissingPrimaryKeysException,
     SchemaColumnTypeChangedException,
     evolve_pyarrow_schema,
     first_per_pk_table,
@@ -337,6 +338,26 @@ class TestLegacyDltTableReconciliation:
         final = result.to_pyarrow_table()
         assert final.num_rows == 3
         assert set(final.column("id").to_pylist()) == {1, 2, 3}
+
+    @pytest.mark.asyncio
+    async def test_incremental_merge_raises_when_primary_key_column_missing_from_batch(self, tmp_path: Path) -> None:
+        """A configured primary key that no longer matches any column in the batch (e.g. a stale
+        persisted key name after the source's schema changed) must fail clearly instead of building
+        an empty merge predicate — delta-rs rejects an empty predicate with an opaque
+        "sql parser error: Expected: an expression, found: EOF" DeltaError."""
+        delta_path = str(tmp_path / "table")
+        deltalake.write_deltalake(delta_path, pa.table({"id": [1, 2], "name": ["a", "b"]}))
+
+        helper = make_local_table_ref(delta_path)
+        batch = pa.table({"name": ["c"]})
+
+        with pytest.raises(MissingPrimaryKeysException):
+            await DeltaWriter(helper).write(
+                data=batch,
+                write_type="incremental",
+                should_overwrite_table=False,
+                primary_keys=["id"],
+            )
 
 
 class TestAppendDecimalReconciliation:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/writer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/writer.py
@@ -14,6 +14,7 @@ from posthog.exceptions_capture import capture_exception
 from posthog.sync import database_sync_to_async_pool
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arrow_utils import (
+    MISSING_PRIMARY_KEYS_ERROR,
     MissingPrimaryKeysException,
     align_incoming_decimals_to_delta,
     first_per_pk_table,
@@ -355,6 +356,18 @@ class DeltaWriter:
                 n = normalize_column_name(x)
                 if n in py_table_column_names:
                     normalized_primary_keys.append(n)
+
+            if not normalized_primary_keys:
+                # None of the configured primary key columns survived into this batch (e.g. a stale
+                # persisted key name that no longer matches the source's columns). Left unguarded, the
+                # unpartitioned path below joins an empty predicate_ops into "" and hands delta-rs an
+                # empty predicate, which its SQL parser rejects with an opaque "Expected: an expression,
+                # found: EOF" — and the partitioned path would merge on partition alone, matching rows
+                # that were never actually the same record. Fail clearly instead of either.
+                raise MissingPrimaryKeysException(
+                    f"{MISSING_PRIMARY_KEYS_ERROR}: none of {list(primary_keys)!r} were found in the "
+                    f"synced data (columns: {py_table_column_names!r})"
+                )
 
             predicate_ops = _merge_predicate_ops(normalized_primary_keys)
 


### PR DESCRIPTION
## Problem

Incremental warehouse syncs fail with an opaque `DeltaError: sql parser error: Expected: an expression, found: EOF` when none of the table's configured primary key columns are present in the batch being merged, instead of a message that tells the customer what to fix. Confirmed on a BigQuery incremental sync of an `orders` table ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019ffa25-2e1d-76c0-9a48-d53d53480c86)).

The stack trace lands in shared Delta-write code (`_do_merge_unpartitioned` / `execute_with_conflict_retry`), not in the BigQuery connector, so any source can hit this once its configured primary key columns stop matching what the current batch actually contains.

## Changes

- `DeltaWriter.write` now raises `MissingPrimaryKeysException` when none of the configured primary keys are found in the incoming batch, before a merge predicate is built.
- Previously, the code silently dropped missing keys and built the predicate from whatever remained. When *none* remained, the unpartitioned merge path joined an empty list into an empty predicate string and handed it to delta-rs, which the SQL parser rejected with the opaque EOF error. The partitioned merge path would have been worse: it always keeps a partition-only predicate term, so the merge could match and overwrite rows that were never actually the same record.

## How did you test this code?

- Added `test_incremental_merge_raises_when_primary_key_column_missing_from_batch` to `test_writer.py`, which reproduces the crash against a real local Delta table and asserts the clear exception instead.
- Ran the full `test_writer.py` suite locally (54 passed), plus `ruff check`, `ruff format --check`, and `mypy` on the changed file. Not run: the broader CI suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal pipeline error handling, no user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged via Claude Code from a PostHog error-tracking alert, using the `investigating-error-issue` skill to pull the stack trace and affected-sync properties, and the `writing-tests` and `writing-pr-descriptions` skills while implementing and describing the fix. Traced the crash from the reported `DeltaError` stack frame down to the empty-predicate root cause in `writer.py`, then scoped the fix to shared code so it protects every source, not just BigQuery.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*