### PR TITLE
fix(warehouse-sources): re-validate batch claims against committed state

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
@@ -280,6 +280,19 @@ class BatchConsumerAdapter(Protocol):
         limit: int,
     ) -> None: ...
 
+    async def filter_still_claimable(
+        self,
+        conn: psycopg.AsyncConnection[Any],
+        *,
+        batches: list[PendingBatch],
+    ) -> set[str]:
+        """Of ``batches``, the ids still claimable according to committed state.
+
+        The poll's candidate list can be stale by however long the poll ran, so the
+        engine re-validates it once the group lease is held and before any work starts.
+        """
+        ...
+
     async def should_process_batch(
         self,
         conn: psycopg.AsyncConnection[Any],
@@ -625,13 +638,19 @@ class BatchConsumer:
                 )
                 return
 
-            for batch in batches:
+            # Never rebind `batches` — the finally below derives the lease to release from it,
+            # and an emptied list would strand this group until its TTL expires.
+            fresh_batches = await self._drop_stale_claims(group_conn, batches, team_id=team_id, schema_id=schema_id)
+            if not fresh_batches:
+                return
+
+            for batch in fresh_batches:
                 if self._shutdown.is_set():
                     logger.info(
                         self._event("shutdown_mid_group"),
                         team_id=team_id,
                         schema_id=schema_id,
-                        remaining=len(batches) - batches.index(batch),
+                        remaining=len(fresh_batches) - fresh_batches.index(batch),
                     )
                     break
                 try:
@@ -659,7 +678,7 @@ class BatchConsumer:
                         team_id=team_id,
                         schema_id=schema_id,
                         run_uuid=batch.run_uuid,
-                        remaining=len(batches) - batches.index(batch) - 1,
+                        remaining=len(fresh_batches) - fresh_batches.index(batch) - 1,
                     )
                     break
         finally:
@@ -669,6 +688,48 @@ class BatchConsumer:
                     await group_conn.close()
                 except Exception:
                     pass
+
+    async def _drop_stale_claims(
+        self,
+        group_conn: psycopg.AsyncConnection[Any],
+        batches: list[PendingBatch],
+        *,
+        team_id: int,
+        schema_id: str,
+    ) -> list[PendingBatch]:
+        """Drop batches that went terminal between the poll's snapshot and this dispatch.
+
+        The claim reads candidates as of the poll's start but takes the lease as of now,
+        so a poll lasting tens of seconds can hand back batches another pod has since
+        finished and released. Processing those repeats their side effects — for a final
+        batch, the whole post-load pass.
+
+        Fails open: an app-DB hiccup here must not wedge the group, and processing a
+        batch twice is what the loader's own idempotency check already absorbs.
+        """
+        try:
+            claimable = await self._adapter.filter_still_claimable(group_conn, batches=batches)
+        except Exception as e:
+            logger.exception(self._event("stale_claim_filter_failed"), team_id=team_id, schema_id=schema_id)
+            capture_exception(e)
+            return batches
+
+        # str() both sides: PendingBatch.id is annotated str but psycopg hands back UUID
+        # objects for the uuid column, and a UUID never matches a str in a set.
+        fresh = [b for b in batches if str(b.id) in claimable]
+        dropped = len(batches) - len(fresh)
+        if dropped:
+            logger.info(
+                self._event("dropped_stale_claims"),
+                team_id=team_id,
+                external_data_schema_id=schema_id,
+                dropped=dropped,
+                remaining=len(fresh),
+            )
+            self._metrics.batches_processed_total.labels(
+                team_id=str(team_id), schema_id=schema_id, status="stale_claim"
+            ).inc(dropped)
+        return fresh
 
     async def _unlock_group(
         self,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
@@ -6,7 +6,7 @@ import signal
 import asyncio
 from collections import defaultdict
 from collections.abc import Callable, Coroutine
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
 from typing import Any, Protocol
 from uuid import uuid4
@@ -285,11 +285,13 @@ class BatchConsumerAdapter(Protocol):
         conn: psycopg.AsyncConnection[Any],
         *,
         batches: list[PendingBatch],
-    ) -> set[str]:
-        """Of ``batches``, the ids still claimable according to committed state.
+        retry_backoff_base_seconds: int,
+    ) -> dict[str, int]:
+        """Of ``batches``, the ids still claimable now, mapped to their current attempt.
 
         The poll's candidate list can be stale by however long the poll ran, so the
         engine re-validates it once the group lease is held and before any work starts.
