### PR TITLE
fix(data-imports): stop reporting admin-shutdown queue DB disconnects to error tracking

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
@@ -103,6 +103,15 @@ def _is_connect_timeout_error(error: BaseException) -> bool:
     return isinstance(error, psycopg.errors.ConnectionTimeout)
 
 
+# SQLSTATE 57P01: the queue DB itself terminated the connection via an administrator
+# command — a managed-Postgres failover, a maintenance restart, or an explicit
+# pg_terminate_backend(). Same self-healing shape as the guards above: the connection
+# is simply gone, _ensure_poll_conn/_ensure_recovery_conn redial on the next cycle, and
+# the caller's existing retry/backoff already covers the gap.
+def _is_admin_shutdown_error(error: BaseException) -> bool:
+    return isinstance(error, psycopg.errors.AdminShutdown)
+
+
 class OwnershipLostError(Exception):
     """Raised when the group lease for a (team_id, schema_id) is no longer held by this consumer."""
 
@@ -489,6 +498,8 @@ class BatchConsumer:
                         logger.warning(self._event("poll_failed_queue_db_starting_up"), error=str(e))
                     elif _is_connect_timeout_error(e):
                         logger.warning(self._event("poll_failed_queue_db_connect_timeout"), error=str(e))
+                    elif _is_admin_shutdown_error(e):
+                        logger.warning(self._event("poll_failed_queue_db_admin_shutdown"), error=str(e))
                     else:
                         logger.exception(self._event("poll_failed_queue_db_unreachable"))
                         capture_exception(e)
@@ -1088,6 +1099,8 @@ class BatchConsumer:
                     logger.warning(self._event("recovery_sweep_db_starting_up"), error=str(e))
                 elif _is_connect_timeout_error(e):
                     logger.warning(self._event("recovery_sweep_connect_timeout"), error=str(e))
+                elif _is_admin_shutdown_error(e):
+                    logger.warning(self._event("recovery_sweep_admin_shutdown"), error=str(e))
                 else:
                     logger.exception(self._event("recovery_sweep_error"))
                     capture_exception(e)
@@ -1114,6 +1127,8 @@ class BatchConsumer:
                         logger.warning(self._event("reconcile_sweep_db_starting_up"), error=str(e))
                     elif _is_connect_timeout_error(e):
                         logger.warning(self._event("reconcile_sweep_connect_timeout"), error=str(e))
