### PR TITLE
feat(dashboards): migrate header tiles to section positions

### DIFF
--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -1079,7 +1079,6 @@ class DashboardTileSerializer(serializers.ModelSerializer):
             # Denormalization for HogQL printing; combined with depth=1, leaving it
             # in expands `team` into a full nested Team dict on every tile response.
             "team",
-            "dashboard_group",
             "parent_group",
         ]
         read_only_fields = ["id", "insight"]
@@ -1726,7 +1725,6 @@ class DashboardSerializer(DashboardMetadataSerializer):
                 group_map[source_group.id] = copied_group
             existing_tiles = (
                 DashboardTile.objects.filter(dashboard=existing_dashboard)
-                .filter(dashboard_group__isnull=True)
                 .exclude(deleted=True)
                 .select_related("insight", "text", "button_tile", "widget", "parent_group")
             )
@@ -3075,13 +3073,8 @@ class DashboardsViewSet(
             dashboard = Dashboard.objects.select_for_update().get(id=dashboard.id)
             groups = list(dashboard.groups.select_for_update().order_by("position", "created_at"))
             if not groups:
-                existing_tiles = (
-                    DashboardTile.objects.select_for_update()
-                    .filter(
-                        dashboard=dashboard,
-                        dashboard_group__isnull=True,
-                    )
-                    .exclude(deleted=True)
+                existing_tiles = DashboardTile.objects.select_for_update().filter(dashboard=dashboard).exclude(
+                    deleted=True
                 )
                 if existing_tiles.exists():
                     anonymous_group = DashboardGroup.all_teams.create(
@@ -3175,7 +3168,7 @@ class DashboardsViewSet(
         with transaction.atomic():
             dashboard = Dashboard.objects.select_for_update().get(id=dashboard.id)
             tile = get_object_or_404(
-                DashboardTile.objects.select_for_update().filter(dashboard=dashboard, dashboard_group__isnull=True),
+                DashboardTile.objects.select_for_update().filter(dashboard=dashboard),
                 id=serializer.validated_data["tile_id"],
             )
             if "create_at_position" in serializer.validated_data:

--- a/products/dashboards/backend/migrations/0020_migrate_dashboard_group_sections.py
+++ b/products/dashboards/backend/migrations/0020_migrate_dashboard_group_sections.py
@@ -1,0 +1,78 @@
+from typing import Any
+
+from django.db import migrations
+
+
+def _layout_y(tile: Any) -> int:
+    layouts = tile.layouts if isinstance(tile.layouts, dict) else {}
+    sm = layouts.get("sm") or {}
+    y = sm.get("y", 0)
+    return y if isinstance(y, int) else 0
+
+
+def migrate_dashboard_group_sections(apps: Any, schema_editor: Any) -> None:
+    Dashboard = apps.get_model("dashboards", "Dashboard")
+    DashboardGroup = apps.get_model("dashboards", "DashboardGroup")
+    DashboardTile = apps.get_model("dashboards", "DashboardTile")
+
+    dashboard_ids = DashboardGroup.all_teams.values_list("dashboard_id", flat=True).distinct()
+    for dashboard_id in dashboard_ids.iterator():
+        dashboard = Dashboard.objects.get(id=dashboard_id)
+        groups = list(DashboardGroup.all_teams.filter(dashboard_id=dashboard_id))
+        header_tiles = list(DashboardTile.objects.filter(dashboard_id=dashboard_id, dashboard_group_id__isnull=False))
+        header_by_group_id = {tile.dashboard_group_id: tile for tile in header_tiles}
+        legacy_groups = sorted(
+            (group for group in groups if group.id in header_by_group_id),
+            key=lambda group: _layout_y(header_by_group_id[group.id]),
+        )
+        section_groups = sorted(
+            (group for group in groups if group.id not in header_by_group_id),
+            key=lambda group: (group.position, group.created_at),
+        )
+
+        ungrouped_tiles = list(
+            DashboardTile.objects.filter(
+                dashboard_id=dashboard_id,
+                dashboard_group_id__isnull=True,
+                parent_group_id__isnull=True,
+            ).exclude(deleted=True)
+        )
+        anonymous_tiles_by_bucket: dict[int, list[Any]] = {}
+        header_ys = [_layout_y(header_by_group_id[group.id]) for group in legacy_groups]
+        for tile in ungrouped_tiles:
+            tile_y = _layout_y(tile)
+            bucket = sum(header_y <= tile_y for header_y in header_ys)
+            anonymous_tiles_by_bucket.setdefault(bucket, []).append(tile)
+
+        section_entries = [(_layout_y(header_by_group_id[group.id]), group, []) for group in legacy_groups]
+        section_position_offset = max(header_ys, default=-1) + 1
+        section_entries.extend((section_position_offset + group.position, group, []) for group in section_groups)
+        for tiles in anonymous_tiles_by_bucket.values():
+            group = DashboardGroup.all_teams.create(
+                dashboard_id=dashboard_id,
+                team_id=dashboard.team_id,
+                name=None,
+                position=0,
+            )
+            section_entries.append((min(_layout_y(tile) for tile in tiles), group, tiles))
+
+        section_entries.sort(key=lambda entry: (entry[0], entry[2] != []))
+        groups_to_update = []
+        tiles_to_update = []
+        for position, (_, group, tiles) in enumerate(section_entries):
+            group.position = position
+            groups_to_update.append(group)
+            for tile in tiles:
+                tile.parent_group_id = group.id
+                tiles_to_update.append(tile)
+
+        DashboardGroup.all_teams.bulk_update(groups_to_update, ["position"])
+        if tiles_to_update:
+            DashboardTile.objects.bulk_update(tiles_to_update, ["parent_group"])
+        DashboardTile.objects.filter(id__in=[tile.id for tile in header_tiles]).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [("dashboards", "0019_dashboardgroup_position_and_nullable_name")]
+
+    operations = [migrations.RunPython(migrate_dashboard_group_sections, migrations.RunPython.noop)]

--- a/products/dashboards/backend/migrations/0021_remove_dashboardtile_dashboard_group_state.py
+++ b/products/dashboards/backend/migrations/0021_remove_dashboardtile_dashboard_group_state.py
@@ -1,0 +1,32 @@
+from django.db import migrations, models
+
+import posthog.models.utils
+
+
+class Migration(migrations.Migration):
+    dependencies = [("dashboards", "0020_migrate_dashboard_group_sections")]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveConstraint(
+                    model_name="dashboardtile",
+                    name="dash_tile_exactly_one_related_object",
+                ),
+                migrations.RemoveField(
+                    model_name="dashboardtile",
+                    name="dashboard_group",
+                ),
+                migrations.AddConstraint(
+                    model_name="dashboardtile",
+                    constraint=models.CheckConstraint(
+                        condition=posthog.models.utils.build_unique_relationship_check(
+                            ("insight", "text", "button_tile", "widget")
+                        ),
+                        name="dash_tile_exactly_one_related_object",
+                    ),
+                ),
+            ],
+            database_operations=[],
+        )
+    ]

--- a/products/dashboards/backend/migrations/max_migration.txt
+++ b/products/dashboards/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0019_dashboardgroup_position_and_nullable_name
+0021_remove_dashboardtile_dashboard_group_state

--- a/products/dashboards/backend/models/dashboard_tile.py
+++ b/products/dashboards/backend/models/dashboard_tile.py
@@ -85,14 +85,6 @@ class DashboardTile(models.Model):
         null=True,
         db_index=False,
     )
