### PR TITLE
feat(dashboard): cross-section tile drag and section reorder

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -27,6 +27,7 @@ import {
 } from 'scenes/dashboard/dashboardUtils'
 import { continueDragGestureInEditMode, continueResizeGestureInEditMode } from 'scenes/dashboard/editLayoutGesture'
 import { InsertTileOverlay } from 'scenes/dashboard/InsertTileOverlay'
+import { DEFAULT_INSERTED_TILE_SIZE } from 'scenes/dashboard/tileLayouts'
 import { useSurveyLinkedInsights } from 'scenes/surveys/hooks/useSurveyLinkedInsights'
 import { getBestSurveyOpportunityFunnel } from 'scenes/surveys/utils/opportunityDetection'
 import { urls } from 'scenes/urls'
@@ -36,11 +37,12 @@ import { insightsModel } from '~/models/insightsModel'
 import { DashboardLayoutSize, DashboardMode, DashboardPlacement, DashboardType } from '~/types'
 
 import { DashboardSection } from './DashboardSection'
-import { sectionDisplayName } from './dashboardSections'
+import { isPersistedSectionKey, sectionDisplayName } from './dashboardSections'
 import { DashboardButtonTileItem } from './items/DashboardButtonTileItem'
 import { DashboardErrorTileItem } from './items/DashboardErrorTileItem'
 import { DashboardTextItem } from './items/DashboardTextItem'
 import { MoveToSectionMenu } from './MoveToSectionMenu'
+import { useCrossSectionDrag, type DashboardDropTarget } from './useCrossSectionDrag'
 
 const DRAG_AUTO_SCROLL_THRESHOLD = 100
 const DRAG_AUTO_SCROLL_SPEED = 50
@@ -247,6 +249,64 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         DashboardPlacement.Builtin,
     ].includes(placement)
 
+    const handleCrossSectionTileDrop = useCallback(
+        (tileId: number, target: Exclude<DashboardDropTarget, null>, event: MouseEvent): void => {
+            const targetSection =
+                target.type === 'section' ? sections.find((section) => section.key === target.sectionKey) : null
+            const targetLayouts = targetSection ? (sectionLayouts[targetSection.key]?.sm ?? []) : []
+            const sourceLayout = Object.values(sectionLayouts)
+                .flatMap((layouts) => layouts.sm ?? [])
+                .find((layout) => layout.i === String(tileId))
+            const w = sourceLayout?.w ?? DEFAULT_INSERTED_TILE_SIZE.w
+            const h = sourceLayout?.h ?? DEFAULT_INSERTED_TILE_SIZE.h
+            const sectionMaxY = Math.max(0, ...targetLayouts.map((layout) => layout.y + layout.h))
+            const x = Math.max(
+                0,
+                Math.min(
+                    BREAKPOINT_COLUMN_COUNTS.sm - w,
+                    Math.floor((event.clientX / Math.max(gridWidth, 1)) * BREAKPOINT_COLUMN_COUNTS.sm)
+                )
+            )
+            const layouts = { sm: { x, y: sectionMaxY, w, h } }
+            if (targetSection?.group && isPersistedSectionKey(targetSection.key)) {
+                moveDashboardTileToGroup({ tileId, groupId: targetSection.group.id, layouts })
+                return
+            }
+            const position =
+                target.type === 'gap'
+                    ? (sections[target.position]?.group?.position ?? dashboard?.groups?.length ?? 0)
+                    : Math.max(0, targetSection ? sections.indexOf(targetSection) : 0)
+            moveDashboardTileToGroup({ tileId, createAtPosition: position, layouts })
+        },
+        [dashboard?.groups?.length, gridWidth, moveDashboardTileToGroup, sectionLayouts, sections]
+    )
+
+    const handleCrossSectionSectionDrop = useCallback(
+        (groupId: string, renderedPosition: number): void => {
+            const groups = dashboard?.groups ?? []
+            const from = groups.find((group) => group.id === groupId)?.position
+            if (from == null) {
+                return
+            }
+            const targetSection = sections[renderedPosition]
+            let to = targetSection?.group?.position ?? groups.length
+            if (from < to) {
+                to -= 1
+            }
+            if (to !== from) {
+                updateDashboardGroupPosition(groupId, to)
+            }
+        },
+        [dashboard?.groups, sections, updateDashboardGroupPosition]
+    )
+
+    const crossSectionDrag = useCrossSectionDrag({
+        sections,
+        disabled: isMobileView || !layoutEditMode || !isEditablePlacement,
+        onTileDrop: handleCrossSectionTileDrop,
+        onSectionDrop: handleCrossSectionSectionDrop,
+    })
+
     const canEnterEditModeFromEdge =
         !!dashboard && canEditDashboard && !layoutEditMode && !isMobileView && isEditablePlacement
 
