### PR TITLE
feat(warehouse-sources): count why coarsening declines a table

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition_controller.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition_controller.py
@@ -33,6 +33,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.rep
     select_repartition_target,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.load.metrics import (
+    DELTA_COARSEN_DECLINE_TOTAL,
     DELTA_REPARTITION_SKIP_TOTAL,
 )
 
@@ -223,12 +224,22 @@ async def maybe_flag_for_coarsening(
     the only route by which a nominated table there is evaluated). Never raises (the caller swallows).
     """
     measured_partitions = len(partition_bytes)
+
+    def _decline(reason: str) -> None:
+        # Why an over-fragmented table did NOT coarsen. Without this a stalled rollout is invisible:
+        # every gate below returns silently, so "nothing happened" and "nothing was eligible" look
+        # identical from outside. A counter rather than an event because this runs per sync per table.
+        DELTA_COARSEN_DECLINE_TOTAL.labels(reason=reason).inc()
+
     # Never fight a rewrite that is already staged or mid-swap, however the evaluation was prompted.
     if schema.repartition_pending is not None or schema.repartition_swap is not None:
         return
 
     requested = schema.coarsen_requested
     if requested is None:
+        # Below these two the table is not over-fragmented, so it is not a coarsening candidate at all
+        # and its decline carries no information — returning before `_decline` keeps the metric to the
+        # population the rollout is about rather than every table on every sync.
         if measured_partitions < COARSEN_MIN_PARTITIONS:
             return
         if max_bytes * COARSEN_TRIGGER_DIVISOR > budget:
@@ -237,10 +248,10 @@ async def maybe_flag_for_coarsening(
         # count is rule-filtered, so a table whose deaths were all explained away passes it — the
         # authoritative raw-signal gate is `has_recent_occurrences` further down.
         if recent_oom_count > 0:
-            return
+            return _decline("oom_history_recent")
         layout_age = _seconds_since_last_repartition(schema)
         if layout_age is not None and layout_age < COARSEN_MIN_LAYOUT_AGE_SECONDS:
-            return
+            return _decline("layout_too_young")
 
     target, reason = await asyncio.to_thread(
         select_coarsen_target, schema, partition_bytes, budget // COARSEN_TARGET_DIVISOR
@@ -266,7 +277,7 @@ async def maybe_flag_for_coarsening(
             max_partition_bytes=max_bytes,
             partition_count=measured_partitions,
         )
-        return
+        return _decline(reason)
 
     if requested is None:
         # Raw occurrences, not the rule-filtered `recent_count`: the rules exist to withhold splits,
@@ -275,7 +286,7 @@ async def maybe_flag_for_coarsening(
         if await asyncio.to_thread(
             ExternalDataSchemaOOMEvent.has_recent_occurrences, schema, days=COARSEN_OOM_FREE_DAYS
         ):
-            return
+            return _decline("oom_within_free_window")
 
         if not await asyncio.to_thread(is_auto_coarsen_enabled, schema):
             await logger.adebug(
@@ -285,7 +296,7 @@ async def maybe_flag_for_coarsening(
                 max_partition_bytes=max_bytes,
                 partition_count=measured_partitions,
             )
-            return
+            return _decline("flag_disabled")
 
     # Distinct reason for a nominated rewrite, the same way an admin-staged one is distinguishable, so
     # the backlog pass can be tracked separately from what the controller does on its own.

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition_controller.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition_controller.py
@@ -454,6 +454,48 @@ class TestCoarsenTrigger:
         schema.refresh_from_db()
         assert schema.repartition_pending is None
 
+    @pytest.mark.parametrize(
+        "case,expected_reason",
+        [
+            ("rule_excluded_oom", "oom_within_free_window"),
+            ("fresh_layout", "layout_too_young"),
+            ("flag_disabled", "flag_disabled"),
+        ],
+    )
+    def test_declining_to_coarsen_records_which_gate_stopped_it(self, team, case, expected_reason):
+        # A stalled rollout is otherwise invisible: every gate returns silently, so "the flag reached
+        # nobody" and "no table was eligible" look identical from outside. The reason label is what
+        # tells those apart without shell access to a customer's tables.
+        schema = self._fragmented_schema(
+            team,
+            **(
+                {"last_repartition_at": datetime.datetime.now(datetime.UTC).isoformat()}
+                if case == "fresh_layout"
+                else {}
+            ),
+        )
+        if case == "rule_excluded_oom":
+            ExternalDataSchemaOOMEvent.objects.for_team(schema.team_id).create(
+                team_id=schema.team_id,
+                schema=schema,
+                run_id="run-1",
+                self_phase="extract",
+                self_report_age_at_death_seconds=1.0,
+            )
+
+        with tempfile.TemporaryDirectory() as d:
+            delta = _write_partitioned_delta(f"{d}/t", [str(bucket) for bucket in range(16)])
+            with (
+                patch.object(ctrl, "target_partition_bytes", return_value=10**12),
+                patch.object(ctrl, "is_auto_repartition_enabled", return_value=True),
+                patch.object(ctrl, "is_auto_coarsen_enabled", return_value=case != "flag_disabled"),
+                patch.object(ctrl, "capture_repartition_event"),
+                patch.object(ctrl, "DELTA_COARSEN_DECLINE_TOTAL") as decline_metric,
+            ):
+                self._detect(team, schema, delta)
+
+        assert decline_metric.labels.call_args.kwargs == {"reason": expected_reason}
+
     def test_operator_nomination_overrides_the_policy_gates(self, team):
         # The backlog of already-over-split tables is blocked by the OOM-free gate, because the signal
         # that over-split them keeps firing. A nomination is how an operator gets past that, so it has

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/metrics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/metrics.py
@@ -47,6 +47,16 @@ DELTA_REPARTITION_SKIP_TOTAL = Counter(
     labelnames=["team_id", "reason"],
 )
 
+# Deliberately unlabelled by team: this fires on every sync of every over-fragmented table fleet-wide,
+# which is the whole population the coarsening rollout is aimed at, so a team label would explode
+# cardinality. `reason` is a bounded set of gate names, which is what "why isn't coarsening firing"
+# actually needs; per-table detail stays in the operator-facing INFO log on a nominated table.
+DELTA_COARSEN_DECLINE_TOTAL = Counter(
+    "warehouse_load_delta_coarsen_decline_total",
+    "Over-fragmented tables the controller declined to coarsen, by gate",
+    labelnames=["reason"],
+)
+
 # deltalite real-write path (phase 2). `outcome` is one of:
 #   written    - deltalite performed the incremental merge and committed
 #   fallback   - deltalite was enabled but failed (or refused), so the delta-rs MERGE ran instead


### PR DESCRIPTION
## Problem

An engineer rolling out automatic coarsening cannot tell whether it reached anyone. Every gate in `maybe_flag_for_coarsening` returns silently, so a table nobody enabled and a table nothing can fix look identical: no events, no metrics, nothing.

Today that cost a working afternoon. We enabled the coarsening flag for one team, saw zero repartition events four hours later, and could not tell which of six gates stopped it. Answering it took nominating tables by hand through `stage_warehouse_coarsening` and reading the INFO log a nomination produces.

## Changes

- The controller now counts every declined coarsening, labelled by the gate that stopped it: `oom_history_recent`, `layout_too_young`, `oom_within_free_window`, `flag_disabled`, plus the selector's own reasons (`datetime_at_coarsest_tier`, `unpartitionable_no_keys`, `no_partitions`).
- Counting starts after the two shape gates, so a table that is not over-fragmented never registers. The metric describes the population the rollout is about, not every table on every sync.
- The metric is a Prometheus counter, not a capture event. This path runs for every within-budget table on every sync, which is roughly 1.5M runs a day, so an event per decline would cost millions of rows to answer a question a counter answers for free.
- The counter carries no `team_id` label. Declines happen across every team with a warehouse table, so a team label would multiply the series by four hundred and rising. Per-table detail already exists in the operator-facing INFO log on a nominated table.

One query replaces the manual nomination loop:

```text
sum by (reason) (increase(warehouse_load_delta_coarsen_decline_total[1h]))
```

## How did you test this code?

Automated only, no manual testing.

- New parameterized test in `TestCoarsenTrigger` pins three gates to their reason labels. It catches a gate that starts returning without recording, which is the exact regression that would return us to a blind rollout.
- The existing coarsening tests cover the gates themselves, so this one asserts only the label.
- Not checked: the counter's behavior against a live Prometheus scrape. The metric follows the same `Counter` pattern as `DELTA_REPARTITION_SKIP_TOTAL` in the same module.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal metric, no user-facing surface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) wrote this after we spent an afternoon unable to explain why coarsening had not run for a pilot team. My first instinct was a capture event per decline; the volume estimate killed it, and the counter is the version that survived. Skills invoked: `/writing-pr-descriptions`, `/writing-code-comments`, `/writing-tests`.
