### PR TITLE
feat(aio): make the AI lane's partition keying a deployment setting

### DIFF
--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -210,6 +210,10 @@ pub struct Config {
     #[envconfig(default = "false")]
     pub overflow_enabled: bool,
 
+    /// Whether a rate-limited analytics event keeps its partition key when it
+    /// reroutes to overflow. The analytics overflow consumer updates persons
+    /// keyed on distinct id, so spreading one hot key across partitions trades
+    /// a hot partition for contended person-row updates.
     #[envconfig(default = "false")]
     pub overflow_preserve_partition_locality: bool,
 
@@ -423,6 +427,27 @@ pub struct KafkaConfig {
     /// here instead of the analytics overflow topic. Refused at boot in import
     /// mode because imports must never overflow.
     pub capture_analytics_ai_events_overflow_topic: Option<String>,
+    /// Whether an AI event keeps its partition key on the AI main topic
+    /// (env: `AI_MAIN_PRESERVE_PARTITION_LOCALITY`). Unset it to spread a hot
+    /// token across the topic's partitions without diverting to overflow and
+    /// without turning person processing off — unlike the overflow lanes,
+    /// this lane's key policy is independent of person processing.
+    #[envconfig(default = "true")]
+    pub ai_main_preserve_partition_locality: bool,
+    /// The same choice for the AI overflow topic
+    /// (env: `AI_OVERFLOW_PRESERVE_PARTITION_LOCALITY`). Separate from the
+    /// analytics lane's `overflow_preserve_partition_locality` because the
+    /// tradeoff differs: the analytics overflow consumer updates persons
+    /// keyed on distinct id, so spreading one key there trades a hot
+    /// partition for contended person-row updates, while the AI consumer only
+    /// reads persons and pays no such cost.
+    ///
+    /// Both AI knobs live on the kafka config because [`pipeline::resolve`]
+    /// is the single place the AI lane's key policy is decided, and the sink
+    /// is what calls it. A force-limited key is keyless regardless: that
+    /// reason exists to break up a hot key.
+    #[envconfig(default = "true")]
+    pub ai_overflow_preserve_partition_locality: bool,
     #[envconfig(default = "false")]
     pub kafka_tls: bool,
     #[envconfig(default = "")]
@@ -522,6 +547,30 @@ mod tests {
         assert_eq!(
             config.kafka.capture_analytics_ai_events_overflow_topic,
             None
+        );
+    }
+
+    /// The AI lanes' locality knobs are independent of the analytics one and
+    /// of each other, and start from the opposite default: a deployment that
+    /// sets only `OVERFLOW_PRESERVE_PARTITION_LOCALITY` must not drag the AI
+    /// lanes along with it in either direction.
+    #[test]
+    fn ai_locality_knobs_are_independent_of_analytics() {
+        let config: Config =
+            envconfig::Envconfig::init_from_hashmap(&required_config_env()).unwrap();
+        assert!(!config.overflow_preserve_partition_locality);
+        assert!(config.kafka.ai_main_preserve_partition_locality);
+        assert!(config.kafka.ai_overflow_preserve_partition_locality);
+
+        let mut env = required_config_env();
+        env.insert("OVERFLOW_PRESERVE_PARTITION_LOCALITY".into(), "true".into());
+        env.insert("AI_MAIN_PRESERVE_PARTITION_LOCALITY".into(), "false".into());
+        let config: Config = envconfig::Envconfig::init_from_hashmap(&env).unwrap();
+        assert!(config.overflow_preserve_partition_locality);
+        assert!(!config.kafka.ai_main_preserve_partition_locality);
+        assert!(
+            config.kafka.ai_overflow_preserve_partition_locality,
+            "the AI main knob must not drag the AI overflow lane with it"
         );
     }
 

--- a/rust/capture/src/pipeline.rs
+++ b/rust/capture/src/pipeline.rs
@@ -84,6 +84,56 @@ impl AddressDecision {
     }
 }
 
+/// The AI lane's deployment policy: which of its topics exist, and how each
+/// keys its records. Every AI key decision reads from here, so the lane's
+/// policy is one struct rather than a stamp on one lane and a config lookup
+/// on another. The analytics and replay lanes are unaffected — they still
+/// carry their key policy per event on [`OverflowReason`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AiLaneRouting {
+    /// The AI overflow valve (`CAPTURE_ANALYTICS_AI_EVENTS_OVERFLOW_TOPIC`) is
+    /// set. Unset means the AI lane never routes to overflow, force_overflow
+    /// and stamped reasons included.
+    pub overflow_armed: bool,
+    /// Whether an AI event keeps its partition key on the main lane. Unlike
+    /// the analytics overflow lane, this is not tied to person processing:
+    /// the key can be dropped while person processing stays on, so events
+    /// spread across the AI topic's partitions and still carry person
+    /// properties.
+    pub preserve_main_locality: bool,
+    /// The same, for the AI overflow lane. A force-limited key ignores this
+    /// and publishes keyless either way — breaking up a hot key is what that
+    /// reason is for.
+    pub preserve_overflow_locality: bool,
+}
+
+impl Default for AiLaneRouting {
+    /// The pre-knob behavior: no valve, both lanes keyed per distinct id.
+    fn default() -> Self {
+        Self {
+            overflow_armed: false,
+            preserve_main_locality: true,
+            preserve_overflow_locality: true,
+        }
+    }
+}
+
+fn keyed(preserve: bool) -> OrderingGuarantee {
+    if preserve {
+        OrderingGuarantee::PerDistinctId
+    } else {
+        OrderingGuarantee::None
+    }
+}
+
+/// Key policy for the AI overflow lane. Person processing being off still
+/// nulls the key on its own, as on the analytics overflow lane — a key whose
+/// person processing was already disabled must not get its partition back.
+/// The config knob decides the remaining case, where person processing is on.
+fn ai_overflow_ordering(ai: AiLaneRouting, person_processing_disabled: bool) -> OrderingGuarantee {
+    keyed(ai.preserve_overflow_locality && !person_processing_disabled)
+}
+
 /// Decide an event's address from its metadata. DLQ and custom-topic
 /// redirects take priority over per-datatype and overflow routing. Consulted
 /// by the sink, which resolves the address to a topic string and the ordering
