### PR TITLE
chore(personhog): stop the traffic bed deleting rows from Postgres

### DIFF
--- a/rust/personhog-test-harness/src/scenarios/traffic.rs
+++ b/rust/personhog-test-harness/src/scenarios/traffic.rs
@@ -17,10 +17,13 @@
 //! expected behavior legitimately differs across stack versions as
 //! admission hardening lands.
 //!
-//! Every database operation — seeding, verification, cleanup — touches
-//! only the configured target table (the writer's validation table), never
-//! posthog_person; a startup sentinel round-trip proves the router serves
-//! that same table before any traffic flows. Shutdown cuts the in-flight
+//! Direct database access is seeding and verification only — confined to
+//! the configured target table (the writer's validation table), never
+//! posthog_person, and never a DELETE: every row removal goes through the
+//! lifecycle delete saga, so leftovers from crashed runs and the saga's
+//! tombstones are external cleanup's business. A startup sentinel
+//! round-trip proves the router serves that same table before any traffic
+//! flows. Shutdown cuts the in-flight
 //! epoch's load short and runs the normal close-out (verify what was
 //! acked, record, clean up) inside the termination grace window.
 
@@ -105,19 +108,13 @@ fn validate_args(args: &TrafficArgs) -> Result<()> {
     }
     for team in args.team_ids.iter().chain([&args.hostile_team_id]) {
         // team_id columns are i32; reject here rather than deep inside
-        // the first seed or janitor query.
+        // the first seed query.
         if i32::try_from(*team).is_err() {
             bail!("team id {team} out of i32 range");
         }
     }
     seed::validate_table_name(&args.pg_target_table)
 }
-
-/// How old a leftover row must be before the startup janitor reaps it.
-/// Far above any epoch length, so a live sibling pod's pool is never
-/// touched; far below forever, so crashed instances' rows don't
-/// accumulate.
-const STALE_ROW_AGE: Duration = Duration::from_secs(3600);
 
 /// Concurrent identity-service create batches while seeding an epoch's
 /// pools. Bounded so a many-team epoch doesn't dogpile the service its
