### PR TITLE
feat(tasks): send comment slack dms to the task in the desktop app

### DIFF
--- a/frontend/src/scenes/appScenes.ts
+++ b/frontend/src/scenes/appScenes.ts
@@ -123,6 +123,7 @@ export const appScenes: Record<Scene | string, () => any> = {
     [Scene.Unsubscribe]: () => import('./Unsubscribe/Unsubscribe'),
     [Scene.CodeCanvasLink]: () => import('./code-canvas/CodeCanvasLink'),
     [Scene.CodeChannelLink]: () => import('./code-canvas/CodeChannelLink'),
+    [Scene.CodeTaskLink]: () => import('./code-canvas/CodeTaskLink'),
     [Scene.VercelConnect]: () => import('./authentication/vercel/VercelConnect'),
     [Scene.VercelLinkError]: () => import('./authentication/vercel/VercelLinkError'),
     [Scene.AgenticAccountMismatch]: () => import('./authentication/account/AgenticAccountMismatch'),

--- a/frontend/src/scenes/code-canvas/CodeTaskLink.tsx
+++ b/frontend/src/scenes/code-canvas/CodeTaskLink.tsx
@@ -10,26 +10,38 @@ import { DESKTOP_SCHEME } from './desktopScheme'
 
 export interface CodeTaskLinkProps {
     taskId: string
+    commentId?: string
+    commentScope?: string
+    commentItemId?: string
 }
 
 export const scene: SceneExport<CodeTaskLinkProps> = {
     component: CodeTaskLink,
-    paramsToProps: ({ params: { taskId } }) => ({
+    paramsToProps: ({ params: { taskId }, searchParams }) => ({
         taskId: taskId ?? '',
+        commentId: searchParams.comment || undefined,
+        commentScope: searchParams.scope || undefined,
+        commentItemId: searchParams.item || undefined,
     }),
 }
 
-/**
- * Public, unauthenticated bridge for desktop-app "task" share links (`/code/task/<taskId>`),
- * used by notifications sent outside the app (e.g. comment Slack DMs). On mount it deep-links
- * into the desktop app via the `posthog-code(-dev)://` custom scheme; for visitors without the
- * app it shows an explanation, a manual "open" button (in case the browser blocks the
- * auto-redirect), and a download link.
- */
-export function CodeTaskLink({ taskId }: CodeTaskLinkProps): JSX.Element {
-    // Null when the task id is missing (a partial URL or params not yet resolved), since firing
-    // with an empty id would send a malformed `<scheme>://task/`.
-    const deepLink = taskId ? `${DESKTOP_SCHEME}://task/${encodeURIComponent(taskId)}` : null
+function taskDeepLink({ taskId, commentId, commentScope, commentItemId }: CodeTaskLinkProps): string {
+    const params = new URLSearchParams()
+    if (commentId) {
+        params.set('comment', commentId)
+    }
+    if (commentScope) {
+        params.set('scope', commentScope)
+    }
+    if (commentItemId) {
+        params.set('item', commentItemId)
+    }
+    const query = params.toString()
+    return `${DESKTOP_SCHEME}://task/${encodeURIComponent(taskId)}${query ? `?${query}` : ''}`
+}
+
+export function CodeTaskLink(props: CodeTaskLinkProps): JSX.Element {
+    const deepLink = props.taskId ? taskDeepLink(props) : null
 
     useEffect(() => {
         if (deepLink) {

--- a/frontend/src/scenes/code-canvas/CodeTaskLink.tsx
+++ b/frontend/src/scenes/code-canvas/CodeTaskLink.tsx
@@ -1,0 +1,69 @@
+import { useEffect } from 'react'
+
+import { IconLaptop } from '@posthog/icons'
+
+import { BridgePage } from 'lib/components/BridgePage/BridgePage'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { SceneExport } from 'scenes/sceneTypes'
+
+import { DESKTOP_SCHEME } from './desktopScheme'
+
+export interface CodeTaskLinkProps {
+    taskId: string
+}
+
+export const scene: SceneExport<CodeTaskLinkProps> = {
+    component: CodeTaskLink,
+    paramsToProps: ({ params: { taskId } }) => ({
+        taskId: taskId ?? '',
+    }),
+}
+
+/**
+ * Public, unauthenticated bridge for desktop-app "task" share links (`/code/task/<taskId>`),
+ * used by notifications sent outside the app (e.g. comment Slack DMs). On mount it deep-links
+ * into the desktop app via the `posthog-code(-dev)://` custom scheme; for visitors without the
+ * app it shows an explanation, a manual "open" button (in case the browser blocks the
+ * auto-redirect), and a download link.
+ */
+export function CodeTaskLink({ taskId }: CodeTaskLinkProps): JSX.Element {
+    // Null when the task id is missing (a partial URL or params not yet resolved), since firing
+    // with an empty id would send a malformed `<scheme>://task/`.
+    const deepLink = taskId ? `${DESKTOP_SCHEME}://task/${encodeURIComponent(taskId)}` : null
+
+    useEffect(() => {
+        if (deepLink) {
+            window.location.href = deepLink
+        }
+    }, [deepLink])
+
+    return (
+        <BridgePage view="code-task-link">
+            <div className="flex flex-col items-center gap-4 text-center max-w-lg mx-auto">
+                <IconLaptop className="text-5xl shrink-0" />
+                <h2 className="text-xl font-semibold m-0">Opening in PostHog Desktop…</h2>
+                <p className="text-muted mb-0">
+                    This task lives in the PostHog Desktop app. If it's installed, it should open automatically. If it
+                    didn't, use the button below, or download the app.
+                </p>
+                <div className="flex flex-col items-center gap-2">
+                    {deepLink && (
+                        <LemonButton
+                            type="primary"
+                            onClick={() => {
+                                window.location.href = deepLink
+                            }}
+                        >
+                            Open in PostHog Desktop
+                        </LemonButton>
+                    )}
+                    <LemonButton type="secondary" to="https://posthog.com/desktop" targetBlank>
+                        Download PostHog Desktop
+                    </LemonButton>
+                </div>
+            </div>
+        </BridgePage>
+    )
+}
+
+export default CodeTaskLink

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -186,6 +186,7 @@ export enum Scene {
     Unsubscribe = 'Unsubscribe',
     CodeCanvasLink = 'CodeCanvasLink',
     CodeChannelLink = 'CodeChannelLink',
+    CodeTaskLink = 'CodeTaskLink',
     UserInterview = 'UserInterview',
     UserInterviewResponse = 'UserInterviewResponse',
     UserInterviews = 'UserInterviews',

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -540,6 +540,7 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
     [Scene.Unsubscribe]: { allowUnauthenticated: true, layout: 'app-raw' },
     [Scene.CodeCanvasLink]: { allowUnauthenticated: true, layout: 'app-raw' },
     [Scene.CodeChannelLink]: { allowUnauthenticated: true, layout: 'app-raw' },
+    [Scene.CodeTaskLink]: { allowUnauthenticated: true, layout: 'app-raw' },
     [Scene.VerifyEmail]: { allowUnauthenticated: true, layout: 'plain' },
     [Scene.WebAnalyticsPageReports]: {
         projectBased: true,
@@ -882,6 +883,7 @@ export const routes: Record<string, [Scene | string, string]> = {
     [urls.codeCanvasLink(':channelId', ':dashboardId')]: [Scene.CodeCanvasLink, 'codeCanvasLink'],
     [urls.codeChannelLink(':channelId')]: [Scene.CodeChannelLink, 'codeChannelLink'],
     [urls.codeChannelLink(':channelId', ':taskId')]: [Scene.CodeChannelLink, 'codeChannelThreadLink'],
+    [urls.codeTaskLink(':taskId')]: [Scene.CodeTaskLink, 'codeTaskLink'],
     [urls.integrationsRedirect(':kind')]: [Scene.IntegrationsRedirect, 'integrationsRedirect'],
     [urls.integration(':slug')]: [Scene.IntegrationsLanding, 'integrationsLanding'],
     [urls.stripeConfirmInstall()]: [Scene.StripeConfirmInstall, 'stripeConfirmInstall'],

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -257,7 +257,6 @@ export const urls = {
     codeCanvasLink: (channelId: string, dashboardId: string): string => `/code/canvas/${channelId}/${dashboardId}`,
     codeChannelLink: (channelId: string, taskId?: string): string =>
         `/code/channel/${channelId}${taskId ? `/tasks/${taskId}` : ''}`,
-    // pinned: URL path — comment Slack DMs link here (see products/tasks comment_slack_dm.py)
     codeTaskLink: (taskId: string): string => `/code/task/${taskId}`,
     integration: (slug: string): string => `/integrations/${slug}`,
     integrationsRedirect: (kind: string): string => `/integrations/${kind}/callback`,

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -257,6 +257,8 @@ export const urls = {
     codeCanvasLink: (channelId: string, dashboardId: string): string => `/code/canvas/${channelId}/${dashboardId}`,
     codeChannelLink: (channelId: string, taskId?: string): string =>
         `/code/channel/${channelId}${taskId ? `/tasks/${taskId}` : ''}`,
+    // pinned: URL path — comment Slack DMs link here (see products/tasks comment_slack_dm.py)
+    codeTaskLink: (taskId: string): string => `/code/task/${taskId}`,
     integration: (slug: string): string => `/integrations/${slug}`,
     integrationsRedirect: (kind: string): string => `/integrations/${kind}/callback`,
     stripeConfirmInstall: (): string => '/integrations/stripe/confirm-install',

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -781,8 +781,9 @@ frontend_unauthenticated_routes = [
     "organization/confirm-creation",
     "login",
     "unsubscribe",
-    # Public bridge for desktop-app canvas share links — deep-links into PostHog Desktop.
+    # Public bridges for desktop-app share links — deep-link into PostHog Desktop.
     r"code/canvas/[^/]+/[^/]+",
+    r"code/task/[^/]+",
     "verify_email",
     r"agentic/account-mismatch",
     # OAuth redirect target when logging the local frontend into a remote cloud region;

--- a/products/desktop/docs/DEEP-LINKS.md
+++ b/products/desktop/docs/DEEP-LINKS.md
@@ -80,6 +80,8 @@ The link is rejected if `url` is missing, is not a `github.com` URL, or does not
 
 Open an existing task. Optionally jump to a specific run.
 
+An **https** bridge also exists for links sent outside the app (e.g. comment Slack DMs): `<instance>/code/task/<taskId>` resolves to a web interstitial in PostHog Cloud, which fires this scheme (or offers the desktop-app download).
+
 | Segment | Required | Description |
 |---|---|---|
 | `<taskId>` | Yes | Task ID |

--- a/products/desktop/docs/DEEP-LINKS.md
+++ b/products/desktop/docs/DEEP-LINKS.md
@@ -80,8 +80,6 @@ The link is rejected if `url` is missing, is not a `github.com` URL, or does not
 
 Open an existing task. Optionally jump to a specific run.
 
-An **https** bridge also exists for links sent outside the app (e.g. comment Slack DMs): `<instance>/code/task/<taskId>` resolves to a web interstitial in PostHog Cloud, which fires this scheme (or offers the desktop-app download).
-
 | Segment | Required | Description |
 |---|---|---|
 | `<taskId>` | Yes | Task ID |

--- a/products/tasks/backend/logic/services/comment_slack_dm.py
+++ b/products/tasks/backend/logic/services/comment_slack_dm.py
@@ -11,6 +11,7 @@ a per-recipient sent marker to store.
 """
 
 from collections.abc import Callable, Mapping
+from urllib.parse import urlencode
 from uuid import UUID
 
 from django.conf import settings
@@ -334,6 +335,14 @@ def _author_name(comment: Comment) -> str:
     return f"{author.first_name} {author.last_name}".strip() or author.email or "Someone"
 
 
+def _bridge_url(*, comment: Comment, task: Task) -> str:
+    params = {"comment": str(comment.source_comment_id or comment.id)}
+    if comment.scope in _LOCATIONS and comment.item_id:
+        params["scope"] = comment.scope
+        params["item"] = comment.item_id
+    return f"{settings.SITE_URL}/code/task/{task.id}?{urlencode(params)}"
+
+
 def _message(
     *,
     kind: str,
@@ -342,9 +351,7 @@ def _message(
     organization_id: str | UUID | None,
     slack_user_id_by_email: Callable[[str], str | None] | None = None,
 ) -> tuple[str, list[dict]]:
-    # The /code/task bridge deep-links into the desktop app, where the comment thread lives —
-    # the web tasks page has no comments UI.
-    url = f"{settings.SITE_URL}/code/task/{task.id}"
+    url = _bridge_url(comment=comment, task=task)
     title = task.title or "a task"
     author = _author_name(comment)
     template = _HEADINGS.get(kind, _HEADINGS[TaskCommentActivity.Kind.MENTION])

--- a/products/tasks/backend/logic/services/comment_slack_dm.py
+++ b/products/tasks/backend/logic/services/comment_slack_dm.py
@@ -342,7 +342,9 @@ def _message(
     organization_id: str | UUID | None,
     slack_user_id_by_email: Callable[[str], str | None] | None = None,
 ) -> tuple[str, list[dict]]:
-    url = f"{settings.SITE_URL}/project/{task.team_id}/tasks/{task.id}"
+    # The /code/task bridge deep-links into the desktop app, where the comment thread lives —
+    # the web tasks page has no comments UI.
+    url = f"{settings.SITE_URL}/code/task/{task.id}"
     title = task.title or "a task"
     author = _author_name(comment)
     template = _HEADINGS.get(kind, _HEADINGS[TaskCommentActivity.Kind.MENTION])

--- a/products/tasks/backend/tests/test_comment_slack_dm.py
+++ b/products/tasks/backend/tests/test_comment_slack_dm.py
@@ -207,6 +207,16 @@ class TestCommentSlackDm(CommentActivityTestCase):
         self._record_activity(comment, [self.author.id])
 
         assert self._dm_channels() == ["U-author"]
+        assert (
+            f"/code/task/{self.task.id}?comment={comment.id}&scope=desktop_canvas&item={canvas.id}" in self._dm_text()
+        )
+
+    def test_dm_links_to_the_desktop_task_bridge_anchored_on_the_comment(self):
+        comment = self._comment()
+
+        self._record_activity(comment, [self.author.id])
+
+        assert f"/code/task/{self.task.id}?comment={comment.id}" in self._dm_text()
 
     def test_canvas_comment_does_not_dm_a_recipient_without_canvas_access(self):
         personal_channel = Channel.objects.unscoped().create(


### PR DESCRIPTION
## Problem

The comment Slack DM links to the web tasks page, which has no comments UI, so the recipient lands somewhere they cannot read or answer the comment. The thread lives in the desktop app.

Replaces [#82716](https://github.com/PostHog/posthog/pull/82716) and absorbs [#82720](https://github.com/PostHog/posthog/pull/82720) — the web bridge and the backend link ship in the same deploy, so one PR.

## Changes

- A new public bridge page, `/code/task/<taskId>`, fires `posthog-code://task/<taskId>` to open the task in the desktop app, with a manual open button and a download link for visitors without the app — same pattern as the canvas and channel bridges. Slack only linkifies http(s) URLs, so the DM cannot carry the scheme link directly.
- The DM now links there instead of the web tasks page, and anchors the exact comment: `?comment=<thread id>`, plus `scope`/`item` for comments on a canvas or artifact. The bridge forwards those params onto the scheme URL.
- Old desktop builds ignore the extra params and open the task; consuming them to scroll to the comment is a desktop-only follow-up PR.

## How did you test this code?

- New backend test pins the DM link shape (`/code/task/<id>?comment=<id>`), and the canvas-comment test now also asserts the `scope`/`item` params — no existing test covered the DM's URL at all. All 22 tests in `test_comment_slack_dm.py` pass locally.
- The scene smoke and urls Jest suites cover the new route registration.
- Not done: clicking a real DM link end to end; this sandbox cannot run the desktop app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The `?comment` deep-link params will be documented in `products/desktop/docs/DEEP-LINKS.md` by the desktop follow-up PR, which owns that surface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code in PostHog Desktop from dogfooding feedback on comment Slack DMs.
- Skills invoked: /writing-tests, /writing-ui-components, /writing-user-facing-copy, /writing-pr-descriptions.
- Started as two PRs (bridge page + link switch) per an earlier strict-split request, then merged back into one on review feedback since both halves deploy together; the comment anchor and code-comment cleanup landed in the same round.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
