### PR TITLE
fix(plausible): stop retrying an unresolvable self-hosted host

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/source.py
@@ -58,6 +58,11 @@ class PlausibleSource(ResumableSource[PlausibleSourceConfig, PlausibleResumeConf
             # missing-site cases are 401/403/404 and handled above). Retrying resends the same
             # request, so stop. Match the status text, not the self-hosted URL, which varies.
             "400 Client Error": "Plausible rejected the request for this site. Check that the site domain is correct and that your Plausible account can access its stats, then reconnect.",
+            # `is_database_host_valid` raises this when the self-hosted Host doesn't resolve via
+            # DNS — a hostname the customer typed wrong or one that's no longer publicly reachable.
+            # Deterministic and permanent until the Host is corrected, so stop retrying. Match the
+            # stable prefix, not the customer's hostname that follows it.
+            "Couldn't resolve the host": "The Plausible host could not be resolved via DNS. Check that it's spelled correctly and reachable from the public internet, then reconnect.",
         }
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/tests/test_plausible_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/plausible/tests/test_plausible_source.py
@@ -68,14 +68,27 @@ class TestSourceConfig:
         assert "401 Client Error" in errors
         assert "403 Client Error" in errors
 
-    def test_bad_request_is_non_retryable(self):
-        # A 400 is a permanent rejection. The import layer classifies an error as non-retryable when
-        # a key is a substring of str(error), so match against the real requests HTTPError message.
+    @pytest.mark.parametrize(
+        "raised,expected_key",
+        [
+            # A 400 is a permanent rejection from Plausible for this site.
+            ("400 Client Error: Bad Request for url: https://plausible.io/api/v2/query", "400 Client Error"),
+            # A self-hosted Host that doesn't resolve via DNS is raised from source_for_pipeline's
+            # host validation; retrying replays the same check, so it must stop.
+            (
+                "Couldn't resolve the host 'stats.example.com'. Check that it's spelled correctly "
+                "and reachable from the public internet.",
+                "Couldn't resolve the host",
+            ),
+        ],
+    )
+    def test_permanent_errors_are_non_retryable(self, raised: str, expected_key: str):
+        # The import layer classifies an error as non-retryable when a key is a substring of
+        # str(error), so match against the real message shape each path produces.
         errors = PlausibleSource().get_non_retryable_errors()
-        raised = "400 Client Error: Bad Request for url: https://plausible.io/api/v2/query"
         matched = [key for key in errors if key in raised]
-        assert matched == ["400 Client Error"]
-        assert errors["400 Client Error"] is not None
+        assert matched == [expected_key]
+        assert errors[expected_key] is not None
 
 
 class TestGetSchemas:


### PR DESCRIPTION
## Problem

A team syncing a self-hosted Plausible instance sees the same import error repeat instead of the sync stopping with a clear reason.

- When the configured Host stops resolving in public DNS, `source_for_pipeline` validates the host and raises `ValueError("Couldn't resolve the host '<host>'. Check that it's spelled correctly and reachable from the public internet.")`.
- This message was absent from `get_non_retryable_errors`, so every retry replayed the identical, deterministic host check, burned the activity's retry budget, and reported the error each attempt.
- Observed in error tracking: [ValueError · Couldn't resolve the host](https://us.posthog.com/project/2/error_tracking/019ffa53-6795-7832-9e5e-b97be172b004).

## Changes

- Classify `"Couldn't resolve the host"` as non-retryable in the Plausible source, with a message pointing the user at the Host field.
- The failure is deterministic and permanent until the user fixes the Host, so retrying can never succeed. This mirrors the Metabase and Custom sources, which already classify the same DNS-resolution error.
- Match the stable prefix, not the customer's hostname that follows it, so no per-team value enters the matcher.
- A transient DNS blip is possible but the dominant cause is a wrong or decommissioned host, and the message itself is user-actionable, so stopping is safer than retrying.

## How did you test this code?

- Parameterized `test_permanent_errors_are_non_retryable` in `test_plausible_source.py` to cover the DNS-failure message alongside the existing 400 case. It catches a regression where removing the key lets an unresolvable host retry forever instead of stopping.
- Ran the Plausible source suite locally: all cases pass.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (actually Claude, via the PostHog error-tracking triage flow) investigated the error-tracking issue, confirmed the stack originates in `plausible/source.py:source_for_pipeline`, and traced the ValueError to the shared host validation in `common/mixins.py`. I judged it a user/upstream config error rather than a bug: the host check is deterministic and the same class Metabase and Custom already treat as non-retryable.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

Decision along the way: scoped to the DNS-resolution message only, rather than also folding in the internal-IP host rejection, to avoid widening retry classification beyond the observed error.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
