### PR TITLE
fix(cdp): saturate cyclotron job counters instead of overflowing

### DIFF
--- a/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
@@ -6,7 +6,7 @@ import { parseJSON } from '~/common/utils/json-parse'
 import { HogInvocationResultsService } from '../monitoring/hog-invocation-results.service'
 import { CyclotronV2Janitor, JANITOR_POISON_PILL_ERROR_KIND } from './janitor'
 import { CyclotronV2Manager } from './manager'
-import { CyclotronV2BatchLimit, CyclotronV2DequeuedJob, CyclotronV2JobInit } from './types'
+import { CYCLOTRON_COUNTER_MAX, CyclotronV2BatchLimit, CyclotronV2DequeuedJob, CyclotronV2JobInit } from './types'
 import { CyclotronV2Worker } from './worker'
 import { CyclotronV2RateLimitedWorker } from './worker-rate-limited'
 
@@ -768,6 +768,27 @@ describe('Cyclotron V2', () => {
             const jobs = await dequeueOneBatch(worker)
             expect(jobs).toHaveLength(2)
             expect(await countByStatus('running')).toBe(2)
+        })
+
+        it('dequeues alongside a job whose transition_count is at the smallint ceiling', async () => {
+            // Dequeue bumps transition_count for the whole batch in one UPDATE, so an
+            // unclamped increment on a saturated row aborts the statement and stops every
+            // job on the queue from being dequeued, not just the saturated one.
+            const saturated = await manager.createJob({ teamId: 1, queueName: QUEUE })
+            const healthy = await manager.createJob({ teamId: 1, queueName: QUEUE })
+            await assertPool.query('UPDATE cyclotron_jobs SET transition_count = $1 WHERE id = $2', [
+                CYCLOTRON_COUNTER_MAX,
+                saturated,
+            ])
+
+            const worker = createWorker()
+            const jobs = await dequeueOneBatch(worker)
+
+            expect(jobs.map((j) => j.id).sort()).toEqual([saturated, healthy].sort())
+            const { rows } = await assertPool.query('SELECT transition_count FROM cyclotron_jobs WHERE id = $1', [
+                saturated,
+            ])
+            expect(rows[0].transition_count).toBe(CYCLOTRON_COUNTER_MAX)
         })
 
         it('respects priority ordering (lower number = higher priority)', async () => {

--- a/nodejs/src/cdp/services/cyclotron-v2/janitor.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/janitor.ts
@@ -7,7 +7,12 @@ import { logger } from '~/common/utils/logger'
 import { CYCLOTRON_INVOCATION_JOB_QUEUES, CyclotronJobInvocationHogFlow } from '../../types'
 import { v2JobToInvocation } from '../job-queue/job-queue-postgres-v2'
 import { HogInvocationResultsService } from '../monitoring/hog-invocation-results.service'
-import { CyclotronV2CleanupResult, CyclotronV2DequeuedJob, CyclotronV2JanitorConfig } from './types'
+import {
+    CYCLOTRON_COUNTER_MAX,
+    CyclotronV2CleanupResult,
+    CyclotronV2DequeuedJob,
+    CyclotronV2JanitorConfig,
+} from './types'
 
 // Stable, low-cardinality `error_kind` stamped on the failed invocation result
 // the janitor writes when it gives up on a poison pill. Lets operators target
@@ -222,7 +227,7 @@ export class CyclotronV2Janitor {
         const result = await this.pool.query<{ id: string }>(
             `UPDATE cyclotron_jobs
              SET status = 'failed', lock_id = NULL, last_heartbeat = NULL,
-                 last_transition = NOW(), transition_count = transition_count + 1
+                 last_transition = NOW(), transition_count = LEAST(transition_count + 1, ${CYCLOTRON_COUNTER_MAX})
              WHERE id IN (
                  SELECT id
                  FROM cyclotron_jobs
@@ -453,7 +458,7 @@ export class CyclotronV2Janitor {
             )
             UPDATE cyclotron_jobs
             SET status = 'available', lock_id = NULL, last_heartbeat = NULL,
-                janitor_touch_count = janitor_touch_count + 1${backoffClause}
+                janitor_touch_count = LEAST(janitor_touch_count + 1, ${CYCLOTRON_COUNTER_MAX})${backoffClause}
             FROM stalled
             WHERE cyclotron_jobs.id = stalled.id`,
             params

--- a/nodejs/src/cdp/services/cyclotron-v2/types.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/types.ts
@@ -3,6 +3,16 @@ import { z } from 'zod'
 
 export type CyclotronV2JobStatus = 'available' | 'running' | 'completed' | 'failed' | 'canceled'
 
+/**
+ * Ceiling for `transition_count` and `janitor_touch_count`, which are SMALLINT.
+ * Incrementing past it raises `smallint out of range`, and because dequeue bumps
+ * `transition_count` in the same UPDATE that claims a batch, one saturated row
+ * aborts the dequeue for every job on its queue rather than just itself. Both
+ * counters are only ever read for observability, never compared against a limit,
+ * so saturating preserves their meaning without that blast radius.
+ */
+export const CYCLOTRON_COUNTER_MAX = 32767
+
 export type CyclotronV2PoolConfig = {
     dbUrl: string
     maxConnections?: number

--- a/nodejs/src/cdp/services/cyclotron-v2/worker.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/worker.ts
@@ -6,6 +6,7 @@ import { logger } from '~/common/utils/logger'
 
 import { assignEmailDequeueSeq } from './manager'
 import {
+    CYCLOTRON_COUNTER_MAX,
     CyclotronV2BulkCreateAndCheckInInput,
     CyclotronV2DequeuedJob,
     CyclotronV2JobInit,
@@ -147,7 +148,7 @@ async function updateSelfInTx(
         const result = await client.query(
             `UPDATE cyclotron_jobs
              SET status = 'completed', lock_id = NULL, last_heartbeat = NULL,
-                 last_transition = NOW(), transition_count = transition_count + 1,
+                 last_transition = NOW(), transition_count = LEAST(transition_count + 1, ${CYCLOTRON_COUNTER_MAX}),
                  janitor_touch_count = 0
              WHERE id = $1 AND lock_id = $2`,
             [jobId, lockId]
@@ -159,7 +160,7 @@ async function updateSelfInTx(
         const result = await client.query(
             `UPDATE cyclotron_jobs
              SET status = 'failed', lock_id = NULL, last_heartbeat = NULL,
-                 last_transition = NOW(), transition_count = transition_count + 1,
+                 last_transition = NOW(), transition_count = LEAST(transition_count + 1, ${CYCLOTRON_COUNTER_MAX}),
                  janitor_touch_count = 0
              WHERE id = $1 AND lock_id = $2`,
             [jobId, lockId]
@@ -174,7 +175,7 @@ async function updateSelfInTx(
         `lock_id = NULL`,
         `last_heartbeat = NULL`,
         `last_transition = NOW()`,
-        `transition_count = transition_count + 1`,
+        `transition_count = LEAST(transition_count + 1, ${CYCLOTRON_COUNTER_MAX})`,
         `janitor_touch_count = 0`,
         `scheduled = $3`,
     ]
@@ -307,7 +308,7 @@ export class CyclotronV2Worker {
                 lock_id = $3,
                 last_heartbeat = NOW(),
                 last_transition = NOW(),
-                transition_count = transition_count + 1
+                transition_count = LEAST(transition_count + 1, ${CYCLOTRON_COUNTER_MAX})
             FROM available
             WHERE cyclotron_jobs.id = available.id
             RETURNING
@@ -368,7 +369,7 @@ export class CyclotronV2Worker {
                 lock_id = $3,
                 last_heartbeat = NOW(),
                 last_transition = NOW(),
-                transition_count = transition_count + 1
+                transition_count = LEAST(transition_count + 1, ${CYCLOTRON_COUNTER_MAX})
             FROM available
             WHERE cyclotron_jobs.id = available.id
             RETURNING
@@ -427,7 +428,7 @@ export class CyclotronV2Worker {
                 await pool.query(
                     `UPDATE cyclotron_jobs
                      SET status = 'completed', lock_id = NULL, last_heartbeat = NULL,
-                         last_transition = NOW(), transition_count = transition_count + 1,
+                         last_transition = NOW(), transition_count = LEAST(transition_count + 1, ${CYCLOTRON_COUNTER_MAX}),
                          janitor_touch_count = 0
                      WHERE id = $1 AND lock_id = $2`,
                     [row.id, lockId]
@@ -439,7 +440,7 @@ export class CyclotronV2Worker {
                 await pool.query(
                     `UPDATE cyclotron_jobs
                      SET status = 'failed', lock_id = NULL, last_heartbeat = NULL,
-                         last_transition = NOW(), transition_count = transition_count + 1,
+                         last_transition = NOW(), transition_count = LEAST(transition_count + 1, ${CYCLOTRON_COUNTER_MAX}),
                          janitor_touch_count = 0
                      WHERE id = $1 AND lock_id = $2`,
                     [row.id, lockId]
@@ -456,7 +457,7 @@ export class CyclotronV2Worker {
                     `lock_id = NULL`,
                     `last_heartbeat = NULL`,
                     `last_transition = NOW()`,
-                    `transition_count = transition_count + 1`,
+                    `transition_count = LEAST(transition_count + 1, ${CYCLOTRON_COUNTER_MAX})`,
                     // A deliberate release means the worker is healthy, so the
                     // poison budget counts CONSECUTIVE stalls — long-lived jobs
                     // (e.g. wait_until_condition polls) don't accrue touches for
@@ -514,7 +515,7 @@ export class CyclotronV2Worker {
                 await pool.query(
                     `UPDATE cyclotron_jobs
                      SET status = 'canceled', lock_id = NULL, last_heartbeat = NULL,
-                         last_transition = NOW(), transition_count = transition_count + 1,
+                         last_transition = NOW(), transition_count = LEAST(transition_count + 1, ${CYCLOTRON_COUNTER_MAX}),
                          janitor_touch_count = 0
                      WHERE id = $1 AND lock_id = $2`,
                     [row.id, lockId]


### PR DESCRIPTION
## Problem

One job row can stop every job on its queue, and the only way out is deleting that row by hand. This happened in prod-us and blocked all reruns for four weeks.

- `cyclotron_jobs.transition_count` and `janitor_touch_count` are Postgres `SMALLINT`, so they raise `smallint out of range` past 32767.
- Dequeue increments `transition_count` in the same UPDATE that claims a batch, so a saturated row fails the claim for every job in that batch rather than only itself.
- Workers then log the failure on every poll and pick up nothing. Jobs are not lost, but nothing on that queue runs.
- The janitor cannot recover it. Both poison paths require `status = 'running'` with a stale heartbeat, and a saturated row parks on `available`.
- `resetStalledJobs` increments `janitor_touch_count` for all stalled jobs in one statement, so saturating that counter breaks stall recovery for every queue at once.

Neither counter is ever compared against a limit. They are read only for observability, so the ceiling enforces itself as a failed UPDATE instead of a check on the offending job.

## Changes

- Both counters saturate at 32767 via `LEAST(counter + 1, CYCLOTRON_COUNTER_MAX)` at all 11 increment sites: both dequeue paths, ack, fail, reschedule, the self-checkin paths, the legacy poison-pill path, and the janitor's stall reset.
- A regression test seeds one saturated row plus one healthy row and expects both back from a single dequeue, which pins the blast radius rather than the arithmetic.

I chose saturation over widening the columns to `integer`. Widening removes the cliff, but it is an `i16` to `i32` change shared with the Rust cyclotron-core plus a rewrite of a hot table. This is the small change that makes the failure survivable, and it does not block that migration later.

This does not change behavior until a counter is already at the ceiling. A job that reaches it keeps working and stops advancing one metric, instead of taking its queue down.

#71701 bounds the loop that produced the saturated row in the first place. They are independent: that one stops the rerun paginator minting a runaway, this one covers every other queue and any future cause. The hogflow queue is the reason it matters beyond reruns, since long-running flows already reach ~11,200 transitions and a polling flow climbs steadily toward the ceiling with no bug involved.

## How did you test this code?

- The new case fails without the change with `error: smallint out of range`, the exact production error, and passes with it. I ran that A/B on current master, not only on the branch I wrote it against.
- `cyclotron-v2.test.ts` passes 123 of 123 against a real Postgres.
- I did not add a test for the janitor's `janitor_touch_count` clamp. Reaching that ceiling needs tens of thousands of stall resets on one row, which the existing janitor tests cannot reach cheaply, and the SQL is identical to the paths that are covered.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Agent-driven, author-reviewed

I (actually Claude) wrote this while diagnosing the prod-us incident, after finding the saturated row and confirming that the ceiling breaks the shared dequeue statement rather than just the offending job. The comment on `CYCLOTRON_COUNTER_MAX` records that reasoning, since the constant looks arbitrary without it.

One consequence worth reviewing: a saturated counter now pins silently, so the "this job is looping" signal disappears at the point it matters most. Alerting on the rate of increase catches a looping job months before the ceiling either way, and PostHog/charts#14234 adds that for the rerun queue.

Skills invoked: `/writing-tests` before the regression case, `/writing-code-comments` for the constant's comment, `/writing-pr-descriptions` for this body.