-    dashboard_group = models.OneToOneField(
-        "dashboards.DashboardGroup",
-        on_delete=models.CASCADE,
-        related_name="tile",
-        null=True,
-        db_index=False,
-        db_constraint=False,
-    )
     parent_group = models.ForeignKey(
         "dashboards.DashboardGroup",
         on_delete=models.PROTECT,
@@ -151,9 +143,7 @@ class DashboardTile(models.Model):
                 condition=Q(("widget__isnull", False)),
             ),
             models.CheckConstraint(
-                condition=build_unique_relationship_check(
-                    ("insight", "text", "button_tile", "widget", "dashboard_group")
-                ),
+                condition=build_unique_relationship_check(("insight", "text", "button_tile", "widget")),
                 name="dash_tile_exactly_one_related_object",
             ),
         ]
@@ -194,23 +184,14 @@ class DashboardTile(models.Model):
         related_fields = sum(
             map(
                 bool,
-                [
-                    getattr(self, relation)
-                    for relation in ("insight", "text", "button_tile", "widget", "dashboard_group")
-                ],
+                [getattr(self, relation) for relation in ("insight", "text", "button_tile", "widget")],
             )
         )
         if related_fields != 1:
-            raise ValidationError(
-                "Can only set exactly one of insight, text, button_tile, widget, or dashboard_group for this tile"
-            )
+            raise ValidationError("Can only set exactly one of insight, text, button_tile, or widget for this tile")
 