+        Implementations must re-apply the same gate the claim used, backoff included.
         """
         ...
 
@@ -708,15 +710,27 @@ class BatchConsumer:
         batch twice is what the loader's own idempotency check already absorbs.
         """
         try:
-            claimable = await self._adapter.filter_still_claimable(group_conn, batches=batches)
+            claimable = await self._adapter.filter_still_claimable(
+                group_conn,
+                batches=batches,
+                retry_backoff_base_seconds=self._config.retry_backoff_base_seconds,
+            )
         except Exception as e:
             logger.exception(self._event("stale_claim_filter_failed"), team_id=team_id, schema_id=schema_id)
             capture_exception(e)
             return batches
 
-        # str() both sides: PendingBatch.id is annotated str but psycopg hands back UUID
-        # objects for the uuid column, and a UUID never matches a str in a set.
-        fresh = [b for b in batches if str(b.id) in claimable]
+        fresh: list[PendingBatch] = []
+        for batch in batches:
+            # str() both sides: PendingBatch.id is annotated str but psycopg hands back
+            # UUID objects for the uuid column, and a UUID never matches a str key.
+            attempt = claimable.get(str(batch.id))
+            if attempt is None:
+                continue
+            # The poll's attempt is from the same stale snapshot; a failure during the poll
+            # already bumped it. Retrying under the old number would keep max_attempts out
+            # of reach for a batch that fails every time.
+            fresh.append(batch if attempt == batch.latest_attempt else replace(batch, latest_attempt=attempt))
         dropped = len(batches) - len(fresh)
         if dropped:
             logger.info(

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
@@ -539,8 +539,11 @@ class DeltaBatchConsumerAdapter:
         conn: psycopg.AsyncConnection[Any],
         *,
         batches: list[PendingBatch],
-    ) -> set[str]:
-        return await BatchQueue.filter_still_claimable(conn, batches=batches)
+        retry_backoff_base_seconds: int,
+    ) -> dict[str, int]:
+        return await BatchQueue.filter_still_claimable(
+            conn, batches=batches, retry_backoff_base_seconds=retry_backoff_base_seconds
+        )
 
     async def should_process_batch(
         self,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
@@ -534,6 +534,14 @@ class DeltaBatchConsumerAdapter:
             return
         OLDEST_UNCLAIMED_BATCH_SECONDS.set(age or 0.0)
 
+    async def filter_still_claimable(
+        self,
+        conn: psycopg.AsyncConnection[Any],
+        *,
+        batches: list[PendingBatch],
+    ) -> set[str]:
+        return await BatchQueue.filter_still_claimable(conn, batches=batches)
+
     async def should_process_batch(
         self,
         conn: psycopg.AsyncConnection[Any],

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
@@ -293,6 +293,30 @@ FAIL_RUN_SCOPED_SQL = _bulk_fail_dual_write_sql(
 )
 
 
+def claimable_state_predicate(alias: str) -> str:
+    """The state gate a batch must pass to be worked on, parameterized on ``backoff``.
+
+    Shared by the claim and by the re-validation that runs after it, and it must stay
+    shared: the re-validation exists to re-apply the claim's own rules against committed
+    data, so any drift between the two silently admits batches the claim itself would
+    have rejected. A ``waiting_retry`` whose backoff has not elapsed is the case that
+    bites — accepting it there skips the retry delay entirely.
+
+    'pending' means no status row yet; 'waiting' is deliberately not claimable.
+    """
+    return f"""
+        (
+            {alias}.latest_state = 'pending'
+            OR (
+                {alias}.latest_state = 'waiting_retry'
+                AND {alias}.state_changed_at <= now() - make_interval(
+                    secs => %(backoff)s * GREATEST({alias}.latest_attempt, 1)
+                )
+            )
+        )
+    """
+
+
 def _state_claim_candidates_sql(sync_type_scope: str = "") -> str:
     """Claimable-batch candidates read from the denormalized state columns.
 
@@ -325,15 +349,7 @@ def _state_claim_candidates_sql(sync_type_scope: str = "") -> str:
         WHERE
             b.created_at > now() - interval '{CLAIM_ELIGIBILITY_INTERVAL}'
             {sync_type_scope}
-            AND (
-                b.latest_state = 'pending'
-                OR (
-                    b.latest_state = 'waiting_retry'
-                    AND b.state_changed_at <= now() - make_interval(
-                        secs => %(backoff)s * GREATEST(b.latest_attempt, 1)
-                    )
-                )
-            )
+            AND {claimable_state_predicate("b")}
             AND NOT EXISTS (
                 SELECT 1
                 FROM {BATCH_TABLE} b_prev
@@ -1319,8 +1335,9 @@ class BatchQueue:
         conn: psycopg.AsyncConnection[Any],
         *,
         batches: list[PendingBatch],
-    ) -> set[str]:
-        """Of ``batches``, the ids whose state is *currently* still claimable.
+        retry_backoff_base_seconds: int,
+    ) -> dict[str, int]:
+        """Of ``batches``, the ids still claimable now, mapped to their current attempt.
 
         ``get_unprocessed_and_lock`` reads its candidates under the statement's snapshot
         (taken when the poll begins), but resolves the lease ``ON CONFLICT DO UPDATE``
@@ -1335,21 +1352,26 @@ class BatchQueue:
         ``FOR UPDATE`` there would re-check each row against its latest version, but
         Postgres rejects ``FOR UPDATE`` alongside the window function the per-team
         fairness ordering needs.
+
+        ``latest_attempt`` rides back with the id because the caller's copy is from the
+        same stale snapshot. A batch that failed and went to ``waiting_retry`` during the
+        poll would otherwise be retried under its pre-failure attempt number, so the
+        counter never climbs and ``max_attempts`` never retires a batch that always fails.
         """
         if not batches:
-            return set()
+            return {}
         ids = [b.id for b in batches]
         async with conn.cursor() as cur:
             await cur.execute(
                 f"""
-                SELECT id FROM {BATCH_TABLE}
+                SELECT id, latest_attempt FROM {BATCH_TABLE}
                 WHERE id = ANY(%(ids)s::uuid[])
                   AND created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
-                  AND latest_state IN ('pending', 'waiting_retry')
+                  AND {claimable_state_predicate(BATCH_TABLE)}
                 """,
-                {"ids": ids},
+                {"ids": ids, "backoff": retry_backoff_base_seconds},
             )
-            return {str(row[0]) for row in await cur.fetchall()}
+            return {str(row[0]): row[1] for row in await cur.fetchall()}
 
     @staticmethod
     async def unlock_for_batches(

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
@@ -1315,6 +1315,43 @@ class BatchQueue:
         return float(row[0])
 
     @staticmethod
+    async def filter_still_claimable(
+        conn: psycopg.AsyncConnection[Any],
+        *,
+        batches: list[PendingBatch],
+    ) -> set[str]:
+        """Of ``batches``, the ids whose state is *currently* still claimable.
+
+        ``get_unprocessed_and_lock`` reads its candidates under the statement's snapshot
+        (taken when the poll begins), but resolves the lease ``ON CONFLICT DO UPDATE``
+        against the latest committed row — Postgres does not use the snapshot for
+        conflict handling. The two halves of the claim therefore disagree about time by
+        the whole duration of the poll. A batch another pod claimed, finished and
+        released the lease for during that window comes back as a candidate carrying its
+        pre-run ``latest_attempt``, and gets processed a second time.
+
+        Re-reading here closes that gap: this runs in its own statement after the claim,
+        so it sees committed state. The candidate query cannot do it itself — a
+        ``FOR UPDATE`` there would re-check each row against its latest version, but
+        Postgres rejects ``FOR UPDATE`` alongside the window function the per-team
+        fairness ordering needs.
+        """
+        if not batches:
+            return set()
+        ids = [b.id for b in batches]
+        async with conn.cursor() as cur:
+            await cur.execute(
+                f"""
+                SELECT id FROM {BATCH_TABLE}
+                WHERE id = ANY(%(ids)s::uuid[])
+                  AND created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
+                  AND latest_state IN ('pending', 'waiting_retry')
+                """,
+                {"ids": ids},
+            )
+            return {str(row[0]) for row in await cur.fetchall()}
+
+    @staticmethod
     async def unlock_for_batches(
         conn: psycopg.AsyncConnection[Any],
         *,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
@@ -107,7 +107,7 @@ def _all_claims_still_fresh():
     with patch(
         "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.filter_still_claimable",
         new_callable=AsyncMock,
-        side_effect=lambda _conn, *, batches: {b.id for b in batches},
+        side_effect=lambda _conn, *, batches, retry_backoff_base_seconds: {b.id: b.latest_attempt for b in batches},
     ):
         yield
 
@@ -320,7 +320,7 @@ class TestProcessGroup:
             patch(
                 "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.filter_still_claimable",
                 new_callable=AsyncMock,
-                return_value={batches[0].id, batches[2].id},
+                return_value={batches[0].id: 0, batches[2].id: 0},
             ),
             patch(
                 "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.update_status_unless_failed",
@@ -343,6 +343,47 @@ class TestProcessGroup:
         # The lease is derived from the batch list, so it must still be released off the
         # full claim — filtering it down to the fresh ones strands the group for a full TTL.
         assert mock_unlock.call_args.kwargs["batches"] == batches
+
+    @pytest.mark.asyncio
+    async def test_retries_under_the_attempt_written_during_the_poll(self):
+        # A batch that failed while the poll was still running comes back carrying its
+        # pre-failure attempt. Retrying under that number leaves the counter flat, so a
+        # batch that fails every time never reaches max_attempts and retries forever.
+        consumer = _make_consumer(max_attempts=3)
+        attempts: list[int] = []
+
+        async def track_status(conn, *, batch_id, job_state, attempt, **kwargs):
+            attempts.append(attempt)
+            return True
+
+        consumer._process_batch = AsyncMock()
+        batch = _make_batch(latest_attempt=0)
+
+        with (
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.filter_still_claimable",
+                new_callable=AsyncMock,
+                return_value={batch.id: 2},
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.update_status_unless_failed",
+                side_effect=track_status,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.unlock_for_batches",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.verify_advisory_lock",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(consumer, "_connect", new_callable=AsyncMock, return_value=_make_healthy_conn()),
+        ):
+            await consumer._process_group((1, "schema-1"), [batch])
+
+        # 2 committed attempts + this one, not the stale 0 + 1.
+        assert attempts == [3, 3]
 
     @pytest.mark.asyncio
     async def test_unlocks_even_on_error(self):

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
@@ -101,6 +101,18 @@ def _make_healthy_conn(closed: bool = False, broken: bool = False) -> AsyncMock:
 
 
 @pytest.fixture(autouse=True)
+def _all_claims_still_fresh():
+    # Group dispatch re-validates the poll's candidates against committed state; the
+    # real SQL can't run against mock connections. The staleness test re-patches this.
+    with patch(
+        "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.filter_still_claimable",
+        new_callable=AsyncMock,
+        side_effect=lambda _conn, *, batches: {b.id for b in batches},
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
 def _lease_renewal_succeeds():
     # Group dispatch renews the lease before processing; the real SQL can't run
     # against mock connections. Tests exercising renewal failure re-patch this.
@@ -287,6 +299,50 @@ class TestProcessGroup:
 
         assert order == [0, 1, 2]
         mock_unlock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_drops_claims_that_went_terminal_during_the_poll(self):
+        # The claim reads candidates under the poll's snapshot but takes the group lease
+        # against current data, so a poll lasting tens of seconds hands back batches another
+        # pod has since finished and released. Reprocessing those repeats their side effects
+        # (for a final batch, the whole post-load pass) — in prod that was two thirds of all
+        # claims. The still-claimable set must gate what reaches _process_batch.
+        consumer = _make_consumer()
+        seen: list[int] = []
+
+        async def track_batch(batch):
+            seen.append(batch.batch_index)
+
+        consumer._process_batch = track_batch
+        batches = [_make_batch(batch_index=i, id=f"00000000-0000-0000-0000-{i + 1:012d}") for i in range(3)]
+
+        with (
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.filter_still_claimable",
+                new_callable=AsyncMock,
+                return_value={batches[0].id, batches[2].id},
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.update_status_unless_failed",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.unlock_for_batches",
+                new_callable=AsyncMock,
+            ) as mock_unlock,
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.verify_advisory_lock",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch.object(consumer, "_connect", new_callable=AsyncMock, return_value=_make_healthy_conn()),
+        ):
+            await consumer._process_group((1, "schema-1"), batches)
+
+        assert seen == [0, 2]
+        # The lease is derived from the batch list, so it must still be released off the
+        # full claim — filtering it down to the fresh ones strands the group for a full TTL.
+        assert mock_unlock.call_args.kwargs["batches"] == batches
 
     @pytest.mark.asyncio
     async def test_unlocks_even_on_error(self):

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
@@ -1460,6 +1460,32 @@ class TestClaimGates:
         waiting = await _insert_batch(conn, team_id=7, schema_id="s-g", run_uuid="run-g", batch_index=0)
         await BatchQueue.update_status(conn, batch_id=waiting, job_state="waiting", attempt=0)
 
+    @pytest.mark.parametrize(
+        "job_state,still_claimable",
+        [
+            (None, True),
+            ("waiting_retry", True),
+            # Another pod holds it, or already finished it, between our poll and our dispatch.
+            ("executing", False),
+            ("succeeded", False),
+            ("failed", False),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_filter_still_claimable_reads_state_written_after_the_claim(self, conn, job_state, still_claimable):
+        # The prod sequence: a slow poll claims this batch, another pod advances it while
+        # the poll is still running, and the re-validation before dispatch has to see that.
+        bid = await _insert_batch(conn)
+        claimed = await _claim(conn)
+        assert [str(b.id) for b in claimed] == [bid]
+
+        if job_state is not None:
+            await BatchQueue.update_status(conn, batch_id=bid, job_state=job_state, attempt=1)
+
+        fresh = await BatchQueue.filter_still_claimable(conn, batches=claimed)
+
+        assert (bid in fresh) is still_claimable
+
     @pytest.mark.asyncio
     async def test_claim_applies_every_gate_at_once(self, conn):
         await self._seed_rich_scenario(conn)

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
@@ -1482,9 +1482,37 @@ class TestClaimGates:
         if job_state is not None:
             await BatchQueue.update_status(conn, batch_id=bid, job_state=job_state, attempt=1)
 
-        fresh = await BatchQueue.filter_still_claimable(conn, batches=claimed)
+        fresh = await BatchQueue.filter_still_claimable(conn, batches=claimed, retry_backoff_base_seconds=0)
 
         assert (bid in fresh) is still_claimable
+
+    @pytest.mark.asyncio
+    async def test_filter_still_claimable_holds_waiting_retry_inside_its_backoff(self, conn):
+        # A batch that failed *during* the poll is waiting_retry with a fresh
+        # state_changed_at. Re-validating on state alone would admit it and skip the
+        # retry delay the claim would have enforced.
+        bid = await _insert_batch(conn)
+        claimed = await _claim(conn)
+        await BatchQueue.update_status(conn, batch_id=bid, job_state="waiting_retry", attempt=1)
+
+        held = await BatchQueue.filter_still_claimable(conn, batches=claimed, retry_backoff_base_seconds=3600)
+        elapsed = await BatchQueue.filter_still_claimable(conn, batches=claimed, retry_backoff_base_seconds=0)
+
+        assert bid not in held
+        assert bid in elapsed
+
+    @pytest.mark.asyncio
+    async def test_filter_still_claimable_returns_the_current_attempt(self, conn):
+        # The caller's attempt is from the stale snapshot. Retrying under it would leave
+        # the counter flat, so a batch that fails every time never reaches max_attempts.
+        bid = await _insert_batch(conn)
+        claimed = await _claim(conn)
+        assert claimed[0].latest_attempt == 0
+        await BatchQueue.update_status(conn, batch_id=bid, job_state="waiting_retry", attempt=2)
+
+        fresh = await BatchQueue.filter_still_claimable(conn, batches=claimed, retry_backoff_base_seconds=0)
+
+        assert fresh[bid] == 2
 
     @pytest.mark.asyncio
     async def test_claim_applies_every_gate_at_once(self, conn):


### PR DESCRIPTION
## Problem

- Two thirds of the V3 loader's work is redundant. Over three hours in prod, 13,552 of 20,310 batch claims were of batches another pod had already finished.
- Every redundant claim of a final batch re-runs the whole post-load pass: delta maintenance, S3 queryable-folder prep with real file copies, schema validation, ClickHouse row counts.
- `get_unprocessed_and_lock` reads its candidates under the poll statement's snapshot, but resolves the group-lease `INSERT … ON CONFLICT DO UPDATE` against the latest committed row. Postgres does not use the snapshot for conflict handling.
- The two halves of the claim therefore disagree about time by the whole duration of the poll, which runs ~55s at p90.
- A batch another pod claimed, finished and released the lease for inside that window returns as a candidate carrying its pre-run `latest_attempt`, and is processed again.

This is also what triggered the CDC companion history wipe fixed in #82696.

## Changes

- `_process_group` re-validates the poll's candidates once the group lease is held and before any batch runs. Stale ones are dropped and logged; the rest process normally.
- `BatchQueue.filter_still_claimable` re-applies the claim's own state predicate against committed data, in its own statement.
- The candidate query cannot do this itself. A `FOR UPDATE` there would re-check each row against its latest version, but Postgres rejects `FOR UPDATE` alongside the window function the per-team fairness ordering needs.
- Dropped batches count under the existing `batches_processed_total` counter as `status="stale_claim"`, so the rate is visible on the current dashboards.
- Fails open. An error in the re-validation leaves the batch list untouched, because a wedged group is worse than the duplicate work the loader's idempotency check already absorbs.

> [!NOTE]
> This removes the duplicate work but not its cause. The poll taking tens of seconds is a separate problem — see below.

## How did you test this code?

- New parameterized case in `test_jobs_db.py` replays the prod sequence against a real Postgres: claim the batch, let another writer advance it, then re-validate. Covers never-written and `waiting_retry` (still claimable) against `executing`, `succeeded` and `failed` (not).
- New case in `test_consumer.py` guards the wiring, that stale ids never reach `_process_batch`. It also asserts the lease is still released off the full claim — filtering the list the `finally` unlocks from would strand the group for a full 300s TTL, which is a bug I wrote and this assertion caught.
- Ran the `pipeline_v3` suite, the full `test_jobs_db.py` against a real Postgres, repo-wide mypy, and ruff locally.
- No manual testing against the live fleet, and no verification that the duplicate-claim rate actually drops — that needs the change deployed. The `status="stale_claim"` counter is how to check it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- I (actually Claude, Opus 5 in Claude Code) investigated this after it surfaced as the trigger for a separate CDC bug, and Daniel ran the read-only prod diagnostics I could not.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Most of the session was eliminating wrong answers. The recovery sweep, same-pod double dispatch, and drift in the denormalized state columns were each ruled out with evidence — the last by a prod audit reporting zero mismatches. I also reproduced the consumer's exact write path against real Postgres, on both a plain and a range-partitioned table, and it was correct both times, which is what pointed at the reader rather than the writer.
- I wrongly dismissed slow polls early on, because the `poll_duration_approaching_lease_ttl` warning had never fired. That warning triggers at `lease_ttl / 2`, which is 150s, so a 55s poll clears it silently. Worth re-basing that threshold; not done here.
- **Follow-up, not addressed here:** the poll itself. p50 batches fetched per poll is 0 while p50 duration is 37s, at ~57 polls/minute fleet-wide. The `row_number() OVER (PARTITION BY team_id …)` in the candidate ordering is evaluated before `LIMIT`, so every poll gates and sorts the entire claimable backlog to return at most a windowful — usually nothing. An `EXISTS` pre-check would collapse the empty polls, and moving the fairness ordering behind the limit would fix the rest.
- Public artifact: the diff is code and tests only. Nothing from the session that is not already public reached this PR.

