### PR TITLE
feat(dashboards): migrate header tiles to section positions

### DIFF
--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -1118,7 +1118,6 @@ class DashboardTileSerializer(serializers.ModelSerializer):
             # Denormalization for HogQL printing; combined with depth=1, leaving it
             # in expands `team` into a full nested Team dict on every tile response.
             "team",
-            "dashboard_group",
             "parent_group",
         ]
         read_only_fields = ["id", "insight"]
@@ -1767,7 +1766,6 @@ class DashboardSerializer(DashboardMetadataSerializer):
                 group_map[source_group.id] = copied_group
             existing_tiles = (
                 DashboardTile.objects.filter(dashboard=existing_dashboard)
-                .filter(dashboard_group__isnull=True)
                 .exclude(deleted=True)
                 .select_related("insight", "text", "button_tile", "widget", "parent_group")
             )
@@ -3182,7 +3180,7 @@ class DashboardsViewSet(
         serializer = MoveDashboardTileToGroupRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         tile = get_object_or_404(
-            DashboardTile.objects.filter(dashboard=dashboard, dashboard_group__isnull=True),
+            DashboardTile.objects.filter(dashboard=dashboard),
             id=serializer.validated_data["tile_id"],
         )
         user = cast(User, request.user)

--- a/products/dashboards/backend/api/test/test_dashboard_groups.py
+++ b/products/dashboards/backend/api/test/test_dashboard_groups.py
@@ -168,7 +168,6 @@ class TestDashboardGroups(APIBaseTest):
         groups = list(dashboard.groups.order_by("position"))
         self.assertEqual([(group.name, group.position) for group in groups], [(None, 0), ("Acquisition", 1), (None, 2)])
         self.assertEqual([group.member_tiles.get().text.body for group in groups], ["Before", "Signups", "After"])
-        self.assertFalse(DashboardTile.objects.filter(dashboard=dashboard, dashboard_group__isnull=False).exists())
 
     def test_template_unknown_group_key_without_headers_stays_ungrouped(self) -> None:
         template = DashboardTemplate(

--- a/products/dashboards/backend/migrations/0020_migrate_dashboard_group_sections.py
+++ b/products/dashboards/backend/migrations/0020_migrate_dashboard_group_sections.py
@@ -1,0 +1,82 @@
+from typing import Any
+
+from django.db import migrations
+
+
+def _layout_y(tile: Any) -> int:
+    layouts = tile.layouts if isinstance(tile.layouts, dict) else {}
+    sm = layouts.get("sm") or {}
+    y = sm.get("y", 0)
+    try:
+        return int(y)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _group_y(group: Any, header_by_group_id: dict[Any, Any]) -> int:
+    header = header_by_group_id.get(group.id)
+    return _layout_y(header) if header is not None else 0
+
+
+def migrate_dashboard_group_sections(apps: Any, schema_editor: Any) -> None:
+    # Inlined from partition_tiles_into_sections: migrations must not import app code.
+    Dashboard = apps.get_model("dashboards", "Dashboard")
+    DashboardGroup = apps.get_model("dashboards", "DashboardGroup")
+    DashboardTile = apps.get_model("dashboards", "DashboardTile")
+    groups_manager = getattr(DashboardGroup, "all_teams", DashboardGroup.objects)
+
+    dashboard_ids = groups_manager.values_list("dashboard_id", flat=True).distinct()
+    for dashboard_id in dashboard_ids.iterator():
+        dashboard = Dashboard.objects.get(id=dashboard_id)
+        groups = list(groups_manager.filter(dashboard_id=dashboard_id))
+        header_tiles = list(DashboardTile.objects.filter(dashboard_id=dashboard_id, dashboard_group_id__isnull=False))
+        header_by_group_id = {tile.dashboard_group_id: tile for tile in header_tiles}
+
+        sorted_groups = sorted(groups, key=lambda group, mapping=header_by_group_id: _group_y(group, mapping))
+        ungrouped_tiles = list(
+            DashboardTile.objects.filter(
+                dashboard_id=dashboard_id,
+                dashboard_group_id__isnull=True,
+                parent_group_id__isnull=True,
+                deleted=False,
+            )
+        )
+        header_ys = [_group_y(group, header_by_group_id) for group in sorted_groups]
+        anonymous_tiles_by_bucket: dict[int, list[Any]] = {}
+        for tile in ungrouped_tiles:
+            tile_y = _layout_y(tile)
+            bucket = sum(header_y <= tile_y for header_y in header_ys)
+            anonymous_tiles_by_bucket.setdefault(bucket, []).append(tile)
+
+        section_entries: list[tuple[int, Any, list[Any]]] = [
+            (_group_y(group, header_by_group_id), group, []) for group in sorted_groups
+        ]
+        for tiles in anonymous_tiles_by_bucket.values():
+            group = groups_manager.create(
+                dashboard_id=dashboard_id,
+                team_id=dashboard.team_id,
+                name=None,
+                position=0,
+            )
+            section_entries.append((min(_layout_y(tile) for tile in tiles), group, tiles))
+
+        section_entries.sort(key=lambda entry: (entry[0], entry[2] != []))
+        groups_to_update = []
+        tiles_to_update = []
+        for position, (_, group, tiles) in enumerate(section_entries):
+            group.position = position
+            groups_to_update.append(group)
+            for tile in tiles:
+                tile.parent_group_id = group.id
+                tiles_to_update.append(tile)
+
+        groups_manager.bulk_update(groups_to_update, ["position"])
+        if tiles_to_update:
+            DashboardTile.objects.bulk_update(tiles_to_update, ["parent_group"])
+        DashboardTile.objects.filter(id__in=[tile.id for tile in header_tiles]).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [("dashboards", "0019_dashboardgroup_position_and_nullable_name")]
+
+    operations = [migrations.RunPython(migrate_dashboard_group_sections, migrations.RunPython.noop)]

--- a/products/dashboards/backend/migrations/0021_remove_dashboardtile_dashboard_group_state.py
+++ b/products/dashboards/backend/migrations/0021_remove_dashboardtile_dashboard_group_state.py
@@ -1,0 +1,32 @@
+from django.db import migrations, models
+
+import posthog.models.utils
+
+
+class Migration(migrations.Migration):
+    dependencies = [("dashboards", "0020_migrate_dashboard_group_sections")]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveConstraint(
+                    model_name="dashboardtile",
+                    name="dash_tile_exactly_one_related_object",
+                ),
+                migrations.RemoveField(
+                    model_name="dashboardtile",
+                    name="dashboard_group",
+                ),
+                migrations.AddConstraint(
+                    model_name="dashboardtile",
+                    constraint=models.CheckConstraint(
+                        condition=posthog.models.utils.build_unique_relationship_check(
+                            ("insight", "text", "button_tile", "widget")
+                        ),
+                        name="dash_tile_exactly_one_related_object",
+                    ),
+                ),
+            ],
+            database_operations=[],
+        )
+    ]

