### PR TITLE
fix(surveys): copy translations when duplicating to another project

### DIFF
--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -3192,8 +3192,11 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
                         "name": f"{source_survey.name} (duplicated at {duplicate_timestamp})",
                         "description": source_survey.description,
                         "type": source_survey.type,
+                        # Per-question translations are stripped here and restored verbatim after
+                        # validation (see below), for the same reason as the survey-level translations.
                         "questions": [
-                            {k: v for k, v in q.items() if k != "id"} for q in (source_survey.questions or [])
+                            {k: v for k, v in q.items() if k not in ("id", "translations")}
+                            for q in (source_survey.questions or [])
                         ],
                         "appearance": source_survey.appearance,
                         "conditions": cleaned_conditions,
@@ -3233,6 +3236,16 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
                         translations=source_survey.translations,
                         **serializer.validated_data,
                     )
+
+                    # Restore per-question translations verbatim. The create serializer grandfathers legacy
+                    # language keys only against an existing instance, so re-validating them here would 400
+                    # a copy the source already saved. Order matches: validate_questions keeps input order.
+                    source_questions = source_survey.questions or []
+                    for index, question in enumerate(new_survey.questions or []):
+                        source_translations = source_questions[index].get("translations")
+                        if source_translations is not None:
+                            question["translations"] = source_translations
+
                     surveys_to_create.append(new_survey)
 
                 for survey in surveys_to_create:

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -3226,6 +3226,11 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
                     new_survey = Survey(
                         team=team,
                         created_by=user,
+                        # Copied outside the serializer so a duplicate is never stricter than its source:
+                        # these values are already sanitized, and surveys with grandfathered language keys
+                        # (which only validate against an existing instance) would otherwise fail to copy.
+                        base_language=source_survey.base_language,
+                        translations=source_survey.translations,
                         **serializer.validated_data,
                     )
                     surveys_to_create.append(new_survey)

--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -6523,18 +6523,34 @@ class TestSurveyBulkDuplication(APIBaseTest):
 
     @parameterized.expand(
         [
-            ("standard_keys", {"fr": {"name": "Sondage"}, "es-MX": {"name": "Encuesta"}}),
-            ("legacy_key", {"FR": {"name": "Sondage"}}),
+            (
+                "standard_keys",
+                {"fr": {"name": "Sondage"}, "es-MX": {"name": "Encuesta"}},
+                {"fr": {"question": "Qu'en pensez-vous?"}},
+            ),
+            # Legacy keys predate language-code validation and only survive edits via grandfathering, which
+            # keys off an existing instance. Duplication is a create, so routing these through the serializer
+            # would reject "english" as an invalid code and 400 the whole batch.
+            (
+                "legacy_keys",
+                {"english": {"name": "Survey"}},
+                {"english": {"question": "What do you think?"}},
+            ),
         ]
     )
-    def test_bulk_duplicate_copies_translations(self, _name: str, translations: dict) -> None:
+    def test_bulk_duplicate_copies_translations(
+        self, _name: str, survey_translations: dict, question_translations: dict
+    ) -> None:
         translated_survey = Survey.objects.create(
             team=self.team,
             name="Translated Survey",
             type="popover",
-            questions=[{"type": "open", "question": "What do you think?"}],
+            questions=[
+                {"type": "open", "question": "What do you think?", "translations": question_translations},
+                {"type": "open", "question": "Any other feedback?"},
+            ],
             base_language="en-GB",
-            translations=translations,
+            translations=survey_translations,
             created_by=self.user,
         )
 
@@ -6547,8 +6563,41 @@ class TestSurveyBulkDuplication(APIBaseTest):
         assert response.status_code == status.HTTP_201_CREATED
 
         duplicated = Survey.objects.get(team=self.team2)
-        assert duplicated.translations == translations
         assert duplicated.base_language == "en-GB"
