### PR TITLE
feat(dashboards): section-based dashboard groups API

### DIFF
--- a/posthog/helpers/dashboard_templates.py
+++ b/posthog/helpers/dashboard_templates.py
@@ -492,6 +492,41 @@ def dashboard_template_from_creation_payload(template: dict[str, Any]) -> Dashbo
     )
 
 
+def _template_tile_y(template_tile: dict[str, Any]) -> int:
+    layouts = template_tile.get("layouts") or {}
+    sm = layouts.get("sm") or {}
+    y = sm.get("y", 0)
+    return y if isinstance(y, int) else 0
+
+
+def _template_tile_section_bucket(header_layouts: list[dict[str, Any]], template_tile: dict[str, Any]) -> int:
+    tile_y = _template_tile_y(template_tile)
+    return sum(_template_tile_y(header) <= tile_y for header in header_layouts)
+
+
+def partition_tiles_into_sections(
+    header_layouts: list[dict[str, Any]], tiles: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    section_entries: list[dict[str, Any]] = [
+        {"header": header, "bucket": -1, "y": _template_tile_y(header)} for header in header_layouts
+    ]
+    anonymous_tiles_by_bucket: dict[int, list[dict[str, Any]]] = {}
+    for tile in tiles:
+        if tile.get("group_key") is not None:
+            continue
+        bucket = _template_tile_section_bucket(header_layouts, tile)
+        anonymous_tiles_by_bucket.setdefault(bucket, []).append(tile)
+    for bucket, anonymous_tiles in anonymous_tiles_by_bucket.items():
+        section_entries.append(
+            {
+                "header": None,
+                "bucket": bucket,
+                "y": min(_template_tile_y(tile) for tile in anonymous_tiles),
+            }
+        )
+    return sorted(section_entries, key=lambda section: (section["y"], section["header"] is None))
+
+
 def create_from_template(
     dashboard: Dashboard,
     template: DashboardTemplate,
@@ -522,9 +557,23 @@ def create_from_template(
         dashboard.tagged_items.create(tag_id=tag.id)
     dashboard.save()
 
+    group_tiles = [template_tile for template_tile in template_tiles if template_tile.get("type") == "GROUP"]
+    content_tiles = [template_tile for template_tile in template_tiles if template_tile.get("type") != "GROUP"]
+    sections = partition_tiles_into_sections(group_tiles, content_tiles)
+
     groups_by_key: dict[str, DashboardGroup] = {}
-    for template_tile in template_tiles:
-        if template_tile.get("type") != "GROUP":
+    anonymous_groups_by_bucket: dict[int, DashboardGroup] = {}
+    for position, section in enumerate(sections):
+        template_tile = section["header"]
+        if template_tile is None:
+            anonymous_groups_by_bucket[section["bucket"]] = DashboardGroup.all_teams.create(
+                dashboard=dashboard,
+                team=dashboard.team,
+                name=None,
+                position=position,
+                created_by=user,
+                last_modified_by=user,
+            )
             continue
         group_key = template_tile.get("group_key")
         if not group_key:
@@ -534,14 +583,9 @@ def create_from_template(
             dashboard=dashboard,
             team=dashboard.team,
             name=template_tile.get("name", "Group"),
+            position=position,
             created_by=user,
             last_modified_by=user,
-        )
-        DashboardTile.objects.create(
-            dashboard=dashboard,
-            team=dashboard.team,
-            dashboard_group=group,
-            layouts=template_tile.get("layouts") or {},
         )
         groups_by_key[group_key] = group
 
@@ -549,7 +593,11 @@ def create_from_template(
         tile_type = template_tile.get("type")
         if tile_type == "GROUP":
             continue
-        parent_group = groups_by_key.get(template_tile.get("group_key"))
+        group_key = template_tile.get("group_key")
+        parent_group = groups_by_key.get(group_key)
+        if group_key is None:
+            bucket = _template_tile_section_bucket(group_tiles, template_tile)
+            parent_group = anonymous_groups_by_bucket.get(bucket)
         if tile_type == "INSIGHT":
             query = template_tile.get("query", None)
             _create_tile_for_insight(

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -4,6 +4,7 @@ import re
 import json
 import uuid
 import builtins
+from collections import defaultdict
 from collections.abc import AsyncGenerator
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import nullcontext
@@ -336,6 +337,17 @@ def _compact_tile_layouts(tiles: list[DashboardTile]) -> set[int]:
             tile.layouts = json.loads(tile.layouts)
 
     changed: set[int] = set()
+    tiles_by_section: dict[uuid.UUID | None, list[DashboardTile]] = defaultdict(list)
+    for tile in tiles:
+        tiles_by_section[tile.parent_group_id].append(tile)
+
+    for section_tiles in tiles_by_section.values():
+        changed.update(_compact_section_tile_layouts(section_tiles))
+    return changed
+
+
+def _compact_section_tile_layouts(tiles: list[DashboardTile]) -> set[int]:
+    changed: set[int] = set()
     breakpoints: set[str] = set()
     for tile in tiles:
         if isinstance(tile.layouts, dict):
@@ -449,6 +461,19 @@ def _apply_reorder_layout(
 ) -> None:
     """Repack tiles. ``preserve`` keeps each tile's existing w/h and reuses the lowest-segment
     greedy algorithm from ``frontend/src/scenes/dashboard/tileLayouts.ts``; the other modes overwrite w/h."""
+    tile_order_by_section: dict[uuid.UUID | None, list[int]] = defaultdict(list)
+    for tile_id in tile_order:
+        tile_order_by_section[tile_map[tile_id].parent_group_id].append(tile_id)
+
+    for section_tile_order in tile_order_by_section.values():
+        _apply_section_reorder_layout(section_tile_order, tile_map, layout_mode)
+
+
+def _apply_section_reorder_layout(
+    tile_order: list[int],
+    tile_map: dict[int, DashboardTile],
+    layout_mode: ReorderLayout,
+) -> None:
     if layout_mode == ReorderLayout.TWO_COLUMN:
         for index, tile_id in enumerate(tile_order):
             row, col = divmod(index, 2)
@@ -499,11 +524,42 @@ def _apply_reorder_layout(
         xs_y += h
 
 
+def _renumber_dashboard_groups(dashboard: Dashboard) -> None:
+    groups = list(dashboard.groups.select_for_update().order_by("position", "created_at"))
+    changed_groups: list[DashboardGroup] = []
+    for position, group in enumerate(groups):
+        if group.position != position:
+            group.position = position
+            changed_groups.append(group)
+    if changed_groups:
+        DashboardGroup.all_teams.bulk_update(changed_groups, ["position"])
+
+
+def resolve_default_section(dashboard: Dashboard, user: User) -> DashboardGroup | None:
+    groups = list(dashboard.groups.select_for_update().order_by("position", "created_at"))
+    if not groups:
+        return None
+    trailing_group = groups[-1]
+    if not trailing_group.name:
+        return trailing_group
+    return DashboardGroup.all_teams.create(
+        dashboard=dashboard,
+        team=dashboard.team,
+        name=None,
+        position=len(groups),
+        created_by=user,
+        last_modified_by=user,
+    )
+
+
 class ReorderTilesRequestSerializer(serializers.Serializer):
     tile_order = serializers.ListField(
         child=serializers.IntegerField(),
         min_length=1,
-        help_text="Array of tile IDs in the desired display order (top to bottom, left to right).",
+        help_text=(
+            "Tile IDs in the desired display order. The endpoint partitions the order by section and repacks "
+            "each section independently."
+        ),
     )
     layout = serializers.ChoiceField(
         choices=[mode.value for mode in ReorderLayout],
@@ -544,29 +600,34 @@ class TileLayoutsSerializer(serializers.Serializer):
 
 class CreateDashboardGroupRequestSerializer(serializers.Serializer):
     name = serializers.CharField(
-        min_length=1,
         max_length=400,
         trim_whitespace=True,
-        help_text="Name displayed in the dashboard group row.",
-    )
-    layouts = TileLayoutsSerializer(
         required=False,
-        help_text="Optional grid layout for the group row. Group rows always span the desktop grid.",
+        allow_null=True,
+        allow_blank=True,
+        help_text="Optional section name. Null or an empty string creates an anonymous section.",
+    )
+    position = serializers.IntegerField(
+        required=False,
+        min_value=0,
+        help_text="Section position. Omit to append the section.",
     )
 
 
 class UpdateDashboardGroupRequestSerializer(serializers.Serializer):
     group_id = serializers.UUIDField(help_text="Dashboard group ID to update.")
     name = serializers.CharField(
-        min_length=1,
         max_length=400,
         trim_whitespace=True,
         required=False,
-        help_text="New group name. Omit to keep the existing name.",
+        allow_null=True,
+        allow_blank=True,
+        help_text="New section name. Null or an empty string converts the section to anonymous.",
     )
-    layouts = TileLayoutsSerializer(
+    position = serializers.IntegerField(
         required=False,
-        help_text="New grid layout for the group row. Omit to keep its current layout.",
+        min_value=0,
+        help_text="New section position. Existing sections are renumbered around it.",
     )
 
 
@@ -574,19 +635,28 @@ class MoveDashboardTileToGroupRequestSerializer(serializers.Serializer):
     tile_id = serializers.IntegerField(help_text="Content tile ID to move.")
     group_id = serializers.UUIDField(
         required=False,
-        allow_null=True,
-        help_text="Destination group ID, or null to move the tile to the ungrouped section.",
+        help_text="Destination section ID.",
+    )
+    create_at_position = serializers.IntegerField(
+        required=False,
+        min_value=0,
+        help_text="Create an anonymous section at this position and move the tile into it.",
     )
     layouts = TileLayoutsSerializer(
         required=False,
         help_text="Optional new layout for the moved tile.",
     )
 
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        if ("group_id" in attrs) == ("create_at_position" in attrs):
+            raise serializers.ValidationError("Provide exactly one destination.")
+        return attrs
+
 
 class DeleteDashboardGroupRequestSerializer(serializers.Serializer):
     group_id = serializers.UUIDField(help_text="Dashboard group ID to delete.")
     member_handling = serializers.ChoiceField(
-        choices=["delete_tiles", "move_to_ungrouped"],
+        choices=["delete_tiles", "ungroup"],
         help_text="How to handle content tiles currently assigned to the group.",
     )
 
@@ -612,6 +682,10 @@ class CreateTextTileRequestSerializer(serializers.Serializer):
             "Optional grid layout per breakpoint. If omitted, the tile is placed at the bottom of the dashboard "
             "using the default size. Text tiles typically use a thin full-width banner (e.g. w=12, h=1)."
         ),
+    )
+    group_id = serializers.UUIDField(
+        required=False,
+        help_text="Section ID for the new tile. Omit to use the dashboard's default section.",
     )
     color = serializers.CharField(
         max_length=400,
@@ -728,6 +802,10 @@ class DashboardPatchWidgetSerializer(DashboardWidgetCoreRequestSerializer):
 
 
 class AddDashboardWidgetsBatchRequestSerializer(serializers.Serializer):
+    group_id = serializers.UUIDField(
+        required=False,
+        help_text="Section ID for the new widgets. Omit to use the dashboard's default section.",
+    )
     widgets = serializers.ListField(
         child=AddDashboardWidgetRequestSerializer(),
         min_length=1,
@@ -741,6 +819,10 @@ class AddDashboardWidgetsBatchRequestSerializer(serializers.Serializer):
 class AddDashboardWidgetsBatchRequestOpenApiSerializer(serializers.Serializer):
     """OpenAPI-only batch-add schema with widget_type-discriminated config shapes for agents."""
 
+    group_id = serializers.UUIDField(
+        required=False,
+        help_text="Section ID for the new widgets. Omit to use the dashboard's default section.",
+    )
     widgets = serializers.ListField(
         child=AddDashboardWidgetRequestOpenApi,
         min_length=1,
@@ -950,12 +1032,6 @@ class SharedDashboardWidgetMetadataSerializer(serializers.ModelSerializer):
 
 
 class DashboardGroupSerializer(serializers.ModelSerializer):
-    tile_id = serializers.IntegerField(source="tile.id", read_only=True, help_text="Grid tile ID for this group row.")
-    layouts = TileLayoutsSerializer(
-        source="tile.layouts",
-        read_only=True,
-        help_text="Grid layout for the group row.",
-    )
     member_tile_ids = serializers.PrimaryKeyRelatedField(
         source="member_tiles",
         many=True,
@@ -968,8 +1044,7 @@ class DashboardGroupSerializer(serializers.ModelSerializer):
         fields = [
             "id",
             "name",
-            "tile_id",
-            "layouts",
+            "position",
             "member_tile_ids",
             "created_at",
             "created_by",
@@ -981,7 +1056,7 @@ class DashboardGroupSerializer(serializers.ModelSerializer):
 
 class SharedDashboardGroupSerializer(DashboardGroupSerializer):
     class Meta(DashboardGroupSerializer.Meta):
-        fields = ["id", "name", "tile_id", "layouts", "member_tile_ids"]
+        fields = ["id", "name", "position", "member_tile_ids"]
 
 
 class DashboardTileSerializer(serializers.ModelSerializer):
@@ -1051,6 +1126,18 @@ class DashboardTileErrorSerializer(DashboardTileSerializer):
             _hide_extra_details(self.context, representation["insight"])
 
         return representation
+
+
+class MoveDashboardTileToGroupResponseSerializer(serializers.Serializer):
+    tile = DashboardTileSerializer(help_text="The moved dashboard tile.")
+    created_group = DashboardGroupSerializer(
+        allow_null=True,
+        help_text="The anonymous section created for the move, or null.",
+    )
+    deleted_group_ids = serializers.ListField(
+        child=serializers.UUIDField(),
+        help_text="Anonymous source section IDs deleted after they became empty.",
+    )
 
 
 class InsightResultSerializer(InsightSerializer):
@@ -1294,11 +1381,13 @@ class DashboardMetadataSerializer(DashboardBasicSerializer):
 
     @extend_schema_field(DashboardGroupSerializer(many=True))
     def get_groups(self, dashboard: Dashboard) -> list[dict[str, Any]]:
-        groups = dashboard.groups.select_related("tile", "created_by", "last_modified_by").prefetch_related(
-            "member_tiles"
+        groups = (
+            dashboard.groups.order_by("position", "created_at")
+            .select_related("created_by", "last_modified_by")
+            .prefetch_related("member_tiles")
         )
         serializer_class = SharedDashboardGroupSerializer if self.context.get("is_shared") else DashboardGroupSerializer
-        return serializer_class(groups, many=True, context=self.context).data
+        return cast(list[dict[str, Any]], serializer_class(groups, many=True, context=self.context).data)
 
     def to_representation(self, instance: Dashboard) -> ReturnDict:
         ret = super().to_representation(instance)
@@ -1625,19 +1714,14 @@ class DashboardSerializer(DashboardMetadataSerializer):
 
         elif existing_dashboard:
             group_map: dict[uuid.UUID, DashboardGroup] = {}
-            for source_group in existing_dashboard.groups.select_related("tile"):
+            for source_group in existing_dashboard.groups.order_by("position", "created_at"):
                 copied_group = DashboardGroup.all_teams.create(
                     dashboard=dashboard,
                     team=dashboard.team,
                     name=source_group.name,
+                    position=source_group.position,
                     created_by=request.user,
                     last_modified_by=request.user,
-                )
-                DashboardTile.objects.create(
-                    dashboard=dashboard,
-                    team=dashboard.team,
-                    dashboard_group=copied_group,
-                    layouts=source_group.tile.layouts,
                 )
                 group_map[source_group.id] = copied_group
             existing_tiles = (
@@ -2346,7 +2430,14 @@ class DashboardSerializer(DashboardMetadataSerializer):
 
         # Sort tiles by layout to ensure insights are computed in order of appearance on dashboard
         # Use the specified layout size to get the correct order for the current viewport
-        sorted_tiles = DashboardTile.sort_tiles_by_layout(tiles, layout_size)
+        group_positions = dict(dashboard.groups.values_list("id", "position"))
+
+        def tile_sort_key(tile: DashboardTile) -> tuple[int, int, int]:
+            layout = tile.layouts.get(layout_size, {}) if isinstance(tile.layouts, dict) else {}
+            section_position = group_positions.get(tile.parent_group_id, len(group_positions))
+            return section_position, layout.get("y", 0), layout.get("x", 0)
+
+        sorted_tiles = sorted(tiles, key=tile_sort_key)
 
         with task_chain_context() if chained_tile_refresh_enabled else nullcontext():
             # Handle case where there are no tiles
@@ -2982,29 +3073,42 @@ class DashboardsViewSet(
         user = cast(User, request.user)
         with transaction.atomic():
             dashboard = Dashboard.objects.select_for_update().get(id=dashboard.id)
-            layouts = serializer.validated_data.get("layouts", {})
-            if "sm" not in layouts:
-                existing_layouts = collect_dashboard_sm_layouts_for_dashboard(dashboard)
-                max_bottom = max((layout["y"] + layout["h"] for layout in existing_layouts), default=0)
-                layouts = {
-                    **layouts,
-                    "sm": {"x": 0, "y": max_bottom, "w": DASHBOARD_GRID_COLUMN_COUNT, "h": 1},
-                }
-            else:
-                layouts["sm"] = {**layouts["sm"], "x": 0, "w": DASHBOARD_GRID_COLUMN_COUNT, "h": 1}
+            groups = list(dashboard.groups.select_for_update().order_by("position", "created_at"))
+            if not groups:
+                existing_tiles = (
+                    DashboardTile.objects.select_for_update()
+                    .filter(
+                        dashboard=dashboard,
+                        dashboard_group__isnull=True,
+                    )
+                    .exclude(deleted=True)
+                )
+                if existing_tiles.exists():
+                    anonymous_group = DashboardGroup.all_teams.create(
+                        dashboard=dashboard,
+                        team=dashboard.team,
+                        name=None,
+                        position=0,
+                        created_by=user,
+                        last_modified_by=user,
+                    )
+                    existing_tiles.update(parent_group=anonymous_group)
+                    groups.append(anonymous_group)
+
+            requested_position = serializer.validated_data.get("position", len(groups))
+            position = min(requested_position, len(groups))
+            DashboardGroup.all_teams.filter(dashboard=dashboard, position__gte=position).update(
+                position=F("position") + 1
+            )
             group = DashboardGroup.all_teams.create(
                 dashboard=dashboard,
                 team=dashboard.team,
-                name=serializer.validated_data["name"],
+                name=serializer.validated_data.get("name") or None,
+                position=position,
                 created_by=user,
                 last_modified_by=user,
             )
-            DashboardTile.objects.create(
-                dashboard=dashboard,
-                team=dashboard.team,
-                dashboard_group=group,
-                layouts=layouts,
-            )
+            _renumber_dashboard_groups(dashboard)
 
         report_user_action(
             user,
@@ -3028,37 +3132,24 @@ class DashboardsViewSet(
         with transaction.atomic():
             dashboard = Dashboard.objects.select_for_update().get(id=dashboard.id)
             group = get_object_or_404(
-                dashboard.groups.select_related("tile").select_for_update(of=("self",)),
+                dashboard.groups.select_for_update(),
                 id=serializer.validated_data["group_id"],
             )
             if "name" in serializer.validated_data:
-                group.name = serializer.validated_data["name"]
+                group.name = serializer.validated_data["name"] or None
                 group.last_modified_by = request.user
                 group.last_modified_at = now()
                 group.save(update_fields=["name", "last_modified_by", "last_modified_at"])
                 fields_changed.append("name")
-            if "layouts" in serializer.validated_data:
-                layouts = {**group.tile.layouts, **serializer.validated_data["layouts"]}
-                if "sm" in layouts:
-                    layouts["sm"] = {**layouts["sm"], "x": 0, "w": DASHBOARD_GRID_COLUMN_COUNT, "h": 1}
-                group_tile = DashboardTile.objects.select_for_update().get(id=group.tile.id)
-                previous_y = group_tile.layouts.get("sm", {}).get("y")
-                next_y = layouts.get("sm", {}).get("y")
-                group_tile.layouts = layouts
-                group_tile.save(update_fields=["layouts"])
-
-                if isinstance(previous_y, int) and isinstance(next_y, int) and previous_y != next_y:
-                    members = list(group.member_tiles.select_for_update())
-                    for member in members:
-                        member_layout = member.layouts.get("sm")
-                        if member_layout is not None and isinstance(member_layout.get("y"), int):
-                            member.layouts = {
-                                **member.layouts,
-                                "sm": {**member_layout, "y": member_layout["y"] + next_y - previous_y},
-                            }
-                    DashboardTile.objects.bulk_update(members, ["layouts"])
-                group.tile = group_tile
-                fields_changed.append("layouts")
+            if "position" in serializer.validated_data:
+                groups = list(dashboard.groups.select_for_update().order_by("position", "created_at"))
+                groups.remove(group)
+                target_position = min(serializer.validated_data["position"], len(groups))
+                groups.insert(target_position, group)
+                for position, ordered_group in enumerate(groups):
+                    ordered_group.position = position
+                DashboardGroup.all_teams.bulk_update(groups, ["position"])
+                fields_changed.append("position")
 
         if fields_changed:
             report_user_action(
@@ -3070,20 +3161,40 @@ class DashboardsViewSet(
             )
         return Response(DashboardGroupSerializer(group, context=self.get_serializer_context()).data)
 
-    @extend_schema(request=MoveDashboardTileToGroupRequestSerializer, responses={200: DashboardTileSerializer})
+    @extend_schema(
+        request=MoveDashboardTileToGroupRequestSerializer,
+        responses={200: MoveDashboardTileToGroupResponseSerializer},
+    )
     @action(methods=["POST"], detail=True, url_path="groups/move-tile", required_scopes=["dashboard:write"])
     def move_tile_to_group(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         dashboard = self.get_object()
         serializer = MoveDashboardTileToGroupRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
+        created_group: DashboardGroup | None = None
+        deleted_group_ids: list[uuid.UUID] = []
         with transaction.atomic():
             dashboard = Dashboard.objects.select_for_update().get(id=dashboard.id)
             tile = get_object_or_404(
                 DashboardTile.objects.select_for_update().filter(dashboard=dashboard, dashboard_group__isnull=True),
                 id=serializer.validated_data["tile_id"],
             )
-            group_id = serializer.validated_data.get("group_id")
-            group = get_object_or_404(dashboard.groups, id=group_id) if group_id is not None else None
+            if "create_at_position" in serializer.validated_data:
+                groups = list(dashboard.groups.select_for_update().order_by("position", "created_at"))
+                position = min(serializer.validated_data["create_at_position"], len(groups))
+                DashboardGroup.all_teams.filter(dashboard=dashboard, position__gte=position).update(
+                    position=F("position") + 1
+                )
+                created_group = DashboardGroup.all_teams.create(
+                    dashboard=dashboard,
+                    team=dashboard.team,
+                    name=None,
+                    position=position,
+                    created_by=request.user,
+                    last_modified_by=request.user,
+                )
+                group = created_group
+            else:
+                group = get_object_or_404(dashboard.groups, id=serializer.validated_data["group_id"])
             source_group_id = tile.parent_group_id
 
             tile.parent_group = group
@@ -3092,6 +3203,13 @@ class DashboardsViewSet(
                 tile.layouts = {**tile.layouts, **serializer.validated_data["layouts"]}
                 update_fields.append("layouts")
             tile.save(update_fields=update_fields)
+
+            if source_group_id and source_group_id != group.id:
+                source_group = dashboard.groups.filter(id=source_group_id, name__isnull=True).first()
+                if source_group and not source_group.member_tiles.exclude(deleted=True).exists():
+                    deleted_group_ids.append(source_group.id)
+                    source_group.delete()
+            _renumber_dashboard_groups(dashboard)
 
         report_user_action(
             cast(User, request.user),
@@ -3105,7 +3223,16 @@ class DashboardsViewSet(
             team=dashboard.team,
             request=request,
         )
-        return Response(DashboardTileSerializer(tile, context=self.get_serializer_context()).data)
+        context = self.get_serializer_context()
+        return Response(
+            {
+                "tile": DashboardTileSerializer(tile, context=context).data,
+                "created_group": DashboardGroupSerializer(created_group, context=context).data
+                if created_group
+                else None,
+                "deleted_group_ids": deleted_group_ids,
+            }
+        )
 
     @extend_schema(request=DeleteDashboardGroupRequestSerializer, responses={204: None})
     @action(methods=["POST"], detail=True, url_path="groups/delete", required_scopes=["dashboard:write"])
@@ -3121,9 +3248,13 @@ class DashboardsViewSet(
             members = group.member_tiles.select_for_update()
             if member_handling == "delete_tiles":
                 members.update(parent_group=None, deleted=True)
+                group.delete()
             else:
-                members.update(parent_group=None)
-            group.delete()
+                group.name = None
+                group.last_modified_by = request.user
+                group.last_modified_at = now()
+                group.save(update_fields=["name", "last_modified_by", "last_modified_at"])
+            _renumber_dashboard_groups(dashboard)
 
         report_user_action(
             cast(User, request.user),
@@ -3161,6 +3292,11 @@ class DashboardsViewSet(
 
         user = cast(User, request.user)
         with transaction.atomic():
+            dashboard = Dashboard.objects.select_for_update().get(id=dashboard.id)
+            if "group_id" in validated:
+                parent_group = get_object_or_404(dashboard.groups, id=validated["group_id"])
+            else:
+                parent_group = resolve_default_section(dashboard, user)
             text = Text.objects.create(
                 body=validated["body"],
                 team=dashboard.team,
@@ -3172,7 +3308,7 @@ class DashboardsViewSet(
                 tile_data["layouts"] = validated["layouts"]
             if "color" in validated:
                 tile_data["color"] = validated["color"]
-            tile, _ = DashboardSerializer._upsert_tile(dashboard, tile_data, text=text)
+            tile, _ = DashboardSerializer._upsert_tile(dashboard, tile_data, text=text, parent_group=parent_group)
 
         return Response(
             DashboardTileSerializer(tile, context=self.get_serializer_context()).data,
@@ -3519,7 +3655,16 @@ class DashboardsViewSet(
         tile_context = {**self.get_serializer_context(), "dashboard": dashboard}
 
         with transaction.atomic():
-            existing_sm_layouts = collect_dashboard_sm_layouts_for_dashboard(dashboard)
+            dashboard = Dashboard.objects.select_for_update().get(id=dashboard.id)
+            group_id = serializer.validated_data.get("group_id")
+            parent_group = (
+                get_object_or_404(dashboard.groups, id=group_id)
+                if group_id
+                else resolve_default_section(dashboard, user)
+            )
+            existing_sm_layouts = collect_dashboard_sm_layouts_for_dashboard(
+                dashboard, parent_group_id=parent_group.id if parent_group else None
+            )
             pending_sm_layouts: builtins.list[dict[str, Any]] = []
             tiles: builtins.list[DashboardTile] = []
 
@@ -3531,6 +3676,7 @@ class DashboardsViewSet(
                     payload=payload,
                     existing_sm_layouts=existing_sm_layouts,
                     pending_sm_layouts=pending_sm_layouts,
+                    parent_group=parent_group,
                 )
                 tiles.append(tile)
                 sm_layout = tile.layouts.get("sm") if isinstance(tile.layouts, dict) else None
@@ -3562,6 +3708,7 @@ class DashboardsViewSet(
         payload: dict[str, Any],
         existing_sm_layouts: builtins.list[dict[str, Any]] | None = None,
         pending_sm_layouts: builtins.list[dict[str, Any]] | None = None,
+        parent_group: DashboardGroup | None = None,
     ) -> DashboardTile:
         widget_type = payload["widget_type"]
         config = payload["config"]
@@ -3599,6 +3746,7 @@ class DashboardsViewSet(
             dashboard=dashboard,
             team_id=dashboard.team_id,
             widget=widget,
+            parent_group=parent_group,
             **tile_defaults,
         )
 

--- a/products/dashboards/backend/api/test/test_dashboard_groups.py
+++ b/products/dashboards/backend/api/test/test_dashboard_groups.py
@@ -17,101 +17,130 @@ class TestDashboardGroups(APIBaseTest):
         self.dashboard_api = DashboardAPI(self.client, self.team, self.assertEqual)
         self.dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "Grouped dashboard"})
 
-    def test_group_lifecycle_and_tile_membership(self) -> None:
-        create_response = self.client.post(
+    def _create_group(self, name: str | None, position: int | None = None) -> dict:
+        payload: dict = {"name": name}
+        if position is not None:
+            payload["position"] = position
+        response = self.client.post(
             f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/",
-            {"name": "Acquisition"},
+            payload,
         )
-        self.assertEqual(create_response.status_code, status.HTTP_201_CREATED)
-        group = create_response.json()
-        self.assertEqual(group["name"], "Acquisition")
-        self.assertEqual(group["layouts"]["sm"], {"x": 0, "y": 0, "w": 12, "h": 1})
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
 
+    def test_first_group_wraps_existing_tiles_in_anonymous_section(self) -> None:
         _, dashboard = self.dashboard_api.create_text_tile(self.dashboard_id, text="Signups")
         tile_id = dashboard["tiles"][0]["id"]
-        move_response = self.client.post(
-            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/move-tile/",
-            {"tile_id": tile_id, "group_id": group["id"]},
-        )
-        self.assertEqual(move_response.status_code, status.HTTP_200_OK)
-        self.assertEqual(move_response.json()["parent_group_id"], group["id"])
+        DashboardTile.objects.filter(id=tile_id).update(deleted=None)
 
-        dashboard_response = self.client.get(f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/")
-        self.assertEqual(dashboard_response.status_code, status.HTTP_200_OK)
-        self.assertEqual(dashboard_response.json()["groups"][0]["member_tile_ids"], [tile_id])
-        self.assertEqual(len(dashboard_response.json()["tiles"]), 1)
+        named_group = self._create_group("Acquisition")
 
-        delete_response = self.client.post(
-            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/delete/",
-            {"group_id": group["id"], "member_handling": "move_to_ungrouped"},
-        )
-        self.assertEqual(delete_response.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertFalse(DashboardGroup.all_teams.filter(id=group["id"]).exists())
-        self.assertIsNone(DashboardTile.objects.get(id=tile_id).parent_group_id)
+        groups = list(DashboardGroup.all_teams.filter(dashboard_id=self.dashboard_id).order_by("position"))
+        self.assertEqual([(group.name, group.position) for group in groups], [(None, 0), ("Acquisition", 1)])
+        self.assertEqual(DashboardTile.objects.get(id=tile_id).parent_group_id, groups[0].id)
+        self.assertNotIn("tile_id", named_group)
+        self.assertNotIn("layouts", named_group)
 
-    def test_moving_a_group_moves_its_members(self) -> None:
-        group = self.client.post(
-            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/",
-            {"name": "Acquisition"},
-        ).json()
+    def test_move_creates_and_removes_anonymous_sections(self) -> None:
+        source_group = self._create_group(None)
         _, dashboard = self.dashboard_api.create_text_tile(self.dashboard_id, text="Signups")
-        tile = dashboard["tiles"][0]
-        self.client.post(
-            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/move-tile/",
-            {"tile_id": tile["id"], "group_id": group["id"], "layouts": {"sm": {"x": 0, "y": 1, "w": 12, "h": 2}}},
-        )
+        tile_id = dashboard["tiles"][0]["id"]
 
         response = self.client.post(
-            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/update/",
-            {"group_id": group["id"], "layouts": {"sm": {"x": 0, "y": 5, "w": 12, "h": 1}}},
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/move-tile/",
+            {"tile_id": tile_id, "create_at_position": 0},
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(DashboardTile.objects.get(id=tile["id"]).layouts["sm"]["y"], 6)
+        payload = response.json()
+        self.assertEqual(payload["tile"]["parent_group_id"], payload["created_group"]["id"])
+        self.assertEqual(payload["deleted_group_ids"], [source_group["id"]])
+        self.assertEqual(
+            list(DashboardGroup.all_teams.filter(dashboard_id=self.dashboard_id).values_list("position", flat=True)),
+            [0],
+        )
+
+    def test_group_position_reorder_renumbers_sections(self) -> None:
+        first = self._create_group("First")
+        second = self._create_group("Second")
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/update/",
+            {"group_id": second["id"], "position": 0},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            list(
+                DashboardGroup.all_teams.filter(dashboard_id=self.dashboard_id)
+                .order_by("position")
+                .values_list("id", "position")
+            ),
+            [(DashboardGroup._meta.pk.to_python(second["id"]), 0), (DashboardGroup._meta.pk.to_python(first["id"]), 1)],
+        )
+
+    def test_ungroup_keeps_tiles_and_converts_section_to_anonymous(self) -> None:
+        group = self._create_group("Acquisition")
+        _, dashboard = self.dashboard_api.create_text_tile(self.dashboard_id, text="Signups")
+        tile_id = dashboard["tiles"][0]["id"]
+        self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/move-tile/",
+            {"tile_id": tile_id, "group_id": group["id"]},
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/delete/",
+            {"group_id": group["id"], "member_handling": "ungroup"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertIsNone(DashboardGroup.all_teams.get(id=group["id"]).name)
+        self.assertEqual(
+            DashboardTile.objects.get(id=tile_id).parent_group_id, DashboardGroup._meta.pk.to_python(group["id"])
+        )
 
     def test_group_rejects_cross_dashboard_membership(self) -> None:
-        group_response = self.client.post(
-            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/",
-            {"name": "Acquisition"},
-        )
+        group = self._create_group("Acquisition")
         other_dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "Other"})
         _, other_dashboard = self.dashboard_api.create_text_tile(other_dashboard_id, text="Other tile")
 
         response = self.client.post(
             f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/move-tile/",
-            {"tile_id": other_dashboard["tiles"][0]["id"], "group_id": group_response.json()["id"]},
+            {"tile_id": other_dashboard["tiles"][0]["id"], "group_id": group["id"]},
         )
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_template_remaps_group_membership(self) -> None:
+    def test_template_preserves_named_and_anonymous_section_order(self) -> None:
         template = DashboardTemplate(
             template_name="Grouped template",
             dashboard_description="",
             dashboard_filters={},
             tags=[],
             tiles=[
+                {"type": "TEXT", "body": "Before", "layouts": {"sm": {"x": 0, "y": 0, "w": 12, "h": 2}}},
                 {
                     "type": "GROUP",
                     "group_key": "acquisition",
                     "name": "Acquisition",
-                    "layouts": {"sm": {"x": 0, "y": 0, "w": 12, "h": 1}},
+                    "layouts": {"sm": {"x": 0, "y": 3, "w": 12, "h": 1}},
                 },
                 {
                     "type": "TEXT",
                     "group_key": "acquisition",
                     "body": "Signups",
-                    "layouts": {"sm": {"x": 0, "y": 1, "w": 12, "h": 2}},
+                    "layouts": {"sm": {"x": 0, "y": 4, "w": 12, "h": 2}},
                 },
+                {"type": "TEXT", "body": "After", "layouts": {"sm": {"x": 0, "y": 7, "w": 12, "h": 2}}},
             ],
         )
         dashboard = Dashboard.objects.create(team=self.team, name="From template")
 
         create_from_template(dashboard, template, self.user)
 
-        group = dashboard.groups.get()
-        self.assertEqual(group.name, "Acquisition")
-        self.assertEqual(group.member_tiles.get().text.body, "Signups")
+        groups = list(dashboard.groups.order_by("position"))
+        self.assertEqual([(group.name, group.position) for group in groups], [(None, 0), ("Acquisition", 1), (None, 2)])
+        self.assertEqual([group.member_tiles.get().text.body for group in groups], ["Before", "Signups", "After"])
 
     def test_template_rejects_unknown_group_membership(self) -> None:
         template = DashboardTemplate(

--- a/products/dashboards/backend/widget_layouts.py
+++ b/products/dashboards/backend/widget_layouts.py
@@ -97,7 +97,9 @@ def _pack_at_bottom(column_heights: list[int], width: int, height: int) -> dict[
     return {"x": best_x, "y": best_y, "w": w, "h": h}
 
 
-def collect_dashboard_sm_layouts_for_dashboard(dashboard: Any) -> list[dict[str, Any]]:
+def collect_dashboard_sm_layouts_for_dashboard(
+    dashboard: Any, *, parent_group_id: Any | None = None
+) -> list[dict[str, Any]]:
     """Existing ``sm`` layouts, plus a synthetic bottom placement for every tile that has
     no persisted layout, so widget placement counts the dashboard's true rendered height.
 
@@ -109,7 +111,10 @@ def collect_dashboard_sm_layouts_for_dashboard(dashboard: Any) -> list[dict[str,
     layoutless_count = 0
     # `deleted` is nullable with no default, so live tiles carry NULL — `filter(deleted=False)`
     # would miss them (NULL never equals False). Exclude only explicit deletes.
-    for layouts in dashboard.tiles.exclude(deleted=True).values_list("layouts", flat=True):
+    tiles = dashboard.tiles.exclude(deleted=True)
+    if dashboard.groups.exists():
+        tiles = tiles.filter(parent_group_id=parent_group_id)
+    for layouts in tiles.values_list("layouts", flat=True):
         if isinstance(layouts, str):
             try:
                 layouts = json.loads(layouts)

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -319,31 +319,11 @@ export type DashboardApiPersistedVariables = { [key: string]: unknown } | null
 
 export type DashboardApiTilesItem = { [key: string]: unknown }
 
-export interface TileLayoutBoxApi {
-    /** Column position in the dashboard grid (0-indexed). */
-    x?: number
-    /** Row position in the dashboard grid (0-indexed). */
-    y?: number
-    /** Width in grid columns. The desktop grid is 12 columns wide. */
-    w?: number
-    /** Height in grid rows. */
-    h?: number
-}
-
-export interface TileLayoutsApi {
-    /** Layout for the standard (desktop) breakpoint. The grid is 12 columns wide. */
-    sm?: TileLayoutBoxApi
-    /** Layout for the small (mobile) breakpoint. The grid is 1 column wide. */
-    xs?: TileLayoutBoxApi
-}
-
 export interface DashboardGroupApi {
     readonly id: string
-    readonly name: string
-    /** Grid tile ID for this group row. */
-    readonly tile_id: number
-    /** Grid layout for the group row. */
-    readonly layouts: TileLayoutsApi
+    /** @nullable */
+    readonly name: string | null
+    readonly position: number
     /** Content tile IDs assigned to this group. */
     readonly member_tile_ids: readonly number[]
     readonly created_at: string
@@ -1017,6 +997,24 @@ export interface CopyDashboardTileRequestApi {
     tileId: number
 }
 
+export interface TileLayoutBoxApi {
+    /** Column position in the dashboard grid (0-indexed). */
+    x?: number
+    /** Row position in the dashboard grid (0-indexed). */
+    y?: number
+    /** Width in grid columns. The desktop grid is 12 columns wide. */
+    w?: number
+    /** Height in grid rows. */
+    h?: number
+}
+
+export interface TileLayoutsApi {
+    /** Layout for the standard (desktop) breakpoint. The grid is 12 columns wide. */
+    sm?: TileLayoutBoxApi
+    /** Layout for the small (mobile) breakpoint. The grid is 1 column wide. */
+    xs?: TileLayoutBoxApi
+}
+
 export interface CreateTextTileRequestApi {
     /**
      * Markdown body for the text tile. Supports headings, lists, and inline formatting. Useful as a dashboard section heading, divider, or annotation between insights. Max 4000 characters.
@@ -1026,6 +1024,8 @@ export interface CreateTextTileRequestApi {
     body: string
     /** Optional grid layout per breakpoint. If omitted, the tile is placed at the bottom of the dashboard using the default size. Text tiles typically use a thin full-width banner (e.g. w=12, h=1). */
     layouts?: TileLayoutsApi
+    /** Section ID for the new tile. Omit to use the dashboard's default section. */
+    group_id?: string
     /**
      * Optional accent color name (e.g. 'blue', 'green', 'purple', 'black').
      * @maxLength 400
@@ -8951,24 +8951,27 @@ export interface DeleteTileRequestApi {
 
 export interface CreateDashboardGroupRequestApi {
     /**
-     * Name displayed in the dashboard group row.
-     * @minLength 1
+     * Optional section name. Null or an empty string creates an anonymous section.
      * @maxLength 400
+     * @nullable
      */
-    name: string
-    /** Optional grid layout for the group row. Group rows always span the desktop grid. */
-    layouts?: TileLayoutsApi
+    name?: string | null
+    /**
+     * Section position. Omit to append the section.
+     * @minimum 0
+     */
+    position?: number
 }
 
 /**
  * * `delete_tiles` - delete_tiles
- * * `move_to_ungrouped` - move_to_ungrouped
+ * * `ungroup` - ungroup
  */
 export type MemberHandlingEnumApi = (typeof MemberHandlingEnumApi)[keyof typeof MemberHandlingEnumApi]
 
 export const MemberHandlingEnumApi = {
     DeleteTiles: 'delete_tiles',
-    MoveToUngrouped: 'move_to_ungrouped',
+    Ungroup: 'ungroup',
 } as const
 
 export interface DeleteDashboardGroupRequestApi {
@@ -8977,33 +8980,47 @@ export interface DeleteDashboardGroupRequestApi {
     /** How to handle content tiles currently assigned to the group.
      *
      * * `delete_tiles` - delete_tiles
-     * * `move_to_ungrouped` - move_to_ungrouped */
+     * * `ungroup` - ungroup */
     member_handling: MemberHandlingEnumApi
 }
 
 export interface MoveDashboardTileToGroupRequestApi {
     /** Content tile ID to move. */
     tile_id: number
+    /** Destination section ID. */
+    group_id?: string
     /**
-     * Destination group ID, or null to move the tile to the ungrouped section.
-     * @nullable
+     * Create an anonymous section at this position and move the tile into it.
+     * @minimum 0
      */
-    group_id?: string | null
+    create_at_position?: number
     /** Optional new layout for the moved tile. */
     layouts?: TileLayoutsApi
+}
+
+export interface MoveDashboardTileToGroupResponseApi {
+    /** The moved dashboard tile. */
+    tile: DashboardTileApi
+    /** The anonymous section created for the move, or null. */
+    created_group: DashboardGroupApi | null
+    /** Anonymous source section IDs deleted after they became empty. */
+    deleted_group_ids: string[]
 }
 
 export interface UpdateDashboardGroupRequestApi {
     /** Dashboard group ID to update. */
     group_id: string
     /**
-     * New group name. Omit to keep the existing name.
-     * @minLength 1
+     * New section name. Null or an empty string converts the section to anonymous.
      * @maxLength 400
+     * @nullable
      */
-    name?: string
-    /** New grid layout for the group row. Omit to keep its current layout. */
-    layouts?: TileLayoutsApi
+    name?: string | null
+    /**
+     * New section position. Existing sections are renumbered around it.
+     * @minimum 0
+     */
+    position?: number
 }
 
 export interface MoveTileTileApi {
@@ -9040,7 +9057,7 @@ export const LayoutEnumApi = {
 
 export interface ReorderTilesRequestApi {
     /**
-     * Array of tile IDs in the desired display order (top to bottom, left to right).
+     * Tile IDs in the desired display order. The endpoint partitions the order by section and repacks each section independently.
      * @minItems 1
      */
     tile_order: number[]
@@ -9356,6 +9373,8 @@ export type AddDashboardWidgetRequestApi =
  * OpenAPI-only batch-add schema with widget_type-discriminated config shapes for agents.
  */
 export interface AddDashboardWidgetsBatchRequestOpenApiApi {
+    /** Section ID for the new widgets. Omit to use the dashboard's default section. */
+    group_id?: string
     /**
      * Widget tiles to add atomically. Supported widget_type values: activity_events_list, conversations_recent_tickets, error_tracking_list, experiment_results, experiments_list, logs_list, session_replay_list, survey_results. Use dashboard-widget-catalog-list for per-type config_schema documentation. (1–10 per request).
      * @minItems 1

--- a/products/dashboards/frontend/generated/api.ts
+++ b/products/dashboards/frontend/generated/api.ts
@@ -56,6 +56,7 @@ import type {
     DeleteDashboardGroupRequestApi,
     DeleteTileRequestApi,
     MoveDashboardTileToGroupRequestApi,
+    MoveDashboardTileToGroupResponseApi,
     MoveTileRequestApi,
     PaginatedDashboardBasicListApi,
     PaginatedDashboardTemplateListApi,
@@ -603,7 +604,7 @@ export const getDashboardsGroupsCreateUrl = (projectId: string, id: number, para
 export const dashboardsGroupsCreate = async (
     projectId: string,
     id: number,
-    createDashboardGroupRequestApi: CreateDashboardGroupRequestApi,
+    createDashboardGroupRequestApi?: CreateDashboardGroupRequestApi,
     params?: DashboardsGroupsCreateParams,
     options?: RequestInit
 ): Promise<DashboardGroupApi> => {
@@ -676,13 +677,16 @@ export const dashboardsGroupsMoveTileCreate = async (
     moveDashboardTileToGroupRequestApi: MoveDashboardTileToGroupRequestApi,
     params?: DashboardsGroupsMoveTileCreateParams,
     options?: RequestInit
-): Promise<DashboardTileApi> => {
-    return apiMutator<DashboardTileApi>(getDashboardsGroupsMoveTileCreateUrl(projectId, id, params), {
-        ...options,
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(moveDashboardTileToGroupRequestApi),
-    })
+): Promise<MoveDashboardTileToGroupResponseApi> => {
+    return apiMutator<MoveDashboardTileToGroupResponseApi>(
+        getDashboardsGroupsMoveTileCreateUrl(projectId, id, params),
+        {
+            ...options,
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', ...options?.headers },
+            body: JSON.stringify(moveDashboardTileToGroupRequestApi),
+        }
+    )
 }
 
 export const getDashboardsGroupsUpdateCreateUrl = (

--- a/products/dashboards/frontend/generated/api.zod.ts
+++ b/products/dashboards/frontend/generated/api.zod.ts
@@ -1091,6 +1091,10 @@ export const DashboardsCreateTextTileCreateBody = /* @__PURE__ */ zod.object({
         .describe(
             'Optional grid layout per breakpoint. If omitted, the tile is placed at the bottom of the dashboard using the default size. Text tiles typically use a thin full-width banner (e.g. w=12, h=1).'
         ),
+    group_id: zod
+        .uuid()
+        .optional()
+        .describe("Section ID for the new tile. Omit to use the dashboard's default section."),
     color: zod
         .string()
         .max(dashboardsCreateTextTileCreateBodyColorMax)
@@ -1111,50 +1115,41 @@ export const DashboardsDeleteTileBody = /* @__PURE__ */ zod.object({
 
 export const dashboardsGroupsCreateBodyNameMax = 400
 
+export const dashboardsGroupsCreateBodyPositionMin = 0
+
 export const DashboardsGroupsCreateBody = /* @__PURE__ */ zod.object({
     name: zod
         .string()
-        .min(1)
         .max(dashboardsGroupsCreateBodyNameMax)
-        .describe('Name displayed in the dashboard group row.'),
-    layouts: zod
-        .object({
-            sm: zod
-                .object({
-                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
-                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
-                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
-                    h: zod.number().optional().describe('Height in grid rows.'),
-                })
-                .optional()
-                .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
-            xs: zod
-                .object({
-                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
-                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
-                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
-                    h: zod.number().optional().describe('Height in grid rows.'),
-                })
-                .optional()
-                .describe('Layout for the small (mobile) breakpoint. The grid is 1 column wide.'),
-        })
+        .nullish()
+        .describe('Optional section name. Null or an empty string creates an anonymous section.'),
+    position: zod
+        .number()
+        .min(dashboardsGroupsCreateBodyPositionMin)
         .optional()
-        .describe('Optional grid layout for the group row. Group rows always span the desktop grid.'),
+        .describe('Section position. Omit to append the section.'),
 })
 
 export const DashboardsGroupsDeleteCreateBody = /* @__PURE__ */ zod.object({
     group_id: zod.uuid().describe('Dashboard group ID to delete.'),
     member_handling: zod
-        .enum(['delete_tiles', 'move_to_ungrouped'])
-        .describe('\* `delete_tiles` - delete_tiles\n\* `move_to_ungrouped` - move_to_ungrouped')
+        .enum(['delete_tiles', 'ungroup'])
+        .describe('\* `delete_tiles` - delete_tiles\n\* `ungroup` - ungroup')
         .describe(
-            'How to handle content tiles currently assigned to the group.\n\n\* `delete_tiles` - delete_tiles\n\* `move_to_ungrouped` - move_to_ungrouped'
+            'How to handle content tiles currently assigned to the group.\n\n\* `delete_tiles` - delete_tiles\n\* `ungroup` - ungroup'
         ),
 })
 
+export const dashboardsGroupsMoveTileCreateBodyCreateAtPositionMin = 0
+
 export const DashboardsGroupsMoveTileCreateBody = /* @__PURE__ */ zod.object({
     tile_id: zod.number().describe('Content tile ID to move.'),
-    group_id: zod.uuid().nullish().describe('Destination group ID, or null to move the tile to the ungrouped section.'),
+    group_id: zod.uuid().optional().describe('Destination section ID.'),
+    create_at_position: zod
+        .number()
+        .min(dashboardsGroupsMoveTileCreateBodyCreateAtPositionMin)
+        .optional()
+        .describe('Create an anonymous section at this position and move the tile into it.'),
     layouts: zod
         .object({
             sm: zod
@@ -1182,37 +1177,20 @@ export const DashboardsGroupsMoveTileCreateBody = /* @__PURE__ */ zod.object({
 
 export const dashboardsGroupsUpdateCreateBodyNameMax = 400
 
+export const dashboardsGroupsUpdateCreateBodyPositionMin = 0
+
 export const DashboardsGroupsUpdateCreateBody = /* @__PURE__ */ zod.object({
     group_id: zod.uuid().describe('Dashboard group ID to update.'),
     name: zod
         .string()
-        .min(1)
         .max(dashboardsGroupsUpdateCreateBodyNameMax)
+        .nullish()
+        .describe('New section name. Null or an empty string converts the section to anonymous.'),
+    position: zod
+        .number()
+        .min(dashboardsGroupsUpdateCreateBodyPositionMin)
         .optional()
-        .describe('New group name. Omit to keep the existing name.'),
-    layouts: zod
-        .object({
-            sm: zod
-                .object({
-                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
-                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
-                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
-                    h: zod.number().optional().describe('Height in grid rows.'),
-                })
-                .optional()
-                .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
-            xs: zod
-                .object({
-                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
-                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
-                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
-                    h: zod.number().optional().describe('Height in grid rows.'),
-                })
-                .optional()
-                .describe('Layout for the small (mobile) breakpoint. The grid is 1 column wide.'),
-        })
-        .optional()
-        .describe('New grid layout for the group row. Omit to keep its current layout.'),
+        .describe('New section position. Existing sections are renumbered around it.'),
 })
 
 export const DashboardsMoveTileCreateBody = /* @__PURE__ */ zod.object({
@@ -1240,7 +1218,9 @@ export const DashboardsReorderTilesCreateBody = /* @__PURE__ */ zod.object({
     tile_order: zod
         .array(zod.number())
         .min(1)
-        .describe('Array of tile IDs in the desired display order (top to bottom, left to right).'),
+        .describe(
+            'Tile IDs in the desired display order. The endpoint partitions the order by section and repacks each section independently.'
+        ),
     layout: zod
         .enum(['preserve', 'two_column', 'full_width'])
         .describe('\* `preserve` - preserve\n\* `two_column` - two_column\n\* `full_width` - full_width')
@@ -1371,6 +1351,10 @@ export const dashboardsWidgetsBatchCreateBodyWidgetsMax = 10
 
 export const DashboardsWidgetsBatchCreateBody = /* @__PURE__ */ zod
     .object({
+        group_id: zod
+            .uuid()
+            .optional()
+            .describe("Section ID for the new widgets. Omit to use the dashboard's default section."),
         widgets: zod
             .array(
                 zod.union([

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -5591,6 +5591,8 @@ export namespace Schemas {
      * OpenAPI-only batch-add schema with widget_type-discriminated config shapes for agents.
      */
     export interface AddDashboardWidgetsBatchRequestOpenApi {
+      /** Section ID for the new widgets. Omit to use the dashboard's default section. */
+      group_id?: string;
       /**
          * Widget tiles to add atomically. Supported widget_type values: activity_events_list, conversations_recent_tickets, error_tracking_list, experiment_results, experiments_list, logs_list, session_replay_list, survey_results. Use dashboard-widget-catalog-list for per-type config_schema documentation. (1–10 per request).
          * @minItems 1
@@ -17406,33 +17408,18 @@ export namespace Schemas {
       memory_gb?: number;
     }
 
-    export interface TileLayoutBox {
-      /** Column position in the dashboard grid (0-indexed). */
-      x?: number;
-      /** Row position in the dashboard grid (0-indexed). */
-      y?: number;
-      /** Width in grid columns. The desktop grid is 12 columns wide. */
-      w?: number;
-      /** Height in grid rows. */
-      h?: number;
-    }
-
-    export interface TileLayouts {
-      /** Layout for the standard (desktop) breakpoint. The grid is 12 columns wide. */
-      sm?: TileLayoutBox;
-      /** Layout for the small (mobile) breakpoint. The grid is 1 column wide. */
-      xs?: TileLayoutBox;
-    }
-
     export interface CreateDashboardGroupRequest {
       /**
-         * Name displayed in the dashboard group row.
-         * @minLength 1
+         * Optional section name. Null or an empty string creates an anonymous section.
          * @maxLength 400
+         * @nullable
          */
-      name: string;
-      /** Optional grid layout for the group row. Group rows always span the desktop grid. */
-      layouts?: TileLayouts;
+      name?: string | null;
+      /**
+         * Section position. Omit to append the section.
+         * @minimum 0
+         */
+      position?: number;
     }
 
     /**
@@ -17705,6 +17692,24 @@ export namespace Schemas {
       always_include?: boolean;
     }
 
+    export interface TileLayoutBox {
+      /** Column position in the dashboard grid (0-indexed). */
+      x?: number;
+      /** Row position in the dashboard grid (0-indexed). */
+      y?: number;
+      /** Width in grid columns. The desktop grid is 12 columns wide. */
+      w?: number;
+      /** Height in grid rows. */
+      h?: number;
+    }
+
+    export interface TileLayouts {
+      /** Layout for the standard (desktop) breakpoint. The grid is 12 columns wide. */
+      sm?: TileLayoutBox;
+      /** Layout for the small (mobile) breakpoint. The grid is 1 column wide. */
+      xs?: TileLayoutBox;
+    }
+
     export interface CreateTextTileRequest {
       /**
          * Markdown body for the text tile. Supports headings, lists, and inline formatting. Useful as a dashboard section heading, divider, or annotation between insights. Max 4000 characters.
@@ -17714,6 +17719,8 @@ export namespace Schemas {
       body: string;
       /** Optional grid layout per breakpoint. If omitted, the tile is placed at the bottom of the dashboard using the default size. Text tiles typically use a thin full-width banner (e.g. w=12, h=1). */
       layouts?: TileLayouts;
+      /** Section ID for the new tile. Omit to use the dashboard's default section. */
+      group_id?: string;
       /**
          * Optional accent color name (e.g. 'blue', 'green', 'purple', 'black').
          * @maxLength 400
@@ -18399,11 +18406,9 @@ export namespace Schemas {
 
     export interface DashboardGroup {
       readonly id: string;
-      readonly name: string;
-      /** Grid tile ID for this group row. */
-      readonly tile_id: number;
-      /** Grid layout for the group row. */
-      readonly layouts: TileLayouts;
+      /** @nullable */
+      readonly name: string | null;
+      readonly position: number;
       /** Content tile IDs assigned to this group. */
       readonly member_tile_ids: readonly number[];
       readonly created_at: string;
@@ -24120,14 +24125,14 @@ export namespace Schemas {
 
     /**
      * * `delete_tiles` - delete_tiles
-     * * `move_to_ungrouped` - move_to_ungrouped
+     * * `ungroup` - ungroup
      */
     export type MemberHandlingEnum = typeof MemberHandlingEnum[keyof typeof MemberHandlingEnum];
 
 
     export const MemberHandlingEnum = {
       DeleteTiles: 'delete_tiles',
-      MoveToUngrouped: 'move_to_ungrouped',
+      Ungroup: 'ungroup',
     } as const;
 
     export interface DeleteDashboardGroupRequest {
@@ -24136,7 +24141,7 @@ export namespace Schemas {
       /** How to handle content tiles currently assigned to the group.
        *
        * * `delete_tiles` - delete_tiles
-       * * `move_to_ungrouped` - move_to_ungrouped */
+       * * `ungroup` - ungroup */
       member_handling: MemberHandlingEnum;
     }
 
@@ -45669,13 +45674,24 @@ export namespace Schemas {
     export interface MoveDashboardTileToGroupRequest {
       /** Content tile ID to move. */
       tile_id: number;
+      /** Destination section ID. */
+      group_id?: string;
       /**
-         * Destination group ID, or null to move the tile to the ungrouped section.
-         * @nullable
+         * Create an anonymous section at this position and move the tile into it.
+         * @minimum 0
          */
-      group_id?: string | null;
+      create_at_position?: number;
       /** Optional new layout for the moved tile. */
       layouts?: TileLayouts;
+    }
+
+    export interface MoveDashboardTileToGroupResponse {
+      /** The moved dashboard tile. */
+      tile: DashboardTile;
+      /** The anonymous section created for the move, or null. */
+      created_group: DashboardGroup | null;
+      /** Anonymous source section IDs deleted after they became empty. */
+      deleted_group_ids: string[];
     }
 
     export interface MoveTileTile {
@@ -66869,7 +66885,7 @@ export namespace Schemas {
 
     export interface ReorderTilesRequest {
       /**
-         * Array of tile IDs in the desired display order (top to bottom, left to right).
+         * Tile IDs in the desired display order. The endpoint partitions the order by section and repacks each section independently.
          * @minItems 1
          */
       tile_order: number[];
@@ -77845,13 +77861,16 @@ export namespace Schemas {
       /** Dashboard group ID to update. */
       group_id: string;
       /**
-         * New group name. Omit to keep the existing name.
-         * @minLength 1
+         * New section name. Null or an empty string converts the section to anonymous.
          * @maxLength 400
+         * @nullable
          */
-      name?: string;
-      /** New grid layout for the group row. Omit to keep its current layout. */
-      layouts?: TileLayouts;
+      name?: string | null;
+      /**
+         * New section position. Existing sections are renumbered around it.
+         * @minimum 0
+         */
+      position?: number;
     }
 
     export interface UpdateDashboardWidgetsBatchResponse {

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -1099,6 +1099,10 @@ export const DashboardsCreateTextTileCreateBody = /* @__PURE__ */ zod.object({
         .describe(
             'Optional grid layout per breakpoint. If omitted, the tile is placed at the bottom of the dashboard using the default size. Text tiles typically use a thin full-width banner (e.g. w=12, h=1).'
         ),
+    group_id: zod
+        .string()
+        .optional()
+        .describe("Section ID for the new tile. Omit to use the dashboard's default section."),
     color: zod
         .string()
         .max(dashboardsCreateTextTileCreateBodyColorMax)
@@ -1145,35 +1149,19 @@ export const DashboardsGroupsCreateQueryParams = /* @__PURE__ */ zod.object({
 
 export const dashboardsGroupsCreateBodyNameMax = 400
 
+export const dashboardsGroupsCreateBodyPositionMin = 0
+
 export const DashboardsGroupsCreateBody = /* @__PURE__ */ zod.object({
     name: zod
         .string()
-        .min(1)
         .max(dashboardsGroupsCreateBodyNameMax)
-        .describe('Name displayed in the dashboard group row.'),
-    layouts: zod
-        .object({
-            sm: zod
-                .object({
-                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
-                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
-                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
-                    h: zod.number().optional().describe('Height in grid rows.'),
-                })
-                .optional()
-                .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
-            xs: zod
-                .object({
-                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
-                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
-                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
-                    h: zod.number().optional().describe('Height in grid rows.'),
-                })
-                .optional()
-                .describe('Layout for the small (mobile) breakpoint. The grid is 1 column wide.'),
-        })
+        .nullish()
+        .describe('Optional section name. Null or an empty string creates an anonymous section.'),
+    position: zod
+        .number()
+        .min(dashboardsGroupsCreateBodyPositionMin)
         .optional()
-        .describe('Optional grid layout for the group row. Group rows always span the desktop grid.'),
+        .describe('Section position. Omit to append the section.'),
 })
 
 export const DashboardsGroupsDeleteCreateParams = /* @__PURE__ */ zod.object({
@@ -1192,10 +1180,10 @@ export const DashboardsGroupsDeleteCreateQueryParams = /* @__PURE__ */ zod.objec
 export const DashboardsGroupsDeleteCreateBody = /* @__PURE__ */ zod.object({
     group_id: zod.string().describe('Dashboard group ID to delete.'),
     member_handling: zod
-        .enum(['delete_tiles', 'move_to_ungrouped'])
-        .describe('\* `delete_tiles` - delete_tiles\n\* `move_to_ungrouped` - move_to_ungrouped')
+        .enum(['delete_tiles', 'ungroup'])
+        .describe('\* `delete_tiles` - delete_tiles\n\* `ungroup` - ungroup')
         .describe(
-            'How to handle content tiles currently assigned to the group.\n\n\* `delete_tiles` - delete_tiles\n\* `move_to_ungrouped` - move_to_ungrouped'
+            'How to handle content tiles currently assigned to the group.\n\n\* `delete_tiles` - delete_tiles\n\* `ungroup` - ungroup'
         ),
 })
 
@@ -1212,12 +1200,16 @@ export const DashboardsGroupsMoveTileCreateQueryParams = /* @__PURE__ */ zod.obj
     format: zod.enum(['json', 'txt']).optional(),
 })
 
+export const dashboardsGroupsMoveTileCreateBodyCreateAtPositionMin = 0
+
 export const DashboardsGroupsMoveTileCreateBody = /* @__PURE__ */ zod.object({
     tile_id: zod.number().describe('Content tile ID to move.'),
-    group_id: zod
-        .string()
-        .nullish()
-        .describe('Destination group ID, or null to move the tile to the ungrouped section.'),
+    group_id: zod.string().optional().describe('Destination section ID.'),
+    create_at_position: zod
+        .number()
+        .min(dashboardsGroupsMoveTileCreateBodyCreateAtPositionMin)
+        .optional()
+        .describe('Create an anonymous section at this position and move the tile into it.'),
     layouts: zod
         .object({
             sm: zod
@@ -1258,37 +1250,20 @@ export const DashboardsGroupsUpdateCreateQueryParams = /* @__PURE__ */ zod.objec
 
 export const dashboardsGroupsUpdateCreateBodyNameMax = 400
 
+export const dashboardsGroupsUpdateCreateBodyPositionMin = 0
+
 export const DashboardsGroupsUpdateCreateBody = /* @__PURE__ */ zod.object({
     group_id: zod.string().describe('Dashboard group ID to update.'),
     name: zod
         .string()
-        .min(1)
         .max(dashboardsGroupsUpdateCreateBodyNameMax)
+        .nullish()
+        .describe('New section name. Null or an empty string converts the section to anonymous.'),
+    position: zod
+        .number()
+        .min(dashboardsGroupsUpdateCreateBodyPositionMin)
         .optional()
-        .describe('New group name. Omit to keep the existing name.'),
-    layouts: zod
-        .object({
-            sm: zod
-                .object({
-                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
-                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
-                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
-                    h: zod.number().optional().describe('Height in grid rows.'),
-                })
-                .optional()
-                .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
-            xs: zod
-                .object({
-                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
-                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
-                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
-                    h: zod.number().optional().describe('Height in grid rows.'),
-                })
-                .optional()
-                .describe('Layout for the small (mobile) breakpoint. The grid is 1 column wide.'),
-        })
-        .optional()
-        .describe('New grid layout for the group row. Omit to keep its current layout.'),
+        .describe('New section position. Existing sections are renumbered around it.'),
 })
 
 export const DashboardsMoveTilePartialUpdateParams = /* @__PURE__ */ zod.object({
@@ -1333,7 +1308,9 @@ export const DashboardsReorderTilesCreateBody = /* @__PURE__ */ zod.object({
     tile_order: zod
         .array(zod.number())
         .min(1)
-        .describe('Array of tile IDs in the desired display order (top to bottom, left to right).'),
+        .describe(
+            'Tile IDs in the desired display order. The endpoint partitions the order by section and repacks each section independently.'
+        ),
     layout: zod
         .enum(['preserve', 'two_column', 'full_width'])
         .describe('\* `preserve` - preserve\n\* `two_column` - two_column\n\* `full_width` - full_width')
@@ -1544,6 +1521,10 @@ export const dashboardsWidgetsBatchCreateBodyWidgetsMax = 10
 
 export const DashboardsWidgetsBatchCreateBody = /* @__PURE__ */ zod
     .object({
+        group_id: zod
+            .string()
+            .optional()
+            .describe("Section ID for the new widgets. Omit to use the dashboard's default section."),
         widgets: zod
             .array(
                 zod.union([

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -164,6 +164,9 @@ const dashboardCreateTextTile = (): ToolBase<
         if (params.layouts !== undefined) {
             body['layouts'] = params.layouts
         }
+        if (params.group_id !== undefined) {
+            body['group_id'] = params.group_id
+        }
         if (params.color !== undefined) {
             body['color'] = params.color
         }
@@ -305,8 +308,8 @@ const dashboardGroupCreate = (): ToolBase<
         if (params.name !== undefined) {
             body['name'] = params.name
         }
-        if (params.layouts !== undefined) {
-            body['layouts'] = params.layouts
+        if (params.position !== undefined) {
+            body['position'] = params.position
         }
         const result = await context.api.request<Schemas.DashboardGroup>({
             method: 'POST',
@@ -348,7 +351,7 @@ const DashboardGroupMoveTileSchema = DashboardsGroupsMoveTileCreateParams.omit({
 
 const dashboardGroupMoveTile = (): ToolBase<
     typeof DashboardGroupMoveTileSchema,
-    WithPostHogUrl<Schemas.DashboardTile>
+    WithPostHogUrl<Schemas.MoveDashboardTileToGroupResponse>
 > => ({
     name: 'dashboard-group-move-tile',
     schema: DashboardGroupMoveTileSchema,
@@ -361,10 +364,13 @@ const dashboardGroupMoveTile = (): ToolBase<
         if (params.group_id !== undefined) {
             body['group_id'] = params.group_id
         }
+        if (params.create_at_position !== undefined) {
+            body['create_at_position'] = params.create_at_position
+        }
         if (params.layouts !== undefined) {
             body['layouts'] = params.layouts
         }
-        const result = await context.api.request<Schemas.DashboardTile>({
+        const result = await context.api.request<Schemas.MoveDashboardTileToGroupResponse>({
             method: 'POST',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/groups/move-tile/`,
             body,
@@ -392,8 +398,8 @@ const dashboardGroupUpdate = (): ToolBase<
         if (params.name !== undefined) {
             body['name'] = params.name
         }
-        if (params.layouts !== undefined) {
-            body['layouts'] = params.layouts
+        if (params.position !== undefined) {
+            body['position'] = params.position
         }
         const result = await context.api.request<Schemas.DashboardGroup>({
             method: 'POST',


### PR DESCRIPTION
## Problem

- Dashboard group actions depend on synthetic header tiles and global coordinates, which cannot represent independent section grids.

## Changes

```mermaid
flowchart LR
    A[Header tile coordinates] --> B[Group membership shims]
    C[Ordered section rows] --> D[Direct tile membership]
```

- Creates, renames, reorders, moves, ungroups, templates, and duplicates ordered sections directly.
- Compacts and reorders layouts inside each section.
- Returns created and deleted section IDs for optimistic clients.
- Regenerates frontend and MCP contracts.

## How did you test this code?

- Django system and OpenAPI schema checks pass.
- API tests could not start because the local environment lacks `sqlx`.
- Updated tests guard wrapping, dense ordering, anonymous cleanup, ungrouping, cross-dashboard isolation, and template interleaving.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No published workflow changes before the frontend layers land.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex used `/improving-drf-endpoints`, `/writing-tests`, `/writing-pr-descriptions`, and `/stacking-prs`.
- The endpoint rewrite replaces coordinate-based group behavior with ordered section operations.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
