### PR TITLE
fix(desktop): bind speech notification settings on web

### DIFF
--- a/products/desktop/apps/web/src/web-container.ts
+++ b/products/desktop/apps/web/src/web-container.ts
@@ -246,7 +246,9 @@ import {
   ACTIVE_VIEW_PROVIDER,
   type IActiveView,
   type INotificationSettings,
+  type ISpeechNotifySettings,
   NOTIFICATION_SETTINGS_PROVIDER,
+  SPEECH_NOTIFY_SETTINGS,
 } from "@posthog/ui/features/notifications/identifiers";
 import { notificationsUiModule } from "@posthog/ui/features/notifications/notifications.module";
 import { OnboardingGithubConnectClient } from "@posthog/ui/features/onboarding/githubConnectClientImpl";
@@ -309,6 +311,7 @@ import {
   webActiveView,
   webNotificationSettings,
   webNotifications,
+  webSpeechNotifySettings,
 } from "./web-notifications";
 import { WebOAuthFlowService } from "./web-oauth-flow";
 import { webDiffWorkerFactory, webReviewHost } from "./web-review-host";
@@ -403,6 +406,7 @@ interface WebBindings {
   [NOTIFICATIONS_SERVICE]: INotifications;
   [NOTIFICATION_SETTINGS_PROVIDER]: INotificationSettings;
   [ACTIVE_VIEW_PROVIDER]: IActiveView;
+  [SPEECH_NOTIFY_SETTINGS]: ISpeechNotifySettings;
   [REPORT_MODEL_RESOLVER]: ReportModelResolver;
 }
 
@@ -817,6 +821,9 @@ container
   .bind(NOTIFICATION_SETTINGS_PROVIDER)
   .toConstantValue(webNotificationSettings);
 container.bind(ACTIVE_VIEW_PROVIDER).toConstantValue(webActiveView);
+container
+  .bind(SPEECH_NOTIFY_SETTINGS)
+  .toConstantValue(webSpeechNotifySettings);
 
 // ── Inbox: resolve the default cloud-run model from the LLM gateway ──
 // Host capability consumed by UI hooks (canvas/home/inbox) that create cloud

--- a/products/desktop/apps/web/src/web-container.ts
+++ b/products/desktop/apps/web/src/web-container.ts
@@ -821,9 +821,7 @@ container
   .bind(NOTIFICATION_SETTINGS_PROVIDER)
   .toConstantValue(webNotificationSettings);
 container.bind(ACTIVE_VIEW_PROVIDER).toConstantValue(webActiveView);
-container
-  .bind(SPEECH_NOTIFY_SETTINGS)
-  .toConstantValue(webSpeechNotifySettings);
+container.bind(SPEECH_NOTIFY_SETTINGS).toConstantValue(webSpeechNotifySettings);
 
 // ── Inbox: resolve the default cloud-run model from the LLM gateway ──
 // Host capability consumed by UI hooks (canvas/home/inbox) that create cloud

--- a/products/desktop/apps/web/src/web-notifications.ts
+++ b/products/desktop/apps/web/src/web-notifications.ts
@@ -6,6 +6,7 @@ import type {
 import type {
   IActiveView,
   INotificationSettings,
+  ISpeechNotifySettings,
   NotificationSettings,
 } from "@posthog/ui/features/notifications/identifiers";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
@@ -73,6 +74,22 @@ export const webNotificationSettings: INotificationSettings = {
       completionVolume: s.completionVolume,
       scaleSoundWithTaskLength: s.scaleSoundWithTaskLength,
       customSounds: s.customSounds,
+    };
+  },
+};
+
+// Spoken notifications are routed by the shared SpeechNotifier. Keep this
+// separate from the toast/native notification settings because they have
+// independent user controls.
+export const webSpeechNotifySettings: ISpeechNotifySettings = {
+  get() {
+    const s = useSettingsStore.getState();
+    return {
+      enabled: s.spokenNotifications,
+      needsInput: s.spokenNotifyNeedsInput,
+      completion: s.spokenNotifyCompletion,
+      progress: s.spokenNotifyProgress,
+      focusMode: s.spokenFocusMode,
     };
   },
 };

--- a/products/desktop/packages/ui/src/shell/requiredHostCapabilities.ts
+++ b/products/desktop/packages/ui/src/shell/requiredHostCapabilities.ts
@@ -7,6 +7,7 @@ import { CONNECTIVITY_CLIENT } from "@posthog/ui/features/connectivity/connectiv
 import { FEATURE_FLAGS } from "@posthog/ui/features/feature-flags/identifiers";
 import { GIT_CACHE_KEY_PROVIDER } from "@posthog/ui/features/git-interaction/gitCacheProvider";
 import { UPDATES_CLIENT } from "@posthog/ui/features/updates/updatesClient";
+import { SPEECH_NOTIFY_SETTINGS } from "@posthog/ui/features/notifications/identifiers";
 import { DIFF_WORKER_FACTORY } from "@posthog/ui/shell/diffWorkerHost";
 
 /**
@@ -64,6 +65,10 @@ export const REQUIRED_HOST_CAPABILITIES: readonly HostCapabilityRequirement[] =
     {
       token: DIFF_WORKER_FACTORY,
       description: "diff computation worker for review/diffs",
+    },
+    {
+      token: SPEECH_NOTIFY_SETTINGS,
+      description: "spoken-notification preferences",
     },
     {
       token: REPORT_MODEL_RESOLVER,

--- a/products/desktop/packages/ui/src/shell/requiredHostCapabilities.ts
+++ b/products/desktop/packages/ui/src/shell/requiredHostCapabilities.ts
@@ -6,8 +6,8 @@ import { REVIEW_HOST } from "@posthog/ui/features/code-review/reviewHost";
 import { CONNECTIVITY_CLIENT } from "@posthog/ui/features/connectivity/connectivityClient";
 import { FEATURE_FLAGS } from "@posthog/ui/features/feature-flags/identifiers";
 import { GIT_CACHE_KEY_PROVIDER } from "@posthog/ui/features/git-interaction/gitCacheProvider";
-import { UPDATES_CLIENT } from "@posthog/ui/features/updates/updatesClient";
 import { SPEECH_NOTIFY_SETTINGS } from "@posthog/ui/features/notifications/identifiers";
+import { UPDATES_CLIENT } from "@posthog/ui/features/updates/updatesClient";
 import { DIFF_WORKER_FACTORY } from "@posthog/ui/shell/diffWorkerHost";
 
 /**


### PR DESCRIPTION
## Problem

Web Desktop fails to start when shared speech notifications resolve their settings provider.

## Changes

- Bind browser-backed spoken-notification preferences in the web container.
- Require this provider through the shared host-capability contract, so host boot CI catches future omissions.

## Why

The web host needs the same speech-notification settings contract as the native renderer for shared notification code to initialize safely.

## How did you test this code?

- `git diff --check`
- TypeScript type-check could not run because this checkout has no installed dependencies.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Codex. No skills were invoked.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*