### PR TITLE
fix(tasks): prepare desktop workspace in background

### DIFF
--- a/products/desktop/packages/agent/src/server/agent-server.repo-ready.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.repo-ready.test.ts
@@ -1,0 +1,34 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { AgentServer } from "./agent-server";
+
+describe("AgentServer repository barrier", () => {
+  let repositoryPath: string | undefined;
+
+  afterEach(async () => {
+    if (repositoryPath) await rm(repositoryPath, { recursive: true });
+  });
+
+  it("rejects deferred credentials without a repository barrier", async () => {
+    repositoryPath = await mkdtemp(join(tmpdir(), "agent-server-barrier-"));
+    const server = new AgentServer({
+      port: 0,
+      repositoryPath,
+      apiUrl: "https://app.example.com",
+      apiKey: "test-api-key",
+      projectId: 1,
+      jwtPublicKey: "test-public-key",
+      mode: "interactive",
+      taskId: "test-task-id",
+      runId: "test-run-id",
+      deferredCredentialsFile: join(repositoryPath, "agent-credentials"),
+      resolveRtkSavings: async () => null,
+    }) as unknown as { waitForRepoReady(): Promise<void> };
+
+    await expect(server.waitForRepoReady()).rejects.toThrow(
+      "Deferred credentials require a repository-ready barrier",
+    );
+  });
+});

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -106,6 +106,7 @@ import {
   normalizeCloudPromptContent,
   promptBlocksToText,
 } from "./cloud-prompt";
+import { consumeDeferredCredentials } from "./deferred-credentials";
 import { TaskRunEventStreamSender } from "./event-stream-sender";
 import { type JwtPayload, JwtValidationError, validateJwt } from "./jwt";
 import { type McpRelayResponse, McpRelayServer } from "./mcp-relay-server";
@@ -561,7 +562,13 @@ export class AgentServer {
       getApiKey: () => config.apiKey,
       userAgent: `posthog/cloud.hog.dev; version: ${config.version ?? packageJson.version}`,
     });
-    if (config.eventIngestToken) {
+    this.configureEventStreamSender();
+    this.app = this.createApp();
+  }
+
+  private configureEventStreamSender(): void {
+    const config = this.config;
+    if (config.eventIngestToken && !this.eventStreamSender) {
       this.eventStreamSender = new TaskRunEventStreamSender({
         apiUrl: config.apiUrl,
         eventIngestBaseUrl: config.eventIngestBaseUrl,
@@ -574,7 +581,6 @@ export class AgentServer {
         streamWindowMs: config.eventIngestStreamWindowMs,
       });
     }
-    this.app = this.createApp();
   }
 
   private getRuntimeAdapter(): Adapter {
@@ -3340,24 +3346,25 @@ export class AgentServer {
   private async waitForRepoReady(): Promise<void> {
     const readyFile = this.config.repoReadyFile;
     if (!readyFile) {
+      if (this.config.deferredCredentialsFile) {
+        throw new Error(
+          "Deferred credentials require a repository-ready barrier",
+        );
+      }
       this.barrierReleasedAtMs = Date.now();
       return;
     }
 
-    const REPO_READY_TIMEOUT_MS = 5 * 60_000;
+    const REPO_READY_TIMEOUT_MS = 15 * 60_000;
     const POLL_MS = 100;
     const startedAt = Date.now();
     let loggedUnexpectedError = false;
 
     for (;;) {
+      let repoReady = false;
       try {
         await access(readyFile);
-        this.barrierReleasedAtMs = Date.now();
-        this.logger.debug("Repo-ready barrier released", {
-          readyFile,
-          waitedMs: Date.now() - startedAt,
-        });
-        return;
+        repoReady = true;
       } catch (err) {
         const code = (err as NodeJS.ErrnoException)?.code;
         if (code !== "ENOENT" && !loggedUnexpectedError) {
@@ -3369,7 +3376,23 @@ export class AgentServer {
           });
         }
       }
+      if (repoReady) {
+        // Credential errors are not repository-readiness errors. Fail session
+        // initialization immediately instead of silently starting without auth.
+        await this.loadDeferredCredentials();
+        this.barrierReleasedAtMs = Date.now();
+        this.logger.debug("Repo-ready barrier released", {
+          readyFile,
+          waitedMs: Date.now() - startedAt,
+        });
+        return;
+      }
       if (Date.now() - startedAt > REPO_READY_TIMEOUT_MS) {
+        if (this.config.deferredCredentialsFile) {
+          throw new Error(
+            "Repository-ready barrier timed out before deferred credentials were activated",
+          );
+        }
         this.barrierReleasedAtMs = Date.now();
         this.logger.warn("Repo-ready barrier timed out; proceeding", {
           readyFile,
@@ -3379,6 +3402,17 @@ export class AgentServer {
       }
       await new Promise((resolve) => setTimeout(resolve, POLL_MS));
     }
+  }
+
+  private async loadDeferredCredentials(): Promise<void> {
+    const credentials = await consumeDeferredCredentials(
+      this.config.deferredCredentialsFile,
+    );
+    if (!credentials) return;
+    this.config.mcpServers = credentials.mcpServers;
+    this.config.eventIngestToken = credentials.eventIngestToken;
+    this.config.taskRunSessionToken = credentials.taskRunSessionToken;
+    this.configureEventStreamSender();
   }
 
   private async autoInitializeSession(): Promise<void> {

--- a/products/desktop/packages/agent/src/server/bin.ts
+++ b/products/desktop/packages/agent/src/server/bin.ts
@@ -140,6 +140,10 @@ program
     "--repoReadyFile <path>",
     "Sentinel file; session creation blocks until it exists (set while cloning concurrently)",
   )
+  .option(
+    "--deferredCredentialsFile <path>",
+    "One-shot credential file loaded after the repository readiness barrier",
+  )
   .requiredOption("--taskId <id>", "Task ID")
   .requiredOption("--runId <id>", "Task run ID")
   .option(
@@ -256,6 +260,7 @@ program
       otelTracesUrl: env.POSTHOG_AGENT_OTEL_TRACES_URL,
       repositoryPath: options.repositoryPath,
       repoReadyFile: options.repoReadyFile,
+      deferredCredentialsFile: options.deferredCredentialsFile,
       apiUrl: env.POSTHOG_API_URL,
       apiKey: env.POSTHOG_PERSONAL_API_KEY,
       projectId: env.POSTHOG_PROJECT_ID,

--- a/products/desktop/packages/agent/src/server/deferred-credentials.test.ts
+++ b/products/desktop/packages/agent/src/server/deferred-credentials.test.ts
@@ -1,0 +1,42 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { consumeDeferredCredentials } from "./deferred-credentials";
+
+describe("consumeDeferredCredentials", () => {
+  it("loads and removes the one-shot credential file", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "agent-credentials-"));
+    const path = join(directory, "credentials.json");
+    await writeFile(
+      path,
+      JSON.stringify({
+        mcpServers: [
+          {
+            type: "http",
+            name: "posthog",
+            url: "https://mcp.example.test/mcp",
+            headers: [{ name: "Authorization", value: "Bearer secret" }],
+          },
+        ],
+        eventIngestToken: "event-token",
+        taskRunSessionToken: "session-token",
+      }),
+    );
+
+    await expect(consumeDeferredCredentials(path)).resolves.toMatchObject({
+      eventIngestToken: "event-token",
+      taskRunSessionToken: "session-token",
+    });
+    await expect(readFile(path)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("removes an invalid credential file", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "agent-credentials-"));
+    const path = join(directory, "credentials.json");
+    await writeFile(path, '{"eventIngestToken":""}');
+
+    await expect(consumeDeferredCredentials(path)).rejects.toBeDefined();
+    await expect(readFile(path)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/products/desktop/packages/agent/src/server/deferred-credentials.ts
+++ b/products/desktop/packages/agent/src/server/deferred-credentials.ts
@@ -1,0 +1,23 @@
+import { readFile, rm } from "node:fs/promises";
+import { z } from "zod/v4";
+import { mcpServersSchema } from "./schemas";
+
+const deferredCredentialsSchema = z.object({
+  mcpServers: mcpServersSchema.optional(),
+  eventIngestToken: z.string().min(1).optional(),
+  taskRunSessionToken: z.string().min(1).optional(),
+});
+
+export type DeferredCredentials = z.output<typeof deferredCredentialsSchema>;
+
+export async function consumeDeferredCredentials(
+  path: string | undefined,
+): Promise<DeferredCredentials | null> {
+  if (!path) return null;
+  const raw = await readFile(path, "utf8");
+  try {
+    return deferredCredentialsSchema.parse(JSON.parse(raw));
+  } finally {
+    await rm(path, { force: true });
+  }
+}

--- a/products/desktop/packages/agent/src/server/pi-agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/pi-agent-server.test.ts
@@ -778,4 +778,26 @@ describe("PiAgentServer", () => {
       }),
     );
   });
+
+  it("holds the repository barrier past ten minutes until the ready file appears", async () => {
+    const repositoryPath = await mkdtemp(join(tmpdir(), "pi-agent-barrier-"));
+    const repoReadyFile = join(repositoryPath, "repo-ready");
+    const server = new PiAgentServer(
+      config({ repositoryPath, repoReadyFile }),
+    ) as unknown as { waitForRepoReady(): Promise<void> };
+
+    vi.useFakeTimers();
+    try {
+      const pending = server.waitForRepoReady();
+      // Slow Desktop preparation: still no ready file well past the previous 10-minute deadline.
+      await vi.advanceTimersByTimeAsync(11 * 60_000);
+      await writeFile(repoReadyFile, "");
+      await vi.advanceTimersByTimeAsync(250);
+      // A 10-minute deadline would already have rejected before the file appeared.
+      await expect(pending).resolves.toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+      await rm(repositoryPath, { recursive: true, force: true });
+    }
+  });
 });

--- a/products/desktop/packages/agent/src/server/pi-agent-server.ts
+++ b/products/desktop/packages/agent/src/server/pi-agent-server.ts
@@ -31,6 +31,7 @@ import { PiRuntime } from "../pi/runtime";
 import { PostHogAPIClient } from "../posthog-api";
 import { resolveLlmGatewayUrl } from "../utils/gateway";
 import { Logger } from "../utils/logger";
+import { consumeDeferredCredentials } from "./deferred-credentials";
 import { TaskRunEventStreamSender } from "./event-stream-sender";
 import { type JwtPayload, JwtValidationError, validateJwt } from "./jwt";
 import { jsonRpcRequestSchema } from "./schemas";
@@ -112,7 +113,7 @@ export class PiAgentServer {
     prefix: "[PiAgentServer]",
   });
   private readonly posthogAPI: PostHogAPIClient;
-  private readonly eventStreamSender: TaskRunEventStreamSender | null;
+  private eventStreamSender: TaskRunEventStreamSender | null = null;
   private server: ServerType | null = null;
   private session: PiCloudSession | null = null;
   private initializationPromise: Promise<void> | null = null;
@@ -141,20 +142,25 @@ export class PiAgentServer {
       getApiKey: () => config.apiKey,
       userAgent: `posthog/pi-cloud`,
     });
-    this.eventStreamSender = config.eventIngestToken
-      ? new TaskRunEventStreamSender({
-          apiUrl: config.apiUrl,
-          eventIngestBaseUrl: config.eventIngestBaseUrl,
-          keepProxyStreamOpen: config.eventIngestKeepStreamOpen,
-          projectId: config.projectId,
-          taskId: config.taskId,
-          runId: config.runId,
-          token: config.eventIngestToken,
-          logger: this.logger.child("EventIngest"),
-          streamWindowMs: config.eventIngestStreamWindowMs,
-        })
-      : null;
+    this.configureEventStreamSender();
     this.app = this.createApp();
+  }
+
+  private configureEventStreamSender(): void {
+    const config = this.config;
+    if (config.eventIngestToken && !this.eventStreamSender) {
+      this.eventStreamSender = new TaskRunEventStreamSender({
+        apiUrl: config.apiUrl,
+        eventIngestBaseUrl: config.eventIngestBaseUrl,
+        keepProxyStreamOpen: config.eventIngestKeepStreamOpen,
+        projectId: config.projectId,
+        taskId: config.taskId,
+        runId: config.runId,
+        token: config.eventIngestToken,
+        logger: this.logger.child("EventIngest"),
+        streamWindowMs: config.eventIngestStreamWindowMs,
+      });
+    }
   }
 
   private createRunTelemetry(
@@ -1034,15 +1040,37 @@ export class PiAgentServer {
     if (!path) {
       return;
     }
-    const deadline = Date.now() + 10 * 60_000;
+    // Match AgentServer.waitForRepoReady. The Desktop bootstrap barrier can stay closed for the
+    // full 12-minute activity budget plus credential activation and mark-repo-ready, so a 10-minute
+    // deadline here expired before a slow preparation finished and the deferred credentials loaded.
+    const REPO_READY_TIMEOUT_MS = 15 * 60_000;
+    const deadline = Date.now() + REPO_READY_TIMEOUT_MS;
     while (Date.now() < deadline) {
+      let repoReady = false;
       try {
         await access(path);
-        return;
+        repoReady = true;
       } catch {
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        // The repository barrier is not ready yet.
       }
+      if (repoReady) {
+        // Do not misclassify missing or invalid credentials as a repository timeout.
+        await this.loadDeferredCredentials();
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250));
     }
     throw new Error(`Repository readiness file was not created: ${path}`);
+  }
+
+  private async loadDeferredCredentials(): Promise<void> {
+    const credentials = await consumeDeferredCredentials(
+      this.config.deferredCredentialsFile,
+    );
+    if (!credentials) return;
+    this.config.mcpServers = credentials.mcpServers;
+    this.config.eventIngestToken = credentials.eventIngestToken;
+    this.config.taskRunSessionToken = credentials.taskRunSessionToken;
+    this.configureEventStreamSender();
   }
 }

