### PR TITLE
fix(hogql): scope unknown-table suggestions to the named schema

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -662,6 +662,9 @@ class Database(BaseModel):
         `get_all_table_names()` — the latter verifies each warehouse entry by
         calling `get_table()`, which would recurse back into this helper when
         a warehouse table fails to resolve.
+
+        A qualified name states which namespace the author meant, so candidates
+        outside it are dropped no matter how well the leaf scores.
         """
         import difflib
 
@@ -677,6 +680,10 @@ class Database(BaseModel):
         # catalog without being available on the source we actually queried.
         lowered = name.casefold()
         candidates = {c for c in candidates if c.casefold() != lowered}
+        prefix, dot, _ = name.rpartition(".")
+        if dot:
+            qualifier = f"{prefix.casefold()}."
+            candidates = {c for c in candidates if c.casefold().startswith(qualifier)}
         if not candidates:
             return []
         return difflib.get_close_matches(name, sorted(candidates), n=limit, cutoff=0.7)

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -663,8 +663,10 @@ class Database(BaseModel):
         calling `get_table()`, which would recurse back into this helper when
         a warehouse table fails to resolve.
 
-        A qualified name states which namespace the author meant, so candidates
-        outside it are dropped no matter how well the leaf scores.
+        A qualified name states which schema the author meant, so candidates
+        outside it are dropped no matter how well the leaf scores. When no such
+        schema exists, the schema itself is the likely typo, so the closest
+        known schema is searched instead.
         """
         import difflib
 
@@ -682,8 +684,12 @@ class Database(BaseModel):
         candidates = {c for c in candidates if c.casefold() != lowered}
         prefix, dot, _ = name.rpartition(".")
         if dot:
-            qualifier = f"{prefix.casefold()}."
-            candidates = {c for c in candidates if c.casefold().startswith(qualifier)}
+            schema = prefix.casefold()
+            if not any(c.casefold().startswith(f"{schema}.") for c in candidates):
+                known = sorted({c.rpartition(".")[0].casefold() for c in candidates if "." in c})
+                nearest = difflib.get_close_matches(schema, known, n=1, cutoff=0.8)
+                schema = nearest[0] if nearest else schema
+            candidates = {c for c in candidates if c.casefold().startswith(f"{schema}.")}
         if not candidates:
             return []
         return difflib.get_close_matches(name, sorted(candidates), n=limit, cutoff=0.7)

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -687,7 +687,7 @@ class Database(BaseModel):
             schema = prefix.casefold()
             if not any(c.casefold().startswith(f"{schema}.") for c in candidates):
                 known = sorted({c.rpartition(".")[0].casefold() for c in candidates if "." in c})
-                nearest = difflib.get_close_matches(schema, known, n=1, cutoff=0.8)
+                nearest = difflib.get_close_matches(schema, known, n=1, cutoff=0.89)
                 schema = nearest[0] if nearest else schema
             candidates = {c for c in candidates if c.casefold().startswith(f"{schema}.")}
         if not candidates:

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -247,6 +247,13 @@ class TestUnknownTableSuggestions(TestCase):
                 "public.customer_orders",
                 "Unknown table `public.customer_orders`.",
             ),
+            (
+                "sibling_schema_on_one_connection_is_not_resolved_to_the_other",
+                ["postgres.pg.customer_orders"],
+                [],
+                "postgres.ph3.customer_orders",
+                "Unknown table `postgres.ph3.customer_orders`.",
+            ),
         ]
     )
     def test_suggestions_stay_within_the_namespace_the_author_named(

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -233,6 +233,20 @@ class TestUnknownTableSuggestions(TestCase):
                 "customer_orders",
                 "Unknown table `customer_orders`. Did you mean: warehouse.customer_orders?",
             ),
