### PR TITLE
fix(desktop): size test notification menu to its content

### DIFF
--- a/products/desktop/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
@@ -821,7 +821,12 @@ function TestSection({
                 </Button>
               }
             />
-            <DropdownMenuContent align="end" side="bottom" sideOffset={6}>
+            <DropdownMenuContent
+              align="end"
+              side="bottom"
+              sideOffset={6}
+              className="w-max"
+            >
               <DropdownMenuItem onClick={testToast} disabled={!bus}>
                 In-app toast
               </DropdownMenuItem>


### PR DESCRIPTION
## Problem

- Desktop users cannot read the full labels in the notification test menu.
- **Why:** Users need each test action label to choose the correct notification channel.

## Changes

before:
<img width="1638" height="522" alt="CleanShot 2026-08-13 at 09 27 46@2x" src="https://github.com/user-attachments/assets/b3c611aa-a588-4c12-b98d-56f47bc60169" />


after:
<img width="1690" height="552" alt="CleanShot 2026-08-13 at 09 27 55@2x" src="https://github.com/user-attachments/assets/82d46f2f-2611-4368-abcd-46ff016a1953" />


- The test menu now sizes to its longest action label.
- Screenshot: Not available. The layout change was not rendered manually in this environment.

## How did you test this code?

- The UI package typecheck passed.
- Desktop lint ran and reported existing `noExplicitAny` warnings outside this change.
- Not run: manual visual verification.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. This fixes an existing UI layout issue.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex changed the dropdown width to fit its action labels.
- Skills used: `/posthog-desktop`, `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*