### PR TITLE
fix(tiktok-ads): retry TikTok internal service error 51002

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_source.py
@@ -123,6 +123,9 @@ class TestTikTokAdsSource:
             ("system_error", 50000, "System error"),
             ("rate_limited", 40100, "Requests made too frequently"),
             ("maintenance", 60001, "The system is in maintenance"),
+            # Internal service error TikTok itself asks callers to retry — must not raise the
+            # non-retryable ValueError the else-branch raises for unclassified codes.
+            ("internal_service_error", 51002, "Internal service error. Please retry later."),
         ]
     )
     def test_retryable_paginator_error_matches_get_retryable_errors(self, name, api_code, message):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/utils.py
@@ -478,6 +478,7 @@ class TikTokAdsPaginator(BasePaginator):
                     50000,  # System error
                     50002,  # Error processing request on TikTok side. Please see error message for details.
                     51001,  # Internal service timeout. Transient TikTok-side error; safe to retry.
+                    51002,  # Internal service error. Transient TikTok-side error; TikTok's own message asks to retry later.
                     51039,  # Internal service timeout. Transient TikTok-side error; safe to retry.
                     51305,  # Satellite service error
                     60001,  # The system is in maintenance.


### PR DESCRIPTION
## Problem

- A team syncing TikTok Ads had its sync fail whenever TikTok returned error code 51002, a transient internal service error.
- TikTok's own message for 51002 asks the caller to retry later ("Internal service error ... Please retry later.").
- The paginator only treats a fixed set of codes as retryable. 51002 was missing, so it fell into the else-branch that raises a non-retryable error and fails the job instead of retrying.
- Its siblings 51001 and 51039 ("Internal service timeout") are already in the retryable set, so 51002 was an inconsistent gap.

## Changes

- Add code 51002 to the paginator's retryable code set, alongside 51001 and 51039.
- A 51002 response now raises the retryable `TikTokAdsAPIError`, so Temporal retries the activity rather than failing the sync.

## How did you test this code?

- Added a parameterized case (`internal_service_error`, 51002) to `test_retryable_paginator_error_matches_get_retryable_errors`. It catches a regression where 51002 is dropped from the retryable set and starts raising the non-retryable `ValueError` again. Ran the tiktok paginator classification tests locally; they pass.
- Not run: the full backend suite (no database in this sandbox).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by an agent (Claude) while triaging a batch of data-warehouse sync failure classes. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`. The failure was identified from the recorded `latest_error` on failed TikTok jobs; the fix mirrors the existing treatment of the neighboring 51001/51039 internal-service codes.