-        if self.dashboard_group_id is not None and self.parent_group_id is not None:
-            raise ValidationError("Dashboard group tiles cannot belong to another group")
-
-        for group in (self.dashboard_group, self.parent_group):
-            if group is not None and group.dashboard_id != self.dashboard_id:
-                raise ValidationError("Dashboard groups and tiles must belong to the same dashboard")
+        if self.parent_group is not None and self.parent_group.dashboard_id != self.dashboard_id:
+            raise ValidationError("Dashboard groups and tiles must belong to the same dashboard")
 
         if self.insight is None and (
             self.filters_hash is not None
@@ -321,7 +302,6 @@ class DashboardTile(models.Model):
                 "text",
                 "button_tile",
                 "widget",
-                "dashboard_group",
                 "parent_group",
                 "insight__created_by",
                 "insight__last_modified_by",
@@ -331,7 +311,6 @@ class DashboardTile(models.Model):
             )
             .prefetch_related("text__dashboard_tiles", "button_tile__dashboard_tiles", "widget__dashboard_tiles")
             .exclude(dashboard__deleted=True, deleted=True)
-            .filter(dashboard_group__isnull=True)
             .filter(Q(insight__deleted=False) | Q(insight__isnull=True))
             .order_by("insight__order")
         )

--- a/products/dashboards/backend/test/test_migration_0020.py
+++ b/products/dashboards/backend/test/test_migration_0020.py
@@ -1,0 +1,101 @@
+from typing import Any
+
+from posthog.test.base import TestMigrations
+
+
+class MigrateDashboardGroupSectionsTest(TestMigrations):
+    migrate_from = "0019_dashboardgroup_position_and_nullable_name"
+    migrate_to = "0020_migrate_dashboard_group_sections"
+
+    @property
+    def app(self) -> str:
+        return "dashboards"
+
+    def setUpBeforeMigration(self, apps: Any) -> None:
+        Dashboard = apps.get_model("dashboards", "Dashboard")
+        DashboardGroup = apps.get_model("dashboards", "DashboardGroup")
+        DashboardTile = apps.get_model("dashboards", "DashboardTile")
+        Text = apps.get_model("dashboards", "Text")
+
+        grouped_dashboard = Dashboard.objects.create(team_id=self.team.id, name="Grouped")
+        untouched_dashboard = Dashboard.objects.create(team_id=self.team.id, name="Untouched")
+        first_group = DashboardGroup.all_teams.create(
+            dashboard=grouped_dashboard,
+            team_id=self.team.id,
+            name="First",
+        )
+        second_group = DashboardGroup.all_teams.create(
+            dashboard=grouped_dashboard,
+            team_id=self.team.id,
+            name="Second",
+        )
+        section_dashboard = Dashboard.objects.create(team_id=self.team.id, name="Already migrated")
+        section_group = DashboardGroup.all_teams.create(
+            dashboard=section_dashboard,
+            team_id=self.team.id,
+            name="Section",
+            position=0,
+        )
+        section_text = Text.objects.create(team_id=self.team.id, body="Section tile")
+        DashboardTile.objects.create(
+            dashboard=section_dashboard,
+            team_id=self.team.id,
+            text=section_text,
+            parent_group=section_group,
+            layouts={"sm": {"x": 0, "y": 0, "w": 6, "h": 5}},
+        )
+        DashboardTile.objects.create(
+            dashboard=grouped_dashboard,
+            team_id=self.team.id,
+            dashboard_group=first_group,
+            layouts={"sm": {"x": 0, "y": 2, "w": 12, "h": 1}},
+        )
+        DashboardTile.objects.create(
+            dashboard=grouped_dashboard,
+            team_id=self.team.id,
+            dashboard_group=second_group,
+            layouts={"sm": {"x": 0, "y": 8, "w": 12, "h": 1}},
+        )
+        for body, y, dashboard in (
+            ("Before", 0, grouped_dashboard),
+            ("Between", 5, grouped_dashboard),
+            ("After", 10, grouped_dashboard),
+            ("Untouched", 0, untouched_dashboard),
+        ):
+            text = Text.objects.create(team_id=self.team.id, body=body)
+            DashboardTile.objects.create(
+                dashboard=dashboard,
+                team_id=self.team.id,
+                text=text,
+                layouts={"sm": {"x": 0, "y": y, "w": 12, "h": 2}},
+            )
+
+        self.grouped_dashboard_id = grouped_dashboard.id
+        self.untouched_dashboard_id = untouched_dashboard.id
+        self.section_dashboard_id = section_dashboard.id
+
+    def test_migration_builds_ordered_sections_and_leaves_group_less_dashboards_untouched(self) -> None:
+        DashboardGroup = self.apps.get_model("dashboards", "DashboardGroup")  # type: ignore[union-attr]
+        DashboardTile = self.apps.get_model("dashboards", "DashboardTile")  # type: ignore[union-attr]
+
+        groups = list(DashboardGroup.all_teams.filter(dashboard_id=self.grouped_dashboard_id).order_by("position"))
+        assert [(group.name, group.position) for group in groups] == [
+            (None, 0),
+            ("First", 1),
+            (None, 2),
+            ("Second", 3),
+            (None, 4),
+        ]
+        assert (
+            DashboardTile.objects.filter(
+                dashboard_id=self.grouped_dashboard_id,
+                dashboard_group_id__isnull=False,
+            ).count()
+            == 0
+        )
+        assert all(group.member_tiles.count() == 1 for group in groups if group.name is None)
+        assert not DashboardGroup.all_teams.filter(dashboard_id=self.untouched_dashboard_id).exists()
+        assert DashboardTile.objects.get(dashboard_id=self.untouched_dashboard_id).parent_group_id is None
+        section_group = DashboardGroup.all_teams.get(dashboard_id=self.section_dashboard_id)
+        assert section_group.position == 0
+        assert section_group.member_tiles.count() == 1


### PR DESCRIPTION
## Problem

- Existing grouped dashboards store section order in synthetic header tiles and leave ungrouped tiles between groups.

## Changes

```mermaid
flowchart LR
    A[Header tile y positions] --> B[Named section positions]
    C[Ungrouped tile runs] --> D[Anonymous sections]
    B --> E[Delete header rows]
    D --> E
```

- Backfills named section positions from header order.
- Creates anonymous sections for interleaved ungrouped runs.
- Removes the legacy model field from Django state while retaining its database column.

## How did you test this code?

- Django reports no migration state drift.
- The migration test guards interleaving and leaves group-less dashboards untouched.
- Database tests could not start because the local environment lacks `sqlx`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No user workflow changes in this migration layer.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex used `/django-migrations`, `/writing-tests`, `/writing-pr-descriptions`, and `/stacking-prs`.
- The database column remains for a separate post-deploy cleanup.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
