### PR TITLE
feat(aio): reclaim PostHog AI sandboxes after 10 minutes idle

### DIFF
--- a/products/tasks/backend/temporal/constants.py
+++ b/products/tasks/backend/temporal/constants.py
@@ -39,8 +39,23 @@ LOOP_RUN_IDLE_TIMEOUT_SECONDS = 2 * 60  # 2 minutes
 # cap is never mistaken for a zombie.
 LOOP_RUN_STALE_SECONDS = MAX_INACTIVITY_TIMEOUT_SECONDS + 30 * 60  # 2.5 hours
 
+# PostHog AI runs are chat-shaped: a human sends a message, reads the reply, and either
+# follows up within a couple of minutes or walks away. Holding the sandbox for the full
+# background window bills idle compute for the walk-away case, and a follow-up that lands
+# after the window is cheap now that a fresh sandbox rebuilds the prior session from the
+# run log (`@posthog/agent` hydrates it and resumes natively) rather than replaying a
+# summary of the conversation.
+POSTHOG_AI_IDLE_TIMEOUT_SECONDS = 10 * 60  # 10 minutes
 
-def resolve_inactivity_timeout(*, is_user_origin: bool = False, state: dict | None = None) -> timedelta:
+# `Task.OriginProduct.POSTHOG_AI.value`, inlined: this module is imported at module scope by
+# the Temporal workflow definitions, which must not pull in Django models. Kept honest by
+# `test_posthog_ai_origin_constant_matches_model_enum`.
+POSTHOG_AI_ORIGIN_PRODUCT = "posthog_ai"
+
+
+def resolve_inactivity_timeout(
+    *, is_user_origin: bool = False, origin_product: str | None = None, state: dict | None = None
+) -> timedelta:
     """Effective inactivity timeout for a task run, in priority order.
 
     1. A per-task override stored at creation time (`inactivity_timeout_seconds`),
@@ -49,7 +64,11 @@ def resolve_inactivity_timeout(*, is_user_origin: bool = False, state: dict | No
     2. The `TASKS_INACTIVITY_TIMEOUT_SECONDS` env var (global fallback, e.g.
        `=30` to force a fast shutdown for local resume-flow testing).
     3. The test default (short, so orphaned runs don't pin a worker).
-    4. The origin-aware production default (longer for user-driven runs).
+    4. The origin-aware production default (longer for user-driven runs, shorter for
+       PostHog AI's chat-shaped ones).
+
+    `origin_product` narrows step 4 only. It stays a plain string so callers can pass
+    `task.origin_product` straight through without this module importing Django models.
     """
     per_task = (state or {}).get("inactivity_timeout_seconds")
     if isinstance(per_task, int | float) and not isinstance(per_task, bool) and per_task > 0:
