### PR TITLE
test: add varied timeline commit fixture

### DIFF
--- a/docs/timeline-fixture/README.md
+++ b/docs/timeline-fixture/README.md
@@ -1,3 +1,3 @@
 # Timeline commit fixture
 
-Temporary fixtures for validating commit timelines with mixed additions and removals.
+Temporary fixtures for validating commit timelines with mixed additions, edits, and removals. The sequence is deliberately uneven so grouping and file-count badges are easy to spot.

--- a/docs/timeline-fixture/README.md
+++ b/docs/timeline-fixture/README.md
@@ -1,3 +1,3 @@
 # Timeline commit fixture
 
-Temporary fixtures for validating commit timelines with mixed additions, edits, and removals. The sequence is deliberately uneven so grouping and file-count badges are easy to spot.
+Temporary fixtures for validating commit timelines with mixed additions, edits, and removals. The sequence is deliberately uneven so grouping and file-count badges are easy to spot. It is safe to delete after timeline testing.

--- a/docs/timeline-fixture/README.md
+++ b/docs/timeline-fixture/README.md
@@ -1,0 +1,3 @@
+# Timeline commit fixture
+
+Temporary fixtures for validating commit timelines with mixed additions and removals.

--- a/docs/timeline-fixture/labels.md
+++ b/docs/timeline-fixture/labels.md
@@ -1,0 +1,3 @@
+# Display labels
+
+Use short labels in the timeline row. Keep the operation visible even when a commit touches many files.

--- a/docs/timeline-fixture/labels.md
+++ b/docs/timeline-fixture/labels.md
@@ -1,3 +1,5 @@
 # Display labels
 
 Use short labels in the timeline row. Keep the operation visible even when a commit touches many files.
+
+Prefer the file count as a secondary visual cue, not as the only label.

--- a/docs/timeline-fixture/operations.md
+++ b/docs/timeline-fixture/operations.md
@@ -1,0 +1,3 @@
+# Operations
+
+The fixture covers five commit sizes: one, three, five, two, and ten changed files. The fourth commit also removes a file, which makes deletion styling visible.

--- a/docs/timeline-fixture/shape.md
+++ b/docs/timeline-fixture/shape.md
@@ -5,3 +5,4 @@ The fixture uses small, human-readable records so a timeline can show additions,
 - `commit_id` identifies a change.
 - `files` records the paths touched by that change.
 - `kind` describes whether the change adds, edits, or removes a file.
+- File order is stable so snapshots do not change between runs.

--- a/docs/timeline-fixture/shape.md
+++ b/docs/timeline-fixture/shape.md
@@ -6,3 +6,4 @@ The fixture uses small, human-readable records so a timeline can show additions,
 - `files` records the paths touched by that change.
 - `kind` describes whether the change adds, edits, or removes a file.
 - File order is stable so snapshots do not change between runs.
+- Empty file lists are valid for metadata-only commits.

--- a/docs/timeline-fixture/shape.md
+++ b/docs/timeline-fixture/shape.md
@@ -1,0 +1,7 @@
+# Shape
+
+The fixture uses small, human-readable records so a timeline can show additions, edits, and deletions without domain noise.
+
+- `commit_id` identifies a change.
+- `files` records the paths touched by that change.
+- `kind` describes whether the change adds, edits, or removes a file.

--- a/fixtures/timeline/variants.json
+++ b/fixtures/timeline/variants.json
@@ -1,5 +1,6 @@
 {
   "add": {"tone": "positive", "label": "Added"},
   "edit": {"tone": "neutral", "label": "Updated"},
-  "remove": {"tone": "critical", "label": "Removed"}
+  "remove": {"tone": "critical", "label": "Removed"},
+  "rename": {"tone": "informative", "label": "Renamed"}
 }

