### PR TITLE
fix(data-imports): stop reusing an unreachable redis client in row tracking

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/row_tracking.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/row_tracking.py
@@ -45,6 +45,10 @@ async def _get_redis():
         await redis.ping()
     except Exception as e:
         capture_exception(e)
+        # get_async_client only builds a lazy client, so a failed ping means redis is
+        # still unreachable - reset it to None so callers' `if not redis: return` guard
+        # actually skips the real command instead of raising the same error uncaught.
+        redis = None
 
     yield redis
 

--- a/products/warehouse_sources/backend/temporal/data_imports/tests/test_row_tracking.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/test_row_tracking.py
@@ -30,6 +30,29 @@ from products.warehouse_sources.backend.temporal.data_imports.row_tracking impor
 )
 
 
+class TestRowTrackingRedisUnavailable(BaseTest):
+    @pytest.mark.asyncio
+    async def test_setup_row_tracking_does_not_raise_when_redis_is_unreachable(self):
+        # get_async_client only builds a lazy client - the ping is the first real
+        # connection attempt. If it fails, the client must not be used again, or the
+        # next command (hset) raises the same connection error, this time uncaught.
+        unreachable_client = mock.AsyncMock()
+        unreachable_client.ping.side_effect = redis_exceptions.ConnectionError(
+            "Error connecting to redis:6379. Temporary failure in name resolution."
+        )
+
+        with (
+            mock.patch(
+                "products.warehouse_sources.backend.temporal.data_imports.row_tracking.get_async_client",
+                return_value=unreachable_client,
+            ),
+            override_settings(DATA_WAREHOUSE_REDIS_HOST="localhost", DATA_WAREHOUSE_REDIS_PORT="6379"),
+        ):
+            await setup_row_tracking(self.team.pk, str(uuid.uuid4()))
+
+        unreachable_client.hset.assert_not_called()
+
+
 @pytest.mark.timeout(600)
 @mock.patch(
     "products.warehouse_sources.backend.temporal.data_imports.row_tracking.database_sync_to_async_pool",


### PR DESCRIPTION
## Problem

Data warehouse import syncs raise an uncaught Redis `ConnectionError` when the row-tracking Redis instance is unreachable, even though row tracking is explicitly designed to fail open. See [error tracking issue](https://us.posthog.com/project/2/error_tracking/019ffb18-cb0f-7dd1-b968-1a4ce9cb52fc).

## Changes

- `_get_redis()` caught a failed `ping()` and reported it, but kept the broken client assigned instead of resetting it to `None`.
- Every caller guards with `if not redis: return` to skip row tracking when Redis is unavailable, but that guard never tripped because the client object was still truthy.
- The next real command (`hset`/`hincrby`/`hget`/...) then hit the same unreachable Redis and raised an uncaught `ConnectionError`, failing the import activity.
- Reset the client to `None` when the ping fails so callers correctly skip row tracking instead of re-attempting a doomed connection.

## How did you test this code?

- Added a test that mocks a Redis client whose `ping()` raises `ConnectionError` and asserts `setup_row_tracking` does not call `hset` and does not raise. Confirmed it fails without the fix.
- Ran the full `test_row_tracking.py` suite locally (13 passed).
- Not run: a live end-to-end import sync against a real, down Redis instance.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal bug fix, no user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking issue by Claude Code. Investigated the stack trace (`row_tracking.py:57` via `redis.asyncio`), read the surrounding pipeline code, and confirmed the guard bug by tracing `get_async_client`'s lazy-connection behavior. Added a regression test and verified it fails without the fix, then passes with it. Skills invoked: `investigating-error-issue`, `writing-tests`, `writing-pr-descriptions`.