### PR TITLE
feat(insights): keep an isolated legend series in the saved insight

### DIFF
--- a/frontend/src/scenes/trends/trendsDataLogic.test.ts
+++ b/frontend/src/scenes/trends/trendsDataLogic.test.ts
@@ -313,6 +313,73 @@ describe('trendsDataLogic', () => {
             })
         })
 
+        it('setResultsHidden hides exactly the given series in one update', async () => {
+            const query: TrendsQuery = {
+                kind: NodeKind.TrendsQuery,
+                series: [],
+                trendsFilter: { display: ChartDisplayType.ActionsPie },
+            }
+            const insight: Partial<InsightModel> = { result: trendPieResult.result }
+
+            await expectLogic(logic, () => {
+                insightVizDataLogic.findMounted(insightProps)?.actions.updateQuerySource(query)
+                builtDataNodeLogic.actions.loadDataSuccess(insight)
+            }).toFinishAllListeners()
+
+            const indexedResults = logic.values.indexedResults
+            const isolated = indexedResults[0]
+            const others = indexedResults.slice(1)
+
+            await expectLogic(logic, () => {
+                logic.actions.setResultsHidden(others.map((r) => String(r.id)))
+            }).toFinishAllListeners()
+
+            const { getTrendsHidden, getIsOnlyVisibleSeriesInLegend } = logic.values
+            expect(getTrendsHidden(isolated)).toBe(false)
+            expect(others.map((r) => getTrendsHidden(r))).toEqual(others.map(() => true))
+            expect(getIsOnlyVisibleSeriesInLegend(isolated)).toBe(true)
+
+            await expectLogic(logic, () => {
+                logic.actions.setResultsHidden([])
+            }).toFinishAllListeners()
+
+            await expectLogic(logic).toMatchValues({ areAllSeriesVisible: true })
+        })
+
+        it('setResultsHidden keeps a shared customization key visible while any of its results is', async () => {
+            // Comparing to the previous period puts a series' current and previous results on one
+            // customization key, so hiding one row cannot hide the other out from under it.
+            const query: TrendsQuery = {
+                kind: NodeKind.TrendsQuery,
+                series: [],
+                compareFilter: { compare: true },
+            }
+            const [current] = trendResult.result
+            const insight: Partial<InsightModel> = {
+                result: [
+                    { ...current, compare: true, compare_label: 'current' },
+                    { ...current, compare: true, compare_label: 'previous' },
+                ],
+            }
+
+            await expectLogic(logic, () => {
+                insightVizDataLogic.findMounted(insightProps)?.actions.updateQuerySource(query)
+                builtDataNodeLogic.actions.loadDataSuccess(insight)
+            }).toFinishAllListeners()
+
+            const [currentRow, previousRow] = logic.values.indexedResults
+            expect(getTrendResultCustomizationKey(ResultCustomizationBy.Value, currentRow)).toBe(
+                getTrendResultCustomizationKey(ResultCustomizationBy.Value, previousRow)
+            )
+
+            await expectLogic(logic, () => {
+                logic.actions.setResultsHidden([String(previousRow.id)])
+            }).toFinishAllListeners()
+
+            const { getTrendsHidden } = logic.values
+            expect([getTrendsHidden(currentRow), getTrendsHidden(previousRow)]).toEqual([false, false])
+        })
+
         it('getIsOnlyVisibleSeriesInLegend is true only for the sole visible series', async () => {
             const query: TrendsQuery = {
                 kind: NodeKind.TrendsQuery,

--- a/frontend/src/scenes/trends/trendsDataLogic.ts
+++ b/frontend/src/scenes/trends/trendsDataLogic.ts
@@ -254,6 +254,9 @@ export interface trendsDataLogicActions {
     setHoveredDatasetIndex: (index: number | null) => {
         index: number | null
     }
+    setResultsHidden: (hiddenIds: string[]) => {
+        hiddenIds: string[]
+    }
     toggleAllResultsHidden: (
         datasets: IndexedTrendResult[],
         hidden: boolean
@@ -497,6 +500,7 @@ export const trendsDataLogic = kea<trendsDataLogicType>([
         toggleResultHidden: (dataset: IndexedTrendResult) => ({ dataset }),
         toggleAllResultsHidden: (datasets: IndexedTrendResult[], hidden: boolean) => ({ datasets, hidden }),
         toggleOtherSeriesHidden: (dataset: IndexedTrendResult) => ({ dataset }),
+        setResultsHidden: (hiddenIds: string[]) => ({ hiddenIds }),
         setHoveredDatasetIndex: (index: number | null) => ({ index }),
     }),
 
@@ -1104,6 +1108,31 @@ export const trendsDataLogic = kea<trendsDataLogicType>([
             actions.updateInsightFilter({
                 resultCustomizations,
             } as Partial<TrendsFilter>)
+        },
+        setResultsHidden: ({ hiddenIds }) => {
+            const { indexedResults, resultCustomizationBy, resultCustomizations } = values
+            const hidden = new Set(hiddenIds)
+            // Customizations are keyed per series identity, which several results can share when
+            // assigning by value. Resolve visibility per key — a key stays visible while any of its
+            // results is — so isolating one of a pair doesn't hide the other out from under it.
+            const visibleKeys = new Set(
+                indexedResults
+                    .filter((r) => !hidden.has(String(r.id)))
+                    .map((r) => getTrendResultCustomizationKey(resultCustomizationBy, r))
+            )
+
+            const next: Record<string, ResultCustomization> = { ...resultCustomizations }
+            for (const result of indexedResults) {
+                const key = getTrendResultCustomizationKey(resultCustomizationBy, result)
+                const existing = getTrendResultCustomization(resultCustomizationBy, result, resultCustomizations)
+                next[key] = {
+                    ...existing,
+                    assignmentBy: resultCustomizationBy,
+                    hidden: !visibleKeys.has(key),
+                }
+            }
+
+            actions.updateInsightFilter({ resultCustomizations: next } as Partial<TrendsFilter>)
         },
         toggleOtherSeriesHidden: ({ dataset }) => {
             const { indexedResults, resultCustomizationBy, resultCustomizations, getTrendsHidden } = values

--- a/products/product_analytics/frontend/insights/trends/shared/useInsightsLegendConfig.test.tsx
+++ b/products/product_analytics/frontend/insights/trends/shared/useInsightsLegendConfig.test.tsx
@@ -1,16 +1,24 @@
-import { renderHook } from '@testing-library/react'
+import { renderHook, waitFor } from '@testing-library/react'
 import { BindLogic } from 'kea'
 
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { getTrendResultCustomizationKey } from 'scenes/insights/utils'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
-import { DataNode, NodeKind, TrendsFilter, TrendsQuery } from '~/queries/schema/schema-general'
+import {
+    CompareFilter,
+    DataNode,
+    NodeKind,
+    ResultCustomizationBy,
+    TrendsFilter,
+    TrendsQuery,
+} from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
-import { InsightLogicProps } from '~/types'
+import { InsightLogicProps, InsightModel } from '~/types'
 
 import { useInsightsLegendConfig } from './useInsightsLegendConfig'
 
@@ -22,18 +30,43 @@ const wrapper = ({ children }: { children: React.ReactNode }): JSX.Element => (
     </BindLogic>
 )
 
-function setup({ trendsFilter }: { trendsFilter?: TrendsFilter } = {}): void {
+function setup({
+    trendsFilter,
+    compareFilter,
+    results,
+}: {
+    trendsFilter?: TrendsFilter
+    compareFilter?: CompareFilter
+    results?: InsightModel['result']
+} = {}): void {
     initKeaTests()
     featureFlagLogic.mount()
 
-    dataNodeLogic({ key: 'InsightViz.new', query: {} as DataNode }).mount()
+    const builtDataNodeLogic = dataNodeLogic({ key: 'InsightViz.new', query: {} as DataNode })
+    builtDataNodeLogic.mount()
     insightDataLogic(insightProps).mount()
     insightLogic(insightProps).mount()
     insightVizDataLogic(insightProps).mount()
     trendsDataLogic(insightProps).mount()
-    const query: TrendsQuery = { kind: NodeKind.TrendsQuery, series: [], trendsFilter }
+    const query: TrendsQuery = { kind: NodeKind.TrendsQuery, series: [], trendsFilter, compareFilter }
     insightVizDataLogic(insightProps).actions.updateQuerySource(query)
+    builtDataNodeLogic.actions.loadDataSuccess({ result: results ?? [] })
 }
+
+const SERIES: InsightModel['result'] = [
+    {
+        action: { id: '$pageview', type: 'events', order: 0, name: '$pageview' },
+        label: '$pageview',
+        data: [1],
+        days: [],
+    },
+    {
+        action: { id: '$autocapture', type: 'events', order: 1, name: '$autocapture' },
+        label: '$autocapture',
+        data: [2],
+        days: [],
+    },
+]
 
 describe('useInsightsLegendConfig', () => {
     it.each([
@@ -57,6 +90,39 @@ describe('useInsightsLegendConfig', () => {
         const { result } = renderHook(() => useInsightsLegendConfig({ insightProps }), { wrapper })
 
         expect(result.current?.show).toBe(expectedShow)
+    })
+
+    it('persists an isolate through onSetHiddenSeries, so a legend click reaches the query', async () => {
+        setup({ trendsFilter: { showLegend: true }, results: SERIES })
+        const { result } = renderHook(() => useInsightsLegendConfig({ insightProps }), { wrapper })
+        const logic = trendsDataLogic(insightProps)
+        const [first, second] = logic.values.indexedResults
+
+        result.current.onSetHiddenSeries!([String(second.id)])
+
+        await waitFor(() => {
+            const { getTrendsHidden } = logic.values
+            expect([getTrendsHidden(first), getTrendsHidden(second)]).toEqual([false, true])
+        })
+    })
+
+    it('groups a compared series two rows onto one visibility key', () => {
+        const [pageview] = SERIES
+        setup({
+            trendsFilter: { showLegend: true },
+            compareFilter: { compare: true },
+            results: [
+                { ...pageview, compare: true, compare_label: 'current' },
+                { ...pageview, compare: true, compare_label: 'previous' },
+            ],
+        })
+        const { result } = renderHook(() => useInsightsLegendConfig({ insightProps }), { wrapper })
+        const [current, previous] = trendsDataLogic(insightProps).values.indexedResults
+
+        const groupOf = result.current.visibilityGroupKey!
+
+        expect(groupOf(String(current.id))).toBe(groupOf(String(previous.id)))
+        expect(groupOf(String(current.id))).toBe(getTrendResultCustomizationKey(ResultCustomizationBy.Value, current))
     })
 
     it.each([

--- a/products/product_analytics/frontend/insights/trends/shared/useInsightsLegendConfig.tsx
+++ b/products/product_analytics/frontend/insights/trends/shared/useInsightsLegendConfig.tsx
@@ -4,6 +4,7 @@ import { useMemo, type ReactNode } from 'react'
 import type { ChartLegendConfig, LegendItem } from '@posthog/quill-charts'
 
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { getTrendResultCustomizationKey } from 'scenes/insights/utils'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 import type { IndexedTrendResult } from 'scenes/trends/types'
 
@@ -24,9 +25,15 @@ export function useInsightsLegendConfig({
     inSharedMode = false,
 }: UseInsightsLegendConfigOptions): ChartLegendConfig {
     const { canEditInsight } = useValues(insightLogic)
-    const { indexedResults, getTrendsHidden, showLegend, legendPosition, legendSeriesIsolationMenuEligible } =
-        useValues(trendsDataLogic(insightProps))
-    const { toggleResultHidden } = useActions(trendsDataLogic(insightProps))
+    const {
+        indexedResults,
+        getTrendsHidden,
+        showLegend,
+        legendPosition,
+        legendSeriesIsolationMenuEligible,
+        resultCustomizationBy,
+    } = useValues(trendsDataLogic(insightProps))
+    const { toggleResultHidden, setResultsHidden } = useActions(trendsDataLogic(insightProps))
 
     const resultById = useMemo(() => {
         const m = new Map<string, IndexedTrendResult>()
@@ -49,6 +56,16 @@ export function useInsightsLegendConfig({
                 if (result) {
                     toggleResultHidden(result)
                 }
+            },
+            // Isolating rewrites the whole hidden set, so it lands as one resultCustomizations
+            // update rather than a toggle per series.
+            onSetHiddenSeries: setResultsHidden,
+            // Hidden state is stored per customization key, and comparing to the previous period puts
+            // a series' two rows on one key — so quill has to treat them as one series when it
+            // isolates, or the twin row it deliberately leaves visible would read as "not isolated".
+            visibilityGroupKey: (key: string) => {
+                const result = resultById.get(key)
+                return result ? getTrendResultCustomizationKey(resultCustomizationBy, result) : key
             },
             renderItem: showContextMenu
                 ? (node: ReactNode, item: LegendItem) => {
@@ -73,6 +90,8 @@ export function useInsightsLegendConfig({
         legendSeriesIsolationMenuEligible,
         resultById,
         toggleResultHidden,
+        setResultsHidden,
+        resultCustomizationBy,
         insightProps,
     ])
 }


### PR DESCRIPTION
## Problem

Every other chart legend isolates a series on click after [#82652](https://github.com/PostHog/posthog/pull/82652). Trends and stickiness still toggle one series per click, so isolating one of twenty breakdown values there still takes nineteen clicks.

They are the surfaces that store legend visibility rather than keeping it in the chart: hidden series live in the insight's `resultCustomizations`, so they survive a reload and travel with the saved insight and its dashboard tiles. That is why they need their own layer — the library can't turn the gesture on for a legend whose state it doesn't own.

Eight displays reach it, through one shared hook (`useInsightsLegendConfig`): trends line, cumulative line, area, bar, unstacked bar and pie, plus stickiness line and bar.

Every other insight type is already done. Lifecycle, funnel-over-time and slope charts keep visibility in the chart, so they started isolating the moment #82652 landed and need nothing here — the trade is that their state is ephemeral rather than saved. Retention and the funnel step charts have no in-chart legend at all. So this PR is the last one needed for the gesture, not the only one that enables it.

## Changes

- A plain click on a trends or stickiness legend row now shows only that series, and the isolate persists into the insight the way hiding a series already does. Clicking the isolated row again restores all of them.
- Cmd/Ctrl-click still toggles one series, unchanged.
- Isolating lands as one `setResultsHidden` action and one `resultCustomizations` write, not a toggle per series. The existing per-series `toggleResultHidden` can't express a whole-set change in one update.

Two details carry the compare case, which is where a naive version breaks:

- `setResultsHidden` resolves visibility per customization key, not per result: a key stays visible while any of its results is. Several results can share a key.
- `visibilityGroupKey` hands the chart that same grouping, so it treats a shared key as one series.

Comparing to the previous period puts a series' current and previous rows on one key. Without the grouping the chart isolates a row, correctly leaves its twin visible, then can't tell the result is isolated — so the second click never restores, and on a single-series compare insight the first click does nothing at all.

The existing trends right-click menu is untouched. It drives `trendsDataLogic` directly, so it keeps working; sharing that menu with the other surfaces, and restyling it, is a later layer.

## How did you test this code?

I (actually Claude) ran the affected Jest suites locally. 4085 tests pass across the quill package, product analytics insights, trends, insights, DataVisualization, and exporter suites.

- `setResultsHidden hides exactly the given series in one update` covers the write and the round trip back through `getTrendsHidden`.
- `setResultsHidden keeps a shared customization key visible while any of its results is` builds a compare-mode insight, asserts both rows really do share a key, then isolates one and asserts the twin stays visible. Without the per-key resolution this fails.
- `persists an isolate through onSetHiddenSeries` covers the wiring itself — delete that one line and a trends legend click silently degrades to toggling with everything else still green.
- `groups a compared series two rows onto one visibility key` pins `visibilityGroupKey` to the customization key.
- Not run: Playwright, and anything needing a backend — this sandbox has neither. I did not exercise this in a browser; the compare-mode behavior is covered by the tests above rather than by a screenshot.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The library-side documentation landed with [#82652](https://github.com/PostHog/posthog/pull/82652).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (Claude Code) at the request of the PR assignee. Skills invoked: `/stacking-prs`, `/writing-pr-descriptions`, `/writing-tests`.

Second layer of the stack split out of [#82548](https://github.com/PostHog/posthog/pull/82548). It deliberately excludes the shared right-click menu and the SQL, lifecycle, and funnel wiring: those pull in a new component and three more consumers, and trends needs none of them to get the gesture.

The compare-mode bug this PR's grouping prevents was found by an adversarial review pass on the original combined PR, not by a test — the first implementation reasoned in legend rows and silently no-opped on any compare-enabled trends insight.

No customer data, tickets, or internal material fed into this change.

---

_Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)_


