### PR TITLE
fix(tasks): comment slack dm duplication, desktop link, settings home

### DIFF
--- a/frontend/src/scenes/appScenes.ts
+++ b/frontend/src/scenes/appScenes.ts
@@ -123,6 +123,7 @@ export const appScenes: Record<Scene | string, () => any> = {
     [Scene.Unsubscribe]: () => import('./Unsubscribe/Unsubscribe'),
     [Scene.CodeCanvasLink]: () => import('./code-canvas/CodeCanvasLink'),
     [Scene.CodeChannelLink]: () => import('./code-canvas/CodeChannelLink'),
+    [Scene.CodeTaskLink]: () => import('./code-canvas/CodeTaskLink'),
     [Scene.VercelConnect]: () => import('./authentication/vercel/VercelConnect'),
     [Scene.VercelLinkError]: () => import('./authentication/vercel/VercelLinkError'),
     [Scene.AgenticAccountMismatch]: () => import('./authentication/account/AgenticAccountMismatch'),

--- a/frontend/src/scenes/code-canvas/CodeTaskLink.tsx
+++ b/frontend/src/scenes/code-canvas/CodeTaskLink.tsx
@@ -1,0 +1,69 @@
+import { useEffect } from 'react'
+
+import { IconLaptop } from '@posthog/icons'
+
+import { BridgePage } from 'lib/components/BridgePage/BridgePage'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { SceneExport } from 'scenes/sceneTypes'
+
+import { DESKTOP_SCHEME } from './desktopScheme'
+
+export interface CodeTaskLinkProps {
+    taskId: string
+}
+
+export const scene: SceneExport<CodeTaskLinkProps> = {
+    component: CodeTaskLink,
+    paramsToProps: ({ params: { taskId } }) => ({
+        taskId: taskId ?? '',
+    }),
+}
+
+/**
+ * Public, unauthenticated bridge for desktop-app "task" share links (`/code/task/<taskId>`),
+ * used by notifications sent outside the app (e.g. comment Slack DMs). On mount it deep-links
+ * into the desktop app via the `posthog-code(-dev)://` custom scheme; for visitors without the
+ * app it shows an explanation, a manual "open" button (in case the browser blocks the
+ * auto-redirect), and a download link.
+ */
+export function CodeTaskLink({ taskId }: CodeTaskLinkProps): JSX.Element {
+    // Null when the task id is missing (a partial URL or params not yet resolved), since firing
+    // with an empty id would send a malformed `<scheme>://task/`.
+    const deepLink = taskId ? `${DESKTOP_SCHEME}://task/${encodeURIComponent(taskId)}` : null
+
+    useEffect(() => {
+        if (deepLink) {
+            window.location.href = deepLink
+        }
+    }, [deepLink])
+
+    return (
+        <BridgePage view="code-task-link">
+            <div className="flex flex-col items-center gap-4 text-center max-w-lg mx-auto">
+                <IconLaptop className="text-5xl shrink-0" />
+                <h2 className="text-xl font-semibold m-0">Opening in PostHog Desktop…</h2>
+                <p className="text-muted mb-0">
+                    This task lives in the PostHog Desktop app. If it's installed, it should open automatically. If it
+                    didn't, use the button below, or download the app.
+                </p>
+                <div className="flex flex-col items-center gap-2">
+                    {deepLink && (
+                        <LemonButton
+                            type="primary"
+                            onClick={() => {
+                                window.location.href = deepLink
+                            }}
+                        >
+                            Open in PostHog Desktop
+                        </LemonButton>
+                    )}
+                    <LemonButton type="secondary" to="https://posthog.com/desktop" targetBlank>
+                        Download PostHog Desktop
+                    </LemonButton>
+                </div>
+            </div>
+        </BridgePage>
+    )
+}
+
+export default CodeTaskLink

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -186,6 +186,7 @@ export enum Scene {
     Unsubscribe = 'Unsubscribe',
     CodeCanvasLink = 'CodeCanvasLink',
     CodeChannelLink = 'CodeChannelLink',
+    CodeTaskLink = 'CodeTaskLink',
     UserInterview = 'UserInterview',
     UserInterviewResponse = 'UserInterviewResponse',
     UserInterviews = 'UserInterviews',

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -540,6 +540,7 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
     [Scene.Unsubscribe]: { allowUnauthenticated: true, layout: 'app-raw' },
     [Scene.CodeCanvasLink]: { allowUnauthenticated: true, layout: 'app-raw' },
     [Scene.CodeChannelLink]: { allowUnauthenticated: true, layout: 'app-raw' },
+    [Scene.CodeTaskLink]: { allowUnauthenticated: true, layout: 'app-raw' },
     [Scene.VerifyEmail]: { allowUnauthenticated: true, layout: 'plain' },
     [Scene.WebAnalyticsPageReports]: {
         projectBased: true,
@@ -882,6 +883,7 @@ export const routes: Record<string, [Scene | string, string]> = {
     [urls.codeCanvasLink(':channelId', ':dashboardId')]: [Scene.CodeCanvasLink, 'codeCanvasLink'],
     [urls.codeChannelLink(':channelId')]: [Scene.CodeChannelLink, 'codeChannelLink'],
     [urls.codeChannelLink(':channelId', ':taskId')]: [Scene.CodeChannelLink, 'codeChannelThreadLink'],
+    [urls.codeTaskLink(':taskId')]: [Scene.CodeTaskLink, 'codeTaskLink'],
     [urls.integrationsRedirect(':kind')]: [Scene.IntegrationsRedirect, 'integrationsRedirect'],
     [urls.integration(':slug')]: [Scene.IntegrationsLanding, 'integrationsLanding'],
     [urls.stripeConfirmInstall()]: [Scene.StripeConfirmInstall, 'stripeConfirmInstall'],

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -257,6 +257,8 @@ export const urls = {
     codeCanvasLink: (channelId: string, dashboardId: string): string => `/code/canvas/${channelId}/${dashboardId}`,
     codeChannelLink: (channelId: string, taskId?: string): string =>
         `/code/channel/${channelId}${taskId ? `/tasks/${taskId}` : ''}`,
+    // pinned: URL path — comment Slack DMs link here (see products/tasks comment_slack_dm.py)
+    codeTaskLink: (taskId: string): string => `/code/task/${taskId}`,
     integration: (slug: string): string => `/integrations/${slug}`,
     integrationsRedirect: (kind: string): string => `/integrations/${kind}/callback`,
     stripeConfirmInstall: (): string => '/integrations/stripe/confirm-install',

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -781,8 +781,9 @@ frontend_unauthenticated_routes = [
     "organization/confirm-creation",
     "login",
     "unsubscribe",
-    # Public bridge for desktop-app canvas share links — deep-links into PostHog Desktop.
+    # Public bridges for desktop-app share links — deep-link into PostHog Desktop.
     r"code/canvas/[^/]+/[^/]+",
+    r"code/task/[^/]+",
     "verify_email",
     r"agentic/account-mismatch",
     # OAuth redirect target when logging the local frontend into a remote cloud region;

--- a/products/desktop/docs/DEEP-LINKS.md
+++ b/products/desktop/docs/DEEP-LINKS.md
@@ -80,6 +80,8 @@ The link is rejected if `url` is missing, is not a `github.com` URL, or does not
 
 Open an existing task. Optionally jump to a specific run.
 
+An **https** bridge also exists for links sent outside the app (e.g. comment Slack DMs): `<instance>/code/task/<taskId>` resolves to a web interstitial in PostHog Cloud, which fires this scheme (or offers the desktop-app download).
+
 | Segment | Required | Description |
 |---|---|---|
 | `<taskId>` | Yes | Task ID |

--- a/products/desktop/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
@@ -36,8 +36,8 @@ import {
   SettingsSection,
 } from "@posthog/ui/features/settings/components/SettingsCard";
 import { SettingsSelect } from "@posthog/ui/features/settings/components/SettingsSelect";
+import { openSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
 import { AddCustomSoundDialog } from "@posthog/ui/features/settings/sections/AddCustomSoundDialog";
-import { SlackCommentNotificationsSettings } from "@posthog/ui/features/settings/sections/SlackCommentNotificationsSettings";
 import {
   type CompletionSound,
   type CustomSound,
@@ -431,7 +431,24 @@ export function NotificationsSettings() {
 
       {spokenNarrationEnabled && <VoiceSection />}
 
-      <SlackCommentNotificationsSettings />
+      {/* Slack config lives in the dedicated Slack section; link out rather than duplicate the controls. */}
+      <SettingsSection label="Slack">
+        <SettingsCard>
+          <SettingsCardRow
+            label="Slack DMs for comments"
+            description="Get a direct message when someone mentions you, replies to your comment, or comments on something you own"
+          >
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => openSettings("slack")}
+            >
+              Manage in Slack settings
+            </Button>
+          </SettingsCardRow>
+        </SettingsCard>
+      </SettingsSection>
 
       <TestSection
         bus={bus}

--- a/products/desktop/packages/ui/src/features/settings/sections/SlackCommentNotificationsSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/SlackCommentNotificationsSettings.tsx
@@ -67,13 +67,9 @@ export function SlackCommentNotificationsSettings() {
   );
 
   return (
-    <>
-      <Text
-        size="sm"
-        weight="medium"
-        className="mt-4 mb-1 block border-gray-6 border-t pt-4"
-      >
-        Slack
+    <div className="flex flex-col border-(--gray-5) border-t border-dashed pt-3">
+      <Text size="sm" weight="medium" className="mb-1 block">
+        Comment notifications
       </Text>
       <Text size="xs" variant="muted" className="mb-1 block">
         Comment notifications can also reach you in Slack, so you hear about
@@ -119,6 +115,6 @@ export function SlackCommentNotificationsSettings() {
           />
         </div>
       </SettingRow>
-    </>
+    </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/settings/sections/SlackSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/SlackSettings.tsx
@@ -1,9 +1,11 @@
 import { ArrowSquareOutIcon } from "@phosphor-icons/react";
+import { Button, Text } from "@posthog/quill";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { useIntegrations } from "@posthog/ui/features/integrations/useIntegrations";
+import { SlackCommentNotificationsSettings } from "@posthog/ui/features/settings/sections/SlackCommentNotificationsSettings";
+import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import { openUrlInBrowser } from "@posthog/ui/utils/browser";
 import { getPostHogUrl } from "@posthog/ui/utils/urls";
-import { Button, Flex, Text, Tooltip } from "@radix-ui/themes";
 import { SlackInboxNotificationsSettings } from "./SlackInboxNotificationsSettings";
 
 export function SlackSettings() {
@@ -20,7 +22,7 @@ export function SlackSettings() {
 
   const manageButton = (
     <Button
-      size="1"
+      size="xs"
       disabled={!slackSettingsUrl}
       onClick={() => {
         if (slackSettingsUrl) void openUrlInBrowser(slackSettingsUrl);
@@ -40,18 +42,20 @@ export function SlackSettings() {
   );
 
   return (
-    <Flex direction="column" gap="3">
+    <div className="flex flex-col gap-3">
       <Text className="text-(--gray-11) text-[13px]">
         Connect Slack to PostHog to kick off tasks like pull requests directly
         from Slack.
       </Text>
 
-      <Flex>{manageButtonWithTooltip}</Flex>
+      <div className="flex">{manageButtonWithTooltip}</div>
 
       <SlackInboxNotificationsSettings
         isLoading={isLoading}
         showHeader={false}
       />
-    </Flex>
+
+      <SlackCommentNotificationsSettings />
+    </div>
   );
 }

--- a/products/tasks/backend/logic/services/comment_slack_dm.py
+++ b/products/tasks/backend/logic/services/comment_slack_dm.py
@@ -159,10 +159,11 @@ def send_comment_slack_dms(*, team_id: int, comment_id: UUID, task_id: UUID, rec
                     lookup_allowances=mention_lookup_allowances,
                 ),
             )
+            # The fallback lives on the attachment: a top-level ``text`` next to attachments is
+            # rendered as message body, showing the heading twice.
             slack.client.chat_postMessage(
                 channel=slack_user_id,
-                text=fallback,
-                attachments=[{"color": _ACCENT, "blocks": blocks}],
+                attachments=[{"color": _ACCENT, "blocks": blocks, "fallback": fallback}],
                 unfurl_links=False,
             )
         except Exception as exc:
@@ -342,7 +343,9 @@ def _message(
     organization_id: str | UUID | None,
     slack_user_id_by_email: Callable[[str], str | None] | None = None,
 ) -> tuple[str, list[dict]]:
-    url = f"{settings.SITE_URL}/project/{task.team_id}/tasks/{task.id}"
+    # The /code/task bridge deep-links into the desktop app, where the comment thread lives —
+    # the web tasks page has no comments UI.
+    url = f"{settings.SITE_URL}/code/task/{task.id}"
     title = task.title or "a task"
     author = _author_name(comment)
     template = _HEADINGS.get(kind, _HEADINGS[TaskCommentActivity.Kind.MENTION])

--- a/products/tasks/backend/tests/test_comment_slack_dm.py
+++ b/products/tasks/backend/tests/test_comment_slack_dm.py
@@ -130,7 +130,10 @@ class TestCommentSlackDm(CommentActivityTestCase):
 
         self._record_activity(self._comment(), [self.author.id])
 
-        fallback = self.slack_client.chat_postMessage.call_args.kwargs["text"]
+        call = self.slack_client.chat_postMessage.call_args
+        # A top-level text next to attachments renders as message body, duplicating the heading.
+        assert "text" not in call.kwargs
+        fallback = call.kwargs["attachments"][0]["fallback"]
         assert fallback == "&lt;@U-ATTACKER&gt; mentioned you on &lt;https://example.com|click me&gt;"
 
     def test_no_dm_when_the_user_opted_out(self):


### PR DESCRIPTION
## Problem

Dogfooding the comment Slack DMs surfaced three issues:

- Every DM shows the same heading line twice. Slack renders a top-level `text` as message body when the blocks sit inside an attachment.
- The DM's link opens the task in PostHog web, which has no comments UI, instead of the desktop app.
- The Slack controls sit on two settings pages: the comment DM toggle under Notifications, everything else under Slack integration.

## Changes

- The plain-text fallback moves onto the attachment's `fallback` field, so the heading renders once and notification previews keep working.
- The DM links to a new public bridge page, `/code/task/<taskId>`, which fires `posthog-code://task/<taskId>` to open the task in the desktop app. Visitors without the app get an open button and a download link, matching the existing canvas and channel bridges. Slack only linkifies http(s) URLs, so a raw scheme link was not an option.
- The "Slack account" link and "Slack DMs for comments" toggle move to the Slack integration settings page, as a "Comment notifications" block. The Notifications page keeps a "Manage in Slack settings" link-out row, the same pattern the Self-driving section uses.
- `SlackSettings.tsx` migrates from Radix to quill while touched, per the desktop convention.

No screenshots: I could not run the desktop app in this sandbox.

## How did you test this code?

- Extended the existing fallback test to assert the DM carries no top-level `text` kwarg. That catches the duplicated-heading regression; no existing test pinned where the fallback lives.
- The scene smoke and urls Jest suites cover the new route registration.
- Not run: the full-app `tsgo` typecheck, which needs more memory than the sandbox has. Classic `tsc` reports no errors in the touched files.
- Not done: a manual or visual check of the settings pages and the bridge page.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`products/desktop/docs/DEEP-LINKS.md` now documents the https bridge for task links.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code in PostHog Desktop from three feedback items reported after dogfooding the feature; the reporter's screenshots showed the duplicated line.
- Skills invoked: /writing-tests, /writing-ui-components, /writing-user-facing-copy, /writing-pr-descriptions.
- The bridge page was chosen over reusing the channel bridge because a task is not always filed to a channel.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
