### PR TITLE
chore(logs): remove fully rolled-out logs-saved-views flag

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4937,17 +4937,17 @@ snapshots:
     products-dashboards-dashboard-widgets-widget-types-experiments-experiments-widget-settings--default--light:
         hash: v1.k794b7964.d5dbe93b525586357874c49627a55275abf01e67d68fb83ece720f205b73fe7e.v9g8wvzfgVkkkaGKaO_PvKGWh6DfkTlfMCC2eiY8rSw
     products-dashboards-dashboard-widgets-widget-types-logs-recent-logs--default--dark:
-        hash: v1.k794b7964.1218b42154e64d863d2ce295a54b7a30162f1fee60ce187153cdb296bba7bf4c.xJPzgpEURMRZop-Rp5b84Lx2g1LZP1Yi28C5MLixQKQ
+        hash: v1.k794b7964.8030c814428bf39109c50aff4651de48b8abac48125f0fd4b33e5758d0630aee.-5otWfkf9AkiSzbZjiVXSgU66b1omRextmYvZdCq1ow
     products-dashboards-dashboard-widgets-widget-types-logs-recent-logs--default--light:
-        hash: v1.k794b7964.09a79a317eddb8e0671abd52fa412ea4a0199aba5ac80c48c7368f68c9eec814.pGn0vgnaZ2L9zvP9vU6pS7b2Uz2S88moRRqduRJSEKw
+        hash: v1.k794b7964.74cb6b134a47f9ca08ea3e3dc6b03af584218928a249ee9bd1960d99bba3fa49.C8W2-v19-rlnqswSjA1ONm68Ipw0KbqyxUY7qsPEfY8
     products-dashboards-dashboard-widgets-widget-types-logs-recent-logs--empty--dark:
-        hash: v1.k794b7964.edb58201c5ff97bc5e8279b8aefbc1fd4ffa2ba264cf21ca547a1f8d9eb454aa.DY3PHLl-lRRjakSe7MNk_falysr6kW43a4UjmTuzmCc
+        hash: v1.k794b7964.230ff6e82f0aa6aa2d2f529eae4373206a419a84d9a8475cf069182413ea7128.Yoq_m5XP4BD3Zb6V9BzLk6oomCn93-nGeD3w17-4VhQ
     products-dashboards-dashboard-widgets-widget-types-logs-recent-logs--empty--light:
-        hash: v1.k794b7964.4f69ddab94cae07421d066cc1a4586ad004aaaa3e0cb4b98de40ce5cb0354e14.2Kuf5yTRWQ9hMtH-Zlb3pPZa_as-BsxYUwBBrb1KqkQ
+        hash: v1.k794b7964.92f72b1291e55fe5ee7650489b6741ccd509fe019834cfbe72371a37b8925f0b.1mcT5yTpk65rN7kH2uReC9RFjxswyaKUsUxgVBgn46A
     products-dashboards-dashboard-widgets-widget-types-logs-recent-logs--loading--dark:
-        hash: v1.k794b7964.0e488c170ef6d52da87a0a450ddaad59dd24e7bdd8050a0c53a2864de58f8c64.GFv5d3uFctY7JRfAaWfMOanvUysHRHtxagCKRVTaqmc
+        hash: v1.k794b7964.da170ab4c6fddf1f320cf1413c59e9ddf56cf2af50bf6ffb5a39eaf64accde47.8XLol5CLjgigNpR-4IuJpVMEmzwTTaJjPh4U0YMoNYI
     products-dashboards-dashboard-widgets-widget-types-logs-recent-logs--loading--light:
