### PR TITLE
feat(dashboards): add position and nullable name to DashboardGroup

### DIFF
--- a/products/dashboards/backend/migrations/0019_dashboardgroup_position_and_nullable_name.py
+++ b/products/dashboards/backend/migrations/0019_dashboardgroup_position_and_nullable_name.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("dashboards", "0018_validate_dashboard_group_constraints")]
+
+    operations = [
+        migrations.AddField(
+            model_name="dashboardgroup",
+            name="position",
+            field=models.IntegerField(default=0),
+        ),
+        migrations.AlterField(
+            model_name="dashboardgroup",
+            name="name",
+            field=models.CharField(blank=True, max_length=400, null=True),
+        ),
+        migrations.AlterModelOptions(
+            name="dashboardgroup",
+            options={
+                "default_manager_name": "all_teams",
+                "ordering": ["position", "created_at"],
+            },
+        ),
+    ]

--- a/products/dashboards/backend/migrations/max_migration.txt
+++ b/products/dashboards/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0018_validate_dashboard_group_constraints
+0019_dashboardgroup_position_and_nullable_name

--- a/products/dashboards/backend/models/dashboard_group.py
+++ b/products/dashboards/backend/models/dashboard_group.py
@@ -7,7 +7,8 @@ from posthog.models.utils import UUIDModel
 
 class DashboardGroup(TeamScopedRootMixin, UUIDModel):
     dashboard = models.ForeignKey("dashboards.Dashboard", on_delete=models.CASCADE, related_name="groups")
-    name = models.CharField(max_length=400)
+    name = models.CharField(max_length=400, null=True, blank=True)
+    position = models.IntegerField(default=0)
     created_at = models.DateTimeField(auto_now_add=True)
     created_by = models.ForeignKey(
         "posthog.User", on_delete=models.SET_NULL, null=True, blank=True, db_constraint=False
@@ -28,3 +29,4 @@ class DashboardGroup(TeamScopedRootMixin, UUIDModel):
     class Meta(TeamScopedRootMixin.Meta):
         db_table = "posthog_dashboardgroup"
         default_manager_name = "all_teams"
+        ordering = ["position", "created_at"]

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-create-text-tile.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-create-text-tile.json
@@ -47,6 +47,28 @@
                         }
                     },
                     "type": "object"
+                },
+                "xs": {
+                    "description": "Layout for the small (mobile) breakpoint. The grid is 1 column wide.",
+                    "properties": {
+                        "h": {
+                            "description": "Height in grid rows.",
+                            "type": "number"
+                        },
+                        "w": {
+                            "description": "Width in grid columns. The desktop grid is 12 columns wide.",
+                            "type": "number"
+                        },
+                        "x": {
+                            "description": "Column position in the dashboard grid (0-indexed).",
+                            "type": "number"
+                        },
+                        "y": {
+                            "description": "Row position in the dashboard grid (0-indexed).",
+                            "type": "number"
+                        }
+                    },
+                    "type": "object"
                 }
             },
             "type": "object"

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-group-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-group-create.json
@@ -29,6 +29,28 @@
                         }
                     },
                     "type": "object"
+                },
+                "xs": {
+                    "description": "Layout for the small (mobile) breakpoint. The grid is 1 column wide.",
+                    "properties": {
+                        "h": {
+                            "description": "Height in grid rows.",
+                            "type": "number"
+                        },
+                        "w": {
+                            "description": "Width in grid columns. The desktop grid is 12 columns wide.",
+                            "type": "number"
+                        },
+                        "x": {
+                            "description": "Column position in the dashboard grid (0-indexed).",
+                            "type": "number"
+                        },
+                        "y": {
+                            "description": "Row position in the dashboard grid (0-indexed).",
+                            "type": "number"
+                        }
+                    },
+                    "type": "object"
                 }
             },
             "type": "object"

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-group-delete.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-group-delete.json
@@ -13,28 +13,6 @@
             "description": "How to handle content tiles currently assigned to the group.\n\n* `delete_tiles` - delete_tiles\n* `move_to_ungrouped` - move_to_ungrouped",
             "enum": ["delete_tiles", "move_to_ungrouped"],
             "type": "string"