@@ -415,11 +475,22 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         }
     }, [dashboard?.id, reportDashboardTileRepositioned, effectiveZoom, flushPendingLayouts])
 
-    const handleDragStart = useCallback(() => {
-        interactionInProgress.current = true
-        scrollContainerRef.current = document.getElementById('main-content')
-        scrollContainerRectRef.current = scrollContainerRef.current?.getBoundingClientRect() ?? null
-    }, [])
+    const handleDragStart = useCallback(
+        (_layout: unknown, _oldItem: unknown, newItem: { i: string } | null) => {
+            interactionInProgress.current = true
+            scrollContainerRef.current = document.getElementById('main-content')
+            scrollContainerRectRef.current = scrollContainerRef.current?.getBoundingClientRect() ?? null
+            if (!newItem) {
+                return
+            }
+            const tileId = Number.parseInt(newItem.i, 10)
+            const sourceSection = sections.find((section) => section.tiles.some((tile) => tile.id === tileId))
+            if (sourceSection) {
+                crossSectionDrag.startTileDrag(tileId, sourceSection.key)
+            }
+        },
+        [crossSectionDrag, sections]
+    )
 
     const handleDrag = useCallback(
         (_layout: unknown, _oldItem: unknown, _newItem: unknown, _placeholder: unknown, e: unknown) => {
@@ -432,13 +503,16 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                 scrollAnimationRef.current = null
             }
 
+            const mouseEvent = e as MouseEvent
+            crossSectionDrag.updateDrag(mouseEvent)
+
             const scrollContainer = scrollContainerRef.current
             const containerRect = scrollContainerRectRef.current
             if (!scrollContainer || !containerRect) {
                 return
             }
 
-            const mouseY = (e as MouseEvent).clientY
+            const mouseY = mouseEvent.clientY
 
             let scrollSpeed = 0
             if (mouseY < containerRect.top + DRAG_AUTO_SCROLL_THRESHOLD) {
@@ -462,27 +536,43 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                 scrollAnimationRef.current = requestAnimationFrame(scroll)
             }
         },
-        []
+        [crossSectionDrag]
     )
 
