### PR TITLE
feat(desktop): carry session id on links to the posthog web app

### DIFF
--- a/products/desktop/apps/code/src/main/external-links.ts
+++ b/products/desktop/apps/code/src/main/external-links.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { isSafeExternalUrl } from "@posthog/shared";
 import { type BrowserWindow, type Session, shell } from "electron";
+import { decorateOutboundUrl } from "./session-stitching";
 import { logger } from "./utils/logger";
 
 const log = logger.scope("external-links");
@@ -36,7 +37,7 @@ function openExternalIfSafe(url: string): void {
   // openExternal rejects when the OS has no handler for the scheme (or the user
   // dismisses the confirmation prompt on some platforms). Swallow it so a failed
   // open never surfaces as an unhandled rejection in the main process.
-  shell.openExternal(url).catch((error) => {
+  shell.openExternal(decorateOutboundUrl(url)).catch((error) => {
     log.warn("shell.openExternal rejected", { scheme: urlScheme(url), error });
   });
 }

--- a/products/desktop/apps/code/src/main/platform-adapters/electron-url-launcher.ts
+++ b/products/desktop/apps/code/src/main/platform-adapters/electron-url-launcher.ts
@@ -1,10 +1,11 @@
 import type { IUrlLauncher } from "@posthog/platform/url-launcher";
 import { shell } from "electron";
 import { injectable } from "inversify";
+import { decorateOutboundUrl } from "../session-stitching";
 
 @injectable()
 export class ElectronUrlLauncher implements IUrlLauncher {
   public async launch(url: string): Promise<void> {
-    await shell.openExternal(url);
+    await shell.openExternal(decorateOutboundUrl(url));
   }
 }

--- a/products/desktop/apps/code/src/main/platform-adapters/posthog-analytics.ts
+++ b/products/desktop/apps/code/src/main/platform-adapters/posthog-analytics.ts
@@ -10,6 +10,10 @@ export class PosthogNodeAnalytics implements IAnalytics {
   private client: PostHog | null = null;
   private currentUserId: string | null = null;
   private sessionId: string | null = null;
+  // Kept separate from the boot-time sessionId above: the renderer's posthog-js
+  // session rotates on idle and logout, while the boot id stays fixed for the
+  // process lifetime and keeps seeding the renderer via preload argv.
+  private rendererSessionId: string | null = null;
 
   initialize(): void {
     if (this.client) {
@@ -46,6 +50,14 @@ export class PosthogNodeAnalytics implements IAnalytics {
     return this.sessionId;
   }
 
+  setRendererSessionId(sessionId: string | null): void {
+    this.rendererSessionId = sessionId;
+  }
+
+  getRendererSessionId(): string | null {
+    return this.rendererSessionId;
+  }
+
   track(eventName: string, properties?: AnalyticsProperties): void {
     if (!this.client) {
       return;
@@ -58,6 +70,12 @@ export class PosthogNodeAnalytics implements IAnalytics {
       event: eventName,
       properties: {
         team: "posthog-code",
+        // Joins main-process events into the same session as renderer and web
+        // events. Only set while cross-surface stitching is enabled, because
+        // the renderer pushes null otherwise.
+        ...(this.rendererSessionId
+          ? { $session_id: this.rendererSessionId }
+          : {}),
         ...properties,
         app_version: getAppVersion(),
         os_platform: process.platform,
@@ -93,10 +111,13 @@ export class PosthogNodeAnalytics implements IAnalytics {
     }
 
     const distinctId = this.currentUserId || "anonymous-app-event";
+    // Prefer the renderer's live session id: the boot id goes stale once the
+    // renderer's posthog-js session rotates on idle or reset.
+    const sessionId = this.rendererSessionId ?? this.sessionId;
     this.client.captureException(error, distinctId, {
       team: "posthog-code",
       ...additionalProperties,
-      ...(this.sessionId ? { $session_id: this.sessionId } : {}),
+      ...(sessionId ? { $session_id: sessionId } : {}),
       app_version: getAppVersion(),
       os_platform: process.platform,
       os_arch: process.arch,

--- a/products/desktop/apps/code/src/main/session-stitching.ts
+++ b/products/desktop/apps/code/src/main/session-stitching.ts
@@ -1,0 +1,26 @@
+import {
+  appendSessionIdIfPostHogUrl,
+  getStitchableOrigins,
+} from "@posthog/shared";
+import { posthogNodeAnalytics } from "./platform-adapters/posthog-analytics";
+import { isDevBuild } from "./utils/env";
+
+/**
+ * Decorate an outbound URL with the renderer's PostHog session id when it
+ * points at the PostHog web app, so events and the recording captured there
+ * carry the same $session_id as this app's (cross-surface session stitching).
+ * Runs at open time, never at link build time, which keeps copyable share
+ * links free of session ids. The renderer only pushes a session id while the
+ * stitching feature flag is on, so this is a no-op otherwise.
+ */
+export function decorateOutboundUrl(url: string): string {
+  const sessionId = posthogNodeAnalytics.getRendererSessionId();
+  if (!sessionId) {
+    return url;
+  }
+  return appendSessionIdIfPostHogUrl(
+    url,
+    sessionId,
+    getStitchableOrigins(isDevBuild()),
+  );
+}

--- a/products/desktop/apps/code/src/renderer/contributions/app-boot.contributions.ts
+++ b/products/desktop/apps/code/src/renderer/contributions/app-boot.contributions.ts
@@ -1,6 +1,10 @@
 import type { Contribution } from "@posthog/di/contribution";
 import {
+  getCurrentSessionId,
   initializePostHog,
+  isFeatureFlagEnabled,
+  onFeatureFlagsLoaded,
+  onSessionIdChanged,
   registerAppVersion,
   registerHostInfo,
 } from "@posthog/ui/shell/posthogAnalyticsImpl";
@@ -9,6 +13,8 @@ import { logger } from "@utils/logger";
 import { injectable } from "inversify";
 
 const log = logger.scope("app-boot");
+
+const SESSION_STITCHING_FLAG = "desktop-web-session-stitching";
 
 @injectable()
 export class AnalyticsBootContribution implements Contribution {
@@ -23,6 +29,7 @@ export class AnalyticsBootContribution implements Contribution {
         }
         initializePostHog(sessionId);
       }
+      this.pushSessionIdToMain();
       try {
         registerAppVersion(await trpcClient.os.getAppVersion.query());
       } catch (error) {
@@ -34,6 +41,32 @@ export class AnalyticsBootContribution implements Contribution {
         log.warn("Failed to register host info super properties", { error });
       }
     })();
+  }
+
+  // Main decorates outbound PostHog web links with the renderer's live session
+  // id (cross-surface session stitching). The flag doubles as a remote kill
+  // switch for shipped binaries: while off, main holds null and never
+  // decorates. Flags load after init, so the flags-loaded hook performs the
+  // initial push; onSessionIdChanged covers idle rotations and logout resets.
+  private pushSessionIdToMain(): void {
+    let lastPushed: string | null | undefined;
+    const sync = () => {
+      const sessionId = isFeatureFlagEnabled(SESSION_STITCHING_FLAG)
+        ? getCurrentSessionId()
+        : null;
+      if (sessionId === lastPushed) {
+        return;
+      }
+      lastPushed = sessionId;
+      trpcClient.analytics.setRendererSessionId
+        .mutate({ sessionId })
+        .catch((error) => {
+          lastPushed = undefined;
+          log.warn("Failed to push session id to main", { error });
+        });
+    };
+    onFeatureFlagsLoaded(sync);
+    onSessionIdChanged(sync);
   }
 }
 

--- a/products/desktop/apps/mobile/src/features/tasks/lib/cloudTaskStream.ts
+++ b/products/desktop/apps/mobile/src/features/tasks/lib/cloudTaskStream.ts
@@ -32,6 +32,8 @@ const mobileCloudTaskAnalytics = {
   setCurrentUserId: () => {},
   getCurrentUserId: () => null,
   getOrCreateSessionId: () => "mobile-cloud-task",
+  // No separate main process to decorate outbound links from.
+  setRendererSessionId: () => {},
   resetUser: () => {},
   captureException: () => {},
   flush: async () => {},

--- a/products/desktop/packages/host-router/src/routers/analytics.router.ts
+++ b/products/desktop/packages/host-router/src/routers/analytics.router.ts
@@ -32,6 +32,14 @@ export const analyticsRouter = router({
         .getOrCreateSessionId(),
     })),
 
+  setRendererSessionId: publicProcedure
+    .input(z.object({ sessionId: z.string().nullable() }))
+    .mutation(({ ctx, input }) => {
+      ctx.container
+        .get<IAnalytics>(ANALYTICS_SERVICE)
+        .setRendererSessionId(input.sessionId);
+    }),
+
   resetUser: publicProcedure.mutation(({ ctx }) => {
     ctx.container.get<IAnalytics>(ANALYTICS_SERVICE).resetUser();
   }),

--- a/products/desktop/packages/platform/src/analytics.ts
+++ b/products/desktop/packages/platform/src/analytics.ts
@@ -8,6 +8,13 @@ export interface IAnalytics {
   getCurrentUserId(): string | null;
   /** Host-owned analytics session id, minted lazily on first request. */
   getOrCreateSessionId(): string;
+  /**
+   * Renderer's live posthog-js session id, pushed whenever it changes (or null
+   * while stitching is off). The Electron main process uses it to decorate
+   * outbound PostHog web links so both surfaces record under one session;
+   * hosts without a separate main process no-op.
+   */
+  setRendererSessionId(sessionId: string | null): void;
   resetUser(): void;
   captureException(
     error: unknown,

--- a/products/desktop/packages/shared/src/index.ts
+++ b/products/desktop/packages/shared/src/index.ts
@@ -330,6 +330,12 @@ export {
   type UserShellExecuteResult,
 } from "./session-events";
 export {
+  appendSessionIdIfPostHogUrl,
+  getStitchableOrigins,
+  isUuidV7,
+  POSTHOG_SESSION_ID_URL_PARAM,
+} from "./session-stitching";
+export {
   type AgentSession,
   cycleModeOption,
   flattenSelectOptions,

--- a/products/desktop/packages/shared/src/session-stitching.test.ts
+++ b/products/desktop/packages/shared/src/session-stitching.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  appendSessionIdIfPostHogUrl,
+  getStitchableOrigins,
+  POSTHOG_SESSION_ID_URL_PARAM,
+} from "./session-stitching";
+
+const SESSION_ID = "01890a5d-ac96-774b-bcce-b302099a8057";
+const PROD_ORIGINS = getStitchableOrigins(false);
+const DEV_ORIGINS = getStitchableOrigins(true);
+
+describe("appendSessionIdIfPostHogUrl", () => {
+  it.each([
+    ["https://us.posthog.com/replay/recent"],
+    ["https://eu.posthog.com/project/2/insights"],
+  ])("decorates %s", (url) => {
+    expect(appendSessionIdIfPostHogUrl(url, SESSION_ID, PROD_ORIGINS)).toBe(
+      `${url}?${POSTHOG_SESSION_ID_URL_PARAM}=${SESSION_ID}`,
+    );
+  });
+
+  it("preserves existing query params and hash", () => {
+    const result = appendSessionIdIfPostHogUrl(
+      "https://us.posthog.com/insights?foo=1#panel=activity",
+      SESSION_ID,
+      PROD_ORIGINS,
+    );
+    expect(result).toBe(
+      `https://us.posthog.com/insights?foo=1&${POSTHOG_SESSION_ID_URL_PARAM}=${SESSION_ID}#panel=activity`,
+    );
+  });
+
+  it("overwrites a pre-existing session id param instead of duplicating it", () => {
+    const spoofed = `https://us.posthog.com/insights?${POSTHOG_SESSION_ID_URL_PARAM}=01890a5d-ac96-774b-bcce-b30209ffffff`;
+    const result = appendSessionIdIfPostHogUrl(
+      spoofed,
+      SESSION_ID,
+      PROD_ORIGINS,
+    );
+    expect(result).toBe(
+      `https://us.posthog.com/insights?${POSTHOG_SESSION_ID_URL_PARAM}=${SESSION_ID}`,
+    );
+  });
+
+  it.each([
+    ["a non-PostHog host", "https://github.com/PostHog/posthog/pull/1"],
+    ["a lookalike suffix domain", "https://us.posthog.com.evil.com/insights"],
+    ["a lookalike prefix subdomain", "https://notus.posthog.com/insights"],
+    ["a non-http scheme", "mailto:hey@posthog.com"],
+    ["a file url", "file:///var/log/app.log"],
+    ["an unparseable url", "not a url"],
+    ["the dev origin outside dev builds", "http://localhost:8010/insights"],
+  ])("leaves %s undecorated", (_name, url) => {
+    expect(appendSessionIdIfPostHogUrl(url, SESSION_ID, PROD_ORIGINS)).toBe(
+      url,
+    );
+  });
+
+  it.each([
+    ["a UUIDv4", "9b0813c0-b661-4f47-92ca-1e0890a3a8c4"],
+    ["garbage", "not-a-session-id"],
+    [
+      "a UUIDv7 shape with non-hex characters",
+      "zzzzzzzz-zzzz-7zzz-8zzz-zzzzzzzzzzzz",
+    ],
+  ])("refuses to decorate with %s as the session id", (_name, sessionId) => {
+    const url = "https://us.posthog.com/insights";
+    expect(appendSessionIdIfPostHogUrl(url, sessionId, PROD_ORIGINS)).toBe(url);
+  });
+
+  it("decorates the dev origin only when dev is included", () => {
+    const url = "http://localhost:8010/insights";
+    expect(appendSessionIdIfPostHogUrl(url, SESSION_ID, DEV_ORIGINS)).toBe(
+      `${url}?${POSTHOG_SESSION_ID_URL_PARAM}=${SESSION_ID}`,
+    );
+  });
+});

--- a/products/desktop/packages/shared/src/session-stitching.ts
+++ b/products/desktop/packages/shared/src/session-stitching.ts
@@ -1,0 +1,61 @@
+import type { CloudRegion } from "./regions";
+import { getCloudUrlFromRegion } from "./urls";
+
+// Paired with frontend/src/lib/utils/crossSurfaceSessionId.ts in the PostHog
+// monorepo, which reads and strips this param before posthog.init so both
+// surfaces record under one session. Keep the param name in sync.
+export const POSTHOG_SESSION_ID_URL_PARAM = "__posthog_session_id";
+
+// posthog-js only adopts a bootstrap session id that is a UUIDv7; anything
+// else would be dropped (or worse, adopted with a broken embedded timestamp),
+// so refuse to decorate with an invalid id.
+const UUID_V7_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function isUuidV7(value: string): boolean {
+  return UUID_V7_REGEX.test(value);
+}
+
+const STITCHABLE_REGIONS: readonly CloudRegion[] = ["us", "eu"];
+
+/** Exact origins of the PostHog web app that outbound links may be decorated for. */
+export function getStitchableOrigins(includeDev: boolean): string[] {
+  const regions = includeDev
+    ? [...STITCHABLE_REGIONS, "dev" as const]
+    : STITCHABLE_REGIONS;
+  return regions.map((region) => new URL(getCloudUrlFromRegion(region)).origin);
+}
+
+/**
+ * Append the PostHog session id to a URL when, and only when, it points at the
+ * PostHog web app. The session id is identifying, so it must never reach other
+ * hosts (including lookalike domains); the origin check is exact membership,
+ * not a suffix match. Overwrites any pre-existing value of the param so a
+ * crafted link cannot smuggle a foreign session id through.
+ */
+export function appendSessionIdIfPostHogUrl(
+  url: string,
+  sessionId: string,
+  allowedOrigins: readonly string[],
+): string {
+  if (!isUuidV7(sessionId)) {
+    return url;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return url;
+  }
+  if (!allowedOrigins.includes(parsed.origin)) {
+    return url;
+  }
+
+  parsed.searchParams.set(POSTHOG_SESSION_ID_URL_PARAM, sessionId);
+  return parsed.toString();
+}

--- a/products/desktop/packages/ui/src/shell/posthogAnalyticsImpl.ts
+++ b/products/desktop/packages/ui/src/shell/posthogAnalyticsImpl.ts
@@ -378,6 +378,29 @@ export function captureException(
 // ============================================================================
 
 /**
+ * The live posthog-js session id, or null before initializePostHog has run
+ * (e.g. no API key configured). Unlike the boot-time id handed to
+ * initializePostHog, this reflects rotations from idle timeouts and resets.
+ */
+export function getCurrentSessionId(): string | null {
+  if (!isInitialized) {
+    return null;
+  }
+  return posthog.get_session_id() || null;
+}
+
+/**
+ * Subscribe to posthog-js session id changes (rotation on idle/reset).
+ * Returns an unsubscribe function; no-ops when PostHog never initialized.
+ */
+export function onSessionIdChanged(callback: () => void): () => void {
+  if (!isInitialized) {
+    return () => {};
+  }
+  return posthog.onSessionId(() => callback());
+}
+
+/**
  * Check if a feature flag is enabled for the current user.
  * Returns false if PostHog is not initialized or flag is not found.
  */
@@ -511,6 +534,9 @@ export const posthogAnalyticsService: IAnalytics = {
     if (!analyticsSessionId) analyticsSessionId = crypto.randomUUID();
     return analyticsSessionId;
   },
+  // Web/mobile hosts have no separate main process opening external links, so
+  // there is nothing to push the renderer session id to.
+  setRendererSessionId: () => {},
   resetUser: () => {
     analyticsCurrentUserId = null;
     resetUser();


### PR DESCRIPTION
## TL;DR

When you click from PostHog Desktop into us.posthog.com, your analytics session currently splits in two: desktop events in one session, web events in another. This PR makes desktop add its session ID to the links it opens, and the web app (PR [#82577](https://github.com/PostHog/posthog/pull/82577)) adopts it. Events and recordings from both surfaces then share one `$session_id`.

## Problem

- A user who prompts in Desktop and continues in the web app produces two unrelated sessions; you cannot join their desktop events to their web events, and their replay splits in two.
- Both surfaces already capture into the same PostHog project; only the session ID differs.
- Origin: [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1786538857245349). Also dogfoods the cross-domain stitching we document for customers.

## Changes

- The Electron main process appends `__posthog_session_id` to outbound links at its two `shell.openExternal` funnels, covering `openExternalUrl` calls, plain anchor clicks, and the OAuth sign-in flow.
- Decoration only applies to exact PostHog web app origins (us/eu, plus localhost:8010 in dev builds); other hosts and lookalike domains never see the ID.
- Decoration happens at open time, never at link build time, so copyable canvas/channel share links stay clean.
- The renderer pushes its live posthog-js session ID to main via a new `analytics.setRendererSessionId` tRPC mutation, re-pushed on rotation (idle timeout, logout reset).
- Main-process posthog-node events get stamped with that live ID too; today they carry no `$session_id` and sit outside every session.
- The `desktop-web-session-stitching` flag gates the renderer push and doubles as a remote kill switch: while off, main holds null and never decorates.

## How did you test this code?

- Vitest suite `session-stitching.test.ts` (packages/shared): catches allowlist regressions (a loosened origin check would leak the session ID to github.com or lookalike domains) and validation regressions (a non-UUIDv7 ID would be silently dropped by posthog-js on the web side).
- `pnpm lint`, `pnpm typecheck` (all 25 packages, includes the `@posthog/web` portability smoke test), `pnpm --filter @posthog/shared test` all pass locally.
- Not run: live desktop-to-web click-through; that needs the flag created and a dev build, listed as follow-up below.

Follow-ups before ramping the flag:
1. Merge the web-side reader ([#82577](https://github.com/PostHog/posthog/pull/82577)) and let it deploy.
2. Create the `desktop-web-session-stitching` flag (default off) in the internal analytics project.
3. Verify a dev-build click-through end to end, then ramp.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None; internal instrumentation, off by default.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude (PostHog Desktop session): scoped the Slack idea, planned two PRs, implemented both sides.
- Skills invoked: /posthog-desktop, /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- Decisions: decorate in the main process at open time rather than in URL builders (covers all three outbound paths with one mechanism and keeps share links clean); push the renderer's live session ID instead of reusing main's boot ID (the boot ID goes stale on session rotation). Reframed from replay-first to session-first after review: the shared `$session_id` joins events, the sessions table, and replay alike.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*