### PR TITLE
fix(data-warehouse): rank claim candidates narrow to avoid sort spill

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
@@ -311,16 +311,16 @@ def _state_claim_candidates_sql(sync_type_scope: str = "") -> str:
     lost its parquet to retention, so it must never be claimed. The gates keep
     ``PARTITION_PRUNING_INTERVAL`` for the same reason the sync-type scope
     stays out of them — they must see every row that still exists.
+
+    Selects only the join-back keys ``(id, created_at)``. The caller's fairness
+    ranking sorts the entire claimable set before its LIMIT can apply, so the
+    sort input must stay narrow: selecting the wide row here (``metadata``
+    alone is ~1 KB per batch) made every poll sort megabytes-to-gigabytes of
+    payload to keep ~50 rows, spilling past ``work_mem`` to disk once a backlog
+    built up and degrading the whole fleet's polls with it.
     """
     return f"""
-        SELECT
-            b.id, b.team_id, b.schema_id, b.source_id, b.job_id,
-            b.run_uuid, b.batch_index, b.s3_path, b.row_count, b.byte_size,
-            b.is_final_batch, b.total_batches, b.total_rows, b.sync_type,
-            b.cumulative_row_count, b.resource_name, b.is_resume,
-            b.is_first_ever_sync, b.metadata,
-            b.latest_attempt,
-            b.created_at
+        SELECT b.id, b.created_at
         FROM {BATCH_TABLE} b
         WHERE
             b.created_at > now() - interval '{CLAIM_ELIGIBILITY_INTERVAL}'
@@ -633,6 +633,13 @@ class BatchQueue:
         dropped by the ``JOIN claimed``. This replaces the old session advisory
         lock so an abandoned group simply expires rather than wedging the fleet.
 
+        Ranking runs over narrow ``(id, created_at)`` candidates and the wide
+        rows are fetched only for the LIMIT winners (the ``candidates``
+        join-back, ~LIMIT primary-key probes): the fairness sort has to process
+        the whole claimable set, so its input must stay narrow or a backlog
+        turns every poll into a disk-spilling sort of full rows (see
+        :func:`_state_claim_candidates_sql`).
+
         Uses a MATERIALIZED CTE so that candidate selection (with LIMIT) is
         fully resolved before the lease claim runs. ``candidate_groups`` is
         ``SELECT DISTINCT`` because ``INSERT ... ON CONFLICT DO UPDATE`` cannot
@@ -681,7 +688,7 @@ class BatchQueue:
         async with conn.cursor(row_factory=dict_row) as cur:
             await cur.execute(
                 f"""
-                WITH candidates AS MATERIALIZED (
+                WITH narrow AS MATERIALIZED (
                     {candidates_sql}
                         AND NOT EXISTS (
                             SELECT 1
@@ -698,6 +705,18 @@ class BatchQueue:
                         b.created_at ASC,
                         b.batch_index ASC
                     LIMIT %(limit)s
+                ),
+                candidates AS MATERIALIZED (
+                    SELECT
+                        b.id, b.team_id, b.schema_id, b.source_id, b.job_id,
+                        b.run_uuid, b.batch_index, b.s3_path, b.row_count, b.byte_size,
+                        b.is_final_batch, b.total_batches, b.total_rows, b.sync_type,
+                        b.cumulative_row_count, b.resource_name, b.is_resume,
+                        b.is_first_ever_sync, b.metadata,
+                        b.latest_attempt,
+                        b.created_at
+                    FROM {BATCH_TABLE} b
+                    JOIN narrow n ON n.id = b.id AND n.created_at = b.created_at
                 ),
                 candidate_groups AS (
                     SELECT DISTINCT team_id, schema_id FROM candidates


### PR DESCRIPTION
## Problem

When a load backlog builds up, warehouse-sources-load polls slow from milliseconds to tens of seconds fleet-wide, so every sync behind the backlog loads later.

- The claim query (`get_unprocessed_and_lock`) materializes the full row of every claimable batch, including the ~1 KB `metadata` JSONB, before the fairness window can apply its LIMIT.
- The fairness sort therefore sorts the whole claimable set as wide rows. Past a few tens of thousands of batches it spills over `work_mem` to disk on every poll, on every pod.
- The NOT EXISTS gates and partial indexes are not the problem: Postgres answers them with hash anti-joins over the small state sets.

## Changes

- The candidate CTE now selects only the join-back keys `(id, created_at)`; the fairness window ranks those narrow rows.
- A new `candidates` CTE fetches full rows by primary key for just the LIMIT winners (~50 index probes).
- Claim results are identical. Gates, per-team fairness, head-of-line order, and the lease-claim CTE fence are unchanged.

Synthetic benchmark, production-shaped dataset (2M retained rows over 14 daily partitions, 300k claimable, `work_mem=4MB`, Postgres 15):

| | before | after |
|---|---|---|
| median claim statement | 1,104 ms | 505 ms |
| sort spill per poll | 242 MB | 18 MB |

The spill reduction is the production win: every pod pays the spill on every poll, so under backlog the fleet's polls degrade together (see the poll-duration bucket comment in `postgres_queue/metrics.py`).

## How did you test this code?

- Existing suites pass locally: `test_jobs_db.py` (includes the EXPLAIN guard that the claim scan still uses `sb_claimable_idx`), `test_consumer.py`, `test_producer.py`.
- Equivalence check on the synthetic 300k-claimable dataset: the new statement returns row-for-row identical results to the old one, and all `PendingBatch` fields survive the join-back.
- No new tests: behavior is unchanged and the existing suite asserts claim semantics.
- Not checked: production bloat and 25-pod concurrency. After deploy, watch `warehouse_pg_consumer_poll_duration_seconds` under backlog.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None (internal queue implementation).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session: mapped every queue query and its index coverage, read fleet metrics in Grafana, then benchmarked the claim statement on a scratch Postgres at growing claimable-set sizes to find the dominant cost.
- Rejected along the way: a group-first rewrite (no speedup, changed claim ordering) and a covering partial index (no added win once visibility maps are set, plus write amplification).
- Skills invoked: /writing-pr-descriptions, /writing-code-comments, /querying-local-postgres.
- The committed change and benchmark data are synthetic; no customer data or session-external material is included.
