### PR TITLE
feat(desktop): mobile thumbs rating on agent turns

### DIFF
--- a/products/desktop/apps/mobile/src/features/chat/components/AgentMessage.test.tsx
+++ b/products/desktop/apps/mobile/src/features/chat/components/AgentMessage.test.tsx
@@ -1,0 +1,68 @@
+import { type ComponentProps, createElement } from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@posthog/core/sessions/thinkingActivities", () => ({
+  pickThinkingActivity: () => "thinking",
+}));
+vi.mock("@/lib/theme", () => ({
+  useThemeColors: () => ({ gray: {}, status: {} }),
+}));
+vi.mock("@/lib/format", () => ({ formatRelativeTime: () => "now" }));
+vi.mock("../hooks/usePeriodicRerender", () => ({
+  usePeriodicRerender: () => {},
+}));
+vi.mock("./MarkdownText", () => ({ MarkdownText: () => null }));
+vi.mock("./ToolMessage", () => ({ ToolMessage: () => null }));
+vi.mock("./CopyButton", () => ({
+  CopyButton: (props: Record<string, unknown>) =>
+    createElement("CopyButton", props),
+}));
+vi.mock("./TurnFeedback", () => ({
+  TurnFeedback: (props: Record<string, unknown>) =>
+    createElement("TurnFeedback", props),
+}));
+
+import { AgentMessage } from "./AgentMessage";
+
+function render(props: ComponentProps<typeof AgentMessage>) {
+  let renderer: ReactTestRenderer | null = null;
+  act(() => {
+    renderer = create(createElement(AgentMessage, props));
+  });
+  if (!renderer) throw new Error("Renderer not created");
+  return renderer as ReactTestRenderer;
+}
+
+function hasTurnFeedback(renderer: ReactTestRenderer) {
+  return (
+    renderer.root.findAll((n) => String(n.type) === "TurnFeedback").length > 0
+  );
+}
+
+describe("AgentMessage", () => {
+  it("shows the thumbs on a completed agent turn", () => {
+    const renderer = render({
+      content: "A reply",
+      timestamp: 1,
+      turnId: "agent-0",
+      taskId: "task-1",
+    });
+    expect(hasTurnFeedback(renderer)).toBe(true);
+  });
+
+  it("hides the thumbs while the turn is still streaming", () => {
+    const renderer = render({
+      content: "partial",
+      isLoading: true,
+      turnId: "agent-0",
+      taskId: "task-1",
+    });
+    expect(hasTurnFeedback(renderer)).toBe(false);
+  });
+
+  it("hides the thumbs when there is no turn id", () => {
+    const renderer = render({ content: "A reply", timestamp: 1 });
+    expect(hasTurnFeedback(renderer)).toBe(false);
+  });
+});

--- a/products/desktop/apps/mobile/src/features/chat/components/AgentMessage.tsx
+++ b/products/desktop/apps/mobile/src/features/chat/components/AgentMessage.tsx
@@ -8,6 +8,7 @@ import { usePeriodicRerender } from "../hooks/usePeriodicRerender";
 import { CopyButton } from "./CopyButton";
 import { MarkdownText } from "./MarkdownText";
 import { ToolMessage } from "./ToolMessage";
