### PR TITLE
feat(dashboard): cross-section tile drag and section reorder

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -284,11 +284,11 @@ export const FEATURE_FLAGS = {
     CUSTOMER_ANALYTICS_JOURNEYS: 'customer-analytics-journeys', // owner: @arthurdedeus #team-customer-analytics
     CUSTOMER_PROFILE_CONFIG_BUTTON: 'customer-profile-config-button', // owner: @arthurdedeus #team-customer-analytics
     DASHBOARD_AUTO_PREVIEW_LIMIT: 'dashboard-auto-preview-limit', // owner: @pauldambra #team-product-analytics
+    DASHBOARD_GROUPS: 'dashboard-groups', // owner: #team-analytics-platform
     DASHBOARD_INLINE_TILE_INSERTION: 'dashboard-inline-tile-insertion', // owner: @MattPua #team-analytics-platform
     DASHBOARD_LAYOUT_DISCARD_PROMPT: 'dashboard-layout-discard-prompt', // owner: @cory.s #team-analytics-platform
     DASHBOARD_TEMPLATE_CHOOSER_EXPERIMENT: 'dashboard-template-chooser-experiment', // owner: @mattp #team-analytics-platform multivariate=control,simple,new
     DASHBOARD_WIDGETS: 'dashboard-widgets', // owner: @mattp #team-analytics-platform
-    DASHBOARD_GROUPS: 'dashboard-groups', // owner: #team-analytics-platform
     DASHBOARDS_LIST_VIEW: 'dashboards-list-view', // owner: @vdekrijger #team-product-analytics multivariate=control,tree
     DATA_MODELING_BACKEND_V2: 'data-modeling-backend-v2', // owner: #team-data-modeling
     DATA_MODELING_MULTI_DAG: 'data-modeling-multi-dag', // owner: #team-data-modeling

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -3,7 +3,7 @@ import './DashboardItems.scss'
 import clsx from 'clsx'
 import { useActions, useAsyncActions, useValues } from 'kea'
 import { router } from 'kea-router'
-import { RefObject, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Fragment, RefObject, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Layout, useContainerWidth } from 'react-grid-layout'
 
 import { DashboardWidgetItem } from '@posthog/products-dashboards/frontend/components/DashboardWidgetItem/DashboardWidgetItem'
@@ -15,6 +15,7 @@ import { EditModeEdge, useResizeHandleScrollbarPassThrough } from 'lib/component
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonMenuItem } from 'lib/lemon-ui/LemonMenu'
 import { DashboardEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { objectsEqual } from 'lib/utils/objects'
 import { addInsightToDashboardLogic } from 'scenes/dashboard/addInsightToDashboardModalLogic'
 import { getAddTileMenuItems } from 'scenes/dashboard/DashboardHeaderActions'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
@@ -35,10 +36,10 @@ import { insightsModel } from '~/models/insightsModel'
 import { DashboardLayoutSize, DashboardMode, DashboardPlacement, DashboardType } from '~/types'
 
 import { DashboardSection } from './DashboardSection'
-import { gridTilePropsEqual } from './gridTilePropsEqual'
 import { DashboardButtonTileItem } from './items/DashboardButtonTileItem'
 import { DashboardErrorTileItem } from './items/DashboardErrorTileItem'
 import { DashboardTextItem } from './items/DashboardTextItem'
+import { DashboardDropTarget, useCrossSectionDrag } from './useCrossSectionDrag'
 
 const DRAG_AUTO_SCROLL_THRESHOLD = 100
 const DRAG_AUTO_SCROLL_SPEED = 50
@@ -49,6 +50,21 @@ const CONTAINER_PADDING: [number, number] = [0, 0]
 
 interface DashboardItemsProps {
     showCreateAnomalyAlertButton?: boolean
+}
+
+/**
+ * Shallow prop compare, except: `style` by value (react-grid-layout rebuilds it every drag/resize mousemove even
+ * for tiles that haven't moved) and `children` ignored (the RGL-injected resize handles, recreated each render
+ * with identical content). Lets untouched tiles skip re-rendering during gestures.
+ */
+function gridTilePropsEqual(prevProps: Record<string, any>, nextProps: Record<string, any>): boolean {
+    return [...new Set([...Object.keys(prevProps), ...Object.keys(nextProps)])].every(
+        (key) =>
+            key === 'children' ||
+            (key === 'style'
+                ? objectsEqual(prevProps.style, nextProps.style)
+                : Object.is(prevProps[key], nextProps[key]))
+    )
 }
 
 const MemoizedInsightCard = memo(InsightCard, gridTilePropsEqual) as typeof InsightCard
@@ -105,6 +121,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         setDashboardMode,
         setAddWidgetModalOpen,
         setPendingInsertion,
+        moveDashboardTileToGroup,
         renameDashboardGroup,
         updateDashboardGroupPosition,
         deleteDashboardGroup,
@@ -229,10 +246,34 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         DashboardPlacement.Builtin,
     ].includes(placement)
 
-    const canEnterEditModeFromEdge =
-        !!dashboard && canEditDashboard && !layoutEditMode && !isMobileView && isEditablePlacement
-
-    const isLayoutZoomToggled = layoutEditMode && layoutZoom !== 1
+    const handleCrossSectionDrop = useCallback(
+        (tileId: number, target: Exclude<DashboardDropTarget, null>, event: MouseEvent): void => {
+            const targetSection =
+                target.type === 'section' ? renderedSections.find((section) => section.key === target.sectionKey) : null
+            const targetPosition = target.type === 'gap' ? target.position : renderedSections.indexOf(targetSection!)
+            const targetLayouts = targetSection ? (renderedSectionLayouts[targetSection.key]?.sm ?? []) : []
+            const sectionMaxY = Math.max(0, ...targetLayouts.map((layout) => layout.y + layout.h))
+            const x = Math.max(
+                0,
+                Math.min(
+                    BREAKPOINT_COLUMN_COUNTS.sm - 1,
+                    Math.floor((event.clientX / gridWidth) * BREAKPOINT_COLUMN_COUNTS.sm)
+                )
+            )
+            moveDashboardTileToGroup({
+                tileId,
+                groupId: targetSection?.group?.id,
+                createAtPosition: targetSection?.group ? undefined : targetPosition,
+                layouts: { sm: { x, y: sectionMaxY + 1, w: 6, h: 5 } },
+            })
+        },
+        [gridWidth, moveDashboardTileToGroup, renderedSectionLayouts, renderedSections]
+    )
+    const crossSectionDrag = useCrossSectionDrag({
+        sections: renderedSections,
+        disabled: isMobileView || !layoutEditMode || !isEditablePlacement,
+        onDrop: handleCrossSectionDrop,
+    })
 
     const getInsertMenuItems = useCallback(
         (sectionKey: string, targetX: number, targetY: number, targetW?: number): LemonMenuItem[] =>
@@ -256,6 +297,11 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
             showAddInsightToDashboardModal,
         ]
     )
