### PR TITLE
fix(desktop): suppress task comment mention emails

### DIFF
--- a/posthog/api/comments.py
+++ b/posthog/api/comments.py
@@ -31,6 +31,7 @@ from posthog.models.comment import Comment, CommentSlackThread
 from posthog.models.comment.comment import TICKET_COMMENT_SCOPES, activity_log_scope_for
 from posthog.models.comment.slack_thread import DISCUSSIONS_SLACK_SYNC_FLAG
 from posthog.models.comment.utils import (
+    DESKTOP_COMMENT_SCOPES,
     build_comment_item_url,
     comment_scope_display_name,
     produce_discussion_mention_events,
@@ -123,11 +124,7 @@ class CommentSlackThreadRefSerializer(serializers.Serializer):
 
 
 def _capture_task_comment_action(comment: Comment, mentions: list[int], team: Team) -> None:
-    if (
-        comment.scope not in {"task", "task_artifact", "desktop_canvas"}
-        or not comment.created_by
-        or not comment.created_by.distinct_id
-    ):
+    if comment.scope not in DESKTOP_COMMENT_SCOPES or not comment.created_by or not comment.created_by.distinct_id:
         return
 
     context = comment.item_context if isinstance(comment.item_context, dict) else {}
@@ -184,7 +181,7 @@ def _record_task_comment_activity(
     activity_at: datetime | None = None,
     include_relationship_recipients: bool = True,
 ) -> None:
-    if comment.scope not in {"task", "task_artifact", "desktop_canvas"}:
+    if comment.scope not in DESKTOP_COMMENT_SCOPES:
         return
 
     owner_id = None
@@ -228,7 +225,7 @@ def _record_task_comment_activity(
 def _mentions_allowed_for_comment_target(
     *, team_id: int, scope: str, item_id: str | None, item_context: dict | None
 ) -> bool:
-    if scope not in {"task", "task_artifact", "desktop_canvas"}:
+    if scope not in DESKTOP_COMMENT_SCOPES:
         return True
     task_id = item_id if scope == "task" else (item_context or {}).get("taskId")
     if not task_id:
@@ -484,7 +481,8 @@ class CommentSerializer(serializers.ModelSerializer):
         comment = super().create(validated_data)
 
         if mentions:
-            send_discussions_mentioned.delay(comment.id, mentions, slug)
+            if comment.scope not in DESKTOP_COMMENT_SCOPES:
+                send_discussions_mentioned.delay(comment.id, mentions, slug)
             produce_discussion_mention_events(comment, mentions, slug)
             send_mention_notifications(comment, mentions, slug)
         _record_task_comment_activity(comment, mentions)
@@ -524,7 +522,8 @@ class CommentSerializer(serializers.ModelSerializer):
                 updated_instance = super().update(locked_instance, validated_data)
 
         if mentions:
-            send_discussions_mentioned.delay(updated_instance.id, mentions, slug)
+            if updated_instance.scope not in DESKTOP_COMMENT_SCOPES:
+                send_discussions_mentioned.delay(updated_instance.id, mentions, slug)
             produce_discussion_mention_events(updated_instance, mentions, slug)
             send_mention_notifications(updated_instance, mentions, slug)
             _record_task_comment_activity(

--- a/posthog/api/test/test_comments.py
+++ b/posthog/api/test/test_comments.py
@@ -97,6 +97,37 @@ class TestComments(APIBaseTest, QueryMatchingTest):
         )
         assert [row["id"] for row in with_task.json()["results"]] == [created.json()["id"]]
 
+    @mock.patch("posthog.api.comments.send_mention_notifications")
+    @mock.patch("posthog.api.comments.produce_discussion_mention_events")
+    @mock.patch("posthog.tasks.email.send_discussions_mentioned.delay")
+    def test_desktop_comment_mentions_do_not_enqueue_email(
+        self,
+        send_email: mock.Mock,
+        produce_events: mock.Mock,
+        send_notifications: mock.Mock,
+    ) -> None:
+        task = self._task_artifact_target()
+        mentioned = User.objects.create_and_join(self.organization, "desktop-mentioned@example.com", None)
+        payload = {
+            "content": "Review this",
+            "scope": "task_artifact",
+            "item_id": "artifact-1",
+            "item_context": {"anchor": {"kind": "document"}, "taskId": str(task.id)},
+            "mentions": [mentioned.id],
+        }
+
+        created = self.client.post(f"/api/projects/{self.team.id}/comments", payload)
+        updated = self.client.patch(
+            f"/api/projects/{self.team.id}/comments/{created.json()['id']}",
+            {"content": "Review this update", "mentions": [mentioned.id]},
+        )
+
+        assert created.status_code == status.HTTP_201_CREATED
+        assert updated.status_code == status.HTTP_200_OK
+        send_email.assert_not_called()
+        assert produce_events.call_count == 2
+        assert send_notifications.call_count == 2
+
     @mock.patch("posthog.api.comments.posthoganalytics.capture")
     def test_task_comment_actions_track_mentions_without_counting_state_as_replies(self, capture: mock.Mock) -> None:
         task = self._task_artifact_target()

--- a/posthog/models/comment/utils.py
+++ b/posthog/models/comment/utils.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
 
 logger = structlog.get_logger(__name__)
 
+DESKTOP_COMMENT_SCOPES = frozenset({"task", "task_artifact", "desktop_canvas"})
+
 SCOPE_TO_SOURCE_TYPE: dict[str, str] = {
     "Replay": "replay",
     "Notebook": "notebook",

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -34,7 +34,7 @@ from posthog.models import (
 )
 from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.comment import Comment
-from posthog.models.comment.utils import build_comment_item_url
+from posthog.models.comment.utils import DESKTOP_COMMENT_SCOPES, build_comment_item_url
 from posthog.models.messaging import MessagingRecord, get_email_hashes
 from posthog.models.scoping import with_team_scope
 from posthog.models.utils import UUIDT
@@ -1498,6 +1498,9 @@ def send_discussions_mentioned(comment_id: str, mentioned_user_ids: list[int], s
         tag("task", "send_discussions_mentioned")
 
         comment = Comment.objects.select_related("created_by", "team").get(id=comment_id)
+
+        if comment.scope in DESKTOP_COMMENT_SCOPES:
+            return
 
         if not is_email_available(with_absolute_urls=True):
             logger.warning("Skipping discussions mentioned email: email service not available")

--- a/posthog/tasks/test/test_email.py
+++ b/posthog/tasks/test/test_email.py
@@ -13,7 +13,7 @@ from parameterized import parameterized
 
 from posthog.api.authentication import password_reset_token_generator
 from posthog.api.email_verification import email_verification_token_generator
-from posthog.models import Organization, Team, User
+from posthog.models import Comment, Organization, Team, User
 from posthog.models.app_metrics2.sql import TRUNCATE_APP_METRICS2_TABLE_SQL
 from posthog.models.instance_setting import set_instance_setting
 from posthog.models.messaging import MessagingRecord, get_email_hashes
@@ -2059,6 +2059,28 @@ class TestEmail(APIBaseTest, ClickhouseTestMixin):
 
         # Verify the href falls back to base URL with discussion panel
         assert mocked_email_messages[0].properties["href"] == f"{settings.SITE_URL}#panel=discussion"
+
+    @parameterized.expand(["task", "task_artifact", "desktop_canvas"])
+    def test_send_discussions_mentioned_skips_desktop_comments(self, MockEmailMessage: MagicMock, scope: str) -> None:
+        mocked_email_messages = mock_email_messages(MockEmailMessage)
+        mentioned_user = User.objects.create_and_join(
+            organization=self.organization, email=f"mentioned-{scope}@posthog.com", password=None
+        )
+        comment = Comment.objects.create(
+            team=self.team,
+            content="Desktop comment",
+            scope=scope,
+            item_id="desktop-item",
+            created_by=self.user,
+        )
+
+        send_discussions_mentioned(
+            comment_id=str(comment.id),
+            mentioned_user_ids=[mentioned_user.id],
+            slug="",
+        )
+
+        assert mocked_email_messages == []
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

People mentioned in desktop task comments receive discussion emails whose links open an unsupported web discussion panel.

**Why:** Desktop task comments already appear in Activity, so the generic discussion email is redundant and cannot navigate to the desktop comment.

## Changes

- Stop enqueueing mention emails for task, artifact, and desktop canvas comment scopes.
- Reject previously queued desktop comment emails in the worker.
- Preserve Activity notifications and mention analytics.
- Use server-trusted comment scopes instead of a client-controlled suppression flag.

## How did you test this code?

- Added API coverage for create and edit mentions, guarding against email enqueue while preserving other notifications.
- Added worker coverage for all three desktop comment scopes.
- Ran existing Replay, Notebook, slug, and fallback email-link tests to guard regular discussions.
- Ran repo-wide mypy and strict CI preflight.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation update is needed because this removes an unintended notification side effect.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and verified the change. Skills used: `posthog-desktop`, `writing-tests`, `running-ci-preflight`, and `writing-pr-descriptions`.

The implementation moved from relying only on API suppression to defense-in-depth worker suppression for queued jobs.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*