+import { TurnFeedback } from "./TurnFeedback";
 
 interface AssistantToolCall {
   id: string;
@@ -24,6 +25,8 @@ interface AgentMessageProps {
   hasHumanMessageAfter?: boolean;
   onOpenTask?: (taskId: string) => void;
   timestamp?: number;
+  turnId?: string;
+  taskId?: string | null;
 }
 
 interface ReasoningBlockProps {
@@ -78,6 +81,8 @@ export function AgentMessage({
   hasHumanMessageAfter,
   onOpenTask,
   timestamp,
+  turnId,
+  taskId,
 }: AgentMessageProps) {
   usePeriodicRerender(isLoading ? THINKING_MESSAGE_INTERVAL_MS : 0);
 
@@ -124,6 +129,9 @@ export function AgentMessage({
       {!isLoading && (hasContent || timestamp) && (
         <View className="flex-row items-center gap-3 px-4 pt-1">
           {isComplete && <CopyButton text={content} label="Copy message" />}
+          {isComplete && turnId && (
+            <TurnFeedback turnId={turnId} taskId={taskId} />
+          )}
           {timestamp && (
             <Text className="font-mono text-[10px] text-gray-8">
               {formatRelativeTime(timestamp)}

--- a/products/desktop/apps/mobile/src/features/chat/components/TurnFeedback.test.tsx
+++ b/products/desktop/apps/mobile/src/features/chat/components/TurnFeedback.test.tsx
@@ -1,0 +1,92 @@
+import { createElement } from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockPosthog = {
+  register: vi.fn(),
+  unregister: vi.fn(),
+  capture: vi.fn(),
+};
+vi.mock("posthog-react-native", () => ({ usePostHog: () => mockPosthog }));
+vi.mock("expo-haptics", () => ({
+  impactAsync: vi.fn(),
+  ImpactFeedbackStyle: { Light: "light" },
+}));
+vi.mock("@/lib/theme", () => ({
+  useThemeColors: () => ({ gray: { 9: "#000000" } }),
+}));
+
+import { useTurnFeedbackStore } from "@/features/tasks/stores/turnFeedbackStore";
+import { TurnFeedback } from "./TurnFeedback";
+
+function render(props: { turnId: string; taskId?: string | null }) {
+  let renderer: ReactTestRenderer | null = null;
+  act(() => {
+    renderer = create(createElement(TurnFeedback, props));
+  });
+  if (!renderer) throw new Error("Renderer not created");
+  return renderer as ReactTestRenderer;
+}
+
+function press(renderer: ReactTestRenderer, label: string) {
+  const node = renderer.root.findAll(
+    (n) => n.props?.accessibilityLabel === label,
+  )[0];
+  act(() => node.props.onPress());
+}
+
+function storedSentiment(turnId: string) {
+  return useTurnFeedbackStore.getState().sentimentByTurnId[turnId] ?? null;
+}
+
+describe("TurnFeedback", () => {
+  beforeEach(() => {
+    mockPosthog.capture.mockReset();
+    useTurnFeedbackStore.setState({ sentimentByTurnId: {} });
+  });
+
+  it("records feedback on the first tap", () => {
+    const renderer = render({ turnId: "agent-0", taskId: "task-1" });
+    press(renderer, "Good response");
+    expect(mockPosthog.capture).toHaveBeenCalledTimes(1);
+    expect(mockPosthog.capture).toHaveBeenCalledWith("Agent turn feedback", {
+      task_id: "task-1",
+      turn_id: "agent-0",
+      sentiment: "positive",
+    });
+    expect(storedSentiment("agent-0")).toBe("positive");
+  });
+
+  it("ignores a re-tap of the already-lit thumb", () => {
+    const renderer = render({ turnId: "agent-0", taskId: "task-1" });
+    press(renderer, "Good response");
+    press(renderer, "Good response");
+    expect(mockPosthog.capture).toHaveBeenCalledTimes(1);
+  });
+
+  it("records the new sentiment when switching thumbs", () => {
+    const renderer = render({ turnId: "agent-0", taskId: "task-1" });
+    press(renderer, "Good response");
+    press(renderer, "Bad response");
+    expect(mockPosthog.capture).toHaveBeenCalledTimes(2);
+    expect(mockPosthog.capture).toHaveBeenLastCalledWith(
+      "Agent turn feedback",
+      {
+        task_id: "task-1",
+        turn_id: "agent-0",
+        sentiment: "negative",
+      },
+    );
+    expect(storedSentiment("agent-0")).toBe("negative");
+  });
+
+  it("sends a null task_id when no task is provided", () => {
+    const renderer = render({ turnId: "agent-0" });
+    press(renderer, "Bad response");
+    expect(mockPosthog.capture).toHaveBeenCalledWith("Agent turn feedback", {
+      task_id: null,
+      turn_id: "agent-0",
+      sentiment: "negative",
+    });
+  });
+});

--- a/products/desktop/apps/mobile/src/features/chat/components/TurnFeedback.tsx
+++ b/products/desktop/apps/mobile/src/features/chat/components/TurnFeedback.tsx
@@ -1,0 +1,68 @@
+import type { AgentTurnFeedbackSentiment } from "@posthog/shared";
+import * as Haptics from "expo-haptics";
+import { ThumbsDown, ThumbsUp } from "phosphor-react-native";
+import { useCallback } from "react";
+import { Pressable, View } from "react-native";
+import {
+  useTurnFeedback,
+  useTurnFeedbackStore,
+} from "@/features/tasks/stores/turnFeedbackStore";
+import { ANALYTICS_EVENTS, useAnalytics } from "@/lib/analytics";
+import { useThemeColors } from "@/lib/theme";
+
+interface TurnFeedbackProps {
+  turnId: string;
+  taskId?: string | null;
+}
+
+export function TurnFeedback({ turnId, taskId }: TurnFeedbackProps) {
+  const themeColors = useThemeColors();
+  const analytics = useAnalytics();
+  const sentiment = useTurnFeedback(turnId);
+  const setTurnFeedback = useTurnFeedbackStore((s) => s.setTurnFeedback);
+
+  const rate = useCallback(
+    (next: AgentTurnFeedbackSentiment) => {
+      if (sentiment === next) return;
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      setTurnFeedback(turnId, next);
+      analytics.track(ANALYTICS_EVENTS.AGENT_TURN_FEEDBACK, {
+        task_id: taskId ?? null,
+        turn_id: turnId,
+        sentiment: next,
+      });
+    },
+    [sentiment, setTurnFeedback, analytics, turnId, taskId],
+  );
+
+  return (
+    <View className="flex-row items-center gap-3">
+      <Pressable
+        onPress={() => rate("positive")}
+        hitSlop={8}
+        accessibilityRole="button"
+        accessibilityLabel="Good response"
+        accessibilityState={{ selected: sentiment === "positive" }}
+      >
+        <ThumbsUp
+          size={14}
+          color={themeColors.gray[9]}
+          weight={sentiment === "positive" ? "fill" : "regular"}
+        />
+      </Pressable>
+      <Pressable
+        onPress={() => rate("negative")}
+        hitSlop={8}
+        accessibilityRole="button"
+        accessibilityLabel="Bad response"
+        accessibilityState={{ selected: sentiment === "negative" }}
+      >
+        <ThumbsDown
+          size={14}
+          color={themeColors.gray[9]}
+          weight={sentiment === "negative" ? "fill" : "regular"}
+        />
+      </Pressable>
+    </View>
+  );
+}

--- a/products/desktop/apps/mobile/src/features/tasks/components/TaskSessionView.tsx
+++ b/products/desktop/apps/mobile/src/features/tasks/components/TaskSessionView.tsx
@@ -965,6 +965,8 @@ export function TaskSessionView({
               content={item.content}
               onOpenTask={onOpenTask}
               timestamp={item.ts}
+              turnId={item.id}
+              taskId={taskId}
             />
           );
         case "thought":
@@ -1018,6 +1020,7 @@ export function TaskSessionView({
       onSendPermissionResponse,
       pendingPermissions,
       renderAttachment,
+      taskId,
     ],
   );
 

--- a/products/desktop/apps/mobile/src/features/tasks/stores/turnFeedbackStore.ts
+++ b/products/desktop/apps/mobile/src/features/tasks/stores/turnFeedbackStore.ts
@@ -1,0 +1,25 @@
+import type { AgentTurnFeedbackSentiment } from "@posthog/shared";
+import { create } from "zustand";
+
+interface TurnFeedbackState {
+  // Keeps the chosen thumb lit as the FlatList recycles turn rows. Feedback is
+  // analytics-only, so this is in-memory only and never persisted.
+  sentimentByTurnId: Record<string, AgentTurnFeedbackSentiment>;
+  setTurnFeedback: (
+    turnId: string,
+    sentiment: AgentTurnFeedbackSentiment,
+  ) => void;
+}
+
+export const useTurnFeedbackStore = create<TurnFeedbackState>((set) => ({
+  sentimentByTurnId: {},
+  setTurnFeedback: (turnId, sentiment) =>
+    set((state) => ({
+      sentimentByTurnId: { ...state.sentimentByTurnId, [turnId]: sentiment },
+    })),
+}));
+
+export const useTurnFeedback = (
+  turnId: string,
+): AgentTurnFeedbackSentiment | null =>
+  useTurnFeedbackStore((s) => s.sentimentByTurnId[turnId] ?? null);

--- a/products/desktop/apps/mobile/src/lib/analytics.ts
+++ b/products/desktop/apps/mobile/src/lib/analytics.ts
@@ -1,3 +1,5 @@
+import type { AgentTurnFeedbackProperties } from "@posthog/shared";
+import { ANALYTICS_EVENTS as SHARED_ANALYTICS_EVENTS } from "@posthog/shared";
 import { type PostHog, usePostHog } from "posthog-react-native";
 import { useEffect, useMemo } from "react";
 
@@ -18,6 +20,7 @@ export const ANALYTICS_EVENTS = {
   SIGN_IN_FAILED: "Sign in failed",
   PROMPT_SENT: "Prompt sent",
   TASK_RUN_STOPPED: "Task run stopped",
+  AGENT_TURN_FEEDBACK: SHARED_ANALYTICS_EVENTS.AGENT_TURN_FEEDBACK,
 } as const;
 
 export type SignInMethod = "oauth" | "dev_api_key" | "qr_scan";
@@ -228,6 +231,7 @@ export type EventPropertyMap = {
   [ANALYTICS_EVENTS.SIGN_IN_FAILED]: SignInFailedProperties;
   [ANALYTICS_EVENTS.PROMPT_SENT]: PromptSentProperties;
   [ANALYTICS_EVENTS.TASK_RUN_STOPPED]: TaskRunStoppedProperties;
+  [ANALYTICS_EVENTS.AGENT_TURN_FEEDBACK]: AgentTurnFeedbackProperties;
 };
 
 export interface Analytics {

--- a/products/desktop/apps/mobile/src/test/setup.ts
+++ b/products/desktop/apps/mobile/src/test/setup.ts
@@ -112,6 +112,7 @@ vi.mock("phosphor-react-native", async () => {
     StopIcon: icon("StopIcon"),
     Terminal: icon("Terminal"),
     ThumbsDown: icon("ThumbsDown"),
+    ThumbsUp: icon("ThumbsUp"),
     Trash: icon("Trash"),
     Tray: icon("Tray"),
     UsersThree: icon("UsersThree"),


### PR DESCRIPTION
## Problem

On mobile, a reader looking at a finished agent turn can now rate it with a thumbs up or thumbs down. Before this, a completed turn showed only a copy button, so there was no way to tell us whether the reply was good.

This ports the rating half of #80961 (desktop) to the React Native app. The desktop "copy just the highlighted text" half is text-selection mechanics with no mobile equivalent and is not ported.

## Changes

- The thumbs sit next to the copy button and appear only on a completed agent turn.
- The first tap records feedback and lights the chosen thumb.
- Re-tapping the lit thumb does nothing; tapping the other thumb records the new sentiment and moves the light.
- Feedback is analytics-only. It never changes the session.
- The chosen thumb is held in an in-memory store keyed by turn id, so it survives the chat list recycling its rows. It is not persisted.
- The event name and property type come from `@posthog/shared` (`AGENT_TURN_FEEDBACK`, `AgentTurnFeedbackProperties`), so desktop and mobile land in one analytics bucket.
- Accessibility labels "Good response" and "Bad response" match desktop.

Visual change: two small thumb icons render after the copy button. I (actually Claude) could not capture a device screenshot — this sandbox has no iOS or Android simulator.

## How did you test this code?

- `TurnFeedback` tests cover the parts easy to get wrong: first tap records the event, re-tap of the lit thumb fires nothing, switching thumbs records the new sentiment, and a missing task id sends `task_id: null`.
- `AgentMessage` tests cover the gate: thumbs show on a completed turn, stay hidden while the turn streams, and stay hidden when there is no turn id.
- Ran the mobile vitest suite and biome lint locally. Not run: any on-device or simulator check, for the reason above.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) ported the feature. Tool: Claude Code. Skills invoked: `/porting-code-prs`, `/simplify`, `/writing-pr-descriptions`, `/writing-tests`.

Decisions along the way:
- Kept the rating state in a new single-concern zustand store under `src/features/tasks/stores/`, matching the mobile pattern of one store per concern, rather than mirroring the desktop `sessionViewStore` that bundles several view-state slices. Mobile has no such aggregate store.
- Reused the shared event name and property type instead of redefining them, wiring `AGENT_TURN_FEEDBACK` through the existing `useAnalytics()` helper.
- `/simplify` reviewers flagged two optional refactors (a shared thumbs primitive, a config-array loop for the two buttons); I skipped both as added indirection for a two-button port, and dropped an unused `size` prop.

No customer data, secrets, or internal material is present in this change. The feature and its test data are generic.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