+
+    const canEnterEditModeFromEdge =
+        !!dashboard && canEditDashboard && !layoutEditMode && !isMobileView && isEditablePlacement
+
+    const isLayoutZoomToggled = layoutEditMode && layoutZoom !== 1
 
     const effectiveZoom = layoutEditMode ? layoutZoom : 1
     const rowHeight = BASE_ROW_HEIGHT * effectiveZoom
@@ -397,11 +443,19 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         }
     }, [dashboard?.id, reportDashboardTileRepositioned, effectiveZoom, flushPendingLayouts])
 
-    const handleDragStart = useCallback(() => {
-        interactionInProgress.current = true
-        scrollContainerRef.current = document.getElementById('main-content')
-        scrollContainerRectRef.current = scrollContainerRef.current?.getBoundingClientRect() ?? null
-    }, [])
+    const handleDragStart = useCallback(
+        (_layout: unknown, _oldItem: unknown, newItem: { i: string }) => {
+            interactionInProgress.current = true
+            scrollContainerRef.current = document.getElementById('main-content')
+            scrollContainerRectRef.current = scrollContainerRef.current?.getBoundingClientRect() ?? null
+            const tileId = Number(newItem.i)
+            const sourceSection = renderedSections.find((section) => section.tiles.some((tile) => tile.id === tileId))
+            if (sourceSection) {
+                crossSectionDrag.startDrag(tileId, sourceSection.key)
+            }
+        },
+        [crossSectionDrag, renderedSections]
+    )
 
     const handleDrag = useCallback(
         (_layout: unknown, _oldItem: unknown, _newItem: unknown, _placeholder: unknown, e: unknown) => {
@@ -420,7 +474,9 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                 return
             }
 
-            const mouseY = (e as MouseEvent).clientY
+            const mouseEvent = e as MouseEvent
+            const mouseY = mouseEvent.clientY
+            crossSectionDrag.updateDrag(mouseEvent)
 
             let scrollSpeed = 0
             if (mouseY < containerRect.top + DRAG_AUTO_SCROLL_THRESHOLD) {
@@ -444,14 +500,16 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                 scrollAnimationRef.current = requestAnimationFrame(scroll)
             }
         },
