### PR TITLE
fix: make LemonTableLink onClick work without a navigation target

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTableLink.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTableLink.tsx
@@ -22,6 +22,13 @@ export function LemonTableLink({
 }: Pick<LinkProps, 'to' | 'onClick' | 'target' | 'className' | 'targetBlankIcon'> &
     LemonTableLinkContentProps): JSX.Element {
     if (!props.to) {
+        if (props.onClick) {
+            return (
+                <Link subtle onClick={props.onClick} className={clsx(props.className, truncateTitle && 'block min-w-0')}>
+                    <LemonTableLinkContent title={title} description={description} truncateTitle={truncateTitle} />
+                </Link>
+            )
+        }
         return <LemonTableLinkContent title={title} description={description} truncateTitle={truncateTitle} />
     }
 
@@ -29,27 +36,5 @@ export function LemonTableLink({
         <Link subtle {...props} className={clsx(props.className, truncateTitle && 'block min-w-0')}>
             <LemonTableLinkContent title={title} description={description} truncateTitle={truncateTitle} />
         </Link>
-    )
-}
-
-function LemonTableLinkContent({ title, description, truncateTitle }: LemonTableLinkContentProps): JSX.Element {
-    return (
-        <div className={clsx('flex flex-col py-1', truncateTitle && 'min-w-0')}>
-            <div className={clsx('flex flex-row items-center font-semibold text-sm gap-1', truncateTitle && 'min-w-0')}>
-                {title}
-            </div>
-
-            {description ? (
-                <div className="text-xs text-tertiary mt-1">
-                    {typeof description === 'string' ? (
-                        <LemonMarkdown className="max-w-[30rem]" lowKeyHeadings>
-                            {description}
-                        </LemonMarkdown>
-                    ) : (
-                        description
-                    )}
-                </div>
-            ) : null}
-        </div>
     )
 }


### PR DESCRIPTION
## Problem

Custom data color themes cannot be edited from the UI. In **Settings → Product analytics → Chart color themes**, clicking a theme's name in the table does nothing — the "Edit theme" modal never opens.

The API works correctly (`PATCH /api/environments/<id>/data_color_themes/<id>/` returns 200), so this is a pure UI bug.

## Root cause

`LemonTableLink` in `DataColorThemes.tsx` is used with only an `onClick` prop and no `to`:

```tsx
<LemonTableLink onClick={() => selectTheme(theme.id)} title={name} />
```

However, when `LemonTableLink` receives no `to` prop, it unconditionally returns a plain `LemonTableLinkContent` — a **non-interactive** presentational component — completely ignoring the `onClick` prop:

```tsx
// Before fix:
if (!props.to) {
    return <LemonTableLinkContent title={title} description={description} truncateTitle={truncateTitle} />
}
```

## Fix

When `LemonTableLink` has no `to` but does have an `onClick`, render a `Link` component (which outputs a semantic `<button>` via `LinkPrimitive` when there is no navigation target) instead of a non-interactive `LemonTableLinkContent`:

```tsx
if (!props.to) {
    if (props.onClick) {
        return (
            <Link subtle onClick={props.onClick} className={...}>
                <LemonTableLinkContent title={title} description={description} truncateTitle={truncateTitle} />
            </Link>
        )
    }
    return <LemonTableLinkContent title={title} description={description} truncateTitle={truncateTitle} />
}
```

This is a targeted fix: only the `onClick + no to` case is affected. All existing callers that pass `to` (with or without `onClick`) and those that pass neither `to` nor `onClick` continue to behave identically.

## Testing notes

1. Go to **Settings → Product analytics → Chart color themes**
2. Create a new theme via **Add theme**
3. Click the theme's name in the table — the "Edit theme" modal should now open
4. Verify that editing and saving the theme works correctly
5. Verify that other `LemonTableLink` usages (e.g. Cohorts list, Hog Functions list) still work as before