### PR TITLE
chore(logs): property-test the pattern masking rules

### DIFF
--- a/products/logs/backend/test/test_log_patterns.py
+++ b/products/logs/backend/test/test_log_patterns.py
@@ -1,11 +1,19 @@
 import re
 import datetime as dt
+from itertools import zip_longest
 
 from unittest import TestCase
 
+from hypothesis import (
+    given,
+    settings,
+    strategies as st,
+)
 from parameterized import parameterized
 
 from products.logs.backend.log_patterns import (
+    _MASKING_INSTRUCTIONS,
+    _PLACEHOLDER_PATTERNS,
     LogSample,
     compile_match_regex,
     extract_match_literal,
@@ -274,3 +282,84 @@ class TestCompileMatchRegex(TestCase):
     )
     def test_extract_match_literal(self, _name: str, template: str, expected: str | None) -> None:
         assert extract_match_literal(template) == expected
+
+
+_uuid_st = st.tuples(st.uuids(), st.booleans()).map(lambda t: str(t[0]).upper() if t[1] else str(t[0]))
+_hex_0x_st = st.text("0123456789abcdefABCDEF", min_size=1, max_size=32).map(lambda s: f"0x{s}")
+_hex_bare_st = st.text("0123456789abcdefABCDEF", min_size=16, max_size=40)
+_num_st = st.integers(min_value=0, max_value=10**12).map(str)
+_word_st = st.text("abcdefghijklmnopqrstuvwxyz", min_size=3, max_size=10)
+
+
+@st.composite
+def _timestamp_st(draw: st.DrawFn) -> str:
+    instant = draw(st.datetimes(min_value=dt.datetime(1000, 1, 1), max_value=dt.datetime(9999, 12, 31, 23, 59, 59)))
+    separator = draw(st.sampled_from(["T", " "]))
+    text = instant.strftime(f"%Y-%m-%d{separator}%H:%M:%S")
+    fraction = draw(st.one_of(st.none(), st.integers(min_value=0, max_value=999_999_999)))
+    if fraction is not None:
+        text += f"{draw(st.sampled_from(['.', ',']))}{fraction}"
+    return text + draw(st.sampled_from(["", "Z", "+00:00", "-05:30", "+0230", "-1145"]))
+
+
+_variable_token_st = st.one_of(_uuid_st, _hex_0x_st, _hex_bare_st, _num_st, _timestamp_st())
+
+
+class TestMaskingProperties(TestCase):
+    def test_every_mask_name_has_a_registered_placeholder(self) -> None:
+        # A masking rule without a placeholder entry produces templates whose match_regex
+        # can never validate, silently degrading the "view matching logs" pivot.
+        for instruction in _MASKING_INSTRUCTIONS:
+            assert f"<{instruction.mask_with}>" in _PLACEHOLDER_PATTERNS
+
+    @given(value=_uuid_st)
+    @settings(deadline=None)
+    def test_any_uuid_masks_to_placeholder(self, value: str) -> None:
+        patterns = mine_patterns([_sample(f"trace {value} start")])
+
+        assert patterns[0].pattern == "trace <uuid> start"
+
+    @given(value=st.one_of(_hex_0x_st, _hex_bare_st))
+    @settings(deadline=None)
+    def test_any_hex_token_masks_to_placeholder(self, value: str) -> None:
+        patterns = mine_patterns([_sample(f"token {value} rejected")])
+
+        assert patterns[0].pattern == "token <hex> rejected"
+
+    @given(value=_num_st)
+    @settings(deadline=None)
+    def test_any_integer_token_masks_to_num(self, value: str) -> None:
+        patterns = mine_patterns([_sample(f"took {value} ms")])
+
+        assert patterns[0].pattern == "took <num> ms"
+
+    @given(value=_timestamp_st())
+    @settings(deadline=None)
+    def test_any_iso_timestamp_masks_to_placeholder(self, value: str) -> None:
+        patterns = mine_patterns([_sample(f"job {value} done")])
+
+        assert patterns[0].pattern == "job <timestamp> done"
+
+    @given(first_instant=_timestamp_st(), second_instant=_timestamp_st())
+    @settings(deadline=None)
+    def test_same_statement_at_two_instants_shares_fingerprint(self, first_instant: str, second_instant: str) -> None:
+        first = mine_patterns([_sample(f"{first_instant} task_retrying attempt=3")])
+        second = mine_patterns([_sample(f"{second_instant} task_retrying attempt=7")])
+
+        assert pattern_fingerprint(first[0].pattern) == pattern_fingerprint(second[0].pattern)
+
+    @given(
+        words=st.lists(_word_st, min_size=1, max_size=6),
+        values=st.lists(_variable_token_st, min_size=1, max_size=4),
+    )
+    @settings(deadline=None)
+    def test_match_regex_round_trips_any_masked_body(self, words: list[str], values: list[str]) -> None:
+        # compile_match_regex validates against the sampled body, so a placeholder pattern
+        # that matches less than its masking rule consumed surfaces here as a None regex.
+        interleaved = [token for pair in zip_longest(words, values) for token in pair if token is not None]
+        body = f"event {' '.join(interleaved)} done"
+        patterns = mine_patterns([_sample(body)])
+
+        assert len(patterns) == 1
+        assert patterns[0].match_regex is not None
+        assert re.search(patterns[0].match_regex, body)

