### PR TITLE
feat(desktop): put starred spaces first in the file-to menu

### DIFF
--- a/products/desktop/packages/core/src/context-menu/context-menu.test.ts
+++ b/products/desktop/packages/core/src/context-menu/context-menu.test.ts
@@ -163,6 +163,26 @@ describe("ContextMenuService.showTaskContextMenu", () => {
     expect(labels(menu.lastItems)).toContain("Archive");
   });
 
+  it("lists starred channels first under File to…", async () => {
+    const menu = new FakeContextMenu();
+    const result = makeService(menu).showTaskContextMenu({
+      ...baseTask,
+      channels: [
+        { id: "1", name: "alpha" },
+        { id: "2", name: "beta", starred: true },
+        { id: "3", name: "gamma" },
+        { id: "4", name: "delta", starred: true },
+      ],
+    });
+    await menu.shown;
+    const submenu = findItem(menu.lastItems, "File to…").submenu ?? [];
+    expect(labels(submenu)).toEqual(["#beta", "#delta", "#alpha", "#gamma"]);
+    findSubmenuItem(menu.lastItems, "File to…", "#delta").click();
+    expect(await result).toEqual({
+      action: { type: "file-to-channel", channelId: "4" },
+    });
+  });
+
   it("resolves to null when the menu is dismissed", async () => {
     const menu = new FakeContextMenu();
     const result = makeService(menu).showTaskContextMenu(baseTask);
@@ -242,6 +262,20 @@ describe("ContextMenuService.showBulkTaskContextMenu", () => {
     expect(await result).toEqual({
       action: { type: "file-to-channel", channelId: "c1" },
     });
+  });
+
+  it("lists starred channels first under File to…", async () => {
+    const menu = new FakeContextMenu();
+    makeService(menu).showBulkTaskContextMenu({
+      taskCount: 2,
+      channels: [
+        { id: "c1", name: "support" },
+        { id: "c2", name: "design", starred: true },
+      ],
+    });
+    await menu.shown;
+    const submenu = findItem(menu.lastItems, "File to…").submenu ?? [];
+    expect(labels(submenu)).toEqual(["#design", "#support"]);
   });
 
   it("gates archive on confirmation", async () => {

--- a/products/desktop/packages/core/src/context-menu/context-menu.ts
+++ b/products/desktop/packages/core/src/context-menu/context-menu.ts
@@ -133,7 +133,7 @@ export class ContextMenuService {
             {
               type: "submenu",
               label: "File to…",
-              items: channels.map((c) => ({
+              items: this.starredFirst(channels).map((c) => ({
                 // Channel names are stored bare; every surface that shows one
                 // adds the hash.
                 label: `#${c.name}`,
@@ -226,7 +226,7 @@ export class ContextMenuService {
             {
               type: "submenu" as const,
               label: "File to…",
-              items: channels.map((c) => ({
+              items: this.starredFirst(channels).map((c) => ({
                 // Channel names are stored bare; every surface that shows one
                 // adds the hash.
                 label: `#${c.name}`,
@@ -393,6 +393,16 @@ export class ContextMenuService {
 
   private separator(): SeparatorDef {
     return { type: "separator" };
+  }
+
+  /**
+   * "File to…" targets in the order the sidebar lists them: starred first. The
+   * sort is stable, so each group keeps the order the caller sent.
+   */
+  private starredFirst<C extends { starred?: boolean }>(channels: C[]): C[] {
+    return [...channels].sort(
+      (a, b) => Number(b.starred ?? false) - Number(a.starred ?? false),
+    );
   }
 
   private disabled(label: string): MenuItemDef<never> {

--- a/products/desktop/packages/core/src/context-menu/schemas.ts
+++ b/products/desktop/packages/core/src/context-menu/schemas.ts
@@ -1,5 +1,12 @@
 import { z } from "zod";
 
+// A "File to…" target. `starred` floats it to the top of the submenu.
+const fileToChannel = z.object({
+  id: z.string(),
+  name: z.string(),
+  starred: z.boolean().optional(),
+});
+
 export const taskContextMenuInput = z.object({
   taskTitle: z.string(),
   worktreePath: z.string().optional(),
@@ -12,7 +19,7 @@ export const taskContextMenuInput = z.object({
   showArchivePrior: z.boolean().optional(),
   // The project's channels available as "File to…" targets.
   // Omit (or pass empty) to hide the submenu entirely.
-  channels: z.array(z.object({ id: z.string(), name: z.string() })).optional(),
+  channels: z.array(fileToChannel).optional(),
 });
 
 export const bulkTaskContextMenuInput = z.object({
@@ -24,7 +31,7 @@ export const bulkTaskContextMenuInput = z.object({
   // Whether archiving would also shut a cloud sandbox down.
   stopsCloudSandbox: z.boolean().optional(),
   // "File to…" targets. Omit (or pass empty) to hide the submenu entirely.
-  channels: z.array(z.object({ id: z.string(), name: z.string() })).optional(),
+  channels: z.array(fileToChannel).optional(),
 });
 
 export const archivedTaskContextMenuInput = z.object({

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskRowMenu.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskRowMenu.tsx
@@ -104,6 +104,7 @@ function TaskRowMenuItems({
     id: channel.id,
     label: channel.name,
     current: channel.id === menu.channelId,
+    starred: channel.starred,
   }));
 
   return (

--- a/products/desktop/packages/ui/src/features/sidebar/components/SidebarMenu.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/SidebarMenu.tsx
@@ -223,9 +223,10 @@ function SidebarMenuComponent() {
             allPinned,
             runningCount: bulkActions.runningCount,
             stopsCloudSandbox: bulkActions.stopsCloudSandbox,
-            channels: bulkActions.channels.map(({ id, name }) => ({
+            channels: bulkActions.channels.map(({ id, name, starred }) => ({
               id,
               name,
+              starred,
             })),
           });
         if (!result.action) return;

--- a/products/desktop/packages/ui/src/features/tasks/useTaskContextMenu.ts
+++ b/products/desktop/packages/ui/src/features/tasks/useTaskContextMenu.ts
@@ -88,7 +88,11 @@ export function useTaskContextMenu() {
           isInCommandCenter,
           hasEmptyCommandCenterCell,
           showArchivePrior,
-          channels: channels.map(({ id, name }) => ({ id, name })),
+          channels: channels.map(({ id, name, starred }) => ({
+            id,
+            name,
+            starred,
+          })),
         });
 
         if (!result.action) return;

--- a/products/desktop/packages/ui/src/primitives/SearchableMenuFlyout.tsx
+++ b/products/desktop/packages/ui/src/primitives/SearchableMenuFlyout.tsx
@@ -1,5 +1,5 @@
 import { Menu as BaseMenu } from "@base-ui/react/menu";
-import { Check } from "@phosphor-icons/react";
+import { Check, Star } from "@phosphor-icons/react";
 import {
   Autocomplete,
   AutocompleteCollection,
@@ -16,6 +16,8 @@ export type MenuFlyoutItem = {
   label: string;
   /** Marks the item with a tick — the one already in effect. */
   current: boolean;
+  /** Sorts the item above the rest and marks it with a star. */
+  starred?: boolean;
   icon?: ReactNode;
 };
 
@@ -84,22 +86,27 @@ export function SearchableMenuFlyout({
   onSelect,
 }: SearchableMenuFlyoutProps) {
   const [query, setQuery] = useState("");
-  // Active item first as the anchor when switching; the rest sorted the same way
-  // the web app orders them (locale-aware, which floats emoji-prefixed names
-  // above plain ones).
-  const sections = useMemo<MenuFlyoutSection[]>(
-    () => [
+  // Active item first as the anchor when switching, then the starred ones, the
+  // same order the sidebar puts them in. Within each group, sorted the way the
+  // web app orders them (locale-aware, which floats emoji-prefixed names above
+  // plain ones).
+  const sections = useMemo<MenuFlyoutSection[]>(() => {
+    const rest = items
+      .filter((item) => !item.current)
+      .sort((a, b) => a.label.localeCompare(b.label));
+    return [
       {
         items: [
           ...items.filter((item) => item.current),
-          ...items
-            .filter((item) => !item.current)
-            .sort((a, b) => a.label.localeCompare(b.label)),
+          ...rest.filter((item) => item.starred),
+          ...rest.filter((item) => !item.starred),
         ],
       },
-    ],
-    [items],
-  );
+    ];
+  }, [items]);
+  // A star column only where stars exist, and then on every row, so the labels
+  // of unstarred items stay on the same line as the starred ones.
+  const showStars = items.some((item) => item.starred);
 
   return (
     // Keep keystrokes away from the surrounding menu: its typeahead handler sits
@@ -163,6 +170,17 @@ export function SearchableMenuFlyout({
                         <Check size={14} className="text-accent-11" />
                       )}
                     </span>
+                    {showStars && (
+                      <span className="flex w-4 shrink-0 items-center justify-center">
+                        {item.starred && (
+                          <Star
+                            size={12}
+                            weight="fill"
+                            className="text-gray-9"
+                          />
+                        )}
+                      </span>
+                    )}
                     {item.icon && (
                       <span className="flex shrink-0 items-center">
                         {item.icon}

--- a/products/desktop/packages/ui/src/primitives/SearchableMenuFlyout.tsx
+++ b/products/desktop/packages/ui/src/primitives/SearchableMenuFlyout.tsx
@@ -173,11 +173,7 @@ export function SearchableMenuFlyout({
                     {showStars && (
                       <span className="flex w-4 shrink-0 items-center justify-center">
                         {item.starred && (
-                          <Star
-                            size={12}
-                            weight="fill"
-                            className="text-gray-9"
-                          />
+                          <Star size={13} className="text-gray-9" />
                         )}
                       </span>
                     )}


### PR DESCRIPTION
## TL;DR

The "File to…" menu listed spaces in plain A-Z order. Now the ones you starred sit at the top, with a star next to them.

## Problem

Anyone filing a task picks from the "File to…" list. It was one alphabetical run of every space in the project, so the two or three you actually file to sat wherever their names landed — you scrolled or searched for a space you had already marked as important. The sidebar already groups starred spaces first; the menu ignored that.

## Changes

- `SearchableMenuFlyout` items take an optional `starred`. Order is now: current space, starred (A-Z), rest (A-Z).
- Starred rows get a small filled star. The star column appears only when the list has stars, so other users of the flyout (project and organization switchers) are unchanged.
- The two native menus sort the same way, via one `starredFirst` helper in `ContextMenuService`. The sort is stable, so names stay in order inside each group.
- `starred` rides on the channel objects the callers already hold, so no extra fetch.

No screenshot: this is a native menu and a hover flyout in the Electron app, which I can't drive from here.

## How did you test this code?

Automated only — I did not run the app.

- New: `context-menu.test.ts` covers both native menus, asserting starred labels come first and that clicking one still resolves the right channel id. Nothing else pinned submenu order, so a regression here was previously silent.
- Existing: `@posthog/core` and `@posthog/ui` typecheck; `@posthog/ui` suite passes; `@posthog/core` passes except `activityTimeline.test.ts`, which fails the same way on unmodified `master` in my checkout.
- Not checked: the flyout's rendering — the star column and the sort have no component test.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with PostHog Code (Claude Opus). No repo skills invoked.

The change first landed in `PostHog/code`, which turned out to be frozen after the monorepo migration, so it was re-applied here against current code — the star flag has since moved onto the channel itself, which made the port smaller than the original. Sorting inside the flyout rather than at each call site keeps the three surfaces from drifting apart; the star icon exists so the ordering doesn't look arbitrary.

No customer or session material is in this diff.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
