### PR TITLE
feat(oauth): allow scoped redirect host wildcards

### DIFF
--- a/docs/published/handbook/engineering/oauth-development-guide.md
+++ b/docs/published/handbook/engineering/oauth-development-guide.md
@@ -103,6 +103,7 @@ See [Client Types](#client-types) section for detailed explanation.
 - **HTTPS required** for non-localhost URIs
 - **HTTP allowed** only for localhost/loopback addresses (127.0.0.1)
 - No fragments (#) allowed
+- Wildcard hostnames are disabled by default. PostHog staff can enable them only for a first-party application; the scheme, port, path, and query parameters still match exactly.
 - Examples:
 
   ```text

--- a/posthog/admin/admins/oauth_admin.py
+++ b/posthog/admin/admins/oauth_admin.py
@@ -289,7 +289,18 @@ class OAuthApplicationAdmin(admin.ModelAdmin):  # nosemgrep: admin-modeladmin-ne
                     },
                 ),
                 ("Ownership", {"fields": ("user", "organization")}),
-                ("Status", {"fields": ("is_verified", "is_first_party", "is_dcr_client", "is_cimd_client")}),
+                (
+                    "Status",
+                    {
+                        "fields": (
+                            "is_verified",
+                            "is_first_party",
+                            "allow_redirect_uri_wildcards",
+                            "is_dcr_client",
+                            "is_cimd_client",
+                        )
+                    },
+                ),
                 (
                     "Provisioning",
                     {
@@ -331,7 +342,7 @@ class OAuthApplicationAdmin(admin.ModelAdmin):  # nosemgrep: admin-modeladmin-ne
                     },
                 ),
                 ("Ownership", {"fields": ("user", "organization")}),
-                ("Status", {"fields": ("is_verified", "is_first_party")}),
+                ("Status", {"fields": ("is_verified", "is_first_party", "allow_redirect_uri_wildcards")}),
             )
 
     def get_form(self, request, obj=None, change=False, **kwargs):

--- a/posthog/migrations/1301_oauthapplication_allow_redirect_uri_wildcards.py
+++ b/posthog/migrations/1301_oauthapplication_allow_redirect_uri_wildcards.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("posthog", "1300_identityproviderconfig_saml_relay_state_unique")]
+
+    operations = [
+        migrations.AddField(
+            model_name="oauthapplication",
+            name="allow_redirect_uri_wildcards",
+            field=models.BooleanField(
+                db_default=False,
+                default=False,
+                help_text="Allow wildcard hostname redirect URIs for this first-party application only.",
+            ),
+        ),
+    ]

--- a/posthog/migrations/1302_enable_hosthog_redirects_for_desktop_oauth.py
+++ b/posthog/migrations/1302_enable_hosthog_redirects_for_desktop_oauth.py
@@ -1,0 +1,27 @@
+from django.db import migrations
+
+DESKTOP_OAUTH_CLIENT_IDS = (
+    "HCWoE0aRFMYxIxFNTTwkOORn5LBjOt2GVDzwSw5W",
+    "AIvijgMS0dxKEmr5z6odvRd8Pkh5vts3nPTzgzU9",
+    "DC5uRLVbGI02YQ82grxgnK6Qn12SXWpCqdPb60oZ",
+)
+HOSTHOG_CALLBACK = "https://*.hosthog.dev/callback"
+
+
+def enable_hosthog_redirects(apps, schema_editor):
+    OAuthApplication = apps.get_model("posthog", "OAuthApplication")
+    for application in OAuthApplication.objects.filter(
+        client_id__in=DESKTOP_OAUTH_CLIENT_IDS,
+        is_first_party=True,
+    ):
+        redirect_uris = application.redirect_uris.split()
+        if HOSTHOG_CALLBACK not in redirect_uris:
+            application.redirect_uris = " ".join([*redirect_uris, HOSTHOG_CALLBACK])
+        application.allow_redirect_uri_wildcards = True
+        application.save(update_fields=["redirect_uris", "allow_redirect_uri_wildcards"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [("posthog", "1301_oauthapplication_allow_redirect_uri_wildcards")]
+
+    operations = [migrations.RunPython(enable_hosthog_redirects, migrations.RunPython.noop)]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1300_identityproviderconfig_saml_relay_state_unique
+1302_enable_hosthog_redirects_for_desktop_oauth

--- a/posthog/models/oauth.py
+++ b/posthog/models/oauth.py
@@ -1,6 +1,6 @@
 import enum
 from typing import TYPE_CHECKING, cast
-from urllib.parse import urlparse
+from urllib.parse import parse_qsl, urlparse
 
 from django.conf import settings
 from django.contrib.auth.signals import user_logged_out
@@ -111,6 +111,15 @@ class OAuthApplication(ModelActivityMixin, AbstractApplication):  # type: ignore
     # First-party apps skip the OAuth consent screen and can use direct token exchange
     is_first_party: models.BooleanField = models.BooleanField(
         default=False, help_text="True if this is a first-party PostHog application that skips OAuth consent"
+    )
+
+    # Wildcard redirect hosts widen the set of origins that can receive an authorization code.
+    # Keep the capability explicit and default-deny rather than relying on the global toolkit
+    # setting, which would grant it to every application.
+    allow_redirect_uri_wildcards: models.BooleanField = models.BooleanField(
+        default=False,
+        db_default=False,
+        help_text="Allow wildcard hostname redirect URIs for this first-party application only.",
     )
 
     auth_brand: models.CharField = models.CharField(
@@ -384,13 +393,18 @@ class OAuthApplication(ModelActivityMixin, AbstractApplication):  # type: ignore
         if self.jwks_uri and not self.requires_client_authentication:
             raise ValidationError("jwks_uri is only meaningful for a confidential client")
 
+    @property
+    def allows_redirect_uri_wildcards(self) -> bool:
+        """Whether this application's redirect URI registrations may use wildcard hosts."""
+        return self.allow_redirect_uri_wildcards or oauth2_settings.ALLOW_URI_WILDCARDS
+
     def _validate_redirect_uris(self):
         validator = AllowedURIValidator(
             {scheme.lower() for scheme in self.get_allowed_schemes()},
             name="redirect uri",
             allow_path=True,
             allow_query=True,
-            allow_hostname_wildcard=oauth2_settings.ALLOW_URI_WILDCARDS,
+            allow_hostname_wildcard=self.allows_redirect_uri_wildcards,
         )
         for uri in self.redirect_uris.split():
             parsed_uri = urlparse(uri)
@@ -419,6 +433,33 @@ class OAuthApplication(ModelActivityMixin, AbstractApplication):  # type: ignore
                         "redirect_uris": f"Redirect URI {uri} must use https (http is only allowed for loopback addresses)"
                     }
                 )
+
+    def redirect_uri_allowed(self, uri: str) -> bool:
+        """Match a redirect URI, allowing wildcard hosts only for opted-in applications."""
+        parsed_uri = urlparse(uri)
+        requested_query = set(parse_qsl(parsed_uri.query))
+        for allowed_uri in self.redirect_uris.split():
+            parsed_allowed_uri = urlparse(allowed_uri)
+            if parsed_allowed_uri.scheme != parsed_uri.scheme:
+                continue
+
+            allowed_host = parsed_allowed_uri.hostname
+            requested_host = parsed_uri.hostname
+            if self.allows_redirect_uri_wildcards and allowed_host and allowed_host.startswith("*"):
+                if not requested_host or not requested_host.endswith(allowed_host[1:]):
+                    continue
+            elif allowed_host != requested_host:
+                continue
+
+            allowed_is_loopback = parsed_allowed_uri.scheme == "http" and allowed_host in {"127.0.0.1", "::1"}
+            if not allowed_is_loopback and parsed_allowed_uri.port != parsed_uri.port:
+                continue
+            if parsed_allowed_uri.path != parsed_uri.path:
+                continue
+            if not set(parse_qsl(parsed_allowed_uri.query)).issubset(requested_query):
+                continue
+            return True
+        return False
 
     def _validate_optional_scopes(self):
         if not self.optional_scopes:
@@ -450,6 +491,11 @@ class OAuthApplication(ModelActivityMixin, AbstractApplication):  # type: ignore
         )
         if not self.redirect_uris.split() and self.authorization_grant_type in code_grant_types:
             raise ValidationError(f"redirect_uris cannot be empty with grant_type {self.authorization_grant_type}")
+
+        if self.allow_redirect_uri_wildcards and not self.is_first_party:
+            raise ValidationError(
+                {"allow_redirect_uri_wildcards": "Wildcard redirect URIs are restricted to first-party applications."}
+            )
 
         allowed_origins = self.allowed_origins.split()
         if allowed_origins:

--- a/posthog/models/oauth.py
+++ b/posthog/models/oauth.py
@@ -1,6 +1,6 @@
 import enum
 from typing import TYPE_CHECKING, cast
-from urllib.parse import parse_qsl, urlparse
+from urllib.parse import urlparse
 
 from django.conf import settings
 from django.contrib.auth.signals import user_logged_out
@@ -437,7 +437,6 @@ class OAuthApplication(ModelActivityMixin, AbstractApplication):  # type: ignore
     def redirect_uri_allowed(self, uri: str) -> bool:
         """Match a redirect URI, allowing wildcard hosts only for opted-in applications."""
         parsed_uri = urlparse(uri)
-        requested_query = set(parse_qsl(parsed_uri.query))
         for allowed_uri in self.redirect_uris.split():
             parsed_allowed_uri = urlparse(allowed_uri)
             if parsed_allowed_uri.scheme != parsed_uri.scheme:
@@ -452,11 +451,15 @@ class OAuthApplication(ModelActivityMixin, AbstractApplication):  # type: ignore
                 continue
 
             allowed_is_loopback = parsed_allowed_uri.scheme == "http" and allowed_host in {"127.0.0.1", "::1"}
-            if not allowed_is_loopback and parsed_allowed_uri.port != parsed_uri.port:
+            try:
+                ports_match = parsed_allowed_uri.port == parsed_uri.port
+            except ValueError:
+                return False
+            if not allowed_is_loopback and not ports_match:
                 continue
             if parsed_allowed_uri.path != parsed_uri.path:
                 continue
-            if not set(parse_qsl(parsed_allowed_uri.query)).issubset(requested_query):
+            if parsed_allowed_uri.query != parsed_uri.query:
                 continue
             return True
         return False

--- a/posthog/models/test/test_oauth.py
+++ b/posthog/models/test/test_oauth.py
@@ -124,6 +124,38 @@ class TestOAuthModels(TestCase):
                 algorithm="RS256",
             )
 
+    def test_wildcard_redirect_uri_requires_application_opt_in(self):
+        with self.assertRaises(ValidationError) as ctx:
+            self._make_app(
+                "Wildcard Disabled",
+                "wildcard_disabled_client",
+                redirect_uris="https://*.hosthog.dev/callback",
+            )
+        self.assertIn("redirect_uris", ctx.exception.message_dict)
+
+    def test_wildcard_redirect_uri_opt_in_requires_first_party_application(self):
+        with self.assertRaises(ValidationError) as ctx:
+            self._make_app(
+                "Wildcard Third Party",
+                "wildcard_third_party_client",
+                allow_redirect_uri_wildcards=True,
+            )
+        self.assertIn("allow_redirect_uri_wildcards", ctx.exception.message_dict)
+
+    def test_first_party_wildcard_redirect_uri_matches_only_its_subdomains(self):
+        app = self._make_app(
+            "Wildcard First Party",
+            "wildcard_first_party_client",
+            is_first_party=True,
+            allow_redirect_uri_wildcards=True,
+            redirect_uris="https://*.hosthog.dev/callback",
+        )
+
+        self.assertTrue(app.redirect_uri_allowed("https://preview.hosthog.dev/callback"))
+        self.assertFalse(app.redirect_uri_allowed("https://hosthog.dev/callback"))
+        self.assertFalse(app.redirect_uri_allowed("https://preview.hosthog.dev/other"))
+        self.assertFalse(app.redirect_uri_allowed("https://preview.hosthog.dev.evil.example/callback"))
+
     @override_settings(DEBUG=True)
     def test_can_create_application_with_http_redirect_url_when_debug_is_true(self):
         OAuthApplication.objects.create(

--- a/posthog/models/test/test_oauth.py
+++ b/posthog/models/test/test_oauth.py
@@ -155,6 +155,8 @@ class TestOAuthModels(TestCase):
         self.assertFalse(app.redirect_uri_allowed("https://hosthog.dev/callback"))
         self.assertFalse(app.redirect_uri_allowed("https://preview.hosthog.dev/other"))
         self.assertFalse(app.redirect_uri_allowed("https://preview.hosthog.dev.evil.example/callback"))
+        self.assertFalse(app.redirect_uri_allowed("https://preview.hosthog.dev/callback?extra=value"))
+        self.assertFalse(app.redirect_uri_allowed("https://preview.hosthog.dev:invalid/callback"))
 
     @override_settings(DEBUG=True)
     def test_can_create_application_with_http_redirect_url_when_debug_is_true(self):


### PR DESCRIPTION
## Problem

First-party web clients hosted on trusted preview subdomains cannot complete OAuth when each deploy uses a distinct hostname.

## Changes

- Add a default-deny wildcard redirect opt-in restricted to first-party OAuth applications.
- Preserve exact scheme, port, path, and query matching for wildcard registrations.
- Enable `*.hosthog.dev/callback` for the existing Desktop OAuth clients through guarded migrations.

## Why

Preview deployments need a safe, repeatable callback pattern without enabling wildcard redirects for every OAuth application.

## How did you test this code?

- `hogli ci:preflight --fix`
- Targeted mypy and Ruff checks
- `DEBUG=1 python manage.py makemigrations --check --dry-run`
- Focused Django tests could not complete because the local disposable test database has inconsistent pre-existing migration state.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the OAuth development guide with the first-party wildcard policy.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Codex. No skills were invoked.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*