### PR TITLE
fix(postgres): actionable message for connect-time connection timeouts

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -536,7 +536,18 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
             "Connection refused": None,
             "No route to host": None,
             "password authentication failed connection": None,
-            "connection timeout expired": None,
+            # psycopg raises ConnectionTimeout ("connection timeout expired") only while establishing
+            # a connection. The read path retries it in-process first (see
+            # `_is_dropped_or_connect_timeout`); reaching here means every reconnect timed out, i.e. a
+            # persistently unreachable host — usually a firewall dropping PostHog's egress IPs, an
+            # IPv6-only host, or a wrong host/port. Stays non-retryable; give the actionable guidance
+            # the bare driver text lacks (mirrors the validate-path message for "timeout expired").
+            "connection timeout expired": (
+                "PostHog couldn't connect to your database before the connection timed out. Check that "
+                "the database is reachable from the public internet and that PostHog's egress IP "
+                "addresses are allowed through your firewall. For a database that can't be exposed "
+                "publicly, use the SSH tunnel option, then re-enable the sync."
+            ),
             # TLS ALPN alert (RFC 7301 "no_application_protocol", alert 120) sent by the server
             # during the TLS handshake. libpq (Postgres 17+) offers the "postgresql" ALPN protocol;
             # an endpoint that negotiates ALPN but doesn't accept it rejects the handshake outright.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -425,6 +425,21 @@ class TestPostgresSourceNonRetryableErrors:
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert is_non_retryable, f"Permanent error should be non-retryable: {error_msg}"
 
+    def test_connect_timeout_surfaces_actionable_message(self, source):
+        # A persistently timing-out connect stays non-retryable, but must surface firewall/reachability
+        # guidance rather than the bare "connection timeout expired" driver text. Mirror the finalizer's
+        # first-match selection (external_data_job.py) so a future reorder that shadows it with an
+        # earlier None-valued timeout key is caught.
+        error_msg = "connection timeout expired"
+        matches = [
+            friendly
+            for pattern, friendly in source.get_non_retryable_errors().items()
+            if error_message_matches(error_msg, [pattern])
+        ]
+        assert matches, "connect timeout must be classified non-retryable"
+        assert matches[0] is not None, "connect timeout must surface an actionable message, not raw driver text"
+        assert "firewall" in matches[0].lower()
+
     @pytest.mark.parametrize(
         "error_msg",
         [


### PR DESCRIPTION
## Problem

- A Postgres source that PostHog can't reach before the connect timeout was disabled with the bare driver text "connection timeout expired". That message names no cause and no next step.
- The error is already non-retryable, and correctly so: the read path retries a connect timeout in-process first, so reaching the disable point means every reconnect timed out, which is a persistently unreachable host (a firewall dropping PostHog's egress IPs, an IPv6-only host, or a wrong host/port).
- The credential-validation path already shows actionable firewall and reachability guidance for a timeout; the sync path did not.

## Changes

- Map the non-retryable "connection timeout expired" key to an actionable message: check the database is reachable, allow PostHog's egress IPs through the firewall, or use the SSH tunnel, then re-enable the sync.
- Retryability is unchanged. Only the surfaced message changes.

## How did you test this code?

- Added `test_connect_timeout_surfaces_actionable_message`. It mirrors the finalizer's first-match message selection, so it catches both a revert to a raw message and a future reorder that shadows this key with an earlier timeout key. No existing test asserted the surfaced message for this case.
- Ran `TestPostgresSourceNonRetryableErrors` locally: 137 passed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by an agent (Claude) while triaging a batch of data-warehouse sync failure classes. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`. The message reuses the wording the validate-credentials path already uses for a timeout, so the two paths stay consistent.
