### PR TITLE
fix(desktop): don't drop shell output while tab is hidden

### DIFF
--- a/products/desktop/packages/ui/src/features/terminal/Terminal.tsx
+++ b/products/desktop/packages/ui/src/features/terminal/Terminal.tsx
@@ -4,11 +4,6 @@ import { Box } from "@radix-ui/themes";
 import "@xterm/xterm/css/xterm.css";
 
 import { resolveTerminalFontFamily } from "@posthog/core/terminal/resolveTerminalFontFamily";
-import { useService } from "@posthog/di/react";
-import {
-  SHELL_CLIENT,
-  type ShellClient,
-} from "@posthog/ui/features/terminal/shellClient";
 import { terminalManager } from "@posthog/ui/features/terminal/TerminalManager";
 import { useCallback, useEffect, useRef } from "react";
 
@@ -34,7 +29,6 @@ export function Terminal({
   onExit,
 }: TerminalProps) {
   const terminalRef = useRef<HTMLDivElement>(null);
-  const shellClient = useService<ShellClient>(SHELL_CLIENT);
   const isDarkMode = useThemeStore((state) => state.isDarkMode);
   const terminalFont = useSettingsStore((s) => s.terminalFont);
   const terminalCustomFontFamily = useSettingsStore(
@@ -84,21 +78,6 @@ export function Terminal({
   useEffect(() => {
     terminalManager.setUseWebgl(terminalGpuRendering);
   }, [terminalGpuRendering]);
-
-  // Subscribe to shell data + exit events via the host shell client.
-  useEffect(() => {
-    if (!sessionId) return;
-    const dataSub = shellClient.onData(sessionId, (event) => {
-      terminalManager.writeData(event.sessionId, event.data);
-    });
-    const exitSub = shellClient.onExit(sessionId, (event) => {
-      terminalManager.handleExit(event.sessionId, event.exitCode ?? undefined);
-    });
-    return () => {
-      dataSub.unsubscribe();
-      exitSub.unsubscribe();
-    };
-  }, [sessionId, shellClient]);
 
   // Event callbacks
   useEffect(() => {

--- a/products/desktop/packages/ui/src/features/terminal/TerminalManager.test.ts
+++ b/products/desktop/packages/ui/src/features/terminal/TerminalManager.test.ts
@@ -293,6 +293,7 @@ describe("TerminalManager shell output subscription", () => {
     mocks.write.mockReset().mockResolvedValue(undefined);
     mocks.resize.mockReset().mockResolvedValue(undefined);
     mocks.onData.mockClear();
+    mocks.onExit.mockClear();
     mocks.terminalInstances.length = 0;
     rafCallbacks.length = 0;
     vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
@@ -319,6 +320,33 @@ describe("TerminalManager shell output subscription", () => {
     expect(mocks.terminalInstances[0].write).toHaveBeenCalledWith(
       "output while hidden",
     );
+  });
+
+  it("delivers shell exit to listeners without a mounted component", () => {
+    terminalManager.create({ sessionId, persistenceKey: "task-hidden" });
+    const exitListener = vi.fn();
+    const off = terminalManager.on("exit", exitListener);
+
+    const emitShellExit = mocks.onExit.mock.calls[0][1];
+    emitShellExit({ sessionId, exitCode: 1 });
+
+    expect(exitListener).toHaveBeenCalledWith({
+      sessionId,
+      persistenceKey: "task-hidden",
+      exitCode: 1,
+    });
+    off();
+  });
+
+  it("unsubscribes from shell data and exit on destroy", () => {
+    terminalManager.create({ sessionId, persistenceKey: "task-hidden" });
+    const dataUnsubscribe = mocks.onData.mock.results[0].value.unsubscribe;
+    const exitUnsubscribe = mocks.onExit.mock.results[0].value.unsubscribe;
+
+    terminalManager.destroy(sessionId);
+
+    expect(dataUnsubscribe).toHaveBeenCalledTimes(1);
+    expect(exitUnsubscribe).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/products/desktop/packages/ui/src/features/terminal/TerminalManager.test.ts
+++ b/products/desktop/packages/ui/src/features/terminal/TerminalManager.test.ts
@@ -7,6 +7,18 @@ const mocks = vi.hoisted(() => {
   const write = vi.fn();
   const resize = vi.fn();
   const openExternal = vi.fn();
+  const onData = vi.fn(
+    (
+      _sessionId: string,
+      _onEvent: (event: { sessionId: string; data: string }) => void,
+    ) => ({ unsubscribe: vi.fn() }),
+  );
+  const onExit = vi.fn(
+    (
+      _sessionId: string,
+      _onEvent: (event: { sessionId: string; exitCode: number | null }) => void,
+    ) => ({ unsubscribe: vi.fn() }),
+  );
   const logInfo = vi.fn();
   const logError = vi.fn();
   const logWarn = vi.fn();
@@ -55,6 +67,8 @@ const mocks = vi.hoisted(() => {
     write,
     resize,
     openExternal,
+    onData,
+    onExit,
     logInfo,
     logError,
     logWarn,
@@ -71,6 +85,8 @@ vi.mock("@posthog/di/container", () => ({
     write: mocks.write,
     resize: mocks.resize,
     openExternal: mocks.openExternal,
+    onData: mocks.onData,
+    onExit: mocks.onExit,
   }),
 }));
 
@@ -264,6 +280,45 @@ describe("TerminalManager.destroyForTask", () => {
     terminalManager.destroy("sess-parked");
     expect(parking?.childElementCount).toBe(0);
     host.remove();
+  });
+});
+
+describe("TerminalManager shell output subscription", () => {
+  const sessionId = "detached-output-test";
+  const rafCallbacks: FrameRequestCallback[] = [];
+
+  beforeEach(() => {
+    mocks.check.mockReset().mockResolvedValue(true);
+    mocks.create.mockReset().mockResolvedValue(undefined);
+    mocks.write.mockReset().mockResolvedValue(undefined);
+    mocks.resize.mockReset().mockResolvedValue(undefined);
+    mocks.onData.mockClear();
+    mocks.terminalInstances.length = 0;
+    rafCallbacks.length = 0;
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      rafCallbacks.push(cb);
+      return rafCallbacks.length;
+    });
+    vi.stubGlobal("cancelAnimationFrame", () => {});
+  });
+
+  afterEach(() => {
+    terminalManager.destroy(sessionId);
+    vi.unstubAllGlobals();
+  });
+
+  it("writes shell data to the terminal without a mounted component", () => {
+    terminalManager.create({ sessionId, persistenceKey: "task-hidden" });
+
+    const emitShellData = mocks.onData.mock.calls[0][1];
+    emitShellData({ sessionId, data: "output while hidden" });
+    for (const cb of rafCallbacks) {
+      cb(0);
+    }
+
+    expect(mocks.terminalInstances[0].write).toHaveBeenCalledWith(
+      "output while hidden",
+    );
   });
 });
 

--- a/products/desktop/packages/ui/src/features/terminal/TerminalManager.ts
+++ b/products/desktop/packages/ui/src/features/terminal/TerminalManager.ts
@@ -192,6 +192,8 @@ class TerminalManagerImpl {
       return existing;
     }
 
+    const shellClient = resolveService<ShellClient>(SHELL_CLIENT);
+
     const term = new XTerm({
       cursorBlink: true,
       fontSize: 12,
@@ -231,21 +233,18 @@ class TerminalManagerImpl {
     }
 
     // Setup user input handler
-    const disposable = term.onData((data: string) => {
-      resolveService<ShellClient>(SHELL_CLIENT)
-        .write({ sessionId, data })
-        .catch((error: Error) => {
-          this.handleMissingSessionError(sessionId, instance, error, {
-            reason: "write",
-            retryData: data,
-          });
+    const inputDisposable = term.onData((data: string) => {
+      shellClient.write({ sessionId, data }).catch((error: Error) => {
+        this.handleMissingSessionError(sessionId, instance, error, {
+          reason: "write",
+          retryData: data,
         });
+      });
       this.scheduleSave(sessionId, instance);
     });
-    instance.cleanups.push(() => disposable.dispose());
+    instance.cleanups.push(() => inputDisposable.dispose());
 
     // Instance-lifetime, not component-lifetime: pty output while the tab is unmounted would otherwise be dropped
-    const shellClient = resolveService<ShellClient>(SHELL_CLIENT);
     const dataSub = shellClient.onData(sessionId, (event) => {
       this.writeData(event.sessionId, event.data);
     });

--- a/products/desktop/packages/ui/src/features/terminal/TerminalManager.ts
+++ b/products/desktop/packages/ui/src/features/terminal/TerminalManager.ts
@@ -244,6 +244,17 @@ class TerminalManagerImpl {
     });
     instance.cleanups.push(() => disposable.dispose());
 
+    // Instance-lifetime, not component-lifetime: pty output while the tab is unmounted would otherwise be dropped
+    const shellClient = resolveService<ShellClient>(SHELL_CLIENT);
+    const dataSub = shellClient.onData(sessionId, (event) => {
+      this.writeData(event.sessionId, event.data);
+    });
+    const exitSub = shellClient.onExit(sessionId, (event) => {
+      this.handleExit(event.sessionId, event.exitCode ?? undefined);
+    });
+    instance.cleanups.push(() => dataSub.unsubscribe());
+    instance.cleanups.push(() => exitSub.unsubscribe());
+
     // Initialize shell session
     this.initializeSession(sessionId, instance, cwd, taskId, command);
 
@@ -310,7 +321,7 @@ class TerminalManagerImpl {
     }
   }
 
-  writeData(sessionId: string, data: string): void {
+  private writeData(sessionId: string, data: string): void {
     const instance = this.instances.get(sessionId);
     if (!instance) {
       return;
@@ -343,7 +354,7 @@ class TerminalManagerImpl {
     this.scheduleSave(sessionId, instance);
   }
 
-  handleExit(sessionId: string, exitCode?: number): void {
+  private handleExit(sessionId: string, exitCode?: number): void {
     const instance = this.instances.get(sessionId);
     if (instance) {
       // Without this, ResizeObserver keeps firing shell.resize against the dead


### PR DESCRIPTION
## Problem

- Running a long command in a Desktop terminal, then switching to another task, silently loses everything the command prints while you are away. The terminal looks stuck when you come back, even though the command finished.
- The mounted Terminal component held the only `shell.onData` subscription. Switching tasks unmounts it, and the shell service drops pty output nobody listens to.

## Changes

- The shell `onData`/`onExit` subscriptions move from the Terminal component into `TerminalManager.create()`, so they live as long as the terminal instance instead of the mounted view.
- Output now lands in the parked xterm buffer while the tab is unmounted. The manager already keeps instances alive across tab switches and refreshes them on reattach.
- `create()` resolves the shell client once at the top, so a resolution failure aborts before the xterm instance is allocated.

No visual change.

## How did you test this code?

- Added regression tests: shell data and exit events emitted while no Terminal component is mounted must reach the terminal, and `destroy()` must unsubscribe both. Each fails if the subscriptions move back to component lifetime or the teardown wiring is dropped.
- Ran the `packages/ui` TerminalManager suite, `pnpm typecheck` and Biome from `products/desktop`.
- Not run: the desktop Playwright e2e suite or a manual check in the running app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session started from an internally reported bug: terminal output frozen at the point of switching away. The agent traced the drop to the component-lifetime subscription against a fire-and-forget pty event stream, then moved the subscription to the instance lifetime. A three-agent review pass added the exit and unsubscribe coverage and the hoisted client resolution. Skills invoked: /posthog-desktop, /writing-tests, /writing-code-comments, /writing-pr-descriptions, /creview.
