### PR TITLE
chore(logs): remove fully rolled-out logs-group-by flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -359,7 +359,6 @@ export const FEATURE_FLAGS = {
     LOGS: 'logs', // owner: #team-logs
     LOGS_ALERTING: 'logs-alerting', // owner: #team-logs
     LOGS_ANOMALIES: 'logs-anomalies', // owner: @jonmcwest #team-logs
-    LOGS_GROUP_BY: 'logs-group-by', // owner: #team-logs
     LOGS_IN_ERROR_TRACKING: 'logs-in-error-tracking', // owner: @jonmcwest #team-logs
     LOGS_METRIC_RULES: 'logs-metric-rules', // owner: #team-logs
     LOGS_PATTERNS_VIEW: 'logs-patterns-view', // owner: #team-logs

--- a/products/logs/frontend/components/LogsViewer/LogsDisplayBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsDisplayBar.tsx
@@ -44,18 +44,18 @@ export const LogsDisplayBar = ({
     const { facetRailCollapsed, viewMode } = useValues(logsViewerConfigLogic)
     const { setFacetRailCollapsed, setViewMode } = useActions(logsViewerConfigLogic)
     const showPatternsView = useFeatureFlag('LOGS_PATTERNS_VIEW')
-    const showGroupBy = useFeatureFlag('LOGS_GROUP_BY')
 
     const inPatternsMode = showPatternsView && viewMode === 'patterns'
     // Group is a third view like Patterns: the mode lives in the segmented bar; the key
-    // picker below is the mode's configuration. Double-gated so it's unreachable flag-off.
-    const inGroupByMode = showGroupBy && viewMode === 'group'
+    // picker below is the mode's configuration.
+    const inGroupByMode = viewMode === 'group'
 
-    // Each lens joins the bar behind its own flag; the bar renders once any non-Logs lens exists.
+    // Patterns joins the bar behind its flag; Group is always available. The bar renders once
+    // any non-Logs lens exists.
     const viewModeOptions = [
         { value: 'logs' as const, label: 'Logs' },
         ...(showPatternsView ? [{ value: 'patterns' as const, label: 'Patterns' }] : []),
-        ...(showGroupBy ? [{ value: 'group' as const, label: 'Group' }] : []),
+        { value: 'group' as const, label: 'Group' },
     ]
 
     return (

--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -128,7 +128,6 @@ function LogsViewerContent({
     const { runQuery, fetchNextLogsPage } = useActions(logsViewerDataLogic)
     const { setDateRange, zoomDateRange } = useActions(logsViewerFiltersLogic)
     const showPatternsView = useFeatureFlag('LOGS_PATTERNS_VIEW')
-    const showGroupBy = useFeatureFlag('LOGS_GROUP_BY')
     const { cellScrollLefts } = useValues(virtualizedLogsListLogic({ id }))
     const { setCellScrollLeft } = useActions(virtualizedLogsListLogic({ id }))
     const messageScrollLeft = cellScrollLefts['message'] ?? 0
@@ -357,7 +356,7 @@ function LogsViewerContent({
     // logsViewerFiltersLogic). Each gates on its flag too, so its query stays unreachable when
     // the flag is off regardless of the (non-persisted) viewMode state.
     const inPatternsMode = showPatternsView && viewMode === 'patterns'
-    const inGroupByMode = showGroupBy && viewMode === 'group'
+    const inGroupByMode = viewMode === 'group'
     const resultsRegion = inPatternsMode ? (
         <LogsPatterns id={id} />
     ) : inGroupByMode ? (

--- a/products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic.ts
@@ -277,8 +277,8 @@ export const logsViewerConfigLogic = kea<logsViewerConfigLogicType>([
                 },
             },
         ],
-        // The Group view's configuration: the ordered dimensions to group by (behind the
-        // logs-group-by flag). Kept separate from viewMode so the choice survives switching
+        // The Group view's configuration: the ordered dimensions to group by. Kept separate
+        // from viewMode so the choice survives switching
         // lenses within a visit — Logs and back returns to the same grouping. Empty = no key
         // chosen yet (empty state). Not persisted across visits — grouping is an explicit,
         // per-visit exploration like Patterns.


### PR DESCRIPTION
## Problem

Everyone using the logs viewer already gets the Group lens: the `logs-group-by` flag sits at 100% rollout with no targeting, so the gate no longer decides anything.

## Changes

- Always offer the Group option in the viewer's lens switch, and derive `inGroupByMode` from `viewMode` alone in `LogsViewer` and `LogsDisplayBar`.
- Remove the `LOGS_GROUP_BY` feature flag constant and the stale flag mentions in the surrounding comments.

This is one of ten PRs, each removing a single logs flag that reached full rollout.

## How did you test this code?

No behavior change: the flag was already true for all users, so the Group lens works as before. No automated tests target this gate. I (Claude) did not run the app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) identified logs feature flags at 100% rollout via the PostHog MCP flag definitions, then removed this flag's code gate. Skills invoked: `/cleaning-up-stale-feature-flags`, `/writing-pr-descriptions`. The flag is left untouched in PostHog; disabling it there waits until this ships.
