### PR TITLE
feat(desktop): show artifact age in the Artifacts tab

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/TaskArtifactsList.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskArtifactsList.test.tsx
@@ -1,4 +1,6 @@
+import type { ThreadTimelineRow } from "@posthog/core/canvas/threadTimeline";
 import type { Task, TaskRun, TaskRunArtifact } from "@posthog/shared";
+import type { TaskThreadMessage } from "@posthog/shared/domain-types";
 import {
   fireEvent,
   render,
@@ -6,7 +8,6 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
-import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -194,20 +195,26 @@ describe("TaskArtifactsList", () => {
   it("shows how long ago each PR and canvas was produced", () => {
     mocks.runs = [];
     const now = Date.now();
-    const timeline = [
+    const message = (id: string): TaskThreadMessage => ({
+      id,
+      task: "task-1",
+      content: "",
+      created_at: "",
+    });
+    const timeline: ThreadTimelineRow<TaskThreadMessage>[] = [
       {
         kind: "artifact",
         timestamp: now - 2 * 86_400_000,
-        message: { id: "m1", created_at: "" },
+        message: message("m1"),
         artifact: { kind: "canvas", name: "Dashboard", url: null },
       },
       {
         kind: "artifact",
         timestamp: now - 43 * 60_000,
-        message: { id: "m2", created_at: "" },
+        message: message("m2"),
         artifact: { kind: "pr", url: "https://github.com/acme/repo/pull/7" },
       },
-    ] as unknown as ComponentProps<typeof TaskArtifactsList>["timeline"];
+    ];
 
     render(<TaskArtifactsList task={task} timeline={timeline} />);
 

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskArtifactsList.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskArtifactsList.test.tsx
@@ -6,6 +6,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
+import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -186,6 +187,32 @@ describe("TaskArtifactsList", () => {
 
     expect(screen.getByText("Pull request #1")).toBeTruthy();
     expect(screen.getByText("Pull request #2")).toBeTruthy();
+  });
+
+  // The age reads from each row's announcing timestamp, so the tab shows how
+  // long ago a PR or canvas was produced next to its state.
+  it("shows how long ago each PR and canvas was produced", () => {
+    mocks.runs = [];
+    const now = Date.now();
+    const timeline = [
+      {
+        kind: "artifact",
+        timestamp: now - 2 * 86_400_000,
+        message: { id: "m1", created_at: "" },
+        artifact: { kind: "canvas", name: "Dashboard", url: null },
+      },
+      {
+        kind: "artifact",
+        timestamp: now - 43 * 60_000,
+        message: { id: "m2", created_at: "" },
+        artifact: { kind: "pr", url: "https://github.com/acme/repo/pull/7" },
+      },
+    ] as unknown as ComponentProps<typeof TaskArtifactsList>["timeline"];
+
+    render(<TaskArtifactsList task={task} timeline={timeline} />);
+
+    expect(screen.getByText("Canvas · 2d")).toBeInTheDocument();
+    expect(screen.getByText("Open · 43m")).toBeInTheDocument();
   });
 
   it("lists uploaded files with their comment count", () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskArtifactsList.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskArtifactsList.tsx
@@ -28,7 +28,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@posthog/quill";
-import { formatRelativeTimeLong } from "@posthog/shared";
+import { formatRelativeTimeShort } from "@posthog/shared";
 import type { Task, TaskThreadMessage } from "@posthog/shared/domain-types";
 import { useMeQuery } from "@posthog/ui/features/auth/useMeQuery";
 import { iconForTemplate } from "@posthog/ui/features/canvas/components/canvasTemplateIcon";
@@ -148,12 +148,17 @@ function stopCardOpen(event: MouseEvent) {
 
 function PrRow({
   url,
+  ts,
   openInPlaceTaskId,
 }: {
   url: string;
+  ts: number;
   openInPlaceTaskId?: string;
 }) {
   const { safeUrl, title, stateLabel, Icon, iconColor } = usePrArtifact(url);
+  const meta = [stateLabel, ts ? formatRelativeTimeShort(ts) : null]
+    .filter(Boolean)
+    .join(" · ");
 
   const [countsWanted, setCountsWanted] = useState(false);
   const comments = usePrComments(countsWanted ? safeUrl : null);
@@ -170,7 +175,7 @@ function PrRow({
     <ArtifactCard
       icon={<Icon size={16} weight="bold" style={{ color: iconColor }} />}
       title={title}
-      meta={stateLabel}
+      meta={meta}
       onHoverStart={() => setCountsWanted(true)}
       onOpen={
         safeUrl
@@ -205,18 +210,21 @@ function PrRow({
 function CanvasRow({
   name,
   url,
+  ts,
   commentCount,
 }: {
   name: string;
   url: string | null;
+  ts: number;
   commentCount: number;
 }) {
   const open = canvasArtifactOpenHandler(url);
+  const meta = ts ? `Canvas · ${formatRelativeTimeShort(ts)}` : "Canvas";
   return (
     <ArtifactCard
       icon={iconForTemplate("", { size: 16, className: "text-amber-11" })}
       title={name}
-      meta="Canvas"
+      meta={meta}
       onOpen={open}
       actions={<CommentCountBadge count={commentCount} />}
     />
@@ -260,7 +268,7 @@ function fileVersionMenuLabel(
   return [
     versionShortLabel(index, total),
     uploaderLabel(artifact, currentUser),
-    artifact.uploaded_at ? formatRelativeTimeLong(artifact.uploaded_at) : null,
+    artifact.uploaded_at ? formatRelativeTimeShort(artifact.uploaded_at) : null,
   ]
     .filter(Boolean)
     .join(" · ");
@@ -312,7 +320,7 @@ function FileRow({
     : undefined;
   const metaText = [
     uploaderLabel(selected, currentUser),
-    selected.uploaded_at ? formatRelativeTimeLong(selected.uploaded_at) : null,
+    selected.uploaded_at ? formatRelativeTimeShort(selected.uploaded_at) : null,
     formatFileSize(selected.size),
   ]
     .filter(Boolean)
@@ -460,6 +468,7 @@ export function TaskArtifactsList({
           <PrRow
             key={row.key}
             url={row.url}
+            ts={row.ts}
             openInPlaceTaskId={canOpenInPlace ? task.id : undefined}
           />
         ) : row.kind === "canvas" ? (
@@ -467,6 +476,7 @@ export function TaskArtifactsList({
             key={row.key}
             name={row.name}
             url={row.url}
+            ts={row.ts}
             commentCount={
               row.dashboardId ? (openCountByItem.get(row.dashboardId) ?? 0) : 0
             }

--- a/products/desktop/packages/ui/src/features/canvas/components/taskArtifactRows.ts
+++ b/products/desktop/packages/ui/src/features/canvas/components/taskArtifactRows.ts
@@ -21,7 +21,7 @@ import { parseHttpsUrl, parseShareLink } from "@posthog/ui/utils/posthogLinks";
 export type RunFile = RunArtifact & { runId: string };
 
 export type ArtifactRow =
-  | { kind: "pr"; key: string; url: string }
+  | { kind: "pr"; key: string; url: string; ts: number }
   | {
       kind: "canvas";
       key: string;
@@ -29,6 +29,7 @@ export type ArtifactRow =
       url: string | null;
       /** The canvas row id, the stable comment target (never the name). */
       dashboardId: string | null;
+      ts: number;
     }
   | {
       kind: "file";
@@ -144,16 +145,16 @@ export function buildRows(
   const rows: ArtifactRow[] = [];
   const seenPrUrls = new Set<string>();
 
-  const addPr = (url: string, key: string) => {
+  const addPr = (url: string, key: string, ts: number) => {
     if (seenPrUrls.has(url)) return;
     seenPrUrls.add(url);
-    rows.push({ kind: "pr", key, url });
+    rows.push({ kind: "pr", key, url, ts });
   };
 
   for (const row of timeline) {
     if (row.kind !== "artifact") continue;
     if (row.artifact.kind === "pr") {
-      addPr(row.artifact.url, row.message.id);
+      addPr(row.artifact.url, row.message.id, row.timestamp);
     } else {
       const url = row.artifact.url;
       rows.push({
@@ -162,6 +163,7 @@ export function buildRows(
         name: row.artifact.name,
         url,
         dashboardId: canvasDashboardId(url),
+        ts: row.timestamp,
       });
     }
   }
@@ -171,8 +173,11 @@ export function buildRows(
 
   const files: RunFile[] = [];
   for (const run of allRuns) {
+    // Runs added straight from output have no announcing timeline message, so
+    // the run's own updated_at is the closest stand-in for the PR's age.
+    const runTs = Date.parse(run.updated_at) || 0;
     for (const outputPr of readPrUrls(run.output)) {
-      addPr(outputPr, `output-pr:${outputPr}`);
+      addPr(outputPr, `output-pr:${outputPr}`, runTs);
     }
     files.push(
       ...readRunOutputs(run).map((file) => ({ ...file, runId: run.id })),


### PR DESCRIPTION
## Problem

In the desktop app's right sidebar, the **Artifacts** tab lists the PRs, canvases, and files a task produced. Only file rows told you how recent they were — PR rows showed just their state ("Open"), and canvas rows showed a bare "Canvas". You couldn't tell at a glance whether an artifact was minutes or weeks old.

## Changes

- PR and canvas rows now show a compact age next to their existing label, e.g. `Open · 2d`, `Canvas · 43m`.
- The age comes from each row's announcing timeline timestamp; PRs discovered only from a run's output fall back to the run's `updated_at`.
- File rows keep the age they already showed but switch from the verbose form ("3 hours ago") to the same compact form, so the whole tab reads consistently. This reuses `formatRelativeTimeShort`, matching the channel-level artifacts surface.

## How did you test this code?

- Added one render case to `TaskArtifactsList.test.tsx`: a timeline with a canvas and a PR artifact renders `Canvas · 2d` and `Open · 43m`. It guards against `buildRows` dropping the timestamp it threads into pr/canvas rows, or those rows reverting to hardcoded meta — no existing test covered canvas rows or the age segment.
- Ran the component's Vitest suite, `@posthog/ui` typecheck, and Biome on the touched files locally.
- Not done: I did not boot the Electron app to screenshot the tab; the render test asserts the exact visible strings.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PostHog Desktop). Explored the desktop `products/desktop` package to locate the Artifacts tab renderer, then added a per-row timestamp to the artifact row model and rendered it with the existing `formatRelativeTimeShort` helper. Invoked the `/writing-tests` skill before adding the test. The user chose the compact time format and to scope the age to PR and canvas rows (the Slack row has no true thread-age timestamp available, so it was left unchanged).

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