+                    elif _is_admin_shutdown_error(e):
+                        logger.warning(self._event("reconcile_sweep_admin_shutdown"), error=str(e))
                     else:
                         logger.exception(self._event("reconcile_sweep_error"))
                         capture_exception(e)

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
@@ -15,6 +15,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.batch_consumer import (
     OwnershipLostError,
+    _is_admin_shutdown_error,
     _is_connect_timeout_error,
     _is_dns_resolution_transient_error,
     _is_server_not_ready_error,
@@ -744,6 +745,135 @@ class TestConnectTimeoutErrorClassification:
             patch(
                 "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_stale_executing",
                 side_effect=raise_connect_timeout,
+            ),
+            patch.object(consumer, "_reconcile_failed_runs", new_callable=AsyncMock),
+            patch(f"{batch_consumer_module.__name__}.capture_exception") as mock_capture,
+        ):
+            loop_task = asyncio.create_task(consumer._recovery_loop())
+            await asyncio.wait_for(swept.wait(), timeout=2.0)
+            consumer._shutdown.set()
+            await asyncio.wait_for(loop_task, timeout=5.0)
+
+        mock_capture.assert_not_called()
+
+
+class TestAdminShutdownErrorClassification:
+    def test_classifies_admin_shutdown(self) -> None:
+        assert (
+            _is_admin_shutdown_error(
+                psycopg.errors.AdminShutdown("terminating connection due to administrator command")
+            )
+            is True
+        )
+
+    def test_ignores_other_operational_errors(self) -> None:
+        # A generic OperationalError carrying similar wording is not the same as psycopg's
+        # dedicated AdminShutdown class (SQLSTATE 57P01) and must not be misclassified.
+        assert (
+            _is_admin_shutdown_error(psycopg.OperationalError("terminating connection due to administrator command"))
+            is False
+        )
+
+    @pytest.mark.asyncio
+    async def test_recovery_loop_does_not_report_admin_shutdown_error(self):
+        # Reproduces the reported issue: the queue DB terminates the recovery connection
+        # via an administrator command (failover, maintenance restart) while the periodic
+        # reconcile sweep is running. The sweep already retries every interval, so this
+        # self-healing disconnect must not be sent to error tracking.
+        config = ConsumerConfig(
+            database_url="postgres://unused:unused@localhost/unused",
+            recovery_interval_seconds=0.01,
+            reconcile_interval_seconds=0,
+        )
+        consumer = BatchConsumer(config=config, process_batch=AsyncMock())
+        consumer._recovery_conn = _make_healthy_conn()
+
+        second_reconcile_started = asyncio.Event()
+        call_count = 0
+
+        async def flaky_reconcile() -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise psycopg.errors.AdminShutdown("terminating connection due to administrator command")
+            second_reconcile_started.set()
+
+        with (
+            patch.object(consumer, "_recovery_sweep_with_timeout", new_callable=AsyncMock),
+            patch.object(consumer, "_reconcile_failed_runs", side_effect=flaky_reconcile),
+            patch(f"{batch_consumer_module.__name__}.capture_exception") as mock_capture,
+        ):
+            loop_task = asyncio.create_task(consumer._recovery_loop())
+            await asyncio.wait_for(second_reconcile_started.wait(), timeout=2.0)
+            consumer._shutdown.set()
+            await asyncio.wait_for(loop_task, timeout=5.0)
+
+        mock_capture.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_poll_failure_does_not_report_admin_shutdown_error(self):
+        # Same self-healing admin-initiated disconnect as above, but hit directly by the
+        # main poll loop's own OperationalError branch — reproduces the reported issue's
+        # exact stack (get_unprocessed_and_lock raising mid-query).
+        config = ConsumerConfig(
+            database_url="postgres://unused:unused@localhost/unused",
+            poll_interval_seconds=0.01,
+        )
+        consumer = BatchConsumer(config=config, process_batch=AsyncMock())
+
+        second_poll_started = asyncio.Event()
+        fetch_calls = 0
+
+        async def flaky_fetch(*args: Any, **kwargs: Any) -> list[PendingBatch]:
+            nonlocal fetch_calls
+            fetch_calls += 1
+            if fetch_calls == 1:
+                raise psycopg.errors.AdminShutdown("terminating connection due to administrator command")
+            second_poll_started.set()
+            return []
+
+        with (
+            patch.object(
+                consumer, "_connect", new_callable=AsyncMock, side_effect=lambda **kwargs: _make_healthy_conn()
+            ),
+            patch.object(consumer, "_install_signal_handlers"),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_stale_executing",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_unprocessed_and_lock",
+                side_effect=flaky_fetch,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.release_all_owned_leases",
+                new_callable=AsyncMock,
+            ),
+            patch(f"{batch_consumer_module.__name__}.capture_exception") as mock_capture,
+        ):
+            run_task = asyncio.create_task(consumer.run())
+            await asyncio.wait_for(second_poll_started.wait(), timeout=2.0)
+            consumer._shutdown.set()
+            await asyncio.wait_for(run_task, timeout=5.0)
+
+        mock_capture.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_recovery_sweep_does_not_report_admin_shutdown_error(self):
+        # Same self-healing admin-initiated disconnect, but hit by the periodic recovery
+        # sweep's own OperationalError branch rather than the reconcile sweep.
+        consumer = _make_consumer(recovery_interval_seconds=0.01)
+        swept = asyncio.Event()
+
+        async def raise_admin_shutdown(*args: Any, **kwargs: Any) -> list[PendingBatch]:
+            swept.set()
+            raise psycopg.errors.AdminShutdown("terminating connection due to administrator command")
+
+        with (
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_stale_executing",
+                side_effect=raise_admin_shutdown,
             ),
             patch.object(consumer, "_reconcile_failed_runs", new_callable=AsyncMock),
             patch(f"{batch_consumer_module.__name__}.capture_exception") as mock_capture,