+            (
+                "misspelled_schema_is_resolved_to_the_closest_one",
+                ["warehouse.customer_orders"],
+                [],
+                "warehous.customer_orders",
+                "Unknown table `warehous.customer_orders`. Did you mean: warehouse.customer_orders?",
+            ),
+            (
+                "unrelated_schema_is_not_resolved_to_any_other",
+                ["warehouse.customer_orders"],
+                ["stg_customer_orders"],
+                "public.customer_orders",
+                "Unknown table `public.customer_orders`.",
+            ),
         ]
     )
     def test_suggestions_stay_within_the_namespace_the_author_named(

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -199,6 +199,60 @@ class TestBuildDatabaseRootNode(TestCase):
                 unpickler.find_class(module, name)
 
 
+def _catalog_node(names: list[str]) -> TableNode:
+    root = TableNode(name="root", children={})
+    for name in names:
+        node = root
+        for part in name.split("."):
+            node = node.children.setdefault(part, TableNode(name=part, children={}))
+        node.table = Table(fields={"id": StringDatabaseField(name="id")})
+    return root
+
+
+class TestUnknownTableSuggestions(TestCase):
+    @parameterized.expand(
+        [
+            (
+                "cross_namespace_candidate_is_not_suggested",
+                [],
+                ["stg_customer_orders"],
+                "warehouse.customer_orders",
+                "Unknown table `warehouse.customer_orders`.",
+            ),
+            (
+                "same_namespace_typo_is_suggested",
+                ["warehouse.customer_order"],
+                [],
+                "warehouse.customer_orders",
+                "Unknown table `warehouse.customer_orders`. Did you mean: warehouse.customer_order?",
+            ),
+            (
+                "unqualified_name_still_reaches_qualified_candidate",
+                ["warehouse.customer_orders"],
+                [],
+                "customer_orders",
+                "Unknown table `customer_orders`. Did you mean: warehouse.customer_orders?",
+            ),
+        ]
+    )
+    def test_suggestions_stay_within_the_namespace_the_author_named(
+        self,
+        _name: str,
+        warehouse_tables: list[str],
+        views: list[str],
+        missing_table: str,
+        expected_message: str,
+    ):
+        database = Database()
+        database._add_warehouse_tables(_catalog_node(warehouse_tables))
+        database._add_views(_catalog_node(views))
+
+        with self.assertRaises(QueryError) as error:
+            database.get_table(missing_table)
+
+        assert str(error.exception) == expected_message
+
+
 class TestDatabase(BaseTest, QueryMatchingTest):
     snapshot: Any
     allow_dual_schema_snapshots = True


### PR DESCRIPTION
## Problem

A query against a missing table gets a "Did you mean" suggestion picked by `difflib` over every table name. The schema prefix is scored as ordinary characters, which distorts the result in both directions.

- A shared substring in the leaf carries an unrelated table over the cutoff. `bigquery.journey_logs` scores 0.74 against the unrelated top-level view `turn_journey_logs`, so a view was suggested to its own body. Following it produces a circular dependency.
- A misspelled schema drags the whole score down. `warehous.customer_orders` scores below the cutoff against every table in `warehouse`, so the author gets no suggestion for a single dropped character.

## Changes

- Suggestions for a qualified name are restricted to tables in that schema. An unqualified name still searches the whole catalog.
- When the named schema holds no tables, it is treated as the typo and the closest known schema is searched instead.
- That fallback requires a 0.89 match, so it accepts a misspelling but not a neighbour. Two schemas on one connection score 0.87 against each other, and hopping between them would reintroduce the bug this PR fixes.

Both changes act on the candidate set. The `difflib` scoring itself is unchanged.

## How did you test this code?

New `TestUnknownTableSuggestions` covers six cases: cross-schema suggestion suppressed, same-schema typo still suggested, unqualified name still reaching a qualified table, misspelled schema resolved, unrelated schema left alone, sibling schema left alone.

Each guard and the cutoff were removed or loosened in turn to confirm the matching case fails without them. At 0.8 the sibling case suggests `postgres.pg.customer_orders` for `postgres.ph3.customer_orders`; at 0.89 it does not.

Local runs against the final commit: `test_database.py`, `test_direct_postgres_query.py` and `test_resolver.py` (433 passed), plus `test_printer.py` and `test_sql_mixins.py`. Those suites hold the existing exact-string assertions, including two on a qualified name.

## 🤖 Agent context

Agent-assisted, human-directed. Prompted by a suggestion seen in production that named the failing view itself.
