### PR TITLE
feat(desktop): focus the comment thread from task deep links

### DIFF
--- a/products/desktop/docs/DEEP-LINKS.md
+++ b/products/desktop/docs/DEEP-LINKS.md
@@ -78,17 +78,23 @@ The link is rejected if `url` is missing, is not a `github.com` URL, or does not
 
 ### `posthog-code://task/<taskId>[/run/<taskRunId>]`
 
-Open an existing task. Optionally jump to a specific run.
+Open an existing task. Optionally jump to a specific run, or focus a comment thread inside the task.
 
-| Segment | Required | Description |
+| Segment / Parameter | Required | Description |
 |---|---|---|
 | `<taskId>` | Yes | Task ID |
 | `run/<taskRunId>` | No | Specific run to open |
+| `comment` | No | Comment thread (root comment id) to focus after the task opens |
+| `scope` | No | Comment target scope when the thread lives on a sub-resource: `desktop_canvas` or `task_artifact`. Defaults to the task itself. |
+| `item` | No | Row id of the canvas/artifact the thread lives on; required alongside `scope` |
 
 ```
 posthog-code://task/abc123
 posthog-code://task/abc123/run/xyz789
+posthog-code://task/abc123?comment=thread-1&scope=desktop_canvas&item=canvas-9
 ```
+
+An **https** bridge also exists for links sent outside the app (e.g. comment Slack DMs): `<instance>/code/task/<taskId>` resolves to a web interstitial in PostHog Cloud, which fires this scheme — forwarding the `comment`, `scope`, and `item` params — or offers the desktop-app download.
 
 ### `posthog-code://inbox/<reportId>`
 

--- a/products/desktop/packages/core/src/links/task-link.test.ts
+++ b/products/desktop/packages/core/src/links/task-link.test.ts
@@ -21,10 +21,10 @@ function createMockDeepLinkService() {
   >();
   return {
     registerHandler: vi.fn((key, handler) => handlers.set(key, handler)),
-    _invoke(key: string, path: string) {
+    _invoke(key: string, path: string, query = "") {
       const handler = handlers.get(key);
       if (!handler) throw new Error(`No handler for key: ${key}`);
-      return handler(path, new URLSearchParams());
+      return handler(path, new URLSearchParams(query));
     },
   };
 }
@@ -105,6 +105,33 @@ describe("TaskLinkService", () => {
         taskRunId: "run-456",
       });
     });