--- a/products/desktop/packages/agent/src/server/types.ts
+++ b/products/desktop/packages/agent/src/server/types.ts
@@ -15,6 +15,8 @@ export interface AgentServerConfig {
   agentStateDir?: string;
   repositoryPath?: string;
   repoReadyFile?: string;
+  /** One-shot root-owned JSON file populated after untrusted repository setup completes. */
+  deferredCredentialsFile?: string;
   apiUrl: string;
   apiKey: string;
   projectId: number;

--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -149,6 +149,7 @@ TASK_SESSION_UPLOAD_FORM_OVERHEAD_BYTES = 64 * 1024
 MODAL_DIRECTORY_RESUME_SNAPSHOTS_FEATURE_FLAG = "tasks-modal-directory-resume-snapshots"
 STREAM_VIA_PROXY_FEATURE_FLAG = "tasks-stream-via-proxy"
 OVERLAP_CLONE_BOOT_FEATURE_FLAG = "tasks-overlap-clone-boot"
+PARALLEL_DESKTOP_PREP_JOB_VM_FEATURE_FLAG = "task-parallel-desktop-prep-job-vm"
 # Kill switch: rtk command-output compression is on by default in cloud sandboxes;
 # enabling this flag disables it fleet-wide — over any per-run override — without
 # an image rebuild.

--- a/products/tasks/backend/logic/services/docker_sandbox.py
+++ b/products/tasks/backend/logic/services/docker_sandbox.py
@@ -876,6 +876,7 @@ class DockerSandbox(SandboxBase):
         event_ingest_url: str | None = None,
         event_ingest_keep_stream_open: bool = False,
         repo_ready_file: str | None = None,
+        deferred_credentials_file: str | None = None,
         rtk_enabled: bool = True,
         posthog_exec_permission_regex: str | None = None,
     ) -> str:
@@ -908,6 +909,9 @@ class DockerSandbox(SandboxBase):
         repo_flag = f" --repositoryPath {shlex.quote(repo_path)}" if repo_path else ""
         domains_flag = f" --allowedDomains {shlex.quote(','.join(allowed_domains))}" if allowed_domains else ""
         repo_ready_flag = f" --repoReadyFile {shlex.quote(repo_ready_file)}" if repo_ready_file else ""
+        deferred_credentials_flag = (
+            f" --deferredCredentialsFile {shlex.quote(deferred_credentials_file)}" if deferred_credentials_file else ""
+        )
         exec_permission_flag = (
             f" --posthogExecPermissionRegex {shlex.quote(posthog_exec_permission_regex)}"
             if posthog_exec_permission_regex
@@ -923,7 +927,7 @@ class DockerSandbox(SandboxBase):
             f"{env_prefix}./node_modules/.bin/agent-server --port {AGENT_SERVER_PORT}{repo_flag} "
             f"--taskId {shlex.quote(task_id)} --runId {shlex.quote(run_id)} --mode {shlex.quote(mode)}"
             f"{create_pr_flag}{auto_publish_flag}{branch_flag}{mcp_servers_arg}{relay_mcp_servers_arg}"
-            f"{domains_flag}{repo_ready_flag}{exec_permission_flag}"
+            f"{domains_flag}{repo_ready_flag}{deferred_credentials_flag}{exec_permission_flag}"
         )
 
         # agentsh injects HTTP_PROXY pointing at a per-session egress proxy port; undici
@@ -990,6 +994,7 @@ class DockerSandbox(SandboxBase):
         event_ingest_url: str | None = None,
         event_ingest_keep_stream_open: bool = False,
         repo_ready_file: str | None = None,
+        deferred_credentials_file: str | None = None,
         wait_for_health: bool = True,
         rtk_enabled: bool = True,
     ) -> None:
@@ -1068,6 +1073,7 @@ class DockerSandbox(SandboxBase):
             event_ingest_url=event_ingest_url,
             event_ingest_keep_stream_open=event_ingest_keep_stream_open,
             repo_ready_file=repo_ready_file,
+            deferred_credentials_file=deferred_credentials_file,
             rtk_enabled=rtk_enabled,
             posthog_exec_permission_regex=exec_permission_regex,
         )
@@ -1123,6 +1129,7 @@ class DockerSandbox(SandboxBase):
                 event_ingest_url=event_ingest_url,
                 event_ingest_keep_stream_open=event_ingest_keep_stream_open,
                 repo_ready_file=repo_ready_file,
+                deferred_credentials_file=deferred_credentials_file,
                 rtk_enabled=rtk_enabled,
                 posthog_exec_permission_regex=exec_permission_regex,
             )

--- a/products/tasks/backend/logic/services/modal_sandbox.py
+++ b/products/tasks/backend/logic/services/modal_sandbox.py
@@ -1218,6 +1218,7 @@ class ModalSandbox(SandboxBase):
         event_ingest_url: str | None = None,
         event_ingest_keep_stream_open: bool = False,
         repo_ready_file: str | None = None,
+        deferred_credentials_file: str | None = None,
         rtk_enabled: bool = True,
         posthog_exec_permission_regex: str | None = None,
     ) -> str:
@@ -1246,6 +1247,9 @@ class ModalSandbox(SandboxBase):
         branch_flag = f" --baseBranch {shlex.quote(branch)}" if branch else ""
         domains_flag = f" --allowedDomains {shlex.quote(','.join(allowed_domains))}" if allowed_domains else ""
         repo_ready_flag = f" --repoReadyFile {shlex.quote(repo_ready_file)}" if repo_ready_file else ""
+        deferred_credentials_flag = (
+            f" --deferredCredentialsFile {shlex.quote(deferred_credentials_file)}" if deferred_credentials_file else ""
+        )
         exec_permission_flag = (
             f" --posthogExecPermissionRegex {shlex.quote(posthog_exec_permission_regex)}"
             if posthog_exec_permission_regex
@@ -1261,10 +1265,10 @@ class ModalSandbox(SandboxBase):
             f"{env_prefix}./node_modules/.bin/agent-server --port {AGENT_SERVER_PORT}{repo_flag} "
             f"--taskId {shlex.quote(task_id)} --runId {shlex.quote(run_id)} --mode {shlex.quote(mode)}"
             f"{create_pr_flag}{auto_publish_flag}{branch_flag}{mcp_servers_arg}{relay_mcp_servers_arg}"
-            f"{domains_flag}{repo_ready_flag}{exec_permission_flag}"
+            f"{domains_flag}{repo_ready_flag}{deferred_credentials_flag}{exec_permission_flag}"
         )
 
-        if repo_ready_file:
+        if repo_ready_file and not deferred_credentials_file:
             # Keep the adapter process from inheriting a repository cwd that does not
             # exist yet, even if an overlaid agent-server mishandles its readiness flag.
             wait_for_repo = f"while [ ! -f {shlex.quote(repo_ready_file)} ]; do sleep 0.1; done; exec {server_cmd}"
@@ -1351,6 +1355,7 @@ class ModalSandbox(SandboxBase):
         event_ingest_url: str | None = None,
         event_ingest_keep_stream_open: bool = False,
         repo_ready_file: str | None = None,
+        deferred_credentials_file: str | None = None,
         wait_for_health: bool = True,
         rtk_enabled: bool = True,
     ) -> None:
@@ -1432,6 +1437,7 @@ class ModalSandbox(SandboxBase):
             event_ingest_url=event_ingest_url,
             event_ingest_keep_stream_open=event_ingest_keep_stream_open,
             repo_ready_file=repo_ready_file,
+            deferred_credentials_file=deferred_credentials_file,
             rtk_enabled=rtk_enabled,
             posthog_exec_permission_regex=exec_permission_regex,
         )

--- a/products/tasks/backend/logic/services/sandbox.py
+++ b/products/tasks/backend/logic/services/sandbox.py
@@ -210,6 +210,7 @@ class SandboxConfig(BaseModel):
 WORKING_DIR = DEFAULT_SANDBOX_WORKING_DIR
 
 REPO_READY_FILE = f"{WORKING_DIR}/.repo-ready"
+DEFERRED_AGENT_CREDENTIALS_FILE = f"{WORKING_DIR}/.agent-credentials"
 
 PUBLIC_SANDBOX_REPOS: frozenset[str] = frozenset({"posthog/hedgebox", "posthog/.github"})
 """Repos the sandbox is allowed to clone unauthenticated, even when the team has no GitHub integration"""
@@ -427,6 +428,13 @@ class SandboxBase(ABC):
         )
         return result.exit_code == 0
 
+    def agent_server_supports_deferred_credentials(self) -> bool:
+        result = self.execute(
+            "grep -q deferredCredentialsFile /scripts/node_modules/.bin/agent-server",
+            timeout_seconds=10,
+        )
+        return result.exit_code == 0
+
     def clone_repository(
         self,
         repository: str,
@@ -513,6 +521,7 @@ class SandboxBase(ABC):
         event_ingest_url: str | None = None,
         event_ingest_keep_stream_open: bool = False,
         repo_ready_file: str | None = None,
+        deferred_credentials_file: str | None = None,
         wait_for_health: bool = True,
         rtk_enabled: bool = True,
     ) -> None:

