### PR TITLE
fix(marketing-analytics): point cost tiles at the real stats table id column

### DIFF
--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/__snapshots__/utils.test.ts.snap
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/__snapshots__/utils.test.ts.snap
@@ -138,9 +138,9 @@ exports[`marketing analytics utils createMarketingTile snapshots BingAds - roas 
 exports[`marketing analytics utils createMarketingTile snapshots GoogleAds - clicks 1`] = `
 {
   "custom_name": "prefix.campaign_overview_stats clicks",
-  "distinct_id_field": "id",
+  "distinct_id_field": "campaign_id",
   "id": "GoogleAds-stats-table-id",
-  "id_field": "id",
+  "id_field": "campaign_id",
   "kind": "DataWarehouseNode",
   "math": "hogql",
   "math_hogql": "SUM(ifNull(toFloat(metrics_clicks), 0))",
@@ -153,9 +153,9 @@ exports[`marketing analytics utils createMarketingTile snapshots GoogleAds - cli
 exports[`marketing analytics utils createMarketingTile snapshots GoogleAds - cost 1`] = `
 {
   "custom_name": "prefix.campaign_overview_stats cost",
-  "distinct_id_field": "id",
+  "distinct_id_field": "campaign_id",
   "id": "GoogleAds-stats-table-id",
-  "id_field": "id",
+  "id_field": "campaign_id",
   "kind": "DataWarehouseNode",
   "math": "hogql",
   "math_hogql": "SUM(toFloat(convertCurrency(coalesce(customer_currency_code, 'USD'), 'USD', toFloat(metrics_cost_micros / 1000000))))",
@@ -168,9 +168,9 @@ exports[`marketing analytics utils createMarketingTile snapshots GoogleAds - cos
 exports[`marketing analytics utils createMarketingTile snapshots GoogleAds - impressions 1`] = `
 {
   "custom_name": "prefix.campaign_overview_stats impressions",
-  "distinct_id_field": "id",
+  "distinct_id_field": "campaign_id",
   "id": "GoogleAds-stats-table-id",
-  "id_field": "id",
+  "id_field": "campaign_id",
   "kind": "DataWarehouseNode",
   "math": "hogql",
   "math_hogql": "SUM(ifNull(toFloat(metrics_impressions), 0))",
@@ -183,9 +183,9 @@ exports[`marketing analytics utils createMarketingTile snapshots GoogleAds - imp
 exports[`marketing analytics utils createMarketingTile snapshots GoogleAds - reported_conversion (missing conversion fields) 1`] = `
 {
   "custom_name": "prefix.campaign_overview_stats reported_conversion",
-  "distinct_id_field": "id",
+  "distinct_id_field": "campaign_id",
   "id": "GoogleAds-stats-table-id",
-  "id_field": "id",
+  "id_field": "campaign_id",
   "kind": "DataWarehouseNode",
   "math": "hogql",
   "math_hogql": "SUM(ifNull(toFloat(metrics_conversions), 0))",
@@ -198,9 +198,9 @@ exports[`marketing analytics utils createMarketingTile snapshots GoogleAds - rep
 exports[`marketing analytics utils createMarketingTile snapshots GoogleAds - reported_conversion 1`] = `
 {
   "custom_name": "prefix.campaign_overview_stats reported_conversion",
-  "distinct_id_field": "id",
+  "distinct_id_field": "campaign_id",
   "id": "GoogleAds-stats-table-id",
-  "id_field": "id",
+  "id_field": "campaign_id",
   "kind": "DataWarehouseNode",
   "math": "hogql",
   "math_hogql": "SUM(ifNull(toFloat(metrics_conversions), 0))",
@@ -213,9 +213,9 @@ exports[`marketing analytics utils createMarketingTile snapshots GoogleAds - rep
 exports[`marketing analytics utils createMarketingTile snapshots GoogleAds - reported_conversion_value (missing conversion fields) 1`] = `
 {
   "custom_name": "prefix.campaign_overview_stats reported_conversion_value",
-  "distinct_id_field": "id",
+  "distinct_id_field": "campaign_id",
   "id": "GoogleAds-stats-table-id",
-  "id_field": "id",
+  "id_field": "campaign_id",
   "kind": "DataWarehouseNode",
   "math": "hogql",
   "math_hogql": "SUM(toFloat(convertCurrency(coalesce(customer_currency_code, 'USD'), 'USD', ifNull(toFloat(metrics_conversions_value), 0))))",
@@ -228,9 +228,9 @@ exports[`marketing analytics utils createMarketingTile snapshots GoogleAds - rep
 exports[`marketing analytics utils createMarketingTile snapshots GoogleAds - reported_conversion_value 1`] = `
 {
   "custom_name": "prefix.campaign_overview_stats reported_conversion_value",
-  "distinct_id_field": "id",
+  "distinct_id_field": "campaign_id",
   "id": "GoogleAds-stats-table-id",
-  "id_field": "id",
+  "id_field": "campaign_id",
   "kind": "DataWarehouseNode",
   "math": "hogql",
   "math_hogql": "SUM(toFloat(convertCurrency(coalesce(customer_currency_code, 'USD'), 'USD', ifNull(toFloat(metrics_conversions_value), 0))))",
@@ -243,9 +243,9 @@ exports[`marketing analytics utils createMarketingTile snapshots GoogleAds - rep
 exports[`marketing analytics utils createMarketingTile snapshots GoogleAds - roas (missing conversion fields) 1`] = `
 {
   "custom_name": "prefix.campaign_overview_stats roas",
-  "distinct_id_field": "id",
+  "distinct_id_field": "campaign_id",
   "id": "GoogleAds-stats-table-id",
-  "id_field": "id",
+  "id_field": "campaign_id",
   "kind": "DataWarehouseNode",
   "math": "hogql",
   "math_hogql": "0",
@@ -258,9 +258,9 @@ exports[`marketing analytics utils createMarketingTile snapshots GoogleAds - roa
 exports[`marketing analytics utils createMarketingTile snapshots GoogleAds - roas 1`] = `
 {
   "custom_name": "prefix.campaign_overview_stats roas",
-  "distinct_id_field": "id",
+  "distinct_id_field": "campaign_id",
   "id": "GoogleAds-stats-table-id",
-  "id_field": "id",
+  "id_field": "campaign_id",
   "kind": "DataWarehouseNode",
   "math": "hogql",
   "math_hogql": "SUM(ifNull(toFloat(metrics_conversions_value), 0)) / nullIf(SUM(toFloat(metrics_cost_micros / 1000000)), 0)",
@@ -273,9 +273,9 @@ exports[`marketing analytics utils createMarketingTile snapshots GoogleAds - roa
 exports[`marketing analytics utils createMarketingTile snapshots LinkedinAds - clicks 1`] = `
 {
   "custom_name": "prefix.campaign_group_stats clicks",
-  "distinct_id_field": "id",
+  "distinct_id_field": "campaign_group_id",
   "id": "LinkedinAds-stats-table-id",
-  "id_field": "id",
+  "id_field": "campaign_group_id",
   "kind": "DataWarehouseNode",
   "math": "hogql",
   "math_hogql": "SUM(ifNull(toFloat(clicks), 0))",
@@ -288,9 +288,9 @@ exports[`marketing analytics utils createMarketingTile snapshots LinkedinAds - c
 exports[`marketing analytics utils createMarketingTile snapshots LinkedinAds - cost 1`] = `
 {
   "custom_name": "prefix.campaign_group_stats cost",
-  "distinct_id_field": "id",
+  "distinct_id_field": "campaign_group_id",
   "id": "LinkedinAds-stats-table-id",
-  "id_field": "id",
+  "id_field": "campaign_group_id",
   "kind": "DataWarehouseNode",
   "math": "hogql",
   "math_hogql": "toFloat(convertCurrency('USD', 'USD', SUM(toFloat(cost_in_usd))))",
@@ -303,9 +303,9 @@ exports[`marketing analytics utils createMarketingTile snapshots LinkedinAds - c
 exports[`marketing analytics utils createMarketingTile snapshots LinkedinAds - impressions 1`] = `
 {
   "custom_name": "prefix.campaign_group_stats impressions",
-  "distinct_id_field": "id",
+  "distinct_id_field": "campaign_group_id",
   "id": "LinkedinAds-stats-table-id",
-  "id_field": "id",
+  "id_field": "campaign_group_id",
   "kind": "DataWarehouseNode",
   "math": "hogql",
   "math_hogql": "SUM(ifNull(toFloat(impressions), 0))",
@@ -318,9 +318,9 @@ exports[`marketing analytics utils createMarketingTile snapshots LinkedinAds - i
 exports[`marketing analytics utils createMarketingTile snapshots LinkedinAds - reported_conversion (missing conversion fields) 1`] = `
 {
   "custom_name": "prefix.campaign_group_stats reported_conversion",
-  "distinct_id_field": "id",
+  "distinct_id_field": "campaign_group_id",
   "id": "LinkedinAds-stats-table-id",
-  "id_field": "id",
+  "id_field": "campaign_group_id",
   "kind": "DataWarehouseNode",
   "math": "hogql",
   "math_hogql": "SUM(ifNull(toFloat(external_website_conversions), 0))",
@@ -333,9 +333,9 @@ exports[`marketing analytics utils createMarketingTile snapshots LinkedinAds - r
 exports[`marketing analytics utils createMarketingTile snapshots LinkedinAds - reported_conversion 1`] = `
 {
   "custom_name": "prefix.campaign_group_stats reported_conversion",
-  "distinct_id_field": "id",
+  "distinct_id_field": "campaign_group_id",
   "id": "LinkedinAds-stats-table-id",
-  "id_field": "id",
+  "id_field": "campaign_group_id",
   "kind": "DataWarehouseNode",
   "math": "hogql",
   "math_hogql": "SUM(ifNull(toFloat(external_website_conversions), 0))",
@@ -348,9 +348,9 @@ exports[`marketing analytics utils createMarketingTile snapshots LinkedinAds - r
 exports[`marketing analytics utils createMarketingTile snapshots LinkedinAds - reported_conversion_value (missing conversion fields) 1`] = `
 {
   "custom_name": "prefix.campaign_group_stats reported_conversion_value",
-  "distinct_id_field": "id",
+  "distinct_id_field": "campaign_group_id",
   "id": "LinkedinAds-stats-table-id",
-  "id_field": "id",
+  "id_field": "campaign_group_id",
   "kind": "DataWarehouseNode",
   "math": "hogql",
   "math_hogql": "0",
@@ -363,9 +363,9 @@ exports[`marketing analytics utils createMarketingTile snapshots LinkedinAds - r
 exports[`marketing analytics utils createMarketingTile snapshots LinkedinAds - reported_conversion_value 1`] = `
 {
   "custom_name": "prefix.campaign_group_stats reported_conversion_value",
-  "distinct_id_field": "id",
+  "distinct_id_field": "campaign_group_id",
   "id": "LinkedinAds-stats-table-id",
-  "id_field": "id",
+  "id_field": "campaign_group_id",
   "kind": "DataWarehouseNode",
   "math": "hogql",
   "math_hogql": "toFloat(convertCurrency('USD', 'USD', SUM(ifNull(toFloat(conversion_value_in_local_currency), 0))))",
@@ -378,9 +378,9 @@ exports[`marketing analytics utils createMarketingTile snapshots LinkedinAds - r
 exports[`marketing analytics utils createMarketingTile snapshots LinkedinAds - roas (missing conversion fields) 1`] = `
 {
   "custom_name": "prefix.campaign_group_stats roas",
-  "distinct_id_field": "id",
+  "distinct_id_field": "campaign_group_id",
   "id": "LinkedinAds-stats-table-id",
-  "id_field": "id",
+  "id_field": "campaign_group_id",
   "kind": "DataWarehouseNode",
   "math": "hogql",
   "math_hogql": "0",
@@ -393,9 +393,9 @@ exports[`marketing analytics utils createMarketingTile snapshots LinkedinAds - r
 exports[`marketing analytics utils createMarketingTile snapshots LinkedinAds - roas 1`] = `
 {
   "custom_name": "prefix.campaign_group_stats roas",
-  "distinct_id_field": "id",
+  "distinct_id_field": "campaign_group_id",
   "id": "LinkedinAds-stats-table-id",
-  "id_field": "id",
+  "id_field": "campaign_group_id",
   "kind": "DataWarehouseNode",
   "math": "hogql",
   "math_hogql": "SUM(ifNull(toFloat(conversion_value_in_local_currency), 0)) / nullIf(SUM(toFloat(cost_in_usd)), 0)",

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/utils.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/utils.ts
@@ -346,7 +346,9 @@ function buildConversionExpr(
 
 const sourceTileConfigs: Record<NativeMarketingSource, SourceTileConfig> = {
     GoogleAds: {
-        idField: 'id',
+        // idField is a column on the stats table, which flattens `campaign.id` to
+        // `campaign_id` and has no bare `id`.
+        idField: 'campaign_id',
         timestampField: 'segments_date',
         columnMappings: {
             cost: 'metrics_cost_micros',
@@ -389,7 +391,8 @@ const sourceTileConfigs: Record<NativeMarketingSource, SourceTileConfig> = {
         },
     },
     LinkedinAds: {
-        idField: 'id',
+        // campaign_group_stats keys rows by `campaign_group_id`, it has no `id`.
+        idField: 'campaign_group_id',
         timestampField: 'date_start',
         columnMappings: {
             cost: 'cost_in_usd',


### PR DESCRIPTION
## Problem

- Marketing analytics tiles for Google Ads and LinkedIn Ads declare an id column their stats table does not have.
- Google Ads' `campaign_overview_stats` flattens `campaign.id` to `campaign_id` and has no bare `id`. LinkedIn's `campaign_group_stats` keys rows by `campaign_group_id`.
- The other six native sources already name the column their stats table exposes.

> [!NOTE]
> The cost, clicks and ROAS tiles render fine today. They aggregate with `SUM(...)` and never name `id`, and HogQL resolves table fields lazily, so the broken field is never expanded. This is a latent misconfiguration, not a visible outage.

The bug surfaces on any path that does resolve the field: person math (`dau`, weekly and monthly active), a drill-down to persons, and funnels, where `funnel_event_query.py` selects `id_field` directly and wraps it in a `throwIf(isNull(...))`.

`id_field` and `distinct_id_field` do not appear in the emitted SQL. They register a virtual `id` and `distinct_id` on the warehouse table in `database.py`, so a wrong value is a wrong column mapping rather than a broken query string.

## Changes

- `sourceTileConfigs.GoogleAds.idField` becomes `campaign_id`.
- `sourceTileConfigs.LinkedinAds.idField` becomes `campaign_group_id`.
- Both now match the backend's `_campaign_stats_fk_column` for the same source, which is the column the adapter joins on.
- Snapshots regenerate for the 18 affected tiles. No other change.

This supersedes #78676, which fixed only Google Ads, added a fallback to `id` that is absent on those same tables, and carried a backend change that #80556 made obsolete.

No screenshot: no rendered output changes.

## How did you test this code?

- I built a local warehouse table with the Google Ads stats columns and no `id`, then ran the cost tile with `id_field='id'` and with `id_field='campaign_id'`. Both returned the same series, which is how I established that this is latent rather than user-visible. I did not keep that test: it asserts equality between a broken and a correct config, so it would pass either way and catch no regression.
- I checked every native source's `idField` against the synced schema for its stats table, not just the two that were wrong. Snapchat uses `id` and the remaining five use `campaign_id`, both correct.
- The existing snapshot suite covers the change: `id_field` and `distinct_id_field` sit in every `createMarketingTile` snapshot, so a future divergence shows as a snapshot diff.
- Not run: person math or funnels over these tables, so the affected paths are reasoned from the code rather than executed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) opened this after reviewing #78676, an autonomous PR that went stale and conflicted. I invoked `/writing-tests` and `/writing-pr-descriptions`.

Three findings shaped the diff. The `Field not found: campaign_id` symptom that opened #78676 was already fixed by #80556, so this PR is not that fix. The LinkedIn mismatch was absent from #78676, which asserted the other seven sources were correct. And #78676's fallback to `id` would have masked exactly that LinkedIn case, since `id` is missing there too, so I dropped it rather than carry it forward.

An earlier revision of this description claimed the tiles fail outright. That was wrong, and the local run described above is what corrected it.