@@ -92,8 +142,9 @@ impl AddressDecision {
 /// returned decision is realizable by the sink.
 pub fn resolve(
     metadata: &ProcessedEventMetadata,
-    ai_events_overflow_armed: bool,
+    ai: AiLaneRouting,
 ) -> Result<AddressDecision, CaptureError> {
+    let ai_events_overflow_armed = ai.overflow_armed;
     // redirect_to_dlq takes priority over all other routing.
     if metadata.redirect_to_dlq {
         return Ok(AddressDecision::redirect(Address::Dlq));
@@ -155,51 +206,43 @@ pub fn resolve(
             }
         }
         DataType::AiEvents => {
-            // Valve armed: the AI lanes route overflow like analytics, except
-            // that a burst may spread while person processing is on — the AI
-            // consumer reads persons without writing them, so keyless
-            // person-on records cause no person-update contention there.
-            // Valve unarmed: AI events never overflow —
-            // force_overflow and stamped reasons are deliberately ignored
-            // (the pipeline never stamps a reason on this lane anyway). The
-            // default route keeps the event key regardless of
-            // skip_person_processing (v1 only nulls keys for
-            // Main/Overflow-shaped destinations). AI events never reroute
-            // historical.
+            // Both AI lanes key from `ai`, not from what the limiter stamped:
+            // the AI consumer reads persons without writing them, so its key
+            // policy is a deployment choice rather than a consequence of
+            // person processing, and both lanes answer it the same way. The
+            // stamped `RateLimited { preserve_locality }` still drives the
+            // analytics lane above; on this lane the reason only says the
+            // event overflowed. Valve unarmed: AI events never overflow, so
+            // force_overflow and stamped reasons are deliberately ignored.
+            // AI events never reroute historical.
             if ai_events_overflow_armed && metadata.force_overflow {
                 AddressDecision::lane(
                     Pipeline::Ai,
                     Lane::Overflow,
-                    person_ordering(metadata.person_processing_disabled()),
+                    ai_overflow_ordering(ai, metadata.person_processing_disabled()),
                 )
             } else if ai_events_overflow_armed {
                 match &metadata.overflow_reason {
+                    // A force-limited key exists to be broken up, so it
+                    // publishes keyless whatever the lane's policy says.
                     Some(OverflowReason::ForceLimited) => {
                         AddressDecision::lane(Pipeline::Ai, Lane::Overflow, OrderingGuarantee::None)
                     }
-                    Some(OverflowReason::RateLimited {
-                        preserve_locality: true,
-                    }) => AddressDecision::lane(
+                    Some(OverflowReason::RateLimited { .. }) => AddressDecision::lane(
                         Pipeline::Ai,
                         Lane::Overflow,
-                        // Same precedence as the analytics overflow lane above.
-                        person_ordering(metadata.person_processing_disabled()),
+                        ai_overflow_ordering(ai, metadata.person_processing_disabled()),
                     ),
-                    Some(OverflowReason::RateLimited {
-                        preserve_locality: false,
-                    }) => {
-                        AddressDecision::lane(Pipeline::Ai, Lane::Overflow, OrderingGuarantee::None)
-                    }
                     // ReplayLimited cannot be stamped on the AI lane either;
                     // treated as unstamped, as above.
                     Some(OverflowReason::ReplayLimited) | None => AddressDecision::lane(
                         Pipeline::Ai,
                         Lane::Main,
-                        OrderingGuarantee::PerDistinctId,
+                        keyed(ai.preserve_main_locality),
                     ),
                 }
             } else {
-                AddressDecision::lane(Pipeline::Ai, Lane::Main, OrderingGuarantee::PerDistinctId)
+                AddressDecision::lane(Pipeline::Ai, Lane::Main, keyed(ai.preserve_main_locality))
             }
         }
         // Single-lane pipelines: capture has no overflow topic for warnings,
@@ -253,6 +296,15 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
+    /// A deployment with the given valve state and both AI lanes keyed, which
+    /// is what every case here assumed before the key policy became config.
+    fn routing(overflow_armed: bool) -> AiLaneRouting {
+        AiLaneRouting {
+            overflow_armed,
+            ..AiLaneRouting::default()
+        }
+    }
+
     fn meta(data_type: DataType) -> ProcessedEventMetadata {
         ProcessedEventMetadata {
             data_type,
@@ -282,7 +334,7 @@ mod tests {
         m.redirect_to_topic = Some("custom".to_string());
         m.force_overflow = true;
         assert_eq!(
-            resolve(&m, false).unwrap(),
+            resolve(&m, routing(false)).unwrap(),
             AddressDecision {
                 address: Address::Dlq,
                 ordering: OrderingGuarantee::PerDistinctId,
@@ -297,7 +349,7 @@ mod tests {
         m.redirect_to_topic = Some("my_topic".to_string());
         m.force_overflow = true;
         assert_eq!(
-            resolve(&m, false).unwrap(),
+            resolve(&m, routing(false)).unwrap(),
             AddressDecision {
                 address: Address::Custom("my_topic".to_string()),
                 ordering: OrderingGuarantee::PerDistinctId,
@@ -319,7 +371,7 @@ mod tests {
         #[case] expected_lane: Lane,
     ) {
         let m = meta(data_type);
-        let d = resolve(&m, false).unwrap();
+        let d = resolve(&m, routing(false)).unwrap();
         assert_eq!(
             d.address,
             lane(pipeline, expected_lane),
@@ -343,7 +395,7 @@ mod tests {
         m.force_overflow = true;
         m.overflow_reason = Some(OverflowReason::ForceLimited);
         assert_eq!(
-            resolve(&m, true).unwrap().address,
+            resolve(&m, routing(true)).unwrap().address,
             lane(pipeline, Lane::Main),
             "overflow intent must not move {data_type:?} off its main lane"
         );
@@ -355,16 +407,16 @@ mod tests {
         let mut m = meta(DataType::AnalyticsMain);
         m.force_overflow = true;
         assert_eq!(
-            resolve(&m, false).unwrap().ordering,
+            resolve(&m, routing(false)).unwrap().ordering,
             OrderingGuarantee::PerDistinctId
         );
         m.skip_person_processing = true;
         assert_eq!(
-            resolve(&m, false).unwrap().ordering,
+            resolve(&m, routing(false)).unwrap().ordering,
             OrderingGuarantee::None
         );
         assert_eq!(
-            resolve(&m, false).unwrap().address,
+            resolve(&m, routing(false)).unwrap().address,
             lane(Pipeline::Analytics, Lane::Overflow)
         );
     }
@@ -376,7 +428,7 @@ mod tests {
         let mut force_limited = base.clone();
         force_limited.overflow_reason = Some(OverflowReason::ForceLimited);
         assert_eq!(
-            resolve(&force_limited, false).unwrap(),
+            resolve(&force_limited, routing(false)).unwrap(),
             AddressDecision {
                 address: lane(Pipeline::Analytics, Lane::Overflow),
                 ordering: OrderingGuarantee::None,
@@ -388,11 +440,11 @@ mod tests {
             preserve_locality: true,
         });
         assert_eq!(
-            resolve(&preserve, false).unwrap().ordering,
+            resolve(&preserve, routing(false)).unwrap().ordering,
             OrderingGuarantee::PerDistinctId
         );
         assert_eq!(
-            resolve(&preserve, false).unwrap().address,
+            resolve(&preserve, routing(false)).unwrap().address,
             lane(Pipeline::Analytics, Lane::Overflow)
         );
 
@@ -404,16 +456,16 @@ mod tests {
             preserve_locality: false,
         });
         assert_eq!(
-            resolve(&no_preserve, false).unwrap().ordering,
+            resolve(&no_preserve, routing(false)).unwrap().ordering,
             OrderingGuarantee::PerDistinctId
         );
         assert_eq!(
-            resolve(&no_preserve, false).unwrap().address,
+            resolve(&no_preserve, routing(false)).unwrap().address,
             lane(Pipeline::Analytics, Lane::Overflow)
         );
         no_preserve.skip_person_processing = true;
         assert_eq!(
-            resolve(&no_preserve, false).unwrap().ordering,
+            resolve(&no_preserve, routing(false)).unwrap().ordering,
             OrderingGuarantee::None
         );
 
@@ -423,7 +475,7 @@ mod tests {
         let mut replay = base;
         replay.overflow_reason = Some(OverflowReason::ReplayLimited);
         assert_eq!(
-            resolve(&replay, false).unwrap().address,
+            resolve(&replay, routing(false)).unwrap().address,
             lane(Pipeline::Analytics, Lane::Main)
         );
     }
@@ -447,14 +499,14 @@ mod tests {
         });
 
         assert_eq!(
-            resolve(&m, armed).unwrap().ordering,
+            resolve(&m, routing(armed)).unwrap().ordering,
             OrderingGuarantee::PerDistinctId,
             "locality is preserved while person processing is on"
         );
 
         m.skip_person_processing = true;
         assert_eq!(
-            resolve(&m, armed).unwrap(),
+            resolve(&m, routing(armed)).unwrap(),
             AddressDecision {
                 address: lane(expected_pipeline, Lane::Overflow),
                 ordering: OrderingGuarantee::None,
@@ -469,7 +521,7 @@ mod tests {
         let mut m = meta(DataType::AiEvents);
         m.force_overflow = true;
         assert_eq!(
-            resolve(&m, false).unwrap(),
+            resolve(&m, routing(false)).unwrap(),
             AddressDecision {
                 address: lane(Pipeline::Ai, Lane::Main),
                 ordering: OrderingGuarantee::PerDistinctId,
@@ -478,27 +530,30 @@ mod tests {
 
         // Valve armed: mirrors the analytics main lane's overflow handling.
         assert_eq!(
-            resolve(&m, true).unwrap().address,
+            resolve(&m, routing(true)).unwrap().address,
             lane(Pipeline::Ai, Lane::Overflow)
         );
         assert_eq!(
-            resolve(&m, true).unwrap().ordering,
+            resolve(&m, routing(true)).unwrap().ordering,
             OrderingGuarantee::PerDistinctId
         );
         m.skip_person_processing = true;
-        assert_eq!(resolve(&m, true).unwrap().ordering, OrderingGuarantee::None);
+        assert_eq!(
+            resolve(&m, routing(true)).unwrap().ordering,
+            OrderingGuarantee::None
+        );
 
         let mut force_limited = meta(DataType::AiEvents);
         force_limited.overflow_reason = Some(OverflowReason::ForceLimited);
         assert_eq!(
-            resolve(&force_limited, true).unwrap(),
+            resolve(&force_limited, routing(true)).unwrap(),
             AddressDecision {
                 address: lane(Pipeline::Ai, Lane::Overflow),
                 ordering: OrderingGuarantee::None,
             }
         );
         assert_eq!(
-            resolve(&force_limited, false).unwrap().address,
+            resolve(&force_limited, routing(false)).unwrap().address,
             lane(Pipeline::Ai, Lane::Main)
         );
     }
@@ -511,7 +566,7 @@ mod tests {
         m.skip_person_processing = true;
         for armed in [false, true] {
             assert_eq!(
-                resolve(&m, armed).unwrap(),
+                resolve(&m, routing(armed)).unwrap(),
                 AddressDecision {
                     address: lane(Pipeline::Ai, Lane::Main),
                     ordering: OrderingGuarantee::PerDistinctId,
@@ -525,7 +580,7 @@ mod tests {
     fn snapshot_routing_keeps_per_session_ordering() {
         let mut m = meta(DataType::SnapshotMain);
         assert_eq!(
-            resolve(&m, false).unwrap(),
+            resolve(&m, routing(false)).unwrap(),
             AddressDecision {
                 address: lane(Pipeline::Replay, Lane::Main),
                 ordering: OrderingGuarantee::PerSession,
@@ -534,18 +589,18 @@ mod tests {
 
         m.force_overflow = true;
         assert_eq!(
-            resolve(&m, false).unwrap().address,
+            resolve(&m, routing(false)).unwrap().address,
             lane(Pipeline::Replay, Lane::Overflow)
         );
         assert_eq!(
-            resolve(&m, false).unwrap().ordering,
+            resolve(&m, routing(false)).unwrap().ordering,
             OrderingGuarantee::PerSession
         );
 
         m.force_overflow = false;
         m.overflow_reason = Some(OverflowReason::ReplayLimited);
         assert_eq!(
-            resolve(&m, false).unwrap().address,
+            resolve(&m, routing(false)).unwrap().address,
             lane(Pipeline::Replay, Lane::Overflow)
         );
     }
@@ -558,13 +613,13 @@ mod tests {
         let mut m = meta(DataType::SnapshotMain);
         m.session_id = None;
         assert!(matches!(
-            resolve(&m, false),
+            resolve(&m, routing(false)),
             Err(CaptureError::MissingSessionId)
         ));
 
         // A dlq redirect keys on the event key, so it stays realizable
         // without a session id.
         m.redirect_to_dlq = true;
-        assert_eq!(resolve(&m, false).unwrap().address, Address::Dlq);
+        assert_eq!(resolve(&m, routing(false)).unwrap().address, Address::Dlq);
     }
 }

--- a/rust/capture/src/pipeline.rs
+++ b/rust/capture/src/pipeline.rs
@@ -95,11 +95,11 @@ pub struct AiLaneRouting {
     /// set. Unset means the AI lane never routes to overflow, force_overflow
     /// and stamped reasons included.
     pub overflow_armed: bool,
-    /// Whether an AI event keeps its partition key on the main lane. Unlike
-    /// the analytics overflow lane, this is not tied to person processing:
-    /// the key can be dropped while person processing stays on, so events
-    /// spread across the AI topic's partitions and still carry person
-    /// properties.
+    /// Whether an AI event keeps its partition key on the main lane while
+    /// person processing is on. Turning it off spreads a hot token across the
+    /// AI topic's partitions without disabling person processing, so those
+    /// events still carry person properties downstream — which no other way
+    /// of spreading an AI burst does.
     pub preserve_main_locality: bool,
     /// The same, for the AI overflow lane. A force-limited key ignores this
     /// and publishes keyless either way — breaking up a hot key is what that
@@ -126,12 +126,14 @@ fn keyed(preserve: bool) -> OrderingGuarantee {
     }
 }
 
-/// Key policy for the AI overflow lane. Person processing being off still
-/// nulls the key on its own, as on the analytics overflow lane — a key whose
-/// person processing was already disabled must not get its partition back.
-/// The config knob decides the remaining case, where person processing is on.
-fn ai_overflow_ordering(ai: AiLaneRouting, person_processing_disabled: bool) -> OrderingGuarantee {
-    keyed(ai.preserve_overflow_locality && !person_processing_disabled)
+/// Key policy for an AI lane. Both lanes answer the same way: person
+/// processing being off nulls the key on its own — an event whose identity
+/// resolution is already disabled is a hot key by construction, and the AI
+/// consumer only reads persons, so it takes keyless records at any time. The
+/// deployment setting decides the remaining case, where person processing is
+/// on.
+fn ai_ordering(preserve_locality: bool, person_processing_disabled: bool) -> OrderingGuarantee {
+    keyed(preserve_locality && !person_processing_disabled)
 }
 
 /// Decide an event's address from its metadata. DLQ and custom-topic
@@ -219,7 +221,10 @@ pub fn resolve(
                 AddressDecision::lane(
                     Pipeline::Ai,
                     Lane::Overflow,
-                    ai_overflow_ordering(ai, metadata.person_processing_disabled()),
+                    ai_ordering(
+                        ai.preserve_overflow_locality,
+                        metadata.person_processing_disabled(),
+                    ),
                 )
             } else if ai_events_overflow_armed {
                 match &metadata.overflow_reason {
@@ -231,18 +236,31 @@ pub fn resolve(
                     Some(OverflowReason::RateLimited { .. }) => AddressDecision::lane(
                         Pipeline::Ai,
                         Lane::Overflow,
-                        ai_overflow_ordering(ai, metadata.person_processing_disabled()),
+                        ai_ordering(
+                            ai.preserve_overflow_locality,
+                            metadata.person_processing_disabled(),
+                        ),
                     ),
                     // ReplayLimited cannot be stamped on the AI lane either;
                     // treated as unstamped, as above.
                     Some(OverflowReason::ReplayLimited) | None => AddressDecision::lane(
                         Pipeline::Ai,
                         Lane::Main,
-                        keyed(ai.preserve_main_locality),
+                        ai_ordering(
+                            ai.preserve_main_locality,
+                            metadata.person_processing_disabled(),
+                        ),
                     ),
                 }
             } else {
-                AddressDecision::lane(Pipeline::Ai, Lane::Main, keyed(ai.preserve_main_locality))
+                AddressDecision::lane(
+                    Pipeline::Ai,
+                    Lane::Main,
+                    ai_ordering(
+                        ai.preserve_main_locality,
+                        metadata.person_processing_disabled(),
+                    ),
+                )
             }
         }
         // Single-lane pipelines: capture has no overflow topic for warnings,
@@ -559,9 +577,12 @@ mod tests {
     }
 
     #[test]
-    fn ai_events_default_route_keeps_event_key() {
-        // skip_person_processing must not null the key on the AI default
-        // route: v1 only nulls keys for Main/Overflow-shaped destinations.
+    fn ai_events_default_route_spreads_once_person_processing_is_off() {
+        // An AI event with identity resolution already disabled is a hot key
+        // by construction, and the AI consumer only reads persons, so the
+        // main lane drops the key without waiting for the deployment setting.
+        // v1's `Destination::absorbs_hot_keys` puts the AI lanes on the same
+        // side, so the two stacks agree.
         let mut m = meta(DataType::AiEvents);
         m.skip_person_processing = true;
         for armed in [false, true] {
@@ -569,11 +590,30 @@ mod tests {
                 resolve(&m, routing(armed)).unwrap(),
                 AddressDecision {
                     address: lane(Pipeline::Ai, Lane::Main),
-                    ordering: OrderingGuarantee::PerDistinctId,
+                    ordering: OrderingGuarantee::None,
                 },
                 "armed={armed}"
             );
         }
+
+        // With person processing on, the deployment setting decides.
+        let m = meta(DataType::AiEvents);
+        assert_eq!(
+            resolve(&m, routing(false)).unwrap().ordering,
+            OrderingGuarantee::PerDistinctId
+        );
+        assert_eq!(
+            resolve(
+                &m,
+                AiLaneRouting {
+                    preserve_main_locality: false,
+                    ..AiLaneRouting::default()
+                }
+            )
+            .unwrap()
+            .ordering,
+            OrderingGuarantee::None
+        );
     }
 
     #[test]

--- a/rust/capture/src/setup.rs
+++ b/rust/capture/src/setup.rs
@@ -298,6 +298,10 @@ pub async fn build_components(
     // governor state (per-`token:distinct_id` budgets) is what must stay
     // isolated, so analytics volume can never push a key's AI events into
     // AI overflow and AI volume never burns the analytics budget.
+    //
+    // The locality argument is inert on this lane: the AI lanes take their
+    // key policy from `pipeline::AiLaneRouting` at routing time, not from the
+    // stamped reason, so nothing reads what this limiter would stamp here.
     let ai_events_overflow_limiter: Option<Arc<OverflowLimiter>> =
         if config.overflow_enabled && ai_events_overflow_enabled {
             let limiter = OverflowLimiter::new(

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -186,6 +186,27 @@ pub struct KafkaSinkBase<P: KafkaProducer> {
     producer: Arc<P>,
     topics: Arc<OutputRegistry>,
     replay_envelope_compression: EnvelopeCompression,
+    /// Key policy for the AI lanes, handed to [`pipeline::resolve`] on every
+    /// record. Which topics exist comes from `topics`; how they key comes
+    /// from config.
+    ai_lane_keys: AiLaneKeys,
+}
+
+/// The configured half of [`pipeline::AiLaneRouting`] — the valve is derived
+/// from the registry, so only the key policy is carried here.
+#[derive(Debug, Clone, Copy)]
+struct AiLaneKeys {
+    preserve_main_locality: bool,
+    preserve_overflow_locality: bool,
+}
+
+impl Default for AiLaneKeys {
+    fn default() -> Self {
+        Self {
+            preserve_main_locality: true,
+            preserve_overflow_locality: true,
+        }
+    }
 }
 
 impl<P: KafkaProducer> Clone for KafkaSinkBase<P> {
@@ -194,6 +215,7 @@ impl<P: KafkaProducer> Clone for KafkaSinkBase<P> {
             producer: Arc::clone(&self.producer),
             topics: Arc::clone(&self.topics),
             replay_envelope_compression: self.replay_envelope_compression,
+            ai_lane_keys: self.ai_lane_keys,
         }
     }
 }
@@ -380,6 +402,10 @@ impl KafkaSink {
             producer: Arc::new(rd_producer),
             topics,
             replay_envelope_compression: config.kafka_replay_envelope_compression,
+            ai_lane_keys: AiLaneKeys {
+                preserve_main_locality: config.ai_main_preserve_partition_locality,
+                preserve_overflow_locality: config.ai_overflow_preserve_partition_locality,
+            },
         })
     }
 }
@@ -393,6 +419,7 @@ impl<P: KafkaProducer> KafkaSinkBase<P> {
             producer: Arc::new(producer),
             topics: Arc::new(topics),
             replay_envelope_compression: EnvelopeCompression::None,
+            ai_lane_keys: AiLaneKeys::default(),
         }
     }
 
@@ -406,7 +433,19 @@ impl<P: KafkaProducer> KafkaSinkBase<P> {
             producer: Arc::new(producer),
             topics: Arc::new(topics),
             replay_envelope_compression,
+            ai_lane_keys: AiLaneKeys::default(),
         }
+    }
+
+    /// Publish the AI lanes without a partition key, so a hot token spreads
+    /// across the topic. Used by tests; production reads config.
+    #[cfg(test)]
+    pub fn without_ai_locality(mut self) -> Self {
+        self.ai_lane_keys = AiLaneKeys {
+            preserve_main_locality: false,
+            preserve_overflow_locality: false,
+        };
+        self
     }
 
     /// CPU-bound prep work: serialize payload + build headers + pick topic/key.
@@ -476,7 +515,14 @@ impl<P: KafkaProducer> KafkaSinkBase<P> {
         // and applies the address-implied side effects in the same match —
         // the dlq output's contract includes the dlq header set, and both
         // admin redirects count their reroutes.
-        let decision = pipeline::resolve(&metadata, self.topics.ai_events_overflow_armed())?;
+        let decision = pipeline::resolve(
+            &metadata,
+            pipeline::AiLaneRouting {
+                overflow_armed: self.topics.ai_events_overflow_armed(),
+                preserve_main_locality: self.ai_lane_keys.preserve_main_locality,
+                preserve_overflow_locality: self.ai_lane_keys.preserve_overflow_locality,
+            },
+        )?;
         let target = match decision.address {
             Address::Dlq => {
                 dlq_reroute_effects(&mut headers, "event_restriction");
@@ -840,6 +886,8 @@ mod tests {
             outputs_completeness_check_enabled: true,
             capture_analytics_ai_events_topic: "events_plugin_ingestion_ai".to_string(),
             capture_analytics_ai_events_overflow_topic: None,
+            ai_main_preserve_partition_locality: true,
+            ai_overflow_preserve_partition_locality: true,
             kafka_traces_topic: "traces_ingestion".to_string(),
             kafka_metrics_topic: "metrics_ingestion".to_string(),
             kafka_tls: false,
@@ -2335,12 +2383,13 @@ mod tests {
             .await;
         }
 
-        /// Stamped overflow reasons on the AI lane, where — unlike the
-        /// analytics lane — a burst without locality preservation spreads
-        /// while person processing is on: the AI consumer reads persons
-        /// without writing them, so keyless person-on records contend
-        /// nothing downstream. `ForceLimited` implies the person-processing
-        /// header on its own, flag or no flag.
+        /// Stamped overflow reasons on the AI lane. The stamped
+        /// `preserve_locality` is the analytics lane's carrier and is ignored
+        /// here — this lane keys from its deployment setting, which the sink
+        /// fixture leaves at preserving — so a rate-limited burst keeps its
+        /// key either way. `ForceLimited` still spreads, since breaking up a
+        /// hot key is what that reason is for, and it implies the
+        /// person-processing header on its own, flag or no flag.
         #[rstest]
         #[case::force_limited(OverflowReason::ForceLimited, false, Some(true))]
         #[case::rate_limited_preserving(
@@ -2350,11 +2399,11 @@ mod tests {
             true,
             None
         )]
-        #[case::rate_limited_spreading(
+        #[case::rate_limited_stamp_is_not_consulted(
             OverflowReason::RateLimited {
                 preserve_locality: false
             },
-            false,
+            true,
             None
         )]
         #[tokio::test]
@@ -2433,6 +2482,57 @@ mod tests {
                 },
             )
             .await;
+        }
+
+        /// With locality off, the AI main lane publishes keyless so a hot
+        /// token spreads across the topic — and person processing stays on,
+        /// which is what separates this from every other way to spread an AI
+        /// burst. Events keep their person properties downstream.
+        #[tokio::test]
+        async fn ai_main_spreads_without_touching_person_processing() {
+            let producer = MockKafkaProducer::new();
+            let sink =
+                KafkaSinkBase::with_producer(producer.clone(), test_topics()).without_ai_locality();
+
+            sink.send(create_test_event(&EventInput {
+                data_type: DataType::AiEvents,
+                ..Default::default()
+            }))
+            .await
+            .unwrap();
+
+            let records = producer.get_records();
+            assert_eq!(records.len(), 1);
+            assert_eq!(records[0].topic, AI_EVENTS_TOPIC);
+            assert_eq!(records[0].key, None, "the main lane must publish keyless");
+            assert_eq!(
+                records[0].headers.force_disable_person_processing, None,
+                "spreading the main lane must not disable person processing"
+            );
+        }
+
+        /// The overflow lane answers to the same deployment setting, so a
+        /// rate-limited burst spreads there too.
+        #[tokio::test]
+        async fn ai_overflow_spreads_when_locality_is_off() {
+            let producer = MockKafkaProducer::new();
+            let sink =
+                KafkaSinkBase::with_producer(producer.clone(), test_topics()).without_ai_locality();
+
+            sink.send(create_test_event(&EventInput {
+                data_type: DataType::AiEvents,
+                overflow_reason: Some(OverflowReason::RateLimited {
+                    preserve_locality: true,
+                }),
+                ..Default::default()
+            }))
+            .await
+            .unwrap();
+
+            let records = producer.get_records();
+            assert_eq!(records.len(), 1);
+            assert_eq!(records[0].topic, AI_EVENTS_OVERFLOW_TOPIC);
+            assert_eq!(records[0].key, None);
         }
 
         #[tokio::test]

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -2457,13 +2457,16 @@ mod tests {
             let records = producer.get_records();
             assert_eq!(records.len(), 1);
             assert_eq!(records[0].topic, AI_EVENTS_TOPIC);
-            assert_eq!(records[0].key.as_deref(), Some("test_token:test_user"));
+            // ForceLimited implies person processing off, which spreads the
+            // key on its own — the unarmed valve only pins the topic here.
+            assert_eq!(records[0].key, None);
         }
 
         #[tokio::test]
-        async fn ai_events_skip_person_keeps_key() {
-            // skip_person_processing sets the header but must not null the
-            // key: v1's sink only nulls keys for Main/Overflow destinations.
+        async fn ai_events_skip_person_spreads() {
+            // skip_person_processing nulls the key on the AI main lane: the
+            // event is a hot key by construction and the AI consumer only
+            // reads persons.
             assert_routing(
                 EventInput {
                     data_type: DataType::AiEvents,
@@ -2476,7 +2479,7 @@ mod tests {
                 },
                 ExpectedRouting {
                     topic: AI_EVENTS_TOPIC,
-                    has_key: true,
+                    has_key: false,
                     force_disable_person_processing: Some(true),
                     ..Default::default()
                 },

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -294,9 +294,9 @@ pub enum OverflowReason {
     /// `skip_person_processing = true` alongside for pipeline-level readers.
     ForceLimited,
     /// Per-key rate exceeded the configured governor quota. Routed to the
-    /// overflow topic. `preserve_locality` mirrors the
-    /// `overflow_preserve_partition_locality` config and determines whether
-    /// the original partition key is preserved on the overflow topic.
+    /// overflow topic. `preserve_locality` comes from the limiter that
+    /// stamped it — each lane carries its own setting — and determines
+    /// whether the original partition key is preserved on the overflow topic.
     RateLimited { preserve_locality: bool },
     /// Session-level replay overflow signalled by the redis-backed limiter.
     /// Routed to the replay overflow topic, keyed on session_id.

--- a/rust/capture/src/v1/analytics/types.rs
+++ b/rust/capture/src/v1/analytics/types.rs
@@ -218,14 +218,15 @@ pub struct WrappedEvent {
     pub details: Option<&'static str>,
     pub destination: Destination,
     pub force_disable_person_processing: bool,
-    /// Set when the overflow limiter decided this key is bursting and should
-    /// be spread across the overflow topic's partitions. Deliberately separate
-    /// from `force_disable_person_processing`: spreading a hot key is a
-    /// partitioning decision, while disabling person processing is a
-    /// customer-visible instruction to skip identity resolution, and the
-    /// overflow limiter only means the former. Consumed by `ordering()`,
-    /// which realizes it only on lanes whose consumers do not write persons —
-    /// elsewhere the key holds until person processing is off.
+    /// Set when something decided this record may publish without a partition
+    /// key. The overflow limiter is one such source, on a key it judged to be
+    /// bursting; deployment config is another. Deliberately separate from
+    /// `force_disable_person_processing`: spreading a key is a partitioning
+    /// decision, while disabling person processing is a customer-visible
+    /// instruction to skip identity resolution, and neither implies the
+    /// other. Consumed by `ordering()`, which realizes it only on lanes whose
+    /// consumers do not write persons — elsewhere the key holds until person
+    /// processing is off.
     pub spread_partitions: bool,
     /// Set by the gateway-provenance step when a valid signature was verified;
     /// read by the quota shim to exempt the event from the llm_events limiter.
@@ -1113,11 +1114,12 @@ mod tests {
         Stamps { person_off: true, ..Stamps::on(Destination::AiEventsOverflow) },
         OrderingGuarantee::None
     )]
-    // Lanes whose consumers need the key regardless: person processing being
-    // off must not spread them, matching v0's route().
+    // The AI main lane spreads once person processing is off, like the AI
+    // overflow lane above and matching v0's resolve(). Its consumer only
+    // reads persons, so a keyless record contends nothing.
     #[case::ai_main_person_off(
         Stamps { person_off: true, ..Stamps::on(Destination::AiEvents) },
-        OrderingGuarantee::PerDistinctId
+        OrderingGuarantee::None
     )]
     #[case::historical_person_off(
         Stamps { person_off: true, ..Stamps::on(Destination::AnalyticsHistorical) },

--- a/rust/capture/src/v1/quota_limiter_shim.rs
+++ b/rust/capture/src/v1/quota_limiter_shim.rs
@@ -174,6 +174,8 @@ mod tests {
                 outputs_completeness_check_enabled: true,
                 capture_analytics_ai_events_topic: "events_plugin_ingestion_ai".to_string(),
                 capture_analytics_ai_events_overflow_topic: None,
+                ai_main_preserve_partition_locality: true,
+                ai_overflow_preserve_partition_locality: true,
                 kafka_traces_topic: "ingestion_traces".to_string(),
                 kafka_metrics_topic: "ingestion_metrics".to_string(),
                 kafka_tls: false,

--- a/rust/capture/src/v1/sinks/types.rs
+++ b/rust/capture/src/v1/sinks/types.rs
@@ -63,21 +63,24 @@ impl Destination {
     ///
     /// Everything else keeps its key even when person processing is off,
     /// because its consumers rely on per-distinct-id ordering: historical
-    /// backfills, the dlq, admin custom redirects, and the AI main topic.
-    /// Matches the lanes legacy `route()` resolves through `person_ordering`.
+    /// backfills, the dlq, and admin custom redirects. Matches the lanes
+    /// legacy `route()` resolves through `person_ordering`.
+    ///
+    /// Both AI lanes sit on the true side. An AI event whose person
+    /// processing is off is a hot key by construction, and the AI consumer
+    /// only reads persons, so it takes keyless records at any time.
     ///
     /// Exhaustive on purpose: a new destination has to state which side it is
     /// on rather than silently inheriting "keeps its key".
     pub fn absorbs_hot_keys(&self) -> bool {
         match self {
-            Self::AnalyticsMain | Self::Overflow | Self::AiEventsOverflow => true,
+            Self::AnalyticsMain | Self::Overflow | Self::AiEvents | Self::AiEventsOverflow => true,
             Self::AnalyticsHistorical
             | Self::Dlq
             | Self::Custom(_)
             | Self::ExceptionErrorTracking
             | Self::HeatmapMain
-            | Self::ClientIngestionWarning
-            | Self::AiEvents => false,
+            | Self::ClientIngestionWarning => false,
             // Never published, so it never reaches a partition key.
             Self::Drop => false,
         }

--- a/rust/capture/tests/common/utils.rs
+++ b/rust/capture/tests/common/utils.rs
@@ -90,6 +90,8 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
         outputs_completeness_check_enabled: true,
         capture_analytics_ai_events_topic: "events_plugin_ingestion_ai".to_string(),
         capture_analytics_ai_events_overflow_topic: None,
+        ai_main_preserve_partition_locality: true,
+        ai_overflow_preserve_partition_locality: true,
         kafka_traces_topic: "ingestion_traces".to_string(),
         kafka_metrics_topic: "ingestion_metrics".to_string(),
         kafka_tls: false,


### PR DESCRIPTION
## Problem

A team sending a burst of `$ai_*` events lands it all on one partition of the AI topic, and every way of spreading it costs that team its person data.

- `pipeline::resolve` keys the AI main lane `PerDistinctId`, with no way to turn it off.
- Spreading a hot key means routing it to overflow, through a force-overflow restriction or `INGESTION_FORCE_OVERFLOW_BY_TOKEN_DISTINCT_ID`.
- Both paths set `person_processing_disabled()`, so ingestion writes those events with `person_properties: {}` and `person_mode: propertyless`.
- Even then the burst does not spread. Both stacks keep the key on the AI main lane, so an event that already gave up person processing still hashes onto one partition.
- The AI overflow lane reads `OVERFLOW_PRESERVE_PARTITION_LOCALITY`, which exists for a tradeoff the AI lane does not have. The analytics overflow consumer updates persons keyed on distinct id, so spreading one key there trades a hot partition for contended person-row updates. The AI consumer only reads persons.

## Changes

- Disabling `AI_MAIN_PRESERVE_PARTITION_LOCALITY` spreads a hot token across the AI topic while person processing stays on, so the events keep their person properties.
- `AI_OVERFLOW_PRESERVE_PARTITION_LOCALITY` does the same for the AI overflow lane, replacing the inherited analytics setting.
- Both default to `true`, so the knobs roll out as a no-op until a chart sets one.
- An AI event with person processing off now publishes keyless on the main lane, in both stacks. `Destination::absorbs_hot_keys` puts both AI lanes on the true side, and `resolve` applies the same rule.
- `AiLaneRouting` carries the AI lane's whole key policy into `resolve`, so one struct answers where AI events go and how they key.
- The AI arm stops reading the stamped `OverflowReason::RateLimited { preserve_locality }`, which collapses its two rate-limited arms into one.
- `spread_partitions` documents what `ordering()` reads it for: a record that may publish without a key, whatever decided that.

Analytics and replay are untouched. They still carry key policy per event on `OverflowReason`, which is why the stamp keeps its field.

> [!WARNING]
> The person-off rule is a behavior change and is not gated by the new settings. Any AI event carrying `skip_person_processing` or `ForceLimited` moves from one partition to all of them the moment this ships. That is the traffic the setting exists to spread, and those events already gave up identity resolution, so nothing downstream loses ordering it was using.

v1 does not get the knobs themselves. Driving `spread_partitions` from config needs the policy on `router::State`, which adds a parameter to `router()` and touches about 25 call sites. Until that lands, flipping a knob spreads the v0 path only, while the person-off rule covers both.

## How did you test this code?

I am an agent. No manual or production testing.

- Two new sink tests: the main lane publishes keyless without setting the person-processing header, and the overflow lane spreads under the same setting.
- One config test pins that the AI knobs move independently of `OVERFLOW_PRESERVE_PARTITION_LOCALITY` and of each other.
- Four tests changed meaning rather than being deleted, two per stack. They pinned the old rule that the AI main lane keeps its key with person processing off, and v0's cited its reason as matching v1.
- `ai_events_stamped_overflow_routing` keeps its third case under the name `rate_limited_stamp_is_not_consulted`, pinning that the AI lane ignores the analytics carrier.

Not done: no load test, and no check of whether anything in the AI consumer depends on per-distinct-id order.

## Automatic notifications

- [ ] Publish to changelog? No. Internal partitioning config.

## Docs update

None. The settings are internal. Add the `skip-inkeep-docs` label.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Assign yourself as DRI.

I (actually Claude) wrote this from a session that started as a review of #81789. Skills invoked: `writing-pr-descriptions`.

The design moved three times under review. The first version added only an overflow knob and wired it into the limiter, so the two AI settings would have reached the router by different paths; the second put both on `AiLaneRouting`. I caught that keying the overflow lane purely from config would have undone the `skip_person_processing` lever and restored that coupling. The person-off rule came last, from asking why `absorbs_hot_keys` shielded the AI main lane at all.

Public-artifact check: the diff, tests, and messages are grounded in this repo. No customer data or session-private material.
