### PR TITLE
chore(logs): remove fully rolled-out logs-sql-view flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -372,7 +372,6 @@ export const FEATURE_FLAGS = {
     LOGS_SETTINGS_RETENTION: 'logs-settings-retention', // owner: #team-logs
     LOGS_SETTINGS_RETENTION_RULES: 'logs-settings-retention-rules', // owner: #team-logs
     LOGS_SPARKLINE_SERVICE_BREAKDOWN: 'logs-sparkline-service-breakdown', // owner: #team-logs
-    LOGS_SQL_VIEW: 'logs-sql-view', // owner: #team-logs
     LOGS_TABBED_VIEW: 'logs-tabbed-view', // owner: #team-logs
     LOGS_TRANSFORMATIONS: 'logs-transformations', // owner: #team-logs
     MANAGED_MIGRATIONS_IAM_ROLE_AUTH: 'managed-migrations-iam-role-auth', // owner: #team-ingestion, gates IAM role auth for S3 batch imports

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -95,7 +95,6 @@ const LogsSceneTabbedContent = (): JSX.Element => {
     const { hasLogs, teamHasLogsCheckFailed } = useValues(logsIngestionLogic)
     const showServicesView = useFeatureFlag('LOGS_SERVICES_VIEW')
     const showAlerting = useFeatureFlag('LOGS_ALERTING')
-    const showSqlView = useFeatureFlag('LOGS_SQL_VIEW')
     const showTransformations = useFeatureFlag('LOGS_TRANSFORMATIONS')
     const showAnomalies = useFeatureFlag('LOGS_ANOMALIES')
 
@@ -104,7 +103,7 @@ const LogsSceneTabbedContent = (): JSX.Element => {
         ...(showServicesView ? [{ key: 'services' as const, label: 'Services' }] : []),
         ...(showAlerting ? [{ key: 'alerts' as const, label: 'Alerts' }] : []),
         ...(showAnomalies ? [{ key: 'anomalies' as const, label: 'Anomalies' }] : []),
-        ...(showSqlView ? [{ key: 'sql' as const, label: 'SQL' }] : []),
+        { key: 'sql', label: 'SQL' },
         ...(showTransformations ? [{ key: 'transformations' as const, label: 'Transformations' }] : []),
         { key: 'configuration', label: 'Configuration' },
     ]
@@ -160,7 +159,7 @@ const LogsSceneTabbedContent = (): JSX.Element => {
             )}
             {activeTab === 'alerts' && showAlerting && <LogsAlertingSection />}
             {activeTab === 'anomalies' && showAnomalies && <LogsAnomalies />}
-            {activeTab === 'sql' && showSqlView && <LogsSqlEditor id={LOGS_SCENE_VIEWER_ID} />}
+            {activeTab === 'sql' && <LogsSqlEditor id={LOGS_SCENE_VIEWER_ID} />}
             {activeTab === 'transformations' && showTransformations && <LogsTransformations />}
             {activeTab === 'configuration' && (
                 <Settings logicKey={LOGS_LOGIC_KEY} sectionId="environment-logs" settingId="logs" handleLocally />


### PR DESCRIPTION
## Problem

Everyone on the logs scene already sees the SQL tab: the `logs-sql-view` flag sits at 100% rollout with no targeting, so the gate no longer decides anything.

## Changes

- Show the SQL tab in the tabbed logs scene unconditionally, and drop the `showSqlView && ...` guard on the editor.
- Remove the `LOGS_SQL_VIEW` feature flag constant.

This is one of ten PRs, each removing a single logs flag that reached full rollout.

## How did you test this code?

No behavior change: the flag was already true for all users, so the SQL tab renders as before. No automated tests target this tab gate. I (Claude) did not run the app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) identified logs feature flags at 100% rollout via the PostHog MCP flag definitions, then removed this flag's code gate. Skills invoked: `/cleaning-up-stale-feature-flags`, `/writing-pr-descriptions`. The flag is left untouched in PostHog; disabling it there waits until this ships.
