### PR TITLE
feat(error-tracking): filter alerts by issue severity

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
@@ -1493,6 +1493,29 @@ describe('taxonomicFilterLogic', () => {
         })
     })
 
+    describe('error tracking issue property selection', () => {
+        it('provides issue severity as a filter with value suggestions', () => {
+            const issueLogic = taxonomicFilterLogic({
+                taxonomicFilterLogicKey: 'errorTrackingIssuePropertySelection',
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.ErrorTrackingIssues],
+                onChange: jest.fn(),
+            })
+            issueLogic.mount()
+
+            const group = issueLogic.values.taxonomicGroups.find(
+                (candidate) => candidate.type === TaxonomicFilterGroupType.ErrorTrackingIssues
+            )
+            const option = group?.options?.find((candidate) => candidate.name === 'Issue severity') as
+                | { name: string; value: string }
+                | undefined
+
+            expect(group?.getValue?.(option)).toBe('severity')
+            expect(group?.valuesEndpoint?.('severity')).toContain('/error_tracking/issues/values?key=severity')
+
+            issueLogic.unmount()
+        })
+    })
+
     describe('event feature flag properties are a separate group from event properties', () => {
         let splitLogic: ReturnType<typeof taxonomicFilterLogic.build>
 

--- a/frontend/src/scenes/hog-functions/configuration/sampleGlobalsContexts.ts
+++ b/frontend/src/scenes/hog-functions/configuration/sampleGlobalsContexts.ts
@@ -30,6 +30,7 @@ export const SAMPLE_GLOBALS_CONTEXTS: Partial<Record<HogFunctionConfigurationCon
             name: issue.name ?? 'Unnamed issue',
             description: 'PostHog test alert',
             status: issue.status,
+            severity: issue.severity,
             fingerprint: fingerprintRecord.fingerprint,
         }
         if (issue.assignee) {

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -48,6 +48,10 @@
         "name": {
             "description": "The name of an issue.",
             "label": "Issue name"
+        },
+        "severity": {
+            "description": "The severity level assigned to an issue.",
+            "label": "Issue severity"
         }
     },
     "event_metadata": {

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -3707,6 +3707,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "assignee": {"label": "Issue assignee", "description": "The current assignee of an issue."},
         "name": {"label": "Issue name", "description": "The name of an issue."},
         "issue_description": {"label": "Issue description", "description": "The description of an issue."},
+        "severity": {"label": "Issue severity", "description": "The severity level assigned to an issue."},
         "first_seen": {
             "label": "Issue first seen",
             "description": "The first time the issue was seen.",

--- a/products/error_tracking/backend/logic/__init__.py
+++ b/products/error_tracking/backend/logic/__init__.py
@@ -317,6 +317,13 @@ def get_issue_values(team_id: int, key: str | None, value: str | None) -> list[s
             if issue_description is not None
         ]
 
+    if key == "severity":
+        return [
+            severity
+            for severity in queryset.filter(severity__icontains=value).values_list("severity", flat=True).distinct()
+            if severity is not None
+        ]
+
     return []
 
 

--- a/products/error_tracking/backend/temporal/lifecycle/issue_created/test/test_workflow.py
+++ b/products/error_tracking/backend/temporal/lifecycle/issue_created/test/test_workflow.py
@@ -50,6 +50,7 @@ def _inputs(fingerprint: str) -> IssueCreatedWorkflowInputs:
             description="Something failed",
             status="active",
             created_at="2026-07-21T12:00:00Z",
+            severity="high",
         ),
         fingerprint=fingerprint,
         event_uuid=event_uuid,

--- a/products/error_tracking/backend/temporal/lifecycle/side_effects.py
+++ b/products/error_tracking/backend/temporal/lifecycle/side_effects.py
@@ -38,6 +38,9 @@ class IssueLifecycleSnapshot(EventPropertiesIssueSnapshot, Protocol):
     @property
     def status(self) -> str: ...
 
+    @property
+    def severity(self) -> str | None: ...
+
 
 class IssueLifecycleWorkflowInputs(Protocol):
     @property
@@ -91,6 +94,7 @@ def produce_issue_lifecycle_internal_event(
         "description": inputs.issue.description,
         "issue_description": inputs.issue.description,
         "first_seen": inputs.issue.created_at,
+        "severity": inputs.issue.severity,
         "fingerprint": inputs.fingerprint,
         "exception_timestamp": timestamp.isoformat(),
         "exception_props": event_properties,

--- a/products/error_tracking/backend/temporal/lifecycle/test/test_side_effects.py
+++ b/products/error_tracking/backend/temporal/lifecycle/test/test_side_effects.py
@@ -33,6 +33,7 @@ def _inputs() -> IssueReopenedWorkflowInputs:
             description="Something failed",
             status="pending_release",
             created_at="2026-07-21T12:00:00Z",
+            severity="high",
         ),
         fingerprint="fingerprint",
         event_uuid="01982721-5e00-7000-8000-000000000003",
@@ -51,6 +52,7 @@ def test_created_internal_event_preserves_raw_status() -> None:
             description="Something failed",
             status="active",
             created_at="2026-07-21T12:00:00Z",
+            severity="critical",
         ),
         fingerprint="fingerprint",
         event_uuid="01982721-5e00-7000-8000-000000000003",
@@ -87,6 +89,7 @@ def test_created_internal_event_preserves_raw_status() -> None:
 
     assert sent_events[0].event == "$error_tracking_issue_created"
     assert sent_events[0].properties["status"] == "active"
+    assert sent_events[0].properties["severity"] == "critical"
 
 
 def test_oversized_internal_event_retries_without_exception_properties() -> None:
@@ -136,6 +139,7 @@ def test_oversized_internal_event_retries_without_exception_properties() -> None
         "description": "Something failed",
         "issue_description": "Something failed",
         "first_seen": "2026-07-21T12:00:00Z",
+        "severity": "high",
         "fingerprint": "fingerprint",
         "exception_timestamp": "2026-07-21T12:05:00+00:00",
         "exception_props": event_properties,
@@ -184,7 +188,9 @@ def test_internal_event_reraises_non_size_kafka_errors() -> None:
         )
 
     assert len(sent_events) == 1
