### PR TITLE
feat(desktop/canvas): call the personal space "personal", not "me"

### DIFF
--- a/products/desktop/packages/core/src/canvas/channelName.test.ts
+++ b/products/desktop/packages/core/src/canvas/channelName.test.ts
@@ -51,4 +51,13 @@ describe("validateChannelName", () => {
       );
     },
   );
+
+  // A space taking either of the private space's names wears its lock and sits
+  // in its place in the list, which is a space impersonating yours.
+  it.each(["personal", "me", "  personal  "])(
+    "reserves %j for the private space",
+    (name) => {
+      expect(validateChannelName(name)).toContain("reserved");
+    },
+  );
 });

--- a/products/desktop/packages/core/src/canvas/channelName.ts
+++ b/products/desktop/packages/core/src/canvas/channelName.ts
@@ -1,3 +1,26 @@
+/** What the backend calls a user's private channel. */
+export const PERSONAL_CHANNEL_NAME = "me";
+
+/**
+ * What that channel is called on screen.
+ *
+ * Renaming the row itself would rewrite every existing channel and any link
+ * that names one, so the swap happens on the way to a reader. Lowercase, like
+ * every other space's name: the sidebar is a column of names the backend
+ * normalized, and one capitalized row reads as a different kind of thing.
+ *
+ * Lives in core because names reach a reader by more routes than the channel
+ * list — an activity row and a mention both carry one of their own.
+ */
+export const PERSONAL_CHANNEL_LABEL = "personal";
+
+/** A channel's name as a reader should see it. */
+export function channelDisplayName(name: string): string;
+export function channelDisplayName(name: string | null): string | null;
+export function channelDisplayName(name: string | null): string | null {
+  return name === PERSONAL_CHANNEL_NAME ? PERSONAL_CHANNEL_LABEL : name;
+}
+
 // A channel's name is used verbatim as its server-side filesystem path segment,
 // so it must be directory-safe: lowercase letters, numbers, and hyphens only.
 export const CHANNEL_NAME_PATTERN = /^[a-z0-9-]+$/;
