### PR TITLE
chore(ci): retry the trunk quarantine gate once

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -29,7 +29,9 @@
 #   TRUNK_UPLOAD_ENABLED repo variable as an upload kill-switch, and its verdict step
 #   on TRUNK_QUARANTINE_ENABLED to decide whether known flakes are masked; since the
 #   shadow strips both the gate and the verdict step entirely, both variables are
-#   no-ops here and there is nothing to mirror)
+#   no-ops here and there is nothing to mirror. Canonical's turbo-tests gate now calls
+#   ./.github/actions/trunk-quarantine-gate, which retries the upload once; the shadow
+#   has no gate to call it from, so there is no ./.depot/actions mirror of it either)
 # - Per-test failure rollup: canonical's django_tests gate uploads product JUnit and, when a
 #   test job fails, downloads that shard's JUnit to list the actual failing tests. The shadow
 #   strips artifact uploads (above), so it has nothing to download and keeps the plain

--- a/.github/actions/trunk-quarantine-gate/action.yml
+++ b/.github/actions/trunk-quarantine-gate/action.yml
@@ -1,0 +1,66 @@
+name: 'Trunk quarantine gate'
+description: 'Upload a shard JUnit report to Trunk, masking known flakes, retrying once on a transient upload failure'
+
+inputs:
+    junit-paths:
+        description: 'Comma-separated glob paths to the JUnit files this shard wrote'
+        required: true
+    previous-step-outcome:
+        description: 'steps.<test step>.outcome, so Trunk can tell a failed shard from a passing one'
+        required: true
+    token:
+        description: 'Trunk API token'
+        required: true
+    variant:
+        description: 'Trunk variant, for suites whose shards upload under one name'
+        required: false
+        default: ''
+
+runs:
+    using: 'composite'
+    steps:
+        - name: Upload to Trunk
+          id: upload
+          continue-on-error: true
+          uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+          with:
+              junit-paths: ${{ inputs.junit-paths }}
+              org-slug: posthog-inc
+              variant: ${{ inputs.variant }}
+              # Pinned rather than 'latest', which costs an extra github.com request to follow the release redirect.
+              cli-version: '0.13.7'
+              quarantine: true
+              previous-step-outcome: ${{ inputs.previous-step-outcome }}
+              token: ${{ inputs.token }}
+
+        # Randomized because a github.com release-asset rate limit or a Trunk outage fails every
+        # shard at once, and a fixed delay would retry them all in the same instant too.
+        - name: Back off before retrying
+          if: ${{ steps.upload.outcome == 'failure' && inputs.previous-step-outcome == 'success' }}
+          shell: bash
+          run: sleep $((15 + RANDOM % 46))
+
+        # Only a shard whose tests passed: the uploader exits non-zero by design when the report has
+        # failures it could not quarantine, and re-uploading those would double-count them in the
+        # flake statistics that decide what gets quarantined.
+        - name: Upload to Trunk (retry)
+          id: upload-retry
+          if: ${{ steps.upload.outcome == 'failure' && inputs.previous-step-outcome == 'success' }}
+          continue-on-error: true
+          uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+          with:
+              junit-paths: ${{ inputs.junit-paths }}
+              org-slug: posthog-inc
+              variant: ${{ inputs.variant }}
+              cli-version: '0.13.7'
+              quarantine: true
+              previous-step-outcome: ${{ inputs.previous-step-outcome }}
+              token: ${{ inputs.token }}
+
+        # Re-raise, so this action's own outcome still means what a bare uploader step meant and
+        # callers can keep gating their verdict on `steps.<gate>.outcome == 'success'`. Without it
+        # the swallowed attempts above would report success and mask every real failure.
+        - name: Fail if no attempt cleared the shard
+          if: ${{ steps.upload.outcome != 'success' && steps.upload-retry.outcome != 'success' }}
+          shell: bash
+          run: exit 1

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1037,7 +1037,7 @@ jobs:
 
             # Best-effort Trunk upload (continue-on-error); the "Fail on test failure" step below is
             # the verdict, so a Trunk outage can't red a passing shard. Internal PRs only (needs the
