### PR TITLE
chore(hogql): fail CI when a field's declared nullability drifts from ClickHouse

### DIFF
--- a/posthog/hogql/database/schema/events.py
+++ b/posthog/hogql/database/schema/events.py
@@ -121,7 +121,7 @@ class EventsTable(Table):
         "$session_id": StringDatabaseField(
             name="$session_id", nullable=False, description="Session this event belongs to; join to `sessions`."
         ),
-        "$session_id_uuid": DatabaseField(name="$session_id_uuid", nullable=False),
+        "$session_id_uuid": DatabaseField(name="$session_id_uuid", nullable=True),
         "$window_id": StringDatabaseField(
             name="$window_id", nullable=False, description="Window/tab identifier within a session."
         ),

--- a/posthog/hogql/database/test/nullability_drift_baseline.txt
+++ b/posthog/hogql/database/test/nullability_drift_baseline.txt
@@ -8,11 +8,8 @@
 
 # --- Declared non-nullable, actually Nullable -------------------------------------------------
 # The dangerous direction: the type system believes NULL is impossible here and can drop null
-# handling that the data needs.
-
-# Materialized as `Nullable(UInt128)` (see posthog/models/event/sql.py) because an event whose
-# `$session_id` property is absent or not a UUID has no value to store.
-events.$session_id_uuid
+# handling that the data needs. Empty, and worth keeping that way — `events.$session_id_uuid` was
+# the only one, and it is fixed.
 
 # --- Declared nullable, actually non-nullable -------------------------------------------------
 # The conservative direction: correctness is safe, but queries carry null handling they do not

--- a/posthog/hogql/database/test/nullability_drift_baseline.txt
+++ b/posthog/hogql/database/test/nullability_drift_baseline.txt
@@ -1,0 +1,75 @@
+# Fields whose declared `nullable=` disagrees with the ClickHouse column behind them.
+#
+# Every entry here is a bug waiting to happen, not an exemption. The type system trusts these
+# declarations, so a wrong one makes it reason about NULLs that cannot appear, or miss ones that
+# can. Burn this list down; do not grow it.
+#
+# Format: one `clickhouse_table.column` per line. See test_nullability_drift.py.
+
+# --- Declared non-nullable, actually Nullable -------------------------------------------------
+# The dangerous direction: the type system believes NULL is impossible here and can drop null
+# handling that the data needs.
+
+# Materialized as `Nullable(UInt128)` (see posthog/models/event/sql.py) because an event whose
+# `$session_id` property is absent or not a UUID has no value to store.
+events.$session_id_uuid
+
+# --- Declared nullable, actually non-nullable -------------------------------------------------
+# The conservative direction: correctness is safe, but queries carry null handling they do not
+# need, which costs both readability and ClickHouse performance.
+
+error_tracking_fingerprint_issue_state.first_seen
+error_tracking_fingerprint_issue_state.issue_id
+error_tracking_fingerprint_issue_state.issue_status
+
+logs_distributed._bytes_uncompressed
+logs_distributed.mat_body_ipv4_matches
+
+session_replay_events.ai_tags_fixed
+session_replay_events.ai_tags_freeform
+session_replay_events.all_urls
+
+web_pre_aggregated_bounces.browser
+web_pre_aggregated_bounces.city_name
+web_pre_aggregated_bounces.country_code
+web_pre_aggregated_bounces.end_pathname
+web_pre_aggregated_bounces.entry_pathname
+web_pre_aggregated_bounces.has_fbclid
+web_pre_aggregated_bounces.has_gad_source_paid_search
+web_pre_aggregated_bounces.has_gclid
+web_pre_aggregated_bounces.mat_metadata_backend
+web_pre_aggregated_bounces.mat_metadata_loggedIn
+web_pre_aggregated_bounces.os
+web_pre_aggregated_bounces.referring_domain
+web_pre_aggregated_bounces.region_code
+web_pre_aggregated_bounces.region_name
+web_pre_aggregated_bounces.utm_campaign
+web_pre_aggregated_bounces.utm_content
+web_pre_aggregated_bounces.utm_medium
+web_pre_aggregated_bounces.utm_source
+web_pre_aggregated_bounces.utm_term
+web_pre_aggregated_bounces.viewport_height
+web_pre_aggregated_bounces.viewport_width
+
+web_pre_aggregated_stats.browser
+web_pre_aggregated_stats.city_name
+web_pre_aggregated_stats.country_code
+web_pre_aggregated_stats.end_pathname
+web_pre_aggregated_stats.entry_pathname
+web_pre_aggregated_stats.has_fbclid
+web_pre_aggregated_stats.has_gad_source_paid_search
+web_pre_aggregated_stats.has_gclid
+web_pre_aggregated_stats.mat_metadata_backend
+web_pre_aggregated_stats.mat_metadata_loggedIn
+web_pre_aggregated_stats.os
+web_pre_aggregated_stats.pathname
+web_pre_aggregated_stats.referring_domain
+web_pre_aggregated_stats.region_code
+web_pre_aggregated_stats.region_name
+web_pre_aggregated_stats.utm_campaign
+web_pre_aggregated_stats.utm_content
+web_pre_aggregated_stats.utm_medium
+web_pre_aggregated_stats.utm_source
+web_pre_aggregated_stats.utm_term
+web_pre_aggregated_stats.viewport_height
+web_pre_aggregated_stats.viewport_width

