### PR TITLE
fix(aio): add vite alias for @posthog/llm-normalizer

### DIFF
--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -69,9 +69,12 @@ export default defineConfig(({ mode }) => {
                 public: resolve(__dirname, 'src/assets'),
                 // Required for production builds — @posthog/icons is in the pnpm store, not node_modules root
                 '@posthog/icons': resolve(__dirname, 'node_modules/@posthog/icons'),
-                // Source-only workspace package (main is src/index.ts) — Vite can't resolve it by
-                // default when imported from products/*/frontend, same as the @posthog/icons case above
-                '@posthog/llm-normalizer': resolve(__dirname, 'node_modules/@posthog/llm-normalizer'),
+                // Source-only workspace package (exports map points at src/*.ts) — Vite can't resolve
+                // it by default when imported from products/*/frontend, like the @posthog/icons case above.
+                // Alias each export explicitly, subpath first: a lone package-root alias would rewrite the
+                // '@posthog/llm-normalizer/types' import to a nonexistent path instead of src/types.ts.
+                '@posthog/llm-normalizer/types': resolve(__dirname, 'node_modules/@posthog/llm-normalizer/src/types.ts'),
+                '@posthog/llm-normalizer': resolve(__dirname, 'node_modules/@posthog/llm-normalizer/src/index.ts'),
                 // These @tiptap packages live only in frontend/node_modules, which products/*/frontend
                 // files can't reach by walking up from their own directory. Alias each package
                 // individually: a blanket '@tiptap' prefix would also rewrite the imports *inside*

--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -69,6 +69,9 @@ export default defineConfig(({ mode }) => {
                 public: resolve(__dirname, 'src/assets'),
                 // Required for production builds — @posthog/icons is in the pnpm store, not node_modules root
                 '@posthog/icons': resolve(__dirname, 'node_modules/@posthog/icons'),
+                // Source-only workspace package (main is src/index.ts) — Vite can't resolve it by
+                // default when imported from products/*/frontend, same as the @posthog/icons case above
+                '@posthog/llm-normalizer': resolve(__dirname, 'node_modules/@posthog/llm-normalizer'),
                 // These @tiptap packages live only in frontend/node_modules, which products/*/frontend
                 // files can't reach by walking up from their own directory. Alias each package
                 // individually: a blanket '@tiptap' prefix would also rewrite the imports *inside*


### PR DESCRIPTION
## Problem

Running the frontend dev server or build fails on master with `Failed to resolve import "@posthog/llm-normalizer" from "products/ai_observability/frontend/settings/parserRecipesLogic.ts"`. The import was added in #72943, but no matching Vite resolve alias was.

`@posthog/llm-normalizer` is a source-only workspace package — its `main` is `src/index.ts` with no build output. Vite does not resolve packages like this by default when they are imported from `products/*/frontend`, which is why the other `@posthog/*` source packages (`@posthog/lemon-ui`, `@posthog/icons`) already have explicit aliases in `frontend/vite.config.mts`.

## Changes

- Add a Vite resolve alias for `@posthog/llm-normalizer`, matching the existing `@posthog/icons` alias.

## How did you test this code?

Not verified in a running build by the agent. The fix mirrors the established `@posthog/icons` alias pattern in the same file, and matches the workaround multiple developers confirmed fixes their local build.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed from a Slack thread where developers hit the unresolved-import error on master. Initial guess (stale local deps) was wrong; inspecting `frontend/vite.config.mts` showed source-only `@posthog/*` workspace packages need explicit aliases, and the new import shipped without one. No skills required for a one-line config alias.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09ADEV3AJD/p1786633749516159)*