-            # secret); cli-version pinned, not 'latest' (skips the release redirect).
+            # secret).
             # TRUNK_UPLOAD_ENABLED is the master kill-switch: when it is not 'true' this gate
             # skips, so nothing uploads and no known flakes are quarantined. TRUNK_QUARANTINE_ENABLED
             # splits the two — it defaults off, so set it to 'true' to let the verdict step below mask
@@ -1046,12 +1046,9 @@ jobs:
               id: quarantine_gate
               continue-on-error: true
               if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' && vars.TRUNK_UPLOAD_ENABLED == 'true' }}
-              uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+              uses: ./.github/actions/trunk-quarantine-gate
               with:
                   junit-paths: products/*/junit-product.xml
-                  org-slug: posthog-inc
-                  cli-version: '0.13.7'
-                  quarantine: true
                   previous-step-outcome: ${{ steps.run-product-tests.outcome }}
                   token: ${{ secrets.TRUNK_API_TOKEN }}
 
@@ -3275,6 +3272,9 @@ jobs:
             # skips, so nothing uploads and no known flakes are quarantined. TRUNK_QUARANTINE_ENABLED
             # splits the two — it defaults off, so set it to 'true' to let the verdict step below mask
             # known flakes; otherwise any real failure reds the job (quarantining needs upload on too).
+            # Inlined rather than ./.github/actions/trunk-quarantine-gate, and so without its retry:
+            # this job checks out the PR head ref, which cannot resolve a local action that only
+            # exists on master until the branch rebases.
             - name: Quarantine gate (Core)
               id: quarantine_gate_core
               continue-on-error: true

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -1038,6 +1038,9 @@ jobs:
             # skips, so nothing uploads and no known flakes are quarantined. TRUNK_QUARANTINE_ENABLED
             # splits the two — it defaults off, so set it to 'true' to let the verdict step below mask
             # known flakes; otherwise any real failure reds the job (quarantining needs upload on too).
+            # Inlined rather than ./.github/actions/trunk-quarantine-gate, and so without its retry:
+            # this job checks out the PR head ref, which cannot resolve a local action that only
+            # exists on master until the branch rebases.
             - name: Quarantine gate
               id: quarantine_gate
               continue-on-error: true

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -804,8 +804,7 @@ jobs:
 
             # Best-effort Trunk upload (continue-on-error); the "Fail on jest failure" step below is
             # the verdict, so a Trunk outage can't red a passing shard. FOSS and EE share test files,
-            # so each segment uploads under its own variant. Internal PRs only (needs the secret);
-            # cli-version pinned, not 'latest' (skips the release redirect).
+            # so each segment uploads under its own variant. Internal PRs only (needs the secret).
             # TRUNK_UPLOAD_ENABLED is the master kill-switch: when it is not 'true' this gate
             # skips, so nothing uploads and no known flakes are quarantined. TRUNK_QUARANTINE_ENABLED
             # splits the two — it defaults off, so set it to 'true' to let the verdict step below mask
@@ -814,13 +813,10 @@ jobs:
               id: quarantine_gate
               continue-on-error: true
               if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' && vars.TRUNK_UPLOAD_ENABLED == 'true' }}
-              uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+              uses: ./.github/actions/trunk-quarantine-gate
               with:
                   junit-paths: junit-results/junit-${{ matrix.segment }}-${{ matrix.chunk }}.xml
-                  org-slug: posthog-inc
                   variant: ${{ matrix.segment }}
-                  cli-version: '0.13.7'
-                  quarantine: true
                   previous-step-outcome: ${{ steps.run-jest.outcome }}
                   token: ${{ secrets.TRUNK_API_TOKEN }}
             # Verdict: red a real failure the gate didn't clear as a quarantined flake. != 'success'
@@ -879,7 +875,7 @@ jobs:
                   retention-days: 1
 
             # Best-effort Trunk upload (continue-on-error); the "Fail on jest failure" step below is
-            # the verdict. See the jest job for the full rationale. cli-version pinned, not 'latest'.
+            # the verdict. See the jest job for the full rationale.
             # TRUNK_UPLOAD_ENABLED is the master kill-switch: when it is not 'true' this gate
             # skips, so nothing uploads and no known flakes are quarantined. TRUNK_QUARANTINE_ENABLED
             # splits the two — it defaults off, so set it to 'true' to let the verdict step below mask
@@ -888,13 +884,10 @@ jobs:
               id: quarantine_gate
               continue-on-error: true
               if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' && vars.TRUNK_UPLOAD_ENABLED == 'true' }}
-              uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+              uses: ./.github/actions/trunk-quarantine-gate
               with:
                   junit-paths: junit-results/junit-replay-shared.xml
-                  org-slug: posthog-inc
                   variant: replay-shared
-                  cli-version: '0.13.7'
-                  quarantine: true
                   previous-step-outcome: ${{ steps.run-jest.outcome }}
                   token: ${{ secrets.TRUNK_API_TOKEN }}
             - name: Fail on jest failure

--- a/.github/workflows/ci-llm-gateway.yml
+++ b/.github/workflows/ci-llm-gateway.yml
@@ -102,7 +102,7 @@ jobs:
 
             # Best-effort Trunk upload (continue-on-error); the "Fail on test failure" step below is
             # the verdict, so a Trunk outage can't red a passing job. Internal PRs only (needs the
-            # secret); cli-version pinned, not 'latest' (skips the release redirect).
+            # secret).
             # TRUNK_UPLOAD_ENABLED is the master kill-switch: when it is not 'true' this gate
             # skips, so nothing uploads and no known flakes are quarantined. TRUNK_QUARANTINE_ENABLED
             # splits the two — it defaults off, so set it to 'true' to let the verdict step below mask
@@ -111,12 +111,9 @@ jobs:
               id: quarantine_gate
               continue-on-error: true
               if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' && vars.TRUNK_UPLOAD_ENABLED == 'true' }}
-              uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+              uses: ./.github/actions/trunk-quarantine-gate
               with:
                   junit-paths: services/llm-gateway/junit.xml
-                  org-slug: posthog-inc
-                  cli-version: '0.13.7'
-                  quarantine: true
                   previous-step-outcome: ${{ steps.run-tests.outcome }}
                   token: ${{ secrets.TRUNK_API_TOKEN }}
 

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -671,7 +671,7 @@ jobs:
 
             # Best-effort Trunk upload (continue-on-error); the "Fail on test failure" step below is
             # the verdict, so a Trunk outage can't red a passing job. Internal PRs only (needs the
-            # secret); cli-version pinned, not 'latest' (skips the release redirect).
+            # secret).
             # TRUNK_UPLOAD_ENABLED is the master kill-switch: when it is not 'true' this gate
             # skips, so nothing uploads and no known flakes are quarantined. TRUNK_QUARANTINE_ENABLED
             # splits the two — it defaults off, so set it to 'true' to let the verdict step below mask
@@ -680,12 +680,9 @@ jobs:
               id: quarantine_gate
               continue-on-error: true
               if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' && vars.TRUNK_UPLOAD_ENABLED == 'true' }}
-              uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+              uses: ./.github/actions/trunk-quarantine-gate
               with:
                   junit-paths: services/mcp/junit-integration.xml
-                  org-slug: posthog-inc
-                  cli-version: '0.13.7'
-                  quarantine: true
                   previous-step-outcome: ${{ steps.run-integration-tests.outcome }}
                   token: ${{ secrets.TRUNK_API_TOKEN }}
 

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -506,7 +506,7 @@ jobs:
 
             # Best-effort Trunk upload (continue-on-error); the "Fail on test failure" step below is
             # the verdict, so a Trunk outage can't red a passing shard. Internal PRs only (needs the
-            # secret); cli-version pinned, not 'latest' (skips the release redirect).
+            # secret).
             # TRUNK_UPLOAD_ENABLED is the master kill-switch: when it is not 'true' this gate
             # skips, so nothing uploads and no known flakes are quarantined. TRUNK_QUARANTINE_ENABLED
             # splits the two — it defaults off, so set it to 'true' to let the verdict step below mask
@@ -515,12 +515,9 @@ jobs:
               id: quarantine_gate
               continue-on-error: true
               if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' && vars.TRUNK_UPLOAD_ENABLED == 'true' }}
-              uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+              uses: ./.github/actions/trunk-quarantine-gate
               with:
                   junit-paths: junit-results/junit-*.xml
-                  org-slug: posthog-inc
-                  cli-version: '0.13.7'
-                  quarantine: true
                   # Worst of the two test steps: the gate must know the run failed even when
                   # only the parity step (shard 1) did. A skipped parity step counts as success.
                   previous-step-outcome: ${{ (steps.run-jest.outcome == 'failure' || steps.run-parity.outcome == 'failure') && 'failure' || 'success' }}

--- a/.github/workflows/desktop-test.yml
+++ b/.github/workflows/desktop-test.yml
@@ -138,7 +138,7 @@ jobs:
 
             # Best-effort Trunk upload (continue-on-error); the "Fail on test failure" step below is
             # the verdict, so a Trunk outage can't red a passing job. Internal PRs only (needs the
-            # secret); cli-version pinned, not 'latest' (skips the release redirect).
+            # secret).
             # TRUNK_UPLOAD_ENABLED is the master kill-switch: when it is not 'true' this gate
             # skips, so nothing uploads and no known flakes are quarantined. TRUNK_QUARANTINE_ENABLED
             # splits the two — it defaults off, so set it to 'true' to let the verdict step below mask
@@ -147,15 +147,12 @@ jobs:
               id: quarantine_gate
               continue-on-error: true
               if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' && vars.TRUNK_UPLOAD_ENABLED == 'true' }}
-              uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+              uses: ./.github/actions/trunk-quarantine-gate
               with:
                   # Scope to each package root. A bare **/junit.xml glob descends into
                   # node_modules, where pnpm symlinks workspace packages, and uploads
                   # every report many times over.
                   junit-paths: 'products/desktop/apps/*/junit.xml,products/desktop/packages/*/junit.xml'
