### PR TITLE
fix(desktop): tell the server which sessions are archived

### DIFF
--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -2605,6 +2605,18 @@ export class PostHogAPIClient {
     return normalizeTaskResponse(data, { teamId });
   }
 
+  /**
+   * Mirror this device's archive state onto the task, so every client agrees on
+   * what is archived — and so the list endpoint, which hides archived tasks,
+   * counts what the app actually shows. `archived` is on the write serializer
+   * but not yet in the generated schema.
+   */
+  async setTaskArchived(taskId: string, archived: boolean): Promise<void> {
+    await this.updateTask(taskId, {
+      archived,
+    } as unknown as Partial<Schemas.Task>);
+  }
+
   async deleteTask(taskId: string) {
     const teamId = await this.getTeamId();
     await this.api.delete(`/api/projects/{project_id}/tasks/{id}/`, {

--- a/products/desktop/packages/core/src/archive/serverArchiveSync.test.ts
+++ b/products/desktop/packages/core/src/archive/serverArchiveSync.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { pendingServerArchiveIds } from "./serverArchiveSync";
+
+const tasks = [{ id: "a" }, { id: "b" }, { id: "c" }, { id: "d" }];
+
+describe("pendingServerArchiveIds", () => {
+  it.each([
+    {
+      name: "picks the archived tasks the server still lists",
+      archived: ["b", "d"],
+      handled: [],
+      limit: 25,
+      expected: ["b", "d"],
+    },
+    {
+      name: "skips ids a pass has already sent",
+      archived: ["b", "d"],
+      handled: ["b"],
+      limit: 25,
+      expected: ["d"],
+    },
+    {
+      name: "stops at the limit",
+      archived: ["a", "b", "c"],
+      handled: [],
+      limit: 2,
+      expected: ["a", "b"],
+    },
+    {
+      name: "has nothing to do when nothing is archived",
+      archived: [],
+      handled: [],
+      limit: 25,
+      expected: [],
+    },
+  ])("$name", ({ archived, handled, limit, expected }) => {
+    expect(
+      pendingServerArchiveIds(
+        tasks,
+        new Set(archived),
+        new Set(handled),
+        limit,
+      ),
+    ).toEqual(expected);
+  });
+});

--- a/products/desktop/packages/core/src/archive/serverArchiveSync.test.ts
+++ b/products/desktop/packages/core/src/archive/serverArchiveSync.test.ts
@@ -1,46 +1,35 @@
 import { describe, expect, it } from "vitest";
 import { pendingServerArchiveIds } from "./serverArchiveSync";
 
-const tasks = [{ id: "a" }, { id: "b" }, { id: "c" }, { id: "d" }];
-
 describe("pendingServerArchiveIds", () => {
   it.each([
     {
-      name: "picks the archived tasks the server still lists",
-      archived: ["b", "d"],
-      handled: [],
-      limit: 25,
-      expected: ["b", "d"],
-    },
-    {
-      name: "skips ids a pass has already sent",
-      archived: ["b", "d"],
-      handled: ["b"],
-      limit: 25,
-      expected: ["d"],
-    },
-    {
-      name: "stops at the limit",
+      name: "picks every archived task not yet mirrored",
       archived: ["a", "b", "c"],
-      handled: [],
-      limit: 2,
-      expected: ["a", "b"],
+      skip: [],
+      expected: ["a", "b", "c"],
+    },
+    {
+      name: "skips ids already synced or already tried this run",
+      archived: ["a", "b", "c"],
+      skip: ["a", "c"],
+      expected: ["b"],
+    },
+    {
+      name: "has nothing to do when the archive is fully mirrored",
+      archived: ["a", "b"],
+      skip: ["a", "b"],
+      expected: [],
     },
     {
       name: "has nothing to do when nothing is archived",
       archived: [],
-      handled: [],
-      limit: 25,
+      skip: ["a"],
       expected: [],
     },
-  ])("$name", ({ archived, handled, limit, expected }) => {
-    expect(
-      pendingServerArchiveIds(
-        tasks,
-        new Set(archived),
-        new Set(handled),
-        limit,
-      ),
-    ).toEqual(expected);
+  ])("$name", ({ archived, skip, expected }) => {
+    expect(pendingServerArchiveIds(new Set(archived), new Set(skip))).toEqual(
+      expected,
+    );
   });
 });

--- a/products/desktop/packages/core/src/archive/serverArchiveSync.ts
+++ b/products/desktop/packages/core/src/archive/serverArchiveSync.ts
@@ -1,38 +1,24 @@
-/** The one field this module needs off a task: which task a list row is. */
-export interface ArchiveSyncTask {
-  id: string;
-}
-
-/** How many tasks one pass mirrors onto the server. */
-export const SERVER_ARCHIVE_SYNC_BATCH = 25;
-
 /**
  * Which locally-archived tasks the server hasn't been told about.
  *
  * Archiving is a per-device act, so the server keeps listing sessions this
  * machine has hidden — and its count is what a space row's "view all" number
  * comes from, which is why that number can run hundreds above the list behind
- * it. Anything still in a list response that this device has archived is out of
- * sync.
+ * it. The whole local archive is the work list: discovering the backlog
+ * through a task-list page starves, because pages are capped at the newest
+ * hundred rows and an archive is precisely the sessions too old to be there.
  *
- * `handled` is the ids a pass has already sent (or given up on), so a failing
- * task can't be retried on every render.
- *
- * Capped, because a device with hundreds of archived sessions would otherwise
- * fire hundreds of requests at once. A synced task drops out of the next list
- * response, so the rest follow on later passes.
+ * `skip` is the ids already mirrored (durably, on this device) plus the ones
+ * this run has already tried, so a task the server keeps refusing can't spin
+ * the drain loop.
  */
 export function pendingServerArchiveIds(
-  tasks: readonly ArchiveSyncTask[],
   archivedTaskIds: ReadonlySet<string>,
-  handled: ReadonlySet<string>,
-  limit: number = SERVER_ARCHIVE_SYNC_BATCH,
+  skip: ReadonlySet<string>,
 ): string[] {
   const pending: string[] = [];
-  for (const task of tasks) {
-    if (pending.length >= limit) break;
-    if (!archivedTaskIds.has(task.id) || handled.has(task.id)) continue;
-    pending.push(task.id);
+  for (const taskId of archivedTaskIds) {
+    if (!skip.has(taskId)) pending.push(taskId);
   }
   return pending;
 }

--- a/products/desktop/packages/core/src/archive/serverArchiveSync.ts
+++ b/products/desktop/packages/core/src/archive/serverArchiveSync.ts
@@ -1,0 +1,38 @@
+/** The one field this module needs off a task: which task a list row is. */
+export interface ArchiveSyncTask {
+  id: string;
+}
+
+/** How many tasks one pass mirrors onto the server. */
+export const SERVER_ARCHIVE_SYNC_BATCH = 25;
+
+/**
+ * Which locally-archived tasks the server hasn't been told about.
+ *
+ * Archiving is a per-device act, so the server keeps listing sessions this
+ * machine has hidden — and its count is what a space row's "view all" number
+ * comes from, which is why that number can run hundreds above the list behind
+ * it. Anything still in a list response that this device has archived is out of
+ * sync.
+ *
+ * `handled` is the ids a pass has already sent (or given up on), so a failing
+ * task can't be retried on every render.
+ *
+ * Capped, because a device with hundreds of archived sessions would otherwise
+ * fire hundreds of requests at once. A synced task drops out of the next list
+ * response, so the rest follow on later passes.
+ */
+export function pendingServerArchiveIds(
+  tasks: readonly ArchiveSyncTask[],
+  archivedTaskIds: ReadonlySet<string>,
+  handled: ReadonlySet<string>,
+  limit: number = SERVER_ARCHIVE_SYNC_BATCH,
+): string[] {
+  const pending: string[] = [];
+  for (const task of tasks) {
+    if (pending.length >= limit) break;
+    if (!archivedTaskIds.has(task.id) || handled.has(task.id)) continue;
+    pending.push(task.id);
+  }
+  return pending;
+}

--- a/products/desktop/packages/ui/src/features/archive/serverArchiveSyncStore.ts
+++ b/products/desktop/packages/ui/src/features/archive/serverArchiveSyncStore.ts
@@ -1,0 +1,64 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+// Beyond this the oldest mirrored ids are dropped. A dropped id costs one
+// redundant (idempotent) PATCH on the next launch, so the cap only bounds
+// storage, not correctness.
+const SYNCED_IDS_CAP = 5000;
+
+interface ServerArchiveSyncStore {
+  /**
+   * Archives this device has mirrored onto the server. Durable, so a backlog
+   * is written once ever rather than once per launch.
+   */
+  syncedTaskIds: string[];
+  /**
+   * Restores whose server-side clear hasn't landed. Durable, because until the
+   * clear lands the session is archived server-side — hidden from every list,
+   * including this device's — and nothing else can rediscover it: the sync
+   * pass reads the local archive, which the restore just removed it from.
+   */
+  pendingUnarchiveTaskIds: string[];
+  markSynced: (taskId: string) => void;
+  forgetSynced: (taskId: string) => void;
+  queueUnarchive: (taskId: string) => void;
+  clearUnarchive: (taskId: string) => void;
+}
+
+export const useServerArchiveSyncStore = create<ServerArchiveSyncStore>()(
+  persist(
+    (set) => ({
+      syncedTaskIds: [],
+      pendingUnarchiveTaskIds: [],
+      markSynced: (taskId) =>
+        set((state) => ({
+          syncedTaskIds: [
+            ...state.syncedTaskIds.filter((id) => id !== taskId),
+            taskId,
+          ].slice(-SYNCED_IDS_CAP),
+        })),
+      forgetSynced: (taskId) =>
+        set((state) => ({
+          syncedTaskIds: state.syncedTaskIds.filter((id) => id !== taskId),
+        })),
+      queueUnarchive: (taskId) =>
+        set((state) =>
+          state.pendingUnarchiveTaskIds.includes(taskId)
+            ? state
+            : {
+                pendingUnarchiveTaskIds: [
+                  ...state.pendingUnarchiveTaskIds,
+                  taskId,
+                ],
+              },
+        ),
+      clearUnarchive: (taskId) =>
+        set((state) => ({
+          pendingUnarchiveTaskIds: state.pendingUnarchiveTaskIds.filter(
+            (id) => id !== taskId,
+          ),
+        })),
+    }),
+    { name: "server-archive-sync" },
+  ),
+);

--- a/products/desktop/packages/ui/src/features/archive/useServerArchiveSync.test.tsx
+++ b/products/desktop/packages/ui/src/features/archive/useServerArchiveSync.test.tsx
@@ -1,0 +1,115 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiClient = vi.hoisted(() => ({ setTaskArchived: vi.fn() }));
+
+vi.mock("@posthog/ui/features/auth/authClient", () => ({
+  useOptionalAuthenticatedClient: () => apiClient,
+}));
+
+const archivedIds = vi.hoisted(() => ({ current: new Set<string>() }));
+
+vi.mock("@posthog/ui/features/archive/useArchivedTaskIds", () => ({
+  useArchivedTaskIds: () => archivedIds.current,
+}));
+
+import { useServerArchiveSyncStore } from "./serverArchiveSyncStore";
+import { useServerArchiveSync } from "./useServerArchiveSync";
+
+let queryClient: QueryClient;
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useServerArchiveSync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    archivedIds.current = new Set();
+    useServerArchiveSyncStore.setState({
+      syncedTaskIds: [],
+      pendingUnarchiveTaskIds: [],
+    });
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+  });
+
+  it("mirrors a locally archived task the server has not been told about", async () => {
+    apiClient.setTaskArchived.mockResolvedValue(undefined);
+    archivedIds.current = new Set(["t1"]);
+
+    renderHook(() => useServerArchiveSync(), { wrapper });
+
+    await waitFor(() =>
+      expect(apiClient.setTaskArchived).toHaveBeenCalledWith("t1", true),
+    );
+    expect(useServerArchiveSyncStore.getState().syncedTaskIds).toContain("t1");
+  });
+
+  it("syncs a task archived after the drain's last read, before the drain ended", async () => {
+    // Regression: the trigger for a task archived mid-drain hit the `running`
+    // guard and returned, and nothing re-fired once the drain finished, so the
+    // task stayed server-visible until an unrelated trigger or a relaunch.
+    let releaseFirstPatch: () => void = () => {};
+    const firstPatchStarted = new Promise<void>((patchCalled) => {
+      apiClient.setTaskArchived.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseFirstPatch = resolve;
+            patchCalled();
+          }),
+      );
+    });
+    apiClient.setTaskArchived.mockResolvedValue(undefined);
+    archivedIds.current = new Set(["t1"]);
+
+    const { rerender } = renderHook(() => useServerArchiveSync(), { wrapper });
+    await firstPatchStarted;
+
+    // A second task is archived while the first PATCH is still in flight.
+    archivedIds.current = new Set(["t1", "t2"]);
+    await act(async () => {
+      rerender();
+      releaseFirstPatch();
+    });
+
+    await waitFor(() =>
+      expect(apiClient.setTaskArchived).toHaveBeenCalledWith("t2", true),
+    );
+  });
+
+  it("leaves a task the server refused out of syncedTaskIds so a later pass retries it", async () => {
+    apiClient.setTaskArchived.mockRejectedValue(new Error("nope"));
+    archivedIds.current = new Set(["t1"]);
+
+    renderHook(() => useServerArchiveSync(), { wrapper });
+
+    await waitFor(() =>
+      expect(apiClient.setTaskArchived).toHaveBeenCalledWith("t1", true),
+    );
+    expect(useServerArchiveSyncStore.getState().syncedTaskIds).not.toContain(
+      "t1",
+    );
+  });
+
+  it("clears a queued restore on the server and drops it from the mirrored record", async () => {
+    apiClient.setTaskArchived.mockResolvedValue(undefined);
+    useServerArchiveSyncStore.setState({
+      syncedTaskIds: ["t1"],
+      pendingUnarchiveTaskIds: ["t1"],
+    });
+
+    renderHook(() => useServerArchiveSync(), { wrapper });
+
+    await waitFor(() =>
+      expect(apiClient.setTaskArchived).toHaveBeenCalledWith("t1", false),
+    );
+    const state = useServerArchiveSyncStore.getState();
+    expect(state.pendingUnarchiveTaskIds).not.toContain("t1");
+    expect(state.syncedTaskIds).not.toContain("t1");
+  });
+});