--- a/products/logs/backend/test/test_log_patterns.py
+++ b/products/logs/backend/test/test_log_patterns.py
@@ -378,20 +378,37 @@ _truncated_uuid_st = st.uuids().map(lambda u: str(u)[:23])
 
 # Tokens the masker deliberately leaves (fully or partly) literal. A pivot regex mined
 # from a masked body must not match a sibling holding one of these in the same slot.
-_impostor_st = st.one_of(_digit_letter_run_st, _date_only_st, _minute_timestamp_st, _letter_hex_st, _truncated_uuid_st)
+# One row per (masked kind, confusable neighbor). Both halves of the row matter: the mask
+# has to tell the pair apart, and so does the pivot regex the mask produces. A single
+# union-of-everything property dilutes each pair to a fraction of the example budget, so
+# every pair draws its own.
+_CONFUSABLE_PAIRS = [
+    ("num_vs_digit_letter_run", _num_st, _digit_letter_run_st),
+    ("timestamp_vs_digit_letter_run", _timestamp_st(), _digit_letter_run_st),
+    ("timestamp_vs_date_only", _timestamp_st(), _date_only_st),
+    ("timestamp_vs_minute_precision", _timestamp_st(), _minute_timestamp_st),
+    ("uuid_vs_truncated_uuid", _uuid_st, _truncated_uuid_st),
+    ("hex_vs_letter_only_hex", st.one_of(_hex_0x_st, _hex_bare_st), _letter_hex_st),
+]
 
 
 class TestPivotSoundness(TestCase):
-    @given(value=_variable_token_st, impostor=_impostor_st)
+    @parameterized.expand([(name,) for name, _, _ in _CONFUSABLE_PAIRS])
+    @given(data=st.data())
     @settings(deadline=None)
-    def test_pivot_rejects_bodies_that_mask_to_another_template(self, value: str, impostor: str) -> None:
-        # A placeholder pattern broader than its masking rule pulls unrelated lines into
-        # the "view matching logs" pivot: the sibling masks to a different template, yet
-        # the pivot regex still matches it.
-        patterns = mine_patterns([_sample(f"event {value} done")])
-        assert patterns[0].match_regex is not None
+    def test_confusable_neighbor_stays_distinguishable(self, name: str, data: st.DataObject) -> None:
+        value_st, impostor_st = next((v, i) for n, v, i in _CONFUSABLE_PAIRS if n == name)
+        value_body = f"event {data.draw(value_st)} done"
+        impostor_body = f"event {data.draw(impostor_st)} done"
 
-        sibling = f"event {impostor} done"
-        sibling_template = mine_patterns([_sample(sibling)])[0].pattern
-        if sibling_template != patterns[0].pattern:
-            assert not re.search(patterns[0].match_regex, sibling)
+        mined = mine_patterns([_sample(value_body)])[0]
+        impostor_template = mine_patterns([_sample(impostor_body)])[0].pattern
+
+        # A masking rule that also swallows its neighbor erases the literal content the
+        # template exists to show. Asserted first, and unconditionally: guarding the pivot
+        # check on "the templates differ" makes an over-broad mask pass by doing nothing.
+        assert impostor_template != mined.pattern
+        # A placeholder broader than the rule that produced it pulls unrelated lines into
+        # the "view matching logs" pivot.
+        assert mined.match_regex is not None
+        assert not re.search(mined.match_regex, impostor_body)

