### PR TITLE
feat(tasks): add shortcut to stop task

### DIFF
--- a/frontend/src/lib/components/Shortcuts/shortcuts.ts
+++ b/frontend/src/lib/components/Shortcuts/shortcuts.ts
@@ -18,6 +18,7 @@ export const keyBinds: Record<string, string[]> = {
     edit: ['e'],
     escape: ['escape'],
     save: [...baseModifier, 's'],
+    stopTask: ['command', 'shift', 'x'],
     dashboardAddTextTile: [...baseModifier, 'a'],
     filter: [...baseModifier, 'f'],
     refresh: [...baseModifier, 'r'],

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunChat.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunChat.tsx
@@ -1,5 +1,7 @@
 import { BindLogic, useActions, useValues } from 'kea'
 
+import { keyBinds } from 'lib/components/Shortcuts/shortcuts'
+import { useShortcut } from 'lib/components/Shortcuts/useShortcut'
 import { AIConsentPopoverWrapper } from 'scenes/settings/organization/AIConsentPopoverWrapper'
 import { userLogic } from 'scenes/userLogic'
 
@@ -77,6 +79,18 @@ function TaskRunChatContent({
     logicProps: RunInteractionLogicProps
     readOnly: boolean
 }): JSX.Element {
+    const { isBusy } = useValues(runInteractionLogic(logicProps))
+    const { cancelRun } = useActions(runInteractionLogic(logicProps))
+
+    useShortcut({
+        name: 'stop-task',
+        keybind: [keyBinds.stopTask],
+        intent: 'Stop task',
+        interaction: 'function',
+        callback: cancelRun,
+        disabled: readOnly || !isBusy,
+    })
+
     // This surface renders the approval card, so persist tools must prompt here — register as a
     // foreground stream (same key resolution as `RunSurface.Root`). A read-only staff view omits the
     // composer and could never answer a forced prompt, so it stays a background consumer.


### PR DESCRIPTION
## Problem

- Task users can stop a run with the visible Stop button.
- Keyboard users need a direct way to stop an active run without archiving the task.

## Changes

- Add `Cmd/Ctrl+Shift+X` to stop the active task run.
- Reuse the existing cancellation relay used by the Stop button.
- Disable the shortcut for terminal runs and read-only viewers.
- No screenshot: this change adds no visible layout change.

## How did you test this code?

- Formatting passed for the frontend workspace.
- Typecheck was attempted, but the workspace lacks built Quill package types and reports unrelated existing errors.
- The shortcut stays inactive when a run is not active, so it cannot archive or alter completed tasks.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No documentation update needed for this keyboard-only control.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: Codex
- Skill invoked: `writing-pr-descriptions`
- The implementation uses the existing run cancellation action and keeps archive behavior separate.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*