### PR TITLE
fix(ui): allow clicks around toast notifications

### DIFF
--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -1388,6 +1388,7 @@
         margin-bottom: 0.5rem !important;
         font-family: var(--font-sans);
         font-size: 1rem;
+        pointer-events: auto;
         cursor: unset;
         border: 1px solid var(--secondary-3000-button-border);
         border-radius: var(--radius);
@@ -1397,6 +1398,7 @@
 
     .Toastify__toast-container {
         padding: 0;
+        pointer-events: none;
     }
 
     .Toastify__toast-body {


### PR DESCRIPTION
## Problem

Empty space inside the toast container can block people from clicking controls beneath it.

Visible toast notifications should still receive clicks and block controls they cover.

## Changes

- Empty toast-container space now ignores pointer events.
- Visible toast notifications remain interactive.
- No visual appearance changes.

## How did you test this code?

- Ran stylelint and Oxfmt on the changed stylesheet.
- Ran 20 headless browser hit tests against the app CSS. Empty space passed clicks through while visible toasts blocked them.
- The full affected Playwright tests could not pass local workspace setup because person ingestion was unavailable.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change is needed because this corrects pointer behavior without changing the interface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex investigated the CI traces and used `/debugging-ci-failures`, `/fixing-flaky-tests`, `/playwright-test`, and `/writing-pr-descriptions`.

The implementation follows the existing toolbar toast pattern. It preserves the visible toast hitbox instead of weakening Playwright clicks.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*