### PR TITLE
fix(data-imports): retry the external data job insert on a Postgres deadlock

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/create_job_model.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/create_job_model.py
@@ -27,6 +27,9 @@ from products.warehouse_sources.backend.temporal.data_imports.external_product_h
     emit_signals_enabled_for,
     person_property_sync_enabled_for,
 )
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.common.db_retry import (
+    retry_on_operational_error,
+)
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.sync_lock import (
     get_v3_pipeline_lock_holder,
 )
@@ -138,6 +141,33 @@ def _build_schema_snapshot(schema: ExternalDataSchema) -> dict[str, Any]:
     }
 
 
+@retry_on_operational_error
+def _create_job(
+    *,
+    team_id: int,
+    source_id: uuid.UUID,
+    schema_id: uuid.UUID,
+    pipeline_version: str,
+    billable: bool,
+    schema_snapshot: dict[str, Any],
+) -> ExternalDataJob:
+    # A deadlock aborts the INSERT without creating a row, so retrying from scratch is safe. This
+    # activity has no Temporal-level retry (see external_data_job.py), because a retry after job
+    # creation succeeds would create a duplicate job — retrying just the INSERT avoids that.
+    return ExternalDataJob.objects.create(
+        team_id=team_id,
+        pipeline_id=source_id,
+        schema_id=schema_id,
+        status=ExternalDataJob.Status.RUNNING,
+        rows_synced=0,
+        workflow_id=activity.info().workflow_id,
+        workflow_run_id=activity.info().workflow_run_id,
+        pipeline_version=pipeline_version,
+        billable=billable,
+        schema_snapshot=schema_snapshot,
+    )
+
+
 # TODO: remove dependency
 
 
