### PR TITLE
fix(error-tracking): keep replay range valid while issue loads

### DIFF
--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
@@ -68,7 +68,8 @@ export const scene: SceneExport<ErrorTrackingIssueSceneLogicProps> = {
 }
 
 export function ErrorTrackingIssueScene(): JSX.Element {
-    const { issue, issueId, lastSeen, mobileDetailOpen } = useValues(errorTrackingIssueSceneLogic)
+    const { issue, issueId, lastSeen, initialEventTimestamp, mobileDetailOpen } =
+        useValues(errorTrackingIssueSceneLogic)
     const { updateAssignee, updateStatus, updateName, setMobileDetailOpen } = useActions(errorTrackingIssueSceneLogic)
     const { isWindowLessThan } = useWindowSize()
     const isMobile = isWindowLessThan('md')
@@ -122,7 +123,11 @@ export function ErrorTrackingIssueScene(): JSX.Element {
                                             <SceneMenuBarItem
                                                 onClick={() => {
                                                     const url = urls.replay(ReplayTabs.Home, {
-                                                        ...getIssueReplayDateRange(issue.first_seen, lastSeen),
+                                                        ...getIssueReplayDateRange(
+                                                            issue.first_seen,
+                                                            lastSeen,
+                                                            initialEventTimestamp
+                                                        ),
                                                         filter_group: getIssueReplayFilterGroup(issue.id),
                                                     })
                                                     newInternalTab(url)
@@ -158,7 +163,11 @@ export function ErrorTrackingIssueScene(): JSX.Element {
                                                 />
                                                 <ViewRecordingsPlaylistButton
                                                     filters={{
-                                                        ...getIssueReplayDateRange(issue.first_seen, lastSeen),
+                                                        ...getIssueReplayDateRange(
+                                                            issue.first_seen,
+                                                            lastSeen,
+                                                            initialEventTimestamp
+                                                        ),
                                                         filter_group: getIssueReplayFilterGroup(issue.id),
                                                     }}
                                                     size="small"

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
@@ -68,7 +68,7 @@ export const scene: SceneExport<ErrorTrackingIssueSceneLogicProps> = {
 }
 
 export function ErrorTrackingIssueScene(): JSX.Element {
-    const { issue, issueId, lastSeen, initialEventTimestamp, mobileDetailOpen } =
+    const { issue, issueId, lastSeen, initialEventTimestamp, selectedEvent, mobileDetailOpen } =
         useValues(errorTrackingIssueSceneLogic)
     const { updateAssignee, updateStatus, updateName, setMobileDetailOpen } = useActions(errorTrackingIssueSceneLogic)
     const { isWindowLessThan } = useWindowSize()
@@ -126,7 +126,7 @@ export function ErrorTrackingIssueScene(): JSX.Element {
                                                         ...getIssueReplayDateRange(
                                                             issue.first_seen,
                                                             lastSeen,
-                                                            initialEventTimestamp
+                                                            selectedEvent?.timestamp ?? initialEventTimestamp
                                                         ),
                                                         filter_group: getIssueReplayFilterGroup(issue.id),
                                                     })
@@ -166,7 +166,7 @@ export function ErrorTrackingIssueScene(): JSX.Element {
                                                         ...getIssueReplayDateRange(
                                                             issue.first_seen,
                                                             lastSeen,
-                                                            initialEventTimestamp
+                                                            selectedEvent?.timestamp ?? initialEventTimestamp
                                                         ),
                                                         filter_group: getIssueReplayFilterGroup(issue.id),
                                                     }}

--- a/products/error_tracking/frontend/utils.test.ts
+++ b/products/error_tracking/frontend/utils.test.ts
@@ -199,7 +199,21 @@ describe('getIssueReplayDateRange', () => {
         expect(range.date_to).toEqual('2024-01-02T13:00:00.000Z')
     })
 
-    it('falls back to first_seen when last_seen is missing or predates it', () => {
+    it('uses the selected event while last_seen is still loading', () => {
+        const range = getIssueReplayDateRange('2024-01-01T12:00:00.000Z', null, '2024-04-01T12:00:00.000Z')
+        expect(range.date_to).toEqual('2024-04-01T13:00:00.000Z')
+    })
+
+    it('uses a selected event that is newer than a stale last_seen', () => {
+        const range = getIssueReplayDateRange(
+            '2024-01-01T12:00:00.000Z',
+            dayjs('2024-02-01T12:00:00.000Z'),
+            '2024-04-01T12:00:00.000Z'
+        )
+        expect(range.date_to).toEqual('2024-04-01T13:00:00.000Z')
+    })
+
+    it('falls back to first_seen when no later timestamp is known', () => {
         const firstSeen = '2024-01-01T12:00:00.000Z'
         expect(getIssueReplayDateRange(firstSeen, null).date_to).toEqual('2024-01-01T13:00:00.000Z')
         expect(getIssueReplayDateRange(firstSeen, dayjs('2023-12-31T00:00:00.000Z')).date_to).toEqual(

--- a/products/error_tracking/frontend/utils.ts
+++ b/products/error_tracking/frontend/utils.ts
@@ -113,9 +113,20 @@ export function isThirdPartyScriptError(value: ErrorTrackingException['value']):
 
 // Recordings match on session start time, so pad past first_seen to catch a session that began
 // before the exception fired, and past last_seen so a single-occurrence issue isn't a zero-width window.
-export function getIssueReplayDateRange(firstSeen: string, lastSeen: Dayjs | null): DateRange {
+// The selected event keeps the range valid when the user clicks before the last_seen query finishes.
+export function getIssueReplayDateRange(
+    firstSeen: string,
+    lastSeen: Dayjs | null,
+    selectedEventTimestamp?: string | null
+): DateRange {
     const from = dayjs(firstSeen)
-    const to = lastSeen && lastSeen.isAfter(from) ? lastSeen : from
+    const selectedEventSeenAt = selectedEventTimestamp ? dayjs(selectedEventTimestamp) : null
+    const latestKnownSeenAt =
+        selectedEventSeenAt?.isValid() && (!lastSeen || selectedEventSeenAt.isAfter(lastSeen))
+            ? selectedEventSeenAt
+            : lastSeen
+    const to = latestKnownSeenAt?.isAfter(from) ? latestKnownSeenAt : from
+
     return {
         date_from: from.subtract(1, 'hour').toISOString(),
         date_to: to.add(1, 'hour').toISOString(),


### PR DESCRIPTION
## Problem

The prior fix in #76412 is deployed, but it does not cover a fast click after the issue page opens.

The issue record loads before its summary. During that gap, `lastSeen` is still null. The View recordings link therefore falls back to a two-hour window around the issue's historical `first_seen`, even when the selected exception occurred today. This sends replay to a valid-looking date range with no matching recordings.

I confirmed this from the reported production flow: the issue page opened at 09:30:53 UTC, View recordings was clicked at 09:30:56 UTC, and the issue summary query completed afterward. The generated replay filter covered the issue's April first-seen timestamp rather than the selected August exception.

## Changes

- Use the selected exception timestamp as an additional upper bound for the replay date range.
- Keep using `lastSeen` once the issue summary has loaded.
- Apply the fix to the header button and scene menu action.
- Add regression coverage for a click while `lastSeen` is loading and for a selected event newer than stale summary data.

## Tests

- `pnpm --filter=@posthog/frontend exec jest products/error_tracking/frontend/utils.test.ts --runInBand`
- `pnpm exec oxfmt --check products/error_tracking/frontend/utils.ts products/error_tracking/frontend/utils.test.ts products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx`
- `pnpm exec oxlint products/error_tracking/frontend/utils.ts products/error_tracking/frontend/utils.test.ts products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx`
- `pnpm --filter=@posthog/frontend typescript:check` was attempted, but the checkout lacks built workspace outputs for `@posthog/quill`, `@posthog/hogvm`, and related packages. The reported errors are unrelated missing-module errors.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed for this bug fix.

---
*Created with [PostHog](https://posthog.com?ref=pr) from [task #150121](https://us.posthog.com/project/2/tasks/fd71cbc8-b7a9-4af5-a6f6-e3cc38c48b4e)*
