### PR TITLE
fix(desktop): move slack comment settings to the slack settings page

### DIFF
--- a/products/desktop/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
@@ -36,7 +36,6 @@ import {
   SettingsSection,
 } from "@posthog/ui/features/settings/components/SettingsCard";
 import { SettingsSelect } from "@posthog/ui/features/settings/components/SettingsSelect";
-import { openSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
 import { AddCustomSoundDialog } from "@posthog/ui/features/settings/sections/AddCustomSoundDialog";
 import {
   type CompletionSound,
@@ -430,25 +429,6 @@ export function NotificationsSettings() {
       />
 
       {spokenNarrationEnabled && <VoiceSection />}
-
-      {/* Slack config lives in the dedicated Slack section; link out rather than duplicate the controls. */}
-      <SettingsSection label="Slack">
-        <SettingsCard>
-          <SettingsCardRow
-            label="Slack DMs for comments"
-            description="Get a direct message when someone mentions you, replies to your comment, or comments on something you own"
-          >
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => openSettings("slack")}
-            >
-              Manage in Slack settings
-            </Button>
-          </SettingsCardRow>
-        </SettingsCard>
-      </SettingsSection>
 
       <TestSection
         bus={bus}

--- a/products/desktop/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/NotificationsSettings.tsx
@@ -36,8 +36,8 @@ import {
   SettingsSection,
 } from "@posthog/ui/features/settings/components/SettingsCard";
 import { SettingsSelect } from "@posthog/ui/features/settings/components/SettingsSelect";
+import { openSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
 import { AddCustomSoundDialog } from "@posthog/ui/features/settings/sections/AddCustomSoundDialog";
-import { SlackCommentNotificationsSettings } from "@posthog/ui/features/settings/sections/SlackCommentNotificationsSettings";
 import {
   type CompletionSound,
   type CustomSound,
@@ -431,7 +431,24 @@ export function NotificationsSettings() {
 
       {spokenNarrationEnabled && <VoiceSection />}
 
-      <SlackCommentNotificationsSettings />
+      {/* Slack config lives in the dedicated Slack section; link out rather than duplicate the controls. */}
+      <SettingsSection label="Slack">
+        <SettingsCard>
+          <SettingsCardRow
+            label="Slack DMs for comments"
+            description="Get a direct message when someone mentions you, replies to your comment, or comments on something you own"
+          >
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => openSettings("slack")}
+            >
+              Manage in Slack settings
+            </Button>
+          </SettingsCardRow>
+        </SettingsCard>
+      </SettingsSection>
 
       <TestSection
         bus={bus}

--- a/products/desktop/packages/ui/src/features/settings/sections/SlackCommentNotificationsSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/SlackCommentNotificationsSettings.tsx
@@ -67,13 +67,9 @@ export function SlackCommentNotificationsSettings() {
   );
 
   return (
-    <>
-      <Text
-        size="sm"
-        weight="medium"
-        className="mt-4 mb-1 block border-gray-6 border-t pt-4"
-      >
-        Slack
+    <div className="flex flex-col border-(--gray-5) border-t border-dashed pt-3">
+      <Text size="sm" weight="medium" className="mb-1 block">
+        Comment notifications
       </Text>
       <Text size="xs" variant="muted" className="mb-1 block">
         Comment notifications can also reach you in Slack, so you hear about
@@ -119,6 +115,6 @@ export function SlackCommentNotificationsSettings() {
           />
         </div>
       </SettingRow>
-    </>
+    </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/settings/sections/SlackSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/SlackSettings.tsx
@@ -1,9 +1,11 @@
 import { ArrowSquareOutIcon } from "@phosphor-icons/react";
+import { Button, Text } from "@posthog/quill";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { useIntegrations } from "@posthog/ui/features/integrations/useIntegrations";
+import { SlackCommentNotificationsSettings } from "@posthog/ui/features/settings/sections/SlackCommentNotificationsSettings";
+import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import { openUrlInBrowser } from "@posthog/ui/utils/browser";
 import { getPostHogUrl } from "@posthog/ui/utils/urls";
-import { Button, Flex, Text, Tooltip } from "@radix-ui/themes";
 import { SlackInboxNotificationsSettings } from "./SlackInboxNotificationsSettings";
 
 export function SlackSettings() {
@@ -20,7 +22,7 @@ export function SlackSettings() {
 
   const manageButton = (
     <Button
-      size="1"
+      size="xs"
       disabled={!slackSettingsUrl}
       onClick={() => {
         if (slackSettingsUrl) void openUrlInBrowser(slackSettingsUrl);
@@ -40,18 +42,20 @@ export function SlackSettings() {
   );
 
   return (
-    <Flex direction="column" gap="3">
+    <div className="flex flex-col gap-3">
       <Text className="text-(--gray-11) text-[13px]">
         Connect Slack to PostHog to kick off tasks like pull requests directly
         from Slack.
       </Text>
 
-      <Flex>{manageButtonWithTooltip}</Flex>
+      <div className="flex">{manageButtonWithTooltip}</div>
 
       <SlackInboxNotificationsSettings
         isLoading={isLoading}
         showHeader={false}
       />
-    </Flex>
+
+      <SlackCommentNotificationsSettings />
+    </div>
   );
 }


### PR DESCRIPTION
## Problem

Slack controls sit on two desktop settings pages: the comment DM toggle and the Slack account link under Notifications, everything else under Slack integration. Dogfooding feedback asked for one place.

Split from [#82716](https://github.com/PostHog/posthog/pull/82716) (desktop frontend slice).

## Changes

- The "Slack account" link and "Slack DMs for comments" toggle move to the Slack integration settings page, as a "Comment notifications" block under the inbox controls.
- The Notifications page no longer mentions Slack at all — no link-out row.
- `SlackSettings.tsx` migrates from Radix to quill while touched, per the desktop convention.

No screenshots: I could not run the desktop app in this sandbox, so the moved block needs a visual check.

## How did you test this code?

- `@posthog/ui` typecheck and Biome pass locally.
- Not done: opening the settings pages in the running app.

No new tests: the change moves existing components between pages without behavior changes.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code in PostHog Desktop from dogfooding feedback on comment Slack DMs.
- Skills invoked: /writing-ui-components, /writing-user-facing-copy, /writing-pr-descriptions.
- First iteration kept a "Manage in Slack settings" link-out row on the Notifications page; removed after feedback so Slack config has exactly one home.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
