### PR TITLE
fix(data-warehouse): keep a job's real failure reason instead of "Cancelled"

### DIFF
--- a/products/data_warehouse/backend/logic/external_data_source/jobs.py
+++ b/products/data_warehouse/backend/logic/external_data_source/jobs.py
@@ -40,6 +40,9 @@ def update_external_job_status(
     with transaction.atomic():
         model = ExternalDataJob.objects.select_for_update().get(id=job_id, team_id=team_id)
 
+        was_already_terminal = model.status in TERMINAL_JOB_STATUSES
+        existing_error = model.latest_error
+
         # The loader may finish a run after lock takeover force-failed its job; only the
         # exact takeover sentinel unseals Failed -> Completed — genuine failures stay absorbing.
         is_takeover_recovery = (
@@ -66,7 +69,16 @@ def update_external_job_status(
             )
 
         model.status = status
-        model.latest_error = latest_error
+
+        # Once a job records a terminal failure reason, a later write of the SAME terminal status
+        # must not overwrite it. When a schema auto-disables, its teardown force-fails every other
+        # still-running job of that schema with the real reason, then cancels their workflows;
+        # Temporal's cancellation re-finalizes each as FAILED with a bare "Cancelled", which would
+        # otherwise clobber the actionable error. Takeover recovery (Failed -> Completed) is exempt
+        # — it deliberately replaces the sentinel with the successful run's empty error.
+        preserve_existing_error = was_already_terminal and not is_takeover_recovery and existing_error is not None
+        error_to_persist = existing_error if preserve_existing_error else latest_error
+        model.latest_error = error_to_persist
 
         # Only stamp finished_at and emit metrics on the first terminal transition. Takeover
         # recovery re-stamps: the Failed stamp predates the load and never emitted success metrics.
@@ -104,7 +116,7 @@ def update_external_job_status(
             )
         else:
             schema.status = schema_status
-            schema.latest_error = latest_error
+            schema.latest_error = error_to_persist
             schema.save(update_fields=["status", "latest_error", "updated_at"])
 
         # Every risky terminal write (any non-Completed terminal, plus the takeover-recovery

--- a/products/data_warehouse/backend/logic/external_data_source/test/test_jobs.py
+++ b/products/data_warehouse/backend/logic/external_data_source/test/test_jobs.py
@@ -269,6 +269,35 @@ class TestUpdateExternalJobStatus:
         expected_error = "first error" if first_status == ExternalDataJob.Status.FAILED else None
         assert db_job.latest_error == expected_error
 
+    def test_terminal_error_not_clobbered_by_later_cancelled_finalization(self):
+        # A schema auto-disable force-fails a still-running sibling job with the real reason, then
+        # cancels its workflow; Temporal re-finalizes that job as FAILED with a bare "Cancelled".
+        # That later same-status write must not overwrite the actionable error on the job or schema.
+        team, _source, schema, job = _create_org_team_source_schema_job()
+
+        with patch("products.data_warehouse.backend.logic.external_data_source.jobs.emit_data_import_app_metrics"):
+            update_external_job_status(
+                job_id=str(job.id),
+                team_id=team.pk,
+                status=ExternalDataJob.Status.FAILED,
+                logger=MagicMock(),
+                latest_error="Tenant or user not found",
+            )
+
+            updated = update_external_job_status(
+                job_id=str(job.id),
+                team_id=team.pk,
+                status=ExternalDataJob.Status.FAILED,
+                logger=MagicMock(),
+                latest_error="Cancelled",
+            )
+
+        assert updated.latest_error == "Tenant or user not found"
+        db_job = ExternalDataJob.objects.get(id=job.id)
+        assert db_job.latest_error == "Tenant or user not found"
+        schema.refresh_from_db()
+        assert schema.latest_error == "Tenant or user not found"
+
     def test_completed_after_lock_takeover_failure_is_allowed(self):
         # A job force-failed by lock takeover while the loader was still working its run
         # must accept the loader's completion instead of rejecting Failed -> Completed.


### PR DESCRIPTION
## Problem

- A data-warehouse sync that failed for a real, actionable reason showed the customer a bare "Cancelled" instead. This hit two Supabase teams hundreds of times in a day, and a Convex team as well.
- A schema auto-disables when it hits a non-retryable error. Its teardown force-fails every other still-running job of that schema with the real reason, then cancels those jobs' Temporal workflows.
- Temporal's cancellation re-finalizes each cancelled job as FAILED a second time, this time with the SDK's default "Cancelled" message.
- `update_external_job_status` treats terminal states as absorbing only across different statuses. A same-status FAILED write was still applied, so the second write overwrote the real error with "Cancelled" on both the job and the schema.

## Changes

- Preserve the first-recorded terminal error when an already-terminal job is written again with the same terminal status. The later "Cancelled" no longer clobbers it, on the job or its schema.
- Lock-takeover recovery (Failed to Completed) is unchanged: it still replaces the takeover sentinel with the successful run's empty error.

## How did you test this code?

- Added `test_terminal_error_not_clobbered_by_later_cancelled_finalization`: fails a job with a real reason, then re-finalizes it FAILED with "Cancelled", and asserts the job and schema keep the real reason. Catches the exact clobber this PR fixes; no existing test exercised a same-status terminal write with a different error.
- Ran the full `TestUpdateExternalJobStatus` suite locally against Postgres and ClickHouse: 19 passed. The existing takeover-recovery and rejection cases still pass.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by an agent (Claude) while triaging a batch of data-warehouse sync failure classes. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`. The root cause was traced from the recorded `latest_error` of "Cancelled": the teardown-cancel race writes the real reason first, then Temporal's cancellation re-finalizes the same job and the same-status write overwrote it. The fix keeps the change to the failure-surfacing path only, leaving retry and disable semantics untouched.
