### PR TITLE
fix(warehouse-sources): stop wiping cdc companion history on redelivery

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/load.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/load.py
@@ -414,6 +414,7 @@ async def _run_cdc_post_load(
     queryable_folder: str,
     cdc_write_mode: Optional[str],
     is_cdc_companion: bool,
+    is_initial_load: bool,
     logger: FilteringBoundLogger,
 ) -> None:
     from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_sync import (
@@ -438,13 +439,16 @@ async def _run_cdc_post_load(
         return
 
     # After the initial snapshot load for a CDC schema, seed the companion _cdc table
-    # with the snapshot rows as synthetic INSERT events.  Only fires when cdc_write_mode
-    # is None (initial non-CDC load), NOT on every CDC consolidated streaming batch.
-    should_seed = cdc_write_mode is None and schema.cdc_table_mode in ("cdc_only", "both")
+    # with the snapshot rows as synthetic INSERT events. Seeding resets the companion, so
+    # it must happen only on the initial load: a missing cdc_write_mode alone does not mean
+    # "initial" — a redelivered final batch reaches post-load without one, and re-seeding
+    # there throws away every SCD2 version the stream has accumulated since.
+    should_seed = is_initial_load and cdc_write_mode is None and schema.cdc_table_mode in ("cdc_only", "both")
     logger.info(
         "cdc_seed_check",
         should_seed=should_seed,
         cdc_write_mode=cdc_write_mode,
+        is_initial_load=is_initial_load,
         sync_type=schema.sync_type,
         cdc_table_mode=schema.cdc_table_mode,
     )
@@ -581,6 +585,9 @@ async def run_post_load_operations(
     # table independently, otherwise we overwrite the snapshot queryable_folder with the SCD2 path.
     is_cdc_companion = cdc_write_mode == "scd2_append"
     is_cdc_schema = schema.sync_type == ExternalDataSchema.SyncType.CDC
+    # Read before the bookkeeping below sets the flag, which would otherwise make every run
+    # look like a continuation.
+    is_initial_load = not schema.initial_sync_complete
 
     await _run_delta_maintenance(schema, delta_table_ref, is_cdc_companion, logger)
 
@@ -610,6 +617,7 @@ async def run_post_load_operations(
             queryable_folder=queryable_folder,
             cdc_write_mode=cdc_write_mode,
             is_cdc_companion=is_cdc_companion,
+            is_initial_load=is_initial_load,
             logger=logger,
         )
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_load.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_load.py
@@ -25,7 +25,14 @@ _PIPELINE_SYNC_MODULE = "products.warehouse_sources.backend.temporal.data_import
 _REPARTITION_MODULE = "products.warehouse_sources.backend.temporal.data_imports.pipelines.core.repartition_controller"
 
 
-def _make_schema(*, is_cdc: bool, sync_type_config: dict | None = None, partition_count: int | None = 7) -> MagicMock:
+def _make_schema(
+    *,
+    is_cdc: bool,
+    sync_type_config: dict | None = None,
+    partition_count: int | None = 7,
+    cdc_table_mode: str = "consolidated",
+    initial_sync_complete: bool = True,
+) -> MagicMock:
     config = sync_type_config if sync_type_config is not None else {}
     schema = MagicMock()
     schema.id = uuid.uuid4()
@@ -36,8 +43,8 @@ def _make_schema(*, is_cdc: bool, sync_type_config: dict | None = None, partitio
     schema.last_vacuum_version = config.get("last_vacuum_version")
     schema.last_vacuum_version_cdc = config.get("last_vacuum_version_cdc")
     schema.partition_count = partition_count
-    schema.cdc_table_mode = "consolidated"
-    schema.initial_sync_complete = True
+    schema.cdc_table_mode = cdc_table_mode
+    schema.initial_sync_complete = initial_sync_complete
     return schema
 
 
@@ -68,6 +75,7 @@ async def _run_post_load(
         patch(f"{_LOAD_MODULE}.notify_revenue_analytics_that_sync_has_completed", AsyncMock()),
         patch(f"{_LOAD_MODULE}.sync_revenue_analytics_views", MagicMock()),
         patch(f"{_LOAD_MODULE}.DataWarehouseTable", MagicMock()),
+        patch(f"{_LOAD_MODULE}.set_initial_sync_complete", AsyncMock()),
         patch.object(DeltaMaintenance, "run_scheduled", run_scheduled),
         patch.object(DeltaMaintenance, "compact_table", compact_table),
         patch(f"{_PIPELINE_SYNC_MODULE}.update_last_synced_at", AsyncMock()),
@@ -170,6 +178,44 @@ class TestRunPostLoadDeltaMaintenance:
 
         assert mock_capture.called is expect_capture
         prepare_s3.assert_awaited_once()
+
+
+class TestCdcCompanionSeeding:
+    @parameterized.expand(
+        [
+            # The seed exists for exactly this: the companion starts as the snapshot's rows.
+            ("initial_snapshot_seeds", "both", False, None, True),
+            # The incident this guards: seeding resets the companion table, so re-running it on a
+            # streaming schema throws away every SCD2 version the stream has accumulated. A
+            # redelivered final batch reaches post-load with no write mode (the loader's
+            # already-processed path), which used to be indistinguishable from an initial load.
+            ("streaming_tick_without_write_mode_does_not_reseed", "both", True, None, False),
+            ("cdc_only_streaming_tick_does_not_reseed", "cdc_only", True, None, False),
+            # A consolidated schema has no companion table to seed.
+            ("consolidated_never_seeds", "consolidated", False, None, False),
+            # A companion write is the stream appending to the companion, never a reason to reset it.
+            ("companion_write_never_seeds", "both", False, "scd2_append", False),
+        ]
+    )
+    @pytest.mark.asyncio
+    async def test_seeds_only_on_the_initial_snapshot(
+        self,
+        _name: str,
+        cdc_table_mode: str,
+        initial_sync_complete: bool,
+        cdc_write_mode: str | None,
+        expect_seed: bool,
+    ) -> None:
+        schema = _make_schema(
+            is_cdc=True,
+            cdc_table_mode=cdc_table_mode,
+            initial_sync_complete=initial_sync_complete,
+        )
+
+        with patch(f"{_LOAD_MODULE}._seed_cdc_companion_from_snapshot", AsyncMock()) as seed:
+            await _run_post_load(schema, _make_helper(), cdc_write_mode=cdc_write_mode)
+
+        assert seed.await_count == (1 if expect_seed else 0)
 
 
 class TestGetIncrementalFieldValue:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
@@ -381,6 +381,7 @@ def _run_post_load_for_already_processed_batch(export_signal: ExportSignalMessag
             table_schema_dict=table_schema_dict,
             resource_name=export_signal.resource_name,
             logger=logger,
+            cdc_write_mode=export_signal.cdc_write_mode,
         )
 
         logger.debug("post_load_operations_complete_for_already_processed_batch")

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/test_processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/test_processor.py
@@ -23,6 +23,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
     _mark_job_completed,
     _promote_staged_cursor,
     _read_existing_rows_by_first_pk,
+    _run_post_load_for_already_processed_batch,
     _trigger_post_import_workflow,
     process_message,
 )
@@ -466,6 +467,40 @@ class TestMarkJobCompleted:
 
         mock_finish_row_tracking.assert_not_awaited()
         mock_release.assert_not_called()
+
+
+class TestRedeliveredFinalBatchPostLoad:
+    @parameterized.expand([("companion", "scd2_append"), ("consolidated", "incremental_merge"), ("snapshot", None)])
+    @patch(f"{_PROCESSOR}.run_post_load_operations", new_callable=AsyncMock, return_value="folder")
+    @patch(f"{_PROCESSOR}.read_parquet", return_value=pa.table({"id": [1]}))
+    @patch(f"{_PROCESSOR}.DeltaTableRef")
+    @patch(f"{_PROCESSOR}.ExternalDataJob")
+    @patch(f"{_PROCESSOR}.s3fs")
+    def test_forwards_the_batch_write_mode(
+        self,
+        _case: str,
+        cdc_write_mode: str | None,
+        _s3fs: MagicMock,
+        mock_job_model: MagicMock,
+        mock_helper_cls: MagicMock,
+        _read: MagicMock,
+        mock_post_load: AsyncMock,
+    ) -> None:
+        # Post-load derives the whole CDC branch from the write mode: whether this is a companion
+        # write (register the _cdc table, leave schema.table alone) or a snapshot to seed the
+        # companion from. Dropping it here let a redelivered streaming batch re-seed the companion,
+        # wiping its SCD2 history, and point schema.table at the companion's folder.
+        delta_table = MagicMock(schema=MagicMock(return_value=pa.schema([_COL_ID])))
+        mock_job_model.objects.prefetch_related.return_value.aget = AsyncMock(return_value=MagicMock())
+        mock_helper_cls.return_value.get_delta_table = AsyncMock(return_value=delta_table)
+
+        signal = MagicMock()
+        signal.cdc_write_mode = cdc_write_mode
+
+        _run_post_load_for_already_processed_batch(signal)
+
+        assert mock_post_load.await_args is not None
+        assert mock_post_load.await_args.kwargs["cdc_write_mode"] == cdc_write_mode
 
 
 class TestPostImportTrigger:


### PR DESCRIPTION
## Problem

- A CDC source with a `_cdc` companion table keeps no change history. The companion holds one row per key and no closed versions, however long the stream has run.
- The loader re-runs post-load when a final batch is redelivered, and that path dropped the batch's `cdc_write_mode`.
- Post-load read the missing write mode as "initial snapshot" and re-seeded the companion. Seeding resets the table first, so every accumulated SCD2 version was deleted.
- The same missing write mode also hid the companion from post-load, so a redelivered companion batch pointed `schema.table` at the companion's folder.
- Redelivery is routine. The loader's already-processed guard exists to tolerate it.

## Changes

- `_run_post_load_for_already_processed_batch` forwards `cdc_write_mode` from the export signal.
- Post-load gates seeding on `initial_sync_complete` rather than on the absence of a write mode.
- Forwarding alone was not enough. The initial snapshot's own final batch has no write mode, so a redelivery of that batch could still re-seed.
- Every resync path already clears `initial_sync_complete`, so the intended seed triggers are unchanged.

> [!NOTE]
> `cdc_table_mode="consolidated"` never seeds, so consolidated CDC sources were never affected. The companion modes (`both`, `cdc_only`) are not in customer use yet.

## How did you test this code?

- New parameterized test in `test_load.py`: seeding happens only on the initial snapshot. The redelivered-streaming-tick case fails on master.
- New test in `test_processor.py`: the already-processed path forwards the write mode. This guards the wiring between the two halves of the fix.
- I ran the warehouse-sources pipelines suite, the CDC suite, and repo-wide mypy locally.
- Not run: the end-to-end suites that need the full dev stack. No manual testing against a live source.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- I (actually Claude, Opus 5 in Claude Code) traced this from a production log sequence showing `cdc_seed_check` firing twice per run, once with a null write mode, then found the caller that drops it.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- My first fix forwarded the write mode only. I added the `initial_sync_complete` gate after working out that the snapshot's own final batch stays exposed under redelivery.
- I also drafted a script to rebuild lost history from the CDC S3 change buffer, then dropped it. The affected schemas belong to a test source, so there was no history worth recovering.
- Separately noted for follow-up, not fixed here: the same queue batch reaches two loader pods with the attempt counter still at 1. The loader tolerates that by design, but it is what triggered this bug.
- Public artifact: the diff is code and tests only. Nothing from the session that is not already public reached this PR.