### PR DESCRIPTION
## Problem

The warehouse batch consumer's queue-DB poll loop raised a bogus bug report every time the queue database dropped a connection via an administrator command (a managed-Postgres failover or maintenance restart). [This error-tracking issue](https://us.posthog.com/project/2/error_tracking/019ffbba-48e6-7b50-9cf3-8b40b0c3d41e) shows `AdminShutdown: terminating connection due to administrator command` raised from `get_unprocessed_and_lock`, deep in the internal Postgres-backed job queue used by `pipeline_v3`'s batch consumer - not a customer source connection.

The consumer already retries this class of failure correctly: the connection is dropped, redialed on the next cycle, and polling resumes with backoff. Several sibling connection failures (DNS blips, "server not ready", connect timeouts) are already classified as self-healing and only logged as warnings. `AdminShutdown` fell through that classification into the generic branch that also calls `capture_exception`, so a fully-recovered, expected event still landed as a false-positive bug.

## Changes

- Add `_is_admin_shutdown_error`, matching `psycopg.errors.AdminShutdown` (SQLSTATE 57P01), alongside the existing DNS/server-not-ready/connect-timeout classifiers in `batch_consumer.py`.
- Wire the new classifier into the three places that already special-case those sibling errors: the main poll loop, the periodic recovery sweep, and the reconcile sweep.
- No retry behavior changes - this only stops a self-healing, already-retried disconnect from being sent to error tracking.

## How did you test this code?

Added 5 tests to `test_consumer.py`, mirroring the existing `TestConnectTimeoutErrorClassification` pattern:
- 2 unit tests for `_is_admin_shutdown_error` (classifies `psycopg.errors.AdminShutdown`, does not misclassify a generic `OperationalError` with similar text).
- 3 reproduction tests, one per call site (poll loop, recovery sweep, reconcile sweep), asserting `capture_exception` is not called when `AdminShutdown` is raised and that the loop continues to the next cycle.

Ran locally:
- `pytest products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py` - 119 passed.
- `ruff check` / `ruff format` - clean.
- `mypy` on the changed file - clean. (Full repo-wide `mypy --cache-fine-grained .` timed out locally after ~5 minutes; not run to completion, deferring to CI for the repo-wide check.)

Not run: no manual/live reproduction against a real queue-DB failover - the classifier is a pure function and the reproduction tests exercise the exact call sites via mocks.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal error-classification behavior, no user-facing or documented workflow change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude Code) triaged an error-tracking issue end to end: pulled the issue and a sample event via the PostHog MCP error-tracking tools, read the full stack trace, and confirmed via event properties (`feature: management_command`, no `warehouse_sources_*` properties) that this fires against PostHog's own internal queue database, not a customer source. I read `batch_consumer.py` and found the existing pattern of three sibling classifiers (`_is_dns_resolution_transient_error`, `_is_server_not_ready_error`, `_is_connect_timeout_error`) already used to suppress `capture_exception` for self-healing queue-DB disconnects, confirmed `AdminShutdown` is a `psycopg.OperationalError` subclass that falls through to the noisy branch, and added a fourth classifier following the same shape.

Skills invoked: `/investigating-error-issue` (issue triage), `/writing-tests` (test-value gate before adding the 5 new tests), `/writing-pr-descriptions` (this body).

I searched open PRs (excluding the `app/posthog` bot, and separately the maintainer's own open PRs) for `AdminShutdown`, `"administrator command"`, `batch_consumer`, and `jobs_db` - no matches, so this is not a duplicate.