-                  org-slug: posthog-inc
-                  cli-version: '0.13.7'
-                  quarantine: true
                   previous-step-outcome: ${{ steps.run-tests.outcome }}
                   token: ${{ secrets.TRUNK_API_TOKEN }}
 
@@ -254,7 +251,7 @@ jobs:
 
             # Best-effort Trunk upload (continue-on-error); the "Fail on E2E failure" step below is
             # the verdict, so a Trunk outage can't red a passing job. Internal PRs only (needs the
-            # secret); cli-version pinned, not 'latest' (skips the release redirect).
+            # secret).
             # TRUNK_UPLOAD_ENABLED is the master kill-switch: when it is not 'true' this gate
             # skips, so nothing uploads and no known flakes are quarantined. TRUNK_QUARANTINE_ENABLED
             # splits the two — it defaults off, so set it to 'true' to let the verdict step below mask
@@ -263,12 +260,9 @@ jobs:
               id: quarantine_gate
               continue-on-error: true
               if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' && vars.TRUNK_UPLOAD_ENABLED == 'true' }}
-              uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+              uses: ./.github/actions/trunk-quarantine-gate
               with:
                   junit-paths: 'products/desktop/apps/code/tests/e2e/junit.xml'
-                  org-slug: posthog-inc
-                  cli-version: '0.13.7'
-                  quarantine: true
                   previous-step-outcome: ${{ steps.run-e2e.outcome }}
                   token: ${{ secrets.TRUNK_API_TOKEN }}
 
