### PR TITLE
fix(hogql): never suggest a view as the fix for its own body

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -649,7 +649,7 @@ class Database(BaseModel):
 
         return self.tables.get_child(table_name)
 
-    def get_table(self, table_name: str | list[str]) -> Table:
+    def get_table(self, table_name: str | list[str], *, invalid_suggestions: set[str] | None = None) -> Table:
         try:
             return cast(Table, self.get_table_node(table_name).get())
         except ResolutionError as e:
@@ -657,11 +657,13 @@ class Database(BaseModel):
                 table_name = ".".join(table_name)
             if self.is_table_access_denied(table_name):
                 raise TableAccessDeniedError(table_name) from e
-            suggestions = self._suggest_table_names(table_name)
+            suggestions = self._suggest_table_names(table_name, invalid_suggestions=invalid_suggestions)
             suffix = f" Did you mean: {', '.join(suggestions)}?" if suggestions else ""
             raise QueryError(f"Unknown table `{table_name}`.{suffix}") from e
 
-    def _suggest_table_names(self, name: str, *, limit: int = 3) -> list[str]:
+    def _suggest_table_names(
+        self, name: str, *, limit: int = 3, invalid_suggestions: set[str] | None = None
+    ) -> list[str]:
         """Return up to `limit` close matches for a mistyped table name.
 
         Uses a relatively strict cutoff so common exact-text assertions on
@@ -677,6 +679,10 @@ class Database(BaseModel):
         outside it are dropped no matter how well the leaf scores. When no such
         schema exists, the schema itself is the likely typo, so the closest
         known schema is searched instead.
+
+        `invalid_suggestions` names views the caller is resolving right now.
+        Offering one as the fix for a table missing from its own body would tell
+        the author to make that view select from itself.
         """
         import difflib
 
@@ -692,6 +698,9 @@ class Database(BaseModel):
         # catalog without being available on the source we actually queried.
         lowered = name.casefold()
         candidates = {c for c in candidates if c.casefold() != lowered}
+        if invalid_suggestions:
+            excluded = {n.casefold() for n in invalid_suggestions}
+            candidates = {c for c in candidates if c.casefold() not in excluded}
         prefix, dot, _ = name.rpartition(".")
         if dot:
             schema = prefix.casefold()

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -365,6 +365,9 @@ class Resolver(CloningVisitor):
         self.scopes: list[ast.SelectQueryType] = scopes or []
         self.ctes: dict[str, ast.CTE] = {}
         self.current_view_depth: int = 0
+        # Views whose bodies are currently being resolved. Only BoundedResolver populates this
+        # today; the base resolver keeps it so the raise seam below can pass it either way.
+        self.resolving_views: set[str] = set()
         self.context = context
         self.dialect = dialect
         self.database = context.database
@@ -1338,7 +1341,9 @@ class Resolver(CloningVisitor):
                 return node
 
             try:
-                database_table = cast(Database, self.database).get_table(table_name_chain)
+                database_table = cast(Database, self.database).get_table(
+                    table_name_chain, invalid_suggestions=self.resolving_views
+                )
             except QueryError:
                 # Direct Postgres/DuckDB sources expose introspected table-valued functions
                 # (range, generate_series, unnest, …) via connection metadata. If the lookup

--- a/products/data_modeling/backend/models/modeling.py
+++ b/products/data_modeling/backend/models/modeling.py
@@ -161,7 +161,7 @@ class BoundedResolver(Resolver):
         self.initial_view_name = initial_view_name
         # views whose bodies are currently being visited; seeded with the current view name so
         # it counts as "visited" for cycle detection
-        self.resolving_views: set[str] = {initial_view_name} if initial_view_name else set()
+        self.resolving_views = {initial_view_name} if initial_view_name else set()
         # set by visit_join_expr, consumed by the body visit it triggers (cycle detection needs
         # the name during resolution, before the id map below is populated)
         self._pending_view_name: str | None = None

--- a/products/data_warehouse/backend/models/test/test_modeling.py
+++ b/products/data_warehouse/backend/models/test/test_modeling.py
@@ -141,6 +141,18 @@ class TestModelPath(BaseTest):
         with pytest.raises(QueryError, match="Unknown table"):
             get_parents_from_model_query(self.team, "test_model", "select * from some_random_view")
 
+    def test_view_is_not_suggested_as_the_fix_for_its_own_body(self):
+        DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="customer_orders_v2",
+            query={"query": "select id from customer_orders"},
+        )
+
+        with pytest.raises(QueryError) as e:
+            get_parents_from_model_query(self.team, "customer_orders_v2", "select id from customer_orders")
+
+        assert str(e.value) == "Unknown table `customer_orders`."
+
     def test_create_from_static_query(self):
         """Test creation of a model path from a query that returns a static set of rows."""
         query = "SELECT 1 AS a, 2 AS b, NOW() AS c"


### PR DESCRIPTION
## Problem

- When a table referenced inside a view's body does not exist, the "Did you mean" suggestion can name that same view.
- Taking the suggestion makes the view select from itself, so the advice is never actionable.
- The suggester works from a flat catalog and has no idea which view is being resolved, so the view stays a candidate while its own body is checked.

## Changes

- `Database.get_table` takes an `invalid_suggestions` keyword and drops those names before scoring.
- The resolver keeps the set of views it is resolving and passes it at the single point that raises `Unknown table`.
- `BoundedResolver` already seeded that set with the view it was asked to resolve, so the data modeling path needed no new plumbing.

## Scope

- This closes the data modeling path, where the view name is known from the start.
- The base resolver still tracks nested views by depth rather than by name, so it passes an empty set. Teaching it to record names is a separate change to shared resolver internals.

## How did you test this code?

- New test on `get_parents_from_model_query`, the path a saved query takes when its dependencies are worked out.
- Removed the filter and confirmed the test fails with `Did you mean: customer_orders_v2?`, matching the reported shape.
- 281 tests pass across the modeling, database and direct Postgres suites. Repo-wide mypy is clean.

## 🤖 Agent context

Written by Claude Code. An earlier design stored the excluded names on `Database`; a review of the call graph showed the data modeling caller builds a second `Database` for resolution, so that design would have had no effect on the path it was meant to fix.