-        []
+        [crossSectionDrag]
     )
 
     const handleDragStop = useCallback(
         (
             _layout: unknown,
             _oldItem: unknown,
-            newItem: { i: string; x: number; y: number; w: number; h: number } | null
+            newItem: { i: string; x: number; y: number; w: number; h: number } | null,
+            _placeholder: unknown,
+            event: MouseEvent
         ) => {
             if (!newItem) {
                 return
@@ -468,12 +526,13 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
             dragEndTimeout.current = window.setTimeout(() => {
                 isDragging.current = false
             }, 250)
+            crossSectionDrag.finishDrag(event)
             flushPendingLayouts()
             if (dashboard?.id) {
                 reportDashboardTileRepositioned(dashboard.id, 'moved', effectiveZoom)
             }
         },
-        [dashboard?.id, reportDashboardTileRepositioned, effectiveZoom, flushPendingLayouts]
+        [crossSectionDrag, dashboard?.id, reportDashboardTileRepositioned, effectiveZoom, flushPendingLayouts]
     )
 
     return (
@@ -494,269 +553,295 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                             !layoutEditMode &&
                             renderedCollapsedSectionIds.includes(section.group.id)
                         return (
-                            <DashboardSection
-                                key={section.key}
-                                group={section.isNamed ? section.group : null}
-                                collapsed={collapsed}
-                                editing={layoutEditMode}
-                                tileCount={section.tiles.length}
-                                sectionCount={renderedSections.length}
-                                onToggle={() => section.group && toggleDashboardSectionCollapsed(section.group.id)}
-                                onRename={(name) => section.group && renameDashboardGroup(section.group.id, name)}
-                                onMove={(position) =>
-                                    section.group && updateDashboardGroupPosition(section.group.id, position)
-                                }
-                                onDelete={(memberHandling) =>
-                                    section.group && deleteDashboardGroup(section.group.id, memberHandling)
-                                }
-                                overlay={
-                                    isEditablePlacement && inlineTileInsertionEnabled ? (
-                                        <InsertTileOverlay
-                                            layout={displayLayouts.sm}
-                                            gridWidth={gridWidth}
-                                            cols={BREAKPOINT_COLUMN_COUNTS.sm}
-                                            rowHeight={rowHeight}
-                                            marginX={margin[0]}
-                                            marginY={margin[1]}
-                                            canEditDashboard={canEditDashboard}
-                                            isMobileView={isMobileView}
-                                            disabled={resizingTileId !== null}
-                                            getMenuItems={(x, y, w) => getInsertMenuItems(section.key, x, y, w)}
-                                        />
-                                    ) : null
-                                }
-                                gridBackgroundProps={
-                                    layoutEditMode && !isMobileView
-                                        ? {
-                                              width: gridWidth,
-                                              cols: BREAKPOINT_COLUMN_COUNTS.sm,
-                                              rowHeight,
-                                              margin,
-                                              containerPadding: CONTAINER_PADDING,
-                                              rows: 'auto',
-                                              height: containerHeight,
-                                              color: 'var(--color-bg-surface-secondary)',
-                                          }
-                                        : null
-                                }
-                                gridProps={{
-                                    width: gridWidth,
-                                    className,
-                                    dragConfig,
-                                    resizeConfig,
-                                    layouts: displayLayouts as Partial<Record<DashboardLayoutSize, Layout>>,
-                                    rowHeight,
-                                    margin,
-                                    containerPadding: CONTAINER_PADDING,
-                                    onLayoutChange: handleLayoutChange,
-                                    onWidthChange: handleWidthChange,
-                                    breakpoints: BREAKPOINTS,
-                                    cols: BREAKPOINT_COLUMN_COUNTS,
-                                    onResizeStart: handleResizeStart,
-                                    onResize: handleResize,
-                                    onResizeStop: handleResizeStop,
-                                    onDragStart: handleDragStart,
-                                    onDrag: handleDrag,
-                                    onDragStop: handleDragStop,
-                                }}
-                            >
-                                {section.tiles.map((tile) => {
-                                    const { insight, text, button_tile, widget } = tile
-                                    const smLayout = displayLayouts['sm']?.find((l) => {
-                                        return l.i == tile.id.toString()
-                                    })
-
-                                    const commonTileProps = {
-                                        dashboardId: dashboard?.id,
-                                        showResizeHandles,
-                                        canEnterEditModeFromEdge,
-                                        onEnterEditModeFromEdge,
-                                        onDragHandleMouseDown,
-                                        showEditingControls,
-                                        moveToDashboard: ({ id, name }: Pick<DashboardType, 'id' | 'name'>) => {
-                                            moveToDashboard(tile, requireDashboardId('move this tile'), id, name)
-                                        },
-                                        copyToDashboard: ({ id, name }: Pick<DashboardType, 'id' | 'name'>) => {
-                                            copyToDashboard(tile, requireDashboardId('copy this tile'), id, name)
-                                        },
-                                        removeFromDashboard: () => removeTile(tile),
+                            <Fragment key={section.key}>
+                                {crossSectionDrag.dropTarget?.type === 'gap' &&
+                                    crossSectionDrag.dropTarget.position === sectionIndex && (
+                                        <div className="h-0.5 bg-accent my-3" />
+                                    )}
+                                <DashboardSection
+                                    group={section.isNamed ? section.group : null}
+                                    collapsed={collapsed}
+                                    editing={layoutEditMode}
+                                    tileCount={section.tiles.length}
+                                    sectionCount={renderedSections.length}
+                                    sectionRef={(element) => crossSectionDrag.registerSection(section.key, element)}
+                                    highlighted={
+                                        crossSectionDrag.dropTarget?.type === 'section' &&
+                                        crossSectionDrag.dropTarget.sectionKey === section.key
                                     }
-
-                                    if (tile.error && !insight) {
-                                        return (
-                                            <MemoizedDashboardErrorTileItem
-                                                key={tile.id}
-                                                tile={tile}
-                                                onRemove={commonTileProps.removeFromDashboard}
-                                                showResizeHandles={showResizeHandles}
-                                                canEnterEditModeFromEdge={canEnterEditModeFromEdge}
-                                                onEnterEditModeFromEdge={onEnterEditModeFromEdge}
-                                                onDragHandleMouseDown={onDragHandleMouseDown}
-                                                showEditingControls={showEditingControls}
-                                            />
-                                        )
+                                    onToggle={() => section.group && toggleDashboardSectionCollapsed(section.group.id)}
+                                    onRename={(name) => section.group && renameDashboardGroup(section.group.id, name)}
+                                    onMove={(position) =>
+                                        section.group && updateDashboardGroupPosition(section.group.id, position)
                                     }
-
-                                    if (insight) {
-                                        // Check if this insight has an error from the server
-                                        const isErrorTile = !!tile.error
-                                        const queryError = getInsightQueryError(insight)
-                                        const apiErrored =
-                                            isErrorTile ||
-                                            !!queryError ||
-                                            refreshStatus[insight.short_id]?.errored ||
-                                            false
-                                        const refreshError = refreshStatus[insight.short_id]?.error
-                                        const apiError = isErrorTile
-                                            ? new ApiError(undefined, 500, undefined, {
-                                                  detail: tile.error!.message,
-                                                  code: 'dashboard_tile_error',
-                                              })
-                                            : refreshError || queryError || undefined
-                                        const loadingQueued = isErrorTile ? false : isRefreshingQueued(insight.short_id)
-                                        const loading = isErrorTile ? false : isRefreshing(insight.short_id)
-
-                                        return (
-                                            <MemoizedInsightCard
-                                                key={tile.id}
-                                                tile={tile}
-                                                insight={insight}
-                                                loadingQueued={loadingQueued}
-                                                loading={loading}
-                                                apiErrored={apiErrored}
-                                                apiError={apiError}
-                                                highlighted={
-                                                    highlightedInsightId && insight.short_id === highlightedInsightId
-                                                }
-                                                updateColor={(color) => updateTileColor(tile.id, color)}
-                                                toggleShowDescription={() => toggleTileDescription(tile.id)}
-                                                ribbonColor={tile.color}
-                                                refresh={() => refreshDashboardItem({ tile })}
-                                                rename={() => renameInsight(insight)}
-                                                duplicate={() => duplicateTile(tile)}
-                                                setOverride={() => setTileOverride(tile)}
-                                                showDetailsControls={showDetailsControls}
-                                                placement={placement}
-                                                loadPriority={
-                                                    smLayout
-                                                        ? sectionIndex * 100_000 + smLayout.y * 1000 + smLayout.x
-                                                        : undefined
-                                                }
-                                                isResizing={resizingTileId === tile.id.toString()}
-                                                filtersOverride={effectiveEditBarFilters}
-                                                variablesOverride={effectiveDashboardVariableOverrides}
-                                                // :HACKY: The two props below aren't actually used in the component, but are needed to trigger a re-render
-                                                breakdownColorOverride={effectiveBreakdownColors}
-                                                dataColorThemeId={dataColorThemeId}
-                                                surveyOpportunity={tile.id === bestSurveyOpportunityFunnel?.id}
-                                                showCreateAnomalyAlertButton={showCreateAnomalyAlertButton}
-                                                {...commonTileProps}
-                                            />
-                                        )
+                                    onDelete={(memberHandling) =>
+                                        section.group && deleteDashboardGroup(section.group.id, memberHandling)
                                     }
-
-                                    if (text) {
-                                        return (
-                                            <MemoizedDashboardTextItem
-                                                key={tile.id}
-                                                tile={tile}
-                                                placement={placement}
-                                                dashboardId={dashboard?.id}
-                                                onEdit={() => {
-                                                    if (dashboard?.id) {
-                                                        push(urls.dashboardTextTile(dashboard.id, tile.id))
-                                                    }
-                                                }}
-                                                onMoveToDashboard={commonTileProps.moveToDashboard}
-                                                onCopyToDashboard={commonTileProps.copyToDashboard}
-                                                onDuplicate={() => duplicateTile(tile)}
-                                                onRemove={commonTileProps.removeFromDashboard}
-                                                showResizeHandles={commonTileProps.showResizeHandles}
-                                                showEditingControls={commonTileProps.showEditingControls}
-                                                canEnterEditModeFromEdge={commonTileProps.canEnterEditModeFromEdge}
-                                                onEnterEditModeFromEdge={commonTileProps.onEnterEditModeFromEdge}
-                                                onDragHandleMouseDown={commonTileProps.onDragHandleMouseDown}
-                                            />
-                                        )
-                                    }
-
-                                    if (button_tile) {
-                                        return (
-                                            <MemoizedDashboardButtonTileItem
-                                                key={tile.id}
-                                                tile={tile}
-                                                placement={placement}
-                                                dashboardId={dashboard?.id}
-                                                isDraggingRef={isDragging}
-                                                onEdit={() => {
-                                                    if (dashboard?.id) {
-                                                        push(urls.dashboardButtonTile(dashboard.id, tile.id))
-                                                    }
-                                                }}
-                                                onMoveToDashboard={commonTileProps.moveToDashboard}
-                                                onDuplicate={() => duplicateTile(tile)}
-                                                onRemove={commonTileProps.removeFromDashboard}
-                                                showResizeHandles={commonTileProps.showResizeHandles}
-                                                showEditingControls={commonTileProps.showEditingControls}
-                                                canEnterEditModeFromEdge={commonTileProps.canEnterEditModeFromEdge}
-                                                onEnterEditModeFromEdge={commonTileProps.onEnterEditModeFromEdge}
-                                                onDragHandleMouseDown={commonTileProps.onDragHandleMouseDown}
-                                            />
-                                        )
-                                    }
-
-                                    if (
-                                        widget &&
-                                        dashboardWidgetsEnabled &&
-                                        isWidgetTileVisibleOnPlacement(placement)
-                                    ) {
-                                        const runResult = widgetResultsByTileId[tile.id]
-                                        const refreshState = widgetRefreshStatus[tile.id]
-
-                                        return (
-                                            <MemoizedDashboardWidgetItem
-                                                key={tile.id}
-                                                tile={tile}
-                                                placement={placement}
-                                                dashboardId={dashboard?.id}
+                                    overlay={
+                                        isEditablePlacement && inlineTileInsertionEnabled ? (
+                                            <InsertTileOverlay
+                                                layout={displayLayouts.sm}
+                                                gridWidth={gridWidth}
+                                                cols={BREAKPOINT_COLUMN_COUNTS.sm}
+                                                rowHeight={rowHeight}
+                                                marginX={margin[0]}
+                                                marginY={margin[1]}
                                                 canEditDashboard={canEditDashboard}
-                                                isDashboardEditMode={dashboardMode === DashboardMode.Edit}
-                                                result={runResult?.result}
-                                                error={getDashboardWidgetFetchDisplayError(
-                                                    runResult?.error ?? refreshState?.error
-                                                )}
-                                                loading={!!refreshState?.loading}
-                                                lastFetchedAt={refreshState?.fetchedAt}
-                                                onRefresh={() =>
-                                                    refreshDashboardWidgets({ tileIds: [tile.id], forceRefresh: true })
-                                                }
-                                                onRefreshWidgetData={scheduleRefreshDashboardWidgets}
-                                                onApplyWidgetIssueMetadataChange={(tileId, issueId, delta, context) => {
-                                                    applyWidgetIssueMetadataChange({
+                                                isMobileView={isMobileView}
+                                                disabled={resizingTileId !== null}
+                                                getMenuItems={(x, y, w) => getInsertMenuItems(section.key, x, y, w)}
+                                            />
+                                        ) : null
+                                    }
+                                    gridBackgroundProps={
+                                        layoutEditMode && !isMobileView
+                                            ? {
+                                                  width: gridWidth,
+                                                  cols: BREAKPOINT_COLUMN_COUNTS.sm,
+                                                  rowHeight,
+                                                  margin,
+                                                  containerPadding: CONTAINER_PADDING,
+                                                  rows: 'auto',
+                                                  height: containerHeight,
+                                                  color: 'var(--color-bg-surface-secondary)',
+                                              }
+                                            : null
+                                    }
+                                    gridProps={{
+                                        width: gridWidth,
+                                        className,
+                                        dragConfig,
+                                        resizeConfig,
+                                        layouts: displayLayouts as Partial<Record<DashboardLayoutSize, Layout>>,
+                                        rowHeight,
+                                        margin,
+                                        containerPadding: CONTAINER_PADDING,
+                                        onLayoutChange: handleLayoutChange,
+                                        onWidthChange: handleWidthChange,
+                                        breakpoints: BREAKPOINTS,
+                                        cols: BREAKPOINT_COLUMN_COUNTS,
+                                        onResizeStart: handleResizeStart,
+                                        onResize: handleResize,
+                                        onResizeStop: handleResizeStop,
+                                        onDragStart: handleDragStart,
+                                        onDrag: handleDrag,
+                                        onDragStop: handleDragStop,
+                                    }}
+                                >
+                                    {section.tiles.map((tile) => {
+                                        const { insight, text, button_tile, widget } = tile
+                                        const smLayout = displayLayouts['sm']?.find((l) => {
+                                            return l.i == tile.id.toString()
+                                        })
+
+                                        const commonTileProps = {
+                                            dashboardId: dashboard?.id,
+                                            showResizeHandles,
+                                            canEnterEditModeFromEdge,
+                                            onEnterEditModeFromEdge,
+                                            onDragHandleMouseDown,
+                                            showEditingControls,
+                                            moveToDashboard: ({ id, name }: Pick<DashboardType, 'id' | 'name'>) => {
+                                                moveToDashboard(tile, requireDashboardId('move this tile'), id, name)
+                                            },
+                                            copyToDashboard: ({ id, name }: Pick<DashboardType, 'id' | 'name'>) => {
+                                                copyToDashboard(tile, requireDashboardId('copy this tile'), id, name)
+                                            },
+                                            removeFromDashboard: () => removeTile(tile),
+                                        }
+
+                                        if (tile.error && !insight) {
+                                            return (
+                                                <MemoizedDashboardErrorTileItem
+                                                    key={tile.id}
+                                                    tile={tile}
+                                                    onRemove={commonTileProps.removeFromDashboard}
+                                                    showResizeHandles={showResizeHandles}
+                                                    canEnterEditModeFromEdge={canEnterEditModeFromEdge}
+                                                    onEnterEditModeFromEdge={onEnterEditModeFromEdge}
+                                                    onDragHandleMouseDown={onDragHandleMouseDown}
+                                                    showEditingControls={showEditingControls}
+                                                />
+                                            )
+                                        }
+
+                                        if (insight) {
+                                            // Check if this insight has an error from the server
+                                            const isErrorTile = !!tile.error
+                                            const queryError = getInsightQueryError(insight)
+                                            const apiErrored =
+                                                isErrorTile ||
+                                                !!queryError ||
+                                                refreshStatus[insight.short_id]?.errored ||
+                                                false
+                                            const refreshError = refreshStatus[insight.short_id]?.error
+                                            const apiError = isErrorTile
+                                                ? new ApiError(undefined, 500, undefined, {
+                                                      detail: tile.error!.message,
+                                                      code: 'dashboard_tile_error',
+                                                  })
+                                                : refreshError || queryError || undefined
+                                            const loadingQueued = isErrorTile
+                                                ? false
+                                                : isRefreshingQueued(insight.short_id)
+                                            const loading = isErrorTile ? false : isRefreshing(insight.short_id)
+
+                                            return (
+                                                <MemoizedInsightCard
+                                                    key={tile.id}
+                                                    tile={tile}
+                                                    insight={insight}
+                                                    loadingQueued={loadingQueued}
+                                                    loading={loading}
+                                                    apiErrored={apiErrored}
+                                                    apiError={apiError}
+                                                    highlighted={
+                                                        highlightedInsightId &&
+                                                        insight.short_id === highlightedInsightId
+                                                    }
+                                                    updateColor={(color) => updateTileColor(tile.id, color)}
+                                                    toggleShowDescription={() => toggleTileDescription(tile.id)}
+                                                    ribbonColor={tile.color}
+                                                    refresh={() => refreshDashboardItem({ tile })}
+                                                    rename={() => renameInsight(insight)}
+                                                    duplicate={() => duplicateTile(tile)}
+                                                    setOverride={() => setTileOverride(tile)}
+                                                    showDetailsControls={showDetailsControls}
+                                                    placement={placement}
+                                                    loadPriority={
+                                                        smLayout
+                                                            ? sectionIndex * 100_000 + smLayout.y * 1000 + smLayout.x
+                                                            : undefined
+                                                    }
+                                                    isResizing={resizingTileId === tile.id.toString()}
+                                                    filtersOverride={effectiveEditBarFilters}
+                                                    variablesOverride={effectiveDashboardVariableOverrides}
+                                                    // :HACKY: The two props below aren't actually used in the component, but are needed to trigger a re-render
+                                                    breakdownColorOverride={effectiveBreakdownColors}
+                                                    dataColorThemeId={dataColorThemeId}
+                                                    surveyOpportunity={tile.id === bestSurveyOpportunityFunnel?.id}
+                                                    showCreateAnomalyAlertButton={showCreateAnomalyAlertButton}
+                                                    {...commonTileProps}
+                                                />
+                                            )
+                                        }
+
+                                        if (text) {
+                                            return (
+                                                <MemoizedDashboardTextItem
+                                                    key={tile.id}
+                                                    tile={tile}
+                                                    placement={placement}
+                                                    dashboardId={dashboard?.id}
+                                                    onEdit={() => {
+                                                        if (dashboard?.id) {
+                                                            push(urls.dashboardTextTile(dashboard.id, tile.id))
+                                                        }
+                                                    }}
+                                                    onMoveToDashboard={commonTileProps.moveToDashboard}
+                                                    onCopyToDashboard={commonTileProps.copyToDashboard}
+                                                    onDuplicate={() => duplicateTile(tile)}
+                                                    onRemove={commonTileProps.removeFromDashboard}
+                                                    showResizeHandles={commonTileProps.showResizeHandles}
+                                                    showEditingControls={commonTileProps.showEditingControls}
+                                                    canEnterEditModeFromEdge={commonTileProps.canEnterEditModeFromEdge}
+                                                    onEnterEditModeFromEdge={commonTileProps.onEnterEditModeFromEdge}
+                                                    onDragHandleMouseDown={commonTileProps.onDragHandleMouseDown}
+                                                />
+                                            )
+                                        }
+
+                                        if (button_tile) {
+                                            return (
+                                                <MemoizedDashboardButtonTileItem
+                                                    key={tile.id}
+                                                    tile={tile}
+                                                    placement={placement}
+                                                    dashboardId={dashboard?.id}
+                                                    isDraggingRef={isDragging}
+                                                    onEdit={() => {
+                                                        if (dashboard?.id) {
+                                                            push(urls.dashboardButtonTile(dashboard.id, tile.id))
+                                                        }
+                                                    }}
+                                                    onMoveToDashboard={commonTileProps.moveToDashboard}
+                                                    onDuplicate={() => duplicateTile(tile)}
+                                                    onRemove={commonTileProps.removeFromDashboard}
+                                                    showResizeHandles={commonTileProps.showResizeHandles}
+                                                    showEditingControls={commonTileProps.showEditingControls}
+                                                    canEnterEditModeFromEdge={commonTileProps.canEnterEditModeFromEdge}
+                                                    onEnterEditModeFromEdge={commonTileProps.onEnterEditModeFromEdge}
+                                                    onDragHandleMouseDown={commonTileProps.onDragHandleMouseDown}
+                                                />
+                                            )
+                                        }
+
+                                        if (
+                                            widget &&
+                                            dashboardWidgetsEnabled &&
+                                            isWidgetTileVisibleOnPlacement(placement)
+                                        ) {
+                                            const runResult = widgetResultsByTileId[tile.id]
+                                            const refreshState = widgetRefreshStatus[tile.id]
+
+                                            return (
+                                                <MemoizedDashboardWidgetItem
+                                                    key={tile.id}
+                                                    tile={tile}
+                                                    placement={placement}
+                                                    dashboardId={dashboard?.id}
+                                                    canEditDashboard={canEditDashboard}
+                                                    isDashboardEditMode={dashboardMode === DashboardMode.Edit}
+                                                    result={runResult?.result}
+                                                    error={getDashboardWidgetFetchDisplayError(
+                                                        runResult?.error ?? refreshState?.error
+                                                    )}
+                                                    loading={!!refreshState?.loading}
+                                                    lastFetchedAt={refreshState?.fetchedAt}
+                                                    onRefresh={() =>
+                                                        refreshDashboardWidgets({
+                                                            tileIds: [tile.id],
+                                                            forceRefresh: true,
+                                                        })
+                                                    }
+                                                    onRefreshWidgetData={scheduleRefreshDashboardWidgets}
+                                                    onApplyWidgetIssueMetadataChange={(
                                                         tileId,
                                                         issueId,
                                                         delta,
-                                                        context,
-                                                    })
-                                                }}
-                                                onUpdateWidgetTile={async (patch) => {
-                                                    await updateWidgetTile({ tile, ...patch })
-                                                }}
-                                                toggleShowDescription={() => toggleTileDescription(tile.id)}
-                                                onDuplicate={() => duplicateTile(tile)}
-                                                onRemove={commonTileProps.removeFromDashboard}
-                                                onMoveToDashboard={commonTileProps.moveToDashboard}
-                                                onCopyToDashboard={commonTileProps.copyToDashboard}
-                                                showResizeHandles={commonTileProps.showResizeHandles}
-                                                showEditingControls={commonTileProps.showEditingControls}
-                                                canEnterEditModeFromEdge={commonTileProps.canEnterEditModeFromEdge}
-                                                onEnterEditModeFromEdge={commonTileProps.onEnterEditModeFromEdge}
-                                                onDragHandleMouseDown={commonTileProps.onDragHandleMouseDown}
-                                            />
-                                        )
-                                    }
-                                })}
-                            </DashboardSection>
+                                                        context
+                                                    ) => {
+                                                        applyWidgetIssueMetadataChange({
+                                                            tileId,
+                                                            issueId,
+                                                            delta,
+                                                            context,
+                                                        })
+                                                    }}
+                                                    onUpdateWidgetTile={async (patch) => {
+                                                        await updateWidgetTile({ tile, ...patch })
+                                                    }}
+                                                    toggleShowDescription={() => toggleTileDescription(tile.id)}
+                                                    onDuplicate={() => duplicateTile(tile)}
+                                                    onRemove={commonTileProps.removeFromDashboard}
+                                                    onMoveToDashboard={commonTileProps.moveToDashboard}
+                                                    onCopyToDashboard={commonTileProps.copyToDashboard}
+                                                    showResizeHandles={commonTileProps.showResizeHandles}
+                                                    showEditingControls={commonTileProps.showEditingControls}
+                                                    canEnterEditModeFromEdge={commonTileProps.canEnterEditModeFromEdge}
+                                                    onEnterEditModeFromEdge={commonTileProps.onEnterEditModeFromEdge}
+                                                    onDragHandleMouseDown={commonTileProps.onDragHandleMouseDown}
+                                                />
+                                            )
+                                        }
+                                    })}
+                                </DashboardSection>
+                                {sectionIndex === renderedSections.length - 1 &&
+                                    crossSectionDrag.dropTarget?.type === 'gap' &&
+                                    crossSectionDrag.dropTarget.position === renderedSections.length && (
+                                        <div className="h-0.5 bg-accent my-3" />
+                                    )}
+                            </Fragment>
                         )
                     })}
                 </div>

--- a/frontend/src/scenes/dashboard/DashboardSection.tsx
+++ b/frontend/src/scenes/dashboard/DashboardSection.tsx
@@ -19,6 +19,8 @@ interface DashboardSectionProps {
     onDelete: (memberHandling: 'delete_tiles' | 'ungroup') => void
     tileCount: number
     sectionCount: number
+    sectionRef: (element: HTMLElement | null) => void
+    highlighted: boolean
     overlay: ReactNode
 }
 
@@ -35,16 +37,20 @@ export function DashboardSection({
     onDelete,
     tileCount,
     sectionCount,
+    sectionRef,
+    highlighted,
     overlay,
 }: DashboardSectionProps): JSX.Element {
+    let sectionClassName = 'relative mb-4'
+    if (group) {
+        sectionClassName += " rounded border bg-surface-tertiary [[theme='dark']_&]:bg-surface-secondary border-primary"
+    }
+    if (highlighted) {
+        sectionClassName += ' border-accent bg-accent-highlight-secondary'
+    }
+
     return (
-        <section
-            className={
-                group
-                    ? "relative mb-4 rounded border border-primary bg-surface-tertiary [[theme='dark']_&]:bg-surface-secondary"
-                    : 'relative mb-4'
-            }
-        >
+        <section ref={sectionRef} className={sectionClassName}>
             {group && (
                 <DashboardSectionHeader
                     group={group}

--- a/frontend/src/scenes/dashboard/DashboardSectionHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardSectionHeader.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { IconChevronRight, IconEllipsis } from '@posthog/icons'
 import type { DashboardGroupApi } from '@posthog/products-dashboards/frontend/generated/api.schemas'
@@ -32,6 +32,37 @@ export function DashboardSectionHeader({
 }: DashboardSectionHeaderProps): JSX.Element {
     const [editing, setEditing] = useState(false)
     const [name, setName] = useState(group.name ?? '')
+    const dragStart = useRef<{ pointerId: number; y: number; headerHeight: number } | null>(null)
+    const [dragOffset, setDragOffset] = useState<number | null>(null)
+
+    useEffect(() => {
+        const handlePointerMove = (event: PointerEvent): void => {
+            if (!dragStart.current || event.pointerId !== dragStart.current.pointerId) {
+                return
+            }
+            setDragOffset(event.clientY - dragStart.current.y)
+        }
+        const handlePointerUp = (event: PointerEvent): void => {
+            if (!dragStart.current || event.pointerId !== dragStart.current.pointerId) {
+                return
+            }
+            const offset = event.clientY - dragStart.current.y
+            const positionDelta = Math.round(offset / dragStart.current.headerHeight)
+            if (positionDelta !== 0) {
+                onMove(Math.max(0, Math.min(sectionCount - 1, group.position + positionDelta)))
+            }
+            dragStart.current = null
+            setDragOffset(null)
+        }
+        window.addEventListener('pointermove', handlePointerMove)
+        window.addEventListener('pointerup', handlePointerUp)
+        window.addEventListener('pointercancel', handlePointerUp)
+        return () => {
+            window.removeEventListener('pointermove', handlePointerMove)
+            window.removeEventListener('pointerup', handlePointerUp)
+            window.removeEventListener('pointercancel', handlePointerUp)
+        }
+    }, [group.position, onMove, sectionCount])
 
     const submitRename = (): void => {
         const trimmedName = name.trim()
@@ -42,7 +73,19 @@ export function DashboardSectionHeader({
     }
 
     return (
-        <div className="flex items-center gap-2 px-3 py-2 drag-handle">
+        <div
+            className="flex items-center gap-2 px-3 py-2 cursor-grab"
+            onPointerDown={(event) => {
+                if ((event.target as Element).closest('button,input')) {
+                    return
+                }
+                dragStart.current = {
+                    pointerId: event.pointerId,
+                    y: event.clientY,
+                    headerHeight: event.currentTarget.getBoundingClientRect().height,
+                }
+            }}
+        >
             <LemonButton
                 icon={<IconChevronRight className={collapsed ? '' : 'rotate-90'} />}
                 size="small"
@@ -105,6 +148,20 @@ export function DashboardSectionHeader({
                     <LemonButton icon={<IconEllipsis />} size="small" data-attr="dashboard-section-menu" />
                 </LemonMenu>
             </div>
+            {dragOffset !== null && Math.abs(dragOffset) > 4 && (
+                <>
+                    <div
+                        className="fixed left-4 right-4 z-[var(--z-modal)] h-0.5 bg-accent pointer-events-none"
+                        style={{ top: group.position * 40 + dragOffset }}
+                    />
+                    <div
+                        className="fixed z-[var(--z-modal)] rounded border border-accent bg-surface-primary px-3 py-2 shadow pointer-events-none"
+                        style={{ left: 24, top: dragStart.current!.y + dragOffset }}
+                    >
+                        {group.name}
+                    </div>
+                </>
+            )}
         </div>
     )
 }

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -716,7 +716,8 @@ export interface dashboardLogicActions {
         action: DashboardLoadAction
     }
     moveDashboardTileToGroup: (payload: {
-        groupId: string
+        createAtPosition?: number
+        groupId?: string
         layouts: {
             sm: {
                 h: number
@@ -727,7 +728,8 @@ export interface dashboardLogicActions {
         }
         tileId: number
     }) => {
-        groupId: string
+        createAtPosition?: number | undefined
+        groupId?: string | undefined
         layouts: {
             sm: {
                 h: number
@@ -1479,8 +1481,15 @@ export const dashboardLogic = kea<dashboardLogicType>([
         toggleDashboardSectionCollapsed: (groupId: string) => ({ groupId }),
         moveDashboardTileToGroup: (payload: {
             tileId: number
-            groupId: string
+            groupId?: string
+            createAtPosition?: number
             layouts: { sm: { x: number; y: number; w: number; h: number } }
+        }) => payload,
+        reconcileDashboardTileGroupMove: (payload: {
+            tile: DashboardTile
+            optimisticGroupId?: string
+            createdGroup: DashboardGroupApi | null
+            deletedGroupIds: string[]
         }) => payload,
         renameDashboardGroup: (groupId: string, name: string) => ({ groupId, name }),
         updateDashboardGroupPosition: (groupId: string, position: number) => ({ groupId, position }),
@@ -2160,6 +2169,103 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         tile.id === tileId ? { ...tile, parent_group_id: groupId } : tile
                     ),
                 }),
+                moveDashboardTileToGroup: (state, { tileId, groupId, createAtPosition, layouts }) => {
+                    if (!state) {
+                        return state
+                    }
+                    const optimisticGroupId = groupId ?? `optimistic-section-${tileId}`
+                    let groups = state.groups ?? []
+                    if (!groupId) {
+                        const position = createAtPosition ?? groups.length
+                        groups = [
+                            ...groups.map((group) => ({
+                                ...group,
+                                position: group.position >= position ? group.position + 1 : group.position,
+                            })),
+                            {
+                                id: optimisticGroupId,
+                                name: null,
+                                position,
+                                member_tile_ids: [tileId],
+                                created_at: '',
+                                created_by: null,
+                                last_modified_at: '',
+                                last_modified_by: null,
+                            },
+                        ].sort((a, b) => a.position - b.position)
+                    }
+                    return {
+                        ...state,
+                        groups,
+                        tiles: state.tiles.map((tile) =>
+                            tile.id === tileId
+                                ? { ...tile, parent_group_id: optimisticGroupId, layouts: { sm: layouts.sm } }
+                                : tile
+                        ),
+                    }
+                },
+                reconcileDashboardTileGroupMove: (
+                    state,
+                    { tile, optimisticGroupId, createdGroup, deletedGroupIds }
+                ) => {
+                    if (!state) {
+                        return state
+                    }
+                    const removedGroupIds = new Set(deletedGroupIds)
+                    let groups = (state.groups ?? []).filter(
+                        (group) => group.id !== optimisticGroupId && !removedGroupIds.has(group.id)
+                    )
+                    if (createdGroup) {
+                        groups = [...groups, createdGroup].sort((a, b) => a.position - b.position)
+                    }
+                    return {
+                        ...state,
+                        groups,
+                        tiles: state.tiles.map((currentTile) => (currentTile.id === tile.id ? tile : currentTile)),
+                    }
+                },
+                renameDashboardGroup: (state, { groupId, name }) =>
+                    state
+                        ? {
+                              ...state,
+                              groups: state.groups?.map((group) => (group.id === groupId ? { ...group, name } : group)),
+                          }
+                        : state,
+                updateDashboardGroupPosition: (state, { groupId, position }) => {
+                    if (!state?.groups) {
+                        return state
+                    }
+                    const movedGroup = state.groups.find((group) => group.id === groupId)
+                    if (!movedGroup) {
+                        return state
+                    }
+                    const groups = state.groups.filter((group) => group.id !== groupId)
+                    groups.splice(Math.max(0, Math.min(position, groups.length)), 0, movedGroup)
+                    return {
+                        ...state,
+                        groups: groups.map((group, nextPosition) => ({ ...group, position: nextPosition })),
+                    }
+                },
+                deleteDashboardGroup: (state, { groupId, memberHandling }) => {
+                    if (!state) {
+                        return state
+                    }
+                    if (memberHandling === 'ungroup') {
+                        return {
+                            ...state,
+                            groups: state.groups?.map((group) =>
+                                group.id === groupId ? { ...group, name: null } : group
+                            ),
+                        }
+                    }
+                    return {
+                        ...state,
+                        groups: state.groups
+                            ?.filter((group) => group.id !== groupId)
+                            .map((group, position) => ({ ...group, position })),
+                        tiles: state.tiles.filter((tile) => tile.parent_group_id !== groupId),
+                    }
+                },
                 removeTile: (state, { tile }) => {
                     // Optimistically drop the tile so the grid reflows immediately; the loader rolls back on failure.
                     return {
@@ -3488,14 +3594,20 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 actions.createDashboardGroupFinished()
             }
         },
-        moveDashboardTileToGroup: async ({ tileId, groupId, layouts }) => {
+        moveDashboardTileToGroup: async ({ tileId, groupId, createAtPosition, layouts }) => {
             try {
-                await dashboardsGroupsMoveTileCreate(String(values.currentTeamId), props.id, {
+                const destination = groupId ? { group_id: groupId } : { create_at_position: createAtPosition }
+                const response = await dashboardsGroupsMoveTileCreate(String(values.currentTeamId), props.id, {
                     tile_id: tileId,
-                    group_id: groupId,
+                    ...destination,
                     layouts,
                 })
-                actions.loadDashboard({ action: DashboardLoadAction.Update })
+                actions.reconcileDashboardTileGroupMove({
+                    tile: response.tile as DashboardTile,
+                    optimisticGroupId: groupId ? undefined : `optimistic-section-${tileId}`,
+                    createdGroup: response.created_group,
+                    deletedGroupIds: response.deleted_group_ids,
+                })
             } catch {
                 actions.loadDashboard({ action: DashboardLoadAction.Update })
                 lemonToast.error('Could not move tile. Try again.')
@@ -3507,7 +3619,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     group_id: groupId,
                     name,
                 })
-                actions.loadDashboard({ action: DashboardLoadAction.Update })
             } catch {
                 actions.loadDashboard({ action: DashboardLoadAction.Update })
                 lemonToast.error('Could not rename group. Try again.')
@@ -3519,7 +3630,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     group_id: groupId,
                     position,
                 })
-                actions.loadDashboard({ action: DashboardLoadAction.Update })
             } catch {
                 actions.loadDashboard({ action: DashboardLoadAction.Update })
                 lemonToast.error('Could not move section. Try again.')
@@ -3531,7 +3641,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     group_id: groupId,
                     member_handling: memberHandling,
                 })
-                actions.loadDashboard({ action: DashboardLoadAction.Update })
             } catch {
                 actions.loadDashboard({ action: DashboardLoadAction.Update })
                 lemonToast.error('Could not delete group. Try again.')

--- a/frontend/src/scenes/dashboard/useCrossSectionDrag.ts
+++ b/frontend/src/scenes/dashboard/useCrossSectionDrag.ts
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import type { DashboardSection } from './dashboardLogic'
+
+export type DashboardDropTarget = { type: 'section'; sectionKey: string } | { type: 'gap'; position: number } | null
+
+interface UseCrossSectionDragProps {
+    sections: DashboardSection[]
+    disabled: boolean
+    onDrop: (tileId: number, target: Exclude<DashboardDropTarget, null>, event: MouseEvent) => void
+}
+
+export function useCrossSectionDrag({ sections, disabled, onDrop }: UseCrossSectionDragProps): {
+    registerSection: (sectionKey: string, element: HTMLElement | null) => void
+    dropTarget: DashboardDropTarget
+    startDrag: (tileId: number, sectionKey: string) => void
+    updateDrag: (event: MouseEvent) => void
+    finishDrag: (event: MouseEvent) => boolean
+} {
+    const sectionElements = useRef(new Map<string, HTMLElement>())
+    const sectionRects = useRef(new Map<string, DOMRect>())
+    const draggedTile = useRef<{ tileId: number; sectionKey: string } | null>(null)
+    const frame = useRef<number | null>(null)
+    const latestEvent = useRef<MouseEvent | null>(null)
+    const currentTarget = useRef<DashboardDropTarget>(null)
+    const [dropTarget, setDropTarget] = useState<DashboardDropTarget>(null)
+
+    const measure = useCallback((): void => {
+        sectionRects.current = new Map(
+            [...sectionElements.current].map(([sectionKey, element]) => [sectionKey, element.getBoundingClientRect()])
+        )
+    }, [])
+
+    useEffect(() => {
+        if (!draggedTile.current) {
+            return
+        }
+        window.addEventListener('scroll', measure, true)
+        return () => window.removeEventListener('scroll', measure, true)
+    }, [dropTarget, measure])
+
+    const registerSection = useCallback((sectionKey: string, element: HTMLElement | null): void => {
+        if (element) {
+            sectionElements.current.set(sectionKey, element)
+        } else {
+            sectionElements.current.delete(sectionKey)
+        }
+    }, [])
+
+    const startDrag = useCallback(
+        (tileId: number, sectionKey: string): void => {
+            if (disabled) {
+                return
+            }
+            draggedTile.current = { tileId, sectionKey }
+            measure()
+        },
+        [disabled, measure]
+    )
+
+    const resolveTarget = useCallback(
+        (event: MouseEvent): DashboardDropTarget => {
+            const orderedRects = sections
+                .map((section, position) => ({ section, position, rect: sectionRects.current.get(section.key) }))
+                .filter((entry): entry is typeof entry & { rect: DOMRect } => !!entry.rect)
+            for (const { section, rect } of orderedRects) {
+                if (event.clientY >= rect.top && event.clientY <= rect.bottom) {
+                    return { type: 'section', sectionKey: section.key }
+                }
+            }
+            for (let position = 0; position <= orderedRects.length; position++) {
+                const before = orderedRects[position - 1]?.rect.bottom ?? Number.NEGATIVE_INFINITY
+                const after = orderedRects[position]?.rect.top ?? Number.POSITIVE_INFINITY
+                if (event.clientY > before && event.clientY < after) {
+                    return { type: 'gap', position }
+                }
+            }
+            return null
+        },
+        [sections]
+    )
+
+    const updateDrag = useCallback(
+        (event: MouseEvent): void => {
+            if (!draggedTile.current) {
+                return
+            }
+            latestEvent.current = event
+            if (frame.current !== null) {
+                return
+            }
+            frame.current = requestAnimationFrame(() => {
+                frame.current = null
+                const nextTarget = latestEvent.current ? resolveTarget(latestEvent.current) : null
+                currentTarget.current = nextTarget
+                setDropTarget(nextTarget)
+            })
+        },
+        [resolveTarget]
+    )
+
+    const finishDrag = useCallback(
+        (event: MouseEvent): boolean => {
+            const dragged = draggedTile.current
+            const target = currentTarget.current
+            draggedTile.current = null
+            currentTarget.current = null
+            setDropTarget(null)
+            if (!dragged || !target) {
+                return false
+            }
+            if (target.type === 'section' && target.sectionKey === dragged.sectionKey) {
+                return false
+            }
+            onDrop(dragged.tileId, target, event)
+            return true
+        },
+        [onDrop]
+    )
+
+    return { registerSection, dropTarget, startDrag, updateDrag, finishDrag }
+}


### PR DESCRIPTION
## Problem

- Users cannot drag tiles between independent section grids because react-grid-layout does not support cross-grid pointer drags.

## Changes

```mermaid
flowchart LR
    A[Pointer drag] --> B{Hit target}
    B -->|Section band| C[Move to section]
    B -->|Gap| D[Create anonymous section]
```

- Tracks section rectangles during tile drags.
- Highlights section targets and renders gap indicators.
- Drops onto expanded, anonymous, or collapsed sections.
- Keeps Move up and Move down as the section reorder fallback.

## How did you test this code?

- Dashboard component, logic, and tile layout suites pass.
- Type checking reports only pre-existing failures outside dashboards.
- Live drag verification was blocked because the local backend health endpoint returned `503`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No published dashboard-group documentation exists to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex used `/writing-ui-components`, `/writing-kea-logics`, `/writing-user-facing-copy`, `/writing-tests`, `/playwright-test`, `/run-posthog`, `/writing-pr-descriptions`, and `/stacking-prs`.
- Pointer tracking stays at the dashboard layer because the grid library exposes no cross-grid drag system.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