-    const handleDragStop = useCallback(() => {
-        if (scrollAnimationRef.current) {
-            cancelAnimationFrame(scrollAnimationRef.current)
-            scrollAnimationRef.current = null
-        }
-        scrollContainerRef.current = null
-        scrollContainerRectRef.current = null
-        if (dragEndTimeout.current) {
-            window.clearTimeout(dragEndTimeout.current)
-        }
-        dragEndTimeout.current = window.setTimeout(() => {
-            isDragging.current = false
-        }, 250)
-        flushPendingLayouts()
-        if (dashboard?.id) {
-            reportDashboardTileRepositioned(dashboard.id, 'moved', effectiveZoom)
-        }
-    }, [dashboard?.id, reportDashboardTileRepositioned, effectiveZoom, flushPendingLayouts])
+    const handleDragStop = useCallback(
+        (
+            _layout: unknown,
+            _oldItem: unknown,
+            _newItem: { i: string } | null,
+            _placeholder: unknown,
+            event: MouseEvent
+        ) => {
+            if (scrollAnimationRef.current) {
+                cancelAnimationFrame(scrollAnimationRef.current)
+                scrollAnimationRef.current = null
+            }
+            scrollContainerRef.current = null
+            scrollContainerRectRef.current = null
+            if (dragEndTimeout.current) {
+                window.clearTimeout(dragEndTimeout.current)
+            }
+            dragEndTimeout.current = window.setTimeout(() => {
+                isDragging.current = false
+            }, 250)
+            const moved = crossSectionDrag.finishDrag(event)
+            if (!moved) {
+                flushPendingLayouts()
+            } else {
+                // The source grid still owns the tile; flushing would persist it in the old section.
+                interactionInProgress.current = false
+                pendingLayouts.current = null
+            }
+            if (dashboard?.id) {
+                reportDashboardTileRepositioned(dashboard.id, 'moved', effectiveZoom)
+            }
+        },
+        [crossSectionDrag, dashboard?.id, reportDashboardTileRepositioned, effectiveZoom, flushPendingLayouts]
+    )
 
     return (
         <div className="dashboard-items-wrapper" ref={containerRef as RefObject<HTMLDivElement>}>
@@ -502,14 +592,35 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                             !layoutEditMode &&
                             collapsedDashboardSectionIds.includes(section.group.id)
                         const isLastSection = sectionIndex === sections.length - 1
+                        const draggableGroupId = layoutEditMode ? section.group?.id : undefined
                         return (
                             <Fragment key={section.key}>
+                                {crossSectionDrag.dropTarget?.type === 'gap' &&
+                                    crossSectionDrag.dropTarget.position === sectionIndex && (
+                                        <div className="h-0.5 bg-accent my-3 rounded-full" />
+                                    )}
                                 <DashboardSection
                                     group={section.isNamed ? section.group : null}
                                     collapsed={collapsed}
                                     canEdit={canEditDashboard && isEditablePlacement}
                                     groupCount={groupCount}
                                     tileCount={section.tiles.length}
+                                    sectionRef={(element) => crossSectionDrag.registerSection(section.key, element)}
+                                    highlighted={
+                                        crossSectionDrag.dropTarget?.type === 'section' &&
+                                        crossSectionDrag.dropTarget.sectionKey === section.key
+                                    }
+                                    onSectionPointerDown={
+                                        draggableGroupId
+                                            ? (event) => {
+                                                  if ((event.target as HTMLElement).closest('button, input, a')) {
+                                                      return
+                                                  }
+                                                  event.preventDefault()
+                                                  crossSectionDrag.startSectionDrag(draggableGroupId, event.nativeEvent)
+                                              }
+                                            : undefined
+                                    }
                                     onToggle={() => section.group && toggleDashboardSectionCollapsed(section.group.id)}
                                     onRename={(name) => section.group && renameDashboardGroup(section.group.id, name)}
                                     onMove={(position) =>
@@ -795,6 +906,10 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                             </Fragment>
                         )
                     })}
