### PR TITLE
feat(desktop): enable Slack comment DMs by default

### DIFF
--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -2010,7 +2010,7 @@ class TestUserAPI(APIBaseTest):
             {
                 "plugin_disabled": False,
                 "discussions_mentioned": False,
-                "task_comments_slack_dm": False,
+                "task_comments_slack_dm": True,
                 "project_weekly_digest_disabled": {"123": True},  # Note: JSON converts int keys to strings
                 "all_weekly_digest_disabled": True,
                 "error_tracking_issue_assigned": False,
@@ -2033,7 +2033,7 @@ class TestUserAPI(APIBaseTest):
             {
                 "plugin_disabled": False,
                 "discussions_mentioned": False,
-                "task_comments_slack_dm": False,
+                "task_comments_slack_dm": True,
                 "project_weekly_digest_disabled": {"123": True},
                 "all_weekly_digest_disabled": True,
                 "error_tracking_issue_assigned": False,
@@ -2304,7 +2304,7 @@ class TestUserAPI(APIBaseTest):
             {
                 "plugin_disabled": True,  # Default value
                 "discussions_mentioned": True,  # Default value
-                "task_comments_slack_dm": False,  # Default value
+                "task_comments_slack_dm": True,  # Default value
                 "project_weekly_digest_disabled": {},  # Default value
                 "all_weekly_digest_disabled": True,
                 "error_tracking_issue_assigned": True,  # Default value

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -66,8 +66,7 @@ NOTIFICATION_DEFAULTS: Notifications = {
     "error_tracking_issue_assigned": True,  # Error tracking issue assignment
     "error_tracking_weekly_digest": True,  # Error tracking weekly digest enabled by default
     "discussions_mentioned": True,  # Mentions in comments enabled by default
-    # Off by default: forwarding comment text into Slack is opt-in, not implied by linking Slack.
-    "task_comments_slack_dm": False,
+    "task_comments_slack_dm": True,
     "project_weekly_digest_disabled": {},  # Empty dict by default - no projects disabled
     "all_weekly_digest_disabled": False,  # Weekly digests enabled by default
     "data_pipeline_error_threshold": 0.01,  # Default: notify when failure rate exceeds 1%

--- a/products/tasks/backend/logic/services/comment_slack_dm.py
+++ b/products/tasks/backend/logic/services/comment_slack_dm.py
@@ -24,7 +24,7 @@ from posthog.models.comment import Comment
 from posthog.models.integration import Integration, SlackIntegration
 from posthog.models.organization import OrganizationMembership
 from posthog.models.team import Team
-from posthog.models.user import User
+from posthog.models.user import NOTIFICATION_DEFAULTS, User
 from posthog.models.user_integration import UserIntegration
 from posthog.user_permissions import UserPermissions
 
@@ -34,7 +34,6 @@ from products.tasks.backend.models import Task, TaskCommentActivity
 
 logger = structlog.get_logger(__name__)
 
-# Opt-in: having linked a Slack account is not consent to have your comments forwarded into it.
 SLACK_DM_SETTING = "task_comments_slack_dm"
 
 # Slack allows 3000 characters per section; a DM that long is unreadable, and the link to the full
@@ -59,7 +58,7 @@ _HEADINGS: Mapping[str, str] = {
 
 
 def send_comment_slack_dms(*, team_id: int, comment_id: UUID, task_id: UUID, recipients: Mapping[int, str]) -> None:
-    """DM each recipient who opted in, can still see the comment, and has linked Slack.
+    """DM each recipient who has not opted out, can still see the comment, and has linked Slack.
 
     ``recipients`` is the map ``comment_activity`` just projected: user id to activity kind.
     """
@@ -73,11 +72,10 @@ def send_comment_slack_dms(*, team_id: int, comment_id: UUID, task_id: UUID, rec
     if skip_reason:
         return _skip(comment_id, skip_reason)
 
-    # Cheapest gate first: most comments have no opted-in recipient, and this keeps the flag call
-    # (a network hop) off that path.
+    # Resolve preferences before the flag call so explicit opt-outs avoid its network hop.
     wanted = _recipients_wanting_dms(team_id=team_id, comment=comment, recipients=recipients)
     if not wanted:
-        return _skip(comment_id, "no_opted_in_recipient")
+        return _skip(comment_id, "no_enabled_recipient")
 
     integrations = list(
         Integration.objects.filter(team_id=team_id, kind=Integration.IntegrationKind.SLACK)
@@ -191,25 +189,24 @@ def _skip_reason(comment: Comment) -> str | None:
 
 
 def _recipients_wanting_dms(*, team_id: int, comment: Comment, recipients: Mapping[int, str]) -> dict[int, str]:
-    """Narrow the Activity recipients to the ones who asked to be DMed.
+    """Narrow the Activity recipients to the ones who have not disabled DMs.
 
     ``THREAD_REPLY`` narrows further: the Activity feed notifies every thread participant, but the
     DM says "replied to your comment", so only the thread's author gets one.
     """
-    # Read the raw partial settings rather than the merged `notification_settings` property: the
-    # setting is opt-in, so an absent key means off and there's no default to merge in.
-    opted_in = {
+    enabled = {
         user_id
         for user_id, partial in User.objects.filter(id__in=list(recipients), is_active=True).values_list(
             "id", "partial_notification_settings"
         )
-        if isinstance(partial, dict) and partial.get(SLACK_DM_SETTING) is True
+        if not isinstance(partial, dict)
+        or partial.get(SLACK_DM_SETTING, NOTIFICATION_DEFAULTS["task_comments_slack_dm"]) is True
     }
-    if not opted_in:
+    if not enabled:
         return {}
 
     root_author_id: int | None = None
-    if any(kind == TaskCommentActivity.Kind.THREAD_REPLY for uid, kind in recipients.items() if uid in opted_in):
+    if any(kind == TaskCommentActivity.Kind.THREAD_REPLY for uid, kind in recipients.items() if uid in enabled):
         root_author_id = (
             Comment.objects.filter(team_id=team_id, id=comment.source_comment_id or comment.id)
             .values_list("created_by_id", flat=True)
@@ -218,7 +215,7 @@ def _recipients_wanting_dms(*, team_id: int, comment: Comment, recipients: Mappi
 
     wanted: dict[int, str] = {}
     for user_id, kind in recipients.items():
-        if user_id not in opted_in:
+        if user_id not in enabled:
             continue
         if kind == TaskCommentActivity.Kind.THREAD_REPLY and user_id != root_author_id:
             continue

--- a/products/tasks/backend/tests/test_comment_slack_dm.py
+++ b/products/tasks/backend/tests/test_comment_slack_dm.py
@@ -24,7 +24,6 @@ class TestCommentSlackDm(CommentActivityTestCase):
             team=self.team, kind="slack", integration_id=SLACK_WORKSPACE_ID, config={"scope": "chat:write"}
         )
         self._link_slack(self.author, "U-author")
-        self._opt_in(self.author)
 
         flag_patch = patch(
             "products.tasks.backend.logic.services.comment_slack_dm.is_slack_app_oauth_enabled", return_value=True
@@ -60,7 +59,7 @@ class TestCommentSlackDm(CommentActivityTestCase):
     def _dm_channels(self) -> list[str]:
         return [call.kwargs["channel"] for call in self.slack_client.chat_postMessage.call_args_list]
 
-    def test_mention_dms_the_mentioned_user(self):
+    def test_mention_dms_the_mentioned_user_by_default(self):
         comment = self._comment()
 
         self._record_activity(comment, [self.author.id])


### PR DESCRIPTION
## Problem

People with Slack available can miss desktop comment activity until they manually enable Slack DMs.

**Why:** Slack should notify people about relevant comment activity without requiring a second opt-in after setup.

## Changes

- Slack comment DMs now default to enabled for users without a saved preference.
- Explicit opt-outs remain disabled.
- Existing Slack identity, access, and workspace safeguards remain unchanged.
- This change has no visual frontend changes.

## How did you test this code?

- Repo-wide mypy completed successfully.
- Ruff lint, Ruff format, Python compilation, and diff checks passed for all changed files.
- The focused Django suites did not complete because this VM stalled during test initialization before running tests.
- Preflight passed freshness, lint, and formatting; OpenAPI generation stopped because the MCP workspace dependency was unavailable locally.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No matching user documentation exists. The desktop setting already explains the behavior and opt-out control.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and reviewed this change using repository tools and the /posthog-desktop, /writing-tests, /writing-code-comments, and /writing-pr-descriptions skills. The regression coverage now exercises delivery without a stored opt-in.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*