### PR TITLE
fix(desktop): align comments empty state

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/TaskCommentsList.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskCommentsList.tsx
@@ -697,7 +697,7 @@ export function TaskCommentsList({
             <Spinner />
           </div>
         ) : visibleThreads.length === 0 ? (
-          <Empty className="py-8">
+          <Empty className="h-full border-0">
             <EmptyHeader>
               <EmptyMedia variant="icon">
                 <ChatCircleIcon />


### PR DESCRIPTION
## Problem

The comments tab shows its empty state inside a centered border, unlike the adjacent artifacts tab.

**Why:** Matching these related views keeps the activity panel consistent and removes unnecessary visual weight.

## Changes

- Make the comments empty state full-height and borderless.
- Keep the Phosphor chat icon and comments-specific guidance.

| Before | After |
| --- | --- |
| ![Comments empty state with a centered border](https://raw.githubusercontent.com/PostHog/pr-assets/e6134d670424f783e9b58deb8ad4b64645df6f6d/2026/08/1b0dc66b-3fa2-444e-9ac4-85cf843f59c8.png) | ![Borderless comments empty state](https://raw.githubusercontent.com/PostHog/pr-assets/e300fedb4447b1c06e70ac569be6562d9f1e8a31/2026/08/802dac96-ae25-4716-aaf2-245a8fb618d6.png) |

## How did you test this code?

- Ran the UI test suite.
- Ran the UI TypeScript check.
- Ran Biome on the changed file.
- Rendered the empty state with the production Quill styles.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex made this targeted change using the posthog-desktop, writing-user-facing-copy, and writing-pr-descriptions skills.

No session-only customer or operational data appears in the change.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*