--- a/products/tasks/backend/temporal/__init__.py
+++ b/products/tasks/backend/temporal/__init__.py
@@ -14,7 +14,9 @@ from .create_snapshot.activities import (
 from .create_snapshot.workflow import CreateSnapshotForRepositoryWorkflow
 from .loops import RunLoopWorkflow, run_loop_trigger_activity
 from .process_task.activities import (
+    activate_agent_server_credentials,
     await_agent_server_ready,
+    await_desktop_workspace_preparation,
     checkout_branch_in_sandbox,
     cleanup_sandbox,
     clone_repository_in_sandbox,
@@ -91,9 +93,11 @@ ACTIVITIES = [
     send_permission_denial_guidance,
     send_permission_response_to_sandbox,
     send_followup_to_sandbox,
+    activate_agent_server_credentials,
     start_agent_server,
     launch_agent_server,
     await_agent_server_ready,
+    await_desktop_workspace_preparation,
     mark_repo_ready,
     read_sandbox_logs,
     cleanup_sandbox,

--- a/products/tasks/backend/temporal/execute_sandbox/workflow.py
+++ b/products/tasks/backend/temporal/execute_sandbox/workflow.py
@@ -64,11 +64,13 @@ from products.tasks.backend.temporal.process_task.activities.get_task_processing
     get_task_processing_context,
 )
 from products.tasks.backend.temporal.process_task.activities.provision_sandbox import (
+    AwaitDesktopWorkspacePreparationInput,
     CheckoutBranchInSandboxInput,
     CloneRepositoryInSandboxInput,
     CreateSandboxForRepositoryInput,
     InjectFreshTokensOnResumeInput,
     PrepareSandboxForRepositoryInput,
+    await_desktop_workspace_preparation,
     checkout_branch_in_sandbox,
     clone_repository_in_sandbox,
     create_sandbox_for_repository,
@@ -90,8 +92,14 @@ from products.tasks.backend.temporal.process_task.activities.send_followup_to_sa
     send_followup_to_sandbox,
 )
 from products.tasks.backend.temporal.process_task.activities.start_agent_server import (
+    ActivateAgentServerCredentialsInput,
+    MarkRepoReadyInput,
     StartAgentServerInput,
     StartAgentServerOutput,
+    activate_agent_server_credentials,
+    await_agent_server_ready,
+    launch_agent_server,
+    mark_repo_ready,
     start_agent_server,
 )
 from products.tasks.backend.temporal.process_task.activities.track_workflow_event import (
@@ -108,6 +116,8 @@ from products.tasks.backend.temporal.process_task.credential_refresh import (
     run_credential_refresh_loop,
 )
 from products.tasks.backend.temporal.utils import log_on_fail
+
+_PATCH_ID_BACKGROUND_DESKTOP_PREPARATION = "tasks-background-desktop-preparation"
 
 # Names of signals this workflow sends back to the TaskManagement parent. Kept
 # as constants so a rename can be done in one place — and so tests can import
@@ -142,7 +152,7 @@ SHUTDOWN_REJECTION_DETAIL = "child_shutting_down"
 FOLLOWUP_SOURCE_USER = "user"
 FOLLOWUP_SOURCE_CI = "ci"
 
-_DESKTOP_BOOTSTRAP_ACTIVITY_TIMEOUT = timedelta(minutes=20)
+_DESKTOP_BOOTSTRAP_ACTIVITY_TIMEOUT = timedelta(minutes=12)
 
 
 @dataclass
@@ -484,8 +494,11 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
             # to the gap between Modal-accepted-create and this activity.
             await self._persist_sandbox_id(run_id, sandbox_id)
 
-            await self._emit_progress("agent", "in_progress", "Starting agent", "setup")
-            agent_server_output = await self._start_agent_server(sandbox_output)
+            if sandbox_output.agent_server_launched:
+                agent_server_output = await self._await_agent_server_ready(sandbox_output)
+            else:
+                await self._emit_progress("agent", "in_progress", "Starting agent", "setup")
+                agent_server_output = await self._start_agent_server(sandbox_output)
             await self._emit_progress("agent", "completed", "Started agent", "setup")
 
             await self._track_workflow_event(
@@ -1107,9 +1120,14 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
         def prepares_desktop(repository: str) -> bool:
             return self.context.custom_image_name == DEV_STACK_IMAGE_NAME and repository.casefold() == "posthog/posthog"
 
+        background_desktop_preparation = workflow.patched(_PATCH_ID_BACKGROUND_DESKTOP_PREPARATION) and (
+            self.context.parallel_desktop_prep_job_vm_enabled is not False
+        )
+        clone_outputs = []
+
         if will_clone:
             await self._emit_progress("clone", "in_progress", "Cloning repository", "setup")
-            await asyncio.gather(
+            clone_outputs = await asyncio.gather(
                 *(
                     workflow.execute_activity(
                         clone_repository_in_sandbox,
@@ -1119,6 +1137,7 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
                             repository=repository,
                             github_token=prepared.github_token,
                             shallow_clone=prepared.shallow_clone,
+                            background_desktop_preparation=background_desktop_preparation,
                         ),
                         start_to_close_timeout=(
                             _DESKTOP_BOOTSTRAP_ACTIVITY_TIMEOUT
@@ -1135,6 +1154,9 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
 
         state = self.context.state or {}
         is_resume = bool(state.get("resume_from_run_id") or state.get("handoff_resumed"))
+        desktop_preparation_started = any(
+            getattr(output, "desktop_preparation_started", False) for output in clone_outputs
+        )
         if will_checkout and not is_resume:
             assert checkout_repository is not None
             assert prepared.branch is not None
@@ -1142,7 +1164,7 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
             branch_label_active = f"Checking out branch {prepared.branch}"
             branch_label_done = f"Checked out branch {prepared.branch}"
             await self._emit_progress("checkout", "in_progress", branch_label_active, "setup")
-            await workflow.execute_activity(
+            checkout_output = await workflow.execute_activity(
                 checkout_branch_in_sandbox,
                 CheckoutBranchInSandboxInput(
                     context=self.context,
@@ -1152,13 +1174,66 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
                     github_token=prepared.github_token,
                     shallow_clone=prepared.shallow_clone,
                     used_snapshot=used_snapshot,
+                    background_desktop_preparation=background_desktop_preparation,
                 ),
                 start_to_close_timeout=(
                     _DESKTOP_BOOTSTRAP_ACTIVITY_TIMEOUT if prepares_repository_desktop else timedelta(minutes=5)
                 ),
                 retry_policy=RetryPolicy(maximum_attempts=3),
             )
+            desktop_preparation_started = desktop_preparation_started or getattr(
+                checkout_output, "desktop_preparation_started", False
+            )
             await self._emit_progress("checkout", "completed", branch_label_done, "setup")
+
+        if background_desktop_preparation and desktop_preparation_started:
+            await self._emit_progress("agent", "in_progress", "Starting agent", "setup")
+            launch_output = await workflow.execute_activity(
+                launch_agent_server,
+                StartAgentServerInput(
+                    context=self.context,
+                    sandbox_id=created.sandbox_id,
+                    sandbox_url=created.sandbox_url,
+                    sandbox_connect_token=created.connect_token,
+                    posthog_mcp_scopes=self._posthog_mcp_scopes,
+                    defer_for_clone=True,
+                    defer_credentials=True,
+                    boot_path="desktop_overlap",
+                    used_snapshot=used_snapshot,
+                ),
+                start_to_close_timeout=timedelta(minutes=5),
+                retry_policy=RetryPolicy(maximum_attempts=3),
+            )
+            agent_server_launched = bool(launch_output and launch_output.process_launched)
+            agent_credentials_deferred = bool(launch_output and launch_output.credentials_deferred)
+            await workflow.execute_activity(
+                await_desktop_workspace_preparation,
+                AwaitDesktopWorkspacePreparationInput(context=self.context, sandbox_id=created.sandbox_id),
+                start_to_close_timeout=_DESKTOP_BOOTSTRAP_ACTIVITY_TIMEOUT,
+                schedule_to_close_timeout=_DESKTOP_BOOTSTRAP_ACTIVITY_TIMEOUT,
+                heartbeat_timeout=timedelta(seconds=30),
+                retry_policy=RetryPolicy(maximum_attempts=3),
+            )
+            if agent_credentials_deferred:
+                await workflow.execute_activity(
+                    activate_agent_server_credentials,
+                    ActivateAgentServerCredentialsInput(
+                        context=self.context,
+                        sandbox_id=created.sandbox_id,
+                        posthog_mcp_scopes=self._posthog_mcp_scopes,
+                    ),
+                    start_to_close_timeout=timedelta(minutes=2),
+                    retry_policy=RetryPolicy(maximum_attempts=3),
+                )
+            if agent_server_launched:
+                await workflow.execute_activity(
+                    mark_repo_ready,
+                    MarkRepoReadyInput(sandbox_id=created.sandbox_id, run_id=self.context.run_id),
+                    start_to_close_timeout=timedelta(seconds=30),
+                    retry_policy=RetryPolicy(maximum_attempts=3),
+                )
+        else:
+            agent_server_launched = False
 
         return GetSandboxForRepositoryOutput(
             sandbox_id=created.sandbox_id,
@@ -1166,6 +1241,8 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
             connect_token=created.connect_token,
             used_snapshot=used_snapshot,
             should_create_snapshot=not used_snapshot,
+            agent_server_launched=agent_server_launched,
+            boot_path="desktop_overlap" if desktop_preparation_started else "classic",
         )
 
     async def _cleanup_sandbox(self, sandbox_id: str) -> None:
@@ -1243,6 +1320,22 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
                 sandbox_url=sandbox_output.sandbox_url,
                 sandbox_connect_token=sandbox_output.connect_token,
                 posthog_mcp_scopes=self._posthog_mcp_scopes,
+            ),
+            start_to_close_timeout=timedelta(minutes=5),
+            retry_policy=RetryPolicy(maximum_attempts=3),
+        )
+
+    async def _await_agent_server_ready(self, sandbox_output: GetSandboxForRepositoryOutput) -> StartAgentServerOutput:
+        return await workflow.execute_activity(
+            await_agent_server_ready,
+            StartAgentServerInput(
+                context=self.context,
+                sandbox_id=sandbox_output.sandbox_id,
+                sandbox_url=sandbox_output.sandbox_url,
+                sandbox_connect_token=sandbox_output.connect_token,
+                posthog_mcp_scopes=self._posthog_mcp_scopes,
+                boot_path=sandbox_output.boot_path,
+                used_snapshot=sandbox_output.used_snapshot,
             ),
             start_to_close_timeout=timedelta(minutes=5),
             retry_policy=RetryPolicy(maximum_attempts=3),

--- a/products/tasks/backend/temporal/process_task/activities/__init__.py
+++ b/products/tasks/backend/temporal/process_task/activities/__init__.py
@@ -12,6 +12,7 @@ from .get_sandbox_for_repository import (
 from .get_task_processing_context import TaskProcessingContext, get_task_processing_context
 from .post_slack_update import PostSlackUpdateInput, post_slack_update
 from .provision_sandbox import (
+    AwaitDesktopWorkspacePreparationInput,
     CheckoutBranchInSandboxInput,
     CheckoutBranchInSandboxOutput,
     CloneRepositoryInSandboxInput,
@@ -22,6 +23,7 @@ from .provision_sandbox import (
     InvalidateResumeSnapshotInput,
     PrepareSandboxForRepositoryInput,
     PrepareSandboxForRepositoryOutput,
+    await_desktop_workspace_preparation,
     checkout_branch_in_sandbox,
     clone_repository_in_sandbox,
     create_sandbox_for_repository,
@@ -52,9 +54,11 @@ from .send_permission_response_to_sandbox import (
 )
 from .slack_agent_design_signals import RelayAgentDesignSignalsInput, relay_agent_design_signals
 from .start_agent_server import (
+    ActivateAgentServerCredentialsInput,
     MarkRepoReadyInput,
     StartAgentServerInput,
     StartAgentServerOutput,
+    activate_agent_server_credentials,
     await_agent_server_ready,
     launch_agent_server,
     mark_repo_ready,
@@ -64,7 +68,9 @@ from .track_workflow_event import TrackWorkflowEventInput, track_workflow_event
 from .update_task_run_status import UpdateTaskRunStatusInput, update_task_run_status
 
 __all__ = [
+    "ActivateAgentServerCredentialsInput",
     "CleanupSandboxInput",
+    "AwaitDesktopWorkspacePreparationInput",
     "CompleteRunStreamInput",
     "CreateResumeSnapshotInput",
     "CreateResumeSnapshotOutput",
@@ -129,6 +135,8 @@ __all__ = [
     "start_agent_server",
     "launch_agent_server",
     "await_agent_server_ready",
+    "activate_agent_server_credentials",
+    "await_desktop_workspace_preparation",
     "mark_repo_ready",
     "track_workflow_event",
     "update_task_run_status",

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -17,6 +17,7 @@ from products.tasks.backend.constants import (
     MODAL_DIRECTORY_RESUME_SNAPSHOTS_FEATURE_FLAG,
     MODAL_NETWORK_ALLOWLIST_FEATURE_FLAG,
     OVERLAP_CLONE_BOOT_FEATURE_FLAG,
+    PARALLEL_DESKTOP_PREP_JOB_VM_FEATURE_FLAG,
     RTK_DISABLED_FEATURE_FLAG,
     SANDBOX_EVENT_INGEST_FEATURE_FLAG,
     get_vm_sandbox_flag_payload,
@@ -98,6 +99,9 @@ class TaskProcessingContext:
     # (request == limit). Captured at workflow start so it's stable across activity retries.
     burstable_sandbox_resources_enabled: bool = True
     overlap_clone_boot_enabled: bool = False
+    # None preserves the parallel path for workflows started before this rollout
+    # stamp existed. New runs always capture a boolean feature-flag decision.
+    parallel_desktop_prep_job_vm_enabled: bool | None = None
     # Captured at workflow start so the agent-proxy stream lifetime stays deterministic across retries.
     agent_proxy_keep_stream_open: bool = False
     # Set only when the run resolved to the VM runtime — custom images layer on the VM base.
@@ -601,6 +605,35 @@ def _is_overlap_clone_boot_enabled(
     return enabled
 
 
+def _is_parallel_desktop_prep_job_vm_enabled(
+    *,
+    distinct_id: str,
+    organization_id: str,
+    run_id: str,
+) -> bool:
+    try:
+        enabled = bool(
+            posthoganalytics.feature_enabled(
+                PARALLEL_DESKTOP_PREP_JOB_VM_FEATURE_FLAG,
+                distinct_id=distinct_id,
+                groups={"organization": organization_id},
+                group_properties={"organization": {"id": organization_id}},
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception as e:
+        log_with_activity_context("parallel_desktop_prep_job_vm_flag_check_failed", run_id=run_id, error=str(e))
+        return False
+
+    log_with_activity_context(
+        "parallel_desktop_prep_job_vm_flag_checked",
+        run_id=run_id,
+        parallel_desktop_prep_job_vm_enabled=enabled,
+    )
+    return enabled
+
+
 def _is_modal_network_allowlist_enabled(
     *,
     distinct_id: str,
@@ -945,6 +978,16 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         "debug",
         f"overlap_clone_boot_enabled: {overlap_clone_boot_enabled} for this task run",
     )
+    parallel_desktop_prep_job_vm_enabled = _is_parallel_desktop_prep_job_vm_enabled(
+        distinct_id=distinct_id,
+        organization_id=organization_id,
+        run_id=run_id,
+    )
+    emit_agent_log(
+        run_id,
+        "debug",
+        f"parallel_desktop_prep_job_vm_enabled: {parallel_desktop_prep_job_vm_enabled} for this task run",
+    )
     use_modal_directory_resume_snapshots = _is_modal_directory_resume_snapshots_enabled(
         distinct_id=distinct_id,
         organization_id=organization_id,
@@ -1020,6 +1063,7 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         use_modal_network_allowlist=use_modal_network_allowlist,
         burstable_sandbox_resources_enabled=burstable_sandbox_resources_enabled,
         overlap_clone_boot_enabled=overlap_clone_boot_enabled,
+        parallel_desktop_prep_job_vm_enabled=parallel_desktop_prep_job_vm_enabled,
         agent_proxy_keep_stream_open=agent_proxy_keep_stream_open,
         custom_image_name=custom_image_name,
         rtk_enabled=rtk_enabled,

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -1,3 +1,4 @@
+import time
 import shlex
 import asyncio
 import logging
@@ -34,6 +35,7 @@ from products.tasks.backend.logic.services.connection_token import (
     get_sandbox_jwt_public_key,
 )
 from products.tasks.backend.logic.services.sandbox import (
+    DEFERRED_AGENT_CREDENTIALS_FILE,
     ExecutionResult,
     Sandbox,
     SandboxBase,
@@ -82,6 +84,10 @@ NETWORK_RESTRICTED_AGENT_ENV = {
     "DISABLE_TELEMETRY": "1",
     "DISABLE_ERROR_REPORTING": "1",
 }
+DESKTOP_BOOTSTRAP_STATE_DIR = "/tmp/desktop-workspace-bootstrap"
+# Poll the detached bootstrap this often. Kept well below the activity's 30s heartbeat timeout so a
+# heartbeat still lands every pass, while avoiding a fresh sandbox exec every single second.
+_DESKTOP_BOOTSTRAP_POLL_INTERVAL_SECONDS = 5
 
 
 @dataclass
@@ -128,11 +134,13 @@ class CreateSandboxForRepositoryOutput:
 @dataclass
 class CloneRepositoryInSandboxOutput:
     clone_ms: int | None = None
+    desktop_preparation_started: bool = False
 
 
 @dataclass
 class CheckoutBranchInSandboxOutput:
     checkout_ms: int | None = None
+    desktop_preparation_started: bool = False
 
 
 @dataclass
@@ -142,6 +150,7 @@ class CloneRepositoryInSandboxInput:
     repository: str
     github_token: str
     shallow_clone: bool
+    background_desktop_preparation: bool = False
 
 
 @dataclass
@@ -153,35 +162,134 @@ class CheckoutBranchInSandboxInput:
     github_token: str
     shallow_clone: bool
     used_snapshot: bool
+    background_desktop_preparation: bool = False
 
 
-def _prepare_posthog_desktop_cloud_task(ctx: TaskProcessingContext, sandbox: SandboxBase, repository: str) -> None:
-    """Build Desktop workspace exports from the task's checked-out source.
+@dataclass(frozen=True)
+class AwaitDesktopWorkspacePreparationInput:
+    context: TaskProcessingContext
+    sandbox_id: str
+
+
+def _prepare_posthog_desktop_cloud_task(
+    ctx: TaskProcessingContext, sandbox: SandboxBase, repository: str, *, background: bool = True
+) -> bool:
+    """Start building Desktop workspace exports from the task's checked-out source.
 
     The dev-stack image warms pnpm's content-addressed store but deliberately does
     not retain checkout-specific node_modules or dist directories. Prepare only the
     internal PostHog checkout that uses that image, after its final branch is in place.
+    The detached process lets the remaining sandbox setup continue while pnpm links
+    and builds the Desktop workspace dependencies.
     """
     if (
         ctx.custom_image_name != DEV_STACK_IMAGE_NAME
         or repository.casefold() != "posthog/posthog"
         or sandbox.config.image_fallback
     ):
-        return
+        return False
 
     repo_path = f"{sandbox_repo_path(repository)}/products/desktop"
-    emit_agent_log(ctx.run_id, "debug", "Preparing Desktop workspace dependencies")
+    if not background:
+        emit_agent_log(ctx.run_id, "debug", "Preparing Desktop workspace dependencies")
+        result = sandbox.execute(
+            f"cd {shlex.quote(repo_path)} && pnpm bootstrap:cloud-task",
+            timeout_seconds=10 * 60,
+        )
+        if result.exit_code != 0:
+            output = (result.stderr or result.stdout)[-2_000:]
+            raise ApplicationError(
+                f"Failed to prepare Desktop workspace: {output}",
+                type="DesktopCloudTaskBootstrapError",
+                non_retryable=True,
+            )
+        return False
+
+    emit_agent_log(ctx.run_id, "debug", "Preparing Desktop workspace dependencies in the background")
+    credentials_tmp = f"{DEFERRED_AGENT_CREDENTIALS_FILE}.tmp"
+    scratch_dir = f"{DESKTOP_BOOTSTRAP_STATE_DIR}/scratch"
+    private_workspace = "/mnt/posthog-desktop-workspace"
+    isolated_bootstrap = (
+        "/usr/bin/mount --make-rprivate / && "
+        "/usr/bin/mount -t tmpfs tmpfs /mnt && "
+        f"mkdir -p {shlex.quote(private_workspace)} && "
+        f"/usr/bin/mount --bind {shlex.quote(repo_path)} {shlex.quote(private_workspace)} && "
+        "/usr/bin/mount -t tmpfs tmpfs /tmp && "
+        f"mkdir -p {shlex.quote(repo_path)} {shlex.quote(scratch_dir)} && "
+        f"/usr/bin/mount --bind {shlex.quote(private_workspace)} {shlex.quote(repo_path)} && "
+        "for target in $(/usr/bin/findmnt -rn -o TARGET | /usr/bin/sort -r); do "
+        'case "$target" in /tmp|/tmp/*|/mnt|/mnt/*) ;; '
+        '*) /usr/bin/mount -o remount,bind,ro "$target" || exit 1 ;; esac; done && '
+        "/usr/bin/mount -t proc proc /proc && "
+        "for socket in /run/systemd/private /run/dbus/system_bus_socket /var/run/docker.sock; do "
+        'if [ -e "$socket" ]; then /usr/bin/mount --bind /dev/null "$socket" || exit 1; fi; '
+        "done && "
+        f"cd {shlex.quote(repo_path)} && "
+        "/usr/bin/setpriv --bounding-set=-all --inh-caps=-all --ambient-caps=-all --no-new-privs "
+        f"/usr/bin/env -i HOME=/root TMPDIR={shlex.quote(scratch_dir)} "
+        "XDG_CACHE_HOME="
+        f"{shlex.quote(scratch_dir)} PATH=/usr/local/bin:/usr/bin:/bin PNPM_CONFIG_OFFLINE=true "
+        "pnpm bootstrap:cloud-task"
+    )
+    bootstrap = (
+        f"/usr/bin/unshare --mount --pid --net --fork /bin/sh -c {shlex.quote(isolated_bootstrap)} "
+        f"> {DESKTOP_BOOTSTRAP_STATE_DIR}/log 2>&1; "
+        f"printf '%s\\n' $? > {DESKTOP_BOOTSTRAP_STATE_DIR}/status"
+    )
     result = sandbox.execute(
-        f"cd {shlex.quote(repo_path)} && pnpm bootstrap:cloud-task",
-        timeout_seconds=10 * 60,
+        f"touch {shlex.quote(DEFERRED_AGENT_CREDENTIALS_FILE)} {shlex.quote(credentials_tmp)} && "
+        f"chmod 000 {shlex.quote(DEFERRED_AGENT_CREDENTIALS_FILE)} {shlex.quote(credentials_tmp)} && "
+        f"cd {shlex.quote(repo_path)} && "
+        f"if mkdir {DESKTOP_BOOTSTRAP_STATE_DIR} 2>/dev/null; then "
+        f"nohup /bin/sh -c {shlex.quote(bootstrap)} "
+        "</dev/null >/dev/null 2>&1 & "
+        f"echo $! > {DESKTOP_BOOTSTRAP_STATE_DIR}/pid; "
+        "fi",
+        timeout_seconds=30,
     )
     if result.exit_code != 0:
         output = (result.stderr or result.stdout)[-2_000:]
+        raise ApplicationError(
+            f"Failed to start Desktop workspace preparation: {output}",
+            type="DesktopCloudTaskBootstrapError",
+            non_retryable=True,
+        )
+    return True
+
+
+@activity.defn
+@asyncify
+def await_desktop_workspace_preparation(input: AwaitDesktopWorkspacePreparationInput) -> None:
+    """Wait for the detached Desktop bootstrap before releasing the agent session."""
+    ctx = input.context
+    sandbox = Sandbox.get_by_id(input.sandbox_id)
+    emit_agent_log(ctx.run_id, "debug", "Waiting for Desktop workspace dependencies to finish")
+    while True:
+        result = sandbox.execute(
+            f"if [ -f {DESKTOP_BOOTSTRAP_STATE_DIR}/status ]; then "
+            f"cat {DESKTOP_BOOTSTRAP_STATE_DIR}/status; "
+            f"elif [ -f {DESKTOP_BOOTSTRAP_STATE_DIR}/pid ] && "
+            f'kill -0 "$(cat {DESKTOP_BOOTSTRAP_STATE_DIR}/pid)" 2>/dev/null; then '
+            "echo pending; "
+            "else echo missing; fi",
+            timeout_seconds=5,
+        )
+        status = result.stdout.strip()
+        if result.exit_code != 0 or status != "pending":
+            break
+        activity.heartbeat()
+        time.sleep(_DESKTOP_BOOTSTRAP_POLL_INTERVAL_SECONDS)
+    if result.exit_code != 0 or status != "0":
+        log_result = sandbox.execute(
+            f"tail -c 2000 {DESKTOP_BOOTSTRAP_STATE_DIR}/log 2>/dev/null || true", timeout_seconds=5
+        )
+        output = (log_result.stdout or result.stderr or result.stdout)[-2_000:]
         raise ApplicationError(
             f"Failed to prepare Desktop workspace: {output}",
             type="DesktopCloudTaskBootstrapError",
             non_retryable=True,
         )
+    emit_agent_log(ctx.run_id, "debug", "Desktop workspace dependencies are ready")
 
 
 @dataclass
@@ -861,10 +969,16 @@ def clone_repository_in_sandbox(input: CloneRepositoryInSandboxInput) -> CloneRe
         # activity. Resumes clone that branch directly, and multi-repo runs do not run
         # the checkout activity, so prepare them here once their final source exists.
         will_checkout_later = len(ctx.repositories) == 1 and bool(ctx.branch) and not is_resume
+        desktop_preparation_started = False
         if not will_checkout_later:
-            _prepare_posthog_desktop_cloud_task(ctx, sandbox, input.repository)
+            desktop_preparation_started = _prepare_posthog_desktop_cloud_task(
+                ctx, sandbox, input.repository, background=input.background_desktop_preparation
+            )
 
-        return CloneRepositoryInSandboxOutput(clone_ms=clone_timer.elapsed_ms)
+        return CloneRepositoryInSandboxOutput(
+            clone_ms=clone_timer.elapsed_ms,
+            desktop_preparation_started=desktop_preparation_started,
+        )
 
 
 def _is_missing_remote_branch_clone_error(result: ExecutionResult) -> bool:
@@ -949,9 +1063,14 @@ def checkout_branch_in_sandbox(input: CheckoutBranchInSandboxInput) -> CheckoutB
             logger.warning("Branch checkout failed", extra={"branch": input.branch, "stderr": result.stderr})
             raise RuntimeError(f"Failed to checkout branch {input.branch}")
 
-        _prepare_posthog_desktop_cloud_task(ctx, sandbox, input.repository)
+        desktop_preparation_started = _prepare_posthog_desktop_cloud_task(
+            ctx, sandbox, input.repository, background=input.background_desktop_preparation
+        )
 
-        return CheckoutBranchInSandboxOutput(checkout_ms=checkout_timer.elapsed_ms)
+        return CheckoutBranchInSandboxOutput(
+            checkout_ms=checkout_timer.elapsed_ms,
+            desktop_preparation_started=desktop_preparation_started,
+        )
 
 
 @activity.defn

--- a/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
@@ -1,3 +1,4 @@
+import json
 import shlex
 import threading
 from dataclasses import dataclass
@@ -17,7 +18,13 @@ from posthog.temporal.oauth import PosthogMcpScopes
 
 from products.tasks.backend.exceptions import OAuthTokenError, SandboxExecutionError, SandboxMissingRepositoryError
 from products.tasks.backend.logic.services.connection_token import create_sandbox_event_ingest_token
-from products.tasks.backend.logic.services.sandbox import REPO_READY_FILE, Sandbox, SandboxBase, sandbox_repo_path
+from products.tasks.backend.logic.services.sandbox import (
+    DEFERRED_AGENT_CREDENTIALS_FILE,
+    REPO_READY_FILE,
+    Sandbox,
+    SandboxBase,
+    sandbox_repo_path,
+)
 from products.tasks.backend.models import Task, TaskRun
 from products.tasks.backend.temporal.metrics import (
     StepTimer,
@@ -144,6 +151,7 @@ class StartAgentServerInput:
     sandbox_connect_token: str | None = None
     posthog_mcp_scopes: PosthogMcpScopes = "read_only"
     defer_for_clone: bool = False
+    defer_credentials: bool = False
     # Which boot architecture produced this run ("classic" serial launch vs "overlap"
     # launch-before-clone); labels the latency metrics so cohorts stay comparable.
     boot_path: str = "classic"
@@ -172,6 +180,15 @@ class StartAgentServerOutput:
     ready_wait_ms: int | None = None
     session_init_ms: int | None = None
     boot_total_ms: int | None = None
+    process_launched: bool = True
+    credentials_deferred: bool = False
+
+
+@dataclass(frozen=True)
+class ActivateAgentServerCredentialsInput:
+    context: TaskProcessingContext
+    sandbox_id: str
+    posthog_mcp_scopes: PosthogMcpScopes = "read_only"
 
 
 @dataclass
@@ -341,6 +358,7 @@ def _invoke_start_agent_server(
     *,
     repo_ready_file: str | None,
     wait_for_health: bool,
+    deferred_credentials_file: str | None = None,
 ) -> None:
     try:
         sandbox.start_agent_server(
@@ -360,14 +378,15 @@ def _invoke_start_agent_server(
             context_window=ctx.context_window,
             fast_mode=ctx.fast_mode,
             initial_permission_mode=ctx.initial_permission_mode,
-            mcp_configs=params.mcp_configs or None,
+            mcp_configs=None if deferred_credentials_file else (params.mcp_configs or None),
             relayed_mcp_servers=params.relayed_mcp_servers or None,
             allowed_domains=params.agentsh_domains,
-            event_ingest_token=params.event_ingest_token,
-            task_run_session_token=params.task_run_session_token,
+            event_ingest_token=None if deferred_credentials_file else params.event_ingest_token,
+            task_run_session_token=None if deferred_credentials_file else params.task_run_session_token,
             event_ingest_url=params.event_ingest_url,
             event_ingest_keep_stream_open=params.event_ingest_keep_stream_open,
             repo_ready_file=repo_ready_file,
+            deferred_credentials_file=deferred_credentials_file,
             wait_for_health=wait_for_health,
             rtk_enabled=ctx.rtk_enabled,
         )
@@ -510,6 +529,13 @@ def launch_agent_server(input: StartAgentServerInput) -> StartAgentServerOutput:
         emit_agent_log(ctx.run_id, "debug", "Launching agent server (deferred readiness)")
 
         sandbox = Sandbox.get_by_id(input.sandbox_id)
+        if input.defer_credentials and not sandbox.agent_server_supports_deferred_credentials():
+            emit_agent_log(ctx.run_id, "debug", "Agent image lacks deferred credentials; using safe serial launch")
+            return StartAgentServerOutput(
+                sandbox_url=input.sandbox_url,
+                connect_token=input.sandbox_connect_token,
+                process_launched=False,
+            )
         params = _prepare_launch(ctx, input.posthog_mcp_scopes, input.sandbox_id)
 
         repo_ready_file = REPO_READY_FILE if input.defer_for_clone else None
@@ -517,13 +543,57 @@ def launch_agent_server(input: StartAgentServerInput) -> StartAgentServerOutput:
         with StepTimer(
             "agent_server_launch", boot_path=input.boot_path, origin_product=ctx.origin_product, runtime=runtime
         ) as launch_timer:
-            _invoke_start_agent_server(sandbox, ctx, params, repo_ready_file=repo_ready_file, wait_for_health=False)
+            _invoke_start_agent_server(
+                sandbox,
+                ctx,
+                params,
+                repo_ready_file=repo_ready_file,
+                wait_for_health=False,
+                deferred_credentials_file=DEFERRED_AGENT_CREDENTIALS_FILE if input.defer_credentials else None,
+            )
 
         activity.logger.info(f"Agent server process launched for task {ctx.task_id}")
         return StartAgentServerOutput(
             sandbox_url=input.sandbox_url,
             connect_token=input.sandbox_connect_token,
             launch_ms=launch_timer.elapsed_ms,
+            credentials_deferred=input.defer_credentials,
+        )
+
+
+@activity.defn
+@asyncify
+def activate_agent_server_credentials(input: ActivateAgentServerCredentialsInput) -> None:
+    """Publish credentials only after untrusted repository setup has stopped."""
+    ctx = input.context
+    sandbox = Sandbox.get_by_id(input.sandbox_id)
+    params = _prepare_launch(ctx, input.posthog_mcp_scopes, input.sandbox_id)
+    credential_payload: dict[str, object] = {
+        "mcpServers": [config.to_dict() for config in params.mcp_configs],
+    }
+    if params.event_ingest_token:
+        credential_payload["eventIngestToken"] = params.event_ingest_token
+    if params.task_run_session_token:
+        credential_payload["taskRunSessionToken"] = params.task_run_session_token
+    payload = json.dumps(credential_payload, separators=(",", ":")).encode()
+    temporary_path = f"{DEFERRED_AGENT_CREDENTIALS_FILE}.tmp"
+    write_result = sandbox.write_file(temporary_path, payload)
+    if write_result.exit_code != 0:
+        raise SandboxExecutionError(
+            "Failed to write deferred agent credentials",
+            {"task_id": ctx.task_id, "sandbox_id": sandbox.id, "error": write_result.stderr},
+            cause=RuntimeError(write_result.stderr or "credential file write failed"),
+        )
+    result = sandbox.execute(
+        f"chmod 600 {shlex.quote(temporary_path)} && mv {shlex.quote(temporary_path)} "
+        f"{shlex.quote(DEFERRED_AGENT_CREDENTIALS_FILE)}",
+        timeout_seconds=10,
+    )
+    if result.exit_code != 0:
+        raise SandboxExecutionError(
+            "Failed to activate deferred agent credentials",
+            {"task_id": ctx.task_id, "sandbox_id": sandbox.id, "error": result.stderr},
+            cause=RuntimeError(result.stderr or "credential activation command failed"),
         )
 
 

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -14,6 +14,7 @@ from products.tasks.backend.constants import (
     CONTINUE_AS_NEW_FEATURE_FLAG,
     MODAL_DIRECTORY_RESUME_SNAPSHOTS_FEATURE_FLAG,
     MODAL_VM_SANDBOX_FEATURE_FLAG,
+    PARALLEL_DESKTOP_PREP_JOB_VM_FEATURE_FLAG,
     RTK_DISABLED_FEATURE_FLAG,
     SANDBOX_EVENT_INGEST_FEATURE_FLAG,
     vm_sandbox_allowed_origin_products,
@@ -32,6 +33,7 @@ from products.tasks.backend.temporal.process_task.activities.get_task_processing
     _is_agent_proxy_keep_stream_open_enabled,
     _is_burstable_sandbox_resources_enabled,
     _is_continue_as_new_enabled,
+    _is_parallel_desktop_prep_job_vm_enabled,
     _is_rtk_enabled,
     _is_sandbox_event_ingest_enabled,
     _resolve_modal_vm_sandbox,
@@ -79,6 +81,46 @@ def test_snapshot_resume_requires_a_resume_marker_and_snapshot(state: dict[str, 
     )
 
     assert context.is_snapshot_resume is expected
+
+
+@pytest.mark.parametrize("flag_value,expected", [(True, True), (False, False), (None, False)])
+def test_parallel_desktop_prep_job_vm_flag_uses_organization_rollout(flag_value, expected):
+    with patch(
+        "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+        return_value=flag_value,
+    ) as feature_enabled_mock:
+        assert (
+            _is_parallel_desktop_prep_job_vm_enabled(
+                distinct_id="distinct-id",
+                organization_id="organization-id",
+                run_id="run-id",
+            )
+            is expected
+        )
+
+    feature_enabled_mock.assert_called_once_with(
+        PARALLEL_DESKTOP_PREP_JOB_VM_FEATURE_FLAG,
+        distinct_id="distinct-id",
+        groups={"organization": "organization-id"},
+        group_properties={"organization": {"id": "organization-id"}},
+        only_evaluate_locally=False,
+        send_feature_flag_events=False,
+    )
+
+
+def test_parallel_desktop_prep_job_vm_flag_fails_closed():
+    with patch(
+        "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+        side_effect=RuntimeError("flag service failed"),
+    ):
+        assert (
+            _is_parallel_desktop_prep_job_vm_enabled(
+                distinct_id="distinct-id",
+                organization_id="organization-id",
+                run_id="run-id",
+            )
+            is False
+        )
 
 
 @pytest.mark.requires_secrets

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_provision_sandbox.py
@@ -14,12 +14,14 @@ from products.tasks.backend.logic.services.sandbox import ExecutionResult, Sandb
 from products.tasks.backend.temporal.process_task.activities import provision_sandbox as provision_sandbox_module
 from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import TaskProcessingContext
 from products.tasks.backend.temporal.process_task.activities.provision_sandbox import (
+    AwaitDesktopWorkspacePreparationInput,
     CloneRepositoryInSandboxInput,
     CreateSandboxForRepositoryInput,
     CreateSandboxForRepositoryOutput,
     PrepareSandboxForRepositoryOutput,
     _prepare_posthog_desktop_cloud_task,
     _sandbox_image_kind,
+    await_desktop_workspace_preparation,
     clone_repository_in_sandbox,
     create_sandbox_for_repository,
 )
@@ -45,16 +47,42 @@ def test_prepares_desktop_workspace_for_posthog_dev_stack_task(mocker):
     sandbox.config.image_fallback = None
     sandbox.execute.return_value = ExecutionResult(stdout="", stderr="", exit_code=0)
 
-    _prepare_posthog_desktop_cloud_task(
+    started = _prepare_posthog_desktop_cloud_task(
         _context_for_desktop_bootstrap(),
         sandbox,
         "PostHog/posthog",
     )
 
-    sandbox.execute.assert_called_once_with(
-        "cd /tmp/workspace/repos/posthog/posthog/products/desktop && pnpm bootstrap:cloud-task",
-        timeout_seconds=10 * 60,
+    assert started is True
+    sandbox.execute.assert_called_once()
+    command = sandbox.execute.call_args.args[0]
+    assert command.startswith("touch /tmp/workspace/.agent-credentials /tmp/workspace/.agent-credentials.tmp && ")
+    assert "nohup /bin/sh -c" in command
+    assert "/usr/bin/unshare --mount --pid --net --fork" in command
+    assert "/usr/bin/setpriv --bounding-set=-all" in command
+    assert "/usr/bin/env -i" in command
+    assert "/usr/bin/mount --make-rprivate /" in command
+    assert "/usr/bin/mount -t tmpfs tmpfs /mnt" in command
+    assert (
+        "mount --bind /tmp/workspace/repos/posthog/posthog/products/desktop /mnt/posthog-desktop-workspace" in command
     )
+    assert "/usr/bin/mount -t tmpfs tmpfs /tmp" in command
+    assert (
+        "mount --bind /mnt/posthog-desktop-workspace /tmp/workspace/repos/posthog/posthog/products/desktop" in command
+    )
+    assert "/usr/bin/findmnt -rn -o TARGET" in command
+    assert '/usr/bin/mount -o remount,bind,ro "$target"' in command
+    assert 'case "$target" in /tmp|/tmp/*|/mnt|/mnt/*)' in command
+    assert "/tmp/desktop-workspace-bootstrap/scratch" in command
+    assert "mount --bind /dev/null /tmp/workspace/.agent-credentials" not in command
+    assert "/run/systemd/private /run/dbus/system_bus_socket /var/run/docker.sock" in command
+    assert "mkdir /tmp/desktop-workspace-bootstrap" in command
+    assert "pnpm fetch" not in command
+    assert "PNPM_CONFIG_OFFLINE=true" in command
+    assert "pnpm bootstrap:cloud-task" in command
+    assert "/tmp/desktop-workspace-bootstrap/status" in command
+    assert command.index("/usr/bin/unshare") < command.index("printf")
+    assert sandbox.execute.call_args.kwargs == {"timeout_seconds": 30}
 
 
 @pytest.mark.parametrize(
@@ -72,16 +100,17 @@ def test_skips_desktop_workspace_preparation_for_other_images_repositories_and_f
     sandbox = mocker.Mock()
     sandbox.config.image_fallback = image_fallback
 
-    _prepare_posthog_desktop_cloud_task(
+    started = _prepare_posthog_desktop_cloud_task(
         _context_for_desktop_bootstrap(image_name=image_name),
         sandbox,
         repository,
     )
 
+    assert started is False
     sandbox.execute.assert_not_called()
 
 
-def test_desktop_workspace_preparation_failure_is_non_retryable(mocker):
+def test_desktop_workspace_preparation_launch_failure_is_non_retryable(mocker):
     from temporalio.exceptions import ApplicationError
 
     sandbox = mocker.Mock()
@@ -93,6 +122,57 @@ def test_desktop_workspace_preparation_failure_is_non_retryable(mocker):
             _context_for_desktop_bootstrap(),
             sandbox,
             "posthog/posthog",
+        )
+
+    assert error.value.non_retryable is True
+    assert "build failed" in str(error.value)
+
+
+def test_awaits_desktop_workspace_preparation(mocker, activity_environment):
+    sandbox = mocker.Mock()
+    sandbox.execute.side_effect = [
+        ExecutionResult(stdout="pending\n", stderr="", exit_code=0),
+        ExecutionResult(stdout="0\n", stderr="", exit_code=0),
+    ]
+    mocker.patch.object(Sandbox, "get_by_id", return_value=sandbox)
+    mocker.patch.object(provision_sandbox_module, "emit_agent_log")
+    heartbeat = mocker.patch.object(provision_sandbox_module.activity, "heartbeat")
+    sleep = mocker.patch.object(provision_sandbox_module.time, "sleep")
+
+    async_to_sync(activity_environment.run)(
+        await_desktop_workspace_preparation,
+        AwaitDesktopWorkspacePreparationInput(
+            context=_context_for_desktop_bootstrap(),
+            sandbox_id="sandbox-id",
+        ),
+    )
+
+    command = sandbox.execute.call_args_list[0].args[0]
+    assert "if [ -f /tmp/desktop-workspace-bootstrap/status ]" in command
+    assert "echo pending" in command
+    assert sandbox.execute.call_args_list[0].kwargs == {"timeout_seconds": 5}
+    heartbeat.assert_called_once_with()
+    sleep.assert_called_once_with(provision_sandbox_module._DESKTOP_BOOTSTRAP_POLL_INTERVAL_SECONDS)
+
+
+def test_desktop_workspace_preparation_failure_includes_background_log(mocker, activity_environment):
+    from temporalio.exceptions import ApplicationError
+
+    sandbox = mocker.Mock()
+    sandbox.execute.side_effect = [
+        ExecutionResult(stdout="", stderr="bootstrap failed", exit_code=1),
+        ExecutionResult(stdout="build failed", stderr="", exit_code=0),
+    ]
+    mocker.patch.object(Sandbox, "get_by_id", return_value=sandbox)
+    mocker.patch.object(provision_sandbox_module, "emit_agent_log")
+
+    with pytest.raises(ApplicationError) as error:
+        async_to_sync(activity_environment.run)(
+            await_desktop_workspace_preparation,
+            AwaitDesktopWorkspacePreparationInput(
+                context=_context_for_desktop_bootstrap(),
+                sandbox_id="sandbox-id",
+            ),
         )
 
     assert error.value.non_retryable is True

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_start_agent_server.py
@@ -1,17 +1,122 @@
 import pytest
 from freezegun import freeze_time
 
-from products.tasks.backend.exceptions import SandboxMissingRepositoryError
+from products.tasks.backend.exceptions import SandboxExecutionError, SandboxMissingRepositoryError
 from products.tasks.backend.logic.services.sandbox import ExecutionResult, sandbox_repo_path
 from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import TaskProcessingContext
 from products.tasks.backend.temporal.process_task.activities.start_agent_server import (
+    ActivateAgentServerCredentialsInput,
     StartAgentServerInput,
     _ensure_repository_on_disk,
     _include_personal_mcp_for_task,
+    _LaunchParams,
     _record_boot_total,
     _resolve_protected_base_branch,
+    activate_agent_server_credentials,
+    launch_agent_server,
     start_agent_server,
 )
+
+
+async def test_credential_activation_stops_when_file_write_fails(mocker) -> None:
+    sandbox = mocker.Mock(id="sandbox-id")
+    sandbox.write_file.return_value = ExecutionResult(stdout="", stderr="disk full", exit_code=1)
+    mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server.Sandbox.get_by_id",
+        return_value=sandbox,
+    )
+    mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server._prepare_launch",
+        return_value=_LaunchParams(
+            mcp_configs=[],
+            relayed_mcp_servers=[],
+            actor_user_id=None,
+            agentsh_domains=None,
+            protected_base_branch=None,
+            event_ingest_token="event-secret",
+            task_run_session_token="session-secret",
+            event_ingest_url=None,
+            event_ingest_keep_stream_open=False,
+        ),
+    )
+
+    with pytest.raises(SandboxExecutionError, match="Failed to write deferred agent credentials"):
+        await activate_agent_server_credentials(
+            ActivateAgentServerCredentialsInput(
+                context=_context(),
+                sandbox_id="sandbox-id",
+            )
+        )
+
+    sandbox.execute.assert_not_called()
+
+
+async def test_deferred_launch_keeps_credentials_out_of_agent_process(mocker) -> None:
+    sandbox = mocker.Mock()
+    sandbox.agent_server_supports_deferred_credentials.return_value = True
+    mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server.Sandbox.get_by_id",
+        return_value=sandbox,
+    )
+    mocker.patch("products.tasks.backend.temporal.process_task.activities.start_agent_server.emit_agent_log")
+    mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server._prepare_launch",
+        return_value=_LaunchParams(
+            mcp_configs=[mocker.Mock()],
+            relayed_mcp_servers=[],
+            actor_user_id=None,
+            agentsh_domains=None,
+            protected_base_branch=None,
+            event_ingest_token="event-secret",
+            task_run_session_token="session-secret",
+            event_ingest_url=None,
+            event_ingest_keep_stream_open=False,
+        ),
+    )
+
+    output = await launch_agent_server(
+        StartAgentServerInput(
+            context=_context(),
+            sandbox_id="sandbox-id",
+            sandbox_url="https://sandbox.example",
+            defer_for_clone=True,
+            defer_credentials=True,
+        )
+    )
+
+    assert output.process_launched is True
+    assert output.credentials_deferred is True
+    kwargs = sandbox.start_agent_server.call_args.kwargs
+    assert kwargs["mcp_configs"] is None
+    assert kwargs["event_ingest_token"] is None
+    assert kwargs["task_run_session_token"] is None
+    assert kwargs["deferred_credentials_file"]
+
+
+async def test_deferred_launch_falls_back_safely_for_old_agent_image(mocker) -> None:
+    sandbox = mocker.Mock()
+    sandbox.agent_server_supports_deferred_credentials.return_value = False
+    mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server.Sandbox.get_by_id",
+        return_value=sandbox,
+    )
+    prepare_launch = mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.start_agent_server._prepare_launch"
+    )
+    mocker.patch("products.tasks.backend.temporal.process_task.activities.start_agent_server.emit_agent_log")
+
+    output = await launch_agent_server(
+        StartAgentServerInput(
+            context=_context(),
+            sandbox_id="sandbox-id",
+            sandbox_url="https://sandbox.example",
+            defer_credentials=True,
+        )
+    )
+
+    assert output.process_launched is False
+    prepare_launch.assert_not_called()
+    sandbox.start_agent_server.assert_not_called()
 
 
 @freeze_time("2026-08-06T12:01:30Z")

--- a/products/tasks/backend/temporal/process_task/tests/test_workflow.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_workflow.py
@@ -28,7 +28,10 @@ from products.tasks.backend.temporal.constants import INACTIVITY_TIMEOUT_USER_SE
 from products.tasks.backend.temporal.process_task import workflow as process_task_workflow_module
 from products.tasks.backend.temporal.process_task.activities import (
     STEER_DECLINED_OUTCOME,
+    CheckoutBranchInSandboxOutput,
     CleanupSandboxInput,
+    CloneRepositoryInSandboxInput,
+    CloneRepositoryInSandboxOutput,
     CompleteRunStreamInput,
     CreateSandboxForRepositoryInput,
     CreateSandboxForRepositoryOutput,
@@ -39,6 +42,8 @@ from products.tasks.backend.temporal.process_task.activities import (
     SendPermissionResponseToSandboxInput,
     StartAgentServerOutput,
     TaskProcessingContext,
+    activate_agent_server_credentials,
+    await_desktop_workspace_preparation,
     checkout_branch_in_sandbox,
     cleanup_sandbox,
     clone_repository_in_sandbox,
@@ -1740,11 +1745,64 @@ class TestProcessTaskWorkflowUnit:
         result = await workflow._get_sandbox_for_repository()
 
         assert cloned == ["posthog/posthog", "posthog/code"]
-        assert clone_options["posthog/posthog"]["start_to_close_timeout"] == timedelta(minutes=20)
+        assert clone_options["posthog/posthog"]["start_to_close_timeout"] == timedelta(minutes=12)
         assert clone_options["posthog/posthog"]["retry_policy"].maximum_attempts == 3
         assert clone_options["posthog/code"]["start_to_close_timeout"] == timedelta(minutes=5)
         assert clone_options["posthog/code"]["retry_policy"].maximum_attempts == 3
         assert result.clone_ms is None
+
+    async def test_get_sandbox_for_repository_keeps_desktop_preparation_synchronous_when_flag_is_off(self, monkeypatch):
+        workflow = ProcessTaskWorkflow()
+        workflow._context = _build_context(
+            github_integration_id=123,
+            repository="posthog/posthog",
+            custom_image_name="posthog-dev-stack",
+            parallel_desktop_prep_job_vm_enabled=False,
+        )
+        prepared = PrepareSandboxForRepositoryOutput(
+            sandbox_name="sandbox-name",
+            repository="posthog/posthog",
+            github_token="ghs_token",
+            branch=None,
+            environment_variables={},
+            snapshot_id=None,
+            snapshot_external_id=None,
+            used_snapshot=False,
+            should_create_snapshot=True,
+            shallow_clone=True,
+            image_source="base_image",
+            image_source_label="published sandbox base image",
+        )
+        created = CreateSandboxForRepositoryOutput(
+            sandbox_id="sandbox-123",
+            sandbox_url="https://sandbox.example",
+            connect_token="connect-token",
+        )
+        clone_inputs: list[CloneRepositoryInSandboxInput] = []
+        activity_calls: list[Any] = []
+
+        async def fake_execute_activity(activity_fn: Any, *args: Any, **kwargs: Any) -> Any:
+            activity_calls.append(activity_fn)
+            if activity_fn is prepare_sandbox_for_repository:
+                return prepared
+            if activity_fn is create_sandbox_for_repository:
+                return created
+            if activity_fn is clone_repository_in_sandbox:
+                clone_inputs.append(args[0])
+                return CloneRepositoryInSandboxOutput()
+            if activity_fn is emit_progress_activity:
+                return None
+            raise AssertionError(f"Unexpected activity call: {activity_fn}")
+
+        monkeypatch.setattr(process_task_workflow_module.workflow, "execute_activity", fake_execute_activity)
+        monkeypatch.setattr(process_task_workflow_module.workflow, "patched", lambda _: True)
+
+        result = await workflow._get_sandbox_for_repository()
+
+        assert clone_inputs[0].background_desktop_preparation is False
+        assert await_desktop_workspace_preparation not in activity_calls
+        assert launch_agent_server not in activity_calls
+        assert result.agent_server_launched is False
 
     async def test_get_sandbox_for_repository_uses_desktop_budget_for_snapshot_checkout(self, monkeypatch):
         workflow = ProcessTaskWorkflow()
@@ -1773,25 +1831,107 @@ class TestProcessTaskWorkflowUnit:
             connect_token="connect-token",
         )
         checkout_options: dict[str, Any] = {}
+        desktop_wait_options: dict[str, Any] = {}
+        activity_calls: list[Any] = []
+        launch_inputs: list[Any] = []
 
         async def fake_execute_activity(activity_fn: Any, *args: Any, **kwargs: Any) -> Any:
+            activity_calls.append(activity_fn)
             if activity_fn is prepare_sandbox_for_repository:
                 return prepared
             if activity_fn is create_sandbox_for_repository:
                 return created
             if activity_fn is checkout_branch_in_sandbox:
                 checkout_options.update(kwargs)
+                return CheckoutBranchInSandboxOutput(desktop_preparation_started=True)
+            if activity_fn is launch_agent_server:
+                launch_inputs.append(args[0])
+                return StartAgentServerOutput(
+                    sandbox_url="https://sandbox.example",
+                    connect_token="connect-token",
+                    credentials_deferred=True,
+                )
+            if activity_fn is await_desktop_workspace_preparation:
+                desktop_wait_options.update(kwargs)
+                return None
+            if activity_fn is activate_agent_server_credentials:
+                return None
+            if activity_fn is mark_repo_ready:
                 return None
             if activity_fn is emit_progress_activity:
                 return None
             raise AssertionError(f"Unexpected activity call: {activity_fn}")
 
         monkeypatch.setattr(process_task_workflow_module.workflow, "execute_activity", fake_execute_activity)
+        monkeypatch.setattr(process_task_workflow_module.workflow, "patched", lambda _: True)
 
         await workflow._get_sandbox_for_repository()
 
-        assert checkout_options["start_to_close_timeout"] == timedelta(minutes=20)
+        assert checkout_options["start_to_close_timeout"] == timedelta(minutes=12)
         assert checkout_options["retry_policy"].maximum_attempts == 3
+        assert desktop_wait_options["schedule_to_close_timeout"] == timedelta(minutes=12)
+        # The launch metric must land in the same boot_path cohort as the downstream readiness
+        # metrics, which the result reports as desktop_overlap.
+        assert launch_inputs[0].boot_path == "desktop_overlap"
+        assert activity_calls.index(launch_agent_server) < activity_calls.index(await_desktop_workspace_preparation)
+        assert activity_calls.index(await_desktop_workspace_preparation) < activity_calls.index(
+            activate_agent_server_credentials
+        )
+        assert activity_calls.index(activate_agent_server_credentials) < activity_calls.index(mark_repo_ready)
+
+    async def test_get_sandbox_for_repository_waits_for_desktop_before_wizard_agent_launch(self, monkeypatch):
+        workflow = ProcessTaskWorkflow()
+        workflow._context = _build_context(
+            github_integration_id=123,
+            repository="posthog/posthog",
+            custom_image_name="posthog-dev-stack",
+            state={"wizard_config": {"prompt": "Configure the workspace"}},
+        )
+        prepared = PrepareSandboxForRepositoryOutput(
+            sandbox_name="sandbox-name",
+            repository="posthog/posthog",
+            github_token="ghs_token",
+            branch="feature-branch",
+            environment_variables={},
+            snapshot_id="repo-snapshot-id",
+            snapshot_external_id=None,
+            used_snapshot=True,
+            should_create_snapshot=False,
+            shallow_clone=True,
+            image_source="repository_snapshot",
+            image_source_label="repository snapshot x",
+        )
+        created = CreateSandboxForRepositoryOutput(
+            sandbox_id="sandbox-123",
+            sandbox_url="https://sandbox.example",
+            connect_token="connect-token",
+        )
+        activity_calls: list[Any] = []
+
+        async def fake_execute_activity(activity_fn: Any, *args: Any, **kwargs: Any) -> Any:
+            activity_calls.append(activity_fn)
+            if activity_fn is prepare_sandbox_for_repository:
+                return prepared
+            if activity_fn is create_sandbox_for_repository:
+                return created
+            if activity_fn is checkout_branch_in_sandbox:
+                return CheckoutBranchInSandboxOutput(desktop_preparation_started=True)
+            if activity_fn is await_desktop_workspace_preparation:
+                return None
+            if activity_fn is mark_repo_ready:
+                return None
+            if activity_fn is emit_progress_activity:
+                return None
+            raise AssertionError(f"Unexpected activity call: {activity_fn}")
+
+        monkeypatch.setattr(process_task_workflow_module.workflow, "execute_activity", fake_execute_activity)
+        monkeypatch.setattr(process_task_workflow_module.workflow, "patched", lambda _: True)
+
+        result = await workflow._get_sandbox_for_repository()
+
+        assert await_desktop_workspace_preparation in activity_calls
+        assert launch_agent_server not in activity_calls
+        assert result.agent_server_launched is False
 
     async def test_overlap_releases_agent_after_primary_clone_and_materializes_failed_secondary(self, monkeypatch):
         workflow = ProcessTaskWorkflow()
@@ -1870,6 +2010,7 @@ class TestProcessTaskWorkflowUnit:
         workflow._context = _build_context(
             github_integration_id=123,
             state={"repositories": ["posthog/posthog"]},
+            custom_image_name="posthog-dev-stack",
         )
         workflow._context.overlap_clone_boot_enabled = True
         prepared = PrepareSandboxForRepositoryOutput(
@@ -1902,11 +2043,16 @@ class TestProcessTaskWorkflowUnit:
             if activity_fn is create_sandbox_for_repository:
                 return created
             if activity_fn is launch_agent_server:
-                return StartAgentServerOutput(sandbox_url=created.sandbox_url)
+                return StartAgentServerOutput(
+                    sandbox_url=created.sandbox_url,
+                    credentials_deferred=True,
+                )
             if activity_fn is clone_repository_in_sandbox:
                 raise RuntimeError("clone timed out")
             if activity_fn is mark_repo_ready:
                 ready_inputs.append(args[0])
+                return None
+            if activity_fn is activate_agent_server_credentials:
                 return None
             if activity_fn is emit_progress_activity:
                 progress.append(args[0])
@@ -1921,10 +2067,14 @@ class TestProcessTaskWorkflowUnit:
 
         assert result.agent_server_launched is True
         assert mark_repo_ready in calls
+        assert activate_agent_server_credentials in calls
+        assert calls.index(activate_agent_server_credentials) < calls.index(mark_repo_ready)
         assert checkout_branch_in_sandbox not in calls
-        assert len(ready_inputs) == 1
+        assert len(ready_inputs) == 2
         assert ready_inputs[0].failed_repositories == ["posthog/posthog"]
-        assert ready_inputs[0].release_barrier is True
+        assert ready_inputs[0].release_barrier is False
+        assert ready_inputs[1].failed_repositories is None
+        assert ready_inputs[1].release_barrier is True
         assert progress[-1].label == "Repository clone failed; continuing without it"
         assert progress[-1].detail == "Could not clone: posthog/posthog"
 

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -55,6 +55,7 @@ from .activities.get_task_processing_context import (
 )
 from .activities.post_slack_update import PostSlackUpdateInput, post_slack_update
 from .activities.provision_sandbox import (
+    AwaitDesktopWorkspacePreparationInput,
     CheckoutBranchInSandboxInput,
     CloneRepositoryInSandboxInput,
     CloneRepositoryInSandboxOutput,
@@ -64,6 +65,7 @@ from .activities.provision_sandbox import (
     InvalidateResumeSnapshotInput,
     PrepareSandboxForRepositoryInput,
     PrepareSandboxForRepositoryOutput,
+    await_desktop_workspace_preparation,
     checkout_branch_in_sandbox,
     clone_repository_in_sandbox,
     create_sandbox_for_repository,
@@ -95,9 +97,11 @@ from .activities.send_permission_response_to_sandbox import (
 )
 from .activities.slack_agent_design_signals import RelayAgentDesignSignalsInput, relay_agent_design_signals
 from .activities.start_agent_server import (
+    ActivateAgentServerCredentialsInput,
     MarkRepoReadyInput,
     StartAgentServerInput,
     StartAgentServerOutput,
+    activate_agent_server_credentials,
     await_agent_server_ready,
     launch_agent_server,
     mark_repo_ready,
@@ -117,6 +121,7 @@ DEAD_SANDBOX_ERROR_TYPES = ("SandboxNotRunningError", "SandboxNotFoundError")
 MAX_ACCEPTED_MESSAGE_IDS = 500
 _PATCH_ID_CANCEL_SANDBOX_CREATION_ON_COMPLETION = "tasks-cancel-sandbox-creation-on-completion"
 _PATCH_ID_CONTINUE_AFTER_REPOSITORY_CLONE_FAILURE = "tasks-continue-after-repository-clone-failure"
+_PATCH_ID_BACKGROUND_DESKTOP_PREPARATION = "tasks-background-desktop-preparation"
 
 
 class _TaskCompletedDuringSandboxCreation(Exception):
@@ -271,9 +276,9 @@ _PATCH_ID_EXCLUDE_WIZARD_FROM_BOOT_TOTAL = "tasks-exclude-wizard-from-boot-total
 # Preserve that command order on replay while new runs can release it after the primary clone.
 _PATCH_ID_AGENT_READY_AFTER_PRIMARY_CLONE = "tasks-agent-ready-after-primary-clone"
 
-# Desktop preparation links a large workspace and writes compiled package outputs. Give
-# that non-idempotent work one attempt with a budget larger than its inner 10-minute cap.
-_DESKTOP_BOOTSTRAP_ACTIVITY_TIMEOUT = timedelta(minutes=20)
+# Desktop preparation used to have a ten-minute command timeout. Keep a small margin
+# for polling and retries without allowing multiple attempts to multiply that bound.
+_DESKTOP_BOOTSTRAP_ACTIVITY_TIMEOUT = timedelta(minutes=12)
 
 # #60923 dropped the redundant slack post that ran immediately after sandbox
 # provisioning — between `_get_sandbox_for_repository` and the agent-start
@@ -1492,20 +1497,39 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             return self.context.custom_image_name == DEV_STACK_IMAGE_NAME and repository.casefold() == "posthog/posthog"
 
         overlap = bool(self.context.overlap_clone_boot_enabled and will_clone)
+        background_desktop_preparation = workflow.patched(_PATCH_ID_BACKGROUND_DESKTOP_PREPARATION) and (
+            self.context.parallel_desktop_prep_job_vm_enabled is not False
+        )
+        defer_agent_credentials = bool(
+            background_desktop_preparation and any(prepares_desktop(repo) for repo in repositories_to_clone)
+        )
         boot_path = "overlap" if overlap else "classic"
         launch_ms: int | None = None
+        agent_server_launched = False
+        agent_credentials_deferred = False
         if overlap:
             await self._emit_progress("agent", "in_progress", "Starting agent", "setup")
-            launch_output = await self._launch_agent_server(created, defer_for_clone=True, used_snapshot=used_snapshot)
+            launch_output = await self._launch_agent_server(
+                created,
+                defer_for_clone=True,
+                defer_credentials=defer_agent_credentials,
+                used_snapshot=used_snapshot,
+                boot_path=boot_path,
+            )
             launch_ms = launch_output.launch_ms if launch_output else None
+            agent_server_launched = bool(launch_output and launch_output.process_launched)
+            agent_credentials_deferred = bool(launch_output and launch_output.credentials_deferred)
 
         clone_ms: int | None = None
+        desktop_preparation_started_by_clone = False
         failed_repositories: set[str] = set()
         materialized_failed_repositories: set[str] = set()
         repo_ready_released = False
         release_after_primary_clone = bool(
             overlap and len(repositories_to_clone) > 1 and workflow.patched(_PATCH_ID_AGENT_READY_AFTER_PRIMARY_CLONE)
         )
+        if background_desktop_preparation and any(prepares_desktop(repo) for repo in repositories_to_clone):
+            release_after_primary_clone = False
         if will_clone:
             await self._emit_progress("clone", "in_progress", "Cloning repository", "setup")
             continue_after_clone_failure = workflow.patched(_PATCH_ID_CONTINUE_AFTER_REPOSITORY_CLONE_FAILURE)
@@ -1523,6 +1547,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                             repository=repository,
                             github_token=prepared.github_token,
                             shallow_clone=prepared.shallow_clone,
+                            background_desktop_preparation=background_desktop_preparation,
                         ),
                         start_to_close_timeout=(
                             _DESKTOP_BOOTSTRAP_ACTIVITY_TIMEOUT if prepares_repository_desktop else timedelta(minutes=5)
@@ -1547,7 +1572,11 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                     clone_failed = False
 
                 is_primary_repository = repository == repositories_to_clone[0]
-                should_release_after_clone = release_after_primary_clone and is_primary_repository
+                should_release_after_clone = (
+                    release_after_primary_clone
+                    and is_primary_repository
+                    and not (background_desktop_preparation and prepares_repository_desktop)
+                )
                 should_materialize_failure = release_after_primary_clone and clone_failed
                 if should_release_after_clone or should_materialize_failure:
                     await self._mark_repo_ready(
@@ -1571,11 +1600,19 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 repo_ready_released = repo_ready_released or released_after_clone
                 if (duration := getattr(clone_output, "clone_ms", None)) is not None:
                     clone_durations.append(duration)
+                desktop_preparation_started_by_clone = desktop_preparation_started_by_clone or getattr(
+                    clone_output, "desktop_preparation_started", False
+                )
             clone_ms = sum(clone_durations) if clone_durations else None
             if failed_repositories:
                 failed_list = ", ".join(sorted(failed_repositories))
                 remaining_failed_repositories = sorted(failed_repositories - materialized_failed_repositories)
-                should_release_barrier = overlap and not repo_ready_released
+                should_release_barrier = (
+                    overlap
+                    and not repo_ready_released
+                    and not desktop_preparation_started_by_clone
+                    and not agent_credentials_deferred
+                )
                 if remaining_failed_repositories or should_release_barrier:
                     await self._mark_repo_ready(
                         created.sandbox_id,
@@ -1597,6 +1634,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         state = self.context.state or {}
         is_resume = bool(state.get("resume_from_run_id") or state.get("handoff_resumed"))
         checkout_ms: int | None = None
+        desktop_preparation_started = False
         if will_checkout and checkout_repository not in failed_repositories and not is_resume:
             assert checkout_repository is not None
             assert prepared.branch is not None
@@ -1614,6 +1652,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                     github_token=prepared.github_token,
                     shallow_clone=prepared.shallow_clone,
                     used_snapshot=used_snapshot,
+                    background_desktop_preparation=background_desktop_preparation,
                 ),
                 start_to_close_timeout=(
                     _DESKTOP_BOOTSTRAP_ACTIVITY_TIMEOUT if prepares_repository_desktop else timedelta(minutes=5)
@@ -1622,9 +1661,52 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             )
             # Pre-rollout histories (and mocked tests) recorded a null result here.
             checkout_ms = getattr(checkout_output, "checkout_ms", None)
+            desktop_preparation_started = getattr(checkout_output, "desktop_preparation_started", False)
             await self._emit_progress("checkout", "completed", branch_label_done, "setup")
 
-        if overlap and not repo_ready_released:
+        if will_clone:
+            desktop_preparation_started = desktop_preparation_started or desktop_preparation_started_by_clone
+        if (
+            background_desktop_preparation
+            and desktop_preparation_started
+            and not agent_server_launched
+            and self.context.wizard_config is None
+        ):
+            await self._emit_progress("agent", "in_progress", "Starting agent", "setup")
+            boot_path = "desktop_overlap"
+            launch_output = await self._launch_agent_server(
+                created,
+                defer_for_clone=True,
+                defer_credentials=True,
+                used_snapshot=used_snapshot,
+                boot_path=boot_path,
+            )
+            launch_ms = launch_output.launch_ms if launch_output else None
+            agent_server_launched = bool(launch_output and launch_output.process_launched)
+            agent_credentials_deferred = bool(launch_output and launch_output.credentials_deferred)
+        if background_desktop_preparation and desktop_preparation_started:
+            await workflow.execute_activity(
+                await_desktop_workspace_preparation,
+                AwaitDesktopWorkspacePreparationInput(context=self.context, sandbox_id=created.sandbox_id),
+                start_to_close_timeout=_DESKTOP_BOOTSTRAP_ACTIVITY_TIMEOUT,
+                schedule_to_close_timeout=_DESKTOP_BOOTSTRAP_ACTIVITY_TIMEOUT,
+                heartbeat_timeout=timedelta(seconds=30),
+                retry_policy=RetryPolicy(maximum_attempts=3),
+            )
+
+        if agent_credentials_deferred:
+            await workflow.execute_activity(
+                activate_agent_server_credentials,
+                ActivateAgentServerCredentialsInput(
+                    context=self.context,
+                    sandbox_id=created.sandbox_id,
+                    posthog_mcp_scopes=self._posthog_mcp_scopes,
+                ),
+                start_to_close_timeout=timedelta(minutes=2),
+                retry_policy=RetryPolicy(maximum_attempts=3),
+            )
+
+        if agent_server_launched and not repo_ready_released:
             await self._mark_repo_ready(created.sandbox_id)
 
         return GetSandboxForRepositoryOutput(
@@ -1633,7 +1715,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             connect_token=created.connect_token,
             used_snapshot=used_snapshot,
             should_create_snapshot=not used_snapshot,
-            agent_server_launched=overlap,
+            agent_server_launched=agent_server_launched,
             boot_path=boot_path,
             image_source=prepared.image_source,
             create_ms=created.create_ms,
@@ -1782,7 +1864,13 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         )
 
     async def _launch_agent_server(
-        self, created: CreateSandboxForRepositoryOutput, *, defer_for_clone: bool, used_snapshot: bool | None = None
+        self,
+        created: CreateSandboxForRepositoryOutput,
+        *,
+        defer_for_clone: bool,
+        defer_credentials: bool = False,
+        used_snapshot: bool | None = None,
+        boot_path: str,
     ) -> StartAgentServerOutput:
         return await workflow.execute_activity(
             launch_agent_server,
@@ -1793,7 +1881,8 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 sandbox_connect_token=created.connect_token,
                 posthog_mcp_scopes=self._posthog_mcp_scopes,
                 defer_for_clone=defer_for_clone,
-                boot_path="overlap",
+                defer_credentials=defer_credentials,
+                boot_path=boot_path,
                 used_snapshot=used_snapshot,
             ),
             start_to_close_timeout=timedelta(minutes=5),


### PR DESCRIPTION
## Problem

Cloud tasks using the PostHog dev-stack image block sandbox startup while Desktop dependencies are prepared.

**Why:** Repository setup and agent-server boot should progress while the Desktop workspace links and builds its dependencies.

## Changes

- Run the Desktop bootstrap as a detached sandbox process after the final checkout.
- Track its PID, exit status, and log while repository cloning and agent-server boot continue.
- Hold the agent session barrier until preparation succeeds, including snapshot, fallback, multi-repository, and clone-failure paths.
- Preserve replay compatibility for in-flight Temporal workflows.