@@ -17,11 +40,26 @@ export function normalizeChannelName(name: string): string {
 // Returns an error message for an invalid name, or null when valid. Empty is
 // treated as valid here — callers already gate on a non-empty trimmed value, so
 // this validator only judges the character set.
+/**
+ * Names a space can't take, because the private space already answers to them
+ * and a second space wearing one is a space pretending to be yours.
+ *
+ * Client-side only, so it stops the two forms that create and rename spaces —
+ * not the API, and not a space that took the name before this landed.
+ */
+const RESERVED_CHANNEL_NAMES = new Set([
+  PERSONAL_CHANNEL_NAME,
+  PERSONAL_CHANNEL_LABEL,
+]);
+
 export function validateChannelName(name: string): string | null {
   const trimmed = name.trim();
   if (!trimmed) return null;
   if (!CHANNEL_NAME_PATTERN.test(trimmed)) {
     return "Use only lowercase letters, numbers, and hyphens.";
+  }
+  if (RESERVED_CHANNEL_NAMES.has(trimmed.toLowerCase())) {
+    return `"${trimmed}" is reserved for your private space.`;
   }
   return null;
 }

--- a/products/desktop/packages/core/src/canvas/mentionActivity.ts
+++ b/products/desktop/packages/core/src/canvas/mentionActivity.ts
@@ -1,4 +1,5 @@
 import type { TaskMention, UserBasic } from "@posthog/shared/domain-types";
+import { channelDisplayName } from "./channelName";
 
 /**
  * The Activity feed — thread messages that @-mention the current user — as
@@ -28,7 +29,7 @@ export function toMentionActivityItems(
     taskId: mention.task_id,
     taskTitle: mention.task_title || "Untitled task",
     channelId: mention.channel_id ?? null,
-    channelName: mention.channel_name ?? null,
+    channelName: channelDisplayName(mention.channel_name ?? null),
     author: mention.author ?? null,
     content: mention.content,
     createdAt: mention.created_at,

--- a/products/desktop/packages/core/src/canvas/taskActivity.ts
+++ b/products/desktop/packages/core/src/canvas/taskActivity.ts
@@ -4,6 +4,7 @@ import type {
   UserBasic,
 } from "@posthog/shared/domain-types";
 import type { CommentTarget } from "../comments/anchors";
+import { channelDisplayName } from "./channelName";
 
 /**
  * The Activity feed — tasks the current user is involved in (created, mentioned
@@ -40,7 +41,7 @@ export function toTaskActivityItems(
     taskId: row.task_id,
     taskTitle: row.task_title || "Untitled task",
     channelId: row.channel_id ?? null,
-    channelName: row.channel_name ?? null,
+    channelName: channelDisplayName(row.channel_name ?? null),
     activityAt: row.activity_at,
     activityKind: row.activity_kind,
     snippet: row.snippet,

--- a/products/desktop/packages/ui/src/features/canvas/AGENTS.md
+++ b/products/desktop/packages/ui/src/features/canvas/AGENTS.md
@@ -51,11 +51,26 @@ The root `AGENTS.md` architecture rules still apply.
   horizontal swipe moves between them (`useChannelPaneSwipe`, wheel `deltaX`
   accumulated per gesture and locked until the wheel goes quiet).
 - In the list, "Starred"/"Spaces" are headings above lightly indented rows. The
-  private "me" row leads the Starred section and takes the same inset as the
-  spaces beside it. No row carries a glyph: "me" drops its lock here so every
-  name starts in the same column, and it still marks the space everywhere it is
-  named on its own (the back row, the breadcrumb). The alpha's more deeply
-  indented Channels tree and hash glyphs are unchanged.
+  private "personal" row leads the Starred section and takes the same inset as the
+  spaces beside it. It is the one row that carries a glyph: the lock is the only
+  thing saying nobody else can see this space, which is worth its name starting a
+  glyph's width right of the others. The alpha's more deeply indented Channels
+  tree and hash glyphs are unchanged.
+- **The private space reads as "personal", and only on screen.** The row is `me`
+  on the backend; `channelDisplayName` (core) swaps it on the way to a reader.
+  Four routes carry a channel's name — the channel list, an activity row, a
+  mention row, and remote search — and each calls it, because only the first
+  goes through `useTaskChannels`.
+  Recognition uses `channel_type`, never the name.
+- **The lock follows what a space is, not what it is called.** `channelGlyph`
+  takes a `personal` flag, and every caller holding the channel passes
+  `channelType === "personal"`; the name match behind it is a fallback for
+  surfaces that hold a bare name.
+  A public space named `personal` used to wear the lock while the real private
+  space showed none, which is a space impersonating yours.
+  `validateChannelName` reserves `personal` and `me` so the create and rename
+  forms refuse them — client-side only, so it neither binds the API nor renames
+  a space that already took one.
 - **The list is a tree.** Each space has a disclosure caret that opens it onto
   its most recent sessions (`useRecentSpaceTasks` — one task query per open
   space, polling slower than the channel feed; expansion lives in

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelBackRow.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelBackRow.tsx
@@ -62,6 +62,7 @@ export function ChannelBackRow({ channelId }: { channelId: string }) {
   const current = channels.find((c) => c.id === channelId);
   const showStar = current != null && current.channelType !== "personal";
   const glyph = channelGlyph(current?.name, {
+    personal: current?.channelType === "personal",
     size: 14,
     space: spacesLayout,
     className: "text-muted-foreground",

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.tsx
@@ -49,7 +49,6 @@ import { useChannelItems } from "@posthog/ui/features/canvas/hooks/useChannelIte
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useChannelTasksRunState } from "@posthog/ui/features/canvas/hooks/useChannelTasksRunState";
 import { useLocalDayStart } from "@posthog/ui/features/canvas/hooks/useLocalDayStart";
-import { PERSONAL_CHANNEL_NAME } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { SHORTCUTS } from "@posthog/ui/features/command/keyboard-shortcuts";
 import { useCommandCenterStore } from "@posthog/ui/features/command-center/commandCenterStore";
 import { placeTaskInCommandCenter } from "@posthog/ui/features/command-center/placeTaskInCommandCenter";
@@ -305,8 +304,10 @@ export function ChannelSidebar({ channelId }: { channelId: string }) {
   // as hidden — otherwise "Other people" carried in from a shared space would
   // empty this list with no visible control to undo it.
   const { channels } = useChannels();
+  // By type, not by name: the list relabels the personal channel on the way in,
+  // so its name is no longer the backend's.
   const isPersonalChannel =
-    channels.find((c) => c.id === channelId)?.name === PERSONAL_CHANNEL_NAME;
+    channels.find((c) => c.id === channelId)?.channelType === "personal";
   // The tab is the list, so everything below it — the filters, the empty state,
   // the sections — is about one kind of thing at a time.
   const tabItems = useMemo(

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.test.tsx
@@ -206,16 +206,16 @@ describe("ChannelsList", () => {
     expect(mocks.navigate).not.toHaveBeenCalled();
   });
 
-  it("pins #me above the channels, with its ⌘1 shortcut", () => {
+  it("pins the personal space above the channels, with its ⌘1 shortcut", () => {
     renderList();
-    const me = screen.getByText("me");
+    const me = screen.getByText("personal");
     const eng = screen.getByText("engineering");
     expect(
       me.compareDocumentPosition(eng) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     // ChannelHotkeys binds ⌘1-9 to the same slots; the list is where they're
     // advertised now that the switcher popover is gone.
-    expect(me.parentElement?.textContent).toMatch(/me(⌘|Ctrl)/);
+    expect(me.parentElement?.textContent).toMatch(/personal(⌘|Ctrl)/);
   });
 
   describe("group headings", () => {
@@ -244,7 +244,7 @@ describe("ChannelsList", () => {
 
       expect(screen.getByText("engineering")).toBeTruthy();
       expect(screen.queryByText("design")).toBeNull();
-      expect(screen.queryByText("me")).toBeNull();
+      expect(screen.queryByText("personal")).toBeNull();
     });
 
     // Grouping is for browsing; once you've named what you want, "Starred" and
@@ -267,7 +267,9 @@ describe("ChannelsList", () => {
       mocks.channelsLayout = false;
       renderList();
       expect(screen.queryByLabelText("Search spaces")).toBeNull();
-      expect(screen.getByText("me").parentElement?.textContent).toBe("me");
+      expect(screen.getByText("personal").parentElement?.textContent).toBe(
+        "personal",
+      );
     });
 
     it("says so when nothing matches", async () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -84,7 +84,10 @@ import {
   useSpaceTaskActionsContext,
 } from "@posthog/ui/features/canvas/hooks/useSpaceTaskActions";
 import { useStarredChannelSlots } from "@posthog/ui/features/canvas/hooks/useStarredChannelSlots";
-import { PERSONAL_CHANNEL_NAME } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
+import {
+  PERSONAL_CHANNEL_LABEL,
+  PERSONAL_CHANNEL_NAME,
+} from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { useIsChannelUnread } from "@posthog/ui/features/canvas/hooks/useUnreadChannels";
 import { useUnreadSessionCount } from "@posthog/ui/features/canvas/hooks/useUnreadSessionCount";
 import {
@@ -237,6 +240,15 @@ const SESSION_PREFETCH_DELAY_MS = 250;
  * of its own outranks it and stays muted under the keyboard while brightening
  * under the pointer.
  */
+/**
+ * What the keyboard calls the personal row before the channel list has loaded.
+ *
+ * The row is provisioned server-side with the first fetch, so until then it has
+ * no id to be identified by. The rendered row and the keyboard's flat node list
+ * both have to spell this, and they have to agree.
+ */
+const PERSONAL_ROW_VALUE = "personal-row";
+
 const ROW_LABEL_TONE =
   "text-muted-foreground group-hover/button:text-foreground group-data-highlighted/button:text-foreground";
 
@@ -985,6 +997,7 @@ const ChannelSection = memo(
     );
 
     const glyph = channelGlyph(channel.name, {
+      personal: channel.channelType === "personal",
       size: 14,
       space: spacesLayout,
       weight: isUnread ? "bold" : undefined,
@@ -1405,33 +1418,28 @@ const PersonalChannelRow = memo(function PersonalChannelRow({
     );
   };
 
-  // No glyph in the list of spaces: nothing else in that column carries one, and
-  // a lock on this row alone would start its name a glyph's width right of every
-  // other. `channelGlyph` keeps the lock for a private channel whatever the
-  // layout, so dropping it is this row's call. It still appears everywhere the
-  // space is named on its own — the back row, the breadcrumb.
-  const glyph = spacesLayout
-    ? null
-    : channelGlyph(PERSONAL_CHANNEL_NAME, {
-        size: 14,
-        weight: isUnread ? "bold" : undefined,
-        className: cn(
-          "shrink-0",
-          isUnread || isActive
-            ? "text-foreground"
-            : "text-muted-foreground group-hover/button:text-foreground",
-        ),
-      });
+  // The one row in the list that carries a glyph, and it earns the exception:
+  // this is the space nobody else can see, and the lock is the only thing that
+  // says so. Its name starts a glyph's width right of the others, which is the
+  // cost of marking it.
+  const glyph = channelGlyph(PERSONAL_CHANNEL_LABEL, {
+    personal: true,
+    size: 14,
+    weight: isUnread ? "bold" : undefined,
+    className: cn(
+      "shrink-0",
+      isUnread || isActive
+        ? "text-foreground"
+        : "text-muted-foreground group-hover/button:text-foreground",
+    ),
+  });
 
   return (
     <>
       <Box className="group/chan relative">
         <SpaceRowSurface
           asOption={spacesLayout}
-          // "me" is provisioned server-side with the first list fetch, so before
-          // it loads there is no id to identify the option by — its name is
-          // unique among spaces either way.
-          optionValue={meChannel?.id ?? PERSONAL_CHANNEL_NAME}
+          optionValue={meChannel?.id ?? PERSONAL_ROW_VALUE}
           data-selected={(isActive && !expanded) || undefined}
           onClick={openPersonalChannel}
           // "me" is a starred space among the others now, so it takes the same
@@ -1441,7 +1449,7 @@ const PersonalChannelRow = memo(function PersonalChannelRow({
           {onToggleExpanded && meChannel && (
             <SpaceDisclosure
               expanded={expanded}
-              spaceName={PERSONAL_CHANNEL_NAME}
+              spaceName={PERSONAL_CHANNEL_LABEL}
               onToggle={() => onToggleExpanded(meChannel.id)}
             />
           )}
@@ -1453,7 +1461,7 @@ const PersonalChannelRow = memo(function PersonalChannelRow({
               isUnread || isActive ? "text-foreground" : ROW_LABEL_TONE,
             )}
           >
-            {PERSONAL_CHANNEL_NAME}
+            {PERSONAL_CHANNEL_LABEL}
           </span>
           <span className="mt-[2px] flex shrink-0 items-center gap-1">
             <SpaceAttentionDot
@@ -1479,7 +1487,7 @@ const PersonalChannelRow = memo(function PersonalChannelRow({
                       <Button
                         variant="outline"
                         size="icon-xs"
-                        aria-label={`New in ${PERSONAL_CHANNEL_NAME}`}
+                        aria-label={`New in ${PERSONAL_CHANNEL_LABEL}`}
                         className={cn(
                           "gap-1 transition-opacity group-hover:border-border",
                           newMenuOpen
@@ -1666,7 +1674,10 @@ export function ChannelsList() {
   // stand between you and the row you already named, and an empty "Starred"
   // heading reads as a result that isn't there.
   const searchResults = channels.filter((c) => matches(c.name));
-  const meMatches = matches(PERSONAL_CHANNEL_NAME);
+  // Its old name too, so someone who still types "me" lands on it. A search
+  // alias, not a second identity: nothing else matches on the old name.
+  const meMatches =
+    matches(PERSONAL_CHANNEL_LABEL) || matches(PERSONAL_CHANNEL_NAME);
   const noMatches =
     normalizedQuery !== "" && !meMatches && !searchResults.length;
 
@@ -1707,9 +1718,7 @@ export function ChannelsList() {
   // A collapsed group or space renders no rows, so it contributes none.
   const collapsedSections = useSidebarStore((s) => s.collapsedSections);
   const toggleSection = useSidebarStore((s) => s.toggleSection);
-  // "me" is provisioned server-side with the first list fetch; before it loads
-  // it has no id to go by.
-  const meValue = me?.id ?? PERSONAL_CHANNEL_NAME;
+  const meValue = me?.id ?? PERSONAL_ROW_VALUE;
   const starredValue = sectionValue(STARRED_SECTION_ID);
   const channelsValue = sectionValue(CHANNELS_SECTION_ID);
   const spaceNodes = (

--- a/products/desktop/packages/ui/src/features/canvas/components/RenameChannelModal.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/RenameChannelModal.tsx
@@ -115,7 +115,11 @@ export function RenameChannelModal({
             }}
           >
             <TextField.Slot>
-              {channelGlyph(channel.name, { size: 16, space: spacesLayout })}
+              {channelGlyph(channel.name, {
+                personal: channel.channelType === "personal",
+                size: 16,
+                space: spacesLayout,
+              })}
             </TextField.Slot>
             <TextField.Slot side="right">
               <Text className="text-gray-9 text-sm tabular-nums">

--- a/products/desktop/packages/ui/src/features/canvas/components/SpaceSelect.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/SpaceSelect.tsx
@@ -75,7 +75,11 @@ export function SpaceSelect({
     ].filter((group) => group.items.length > 0);
   }, [channels]);
 
-  const triggerGlyph = channelGlyph(current?.name, { size: 14, space: true });
+  const triggerGlyph = channelGlyph(current?.name, {
+    personal: current?.channelType === "personal",
+    size: 14,
+    space: true,
+  });
 
   return (
     <Combobox<string>
@@ -139,7 +143,11 @@ export function SpaceSelect({
                       title={space.name}
                       className="relative"
                     >
-                      {channelGlyph(space.name, { size: 14, space: true })}
+                      {channelGlyph(space.name, {
+                        personal: space.channelType === "personal",
+                        size: 14,
+                        space: true,
+                      })}
                       {space.name}
                     </ComboboxItem>
                   );

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteChannelLoops.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteChannelLoops.test.tsx
@@ -2,11 +2,22 @@ import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mocks = vi.hoisted(() => ({
-  channels: [{ id: "personal-space", name: "me", path: "/me" }],
-  channelsLoading: false,
-  useLoops: vi.fn(() => ({ data: [], isLoading: false, isError: false })),
-}));
+const mocks = vi.hoisted(() => {
+  // Inside the hoisted block, because `vi.hoisted` runs before module scope and
+  // cannot reach a const declared out here.
+  const personalSpace = {
+    id: "personal-space",
+    name: "personal",
+    channelType: "personal",
+    path: "/me",
+  };
+  return {
+    personalSpace,
+    channels: [personalSpace],
+    channelsLoading: false,
+    useLoops: vi.fn(() => ({ data: [], isLoading: false, isError: false })),
+  };
+});
 
 vi.mock("@posthog/ui/features/canvas/hooks/useChannels", () => ({
   useChannels: () => ({
@@ -54,9 +65,6 @@ vi.mock("@posthog/ui/features/loops/components/LoopsEmptyState", () => ({
 vi.mock("@posthog/ui/features/loops/components/LoopTemplatesSection", () => ({
   LoopTemplatesSection: () => null,
 }));
-vi.mock("@posthog/ui/features/canvas/hooks/useTaskChannels", () => ({
-  PERSONAL_CHANNEL_NAME: "me",
-}));
 vi.mock("@posthog/ui/features/loops/components/LoopsListView", () => ({
   LoopsListView: ({ headerContent }: { headerContent?: ReactNode }) => (
     <div>
@@ -70,12 +78,12 @@ import { WebsiteChannelLoops } from "./WebsiteChannelLoops";
 
 describe("WebsiteChannelLoops", () => {
   beforeEach(() => {
-    mocks.channels = [{ id: "personal-space", name: "me", path: "/me" }];
+    mocks.channels = [mocks.personalSpace];
     mocks.channelsLoading = false;
     mocks.useLoops.mockClear();
   });
 
-  it("shows the project loops registry in the Personal space", () => {
+  it("shows the project loops registry in the personal space", () => {
     render(<WebsiteChannelLoops channelId="personal-space" />);
 
     expect(screen.getByText("Project loops registry")).toBeInTheDocument();

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteChannelLoops.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteChannelLoops.tsx
@@ -30,7 +30,6 @@ import { defaultLoopContextOutputs } from "../../loops/loopFormTypes";
 import type { LoopTemplate } from "../../loops/loopTemplates";
 import { useChannels } from "../hooks/useChannels";
 import { useOrgMembers } from "../hooks/useOrgMembers";
-import { PERSONAL_CHANNEL_NAME } from "../hooks/useTaskChannels";
 
 function contextQuickStarts(name: string): { label: string; prompt: string }[] {
   return [
@@ -75,7 +74,7 @@ export function WebsiteChannelLoops({ channelId }: { channelId: string }) {
   // layout. API-created and other unattached loops have no context_target, so
   // rendering the space-scoped list here incorrectly produces the global
   // "Create your first loop" empty state while those loops already exist.
-  if (channel?.name === PERSONAL_CHANNEL_NAME) {
+  if (channel?.channelType === "personal") {
     return <LoopsListView headerContent={headerContent} />;
   }
 

--- a/products/desktop/packages/ui/src/features/canvas/components/channelGlyph.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/channelGlyph.test.tsx
@@ -5,14 +5,17 @@ import { channelGlyph, isPrivateChannel } from "./channelGlyph";
 
 describe("isPrivateChannel", () => {
   it.each([
-    ["me", true],
-    ["  Me  ", true],
-    ["ME", true],
+    ["personal", true],
+    ["  Personal  ", true],
+    ["PERSONAL", true],
+    // The backend's own name for it, which no longer reaches here: every name
+    // a reader sees has been through `channelDisplayName` first.
+    ["me", false],
     ["code", false],
     ["posthog-feedback", false],
     // Not a prefix match: only the personal channel itself is private.
-    ["meeting-notes", false],
-    ["team-me", false],
+    ["personal-notes", false],
+    ["team-personal", false],
     [undefined, false],
     ["", false],
   ])("%s -> %s", (name, expected) => {
@@ -25,7 +28,7 @@ describe("channelGlyph", () => {
     ["channel", false, HashIcon],
     ["private space", true, LockSimpleIcon],
   ])("renders the %s glyph", (_, space, expectedIcon) => {
-    const name = expectedIcon === LockSimpleIcon ? "me" : "engineering";
+    const name = expectedIcon === LockSimpleIcon ? "personal" : "engineering";
     const glyph = channelGlyph(name, { space }) as ReactElement;
 
     expect(glyph.type).toBe(expectedIcon);
@@ -35,5 +38,22 @@ describe("channelGlyph", () => {
   // didn't, and only the private one is worth calling out.
   it("gives a shared space no glyph", () => {
     expect(channelGlyph("engineering", { space: true })).toBeNull();
+  });
+
+  // The flag beats the name in both directions. Without it, a public space
+  // called "personal" wore the lock and the real private space showed none.
+  it("locks the private space whatever it is called", () => {
+    const glyph = channelGlyph("anything", {
+      personal: true,
+      space: true,
+    }) as ReactElement;
+
+    expect(glyph.type).toBe(LockSimpleIcon);
+  });
+
+  it("leaves a public space named personal unmarked", () => {
+    expect(
+      channelGlyph("personal", { personal: false, space: true }),
+    ).toBeNull();
   });
 });

--- a/products/desktop/packages/ui/src/features/canvas/components/channelGlyph.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/channelGlyph.tsx
@@ -3,20 +3,20 @@ import {
   type IconWeight,
   LockSimpleIcon,
 } from "@phosphor-icons/react";
-import { PERSONAL_CHANNEL_NAME } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
+import { PERSONAL_CHANNEL_LABEL } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import type { ReactNode } from "react";
 
 /**
- * Whether only its own members can see a channel.
+ * Whether only its own members can see a channel, judged by its name.
  *
- * The personal "#me" channel is the only one today — it is per-user and can't
- * be shared. Channel names arrive server-normalized (lowercase-dashed), so a
- * case-insensitive match is enough; `Channel` carries no general privacy flag,
- * so this is the one place that has to learn about it when one lands.
+ * A guess, and the fallback for surfaces that hold a name and nothing else. Any
+ * caller with the channel in hand should pass `personal` to `channelGlyph`
+ * instead — a public space named "personal" reaches this function looking
+ * exactly like the private one.
  */
 export function isPrivateChannel(channelName: string | undefined): boolean {
   if (!channelName) return false;
-  return channelName.trim().toLowerCase() === PERSONAL_CHANNEL_NAME;
+  return channelName.trim().toLowerCase() === PERSONAL_CHANNEL_LABEL;
 }
 
 /**
@@ -35,10 +35,17 @@ export function channelGlyph(
     className?: string;
     weight?: IconWeight;
     space?: boolean;
+    /**
+     * Whether this is the viewer's private space. Pass it wherever the channel
+     * is in hand: the lock says "only you can see this", and deciding that from
+     * a name hands it to any public space that took the name.
+     */
+    personal?: boolean;
   },
 ): ReactNode {
-  if (!isPrivateChannel(channelName) && opts?.space) return null;
-  const Icon = isPrivateChannel(channelName) ? LockSimpleIcon : HashIcon;
+  const personal = opts?.personal ?? isPrivateChannel(channelName);
+  if (!personal && opts?.space) return null;
+  const Icon = personal ? LockSimpleIcon : HashIcon;
   return (
     <Icon
       size={opts?.size ?? 16}

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useTaskChannels.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useTaskChannels.test.tsx
@@ -58,7 +58,12 @@ describe("useTaskChannels", () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(result.current.channels.map((c) => c.id)).toEqual(["1", "p1"]);
-    expect(result.current.personalChannel).toBe(personal);
+    // Relabelled on the way in: the row is `me` on the backend and "personal"
+    // everywhere a person reads it.
+    expect(result.current.personalChannel).toEqual({
+      ...personal,
+      name: "personal",
+    });
   });
 
   it("reports loading (and no personal channel) until the list lands", () => {

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useTaskChannels.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useTaskChannels.ts
@@ -1,3 +1,4 @@
+import { channelDisplayName } from "@posthog/core/canvas/channelName";
 import type { TaskChannel } from "@posthog/shared/domain-types";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
@@ -7,8 +8,12 @@ import { useMemo } from "react";
 const TASK_CHANNELS_POLL_INTERVAL_MS = 30_000;
 export const TASK_CHANNELS_QUERY_KEY = ["task-channels"] as const;
 
-/** Name reserved for the personal channel; mirrors the backend constant. */
-export const PERSONAL_CHANNEL_NAME = "me";
+// One definition, in core: an activity row and a mention carry a channel name
+// of their own, and neither goes through this hook.
+export {
+  PERSONAL_CHANNEL_LABEL,
+  PERSONAL_CHANNEL_NAME,
+} from "@posthog/core/canvas/channelName";
 
 /**
  * Backend task channels — the single channel identity (feed, threads,
@@ -28,7 +33,15 @@ export function useTaskChannels(options?: { enabled?: boolean }): {
       refetchInterval: TASK_CHANNELS_POLL_INTERVAL_MS,
     },
   );
-  const channels = useMemo(() => query.data ?? [], [query.data]);
+  const channels = useMemo(
+    () =>
+      (query.data ?? []).map((channel) =>
+        channel.channel_type === "personal"
+          ? { ...channel, name: channelDisplayName(channel.name) }
+          : channel,
+      ),
+    [query.data],
+  );
   const personalChannel = useMemo(
     () => channels.find((c) => c.channel_type === "personal"),
     [channels],

--- a/products/desktop/packages/ui/src/features/command/CommandMenu.tsx
+++ b/products/desktop/packages/ui/src/features/command/CommandMenu.tsx
@@ -553,6 +553,7 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
           label: channel.name,
           keywords: "space channel",
           icon: channelGlyph(channel.name, {
+            personal: channel.channelType === "personal",
             size: 12,
             space: spacesLayout,
             className: "text-muted-foreground",

--- a/products/desktop/packages/ui/src/features/command/useSearchSections.tsx
+++ b/products/desktop/packages/ui/src/features/command/useSearchSections.tsx
@@ -1,4 +1,5 @@
 import { GitDiffIcon } from "@phosphor-icons/react";
+import { channelDisplayName } from "@posthog/core/canvas/channelName";
 import type { CommandMenuAction } from "@posthog/shared/analytics-events";
 import type { Task, TaskSearchResult } from "@posthog/shared/domain-types";
 import { channelGlyph } from "@posthog/ui/features/canvas/components/channelGlyph";
@@ -79,9 +80,15 @@ export function useSearchSections({
       }
 
       const task = result.task_id ? tasksById.get(result.task_id) : undefined;
+      // Remote search answers with the backend's own name, so a channel row is
+      // the one result that has not been through the channel list.
+      const title =
+        result.kind === "channel"
+          ? channelDisplayName(result.title)
+          : result.title;
       items.push({
         id: `search-${result.id}`,
-        label: result.title,
+        label: title,
         detail: result.subtitle || undefined,
         detailPrefix: "",
         keywords: `${remoteQuery} ${result.subtitle} ${Object.values(result.metadata).join(" ")}`,
@@ -89,7 +96,7 @@ export function useSearchSections({
           result.kind === "pull_request" ? (
             <GitDiffIcon size={12} className="text-gray-11" />
           ) : result.kind === "channel" ? (
-            channelGlyph(result.title, {
+            channelGlyph(title, {
               size: 12,
               space: spacesLayout,
               className: "text-muted-foreground",


### PR DESCRIPTION
## Problem

- The desktop sidebar calls your private space "me" — the one name in a column of space names that reads as a pronoun rather than a place.
- The name is `me` on the backend, so renaming the row would rewrite every existing channel and any link that names one.


<img width="2070" height="1358" alt="2026-08-13 15 46 36" src="https://github.com/user-attachments/assets/80dd1591-9b95-4d0f-aef6-14510b547eda" />


## Changes

- The space reads as "personal" everywhere a person sees it. Lowercase, like every other space in that column.
- `channelDisplayName` in `packages/core/src/canvas/channelName.ts` is the one place that knows the two names.
- Four surfaces call it, because a channel's name reaches a reader by four routes: the channel list, an activity row, a mention row, and the command palette's remote search. The last three never went through the channel list.
- Recognition moved off the name and onto `channel_type` wherever a channel object is in hand — `ChannelSidebar` and `WebsiteChannelLoops` compared names before.
- The lock now follows what a space is: `channelGlyph` takes a `personal` flag, and every caller holding the channel passes `channelType === "personal"`.
- The private space wears its lock in the sidebar list again. It is the one row there with a glyph, which costs its name a glyph's width of indent and is worth it — nothing else says the space is unshared.
- `validateChannelName` reserves `personal` and `me`, so the create and rename forms refuse them.
- The search box keeps "me" as an alias, so someone who still types it lands on the row. That is a search convenience, not a second identity.
- The backend row is untouched: no migration, no API change, no broken link.

> [!NOTE]
> Two gaps, both deliberate. The reservation is client-side, so it does not bind the API, and it does not rename a space that already took the name. A surface holding only a channel name — the header, the breadcrumb, a tab — still decides the lock from that name.

## How did you test this code?

- `channelGlyph.test.tsx` covers the lock from both sides: it fails if the flag stops beating the name, which is what put a lock on a public space called "personal" and left the real one bare.
- `channelName.test.ts` fails if the reserved names are dropped.
- `useTaskChannels.test.tsx` covers the relabel at the channel list.
- 732 tests pass across the desktop canvas, command and sidebar suites; `@posthog/core` and `@posthog/ui` typecheck; Biome clean.
- 819 tests pass across `@posthog/core` and the desktop canvas and command suites.
- Not run: the app itself. I checked the call sites and the suites; nobody has opened the sidebar against this build. The sidebar list has no story to render, so the restored lock is unverified visually.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. No documented workflow names this space.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude Opus 5) wrote this. Skills invoked: `/simplify`, `/writing-pr-descriptions`.

The first version rewrote the name inside the channel-list hook alone and matched both names when deciding which space is private. A `/simplify` pass found three display surfaces that never go through that hook and still said "me", and found that the two-name match would put a lock on any public space named "personal". Both are fixed here.

This started as a larger request that also added a "#general" space and a joining announcement. That backend work is not in this PR — it was removed on request, and nothing of it remains.
