### PR TITLE
fix(notebooks): open the code editor on a new SQL or Python cell

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.test.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.test.tsx
@@ -6,6 +6,8 @@ import {
     mergeMarkdownNotebookRegistries,
     omitInsertCommands,
 } from 'lib/components/MarkdownNotebook'
+import { getInsertedComponentPanelVisibility } from 'lib/components/MarkdownNotebook/componentPanels'
+import type { NotebookComponentBlockNode } from 'lib/components/MarkdownNotebook/types'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { FeatureFlagsSet } from 'lib/logic/featureFlagLogic'
 
@@ -78,6 +80,33 @@ describe('markdownNotebookRegistry', () => {
             const flagOff = getMarkdownRegistryForFeatureFlags({})
             expect(flagOff.components.SQLV2.insertCommand).toBeUndefined()
             expect(flagOff.components.PythonV2.insertCommand).toBeUndefined()
+        })
+
+        // An inserted code cell holds no code and no result, so a closed editor panel leaves the
+        // user an empty box. Resolving through getInsertedComponentPanelVisibility rather than
+        // reading the prop keeps this honest if the panel prop is renamed again.
+        it.each([
+            ['SQL', 'component-SQLV2'],
+            ['Python', 'component-PythonV2'],
+        ])('inserts a %s cell with its code editor open', (_label, commandKey) => {
+            const insertedNodes: NotebookComponentBlockNode[] = []
+            const noop = (): void => {}
+            const commands = buildInsertCommands(
+                mergeMarkdownNotebookRegistries(
+                    getMarkdownNotebookDefaultRegistry(),
+                    getMarkdownRegistryForFeatureFlags({ [FEATURE_FLAGS.REVAMPED_PY_NOTEBOOKS]: true })
+                ),
+                (_nodeId, node) => insertedNodes.push(node),
+                noop,
+                noop,
+                noop,
+                noop
+            )
+
+            commands.find((command) => command.key === commandKey)?.run('target-node')
+
+            expect(insertedNodes).toHaveLength(1)
+            expect(getInsertedComponentPanelVisibility(insertedNodes[0]).filters).toBe(true)
         })
     })
 

--- a/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.tsx
@@ -227,6 +227,11 @@ function getMarkdownNodeOptions(tagName: string): CreatePostHogWidgetNodeOptions
     return nodeType ? KNOWN_NODES[nodeType] : null
 }
 
+// A code cell's `filters` panel is its code editor, and the shell leaves that panel closed
+// unless the node carries `showFilters`. A cell the user just inserted holds no code and no
+// result, so without this it renders as an empty box with nothing to type into.
+const CODE_CELL_EDITOR_OPEN_PROPS: NotebookComponentProps = { showFilters: true }
+
 export const MARKDOWN_NODE_DEFINITIONS: {
     tagName: string
     category: string
@@ -251,7 +256,11 @@ export const MARKDOWN_NODE_DEFINITIONS: {
         label: 'Python',
         insertCommand: {
             aliases: ['python', 'py'],
-            defaultProps: () => ({ ...getDefaultPropsForNodeType(NotebookNodeType.PythonV2), nodeId: uuid() }),
+            defaultProps: () => ({
+                ...getDefaultPropsForNodeType(NotebookNodeType.PythonV2),
+                ...CODE_CELL_EDITOR_OPEN_PROPS,
+                nodeId: uuid(),
+            }),
         },
     },
     { tagName: 'DuckSQL', category: 'SQL', label: 'SQL (DuckDB)' },
@@ -273,7 +282,11 @@ export const MARKDOWN_NODE_DEFINITIONS: {
             // New cells get a durable nodeId up front: parsed markdown block ids are content
             // fingerprints, so without a persisted id every prop change (running the cell
             // writes runId/result) would orphan the cell's run history and cross-cell refs.
-            defaultProps: () => ({ ...getDefaultPropsForNodeType(NotebookNodeType.SQLV2), nodeId: uuid() }),
+            defaultProps: () => ({
+                ...getDefaultPropsForNodeType(NotebookNodeType.SQLV2),
+                ...CODE_CELL_EDITOR_OPEN_PROPS,
+                nodeId: uuid(),
+            }),
         },
     },
     { tagName: 'RecordingPlaylist', category: 'Data', label: 'Session recordings' },


### PR DESCRIPTION
## Problem

A person who inserts a SQL or Python cell in a markdown notebook gets an empty box with nothing to type into.

- The cell's code editor lives in the shell's `filters` panel, which stays closed unless the node carries `showFilters`.
- A new cell holds no code and no result, so both of its panels render blank.
- #81036 flipped the shell's insert default for that panel from open to closed, and took the code cells with it.

## Changes

- The `SQLV2` and `PythonV2` insert commands now set `showFilters` on the node they create.
- The pencil toggle, the persisted prop, and every other node type keep their current behavior.
- I set the prop on the insert command instead of defaulting the panel per node definition.
- `getInsertedComponentPanelVisibility` also runs on a reconciliation effect that treats a swapped document's nodes as freshly inserted.
- A definition-level default would therefore open every code cell in an existing notebook and rewrite the document.
- No screenshot: I could not run the app, see below.

## How did you test this code?

- I added two parameterized cases to `markdownNotebookRegistry.test.tsx`. They run the real insert command and assert the new node resolves to an open editor panel.
- The cases resolve through `getInsertedComponentPanelVisibility` rather than reading the prop, so a second rename of the panel prop fails them too.
- I confirmed both cases fail without the fix, and pass with it.
- Not run: the app. This worktree has no Python environment, so I did not open a notebook or take a screenshot.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. `COMPONENTS.md` already documents `showFilters` as the opt-in for the filters panel, which this change uses rather than changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- I (actually Claude Opus 5, in Claude Code) traced the behavior and wrote the fix. Sinan directed the work.
- Skills invoked: `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.
- The first candidate fix added an `insertWithFiltersOpen` flag to `NotebookComponentDefinition`. I dropped it once I found the reconciliation effect named under Changes.
