### PR TITLE
feat(desktop): clickable prototype of tags replacing spaces

### DIFF
--- a/products/desktop/packages/ui/src/features/prototypes/tags/HomeView.tsx
+++ b/products/desktop/packages/ui/src/features/prototypes/tags/HomeView.tsx
@@ -1,0 +1,205 @@
+import {
+  cn,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  ToggleGroup,
+  ToggleGroupItem,
+} from "@posthog/quill";
+import {
+  HOME_SECTION_LABELS,
+  type PrototypeTask,
+  type PrototypeTaskStatus,
+  STATUS_ORDER,
+  TAGS,
+} from "@posthog/ui/features/prototypes/tags/mockData";
+import { SectionLabel } from "@posthog/ui/features/prototypes/tags/shared";
+import { TaskRow } from "@posthog/ui/features/prototypes/tags/TaskRow";
+import { useState } from "react";
+
+type HomeFilter = "all" | "mine" | "running" | "needs_you";
+type GroupBy = "status" | "tag";
+
+function applyFilter(
+  tasks: PrototypeTask[],
+  filter: HomeFilter,
+): PrototypeTask[] {
+  switch (filter) {
+    case "mine":
+      return tasks.filter((t) => t.participantIds.includes("you"));
+    case "running":
+      return tasks.filter(
+        (t) => t.status === "running" || t.status === "queued",
+      );
+    case "needs_you":
+      return tasks.filter(
+        (t) =>
+          (t.status === "needs_input" || t.unread) &&
+          t.participantIds.includes("you"),
+      );
+    default:
+      return tasks;
+  }
+}
+
+export function HomeView({
+  tasks,
+  selectedTaskId,
+  onSelectTask,
+  onOpenTag,
+}: {
+  tasks: PrototypeTask[];
+  selectedTaskId: string | null;
+  onSelectTask: (id: string) => void;
+  onOpenTag: (tagId: string) => void;
+}) {
+  const [filter, setFilter] = useState<HomeFilter>("all");
+  const [groupBy, setGroupBy] = useState<GroupBy>("status");
+
+  const filtered = applyFilter(tasks, filter);
+  const runningCount = tasks.filter((t) => t.status === "running").length;
+  const needsYouCount = tasks.filter(
+    (t) => t.status === "needs_input" && t.participantIds.includes("you"),
+  ).length;
+
+  return (
+    <div className="flex h-full min-w-0 flex-1 flex-col">
+      <div className="shrink-0 border-border border-b px-5 pt-4 pb-0">
+        <div className="flex items-baseline gap-3">
+          <h1 className="font-semibold text-[17px] text-gray-12">Home</h1>
+          <span className="text-[12px] text-gray-10">
+            {runningCount} agents running
+            {needsYouCount > 0 && (
+              <>
+                {" · "}
+                <span className="text-(--amber-11)">
+                  {needsYouCount} waiting on you
+                </span>
+              </>
+            )}
+          </span>
+        </div>
+        <div className="mt-2 flex items-center justify-between">
+          <Tabs
+            value={filter}
+            onValueChange={(v) => setFilter(v as HomeFilter)}
+          >
+            <TabsList variant="line" className="h-auto gap-0.5">
+              <TabsTrigger value="all" className="px-2.5 py-2 text-[13px]">
+                All
+              </TabsTrigger>
+              <TabsTrigger
+                value="needs_you"
+                className="px-2.5 py-2 text-[13px]"
+              >
+                Needs you
+              </TabsTrigger>
+              <TabsTrigger value="running" className="px-2.5 py-2 text-[13px]">
+                Running
+              </TabsTrigger>
+              <TabsTrigger value="mine" className="px-2.5 py-2 text-[13px]">
+                Involving me
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+          <ToggleGroup
+            value={[groupBy]}
+            onValueChange={(v) => {
+              const next = v[0] as GroupBy | undefined;
+              if (next) setGroupBy(next);
+            }}
+            className="mb-1"
+          >
+            <ToggleGroupItem value="status" className="px-2 text-[11px]">
+              By status
+            </ToggleGroupItem>
+            <ToggleGroupItem value="tag" className="px-2 text-[11px]">
+              By tag
+            </ToggleGroupItem>
+          </ToggleGroup>
+        </div>
+      </div>
+
+      <div className="@container min-h-0 flex-1 overflow-y-auto px-3 py-2">
+        {groupBy === "status"
+          ? STATUS_ORDER.map((status) => (
+              <StatusSection
+                key={status}
+                status={status}
+                tasks={filtered.filter((t) => t.status === status)}
+                selectedTaskId={selectedTaskId}
+                onSelectTask={onSelectTask}
+                onOpenTag={onOpenTag}
+              />
+            ))
+          : TAGS.map((tag) => {
+              const tagTasks = filtered.filter((t) =>
+                t.tagIds.includes(tag.id),
+              );
+              if (tagTasks.length === 0) return null;
+              return (
+                <div key={tag.id}>
+                  <SectionLabel count={tagTasks.length}>
+                    <button
+                      type="button"
+                      className={cn("uppercase hover:underline")}
+                      style={{ color: `var(--${tag.hue}-11)` }}
+                      onClick={() => onOpenTag(tag.id)}
+                    >
+                      {tag.name}
+                    </button>
+                  </SectionLabel>
+                  {tagTasks.map((task) => (
+                    <TaskRow
+                      key={task.id}
+                      task={task}
+                      selected={task.id === selectedTaskId}
+                      hideTagId={tag.id}
+                      onSelect={() => onSelectTask(task.id)}
+                      onTagClick={onOpenTag}
+                    />
+                  ))}
+                </div>
+              );
+            })}
+        {filtered.length === 0 && (
+          <div className="px-2 py-10 text-center text-[13px] text-gray-10">
+            Nothing here — switch filters or start a new task.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatusSection({
+  status,
+  tasks,
+  selectedTaskId,
+  onSelectTask,
+  onOpenTag,
+}: {
+  status: PrototypeTaskStatus;
+  tasks: PrototypeTask[];
+  selectedTaskId: string | null;
+  onSelectTask: (id: string) => void;
+  onOpenTag: (tagId: string) => void;
+}) {
+  if (tasks.length === 0) return null;
+  return (
+    <div>
+      <SectionLabel count={tasks.length}>
+        {HOME_SECTION_LABELS[status]}
+      </SectionLabel>
+      {tasks.map((task) => (
+        <TaskRow
+          key={task.id}
+          task={task}
+          selected={task.id === selectedTaskId}
+          onSelect={() => onSelectTask(task.id)}
+          onTagClick={onOpenTag}
+        />
+      ))}
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/prototypes/tags/NewTaskDialog.tsx
+++ b/products/desktop/packages/ui/src/features/prototypes/tags/NewTaskDialog.tsx
@@ -1,0 +1,126 @@
+import { BookOpenIcon, GitBranchIcon, RobotIcon } from "@phosphor-icons/react";
+import {
+  Button,
+  cn,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@posthog/quill";
+import { TAGS } from "@posthog/ui/features/prototypes/tags/mockData";
+import { useState } from "react";
+
+export function NewTaskDialog({
+  open,
+  initialTagId,
+  onOpenChange,
+  onStartTask,
+}: {
+  open: boolean;
+  initialTagId?: string;
+  onOpenChange: (open: boolean) => void;
+  onStartTask: (title: string, tagIds: string[]) => void;
+}) {
+  const [title, setTitle] = useState("");
+  const [tagIds, setTagIds] = useState<string[]>(
+    initialTagId ? [initialTagId] : [],
+  );
+
+  const selected = TAGS.filter((t) => tagIds.includes(t.id));
+  const repos = [...new Set(selected.flatMap((t) => t.repos))];
+  const context = [...new Set(selected.flatMap((t) => t.context))];
+
+  const toggle = (id: string) => {
+    setTagIds((prev) =>
+      prev.includes(id) ? prev.filter((t) => t !== id) : [...prev, id],
+    );
+  };
+
+  const start = () => {
+    if (!title.trim() || tagIds.length === 0) return;
+    onStartTask(title.trim(), tagIds);
+    setTitle("");
+    setTagIds([]);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>New task</DialogTitle>
+          <DialogDescription>
+            Pick tags to shape what the agent starts with — repos and context
+            come from the tags, and stack when you pick more than one.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-3">
+          <input
+            className="w-full rounded-md border border-border bg-gray-2 px-3 py-2 text-[13px] text-gray-12 outline-none placeholder:text-gray-9 focus:border-gray-7"
+            placeholder="What should the agent do?"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            autoFocus
+          />
+          <div className="flex flex-wrap gap-1.5">
+            {TAGS.map((tag) => {
+              const active = tagIds.includes(tag.id);
+              return (
+                <button
+                  key={tag.id}
+                  type="button"
+                  onClick={() => toggle(tag.id)}
+                  className={cn(
+                    "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[12px] transition-colors",
+                    active
+                      ? "border-gray-8 bg-gray-4 text-gray-12"
+                      : "border-border bg-gray-2 text-gray-10 hover:bg-gray-3",
+                  )}
+                >
+                  <span
+                    className="inline-block h-1.5 w-1.5 rounded-full"
+                    style={{ background: `var(--${tag.hue}-9)` }}
+                  />
+                  {tag.name}
+                </button>
+              );
+            })}
+          </div>
+          {selected.length > 0 && (
+            <div className="rounded-md border border-border bg-gray-2 px-3 py-2 text-[11px] text-gray-10">
+              <div className="mb-1 font-semibold text-[10px] text-gray-9 uppercase tracking-wide">
+                The agent will start with
+              </div>
+              <div className="flex items-center gap-1.5">
+                <GitBranchIcon size={11} className="shrink-0" />
+                <span className="truncate">{repos.join(", ")}</span>
+              </div>
+              <div className="mt-1 flex items-center gap-1.5">
+                <BookOpenIcon size={11} className="shrink-0" />
+                <span className="truncate">{context.join(", ")}</span>
+              </div>
+              <div className="mt-1 flex items-center gap-1.5">
+                <RobotIcon size={11} className="shrink-0" />
+                <span className="truncate">{selected[0].agentPreset}</span>
+              </div>
+            </div>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            disabled={!title.trim() || tagIds.length === 0}
+            onClick={start}
+          >
+            Start agent
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/products/desktop/packages/ui/src/features/prototypes/tags/PrototypeSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/prototypes/tags/PrototypeSidebar.tsx
@@ -1,0 +1,194 @@
+import {
+  HouseIcon,
+  MagnifyingGlassIcon,
+  PlusIcon,
+} from "@phosphor-icons/react";
+import {
+  Button,
+  cn,
+  Kbd,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@posthog/quill";
+import {
+  PEOPLE,
+  type PrototypeTag,
+  type PrototypeTask,
+  TAGS,
+} from "@posthog/ui/features/prototypes/tags/mockData";
+import { FaceStack } from "@posthog/ui/features/prototypes/tags/shared";
+import type { PrototypeView } from "@posthog/ui/features/prototypes/tags/TagsPrototype";
+
+function TagRow({
+  tag,
+  tasks,
+  active,
+  onClick,
+}: {
+  tag: PrototypeTag;
+  tasks: PrototypeTask[];
+  active: boolean;
+  onClick: () => void;
+}) {
+  const tagTasks = tasks.filter((t) => t.tagIds.includes(tag.id));
+  const running = tagTasks.filter((t) => t.status === "running").length;
+  const needsYou = tagTasks.filter((t) => t.status === "needs_input").length;
+  const unread = tagTasks.filter((t) => t.unread).length;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors",
+        active ? "bg-gray-4 text-gray-12" : "text-gray-11 hover:bg-gray-3",
+      )}
+    >
+      <span
+        className="inline-block h-2 w-2 shrink-0 rounded-full"
+        style={{ background: `var(--${tag.hue}-9)` }}
+      />
+      <span className="min-w-0 flex-1 truncate text-[13px]">{tag.name}</span>
+      {tag.onlineIds.length > 0 && (
+        <FaceStack personIds={tag.onlineIds} online={tag.onlineIds} max={2} />
+      )}
+      {running > 0 && (
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <span className="flex items-center gap-1 text-(--green-11) text-[11px]">
+                <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-(--green-9)" />
+                {running}
+              </span>
+            }
+          />
+          <TooltipContent side="right">
+            {running} agent{running > 1 ? "s" : ""} running
+          </TooltipContent>
+        </Tooltip>
+      )}
+      {(needsYou > 0 || unread > 0) && (
+        <span className="flex h-4 min-w-4 items-center justify-center rounded-full bg-(--primary) px-1 font-semibold text-(--primary-foreground) text-[10px]">
+          {needsYou + unread}
+        </span>
+      )}
+    </button>
+  );
+}
+
+export function PrototypeSidebar({
+  view,
+  tasks,
+  onNavigate,
+  onNewTask,
+}: {
+  view: PrototypeView;
+  tasks: PrototypeTask[];
+  onNavigate: (view: PrototypeView) => void;
+  onNewTask: () => void;
+}) {
+  const needsYou = tasks.filter(
+    (t) => t.status === "needs_input" || t.unread,
+  ).length;
+  const online = PEOPLE.filter((p) => !p.isViewer).slice(0, 4);
+  return (
+    <div className="flex h-full w-60 shrink-0 flex-col border-border border-r bg-chrome">
+      <div className="flex items-center gap-1 px-2 pt-2 pb-1">
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                onClick={() => onNavigate({ kind: "home" })}
+                className={cn(
+                  "relative flex h-7 w-7 items-center justify-center rounded-md transition-colors",
+                  view.kind === "home"
+                    ? "bg-gray-4 text-gray-12"
+                    : "text-gray-10 hover:bg-gray-3 hover:text-gray-12",
+                )}
+                aria-label="Home"
+              >
+                <HouseIcon
+                  size={16}
+                  weight={view.kind === "home" ? "fill" : "regular"}
+                />
+                {needsYou > 0 && view.kind !== "home" && (
+                  <span className="absolute top-0.5 right-0.5 h-1.5 w-1.5 rounded-full bg-(--primary)" />
+                )}
+              </button>
+            }
+          />
+          <TooltipContent side="bottom">
+            Home — everything across tags <Kbd>⌘1</Kbd>
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                className="flex h-7 w-7 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-3 hover:text-gray-12"
+                aria-label="Search"
+              >
+                <MagnifyingGlassIcon size={16} />
+              </button>
+            }
+          />
+          <TooltipContent side="bottom">
+            Search <Kbd>⌘K</Kbd>
+          </TooltipContent>
+        </Tooltip>
+        <div className="flex-1" />
+        <Button size="sm" variant="primary" onClick={onNewTask}>
+          <PlusIcon size={13} />
+          New task
+        </Button>
+      </div>
+
+      <div className="mt-2 flex items-center px-3 pb-1">
+        <span className="font-semibold text-[11px] text-gray-9 uppercase tracking-wide">
+          Tags
+        </span>
+        <div className="flex-1" />
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                className="flex h-5 w-5 items-center justify-center rounded text-gray-9 hover:bg-gray-3 hover:text-gray-12"
+                aria-label="New tag"
+              >
+                <PlusIcon size={12} />
+              </button>
+            }
+          />
+          <TooltipContent side="right">New tag</TooltipContent>
+        </Tooltip>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto px-2">
+        {TAGS.map((tag) => (
+          <TagRow
+            key={tag.id}
+            tag={tag}
+            tasks={tasks}
+            active={view.kind === "tag" && view.tagId === tag.id}
+            onClick={() => onNavigate({ kind: "tag", tagId: tag.id })}
+          />
+        ))}
+        <div className="px-2 pt-3 text-[11px] text-gray-9 leading-relaxed">
+          Tags are flat and many-to-many: a task can carry several, and each tag
+          brings its own repos and context to new tasks.
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 border-border border-t px-3 py-2">
+        <FaceStack
+          personIds={online.map((p) => p.id)}
+          online={online.slice(0, 3).map((p) => p.id)}
+          max={4}
+        />
+        <span className="text-[11px] text-gray-10">3 teammates online</span>
+      </div>
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/prototypes/tags/TagView.tsx
+++ b/products/desktop/packages/ui/src/features/prototypes/tags/TagView.tsx
@@ -1,0 +1,168 @@
+import {
+  BookOpenIcon,
+  GitBranchIcon,
+  PaperPlaneRightIcon,
+  RobotIcon,
+} from "@phosphor-icons/react";
+import {
+  Button,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@posthog/quill";
+import {
+  HOME_SECTION_LABELS,
+  type PrototypeTag,
+  type PrototypeTask,
+  STATUS_ORDER,
+} from "@posthog/ui/features/prototypes/tags/mockData";
+import {
+  FaceStack,
+  SectionLabel,
+  TagGlyph,
+} from "@posthog/ui/features/prototypes/tags/shared";
+import { TaskRow } from "@posthog/ui/features/prototypes/tags/TaskRow";
+import { useState } from "react";
+
+function MetadataPill({
+  icon,
+  label,
+  tooltip,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  tooltip: string;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span className="inline-flex cursor-default items-center gap-1.5 rounded-md border border-border bg-gray-2 px-2 py-1 text-[11px] text-gray-11">
+            {icon}
+            {label}
+          </span>
+        }
+      />
+      <TooltipContent side="bottom">{tooltip}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function TagView({
+  tag,
+  tasks,
+  selectedTaskId,
+  onSelectTask,
+  onOpenTag,
+  onStartTask,
+}: {
+  tag: PrototypeTag;
+  tasks: PrototypeTask[];
+  selectedTaskId: string | null;
+  onSelectTask: (id: string) => void;
+  onOpenTag: (tagId: string) => void;
+  onStartTask: (title: string, tagIds: string[]) => void;
+}) {
+  const [draft, setDraft] = useState("");
+  const tagTasks = tasks.filter((t) => t.tagIds.includes(tag.id));
+
+  const start = () => {
+    const title = draft.trim();
+    if (!title) return;
+    onStartTask(title, [tag.id]);
+    setDraft("");
+  };
+
+  return (
+    <div className="flex h-full min-w-0 flex-1 flex-col">
+      <div className="shrink-0 border-border border-b px-5 pt-4 pb-3">
+        <div className="flex items-center gap-2.5">
+          <TagGlyph tag={tag} size={18} />
+          <h1 className="font-semibold text-[17px] text-gray-12">{tag.name}</h1>
+          <div className="flex-1" />
+          <FaceStack personIds={tag.memberIds} online={tag.onlineIds} max={5} />
+          <span className="text-[11px] text-gray-10">
+            {tag.onlineIds.length} online
+          </span>
+        </div>
+        <p className="mt-1 text-[12px] text-gray-10">{tag.description}</p>
+        <div className="mt-2.5 flex flex-wrap items-center gap-1.5">
+          {tag.repos.map((repo) => (
+            <MetadataPill
+              key={repo}
+              icon={<GitBranchIcon size={12} />}
+              label={repo}
+              tooltip="Cloned automatically when a task starts under this tag"
+            />
+          ))}
+          {tag.context.map((doc) => (
+            <MetadataPill
+              key={doc}
+              icon={<BookOpenIcon size={12} />}
+              label={doc}
+              tooltip="Attached to the agent's context on every new task"
+            />
+          ))}
+          <MetadataPill
+            icon={<RobotIcon size={12} />}
+            label={tag.agentPreset}
+            tooltip="Default agent preset for this tag"
+          />
+        </div>
+      </div>
+
+      <div className="@container min-h-0 flex-1 overflow-y-auto px-3 py-2">
+        {STATUS_ORDER.map((status) => {
+          const sectionTasks = tagTasks.filter((t) => t.status === status);
+          if (sectionTasks.length === 0) return null;
+          return (
+            <div key={status}>
+              <SectionLabel count={sectionTasks.length}>
+                {HOME_SECTION_LABELS[status]}
+              </SectionLabel>
+              {sectionTasks.map((task) => (
+                <TaskRow
+                  key={task.id}
+                  task={task}
+                  selected={task.id === selectedTaskId}
+                  hideTagId={tag.id}
+                  onSelect={() => onSelectTask(task.id)}
+                  onTagClick={onOpenTag}
+                />
+              ))}
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="shrink-0 border-border border-t p-3">
+        <div className="rounded-lg border border-border bg-gray-2 focus-within:border-gray-7">
+          <input
+            className="w-full bg-transparent px-3 pt-2.5 pb-1 text-[13px] text-gray-12 outline-none placeholder:text-gray-9"
+            placeholder={`Start an agent in ${tag.name}…`}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") start();
+            }}
+          />
+          <div className="flex items-center gap-1.5 px-3 pb-2">
+            <span className="text-[10px] text-gray-9">
+              Starts with {tag.repos.join(" + ")} · {tag.context.join(", ")}
+            </span>
+            <div className="flex-1" />
+            <Button
+              size="sm"
+              variant="primary"
+              disabled={!draft.trim()}
+              onClick={start}
+            >
+              <PaperPlaneRightIcon size={12} />
+              Start agent
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/prototypes/tags/TagsPrototype.stories.tsx
+++ b/products/desktop/packages/ui/src/features/prototypes/tags/TagsPrototype.stories.tsx
@@ -1,0 +1,32 @@
+import { TagsPrototype } from "@posthog/ui/features/prototypes/tags/TagsPrototype";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+/**
+ * Clickable prototype exploring "tags" as a replacement for spaces:
+ * flat many-to-many tags with startup metadata (repos, context, agent
+ * preset), a single global left nav, and a Linear-style Home view for
+ * running many agents at once.
+ *
+ * Things to click:
+ * - Home icon (top of sidebar) vs. tag rows in the sidebar
+ * - Home filters ("Needs you", "Running") and the "By tag" grouping
+ * - Any task row → opens the detail panel; add/remove tags there
+ * - A tag view's composer or the "New task" button → starting a task
+ *   shows the repos/context the tags contribute
+ */
+const meta = {
+  title: "Prototypes/TagsPrototype",
+  component: TagsPrototype,
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof TagsPrototype>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Prototype: Story = {
+  render: () => (
+    <div className="h-screen w-screen">
+      <TagsPrototype />
+    </div>
+  ),
+};

--- a/products/desktop/packages/ui/src/features/prototypes/tags/TagsPrototype.tsx
+++ b/products/desktop/packages/ui/src/features/prototypes/tags/TagsPrototype.tsx
@@ -1,0 +1,121 @@
+import { HomeView } from "@posthog/ui/features/prototypes/tags/HomeView";
+import {
+  type PrototypeTask,
+  TAGS,
+  TASKS,
+} from "@posthog/ui/features/prototypes/tags/mockData";
+import { NewTaskDialog } from "@posthog/ui/features/prototypes/tags/NewTaskDialog";
+import { PrototypeSidebar } from "@posthog/ui/features/prototypes/tags/PrototypeSidebar";
+import { TagView } from "@posthog/ui/features/prototypes/tags/TagView";
+import { TaskPanel } from "@posthog/ui/features/prototypes/tags/TaskPanel";
+import { useState } from "react";
+
+export type PrototypeView = { kind: "home" } | { kind: "tag"; tagId: string };
+
+/**
+ * Clickable prototype: what the app could feel like if spaces became flat,
+ * many-to-many tags with startup metadata (repos + context), a single global
+ * left nav, and a Linear-style Home for staying on top of many agents at once.
+ *
+ * Everything is local state over invented fixtures — no routing, no stores,
+ * no backend. Not production code.
+ */
+export function TagsPrototype() {
+  const [view, setView] = useState<PrototypeView>({ kind: "home" });
+  const [tasks, setTasks] = useState<PrototypeTask[]>(TASKS);
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [newTaskOpen, setNewTaskOpen] = useState(false);
+
+  const selectedTask = tasks.find((t) => t.id === selectedTaskId) ?? null;
+
+  const openTag = (tagId: string) => {
+    setView({ kind: "tag", tagId });
+  };
+
+  const toggleTag = (taskId: string, tagId: string) => {
+    setTasks((prev) =>
+      prev.map((task) => {
+        if (task.id !== taskId) return task;
+        const has = task.tagIds.includes(tagId);
+        if (has && task.tagIds.length === 1) return task;
+        return {
+          ...task,
+          tagIds: has
+            ? task.tagIds.filter((t) => t !== tagId)
+            : [...task.tagIds, tagId],
+        };
+      }),
+    );
+  };
+
+  const startTask = (title: string, tagIds: string[]) => {
+    const task: PrototypeTask = {
+      id: `new-${Date.now()}`,
+      title,
+      tagIds,
+      status: "running",
+      statusDetail: "Cloning repos and loading tag context…",
+      ownerId: "you",
+      participantIds: ["you"],
+      repo: "acme/webapp",
+      updated: "just now",
+      progress: 5,
+      activity: [
+        { time: "now", actor: "you", text: "Started the task." },
+        {
+          time: "now",
+          actor: "agent",
+          text: "Cloning repos and loading tag context.",
+        },
+      ],
+    };
+    setTasks((prev) => [task, ...prev]);
+    setSelectedTaskId(task.id);
+  };
+
+  return (
+    <div className="flex h-full w-full overflow-hidden bg-(--color-background) text-gray-12">
+      <PrototypeSidebar
+        view={view}
+        tasks={tasks}
+        onNavigate={(next) => {
+          setView(next);
+        }}
+        onNewTask={() => setNewTaskOpen(true)}
+      />
+      {view.kind === "home" || !TAGS_BY_ID[view.tagId] ? (
+        <HomeView
+          tasks={tasks}
+          selectedTaskId={selectedTaskId}
+          onSelectTask={setSelectedTaskId}
+          onOpenTag={openTag}
+        />
+      ) : (
+        <TagView
+          tag={TAGS_BY_ID[view.tagId]}
+          tasks={tasks}
+          selectedTaskId={selectedTaskId}
+          onSelectTask={setSelectedTaskId}
+          onOpenTag={openTag}
+          onStartTask={startTask}
+        />
+      )}
+      {selectedTask && (
+        <TaskPanel
+          task={selectedTask}
+          onClose={() => setSelectedTaskId(null)}
+          onOpenTag={openTag}
+          onToggleTag={toggleTag}
+        />
+      )}
+      <NewTaskDialog
+        open={newTaskOpen}
+        initialTagId={view.kind === "tag" ? view.tagId : undefined}
+        onOpenChange={setNewTaskOpen}
+        onStartTask={startTask}
+      />
+    </div>
+  );
+}
+
+const TAGS_BY_ID = Object.fromEntries(TAGS.map((t) => [t.id, t]));

--- a/products/desktop/packages/ui/src/features/prototypes/tags/TaskPanel.tsx
+++ b/products/desktop/packages/ui/src/features/prototypes/tags/TaskPanel.tsx
@@ -1,0 +1,216 @@
+import {
+  GitBranchIcon,
+  GitMergeIcon,
+  GitPullRequestIcon,
+  PlusIcon,
+  RobotIcon,
+  XIcon,
+} from "@phosphor-icons/react";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Progress,
+  Separator,
+} from "@posthog/quill";
+import {
+  type PrototypeTask,
+  personById,
+  STATUS_META,
+  TAGS,
+} from "@posthog/ui/features/prototypes/tags/mockData";
+import {
+  FaceStack,
+  StatusDot,
+  TagChip,
+} from "@posthog/ui/features/prototypes/tags/shared";
+
+export function TaskPanel({
+  task,
+  onClose,
+  onOpenTag,
+  onToggleTag,
+}: {
+  task: PrototypeTask;
+  onClose: () => void;
+  onOpenTag: (tagId: string) => void;
+  onToggleTag: (taskId: string, tagId: string) => void;
+}) {
+  const taskTags = TAGS.filter((t) => task.tagIds.includes(t.id));
+  const availableTags = TAGS.filter((t) => !task.tagIds.includes(t.id));
+  const meta = STATUS_META[task.status];
+
+  return (
+    <div className="flex h-full w-80 shrink-0 flex-col border-border border-l bg-chrome">
+      <div className="flex items-start gap-2 px-4 pt-3 pb-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <StatusDot status={task.status} />
+            <span className="text-[11px] text-gray-10">{meta.label}</span>
+          </div>
+          <h2 className="mt-1 font-semibold text-[14px] text-gray-12 leading-snug">
+            {task.title}
+          </h2>
+        </div>
+        <button
+          type="button"
+          className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded text-gray-9 hover:bg-gray-3 hover:text-gray-12"
+          onClick={onClose}
+          aria-label="Close panel"
+        >
+          <XIcon size={14} />
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-3 overflow-y-auto px-4 pb-4">
+        {task.status === "running" && task.progress !== undefined && (
+          <div>
+            <Progress value={task.progress} className="h-1" />
+            <p className="mt-1.5 text-[11px] text-gray-10">
+              {task.statusDetail}
+            </p>
+          </div>
+        )}
+        {task.status === "needs_input" && (
+          <div
+            className="rounded-md border px-3 py-2 text-[12px]"
+            style={{
+              borderColor: "var(--amber-6)",
+              background: "var(--amber-2)",
+              color: "var(--amber-11)",
+            }}
+          >
+            {task.statusDetail}
+            <div className="mt-2 flex gap-1.5">
+              <Button size="sm" variant="primary">
+                Answer agent
+              </Button>
+              <Button size="sm" variant="outline">
+                Open session
+              </Button>
+            </div>
+          </div>
+        )}
+
+        <div>
+          <div className="mb-1.5 font-semibold text-[11px] text-gray-9 uppercase tracking-wide">
+            Tags
+          </div>
+          <div className="flex flex-wrap items-center gap-1.5">
+            {taskTags.map((tag) => (
+              <TagChip
+                key={tag.id}
+                tag={tag}
+                size="md"
+                onClick={() => onOpenTag(tag.id)}
+                onRemove={
+                  task.tagIds.length > 1
+                    ? () => onToggleTag(task.id, tag.id)
+                    : undefined
+                }
+              />
+            ))}
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                render={
+                  <button
+                    type="button"
+                    className="flex h-5 w-5 items-center justify-center rounded-full border border-border border-dashed text-gray-9 hover:bg-gray-3 hover:text-gray-12"
+                    aria-label="Add tag"
+                  >
+                    <PlusIcon size={11} />
+                  </button>
+                }
+              />
+              <DropdownMenuContent align="start">
+                {availableTags.map((tag) => (
+                  <DropdownMenuItem
+                    key={tag.id}
+                    onClick={() => onToggleTag(task.id, tag.id)}
+                  >
+                    <span
+                      className="mr-1.5 inline-block h-2 w-2 rounded-full"
+                      style={{ background: `var(--${tag.hue}-9)` }}
+                    />
+                    {tag.name}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+          <p className="mt-1.5 text-[10px] text-gray-9">
+            A task can live in several tags — everyone following any of them
+            sees it.
+          </p>
+        </div>
+
+        <Separator />
+
+        <div className="flex flex-col gap-2 text-[12px]">
+          <div className="flex items-center gap-2 text-gray-11">
+            <GitBranchIcon size={13} className="text-gray-9" />
+            {task.repo}
+            {task.branch && (
+              <span className="rounded bg-gray-3 px-1.5 py-px font-mono text-[10px] text-gray-10">
+                {task.branch}
+              </span>
+            )}
+          </div>
+          {task.prUrl && (
+            <div className="flex items-center gap-2 text-gray-11">
+              {task.prState === "merged" ? (
+                <GitMergeIcon size={13} style={{ color: "var(--purple-11)" }} />
+              ) : (
+                <GitPullRequestIcon
+                  size={13}
+                  style={{ color: "var(--green-11)" }}
+                />
+              )}
+              Pull request {task.prUrl}
+              <span className="text-gray-9">({task.prState})</span>
+            </div>
+          )}
+          <div className="flex items-center gap-2 text-gray-11">
+            <RobotIcon size={13} className="text-gray-9" />
+            Agent session
+            <Button size="sm" variant="outline" className="ml-auto">
+              Open
+            </Button>
+          </div>
+        </div>
+
+        <Separator />
+
+        <div>
+          <div className="mb-1.5 flex items-center gap-2">
+            <span className="font-semibold text-[11px] text-gray-9 uppercase tracking-wide">
+              People
+            </span>
+            <FaceStack personIds={task.participantIds} max={5} />
+          </div>
+          <div className="mt-3 mb-1.5 font-semibold text-[11px] text-gray-9 uppercase tracking-wide">
+            Activity
+          </div>
+          <div className="flex flex-col gap-2.5 border-border border-l pl-3">
+            {task.activity.map((entry) => (
+              <div key={`${entry.time}-${entry.text}`} className="text-[11px]">
+                <span className="text-gray-9">
+                  {entry.actor === "agent"
+                    ? "Agent"
+                    : personById(entry.actor).name}
+                  {" · "}
+                  {entry.time} ago
+                </span>
+                <p className="mt-0.5 text-[12px] text-gray-11 leading-snug">
+                  {entry.text}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/prototypes/tags/TaskRow.tsx
+++ b/products/desktop/packages/ui/src/features/prototypes/tags/TaskRow.tsx
@@ -1,0 +1,110 @@
+import {
+  GitBranchIcon,
+  GitMergeIcon,
+  GitPullRequestIcon,
+} from "@phosphor-icons/react";
+import { cn } from "@posthog/quill";
+import {
+  type PrototypeTask,
+  TAGS,
+} from "@posthog/ui/features/prototypes/tags/mockData";
+import {
+  FaceStack,
+  StatusDot,
+  TagChip,
+} from "@posthog/ui/features/prototypes/tags/shared";
+
+export function TaskRow({
+  task,
+  selected,
+  hideTagId,
+  onSelect,
+  onTagClick,
+}: {
+  task: PrototypeTask;
+  selected: boolean;
+  /** In a tag view, the scoping tag is implied — don't repeat its chip */
+  hideTagId?: string;
+  onSelect: () => void;
+  onTagClick: (tagId: string) => void;
+}) {
+  const tags = TAGS.filter(
+    (t) => task.tagIds.includes(t.id) && t.id !== hideTagId,
+  );
+  const live = task.status === "running" || task.status === "needs_input";
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        "group flex w-full cursor-pointer items-center gap-2.5 rounded-md border border-transparent px-2 py-1.5 text-left transition-colors",
+        selected ? "border-border bg-gray-3" : "hover:bg-gray-2",
+      )}
+    >
+      <StatusDot status={task.status} />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5">
+          <span
+            className={cn(
+              "truncate text-[13px]",
+              task.unread
+                ? "font-semibold text-gray-12"
+                : "font-medium text-gray-12",
+              task.status === "done" && "text-gray-10",
+            )}
+          >
+            {task.title}
+          </span>
+          {task.unread && (
+            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-(--primary)" />
+          )}
+        </div>
+        <div className="mt-0.5 flex items-center gap-1.5 text-[11px] text-gray-10">
+          <span
+            className={cn("truncate", live && "text-gray-11")}
+            style={
+              task.status === "needs_input"
+                ? { color: "var(--amber-11)" }
+                : undefined
+            }
+          >
+            {task.statusDetail}
+          </span>
+        </div>
+      </div>
+      <div className="@lg:flex hidden items-center gap-1">
+        {tags.map((tag) => (
+          <TagChip key={tag.id} tag={tag} onClick={() => onTagClick(tag.id)} />
+        ))}
+      </div>
+      {task.prUrl && (
+        <span
+          className="@md:flex hidden items-center gap-1 text-[11px]"
+          style={{
+            color:
+              task.prState === "merged"
+                ? "var(--purple-11)"
+                : task.prState === "draft"
+                  ? "var(--gray-10)"
+                  : "var(--green-11)",
+          }}
+        >
+          {task.prState === "merged" ? (
+            <GitMergeIcon size={12} />
+          ) : (
+            <GitPullRequestIcon size={12} />
+          )}
+          {task.prUrl}
+        </span>
+      )}
+      <span className="@xl:flex hidden items-center gap-1 text-[11px] text-gray-9">
+        <GitBranchIcon size={11} />
+        {task.repo.split("/")[1]}
+      </span>
+      <FaceStack personIds={task.participantIds} />
+      <span className="w-12 shrink-0 text-right text-[11px] text-gray-9">
+        {task.updated}
+      </span>
+    </button>
+  );
+}

--- a/products/desktop/packages/ui/src/features/prototypes/tags/mockData.ts
+++ b/products/desktop/packages/ui/src/features/prototypes/tags/mockData.ts
@@ -1,0 +1,455 @@
+/**
+ * Static fixture data for the tags prototype. Everything here is invented —
+ * people, repos, tasks, and timings exist only to make the prototype feel
+ * inhabited. Nothing reads or writes real app state.
+ */
+
+export type PrototypeTaskStatus =
+  | "needs_input"
+  | "running"
+  | "review"
+  | "queued"
+  | "done"
+  | "failed";
+
+export interface PrototypePerson {
+  id: string;
+  name: string;
+  initials: string;
+  /** Radix scale name used for the avatar fill, e.g. "blue" */
+  hue: string;
+  isViewer?: boolean;
+}
+
+export interface PrototypeTag {
+  id: string;
+  name: string;
+  /** Radix scale name for the tag's dot and chips */
+  hue: string;
+  description: string;
+  /** Repos an agent clones when a task starts under this tag */
+  repos: string[];
+  /** Context documents / prompts attached to new tasks under this tag */
+  context: string[];
+  /** Default agent preset for the tag */
+  agentPreset: string;
+  memberIds: string[];
+  /** Subset of memberIds currently online (multiplayer presence) */
+  onlineIds: string[];
+}
+
+export interface PrototypeActivityEntry {
+  time: string;
+  actor: string;
+  text: string;
+}
+
+export interface PrototypeTask {
+  id: string;
+  title: string;
+  tagIds: string[];
+  status: PrototypeTaskStatus;
+  /** One-line live description, e.g. "Writing migration tests…" */
+  statusDetail: string;
+  ownerId: string;
+  participantIds: string[];
+  repo: string;
+  branch?: string;
+  prUrl?: string;
+  prState?: "open" | "merged" | "draft";
+  updated: string;
+  unread?: boolean;
+  /** 0-100, only meaningful while running */
+  progress?: number;
+  activity: PrototypeActivityEntry[];
+}
+
+export const PEOPLE: PrototypePerson[] = [
+  { id: "you", name: "You", initials: "YO", hue: "orange", isViewer: true },
+  { id: "mara", name: "Mara Okafor", initials: "MO", hue: "blue" },
+  { id: "dev", name: "Dev Chatterjee", initials: "DC", hue: "purple" },
+  { id: "lena", name: "Lena Vogel", initials: "LV", hue: "green" },
+  { id: "sam", name: "Sam Ruiz", initials: "SR", hue: "red" },
+  { id: "kit", name: "Kit Andersen", initials: "KA", hue: "cyan" },
+];
+
+export const TAGS: PrototypeTag[] = [
+  {
+    id: "growth",
+    name: "growth-experiments",
+    hue: "green",
+    description: "Signup funnel, activation and pricing-page experiments.",
+    repos: ["acme/webapp", "acme/marketing-site"],
+    context: ["Growth playbook.md", "Experiment naming rules"],
+    agentPreset: "Claude · experiments preset",
+    memberIds: ["you", "mara", "lena", "kit"],
+    onlineIds: ["mara", "kit"],
+  },
+  {
+    id: "billing",
+    name: "billing",
+    hue: "blue",
+    description: "Invoicing, usage metering and the payments service.",
+    repos: ["acme/billing-service"],
+    context: ["Billing architecture notes", "Stripe test accounts"],
+    agentPreset: "Claude · backend preset",
+    memberIds: ["you", "dev", "sam"],
+    onlineIds: ["dev"],
+  },
+  {
+    id: "mobile",
+    name: "mobile-replay",
+    hue: "purple",
+    description: "Session replay capture on iOS and Android.",
+    repos: ["acme/sdk-ios", "acme/sdk-android"],
+    context: ["Replay wire format spec"],
+    agentPreset: "Claude · mobile preset",
+    memberIds: ["lena", "sam"],
+    onlineIds: [],
+  },
+  {
+    id: "desktop",
+    name: "desktop-app",
+    hue: "yellow",
+    description: "The Electron shell, sidebar and agent surfaces.",
+    repos: ["acme/desktop"],
+    context: ["Desktop UI conventions"],
+    agentPreset: "Claude · frontend preset",
+    memberIds: ["you", "mara", "dev", "lena", "kit"],
+    onlineIds: ["mara", "dev", "lena"],
+  },
+  {
+    id: "bugbash",
+    name: "bug-bash",
+    hue: "red",
+    description: "Cross-team sweep of the top crash reports before release.",
+    repos: ["acme/webapp", "acme/billing-service", "acme/desktop"],
+    context: ["Release 2.4 crash triage"],
+    agentPreset: "Claude · default",
+    memberIds: ["you", "mara", "dev", "lena", "sam", "kit"],
+    onlineIds: ["sam"],
+  },
+];
+
+export const TASKS: PrototypeTask[] = [
+  {
+    id: "t1",
+    title: "Fix double-charge when a plan changes mid-cycle",
+    tagIds: ["billing", "bugbash"],
+    status: "needs_input",
+    statusDetail: "Agent is asking: proration strategy A or B?",
+    ownerId: "you",
+    participantIds: ["you", "dev"],
+    repo: "acme/billing-service",
+    branch: "fix/mid-cycle-proration",
+    updated: "2m",
+    unread: true,
+    activity: [
+      {
+        time: "24m",
+        actor: "agent",
+        text: "Cloned acme/billing-service and reproduced the double charge in a test.",
+      },
+      {
+        time: "9m",
+        actor: "agent",
+        text: "Found two viable proration strategies; drafted both.",
+      },
+      {
+        time: "2m",
+        actor: "agent",
+        text: "Waiting for you: pick strategy A (credit note) or B (delta invoice).",
+      },
+    ],
+  },
+  {
+    id: "t2",
+    title: "Pricing page experiment: annual-first toggle",
+    tagIds: ["growth"],
+    status: "running",
+    statusDetail: "Writing Playwright coverage for the toggle…",
+    ownerId: "mara",
+    participantIds: ["mara", "you"],
+    repo: "acme/marketing-site",
+    branch: "exp/annual-first",
+    updated: "just now",
+    progress: 62,
+    activity: [
+      {
+        time: "41m",
+        actor: "mara",
+        text: "Started the task with the growth-experiments context.",
+      },
+      {
+        time: "12m",
+        actor: "agent",
+        text: "Implemented the toggle behind the annual-first flag.",
+      },
+      {
+        time: "1m",
+        actor: "agent",
+        text: "Writing Playwright coverage for the toggle.",
+      },
+    ],
+  },
+  {
+    id: "t3",
+    title: "Sidebar: collapse archived tasks into a footer row",
+    tagIds: ["desktop"],
+    status: "review",
+    statusDetail: "PR #4821 open · 2 comments from Lena",
+    ownerId: "you",
+    participantIds: ["you", "lena"],
+    repo: "acme/desktop",
+    branch: "feat/archived-footer",
+    prUrl: "#4821",
+    prState: "open",
+    updated: "18m",
+    unread: true,
+    activity: [
+      { time: "3h", actor: "agent", text: "Opened PR #4821." },
+      {
+        time: "18m",
+        actor: "lena",
+        text: "Left 2 comments about keyboard focus.",
+      },
+    ],
+  },
+  {
+    id: "t4",
+    title: "Android replay: frames drop on foldables",
+    tagIds: ["mobile", "bugbash"],
+    status: "running",
+    statusDetail: "Bisecting the capture loop regression…",
+    ownerId: "lena",
+    participantIds: ["lena", "sam"],
+    repo: "acme/sdk-android",
+    branch: "fix/foldable-frames",
+    updated: "5m",
+    progress: 30,
+    activity: [
+      {
+        time: "1h",
+        actor: "lena",
+        text: "Started from crash report cluster #88.",
+      },
+      {
+        time: "5m",
+        actor: "agent",
+        text: "Bisecting the capture loop regression.",
+      },
+    ],
+  },
+  {
+    id: "t5",
+    title: "Usage metering: backfill March gaps",
+    tagIds: ["billing"],
+    status: "running",
+    statusDetail: "Dry-running the backfill against staging…",
+    ownerId: "dev",
+    participantIds: ["dev"],
+    repo: "acme/billing-service",
+    branch: "chore/march-backfill",
+    updated: "just now",
+    progress: 84,
+    activity: [
+      {
+        time: "2h",
+        actor: "dev",
+        text: "Kicked off with the billing context pack.",
+      },
+      {
+        time: "3m",
+        actor: "agent",
+        text: "Dry-running the backfill against staging.",
+      },
+    ],
+  },
+  {
+    id: "t6",
+    title: "Signup funnel: cut step 3 (company size)",
+    tagIds: ["growth"],
+    status: "review",
+    statusDetail: "PR #1204 merged to staging, awaiting experiment start",
+    ownerId: "kit",
+    participantIds: ["kit", "mara"],
+    repo: "acme/webapp",
+    prUrl: "#1204",
+    prState: "merged",
+    updated: "1h",
+    activity: [
+      { time: "1d", actor: "kit", text: "Started the task." },
+      {
+        time: "1h",
+        actor: "kit",
+        text: "Merged to staging; experiment starts Monday.",
+      },
+    ],
+  },
+  {
+    id: "t7",
+    title: "Crash: NSInvalidArgumentException in replay encoder",
+    tagIds: ["mobile", "bugbash"],
+    status: "needs_input",
+    statusDetail: "Agent needs a sample session file to reproduce",
+    ownerId: "sam",
+    participantIds: ["sam"],
+    repo: "acme/sdk-ios",
+    updated: "32m",
+    activity: [
+      {
+        time: "50m",
+        actor: "agent",
+        text: "Could not reproduce from the stack trace alone.",
+      },
+      {
+        time: "32m",
+        actor: "agent",
+        text: "Waiting for a sample session file.",
+      },
+    ],
+  },
+  {
+    id: "t8",
+    title: "Command palette: fuzzy match on tag names",
+    tagIds: ["desktop"],
+    status: "queued",
+    statusDetail: "Queued behind 2 desktop tasks",
+    ownerId: "you",
+    participantIds: ["you"],
+    repo: "acme/desktop",
+    updated: "3h",
+    activity: [{ time: "3h", actor: "you", text: "Queued the task." }],
+  },
+  {
+    id: "t9",
+    title: "Invoice PDFs render blank for JPY currencies",
+    tagIds: ["billing", "bugbash"],
+    status: "done",
+    statusDetail: "PR #339 merged · shipped in 2.3.9",
+    ownerId: "dev",
+    participantIds: ["dev", "you"],
+    repo: "acme/billing-service",
+    prUrl: "#339",
+    prState: "merged",
+    updated: "1d",
+    activity: [{ time: "1d", actor: "agent", text: "PR #339 merged." }],
+  },
+  {
+    id: "t10",
+    title: "Homepage hero: rotate customer logos experiment",
+    tagIds: ["growth"],
+    status: "done",
+    statusDetail: "Experiment concluded: +2.1% CTR, shipping variant B",
+    ownerId: "mara",
+    participantIds: ["mara", "kit"],
+    repo: "acme/marketing-site",
+    prState: "merged",
+    updated: "2d",
+    activity: [
+      { time: "2d", actor: "mara", text: "Concluded: shipping variant B." },
+    ],
+  },
+  {
+    id: "t11",
+    title: "Windows: tray icon vanishes after sleep",
+    tagIds: ["desktop", "bugbash"],
+    status: "failed",
+    statusDetail: "Agent run failed: could not reproduce on CI runner",
+    ownerId: "kit",
+    participantIds: ["kit"],
+    repo: "acme/desktop",
+    updated: "4h",
+    activity: [
+      {
+        time: "5h",
+        actor: "agent",
+        text: "Attempted repro on the Windows CI runner.",
+      },
+      {
+        time: "4h",
+        actor: "agent",
+        text: "Run failed: sleep/resume cannot be simulated on CI.",
+      },
+    ],
+  },
+  {
+    id: "t12",
+    title: "Meter events: dedupe retries at the edge",
+    tagIds: ["billing"],
+    status: "review",
+    statusDetail: "PR #351 draft · benchmark results attached",
+    ownerId: "you",
+    participantIds: ["you", "dev", "sam"],
+    repo: "acme/billing-service",
+    prUrl: "#351",
+    prState: "draft",
+    updated: "42m",
+    activity: [
+      {
+        time: "2h",
+        actor: "agent",
+        text: "Opened draft PR #351 with benchmarks.",
+      },
+      {
+        time: "42m",
+        actor: "sam",
+        text: "Asked for a p99 latency comparison.",
+      },
+    ],
+  },
+];
+
+export function personById(id: string): PrototypePerson {
+  return PEOPLE.find((p) => p.id === id) ?? PEOPLE[0];
+}
+
+export const STATUS_META: Record<
+  PrototypeTaskStatus,
+  { label: string; tone: string; filled: boolean; pulse: boolean }
+> = {
+  needs_input: {
+    label: "Needs you",
+    tone: "var(--amber-9)",
+    filled: true,
+    pulse: true,
+  },
+  running: {
+    label: "Running",
+    tone: "var(--green-9)",
+    filled: true,
+    pulse: true,
+  },
+  review: {
+    label: "In review",
+    tone: "var(--blue-9)",
+    filled: true,
+    pulse: false,
+  },
+  queued: {
+    label: "Queued",
+    tone: "var(--gray-8)",
+    filled: false,
+    pulse: false,
+  },
+  done: { label: "Done", tone: "var(--gray-8)", filled: false, pulse: false },
+  failed: { label: "Failed", tone: "var(--red-9)", filled: true, pulse: false },
+};
+
+export const STATUS_ORDER: PrototypeTaskStatus[] = [
+  "needs_input",
+  "running",
+  "review",
+  "queued",
+  "failed",
+  "done",
+];
+
+export const HOME_SECTION_LABELS: Record<PrototypeTaskStatus, string> = {
+  needs_input: "Needs your attention",
+  running: "Running now",
+  review: "In review",
+  queued: "Queued",
+  failed: "Failed",
+  done: "Recently done",
+};

--- a/products/desktop/packages/ui/src/features/prototypes/tags/shared.tsx
+++ b/products/desktop/packages/ui/src/features/prototypes/tags/shared.tsx
@@ -1,0 +1,186 @@
+import { TagIcon } from "@phosphor-icons/react";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarGroup,
+  cn,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@posthog/quill";
+import {
+  type PrototypeTag,
+  type PrototypeTaskStatus,
+  personById,
+  STATUS_META,
+} from "@posthog/ui/features/prototypes/tags/mockData";
+import { NestedButton } from "@posthog/ui/primitives/NestedButton";
+
+export function StatusDot({
+  status,
+  size = 8,
+}: {
+  status: PrototypeTaskStatus;
+  size?: number;
+}) {
+  const meta = STATUS_META[status];
+  return (
+    <span
+      className={cn(
+        "inline-block shrink-0 rounded-full",
+        meta.pulse && "animate-pulse",
+      )}
+      style={{
+        width: size,
+        height: size,
+        background: meta.filled ? meta.tone : "transparent",
+        boxShadow: meta.filled ? undefined : `inset 0 0 0 1.5px ${meta.tone}`,
+      }}
+      title={meta.label}
+    />
+  );
+}
+
+export function TagChip({
+  tag,
+  onClick,
+  onRemove,
+  size = "sm",
+}: {
+  tag: PrototypeTag;
+  onClick?: () => void;
+  onRemove?: () => void;
+  size?: "sm" | "md";
+}) {
+  const className = cn(
+    "inline-flex items-center gap-1 rounded-full border border-border bg-gray-2 text-gray-11",
+    size === "sm" ? "px-1.5 py-px text-[11px]" : "px-2 py-0.5 text-[12px]",
+    onClick && "cursor-pointer transition-colors hover:bg-gray-3",
+  );
+  const body = (
+    <>
+      <span
+        className="inline-block h-1.5 w-1.5 rounded-full"
+        style={{ background: `var(--${tag.hue}-9)` }}
+      />
+      {tag.name}
+      {onRemove && (
+        <NestedButton
+          onActivate={onRemove}
+          className="ml-0.5 rounded-full text-gray-9 hover:text-gray-12"
+          aria-label={`Remove ${tag.name}`}
+        >
+          ×
+        </NestedButton>
+      )}
+    </>
+  );
+  if (onClick) {
+    // Chips can sit inside a task row that is itself a <button>.
+    return (
+      <NestedButton onActivate={onClick} className={className}>
+        {body}
+      </NestedButton>
+    );
+  }
+  return <span className={className}>{body}</span>;
+}
+
+export function TagGlyph({
+  tag,
+  size = 16,
+}: {
+  tag: PrototypeTag;
+  size?: number;
+}) {
+  return (
+    <span
+      className="flex shrink-0 items-center justify-center rounded"
+      style={{
+        width: size + 6,
+        height: size + 6,
+        background: `var(--${tag.hue}-4)`,
+        color: `var(--${tag.hue}-11)`,
+      }}
+    >
+      <TagIcon size={size - 4} weight="bold" />
+    </span>
+  );
+}
+
+export function FaceStack({
+  personIds,
+  online,
+  max = 3,
+}: {
+  personIds: string[];
+  online?: string[];
+  max?: number;
+}) {
+  const shown = personIds.slice(0, max);
+  const extra = personIds.length - shown.length;
+  return (
+    <AvatarGroup stacked reverse size="xs" className="shrink-0">
+      {extra > 0 && (
+        <Avatar size="xs">
+          <AvatarFallback className="bg-gray-4 text-[9px] text-gray-11">
+            +{extra}
+          </AvatarFallback>
+        </Avatar>
+      )}
+      {shown.map((id) => {
+        const person = personById(id);
+        const isOnline = online?.includes(id);
+        return (
+          <Tooltip key={id}>
+            <TooltipTrigger
+              render={
+                <Avatar
+                  size="xs"
+                  className={cn(
+                    isOnline && "ring-(--green-9) ring-1 ring-offset-1",
+                  )}
+                >
+                  <AvatarFallback
+                    className="text-[9px]"
+                    style={{
+                      background: `var(--${person.hue}-5)`,
+                      color: `var(--${person.hue}-11)`,
+                    }}
+                  >
+                    {person.initials}
+                  </AvatarFallback>
+                </Avatar>
+              }
+            />
+            <TooltipContent side="top">
+              {person.name}
+              {isOnline ? " · online" : ""}
+            </TooltipContent>
+          </Tooltip>
+        );
+      })}
+    </AvatarGroup>
+  );
+}
+
+export function SectionLabel({
+  children,
+  count,
+}: {
+  children: React.ReactNode;
+  count?: number;
+}) {
+  return (
+    <div className="flex items-center gap-1.5 px-1 pt-4 pb-1.5 first:pt-1">
+      <span className="font-semibold text-[11px] text-gray-10 uppercase tracking-wide">
+        {children}
+      </span>
+      {count !== undefined && (
+        <span className="rounded bg-gray-3 px-1 text-[10px] text-gray-10">
+          {count}
+        </span>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Problem

Spaces make finding a task expensive: they force a two-level nav (space list → space contents), so working across many agents means clicking in and out of spaces all day.

This PR is a clickable prototype, not a production feature: it explores replacing spaces with flat, many-to-many **tags** plus a Linear-style **Home**, so we can feel the model before building it.

## Changes

Storybook-only prototype under `Prototypes/TagsPrototype` (`packages/ui/src/features/prototypes/tags/`). Everything is local state over invented fixtures – no routing, no stores, no backend, nothing reachable from the app.

The model it demonstrates:

- Tags are flat and many-to-many: one task can carry several tags, and everyone following any of them sees it (the multiplayer benefit of spaces, without exclusive containment).
- Tags carry startup metadata: repos to clone, context docs, and an agent preset. Starting a task under a tag inherits them; picking several tags stacks them.
- One global left nav: a Home icon at the top, then every tag with presence avatars, running-agent counts, and needs-you badges. No second nav level.
- Home is a Linear-style triage view: sections for "Needs your attention" / "Running now" / "In review", filters (Needs you, Running, Involving me), and a by-status/by-tag grouping toggle.

Home, grouped by status:

![home](https://raw.githubusercontent.com/PostHog/pr-assets/a8aa4e634fd481092258ff2baae337643d19b11b/2026/08/4c077c01-ce67-48c7-92a1-6416506ff790.png)

Home regrouped by tag – the same tasks appear under every tag they carry:

![home by tag](https://raw.githubusercontent.com/PostHog/pr-assets/7ae4660e8554e785f280db9987a2eb632e420c52/2026/08/f1e78191-3689-4ce1-b39e-15fcfd936dcd.png)

Task detail panel – tags are editable chips, so retagging a task re-homes it instantly:

![task panel](https://raw.githubusercontent.com/PostHog/pr-assets/0c9d1ca4470b83e8b9b9807322b3228b7bf191a5/2026/08/decaa6f4-77fb-445a-a812-c3dbde432984.png)

A tag view – members online, metadata pills (repos, context, preset), and a composer that shows what a new agent starts with:

![tag view](https://raw.githubusercontent.com/PostHog/pr-assets/1ce0803b722fbcd681de859181e0fe95676ac9ce/2026/08/be6bc819-c7ca-4a63-9825-5a7e906ea923.png)

New task dialog – picking multiple tags stacks their repos and context:

![new task dialog](https://raw.githubusercontent.com/PostHog/pr-assets/f5734bbdf13040e6fd19f481f031e6466e22038e/2026/08/1fd0c53c-05e6-4d57-ab57-521f627c2911.png)

Things to click in the story: the Home icon vs tag rows, the Home filters and grouping toggle, any task row (opens the panel), add/remove tags in the panel, a tag composer or the New task button (both create a mock running task).

## How did you test this code?

- Ran the story in Storybook (`apps/code`) and drove it with a Playwright script: navigation, filters, grouping, the task panel, adding a tag, starting a task from the composer, and the new task dialog all behave; no page errors.
- `biome check` and `pnpm --filter @posthog/ui typecheck` pass; `hogli ci:preflight --fix` clean.
- No unit tests: this is a throwaway prototype, not production code.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None – prototype only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with pi (Claude) in a cloud task; skills invoked: /writing-pr-descriptions.
- All fixture data (people, repos, tasks) is invented for the prototype; nothing is derived from real customer or internal data.
- Chose a Storybook story over an app route so the prototype stays completely isolated from routing, flags, and stores while remaining clickable.
- Screenshots verified via automated DOM/geometry assertions; the sandbox could not render images for manual visual review.
