### PR TITLE
fix(error-tracking): attach git metadata to frontend releases

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -125,8 +125,16 @@ jobs:
                   labels: ${{ steps.docker-meta.outputs.labels }}
                   annotations: ${{ steps.docker-meta.outputs.annotations }}
                   platforms: linux/arm64,linux/amd64
+                  # The GITHUB_* args become the git metadata on the error tracking release the
+                  # sourcemap upload stage creates. That stage builds in a container with no .git
+                  # directory, so the workflow has to hand them in (see Dockerfile).
                   build-args: |
                       COMMIT_HASH=${{ github.sha }}
+                      GITHUB_ACTIONS=true
+                      GITHUB_SHA=${{ github.sha }}
+                      GITHUB_REF_NAME=${{ github.ref_name }}
+                      GITHUB_REPOSITORY=${{ github.repository }}
+                      GITHUB_SERVER_URL=${{ github.server_url }}
                   secrets: |
                       posthog_upload_sourcemaps_cli_api_key=${{ secrets.POSTHOG_UPLOAD_SOURCEMAPS_CLI_API_KEY }}
 
@@ -194,8 +202,16 @@ jobs:
                   labels: ${{ steps.docker-meta.outputs.labels }}
                   annotations: ${{ steps.docker-meta.outputs.annotations }}
                   platforms: linux/arm64,linux/amd64
+                  # The GITHUB_* args become the git metadata on the error tracking release the
+                  # sourcemap upload stage creates. That stage builds in a container with no .git
+                  # directory, so the workflow has to hand them in (see Dockerfile).
                   build-args: |
                       COMMIT_HASH=${{ github.sha }}
+                      GITHUB_ACTIONS=true
+                      GITHUB_SHA=${{ github.sha }}
+                      GITHUB_REF_NAME=${{ github.ref_name }}
+                      GITHUB_REPOSITORY=${{ github.repository }}
+                      GITHUB_SERVER_URL=${{ github.server_url }}
                   secrets: |
                       posthog_upload_sourcemaps_cli_api_key=${{ secrets.POSTHOG_UPLOAD_SOURCEMAPS_CLI_API_KEY }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,22 @@ COPY --from=frontend-build /code/frontend/dist /code/frontend/dist
 #   curl -LsSf "https://github.com/PostHog/posthog/releases/download/posthog-cli%2Fv<X.Y.Z>/posthog-cli-installer.sh" | sha256sum
 ARG POSTHOG_CLI_VERSION=0.11.0
 ARG POSTHOG_CLI_INSTALLER_SHA256=74b0e2d967b688f57432be5bbb78f96cb5dde69f9283c0d8930a01efc132fbc2
+# The CLI stamps the release it creates with git metadata (branch, remote, repo name) read from the
+# GitHub Actions environment. Only frontend/dist is copied into this stage, so there is no .git
+# directory to fall back on: without these the release is created with no link back to the code it
+# was built from, and the CLI skips the metadata silently because --release-name/--release-version
+# already let it create the release. The CLI treats empty values as absent, so local builds that
+# pass none of these behave as before.
+ARG GITHUB_ACTIONS
+ARG GITHUB_SHA
+ARG GITHUB_REF_NAME
+ARG GITHUB_REPOSITORY
+ARG GITHUB_SERVER_URL
+ENV GITHUB_ACTIONS=$GITHUB_ACTIONS \
+    GITHUB_SHA=$GITHUB_SHA \
+    GITHUB_REF_NAME=$GITHUB_REF_NAME \
+    GITHUB_REPOSITORY=$GITHUB_REPOSITORY \
+    GITHUB_SERVER_URL=$GITHUB_SERVER_URL
 RUN --mount=type=secret,id=posthog_upload_sourcemaps_cli_api_key \
     if ( \
         [ -f /run/secrets/posthog_upload_sourcemaps_cli_api_key ] && \


### PR DESCRIPTION
## Problem

Anyone triaging an exception in error tracking cannot get from the release to the code it was built from, because our releases carry a commit sha as their version and no git metadata at all.

- `posthog-cli` creates the release inside the `sourcemap-upload` stage of the root `Dockerfile`, which receives only `frontend/dist`.
- The CLI reads branch, remote URL, and repository name from a `.git` directory or the GitHub Actions environment, and that stage has neither.
- The CLI then skips the metadata without warning, because `--release-name` and `--release-version` already let it create the release.

## Changes

- The container CD workflow forwards `GITHUB_ACTIONS`, `GITHUB_SHA`, `GITHUB_REF_NAME`, `GITHUB_REPOSITORY`, and `GITHUB_SERVER_URL` as build args, in both the build step and its retry.
- The `sourcemap-upload` stage declares them and promotes them to environment variables so the CLI reads them.
- New releases get `metadata.git`, which cymbal embeds in `$exception_release` on each matching event.
- Existing releases are not backfilled.
- Builds that pass none of the args stay as they are, because the CLI treats an empty value as absent.

## How did you test this code?

I did not run the container build. It needs the upload secret and would create a real release.

- The pinned CLI v0.11.0 reads these five variables: [git.rs](https://github.com/PostHog/posthog/blob/06bb7c4bdc90eb6994cf62df88d0756c0258c034/cli/src/utils/git.rs#L57-L63).
- The same version drops the metadata silently once release args are supplied: [inject.rs](https://github.com/PostHog/posthog/blob/06bb7c4bdc90eb6994cf62df88d0756c0258c034/cli/src/sourcemaps/inject.rs#L239-L250).
- Not checked: the release row a master build produces, which needs the build to run.
- No tests added, because the change is build wiring.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The change is internal build wiring.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by the PostHog Slack app, from the linked thread asking why git info was missing from our own releases.
- Skills invoked: `/authoring-ci-workflows`, `/writing-code-comments`, `/writing-pr-descriptions`.
- I first looked for the gap in ingestion and in the release model, and ruled both out: the model stores `metadata` as opaque JSON and cymbal serializes it whenever it is set, so the missing data had to come from the build.
- The Rust image build also uploads symbols from inside a container, but it creates no release by design, so it needs no equivalent change.
- Public artifact: every value in this diff and description comes from this repository.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C07AA937K9A/p1786638263765199?thread_ts=1786638263.765199&cid=C07AA937K9A)*
