### PR TITLE
fix(playwright): avoid signup email collisions

### DIFF
--- a/playwright/e2e/signup.spec.ts
+++ b/playwright/e2e/signup.spec.ts
@@ -1,3 +1,4 @@
+import { randomString } from '@playwright-utils'
 import type { APIRequestContext, Page } from '@playwright/test'
 
 import { expect, test } from '../utils/workspace-test-base'
@@ -67,7 +68,7 @@ test.describe('Signup', () => {
             await route.continue()
         })
 
-        const email = `new_user-${Math.floor(Math.random() * 10000)}@posthog.com`
+        const email = `${randomString('new_user')}@posthog.com`
         await startSignupFlow(page, email, VALID_PASSWORD)
         await page.locator('[data-attr=signup-name]').fill('Alice Bob')
         await expect(page.locator('[data-attr=signup-name]')).toHaveValue('Alice Bob')
@@ -88,7 +89,7 @@ test.describe('Signup', () => {
 
     test('Can submit the signup form multiple times if there is a generic email set', async ({ page }) => {
         let signupRequestBody: string | null = null
-        const email = `new_user-generic_error_test_${Math.floor(Math.random() * 10000)}@posthog.com`
+        const email = `${randomString('new_user-generic_error_test')}@posthog.com`
 
         await page.route('/api/signup/', async (route) => {
             signupRequestBody = route.request().postData()
@@ -122,7 +123,7 @@ test.describe('Signup', () => {
         await submitEmailAndExpectExistingAccount(page, email)
 
         // Update email to generic email and retry
-        const newEmail = `new_user-${Math.floor(Math.random() * 10000)}@posthog.com`
+        const newEmail = `${randomString('new_user')}@posthog.com`
         await startSignupFlow(page, newEmail, VALID_PASSWORD)
         await page.locator('[data-attr=signup-name]').fill('Alice Bob')
         await expect(page.locator('[data-attr=signup-name]')).toHaveValue('Alice Bob')
@@ -196,7 +197,7 @@ test.describe('Signup', () => {
         // Start signup with next parameter
         await page.goto('/signup?next=/custom_path')
 
-        const email = `new_user-${Math.floor(Math.random() * 10000)}@posthog.com`
+        const email = `${randomString('new_user')}@posthog.com`
         await startSignupFlow(page, email, VALID_PASSWORD)
         await page.locator('[data-attr=signup-name]').fill('Alice Bob')
         await expect(page.locator('[data-attr=signup-name]')).toHaveValue('Alice Bob')


### PR DESCRIPTION
🤖 Robot-authored PR.

## Problem

The signup Playwright flow can fail when its small random email range repeats an account left by an earlier run.

## Changes

- Use the shared Playwright name generator for every new signup email.
- Keep the existing signup behavior and assertions unchanged.

## How did you test this code?

- Oxfmt and CI preflight pass.
- The local signup suite ran against a reused stack whose signup configuration differs from CI.
- The full TypeScript check exceeded this runner memory limit.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update is needed because this only changes test data generation.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used the `/playwright-test`, `/writing-pr-descriptions`, and `/stacking-prs` skills. The change follows the shared helper already used by nearby signup tests.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*