@@ -297,12 +291,9 @@ jobs:
               id: quarantine_gate_web
               continue-on-error: true
               if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' && vars.TRUNK_UPLOAD_ENABLED == 'true' }}
-              uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
+              uses: ./.github/actions/trunk-quarantine-gate
               with:
                   junit-paths: 'products/desktop/apps/web/tests/e2e/junit.xml'
-                  org-slug: posthog-inc
-                  cli-version: '0.13.7'
-                  quarantine: true
                   previous-step-outcome: ${{ steps.run-web-e2e.outcome }}
                   token: ${{ secrets.TRUNK_API_TOKEN }}
 


### PR DESCRIPTION
## Problem

- A failed Trunk upload takes that shard's test results with it, so flake detection loses the data that decides what gets quarantined.
- The gate makes one attempt today.
- The uploader fetches its CLI from github.com release assets unauthenticated, against a per-source-IP limit the whole CI fleet shares. A 429 or a 5xx there fails every shard at once.
- [Decoupling the verdict from the upload](https://github.com/PostHog/posthog/pull/69805) made that harmless to the verdict. The lost data is what remains.

## Changes

- Adds `.github/actions/trunk-quarantine-gate`, which retries the upload once after a randomized 15 to 60 second wait.
- The wait is randomized because a shared rate limit fails all shards together, and a fixed delay would retry them together too.
- The retry runs only for a shard whose tests passed. The uploader exits non-zero by design on failures it could not quarantine, and re-uploading those would double-count them in the flake statistics.
- That guard also means the retry cannot change any verdict, since a verdict only fires when the test step failed. This buys data completeness, not correctness.
- The action re-raises when no attempt cleared the shard. All 12 verdict expressions stay byte-identical to master.

| Gate | State |
| --- | --- |
| turbo-tests, jest, jest-replay-shared, mcp, nodejs, llm-gateway, desktop unit, desktop e2e, desktop web e2e | On the new action, retries once |
| django Core, django Temporal, playwright | Unchanged, no retry |

> [!NOTE]
> Those three jobs check out the PR head ref, so a local action that only exists on master cannot resolve until the branch rebases. `ci-backend.yml` already inlines `setup-python-cached` for the same reason. They can move once this action reaches every open branch.

### Rejected alternatives

- `Wandalen/wretry.action` is the usual way to retry a `uses:` step. Its `attempt_delay` is fixed, so every shard would retry in the same instant against the same limit.
- It also cannot condition the retry on the test step outcome, so it would re-upload real failures.
- Its last release is January 2025, past the staleness bar in AGENTS.md.
- The uploader's own `use-cache` input would remove the download instead of repeating it.
- One flag controls both restore and save, so on a PR ref it writes a per-branch cache entry nobody else can read. `WF006-cache-writes` forbids that.

## How did you test this code?

I (actually Claude) ran, in this worktree:

- `bin/hogli lint:workflows`, 8 checks over 126 workflows.
- `actionlint` on the 7 changed workflows, diffed against the same command on master. Byte-identical, so no new diagnostics.
- A script asserting each of the 12 gates keeps its `id`, `if`, and inputs, and that the 3 inline gates are byte-identical to master.
- A script asserting every job that references the new action takes a default merge-ref checkout.

Not checked: the retry path itself. It needs a live upload failure, which I cannot produce locally.

No tests added. Nothing in this repo executes workflow YAML, so a test could only assert the shape of `action.yml`, which is a change detector that never exercises the runner's expression evaluation. The fail-open risk it would guard is instead named in a comment on the re-raise step.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5). Skills invoked: `/authoring-ci-workflows`, `/writing-code-comments`, `/writing-tests`, `/code-review`, `/writing-pr-descriptions`.

Two designs were rejected during the session.

The first extracted the gate into a composite that exposed an `outcome` output, which required rewriting all 12 verdict expressions to read `outputs.outcome`. Correct, but it left a trap: the composite swallows a failed attempt, so anyone reverting to `.outcome` would make the gate fail open and mask every real failure. Re-raising inside the action removes both the rewrite and the trap.

The second put all 12 gates on the composite. A review pass caught that three of them sit in jobs checking out the PR head ref, which would have silently disabled quarantine masking on the django and playwright suites for every unrebased PR.

Separately: `cli-version` is pinned at `0.13.7` while trunk-analytics-cli is at `0.15.2`. Bumping it changes quarantining behavior, so it belongs in its own PR.
