### PR TITLE
fix(eng-analytics): pin one seed clock per test so day gaps stay exact

### DIFF
--- a/products/engineering_analytics/backend/tests/_logic_helpers.py
+++ b/products/engineering_analytics/backend/tests/_logic_helpers.py
@@ -55,6 +55,25 @@ def _dt(value: str) -> datetime:
     return datetime.fromisoformat(value).replace(tzinfo=UTC)
 
 
+_seed_clock: datetime | None = None
+
+
+def anchor_seed_clock() -> None:
+    """Pin the clock every seed in one test reads from. Called per test by the autouse fixture.
+
+    Seeds format to whole seconds, so two calls that straddle a wall-clock second land a second
+    apart even when the test asked for an exact number of days between them. Tests assert on the
+    distance between seeded rows (`merged_at` minus a `ready_for_review` event, for one), so
+    sampling the clock per call turned that distance into a coin flip on sub-second timing.
+    """
+    global _seed_clock
+    _seed_clock = timezone.now()
+
+
+def _seed_now() -> datetime:
+    return _seed_clock if _seed_clock is not None else timezone.now()
+
+
 def _ago(days: int) -> str:
     return _ago_with_duration(days, 0)[0]
 
@@ -62,7 +81,7 @@ def _ago(days: int) -> str:
 def _ago_with_duration(days: int, duration_seconds: int) -> tuple[str, str]:
     # Seed dates relative to real time: HogQL now() runs server-side and ignores
     # freezegun, so window/age assertions must share the clock the query uses.
-    started_at = timezone.now() - timedelta(days=days)
+    started_at = _seed_now() - timedelta(days=days)
     updated_at = started_at + timedelta(seconds=duration_seconds)
     fmt = "%Y-%m-%d %H:%M:%S"
     return started_at.strftime(fmt), updated_at.strftime(fmt)
@@ -70,7 +89,7 @@ def _ago_with_duration(days: int, duration_seconds: int) -> tuple[str, str]:
 
 def _ago_offset_with_duration(days: int, offset_seconds: int, duration_seconds: int) -> tuple[str, str]:
     """Like ``_ago_with_duration`` but shifted forward, so several runs can share one round anchor."""
-    started_at = timezone.now() - timedelta(days=days) + timedelta(seconds=offset_seconds)
+    started_at = _seed_now() - timedelta(days=days) + timedelta(seconds=offset_seconds)
     updated_at = started_at + timedelta(seconds=duration_seconds)
     fmt = "%Y-%m-%d %H:%M:%S"
     return started_at.strftime(fmt), updated_at.strftime(fmt)

--- a/products/engineering_analytics/backend/tests/conftest.py
+++ b/products/engineering_analytics/backend/tests/conftest.py
@@ -3,6 +3,8 @@ from unittest.mock import patch
 
 from posthog.models.scoping import team_scope
 
+from products.engineering_analytics.backend.tests._logic_helpers import anchor_seed_clock
+
 
 def _only_engineering_analytics_flag(flag_key: str, *args: object, **kwargs: object) -> bool:
     # Enable just the engineering-analytics rollout flag; leave every other flag at its
@@ -15,6 +17,11 @@ def _enable_engineering_analytics_flag():
     # The viewset is gated on PostHogFeatureFlagPermission; without this every endpoint test 403s.
     with patch("posthoganalytics.feature_enabled", side_effect=_only_engineering_analytics_flag):
         yield
+
+
+@pytest.fixture(autouse=True)
+def _anchor_seed_clock():
+    anchor_seed_clock()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Problem

`test_repo_overview_ready_to_merge_median_and_series` fails for about a third of the people who run the engineering-analytics suite, and blocks unrelated PRs at the `Django Tests Pass` gate. It asserts a three-day gap of 259200 seconds and gets 259199.

I hit it on an unrelated PR ([#82140](https://github.com/PostHog/posthog/pull/82140), [failing job](https://github.com/PostHog/posthog/actions/runs/31699102920/job/94444340236)) and reproduced it locally at 4 failures in 12 runs.

The test arrived with #79923 earlier today, so the flake is new and has not been triaged yet.

## Changes

- `_ago()` read the clock separately on every call, then formatted the seed to whole seconds.
- The test seeds `merged_at` and a `ready_for_review` event with two separate calls, with a ClickHouse insert between them.
- A wall-clock second ticking between those two calls moved the seeds one second closer after truncation, so the gap came out at 259199.
- Every seed in one test now reads a single clock, pinned by an autouse fixture in the package's `conftest.py`.
- Seeds stay relative to real time, which HogQL's server-side `now()` requires. Only the sub-second drift between calls is removed.
- The anchor sits in the shared helpers, so the same latent failure is closed for every other test that asserts a distance between two seeds.

I fixed the helper rather than the one assertion because the bug is in how seeds are produced. Pinning the assertion (a tolerance of a second) would have hidden the same defect in the other 144 `_ago` call sites.

## How did you test this code?

- Reproduced first: 4 failures in 12 runs of the named test, same assertion and same 259199 value CI reported.
- Validated the fix: 20 consecutive passes of that test. Sized from the observed rate (~1 in 3), where 20 runs give about 95% confidence the flake is gone.
- Ran `test_logic_workflows.py`, `test_logic_pull_requests.py`, and `test_logic_sources.py` together (100 tests) to confirm the shared anchor did not disturb the window and age assertions that also read these helpers.
- No new test. The regression this guards is the flake itself, and the fixed test is the guard.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- I (actually Claude Code) hit this while getting CI green on an unrelated PR, and split it out rather than folding an unrelated fix into that diff.
- Skills invoked: /fixing-flaky-tests, /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- I considered deleting or re-leveling the test first, as that skill requires. It guards `ready_to_merge_seconds` anchoring on the last ready transition, which is a locked decision in the product SPEC, so stabilizing it was the right outcome.
- Public artifact: nothing here comes from outside this repository.