### PR TITLE
fix(data-warehouse): cancel the workflow the running job recorded

### DIFF
--- a/products/data_warehouse/backend/presentation/views/saved_query.py
+++ b/products/data_warehouse/backend/presentation/views/saved_query.py
@@ -15,7 +15,6 @@ from rest_framework import exceptions, filters, request, response, serializers, 
 from rest_framework.decorators import action
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
-from temporalio.client import ScheduleActionExecutionStartWorkflow
 
 from posthog.schema import DataWarehouseManagedViewsetKind
 
@@ -1454,52 +1453,34 @@ class DataWarehouseSavedQueryViewSet(TeamAndOrgViewSetMixin, AccessControlViewSe
         """Cancel a running saved query workflow."""
         saved_query = self.get_object()
 
-        if saved_query.status != DataWarehouseSavedQuery.Status.RUNNING:
+        running_workflows = {
+            (job.workflow_id, job.workflow_run_id)
+            for job in DataModelingJob.objects.filter(
+                team_id=self.team_id,
+                saved_query=saved_query,
+                status=DataModelingJob.Status.RUNNING,
+            )
+            if job.workflow_id
+        }
+
+        if not running_workflows:
             return response.Response(
                 {"error": "Cannot cancel a query that is not running"}, status=status.HTTP_400_BAD_REQUEST
             )
 
         temporal = sync_connect()
-        workflow_id = f"data-modeling-run-{saved_query.id.hex}"
 
         try:
-            # Ad-hoc handling
-            try:
-                workflow_handle = temporal.get_workflow_handle(workflow_id)
-                if workflow_handle:
-                    async_to_sync(workflow_handle.cancel)()
-            except Exception:
-                logger.info("No ad-hoc workflow to cancel", workflow_id=workflow_id)
+            for workflow_id, workflow_run_id in running_workflows:
+                workflow_handle = temporal.get_workflow_handle(workflow_id, run_id=workflow_run_id)
+                async_to_sync(workflow_handle.cancel)()
 
-            # Schedule handling
-            try:
-                scheduled_workflow_handle = temporal.get_schedule_handle(str(saved_query.id))
-                desc = async_to_sync(scheduled_workflow_handle.describe)()
-                recent_actions = desc.info.running_actions
-                if len(recent_actions) > 0:
-                    most_recent_action = recent_actions[-1]
-                    if isinstance(most_recent_action, ScheduleActionExecutionStartWorkflow):
-                        workflow_id_to_cancel = most_recent_action.workflow_id
-                    else:
-                        logger.warning(
-                            "Unexpected action type in schedule",
-                            action_type=type(most_recent_action).__name__,
-                        )
-
-                    workflow_handle_to_cancel = temporal.get_workflow_handle(workflow_id_to_cancel)
-                    if workflow_handle_to_cancel:
-                        async_to_sync(workflow_handle_to_cancel.cancel)()
-            except Exception:
-                logger.info("No scheduled workflow to cancel", saved_query_id=str(saved_query.id))
-
-            # Update saved query status, but not the data modeling job which occurs in the workflow
-            # This is because the saved_query is used by our UI to prevent multiple cancellations
             saved_query.status = DataWarehouseSavedQuery.Status.CANCELLED
             saved_query.save()
         except Exception as e:
-            logger.exception("Failed to cancel workflow", workflow_id=workflow_id, error=str(e))
+            logger.exception("Failed to cancel workflow", saved_query_id=str(saved_query.id), error=str(e))
             return response.Response(
-                {"error": f"Failed to cancel workflow"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                {"error": "Failed to cancel workflow"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
 
         log_activity(

--- a/products/data_warehouse/backend/presentation/views/saved_query.py
+++ b/products/data_warehouse/backend/presentation/views/saved_query.py
@@ -1,4 +1,5 @@
 import uuid
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, cast
 
@@ -75,6 +76,13 @@ from products.warehouse_sources.backend.facade.models import (
 )
 
 logger = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class _CancelTarget:
+    workflow_id: str
+    workflow_run_id: str | None
+
 
 # A DataWarehouseSavedQuery's activity log also records materialization syncs and status
 # transitions (activity="sync_triggered", status changes) that advance the log without the query
@@ -1453,8 +1461,8 @@ class DataWarehouseSavedQueryViewSet(TeamAndOrgViewSetMixin, AccessControlViewSe
         """Cancel a running saved query workflow."""
         saved_query = self.get_object()
 
-        running_workflows = {
-            (job.workflow_id, job.workflow_run_id)
+        targets = {
+            _CancelTarget(workflow_id=job.workflow_id, workflow_run_id=job.workflow_run_id)
             for job in DataModelingJob.objects.filter(
                 team_id=self.team_id,
                 saved_query=saved_query,
@@ -1463,25 +1471,34 @@ class DataWarehouseSavedQueryViewSet(TeamAndOrgViewSetMixin, AccessControlViewSe
             if job.workflow_id
         }
 
-        if not running_workflows:
+        if not targets:
             return response.Response(
                 {"error": "Cannot cancel a query that is not running"}, status=status.HTTP_400_BAD_REQUEST
             )
 
         temporal = sync_connect()
+        failed = False
 
-        try:
-            for workflow_id, workflow_run_id in running_workflows:
-                workflow_handle = temporal.get_workflow_handle(workflow_id, run_id=workflow_run_id)
+        for target in sorted(targets, key=lambda target: target.workflow_id):
+            try:
+                workflow_handle = temporal.get_workflow_handle(target.workflow_id, run_id=target.workflow_run_id)
                 async_to_sync(workflow_handle.cancel)()
+            except Exception as e:
+                failed = True
+                logger.exception(
+                    "Failed to cancel workflow",
+                    saved_query_id=str(saved_query.id),
+                    workflow_id=target.workflow_id,
+                    error=str(e),
+                )
 
-            saved_query.status = DataWarehouseSavedQuery.Status.CANCELLED
-            saved_query.save()
-        except Exception as e:
-            logger.exception("Failed to cancel workflow", saved_query_id=str(saved_query.id), error=str(e))
+        if failed:
             return response.Response(
                 {"error": "Failed to cancel workflow"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
+
+        saved_query.status = DataWarehouseSavedQuery.Status.CANCELLED
+        saved_query.save()
 
         log_activity(
             organization_id=self.team.organization_id,

--- a/products/data_warehouse/backend/tests/api/test_saved_query.py
+++ b/products/data_warehouse/backend/tests/api/test_saved_query.py
@@ -2285,6 +2285,56 @@ class TestSavedQueryRunV2Aware(APIBaseTest):
         self.assertEqual(response.status_code, 200, response.content)
         mock_trigger.assert_called_once()
 
+    @parameterized.expand(
+        [
+            ("v1", "019c4fca-ee53-0000-e7e4-fd76c23d5157-2026-08-13T04:30:00Z"),
+            ("v2", "materialize-view-019e4ccb-8369-71dd-9270-9bf570948062-2026-08-13T04:30:00Z"),
+        ]
+    )
+    @patch("products.data_warehouse.backend.presentation.views.saved_query.sync_connect")
+    def test_cancel_cancels_the_workflow_recorded_on_the_running_job(
+        self, _name: str, workflow_id: str, mock_sync_connect
+    ):
+        saved_query, _dag, _node = self._make_saved_query_with_node(f"cancel_view_{_name}")
+        DataModelingJob.objects.create(
+            team=self.team,
+            saved_query=saved_query,
+            status=DataModelingJob.Status.RUNNING,
+            workflow_id=workflow_id,
+            workflow_run_id="run-id-1",
+        )
+        mock_client = mock.MagicMock()
+        mock_handle = AsyncMock()
+        mock_client.get_workflow_handle.return_value = mock_handle
+        mock_sync_connect.return_value = mock_client
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query.id}/cancel/",
+        )
+
+        self.assertEqual(response.status_code, 200, response.content)
+        mock_client.get_workflow_handle.assert_called_once_with(workflow_id, run_id="run-id-1")
+        mock_handle.cancel.assert_awaited_once()
+        saved_query.refresh_from_db()
+        self.assertEqual(saved_query.status, DataWarehouseSavedQuery.Status.CANCELLED)
+
+    @patch("products.data_warehouse.backend.presentation.views.saved_query.sync_connect")
+    def test_cancel_is_rejected_when_no_job_is_running(self, mock_sync_connect):
+        saved_query, _dag, _node = self._make_saved_query_with_node("idle_view")
+        DataModelingJob.objects.create(
+            team=self.team,
+            saved_query=saved_query,
+            status=DataModelingJob.Status.COMPLETED,
+            workflow_id="materialize-view-already-done",
+        )
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query.id}/cancel/",
+        )
+
+        self.assertEqual(response.status_code, 400, response.content)
+        mock_sync_connect.assert_not_called()
+
 
 class TestSavedQueryDescription(APIBaseTest):
     def _base(self) -> str:

--- a/products/data_warehouse/backend/tests/api/test_saved_query.py
+++ b/products/data_warehouse/backend/tests/api/test_saved_query.py
@@ -2335,6 +2335,39 @@ class TestSavedQueryRunV2Aware(APIBaseTest):
         self.assertEqual(response.status_code, 400, response.content)
         mock_sync_connect.assert_not_called()
 
+    @patch("products.data_warehouse.backend.presentation.views.saved_query.sync_connect")
+    def test_cancel_attempts_every_running_workflow_when_one_fails(self, mock_sync_connect):
+        saved_query, _dag, _node = self._make_saved_query_with_node("partial_cancel_view")
+        for workflow_id in ("materialize-view-1-unreachable", "materialize-view-2-healthy"):
+            DataModelingJob.objects.create(
+                team=self.team,
+                saved_query=saved_query,
+                status=DataModelingJob.Status.RUNNING,
+                workflow_id=workflow_id,
+                workflow_run_id="run-id-1",
+            )
+
+        healthy_handle = AsyncMock()
+
+        def handle_for(workflow_id, run_id=None):
+            if workflow_id == "materialize-view-1-unreachable":
+                raise RuntimeError("temporal refused the handle")
+            return healthy_handle
+
+        mock_client = mock.MagicMock()
+        mock_client.get_workflow_handle.side_effect = handle_for
+        mock_sync_connect.return_value = mock_client
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query.id}/cancel/",
+        )
+
+        self.assertEqual(response.status_code, 500, response.content)
+        self.assertEqual(mock_client.get_workflow_handle.call_count, 2)
+        healthy_handle.cancel.assert_awaited_once()
+        saved_query.refresh_from_db()
+        self.assertNotEqual(saved_query.status, DataWarehouseSavedQuery.Status.CANCELLED)
+
 
 class TestSavedQueryDescription(APIBaseTest):
     def _base(self) -> str:


### PR DESCRIPTION
## Problem

- Cancelling a materialization does nothing for a saved query running on the v2 data modeling backend.
- The action gated on `saved_query.status == Running`. Only the v1 workflow writes that value, in `run_workflow.py:1543`.
- A v2 run never sets it, so the request returns 400 "Cannot cancel a query that is not running".
- Past that gate the action built the id `data-modeling-run-{saved_query.id.hex}` and read a schedule handle at `saved_query.id`. Both are v1 shapes, so a v2 workflow would not be found either.

## Changes

- The action now finds `DataModelingJob` rows with status `Running` that carry a workflow id.
- Both backends write those rows, so the lookup no longer depends on which one ran the job.
- It cancels each recorded `(workflow_id, workflow_run_id)` pair instead of constructing an id.

> [!NOTE]
> The 400 condition changed. It was "the saved query is not marked Running". It is now "no running job row carries a workflow id".

## How did you test this code?

- Added a parameterized test that cancels a job recorded under a v1 id and one recorded under a v2 id. No cancel test existed before, so nothing pinned the id shape.
- Added a test that returns 400 and never connects to Temporal when no job is running.
- Ran mypy repo-wide, which is clean.
- I did not exercise a live cancel. The tests mock the Temporal client.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) wrote this while auditing data modeling schedules. Jovan directed the work.

- Skills invoked: `/quick-fix-pr`, `/improving-drf-endpoints`, `/writing-tests`, `/writing-pr-descriptions`.
- The first reading of this bug blamed only the hardcoded ids. Writing the test showed the status gate rejects the request first, so the ids were never reached.
- The action still writes `saved_query.status = Cancelled`. Nothing in this repo branches on `Cancelled`, but the field is on the serializer, so dropping that write is an API-visible change and belongs in its own PR.
