### PR TITLE
fix(logs): cut a 20s query from the services tab and unclip pagination

### DIFF
--- a/products/logs/backend/services_query_runner.py
+++ b/products/logs/backend/services_query_runner.py
@@ -224,24 +224,9 @@ class ServicesQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryRunn
             sparkline_rows = sparkline_response.results
 
         # True distinct-service count, unaffected by SERVICES_LIMIT — the UI
-        # uses it to disclose truncation. An aggregates result under the cap is
-        # already the complete distinct set, so only run the extra count when
-        # the cap was actually hit.
-        if len(aggregates_response.results) < SERVICES_LIMIT:
-            total_services = len(aggregates_response.results)
-        else:
-            total_response = execute_hogql_query(
-                query_type="LogsQuery",
-                query=self._total_services_query(),
-                modifiers=self.modifiers,
-                team=self.team,
-                workload=Workload.LOGS,
-                timings=self.timings,
-                limit_context=self.limit_context,
-                filters=self.query_date_range.to_hogql_filters(),
-                settings=self.settings,
-            )
-            total_services = int(total_response.results[0][0]) if total_response.results else 0
+        # uses it to disclose truncation. The window function counts the groups
+        # before LIMIT applies, so every row carries the same total.
+        total_services = int(aggregates_response.results[0][6]) if aggregates_response.results else 0
 
         enabled_rules = list(
             LogsExclusionRule.objects.filter(team_id=self.team.pk, enabled=True).order_by("priority", "created_at")
@@ -335,14 +320,6 @@ class ServicesQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryRunn
         )
         return ast.And(exprs=[base, search])
 