--- a/products/desktop/packages/ui/src/features/archive/useServerArchiveSync.ts
+++ b/products/desktop/packages/ui/src/features/archive/useServerArchiveSync.ts
@@ -72,13 +72,21 @@ export function useServerArchiveSync(): void {
     if (!client || running.current) return;
     // The triggers, checked directly: don't start a drain that would find
     // nothing. The loop below re-reads both sources fresh each pass.
+    const mirrored = new Set(
+      useServerArchiveSyncStore.getState().syncedTaskIds,
+    );
     if (
       pendingUnarchive.length === 0 &&
-      pendingServerArchiveIds(
-        archivedTaskIds,
-        new Set(useServerArchiveSyncStore.getState().syncedTaskIds),
-      ).length === 0
+      pendingServerArchiveIds(archivedTaskIds, mirrored).length === 0
     ) {
+      // Distinguishes "nothing to mirror" from "never ran" — the two are
+      // otherwise identical in the console, and each app instance has its own
+      // archive DB (dev vs packaged), so an unexpectedly small count here is
+      // the tell that you're looking at the other instance's backlog.
+      log.debug("Archive sync idle", {
+        archivedLocally: archivedTaskIds.size,
+        alreadyMirrored: mirrored.size,
+      });
       return;
     }
 
@@ -88,6 +96,14 @@ export function useServerArchiveSync(): void {
       // next launch or trigger, but not by the very next pass of this loop.
       const attempted = new Set<string>();
       let changed = 0;
+      // The drain's outcome IS the diagnosis when a count reads wrong, and a
+      // run that finds work is rare (once per backlog) — so say what was found
+      // and what happened to it, not just the failures.
+      log.info("Draining archive state to the server", {
+        archivedLocally: archivedTaskIds.size,
+        alreadyMirrored: mirrored.size,
+        pendingUnarchive: pendingUnarchive.length,
+      });
       try {
         for (;;) {
           const api = clientRef.current;
@@ -135,6 +151,10 @@ export function useServerArchiveSync(): void {
       } finally {
         running.current = false;
       }
+      log.info("Archive drain finished", {
+        synced: changed,
+        refused: attempted.size,
+      });
       if (changed === 0) return;
       // Refetches the lists the drain just shortened, which is what moves the
       // space counts drawn from them.

--- a/products/desktop/packages/ui/src/features/archive/useServerArchiveSync.ts
+++ b/products/desktop/packages/ui/src/features/archive/useServerArchiveSync.ts
@@ -64,6 +64,17 @@ export function useServerArchiveSync(): void {
 
   useEffect(() => {
     if (!client || running.current) return;
+    // The triggers, checked directly: don't start a drain that would find
+    // nothing. The loop below re-reads both sources fresh each pass.
+    if (
+      pendingUnarchive.length === 0 &&
+      pendingServerArchiveIds(
+        archivedTaskIds,
+        new Set(useServerArchiveSyncStore.getState().syncedTaskIds),
+      ).length === 0
+    ) {
+      return;
+    }
 
     running.current = true;
     void (async () => {

--- a/products/desktop/packages/ui/src/features/archive/useServerArchiveSync.ts
+++ b/products/desktop/packages/ui/src/features/archive/useServerArchiveSync.ts
@@ -54,13 +54,19 @@ export function useServerArchiveSync(): void {
     (s) => s.pendingUnarchiveTaskIds,
   );
   const running = useRef(false);
-  // The drain loop re-reads these between passes, so sessions archived while
-  // it runs are picked up by the loop that's already going — the effect that
-  // fires for them lands on the `running` guard and is skipped.
   const archivedRef = useRef(archivedTaskIds);
-  archivedRef.current = archivedTaskIds;
   const clientRef = useRef(client);
-  clientRef.current = client;
+
+  // The drain loop re-reads these between passes, so a session archived while
+  // it runs is picked up by the loop that's already going, and the effect that
+  // fires for it lands on the `running` guard and is skipped. Written after the
+  // render rather than during it, and before the drain effect below, which runs
+  // later in the same commit — so the drain never reads a ref left behind by a
+  // render React went on to discard.
+  useEffect(() => {
+    archivedRef.current = archivedTaskIds;
+    clientRef.current = client;
+  });
 
   useEffect(() => {
     if (!client || running.current) return;
@@ -94,6 +100,9 @@ export function useServerArchiveSync(): void {
             archivedRef.current,
             new Set([...store.syncedTaskIds, ...attempted]),
           );
+          // No await stands between this read and the guard release below, so
+          // a trigger either lands early enough for the next pass to see it or
+          // late enough to start its own drain. There is no gap to lose one in.
           if (unarchive.length === 0 && archive.length === 0) break;
 
           // Restores lead: a session the server still has archived is

--- a/products/desktop/packages/ui/src/features/archive/useServerArchiveSync.ts
+++ b/products/desktop/packages/ui/src/features/archive/useServerArchiveSync.ts
@@ -13,6 +13,32 @@ import { useEffect, useRef } from "react";
 const log = logger.scope("server-archive-sync");
 
 /**
+ * Ids already mirrored onto the server, and restores whose clear didn't land.
+ *
+ * Module state rather than refs on the hook: the hook mounts once, and the
+ * restore path has to reach both sets — a restored task has to be forgotten
+ * (archiving it again later in the session would otherwise be skipped as
+ * already sent), and a failed clear has to leave something behind to retry.
+ */
+const syncedTaskIds = new Set<string>();
+const pendingUnarchiveIds = new Set<string>();
+
+/**
+ * A restore that couldn't reach the server. Until the clear lands the session
+ * is archived server-side, which hides it from every list — including this
+ * device's, where it was just restored — so the next pass tries again.
+ */
+export function retryServerUnarchive(taskId: string): void {
+  syncedTaskIds.delete(taskId);
+  pendingUnarchiveIds.add(taskId);
+}
+
+/** A restored task, which may well be archived again before the app closes. */
+export function forgetServerArchive(taskId: string): void {
+  syncedTaskIds.delete(taskId);
+}
+
+/**
  * Tell the server about the sessions this device has archived.
  *
  * Archiving has always been local, so the server kept listing sessions the app
@@ -24,45 +50,56 @@ const log = logger.scope("server-archive-sync");
  * A reconciler rather than a call in the archive path: it fixes archives made
  * before this shipped, and one made while offline, without any of them needing
  * a queue to sit in. It rides the task poll the app already runs — a synced
- * task leaves the next response, so each pass is handed the next batch.
+ * task leaves the next response, so each pass is handed the next batch, and a
+ * failed one is simply picked up again on the pass after.
  */
 export function useServerArchiveSync(): void {
   const client = useOptionalAuthenticatedClient();
   const { data: tasks } = useTasks();
   const archivedTaskIds = useArchivedTaskIds();
   const queryClient = useQueryClient();
-  // Ids this session has sent or given up on. Without it a task the server
-  // refuses would be retried on every render for as long as the app is open.
-  const handled = useRef(new Set<string>());
   const running = useRef(false);
 
   useEffect(() => {
     if (!client || !tasks || running.current) return;
-    const pending = pendingServerArchiveIds(
+    const unarchive = [...pendingUnarchiveIds];
+    const archive = pendingServerArchiveIds(
       tasks,
       archivedTaskIds,
-      handled.current,
+      syncedTaskIds,
       SERVER_ARCHIVE_SYNC_BATCH,
     );
-    if (pending.length === 0) return;
+    if (unarchive.length === 0 && archive.length === 0) return;
 
     running.current = true;
     void (async () => {
-      let synced = 0;
+      let changed = 0;
+      // Restores lead: a session the server still has archived is invisible
+      // everywhere, which is worse than a count that reads high.
+      for (const taskId of unarchive) {
+        try {
+          await client.setTaskArchived(taskId, false);
+          pendingUnarchiveIds.delete(taskId);
+          changed++;
+        } catch (error) {
+          log.warn(`Failed to unarchive task ${taskId} on the server`, error);
+        }
+      }
       // Sequential: this is background repair of a backlog that can run to
       // hundreds, and it must not compete with the requests the user is
-      // waiting on.
-      for (const taskId of pending) {
-        handled.current.add(taskId);
+      // waiting on. Only what landed is remembered, so anything the server
+      // refused this pass is tried again on the next poll.
+      for (const taskId of archive) {
         try {
           await client.setTaskArchived(taskId, true);
-          synced++;
+          syncedTaskIds.add(taskId);
+          changed++;
         } catch (error) {
           log.warn(`Failed to archive task ${taskId} on the server`, error);
         }
       }
       running.current = false;
-      if (synced === 0) return;
+      if (changed === 0) return;
       // Refetches the list this pass just shortened, which both updates the
       // counts drawn from it and hands the next pass the next batch.
       await queryClient.invalidateQueries({ queryKey: taskKeys.lists() });

--- a/products/desktop/packages/ui/src/features/archive/useServerArchiveSync.ts
+++ b/products/desktop/packages/ui/src/features/archive/useServerArchiveSync.ts
@@ -1,11 +1,8 @@
-import {
-  pendingServerArchiveIds,
-  SERVER_ARCHIVE_SYNC_BATCH,
-} from "@posthog/core/archive/serverArchiveSync";
+import { pendingServerArchiveIds } from "@posthog/core/archive/serverArchiveSync";
+import { useServerArchiveSyncStore } from "@posthog/ui/features/archive/serverArchiveSyncStore";
 import { useArchivedTaskIds } from "@posthog/ui/features/archive/useArchivedTaskIds";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { taskKeys } from "@posthog/ui/features/tasks/taskKeys";
-import { useTasks } from "@posthog/ui/features/tasks/useTasks";
 import { logger } from "@posthog/ui/shell/logger";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
@@ -13,29 +10,20 @@ import { useEffect, useRef } from "react";
 const log = logger.scope("server-archive-sync");
 
 /**
- * Ids already mirrored onto the server, and restores whose clear didn't land.
- *
- * Module state rather than refs on the hook: the hook mounts once, and the
- * restore path has to reach both sets — a restored task has to be forgotten
- * (archiving it again later in the session would otherwise be skipped as
- * already sent), and a failed clear has to leave something behind to retry.
- */
-const syncedTaskIds = new Set<string>();
-const pendingUnarchiveIds = new Set<string>();
-
-/**
  * A restore that couldn't reach the server. Until the clear lands the session
  * is archived server-side, which hides it from every list — including this
- * device's, where it was just restored — so the next pass tries again.
+ * device's, where it was just restored — so the queue is durable and the sync
+ * pass keeps trying.
  */
 export function retryServerUnarchive(taskId: string): void {
-  syncedTaskIds.delete(taskId);
-  pendingUnarchiveIds.add(taskId);
+  const store = useServerArchiveSyncStore.getState();
+  store.forgetSynced(taskId);
+  store.queueUnarchive(taskId);
 }
 
-/** A restored task, which may well be archived again before the app closes. */
+/** A restored task, which may well be archived again before long. */
 export function forgetServerArchive(taskId: string): void {
-  syncedTaskIds.delete(taskId);
+  useServerArchiveSyncStore.getState().forgetSynced(taskId);
 }
 
 /**
@@ -47,62 +35,90 @@ export function forgetServerArchive(taskId: string): void {
  * task archived server-side drops it from the same list every count comes from,
  * and carries the archive to the user's other devices.
  *
- * A reconciler rather than a call in the archive path: it fixes archives made
- * before this shipped, and one made while offline, without any of them needing
- * a queue to sit in. It rides the task poll the app already runs — a synced
- * task leaves the next response, so each pass is handed the next batch, and a
- * failed one is simply picked up again on the pass after.
+ * The work list is the local archive itself, diffed against a durable record of
+ * what this device has already mirrored — not a task-list page. Pages are
+ * capped at the newest hundred rows, and an archive is precisely the sessions
+ * too old to be there: discovery through a page synced whatever happened to be
+ * recent and then starved. The drain runs once per backlog ever (the record
+ * survives relaunch), sequentially, so it never competes with requests the
+ * user is waiting on.
  */
 export function useServerArchiveSync(): void {
   const client = useOptionalAuthenticatedClient();
-  const { data: tasks } = useTasks();
   const archivedTaskIds = useArchivedTaskIds();
   const queryClient = useQueryClient();
+  // Queued restores re-fire the effect. Mirrored-id progress deliberately
+  // doesn't: this hook lives at the root, and subscribing to a record that
+  // grows once per PATCH would re-render the tree hundreds of times per drain.
+  const pendingUnarchive = useServerArchiveSyncStore(
+    (s) => s.pendingUnarchiveTaskIds,
+  );
   const running = useRef(false);
+  // The drain loop re-reads these between passes, so sessions archived while
+  // it runs are picked up by the loop that's already going — the effect that
+  // fires for them lands on the `running` guard and is skipped.
+  const archivedRef = useRef(archivedTaskIds);
+  archivedRef.current = archivedTaskIds;
+  const clientRef = useRef(client);
+  clientRef.current = client;
 
   useEffect(() => {
-    if (!client || !tasks || running.current) return;
-    const unarchive = [...pendingUnarchiveIds];
-    const archive = pendingServerArchiveIds(
-      tasks,
-      archivedTaskIds,
-      syncedTaskIds,
-      SERVER_ARCHIVE_SYNC_BATCH,
-    );
-    if (unarchive.length === 0 && archive.length === 0) return;
+    if (!client || running.current) return;
 
     running.current = true;
     void (async () => {
+      // Ids this run has already tried and the server refused — retried on the
+      // next launch or trigger, but not by the very next pass of this loop.
+      const attempted = new Set<string>();
       let changed = 0;
-      // Restores lead: a session the server still has archived is invisible
-      // everywhere, which is worse than a count that reads high.
-      for (const taskId of unarchive) {
-        try {
-          await client.setTaskArchived(taskId, false);
-          pendingUnarchiveIds.delete(taskId);
-          changed++;
-        } catch (error) {
-          log.warn(`Failed to unarchive task ${taskId} on the server`, error);
+      try {
+        for (;;) {
+          const api = clientRef.current;
+          if (!api) break;
+          const store = useServerArchiveSyncStore.getState();
+          const unarchive = store.pendingUnarchiveTaskIds.filter(
+            (id) => !attempted.has(id),
+          );
+          const archive = pendingServerArchiveIds(
+            archivedRef.current,
+            new Set([...store.syncedTaskIds, ...attempted]),
+          );
+          if (unarchive.length === 0 && archive.length === 0) break;
+
+          // Restores lead: a session the server still has archived is
+          // invisible everywhere, which is worse than a count that reads high.
+          for (const taskId of unarchive) {
+            try {
+              await api.setTaskArchived(taskId, false);
+              store.clearUnarchive(taskId);
+              store.forgetSynced(taskId);
+              changed++;
+            } catch (error) {
+              attempted.add(taskId);
+              log.warn(
+                `Failed to unarchive task ${taskId} on the server`,
+                error,
+              );
+            }
+          }
+          for (const taskId of archive) {
+            try {
+              await api.setTaskArchived(taskId, true);
+              store.markSynced(taskId);
+              changed++;
+            } catch (error) {
+              attempted.add(taskId);
+              log.warn(`Failed to archive task ${taskId} on the server`, error);
+            }
+          }
         }
+      } finally {
+        running.current = false;
       }
-      // Sequential: this is background repair of a backlog that can run to
-      // hundreds, and it must not compete with the requests the user is
-      // waiting on. Only what landed is remembered, so anything the server
-      // refused this pass is tried again on the next poll.
-      for (const taskId of archive) {
-        try {
-          await client.setTaskArchived(taskId, true);
-          syncedTaskIds.add(taskId);
-          changed++;
-        } catch (error) {
-          log.warn(`Failed to archive task ${taskId} on the server`, error);
-        }
-      }
-      running.current = false;
       if (changed === 0) return;
-      // Refetches the list this pass just shortened, which both updates the
-      // counts drawn from it and hands the next pass the next batch.
+      // Refetches the lists the drain just shortened, which is what moves the
+      // space counts drawn from them.
       await queryClient.invalidateQueries({ queryKey: taskKeys.lists() });
     })();
-  }, [client, tasks, archivedTaskIds, queryClient]);
+  }, [client, archivedTaskIds, pendingUnarchive, queryClient]);
 }

--- a/products/desktop/packages/ui/src/features/archive/useServerArchiveSync.ts
+++ b/products/desktop/packages/ui/src/features/archive/useServerArchiveSync.ts
@@ -1,0 +1,71 @@
+import {
+  pendingServerArchiveIds,
+  SERVER_ARCHIVE_SYNC_BATCH,
+} from "@posthog/core/archive/serverArchiveSync";
+import { useArchivedTaskIds } from "@posthog/ui/features/archive/useArchivedTaskIds";
+import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
+import { taskKeys } from "@posthog/ui/features/tasks/taskKeys";
+import { useTasks } from "@posthog/ui/features/tasks/useTasks";
+import { logger } from "@posthog/ui/shell/logger";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
+
+const log = logger.scope("server-archive-sync");
+
+/**
+ * Tell the server about the sessions this device has archived.
+ *
+ * Archiving has always been local, so the server kept listing sessions the app
+ * hides. Its count is what a space row's "view all" number is drawn from, which
+ * left that number reading hundreds above the list it leads to. Marking the
+ * task archived server-side drops it from the same list every count comes from,
+ * and carries the archive to the user's other devices.
+ *
+ * A reconciler rather than a call in the archive path: it fixes archives made
+ * before this shipped, and one made while offline, without any of them needing
+ * a queue to sit in. It rides the task poll the app already runs — a synced
+ * task leaves the next response, so each pass is handed the next batch.
+ */
+export function useServerArchiveSync(): void {
+  const client = useOptionalAuthenticatedClient();
+  const { data: tasks } = useTasks();
+  const archivedTaskIds = useArchivedTaskIds();
+  const queryClient = useQueryClient();
+  // Ids this session has sent or given up on. Without it a task the server
+  // refuses would be retried on every render for as long as the app is open.
+  const handled = useRef(new Set<string>());
+  const running = useRef(false);
+
+  useEffect(() => {
+    if (!client || !tasks || running.current) return;
+    const pending = pendingServerArchiveIds(
+      tasks,
+      archivedTaskIds,
+      handled.current,
+      SERVER_ARCHIVE_SYNC_BATCH,
+    );
+    if (pending.length === 0) return;
+
+    running.current = true;
+    void (async () => {
+      let synced = 0;
+      // Sequential: this is background repair of a backlog that can run to
+      // hundreds, and it must not compete with the requests the user is
+      // waiting on.
+      for (const taskId of pending) {
+        handled.current.add(taskId);
+        try {
+          await client.setTaskArchived(taskId, true);
+          synced++;
+        } catch (error) {
+          log.warn(`Failed to archive task ${taskId} on the server`, error);
+        }
+      }
+      running.current = false;
+      if (synced === 0) return;
+      // Refetches the list this pass just shortened, which both updates the
+      // counts drawn from it and hands the next pass the next batch.
+      await queryClient.invalidateQueries({ queryKey: taskKeys.lists() });
+    })();
+  }, [client, tasks, archivedTaskIds, queryClient]);
+}

--- a/products/desktop/packages/ui/src/features/archive/useUnarchiveTask.test.tsx
+++ b/products/desktop/packages/ui/src/features/archive/useUnarchiveTask.test.tsx
@@ -17,8 +17,14 @@ const controller = vi.hoisted(() => ({
   runContextMenuAction: vi.fn(),
 }));
 
+const apiClient = vi.hoisted(() => ({ setTaskArchived: vi.fn() }));
+
 vi.mock("@posthog/di/react", () => ({
   useService: () => controller,
+}));
+
+vi.mock("@posthog/ui/features/auth/authClient", () => ({
+  useOptionalAuthenticatedClient: () => apiClient,
 }));
 
 vi.mock("@posthog/host-router/react", () => ({
@@ -113,6 +119,29 @@ describe("useUnarchiveTask", () => {
         });
       } else {
         expect(invalidateSpy).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it.each<[string, RestoreOutcome, boolean]>([
+    ["restored", { kind: "restored", navigateToTaskId: "t1" }, true],
+    ["error", { kind: "error", message: "nope" }, false],
+  ])(
+    // A task left archived server-side is hidden from every list, so the row
+    // would come back here and stay gone from the counts drawn off that list.
+    "restore() with outcome %s clears the task's server archive: %s",
+    async (_name, outcome, shouldClear) => {
+      controller.restore.mockResolvedValue(outcome);
+      const { result } = renderHook(() => useUnarchiveTask(), { wrapper });
+
+      await act(async () => {
+        await result.current.restore("t1", true);
+      });
+
+      if (shouldClear) {
+        expect(apiClient.setTaskArchived).toHaveBeenCalledWith("t1", false);
+      } else {
+        expect(apiClient.setTaskArchived).not.toHaveBeenCalled();
       }
     },
   );

--- a/products/desktop/packages/ui/src/features/archive/useUnarchiveTask.test.tsx
+++ b/products/desktop/packages/ui/src/features/archive/useUnarchiveTask.test.tsx
@@ -23,9 +23,16 @@ vi.mock("@posthog/di/react", () => ({
   useService: () => controller,
 }));
 
+const archiveSync = vi.hoisted(() => ({
+  forgetServerArchive: vi.fn(),
+  retryServerUnarchive: vi.fn(),
+}));
+
 vi.mock("@posthog/ui/features/auth/authClient", () => ({
   useOptionalAuthenticatedClient: () => apiClient,
 }));
+
+vi.mock("@posthog/ui/features/archive/useServerArchiveSync", () => archiveSync);
 
 vi.mock("@posthog/host-router/react", () => ({
   useHostTRPC: () => ({
@@ -145,6 +152,24 @@ describe("useUnarchiveTask", () => {
       }
     },
   );
+
+  it("hands a clear the server refused to the sync pass to retry", async () => {
+    // Nothing else can find it: the reconciler reads task lists, and a task
+    // the server has archived is in none of them.
+    controller.restore.mockResolvedValue({
+      kind: "restored",
+      navigateToTaskId: "t1",
+    } as RestoreOutcome);
+    apiClient.setTaskArchived.mockRejectedValueOnce(new Error("offline"));
+    const { result } = renderHook(() => useUnarchiveTask(), { wrapper });
+
+    await act(async () => {
+      await result.current.restore("t1", true);
+    });
+
+    expect(archiveSync.retryServerUnarchive).toHaveBeenCalledWith("t1");
+    expect(archiveSync.forgetServerArchive).not.toHaveBeenCalled();
+  });
 
   it.each<[string, ContextMenuOutcome, boolean]>([
     ["noop", { kind: "noop" }, false],

--- a/products/desktop/packages/ui/src/features/archive/useUnarchiveTask.ts
+++ b/products/desktop/packages/ui/src/features/archive/useUnarchiveTask.ts
@@ -7,6 +7,10 @@ import {
 } from "@posthog/core/archive/archivedTasksController";
 import { useService } from "@posthog/di/react";
 import { useHostTRPC } from "@posthog/host-router/react";
+import {
+  forgetServerArchive,
+  retryServerUnarchive,
+} from "@posthog/ui/features/archive/useServerArchiveSync";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { WORKSPACE_QUERY_KEY } from "@posthog/ui/features/workspace/identifiers";
 import { logger } from "@posthog/ui/shell/logger";
@@ -40,13 +44,21 @@ export function useUnarchiveTask(): UseUnarchiveTask {
   // The archive is mirrored onto the task server-side, where it hides the task
   // from every list — so restoring locally has to clear it, or the row comes
   // back on this device and stays gone from the lists the counts are drawn from.
+  // A clear that doesn't land goes to the sync pass, which keeps trying: this
+  // is the one direction the reconciler can't discover on its own, because a
+  // task the server has archived is in none of the lists it reads.
   const clearServerArchived = useCallback(
     async (taskId: string) => {
-      if (!client) return;
+      if (!client) {
+        retryServerUnarchive(taskId);
+        return;
+      }
       try {
         await client.setTaskArchived(taskId, false);
+        forgetServerArchive(taskId);
       } catch (error) {
         log.warn(`Failed to unarchive task ${taskId} on the server`, error);
+        retryServerUnarchive(taskId);
       }
     },
     [client],

--- a/products/desktop/packages/ui/src/features/archive/useUnarchiveTask.ts
+++ b/products/desktop/packages/ui/src/features/archive/useUnarchiveTask.ts
@@ -7,9 +7,13 @@ import {
 } from "@posthog/core/archive/archivedTasksController";
 import { useService } from "@posthog/di/react";
 import { useHostTRPC } from "@posthog/host-router/react";
+import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { WORKSPACE_QUERY_KEY } from "@posthog/ui/features/workspace/identifiers";
+import { logger } from "@posthog/ui/shell/logger";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
+
+const log = logger.scope("unarchive-task");
 
 export interface UseUnarchiveTask {
   restore(
@@ -31,6 +35,22 @@ export function useUnarchiveTask(): UseUnarchiveTask {
   );
   const trpc = useHostTRPC();
   const queryClient = useQueryClient();
+  const client = useOptionalAuthenticatedClient();
+
+  // The archive is mirrored onto the task server-side, where it hides the task
+  // from every list — so restoring locally has to clear it, or the row comes
+  // back on this device and stays gone from the lists the counts are drawn from.
+  const clearServerArchived = useCallback(
+    async (taskId: string) => {
+      if (!client) return;
+      try {
+        await client.setTaskArchived(taskId, false);
+      } catch (error) {
+        log.warn(`Failed to unarchive task ${taskId} on the server`, error);
+      }
+    },
+    [client],
+  );
 
   const invalidateTaskListCaches = useCallback(async () => {
     await Promise.all([
@@ -48,11 +68,12 @@ export function useUnarchiveTask(): UseUnarchiveTask {
     ) => {
       const outcome = await controller.restore(taskId, hasTask, options);
       if (outcome.kind === "restored") {
+        await clearServerArchived(taskId);
         await invalidateTaskListCaches();
       }
       return outcome;
     },
-    [controller, invalidateTaskListCaches],
+    [controller, clearServerArchived, invalidateTaskListCaches],
   );
 
   const remove = useCallback(
@@ -74,6 +95,7 @@ export function useUnarchiveTask(): UseUnarchiveTask {
         hasTask,
       );
       if (outcome.kind === "restore" && outcome.outcome.kind === "restored") {
+        await clearServerArchived(taskId);
         await invalidateTaskListCaches();
       } else if (
         outcome.kind === "delete" &&
@@ -83,7 +105,7 @@ export function useUnarchiveTask(): UseUnarchiveTask {
       }
       return outcome;
     },
-    [controller, invalidateTaskListCaches],
+    [controller, clearServerArchived, invalidateTaskListCaches],
   );
 
   return { restore, remove, runContextMenuAction };

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useRecentSpaceTasks.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useRecentSpaceTasks.ts
@@ -223,7 +223,9 @@ export function useRecentSpaceTasks(
       });
       // A page that came back short is the whole space, so the count is exact
       // once the archived ones are dropped. A full page falls back to the
-      // server's total, which still counts anything archived in it.
+      // server's total, which excludes archived tasks — bar any this device has
+      // archived and not yet mirrored, which `useServerArchiveSync` is working
+      // through.
       const built: SpaceTasks = {
         items: spaceTreeOrder(available, viewedAt, blockedTaskIds).slice(
           0,
@@ -317,7 +319,8 @@ export function useSpaceOverview(
       people: spacePeople(live, createdBy, peopleLimit),
       // A page that came back short is the whole space, so the count is exact
       // once the archived ones are dropped. A full page falls back to the
-      // server's total, which still counts anything archived in it.
+      // server's total, which excludes archived tasks — bar any this device has
+      // archived and not yet mirrored.
       total: data.tasks.length < TREE_FETCH_LIMIT ? live.length : data.count,
     };
   }, [data, archivedTaskIds, createdBy, peopleLimit]);

--- a/products/desktop/packages/ui/src/router/routes/__root.tsx
+++ b/products/desktop/packages/ui/src/router/routes/__root.tsx
@@ -12,6 +12,7 @@ import { DeepLinkApprovalModal } from "@posthog/ui/features/agent-applications/c
 import { useApprovalDeepLink } from "@posthog/ui/features/agent-applications/hooks/useApprovalDeepLink";
 import { AnnouncementBanner } from "@posthog/ui/features/announcements/AnnouncementBanner";
 import { AnnouncementsHost } from "@posthog/ui/features/announcements/AnnouncementsHost";
+import { useServerArchiveSync } from "@posthog/ui/features/archive/useServerArchiveSync";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { UsageButton } from "@posthog/ui/features/billing/UsageButton";
 import { UsageLimitModal } from "@posthog/ui/features/billing/UsageLimitModal";
@@ -235,6 +236,7 @@ function RootLayout() {
   const approvalDeepLink = useApprovalDeepLink();
   useSetupDiscovery();
   useNewTaskDeepLink();
+  useServerArchiveSync();
 
   // hydrateTask is no longer needed — the URL is the source of truth and the
   // task cache populates the route automatically.


### PR DESCRIPTION
## TL;DR

When you archive a session, only your machine knows. The server keeps counting it, so a space's "view all" reads far above the list behind it, and your other devices still show everything you archived. Now archiving tells the server too.

## Problem

Archiving is per-device: the app writes the task id to a local archive and filters it out of every list. The server never hears about it.

A space row's "view all N" comes from the server's task count for that space (`useRecentSpaceTasks.ts`), which counts sessions the app is hiding. Reported from a space whose "view all" claimed 370 with far fewer sessions inside.

`Task.archived` already exists server-side, documented as "used by PostHog Desktop clients to share archive state across desktop and mobile". No client ever wrote it.

## Changes

- Archiving a session now hides it on your other devices and in the web app, not only on the machine you archived it on.
- A space's "view all N" falls to match the list behind it, because both now read the same server list.
- `setTaskArchived` on the API client, over the existing task PATCH surface.
- `useServerArchiveSync` reconciles instead of writing on the archive path, so it also repairs archives made before this shipped or while offline.
- The work list is the whole local archive, diffed against a durable per-device record of what is mirrored. A task-list page would starve, because pages cap at the newest rows and an archive is precisely the sessions too old to be there.
- Restoring clears the flag before the caches refresh, so a restored row does not come back locally while staying hidden in every list.
- A restore that cannot reach the server goes to a durable queue, because a task the server has archived sits in none of the lists the reconciler reads.
- Three log lines say what the drain found and did. Was #83097, folded in here after the rebase left its base branch gone.

Nothing looks different. The only visible effect is which sessions a list contains, and the counts drawn from it.

> [!NOTE]
> The PATCH bumps `updated_at`, so working through a large backlog moves those tasks in an "updated" sort for anyone who can see them.

Follow-ups, deliberately not here: the space pane still renders at most 30 rows, so "view all" leads to a capped list; and a task archived on one machine does not appear in the Archived view on another, because that view lists local records.

## How did you test this code?

Automated only. The app did not run.

- New `useServerArchiveSync.test.tsx` covers the hook for the first time: the mirror path, a refused write staying out of the mirrored record so a later pass retries it, a queued restore clearing on the server, and a task archived mid-drain being picked up by the running loop.
- New `pendingServerArchiveIds` tests in `packages/core`: picks archived tasks the server has not been told about, skips ids already sent.
- New `useUnarchiveTask` case: a restored task clears its server archive, and a failed restore does not.

Not checked: the live PATCH against a real project, and how a several-hundred-task backlog behaves in practice.

## 🤖 Agent context

Written by PostHog Code, running autonomously.

- Reopened and rebased onto master after this PR was self-closed unmerged on 2026-08-17. The rebase was clean, because master had not touched these files.
- Two React Doctor errors from the review were real. `archivedRef` and `clientRef` were written during render, so a render React discarded could leave a value the drain loop later read. Both writes moved into an effect that runs before the drain effect.
- One review finding was not acted on. The claim that a task archived after the drain's final read gets dropped does not hold: every await is followed by another read before the loop breaks, and the break and the guard release have no await between them. The new mid-drain test passes against the code as it stood, which is the evidence. It stays, to pin the re-read that closes the gap. Answered on the thread.
- Skills invoked: `writing-pr-descriptions`.

## Automatic notifications

- [ ] Publish to changelog?