+
+    it.each([
+      [
+        "with target params",
+        "comment=thread-1&scope=desktop_canvas&item=canvas-9",
+        { threadId: "thread-1", scope: "desktop_canvas", itemId: "canvas-9" },
+      ],
+      [
+        "bare",
+        "comment=thread-1",
+        { threadId: "thread-1", scope: undefined, itemId: undefined },
+      ],
+    ])(
+      "parses a comment anchor from query params (%s)",
+      (_name, query, expected) => {
+        const listener = vi.fn();
+        service.on(TaskLinkEvent.OpenTask, listener);
+
+        mockDeepLink._invoke("task", "task-123", query);
+
+        expect(listener).toHaveBeenCalledWith({
+          taskId: "task-123",
+          taskRunId: undefined,
+          comment: expected,
+        });
+      },
+    );
 
     it("ignores a second path segment that is not 'run'", () => {
       const listener = vi.fn();

--- a/products/desktop/packages/core/src/links/task-link.ts
+++ b/products/desktop/packages/core/src/links/task-link.ts
@@ -15,14 +15,23 @@ export const TaskLinkEvent = {
   OpenTask: "openTask",
 } as const;
 
-export interface TaskLinkEvents {
-  [TaskLinkEvent.OpenTask]: { taskId: string; taskRunId?: string };
+export interface TaskLinkCommentAnchor {
+  threadId: string;
+  scope?: string;
+  itemId?: string;
 }
 
-export interface PendingDeepLink {
+export interface TaskLinkPayload {
   taskId: string;
   taskRunId?: string;
+  comment?: TaskLinkCommentAnchor;
 }
+
+export interface TaskLinkEvents {
+  [TaskLinkEvent.OpenTask]: TaskLinkPayload;
+}
+
+export type PendingDeepLink = TaskLinkPayload;
 
 @injectable()
 export class TaskLinkService extends TypedEventEmitter<TaskLinkEvents> {
@@ -40,12 +49,12 @@ export class TaskLinkService extends TypedEventEmitter<TaskLinkEvents> {
     super();
     this.log = rootLogger.scope("task-link-service");
 
-    this.deepLinkService.registerHandler("task", (path) =>
-      this.handleTaskLink(path),
+    this.deepLinkService.registerHandler("task", (path, searchParams) =>
+      this.handleTaskLink(path, searchParams),
     );
   }
 
-  private handleTaskLink(path: string): boolean {
+  private handleTaskLink(path: string, searchParams: URLSearchParams): boolean {
     const parts = path.split("/");
     const taskId = parts[0];
     const taskRunId = parts[1] === "run" ? parts[2] : undefined;
@@ -55,18 +64,28 @@ export class TaskLinkService extends TypedEventEmitter<TaskLinkEvents> {
       return false;
     }
 
+    const threadId = searchParams.get("comment");
+    const comment: TaskLinkCommentAnchor | undefined = threadId
+      ? {
+          threadId,
+          scope: searchParams.get("scope") ?? undefined,
+          itemId: searchParams.get("item") ?? undefined,
+        }
+      : undefined;
+    const payload: TaskLinkPayload = { taskId, taskRunId, comment };
+
     const hasListeners = this.listenerCount(TaskLinkEvent.OpenTask) > 0;
 
     if (hasListeners) {
       this.log.info(
-        `Emitting task link event: taskId=${taskId}, taskRunId=${taskRunId ?? "none"}`,
+        `Emitting task link event: taskId=${taskId}, taskRunId=${taskRunId ?? "none"}, comment=${threadId ?? "none"}`,
       );
-      this.emit(TaskLinkEvent.OpenTask, { taskId, taskRunId });
+      this.emit(TaskLinkEvent.OpenTask, payload);
     } else {
       this.log.info(
-        `Queueing task link (renderer not ready): taskId=${taskId}, taskRunId=${taskRunId ?? "none"}`,
+        `Queueing task link (renderer not ready): taskId=${taskId}, taskRunId=${taskRunId ?? "none"}, comment=${threadId ?? "none"}`,
       );
-      this.pendingDeepLink = { taskId, taskRunId };
+      this.pendingDeepLink = payload;
     }
 
     this.log.info("Deep link focusing window", { taskId, taskRunId });

--- a/products/desktop/packages/ui/src/features/deep-links/useHandleOpenTask.ts
+++ b/products/desktop/packages/ui/src/features/deep-links/useHandleOpenTask.ts
@@ -1,3 +1,5 @@
+import type { CommentTarget } from "@posthog/core/comments/anchors";
+import type { TaskLinkCommentAnchor } from "@posthog/core/links/task-link";
 import {
   TASK_SERVICE,
   type TaskService,
@@ -8,6 +10,7 @@ import type { Task } from "@posthog/shared/domain-types";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useTaskChannelMap } from "@posthog/ui/features/canvas/hooks/useTaskChannelMap";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
+import { useCommentNavigationStore } from "@posthog/ui/features/sessions/commentNavigationStore";
 import { useTaskViewed } from "@posthog/ui/features/sidebar/useTaskViewed";
 import { taskKeys } from "@posthog/ui/features/tasks/taskKeys";
 import { toast } from "@posthog/ui/primitives/toast";
@@ -25,9 +28,23 @@ const log = logger.scope("open-task");
  * (`useTaskDeepLink`) and the generic notification-target consumer
  * (`useOpenTargetDeepLink`).
  */
+function commentTargetFromAnchor(
+  taskId: string,
+  anchor: TaskLinkCommentAnchor,
+): CommentTarget {
+  if (
+    (anchor.scope === "desktop_canvas" || anchor.scope === "task_artifact") &&
+    anchor.itemId
+  ) {
+    return { scope: anchor.scope, itemId: anchor.itemId };
+  }
+  return { scope: "task", itemId: taskId };
+}
+
 export function useHandleOpenTask(): (
   taskId: string,
   taskRunId?: string,
+  comment?: TaskLinkCommentAnchor,
 ) => Promise<void> {
   const taskService = useService<TaskService>(TASK_SERVICE);
   const { markAsViewed } = useTaskViewed();
@@ -49,7 +66,11 @@ export function useHandleOpenTask(): (
   }, [channelMap]);
 
   return useCallback(
-    async (taskId: string, taskRunId?: string) => {
+    async (
+      taskId: string,
+      taskRunId?: string,
+      comment?: TaskLinkCommentAnchor,
+    ) => {
       log.info(
         `Opening task from deep link: ${taskId}${taskRunId ? `, run: ${taskRunId}` : ""}`,
       );
@@ -87,6 +108,15 @@ export function useHandleOpenTask(): (
           task,
           channel ? { channelId: channel.id } : undefined,
         );
+        if (comment) {
+          useCommentNavigationStore
+            .getState()
+            .requestCommentFocus(
+              taskId,
+              commentTargetFromAnchor(taskId, comment),
+              comment.threadId,
+            );
+        }
         log.info(`Opened task from deep link: ${taskId}`);
       } catch (error) {
         log.error("Unexpected error opening task from deep link:", error);

--- a/products/desktop/packages/ui/src/features/deep-links/useTaskDeepLink.ts
+++ b/products/desktop/packages/ui/src/features/deep-links/useTaskDeepLink.ts
@@ -31,7 +31,7 @@ export function useTaskDeepLink() {
           log.info(
             `Found pending deep link: taskId=${pending.taskId}, taskRunId=${pending.taskRunId ?? "none"}`,
           );
-          handleOpenTask(pending.taskId, pending.taskRunId);
+          handleOpenTask(pending.taskId, pending.taskRunId, pending.comment);
         }
       } catch (error) {
         log.error("Failed to check for pending deep link:", error);
@@ -49,7 +49,7 @@ export function useTaskDeepLink() {
           `Received deep link event: taskId=${data.taskId}, taskRunId=${data.taskRunId ?? "none"}`,
         );
         if (!data?.taskId) return;
-        handleOpenTask(data.taskId, data.taskRunId);
+        handleOpenTask(data.taskId, data.taskRunId, data.comment);
       },
     });
     return () => subscription.unsubscribe();


### PR DESCRIPTION
## Problem

A task deep link opens the task, but a link that came from a comment notification should land on the comment itself. The `task` handler drops query params today, so there is no way to carry that intent into the app.

Desktop half of [#82722](https://github.com/PostHog/posthog/pull/82722), which makes comment Slack DMs send `?comment=<threadId>` (plus `scope`/`item` for canvas and artifact threads) through the `/code/task` bridge.

## Changes

- `posthog-code://task/<taskId>` now accepts `comment`, `scope`, and `item` query params, following the `scout` link's `?finding` precedent.
- After the task opens, the renderer requests focus on that thread through the existing comment navigation store — the same path the Activity timeline uses — so the comments tab opens and scrolls to the thread.
- Links without the params behave exactly as before, and an unknown or incomplete `scope`/`item` pair falls back to the task's own thread list.
- Documented the params and the https bridge in `DEEP-LINKS.md`.

Safe to ship in either order relative to the backend PR: old links carry no params, and new params on an old build were already ignored.

## How did you test this code?

- Two new parameterized cases in `task-link.test.ts` pin the query-param parsing — the regression is reverting the handler to its path-only signature, which silently drops the anchor (today's behavior). All 13 tests pass.
- `@posthog/core` and `@posthog/ui` typecheck and Biome pass.
- Not done: clicking a real DM link through to a focused comment; this sandbox cannot run the Electron app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`products/desktop/docs/DEEP-LINKS.md` updated in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code in PostHog Desktop from dogfooding feedback on comment Slack DMs.
- Skills invoked: /writing-tests, /writing-pr-descriptions.
- The anchor carries the `(threadId, scope, item)` triple the navigation store needs, rather than a bare comment id, so the app does not have to resolve a reply id to its thread root.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