+                    {crossSectionDrag.dropTarget?.type === 'gap' &&
+                        crossSectionDrag.dropTarget.position === sections.length && (
+                            <div className="h-0.5 bg-accent my-3 rounded-full" />
+                        )}
                 </div>
             )}
             {dashboardStreaming && (

--- a/frontend/src/scenes/dashboard/DashboardSection.stories.tsx
+++ b/frontend/src/scenes/dashboard/DashboardSection.stories.tsx
@@ -61,3 +61,7 @@ export const Anonymous: Story = {
 export const Collapsed: Story = {
     args: { collapsed: true },
 }
+
+export const Highlighted: Story = {
+    args: { highlighted: true },
+}

--- a/frontend/src/scenes/dashboard/DashboardSection.tsx
+++ b/frontend/src/scenes/dashboard/DashboardSection.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { ComponentProps, ReactNode } from 'react'
+import { ComponentProps, PointerEvent, ReactNode } from 'react'
 import { Responsive as ReactGridLayout } from 'react-grid-layout'
 import { GridBackground } from 'react-grid-layout/extras'
 
@@ -18,6 +18,9 @@ export interface DashboardSectionProps {
     tileCount: number
     children: ReactNode
     overlay: ReactNode
+    sectionRef?: (element: HTMLElement | null) => void
+    highlighted?: boolean
+    onSectionPointerDown?: (event: PointerEvent<HTMLDivElement>) => void
     gridProps: ComponentProps<typeof ReactGridLayout>
     gridBackgroundProps: ComponentProps<typeof GridBackground> | null
     onToggle: () => void
@@ -34,6 +37,9 @@ export function DashboardSection({
     tileCount,
     children,
     overlay,
+    sectionRef,
+    highlighted = false,
+    onSectionPointerDown,
     gridProps,
     gridBackgroundProps,
     onToggle,
@@ -43,9 +49,11 @@ export function DashboardSection({
 }: DashboardSectionProps): JSX.Element {
     return (
         <section
+            ref={sectionRef}
             className={clsx(
                 'relative mb-4',
-                group && "rounded border bg-surface-tertiary [[theme='dark']_&]:bg-surface-secondary border-primary"
+                group && "rounded border bg-surface-tertiary [[theme='dark']_&]:bg-surface-secondary border-primary",
+                highlighted && 'border-accent bg-accent-highlight-secondary'
             )}
         >
             {group && (
@@ -59,6 +67,7 @@ export function DashboardSection({
                     onRename={onRename}
                     onMove={onMove}
                     onDelete={onDelete}
+                    onSectionPointerDown={onSectionPointerDown}
                 />
             )}
             {!collapsed && (

--- a/frontend/src/scenes/dashboard/DashboardSectionHeader.stories.tsx
+++ b/frontend/src/scenes/dashboard/DashboardSectionHeader.stories.tsx
@@ -37,6 +37,10 @@ type Story = StoryObj<typeof DashboardSectionHeader>
 
 export const Default: Story = {}
 
+export const Draggable: Story = {
+    args: { onSectionPointerDown: () => {} },
+}
+
 export const Collapsed: Story = {
     args: { collapsed: true },
 }

--- a/frontend/src/scenes/dashboard/DashboardSectionHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardSectionHeader.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import clsx from 'clsx'
+import { useState, type PointerEvent } from 'react'
 
 import { IconChevronRight, IconEllipsis } from '@posthog/icons'
 import type {
@@ -24,6 +25,7 @@ export interface DashboardSectionHeaderProps {
     onRename: (name: string) => void
     onMove: (position: number) => void
     onDelete: (memberHandling: MemberHandlingEnumApi) => void
+    onSectionPointerDown?: (event: PointerEvent<HTMLDivElement>) => void
 }
 
 export function DashboardSectionHeader({
@@ -36,6 +38,7 @@ export function DashboardSectionHeader({
     onRename,
     onMove,
     onDelete,
+    onSectionPointerDown,
 }: DashboardSectionHeaderProps): JSX.Element {
     const [editing, setEditing] = useState(false)
     const [name, setName] = useState(group.name ?? '')
@@ -51,7 +54,10 @@ export function DashboardSectionHeader({
     }
 
     return (
-        <div className="flex items-center gap-2 px-3 py-2">
+        <div
+            className={clsx('flex items-center gap-2 px-3 py-2', onSectionPointerDown && 'cursor-grab touch-none')}
+            onPointerDown={onSectionPointerDown}
+        >
             <LemonButton
                 icon={<IconChevronRight className={collapsed ? '' : 'rotate-90'} />}
                 size="small"

--- a/frontend/src/scenes/dashboard/useCrossSectionDrag.ts
+++ b/frontend/src/scenes/dashboard/useCrossSectionDrag.ts
@@ -1,0 +1,188 @@
+import { useCallback, useRef, useState } from 'react'
+
+import type { DashboardSection } from './dashboardSections'
+
+export type DashboardDropTarget = { type: 'section'; sectionKey: string } | { type: 'gap'; position: number } | null
+
+type DragSession = { kind: 'tile'; tileId: number; sectionKey: string } | { kind: 'section'; groupId: string } | null
+
+const SECTION_EDGE_PX = 8
+
+interface UseCrossSectionDragProps {
+    sections: DashboardSection[]
+    disabled: boolean
+    onTileDrop: (tileId: number, target: Exclude<DashboardDropTarget, null>, event: MouseEvent) => void
+    onSectionDrop: (groupId: string, position: number) => void
+}
+
+export function useCrossSectionDrag({ sections, disabled, onTileDrop, onSectionDrop }: UseCrossSectionDragProps): {
+    registerSection: (sectionKey: string, element: HTMLElement | null) => void
+    dropTarget: DashboardDropTarget
+    startTileDrag: (tileId: number, sectionKey: string) => void
+    startSectionDrag: (groupId: string, event: PointerEvent) => void
+    updateDrag: (event: MouseEvent) => void
+    finishDrag: (event: MouseEvent) => boolean
+} {
+    const sectionElements = useRef(new Map<string, HTMLElement>())
+    const sectionRects = useRef(new Map<string, DOMRect>())
+    const dragged = useRef<DragSession>(null)
+    const frame = useRef<number | null>(null)
+    const latestEvent = useRef<MouseEvent | null>(null)
+    const currentTarget = useRef<DashboardDropTarget>(null)
+    const sectionsRef = useRef(sections)
+    const onTileDropRef = useRef(onTileDrop)
+    const onSectionDropRef = useRef(onSectionDrop)
+    const detachScroll = useRef<(() => void) | null>(null)
+    const [dropTarget, setDropTarget] = useState<DashboardDropTarget>(null)
+
+    sectionsRef.current = sections
+    onTileDropRef.current = onTileDrop
+    onSectionDropRef.current = onSectionDrop
+
+    const measure = useCallback((): void => {
+        sectionRects.current = new Map(
+            [...sectionElements.current].map(([sectionKey, element]) => [sectionKey, element.getBoundingClientRect()])
+        )
+    }, [])
+
+    const clearDrag = useCallback((): void => {
+        dragged.current = null
+        currentTarget.current = null
+        latestEvent.current = null
+        detachScroll.current?.()
+        detachScroll.current = null
+        if (frame.current !== null) {
+            cancelAnimationFrame(frame.current)
+            frame.current = null
+        }
+        setDropTarget(null)
+    }, [])
+
+    const registerSection = useCallback((sectionKey: string, element: HTMLElement | null): void => {
+        if (element) {
+            sectionElements.current.set(sectionKey, element)
+        } else {
+            sectionElements.current.delete(sectionKey)
+        }
+    }, [])
+
+    const resolveTarget = useCallback((event: MouseEvent): DashboardDropTarget => {
+        const orderedRects = sectionsRef.current
+            .map((section, position) => ({ section, position, rect: sectionRects.current.get(section.key) }))
+            .filter((entry): entry is typeof entry & { rect: DOMRect } => !!entry.rect)
+
+        for (const { section, rect } of orderedRects) {
+            if (event.clientY >= rect.top + SECTION_EDGE_PX && event.clientY <= rect.bottom - SECTION_EDGE_PX) {
+                return { type: 'section', sectionKey: section.key }
+            }
+        }
+
+        for (let position = 0; position <= orderedRects.length; position++) {
+            const before = (orderedRects[position - 1]?.rect.bottom ?? Number.NEGATIVE_INFINITY) - SECTION_EDGE_PX
+            const after = (orderedRects[position]?.rect.top ?? Number.POSITIVE_INFINITY) + SECTION_EDGE_PX
+            if (event.clientY >= before && event.clientY <= after) {
+                return { type: 'gap', position }
+            }
+        }
+        return null
+    }, [])
+
+    const updateDrag = useCallback(
+        (event: MouseEvent): void => {
+            if (!dragged.current) {
+                return
+            }
+            latestEvent.current = event
+            if (frame.current !== null) {
+                return
+            }
+            frame.current = requestAnimationFrame(() => {
+                frame.current = null
+                const nextTarget = latestEvent.current ? resolveTarget(latestEvent.current) : null
+                currentTarget.current = nextTarget
+                setDropTarget(nextTarget)
+            })
+        },
+        [resolveTarget]
+    )
+
+    const finishDrag = useCallback(
+        (event: MouseEvent): boolean => {
+            const session = dragged.current
+            const target = currentTarget.current ?? resolveTarget(event)
+            clearDrag()
+            if (!session || !target) {
+                return false
+            }
+            if (session.kind === 'tile') {
+                if (target.type === 'section' && target.sectionKey === session.sectionKey) {
+                    return false
+                }
+                onTileDropRef.current(session.tileId, target, event)
+                return true
+            }
+            const position =
+                target.type === 'gap'
+                    ? target.position
+                    : sectionsRef.current.findIndex((section) => section.key === target.sectionKey)
+            if (position < 0) {
+                return false
+            }
+            onSectionDropRef.current(session.groupId, position)
+            return true
+        },
+        [clearDrag, resolveTarget]
+    )
+
+    const attachScrollMeasure = useCallback((): void => {
+        detachScroll.current?.()
+        const onScroll = (): void => {
+            measure()
+            if (!latestEvent.current) {
+                return
+            }
+            const nextTarget = resolveTarget(latestEvent.current)
+            currentTarget.current = nextTarget
+            setDropTarget(nextTarget)
+        }
+        window.addEventListener('scroll', onScroll, true)
+        detachScroll.current = () => window.removeEventListener('scroll', onScroll, true)
+    }, [measure, resolveTarget])
+
+    const startTileDrag = useCallback(
+        (tileId: number, sectionKey: string): void => {
+            if (disabled) {
+                return
+            }
+            dragged.current = { kind: 'tile', tileId, sectionKey }
+            measure()
+            attachScrollMeasure()
+        },
+        [attachScrollMeasure, disabled, measure]
+    )
+
+    const startSectionDrag = useCallback(
+        (groupId: string, event: PointerEvent): void => {
+            if (disabled) {
+                return
+            }
+            dragged.current = { kind: 'section', groupId }
+            measure()
+            attachScrollMeasure()
+            const handleMove = (moveEvent: PointerEvent): void => {
+                updateDrag(moveEvent)
+            }
+            const handleUp = (upEvent: PointerEvent): void => {
+                window.removeEventListener('pointermove', handleMove)
+                window.removeEventListener('pointerup', handleUp)
+                finishDrag(upEvent)
+            }
+            window.addEventListener('pointermove', handleMove)
+            window.addEventListener('pointerup', handleUp)
+            updateDrag(event)
+        },
+        [attachScrollMeasure, disabled, finishDrag, measure, updateDrag]
+    )
+
+    return { registerSection, dropTarget, startTileDrag, startSectionDrag, updateDrag, finishDrag }
+}


### PR DESCRIPTION
## Problem

- #82823 draws one grid per section. react-grid-layout cannot drag a tile from one grid into another.
- Users still reorder sections with Move up and Move down only.

No screenshot. This session did not run the app.

## Changes

```mermaid
flowchart LR
    A[Pointer] --> B{Hit}
    B -->|Section interior| C[Move tile into that section]
    B -->|Gap| D[Create anonymous section]
    E[Header drag] --> F[Reorder section]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A,E phYellow;
    class C,D,F phBlue;
```

- App-level pointer tracking measures section rects during a drag, including scroll.
- Drop on a section calls move-tile with that group. Drop on a gap creates a section at that position.
- A cross-section drop skips flushing the source grid layout so the tile does not write back into the old section.
- Named section headers start a section reorder. Buttons and inputs on the header do not.

## How did you test this code?

- No Jest for the drag hook. Pointer geometry against live layout is not cheap to fake.
- Frontend lint and format on the changed files.
- Not run: Playwright or a live dashboard.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. No published dashboard-groups guide exists to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Cursor. Skills: `/writing-ui-components`, `/writing-code-comments`, `/writing-pr-descriptions`, `/stacking-prs`.
- Top of a new stack on #77841. Replaces duplicate #82794.
- Drag stays a view hook. The grid library has no cross-grid drag API.