@@ -130,8 +127,8 @@ pub async fn run(args: TrafficArgs) -> Result<()> {
     let team_ids = args.team_ids.clone();
     let hostile_team_id = args.hostile_team_id;
     // Instances share the team set; disjointness comes from the boot
-    // nonce in every distinct id, so verification (id-scoped) and the
-    // janitor (age-guarded) never cross instances.
+    // nonce in every distinct id, so verification (id-scoped) never
+    // crosses instances.
     let nonce = format!("{:08x}", rand::random::<u32>());
     tracing::info!(%nonce, ?team_ids, hostile_team_id, "instance identity");
 
@@ -156,15 +153,14 @@ pub async fn run(args: TrafficArgs) -> Result<()> {
     // restart loop retries — which also rides out startup races where the
     // leader hasn't claimed partitions yet. One team suffices: the check
     // proves the router/database pairing, not per-team routing.
-    sentinel_round_trip(&client, &pool, &args.pg_target_table, team_ids[0]).await?;
-
-    // A crashed prior run leaves rows behind; reap the ones old enough
-    // that they cannot belong to a live sibling — a rolling restart
-    // briefly runs two bed pods against the same team, each on its own
-    // disjoint id pool, and a fresh row is the sibling's business.
-    for team in team_ids.iter().chain([&hostile_team_id]) {
-        seed::reap_stale_team_rows(&pool, &args.pg_target_table, *team, STALE_ROW_AGE).await?;
-    }
+    sentinel_round_trip(
+        &client,
+        &lifecycle,
+        &pool,
+        &args.pg_target_table,
+        team_ids[0],
+    )
+    .await?;
 
     // Hostile targets live for the process lifetime: their documents stay
     // small (fixed keys, no journal growth) and their outcomes are only
@@ -225,19 +221,6 @@ pub async fn run(args: TrafficArgs) -> Result<()> {
             teams = team_ids.len(),
             "epoch starting"
         );
-
-        // The hostile pool outlives epochs; keep its liveness stamp fresh
-        // so a sibling pod's startup janitor never reaps it mid-use.
-        seed::refresh_created_at(&pool, &args.pg_target_table, hostile_team_id, &hostile_ids)
-            .await?;
-
-        // The per-epoch janitor: crashed-run leftovers and the
-        // tombstones lifecycle rotation leaves behind both age into
-        // eligibility; without this the table grows one pool per epoch
-        // for the life of the deployment.
-        for team in team_ids.iter().chain([&hostile_team_id]) {
-            seed::reap_stale_team_rows(&pool, &args.pg_target_table, *team, STALE_ROW_AGE).await?;
-        }
 
         // Seed every lane's pool before any lane starts, concurrently
         // but bounded so one epoch's create batches don't dogpile the
@@ -415,7 +398,8 @@ pub async fn run(args: TrafficArgs) -> Result<()> {
         traffic_metrics::record_violations(epoch, &violations);
         if let Some(error) = close_error {
             // The healthy lanes' violations are recorded above; the
-            // unrotated pools age into the janitor's reap.
+            // unrotated pools stay behind — the bed never deletes from
+            // Postgres, so leftovers are external cleanup's business.
             return Err(error);
         }
 
@@ -438,7 +422,7 @@ pub async fn run(args: TrafficArgs) -> Result<()> {
         // whatever chaos is running. By id, not by team — a successor
         // pod may already be running its own pool against these teams.
         // Every pool's rotation is attempted before the first failure
-        // propagates; a missed pool ages into the janitor's reap.
+        // propagates; a missed pool is left behind for external cleanup.
         for result in futures::future::join_all(
             lanes
                 .iter()
@@ -607,9 +591,9 @@ async fn hold_and_run(
 }
 
 /// Delete the epoch's pool through the saga and account for every
-/// outcome. `deleted` is the expected answer; `not_found` means someone
-/// else already removed the row (a startup janitor's reap, never a
-/// second bed — pools are id-disjoint) and is counted, not fatal;
+/// outcome. `deleted` is the expected answer; `not_found` means the row
+/// was already gone (a replayed saga op, never a second bed — pools are
+/// id-disjoint) and is counted, not fatal;
 /// `skipped_conflict` means a lifecycle operation is stuck holding a
 /// pool person, which the bed exists to surface, so it fails the run.
 async fn delete_pool(lifecycle: &LifecycleClient, team_id: i64, person_ids: &[i64]) -> Result<()> {
@@ -743,9 +727,11 @@ fn hostile_payload(counter: u64) -> (&'static str, Value) {
 /// and require an exact match. The router path terminates in the leader's
 /// PG fallback, so a router pointed at any other environment cannot
 /// return a value that was generated here moments ago. The row is
-/// removed by the boot cleanup that follows.
+/// retired through the lifecycle delete saga — traffic mode never
+/// deletes from Postgres directly.
 async fn sentinel_round_trip(
     client: &HarnessClient,
+    lifecycle: &LifecycleClient,
     pool: &PgPool,
     table: &str,
     team_id: i64,
@@ -787,14 +773,9 @@ async fn sentinel_round_trip(
         );
     }
     tracing::info!("sentinel round-trip verified: router and database agree");
-    sqlx::query(&format!(
-        "DELETE FROM {table} WHERE team_id = $1 AND id = $2"
-    ))
-    .bind(team)
-    .bind(person_id)
-    .execute(pool)
-    .await
-    .context("deleting the sentinel person")?;
+    delete_pool(lifecycle, team_id, &[person_id])
+        .await
+        .context("retiring the sentinel person through the delete saga")?;
     Ok(())
 }
 

--- a/rust/personhog-test-harness/src/seed.rs
+++ b/rust/personhog-test-harness/src/seed.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use anyhow::{bail, Context, Result};
 use metrics::{counter, histogram};
 use personhog_proto::personhog::identity::v1::GetOrCreatePersonEntry;
@@ -139,85 +137,6 @@ pub async fn cleanup_team(pool: &PgPool, table: &str, team_id: i64) -> Result<u6
         .await
         .with_context(|| format!("cleaning up {table}"))?
         .rows_affected();
-    Ok(deleted)
-}
-
-/// Re-stamp `created_at` on the given rows. The janitor's age guard
-/// reads `created_at` as a liveness stamp, so rows that live across
-/// epochs (the hostile pool) must be refreshed each epoch — otherwise a
-/// successor pod's janitor reaps them mid-use once their seeding time
-/// ages past the threshold, even though their owner is still running.
-pub async fn refresh_created_at(
-    pool: &PgPool,
-    table: &str,
-    team_id: i64,
-    ids: &[i64],
-) -> Result<()> {
-    validate_table_name(table)?;
-    if ids.is_empty() {
-        return Ok(());
-    }
-    let team: i32 = team_id.try_into().context("team_id out of i32 range")?;
-    sqlx::query(&format!(
-        "UPDATE {table} SET created_at = now() WHERE team_id = $1 AND id = ANY($2)"
-    ))
-    .bind(team)
-    .bind(ids)
-    .execute(pool)
-    .await
-    .with_context(|| format!("refreshing created_at in {table}"))?;
-    Ok(())
-}
-
-/// Reap a team's person rows older than `older_than` — the startup
-/// janitor for leftovers from crashed or killed instances. The age guard
-/// keeps it off a live sibling pod's fresh pool during a rolling-restart
-/// overlap, while dead instances' rows age into eligibility. Every
-/// delete is scoped to rows the harness's own write path produces:
-/// tables it never writes (the personless table) are never touched,
-/// however stray their contents look.
-pub async fn reap_stale_team_rows(
-    pool: &PgPool,
-    table: &str,
-    team_id: i64,
-    older_than: Duration,
-) -> Result<u64> {
-    validate_table_name(table)?;
-    let team: i32 = team_id.try_into().context("team_id out of i32 range")?;
-
-    // Mapping rows scoped to the person rows being reaped: the bed's
-    // identity-service seeding writes live mappings for its current
-    // pool, so a team-wide sweep here would tear them out from under a
-    // running sibling. Lifecycle deletes leave tombstoned mappings on
-    // aged rows, and those go with their persons.
-    for pdi_table in distinct_id_tables_for(table) {
-        sqlx::query(&format!(
-            "DELETE FROM {pdi_table} \
-             WHERE team_id = $1 AND person_id IN ( \
-                 SELECT id FROM {table} \
-                 WHERE team_id = $1 AND created_at < now() - make_interval(secs => $2))"
-        ))
-        .bind(team)
-        .bind(older_than.as_secs_f64())
-        .execute(pool)
-        .await
-        .with_context(|| format!("deleting distinct ids from {pdi_table}"))?;
-    }
-
-    // Age-guarded and deliberately blind to is_deleted: it purges both
-    // crashed-run leftovers and the tombstones lifecycle deletes leave
-    // behind, which would otherwise grow the table by one pool per
-    // epoch forever.
-    let deleted = sqlx::query(&format!(
-        "DELETE FROM {table} \
-         WHERE team_id = $1 AND created_at < now() - make_interval(secs => $2)"
-    ))
-    .bind(team)
-    .bind(older_than.as_secs_f64())
-    .execute(pool)
-    .await
-    .with_context(|| format!("reaping stale rows in {table}"))?
-    .rows_affected();
     Ok(deleted)
 }
 


### PR DESCRIPTION
## Problem

The dev traffic bed cleans up after itself with direct SQL deletes: an age-guarded janitor runs team-wide `DELETE`s against the person table and `posthog_persondistinctid` at boot and every epoch.
Nothing ties the configured team ids to harness-reserved teams, so one wrong id in `TRAFFIC_TEAM_IDS` deletes a real team's rows.
This PR removes that failure class: traffic mode no longer issues any `DELETE` against Postgres.

## Changes

- Traffic mode now removes rows only through the lifecycle delete saga, the same path production deletes take.
- The startup and per-epoch janitor (`reap_stale_team_rows`) is gone, along with the `created_at` refresh that defended the hostile pool from it.
- The boot sentinel row is retired through the saga instead of a direct SQL delete.
- The gate (local/CI stack) and the `cleanup` CLI command keep their team-scoped deletes.

> [!NOTE]
> Nothing in the bed bounds dev table growth anymore. Saga rotation tombstones rows rather than removing them, and crashed-run leftovers stay live. The `cleanup` command is the manual escape hatch until a scheduled purge exists.

## How did you test this code?

- `cargo clippy --all-targets -- -D warnings` and the crate's unit tests, run locally against master.
- No new tests: the change removes behavior, and the existing `validate_table_name` test still covers the SQL-interpolation guard.
- Not run: the gate e2e (needs a local etcd and stack). The sentinel's saga-delete path reuses `delete_pool`, which the gate's fence path already exercises against mappingless direct-SQL rows.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. José asked for the harness to stop deleting rows from PG and chose this scope (traffic mode only) over guarding the deletes with a team allowlist or removing deletes everywhere.
Skills invoked: /writing-pr-descriptions.