-        hash: v1.k794b7964.db009d4e427c5e30801c70eadf4a10a7c76c62dc9d58e18b074192eaa476b28b.79QRoddSWClznTaeKH1MqI1p1VkZrH2929m2j3Fsopk
+        hash: v1.k794b7964.6260ad900fc8658a1d423a7c39e2b771ad0f61cd3397b71dca6f244c3c71534c.AlHcVNrlN7e7gRxzpfxlALVm-zSY_DUjUOMZGASlhyg
     products-dashboards-dashboard-widgets-widget-types-logs-recent-logs--tile-filters-read-only--dark:
         hash: v1.k794b7964.6ed7f2977028a97730ba21035ce9e01cb64c87b8c179dfd215394d0da4a3c6bc.JisUFkgqMo7wRS4k5VI6CqEMd_kSh42yYc9ybyH1_xs
     products-dashboards-dashboard-widgets-widget-types-logs-recent-logs--tile-filters-read-only--light:

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -367,7 +367,6 @@ export const FEATURE_FLAGS = {
     LOGS_ANOMALIES: 'logs-anomalies', // owner: @jonmcwest #team-logs
     LOGS_IN_ERROR_TRACKING: 'logs-in-error-tracking', // owner: @jonmcwest #team-logs
     LOGS_METRIC_RULES: 'logs-metric-rules', // owner: #team-logs
-    LOGS_SAVED_VIEWS: 'logs-saved-views', // owner: #team-logs
     LOGS_SERVICES_VIEW: 'logs-services-view', // owner: #team-logs
     LOGS_SERVICES_VIEW_V2: 'logs-services-view-v2', // owner: #team-logs
     LOGS_SETTINGS_JSON: 'logs-settings-json', // owner: #team-logs

--- a/products/dashboards/frontend/widgets/logs/LogsWidgetTileFilters.tsx
+++ b/products/dashboards/frontend/widgets/logs/LogsWidgetTileFilters.tsx
@@ -3,9 +3,7 @@ import { useEffect, useMemo } from 'react'
 
 import { IconExternal } from '@posthog/icons'
 
-import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { urls } from 'scenes/urls'
 
 import type { DateRange, LogMessage } from '~/queries/schema/schema-general'
@@ -68,19 +66,12 @@ export function LogsWidgetTileFilters({
     const savedViewId = parsed.savedViewId ?? null
     const hasSavedView = !!savedViewId
 
-    const { featureFlags } = useValues(featureFlagLogic)
-    const savedViewsEnabled = !!featureFlags[FEATURE_FLAGS.LOGS_SAVED_VIEWS]
-    // Keep the picker reachable when a view is already persisted, even if the flag is later turned
-    // off — otherwise the tile would be stuck on that view with no way to clear it.
-    const showSavedViewPicker = savedViewsEnabled || hasSavedView
     const { savedViewOptions, savedViewsLoading, savedViewLabelById } = useValues(logsWidgetSavedViewsLogic)
     const { ensureSavedViewsLoaded } = useActions(logsWidgetSavedViewsLogic)
 
     useEffect(() => {
-        if (showSavedViewPicker) {
-            ensureSavedViewsLoaded()
-        }
-    }, [showSavedViewPicker, ensureSavedViewsLoaded])
+        ensureSavedViewsLoaded()
+    }, [ensureSavedViewsLoaded])
 
     const savedViewSelectOptions = useMemo(
         () => [
@@ -149,16 +140,14 @@ export function LogsWidgetTileFilters({
 
     return (
         <WidgetTileFiltersBar dataAttr="logs-widget-tile-filters">
-            {showSavedViewPicker ? (
-                <LemonSelect
-                    size="small"
-                    value={savedViewId}
-                    loading={savedViewsLoading}
-                    options={savedViewSelectOptions}
-                    placeholder="Saved view"
-                    onChange={(value) => void applySavedView(value ?? null)}
-                />
-            ) : null}
+            <LemonSelect
+                size="small"
+                value={savedViewId}
+                loading={savedViewsLoading}
+                options={savedViewSelectOptions}
+                placeholder="Saved view"
+                onChange={(value) => void applySavedView(value ?? null)}
+            />
             {!hasSavedView ? (
                 <>
                     <SeverityLevelsFilter

--- a/products/logs/backend/presentation/views/views_api.py
+++ b/products/logs/backend/presentation/views/views_api.py
@@ -5,7 +5,6 @@ from rest_framework import serializers, viewsets
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.event_usage import report_user_action
-from posthog.permissions import PostHogFeatureFlagPermission
 
 from products.logs.backend.models import LogsView
 
@@ -98,8 +97,6 @@ class LogsViewViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     queryset = LogsView.objects.all().order_by("-created_at")
     serializer_class = LogsViewSerializer
     lookup_field = "short_id"
-    posthog_feature_flag = "logs-saved-views"
-    permission_classes = [PostHogFeatureFlagPermission]
 
     def safely_get_queryset(self, queryset: Any) -> Any:
         queryset = queryset.filter(team_id=self.team_id)

--- a/products/logs/backend/test/test_views_api.py
+++ b/products/logs/backend/test/test_views_api.py
@@ -19,9 +19,6 @@ class TestLogsViewAPI(APIBaseTest):
     def setUp(self):
         super().setUp()
         self.base_url = f"/api/environments/{self.team.pk}/logs/views/"
-        self._ff_patcher = patch("posthoganalytics.feature_enabled", return_value=True)
-        self._ff_patcher.start()
-        self.addCleanup(self._ff_patcher.stop)
 
     def _valid_payload(self, **overrides) -> dict:
         defaults = {
@@ -276,13 +273,6 @@ class TestLogsViewAPI(APIBaseTest):
         client = APIClient()
         response = client.get(self.base_url)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-    # --- Feature flag ---
-
-    @patch("posthoganalytics.feature_enabled", return_value=False)
-    def test_returns_403_when_feature_flag_disabled(self, _mock_feature_enabled):
-        response = self.client.get(self.base_url)
-        assert response.status_code == status.HTTP_403_FORBIDDEN
 
     # --- Pinned ---
 

--- a/products/logs/frontend/components/LogsViews/SavedViewsButton.tsx
+++ b/products/logs/frontend/components/LogsViews/SavedViewsButton.tsx
@@ -3,8 +3,6 @@ import { useActions } from 'kea'
 import { IconBookmark } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
-
 import { logsViewsListLogic } from './logsViewsListLogic'
 import { LogsViewsLogicProps } from './logsViewsLogic'
 import { SavedViewsModal } from './SavedViewsModal'
@@ -13,7 +11,7 @@ interface SavedViewsButtonProps extends LogsViewsLogicProps {
     iconOnly?: boolean
 }
 
-function SavedViewsButtonInner({ id, iconOnly }: SavedViewsButtonProps): JSX.Element {
+export function SavedViewsButton({ id, iconOnly }: SavedViewsButtonProps): JSX.Element {
     const { openModal } = useActions(logsViewsListLogic({ id }))
 
     return (
@@ -30,14 +28,4 @@ function SavedViewsButtonInner({ id, iconOnly }: SavedViewsButtonProps): JSX.Ele
             <SavedViewsModal id={id} />
         </>
     )
-}
-
-export function SavedViewsButton({ id, iconOnly }: SavedViewsButtonProps): JSX.Element | null {
-    const enabled = useFeatureFlag('LOGS_SAVED_VIEWS')
-
-    if (!enabled) {
-        return null
-    }
-
-    return <SavedViewsButtonInner id={id} iconOnly={iconOnly} />
 }


### PR DESCRIPTION
## Problem

Everyone using logs already has saved views: the `logs-saved-views` flag sits at 100% rollout with no targeting, so the gate no longer decides anything.

## Changes

- Render `SavedViewsButton` unconditionally and drop its wrapper that returned null when the flag was off.
- Always show the saved-view picker in the logs dashboard widget filter, removing the `featureFlagLogic` read there.
- Remove the `logs-saved-views` permission gate from `LogsViewViewSet`, so it falls back to the standard team and scope permissions.
- Remove the `LOGS_SAVED_VIEWS` feature flag constant.
- Delete `test_returns_403_when_feature_flag_disabled` and the `setUp` patcher that forced the flag on. Both arrived with the gate in #52232, so they asserted behavior this PR removes.

This is one of ten PRs, each removing a single logs flag that reached full rollout.

## How did you test this code?

Nobody sees a behavior change: the flag was already true for every user, so saved views and the widget picker work as before.

`pytest products/logs/backend/test/test_views_api.py` passes, 27 tests, against a local Postgres and ClickHouse.

Six storybook snapshots change, all of them the logs dashboard widget across its default, empty and loading states in both themes. The filter row gains the saved-view picker, which wraps "Newest first" onto a second line. Storybook sets no flags, so these baselines recorded a flag-off state that no real user sees.

| Before | After |
| --- | --- |
| ![logs-widget-before](https://raw.githubusercontent.com/PostHog/pr-assets/e52f3baef9d5554e62d6a8975d3524f78d82bf7e/2026/08/eb288e43-2bb9-4252-97aa-acc879710aaf.png) | ![logs-widget-after](https://raw.githubusercontent.com/PostHog/pr-assets/82db72063482723cc8ed3fff265b0c144860487f/2026/08/4567c263-e4c5-4358-af6c-9b7941baccd0.png) |

Not run: the rest of the backend suite, and the app itself.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude identified logs feature flags at 100% rollout via the PostHog MCP flag definitions, then removed this flag's frontend gates and its backend viewset permission gate. A later session deleted the stale flag test that CI caught, and merged the base branch in to pick up an unrelated typecheck fix. Skills invoked: `/cleaning-up-stale-feature-flags`, `/improving-drf-endpoints`, `/writing-tests`, `/triaging-visual-review-runs`, `/writing-pr-descriptions`. The flag stays untouched in PostHog; disabling it there waits until this ships.