+        assert duplicated.translations == survey_translations
+        # Per-question translations are restored onto the right question, and questions without any are untouched.
+        assert duplicated.questions[0]["translations"] == question_translations
+        assert "translations" not in duplicated.questions[1]
+
+    def test_bulk_duplicate_copies_question_translation_matching_default_base_language(self) -> None:
+        # A non-English base language with an "en" question translation is valid at the source, but the create
+        # serializer resolves base_language to the default "en" and would reject "en" as colliding with it.
+        translated_survey = Survey.objects.create(
+            team=self.team,
+            name="French Survey",
+            type="popover",
+            questions=[
+                {
+                    "type": "open",
+                    "question": "Qu'en pensez-vous?",
+                    "translations": {"en": {"question": "What do you think?"}},
+                }
+            ],
+            base_language="fr",
+            created_by=self.user,
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.project_id}/surveys/{translated_survey.id}/duplicate_to_projects/",
+            data={"target_team_ids": [self.team2.id]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        duplicated = Survey.objects.get(team=self.team2)
+        assert duplicated.base_language == "fr"
+        assert duplicated.questions[0]["translations"] == {"en": {"question": "What do you think?"}}
 
     def test_bulk_duplicate_transaction_rollback_on_error(self):
         """Test that all duplications are rolled back if one fails"""

--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -6521,6 +6521,35 @@ class TestSurveyBulkDuplication(APIBaseTest):
         # Generic condition fields SHOULD be copied
         assert duplicated.conditions.get("url") == "https://example.com"
 
+    @parameterized.expand(
+        [
+            ("standard_keys", {"fr": {"name": "Sondage"}, "es-MX": {"name": "Encuesta"}}),
+            ("legacy_key", {"FR": {"name": "Sondage"}}),
+        ]
+    )
+    def test_bulk_duplicate_copies_translations(self, _name: str, translations: dict) -> None:
+        translated_survey = Survey.objects.create(
+            team=self.team,
+            name="Translated Survey",
+            type="popover",
+            questions=[{"type": "open", "question": "What do you think?"}],
+            base_language="en-GB",
+            translations=translations,
+            created_by=self.user,
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.project_id}/surveys/{translated_survey.id}/duplicate_to_projects/",
+            data={"target_team_ids": [self.team2.id]},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        duplicated = Survey.objects.get(team=self.team2)
+        assert duplicated.translations == translations
+        assert duplicated.base_language == "en-GB"
+
     def test_bulk_duplicate_transaction_rollback_on_error(self):
         """Test that all duplications are rolled back if one fails"""
         # Create a survey with the same name in team2 to cause a conflict

--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -6565,6 +6565,7 @@ class TestSurveyBulkDuplication(APIBaseTest):
         duplicated = Survey.objects.get(team=self.team2)
         assert duplicated.base_language == "en-GB"
         assert duplicated.translations == survey_translations
+        assert duplicated.questions is not None
         # Per-question translations are restored onto the right question, and questions without any are untouched.
         assert duplicated.questions[0]["translations"] == question_translations
         assert "translations" not in duplicated.questions[1]
@@ -6597,6 +6598,7 @@ class TestSurveyBulkDuplication(APIBaseTest):
 
         duplicated = Survey.objects.get(team=self.team2)
         assert duplicated.base_language == "fr"
+        assert duplicated.questions is not None
         assert duplicated.questions[0]["translations"] == {"en": {"question": "What do you think?"}}
 
     def test_bulk_duplicate_transaction_rollback_on_error(self):


### PR DESCRIPTION
## Problem

Someone who duplicates a survey into another project loses its translations: the copy opens with an empty Translations tab, even though the source survey has languages configured.

- Cross-project duplication builds the new survey from a field whitelist that omits `base_language` and `translations`.
- Per-question translations still reach the copy, because they ride inside the copied `questions` array. That makes the loss easy to miss in the API response.
- The editor lists languages from the survey-level `translations` map, so the tab renders empty.
- Per-question translations take a second path: the copy re-validates them as new input, so a source survey with a legacy language key, or with a non-English base language plus an "en" question translation, fails the whole batch with a 400.

## Changes

- `duplicate_to_projects` copies `base_language` and `translations` onto each new survey.
- Per-question translations are stripped before validation and restored verbatim onto each built survey.
- All three bypass the create serializer. The source values are already sanitized, and the serializer grandfathers legacy language keys only against an existing instance, so re-validating them would reject a copy the source already saved.

## How did you test this code?

Added a parameterized test plus one case to `TestSurveyBulkDuplication`, covering standard keys, legacy keys, and a non-English base language with an "en" question translation. No existing duplication test asserted on translations at all, and the legacy cases guard the copy path against the stricter create-time validation.

Ran `products/surveys/backend/api/test/test_survey.py -k TestSurveyBulkDuplication` and repo-wide `mypy --cache-fine-grained .` locally: both clean. Not checked: the rest of the survey suite, and no manual run through the UI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The API shape does not change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (actually the PostHog Slack app, running Claude) wrote the survey-level fix from a support report that duplicated surveys showed no translations. A second agent run added the per-question fix on the same branch, and I then fixed the mypy failure it introduced. Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-pr-descriptions`.

The open question was whether to route the translation fields through the create serializer with the rest of the whitelist. We chose the verbatim copy after finding the grandfathering branch in `validate_translations`, which only applies when the serializer has an instance.

No customer material reached this PR. The test fixture languages and survey names are invented.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1786641568348159)*
