### PR TITLE
feat(aio): keep evaluator save action visible while scrolling

### DIFF
--- a/frontend/src/layout/scenes/components/SceneStickyBar.tsx
+++ b/frontend/src/layout/scenes/components/SceneStickyBar.tsx
@@ -17,7 +17,9 @@ export function SceneStickyBar({
         <div
             className={cn(
                 'scene-sticky-bar @2xl/main-content:sticky z-20 bg-primary @2xl/main-content:top-[34px] space-y-2 py-2 -mx-4 px-4 rounded-t-xl',
-                !hasSceneTitleSection && '@2xl/main-content:top-0',
+                // Without a title section above it there's nothing to stick below, so cancel the
+                // scene container's padding — at top-0 the padding strip shows content scrolling past.
+                !hasSceneTitleSection && '@2xl/main-content:-top-4',
                 className,
                 showBorderBottom && 'border-b'
             )}

--- a/products/ai_observability/frontend/evaluations/AIObservabilityEvaluation.tsx
+++ b/products/ai_observability/frontend/evaluations/AIObservabilityEvaluation.tsx
@@ -252,6 +252,22 @@ export function AIObservabilityEvaluation(): JSX.Element {
         push(evaluationBackTarget.path)
     }
 
+    const saveButton = (
+        <AccessControlAction
+            resourceType={AccessControlResourceType.LlmAnalytics}
+            minAccessLevel={AccessControlLevel.Editor}
+        >
+            <LemonButton
+                type="primary"
+                onClick={handleSave}
+                disabledReason={saveButtonDisabledReason}
+                loading={evaluationFormSubmitting}
+            >
+                {isNewEvaluation ? 'Create evaluation' : 'Save changes'}
+            </LemonButton>
+        </AccessControlAction>
+    )
+
     const hogEvaluationMethodOptions: { value: EvaluationType; label: string }[] = [
         {
             value: 'hog',
@@ -321,21 +337,7 @@ export function AIObservabilityEvaluation(): JSX.Element {
                     <LemonButton type="secondary" icon={<IconArrowLeft />} onClick={handleCancel}>
                         {hasUnsavedChanges ? 'Cancel' : 'Back'}
                     </LemonButton>
-                    {activeTab !== 'runs' && (
-                        <AccessControlAction
-                            resourceType={AccessControlResourceType.LlmAnalytics}
-                            minAccessLevel={AccessControlLevel.Editor}
-                        >
-                            <LemonButton
-                                type="primary"
-                                onClick={handleSave}
-                                disabledReason={saveButtonDisabledReason}
-                                loading={evaluationFormSubmitting}
-                            >
-                                {isNewEvaluation ? 'Create evaluation' : 'Save changes'}
-                            </LemonButton>
-                        </AccessControlAction>
-                    )}
+                    {activeTab !== 'runs' && saveButton}
                 </div>
             </div>
 
@@ -748,6 +750,12 @@ export function AIObservabilityEvaluation(): JSX.Element {
                                     {isNewEvaluation && isReportableEvaluation && (
                                         <EvaluationReportConfig evaluationId="new" />
                                     )}
+
+                                    {/* The form is long enough that the header action scrolls out of sight */}
+                                    <div className="flex items-center justify-end gap-2">
+                                        {hasUnsavedChanges && <LemonTag type="warning">Unsaved changes</LemonTag>}
+                                        {saveButton}
+                                    </div>
                                 </Form>
 
                                 {/* Scheduled Reports (for existing evaluations, outside the form) */}

--- a/products/ai_observability/frontend/evaluations/AIObservabilityEvaluation.tsx
+++ b/products/ai_observability/frontend/evaluations/AIObservabilityEvaluation.tsx
@@ -27,6 +27,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 
 import { SceneBreadcrumbBackButton } from '~/layout/scenes/components/SceneBreadcrumbs'
+import { SceneStickyBar } from '~/layout/scenes/components/SceneStickyBar'
 import { InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
 import { urls } from '~/scenes/urls'
 import { AccessControlLevel, AccessControlResourceType, ChartDisplayType, HogQLMathType } from '~/types'
@@ -252,22 +253,6 @@ export function AIObservabilityEvaluation(): JSX.Element {
         push(evaluationBackTarget.path)
     }
 
-    const saveButton = (
-        <AccessControlAction
-            resourceType={AccessControlResourceType.LlmAnalytics}
-            minAccessLevel={AccessControlLevel.Editor}
-        >
-            <LemonButton
-                type="primary"
-                onClick={handleSave}
-                disabledReason={saveButtonDisabledReason}
-                loading={evaluationFormSubmitting}
-            >
-                {isNewEvaluation ? 'Create evaluation' : 'Save changes'}
-            </LemonButton>
-        </AccessControlAction>
-    )
-
     const hogEvaluationMethodOptions: { value: EvaluationType; label: string }[] = [
         {
             value: 'hog',
@@ -289,28 +274,27 @@ export function AIObservabilityEvaluation(): JSX.Element {
     return (
         <div className="space-y-6">
             <SceneBreadcrumbBackButton />
-            {/* Header */}
-            <div className="flex justify-between items-start pb-4 border-b">
-                <div className="space-y-2">
-                    <h1 className="text-2xl font-semibold">{isNewEvaluation ? 'New evaluation' : evaluation.name}</h1>
-                    <div className="flex items-center gap-2">
-                        {isNewEvaluation ? (
-                            <LemonTag type="primary">New</LemonTag>
-                        ) : (
-                            <>
-                                {evaluation.status === 'error' ? (
-                                    <LemonTag type="danger" icon={<IconWarning />}>
-                                        Error
-                                    </LemonTag>
-                                ) : (
-                                    <LemonTag type={evaluation.enabled ? 'success' : 'default'}>
-                                        {evaluation.enabled ? 'Enabled' : 'Disabled'}
-                                    </LemonTag>
-                                )}
-                                {hasUnsavedChanges && <LemonTag type="warning">Unsaved changes</LemonTag>}
-                            </>
-                        )}
-                    </div>
+            {/* Header. The status and actions live in a sticky bar so saving stays one click away
+                while scrolling the long configuration form. */}
+            <h1 className="text-2xl font-semibold">{isNewEvaluation ? 'New evaluation' : evaluation.name}</h1>
+            <SceneStickyBar hasSceneTitleSection={false} className="flex items-center justify-between gap-2 space-y-0">
+                <div className="flex items-center gap-2">
+                    {isNewEvaluation ? (
+                        <LemonTag type="primary">New</LemonTag>
+                    ) : (
+                        <>
+                            {evaluation.status === 'error' ? (
+                                <LemonTag type="danger" icon={<IconWarning />}>
+                                    Error
+                                </LemonTag>
+                            ) : (
+                                <LemonTag type={evaluation.enabled ? 'success' : 'default'}>
+                                    {evaluation.enabled ? 'Enabled' : 'Disabled'}
+                                </LemonTag>
+                            )}
+                            {hasUnsavedChanges && <LemonTag type="warning">Unsaved changes</LemonTag>}
+                        </>
+                    )}
                 </div>
                 <div className="flex gap-2">
                     {trendInsightUrl ? (
@@ -337,9 +321,23 @@ export function AIObservabilityEvaluation(): JSX.Element {
                     <LemonButton type="secondary" icon={<IconArrowLeft />} onClick={handleCancel}>
                         {hasUnsavedChanges ? 'Cancel' : 'Back'}
                     </LemonButton>
-                    {activeTab !== 'runs' && saveButton}
+                    {activeTab !== 'runs' && (
+                        <AccessControlAction
+                            resourceType={AccessControlResourceType.LlmAnalytics}
+                            minAccessLevel={AccessControlLevel.Editor}
+                        >
+                            <LemonButton
+                                type="primary"
+                                onClick={handleSave}
+                                disabledReason={saveButtonDisabledReason}
+                                loading={evaluationFormSubmitting}
+                            >
+                                {isNewEvaluation ? 'Create evaluation' : 'Save changes'}
+                            </LemonButton>
+                        </AccessControlAction>
+                    )}
                 </div>
-            </div>
+            </SceneStickyBar>
 
             {evaluation.status === 'error' && (
                 <LemonBanner type="error">
@@ -750,12 +748,6 @@ export function AIObservabilityEvaluation(): JSX.Element {
                                     {isNewEvaluation && isReportableEvaluation && (
                                         <EvaluationReportConfig evaluationId="new" />
                                     )}
-
-                                    {/* The form is long enough that the header action scrolls out of sight */}
-                                    <div className="flex items-center justify-end gap-2">
-                                        {hasUnsavedChanges && <LemonTag type="warning">Unsaved changes</LemonTag>}
-                                        {saveButton}
-                                    </div>
                                 </Form>
 
                                 {/* Scheduled Reports (for existing evaluations, outside the form) */}


### PR DESCRIPTION
## Problem

Someone configuring an evaluator in AI evals scrolls down through the Configuration tab, finishes editing, and then has to scroll all the way back to the page header to save. The only "Save changes" button lives in the header, which does not stick, so it is off screen exactly where the work ends.

## Changes

- The evaluator's status tags and actions ("Save changes", "Cancel", "Trend insight", "Open in Playground") now sit in a `SceneStickyBar`, so they stay pinned to the top of the scroll area on every tab.
- The evaluation name stays above the bar and scrolls away with the page.
- `SceneStickyBar`'s `hasSceneTitleSection={false}` offset was `top-0`. The scene container has 16px of padding, so at `top-0` a strip of content shows scrolling past above the bar. It now cancels that padding and sits flush. No existing caller passes `false`, so nothing else moves.

The first version of this PR added a second "Save changes" button at the end of the form instead. A sticky bar is better: one save action rather than two, and it works from anywhere in the form rather than only at the bottom.

## How did you test this code?

I could not verify this in a running app — the sandbox has one core, so bringing up the dev stack was not practical, and this scene has no Storybook story. **A reviewer should eyeball the scrolled header before this merges.**

- The sticky offset question is the one thing I did verify: an isolated repro of the scroll container (16px padding, `overflow-y: auto`, sticky child) confirms `top: 0` leaves the padding strip see-through and `-16px` sits flush.
- Existing Jest suites for the evaluations area pass (`pnpm --filter=@posthog/frontend exec jest evaluations`).
- `tsgo --noEmit` reports no errors in either changed file. The pre-existing `@posthog/quill` module-resolution errors elsewhere in the repo are unrelated and unaffected.
- No tests added: this is layout-only, and the actions it moves are unchanged.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing docs describe where these actions sit.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised in Slack by someone hitting the scroll-back-to-top problem while configuring an evaluator.

Written by the PostHog Slack app (Claude Code). No repo skills were invoked; the work is two frontend files. It started as the bottom-button version, then moved to the sticky bar on the reporter's suggestion — which is also the pattern the logs detail scenes use.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1786638397190589?thread_ts=1786638397.190589&cid=C0ACRAMJUAG)*
