### PR TITLE
fix(admin): hide password hash and reset link in user admin

### DIFF
--- a/posthog/admin/admins/user_admin.py
+++ b/posthog/admin/admins/user_admin.py
@@ -47,17 +47,6 @@ class UserChangeForm(DjangoUserChangeForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["password"].widget = ReadOnlyPasswordHashWidget()
-        # This is a riff on https://github.com/django/django/blob/stable/4.1.x/django/contrib/auth/forms.py#L151-L153.
-        # The difference from the Django default is that instead of a form where the _admin_ sets the new password,
-        # we have a link to the password reset page which the _user_ can use themselves.
-        # This way if some user needs to reset their password and there's a problem with receiving the reset link email,
-        # an admin can provide that reset link manually – much better than sending a new password in plain text.
-        password_reset_token = password_reset_token_generator.make_token(self.instance)
-        self.fields["password"].help_text = (
-            "Raw passwords are not stored, so there is no way to see this user's password, but you can send them "
-            f'<a target="_blank" href="/reset/{self.instance.uuid}/{password_reset_token}">this password reset link</a> '
-            "(it only works when logged out)."
-        )
 
     def clean_is_staff(self):
         is_staff = bool(self.cleaned_data.get("is_staff", False))

--- a/posthog/admin/admins/user_admin.py
+++ b/posthog/admin/admins/user_admin.py
@@ -1,13 +1,20 @@
 import datetime
+from typing import Any
 
 from django.contrib import admin, messages
 from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
-from django.contrib.auth.forms import UserChangeForm as DjangoUserChangeForm
+from django.contrib.auth.forms import (
+    ReadOnlyPasswordHashWidget as DjangoReadOnlyPasswordHashWidget,
+    UserChangeForm as DjangoUserChangeForm,
+)
 from django.core.exceptions import ValidationError
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.html import format_html
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import (
+    gettext,
+    gettext_lazy as _,
+)
 
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
@@ -24,10 +31,22 @@ from posthog.models.webauthn_credential import WebauthnCredential
 from posthog.session.activity import revoke_other_sessions
 from posthog.tasks.email import send_password_reset, send_two_factor_reset_email
 
+# Django's default widget masks salt/hash but still shows their first few characters; keep those out of the admin entirely.
+_HIDDEN_SUMMARY_LABELS = {"salt", "hash", "checksum"}
+
+
+class ReadOnlyPasswordHashWidget(DjangoReadOnlyPasswordHashWidget):
+    def get_context(self, name: str, value: str | None, attrs: dict[str, Any] | None) -> dict[str, Any]:
+        context = super().get_context(name, value, attrs)
+        hidden_labels = {gettext(label) for label in _HIDDEN_SUMMARY_LABELS}
+        context["summary"] = [entry for entry in context["summary"] if entry["label"] not in hidden_labels]
+        return context
+
 
 class UserChangeForm(DjangoUserChangeForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.fields["password"].widget = ReadOnlyPasswordHashWidget()
         # This is a riff on https://github.com/django/django/blob/stable/4.1.x/django/contrib/auth/forms.py#L151-L153.
         # The difference from the Django default is that instead of a form where the _admin_ sets the new password,
         # we have a link to the password reset page which the _user_ can use themselves.

--- a/posthog/admin/test_user_admin.py
+++ b/posthog/admin/test_user_admin.py
@@ -11,7 +11,7 @@ from django.contrib.messages.storage.fallback import FallbackStorage
 from django.test import RequestFactory
 from django.urls import reverse
 
-from posthog.admin.admins.user_admin import UserAdmin
+from posthog.admin.admins.user_admin import UserAdmin, UserChangeForm
 from posthog.models import User
 from posthog.session.models import Session
 
@@ -85,3 +85,17 @@ class TestUserAdminPasswordReset(BaseTest):
         # A usable reset token must be forwarded — an empty/None token would email a dead link.
         self.assertIsInstance(token, str)
         self.assertTrue(token)
+
+
+class TestUserChangeFormPasswordField(BaseTest):
+    def test_password_field_omits_salt_and_hash(self):
+        # Guards against the partial (masked) hash material Django's default widget shows reappearing.
+        user = User.objects.create(email=f"test-{uuid.uuid4()}@example.com", distinct_id=str(uuid.uuid4()))
+        user.set_password("a-strong-password-123")
+        user.save()
+
+        rendered = str(UserChangeForm(instance=user)["password"])
+
+        self.assertIn("algorithm", rendered)
+        self.assertNotIn("salt", rendered)
+        self.assertNotIn("hash", rendered)

--- a/posthog/admin/test_user_admin.py
+++ b/posthog/admin/test_user_admin.py
@@ -91,6 +91,7 @@ class TestUserChangeFormPasswordField(BaseTest):
     def test_password_field_omits_salt_and_hash(self):
         # Guards against the partial (masked) hash material Django's default widget shows reappearing.
         user = User.objects.create(email=f"test-{uuid.uuid4()}@example.com", distinct_id=str(uuid.uuid4()))
+        # nosemgrep: python.django.security.audit.unvalidated-password.unvalidated-password (test fixture, not a user-facing password-set path)
         user.set_password("a-strong-password-123")
         user.save()
 

--- a/posthog/admin/test_user_admin.py
+++ b/posthog/admin/test_user_admin.py
@@ -99,3 +99,13 @@ class TestUserChangeFormPasswordField(BaseTest):
         self.assertIn("algorithm", rendered)
         self.assertNotIn("salt", rendered)
         self.assertNotIn("hash", rendered)
+
+    def test_password_field_help_text_omits_reset_link(self):
+        # A raw reset link/token in the help text would let a staff member reset the user's
+        # password themselves; the "Reset password" button emails it to the user instead.
+        user = User.objects.create(email=f"test-{uuid.uuid4()}@example.com", distinct_id=str(uuid.uuid4()))
+
+        help_text = UserChangeForm(instance=user).fields["password"].help_text
+
+        self.assertNotIn("/reset/", help_text)
+        self.assertNotIn("href", help_text)


### PR DESCRIPTION
## Problem

The Django admin user change page showed partial password hash material (masked salt and hash) and a live, clickable password-reset link with a valid token, both visible to any staff member who opened the page.

## Changes

- Drop the salt/hash/checksum rows from the password field summary; only algorithm and cost parameters (e.g. iterations) remain.
- Remove the help text that embedded a raw reset link/token. Password reset now only happens through the existing "Reset password" button, which emails the link to the user instead of showing it on the page.

## How did you test this code?

- Added `TestUserChangeFormPasswordField` with two cases, each written to fail before the fix and pass after:
  - `test_password_field_omits_salt_and_hash` — confirmed it showed `salt: vu***`/`hash: d616ed***` before the widget change.
  - `test_password_field_help_text_omits_reset_link` — confirmed it showed a `/reset/<uuid>/<token>` URL before the help text was removed.
- Ran `ruff check`/`ruff format` and `mypy` on the changed files; no new errors.
- Not run: manual click-through of the admin page in a browser.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no documented behavior changed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Invoked `/writing-tests` before adding the test cases, `/writing-code-comments` before writing the comments in the widget, and `/writing-pr-descriptions` for this body.