--- a/products/dashboards/backend/migrations/max_migration.txt
+++ b/products/dashboards/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0019_dashboardgroup_position_and_nullable_name
+0021_remove_dashboardtile_dashboard_group_state

--- a/products/dashboards/backend/models/dashboard_tile.py
+++ b/products/dashboards/backend/models/dashboard_tile.py
@@ -85,14 +85,6 @@ class DashboardTile(models.Model):
         null=True,
         db_index=False,
     )
-    dashboard_group = models.OneToOneField(
-        "dashboards.DashboardGroup",
-        on_delete=models.CASCADE,
-        related_name="tile",
-        null=True,
-        db_index=False,
-        db_constraint=False,
-    )
     parent_group = models.ForeignKey(
         "dashboards.DashboardGroup",
         on_delete=models.PROTECT,
@@ -151,9 +143,7 @@ class DashboardTile(models.Model):
                 condition=Q(("widget__isnull", False)),
             ),
             models.CheckConstraint(
-                condition=build_unique_relationship_check(
-                    ("insight", "text", "button_tile", "widget", "dashboard_group")
-                ),
+                condition=build_unique_relationship_check(("insight", "text", "button_tile", "widget")),
                 name="dash_tile_exactly_one_related_object",
             ),
         ]
@@ -194,23 +184,14 @@ class DashboardTile(models.Model):
         related_fields = sum(
             map(
                 bool,
-                [
-                    getattr(self, relation)
-                    for relation in ("insight", "text", "button_tile", "widget", "dashboard_group")
-                ],
+                [getattr(self, relation) for relation in ("insight", "text", "button_tile", "widget")],
             )
         )
         if related_fields != 1:
-            raise ValidationError(
-                "Can only set exactly one of insight, text, button_tile, widget, or dashboard_group for this tile"
-            )
+            raise ValidationError("Can only set exactly one of insight, text, button_tile, or widget for this tile")
 
-        if self.dashboard_group_id is not None and self.parent_group_id is not None:
-            raise ValidationError("Dashboard group tiles cannot belong to another group")
-
-        for group in (self.dashboard_group, self.parent_group):
-            if group is not None and group.dashboard_id != self.dashboard_id:
-                raise ValidationError("Dashboard groups and tiles must belong to the same dashboard")
+        if self.parent_group is not None and self.parent_group.dashboard_id != self.dashboard_id:
+            raise ValidationError("Dashboard groups and tiles must belong to the same dashboard")
 
         if self.insight is None and (
             self.filters_hash is not None
@@ -321,7 +302,6 @@ class DashboardTile(models.Model):
                 "text",
                 "button_tile",
                 "widget",
-                "dashboard_group",
                 "parent_group",
                 "insight__created_by",
                 "insight__last_modified_by",
@@ -331,7 +311,6 @@ class DashboardTile(models.Model):
             )
             .prefetch_related("text__dashboard_tiles", "button_tile__dashboard_tiles", "widget__dashboard_tiles")
             .exclude(dashboard__deleted=True, deleted=True)
-            .filter(dashboard_group__isnull=True)
             .filter(Q(insight__deleted=False) | Q(insight__isnull=True))
             .order_by("insight__order")
         )

--- a/products/dashboards/backend/section_ops.py
+++ b/products/dashboards/backend/section_ops.py
@@ -31,7 +31,7 @@ def lock_dashboard(dashboard: Dashboard) -> Dashboard:
 
 
 def content_tiles_qs(dashboard: Dashboard) -> QuerySet[DashboardTile]:
-    return DashboardTile.objects.filter(dashboard=dashboard, dashboard_group__isnull=True).exclude(deleted=True)
+    return DashboardTile.objects.filter(dashboard=dashboard).exclude(deleted=True)
 
 
 def ordered_groups(dashboard: Dashboard) -> list[DashboardGroup]:

--- a/products/dashboards/backend/test/test_migration_0020.py
+++ b/products/dashboards/backend/test/test_migration_0020.py
@@ -1,0 +1,84 @@
+from typing import Any
+
+from posthog.test.base import TestMigrations
+
+
+class MigrateDashboardGroupSectionsTest(TestMigrations):
+    migrate_from = "0019_dashboardgroup_position_and_nullable_name"
+    migrate_to = "0020_migrate_dashboard_group_sections"
+
+    @property
+    def app(self) -> str:
+        return "dashboards"
+
+    def setUpBeforeMigration(self, apps: Any) -> None:
+        Dashboard = apps.get_model("dashboards", "Dashboard")
+        DashboardGroup = apps.get_model("dashboards", "DashboardGroup")
+        DashboardTile = apps.get_model("dashboards", "DashboardTile")
+        Text = apps.get_model("dashboards", "Text")
+        groups_manager = getattr(DashboardGroup, "all_teams", DashboardGroup.objects)
+
+        grouped_dashboard = Dashboard.objects.create(team_id=self.team.id, name="Grouped")
+        untouched_dashboard = Dashboard.objects.create(team_id=self.team.id, name="Untouched")
+        first_group = groups_manager.create(
+            dashboard=grouped_dashboard,
+            team_id=self.team.id,
+            name="First",
+        )
+        second_group = groups_manager.create(
+            dashboard=grouped_dashboard,
+            team_id=self.team.id,
+            name="Second",
+        )
+        DashboardTile.objects.create(
+            dashboard=grouped_dashboard,
+            team_id=self.team.id,
+            dashboard_group=first_group,
+            layouts={"sm": {"x": 0, "y": 2, "w": 12, "h": 1}},
+        )
+        DashboardTile.objects.create(
+            dashboard=grouped_dashboard,
+            team_id=self.team.id,
+            dashboard_group=second_group,
+            layouts={"sm": {"x": 0, "y": 8, "w": 12, "h": 1}},
+        )
+        for body, y, dashboard in (
+            ("Before", 0, grouped_dashboard),
+            ("Between", 5, grouped_dashboard),
+            ("After", 10, grouped_dashboard),
+            ("Untouched", 0, untouched_dashboard),
+        ):
+            text = Text.objects.create(team_id=self.team.id, body=body)
+            DashboardTile.objects.create(
+                dashboard=dashboard,
+                team_id=self.team.id,
+                text=text,
+                layouts={"sm": {"x": 0, "y": y, "w": 12, "h": 2}},
+            )
+
+        self.grouped_dashboard_id = grouped_dashboard.id
+        self.untouched_dashboard_id = untouched_dashboard.id
+
+    def test_migration_builds_ordered_sections_and_leaves_group_less_dashboards_untouched(self) -> None:
+        DashboardGroup = self.apps.get_model("dashboards", "DashboardGroup")  # type: ignore[union-attr]
+        DashboardTile = self.apps.get_model("dashboards", "DashboardTile")  # type: ignore[union-attr]
+        groups_manager = getattr(DashboardGroup, "all_teams", DashboardGroup.objects)
+
+        groups = list(groups_manager.filter(dashboard_id=self.grouped_dashboard_id).order_by("position"))
+        assert [(group.name, group.position) for group in groups] == [
+            (None, 0),
+            ("First", 1),
+            (None, 2),
+            ("Second", 3),
+            (None, 4),
+        ]
+        assert (
+            DashboardTile.objects.filter(
+                dashboard_id=self.grouped_dashboard_id,
+                dashboard_group_id__isnull=False,
+            ).count()
+            == 0
+        )
+        assert all(group.member_tiles.count() == 1 for group in groups if group.name is None)
+        assert not groups_manager.filter(dashboard_id=self.untouched_dashboard_id).exists()
+        assert DashboardTile.objects.get(dashboard_id=self.untouched_dashboard_id).parent_group_id is None


### PR DESCRIPTION
## Problem

- #82819 stores sections as ordered `DashboardGroup` rows. Existing dashboards still encode sections as synthetic GROUP header tiles.
- The frontend in later layers cannot render per-section grids until those headers become `position` plus `parent_group`.

## Changes

- Backfill `position` from each header tile's y.
- Insert anonymous sections for ungrouped tile runs between headers.
- Point member tiles at `parent_group` and delete header rows.
- Dashboards with no groups stay untouched.
- Drop `DashboardTile.dashboard_group` from Django state. The column stays until a later deploy cycle.

> [!NOTE]
> Member tile y is already section-local after compaction. This migration does not rewrite member coordinates.

## How did you test this code?

- Added `test_migration_0020.py` for header-to-section backfill, anonymous runs, and group-less dashboards.
- Not run at submit time: Django tests. Shared Postgres in this environment conflicts across workspaces.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. Data migration only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Cursor. Skills: `/django-migrations`, `/writing-tests`, `/writing-pr-descriptions`, `/stacking-prs`.
- Sits on #82819. Replaces duplicate #82791.
- Column drop is a follow-up after this ships, not this PR.