@@ -212,14 +242,10 @@ def create_external_data_job_model_activity(
             pipeline_version = ExternalDataJob.PipelineVersion.V3
             _verify_v3_lock_still_held(inputs.team_id, inputs.schema_id)
 
-        job = ExternalDataJob.objects.create(
+        job = _create_job(
             team_id=inputs.team_id,
-            pipeline_id=inputs.source_id,
+            source_id=inputs.source_id,
             schema_id=inputs.schema_id,
-            status=ExternalDataJob.Status.RUNNING,
-            rows_synced=0,
-            workflow_id=activity.info().workflow_id,
-            workflow_run_id=activity.info().workflow_run_id,
             pipeline_version=pipeline_version,
             billable=inputs.billable,
             schema_snapshot=_build_schema_snapshot(schema),

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_create_job_model.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_create_job_model.py
@@ -4,6 +4,7 @@ import datetime as dt
 import pytest
 from unittest.mock import MagicMock, patch
 
+from django.db import OperationalError
 from django.utils import timezone
 
 from parameterized import parameterized
@@ -14,16 +15,19 @@ from posthog.models import Organization, Team
 from products.warehouse_sources.backend.models.column_annotation import WarehouseColumnAnnotation
 from products.warehouse_sources.backend.models.column_statistics import WarehouseColumnStatistics
 from products.warehouse_sources.backend.models.credential import DataWarehouseCredential
+from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 from products.warehouse_sources.backend.models.table import DataWarehouseTable
 from products.warehouse_sources.backend.temporal.data_imports.workflow_activities.create_job_model import (
+    _create_job,
     _enrichment_pending,
     _statistics_stale,
     _verify_v3_lock_still_held,
 )
 
 MODULE = "products.warehouse_sources.backend.temporal.data_imports.workflow_activities.create_job_model"
+DB_RETRY_MODULE = "products.warehouse_sources.backend.temporal.data_imports.pipelines.common.db_retry"
 
 
 def _team() -> Team:
@@ -171,3 +175,46 @@ class TestEnrichmentPending:
         self._annotate(team, table, "amount")
         self._annotate(team, table, "")
         assert _enrichment_pending(team.id, table, _schema(team, table, description=None)) is False
+
+
+@pytest.mark.django_db
+class TestCreateJob:
+    # Guards the deadlock we saw in production: Postgres can abort the ExternalDataJob INSERT with
+    # "deadlock detected" while taking its FK lock on posthog_team. The INSERT leaves no row behind,
+    # so retrying from scratch is safe — this activity has no Temporal-level retry (a retry after the
+    # job row exists would create a duplicate), so the retry has to happen around the INSERT itself.
+    @patch(f"{DB_RETRY_MODULE}.close_old_connections")
+    @patch(f"{DB_RETRY_MODULE}.time.sleep")
+    @patch(f"{MODULE}.activity")
+    def test_retries_once_on_deadlock_then_succeeds(
+        self, mock_activity: MagicMock, mock_sleep: MagicMock, mock_close_connections: MagicMock
+    ) -> None:
+        mock_activity.info.return_value.workflow_id = "wf-1"
+        mock_activity.info.return_value.workflow_run_id = "run-1"
+
+        team = _team()
+        schema = _schema(team, None)
+        original_create = ExternalDataJob.objects.create
+
+        def flaky_create(*args: object, **kwargs: object) -> ExternalDataJob:
+            flaky_create.calls += 1  # type: ignore[attr-defined]
+            if flaky_create.calls == 1:  # type: ignore[attr-defined]
+                raise OperationalError("deadlock detected")
+            return original_create(*args, **kwargs)
+
+        flaky_create.calls = 0  # type: ignore[attr-defined]
+
+        with patch.object(ExternalDataJob.objects, "create", side_effect=flaky_create) as mock_create:
+            job = _create_job(
+                team_id=team.id,
+                source_id=schema.source_id,
+                schema_id=schema.id,
+                pipeline_version=ExternalDataJob.PipelineVersion.V2,
+                billable=True,
+                schema_snapshot={},
+            )
+
+        assert mock_create.call_count == 2
+        assert ExternalDataJob.objects.filter(schema_id=schema.id).count() == 1
+        assert job.id is not None
+        mock_sleep.assert_called_once()


### PR DESCRIPTION
## Problem

A data warehouse sync can fail outright when Postgres deadlocks while creating its job record, even though retrying would very likely succeed. [Error tracking caught one occurrence](https://us.posthog.com/project/2/error_tracking/019ffb4e-161b-77f1-a22b-8003327c84e9): `OperationalError: deadlock detected` while locking a `posthog_team` row for the job insert's foreign key check.

## Changes

- `create_external_data_job_model_activity` creates the `ExternalDataJob` row with no retry at the Temporal level (`maximum_attempts=1`), by design: retrying the whole activity after the row already exists would create a duplicate job.
- A deadlock rolls back the insert statement itself, so no row is created and the insert is safe to retry on its own.
- Extracted the insert into `_create_job` and wrapped it with `retry_on_operational_error`, the same helper already used for other idempotent writes in this pipeline (e.g. `pipeline_sync.py`, `load.py`).
- Scoping the retry to just the insert keeps the rest of the activity's Temporal-level retry behavior unchanged.

## How did you test this code?

Added `TestCreateJob.test_retries_once_on_deadlock_then_succeeds`, which makes `ExternalDataJob.objects.create` raise `OperationalError` once and asserts `_create_job` retries and creates exactly one row. No existing test covered this retry path since `_create_job` is new.

Ran locally: `pytest products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_create_job_model.py` (14 passed) and `pytest products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_db_retry.py` (4 passed, unchanged). Also ran `ruff check`/`ruff format --check` and `uv run mypy --cache-fine-grained .` clean.

Not run: a live Postgres deadlock reproduction, since that needs concurrent transactions racing on the same row.

## Docs update

None needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via the `investigating-error-issue` skill against the linked error tracking issue, then read the stack trace and the workflow's retry policy in `external_data_job.py` to confirm the fix could not just bump `maximum_attempts`. Searched open PRs (including the maintainer's own) for a prior fix; found none addressing this deadlock.