### PR TITLE
fix(canvas): prefill the task session composer from ask-agent-to-fix

### DIFF
--- a/products/desktop/packages/core/src/canvas/dashboardSchemas.ts
+++ b/products/desktop/packages/core/src/canvas/dashboardSchemas.ts
@@ -138,3 +138,11 @@ export const setPinnedInput = z.object({
   id: z.string().min(1),
   pinned: z.boolean(),
 });
+
+// File a rendering error against the build that threw it. Only the error's
+// class name crosses the boundary — the full message can carry viewer data.
+export const reportCanvasErrorInput = z.object({
+  id: z.string().min(1),
+  buildId: z.string().min(1),
+  errorType: z.string().min(1).max(64),
+});

--- a/products/desktop/packages/core/src/canvas/dashboardsService.ts
+++ b/products/desktop/packages/core/src/canvas/dashboardsService.ts
@@ -206,6 +206,32 @@ export class DashboardsService {
     return this.patch(input.id, { pinned: input.pinned }, "set pin");
   }
 
+  // File a rendering error in the canvas's authoring-task thread (the server
+  // dedupes per build and error type). Best-effort: a report must never affect
+  // the render, and backends without the endpoint just refuse it, so every
+  // failure is swallowed.
+  async reportError(input: {
+    id: string;
+    buildId: string;
+    errorType: string;
+  }): Promise<void> {
+    try {
+      await this.api.fetch(
+        `canvases/${encodeURIComponent(input.id)}/report_error/`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            build_id: input.buildId,
+            error_type: input.errorType,
+          }),
+        },
+      );
+    } catch {
+      // Advisory call — rendering carries on regardless.
+    }
+  }
+
   rename(input: { id: string; name: string }): Promise<DashboardRecord> {
     return this.patch(input.id, { name: input.name }, "rename canvas");
   }

--- a/products/desktop/packages/core/src/canvas/services.ts
+++ b/products/desktop/packages/core/src/canvas/services.ts
@@ -48,6 +48,12 @@ export interface IDashboardsService {
     taskId: string | null;
   }): Promise<DashboardRecord>;
   setPinned(input: { id: string; pinned: boolean }): Promise<DashboardRecord>;
+  // File a rendering error against the build that threw it (best-effort).
+  reportError(input: {
+    id: string;
+    buildId: string;
+    errorType: string;
+  }): Promise<void>;
   // Read the canvas's source project (the head, or a historical version).
   getSource(input: { id: string; versionId?: string }): Promise<CanvasSource>;
   // The canvas's source-version history, newest first (metadata only).

