### PR TITLE
fix(ci): restore github.token for node schema download

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -416,8 +416,8 @@ jobs:
                   SECRET_KEY: 'abcdef' # unsafe - for testing only
                   DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
                   BEHAVIORAL_COHORTS_DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/test_behavioral_cohorts'
-                  # Schema artifact lookup pages the artifacts API; keep it off the shared per-repo bucket
-                  GH_TOKEN: ${{ steps.setup-gh-token.outputs.token || github.token }}
+                  # Downloading an artifact requires the Actions permission, which the setup-actions app does not hold
+                  GH_TOKEN: ${{ github.token }}
               run: |
                   # Download pre-migrated schema from CI
                   ./bin/hogli db:download-schema
@@ -689,8 +689,8 @@ jobs:
                   SECRET_KEY: 'abcdef' # unsafe - for testing only
                   DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
                   BEHAVIORAL_COHORTS_DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/test_behavioral_cohorts'
-                  # Schema artifact lookup pages the artifacts API; keep it off the shared per-repo bucket
-                  GH_TOKEN: ${{ steps.setup-gh-token.outputs.token || github.token }}
+                  # Downloading an artifact requires the Actions permission, which the setup-actions app does not hold
+                  GH_TOKEN: ${{ github.token }}
               run: |
                   # Download pre-migrated schema from CI
                   ./bin/hogli db:download-schema


### PR DESCRIPTION
## Problem

- Node.js test shards fail at database setup on any PR that touches node code, before a single test runs.
- [Cap schema artifact listing pagination](https://github.com/PostHog/posthog/pull/81639) switched the schema download to the setup-actions app token, which holds only contents, metadata, and pull_requests read.
- Downloading an Actions artifact requires the Actions permission, so the download returns 403 and fails the step.
- No run has hit this yet. Every run since that merge either skipped the node jobs or took the migrations path.

## Changes

- Both fast-path steps in `ci-nodejs.yml` read `github.token` again.
- The swap is no longer needed, because the same PR cut the artifact listing to one request from about 214 pages.

## How did you test this code?

- Not run: the fast path end to end, because it needs an app token that only CI can mint.
- [GitHub's app permission table](https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps) lists both artifact endpoints under the Actions permission. `gh api /apps/posthog-setup-actions` returns contents, metadata, and pull_requests.
- Anonymous artifact download returns 401 and anonymous listing returns 200, so the listing succeeds and the download is the call that fails.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None (internal CI tooling).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- I (actually Claude) checked the merged PR against production and found this before it fired.
- Skills invoked: `/writing-code-comments`, `/authoring-ci-workflows`, `/writing-pr-descriptions`.
- I considered granting the app the Actions permission instead. The pagination cap removed the reason for the swap, so reverting the token is the smaller change.
