### PR TITLE
feat(signals): add reviewer action labels to inbox ranking dataset

### DIFF
--- a/products/signals/dags/inbox_ranking/dataset/dag.py
+++ b/products/signals/dags/inbox_ranking/dataset/dag.py
@@ -73,7 +73,7 @@ from products.signals.dags.inbox_ranking.dataset.queries import (
     valid_report_uuids,
 )
 
-FEATURE_SCHEMA_VERSION = 2
+FEATURE_SCHEMA_VERSION = 3
 
 # Statuses a report can be authored straight into and still be in the inbox (`create_scout_report`
 # and `create_custom_agent_ready_report`), which is how a report reaches the spine without a
@@ -189,6 +189,10 @@ LABEL_FIELDS: list[tuple[str, pa.DataType]] = [
     ("refund_reason", pa.string()),
     ("refund_billing_path", pa.string()),
     ("refund_credits", pa.int64()),
+    ("reviewer_add_count", pa.int32()),
+    ("first_reviewer_added_at", _TIMESTAMP),
+    ("reviewer_remove_count", pa.int32()),
+    ("first_reviewer_removed_at", _TIMESTAMP),
 ]
 
 _LABELS_FIELDS: list[tuple[str, pa.DataType]] = [

--- a/products/signals/dags/inbox_ranking/dataset/queries.py
+++ b/products/signals/dags/inbox_ranking/dataset/queries.py
@@ -231,10 +231,19 @@ ACTIONS_COLUMNS = (
     "first_create_pr_clicked_at",
     "discuss_count",
     "snooze_count",
+    "reviewer_add_count",
+    "first_reviewer_added_at",
+    "reviewer_remove_count",
+    "first_reviewer_removed_at",
 )
 # Bulk action rows carry no report_id and are excluded; bulk dismissals are recovered from the
 # server-side status stream instead. minIf misses fill non-nullable datetimes with epoch 0, hence
 # the nullIf(..., fromUnixTimestamp(0)) wraps here and below.
+#
+# The reviewer actions edit the report's suggested-reviewer list: adding one is a mild positive
+# engagement signal, removing one plausibly means the suggested-reviewer heuristic mis-routed the
+# report, which is useful to the policy layer even if never a model head. `click_suggested_reviewer`
+# also exists but is deliberately not aggregated: it fires so rarely it carries no signal.
 ACTIONS_SQL = """
 SELECT
     toString(properties.report_id) AS report_id,
@@ -243,7 +252,11 @@ SELECT
     countIf(toString(properties.action_type) = 'create_pr') AS create_pr_click_count,
     nullIf(minIf(timestamp, toString(properties.action_type) = 'create_pr'), fromUnixTimestamp(0)) AS first_create_pr_clicked_at,
     countIf(toString(properties.action_type) = 'discuss') AS discuss_count,
-    countIf(toString(properties.action_type) = 'snooze') AS snooze_count
+    countIf(toString(properties.action_type) = 'snooze') AS snooze_count,
+    countIf(toString(properties.action_type) = 'add_suggested_reviewer') AS reviewer_add_count,
+    nullIf(minIf(timestamp, toString(properties.action_type) = 'add_suggested_reviewer'), fromUnixTimestamp(0)) AS first_reviewer_added_at,
+    countIf(toString(properties.action_type) = 'remove_suggested_reviewer') AS reviewer_remove_count,
+    nullIf(minIf(timestamp, toString(properties.action_type) = 'remove_suggested_reviewer'), fromUnixTimestamp(0)) AS first_reviewer_removed_at
 FROM events
 WHERE event = 'Inbox report action'
   AND timestamp >= toDateTime({labels_epoch}) AND timestamp < toDateTime({snapshot_end})
@@ -460,6 +473,10 @@ LABEL_DEFAULTS: dict[str, Any] = {
     "refund_reason": None,
     "refund_billing_path": None,
     "refund_credits": None,
+    "reviewer_add_count": 0,
+    "first_reviewer_added_at": None,
+    "reviewer_remove_count": 0,
+    "first_reviewer_removed_at": None,
 }
 
 _TIMESTAMP_LABEL_COLUMNS = frozenset(name for name in LABEL_DEFAULTS if name.endswith("_at"))

--- a/products/signals/dags/inbox_ranking/tests/test_dataset.py
+++ b/products/signals/dags/inbox_ranking/tests/test_dataset.py
@@ -97,7 +97,7 @@ def test_merge_label_streams_fills_defaults_and_maps_columns():
     stream_rows: dict[str, list[tuple[Any, ...]]] = {
         "impressions": [(UUID_A, T1.replace(tzinfo=None), 5, 2, 3, 1, ["error_tracking"])],
         "opens": [(UUID_A.upper(), T2, 4, 2), (UUID_B, T2, 1, 1)],
-        "actions": [("bogus-id", 1, T1, 1, T1, 1, 1)],
+        "actions": [("bogus-id", 1, T1, 1, T1, 1, 1, 1, T1, 1, T1)],
         "status_changes": [],
         "pr_events": [],
     }

--- a/products/signals/dags/inbox_ranking/tests/test_dataset.py
+++ b/products/signals/dags/inbox_ranking/tests/test_dataset.py
@@ -97,7 +97,12 @@ def test_merge_label_streams_fills_defaults_and_maps_columns():
     stream_rows: dict[str, list[tuple[Any, ...]]] = {
         "impressions": [(UUID_A, T1.replace(tzinfo=None), 5, 2, 3, 1, ["error_tracking"])],
         "opens": [(UUID_A.upper(), T2, 4, 2), (UUID_B, T2, 1, 1)],
-        "actions": [("bogus-id", 1, T1, 1, T1, 1, 1, 1, T1, 1, T1)],
+        "actions": [
+            ("bogus-id", 1, T1, 1, T1, 1, 1, 1, T1, 1, T1),
+            # Distinct values per column, so a shifted or swapped ACTIONS_SQL/ACTIONS_COLUMNS
+            # position lands a wrong value in some asserted field below.
+            (UUID_B, 5, T1, 0, None, 0, 0, 2, T1, 3, T2),
+        ],
         "status_changes": [],
         "pr_events": [],
     }
@@ -117,6 +122,11 @@ def test_merge_label_streams_fills_defaults_and_maps_columns():
     assert r2["impression_unit_count"] == 0
     assert r2["first_impressed_at"] is None
     assert r2["pr_created_count"] == 0
+    assert r2["ui_dismiss_count"] == 5
+    assert r2["reviewer_add_count"] == 2
+    assert r2["first_reviewer_added_at"] == T1
+    assert r2["reviewer_remove_count"] == 3
+    assert r2["first_reviewer_removed_at"] == T2
 
 
 @pytest.mark.parametrize("alias_first", [True, False])


### PR DESCRIPTION
## Problem

The inbox surfaces suggested reviewers on a report, and users add or remove them, but the ranking dataset never records those edits.
Removing a suggested reviewer plausibly means the suggestion mis-routed the report; adding one is a mild positive engagement signal.
Volume is a few reports per day, too thin to train a head on today, so capturing now lets history accumulate (same reasoning as the thumbs feedback columns).

## Changes

- The actions label stream in `inbox_report_labels` gains four columns: `reviewer_add_count`, `first_reviewer_added_at`, `reviewer_remove_count`, `first_reviewer_removed_at`.
- `FEATURE_SCHEMA_VERSION` bumps 2 to 3 (additive nullable columns, per the dag's schema-change convention).
- No new label stream: the source event `Inbox report action` already sits on the labeled-ids spine, so this follows the refund columns PR #81586 with fewer moving parts.
- `click_suggested_reviewer` stays unaggregated: it fires too rarely to carry signal.

## How did you test this code?

- Ran `hogli test products/signals/dags/inbox_ranking/tests/` locally, all green.
- Imported `posthog.dags.locations.signals` under Django and asserted the parquet label fields and `LABEL_DEFAULTS` keys agree exactly (43 each), the mismatch `pa.Table.from_pylist` would otherwise hide.
- Not run: a live partition build. The first schema-v3 partition lands with the next scheduled daily run after deploy; the downstream warehouse table then needs a `refresh_schema` call, since self-managed table columns freeze at create.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The dag README's stream count is unchanged (no new stream), and there are no user-facing docs for this internal dataset.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @andrewm4894, following the plan recorded in the inbox-ranking tracker skill.
Skills invoked: `/phs inbox-ranking`, `/writing-code-comments`, `/writing-pr-descriptions`.
The column names, defaults, and schema placement mirror the refund labels PR #81586 by design; the test fixture width change only keeps the actions stream row representative.

https://claude.ai/code/session_013EY9AwSUbsx4Xbrjrie4gM
