### PR TITLE
feat(dashboard): render dashboards as per-section grids

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
@@ -131,6 +131,28 @@ export function DashboardAddTileButton(): JSX.Element | null {
     )
 }
 
+export function DashboardAddSectionButton(): JSX.Element | null {
+    const { dashboard, canEditDashboard, createDashboardGroupLoading } = useValues(dashboardLogic)
+    const { createDashboardGroup } = useActions(dashboardLogic)
+
+    if (!dashboard || !canEditDashboard) {
+        return null
+    }
+
+    return (
+        <LemonButton
+            type="secondary"
+            size="small"
+            data-attr="dashboard-add-section"
+            loading={createDashboardGroupLoading}
+            disabledReason={createDashboardGroupLoading ? 'Adding section' : undefined}
+            onClick={() => createDashboardGroup('New section')}
+        >
+            Add section
+        </LemonButton>
+    )
+}
+
 export function DashboardEditSaveCancelButtons({
     withShortcuts = true,
     applyFiltersButton,
@@ -217,6 +239,7 @@ export function EditModeActions(): JSX.Element {
         <>
             <DashboardSubscribeButton />
             {layoutEditMode && <DashboardEditSaveCancelButtons />}
+            <DashboardAddSectionButton />
             <DashboardAddTileButton />
         </>
     )
@@ -292,6 +315,7 @@ export function ViewModeActions(): JSX.Element {
                     </LemonButton>
                 </Shortcut>
             )}
+            <DashboardAddSectionButton />
             <DashboardAddTileButton />
         </>
     )

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -3,9 +3,8 @@ import './DashboardItems.scss'
 import clsx from 'clsx'
 import { useActions, useAsyncActions, useValues } from 'kea'
 import { router } from 'kea-router'
-import { RefObject, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Layout, Responsive as ReactGridLayout, useContainerWidth } from 'react-grid-layout'
-import { GridBackground } from 'react-grid-layout/extras'
+import { RefObject, Fragment, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Layout, useContainerWidth } from 'react-grid-layout'
 
 import { DashboardWidgetItem } from '@posthog/products-dashboards/frontend/components/DashboardWidgetItem/DashboardWidgetItem'
 import { getDashboardWidgetFetchDisplayError } from '@posthog/products-dashboards/frontend/widgets/constants'
@@ -36,9 +35,12 @@ import { getCurrentExporterData } from '~/exporter/exporterViewLogic'
 import { insightsModel } from '~/models/insightsModel'
 import { DashboardLayoutSize, DashboardMode, DashboardPlacement, DashboardType } from '~/types'
 
+import { DashboardSection } from './DashboardSection'
+import { sectionDisplayName } from './dashboardSections'
 import { DashboardButtonTileItem } from './items/DashboardButtonTileItem'
 import { DashboardErrorTileItem } from './items/DashboardErrorTileItem'
 import { DashboardTextItem } from './items/DashboardTextItem'
+import { MoveToSectionMenu } from './MoveToSectionMenu'
 
 const DRAG_AUTO_SCROLL_THRESHOLD = 100
 const DRAG_AUTO_SCROLL_SPEED = 50
@@ -79,7 +81,6 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
     const {
         dashboard,
         tiles,
-        layouts,
         dashboardMode,
         layoutEditMode,
         placement,
@@ -98,6 +99,9 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         widgetResultsByTileId,
         widgetRefreshStatus,
         scrollToBottomSignal,
+        sections,
+        sectionLayouts,
+        collapsedDashboardSectionIds,
     } = useValues(dashboardLogic)
     const { layoutZoom = 1 } = useValues(dashboardLogic)
     const {
@@ -117,6 +121,11 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         setDashboardMode,
         setAddWidgetModalOpen,
         setPendingInsertion,
+        renameDashboardGroup,
+        updateDashboardGroupPosition,
+        deleteDashboardGroup,
+        toggleDashboardSectionCollapsed,
+        moveDashboardTileToGroup,
     } = useActions(dashboardLogic)
     const { showAddInsightToDashboardModal } = useActions(addInsightToDashboardLogic)
     const { updateWidgetTile } = useAsyncActions(dashboardLogic)
@@ -180,15 +189,19 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
             cancelAnimationFrame(secondFrame)
         }
     }, [scrollToBottomSignal])
-    const className = clsx({
-        'dashboard-view-mode mb-8': !layoutEditMode,
-        // In edit mode, dragging is bounded to the grid's own clientHeight, which is exactly the
-        // content height — so there's nowhere to drag a tile into to create a new bottom row.
-        // box-content + padding-bottom grows clientHeight (padding only counts under content-box,
-        // since preflight defaults everything to border-box), opening up draggable space below the
-        // last tile that scales with content. A margin wouldn't work — it sits outside clientHeight.
-        'dashboard-edit-mode box-content pb-[40vh]': layoutEditMode,
-    })
+    const groupCount = dashboard?.groups?.length ?? 0
+
+    const classNameForSection = (isLastSection: boolean): string =>
+        clsx({
+            'dashboard-view-mode mb-8': !layoutEditMode,
+            // In edit mode, dragging is bounded to the grid's own clientHeight, which is exactly the
+            // content height — so there's nowhere to drag a tile into to create a new bottom row.
+            // box-content + padding-bottom grows clientHeight (padding only counts under content-box,
+            // since preflight defaults everything to border-box), opening up draggable space below the
+            // last tile that scales with content. A margin wouldn't work — it sits outside clientHeight.
+            'dashboard-edit-mode box-content': layoutEditMode,
+            'pb-[40vh]': layoutEditMode && isLastSection,
+        })
 
     const { width, containerRef, mounted } = useContainerWidth()
 
