### PR TITLE
feat(desktop): mobile cloud artifacts in the composer

### DIFF
--- a/products/desktop/apps/mobile/src/app/task/[id].tsx
+++ b/products/desktop/apps/mobile/src/app/task/[id].tsx
@@ -42,6 +42,7 @@ import { FloatingTaskHeader } from "@/features/tasks/components/FloatingTaskHead
 import { PrDiffStatsBadge } from "@/features/tasks/components/PrDiffStatsBadge";
 import { PrStatusBadge } from "@/features/tasks/components/PrStatusBadge";
 import { StopRunButton } from "@/features/tasks/components/StopRunButton";
+import { TaskArtifacts } from "@/features/tasks/components/TaskArtifacts";
 import { TaskSessionView } from "@/features/tasks/components/TaskSessionView";
 import { buildCloudPromptBlocks } from "@/features/tasks/composer/attachments/buildCloudPrompt";
 import type { PendingAttachment } from "@/features/tasks/composer/attachments/types";
@@ -837,7 +838,6 @@ export default function TaskDetailScreen() {
         <TaskSessionView
           events={session?.events ?? []}
           taskId={taskId}
-          runId={task?.latest_run?.id}
           pendingPermissions={session?.pendingPermissions}
           isConnecting={isConnecting}
           isThinking={isThinking}
@@ -929,6 +929,13 @@ export default function TaskDetailScreen() {
             messagingMode={messagingMode}
             queuedCount={queuedCount}
             onToggleMessagingMode={toggleMessagingMode}
+            artifactsSlot={
+              <TaskArtifacts
+                taskId={taskId}
+                runId={task?.latest_run?.id}
+                enabled={!retrying && !!session?.terminalStatus}
+              />
+            }
           />
         </Animated.View>
       </Animated.View>

--- a/products/desktop/apps/mobile/src/features/tasks/api.ts
+++ b/products/desktop/apps/mobile/src/features/tasks/api.ts
@@ -4,6 +4,7 @@ import type {
   StoredLogEntry,
   Task,
   TaskRun,
+  TaskRunArtifact,
 } from "@posthog/shared";
 import { fetch } from "expo/fetch";
 import {
@@ -173,6 +174,36 @@ export async function presignTaskRunArtifact(
 
   const data = (await response.json()) as { url: string };
   return data.url;
+}
+
+/** Hides or restores every version of a file on the run, returning the updated manifest. */
+export async function dismissTaskRunArtifacts(
+  taskId: string,
+  runId: string,
+  artifactIds: string[],
+  dismissed: boolean,
+): Promise<TaskRunArtifact[]> {
+  const baseUrl = getBaseUrl();
+  const projectId = getProjectId();
+
+  const response = await authedFetch(
+    `${baseUrl}/api/projects/${projectId}/tasks/${taskId}/runs/${runId}/artifacts/dismiss/`,
+    {
+      method: "POST",
+      body: JSON.stringify({ artifact_ids: artifactIds, dismissed }),
+    },
+  );
+
+  if (!response.ok) {
+    throw new HttpError(
+      response.status,
+      response.statusText,
+      "Failed to update artifact",
+    );
+  }
+
+  const data = (await response.json()) as { artifacts?: TaskRunArtifact[] };
+  return data.artifacts ?? [];
 }
 
 export async function cancelRun(

--- a/products/desktop/apps/mobile/src/features/tasks/components/TaskArtifacts.test.tsx
+++ b/products/desktop/apps/mobile/src/features/tasks/components/TaskArtifacts.test.tsx
@@ -1,13 +1,51 @@
 import type { TaskRunArtifact } from "@posthog/shared";
 import { createElement } from "react";
 import { act, create } from "react-test-renderer";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TaskArtifacts } from "./TaskArtifacts";
 
 const mockUseTaskArtifacts = vi.fn();
+const mockUseUserQuery = vi.fn();
+const dismissTaskRunArtifacts = vi.fn(async () => [] as TaskRunArtifact[]);
 
 vi.mock("../hooks/useTaskArtifacts", () => ({
   useTaskArtifacts: (...args: unknown[]) => mockUseTaskArtifacts(...args),
+}));
+
+vi.mock("@/features/auth", () => ({
+  useUserQuery: () => mockUseUserQuery(),
+}));
+
+vi.mock("../api", () => ({
+  presignTaskRunArtifact: vi.fn(),
+  dismissTaskRunArtifacts: (...args: unknown[]) =>
+    dismissTaskRunArtifacts(...(args as [])),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useMutation: (opts: {
+    mutationFn: (vars: unknown) => Promise<unknown>;
+    onSuccess?: (data: unknown) => void;
+    onError?: (error: unknown) => void;
+  }) => ({
+    isPending: false,
+    mutate: (vars: unknown) => {
+      Promise.resolve(opts.mutationFn(vars)).then(
+        opts.onSuccess ?? (() => undefined),
+        opts.onError ?? (() => undefined),
+      );
+    },
+  }),
+}));
+
+vi.mock("@/components/SheetContainer", () => ({
+  SheetContainer: ({
+    open,
+    children,
+  }: {
+    open: boolean;
+    children: React.ReactNode;
+  }) => (open ? createElement("SheetContainer", null, children) : null),
 }));
 
 vi.mock("./ArtifactPreview", () => ({
@@ -15,22 +53,24 @@ vi.mock("./ArtifactPreview", () => ({
     createElement("ArtifactPreview", props),
 }));
 
-vi.mock("../api", () => ({ presignTaskRunArtifact: vi.fn() }));
-
 vi.mock("@/lib/openExternalUrl", () => ({ openExternalUrl: vi.fn() }));
 
 vi.mock("phosphor-react-native", () => ({
-  ArrowSquareOut: (props: Record<string, unknown>) =>
-    createElement("ArrowSquareOut", props),
   CaretDown: (props: Record<string, unknown>) =>
     createElement("CaretDown", props),
-  CaretRight: (props: Record<string, unknown>) =>
-    createElement("CaretRight", props),
+  Check: (props: Record<string, unknown>) => createElement("Check", props),
+  DownloadSimple: (props: Record<string, unknown>) =>
+    createElement("DownloadSimple", props),
   File: (props: Record<string, unknown>) => createElement("File", props),
+  Package: (props: Record<string, unknown>) => createElement("Package", props),
+  X: (props: Record<string, unknown>) => createElement("X", props),
 }));
 
 vi.mock("@/lib/theme", () => ({
-  useThemeColors: () => ({ gray: { 9: "#777", 11: "#555" } }),
+  useThemeColors: () => ({
+    gray: { 4: "#eee", 10: "#888", 11: "#555", 12: "#111" },
+    accent: { 9: "#09f", 11: "#06c" },
+  }),
 }));
 
 function element() {
@@ -42,7 +82,7 @@ function element() {
 }
 
 function mount(artifacts: TaskRunArtifact[] | undefined) {
-  mockUseTaskArtifacts.mockReturnValue({ data: artifacts });
+  mockUseTaskArtifacts.mockReturnValue({ data: artifacts, refetch: vi.fn() });
   let renderer: ReturnType<typeof create> | null = null;
   act(() => {
     renderer = create(element());
@@ -51,89 +91,146 @@ function mount(artifacts: TaskRunArtifact[] | undefined) {
   return renderer as ReturnType<typeof create>;
 }
 
-function update(
-  renderer: ReturnType<typeof create>,
-  artifacts: TaskRunArtifact[] | undefined,
-) {
-  mockUseTaskArtifacts.mockReturnValue({ data: artifacts });
-  act(() => {
-    renderer.update(element());
-  });
-}
-
 function json(renderer: ReturnType<typeof create>) {
   return JSON.stringify(renderer.toJSON());
 }
 
-function render(artifacts: TaskRunArtifact[] | undefined) {
-  return json(mount(artifacts));
+function pressLabel(renderer: ReturnType<typeof create>, label: string) {
+  const node = renderer.root.findByProps({ accessibilityLabel: label });
+  act(() => {
+    node.props.onPress();
+  });
 }
 
-function pressHeader(renderer: ReturnType<typeof create>) {
-  const header = renderer.root.findByProps({ accessibilityRole: "button" });
+function openSheet(renderer: ReturnType<typeof create>) {
+  const trigger = renderer.root.find((node) =>
+    Boolean(
+      (node.props.accessibilityLabel as string | undefined)?.startsWith(
+        "Files (",
+      ),
+    ),
+  );
   act(() => {
-    header.props.onPress();
+    trigger.props.onPress();
   });
+}
+
+function hasLabel(renderer: ReturnType<typeof create>, label: string): boolean {
+  return (
+    renderer.root.findAll((node) => node.props.accessibilityLabel === label)
+      .length > 0
+  );
 }
 
 describe("TaskArtifacts", () => {
+  beforeEach(() => {
+    dismissTaskRunArtifacts.mockClear();
+    mockUseUserQuery.mockReturnValue({ data: { id: 7 } });
+  });
+
   it("renders nothing when there are no artifacts", () => {
-    expect(render([])).toBe("null");
-    expect(render(undefined)).toBe("null");
+    expect(json(mount([]))).toBe("null");
+    expect(json(mount(undefined))).toBe("null");
   });
 
-  it("lists artifact names and sizes, expanded by default", () => {
-    const output = render([
+  it("shows a count on the trigger and lists files once opened", () => {
+    const renderer = mount([
       { id: "a1", name: "report.md", type: "output", size: 2_400 },
       { id: "a2", name: "chart.png", type: "output", size: 512 },
     ]);
-    expect(output).toContain("Files (2)");
-    expect(output).toContain("report.md");
-    expect(output).toContain("chart.png");
-    expect(output).toContain("2 KB");
-    expect(output).toContain("512 B");
-  });
-
-  it("hides the list when the header is tapped and shows it again", () => {
-    const renderer = mount([
-      { id: "a1", name: "report.md", type: "output", size: 2_400 },
-    ]);
-    expect(json(renderer)).toContain("report.md");
-
-    pressHeader(renderer);
-    const collapsed = json(renderer);
-    expect(collapsed).toContain("Files (1)");
-    expect(collapsed).not.toContain("report.md");
-
-    pressHeader(renderer);
-    expect(json(renderer)).toContain("report.md");
-  });
-
-  it("stays collapsed across a re-render with the same files", () => {
-    const files: TaskRunArtifact[] = [
-      { id: "a1", name: "report.md", type: "output", size: 2_400 },
-    ];
-    const renderer = mount(files);
-    pressHeader(renderer);
+    expect(hasLabel(renderer, "Files (2)")).toBe(true);
     expect(json(renderer)).not.toContain("report.md");
 
-    update(renderer, [...files]);
-    expect(json(renderer)).not.toContain("report.md");
-  });
-
-  it("re-expands when the file list changes", () => {
-    const renderer = mount([
-      { id: "a1", name: "report.md", type: "output", size: 2_400 },
-    ]);
-    pressHeader(renderer);
-    expect(json(renderer)).not.toContain("report.md");
-
-    update(renderer, [
-      { id: "a1", name: "report.md", type: "output", size: 2_400 },
-      { id: "a2", name: "chart.png", type: "output", size: 512 },
-    ]);
+    openSheet(renderer);
     const shown = json(renderer);
     expect(shown).toContain("report.md");
     expect(shown).toContain("chart.png");
+  });
+
+  it("shows the version picker only when a file has more than one version", () => {
+    const renderer = mount([
+      {
+        id: "a1",
+        name: "report.md",
+        type: "output",
+        uploaded_at: "2024-01-01T00:00:00Z",
+      },
+      {
+        id: "a2",
+        name: "report.md",
+        type: "output",
+        uploaded_at: "2024-02-01T00:00:00Z",
+      },
+      { id: "b1", name: "chart.png", type: "output" },
+    ]);
+    openSheet(renderer);
+
+    expect(hasLabel(renderer, "Choose a version of report.md")).toBe(true);
+    expect(hasLabel(renderer, "Choose a version of chart.png")).toBe(false);
+  });
+
+  it("labels the uploader as the current user, a teammate, or the agent", () => {
+    const renderer = mount([
+      {
+        id: "a1",
+        name: "mine.md",
+        type: "output",
+        uploaded_by: "user",
+        uploaded_by_user_id: 7,
+      },
+      {
+        id: "a2",
+        name: "theirs.md",
+        type: "output",
+        uploaded_by: "user",
+        uploaded_by_user_id: 99,
+      },
+      { id: "a3", name: "agent.md", type: "output", uploaded_by: "agent" },
+    ]);
+    openSheet(renderer);
+
+    const shown = json(renderer);
+    expect(shown).toContain("You");
+    expect(shown).toContain("Teammate");
+    expect(shown).toContain("Agent");
+  });
+
+  it("dismisses a file through the api", () => {
+    const renderer = mount([
+      { id: "a1", name: "report.md", type: "output", size: 2_400 },
+    ]);
+    openSheet(renderer);
+
+    pressLabel(renderer, "Dismiss report.md");
+
+    expect(dismissTaskRunArtifacts).toHaveBeenCalledWith(
+      "t1",
+      "r1",
+      ["a1"],
+      true,
+    );
+  });
+
+  it("restores a dismissed file through the api", () => {
+    const renderer = mount([
+      {
+        id: "a1",
+        name: "report.md",
+        type: "output",
+        dismissed_at: "2024-03-01T00:00:00Z",
+      },
+    ]);
+    expect(hasLabel(renderer, "Files (0)")).toBe(true);
+
+    openSheet(renderer);
+    pressLabel(renderer, "Show 1 dismissed");
+    pressLabel(renderer, "Restore report.md");
+
+    expect(dismissTaskRunArtifacts).toHaveBeenCalledWith(
+      "t1",
+      "r1",
+      ["a1"],
+      false,
+    );
   });
 });

--- a/products/desktop/apps/mobile/src/features/tasks/components/TaskArtifacts.tsx
+++ b/products/desktop/apps/mobile/src/features/tasks/components/TaskArtifacts.tsx
@@ -1,19 +1,40 @@
-import { artifactFilesListKey } from "@posthog/core/sessions/artifactFilesListKey";
-import type { TaskRunArtifact } from "@posthog/shared";
+import { Text } from "@components/text";
 import {
-  ArrowSquareOut,
+  groupRunArtifactVersions,
+  type RunArtifactVersions,
+  runArtifactUploaderLabel,
+  runArtifactVersionKey,
+  runArtifactVersionMetaLabel,
+  runArtifactVersionShortLabel,
+} from "@posthog/core/canvas/runArtifactSchemas";
+import { formatRelativeTimeLong, type TaskRunArtifact } from "@posthog/shared";
+import { useMutation } from "@tanstack/react-query";
+import {
   CaretDown,
-  CaretRight,
+  Check,
+  DownloadSimple,
   File as FileIcon,
+  Package,
+  X,
 } from "phosphor-react-native";
-import { useCallback, useState } from "react";
-import { ActivityIndicator, Alert, Pressable, Text, View } from "react-native";
+import { useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  Alert,
+  Pressable,
+  ScrollView,
+  View,
+} from "react-native";
+import { SheetContainer } from "@/components/SheetContainer";
+import { useUserQuery } from "@/features/auth";
 import { openExternalUrl } from "@/lib/openExternalUrl";
 import { useThemeColors } from "@/lib/theme";
-import { presignTaskRunArtifact } from "../api";
+import { dismissTaskRunArtifacts, presignTaskRunArtifact } from "../api";
 import { useTaskArtifacts } from "../hooks/useTaskArtifacts";
 import { formatArtifactSize } from "../utils/artifactPreview";
 import { ArtifactPreview } from "./ArtifactPreview";
+
+type ArtifactGroup = RunArtifactVersions<TaskRunArtifact>;
 
 interface TaskArtifactsProps {
   taskId: string | undefined;
@@ -24,111 +45,326 @@ interface TaskArtifactsProps {
 
 export function TaskArtifacts({ taskId, runId, enabled }: TaskArtifactsProps) {
   const themeColors = useThemeColors();
-  const { data: artifacts } = useTaskArtifacts(taskId, runId, enabled);
+  const { data: artifacts, refetch } = useTaskArtifacts(taskId, runId, enabled);
+  const { data: currentUser } = useUserQuery();
+  const [open, setOpen] = useState(false);
   const [preview, setPreview] = useState<TaskRunArtifact | null>(null);
   const [sharingId, setSharingId] = useState<string | null>(null);
-  const fileListKey = artifactFilesListKey(
-    runId,
-    (artifacts ?? []).map((artifact) => artifact.name ?? ""),
-  );
-  const [collapse, setCollapse] = useState({
-    collapsed: false,
-    key: fileListKey,
-  });
-  if (collapse.key !== fileListKey) {
-    setCollapse({ collapsed: false, key: fileListKey });
-  }
-  const collapsed = collapse.collapsed;
+  const [showDismissed, setShowDismissed] = useState(false);
+  const [versionPickerFor, setVersionPickerFor] = useState<string | null>(null);
+  const [selectedVersionByName, setSelectedVersionByName] = useState<
+    Record<string, string>
+  >({});
+  const [dismissalOverrides, setDismissalOverrides] = useState<
+    Record<string, string | null>
+  >({});
 
-  const shareArtifact = useCallback(
-    async (artifact: TaskRunArtifact): Promise<void> => {
-      if (!taskId || !runId || !artifact.storage_path) return;
-      setSharingId(artifact.id ?? artifact.storage_path);
-      try {
-        const url = await presignTaskRunArtifact(
-          taskId,
-          runId,
-          artifact.storage_path,
-        );
-        openExternalUrl(url);
-      } catch {
-        Alert.alert("Couldn't open file", "Please try again.");
-      } finally {
-        setSharingId(null);
+  const groups = useMemo(
+    () =>
+      groupRunArtifactVersions(
+        (artifacts ?? []).map((artifact) =>
+          artifact.id && artifact.id in dismissalOverrides
+            ? { ...artifact, dismissed_at: dismissalOverrides[artifact.id] }
+            : artifact,
+        ),
+      ),
+    [artifacts, dismissalOverrides],
+  );
+  const visibleGroups = groups.filter((group) => !group.dismissed);
+  const dismissedGroups = groups.filter((group) => group.dismissed);
+
+  const dismissal = useMutation({
+    mutationFn: ({
+      group,
+      dismissed,
+    }: {
+      group: ArtifactGroup;
+      dismissed: boolean;
+    }) => {
+      const ids = group.versions.flatMap((v) => (v.id ? [v.id] : []));
+      if (ids.length !== group.versions.length) {
+        throw new Error("Artifact versions are still uploading");
       }
+      return dismissTaskRunArtifacts(taskId ?? "", runId ?? "", ids, dismissed);
     },
-    [taskId, runId],
-  );
+    // Overlay just the dismissal stamps from the response, then refetch and drop
+    // the overlay so the manifest stays the source of truth.
+    onSuccess: async (manifest) => {
+      setDismissalOverrides((current) => ({
+        ...current,
+        ...Object.fromEntries(
+          manifest.flatMap((entry) =>
+            entry.id ? [[entry.id, entry.dismissed_at ?? null]] : [],
+          ),
+        ),
+      }));
+      const refreshed = await refetch();
+      if (refreshed?.data) setDismissalOverrides({});
+    },
+    onError: () =>
+      Alert.alert("Couldn't update this file", "Please try again."),
+  });
 
-  if (!taskId || !runId || !artifacts || artifacts.length === 0) return null;
+  const shareArtifact = async (artifact: TaskRunArtifact): Promise<void> => {
+    if (!taskId || !runId || !artifact.storage_path) return;
+    setSharingId(artifact.id ?? artifact.storage_path);
+    try {
+      const url = await presignTaskRunArtifact(
+        taskId,
+        runId,
+        artifact.storage_path,
+      );
+      openExternalUrl(url);
+    } catch {
+      Alert.alert("Couldn't open file", "Please try again.");
+    } finally {
+      setSharingId(null);
+    }
+  };
 
-  return (
-    <View className="mx-4 mb-2 rounded-lg border border-gray-5 bg-gray-2 p-3">
-      <Pressable
-        onPress={() => setCollapse({ collapsed: !collapsed, key: fileListKey })}
-        hitSlop={6}
-        accessibilityRole="button"
-        accessibilityLabel={`Files (${artifacts.length})`}
-        accessibilityState={{ expanded: !collapsed }}
-        className="flex-row items-center gap-1.5 self-start py-1 active:opacity-60"
+  if (!taskId || !runId || groups.length === 0) return null;
+
+  const renderRow = (group: ArtifactGroup) => {
+    const pickedIndex = group.versions.findIndex(
+      (version) =>
+        runArtifactVersionKey(version) === selectedVersionByName[group.name],
+    );
+    const newestVisibleIndex = group.versions.findIndex(
+      (version) => !version.dismissed_at,
+    );
+    const selectedIndex =
+      pickedIndex >= 0 ? pickedIndex : Math.max(newestVisibleIndex, 0);
+    const selected = group.versions[selectedIndex];
+    const size = formatArtifactSize(selected.size);
+    const canPreview = Boolean(selected.id);
+    const canChangeDismissal = group.versions.every((version) => version.id);
+    const hasVersions = group.versions.length > 1;
+    const pickerOpen = versionPickerFor === group.name;
+
+    const meta = [
+      runArtifactUploaderLabel(selected, currentUser),
+      selected.uploaded_at
+        ? formatRelativeTimeLong(selected.uploaded_at)
+        : null,
+      size,
+    ]
+      .filter(Boolean)
+      .join(" · ");
+
+    return (
+      <View
+        key={group.name}
+        className="rounded-lg border border-gray-5 bg-gray-2"
       >
-        {collapsed ? (
-          <CaretRight size={14} color={themeColors.gray[12]} />
-        ) : (
-          <CaretDown size={14} color={themeColors.gray[12]} />
-        )}
-        <Text className="font-semibold text-[13px] text-gray-12">
-          Files ({artifacts.length})
-        </Text>
-      </Pressable>
-      {collapsed ? null : (
-        <View className="mt-2 gap-1">
-          {artifacts.map((artifact) => {
-            const sharingKey = artifact.id ?? artifact.storage_path;
-            const size = formatArtifactSize(artifact.size);
-            const canPreview = Boolean(artifact.id);
-            return (
-              <View
-                key={sharingKey ?? artifact.name}
-                className="flex-row items-center gap-3 rounded-md bg-background px-2 py-1.5"
+        <View className="flex-row items-center gap-2.5 py-2 pr-1.5 pl-2">
+          <Pressable
+            className="min-w-0 flex-1 flex-row items-center gap-2.5 active:opacity-70"
+            disabled={!canPreview}
+            accessibilityRole="button"
+            accessibilityLabel={`View ${group.name}`}
+            onPress={() => {
+              setOpen(false);
+              setPreview(selected);
+            }}
+          >
+            <View className="h-8 w-8 shrink-0 items-center justify-center rounded-md bg-gray-4">
+              <FileIcon size={16} color={themeColors.gray[11]} />
+            </View>
+            <View className="min-w-0 flex-1">
+              <Text
+                className="font-medium text-[13px] text-gray-12"
+                numberOfLines={1}
               >
-                <Pressable
-                  className="min-w-0 flex-1 flex-row items-center gap-2 active:opacity-70"
-                  disabled={!canPreview}
-                  onPress={() => setPreview(artifact)}
-                >
-                  <FileIcon size={16} color={themeColors.gray[11]} />
-                  <Text
-                    className="flex-shrink text-[13px] text-gray-12"
-                    numberOfLines={1}
-                  >
-                    {artifact.name ?? "artifact"}
+                {group.name}
+              </Text>
+              <View className="flex-row items-center gap-1">
+                {meta ? (
+                  <Text className="text-[12px] text-gray-10" numberOfLines={1}>
+                    {meta}
                   </Text>
-                  {size ? (
-                    <Text className="text-[12px] text-gray-9">{size}</Text>
-                  ) : null}
-                </Pressable>
+                ) : null}
+                {hasVersions ? (
+                  <>
+                    {meta ? (
+                      <Text className="text-[12px] text-gray-10">·</Text>
+                    ) : null}
+                    <Pressable
+                      hitSlop={6}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Choose a version of ${group.name}`}
+                      onPress={() =>
+                        setVersionPickerFor(pickerOpen ? null : group.name)
+                      }
+                      className="flex-row items-center gap-0.5 active:opacity-60"
+                    >
+                      <Text className="text-[12px] text-gray-12">
+                        {runArtifactVersionShortLabel(
+                          selectedIndex,
+                          group.versions.length,
+                        )}
+                      </Text>
+                      <CaretDown size={10} color={themeColors.gray[11]} />
+                    </Pressable>
+                  </>
+                ) : null}
+              </View>
+            </View>
+          </Pressable>
+
+          <View className="shrink-0 flex-row items-center gap-1">
+            {group.dismissed ? (
+              <Pressable
+                hitSlop={6}
+                disabled={dismissal.isPending || !canChangeDismissal}
+                onPress={() => dismissal.mutate({ group, dismissed: false })}
+                accessibilityRole="button"
+                accessibilityLabel={`Restore ${group.name}`}
+                className="rounded-md px-2 py-1.5 active:opacity-60"
+              >
+                <Text className="font-medium text-[13px] text-gray-12">
+                  Restore
+                </Text>
+              </Pressable>
+            ) : (
+              <>
                 <Pressable
-                  hitSlop={8}
-                  className="active:opacity-60"
-                  disabled={!artifact.storage_path}
-                  onPress={() => void shareArtifact(artifact)}
-                  accessibilityLabel="Open externally"
+                  hitSlop={6}
+                  disabled={!canPreview || sharingId !== null}
+                  onPress={() => void shareArtifact(selected)}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Download ${group.name}`}
+                  className="h-8 w-8 items-center justify-center active:opacity-60"
                 >
-                  {sharingId === sharingKey ? (
+                  {sharingId === (selected.id ?? selected.storage_path) ? (
                     <ActivityIndicator
                       size="small"
                       color={themeColors.gray[11]}
                     />
                   ) : (
-                    <ArrowSquareOut size={16} color={themeColors.gray[11]} />
+                    <DownloadSimple size={16} color={themeColors.gray[11]} />
                   )}
                 </Pressable>
-              </View>
-            );
-          })}
+                <Pressable
+                  hitSlop={6}
+                  disabled={dismissal.isPending || !canChangeDismissal}
+                  onPress={() => dismissal.mutate({ group, dismissed: true })}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Dismiss ${group.name}`}
+                  className="h-8 w-8 items-center justify-center active:opacity-60"
+                >
+                  <X size={16} color={themeColors.gray[11]} />
+                </Pressable>
+              </>
+            )}
+          </View>
         </View>
-      )}
+
+        {pickerOpen && hasVersions ? (
+          <View className="border-gray-5 border-t px-2 py-1">
+            {group.versions.map((version, index) => {
+              const key = runArtifactVersionKey(version);
+              return (
+                <Pressable
+                  key={key}
+                  onPress={() => {
+                    setSelectedVersionByName((current) => ({
+                      ...current,
+                      [group.name]: key,
+                    }));
+                    setVersionPickerFor(null);
+                  }}
+                  className="flex-row items-center gap-2 rounded-md px-2 py-2 active:bg-gray-3"
+                >
+                  <Text
+                    className="min-w-0 flex-1 text-[13px] text-gray-12"
+                    numberOfLines={1}
+                  >
+                    {runArtifactVersionMetaLabel(
+                      version,
+                      index,
+                      group.versions.length,
+                      currentUser,
+                    )}
+                  </Text>
+                  {index === selectedIndex ? (
+                    <Check size={14} color={themeColors.accent[9]} />
+                  ) : null}
+                </Pressable>
+              );
+            })}
+          </View>
+        ) : null}
+      </View>
+    );
+  };
+
+  const dismissedToggleLabel = showDismissed
+    ? "Hide dismissed"
+    : `Show ${dismissedGroups.length} dismissed`;
+
+  return (
+    <>
+      <Pressable
+        onPress={() => setOpen(true)}
+        hitSlop={8}
+        accessibilityRole="button"
+        accessibilityLabel={`Files (${visibleGroups.length})`}
+        className="h-9 w-9 items-center justify-center active:opacity-60"
+      >
+        <Package
+          size={18}
+          color={
+            visibleGroups.length > 0
+              ? themeColors.accent[11]
+              : themeColors.gray[10]
+          }
+          weight={visibleGroups.length > 0 ? "fill" : "regular"}
+        />
+        {visibleGroups.length > 0 ? (
+          <View className="absolute top-1 right-1 h-4 min-w-4 items-center justify-center rounded-full bg-accent-9 px-0.5">
+            <Text className="font-semibold text-[9px] text-accent-contrast">
+              {visibleGroups.length}
+            </Text>
+          </View>
+        ) : null}
+      </Pressable>
+
+      <SheetContainer open={open} onClose={() => setOpen(false)}>
+        {open ? (
+          <>
+            <View className="flex-row items-center justify-between px-4 pt-2 pb-2">
+              <Text className="font-semibold text-[16px] text-gray-12">
+                Files
+              </Text>
+              <Text className="text-[12px] text-gray-10">
+                {visibleGroups.length === 1
+                  ? "1 file"
+                  : `${visibleGroups.length} files`}
+              </Text>
+            </View>
+
+            <ScrollView
+              className="max-h-96 px-4"
+              contentContainerStyle={{ paddingBottom: 8, gap: 6 }}
+            >
+              {visibleGroups.map(renderRow)}
+              {showDismissed ? dismissedGroups.map(renderRow) : null}
+              {dismissedGroups.length > 0 ? (
+                <Pressable
+                  onPress={() => setShowDismissed((current) => !current)}
+                  accessibilityRole="button"
+                  accessibilityLabel={dismissedToggleLabel}
+                  className="self-start py-1 active:opacity-60"
+                >
+                  <Text className="font-medium text-[13px] text-accent-11">
+                    {dismissedToggleLabel}
+                  </Text>
+                </Pressable>
+              ) : null}
+            </ScrollView>
+          </>
+        ) : null}
+      </SheetContainer>
 
       {preview?.id ? (
         <ArtifactPreview
@@ -138,6 +374,6 @@ export function TaskArtifacts({ taskId, runId, enabled }: TaskArtifactsProps) {
           onClose={() => setPreview(null)}
         />
       ) : null}
-    </View>
+    </>
   );
 }

--- a/products/desktop/apps/mobile/src/features/tasks/components/TaskSessionView.tsx
+++ b/products/desktop/apps/mobile/src/features/tasks/components/TaskSessionView.tsx
@@ -34,7 +34,6 @@ import { CloudMessageAttachment } from "./CloudMessageAttachment";
 import { PlanApprovalCard } from "./PlanApprovalCard";
 import { PlanStatusBar } from "./PlanStatusBar";
 import { QuestionCard } from "./QuestionCard";
-import { TaskArtifacts } from "./TaskArtifacts";
 import { TerminalStatusBanner } from "./TerminalStatusBanner";
 
 interface PermissionResponseArgs {
@@ -57,8 +56,6 @@ interface OptimisticUserMessage {
 interface TaskSessionViewProps {
   events: SessionEvent[];
   taskId?: string;
-  // Latest run id, used to list the run's generated output artifacts.
-  runId?: string;
   pendingPermissions?: Record<string, CloudPendingPermissionRequest>;
   isConnecting?: boolean;
   isThinking?: boolean;
@@ -807,7 +804,6 @@ function ConnectingIndicator() {
 export function TaskSessionView({
   events,
   taskId,
-  runId,
   pendingPermissions,
   isConnecting,
   isThinking,
@@ -1022,25 +1018,17 @@ export function TaskSessionView({
   );
 
   // Memoized so a live session's frequent re-renders (streaming, timers) don't
-  // reconcile the banner + artifacts subtree on every tick.
+  // reconcile the banner subtree on every tick.
   const listHeader = useMemo(
-    () => (
-      <>
-        {terminalStatus ? (
-          <TerminalStatusBanner
-            terminalStatus={terminalStatus}
-            lastError={lastError}
-            onRetry={onRetry}
-          />
-        ) : null}
-        <TaskArtifacts
-          taskId={taskId}
-          runId={runId}
-          enabled={!!terminalStatus}
+    () =>
+      terminalStatus ? (
+        <TerminalStatusBanner
+          terminalStatus={terminalStatus}
+          lastError={lastError}
+          onRetry={onRetry}
         />
-      </>
-    ),
-    [terminalStatus, lastError, onRetry, taskId, runId],
+      ) : null,
+    [terminalStatus, lastError, onRetry],
   );
 
   return (

--- a/products/desktop/apps/mobile/src/features/tasks/composer/TaskChatComposer.tsx
+++ b/products/desktop/apps/mobile/src/features/tasks/composer/TaskChatComposer.tsx
@@ -21,6 +21,7 @@ import {
   Stop,
 } from "phosphor-react-native";
 import { useFeatureFlag } from "posthog-react-native";
+import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
@@ -96,6 +97,8 @@ interface TaskChatComposerProps {
   /** True while editing a queued message in place; the next send saves it. */
   editing?: boolean;
   onCancelEdit?: () => void;
+  /** Run artifacts trigger, rendered in the composer toolbar row. */
+  artifactsSlot?: ReactNode;
 }
 
 export function TaskChatComposer({
@@ -124,6 +127,7 @@ export function TaskChatComposer({
   restoredDraft,
   editing = false,
   onCancelEdit,
+  artifactsSlot,
 }: TaskChatComposerProps) {
   const themeColors = useThemeColors();
   const { configOptions: liveConfigOptions, hasLiveConfig } =
@@ -397,6 +401,8 @@ export function TaskChatComposer({
                   weight={attachments.length > 0 ? "fill" : "regular"}
                 />
               </Pressable>
+
+              {artifactsSlot}
 
               <ScrollView
                 horizontal

--- a/products/desktop/packages/core/src/canvas/runArtifactSchemas.ts
+++ b/products/desktop/packages/core/src/canvas/runArtifactSchemas.ts
@@ -1,3 +1,4 @@
+import { formatRelativeTimeLong } from "@posthog/shared";
 import { z } from "zod";
 
 export const runArtifactSchema = z.object({
@@ -38,6 +39,54 @@ export function parseRunArtifacts(
 /** Names a version by its position in a newest-first group. */
 export function runArtifactVersionLabel(index: number, total: number): string {
   return index === 0 ? "Latest" : `Version ${total - index}`;
+}
+
+/** Compact one-based version label: v1 is the oldest upload, v{total} the newest. */
+export function runArtifactVersionShortLabel(
+  index: number,
+  total: number,
+): string {
+  return `v${total - index}`;
+}
+
+export interface RunArtifactUploader {
+  id?: number;
+  first_name?: string | null;
+}
+
+/** Who uploaded a version: the current user's name (or "You"), a teammate, or the agent. */
+export function runArtifactUploaderLabel(
+  artifact: { uploaded_by?: "agent" | "user"; uploaded_by_user_id?: number },
+  currentUser: RunArtifactUploader | undefined,
+): string {
+  if (artifact.uploaded_by !== "user") return "Agent";
+  if (
+    currentUser?.id !== undefined &&
+    artifact.uploaded_by_user_id === currentUser.id
+  ) {
+    return currentUser.first_name?.trim() || "You";
+  }
+  return "Teammate";
+}
+
+/** A version's picker line: "v{n} · <uploader> · <uploaded time>". */
+export function runArtifactVersionMetaLabel(
+  artifact: {
+    uploaded_by?: "agent" | "user";
+    uploaded_by_user_id?: number;
+    uploaded_at?: string;
+  },
+  index: number,
+  total: number,
+  currentUser: RunArtifactUploader | undefined,
+): string {
+  return [
+    runArtifactVersionShortLabel(index, total),
+    runArtifactUploaderLabel(artifact, currentUser),
+    artifact.uploaded_at ? formatRelativeTimeLong(artifact.uploaded_at) : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
 }
 
 /**


### PR DESCRIPTION
## Problem

On mobile, a finished task's output files sat in a collapsible "Files (n)" box pinned above the composer in the thread. This ports the desktop redesign in #82155, which takes that list off the thread and puts it behind a button in the composer toolbar.

port of #82155

## Changes

- A files button appears in the composer toolbar when a run has output files, with a count badge, and stays hidden when there are none.
- Tapping the button opens a bottom sheet listing each file as a card: an icon, the name, and a `uploader · uploaded time · size` meta line.
- The uploader reads as the current user's first name (or "You"), "Teammate", or "Agent".
- A file with more than one version gets an inline `v{n}` picker in the meta line, where v1 is the oldest upload and v{total} the newest.
- Each card downloads or dismisses the file; a dismissed file shows Restore, and tapping the card opens the file preview.
- The old inline `TaskArtifacts` box and its local collapse state are removed, matching what desktop deleted.
- The three uploader and version label helpers move into `@posthog/core`, so the logic is host-agnostic and the mobile view is a thin binding over it. This PR does not touch `packages/ui`; the desktop copies are left for a later sweep.

Design note: a popover is the wrong control on a phone, so the desktop popover becomes the app's existing bottom sheet, opened from a toolbar button rather than hovering off it. The version picker stays inline in the card instead of a second sheet, to avoid stacking React Native modals. The desktop icon tile's blurred, scaled-up backdrop is dropped because it does not earn its place at mobile size.

## How did you test this code?

- Updated `TaskArtifacts.test.tsx` (vitest) to cover the behavior that changed: the trigger is hidden with no files, the version picker appears only when a file has more than one version, dismiss and restore call the API with the right flag, and the uploader label resolves to "You", "Teammate", or "Agent".
- Ran the mobile vitest suite and the core suite locally, ran biome, and ran tsc over the changed files.
- Not done: I did not run the app on a device or simulator, which this environment cannot start, so no screenshot is attached. The change is visual — it adds a toolbar button and a bottom sheet.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Ported #82155 (desktop popover) to the React Native host as a bottom sheet.
- Skills invoked: `/simplify` (applied: moved the label helpers into `@posthog/core`, gated the sheet body render on open state, folded a repeated label into one binding), `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.
- Reused the shared `groupRunArtifactVersions` and `runArtifactVersionKey` helpers, the app's `SheetContainer`, `formatRelativeTimeLong`, and `useUserQuery` rather than reimplementing them.
- Public artifact: no customer conversation, ticket, or session material is present in the code, tests, or this description.