+    assert sent_events[0].event == "$error_tracking_issue_spiking"
     assert "status" not in sent_events[0].properties
+    assert sent_events[0].properties["severity"] == "high"
 
 
 @pytest.mark.asyncio

--- a/products/error_tracking/backend/temporal/lifecycle/types.py
+++ b/products/error_tracking/backend/temporal/lifecycle/types.py
@@ -8,6 +8,7 @@ class LifecycleIssueSnapshot:
     description: str | None
     status: str
     created_at: str
+    severity: str | None = None
 
 
 class SpikeEventPersistenceStatus(StrEnum):

--- a/products/error_tracking/backend/test/test_facade_api.py
+++ b/products/error_tracking/backend/test/test_facade_api.py
@@ -23,8 +23,10 @@ from ee.models.rbac.role import Role
 
 
 class TestErrorTrackingFacadeAPI(BaseTest):
-    def _create_issue(self, *, team, name: str, description: str | None = None) -> ErrorTrackingIssue:
-        issue = ErrorTrackingIssue.objects.create(team=team, name=name, description=description)
+    def _create_issue(
+        self, *, team, name: str, description: str | None = None, severity: str | None = None
+    ) -> ErrorTrackingIssue:
+        issue = ErrorTrackingIssue.objects.create(team=team, name=name, description=description, severity=severity)
         ErrorTrackingIssueFingerprintV2.objects.create(team=team, issue=issue, fingerprint=f"fp-{issue.id}")
         return issue
 
@@ -162,13 +164,19 @@ class TestErrorTrackingFacadeAPI(BaseTest):
         [
             ["name", "name", "checkout", ["Checkout timeout", "Checkout type error"]],
             ["issue_description", "issue_description", "timeout", ["A timeout during payment"]],
+            ["severity", "severity", "hi", ["high"]],
             ["missing_key", None, "timeout", []],
             ["missing_value", "name", None, []],
             ["unknown_key", "unknown", "checkout", []],
         ]
     )
     def test_get_issue_values(self, _name: str, key: str | None, value: str | None, expected: list[str]):
-        self._create_issue(team=self.team, name="Checkout timeout", description="A timeout during payment")
+        self._create_issue(
+            team=self.team,
+            name="Checkout timeout",
+            description="A timeout during payment",
+            severity=ErrorTrackingIssue.Severity.HIGH,
+        )
         self._create_issue(team=self.team, name="Checkout type error", description="Type mismatch in checkout")
 
         values = api.get_issue_values(team_id=self.team.id, key=key, value=value)