-    def _total_services_query(self) -> ast.SelectQuery:
-        query = parse_select(
-            "SELECT uniq(service_name) FROM logs WHERE {where}",
-            placeholders={"where": self._where_with_search},
-        )
-        assert isinstance(query, ast.SelectQuery)
-        return query
-
     def _aggregates_query(self) -> ast.SelectQuery:
         query = parse_select(
             """
@@ -352,7 +329,10 @@ class ServicesQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryRunn
                 sumIf(cnt, in(severity_text, tuple('error', 'fatal'))) AS error_count,
                 sumIf(cnt, in(severity_text, tuple('trace', 'debug'))) AS severity_debug,
                 sumIf(cnt, severity_text = 'info') AS severity_info,
-                sumIf(cnt, in(severity_text, tuple('warn', 'warning'))) AS severity_warn
+                sumIf(cnt, in(severity_text, tuple('warn', 'warning'))) AS severity_warn,
+                -- Counts the grouped rows before LIMIT, so the caller learns the
+                -- true service count without a second scan of the window.
+                count() OVER () AS total_services
             FROM (
                 SELECT
                     service_name,

--- a/products/logs/backend/test/test_services_query_runner.py
+++ b/products/logs/backend/test/test_services_query_runner.py
@@ -252,10 +252,18 @@ class TestServicesQueryDateRange(ClickhouseTestMixin, APIBaseTest):
     # whose date subclasses cannot be built while freezegun has datetime.date patched.
     def test_cap_limits_services_but_not_total_count(self):
         with patch.object(services_query_runner, "SERVICES_LIMIT", 5):
-            result = self._services("2025-12-16T00:00:00Z", "2025-12-16T23:59:59Z")
+            with patch.object(
+                services_query_runner,
+                "execute_hogql_query",
+                wraps=services_query_runner.execute_hogql_query,
+            ) as execute_spy:
+                result = self._services("2025-12-16T00:00:00Z", "2025-12-16T23:59:59Z")
 
         self.assertEqual(len(result["services"]), 5)
         self.assertEqual(result["total_services"], 12)
+        # Counting the services with a second, uncapped scan of the window instead
+        # of the aggregates query's window function added 20s on a large project.
+        self.assertEqual(execute_spy.call_count, 2, "expected only the aggregates and sparkline queries")
         # The cap keeps the highest-volume services: every kept fixture service has
         # 97+ rows, so the smallest two (11 and 3 rows) are the ones cut.
         self.assertTrue(all(s["log_count"] >= 97 for s in result["services"]))

--- a/products/logs/frontend/components/LogsServices/LogsServices.tsx
+++ b/products/logs/frontend/components/LogsServices/LogsServices.tsx
@@ -345,29 +345,33 @@ export function LogsServices(): JSX.Element {
                     />
                 </div>
             </div>
-            {/* Pagination and sorting are controlled by the logic (which passes in the
-                pre-sorted page slice) so it knows which rows are visible and can lazy-load
-                their sparklines; the backend only sparklines the top rows per request. */}
-            <LemonTable
-                columns={columns}
-                dataSource={pageRows}
-                loading={servicesDataLoading}
-                sorting={sorting}
-                onSort={(newSorting) => setSorting(newSorting)}
-                useURLForSorting={false}
-                pagination={{
-                    controlled: true,
-                    pageSize: SERVICES_PAGE_SIZE,
-                    currentPage: page,
-                    entryCount: services.length,
-                    onForward: () => setPage(page + 1),
-                    onBackward: () => setPage(page - 1),
-                    useUrl: false,
-                }}
-                emptyState={searchTerm ? 'No services match your search' : 'No services found in this time range'}
-                rowKey="service_name"
-                size="small"
-            />
+            {/* The scene container is a fixed height, so this region scrolls. Without it the
+                table is squeezed and clips its own last rows and the pagination control. */}
+            <div className="flex-1 min-h-0 overflow-y-auto">
+                {/* Pagination and sorting are controlled by the logic (which passes in the
+                    pre-sorted page slice) so it knows which rows are visible and can lazy-load
+                    their sparklines; the backend only sparklines the top rows per request. */}
+                <LemonTable
+                    columns={columns}
+                    dataSource={pageRows}
+                    loading={servicesDataLoading}
+                    sorting={sorting}
+                    onSort={(newSorting) => setSorting(newSorting)}
+                    useURLForSorting={false}
+                    pagination={{
+                        controlled: true,
+                        pageSize: SERVICES_PAGE_SIZE,
+                        currentPage: page,
+                        entryCount: services.length,
+                        onForward: () => setPage(page + 1),
+                        onBackward: () => setPage(page - 1),
+                        useUrl: false,
+                    }}
+                    emptyState={searchTerm ? 'No services match your search' : 'No services found in this time range'}
+                    rowKey="service_name"
+                    size="small"
+                />
+            </div>
         </div>
     )
 }


### PR DESCRIPTION
## Problem

- The logs Services tab takes about 32 seconds to load on a project with many services, and once it loads the pagination control is invisible, so nobody can reach page 2.
- Both arrived with #81761, which added pagination to this tab.

## Changes

- `total_services` now comes from a `count() OVER ()` window function in the aggregates query. The window function counts the groups before `LIMIT` applies, so the count is exact.
- This removes a separate `uniq(service_name)` query. `system.query_log` shows that query read almost exactly what the aggregates query read, so the tab read close to twice the data it needed on every request, to answer with one integer.
- On the environment where the problem was reported, that query measured about 20 seconds, roughly 60% of the load time. The rest is the aggregates and sparkline queries, which this tab always ran.
- The table region scrolls, through `flex-1 min-h-0 overflow-y-auto` (the pattern `FacetRail` already uses). The banners, the search box, and the date selector stay in place above it.
- The scene container is a fixed height and does not scroll. The table was a flex child of it, so the browser squeezed the table to 667px and clipped whatever did not fit, including the pagination control.
- The control was always in the DOM with the correct state. It rendered at y=1187 in a 958px viewport, below the clipped edge, and no ancestor could scroll to it.

## How did you test this code?

- Extended the existing cap test with a query-count assertion. It fails if a second full-window query comes back, which is the regression this PR fixes.
- The existing tests already cover the count itself, and they pass unchanged against the window function.
- Ran all three query shapes against a high-cardinality project and read the results back from `system.query_log`. The window function returns the same count as the separate `uniq` query, reads the same bytes as the plain aggregates query, and costs no measurable time. It holds the grouped rows in memory to count them, which raised peak memory by about 15%.
- Verified the layout fix on the live page: I injected the same wrapper into the running tab and measured the result. The table went from a clipped 667px to its natural 960px, the region became scrollable, and the pagination control moved into view. Page 2 then loaded and lazy-fetched its own sparklines.
- Not done: I did not run the built branch in a local stack. The layout fix is verified by DOM measurement against the shipped code, not by rendering the patched code.

### Follow-up, not in this PR

Each page turn re-requests the whole endpoint but reads only the sparkline. The aggregates query therefore runs again, for rows the client already holds. A `sparklineOnly` request flag would cut that, and it needs an API field, so it belongs in its own change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: Claude Code (Fable 5). Jon reported both symptoms and asked me to reproduce them in the browser.
- Skills invoked: /claude-in-chrome, /writing-tests, /writing-pr-descriptions, /ste-writing.
- I reproduced both symptoms against a running environment through the Chrome extension, then timed the endpoint and each candidate query from the page. The 20-second figure and the DOM measurements come from those runs, not from reading the code.
- The window function replaced a conditional that skipped the extra query when the response was under the cap. That conditional never helped a project large enough to hit the cap, which is exactly where the cost lands.