--- a/posthog/hogql/database/test/test_nullability_drift.py
+++ b/posthog/hogql/database/test/test_nullability_drift.py
@@ -1,0 +1,147 @@
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from posthog.test.base import BaseTest, ClickhouseTestMixin
+
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.database import Database
+from posthog.hogql.database.models import (
+    DatabaseField,
+    ExpressionField,
+    FunctionCallTable,
+    LazyTable,
+    SavedQuery,
+    Table,
+    VirtualTable,
+)
+
+from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.query_tagging import tags_context
+
+BASELINE_PATH = Path(__file__).parent / "nullability_drift_baseline.txt"
+
+# A table backed by a subquery, an S3 file, or a table function has no `system.columns` row to
+# compare against, so only tables mapping to a physical ClickHouse table are checked.
+NON_PHYSICAL_TABLE_TYPES = (LazyTable, VirtualTable, FunctionCallTable, SavedQuery)
+
+_LOW_CARDINALITY = re.compile(r"LowCardinality\((.*)\)")
+_SIMPLE_AGGREGATE = re.compile(r"SimpleAggregateFunction\([^,]+,\s*(.*)\)")
+
+
+# Whether reading a column of this type can yield NULL. `LowCardinality` and
+# `SimpleAggregateFunction` wrap a value that reads back as its inner type, so
+# `LowCardinality(Nullable(String))` is every bit as nullable as `Nullable(String)`.
+# `Array(Nullable(String))` is not — the array itself is always present.
+def clickhouse_type_is_nullable(clickhouse_type: str) -> bool:
+    previous = None
+    while previous != clickhouse_type:
+        previous = clickhouse_type
+        for pattern in (_LOW_CARDINALITY, _SIMPLE_AGGREGATE):
+            match = pattern.fullmatch(clickhouse_type)
+            if match:
+                clickhouse_type = match.group(1)
+                break
+    return clickhouse_type.startswith("Nullable(")
+
+
+def read_baseline() -> set[str]:
+    entries = set()
+    for line in BASELINE_PATH.read_text().splitlines():
+        line = line.split("#", 1)[0].strip()
+        if line:
+            entries.add(line)
+    return entries
+
+
+@dataclass(frozen=True, kw_only=True)
+class DriftReport:
+    # `table.column` -> why it disagrees, for every field checked against a real column.
+    drift: dict[str, str]
+    # Every `table.column` we were able to compare, drifting or not.
+    compared: set[str]
+
+
+class TestNullabilityDrift(ClickhouseTestMixin, BaseTest):
+    def _collect(self) -> DriftReport:
+        database = Database.create_for(team=self.team)
+        context = HogQLContext(team_id=self.team.pk, database=database, enable_select_queries=True)
+
+        with tags_context(product="internal", feature="schema_introspection"):
+            rows = sync_execute("SELECT table, name, type FROM system.columns WHERE database = currentDatabase()")
+        clickhouse_columns: dict[tuple[str, str], str] = {(table, name): type_ for table, name, type_ in rows}
+        clickhouse_tables = {table for table, _ in clickhouse_columns}
+
+        drift: dict[str, str] = {}
+        compared: set[str] = set()
+
+        for table_name in database.tables.resolve_all_table_names():
+            try:
+                table = database.get_table(table_name)
+            except Exception:
+                continue
+            if not isinstance(table, Table) or isinstance(table, NON_PHYSICAL_TABLE_TYPES):
+                continue
+            try:
+                clickhouse_table = table.to_printed_clickhouse(context).strip("`")
+            except Exception:
+                continue
+            if clickhouse_table not in clickhouse_tables:
+                continue
+
+            for field in table.fields.values():
+                if not isinstance(field, DatabaseField) or isinstance(field, ExpressionField):
+                    continue
+                clickhouse_type = clickhouse_columns.get((clickhouse_table, field.name))
+                if clickhouse_type is None:
+                    continue
+                # An aggregate state column reads back as whatever merging it produces, which is
+                # what the field already declares. Comparing the two would mean modeling the
+                # return type of every aggregate function.
+                if clickhouse_type.startswith("AggregateFunction("):
+                    continue
+
+                key = f"{clickhouse_table}.{field.name}"
+                compared.add(key)
+                if clickhouse_type_is_nullable(clickhouse_type) != field.is_nullable():
+                    declared = "nullable" if field.is_nullable() else "non-nullable"
+                    drift[key] = f"declared {declared}, ClickHouse stores {clickhouse_type}"
+
+        return DriftReport(drift=drift, compared=compared)
+
+    def test_declared_nullability_matches_clickhouse(self) -> None:
+        report = self._collect()
+        baseline = read_baseline()
+
+        # Without a floor this test passes vacuously the moment table names stop lining up with
+        # `system.columns` — say if `to_printed_clickhouse` starts qualifying them with a database.
+        # The real count is several hundred; this only catches the mapping breaking wholesale.
+        assert len(report.compared) > 200, (
+            f"Only {len(report.compared)} columns could be matched to ClickHouse, so this check is "
+            "no longer testing anything. Table names from `to_printed_clickhouse` most likely "
+            "stopped matching `system.columns`."
+        )
+
+        new_drift = sorted(set(report.drift) - baseline)
+        # Only entries we actually compared can be called stale — a table missing from this
+        # ClickHouse was never checked, so its baseline entry tells us nothing either way.
+        stale = sorted(entry for entry in baseline & report.compared if entry not in report.drift)
+
+        problems = []
+        if new_drift:
+            problems.append(
+                "These fields declare a nullability ClickHouse disagrees with:\n"
+                + "\n".join(f"  {entry}: {report.drift[entry]}" for entry in new_drift)
+                + "\n\nSet `nullable=` on the field to match the column. A field claiming to be "
+                "non-nullable when the column is Nullable makes the type system drop null handling "
+                "it needs. If the mismatch is deliberate, add it to "
+                f"{BASELINE_PATH.name} with a comment saying why."
+            )
+        if stale:
+            problems.append(
+                "These fields are listed as known drift but now agree with ClickHouse:\n"
+                + "\n".join(f"  {entry}" for entry in stale)
+                + f"\n\nRemove them from {BASELINE_PATH.name}."
+            )
+
+        assert not problems, "\n\n".join(problems)