--- a/products/desktop/packages/host-router/src/routers/dashboards.router.ts
+++ b/products/desktop/packages/host-router/src/routers/dashboards.router.ts
@@ -15,6 +15,7 @@ import {
   listDashboardsInput,
   promoteCanvasInput,
   renameDashboardInput,
+  reportCanvasErrorInput,
   revertCanvasInput,
   saveContextInput,
   setGenerationTaskInput,
@@ -125,6 +126,13 @@ export const dashboardsRouter = router({
       ctx.container
         .get<IDashboardsService>(DASHBOARDS_SERVICE)
         .setPinned(input),
+    ),
+  reportError: publicProcedure
+    .input(reportCanvasErrorInput)
+    .mutation(({ ctx, input }) =>
+      ctx.container
+        .get<IDashboardsService>(DASHBOARDS_SERVICE)
+        .reportError(input),
     ),
   rename: publicProcedure
     .input(renameDashboardInput)

--- a/products/desktop/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
@@ -38,6 +38,10 @@ import {
   EmptyHeader,
   EmptyMedia,
   EmptyTitle,
+  Tooltip as QuillTooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
 } from "@posthog/quill";
 import { CANVAS_COMPONENT_PATH } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
@@ -81,7 +85,7 @@ import {
   Text,
   Tooltip,
 } from "@radix-ui/themes";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -558,18 +562,37 @@ export function FreeformCanvasView({
     }),
     [channelId, dashboardId, pinnedArtifact?.buildId],
   );
+  const { mutate: reportRuntimeError } = useMutation(
+    trpc.dashboards.reportError.mutationOptions(),
+  );
   const onError = useCallback(
     (message: string) => {
       if (message !== lastRuntimeErrorRef.current) {
         lastRuntimeErrorRef.current = message;
+        const errorType = canvasErrorType(message);
         track(ANALYTICS_EVENTS.CANVAS_RUNTIME_ERROR, {
           ...canvasTrackProps,
-          error_type: canvasErrorType(message),
+          error_type: errorType,
         });
+        // File the error in the authoring task's thread so its agent hears
+        // about it — the class name only; the full message stays client-side.
+        if (canvasTrackProps.build_id) {
+          reportRuntimeError({
+            id: dashboardId,
+            buildId: canvasTrackProps.build_id,
+            errorType,
+          });
+        }
       }
       setRuntimeError(threadId, message);
     },
-    [threadId, setRuntimeError, canvasTrackProps],
+    [
+      threadId,
+      setRuntimeError,
+      canvasTrackProps,
+      dashboardId,
+      reportRuntimeError,
+    ],
   );
   const onRendered = useCallback(() => {
     // "rendered" is as good as "ready" as proof the pinned artifact URL loaded.
@@ -811,10 +834,23 @@ export function FreeformCanvasView({
                 ) : (
                   runtimeError && (
                     <>
-                      <Flex align="center" gap="1" className="text-red-11">
-                        <WarningIcon size={14} />
-                        <Text size="1">Runtime error</Text>
-                      </Flex>
+                      <TooltipProvider delay={0}>
+                        <QuillTooltip>
+                          <TooltipTrigger
+                            render={
+                              <div className="flex items-center gap-1 text-red-11">
+                                <WarningIcon size={14} />
+                                <Text size="1">Runtime error</Text>
+                              </div>
+                            }
+                          />
+                          <TooltipContent>
+                            <span className="block max-w-sm whitespace-pre-wrap break-words">
+                              {runtimeError}
+                            </span>
+                          </TooltipContent>
+                        </QuillTooltip>
+                      </TooltipProvider>
                       <Button
                         size="sm"
                         variant="outline"

--- a/products/desktop/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
@@ -23,6 +23,7 @@ import {
   type CanvasTextSelection,
   limitCanvasCommentHighlights,
 } from "@posthog/core/canvas/freeformSchemas";
+import { textToContent } from "@posthog/core/message-editor/content";
 import { useHostTRPC } from "@posthog/host-router/react";
 import {
   Badge,
@@ -59,6 +60,7 @@ import {
   useFreeformChatStore,
   useFreeformThread,
 } from "@posthog/ui/features/canvas/stores/freeformChatStore";
+import { useDraftStore } from "@posthog/ui/features/message-editor/draftStore";
 import type { EditorHandle } from "@posthog/ui/features/message-editor/types";
 import { useCommentNavigationStore } from "@posthog/ui/features/sessions/commentNavigationStore";
 import {
@@ -586,15 +588,25 @@ export function FreeformCanvasView({
 
   // The edit composer's editor handle, so self-repair can prefill it.
   const editorRef = useRef<EditorHandle>(null);
-  // Reveal the panel composer and prefill it. The panel stays mounted while
-  // collapsed, so the editor handle is available even from a minimized panel.
+  const setPanelTab = useCanvasChatPanelStore((s) => s.setTab);
+  const draftActions = useDraftStore((s) => s.actions);
+  // Reveal the panel's chat composer and prefill it. A canvas that has ever
+  // generated shows the task session's composer, which receives content
+  // through the draft store keyed by task id — the editor ref only exists on
+  // the generate bar a never-generated canvas mounts.
   const prefillComposer = useCallback(
     (message: string) => {
       setCollapsed(false);
+      setPanelTab("chat");
+      if (effectiveTaskId) {
+        draftActions.setPendingContent(effectiveTaskId, textToContent(message));
+        draftActions.requestFocus(effectiveTaskId);
+        return;
+      }
       editorRef.current?.setContent(message);
       editorRef.current?.focus();
     },
-    [setCollapsed],
+    [setCollapsed, setPanelTab, effectiveTaskId, draftActions],
   );
   const askAgentToFix = () => {
     if (!runtimeError) return;


### PR DESCRIPTION
## Problem

Dogfooding the canvas error loop surfaced three dead ends when a canvas throws at runtime:

- Clicking "Ask agent to fix" opened the side panel and did nothing. The prefill wrote through an editor ref that only exists on the generate bar a never-generated canvas mounts; any canvas with a generation task shows the task session's chat instead, so the ref was null and the click silently no-oped.
- Hovering the toolbar's "Runtime error" indicator showed nothing — no tooltip was ever wired, unlike the build-failure indicator.
- The authoring task's agent never heard about runtime errors: nothing on the client reported them anywhere the agent (or the task thread) could see.

## Changes

- The fix prompt now reaches the composer through the draft store keyed by task id (`setPendingContent` + `requestFocus`) and the panel switches to the chat tab; the editor-ref path remains as fallback for a never-generated canvas.
- The "Runtime error" indicator gets a tooltip with the error message, mirroring the build-failure indicator. The message never leaves the client.
- The renderer files a best-effort error report (error class name only) through a new `dashboards.reportError` tRPC procedure to the canvas `report_error` endpoint, which posts a deduped update in the authoring task's thread. Backends without the endpoint (it ships in [#81643](https://github.com/PostHog/posthog/pull/81643)) refuse the call and the renderer carries on.

Split out of [#82550](https://github.com/PostHog/posthog/pull/82550): the desktop/backend coupling check requires desktop changes in their own PR.

## How did you test this code?

- `@posthog/core`, `@posthog/host-router`, and `@posthog/ui` typechecks clean; Biome clean.
- All 126 freeform canvas UI tests and 249 core canvas tests pass.
- Not run: live desktop click-through (no desktop client in this environment).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via PostHog Desktop) fixed these from a user's dogfooding reports: the button "opens the side panel and does nothing", "on hover i see nothing", and "the chat has no visibility of the error". This is the desktop half of the canvas error-report loop whose backend is #81643.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*