@@ -245,7 +258,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
     const margin = useMemo(() => BASE_MARGIN.map((m) => m * spacingFactor) as [number, number], [spacingFactor])
 
     const getInsertMenuItems = useCallback(
-        (targetX: number, targetY: number, targetW?: number): LemonMenuItem[] =>
+        (sectionKey: string, targetX: number, targetY: number, targetW?: number): LemonMenuItem[] =>
             dashboard
                 ? getAddTileMenuItems({
                       dashboardId: dashboard.id,
@@ -253,7 +266,8 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                       onAddInsight: showAddInsightToDashboardModal,
                       push,
                       setAddWidgetModalOpen,
-                      onBeforeSelect: () => setPendingInsertion({ x: targetX, y: targetY, w: targetW ?? null }),
+                      onBeforeSelect: () =>
+                          setPendingInsertion({ sectionKey, x: targetX, y: targetY, w: targetW ?? null }),
                   })
                 : [],
         [
@@ -480,237 +494,307 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
             )}
             {mounted && (
                 <div className="relative">
-                    {layoutEditMode && !isMobileView && (
-                        <GridBackground
-                            width={gridWidth}
-                            cols={BREAKPOINT_COLUMN_COUNTS.sm}
-                            rowHeight={rowHeight}
-                            margin={margin}
-                            containerPadding={CONTAINER_PADDING}
-                            rows="auto"
-                            height={containerHeight} // kept in sync via ResizeObserver
-                            color="var(--color-bg-surface-secondary)"
-                        />
-                    )}
+                    {sections.map((section, sectionIndex) => {
+                        const displayLayouts = sectionLayouts[section.key] ?? {}
+                        const collapsed =
+                            !!section.group &&
+                            placement !== DashboardPlacement.Export &&
+                            !layoutEditMode &&
+                            collapsedDashboardSectionIds.includes(section.group.id)
+                        const isLastSection = sectionIndex === sections.length - 1
+                        return (
+                            <Fragment key={section.key}>
+                                <DashboardSection
+                                    group={section.isNamed ? section.group : null}
+                                    collapsed={collapsed}
+                                    canEdit={canEditDashboard && isEditablePlacement}
+                                    groupCount={groupCount}
+                                    tileCount={section.tiles.length}
+                                    onToggle={() => section.group && toggleDashboardSectionCollapsed(section.group.id)}
+                                    onRename={(name) => section.group && renameDashboardGroup(section.group.id, name)}
+                                    onMove={(position) =>
+                                        section.group && updateDashboardGroupPosition(section.group.id, position)
+                                    }
+                                    onDelete={(memberHandling) =>
+                                        section.group && deleteDashboardGroup(section.group.id, memberHandling)
+                                    }
+                                    overlay={
+                                        isEditablePlacement && inlineTileInsertionEnabled ? (
+                                            <InsertTileOverlay
+                                                layout={displayLayouts.sm}
+                                                gridWidth={gridWidth}
+                                                cols={BREAKPOINT_COLUMN_COUNTS.sm}
+                                                rowHeight={rowHeight}
+                                                marginX={margin[0]}
+                                                marginY={margin[1]}
+                                                canEditDashboard={canEditDashboard}
+                                                isMobileView={isMobileView}
+                                                disabled={resizingTileId !== null}
+                                                getMenuItems={(x, y, w) => getInsertMenuItems(section.key, x, y, w)}
+                                            />
+                                        ) : null
+                                    }
+                                    gridBackgroundProps={
+                                        layoutEditMode && !isMobileView
+                                            ? {
+                                                  width: gridWidth,
+                                                  cols: BREAKPOINT_COLUMN_COUNTS.sm,
+                                                  rowHeight,
+                                                  margin,
+                                                  containerPadding: CONTAINER_PADDING,
+                                                  rows: 'auto',
+                                                  height: containerHeight,
+                                                  color: 'var(--color-bg-surface-secondary)',
+                                              }
+                                            : null
+                                    }
+                                    gridProps={{
+                                        width: gridWidth,
+                                        className: classNameForSection(isLastSection),
+                                        dragConfig,
+                                        resizeConfig,
+                                        layouts: displayLayouts as Partial<Record<DashboardLayoutSize, Layout>>,
+                                        rowHeight,
+                                        margin,
+                                        containerPadding: CONTAINER_PADDING,
+                                        onLayoutChange: handleLayoutChange,
+                                        onWidthChange: handleWidthChange,
+                                        breakpoints: BREAKPOINTS,
+                                        cols: BREAKPOINT_COLUMN_COUNTS,
+                                        onResizeStart: handleResizeStart,
+                                        onResize: handleResize,
+                                        onResizeStop: handleResizeStop,
+                                        onDragStart: handleDragStart,
+                                        onDrag: handleDrag,
+                                        onDragStop: handleDragStop,
+                                    }}
+                                >
+                                    {section.tiles.map((tile) => {
+                                        const { insight, text, button_tile, widget } = tile
+                                        const smLayout = displayLayouts['sm']?.find((l) => {
+                                            return l.i == tile.id.toString()
+                                        })
+                                        const extraMoreOverlay = (
+                                            <MoveToSectionMenu
+                                                destinations={sections
+                                                    .filter(
+                                                        (candidate) => candidate.group && candidate.key !== section.key
+                                                    )
+                                                    .map((candidate) => ({
+                                                        groupId: candidate.group!.id,
+                                                        label: sectionDisplayName(candidate.group!),
+                                                    }))}
+                                                onMove={(groupId) =>
+                                                    moveDashboardTileToGroup({ tileId: tile.id, groupId })
+                                                }
+                                            />
+                                        )
 
-                    <ReactGridLayout
-                        width={gridWidth}
-                        className={className}
-                        dragConfig={dragConfig}
-                        resizeConfig={resizeConfig}
-                        layouts={layouts as Partial<Record<DashboardLayoutSize, Layout>>}
-                        rowHeight={rowHeight}
-                        margin={margin}
-                        containerPadding={CONTAINER_PADDING}
-                        onLayoutChange={handleLayoutChange}
-                        onWidthChange={handleWidthChange}
-                        breakpoints={BREAKPOINTS}
-                        cols={BREAKPOINT_COLUMN_COUNTS}
-                        onResizeStart={handleResizeStart}
-                        onResize={handleResize}
-                        onResizeStop={handleResizeStop}
-                        onDragStart={handleDragStart}
-                        onDrag={handleDrag}
-                        onDragStop={handleDragStop}
-                    >
-                        {tiles?.map((tile) => {
-                            const { insight, text, button_tile, widget } = tile
-                            const smLayout = layouts['sm']?.find((l) => {
-                                return l.i == tile.id.toString()
-                            })
-
-                            const commonTileProps = {
-                                dashboardId: dashboard?.id,
-                                showResizeHandles,
-                                canEnterEditModeFromEdge,
-                                onEnterEditModeFromEdge,
-                                onDragHandleMouseDown,
-                                showEditingControls,
-                                moveToDashboard: ({ id, name }: Pick<DashboardType, 'id' | 'name'>) => {
-                                    moveToDashboard(tile, requireDashboardId('move this tile'), id, name)
-                                },
-                                copyToDashboard: ({ id, name }: Pick<DashboardType, 'id' | 'name'>) => {
-                                    copyToDashboard(tile, requireDashboardId('copy this tile'), id, name)
-                                },
-                                removeFromDashboard: () => removeTile(tile),
-                            }
-
-                            if (tile.error && !insight) {
-                                return (
-                                    <MemoizedDashboardErrorTileItem
-                                        key={tile.id}
-                                        tile={tile}
-                                        onRemove={commonTileProps.removeFromDashboard}
-                                        showResizeHandles={showResizeHandles}
-                                        canEnterEditModeFromEdge={canEnterEditModeFromEdge}
-                                        onEnterEditModeFromEdge={onEnterEditModeFromEdge}
-                                        onDragHandleMouseDown={onDragHandleMouseDown}
-                                        showEditingControls={showEditingControls}
-                                    />
-                                )
-                            }
-
-                            if (insight) {
-                                // Check if this insight has an error from the server
-                                const isErrorTile = !!tile.error
-                                const queryError = getInsightQueryError(insight)
-                                const apiErrored =
-                                    isErrorTile || !!queryError || refreshStatus[insight.short_id]?.errored || false
-                                const refreshError = refreshStatus[insight.short_id]?.error
-                                const apiError = isErrorTile
-                                    ? new ApiError(undefined, 500, undefined, {
-                                          detail: tile.error!.message,
-                                          code: 'dashboard_tile_error',
-                                      })
-                                    : refreshError || queryError || undefined
-                                const loadingQueued = isErrorTile ? false : isRefreshingQueued(insight.short_id)
-                                const loading = isErrorTile ? false : isRefreshing(insight.short_id)
-
-                                return (
-                                    <MemoizedInsightCard
-                                        key={tile.id}
-                                        tile={tile}
-                                        insight={insight}
-                                        loadingQueued={loadingQueued}
-                                        loading={loading}
-                                        apiErrored={apiErrored}
-                                        apiError={apiError}
-                                        highlighted={highlightedInsightId && insight.short_id === highlightedInsightId}
-                                        updateColor={(color) => updateTileColor(tile.id, color)}
-                                        toggleShowDescription={() => toggleTileDescription(tile.id)}
-                                        ribbonColor={tile.color}
-                                        refresh={() => refreshDashboardItem({ tile })}
-                                        rename={() => renameInsight(insight)}
-                                        duplicate={() => duplicateTile(tile)}
-                                        setOverride={() => setTileOverride(tile)}
-                                        showDetailsControls={showDetailsControls}
-                                        placement={placement}
-                                        loadPriority={smLayout ? smLayout.y * 1000 + smLayout.x : undefined}
-                                        isResizing={resizingTileId === tile.id.toString()}
-                                        filtersOverride={effectiveEditBarFilters}
-                                        variablesOverride={effectiveDashboardVariableOverrides}
-                                        // :HACKY: The two props below aren't actually used in the component, but are needed to trigger a re-render
-                                        breakdownColorOverride={effectiveBreakdownColors}
-                                        dataColorThemeId={dataColorThemeId}
-                                        surveyOpportunity={tile.id === bestSurveyOpportunityFunnel?.id}
-                                        showCreateAnomalyAlertButton={showCreateAnomalyAlertButton}
-                                        {...commonTileProps}
-                                    />
-                                )
-                            }
-
-                            if (text) {
-                                return (
-                                    <MemoizedDashboardTextItem
-                                        key={tile.id}
-                                        tile={tile}
-                                        placement={placement}
-                                        dashboardId={dashboard?.id}
-                                        onEdit={() => {
-                                            if (dashboard?.id) {
-                                                push(urls.dashboardTextTile(dashboard.id, tile.id))
-                                            }
-                                        }}
-                                        onMoveToDashboard={commonTileProps.moveToDashboard}
-                                        onCopyToDashboard={commonTileProps.copyToDashboard}
-                                        onDuplicate={() => duplicateTile(tile)}
-                                        onRemove={commonTileProps.removeFromDashboard}
-                                        showResizeHandles={commonTileProps.showResizeHandles}
-                                        showEditingControls={commonTileProps.showEditingControls}
-                                        canEnterEditModeFromEdge={commonTileProps.canEnterEditModeFromEdge}
-                                        onEnterEditModeFromEdge={commonTileProps.onEnterEditModeFromEdge}
-                                        onDragHandleMouseDown={commonTileProps.onDragHandleMouseDown}
-                                    />
-                                )
-                            }
-
-                            if (button_tile) {
-                                return (
-                                    <MemoizedDashboardButtonTileItem
-                                        key={tile.id}
-                                        tile={tile}
-                                        placement={placement}
-                                        dashboardId={dashboard?.id}
-                                        isDraggingRef={isDragging}
-                                        onEdit={() => {
-                                            if (dashboard?.id) {
-                                                push(urls.dashboardButtonTile(dashboard.id, tile.id))
-                                            }
-                                        }}
-                                        onMoveToDashboard={commonTileProps.moveToDashboard}
-                                        onDuplicate={() => duplicateTile(tile)}
-                                        onRemove={commonTileProps.removeFromDashboard}
-                                        showResizeHandles={commonTileProps.showResizeHandles}
-                                        showEditingControls={commonTileProps.showEditingControls}
-                                        canEnterEditModeFromEdge={commonTileProps.canEnterEditModeFromEdge}
-                                        onEnterEditModeFromEdge={commonTileProps.onEnterEditModeFromEdge}
-                                        onDragHandleMouseDown={commonTileProps.onDragHandleMouseDown}
-                                    />
-                                )
-                            }
-
-                            if (widget && dashboardWidgetsEnabled && isWidgetTileVisibleOnPlacement(placement)) {
-                                const runResult = widgetResultsByTileId[tile.id]
-                                const refreshState = widgetRefreshStatus[tile.id]
-
-                                return (
-                                    <MemoizedDashboardWidgetItem
-                                        key={tile.id}
-                                        tile={tile}
-                                        placement={placement}
-                                        dashboardId={dashboard?.id}
-                                        canEditDashboard={canEditDashboard}
-                                        isDashboardEditMode={dashboardMode === DashboardMode.Edit}
-                                        result={runResult?.result}
-                                        error={getDashboardWidgetFetchDisplayError(
-                                            runResult?.error ?? refreshState?.error
-                                        )}
-                                        loading={!!refreshState?.loading}
-                                        lastFetchedAt={refreshState?.fetchedAt}
-                                        onRefresh={() =>
-                                            refreshDashboardWidgets({ tileIds: [tile.id], forceRefresh: true })
+                                        const commonTileProps = {
+                                            dashboardId: dashboard?.id,
+                                            showResizeHandles,
+                                            canEnterEditModeFromEdge,
+                                            onEnterEditModeFromEdge,
+                                            onDragHandleMouseDown,
+                                            showEditingControls,
+                                            moveToDashboard: ({ id, name }: Pick<DashboardType, 'id' | 'name'>) => {
+                                                moveToDashboard(tile, requireDashboardId('move this tile'), id, name)
+                                            },
+                                            copyToDashboard: ({ id, name }: Pick<DashboardType, 'id' | 'name'>) => {
+                                                copyToDashboard(tile, requireDashboardId('copy this tile'), id, name)
+                                            },
+                                            removeFromDashboard: () => removeTile(tile),
                                         }
-                                        onRefreshWidgetData={scheduleRefreshDashboardWidgets}
-                                        onApplyWidgetIssueMetadataChange={(tileId, issueId, delta, context) => {
-                                            applyWidgetIssueMetadataChange({
-                                                tileId,
-                                                issueId,
-                                                delta,
-                                                context,
-                                            })
-                                        }}
-                                        onUpdateWidgetTile={async (patch) => {
-                                            await updateWidgetTile({ tile, ...patch })
-                                        }}
-                                        toggleShowDescription={() => toggleTileDescription(tile.id)}
-                                        onDuplicate={() => duplicateTile(tile)}
-                                        onRemove={commonTileProps.removeFromDashboard}
-                                        onMoveToDashboard={commonTileProps.moveToDashboard}
-                                        onCopyToDashboard={commonTileProps.copyToDashboard}
-                                        showResizeHandles={commonTileProps.showResizeHandles}
-                                        showEditingControls={commonTileProps.showEditingControls}
-                                        canEnterEditModeFromEdge={commonTileProps.canEnterEditModeFromEdge}
-                                        onEnterEditModeFromEdge={commonTileProps.onEnterEditModeFromEdge}
-                                        onDragHandleMouseDown={commonTileProps.onDragHandleMouseDown}
-                                    />
-                                )
-                            }
-                        })}
-                    </ReactGridLayout>
-                    {isEditablePlacement && inlineTileInsertionEnabled && (
-                        <InsertTileOverlay
-                            layout={layouts['sm']}
-                            gridWidth={gridWidth}
-                            cols={BREAKPOINT_COLUMN_COUNTS.sm}
-                            rowHeight={rowHeight}
-                            marginX={margin[0]}
-                            marginY={margin[1]}
-                            canEditDashboard={canEditDashboard}
-                            isMobileView={isMobileView}
-                            disabled={resizingTileId !== null}
-                            getMenuItems={getInsertMenuItems}
-                        />
-                    )}
+
+                                        if (tile.error && !insight) {
+                                            return (
+                                                <MemoizedDashboardErrorTileItem
+                                                    key={tile.id}
+                                                    tile={tile}
+                                                    onRemove={commonTileProps.removeFromDashboard}
+                                                    showResizeHandles={showResizeHandles}
+                                                    canEnterEditModeFromEdge={canEnterEditModeFromEdge}
+                                                    onEnterEditModeFromEdge={onEnterEditModeFromEdge}
+                                                    onDragHandleMouseDown={onDragHandleMouseDown}
+                                                    showEditingControls={showEditingControls}
+                                                />
+                                            )
+                                        }
+
+                                        if (insight) {
+                                            // Check if this insight has an error from the server
+                                            const isErrorTile = !!tile.error
+                                            const queryError = getInsightQueryError(insight)
+                                            const apiErrored =
+                                                isErrorTile ||
+                                                !!queryError ||
+                                                refreshStatus[insight.short_id]?.errored ||
+                                                false
+                                            const refreshError = refreshStatus[insight.short_id]?.error
+                                            const apiError = isErrorTile
+                                                ? new ApiError(undefined, 500, undefined, {
+                                                      detail: tile.error!.message,
+                                                      code: 'dashboard_tile_error',
+                                                  })
+                                                : refreshError || queryError || undefined
+                                            const loadingQueued = isErrorTile
+                                                ? false
+                                                : isRefreshingQueued(insight.short_id)
+                                            const loading = isErrorTile ? false : isRefreshing(insight.short_id)
+
+                                            return (
+                                                <MemoizedInsightCard
+                                                    key={tile.id}
+                                                    tile={tile}
+                                                    insight={insight}
+                                                    loadingQueued={loadingQueued}
+                                                    loading={loading}
+                                                    apiErrored={apiErrored}
+                                                    apiError={apiError}
+                                                    highlighted={
+                                                        highlightedInsightId &&
+                                                        insight.short_id === highlightedInsightId
+                                                    }
+                                                    updateColor={(color) => updateTileColor(tile.id, color)}
+                                                    toggleShowDescription={() => toggleTileDescription(tile.id)}
+                                                    ribbonColor={tile.color}
+                                                    refresh={() => refreshDashboardItem({ tile })}
+                                                    rename={() => renameInsight(insight)}
+                                                    duplicate={() => duplicateTile(tile)}
+                                                    setOverride={() => setTileOverride(tile)}
+                                                    showDetailsControls={showDetailsControls}
+                                                    placement={placement}
+                                                    loadPriority={smLayout ? smLayout.y * 1000 + smLayout.x : undefined}
+                                                    isResizing={resizingTileId === tile.id.toString()}
+                                                    filtersOverride={effectiveEditBarFilters}
+                                                    variablesOverride={effectiveDashboardVariableOverrides}
+                                                    // :HACKY: The two props below aren't actually used in the component, but are needed to trigger a re-render
+                                                    breakdownColorOverride={effectiveBreakdownColors}
+                                                    dataColorThemeId={dataColorThemeId}
+                                                    surveyOpportunity={tile.id === bestSurveyOpportunityFunnel?.id}
+                                                    moreButtons={extraMoreOverlay}
+                                                    showCreateAnomalyAlertButton={showCreateAnomalyAlertButton}
+                                                    {...commonTileProps}
+                                                />
+                                            )
+                                        }
+
+                                        if (text) {
+                                            return (
+                                                <MemoizedDashboardTextItem
+                                                    key={tile.id}
+                                                    tile={tile}
+                                                    placement={placement}
+                                                    dashboardId={dashboard?.id}
+                                                    onEdit={() => {
+                                                        if (dashboard?.id) {
+                                                            push(urls.dashboardTextTile(dashboard.id, tile.id))
+                                                        }
+                                                    }}
+                                                    onMoveToDashboard={commonTileProps.moveToDashboard}
+                                                    onCopyToDashboard={commonTileProps.copyToDashboard}
+                                                    onDuplicate={() => duplicateTile(tile)}
+                                                    onRemove={commonTileProps.removeFromDashboard}
+                                                    showResizeHandles={commonTileProps.showResizeHandles}
+                                                    showEditingControls={commonTileProps.showEditingControls}
+                                                    canEnterEditModeFromEdge={commonTileProps.canEnterEditModeFromEdge}
+                                                    onEnterEditModeFromEdge={commonTileProps.onEnterEditModeFromEdge}
+                                                    onDragHandleMouseDown={commonTileProps.onDragHandleMouseDown}
+                                                    extraMoreOverlay={extraMoreOverlay}
+                                                />
+                                            )
+                                        }
+
+                                        if (button_tile) {
+                                            return (
+                                                <MemoizedDashboardButtonTileItem
+                                                    key={tile.id}
+                                                    tile={tile}
+                                                    placement={placement}
+                                                    dashboardId={dashboard?.id}
+                                                    isDraggingRef={isDragging}
+                                                    onEdit={() => {
+                                                        if (dashboard?.id) {
+                                                            push(urls.dashboardButtonTile(dashboard.id, tile.id))
+                                                        }
+                                                    }}
+                                                    onMoveToDashboard={commonTileProps.moveToDashboard}
+                                                    onDuplicate={() => duplicateTile(tile)}
+                                                    onRemove={commonTileProps.removeFromDashboard}
+                                                    showResizeHandles={commonTileProps.showResizeHandles}
+                                                    showEditingControls={commonTileProps.showEditingControls}
+                                                    canEnterEditModeFromEdge={commonTileProps.canEnterEditModeFromEdge}
+                                                    onEnterEditModeFromEdge={commonTileProps.onEnterEditModeFromEdge}
+                                                    onDragHandleMouseDown={commonTileProps.onDragHandleMouseDown}
+                                                    extraMoreOverlay={extraMoreOverlay}
+                                                />
+                                            )
+                                        }
+
+                                        if (
+                                            widget &&
+                                            dashboardWidgetsEnabled &&
+                                            isWidgetTileVisibleOnPlacement(placement)
+                                        ) {
+                                            const runResult = widgetResultsByTileId[tile.id]
+                                            const refreshState = widgetRefreshStatus[tile.id]
+
+                                            return (
+                                                <MemoizedDashboardWidgetItem
+                                                    key={tile.id}
+                                                    tile={tile}
+                                                    placement={placement}
+                                                    dashboardId={dashboard?.id}
+                                                    canEditDashboard={canEditDashboard}
+                                                    isDashboardEditMode={dashboardMode === DashboardMode.Edit}
+                                                    result={runResult?.result}
+                                                    error={getDashboardWidgetFetchDisplayError(
+                                                        runResult?.error ?? refreshState?.error
+                                                    )}
+                                                    loading={!!refreshState?.loading}
+                                                    lastFetchedAt={refreshState?.fetchedAt}
+                                                    onRefresh={() =>
+                                                        refreshDashboardWidgets({
+                                                            tileIds: [tile.id],
+                                                            forceRefresh: true,
+                                                        })
+                                                    }
+                                                    onRefreshWidgetData={scheduleRefreshDashboardWidgets}
+                                                    onApplyWidgetIssueMetadataChange={(
+                                                        tileId,
+                                                        issueId,
+                                                        delta,
+                                                        context
+                                                    ) => {
+                                                        applyWidgetIssueMetadataChange({
+                                                            tileId,
+                                                            issueId,
+                                                            delta,
+                                                            context,
+                                                        })
+                                                    }}
+                                                    onUpdateWidgetTile={async (patch) => {
+                                                        await updateWidgetTile({ tile, ...patch })
+                                                    }}
+                                                    toggleShowDescription={() => toggleTileDescription(tile.id)}
+                                                    onDuplicate={() => duplicateTile(tile)}
+                                                    onRemove={commonTileProps.removeFromDashboard}
+                                                    onMoveToDashboard={commonTileProps.moveToDashboard}
+                                                    onCopyToDashboard={commonTileProps.copyToDashboard}
+                                                    showResizeHandles={commonTileProps.showResizeHandles}
+                                                    showEditingControls={commonTileProps.showEditingControls}
+                                                    canEnterEditModeFromEdge={commonTileProps.canEnterEditModeFromEdge}
+                                                    onEnterEditModeFromEdge={commonTileProps.onEnterEditModeFromEdge}
+                                                    onDragHandleMouseDown={commonTileProps.onDragHandleMouseDown}
+                                                    extraMoreOverlay={extraMoreOverlay}
+                                                />
+                                            )
+                                        }
+                                    })}
+                                </DashboardSection>
+                            </Fragment>
+                        )
+                    })}
                 </div>
             )}
             {dashboardStreaming && (

--- a/frontend/src/scenes/dashboard/DashboardSection.stories.tsx
+++ b/frontend/src/scenes/dashboard/DashboardSection.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { DashboardSection } from './DashboardSection'
+
+const group = {
+    id: 'section-1',
+    name: 'Acquisition',
+    position: 0,
+    member_tile_ids: [1],
+    created_at: '2026-01-01T00:00:00Z',
+    created_by: null,
+    last_modified_at: '2026-01-01T00:00:00Z',
+    last_modified_by: null,
+}
+
+const gridProps = {
+    width: 640,
+    rowHeight: 80,
+    margin: [16, 16] as [number, number],
+    containerPadding: [0, 0] as [number, number],
+    layouts: {
+        sm: [{ i: '1', x: 0, y: 0, w: 6, h: 2 }],
+    },
+    cols: { sm: 12, xs: 1 },
+    breakpoints: { sm: 768, xs: 0 },
+}
+
+const meta: Meta<typeof DashboardSection> = {
+    title: 'Scenes/Dashboard/Dashboard Section',
+    component: DashboardSection,
+    args: {
+        group,
+        collapsed: false,
+        canEdit: true,
+        groupCount: 2,
+        tileCount: 1,
+        overlay: null,
+        gridBackgroundProps: null,
+        gridProps,
+        onToggle: () => {},
+        onRename: () => {},
+        onMove: () => {},
+        onDelete: () => {},
+        children: (
+            <div key="1" className="bg-surface-primary border border-primary rounded p-2">
+                Sample tile
+            </div>
+        ),
+    },
+}
+export default meta
+
+type Story = StoryObj<typeof DashboardSection>
+
+export const Named: Story = {}
+
+export const Anonymous: Story = {
+    args: { group: null },
+}
+
+export const Collapsed: Story = {
+    args: { collapsed: true },
+}

--- a/frontend/src/scenes/dashboard/DashboardSection.tsx
+++ b/frontend/src/scenes/dashboard/DashboardSection.tsx
@@ -1,0 +1,73 @@
+import clsx from 'clsx'
+import { ComponentProps, ReactNode } from 'react'
+import { Responsive as ReactGridLayout } from 'react-grid-layout'
+import { GridBackground } from 'react-grid-layout/extras'
+
+import type {
+    DashboardGroupApi,
+    MemberHandlingEnumApi,
+} from '@posthog/products-dashboards/frontend/generated/api.schemas'
+
+import { DashboardSectionHeader } from './DashboardSectionHeader'
+
+export interface DashboardSectionProps {
+    group: DashboardGroupApi | null
+    collapsed: boolean
+    canEdit: boolean
+    groupCount: number
+    tileCount: number
+    children: ReactNode
+    overlay: ReactNode
+    gridProps: ComponentProps<typeof ReactGridLayout>
+    gridBackgroundProps: ComponentProps<typeof GridBackground> | null
+    onToggle: () => void
+    onRename: (name: string) => void
+    onMove: (position: number) => void
+    onDelete: (memberHandling: MemberHandlingEnumApi) => void
+}
+
+export function DashboardSection({
+    group,
+    collapsed,
+    canEdit,
+    groupCount,
+    tileCount,
+    children,
+    overlay,
+    gridProps,
+    gridBackgroundProps,
+    onToggle,
+    onRename,
+    onMove,
+    onDelete,
+}: DashboardSectionProps): JSX.Element {
+    return (
+        <section
+            className={clsx(
+                'relative mb-4',
+                group && "rounded border bg-surface-tertiary [[theme='dark']_&]:bg-surface-secondary border-primary"
+            )}
+        >
+            {group && (
+                <DashboardSectionHeader
+                    group={group}
+                    collapsed={collapsed}
+                    canEdit={canEdit}
+                    groupCount={groupCount}
+                    tileCount={tileCount}
+                    onToggle={onToggle}
+                    onRename={onRename}
+                    onMove={onMove}
+                    onDelete={onDelete}
+                />
+            )}
+            {!collapsed && (
+                <div className={clsx('relative', group && 'px-3')}>
+                    {gridBackgroundProps && <GridBackground {...gridBackgroundProps} />}
+                    <ReactGridLayout {...gridProps}>{children}</ReactGridLayout>
+                    {overlay}
+                </div>
+            )}
+        </section>
+    )
+}

--- a/frontend/src/scenes/dashboard/DashboardSectionHeader.stories.tsx
+++ b/frontend/src/scenes/dashboard/DashboardSectionHeader.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import type { DashboardGroupApi } from '@posthog/products-dashboards/frontend/generated/api.schemas'
+
+import { DashboardSectionHeader } from './DashboardSectionHeader'
+
+const group = (overrides: Partial<DashboardGroupApi> = {}): DashboardGroupApi => ({
+    id: 'section-1',
+    name: 'Acquisition',
+    position: 1,
+    member_tile_ids: [1, 2],
+    created_at: '2026-01-01T00:00:00Z',
+    created_by: null,
+    last_modified_at: '2026-01-01T00:00:00Z',
+    last_modified_by: null,
+    ...overrides,
+})
+
+const meta: Meta<typeof DashboardSectionHeader> = {
+    title: 'Scenes/Dashboard/Dashboard Section Header',
+    component: DashboardSectionHeader,
+    args: {
+        group: group(),
+        collapsed: false,
+        canEdit: true,
+        groupCount: 3,
+        tileCount: 2,
+        onToggle: () => {},
+        onRename: () => {},
+        onMove: () => {},
+        onDelete: () => {},
+    },
+}
+export default meta
+
+type Story = StoryObj<typeof DashboardSectionHeader>
+
+export const Default: Story = {}
+
+export const Collapsed: Story = {
+    args: { collapsed: true },
+}
+
+export const ReadOnly: Story = {
+    args: { canEdit: false },
+}
+
+export const Untitled: Story = {
+    args: { group: group({ name: null }) },
+}
+
+export const FirstSection: Story = {
+    args: { group: group({ position: 0 }) },
+}

--- a/frontend/src/scenes/dashboard/DashboardSectionHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardSectionHeader.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'react'
+
+import { IconChevronRight, IconEllipsis } from '@posthog/icons'
+import type {
+    DashboardGroupApi,
+    MemberHandlingEnumApi,
+} from '@posthog/products-dashboards/frontend/generated/api.schemas'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
+import { LemonInput } from 'lib/lemon-ui/LemonInput'
+import { LemonMenu } from 'lib/lemon-ui/LemonMenu'
+import { pluralize } from 'lib/utils/strings'
+
+import { sectionDisplayName } from './dashboardSections'
+
+export interface DashboardSectionHeaderProps {
+    group: DashboardGroupApi
+    collapsed: boolean
+    canEdit: boolean
+    groupCount: number
+    tileCount: number
+    onToggle: () => void
+    onRename: (name: string) => void
+    onMove: (position: number) => void
+    onDelete: (memberHandling: MemberHandlingEnumApi) => void
+}
+
+export function DashboardSectionHeader({
+    group,
+    collapsed,
+    canEdit,
+    groupCount,
+    tileCount,
+    onToggle,
+    onRename,
+    onMove,
+    onDelete,
+}: DashboardSectionHeaderProps): JSX.Element {
+    const [editing, setEditing] = useState(false)
+    const [name, setName] = useState(group.name ?? '')
+
+    const submitRename = (): void => {
+        const trimmedName = name.trim()
+        setEditing(false)
+        if (trimmedName && trimmedName !== group.name) {
+            onRename(trimmedName)
+        } else {
+            setName(group.name ?? '')
+        }
+    }
+
+    return (
+        <div className="flex items-center gap-2 px-3 py-2">
+            <LemonButton
+                icon={<IconChevronRight className={collapsed ? '' : 'rotate-90'} />}
+                size="small"
+                onClick={onToggle}
+                tooltip={collapsed ? 'Expand section' : 'Collapse section'}
+                data-attr="dashboard-section-collapse"
+            />
+            {editing ? (
+                <LemonInput
+                    autoFocus
+                    value={name}
+                    onChange={setName}
+                    onBlur={submitRename}
+                    onKeyDown={(event) => {
+                        if (event.key === 'Enter') {
+                            submitRename()
+                        }
+                        if (event.key === 'Escape') {
+                            setName(group.name ?? '')
+                            setEditing(false)
+                        }
+                    }}
+                    data-attr="dashboard-section-rename-input"
+                />
+            ) : (
+                <h4 className="font-semibold mb-0">{sectionDisplayName(group)}</h4>
+            )}
+            <span className="text-muted text-sm">{pluralize(tileCount, 'tile')}</span>
+            {canEdit && (
+                <div className="ml-auto">
+                    <LemonMenu
+                        items={[
+                            { label: 'Rename', onClick: () => setEditing(true) },
+                            {
+                                label: 'Move up',
+                                disabledReason: group.position === 0 ? 'This section is first' : undefined,
+                                onClick: () => onMove(group.position - 1),
+                            },
+                            {
+                                label: 'Move down',
+                                disabledReason: group.position === groupCount - 1 ? 'This section is last' : undefined,
+                                onClick: () => onMove(group.position + 1),
+                            },
+                            {
+                                label: 'Delete',
+                                status: 'danger',
+                                onClick: () =>
+                                    LemonDialog.open({
+                                        title: 'Delete section?',
+                                        description:
+                                            'Delete the section and its tiles, or ungroup to keep the tiles without a heading.',
+                                        primaryButton: {
+                                            children: 'Delete section and tiles',
+                                            status: 'danger',
+                                            onClick: () => onDelete('delete_tiles'),
+                                        },
+                                        secondaryButton: {
+                                            children: 'Ungroup',
+                                            onClick: () => onDelete('ungroup'),
+                                        },
+                                        tertiaryButton: { children: 'Cancel' },
+                                    }),
+                            },
+                        ]}
+                    >
+                        <LemonButton icon={<IconEllipsis />} size="small" data-attr="dashboard-section-menu" />
+                    </LemonMenu>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/scenes/dashboard/MoveToSectionMenu.stories.tsx
+++ b/frontend/src/scenes/dashboard/MoveToSectionMenu.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { MoveToSectionMenu } from './MoveToSectionMenu'
+
+const meta: Meta<typeof MoveToSectionMenu> = {
+    title: 'Scenes/Dashboard/Move To Section Menu',
+    component: MoveToSectionMenu,
+    args: {
+        destinations: [
+            { groupId: 'a', label: 'Acquisition' },
+            { groupId: 'b', label: 'Untitled section' },
+        ],
+        onMove: () => {},
+    },
+}
+export default meta
+
+type Story = StoryObj<typeof MoveToSectionMenu>
+
+export const Default: Story = {}
+
+export const HiddenWhenEmpty: Story = {
+    args: { destinations: [] },
+}

--- a/frontend/src/scenes/dashboard/MoveToSectionMenu.tsx
+++ b/frontend/src/scenes/dashboard/MoveToSectionMenu.tsx
@@ -1,0 +1,31 @@
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonMenu } from 'lib/lemon-ui/LemonMenu'
+
+export interface MoveToSectionDestination {
+    groupId: string
+    label: string
+}
+
+export interface MoveToSectionMenuProps {
+    destinations: MoveToSectionDestination[]
+    onMove: (groupId: string) => void
+}
+
+export function MoveToSectionMenu({ destinations, onMove }: MoveToSectionMenuProps): JSX.Element | null {
+    if (destinations.length === 0) {
+        return null
+    }
+
+    return (
+        <LemonMenu
+            items={destinations.map((destination) => ({
+                label: destination.label,
+                onClick: () => onMove(destination.groupId),
+            }))}
+        >
+            <LemonButton fullWidth data-attr="dashboard-tile-move-to-section">
+                Move to section
+            </LemonButton>
+        </LemonMenu>
+    )
+}

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -393,6 +393,26 @@ describe('dashboardLogic', () => {
             )
         })
 
+        it('updateLayouts for a subset of tiles leaves other tiles layouts alone', async () => {
+            await expectLogic(logic).toFinishAllListeners()
+
+            const tiles = logic.values.dashboard!.tiles
+            expect(tiles.length).toBeGreaterThan(1)
+            const firstTile = tiles[0]
+            const secondTile = tiles[1]
+            const secondLayouts = secondTile.layouts
+
+            await expectLogic(logic, () => {
+                logic.actions.updateLayouts({
+                    sm: [{ i: String(firstTile.id), x: 3, y: 0, w: 6, h: 5 }],
+                })
+            }).toFinishAllListeners()
+
+            const updatedTiles = logic.values.dashboard!.tiles
+            expect(updatedTiles.find((tile) => tile.id === firstTile.id)?.layouts.sm).toMatchObject({ x: 3, y: 0 })
+            expect(updatedTiles.find((tile) => tile.id === secondTile.id)?.layouts).toEqual(secondLayouts)
+        })
+
         it('saving after filter change calls api', async () => {
             await expectLogic(logic).toFinishAllListeners()
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -23,7 +23,17 @@ import { ResponsiveLayouts } from 'react-grid-layout'
 import type { Layout } from 'react-grid-layout'
 
 import { LemonDialog, lemonToast } from '@posthog/lemon-ui'
-import type { DashboardWidgetRunResultApi } from '@posthog/products-dashboards/frontend/generated/api.schemas'
+import {
+    dashboardsGroupsCreate,
+    dashboardsGroupsDeleteCreate,
+    dashboardsGroupsMoveTileCreate,
+    dashboardsGroupsUpdatePartialUpdate,
+} from '@posthog/products-dashboards/frontend/generated/api'
+import type {
+    DashboardWidgetRunResultApi,
+    MemberHandlingEnumApi,
+    TileLayoutsApi,
+} from '@posthog/products-dashboards/frontend/generated/api.schemas'
 import { isWidgetConfigValidationError, updateDashboardWidgetTile } from '@posthog/products-dashboards/frontend/utils'
 import {
     DASHBOARD_WIDGET_CATALOG,
@@ -126,6 +136,7 @@ import {
     mergeBreakdownColorConfigs,
 } from './dashboardBreakdownColors'
 import { AUTO_REFRESH_INITIAL_INTERVAL_SECONDS } from './dashboardConstants'
+import { partitionDashboardSections, isPersistedSectionKey, type DashboardSection } from './dashboardSections'
 import {
     BREAKPOINT_COLUMN_COUNTS,
     DASHBOARD_MIN_REFRESH_INTERVAL_MINUTES,
@@ -193,6 +204,7 @@ export enum RefreshDashboardItemsAction {
 export type DashboardTileLayoutUpdatePayload = Pick<DashboardTile, 'id' | 'layouts'>
 
 export interface PendingInsertion {
+    sectionKey: string
     x: number
     y: number
     // Width override for the full-width fallback when the hovered column can't anchor the tile; else null.
@@ -264,8 +276,10 @@ export interface dashboardLogicValues {
     canRestrictDashboard: boolean
     canSaveProjectDashboardTemplate: boolean
     cancellingPreview: boolean
+    collapsedDashboardSectionIds: string[]
     columns: number | null
     containerWidth: number | null
+    createDashboardGroupLoading: boolean
     currentLayoutSize: 'sm' | 'xs'
     dashboard: DashboardType<QueryBasedInsightModel> | null
     dashboardFailedToLoad: boolean
@@ -334,6 +348,8 @@ export interface dashboardLogicValues {
     refreshStatus: Record<string, RefreshStatus>
     refreshTilesTotal: number | null
     scrollToBottomSignal: number
+    sectionLayouts: Record<string, Partial<Record<DashboardLayoutSize, Layout>>>
+    sections: DashboardSection[]
     shouldReportOnAPILoad: boolean
     shouldUseStreaming: boolean
     showApplyFiltersBanner: boolean
@@ -459,8 +475,21 @@ export interface dashboardLogicActions {
             toDashboardName: string
         }
     }
+    createDashboardGroup: (name: string) => {
+        name: string
+    }
+    createDashboardGroupFinished: () => {
+        value: true
+    }
     dashboardNotFound: () => {
         value: true
+    }
+    deleteDashboardGroup: (
+        groupId: string,
+        memberHandling: MemberHandlingEnumApi
+    ) => {
+        groupId: string
+        memberHandling: MemberHandlingEnumApi
     }
     duplicateTile: (tile: DashboardTile<QueryBasedInsightModel>) => {
         tile: DashboardTile<QueryBasedInsightModel<Node<Record<string, any>>>>
@@ -536,6 +565,17 @@ export interface dashboardLogicActions {
     }
     loadingDashboardItemsStarted: (action: DashboardLoadAction) => {
         action: DashboardLoadAction
+    }
+    moveDashboardTileToGroup: (payload: {
+        createAtPosition?: number
+        groupId?: string
+        layouts?: TileLayoutsApi
+        tileId: number
+    }) => {
+        createAtPosition?: number | undefined
+        groupId?: string | undefined
+        layouts?: TileLayoutsApi | undefined
+        tileId: number
     }
     moveToDashboard: (
         tile: DashboardTile<QueryBasedInsightModel>,
@@ -626,6 +666,13 @@ export interface dashboardLogicActions {
         payload?: {
             tile: DashboardTile<QueryBasedInsightModel<Node<Record<string, any>>>>
         }
+    }
+    renameDashboardGroup: (
+        groupId: string,
+        name: string | null
+    ) => {
+        groupId: string
+        name: string | null
     }
     reportDashboardViewed: () => {
         value: true
@@ -862,6 +909,9 @@ export interface dashboardLogicActions {
     toggleAddWidgetSelectedType: (widgetType: string) => {
         widgetType: string
     }
+    toggleDashboardSectionCollapsed: (groupId: string) => {
+        groupId: string
+    }
     togglePinned: () => {
         value: true
     }
@@ -880,6 +930,13 @@ export interface dashboardLogicActions {
     ) => {
         columns: number
         containerWidth: number
+    }
+    updateDashboardGroupPosition: (
+        groupId: string,
+        position: number
+    ) => {
+        groupId: string
+        position: number
     }
     updateDashboardLastRefresh: (lastDashboardRefresh: Dayjs) => {
         lastDashboardRefresh: Dayjs
@@ -1084,6 +1141,13 @@ export interface dashboardLogicMeta {
             currentTeam: null | import('~/types').TeamPublicType | import('~/types').TeamType
         ) => boolean
         sizeKey: (columns: number | null) => DashboardLayoutSize | undefined
+        sections: (
+            tiles: DashboardTile<QueryBasedInsightModel<Node<Record<string, any>>>>[],
+            dashboard: DashboardType<QueryBasedInsightModel<Node<Record<string, any>>>> | null
+        ) => DashboardSection[]
+        sectionLayouts: (
+            sections: DashboardSection<QueryBasedInsightModel<Node<Record<string, any>>>>[]
+        ) => Record<string, Partial<Record<DashboardLayoutSize, Layout>>>
         layouts: (
             tiles: DashboardTile<QueryBasedInsightModel<Node<Record<string, any>>>>[]
         ) => Partial<Record<DashboardLayoutSize, Layout>>
@@ -1319,6 +1383,21 @@ export const dashboardLogic = kea<dashboardLogicType>([
         updateLayouts: (layouts: ResponsiveLayouts) => ({ layouts }),
         setPendingInsertion: (pendingInsertion: PendingInsertion | null) => ({ pendingInsertion }),
         applyPendingInsertion: true,
+        createDashboardGroup: (name: string) => ({ name }),
+        createDashboardGroupFinished: true,
+        renameDashboardGroup: (groupId: string, name: string | null) => ({ groupId, name }),
+        updateDashboardGroupPosition: (groupId: string, position: number) => ({ groupId, position }),
+        deleteDashboardGroup: (groupId: string, memberHandling: MemberHandlingEnumApi) => ({
+            groupId,
+            memberHandling,
+        }),
+        moveDashboardTileToGroup: (payload: {
+            tileId: number
+            groupId?: string
+            createAtPosition?: number
+            layouts?: TileLayoutsApi
+        }) => payload,
+        toggleDashboardSectionCollapsed: (groupId: string) => ({ groupId }),
         updateContainerWidth: (containerWidth: number, columns: number) => ({ containerWidth, columns }),
         updateTileColor: (tileId: number, color: InsightColor | null) => ({ tileId, color }),
         toggleTileDescription: (tileId: number) => ({ tileId }),
@@ -1602,7 +1681,14 @@ export const dashboardLogic = kea<dashboardLogicType>([
                             newTile.text = { body: newTile.text.body } as TextModel
                         }
 
-                        const { duplicateLayouts, tilesToUpdate } = calculateDuplicateLayout(values.layouts, tile.id)
+                        const { duplicateLayouts, tilesToUpdate } = calculateDuplicateLayout(
+                            values.sectionLayouts[
+                                values.sections.find((section) =>
+                                    section.tiles.some((candidate) => candidate.id === tile.id)
+                                )?.key ?? ''
+                            ] ?? values.layouts,
+                            tile.id
+                        )
 
                         const dashboard: DashboardType<InsightModel> = await api.update(
                             `api/environments/${values.currentTeamId}/dashboards/${props.id}`,
@@ -1886,12 +1972,14 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 updateLayouts: (state, { layouts }) => {
                     const itemLayouts = layoutsByTile(layouts)
 
-                    // Only persist sm layouts; xs layouts are derived on the fly
+                    // Only persist sm layouts; xs layouts are derived on the fly.
+                    // Tiles missing from this payload keep their current layouts so a
+                    // per-section grid cannot wipe another section's geometry.
                     return {
                         ...state,
                         tiles: state?.tiles?.map((tile) => ({
                             ...tile,
-                            layouts: itemLayouts[tile.id]?.sm ? { sm: itemLayouts[tile.id].sm } : {},
+                            layouts: itemLayouts[tile.id]?.sm ? { sm: itemLayouts[tile.id].sm } : tile.layouts,
                         })),
                     } as DashboardType<QueryBasedInsightModel>
                 },
@@ -1900,6 +1988,59 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         ...state,
                         tiles: state?.tiles?.map((tile) => (tile.id === tileId ? { ...tile, ...properties } : tile)),
                     } as DashboardType<QueryBasedInsightModel>
+                },
+                renameDashboardGroup: (state, { groupId, name }) =>
+                    state
+                        ? {
+                              ...state,
+                              groups: state.groups?.map((group) => (group.id === groupId ? { ...group, name } : group)),
+                          }
+                        : state,
+                updateDashboardGroupPosition: (state, { groupId, position }) => {
+                    if (!state?.groups) {
+                        return state
+                    }
+                    const movedGroup = state.groups.find((group) => group.id === groupId)
+                    if (!movedGroup) {
+                        return state
+                    }
+                    const groups = state.groups.filter((group) => group.id !== groupId)
+                    groups.splice(Math.max(0, Math.min(position, groups.length)), 0, movedGroup)
+                    return {
+                        ...state,
+                        groups: groups.map((group, nextPosition) => ({ ...group, position: nextPosition })),
+                    }
+                },
+                deleteDashboardGroup: (state, { groupId, memberHandling }) => {
+                    if (!state) {
+                        return state
+                    }
+                    if (memberHandling === 'ungroup') {
+                        return {
+                            ...state,
+                            groups: state.groups?.map((group) =>
+                                group.id === groupId ? { ...group, name: null } : group
+                            ),
+                        }
+                    }
+                    return {
+                        ...state,
+                        groups: state.groups
+                            ?.filter((group) => group.id !== groupId)
+                            .map((group, position) => ({ ...group, position })),
+                        tiles: state.tiles.filter((tile) => tile.parent_group_id !== groupId),
+                    }
+                },
+                moveDashboardTileToGroup: (state, { tileId, groupId }) => {
+                    if (!state || !groupId) {
+                        return state
+                    }
+                    return {
+                        ...state,
+                        tiles: state.tiles.map((tile) =>
+                            tile.id === tileId ? { ...tile, parent_group_id: groupId } : tile
+                        ),
+                    }
                 },
                 removeTile: (state, { tile }) => {
                     // Optimistically drop the tile so the grid reflows immediately; the loader rolls back on failure.
@@ -2389,6 +2530,20 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 addWidgetTileFinished: () => false,
             },
         ],
+        createDashboardGroupLoading: [
+            false,
+            {
+                createDashboardGroup: () => true,
+                createDashboardGroupFinished: () => false,
+            },
+        ],
+        collapsedDashboardSectionIds: [
+            [] as string[],
+            {
+                toggleDashboardSectionCollapsed: (state, { groupId }) =>
+                    state.includes(groupId) ? state.filter((id) => id !== groupId) : [...state, groupId],
+            },
+        ],
         // Incremented on each scroll-to-bottom request; the view effects on the change.
         scrollToBottomSignal: [
             0,
@@ -2851,6 +3006,20 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 return size
             },
         ],
+        sections: [
+            (s) => [s.tiles, s.dashboard],
+            (
+                tiles: DashboardTile<QueryBasedInsightModel>[],
+                dashboard: DashboardType<QueryBasedInsightModel> | null
+            ): DashboardSection[] => partitionDashboardSections(tiles, dashboard?.groups),
+            { resultEqualityCheck: objectsEqual },
+        ],
+        sectionLayouts: [
+            (s) => [s.sections],
+            (sections: DashboardSection[]): Record<string, Partial<Record<DashboardLayoutSize, Layout>>> =>
+                Object.fromEntries(sections.map((section) => [section.key, calculateLayouts(section.tiles)])),
+            { resultEqualityCheck: objectsEqual },
+        ],
         layouts: [
             (s) => [s.tiles],
             (
@@ -3140,6 +3309,80 @@ export const dashboardLogic = kea<dashboardLogicType>([
         },
     })),
     listeners(({ actions, values, cache, props, sharedListeners }) => ({
+        createDashboardGroup: async ({ name }) => {
+            try {
+                if (values.currentTeamId == null) {
+                    return
+                }
+                await dashboardsGroupsCreate(String(values.currentTeamId), props.id, { name })
+                actions.loadDashboard({ action: DashboardLoadAction.Update })
+                lemonToast.success('Section added')
+            } catch {
+                lemonToast.error("Couldn't add section. Try again.")
+            } finally {
+                actions.createDashboardGroupFinished()
+            }
+        },
+        renameDashboardGroup: async ({ groupId, name }) => {
+            try {
+                if (values.currentTeamId == null) {
+                    return
+                }
+                await dashboardsGroupsUpdatePartialUpdate(String(values.currentTeamId), props.id, {
+                    group_id: groupId,
+                    name,
+                })
+            } catch {
+                actions.loadDashboard({ action: DashboardLoadAction.Update })
+                lemonToast.error("Couldn't rename section. Try again.")
+            }
+        },
+        updateDashboardGroupPosition: async ({ groupId, position }) => {
+            try {
+                if (values.currentTeamId == null) {
+                    return
+                }
+                await dashboardsGroupsUpdatePartialUpdate(String(values.currentTeamId), props.id, {
+                    group_id: groupId,
+                    position,
+                })
+            } catch {
+                actions.loadDashboard({ action: DashboardLoadAction.Update })
+                lemonToast.error("Couldn't move section. Try again.")
+            }
+        },
+        deleteDashboardGroup: async ({ groupId, memberHandling }) => {
+            try {
+                if (values.currentTeamId == null) {
+                    return
+                }
+                await dashboardsGroupsDeleteCreate(String(values.currentTeamId), props.id, {
+                    group_id: groupId,
+                    member_handling: memberHandling,
+                })
+                actions.loadDashboard({ action: DashboardLoadAction.Update })
+            } catch {
+                actions.loadDashboard({ action: DashboardLoadAction.Update })
+                lemonToast.error("Couldn't delete section. Try again.")
+            }
+        },
+        moveDashboardTileToGroup: async ({ tileId, groupId, createAtPosition, layouts }) => {
+            try {
+                if (values.currentTeamId == null) {
+                    return
+                }
+                const destination = groupId ? { group_id: groupId } : { create_at_position: createAtPosition }
+                await dashboardsGroupsMoveTileCreate(String(values.currentTeamId), props.id, {
+                    tile_id: tileId,
+                    ...destination,
+                    layouts,
+                })
+                actions.loadDashboard({ action: DashboardLoadAction.Update })
+            } catch {
+                actions.loadDashboard({ action: DashboardLoadAction.Update })
+                lemonToast.error("Couldn't move tile. Try again.")
+            }
+        },
         scheduleRefreshDashboardWidgets: ({ tileId }: { tileId: number }) => {
             if (!cache.widgetTileRefreshScheduler) {
                 cache.widgetTileRefreshScheduler = createDashboardWidgetTileRefreshScheduler((id) =>
@@ -3279,7 +3522,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
             // Clear before persisting so the resulting updateDashboardSuccess doesn't re-enter this listener.
             actions.setPendingInsertion(null)
 
-            const smLayout = values.layouts?.sm
+            const smLayout = (values.sectionLayouts[slot.sectionKey] ?? values.layouts)?.sm
             const newTileLayoutEntry = smLayout?.find((l) => String(l.i) === String(newTile.id))
             const w = slot.w ?? newTileLayoutEntry?.w ?? DEFAULT_INSERTED_TILE_SIZE.w
             const h = newTileLayoutEntry?.h ?? DEFAULT_INSERTED_TILE_SIZE.h
@@ -3303,6 +3546,14 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 return shifted ? { ...l, ...shifted } : l
             })
             actions.updateLayouts({ ...values.layouts, sm: newSmLayout })
+
+            if (isPersistedSectionKey(slot.sectionKey) && newTile.parent_group_id !== slot.sectionKey) {
+                actions.moveDashboardTileToGroup({
+                    tileId: newTile.id,
+                    groupId: slot.sectionKey,
+                    layouts: newTileLayout,
+                })
+            }
 
             // The inline insert has now landed at the line — report it (outcome, vs the option-clicked intent).
             const insertedTileType = newTile.text
@@ -3877,6 +4128,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     actions.setPendingInsertion(null)
                 }
                 const insertSlot = widgets.length === 1 ? values.pendingInsertion : null
+                const insertGroupId =
+                    insertSlot && isPersistedSectionKey(insertSlot.sectionKey) ? insertSlot.sectionKey : undefined
                 const widgetsPayload = widgets.map(({ widgetType, config }) => {
                     if (!insertSlot) {
                         return { widget_type: widgetType, config }
@@ -3891,6 +4144,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         widget_type: widgetType,
                         config,
                         layouts: { sm: { x: insertSlot.x, y: insertSlot.y, w, h } },
+                        ...(insertGroupId ? { group_id: insertGroupId } : {}),
                     }
                 })
 

--- a/frontend/src/scenes/dashboard/dashboardSections.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardSections.test.ts
@@ -1,0 +1,72 @@
+import type { DashboardGroupApi } from '@posthog/products-dashboards/frontend/generated/api.schemas'
+
+import type { DashboardTile, QueryBasedInsightModel } from '~/types'
+
+import {
+    IMPLICIT_SECTION_KEY,
+    ORPHAN_SECTION_KEY,
+    partitionDashboardSections,
+    sectionDisplayName,
+} from './dashboardSections'
+
+const tile = (id: number, parentGroupId?: string | null): DashboardTile<QueryBasedInsightModel> => ({
+    id,
+    layouts: {},
+    color: null,
+    parent_group_id: parentGroupId,
+})
+
+const group = (
+    overrides: Partial<DashboardGroupApi> & Pick<DashboardGroupApi, 'id' | 'position'>
+): DashboardGroupApi => ({
+    name: null,
+    member_tile_ids: [],
+    created_at: '2026-01-01T00:00:00Z',
+    created_by: null,
+    last_modified_at: '2026-01-01T00:00:00Z',
+    last_modified_by: null,
+    ...overrides,
+})
+
+describe('partitionDashboardSections', () => {
+    it('returns a single implicit section when the dashboard has no groups', () => {
+        const tiles = [tile(1), tile(2)]
+        expect(partitionDashboardSections(tiles, [])).toEqual([
+            { key: IMPLICIT_SECTION_KEY, group: null, isNamed: false, tiles },
+        ])
+    })
+
+    it('keeps named empty sections and drops empty anonymous ones', () => {
+        const named = group({ id: 'named', name: 'Revenue', position: 0 })
+        const anonymous = group({ id: 'anon', name: null, position: 1 })
+        const sections = partitionDashboardSections([], [anonymous, named])
+
+        expect(sections.map((section) => section.key)).toEqual(['named'])
+        expect(sections[0].isNamed).toBe(true)
+    })
+
+    it('orders by position then created_at and buckets tiles by parent_group_id', () => {
+        const first = group({ id: 'a', name: 'A', position: 1, created_at: '2026-01-02T00:00:00Z' })
+        const second = group({ id: 'b', name: 'B', position: 0, created_at: '2026-01-03T00:00:00Z' })
+        const third = group({ id: 'c', name: 'C', position: 1, created_at: '2026-01-01T00:00:00Z' })
+        const sections = partitionDashboardSections(
+            [tile(1, 'a'), tile(2, 'c'), tile(3, 'missing'), tile(4, null)],
+            [first, second, third]
+        )
+
+        expect(sections.map((section) => section.key)).toEqual(['b', 'c', 'a', ORPHAN_SECTION_KEY])
+        expect(sections[1].tiles.map((item) => item.id)).toEqual([2])
+        expect(sections[2].tiles.map((item) => item.id)).toEqual([1])
+        expect(sections[3].tiles.map((item) => item.id)).toEqual([3, 4])
+    })
+})
+
+describe('sectionDisplayName', () => {
+    it.each([
+        ['Revenue', 'Revenue'],
+        ['  ', 'Untitled section'],
+        [null, 'Untitled section'],
+    ])('name=%j → %s', (name, expected) => {
+        expect(sectionDisplayName(group({ id: 'g', position: 0, name }))).toBe(expected)
+    })
+})

--- a/frontend/src/scenes/dashboard/dashboardSections.ts
+++ b/frontend/src/scenes/dashboard/dashboardSections.ts
@@ -1,0 +1,64 @@
+import type { DashboardGroupApi } from '@posthog/products-dashboards/frontend/generated/api.schemas'
+
+import type { DashboardTile, QueryBasedInsightModel } from '~/types'
+
+export const IMPLICIT_SECTION_KEY = 'implicit'
+export const ORPHAN_SECTION_KEY = 'orphan'
+
+export interface DashboardSection<T = QueryBasedInsightModel> {
+    key: string
+    group: DashboardGroupApi | null
+    isNamed: boolean
+    tiles: DashboardTile<T>[]
+}
+
+export function isPersistedSectionKey(key: string): boolean {
+    return key !== IMPLICIT_SECTION_KEY && key !== ORPHAN_SECTION_KEY
+}
+
+export function sectionDisplayName(group: DashboardGroupApi): string {
+    const name = group.name?.trim()
+    return name || 'Untitled section'
+}
+
+export function partitionDashboardSections<T = QueryBasedInsightModel>(
+    tiles: DashboardTile<T>[],
+    groups: readonly DashboardGroupApi[] | undefined
+): DashboardSection<T>[] {
+    const sortedGroups = [...(groups ?? [])].sort(
+        (firstGroup, secondGroup) =>
+            firstGroup.position - secondGroup.position || firstGroup.created_at.localeCompare(secondGroup.created_at)
+    )
+    if (sortedGroups.length === 0) {
+        return [{ key: IMPLICIT_SECTION_KEY, group: null, isNamed: false, tiles }]
+    }
+
+    const tilesByGroup = new Map<string, DashboardTile<T>[]>()
+    const orphanTiles: DashboardTile<T>[] = []
+    const groupIds = new Set(sortedGroups.map((group) => group.id))
+    for (const tile of tiles) {
+        if (tile.parent_group_id && groupIds.has(tile.parent_group_id)) {
+            const groupTiles = tilesByGroup.get(tile.parent_group_id) ?? []
+            groupTiles.push(tile)
+            tilesByGroup.set(tile.parent_group_id, groupTiles)
+        } else {
+            orphanTiles.push(tile)
+        }
+    }
+
+    const sections = sortedGroups
+        .map(
+            (group): DashboardSection<T> => ({
+                key: group.id,
+                group,
+                isNamed: !!group.name,
+                tiles: tilesByGroup.get(group.id) ?? [],
+            })
+        )
+        .filter((section) => section.isNamed || section.tiles.length > 0)
+
+    if (orphanTiles.length > 0) {
+        sections.push({ key: ORPHAN_SECTION_KEY, group: null, isNamed: false, tiles: orphanTiles })
+    }
+    return sections
+}

--- a/frontend/src/scenes/dashboard/dashboardUtils.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.test.ts
@@ -69,6 +69,76 @@ describe('dashboardToSaveableTemplate', () => {
             button_tile: { url: '/replay/home', text: 'Watch replays' },
         })
     })
+
+    it('emits named group headers and remaps anonymous tiles by y without a group_key', () => {
+        const named = {
+            id: 'named',
+            name: 'Revenue',
+            position: 0,
+            member_tile_ids: [1],
+            created_at: '2026-01-01T00:00:00Z',
+            created_by: null,
+            last_modified_at: '2026-01-01T00:00:00Z',
+            last_modified_by: null,
+        }
+        const anonymous = {
+            id: 'anon',
+            name: null,
+            position: 1,
+            member_tile_ids: [2],
+            created_at: '2026-01-01T00:00:00Z',
+            created_by: null,
+            last_modified_at: '2026-01-01T00:00:00Z',
+            last_modified_by: null,
+        }
+        const dashboard = {
+            name: 'My dashboard',
+            description: '',
+            filters: {},
+            tags: [],
+            groups: [named, anonymous],
+            tiles: [
+                {
+                    id: 1,
+                    text: { body: 'Named', last_modified_at: '2026-01-01T00:00:00Z' },
+                    layouts: { sm: { x: 0, y: 0, w: 12, h: 1 } },
+                    color: null,
+                    parent_group_id: 'named',
+                },
+                {
+                    id: 2,
+                    text: { body: 'Anon', last_modified_at: '2026-01-01T00:00:00Z' },
+                    layouts: { sm: { x: 0, y: 0, w: 12, h: 2 } },
+                    color: null,
+                    parent_group_id: 'anon',
+                },
+            ],
+        } as unknown as DashboardType<InsightModel>
+
+        const tiles = dashboardToSaveableTemplate(dashboard)?.tiles
+        expect(tiles).toEqual([
+            {
+                type: 'GROUP',
+                group_key: 'named',
+                name: 'Revenue',
+                layouts: { sm: { x: 0, y: 0, w: 12, h: 1 } },
+            },
+            {
+                type: 'TEXT',
+                body: 'Named',
+                layouts: { sm: { x: 0, y: 1, w: 12, h: 1 } },
+                color: null,
+                group_key: 'named',
+            },
+            {
+                type: 'TEXT',
+                body: 'Anon',
+                layouts: { sm: { x: 0, y: 2, w: 12, h: 2 } },
+                color: null,
+                group_key: undefined,
+            },
+        ])
+    })
 })
 
 describe('isWidgetTileVisibleOnPlacement', () => {

--- a/frontend/src/scenes/dashboard/dashboardUtils.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.ts
@@ -22,6 +22,7 @@ import {
     DashboardLayoutSize,
     DashboardPlacement,
     DashboardTemplateEditorType,
+    DashboardTemplateStoredTile,
     DashboardTile,
     DashboardType,
     DashboardWidgetType,
@@ -31,6 +32,7 @@ import {
 } from '~/types'
 
 import { SHARED_DASHBOARD_AUTO_FORCE_IF_STALE_MINUTES } from './dashboardConstants'
+import { partitionDashboardSections } from './dashboardSections'
 
 export function getInsightQueryError(insight: QueryBasedInsightModel): ApiError | null {
     const queryStatus = insight.query_status
@@ -46,6 +48,58 @@ export function getInsightQueryError(insight: QueryBasedInsightModel): ApiError 
     })
 }
 
+function serializeDashboardTileForTemplate(
+    tile: DashboardTile<InsightModel>,
+    layouts: DashboardTile['layouts'],
+    groupKey: string | undefined
+): DashboardTemplateStoredTile {
+    if (tile.text) {
+        return {
+            type: 'TEXT',
+            body: tile.text.body,
+            layouts,
+            color: tile.color,
+            group_key: groupKey,
+        }
+    }
+    if (tile.insight) {
+        return {
+            type: 'INSIGHT',
+            name: tile.insight.name,
+            description: tile.insight.description || '',
+            query: tile.insight.query,
+            layouts,
+            color: tile.color,
+            group_key: groupKey,
+        }
+    }
+    if (tile.button_tile) {
+        return {
+            type: 'BUTTON',
+            button_tile: {
+                url: tile.button_tile.url,
+                text: tile.button_tile.text,
+                placement: tile.button_tile.placement,
+                style: tile.button_tile.style,
+            },
+            layouts,
+            color: tile.color,
+            group_key: groupKey,
+        }
+    }
+    if (tile.widget) {
+        return {
+            type: 'WIDGET',
+            widget_type: tile.widget.widget_type,
+            config: tile.widget.config,
+            layouts,
+            color: tile.color,
+            group_key: groupKey,
+        }
+    }
+    throw new Error('Unknown tile type')
+}
+
 /** Shape used for staff JSON export, customer save-as-template, and API `create_from_template_json`. */
 export function dashboardToSaveableTemplate(
     dashboard: DashboardType<InsightModel> | null | undefined
@@ -53,77 +107,46 @@ export function dashboardToSaveableTemplate(
     if (!dashboard) {
         return undefined
     }
+
+    const sections = partitionDashboardSections(
+        dashboard.tiles.filter((tile) => !tile.error),
+        dashboard.groups
+    )
+    const tiles: DashboardTemplateStoredTile[] = []
+    let globalY = 0
+
+    for (const section of sections) {
+        const namedGroup = section.isNamed ? section.group : null
+        if (namedGroup?.name) {
+            tiles.push({
+                type: 'GROUP',
+                group_key: namedGroup.id,
+                name: namedGroup.name,
+                layouts: {
+                    sm: { x: 0, y: globalY, w: BREAKPOINT_COLUMN_COUNTS.sm, h: 1 },
+                },
+            })
+            globalY += 1
+        }
+
+        let sectionHeight = 0
+        for (const tile of section.tiles) {
+            const sm = tile.layouts?.sm
+            const localY = sm?.y ?? 0
+            const height = sm?.h ?? 1
+            sectionHeight = Math.max(sectionHeight, localY + height)
+            const layouts = sm ? { ...tile.layouts, sm: { ...sm, y: localY + globalY } } : tile.layouts
+            tiles.push(serializeDashboardTileForTemplate(tile, layouts, namedGroup ? namedGroup.id : undefined))
+        }
+        globalY += sectionHeight
+    }
+
     return {
         template_name: dashboard.name,
         dashboard_description: dashboard.description,
         dashboard_filters: dashboard.filters,
         tags: dashboard.tags || [],
-        tiles: [
-            ...(dashboard.groups ?? []).map((group) => ({
-                type: 'GROUP' as const,
-                group_key: group.id,
-                name: group.name,
-                layouts: group.layouts.sm
-                    ? {
-                          sm: {
-                              x: group.layouts.sm.x ?? 0,
-                              y: group.layouts.sm.y ?? 0,
-                              w: group.layouts.sm.w ?? BREAKPOINT_COLUMN_COUNTS.sm,
-                              h: group.layouts.sm.h ?? 1,
-                          },
-                      }
-                    : {},
-            })),
-            ...dashboard.tiles
-                .filter((tile) => !tile.error)
-                .map((tile) => {
-                    if (tile.text) {
-                        return {
-                            type: 'TEXT' as const,
-                            body: tile.text.body,
-                            layouts: tile.layouts,
-                            color: tile.color,
-                            group_key: tile.parent_group_id ?? undefined,
-                        }
-                    }
-                    if (tile.insight) {
-                        return {
-                            type: 'INSIGHT' as const,
-                            name: tile.insight.name,
-                            description: tile.insight.description || '',
-                            query: tile.insight.query,
-                            layouts: tile.layouts,
-                            color: tile.color,
-                            group_key: tile.parent_group_id ?? undefined,
-                        }
-                    }
-                    if (tile.button_tile) {
-                        return {
-                            type: 'BUTTON' as const,
-                            button_tile: {
-                                url: tile.button_tile.url,
-                                text: tile.button_tile.text,
-                                placement: tile.button_tile.placement,
-                                style: tile.button_tile.style,
-                            },
-                            layouts: tile.layouts,
-                            color: tile.color,
-                            group_key: tile.parent_group_id ?? undefined,
-                        }
-                    }
-                    if (tile.widget) {
-                        return {
-                            type: 'WIDGET' as const,
-                            widget_type: tile.widget.widget_type,
-                            config: tile.widget.config,
-                            layouts: tile.layouts,
-                            color: tile.color,
-                            group_key: tile.parent_group_id ?? undefined,
-                        }
-                    }
-                    throw new Error('Unknown tile type')
-                }),
-        ],
+        tiles,
         variables: [],
     }
 }

--- a/frontend/src/scenes/dashboard/items/DashboardButtonTileItem.tsx
+++ b/frontend/src/scenes/dashboard/items/DashboardButtonTileItem.tsx
@@ -22,6 +22,7 @@ interface DashboardButtonTileItemProps extends Omit<
     onMoveToDashboard?: (target: Pick<DashboardType, 'id' | 'name'>) => void
     onDuplicate: () => void
     onRemove?: () => void
+    extraMoreOverlay?: React.ReactNode
 }
 
 function DashboardButtonTileItemInternal(
@@ -33,6 +34,7 @@ function DashboardButtonTileItemInternal(
         onMoveToDashboard,
         onDuplicate,
         onRemove,
+        extraMoreOverlay,
         ...buttonTileCardProps
     }: DashboardButtonTileItemProps,
     ref: React.ForwardedRef<HTMLDivElement>
@@ -62,6 +64,7 @@ function DashboardButtonTileItemInternal(
                         placementDestinations={copyToDestinations}
                         onMoveToDashboard={onMoveToDashboard}
                     />
+                    {extraMoreOverlay}
 
                     <LemonButton onClick={onDuplicate} fullWidth data-attr="duplicate-button-tile-from-dashboard">
                         Duplicate

--- a/frontend/src/scenes/dashboard/items/DashboardTextItem.tsx
+++ b/frontend/src/scenes/dashboard/items/DashboardTextItem.tsx
@@ -20,6 +20,7 @@ interface DashboardTextItemProps extends Omit<BaseTextCardProps, 'textTile' | 'p
     onCopyToDashboard?: (target: Pick<DashboardType, 'id' | 'name'>) => void
     onDuplicate: () => void
     onRemove?: () => void
+    extraMoreOverlay?: React.ReactNode
 }
 
 function DashboardTextItemInternal(
@@ -32,6 +33,7 @@ function DashboardTextItemInternal(
         onCopyToDashboard,
         onDuplicate,
         onRemove,
+        extraMoreOverlay,
         ...textCardProps
     }: DashboardTextItemProps,
     ref: React.ForwardedRef<HTMLDivElement>
@@ -62,6 +64,7 @@ function DashboardTextItemInternal(
                         onMoveToDashboard={onMoveToDashboard}
                         onCopyToDashboard={onCopyToDashboard}
                     />
+                    {extraMoreOverlay}
 
                     <LemonButton onClick={onDuplicate} fullWidth data-attr="duplicate-text-from-dashboard">
                         Duplicate

--- a/products/dashboards/frontend/components/DashboardWidgetItem/DashboardWidgetItem.tsx
+++ b/products/dashboards/frontend/components/DashboardWidgetItem/DashboardWidgetItem.tsx
@@ -76,6 +76,7 @@ type DashboardWidgetItemProps = {
     onRemove?: () => void
     onMoveToDashboard?: (target: Pick<DashboardType, 'id' | 'name'>) => void
     onCopyToDashboard?: (target: Pick<DashboardType, 'id' | 'name'>) => void
+    extraMoreOverlay?: React.ReactNode
     /** Injected by react-grid-layout / react-resizable — must render inside the card root. */
     children?: React.ReactNode
 } & Omit<React.HTMLAttributes<HTMLDivElement>, 'children'>
@@ -154,6 +155,7 @@ function DashboardWidgetItemContent({
     onRemove,
     onMoveToDashboard,
     onCopyToDashboard,
+    extraMoreOverlay,
     copyToDestinations,
     editOpen,
     setEditOpen,
@@ -202,7 +204,7 @@ function DashboardWidgetItemContent({
     const EditModal = definition?.EditModal
 
     const hasDashboardSectionActions =
-        !!(onMoveToDashboard || onCopyToDashboard || onRemove) ||
+        !!(onMoveToDashboard || onCopyToDashboard || onRemove || extraMoreOverlay) ||
         (showEditingControls && toggleShowDescription && !!description) ||
         (showEditingControls && onUpdateWidgetTile && !showDescription && !description)
 
@@ -280,6 +282,7 @@ function DashboardWidgetItemContent({
                                         onCopyToDashboard={onCopyToDashboard}
                                     />
                                 )}
+                                {extraMoreOverlay}
                                 {onRemove && (
                                     <LemonButton status="danger" fullWidth onClick={onRemove}>
                                         Remove from dashboard
@@ -390,6 +393,7 @@ export const DashboardWidgetItem = React.forwardRef<HTMLDivElement, DashboardWid
             onRemove,
             onMoveToDashboard,
             onCopyToDashboard,
+            extraMoreOverlay,
             children,
             className,
             style,
@@ -460,6 +464,7 @@ export const DashboardWidgetItem = React.forwardRef<HTMLDivElement, DashboardWid
                     onRemove={onRemove}
                     onMoveToDashboard={onMoveToDashboard}
                     onCopyToDashboard={onCopyToDashboard}
+                    extraMoreOverlay={extraMoreOverlay}
                     copyToDestinations={copyToDestinations}
                     editOpen={editOpen}
                     setEditOpen={setEditOpen}


### PR DESCRIPTION
## Problem

- #82821 makes sections real rows. The dashboard still draws one grid and fakes headers as tiles.
- Users cannot add, rename, collapse, or move tiles between sections as sections.

No screenshot. This session did not run the app.

## Changes

- Each section gets its own react-grid-layout instance.
- Named sections render a header. Anonymous sections render a bare grid.
- Add section, rename, move up/down, and delete (tiles or ungroup) go through the groups API.
- Tile menus can move a tile to another section.
- `updateLayouts` merges by tile id so one section's grid does not wipe the others.

## How did you test this code?

- Jest: `dashboardSections.test.ts`, template export in `dashboardUtils`, and `dashboardLogic` including the subset-layout merge.
- Frontend lint and format on the changed files.
- Not run: Playwright, Storybook, or a live dashboard.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. No published dashboard-groups guide exists to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Cursor. Skills: `/writing-ui-components`, `/writing-kea-logics`, `/writing-user-facing-copy`, `/writing-tests`, `/adopting-generated-api-types`, `/writing-pr-descriptions`, `/stacking-prs`.
- Sits on #82821. Replaces #77842 and duplicate #82793.
- Cross-section pointer drag is #82825, not this PR.