### PR TITLE
fix(replay): allow personal API key access to playlist recording endpoints

### DIFF
--- a/posthog/session_recordings/session_recording_playlist_api.py
+++ b/posthog/session_recordings/session_recording_playlist_api.py
@@ -631,6 +631,15 @@ class SessionRecordingPlaylistViewSet(
 ):
     scope_object = "session_recording_playlist"
     scope_object_read_actions = ["list", "retrieve", "recordings"]
+    scope_object_write_actions = [
+        "create",
+        "update",
+        "partial_update",
+        "patch",
+        "modify_recordings",
+        "bulk_add_recordings",
+        "bulk_delete_recordings",
+    ]
     queryset = SessionRecordingPlaylist.objects.all()
     serializer_class = SessionRecordingPlaylistSerializer
     throttle_classes = [ClickHouseBurstRateThrottle, ClickHouseSustainedRateThrottle]

--- a/posthog/session_recordings/test/test_session_recording_playlist.py
+++ b/posthog/session_recordings/test/test_session_recording_playlist.py
@@ -1404,6 +1404,42 @@ class TestSessionRecordingPlaylistPersonalAPIKey(APIBaseTest):
 
     @parameterized.expand(
         [
+            ("create", "", {"name": "new playlist", "type": "collection"}, status.HTTP_201_CREATED),
+            ("add_recording", "/{short_id}/recordings/test_session_id", None, status.HTTP_200_OK),
+            (
+                "bulk_add",
+                "/{short_id}/recordings/bulk_add",
+                {"session_recording_ids": ["test_session_id"]},
+                status.HTTP_200_OK,
+            ),
+            (
+                "bulk_delete",
+                "/{short_id}/recordings/bulk_delete",
+                {"session_recording_ids": ["test_session_id"]},
+                status.HTTP_200_OK,
+            ),
+        ]
+    )
+    def test_personal_api_key_can_access_write_endpoints(
+        self, _name: str, path_suffix: str, data: dict | None, expected_status: int
+    ) -> None:
+        playlist = SessionRecordingPlaylist.objects.create(
+            team=self.team,
+            name="test playlist",
+            created_by=self.user,
+            type=SessionRecordingPlaylist.PlaylistType.COLLECTION,
+        )
+        personal_api_key = self._create_personal_api_key(["session_recording_playlist:write"])
+        url = (
+            f"/api/projects/{self.team.pk}/session_recording_playlists{path_suffix.format(short_id=playlist.short_id)}"
+        )
+
+        response = self.client.post(url, data, headers={"authorization": f"Bearer {personal_api_key}"})
+
+        assert response.status_code == expected_status
+
+    @parameterized.expand(
+        [
             ("wrong_scope", ["some_other_scope:read"], None),
             ("wrong_team", ["session_recording_playlist:read"], "other_team"),
         ]

--- a/posthog/session_recordings/test/test_session_recording_playlist.py
+++ b/posthog/session_recordings/test/test_session_recording_playlist.py
@@ -1440,6 +1440,32 @@ class TestSessionRecordingPlaylistPersonalAPIKey(APIBaseTest):
 
     @parameterized.expand(
         [
+            ("create", "", {"name": "new playlist", "type": "collection"}),
+            ("add_recording", "/{short_id}/recordings/test_session_id", None),
+            ("bulk_add", "/{short_id}/recordings/bulk_add", {"session_recording_ids": ["test_session_id"]}),
+            ("bulk_delete", "/{short_id}/recordings/bulk_delete", {"session_recording_ids": ["test_session_id"]}),
+        ]
+    )
+    def test_personal_api_key_with_read_scope_denied_on_write_endpoints(
+        self, _name: str, path_suffix: str, data: dict | None
+    ) -> None:
+        playlist = SessionRecordingPlaylist.objects.create(
+            team=self.team,
+            name="test playlist",
+            created_by=self.user,
+            type=SessionRecordingPlaylist.PlaylistType.COLLECTION,
+        )
+        personal_api_key = self._create_personal_api_key(["session_recording_playlist:read"])
+        url = (
+            f"/api/projects/{self.team.pk}/session_recording_playlists{path_suffix.format(short_id=playlist.short_id)}"
+        )
+
+        response = self.client.post(url, data, headers={"authorization": f"Bearer {personal_api_key}"})
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @parameterized.expand(
+        [
             ("wrong_scope", ["some_other_scope:read"], None),
             ("wrong_team", ["session_recording_playlist:read"], "other_team"),
         ]


### PR DESCRIPTION
## Problem

Adding or removing recordings on a session recording playlist with a personal API key fails with a 403, "This action does not support personal API key access", no matter which scopes the key has. Reported by a customer via support.

- The custom actions `modify_recordings`, `bulk_add_recordings`, and `bulk_delete_recordings` were never listed in `scope_object_write_actions` on the playlist viewset.
- The scope permission layer maps an action to a required scope through that list. An unlisted action gets no scope, and the layer rejects every API key.
- Creating a playlist and listing its recordings already worked, because those are default or registered actions.

## Changes

- Registers the three recording actions as write actions, so a key with `session_recording_playlist:write` can add and remove recordings, including via `bulk_add` and `bulk_delete`.
- Re-declares the default write actions (`create`, `update`, `partial_update`, `patch`) in the same list, because declaring `scope_object_write_actions` replaces the default list rather than extending it. `destroy` stays out, the viewset forbids it.

No frontend or schema change. `scope_object_write_actions` is a permissions attribute, not part of the OpenAPI spec.

## How did you test this code?

- Added a parameterized test: a personal API key with `session_recording_playlist:write` succeeds on create, single add, `bulk_add`, and `bulk_delete`. Before the fix, the three recording cases return 403. The create case guards against a future edit trimming the override and dropping default write access.
- Ran the full playlist API test file locally, all passing.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The documented playlist endpoints now behave as the API docs already describe.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code from a support conversation about the 403. Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-pr-descriptions`. The description contains no customer material; the failing endpoint and error message are reproducible from the public API alone. Mid-session correction: the first draft of the fix listed only the three custom actions, which would have dropped API key access to `create` and `update`, because the override replaces the defaults.