### PR DESCRIPTION
## Problem

Someone querying sessions got a wrong bounce rate, because HogQL declared `$is_bounce` non-nullable while ClickHouse stored it as `Nullable`. The type system trusts these declarations, so a wrong one makes it drop null handling the data needs.

We found that mismatch four separate times, each by hand: #75990, #76931, #78341, and `events.$session_id_uuid`. Nothing catches the fifth.

## Changes

- A test compares every HogQL `DatabaseField` against the column ClickHouse actually stores, and fails on any disagreement.
- The 52 fields that already disagree live in `nullability_drift_baseline.txt`, so the check goes green now and blocks new drift.
- The check also fails when a baseline entry stops drifting, which keeps the list burning down instead of going stale.
- `events.$session_id_uuid` moves to `nullable=True`, matching the `Nullable(UInt128)` column it reads.

The check reads `system.columns` rather than parsing our `CREATE TABLE` strings. Parsing would miss every column added by a ClickHouse migration, and it would prove nothing about the database a query actually runs against.

Three ClickHouse types need care, and the test handles each:

| Stored type | Reads back as | Treated as |
| --- | --- | --- |
| `LowCardinality(Nullable(String))` | `Nullable(String)` | nullable |
| `SimpleAggregateFunction(max, Nullable(Int64))` | `Nullable(Int64)` | nullable |
| `AggregateFunction(argMin, ...)` | whatever merging returns | skipped |

Only one of the 52 runs in the dangerous direction. `events.$session_id_uuid` claims to be non-nullable over a `Nullable(UInt128)` column, so the type system believes NULL is impossible there. The other 51 declare nullable over a non-null column, which is safe but costs queries null handling they do not need.

> [!NOTE]
> The check covers tables that map to a physical ClickHouse table. Lazy tables, virtual tables and expression fields have no `system.columns` row to compare against, so they stay uncovered. Every mismatch we have found so far sat on a physical column.

## How did you test this code?

I (actually Claude) verified the check fails in both directions, since a baseline comparison that always passes is worse than no check.

- Removing `events.$session_id_uuid` from the baseline fails the test and names the column and its stored type.
- Adding a healthy column, `events.timestamp`, to the baseline fails the test as a stale entry.
- A coverage floor fails the test if fewer than 200 columns match, so the check cannot pass by silently comparing nothing. It compares 606 locally.

The `nullable=True` flip changes no generated SQL in the suites I ran, which surprised me until I read the printer: `in_join_constraint` suppresses `ifNull` wrapping, and `$session_id` comparisons take an earlier optimized path. Both are the only places this column appears.

Ran locally: the HogQL printer suite, the sessions v2 and v3 schema suites, the session where-clause extractor suite, and the HogQL database suite.

Not checked locally: the full `posthog/hogql/` suite and the web analytics query runners were still running when I opened this. CI covers both.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via Claude Code) wrote this after four rounds of finding the same bug class by hand. George asked for the systemic fix rather than a fifth one-line correction.

Skills invoked: `/writing-tests` and `/writing-pr-descriptions`.

Two decisions worth flagging. I first wrote the stale-entry check to flag any baseline entry not in the current drift set, which would misfire whenever CI's ClickHouse lacked a table that a developer's machine has. It now only flags entries it actually compared. I also considered fixing all 52 fields here, but the 51 over-declared ones change generated SQL across web analytics preaggregation, so they belong in their own PR with their own validation.
