### PR TITLE
fix(desktop): stop a hidden window stalling app boot

### DIFF
--- a/products/desktop/packages/ui/src/router/yieldToPaint.test.ts
+++ b/products/desktop/packages/ui/src/router/yieldToPaint.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { yieldToPaint } from "./yieldToPaint";
+
+describe("yieldToPaint", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  function stubVisibility(state: DocumentVisibilityState): void {
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue(state);
+  }
+
+  function stallFrames(): void {
+    vi.spyOn(globalThis, "requestAnimationFrame").mockReturnValue(0);
+  }
+
+  it("resolves while the window is hidden and no frame ever arrives", async () => {
+    stubVisibility("hidden");
+    stallFrames();
+
+    await expect(yieldToPaint()).resolves.toBeUndefined();
+    expect(globalThis.requestAnimationFrame).not.toHaveBeenCalled();
+  });
+
+  it("resolves on a timeout when frames stall while the window reports visible", async () => {
+    vi.useFakeTimers();
+    stubVisibility("visible");
+    stallFrames();
+
+    const settled = vi.fn();
+    const pending = yieldToPaint().then(settled);
+
+    await vi.advanceTimersByTimeAsync(99);
+    expect(settled).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await pending;
+    expect(settled).toHaveBeenCalled();
+  });
+
+  it("resolves on the second frame rather than waiting out the timeout", async () => {
+    vi.useFakeTimers();
+    stubVisibility("visible");
+    const frames: FrameRequestCallback[] = [];
+    vi.spyOn(globalThis, "requestAnimationFrame").mockImplementation((cb) => {
+      frames.push(cb);
+      return frames.length;
+    });
+
+    const settled = vi.fn();
+    const pending = yieldToPaint().then(settled);
+
+    frames[0]?.(0);
+    frames[1]?.(0);
+    await vi.advanceTimersByTimeAsync(0);
+    await pending;
+
+    expect(settled).toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/products/desktop/packages/ui/src/router/yieldToPaint.ts
+++ b/products/desktop/packages/ui/src/router/yieldToPaint.ts
@@ -15,15 +15,28 @@
  * makes the route un-navigable when the fetch hangs. Cold-miss fetches belong
  * in the component.
  */
+const FRAME_WAIT_TIMEOUT_MS = 100;
+
 export function yieldToPaint(): Promise<void> {
+  if (
+    typeof document !== "undefined" &&
+    document.visibilityState === "hidden"
+  ) {
+    return Promise.resolve();
+  }
   return new Promise((resolve) => {
+    const timer = setTimeout(resolve, FRAME_WAIT_TIMEOUT_MS);
+    const settle = (): void => {
+      clearTimeout(timer);
+      resolve();
+    };
     // Double rAF: the first fires before the next frame paints, the second
     // before the frame after — so exactly one frame (the one showing the
     // pending skeleton) is guaranteed to reach the screen in between. A single
     // rAF can resolve before the pending state ever commits, letting the
     // router skip straight to the heavy mount with nothing painted.
     requestAnimationFrame(() => {
-      requestAnimationFrame(() => setTimeout(resolve, 0));
+      requestAnimationFrame(() => setTimeout(settle, 0));
     });
   });
 }


### PR DESCRIPTION
## Problem

The app never finishes starting when its window is not visible while it boots. It sits on the loading screen, then shows "PostHog is taking longer than expected to start", and Retry does not help. Showing the window releases it.

## Changes

- `yieldToPaint()` returns immediately while `document.visibilityState` is `hidden`
- The frame wait is capped at 100 ms for the case where frames stall but the document still reports itself visible, which covers an occluded or minimized window and background throttling