--- a/fixtures/timeline/variants.json
+++ b/fixtures/timeline/variants.json
@@ -1,0 +1,5 @@
+{
+  "add": {"tone": "positive", "label": "Added"},
+  "edit": {"tone": "neutral", "label": "Updated"},
+  "remove": {"tone": "critical", "label": "Removed"}
+}

--- a/src/timeline_fixture/commits.json
+++ b/src/timeline_fixture/commits.json
@@ -1,0 +1,7 @@
+[
+  {
+    "commit_id": "fixture-001",
+    "files": ["docs/timeline-fixture/README.md"],
+    "kind": "add"
+  }
+]

--- a/src/timeline_fixture/commits.json
+++ b/src/timeline_fixture/commits.json
@@ -2,6 +2,7 @@
   {
     "commit_id": "fixture-001",
     "files": ["docs/timeline-fixture/README.md"],
-    "kind": "add"
+    "kind": "add",
+    "file_count": 1
   }
 ]

--- a/src/timeline_fixture/normalize.py
+++ b/src/timeline_fixture/normalize.py
@@ -3,4 +3,4 @@
 
 def normalize_files(files: list[str]) -> list[str]:
     """Return unique paths in display order."""
-    return list(dict.fromkeys(files))
+    return sorted(dict.fromkeys(files))

--- a/src/timeline_fixture/normalize.py
+++ b/src/timeline_fixture/normalize.py
@@ -1,0 +1,6 @@
+"""Small helpers for the commit timeline fixture."""
+
+
+def normalize_files(files: list[str]) -> list[str]:
+    """Return unique paths in display order."""
+    return list(dict.fromkeys(files))

--- a/src/timeline_fixture/summary.py
+++ b/src/timeline_fixture/summary.py
@@ -1,0 +1,6 @@
+from collections.abc import Iterable
+
+
+def file_count(paths: Iterable[str]) -> int:
+    """Count unique paths for a timeline badge."""
+    return len(set(paths))

--- a/tests/timeline_fixture/README.md
+++ b/tests/timeline_fixture/README.md
@@ -1,0 +1,3 @@
+# Timeline fixture checks
+
+These files are intentionally lightweight. They provide stable content for a UI test that renders commit counts and file-level change summaries.

--- a/tests/timeline_fixture/README.md
+++ b/tests/timeline_fixture/README.md
@@ -1,3 +1,0 @@
-# Timeline fixture checks
-
-These files are intentionally lightweight. They provide stable content for a UI test that renders commit counts and file-level change summaries.

--- a/tests/timeline_fixture/test_normalize.py
+++ b/tests/timeline_fixture/test_normalize.py
@@ -1,0 +1,5 @@
+from src.timeline_fixture.normalize import normalize_files
+
+
+def test_normalize_files_keeps_first_seen_order():
+    assert normalize_files(["b", "a", "b"]) == ["b", "a"]

--- a/tests/timeline_fixture/test_normalize.py
+++ b/tests/timeline_fixture/test_normalize.py
@@ -1,5 +1,5 @@
 from src.timeline_fixture.normalize import normalize_files
 
 
-def test_normalize_files_keeps_first_seen_order():
-    assert normalize_files(["b", "a", "b"]) == ["b", "a"]
+def test_normalize_files_returns_sorted_unique_paths():
+    assert normalize_files(["b", "a", "b"]) == ["a", "b"]

--- a/tests/timeline_fixture/test_summary.py
+++ b/tests/timeline_fixture/test_summary.py
@@ -1,0 +1,5 @@
+from src.timeline_fixture.summary import file_count
+
+
+def test_file_count_deduplicates_paths():
+    assert file_count(["a", "a", "b"]) == 2


### PR DESCRIPTION
## Summary
- add a temporary fixture with five commits touching 1, 3, 5, 2, and 10 files
- include both additions, edits, and a deletion for timeline rendering coverage
- add small normalization and file-count tests

## Verification
- `uv run pytest tests/timeline_fixture -q` (2 passed)