### PR TITLE
feat(personhog): record changelog produce payload sizes in leader

### DIFF
--- a/rust/personhog-leader/src/fencing.rs
+++ b/rust/personhog-leader/src/fencing.rs
@@ -1181,6 +1181,11 @@ impl FencedChangelogProducers {
         // ordinary batching alongside its window-mates.
         let key = changelog_message_key(person.team_id, person.id);
         let payload = person.encode_to_vec();
+        // Same metric as the unfenced path in kafka.rs, so the size
+        // distribution covers all changelog produces regardless of the
+        // fencing rollout. Recorded before the send so a payload rejected
+        // by the broker (message.max.bytes) still shows up.
+        histogram!("personhog_leader_kafka_produce_bytes").record(payload.len() as f64);
         let record = FutureRecord::to(&self.topic)
             .partition(partition as i32)
             .key(&key)

--- a/rust/personhog-leader/src/kafka.rs
+++ b/rust/personhog-leader/src/kafka.rs
@@ -48,6 +48,9 @@ pub async fn produce_person_changelog(
 ) -> Result<i64, String> {
     let key = changelog_message_key(person.team_id, person.id);
     let payload = person.encode_to_vec();
+    // Recorded before the send so a payload rejected by the broker
+    // (message.max.bytes) still shows up in the distribution.
+    histogram!("personhog_leader_kafka_produce_bytes").record(payload.len() as f64);
 
     let record = FutureRecord::to(topic)
         .partition(partition as i32)

--- a/rust/personhog-leader/src/main.rs
+++ b/rust/personhog-leader/src/main.rs
@@ -153,6 +153,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }),
         )
         .route("/_liveness", get(move || async move { liveness.check() }));
+    // Changelog payload sizes: dense through the small-person range,
+    // with the top boundaries straddling the broker's message.max.bytes
+    // (typically 1 MiB) so p99 creeping toward the produce limit is
+    // visible before messages start getting rejected.
+    const CHANGELOG_PRODUCE_SIZE_BUCKETS_BYTES: &[f64] = &[
+        256.0, 1024.0, 4096.0, 16384.0, 65536.0, 262144.0, 524288.0, 1048576.0, 2097152.0,
+    ];
     // The write path and warms are tuned in single-digit milliseconds;
     // the default ladder's 10 → 50 ms step blurs exactly the spans the
     // fencing and warm work steers by, and pins interpolated quantiles
@@ -204,6 +211,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             (
                 Matcher::Full("personhog_leader_warm_span_ms".into()),
                 WARM_LATENCY_BUCKETS_MS,
+            ),
+            (
+                Matcher::Full("personhog_leader_kafka_produce_bytes".into()),
+                CHANGELOG_PRODUCE_SIZE_BUCKETS_BYTES,
             ),
         ],
     );


### PR DESCRIPTION
## Problem

Operators cannot see how large the leader's changelog messages are, so payloads creeping toward the broker's produce limit (message.max.bytes, typically 1 MiB) would only surface as produce failures.

## Changes

- Adds a `personhog_leader_kafka_produce_bytes` histogram recording the encoded payload size of every changelog produce.
- Records the size before the send, so a payload the broker rejects for size still lands in the distribution.
- Registers a byte-shaped bucket ladder (256 B to 2 MiB) for the metric, because the leader's default buckets are millisecond-shaped.
- The top buckets straddle 1 MiB, so p99 approaching the limit is visible before produces fail.

## How did you test this code?

Metrics-only change with no behavior to regress, so no new tests. `cargo clippy --all-targets --all-features -- -D warnings` and the crate's unit tests pass locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: /writing-code-comments, /writing-pr-descriptions. The bucket ladder follows the precedent of `personhog_router_response_size_bytes` in personhog-router.