--- a/products/logs/backend/test/test_log_patterns.py
+++ b/products/logs/backend/test/test_log_patterns.py
@@ -363,3 +363,35 @@ class TestMaskingProperties(TestCase):
         assert len(patterns) == 1
         assert patterns[0].match_regex is not None
         assert re.search(patterns[0].match_regex, body)
+
+
+_letter_st = st.text("ABCDEFGHIJKLMNOPQRSTUVWXYZ", min_size=1, max_size=2)
+_digit_letter_run_st = st.tuples(st.integers(0, 99), _letter_st, st.integers(0, 999999)).map(
+    lambda t: f"{t[0]}{t[1]}{t[2]}"
+)
+_date_only_st = st.dates(min_value=dt.date(1000, 1, 1)).map(str)
+_minute_timestamp_st = st.datetimes(min_value=dt.datetime(1000, 1, 1)).map(
+    lambda instant: instant.strftime("%Y-%m-%dT%H:%M")
+)
+_letter_hex_st = st.text("abcdef", min_size=4, max_size=12)
+_truncated_uuid_st = st.uuids().map(lambda u: str(u)[:23])
+
+# Tokens the masker deliberately leaves (fully or partly) literal. A pivot regex mined
+# from a masked body must not match a sibling holding one of these in the same slot.
+_impostor_st = st.one_of(_digit_letter_run_st, _date_only_st, _minute_timestamp_st, _letter_hex_st, _truncated_uuid_st)
+
+
+class TestPivotSoundness(TestCase):
+    @given(value=_variable_token_st, impostor=_impostor_st)
+    @settings(deadline=None)
+    def test_pivot_rejects_bodies_that_mask_to_another_template(self, value: str, impostor: str) -> None:
+        # A placeholder pattern broader than its masking rule pulls unrelated lines into
+        # the "view matching logs" pivot: the sibling masks to a different template, yet
+        # the pivot regex still matches it.
+        patterns = mine_patterns([_sample(f"event {value} done")])
+        assert patterns[0].match_regex is not None
+
+        sibling = f"event {impostor} done"
+        sibling_template = mine_patterns([_sample(sibling)])[0].pattern
+        if sibling_template != patterns[0].pattern:
+            assert not re.search(patterns[0].match_regex, sibling)


### PR DESCRIPTION
## Problem

- The pattern miner's masking rules are guarded by example tests only. The timestamp leak fixed in #81752 sat in production because no example carried a `T` separator.
- The five open masking PRs (#82018, #82021, #82022, #82025, #82026) property-test the rules they add, but the rules already on master (`<uuid>`, `<hex>`, `<num>`, `<timestamp>`) have no property coverage.

## Changes

- Add a Hypothesis property suite for the shipped rules: any generated UUID, hex token, integer, or ISO-8601 timestamp masks to its placeholder.
- Add a fingerprint-stability property: the same statement at any two instants gives one fingerprint.
- Add a compile round-trip property over bodies mixing literal words with generated variable tokens. A placeholder pattern that matches less than its masking rule consumed surfaces as a `None` regex here.
- Add a pivot soundness property in the other direction. A sibling body that masks to a different template must not match the mined `match_regex`, so a placeholder pattern broader than its masking rule surfaces as a false pivot match.
- Add the guard that every `mask_with` name has a `_PLACEHOLDER_PATTERNS` entry. Four of the open masking PRs add this same test, so it lands once here and they drop it on rebase.
- Hypothesis runs the default 100 examples per property with `deadline=None`. The full test file runs in under two seconds.

> [!NOTE]
> This PR touches the same test file as the five open masking PRs. Merging this first gives them one rebase each and removes their duplicated guard test.

## How did you test this code?

- The whole file passed locally in 1.3s.
- The round-trip property catches mask/placeholder drift no example test covers. The per-rule properties catch boundary regressions of the `\b`-between-digit-and-letter kind that example tests missed for months.
- The pivot soundness property catches the opposite drift: a placeholder that matches more than its rule masked, which pulls unrelated lines into the "view matching logs" pivot.
- Not run: DB-backed logs suites — this environment has no dev-stack Postgres.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code after an assessment of the property-test approach in the five open masking PRs.
- Skills invoked: /writing-tests, /writing-pr-descriptions.
- All test data is generated by Hypothesis strategies; no production log content appears.