--- a/rust/cymbal/src/core/types/notification.rs
+++ b/rust/cymbal/src/core/types/notification.rs
@@ -249,6 +249,8 @@ pub struct IssueSnapshot {
     pub name: Option<String>,
     pub description: Option<String>,
     pub status: String,
+    #[serde(default)]
+    pub severity: Option<String>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -270,6 +272,7 @@ mod tests {
                     name: Some("Example".to_string()),
                     description: Some("Example issue".to_string()),
                     status: "active".to_string(),
+                    severity: Some("high".to_string()),
                     created_at: DateTime::from_timestamp(0, 0).unwrap(),
                 },
                 event_properties: serde_json::from_value(serde_json::json!({
@@ -297,6 +300,7 @@ mod tests {
         assert_eq!(json["type"], "issue_created");
         assert_eq!(json["team_id"], 42);
         assert_eq!(json["fingerprint"], "abc");
+        assert_eq!(json["issue"]["severity"], "high");
         assert_eq!(json["event_properties"]["$exception_fingerprint"], "abc");
 
         // Round-trips back to the same JSON through the typed enum.
@@ -346,6 +350,7 @@ mod tests {
                     name: Some("Example".to_string()),
                     description: Some("Example issue".to_string()),
                     status: "active".to_string(),
+                    severity: None,
                     created_at: DateTime::from_timestamp(0, 0).unwrap(),
                 },
                 event_properties: serde_json::from_value(serde_json::json!({
@@ -372,6 +377,12 @@ mod tests {
         object.remove("notification_id");
         object.remove("event_uuid");
         object.remove("event_timestamp");
+        object
+            .get_mut("issue")
+            .unwrap()
+            .as_object_mut()
+            .unwrap()
+            .remove("severity");
 
         let decoded: IngestionNotification = serde_json::from_value(legacy_json).unwrap();
         let fallback_key = format!(

--- a/rust/cymbal/src/modes/notifications/temporal.rs
+++ b/rust/cymbal/src/modes/notifications/temporal.rs
@@ -243,6 +243,7 @@ mod tests {
                 name: Some("TypeError".to_string()),
                 description: Some("boom".to_string()),
                 status: "active".to_string(),
+                severity: Some("high".to_string()),
                 created_at: Utc::now(),
             },
             event_properties: serde_json::from_value::<ProcessedExceptionProperties>(
@@ -315,6 +316,7 @@ mod tests {
         for value in values {
             assert_eq!(value["team_id"], 42);
             assert_eq!(value["fingerprint"], "fingerprint");
+            assert_eq!(value["issue"]["severity"], "high");
             assert!(value.get("event_properties").is_none());
         }
     }

--- a/rust/cymbal/src/modes/processing/issue_resolution.rs
+++ b/rust/cymbal/src/modes/processing/issue_resolution.rs
@@ -587,6 +587,7 @@ fn issue_snapshot(issue: &Issue) -> IssueSnapshot {
         name: issue.name.clone(),
         description: issue.description.clone(),
         status: issue.status.to_string(),
+        severity: issue.severity.clone(),
         created_at: issue.created_at,
     }
 }


### PR DESCRIPTION
## Problem

Error tracking lifecycle events do not include the issue severity. Alert destinations therefore cannot subscribe to only low, medium, high, or critical issues.

## Changes

- Carry the issue severity in Cymbal's issue snapshot for created, reopened, and spiking notifications.
- Preserve compatibility with older notification payloads that do not contain severity.
- Add `severity` to the three Temporal lifecycle internal events.
- Expose **Issue severity** in the error tracking alert property picker.
- Return severity value suggestions from the issue values endpoint.
- Include severity in alert test-event globals.

This complements #81913. This PR works with existing manually assigned severities; #81913 also gives newly created issues an inferred severity.

## How did you test this code?

- `cargo fmt --manifest-path rust/cymbal/Cargo.toml -- --check`
- `SQLX_OFFLINE=true cargo test --manifest-path rust/cymbal/Cargo.toml core::types::notification --lib`
- `SQLX_OFFLINE=true cargo test --manifest-path rust/cymbal/Cargo.toml modes::notifications::temporal --lib`
- `uv run pytest products/error_tracking/backend/temporal/lifecycle/test/test_side_effects.py products/error_tracking/backend/temporal/lifecycle/issue_created/test/test_workflow.py -q`
- `pnpm exec jest --runInBand src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts` from `frontend/`
- `ruff format --check` and `ruff check` on changed Python files
- `oxfmt --check` and `oxlint --quiet` on changed frontend files

The database-backed issue-value test could not run locally because PostgreSQL was not available. CI will run it.
