### PR TITLE
chore(logs): remove fully rolled-out logs-column-configuration flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -359,7 +359,6 @@ export const FEATURE_FLAGS = {
     LOGS: 'logs', // owner: #team-logs
     LOGS_ALERTING: 'logs-alerting', // owner: #team-logs
     LOGS_ANOMALIES: 'logs-anomalies', // owner: @jonmcwest #team-logs
-    LOGS_COLUMN_CONFIGURATION: 'logs-column-configuration', // owner: #team-logs
     LOGS_GROUP_BY: 'logs-group-by', // owner: #team-logs
     LOGS_IN_ERROR_TRACKING: 'logs-in-error-tracking', // owner: @jonmcwest #team-logs
     LOGS_METRIC_RULES: 'logs-metric-rules', // owner: #team-logs

--- a/products/logs/frontend/components/LogsViewer/LogsViewerToolbar.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewerToolbar.tsx
@@ -6,7 +6,6 @@ import { LemonButton, Tooltip } from '@posthog/lemon-ui'
 import { KeyboardShortcut } from 'lib/components/KeyboardShortcut/KeyboardShortcut'
 import { Shortcut } from 'lib/components/Shortcuts/Shortcut'
 import { keyBinds } from 'lib/components/Shortcuts/shortcuts'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { IconPauseCircle, IconPlayCircle } from 'lib/lemon-ui/icons'
 import { Scene } from 'scenes/sceneTypes'
 
@@ -33,7 +32,6 @@ export interface LogsViewerToolbarProps {
  */
 export const LogsViewerToolbar = ({ totalLogsCount }: LogsViewerToolbarProps): JSX.Element => {
     const { liveTailRunning, liveTailDisabledReason } = useValues(logsViewerDataLogic)
-    const showColumnConfigurator = useFeatureFlag('LOGS_COLUMN_CONFIGURATION')
     const { setLiveTailRunning } = useActions(logsViewerDataLogic)
 
     return (
@@ -56,7 +54,7 @@ export const LogsViewerToolbar = ({ totalLogsCount }: LogsViewerToolbarProps): J
                 </LemonButton>
             </Shortcut>
             <LogsViewSettings />
-            {showColumnConfigurator && <LogsColumnConfigurator />}
+            <LogsColumnConfigurator />
             <LogsExportMenu totalLogsCount={totalLogsCount} />
             <Tooltip
                 title={


### PR DESCRIPTION
## Problem

Everyone using the logs viewer already sees the column configurator: the `logs-column-configuration` flag sits at 100% rollout with no targeting, so the gate no longer decides anything.

## Changes

- Show `LogsColumnConfigurator` in the logs viewer toolbar unconditionally.
- Remove the `LOGS_COLUMN_CONFIGURATION` feature flag constant and the now-unused `useFeatureFlag` import.

This is one of ten PRs, each removing a single logs flag that reached full rollout.

## How did you test this code?

No behavior change: the flag was already true for all users, so the configurator renders exactly as before. No automated tests target this toolbar gate. I (Claude) did not run the app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) identified logs feature flags at 100% rollout via the PostHog MCP flag definitions, then removed this flag's code gate. Skills invoked: `/cleaning-up-stale-feature-flags`, `/writing-pr-descriptions`. The flag is left untouched in PostHog; disabling it there waits until this ships.
