### PR TITLE
fix(signals): propose crowded-area contributors before returning no reviewers

### DIFF
--- a/products/signals/backend/report_generation/resolve_reviewers.py
+++ b/products/signals/backend/report_generation/resolve_reviewers.py
@@ -143,7 +143,9 @@ def resolve_suggested_reviewers(
     Blame candidates (commit authors, weighted by finding position) are recency-shaped
     against cached area activity, and recently-active area contributors enter as capped
     fallbacks — see ``_score_candidates``. With no activity data available at all, scoring
-    degrades to blame-only.
+    degrades to blame-only. This path never proposes nobody while activity data exists:
+    an unrouted report goes unreviewed, so crowded-area contributors are proposed as the
+    final fallback (``allow_crowd_fallback``).
     """
     if not commit_hashes_with_reasons or not repository:
         return []
@@ -200,7 +202,9 @@ def resolve_suggested_reviewers(
     touched_paths = [path for info in author_results.values() if info is not None for path in info.file_paths]
     activity_by_login = _relevant_area_activity(team_id, repository, touched_paths)
 
-    return _rank_scored_candidates(login_weights, activity_by_login, login_commits, login_names)
+    return _rank_scored_candidates(
+        login_weights, activity_by_login, login_commits, login_names, allow_crowd_fallback=True
+    )
 
 
 def rank_assignee_candidates(
@@ -234,8 +238,10 @@ def _rank_scored_candidates(
     activity_by_login: dict[str, _AreaContributor],
     login_commits: dict[str, list[RelevantCommit]],
     login_names: dict[str, str | None],
+    *,
+    allow_crowd_fallback: bool = False,
 ) -> list[_ResolvedReviewer]:
-    scores = _score_candidates(login_weights, activity_by_login)
+    scores = _score_candidates(login_weights, activity_by_login, allow_crowd_fallback=allow_crowd_fallback)
 
     def rank_key(item: tuple[str, float]) -> tuple[float, int, str]:
         login, score = item
@@ -284,8 +290,9 @@ class _AreaContributor:
     last_commit_url: str
     area: str  # the area of the evidence (freshest) commit, for evidence wording
     # True if *any* area this contributor was drawn from is focused enough to count as owned.
-    # Not tied to the evidence area: a crowded area still supplies recency, it just proposes
-    # nobody, and it must not cancel a claim earned in a focused one.
+    # Not tied to the evidence area: a crowded area still supplies recency, it proposes
+    # contributors only as the crowd fallback of last resort (see _score_candidates), and it
+    # must not cancel a claim earned in a focused one.
     is_likely_owner_of_area: bool
 
 
@@ -402,6 +409,8 @@ def _has_live_reviewer(
 def _score_candidates(
     login_weights: Counter[str],
     activity_by_login: dict[str, _AreaContributor],
+    *,
+    allow_crowd_fallback: bool = False,
 ) -> dict[str, float]:
     """Blend blame weights with area recency; add capped activity-only fallbacks.
 
@@ -410,6 +419,12 @@ def _score_candidates(
     last resort: no live reviewer, and an area focused enough to imply ownership. Their base
     starts above the stale floor, so they outrank authors who have left the area. With no
     activity data at all, blame weights pass through unchanged (legacy behavior).
+
+    ``allow_crowd_fallback`` decides what happens when even that yields nobody (no blame
+    candidate at all, and every relevant area too crowded to imply ownership): the pipeline
+    reviewer path proposes the crowded areas' most active contributors, because an empty
+    suggestion list leaves the report unrouted; the agent re-ranking path keeps returning
+    nothing, so the agent's own judgment (including a deliberate "no clear candidate") wins.
     """
     if not activity_by_login:
         return {login: float(weight) for login, weight in login_weights.items()}
@@ -424,13 +439,22 @@ def _score_candidates(
         return scores
 
     # If not, nobody the report points at is around to review, so fall back to area contributors.
-    max_blame_weight = float(max(login_weights.values(), default=0)) or 1.0
+    def activity_only_score(activity: _AreaContributor) -> float:
+        max_blame_weight = float(max(login_weights.values(), default=0)) or 1.0
+        saturation = min(activity.commit_count, ACTIVITY_BONUS_SATURATION_COMMITS) / ACTIVITY_BONUS_SATURATION_COMMITS
+        base = STALE_BLAME_MULTIPLIER + (ACTIVITY_ONLY_SCORE_CAP - STALE_BLAME_MULTIPLIER) * saturation
+        return max_blame_weight * base * _recency_multiplier(activity.days_since_last_commit)
+
     for login, activity in activity_by_login.items():
         if login in scores or not activity.is_likely_owner_of_area:
             continue
-        saturation = min(activity.commit_count, ACTIVITY_BONUS_SATURATION_COMMITS) / ACTIVITY_BONUS_SATURATION_COMMITS
-        base = STALE_BLAME_MULTIPLIER + (ACTIVITY_ONLY_SCORE_CAP - STALE_BLAME_MULTIPLIER) * saturation
-        scores[login] = max_blame_weight * base * _recency_multiplier(activity.days_since_last_commit)
+        scores[login] = activity_only_score(activity)
+
+    if scores or not allow_crowd_fallback:
+        return scores
+
+    for login, activity in activity_by_login.items():
+        scores[login] = activity_only_score(activity)
     return scores
 
 

--- a/products/signals/backend/test/test_resolve_reviewers.py
+++ b/products/signals/backend/test/test_resolve_reviewers.py
@@ -200,7 +200,8 @@ class TestRecencyScoring:
 
     def test_crowded_area_nominates_nobody_but_still_decays_blame(self):
         weights = Counter({"old-timer": 10})
-        # The blame author is past the window, so only the crowded area keeps the stranger out.
+        # The blame author is past the window, so only the crowded area keeps the stranger out —
+        # even with the crowd fallback allowed, since a blame candidate exists.
         activity = {
             "old-timer": _area_contributor(
                 days_since_last_commit=ACTIVITY_WINDOW_DAYS + 5, is_likely_owner_of_area=False
@@ -208,10 +209,29 @@ class TestRecencyScoring:
             "prolific-stranger": _area_contributor(days_since_last_commit=1, is_likely_owner_of_area=False),
         }
 
-        scores = _score_candidates(weights, activity)
+        scores = _score_candidates(weights, activity, allow_crowd_fallback=True)
 
         assert set(scores) == {"old-timer"}
         assert scores["old-timer"] < 10.0
+
+    @pytest.mark.parametrize(
+        ("allow_crowd_fallback", "expected_logins"),
+        [(True, {"crowd-regular", "crowd-passerby"}), (False, set())],
+    )
+    def test_crowd_fallback_fires_only_on_the_reviewer_path(self, allow_crowd_fallback, expected_logins):
+        # No blame candidate at all and no focused area: the pipeline reviewer path must
+        # propose the crowd's contributors rather than nobody, while the agent re-ranking
+        # path must keep returning nothing so the agent's own judgment wins.
+        activity = {
+            "crowd-regular": _area_contributor(days_since_last_commit=1, is_likely_owner_of_area=False),
+            "crowd-passerby": _area_contributor(
+                days_since_last_commit=5, commit_count=2, is_likely_owner_of_area=False
+            ),
+        }
+
+        scores = _score_candidates(Counter(), activity, allow_crowd_fallback=allow_crowd_fallback)
+
+        assert set(scores) == expected_logins
 
     def test_half_stale_bystander_does_not_beat_stale_blame(self):
         weights = Counter({"long-gone": 1})
@@ -343,6 +363,17 @@ class TestRankAssigneeCandidates:
 
         assert [candidate.login for candidate in ranked] == ["first-pick", "second-pick"]
 
+    def test_no_candidates_and_crowded_area_returns_nothing(self, team):
+        # The agent path must not inherit the reviewer path's crowd fallback: when the agent
+        # deliberately proposed nobody and only a crowded area is cached, an empty result
+        # lets the caller keep the agent's judgment.
+        _seed_area(team, "products/signals", [(f"dev-{i}", 3, 1) for i in range(MAX_CONTRIBUTORS_FOR_OWNERSHIP + 1)])
+
+        with patch("products.signals.backend.report_generation.resolve_reviewers._schedule_activity_rebuild"):
+            ranked = rank_assignee_candidates(team.id, "acme/app", [], ["products/signals/backend/models.py"])
+
+        assert ranked == []
+
 
 @pytest.mark.django_db
 class TestResolveSuggestedReviewersEndToEnd:
@@ -443,6 +474,54 @@ class TestResolveSuggestedReviewersEndToEnd:
 
         assert [r.login for r in reviewers] == ["active-author"]
         assert reviewers[0].commits[0].sha == "d" * 7
+
+    def test_bot_only_blame_in_crowded_area_still_proposes_contributors(self, team):
+        # The production regression this guards: every finding commit is bot-authored, and the
+        # only cached activity level is too crowded to imply ownership (a monorepo norm), so
+        # the resolver used to return nobody and the report went unrouted.
+        class FakeGitHub:
+            def get_commit_author_info(self, repository, sha):
+                return GitHubCommitAuthor(
+                    login="release-bot",
+                    name="Release Bot",
+                    commit_url=f"https://github.com/acme/app/commit/{sha}",
+                    file_paths=("products/signals/backend/models.py",),
+                    is_bot=True,
+                )
+
+        activity = {
+            "products/signals": [
+                ContributorActivity(
+                    login=f"dev-{i}",
+                    name=f"Dev {i}",
+                    commit_count=MAX_CONTRIBUTORS_FOR_OWNERSHIP + 1 - i,
+                    last_commit_at=timezone.now() - timedelta(days=1),
+                    last_commit_sha="c" * 7,
+                    last_commit_url="https://github.com/acme/app/commit/ccccccc",
+                )
+                for i in range(MAX_CONTRIBUTORS_FOR_OWNERSHIP + 1)
+            ]
+        }
+
+        with (
+            patch(
+                "products.signals.backend.report_generation.resolve_reviewers.GitHubIntegration.first_for_team_repository",
+                return_value=FakeGitHub(),
+            ),
+            patch(
+                "products.signals.backend.report_generation.resolve_reviewers.get_area_activity",
+                return_value=activity,
+            ),
+            patch(
+                "products.signals.backend.report_generation.resolve_reviewers.repository_activity_needs_rebuild",
+                return_value=False,
+            ),
+        ):
+            reviewers = resolve_suggested_reviewers(team.id, "acme/app", {"d" * 7: "introduced the bug"})
+
+        # Ties on score break by commit count, so the crowd's most active contributors surface.
+        assert [r.login for r in reviewers] == ["dev-0", "dev-1", "dev-2"]
+        assert "Recently active in `products/signals`" in reviewers[0].commits[0].reason
 
     def test_stale_cached_blame_author_does_not_suppress_fresh_owner(self, team):
         class FakeGitHub:


### PR DESCRIPTION
## Problem

- Reports on busy monorepos routinely get no suggested reviewer, and an unrouted report mostly goes unreviewed.
- #74970 and #75764 each cut a source of noisy suggestions, but together they closed the only path that names a reviewer without a live blame author.
- When no finding commit resolves to a human author, the fallback only proposes contributors from an area with at most `MAX_CONTRIBUTORS_FOR_OWNERSHIP` (30) recent contributors.
- On a large monorepo, hot areas and every walk-up level (`products`, repo-wide) fail that test, so the resolver returns nobody.
- Origin: [Slack investigation thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1786627213647469).

## Changes

- `resolve_suggested_reviewers` now proposes the crowded areas' most active contributors when it would otherwise return an empty list.
- The crowd fallback reuses the existing capped activity score, so it ranks below any blame candidate and keeps the top-3 cap.
- The ownership gate still holds whenever anyone else can be proposed: focused-area owners and blame authors, even stale ones, keep the crowd out.
- The scout re-ranking path (`rank_assignee_candidates`) is unchanged: an empty ranking still lets the agent's own judgment stand, including a deliberate "no clear candidate".
- No UI changes.

## How did you test this code?

- New end-to-end test: bot-only blame in a 31-contributor area returned nobody before this fix and returns the top contributors after it.
- New parameterized scoring test: the crowd fallback fires on the reviewer path and stays off on the scout path.
- New scout-path test: no candidates plus a crowded area still returns an empty ranking.
- Extended the crowded-area scoring test: a stale blame author keeps the crowd out even with the fallback allowed.
- Ran the signals reviewer test files and repo-wide mypy locally; not run: the rest of the backend suite (CI covers it).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code, working from the linked Slack thread's diagnosis; I (Claude) verified the mechanism in `resolve_reviewers.py` and the two suspect PRs before changing anything.
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- Considered loosening `MAX_CONTRIBUTORS_FOR_OWNERSHIP` or making it depth-aware instead; kept the gate and added a fallback so the noise #74970/#75764 removed stays removed.
- Follow-up (not in this PR): the resolver still returns nobody with no repository or no GitHub integration; routing those to an agentic assignee path is the next lever.