@@ -58,6 +77,8 @@ def resolve_inactivity_timeout(*, is_user_origin: bool = False, state: dict | No
         return timedelta(seconds=settings.TASKS_INACTIVITY_TIMEOUT_SECONDS)
     if settings.TEST:
         return timedelta(seconds=INACTIVITY_TIMEOUT_TEST_SECONDS)
+    if origin_product == POSTHOG_AI_ORIGIN_PRODUCT:
+        return timedelta(seconds=POSTHOG_AI_IDLE_TIMEOUT_SECONDS)
     return timedelta(seconds=INACTIVITY_TIMEOUT_USER_SECONDS if is_user_origin else INACTIVITY_TIMEOUT_DEFAULT_SECONDS)
 
 

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -209,7 +209,9 @@ class TaskProcessingContext:
 
     def inactivity_timeout(self) -> timedelta:
         """Idle time before the workflow times the run out; longer for user-driven runs."""
-        return resolve_inactivity_timeout(is_user_origin=self._is_user_origin(), state=self.state)
+        return resolve_inactivity_timeout(
+            is_user_origin=self._is_user_origin(), origin_product=self.origin_product, state=self.state
+        )
 
     def _is_user_origin(self) -> bool:
         return not self.origin_product or self.origin_product in (

--- a/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
@@ -124,7 +124,7 @@ async def _relay_sandbox_events(input: RelaySandboxEventsInput, *, finalize_stre
     origin_product = task_run.task.origin_product
     is_user_origin = not origin_product or origin_product == TaskModel.OriginProduct.USER_CREATED.value
     inactivity_timeout_seconds = resolve_inactivity_timeout(
-        is_user_origin=is_user_origin, state=task_run.state
+        is_user_origin=is_user_origin, origin_product=origin_product, state=task_run.state
     ).total_seconds()
 
     stream_key = get_task_run_stream_key(input.run_id)

--- a/products/tasks/backend/temporal/process_task/tests/test_inactivity_timeout.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_inactivity_timeout.py
@@ -4,31 +4,56 @@ from django.test import SimpleTestCase, override_settings
 
 from parameterized import parameterized
 
+from products.tasks.backend.models import Task
 from products.tasks.backend.temporal.constants import (
     INACTIVITY_TIMEOUT_DEFAULT_SECONDS,
     INACTIVITY_TIMEOUT_TEST_SECONDS,
     INACTIVITY_TIMEOUT_USER_SECONDS,
     MAX_INACTIVITY_TIMEOUT_SECONDS,
+    POSTHOG_AI_IDLE_TIMEOUT_SECONDS,
+    POSTHOG_AI_ORIGIN_PRODUCT,
     resolve_inactivity_timeout,
 )
+from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import TaskProcessingContext
 
 
 class TestResolveInactivityTimeout(SimpleTestCase):
     @parameterized.expand(
         [
-            ("user_origin", True, INACTIVITY_TIMEOUT_USER_SECONDS),
-            ("non_user_origin", False, INACTIVITY_TIMEOUT_DEFAULT_SECONDS),
+            ("user_origin", True, None, INACTIVITY_TIMEOUT_USER_SECONDS),
+            ("non_user_origin", False, "signals_scout", INACTIVITY_TIMEOUT_DEFAULT_SECONDS),
+            ("posthog_ai", False, POSTHOG_AI_ORIGIN_PRODUCT, POSTHOG_AI_IDLE_TIMEOUT_SECONDS),
         ]
     )
     @override_settings(TEST=False, TASKS_INACTIVITY_TIMEOUT_SECONDS=0)
-    def test_production_default_depends_on_origin(self, _name, is_user_origin, expected_seconds):
-        result = resolve_inactivity_timeout(is_user_origin=is_user_origin)
+    def test_production_default_depends_on_origin(self, _name, is_user_origin, origin_product, expected_seconds):
+        result = resolve_inactivity_timeout(is_user_origin=is_user_origin, origin_product=origin_product)
         self.assertEqual(result, timedelta(seconds=expected_seconds))
+
+    def test_posthog_ai_origin_constant_matches_model_enum(self):
+        self.assertEqual(POSTHOG_AI_ORIGIN_PRODUCT, Task.OriginProduct.POSTHOG_AI.value)
+
+    @override_settings(TEST=False, TASKS_INACTIVITY_TIMEOUT_SECONDS=0)
+    def test_context_forwards_its_origin_to_the_resolver(self):
+        # Guards the wiring, not the resolver: dropping `origin_product=` at this call site
+        # would leave every resolver case green while PostHog AI silently fell back to 30 minutes.
+        context = TaskProcessingContext(
+            task_id="task-id",
+            run_id="run-id",
+            team_id=1,
+            team_uuid="team-uuid",
+            organization_id="org-id",
+            github_integration_id=123,
+            repository="explore-science/paper-wizard-frontend",
+            distinct_id="distinct",
+            origin_product=POSTHOG_AI_ORIGIN_PRODUCT,
+        )
+        self.assertEqual(context.inactivity_timeout(), timedelta(seconds=POSTHOG_AI_IDLE_TIMEOUT_SECONDS))
 
     @override_settings(TEST=True, TASKS_INACTIVITY_TIMEOUT_SECONDS=0)
     def test_test_default_is_short_regardless_of_origin(self):
-        for is_user_origin in (True, False):
-            result = resolve_inactivity_timeout(is_user_origin=is_user_origin)
+        for is_user_origin, origin_product in ((True, None), (False, None), (False, POSTHOG_AI_ORIGIN_PRODUCT)):
+            result = resolve_inactivity_timeout(is_user_origin=is_user_origin, origin_product=origin_product)
             self.assertEqual(result, timedelta(seconds=INACTIVITY_TIMEOUT_TEST_SECONDS))
 
     @override_settings(TEST=False, TASKS_INACTIVITY_TIMEOUT_SECONDS=42)


### PR DESCRIPTION
## Problem

A PostHog AI sandbox keeps running for 30 minutes after the person stops chatting, billing idle compute for every conversation someone walks away from.

- PostHog AI runs are chat-shaped: one message, one reply, then a quick follow-up or nothing.
- The `posthog_ai` origin is not `USER_CREATED`, so these runs take the 30-minute background default.
- That window only paid for itself while resuming on a fresh sandbox was expensive.

## Changes

`posthog_ai`-origin runs now idle out after 10 minutes instead of 30.

| Origin | Before | After |
| --- | --- | --- |
| `user_created`, or none | 1 hour | unchanged |
| `posthog_ai` | 30 minutes | 10 minutes |
| every other origin | 30 minutes | unchanged |

- The new branch sits at step 4 of `resolve_inactivity_timeout`, below every override.
- A per-task `inactivity_timeout_seconds`, `TASKS_INACTIVITY_TIMEOUT_SECONDS`, and the test default all still win.
- `TaskProcessingContext` and the relay activity forward `origin_product` to the resolver.
- The origin string is inlined in `constants.py` because Temporal workflow modules import it and must not pull in Django models.

Shortening the window is only safe because a follow-up landing on a dead sandbox is now cheap. `@posthog/agent` rebuilds the prior Claude session from the run log and resumes it natively (`prepareNativeResume` and `hydrateSessionJsonl`, 2.4.34). Earlier versions replayed a summary of the conversation into the next turn instead.

> [!NOTE]
> `SANDBOX_TTL_SECONDS` (6 hours) is unchanged, and this PR is not a TTL change. That value is a provider kill deadline measured from sandbox creation, not an idle timer, so lowering it would terminate live runs mid-turn across every product that uses tasks.

In-flight runs deployed over may take the new 10-minute timer on their next wait, because the context recomputes the value rather than reading it from history. The timer position in the workflow does not change, so this is a duration change, not a command-sequence change.

## How did you test this code?

Three additions to `test_inactivity_timeout`, each naming a regression nothing else caught:

- A parameterized `posthog_ai` case: catches a branch reorder that would silently restore the 30-minute window.
- A constant-versus-enum guard: the origin string is inlined, so renaming `Task.OriginProduct.POSTHOG_AI` would otherwise go unnoticed.
- A context wiring guard: I removed the new `origin_product=` argument and confirmed the test fails with `1800 != 600`.

I ran the resolver, relay activity, `execute_sandbox` workflow, and sandbox-resource-override suites locally.

Not verified: reclaim behavior against a live Modal sandbox. I did not run the dev stack, so the 10-minute window is checked at the resolver and context, not end to end.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior, API, or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude Opus 5, in Claude Code) wrote this.

The original ask was to reduce the PostHog AI sandbox TTL to 10 minutes. Reading the code showed `SANDBOX_TTL_SECONDS` is a hard provider kill deadline from creation and global to every tasks-based product, so 10 minutes there would have killed live runs mid-turn. I raised that, and we agreed to move the 10 minutes onto the inactivity window instead, which is what actually governs how long a PostHog AI sandbox lingers.

The premise behind the original ask was that a killed sandbox made the agent replay a conversation summary on the next start. I checked that against the published `@posthog/agent` package rather than the dev stack, and ran `hydrateSessionJsonl` from its shipped build with no session file on disk. It rebuilt the transcript from the run log and reported `hasSession: true`, which routes resume down the native path and skips the summary block. The summary path still exists as a fallback, most notably for Codex on a fresh sandbox.

Skills invoked: `/writing-tests` (gated the three test additions), `/writing-pr-descriptions` (this body).
