### PR TITLE
[Dummy timeline test] Task timeline E2E fixture commits

### DIFF
--- a/products/tasks/backend/tests/fixtures/timeline_e2e_dummy/timeline_case_01.json
+++ b/products/tasks/backend/tests/fixtures/timeline_e2e_dummy/timeline_case_01.json
@@ -1,0 +1,5 @@
+{
+  "case": "timeline-e2e-01",
+  "event": "task_created",
+  "status": "pending"
+}

--- a/products/tasks/backend/tests/fixtures/timeline_e2e_dummy/timeline_case_01.json
+++ b/products/tasks/backend/tests/fixtures/timeline_e2e_dummy/timeline_case_01.json
@@ -1,5 +1,6 @@
 {
   "case": "timeline-e2e-01",
   "event": "task_created",
-  "status": "pending"
+  "status": "queued",
+  "timeline_step": "created"
 }

--- a/products/tasks/backend/tests/fixtures/timeline_e2e_dummy/timeline_case_02.json
+++ b/products/tasks/backend/tests/fixtures/timeline_e2e_dummy/timeline_case_02.json
@@ -1,5 +1,6 @@
 {
   "case": "timeline-e2e-02",
   "event": "task_started",
-  "status": "running"
+  "status": "paused",
+  "timeline_step": "awaiting_input"
 }

--- a/products/tasks/backend/tests/fixtures/timeline_e2e_dummy/timeline_case_02.json
+++ b/products/tasks/backend/tests/fixtures/timeline_e2e_dummy/timeline_case_02.json
@@ -1,0 +1,5 @@
+{
+  "case": "timeline-e2e-02",
+  "event": "task_started",
+  "status": "running"
+}

--- a/products/tasks/backend/tests/fixtures/timeline_e2e_dummy/timeline_case_03.json
+++ b/products/tasks/backend/tests/fixtures/timeline_e2e_dummy/timeline_case_03.json
@@ -1,5 +1,0 @@
-{
-  "case": "timeline-e2e-03",
-  "event": "task_completed",
-  "status": "done"
-}

--- a/products/tasks/backend/tests/fixtures/timeline_e2e_dummy/timeline_case_03.json
+++ b/products/tasks/backend/tests/fixtures/timeline_e2e_dummy/timeline_case_03.json
@@ -1,0 +1,5 @@
+{
+  "case": "timeline-e2e-03",
+  "event": "task_completed",
+  "status": "done"
+}

--- a/products/tasks/backend/tests/fixtures/timeline_e2e_dummy/timeline_case_04.json
+++ b/products/tasks/backend/tests/fixtures/timeline_e2e_dummy/timeline_case_04.json
@@ -1,0 +1,5 @@
+{
+  "case": "timeline-e2e-04",
+  "event": "task_resumed",
+  "status": "running"
+}

--- a/products/tasks/backend/tests/fixtures/timeline_e2e_dummy/timeline_case_05.json
+++ b/products/tasks/backend/tests/fixtures/timeline_e2e_dummy/timeline_case_05.json
@@ -1,0 +1,5 @@
+{
+  "case": "timeline-e2e-05",
+  "event": "task_comment_added",
+  "status": "in_progress"
+}

--- a/products/tasks/backend/tests/fixtures/timeline_e2e_dummy/timeline_case_06.json
+++ b/products/tasks/backend/tests/fixtures/timeline_e2e_dummy/timeline_case_06.json
@@ -1,0 +1,5 @@
+{
+  "case": "timeline-e2e-06",
+  "event": "task_archived",
+  "status": "closed"
+}


### PR DESCRIPTION
## Dummy task timeline test

This draft PR intentionally exercises the task timeline with three signed commits.

- Test-only fixture changes are isolated to `products/tasks/backend/tests/fixtures/timeline_e2e_dummy/`.
- The commit sequence uses 1, 3, and 5 touched files.
- This is a dummy timeline test and is not intended for production behavior changes.