### PR TITLE
feat(ingestion): jitter retry backoff by 5% by default

### DIFF
--- a/nodejs/src/common/utils/retries.test.ts
+++ b/nodejs/src/common/utils/retries.test.ts
@@ -1,0 +1,47 @@
+import { DEFAULT_JITTER_FACTOR, retryIfRetriable } from '~/common/utils/retries'
+
+describe('retryIfRetriable jitter', () => {
+    function captureSleeps(): number[] {
+        const sleeps: number[] = []
+        jest.spyOn(global, 'setTimeout').mockImplementation(((fn: () => void, ms?: number) => {
+            sleeps.push(ms ?? 0)
+            fn()
+            return 0 as unknown as NodeJS.Timeout
+        }) as typeof setTimeout)
+        return sleeps
+    }
+
+    function failThenSucceed(failures: number): () => Promise<string> {
+        let attempts = 0
+        return () => {
+            attempts++
+            if (attempts <= failures) {
+                return Promise.reject(Object.assign(new Error('x'), { isRetriable: true }))
+            }
+            return Promise.resolve('ok')
+        }
+    }
+
+    afterEach(() => jest.restoreAllMocks())
+
+    it('jitters each sleep down by up to the default factor', async () => {
+        const sleeps = captureSleeps()
+        jest.spyOn(Math, 'random').mockReturnValue(0) // worst case: the full downward jitter
+        await retryIfRetriable(failThenSucceed(2), 5, 100)
+        // 100 and 200 backoff, each scaled by (1 - DEFAULT_JITTER_FACTOR).
+        expect(sleeps).toEqual([100 * (1 - DEFAULT_JITTER_FACTOR), 200 * (1 - DEFAULT_JITTER_FACTOR)])
+    })
+
+    it('is deterministic when jitter is explicitly disabled', async () => {
+        const sleeps = captureSleeps()
+        await retryIfRetriable(failThenSucceed(2), 5, 100, 0)
+        expect(sleeps).toEqual([100, 200])
+    })
+
+    it('applies a stronger jitter factor when asked', async () => {
+        const sleeps = captureSleeps()
+        jest.spyOn(Math, 'random').mockReturnValue(0)
+        await retryIfRetriable(failThenSucceed(1), 5, 100, 1) // full jitter -> floor is 0
+        expect(sleeps[0]).toBe(0)
+    })
+})

--- a/nodejs/src/common/utils/retries.ts
+++ b/nodejs/src/common/utils/retries.ts
@@ -47,10 +47,21 @@ export function getNextRetryMs(baseMs: number, multiplier: number, attempt: numb
     return baseMs * multiplier ** (attempt - 1)
 }
 
+/** Fraction of each backoff to jitter by default, de-correlating retries across workers. */
+export const DEFAULT_JITTER_FACTOR = 0.05
+
 /**
  * Retry a function, respecting `error.isRetriable`.
+ *
+ * Each sleep is jittered down by up to `jitterFactor` of the backoff so
+ * concurrent callers don't retry in lockstep. Pass `0` to opt out.
  */
-export async function retryIfRetriable<T>(fn: () => Promise<T>, tries = 3, sleepMs = 100): Promise<T> {
+export async function retryIfRetriable<T>(
+    fn: () => Promise<T>,
+    tries = 3,
+    sleepMs = 100,
+    jitterFactor = DEFAULT_JITTER_FACTOR
+): Promise<T> {
     let currentSleepMs = sleepMs
     for (let i = 0; i < tries; i++) {
         try {
@@ -62,7 +73,9 @@ export async function retryIfRetriable<T>(fn: () => Promise<T>, tries = 3, sleep
             }
 
             // Fall through, `fn` will retry after sleep.
-            await sleep(currentSleepMs)
+            const jitteredSleepMs =
+                jitterFactor > 0 ? currentSleepMs * (1 - jitterFactor + Math.random() * jitterFactor) : currentSleepMs
+            await sleep(jitteredSleepMs)
             currentSleepMs = Math.min(
                 currentSleepMs * defaultRetryConfig.BACKOFF_FACTOR,
                 defaultRetryConfig.MAX_INTERVAL

--- a/nodejs/src/ingestion/framework/retry.ts
+++ b/nodejs/src/ingestion/framework/retry.ts
@@ -12,6 +12,8 @@ export interface RetryOptions {
     name?: string
     tries?: number
     sleepMs?: number
+    /** Fraction of each backoff to jitter by. Defaults to `DEFAULT_JITTER_FACTOR`; pass `0` to opt out. */
+    jitter?: number
 }
 
 /**
@@ -41,7 +43,8 @@ export function withStepRetry<T, U, R extends string = never>(
                     return step(value)
                 },
                 options.tries ?? 3,
-                options.sleepMs ?? 100
+                options.sleepMs ?? 100,
+                options.jitter
             )
             pipelineRetryAttemptsHistogram.labels({ name, outcome: 'completed' }).observe(attempts)
             return result
@@ -96,7 +99,8 @@ export function withChunkRetry<T, U, R extends string = never>(
                     return step(values)
                 },
                 options.tries ?? 3,
-                options.sleepMs ?? 100
+                options.sleepMs ?? 100,
+                options.jitter
             )
             pipelineRetryAttemptsHistogram.labels({ name, outcome: 'completed' }).observe(attempts)
             return result


### PR DESCRIPTION
## Problem

Every `retryIfRetriable` caller backs off deterministically (100 → 200 → 400ms…), so workers that fail together retry in lockstep and re-hammer the throttled dependency. This bites hardest on the AI blob-offload S3 path as multimodal capture rolls out fleet-wide.

## Changes

- `retryIfRetriable` jitters each sleep down by up to 5% of its backoff (`DEFAULT_JITTER_FACTOR = 0.05`); pass `jitterFactor: 0` to opt out.
- `RetryOptions.jitter` threads through the pipeline retry wrappers; unset defers to the default, so the `offload_ai_blobs` retry inherits 5% with no per-site change.
- Blast-radius note: the default applies to every `retryIfRetriable` caller (framework step/chunk retries plus both Kafka consumers), not just the offload path. Happy to scope narrower if preferred.

Split out of #81789 following review feedback.

## How did you test this code?

- Jest `retries.test.ts`: default jitter scales sleeps by (1 − 0.05) with `Math.random` mocked; explicit `0` keeps the exact deterministic sequence; `1` gives full jitter.
- `retry.test.ts` framework suite passes unchanged.
- Kafka consumer unit suites pass; the `*.integration.test.ts` failures are broker-connection-only (no Kafka in the sandbox), pre-existing.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None (internal retry behavior). Add the `skip-inkeep-docs` label.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — assignee is the DRI.

Built with PostHog Code (Claude Fable 5). Split from #81789 at review request; originally jitter was opt-in and enabled only on the offload retry, this PR makes a small default apply everywhere instead. No session-private material in the diff or description.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*