-        },
-        "xs": {
-            "description": "Layout for the small (mobile) breakpoint. The grid is 1 column wide.",
-            "properties": {
-                "h": {
-                    "description": "Height in grid rows.",
-                    "type": "number"
-                },
-                "w": {
-                    "description": "Width in grid columns. The desktop grid is 12 columns wide.",
-                    "type": "number"
-                },
-                "x": {
-                    "description": "Column position in the dashboard grid (0-indexed).",
-                    "type": "number"
-                },
-                "y": {
-                    "description": "Row position in the dashboard grid (0-indexed).",
-                    "type": "number"
-                }
-            },
-            "type": "object"
         }
     },
     "required": ["id", "group_id", "member_handling"],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-group-move-tile.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-group-move-tile.json
@@ -40,6 +40,28 @@
                         }
                     },
                     "type": "object"
+                },
+                "xs": {
+                    "description": "Layout for the small (mobile) breakpoint. The grid is 1 column wide.",
+                    "properties": {
+                        "h": {
+                            "description": "Height in grid rows.",
+                            "type": "number"
+                        },
+                        "w": {
+                            "description": "Width in grid columns. The desktop grid is 12 columns wide.",
+                            "type": "number"
+                        },
+                        "x": {
+                            "description": "Column position in the dashboard grid (0-indexed).",
+                            "type": "number"
+                        },
+                        "y": {
+                            "description": "Row position in the dashboard grid (0-indexed).",
+                            "type": "number"
+                        }
+                    },
+                    "type": "object"
                 }
             },
             "type": "object"

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-group-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-group-update.json
@@ -33,6 +33,28 @@
                         }
                     },
                     "type": "object"
+                },
+                "xs": {
+                    "description": "Layout for the small (mobile) breakpoint. The grid is 1 column wide.",
+                    "properties": {
+                        "h": {
+                            "description": "Height in grid rows.",
+                            "type": "number"
+                        },
+                        "w": {
+                            "description": "Width in grid columns. The desktop grid is 12 columns wide.",
+                            "type": "number"
+                        },
+                        "x": {
+                            "description": "Column position in the dashboard grid (0-indexed).",
+                            "type": "number"
+                        },
+                        "y": {
+                            "description": "Row position in the dashboard grid (0-indexed).",
+                            "type": "number"
+                        }
+                    },
+                    "type": "object"
                 }
             },
             "type": "object"
@@ -44,6 +66,6 @@
             "type": "string"
         }
     },
-    "required": ["id"],
+    "required": ["id", "group_id"],
     "type": "object"
 }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-update-text-tile.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-update-text-tile.json
@@ -47,6 +47,28 @@
                         }
                     },
                     "type": "object"
+                },
+                "xs": {
+                    "description": "Layout for the small (mobile) breakpoint. The grid is 1 column wide.",
+                    "properties": {
+                        "h": {
+                            "description": "Height in grid rows.",
+                            "type": "number"
+                        },
+                        "w": {
+                            "description": "Width in grid columns. The desktop grid is 12 columns wide.",
+                            "type": "number"
+                        },
+                        "x": {
+                            "description": "Column position in the dashboard grid (0-indexed).",
+                            "type": "number"
+                        },
+                        "y": {
+                            "description": "Row position in the dashboard grid (0-indexed).",
+                            "type": "number"
+                        }
+                    },
+                    "type": "object"
                 }
             },
             "type": "object"


### PR DESCRIPTION
## Problem

- Dashboard groups have no stable order, so moving a group rewrites synthetic tile coordinates.

## Changes

- Adds a dense integer position to each dashboard group.
- Allows anonymous sections through nullable and blank names.
- Orders groups by position, then creation time.

## How did you test this code?

- Django reports no migration state drift.
- `sqlmigrate` confirms one additive column and one nullable-field alteration.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No documentation change. This layer only adds schema support.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex used `/django-migrations`, `/writing-tests`, `/writing-pr-descriptions`, and `/stacking-prs`.
- The change follows Matt's ordered-section design.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
