### PR TITLE
feat(dashboards): add section-based dashboard groups API

### DIFF
--- a/posthog/helpers/dashboard_templates.py
+++ b/posthog/helpers/dashboard_templates.py
@@ -16,6 +16,7 @@ from products.dashboards.backend.models.dashboard_group import DashboardGroup
 from products.dashboards.backend.models.dashboard_templates import DashboardTemplate
 from products.dashboards.backend.models.dashboard_tile import ButtonTile, DashboardTile, Text
 from products.dashboards.backend.models.dashboard_widget import DashboardWidget
+from products.dashboards.backend.section_ops import partition_tiles_into_sections
 from products.product_analytics.backend.models.insight import Insight
 
 if TYPE_CHECKING:
@@ -513,34 +514,38 @@ def create_from_template(
         dashboard.tagged_items.create(tag_id=tag.id)
     dashboard.save()
 
-    groups_by_key: dict[str, DashboardGroup] = {}
-    for template_tile in template.tiles or []:
-        if template_tile.get("type") != "GROUP":
-            continue
-        group_key = template_tile.get("group_key")
-        if not group_key:
+    template_tiles = list(template.tiles or [])
+    header_tiles = [tile for tile in template_tiles if tile.get("type") == "GROUP"]
+    content_tiles = [tile for tile in template_tiles if tile.get("type") != "GROUP"]
+    for header in header_tiles:
+        if not header.get("group_key"):
             logger.error("dashboard_templates.creation.group_missing_key", template=template)
-            continue
-        group = DashboardGroup.all_teams.create(
-            dashboard=dashboard,
-            team=dashboard.team,
-            name=template_tile.get("name", "Group"),
-            created_by=user,
-            last_modified_by=user,
-        )
-        DashboardTile.objects.create(
-            dashboard=dashboard,
-            team=dashboard.team,
-            dashboard_group=group,
-            layouts=template_tile.get("layouts") or {},
-        )
-        groups_by_key[group_key] = group
 
-    for template_tile in template.tiles or []:
+    known_keys = {header.get("group_key") for header in header_tiles if header.get("group_key")}
+    for tile in content_tiles:
+        key = tile.get("group_key")
+        if key and key not in known_keys:
+            logger.error("dashboard_templates.creation.unknown_group_key", template=template, group_key=key)
+
+    sections = partition_tiles_into_sections(header_tiles, content_tiles)
+    tiles_with_parent: list[tuple[dict[str, Any], DashboardGroup | None]] = []
+    if sections:
+        for position, section in enumerate(sections):
+            group = DashboardGroup.all_teams.create(
+                dashboard=dashboard,
+                team=dashboard.team,
+                name=section.name,
+                position=position,
+                created_by=user,
+                last_modified_by=user,
+            )
+            for tile in section.tiles:
+                tiles_with_parent.append((tile, group))
+    else:
+        tiles_with_parent = [(tile, None) for tile in content_tiles]
+
+    for template_tile, parent_group in tiles_with_parent:
         tile_type = template_tile.get("type")
-        if tile_type == "GROUP":
-            continue
-        parent_group = groups_by_key.get(template_tile.get("group_key"))
         if tile_type == "INSIGHT":
             query = template_tile.get("query", None)
             _create_tile_for_insight(

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -120,6 +120,16 @@ from products.dashboards.backend.models.dashboard import Dashboard
 from products.dashboards.backend.models.dashboard_group import DashboardGroup
 from products.dashboards.backend.models.dashboard_tile import ButtonTile, DashboardTile, Text
 from products.dashboards.backend.models.dashboard_widget import DashboardWidget
+from products.dashboards.backend.section_ops import (
+    assign_tile_to_section,
+    content_tiles_qs,
+    create_section,
+    lock_dashboard,
+    move_section,
+    normalize_section_name,
+    renumber_section_positions,
+    resolve_default_section,
+)
 from products.dashboards.backend.widget_access import (
     check_widget_tile_product_access,
     get_widget_api_scope_error,
@@ -129,6 +139,7 @@ from products.dashboards.backend.widget_availability import get_widget_feature_e
 from products.dashboards.backend.widget_catalog import get_widget_catalog_entries
 from products.dashboards.backend.widget_create import prepare_widget_tile_create
 from products.dashboards.backend.widget_layouts import (
+    collect_dashboard_sm_layouts,
     collect_dashboard_sm_layouts_for_dashboard,
     stack_widget_layout_at_bottom,
 )
@@ -329,8 +340,20 @@ def _compact_tile_layouts(tiles: list[DashboardTile]) -> set[int]:
     """Vertically compact tile layouts in place, mirroring the dashboard grid's default
     react-grid-layout vertical compaction (gravity up). Each breakpoint is compacted
     independently: tiles keep their x/w/h and are pulled up to the lowest free row.
-    Returns the ids of tiles whose layouts changed.
+    Compaction is per `parent_group_id` so one section's tiles cannot fill another
+    section's holes. Returns the ids of tiles whose layouts changed.
     """
+    buckets: dict[Any, list[DashboardTile]] = {}
+    for tile in tiles:
+        buckets.setdefault(tile.parent_group_id, []).append(tile)
+
+    changed: set[int] = set()
+    for bucket_tiles in buckets.values():
+        changed.update(_compact_tile_layouts_in_section(bucket_tiles))
+    return changed
+
+
+def _compact_tile_layouts_in_section(tiles: list[DashboardTile]) -> set[int]:
     for tile in tiles:
         if isinstance(tile.layouts, str):
             tile.layouts = json.loads(tile.layouts)
@@ -363,6 +386,36 @@ def _compact_tile_layouts(tiles: list[DashboardTile]) -> set[int]:
                 changed.add(tile.id)
 
     return changed
+
+
+def _section_layout_sort_key(
+    tile: DashboardTile,
+    group_positions: dict[Any, int],
+    layout_size: str,
+) -> tuple[int, int, int]:
+    layouts = tile.layouts if isinstance(tile.layouts, dict) else {}
+    box = layouts.get(layout_size) if isinstance(layouts, dict) else None
+    if not isinstance(box, dict):
+        box = {}
+    section_position = group_positions.get(tile.parent_group_id, 10**9)
+    return (section_position, box.get("y", 100), box.get("x", 100))
+
+
+def _sort_tiles_by_section_layout(
+    tiles: list[DashboardTile] | Any,
+    dashboard: Dashboard,
+    layout_size: str = "sm",
+) -> list[DashboardTile]:
+    group_positions = {group.id: group.position for group in dashboard.groups.all()}
+    return sorted(tiles, key=lambda tile: _section_layout_sort_key(tile, group_positions, layout_size))
+
+
+def _resolve_parent_group_for_new_tile(
+    dashboard: Dashboard, user: User | None, group_id: uuid.UUID | None
+) -> DashboardGroup | None:
+    if group_id is not None:
+        return get_object_or_404(dashboard.groups, id=group_id)
+    return resolve_default_section(dashboard, user)
 
 
 def tile_insight_prefetches() -> list[Prefetch]:
@@ -448,7 +501,26 @@ def _apply_reorder_layout(
     layout_mode: ReorderLayout,
 ) -> None:
     """Repack tiles. ``preserve`` keeps each tile's existing w/h and reuses the lowest-segment
-    greedy algorithm from ``frontend/src/scenes/dashboard/tileLayouts.ts``; the other modes overwrite w/h."""
+    greedy algorithm from ``frontend/src/scenes/dashboard/tileLayouts.ts``; the other modes overwrite w/h.
+
+    On a grouped dashboard the submitted order is split by ``parent_group_id`` and each
+    section is packed as its own grid, so y=0 is the top of that section, not the dashboard.
+    """
+    buckets: dict[Any, list[int]] = {}
+    for tile_id in tile_order:
+        buckets.setdefault(tile_map[tile_id].parent_group_id, []).append(tile_id)
+    if len(buckets) > 1:
+        for bucket_order in buckets.values():
+            _apply_reorder_layout_in_section(bucket_order, tile_map, layout_mode)
+        return
+    _apply_reorder_layout_in_section(tile_order, tile_map, layout_mode)
+
+
+def _apply_reorder_layout_in_section(
+    tile_order: list[int],
+    tile_map: dict[int, DashboardTile],
+    layout_mode: ReorderLayout,
+) -> None:
     if layout_mode == ReorderLayout.TWO_COLUMN:
         for index, tile_id in enumerate(tile_order):
             row, col = divmod(index, 2)
@@ -512,7 +584,9 @@ class ReorderTilesRequestSerializer(serializers.Serializer):
         help_text=(
             "How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height "
             "and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per "
-            "row). 'full_width' forces each tile to span the full 12-column row at height 5."
+            "row). 'full_width' forces each tile to span the full 12-column row at height 5. On a grouped dashboard "
+            "the submitted order is partitioned by section and each section is packed independently, so a tile cannot "
+            "be reordered into a different section here."
         ),
     )
 
@@ -540,29 +614,37 @@ class TileLayoutsSerializer(serializers.Serializer):
 
 class CreateDashboardGroupRequestSerializer(serializers.Serializer):
     name = serializers.CharField(
-        min_length=1,
         max_length=400,
         trim_whitespace=True,
-        help_text="Name displayed in the dashboard group row.",
-    )
-    layouts = TileLayoutsSerializer(
         required=False,
-        help_text="Optional grid layout for the group row. Group rows always span the desktop grid.",
+        allow_null=True,
+        allow_blank=True,
+        help_text=(
+            "Section name. Null or empty creates an anonymous section (a bare grid with no header). "
+            "Omit to create an anonymous section."
+        ),
+    )
+    position = serializers.IntegerField(
+        required=False,
+        min_value=0,
+        help_text="0-indexed section position. Omit to append after existing sections.",
     )
 
 
 class UpdateDashboardGroupRequestSerializer(serializers.Serializer):
     group_id = serializers.UUIDField(help_text="Dashboard group ID to update.")
     name = serializers.CharField(
-        min_length=1,
         max_length=400,
         trim_whitespace=True,
         required=False,
-        help_text="New group name. Omit to keep the existing name.",
+        allow_null=True,
+        allow_blank=True,
+        help_text="New section name. Null converts the section to anonymous. Omit to keep the current name.",
     )
-    layouts = TileLayoutsSerializer(
+    position = serializers.IntegerField(
         required=False,
-        help_text="New grid layout for the group row. Omit to keep its current layout.",
+        min_value=0,
+        help_text="New 0-indexed section position. Omit to keep the current position.",
     )
 
 
@@ -570,24 +652,37 @@ class MoveDashboardTileToGroupRequestSerializer(serializers.Serializer):
     tile_id = serializers.IntegerField(help_text="Content tile ID to move.")
     group_id = serializers.UUIDField(
         required=False,
-        allow_null=True,
-        help_text="Destination group ID, or null to move the tile to the ungrouped section.",
+        help_text="Destination section ID. Provide this or create_at_position, not both.",
+    )
+    create_at_position = serializers.IntegerField(
+        required=False,
+        min_value=0,
+        help_text=(
+            "Create an anonymous section at this 0-indexed position and move the tile into it. "
+            "Provide this or group_id, not both."
+        ),
     )
     layouts = TileLayoutsSerializer(
         required=False,
-        help_text="Optional new layout for the moved tile.",
+        help_text="Optional new layout for the moved tile, relative to the destination section.",
     )
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        has_group_id = "group_id" in attrs
+        has_create_at = "create_at_position" in attrs
+        if has_group_id == has_create_at:
+            raise serializers.ValidationError("Provide exactly one of group_id or create_at_position.")
+        return attrs
 
 
 class DeleteDashboardGroupRequestSerializer(serializers.Serializer):
     group_id = serializers.UUIDField(help_text="Dashboard group ID to delete.")
     member_handling = serializers.ChoiceField(
-        choices=["delete_tiles", "move_to_ungrouped"],
-        help_text="How to handle content tiles currently assigned to the group.",
-    )
-    xs = TileLayoutBoxSerializer(
-        required=False,
-        help_text="Layout for the small (mobile) breakpoint. The grid is 1 column wide.",
+        choices=["delete_tiles", "ungroup"],
+        help_text=(
+            "How to handle tiles in the section. 'delete_tiles' soft-deletes the tiles and removes the section. "
+            "'ungroup' clears the section name in place so it becomes anonymous; tiles stay put."
+        ),
     )
 
 
@@ -609,8 +704,9 @@ class CreateTextTileRequestSerializer(serializers.Serializer):
     layouts = TileLayoutsSerializer(
         required=False,
         help_text=(
-            "Optional grid layout per breakpoint. If omitted, the tile is placed at the bottom of the dashboard "
-            "using the default size. Text tiles typically use a thin full-width banner (e.g. w=12, h=1)."
+            "Optional grid layout per breakpoint. If omitted, the tile is placed at the bottom of the "
+            "destination section using the default size. Text tiles typically use a thin full-width banner "
+            "(e.g. w=12, h=1)."
         ),
     )
     color = serializers.CharField(
@@ -620,6 +716,13 @@ class CreateTextTileRequestSerializer(serializers.Serializer):
         allow_blank=True,
         help_text="Optional accent color name (e.g. 'blue', 'green', 'purple', 'black').",
         error_messages={"max_length": "Color cannot exceed 400 characters"},
+    )
+    group_id = serializers.UUIDField(
+        required=False,
+        help_text=(
+            "Section to add the tile to. On a grouped dashboard, omit to append to the trailing "
+            "anonymous section (created if needed)."
+        ),
     )
 
 
@@ -712,6 +815,13 @@ class AddDashboardWidgetRequestSerializer(DashboardWidgetCoreRequestSerializer):
     show_description = serializers.BooleanField(
         required=False,
         help_text="Whether to show the description on the dashboard tile.",
+    )
+    group_id = serializers.UUIDField(
+        required=False,
+        help_text=(
+            "Section to add the widget to. On a grouped dashboard, omit to append to the trailing "
+            "anonymous section (created if needed)."
+        ),
     )
 
 
@@ -950,17 +1060,18 @@ class SharedDashboardWidgetMetadataSerializer(serializers.ModelSerializer):
 
 
 class DashboardGroupSerializer(serializers.ModelSerializer):
-    tile_id = serializers.IntegerField(source="tile.id", read_only=True, help_text="Grid tile ID for this group row.")
-    layouts = TileLayoutsSerializer(
-        source="tile.layouts",
-        read_only=True,
-        help_text="Grid layout for the group row.",
-    )
     member_tile_ids = serializers.PrimaryKeyRelatedField(
         source="member_tiles",
         many=True,
         read_only=True,
-        help_text="Content tile IDs assigned to this group.",
+        help_text="Content tile IDs assigned to this section.",
+    )
+    name = serializers.CharField(
+        allow_null=True,
+        help_text="Section name. Null or empty means an anonymous section (bare grid, no header).",
+    )
+    position = serializers.IntegerField(
+        help_text="0-indexed order of this section on the dashboard.",
     )
 
     class Meta:
@@ -968,8 +1079,7 @@ class DashboardGroupSerializer(serializers.ModelSerializer):
         fields = [
             "id",
             "name",
-            "tile_id",
-            "layouts",
+            "position",
             "member_tile_ids",
             "created_at",
             "created_by",
@@ -979,13 +1089,22 @@ class DashboardGroupSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
+class SharedDashboardGroupSerializer(DashboardGroupSerializer):
+    class Meta(DashboardGroupSerializer.Meta):
+        fields = ["id", "name", "position", "member_tile_ids"]
+
+
 class DashboardTileSerializer(serializers.ModelSerializer):
     id: serializers.IntegerField = serializers.IntegerField(required=False)
     insight: InsightBasicSerializer = InsightSerializer()
     text = TextSerializer()
     button_tile = ButtonTileSerializer()
     widget = DashboardWidgetSerializer(required=False, allow_null=True)
-    parent_group_id = serializers.UUIDField(read_only=True, allow_null=True)
+    parent_group_id = serializers.UUIDField(
+        read_only=True,
+        allow_null=True,
+        help_text="Section this content tile belongs to. Null on dashboards with no groups.",
+    )
 
     class Meta:
         model = DashboardTile
@@ -1046,6 +1165,18 @@ class DashboardTileErrorSerializer(DashboardTileSerializer):
             _hide_extra_details(self.context, representation["insight"])
 
         return representation
+
+
+class MoveDashboardTileToGroupResponseSerializer(serializers.Serializer):
+    tile = DashboardTileSerializer(help_text="The moved tile, including its new parent_group_id.")
+    created_group = DashboardGroupSerializer(
+        allow_null=True,
+        help_text="The anonymous section created when create_at_position was used. Null otherwise.",
+    )
+    deleted_group_ids = serializers.ListField(
+        child=serializers.UUIDField(),
+        help_text="Anonymous source sections removed because they had no remaining tiles.",
+    )
 
 
 class InsightResultSerializer(InsightSerializer):
@@ -1262,7 +1393,9 @@ class DashboardMetadataSerializer(DashboardBasicSerializer):
     )
     persisted_filters = serializers.SerializerMethodField()
     persisted_variables = serializers.SerializerMethodField()
-    groups = serializers.SerializerMethodField(help_text="Ordered groups configured on this dashboard.")
+    groups = serializers.SerializerMethodField(
+        help_text="Ordered sections on this dashboard. Empty when the dashboard has no groups."
+    )
 
     class Meta:
         model = Dashboard
@@ -1289,10 +1422,13 @@ class DashboardMetadataSerializer(DashboardBasicSerializer):
 
     @extend_schema_field(DashboardGroupSerializer(many=True))
     def get_groups(self, dashboard: Dashboard) -> list[dict[str, Any]]:
-        groups = dashboard.groups.select_related("tile", "created_by", "last_modified_by").prefetch_related(
-            "member_tiles"
+        groups = (
+            dashboard.groups.order_by("position", "created_at")
+            .select_related("created_by", "last_modified_by")
+            .prefetch_related("member_tiles")
         )
-        return DashboardGroupSerializer(groups, many=True, context=self.context).data
+        serializer_class = SharedDashboardGroupSerializer if self.context.get("is_shared") else DashboardGroupSerializer
+        return cast(list[dict[str, Any]], serializer_class(groups, many=True, context=self.context).data)
 
     def to_representation(self, instance: Dashboard) -> ReturnDict:
         ret = super().to_representation(instance)
@@ -1619,19 +1755,14 @@ class DashboardSerializer(DashboardMetadataSerializer):
 
         elif existing_dashboard:
             group_map: dict[uuid.UUID, DashboardGroup] = {}
-            for source_group in existing_dashboard.groups.select_related("tile"):
+            for source_group in existing_dashboard.groups.order_by("position", "created_at"):
                 copied_group = DashboardGroup.all_teams.create(
                     dashboard=dashboard,
                     team=dashboard.team,
                     name=source_group.name,
+                    position=source_group.position,
                     created_by=request.user,
                     last_modified_by=request.user,
-                )
-                DashboardTile.objects.create(
-                    dashboard=dashboard,
-                    team=dashboard.team,
-                    dashboard_group=copied_group,
-                    layouts=source_group.tile.layouts,
                 )
                 group_map[source_group.id] = copied_group
             existing_tiles = (
@@ -1800,6 +1931,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
             filters_overrides=source_tile.filters_overrides,
             show_description=source_tile.show_description,
             transparent_background=source_tile.transparent_background,
+            parent_group=resolve_default_section(destination, user),
         )
 
     @staticmethod
@@ -2016,6 +2148,13 @@ class DashboardSerializer(DashboardMetadataSerializer):
         )
 
     @staticmethod
+    def _new_tile_parent_group(instance: Dashboard, tile_data: dict, user: User) -> dict[str, Any]:
+        if tile_data.get("id") is not None:
+            return {}
+        parent_group = _resolve_parent_group_for_new_tile(instance, user, None)
+        return {"parent_group": parent_group} if parent_group is not None else {}
+
+    @staticmethod
     def _update_existing_tile_display_fields(
         instance: Dashboard, tile_data: dict, user: User
     ) -> tuple[DashboardTile | None, bool]:
@@ -2121,7 +2260,12 @@ class DashboardSerializer(DashboardMetadataSerializer):
                     raise serializers.ValidationError({"text": "Text tile not found in this team."})
             else:
                 text = Text.objects.create(**validated_data)
-            tile, created = DashboardSerializer._upsert_tile(instance, tile_data, text=text)
+            tile, created = DashboardSerializer._upsert_tile(
+                instance,
+                tile_data,
+                text=text,
+                **DashboardSerializer._new_tile_parent_group(instance, tile_data, user),
+            )
             return tile, created
         elif tile_data.get("button_tile", None):
             button_tile_json: dict = tile_data.get("button_tile", {})
@@ -2162,7 +2306,12 @@ class DashboardSerializer(DashboardMetadataSerializer):
                     raise serializers.ValidationError({"button_tile": "Button tile not found in this team."})
             else:
                 button_tile = ButtonTile.objects.create(**validated_data)
-            tile, created = DashboardSerializer._upsert_tile(instance, tile_data, button_tile=button_tile)
+            tile, created = DashboardSerializer._upsert_tile(
+                instance,
+                tile_data,
+                button_tile=button_tile,
+                **DashboardSerializer._new_tile_parent_group(instance, tile_data, user),
+            )
             return tile, created
         elif tile_data.get("widget", None):
             widget_json: dict = tile_data.get("widget", {})
@@ -2212,7 +2361,12 @@ class DashboardSerializer(DashboardMetadataSerializer):
                     created_by=user,
                     last_modified_by=user,
                 )
-            tile, created = DashboardSerializer._upsert_tile(instance, tile_data, widget=widget)
+            tile, created = DashboardSerializer._upsert_tile(
+                instance,
+                tile_data,
+                widget=widget,
+                **DashboardSerializer._new_tile_parent_group(instance, tile_data, user),
+            )
             return tile, created
         elif (
             "deleted" in tile_data
@@ -2338,9 +2492,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
 
         layout_size = "sm"  # default layout size
 
-        # Sort tiles by layout to ensure insights are computed in order of appearance on dashboard
-        # Use the specified layout size to get the correct order for the current viewport
-        sorted_tiles = DashboardTile.sort_tiles_by_layout(tiles, layout_size)
+        sorted_tiles = _sort_tiles_by_section_layout(list(tiles), dashboard, layout_size)
 
         with task_chain_context() if chained_tile_refresh_enabled else nullcontext():
             # Handle case where there are no tiles
@@ -2703,13 +2855,7 @@ class DashboardsViewSet(
 
         layout_size = self._get_layout_size_from_request(request)
 
-        sorted_tiles = sorted(
-            tiles,
-            key=lambda tile: (
-                tile.layouts.get(layout_size, {}).get("y", 100),
-                tile.layouts.get(layout_size, {}).get("x", 100),
-            ),
-        )
+        sorted_tiles = _sort_tiles_by_section_layout(list(tiles), dashboard, layout_size)
 
         # Async generator that handles progressive tile serialization and streaming
         async def async_tile_stream_generator() -> AsyncGenerator[bytes]:
@@ -2973,28 +3119,13 @@ class DashboardsViewSet(
         serializer = CreateDashboardGroupRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        layouts = serializer.validated_data.get("layouts")
-        if layouts is None:
-            existing_layouts = collect_dashboard_sm_layouts_for_dashboard(dashboard)
-            max_bottom = max((layout["y"] + layout["h"] for layout in existing_layouts), default=0)
-            layouts = {"sm": {"x": 0, "y": max_bottom, "w": DASHBOARD_GRID_COLUMN_COUNT, "h": 1}}
-        elif "sm" in layouts:
-            layouts["sm"] = {**layouts["sm"], "x": 0, "w": DASHBOARD_GRID_COLUMN_COUNT, "h": 1}
-
         user = cast(User, request.user)
         with transaction.atomic():
-            group = DashboardGroup.all_teams.create(
-                dashboard=dashboard,
-                team=dashboard.team,
-                name=serializer.validated_data["name"],
-                created_by=user,
-                last_modified_by=user,
-            )
-            DashboardTile.objects.create(
-                dashboard=dashboard,
-                team=dashboard.team,
-                dashboard_group=group,
-                layouts=layouts,
+            group = create_section(
+                dashboard,
+                user=user,
+                name=serializer.validated_data.get("name"),
+                position=serializer.validated_data.get("position"),
             )
 
         report_user_action(
@@ -3015,22 +3146,21 @@ class DashboardsViewSet(
         dashboard = self.get_object()
         serializer = UpdateDashboardGroupRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        group = get_object_or_404(dashboard.groups.select_related("tile"), id=serializer.validated_data["group_id"])
+        group = get_object_or_404(dashboard.groups, id=serializer.validated_data["group_id"])
 
         fields_changed: list[str] = []
-        if "name" in serializer.validated_data:
-            group.name = serializer.validated_data["name"]
-            group.last_modified_by = request.user
-            group.last_modified_at = now()
-            group.save(update_fields=["name", "last_modified_by", "last_modified_at"])
-            fields_changed.append("name")
-        if "layouts" in serializer.validated_data:
-            layouts = serializer.validated_data["layouts"]
-            if "sm" in layouts:
-                layouts["sm"] = {**layouts["sm"], "x": 0, "w": DASHBOARD_GRID_COLUMN_COUNT, "h": 1}
-            group.tile.layouts = layouts
-            group.tile.save(update_fields=["layouts"])
-            fields_changed.append("layouts")
+        with transaction.atomic():
+            lock_dashboard(dashboard)
+            group = dashboard.groups.get(id=group.id)
+            if "name" in serializer.validated_data:
+                group.name = normalize_section_name(serializer.validated_data["name"])
+                group.last_modified_by = request.user
+                group.last_modified_at = now()
+                group.save(update_fields=["name", "last_modified_by", "last_modified_at"])
+                fields_changed.append("name")
+            if "position" in serializer.validated_data:
+                group = move_section(dashboard, group, serializer.validated_data["position"])
+                fields_changed.append("position")
 
         if fields_changed:
             report_user_action(
@@ -3042,7 +3172,10 @@ class DashboardsViewSet(
             )
         return Response(DashboardGroupSerializer(group, context=self.get_serializer_context()).data)
 
-    @extend_schema(request=MoveDashboardTileToGroupRequestSerializer, responses={200: DashboardTileSerializer})
+    @extend_schema(
+        request=MoveDashboardTileToGroupRequestSerializer,
+        responses={200: MoveDashboardTileToGroupResponseSerializer},
+    )
     @action(methods=["POST"], detail=True, url_path="groups/move-tile", required_scopes=["dashboard:write"])
     def move_tile_to_group(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         dashboard = self.get_object()
@@ -3052,30 +3185,55 @@ class DashboardsViewSet(
             DashboardTile.objects.filter(dashboard=dashboard, dashboard_group__isnull=True),
             id=serializer.validated_data["tile_id"],
         )
-        group_id = serializer.validated_data.get("group_id")
-        group = get_object_or_404(dashboard.groups, id=group_id) if group_id is not None else None
+        user = cast(User, request.user)
+        created_group: DashboardGroup | None = None
         source_group_id = tile.parent_group_id
+        deleted_group_ids: list[uuid.UUID] = []
 
-        tile.parent_group = group
-        update_fields = ["parent_group"]
-        if "layouts" in serializer.validated_data:
-            tile.layouts = serializer.validated_data["layouts"]
-            update_fields.append("layouts")
-        tile.save(update_fields=update_fields)
+        with transaction.atomic():
+            lock_dashboard(dashboard)
+            if "create_at_position" in serializer.validated_data:
+                created_group = create_section(
+                    dashboard,
+                    user=user,
+                    name=None,
+                    position=serializer.validated_data["create_at_position"],
+                    wrap_existing=False,
+                )
+                destination = created_group
+            else:
+                destination = get_object_or_404(dashboard.groups, id=serializer.validated_data["group_id"])
+
+            if "layouts" in serializer.validated_data:
+                tile.layouts = serializer.validated_data["layouts"]
+                tile.save(update_fields=["layouts"])
+
+            deleted_id = assign_tile_to_section(tile, destination)
+            if deleted_id is not None:
+                deleted_group_ids.append(deleted_id)
 
         report_user_action(
-            cast(User, request.user),
+            user,
             "dashboard tile moved between groups",
             {
                 "dashboard_id": dashboard.id,
                 "tile_id": tile.id,
                 "source_group_id": str(source_group_id) if source_group_id else None,
-                "destination_group_id": str(group.id) if group else None,
+                "destination_group_id": str(destination.id),
             },
             team=dashboard.team,
             request=request,
         )
-        return Response(DashboardTileSerializer(tile, context=self.get_serializer_context()).data)
+        tile_context = {**self.get_serializer_context(), "dashboard": dashboard}
+        return Response(
+            {
+                "tile": DashboardTileSerializer(tile, context=tile_context).data,
+                "created_group": DashboardGroupSerializer(created_group, context=tile_context).data
+                if created_group
+                else None,
+                "deleted_group_ids": [str(group_id) for group_id in deleted_group_ids],
+            }
+        )
 
     @extend_schema(request=DeleteDashboardGroupRequestSerializer, responses={204: None})
     @action(methods=["POST"], detail=True, url_path="groups/delete", required_scopes=["dashboard:write"])
@@ -3087,15 +3245,20 @@ class DashboardsViewSet(
         member_handling = serializer.validated_data["member_handling"]
 
         with transaction.atomic():
-            members = list(group.member_tiles.select_for_update())
-            for member in members:
-                member.parent_group = None
-                update_fields = ["parent_group"]
-                if member_handling == "delete_tiles":
+            lock_dashboard(dashboard)
+            group = dashboard.groups.get(id=group.id)
+            if member_handling == "ungroup":
+                group.name = None
+                group.last_modified_by = request.user
+                group.last_modified_at = now()
+                group.save(update_fields=["name", "last_modified_by", "last_modified_at"])
+            else:
+                members = list(group.member_tiles.select_for_update())
+                for member in members:
                     member.deleted = True
-                    update_fields.append("deleted")
-                member.save(update_fields=update_fields)
-            group.delete()
+                    member.save(update_fields=["deleted"])
+                group.delete()
+                renumber_section_positions(dashboard)
 
         report_user_action(
             cast(User, request.user),
@@ -3144,7 +3307,8 @@ class DashboardsViewSet(
                 tile_data["layouts"] = validated["layouts"]
             if "color" in validated:
                 tile_data["color"] = validated["color"]
-            tile, _ = DashboardSerializer._upsert_tile(dashboard, tile_data, text=text)
+            parent_group = _resolve_parent_group_for_new_tile(dashboard, user, validated.get("group_id"))
+            tile, _ = DashboardSerializer._upsert_tile(dashboard, tile_data, text=text, parent_group=parent_group)
 
         return Response(
             DashboardTileSerializer(tile, context=self.get_serializer_context()).data,
@@ -3491,11 +3655,19 @@ class DashboardsViewSet(
         tile_context = {**self.get_serializer_context(), "dashboard": dashboard}
 
         with transaction.atomic():
-            existing_sm_layouts = collect_dashboard_sm_layouts_for_dashboard(dashboard)
-            pending_sm_layouts: builtins.list[dict[str, Any]] = []
+            pending_by_section: dict[Any, builtins.list[dict[str, Any]]] = {}
             tiles: builtins.list[DashboardTile] = []
 
             for payload in widget_payloads:
+                parent_group = _resolve_parent_group_for_new_tile(dashboard, user, payload.get("group_id"))
+                section_key = parent_group.id if parent_group else None
+                pending_sm_layouts = pending_by_section.setdefault(section_key, [])
+                if parent_group is not None:
+                    existing_sm_layouts = collect_dashboard_sm_layouts(
+                        list(content_tiles_qs(dashboard).filter(parent_group=parent_group))
+                    )
+                else:
+                    existing_sm_layouts = collect_dashboard_sm_layouts_for_dashboard(dashboard)
                 tile = self._create_widget_tile_from_payload(
                     dashboard=dashboard,
                     user=user,
@@ -3503,6 +3675,7 @@ class DashboardsViewSet(
                     payload=payload,
                     existing_sm_layouts=existing_sm_layouts,
                     pending_sm_layouts=pending_sm_layouts,
+                    parent_group=parent_group,
                 )
                 tiles.append(tile)
                 sm_layout = tile.layouts.get("sm") if isinstance(tile.layouts, dict) else None
@@ -3534,6 +3707,7 @@ class DashboardsViewSet(
         payload: dict[str, Any],
         existing_sm_layouts: builtins.list[dict[str, Any]] | None = None,
         pending_sm_layouts: builtins.list[dict[str, Any]] | None = None,
+        parent_group: DashboardGroup | None = None,
     ) -> DashboardTile:
         widget_type = payload["widget_type"]
         config = payload["config"]
@@ -3571,6 +3745,7 @@ class DashboardsViewSet(
             dashboard=dashboard,
             team_id=dashboard.team_id,
             widget=widget,
+            parent_group=parent_group,
             **tile_defaults,
         )
 

--- a/products/dashboards/backend/api/test/test_dashboard_groups.py
+++ b/products/dashboards/backend/api/test/test_dashboard_groups.py
@@ -17,71 +17,147 @@ class TestDashboardGroups(APIBaseTest):
         self.dashboard_api = DashboardAPI(self.client, self.team, self.assertEqual)
         self.dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "Grouped dashboard"})
 
-    def test_group_lifecycle_and_tile_membership(self) -> None:
-        create_response = self.client.post(
+    def _create_group(self, name: str | None, position: int | None = None) -> dict:
+        payload: dict = {"name": name}
+        if position is not None:
+            payload["position"] = position
+        response = self.client.post(
             f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/",
-            {"name": "Acquisition"},
+            payload,
         )
-        self.assertEqual(create_response.status_code, status.HTTP_201_CREATED)
-        group = create_response.json()
-        self.assertEqual(group["name"], "Acquisition")
-        self.assertEqual(group["layouts"]["sm"], {"x": 0, "y": 0, "w": 12, "h": 1})
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        return response.json()
 
+    def test_first_group_wraps_existing_tiles_in_anonymous_section(self) -> None:
         _, dashboard = self.dashboard_api.create_text_tile(self.dashboard_id, text="Signups")
         tile_id = dashboard["tiles"][0]["id"]
-        move_response = self.client.post(
+
+        named_group = self._create_group("Acquisition")
+
+        groups = list(DashboardGroup.all_teams.filter(dashboard_id=self.dashboard_id).order_by("position"))
+        self.assertEqual([(group.name, group.position) for group in groups], [(None, 0), ("Acquisition", 1)])
+        self.assertEqual(DashboardTile.objects.get(id=tile_id).parent_group_id, groups[0].id)
+        self.assertNotIn("tile_id", named_group)
+        self.assertNotIn("layouts", named_group)
+
+    def test_new_tile_appends_to_trailing_anonymous_section(self) -> None:
+        self._create_group("Named")
+        _, dashboard = self.dashboard_api.create_text_tile(self.dashboard_id, text="Signups")
+        tile = DashboardTile.objects.get(id=dashboard["tiles"][0]["id"])
+
+        groups = list(DashboardGroup.all_teams.filter(dashboard_id=self.dashboard_id).order_by("position"))
+        self.assertEqual([group.name for group in groups], ["Named", None])
+        self.assertEqual(tile.parent_group_id, groups[1].id)
+
+    def test_move_creates_and_removes_anonymous_sections(self) -> None:
+        source_group = self._create_group(None)
+        _, dashboard = self.dashboard_api.create_text_tile(self.dashboard_id, text="Signups")
+        tile_id = dashboard["tiles"][0]["id"]
+        tile = DashboardTile.objects.get(id=tile_id)
+        self.assertEqual(str(tile.parent_group_id), source_group["id"], "tile should start in the source section")
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/move-tile/",
+            {"tile_id": tile_id, "create_at_position": 0},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        payload = response.json()
+        self.assertEqual(payload["tile"]["parent_group_id"], payload["created_group"]["id"])
+        self.assertEqual(payload["deleted_group_ids"], [source_group["id"]])
+        self.assertEqual(
+            list(DashboardGroup.all_teams.filter(dashboard_id=self.dashboard_id).values_list("position", flat=True)),
+            [0],
+        )
+
+    def test_group_position_reorder_renumbers_sections(self) -> None:
+        first = self._create_group("First")
+        second = self._create_group("Second")
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/update/",
+            {"group_id": second["id"], "position": 0},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            [
+                (str(group_id), position)
+                for group_id, position in DashboardGroup.all_teams.filter(dashboard_id=self.dashboard_id)
+                .order_by("position")
+                .values_list("id", "position")
+            ],
+            [(second["id"], 0), (first["id"], 1)],
+        )
+
+    def test_ungroup_keeps_tiles_and_converts_section_to_anonymous(self) -> None:
+        group = self._create_group("Acquisition")
+        _, dashboard = self.dashboard_api.create_text_tile(self.dashboard_id, text="Signups")
+        tile_id = dashboard["tiles"][0]["id"]
+        self.client.post(
             f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/move-tile/",
             {"tile_id": tile_id, "group_id": group["id"]},
         )
-        self.assertEqual(move_response.status_code, status.HTTP_200_OK)
-        self.assertEqual(move_response.json()["parent_group_id"], group["id"])
 
-        dashboard_response = self.client.get(f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/")
-        self.assertEqual(dashboard_response.status_code, status.HTTP_200_OK)
-        self.assertEqual(dashboard_response.json()["groups"][0]["member_tile_ids"], [tile_id])
-        self.assertEqual(len(dashboard_response.json()["tiles"]), 1)
-
-        delete_response = self.client.post(
+        response = self.client.post(
             f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/delete/",
-            {"group_id": group["id"], "member_handling": "move_to_ungrouped"},
+            {"group_id": group["id"], "member_handling": "ungroup"},
         )
-        self.assertEqual(delete_response.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertFalse(DashboardGroup.all_teams.filter(id=group["id"]).exists())
-        self.assertIsNone(DashboardTile.objects.get(id=tile_id).parent_group_id)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertIsNone(DashboardGroup.all_teams.get(id=group["id"]).name)
+        self.assertEqual(str(DashboardTile.objects.get(id=tile_id).parent_group_id), group["id"])
 
     def test_group_rejects_cross_dashboard_membership(self) -> None:
-        group_response = self.client.post(
-            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/",
-            {"name": "Acquisition"},
-        )
+        group = self._create_group("Acquisition")
         other_dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "Other"})
         _, other_dashboard = self.dashboard_api.create_text_tile(other_dashboard_id, text="Other tile")
 
         response = self.client.post(
             f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/move-tile/",
-            {"tile_id": other_dashboard["tiles"][0]["id"], "group_id": group_response.json()["id"]},
+            {"tile_id": other_dashboard["tiles"][0]["id"], "group_id": group["id"]},
         )
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_template_remaps_group_membership(self) -> None:
+    def test_duplicate_dashboard_preserves_section_positions(self) -> None:
+        self._create_group("First")
+        self._create_group("Second")
+
+        _, duplicated = self.dashboard_api.create_dashboard(
+            {"name": "copy", "use_dashboard": self.dashboard_id, "duplicate_tiles": True}
+        )
+
+        self.assertEqual(
+            [(group["name"], group["position"]) for group in duplicated["groups"]],
+            [("First", 0), ("Second", 1)],
+        )
+
+    def test_template_preserves_named_and_anonymous_section_order(self) -> None:
         template = DashboardTemplate(
             template_name="Grouped template",
             dashboard_description="",
             dashboard_filters={},
             tags=[],
             tiles=[
+                {"type": "TEXT", "body": "Before", "layouts": {"sm": {"x": 0, "y": 0, "w": 12, "h": 2}}},
                 {
                     "type": "GROUP",
                     "group_key": "acquisition",
                     "name": "Acquisition",
-                    "layouts": {"sm": {"x": 0, "y": 0, "w": 12, "h": 1}},
+                    "layouts": {"sm": {"x": 0, "y": 3, "w": 12, "h": 1}},
                 },
                 {
                     "type": "TEXT",
                     "group_key": "acquisition",
                     "body": "Signups",
-                    "layouts": {"sm": {"x": 0, "y": 1, "w": 12, "h": 2}},
+                    "layouts": {"sm": {"x": 0, "y": 4, "w": 12, "h": 2}},
+                },
+                {
+                    "type": "TEXT",
+                    "group_key": "unknown",
+                    "body": "After",
+                    "layouts": {"sm": {"x": 0, "y": 7, "w": 12, "h": 2}},
                 },
             ],
         )
@@ -89,6 +165,29 @@ class TestDashboardGroups(APIBaseTest):
 
         create_from_template(dashboard, template, self.user)
 
-        group = dashboard.groups.get()
-        self.assertEqual(group.name, "Acquisition")
-        self.assertEqual(group.member_tiles.get().text.body, "Signups")
+        groups = list(dashboard.groups.order_by("position"))
+        self.assertEqual([(group.name, group.position) for group in groups], [(None, 0), ("Acquisition", 1), (None, 2)])
+        self.assertEqual([group.member_tiles.get().text.body for group in groups], ["Before", "Signups", "After"])
+        self.assertFalse(DashboardTile.objects.filter(dashboard=dashboard, dashboard_group__isnull=False).exists())
+
+    def test_template_unknown_group_key_without_headers_stays_ungrouped(self) -> None:
+        template = DashboardTemplate(
+            template_name="Unknown key template",
+            dashboard_description="",
+            dashboard_filters={},
+            tags=[],
+            tiles=[
+                {
+                    "type": "TEXT",
+                    "group_key": "unknown",
+                    "body": "Signups",
+                    "layouts": {"sm": {"x": 0, "y": 1, "w": 12, "h": 2}},
+                }
+            ],
+        )
+        dashboard = Dashboard.objects.create(team=self.team, name="From unknown template")
+
+        create_from_template(dashboard, template, self.user)
+
+        self.assertFalse(dashboard.groups.exists())
+        self.assertIsNone(DashboardTile.objects.get(dashboard=dashboard).parent_group_id)

--- a/products/dashboards/backend/section_ops.py
+++ b/products/dashboards/backend/section_ops.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from django.db.models import F, QuerySet
+
+from posthog.dataclasses import frozen
+
+from products.dashboards.backend.models.dashboard import Dashboard
+from products.dashboards.backend.models.dashboard_group import DashboardGroup
+from products.dashboards.backend.models.dashboard_tile import DashboardTile
+
+if TYPE_CHECKING:
+    from posthog.models import User
+
+
+def is_anonymous_section(group: DashboardGroup) -> bool:
+    return not (group.name or "").strip()
+
+
+def normalize_section_name(name: str | None) -> str | None:
+    if name is None:
+        return None
+    stripped = name.strip()
+    return stripped or None
+
+
+def lock_dashboard(dashboard: Dashboard) -> Dashboard:
+    return Dashboard.objects.select_for_update().get(pk=dashboard.pk)
+
+
+def content_tiles_qs(dashboard: Dashboard) -> QuerySet[DashboardTile]:
+    return DashboardTile.objects.filter(dashboard=dashboard, dashboard_group__isnull=True).exclude(deleted=True)
+
+
+def ordered_groups(dashboard: Dashboard) -> list[DashboardGroup]:
+    return list(DashboardGroup.all_teams.filter(dashboard=dashboard).order_by("position", "created_at"))
+
+
+def renumber_section_positions(dashboard: Dashboard) -> None:
+    for index, group in enumerate(ordered_groups(dashboard)):
+        if group.position != index:
+            group.position = index
+            group.save(update_fields=["position"])
+
+
+def _shift_positions_from(dashboard: Dashboard, insert_at: int) -> None:
+    dashboard.groups.filter(position__gte=insert_at).update(position=F("position") + 1)
+
+
+def wrap_ungrouped_tiles_as_anonymous_section(dashboard: Dashboard, user: User | None) -> DashboardGroup | None:
+    ungrouped = list(content_tiles_qs(dashboard).filter(parent_group__isnull=True))
+    if not ungrouped:
+        return None
+    _shift_positions_from(dashboard, 0)
+    group = DashboardGroup.all_teams.create(
+        dashboard=dashboard,
+        team=dashboard.team,
+        name=None,
+        position=0,
+        created_by=user,
+        last_modified_by=user,
+    )
+    DashboardTile.objects.filter(id__in=[tile.id for tile in ungrouped]).update(parent_group=group)
+    return group
+
+
+def create_section(
+    dashboard: Dashboard,
+    *,
+    user: User | None,
+    name: str | None,
+    position: int | None,
+    wrap_existing: bool = True,
+) -> DashboardGroup:
+    dashboard = lock_dashboard(dashboard)
+    existing = ordered_groups(dashboard)
+    if wrap_existing and not existing:
+        wrap_ungrouped_tiles_as_anonymous_section(dashboard, user)
+        existing = ordered_groups(dashboard)
+
+    insert_at = len(existing) if position is None else max(0, min(position, len(existing)))
+    _shift_positions_from(dashboard, insert_at)
+    group = DashboardGroup.all_teams.create(
+        dashboard=dashboard,
+        team=dashboard.team,
+        name=normalize_section_name(name),
+        position=insert_at,
+        created_by=user,
+        last_modified_by=user,
+    )
+    renumber_section_positions(dashboard)
+    group.refresh_from_db()
+    return group
+
+
+def move_section(dashboard: Dashboard, group: DashboardGroup, new_position: int) -> DashboardGroup:
+    lock_dashboard(dashboard)
+    remaining = [item for item in ordered_groups(dashboard) if item.id != group.id]
+    insert_at = max(0, min(new_position, len(remaining)))
+    remaining.insert(insert_at, group)
+    for index, item in enumerate(remaining):
+        if item.position != index:
+            item.position = index
+            item.save(update_fields=["position"])
+    group.refresh_from_db()
+    return group
+
+
+def resolve_default_section(dashboard: Dashboard, user: User | None) -> DashboardGroup | None:
+    groups = ordered_groups(dashboard)
+    if not groups:
+        return None
+    last = groups[-1]
+    if is_anonymous_section(last):
+        return last
+    return create_section(dashboard, user=user, name=None, position=None, wrap_existing=False)
+
+
+def delete_emptied_anonymous_section(group: DashboardGroup) -> bool:
+    if not is_anonymous_section(group):
+        return False
+    if content_tiles_qs(group.dashboard).filter(parent_group=group).exists():
+        return False
+    dashboard = group.dashboard
+    group.delete()
+    renumber_section_positions(dashboard)
+    return True
+
+
+def assign_tile_to_section(tile: DashboardTile, group: DashboardGroup | None) -> UUID | None:
+    source_id = tile.parent_group_id
+    tile.parent_group = group
+    tile.save(update_fields=["parent_group"])
+    if source_id is None or (group is not None and source_id == group.id):
+        return None
+    source = DashboardGroup.all_teams.filter(id=source_id).first()
+    if source is None:
+        return None
+    if delete_emptied_anonymous_section(source):
+        return source_id
+    return None
+
+
+def _tile_y(tile: dict[str, Any]) -> int:
+    layouts = tile.get("layouts") or {}
+    sm = layouts.get("sm") if isinstance(layouts, dict) else None
+    if not isinstance(sm, dict):
+        return 0
+    try:
+        return int(sm.get("y", 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+@frozen
+class SectionPartition:
+    name: str | None
+    group_key: str | None
+    tiles: list[dict[str, Any]]
+
+
+def partition_tiles_into_sections(
+    header_layouts: list[dict[str, Any]],
+    tiles: list[dict[str, Any]],
+) -> list[SectionPartition]:
+    """Bucket content tiles into named groups and anonymous runs between them.
+
+    Named membership is by `group_key`. Tiles with a missing or unknown key are
+    placed by y relative to the sorted header ys, so ungrouped runs can sit
+    between named groups. A template with no GROUP tiles returns no sections.
+    """
+    headers = sorted(header_layouts, key=_tile_y)
+    if not headers:
+        return []
+
+    known_keys = {header.get("group_key") for header in headers if header.get("group_key")}
+    members_by_key: dict[str, list[dict[str, Any]]] = {str(key): [] for key in known_keys}
+    ungrouped: list[dict[str, Any]] = []
+    for tile in tiles:
+        key = tile.get("group_key")
+        if key and key in members_by_key:
+            members_by_key[key].append(tile)
+        else:
+            ungrouped.append(tile)
+
+    ungrouped.sort(key=_tile_y)
+    header_ys = [_tile_y(header) for header in headers]
+    buckets: list[list[dict[str, Any]]] = [[] for _ in range(len(headers) + 1)]
+    for tile in ungrouped:
+        y = _tile_y(tile)
+        placed = False
+        for index, header_y in enumerate(header_ys):
+            if y < header_y:
+                buckets[index].append(tile)
+                placed = True
+                break
+        if not placed:
+            buckets[-1].append(tile)
+
+    sections: list[SectionPartition] = []
+    for index, header in enumerate(headers):
+        if buckets[index]:
+            sections.append(SectionPartition(name=None, group_key=None, tiles=buckets[index]))
+        group_key = header.get("group_key")
+        sections.append(
+            SectionPartition(
+                name=normalize_section_name(header.get("name")) or "Group",
+                group_key=str(group_key) if group_key else None,
+                tiles=members_by_key.get(str(group_key), []) if group_key else [],
+            )
+        )
+    if buckets[-1]:
+        sections.append(SectionPartition(name=None, group_key=None, tiles=buckets[-1]))
+    return sections

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -319,30 +319,16 @@ export type DashboardApiPersistedVariables = { [key: string]: unknown } | null
 
 export type DashboardApiTilesItem = { [key: string]: unknown }
 
-export interface TileLayoutBoxApi {
-    /** Column position in the dashboard grid (0-indexed). */
-    x?: number
-    /** Row position in the dashboard grid (0-indexed). */
-    y?: number
-    /** Width in grid columns. The desktop grid is 12 columns wide. */
-    w?: number
-    /** Height in grid rows. */
-    h?: number
-}
-
-export interface TileLayoutsApi {
-    /** Layout for the standard (desktop) breakpoint. The grid is 12 columns wide. */
-    sm?: TileLayoutBoxApi
-}
-
 export interface DashboardGroupApi {
     readonly id: string
-    readonly name: string
-    /** Grid tile ID for this group row. */
-    readonly tile_id: number
-    /** Grid layout for the group row. */
-    readonly layouts: TileLayoutsApi
-    /** Content tile IDs assigned to this group. */
+    /**
+     * Section name. Null or empty means an anonymous section (bare grid, no header).
+     * @nullable
+     */
+    name: string | null
+    /** 0-indexed order of this section on the dashboard. */
+    position: number
+    /** Content tile IDs assigned to this section. */
     readonly member_tile_ids: readonly number[]
     readonly created_at: string
     /** @nullable */
@@ -420,7 +406,7 @@ export interface DashboardApi {
      * @nullable
      */
     quick_filter_ids?: string[] | null
-    /** Ordered groups configured on this dashboard. */
+    /** Ordered sections on this dashboard. Empty when the dashboard has no groups. */
     readonly groups: readonly DashboardGroupApi[]
     /** @nullable */
     readonly tiles: readonly DashboardApiTilesItem[] | null
@@ -1015,6 +1001,22 @@ export interface CopyDashboardTileRequestApi {
     tileId: number
 }
 
+export interface TileLayoutBoxApi {
+    /** Column position in the dashboard grid (0-indexed). */
+    x?: number
+    /** Row position in the dashboard grid (0-indexed). */
+    y?: number
+    /** Width in grid columns. The desktop grid is 12 columns wide. */
+    w?: number
+    /** Height in grid rows. */
+    h?: number
+}
+
+export interface TileLayoutsApi {
+    /** Layout for the standard (desktop) breakpoint. The grid is 12 columns wide. */
+    sm?: TileLayoutBoxApi
+}
+
 export interface CreateTextTileRequestApi {
     /**
      * Markdown body for the text tile. Supports headings, lists, and inline formatting. Useful as a dashboard section heading, divider, or annotation between insights. Max 4000 characters.
@@ -1022,7 +1024,7 @@ export interface CreateTextTileRequestApi {
      * @maxLength 4000
      */
     body: string
-    /** Optional grid layout per breakpoint. If omitted, the tile is placed at the bottom of the dashboard using the default size. Text tiles typically use a thin full-width banner (e.g. w=12, h=1). */
+    /** Optional grid layout per breakpoint. If omitted, the tile is placed at the bottom of the destination section using the default size. Text tiles typically use a thin full-width banner (e.g. w=12, h=1). */
     layouts?: TileLayoutsApi
     /**
      * Optional accent color name (e.g. 'blue', 'green', 'purple', 'black').
@@ -1030,6 +1032,8 @@ export interface CreateTextTileRequestApi {
      * @nullable
      */
     color?: string | null
+    /** Section to add the tile to. On a grouped dashboard, omit to append to the trailing anonymous section (created if needed). */
+    group_id?: string
 }
 
 export type InsightVizNodeApiKind = (typeof InsightVizNodeApiKind)[keyof typeof InsightVizNodeApiKind]
@@ -8927,7 +8931,10 @@ export interface DashboardTileApi {
     text: TextApi
     button_tile: ButtonTileApi
     widget?: DashboardWidgetApi | null
-    /** @nullable */
+    /**
+     * Section this content tile belongs to. Null on dashboards with no groups.
+     * @nullable
+     */
     readonly parent_group_id: string | null
     layouts?: unknown
     /**
@@ -8949,61 +8956,76 @@ export interface DeleteTileRequestApi {
 
 export interface CreateDashboardGroupRequestApi {
     /**
-     * Name displayed in the dashboard group row.
-     * @minLength 1
+     * Section name. Null or empty creates an anonymous section (a bare grid with no header). Omit to create an anonymous section.
      * @maxLength 400
+     * @nullable
      */
-    name: string
-    /** Optional grid layout for the group row. Group rows always span the desktop grid. */
-    layouts?: TileLayoutsApi
+    name?: string | null
+    /**
+     * 0-indexed section position. Omit to append after existing sections.
+     * @minimum 0
+     */
+    position?: number
 }
 
 /**
  * * `delete_tiles` - delete_tiles
- * * `move_to_ungrouped` - move_to_ungrouped
+ * * `ungroup` - ungroup
  */
 export type MemberHandlingEnumApi = (typeof MemberHandlingEnumApi)[keyof typeof MemberHandlingEnumApi]
 
 export const MemberHandlingEnumApi = {
     DeleteTiles: 'delete_tiles',
-    MoveToUngrouped: 'move_to_ungrouped',
+    Ungroup: 'ungroup',
 } as const
 
 export interface DeleteDashboardGroupRequestApi {
     /** Dashboard group ID to delete. */
     group_id: string
-    /** How to handle content tiles currently assigned to the group.
+    /** How to handle tiles in the section. 'delete_tiles' soft-deletes the tiles and removes the section. 'ungroup' clears the section name in place so it becomes anonymous; tiles stay put.
      *
      * * `delete_tiles` - delete_tiles
-     * * `move_to_ungrouped` - move_to_ungrouped */
+     * * `ungroup` - ungroup */
     member_handling: MemberHandlingEnumApi
-    /** Layout for the small (mobile) breakpoint. The grid is 1 column wide. */
-    xs?: TileLayoutBoxApi
 }
 
 export interface MoveDashboardTileToGroupRequestApi {
     /** Content tile ID to move. */
     tile_id: number
+    /** Destination section ID. Provide this or create_at_position, not both. */
+    group_id?: string
     /**
-     * Destination group ID, or null to move the tile to the ungrouped section.
-     * @nullable
+     * Create an anonymous section at this 0-indexed position and move the tile into it. Provide this or group_id, not both.
+     * @minimum 0
      */
-    group_id?: string | null
-    /** Optional new layout for the moved tile. */
+    create_at_position?: number
+    /** Optional new layout for the moved tile, relative to the destination section. */
     layouts?: TileLayoutsApi
+}
+
+export interface MoveDashboardTileToGroupResponseApi {
+    /** The moved tile, including its new parent_group_id. */
+    tile: DashboardTileApi
+    /** The anonymous section created when create_at_position was used. Null otherwise. */
+    created_group: DashboardGroupApi | null
+    /** Anonymous source sections removed because they had no remaining tiles. */
+    deleted_group_ids: string[]
 }
 
 export interface PatchedUpdateDashboardGroupRequestApi {
     /** Dashboard group ID to update. */
     group_id?: string
     /**
-     * New group name. Omit to keep the existing name.
-     * @minLength 1
+     * New section name. Null converts the section to anonymous. Omit to keep the current name.
      * @maxLength 400
+     * @nullable
      */
-    name?: string
-    /** New grid layout for the group row. Omit to keep its current layout. */
-    layouts?: TileLayoutsApi
+    name?: string | null
+    /**
+     * New 0-indexed section position. Omit to keep the current position.
+     * @minimum 0
+     */
+    position?: number
 }
 
 export interface MoveTileTileApi {
@@ -9044,7 +9066,7 @@ export interface ReorderTilesRequestApi {
      * @minItems 1
      */
     tile_order: number[]
-    /** How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per row). 'full_width' forces each tile to span the full 12-column row at height 5.
+    /** How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per row). 'full_width' forces each tile to span the full 12-column row at height 5. On a grouped dashboard the submitted order is partitioned by section and each section is packed independently, so a tile cannot be reordered into a different section here.
      *
      * * `preserve` - preserve
      * * `two_column` - two_column

--- a/products/dashboards/frontend/generated/api.ts
+++ b/products/dashboards/frontend/generated/api.ts
@@ -56,6 +56,7 @@ import type {
     DeleteDashboardGroupRequestApi,
     DeleteTileRequestApi,
     MoveDashboardTileToGroupRequestApi,
+    MoveDashboardTileToGroupResponseApi,
     MoveTileRequestApi,
     PaginatedDashboardBasicListApi,
     PaginatedDashboardTemplateListApi,
@@ -603,7 +604,7 @@ export const getDashboardsGroupsCreateUrl = (projectId: string, id: number, para
 export const dashboardsGroupsCreate = async (
     projectId: string,
     id: number,
-    createDashboardGroupRequestApi: CreateDashboardGroupRequestApi,
+    createDashboardGroupRequestApi?: CreateDashboardGroupRequestApi,
     params?: DashboardsGroupsCreateParams,
     options?: RequestInit
 ): Promise<DashboardGroupApi> => {
@@ -676,13 +677,16 @@ export const dashboardsGroupsMoveTileCreate = async (
     moveDashboardTileToGroupRequestApi: MoveDashboardTileToGroupRequestApi,
     params?: DashboardsGroupsMoveTileCreateParams,
     options?: RequestInit
-): Promise<DashboardTileApi> => {
-    return apiMutator<DashboardTileApi>(getDashboardsGroupsMoveTileCreateUrl(projectId, id, params), {
-        ...options,
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(moveDashboardTileToGroupRequestApi),
-    })
+): Promise<MoveDashboardTileToGroupResponseApi> => {
+    return apiMutator<MoveDashboardTileToGroupResponseApi>(
+        getDashboardsGroupsMoveTileCreateUrl(projectId, id, params),
+        {
+            ...options,
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', ...options?.headers },
+            body: JSON.stringify(moveDashboardTileToGroupRequestApi),
+        }
+    )
 }
 
 export const getDashboardsGroupsUpdatePartialUpdateUrl = (

--- a/products/dashboards/frontend/generated/api.zod.ts
+++ b/products/dashboards/frontend/generated/api.zod.ts
@@ -1080,13 +1080,19 @@ export const DashboardsCreateTextTileCreateBody = /* @__PURE__ */ zod.object({
         })
         .optional()
         .describe(
-            'Optional grid layout per breakpoint. If omitted, the tile is placed at the bottom of the dashboard using the default size. Text tiles typically use a thin full-width banner (e.g. w=12, h=1).'
+            'Optional grid layout per breakpoint. If omitted, the tile is placed at the bottom of the destination section using the default size. Text tiles typically use a thin full-width banner (e.g. w=12, h=1).'
         ),
     color: zod
         .string()
         .max(dashboardsCreateTextTileCreateBodyColorMax)
         .nullish()
         .describe("Optional accent color name (e.g. 'blue', 'green', 'purple', 'black')."),
+    group_id: zod
+        .uuid()
+        .optional()
+        .describe(
+            'Section to add the tile to. On a grouped dashboard, omit to append to the trailing anonymous section (created if needed).'
+        ),
 })
 
 /**
@@ -1102,50 +1108,45 @@ export const DashboardsDeleteTileBody = /* @__PURE__ */ zod.object({
 
 export const dashboardsGroupsCreateBodyNameMax = 400
 
+export const dashboardsGroupsCreateBodyPositionMin = 0
+
 export const DashboardsGroupsCreateBody = /* @__PURE__ */ zod.object({
     name: zod
         .string()
-        .min(1)
         .max(dashboardsGroupsCreateBodyNameMax)
-        .describe('Name displayed in the dashboard group row.'),
-    layouts: zod
-        .object({
-            sm: zod
-                .object({
-                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
-                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
-                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
-                    h: zod.number().optional().describe('Height in grid rows.'),
-                })
-                .optional()
-                .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
-        })
+        .nullish()
+        .describe(
+            'Section name. Null or empty creates an anonymous section (a bare grid with no header). Omit to create an anonymous section.'
+        ),
+    position: zod
+        .number()
+        .min(dashboardsGroupsCreateBodyPositionMin)
         .optional()
-        .describe('Optional grid layout for the group row. Group rows always span the desktop grid.'),
+        .describe('0-indexed section position. Omit to append after existing sections.'),
 })
 
 export const DashboardsGroupsDeleteCreateBody = /* @__PURE__ */ zod.object({
     group_id: zod.uuid().describe('Dashboard group ID to delete.'),
     member_handling: zod
-        .enum(['delete_tiles', 'move_to_ungrouped'])
-        .describe('\* `delete_tiles` - delete_tiles\n\* `move_to_ungrouped` - move_to_ungrouped')
+        .enum(['delete_tiles', 'ungroup'])
+        .describe('\* `delete_tiles` - delete_tiles\n\* `ungroup` - ungroup')
         .describe(
-            'How to handle content tiles currently assigned to the group.\n\n\* `delete_tiles` - delete_tiles\n\* `move_to_ungrouped` - move_to_ungrouped'
+            "How to handle tiles in the section. 'delete_tiles' soft-deletes the tiles and removes the section. 'ungroup' clears the section name in place so it becomes anonymous; tiles stay put.\n\n\* `delete_tiles` - delete_tiles\n\* `ungroup` - ungroup"
         ),
-    xs: zod
-        .object({
-            x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
-            y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
-            w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
-            h: zod.number().optional().describe('Height in grid rows.'),
-        })
-        .optional()
-        .describe('Layout for the small (mobile) breakpoint. The grid is 1 column wide.'),
 })
+
+export const dashboardsGroupsMoveTileCreateBodyCreateAtPositionMin = 0
 
 export const DashboardsGroupsMoveTileCreateBody = /* @__PURE__ */ zod.object({
     tile_id: zod.number().describe('Content tile ID to move.'),
-    group_id: zod.uuid().nullish().describe('Destination group ID, or null to move the tile to the ungrouped section.'),
+    group_id: zod.uuid().optional().describe('Destination section ID. Provide this or create_at_position, not both.'),
+    create_at_position: zod
+        .number()
+        .min(dashboardsGroupsMoveTileCreateBodyCreateAtPositionMin)
+        .optional()
+        .describe(
+            'Create an anonymous section at this 0-indexed position and move the tile into it. Provide this or group_id, not both.'
+        ),
     layouts: zod
         .object({
             sm: zod
@@ -1159,33 +1160,25 @@ export const DashboardsGroupsMoveTileCreateBody = /* @__PURE__ */ zod.object({
                 .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
         })
         .optional()
-        .describe('Optional new layout for the moved tile.'),
+        .describe('Optional new layout for the moved tile, relative to the destination section.'),
 })
 
 export const dashboardsGroupsUpdatePartialUpdateBodyNameMax = 400
+
+export const dashboardsGroupsUpdatePartialUpdateBodyPositionMin = 0
 
 export const DashboardsGroupsUpdatePartialUpdateBody = /* @__PURE__ */ zod.object({
     group_id: zod.uuid().optional().describe('Dashboard group ID to update.'),
     name: zod
         .string()
-        .min(1)
         .max(dashboardsGroupsUpdatePartialUpdateBodyNameMax)
+        .nullish()
+        .describe('New section name. Null converts the section to anonymous. Omit to keep the current name.'),
+    position: zod
+        .number()
+        .min(dashboardsGroupsUpdatePartialUpdateBodyPositionMin)
         .optional()
-        .describe('New group name. Omit to keep the existing name.'),
-    layouts: zod
-        .object({
-            sm: zod
-                .object({
-                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
-                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
-                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
-                    h: zod.number().optional().describe('Height in grid rows.'),
-                })
-                .optional()
-                .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
-        })
-        .optional()
-        .describe('New grid layout for the group row. Omit to keep its current layout.'),
+        .describe('New 0-indexed section position. Omit to keep the current position.'),
 })
 
 export const DashboardsMoveTileCreateBody = /* @__PURE__ */ zod.object({
@@ -1219,7 +1212,7 @@ export const DashboardsReorderTilesCreateBody = /* @__PURE__ */ zod.object({
         .describe('\* `preserve` - preserve\n\* `two_column` - two_column\n\* `full_width` - full_width')
         .default(dashboardsReorderTilesCreateBodyLayoutDefault)
         .describe(
-            "How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per row). 'full_width' forces each tile to span the full 12-column row at height 5.\n\n\* `preserve` - preserve\n\* `two_column` - two_column\n\* `full_width` - full_width"
+            "How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per row). 'full_width' forces each tile to span the full 12-column row at height 5. On a grouped dashboard the submitted order is partitioned by section and each section is packed independently, so a tile cannot be reordered into a different section here.\n\n\* `preserve` - preserve\n\* `two_column` - two_column\n\* `full_width` - full_width"
         ),
 })
 

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -107,7 +107,7 @@ tools:
             idempotent: false
         enrich_url: '{params.id}'
         title: Create dashboard group
-        description: Create a named group at the bottom of a dashboard.
+        description: Create a section on a dashboard. Pass a name for a headed section, or omit name for an anonymous section. Existing ungrouped tiles are wrapped into an anonymous section at position 0 when this is the first group. Pass position to insert; omit to append.
         param_overrides:
             id:
                 cast: string-int
@@ -122,7 +122,7 @@ tools:
             idempotent: true
         enrich_url: '{params.id}'
         title: Update dashboard group
-        description: Rename a dashboard group or update its full-width grid position.
+        description: Rename a dashboard section or move it to a new 0-indexed position. Null name converts the section to anonymous. Member tiles stay in the section.
         param_overrides:
             id:
                 cast: string-int
@@ -137,7 +137,7 @@ tools:
             idempotent: true
         enrich_url: '{params.id}'
         title: Move tile to dashboard group
-        description: Move a content tile into a group or into the ungrouped section.
+        description: Move a content tile into an existing section (group_id) or into a new anonymous section at create_at_position. Provide exactly one of those. Emptied anonymous source sections are removed.
         param_overrides:
             id:
                 cast: string-int
@@ -152,7 +152,7 @@ tools:
             idempotent: false
         enrich_url: '{params.id}'
         title: Delete dashboard group
-        description: Delete a group and either delete its member tiles or move them to the ungrouped section.
+        description: Delete a section. member_handling delete_tiles soft-deletes the tiles and removes the section. ungroup clears the section name so it becomes anonymous; tiles stay put.
         param_overrides:
             id:
                 cast: string-int

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -150,6 +150,7 @@ from products.dashboards.backend.access import (
 )
 from products.dashboards.backend.models.dashboard import Dashboard
 from products.dashboards.backend.models.dashboard_tile import DashboardTile
+from products.dashboards.backend.section_ops import resolve_default_section
 from products.product_analytics.backend.api.insight_metadata import (
     InsightMetadataTimeoutError,
     generate_insight_metadata,
@@ -811,7 +812,11 @@ class InsightSerializer(InsightBasicSerializer):
 
         for dashboard in target_dashboards:
             DashboardTile.objects.create(
-                insight=insight, dashboard=dashboard, team_id=dashboard.team_id, last_refresh=now()
+                insight=insight,
+                dashboard=dashboard,
+                team_id=dashboard.team_id,
+                last_refresh=now(),
+                parent_group=resolve_default_section(dashboard, request.user),
             )
             report_user_action(
                 self.context["request"].user,

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -2082,7 +2082,7 @@
         }
     },
     "dashboard-group-create": {
-        "description": "Create a named group at the bottom of a dashboard.",
+        "description": "Create a section on a dashboard. Pass a name for a headed section, or omit name for an anonymous section. Existing ungrouped tiles are wrapped into an anonymous section at position 0 when this is the first group. Pass position to insert; omit to append.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Create dashboard group",
@@ -2096,7 +2096,7 @@
         }
     },
     "dashboard-group-delete": {
-        "description": "Delete a group and either delete its member tiles or move them to the ungrouped section.",
+        "description": "Delete a section. member_handling delete_tiles soft-deletes the tiles and removes the section. ungroup clears the section name so it becomes anonymous; tiles stay put.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Delete dashboard group",
@@ -2110,7 +2110,7 @@
         }
     },
     "dashboard-group-move-tile": {
-        "description": "Move a content tile into a group or into the ungrouped section.",
+        "description": "Move a content tile into an existing section (group_id) or into a new anonymous section at create_at_position. Provide exactly one of those. Emptied anonymous source sections are removed.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Move tile to dashboard group",
@@ -2124,7 +2124,7 @@
         }
     },
     "dashboard-group-update": {
-        "description": "Rename a dashboard group or update its full-width grid position.",
+        "description": "Rename a dashboard section or move it to a new 0-indexed position. Null name converts the section to anonymous. Member tiles stay in the section.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Update dashboard group",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -2097,7 +2097,7 @@
         }
     },
     "dashboard-group-create": {
-        "description": "Create a named group at the bottom of a dashboard.",
+        "description": "Create a section on a dashboard. Pass a name for a headed section, or omit name for an anonymous section. Existing ungrouped tiles are wrapped into an anonymous section at position 0 when this is the first group. Pass position to insert; omit to append.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Create dashboard group",
@@ -2111,7 +2111,7 @@
         }
     },
     "dashboard-group-delete": {
-        "description": "Delete a group and either delete its member tiles or move them to the ungrouped section.",
+        "description": "Delete a section. member_handling delete_tiles soft-deletes the tiles and removes the section. ungroup clears the section name so it becomes anonymous; tiles stay put.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Delete dashboard group",
@@ -2125,7 +2125,7 @@
         }
     },
     "dashboard-group-move-tile": {
-        "description": "Move a content tile into a group or into the ungrouped section.",
+        "description": "Move a content tile into an existing section (group_id) or into a new anonymous section at create_at_position. Provide exactly one of those. Emptied anonymous source sections are removed.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Move tile to dashboard group",
@@ -2139,7 +2139,7 @@
         }
     },
     "dashboard-group-update": {
-        "description": "Rename a dashboard group or update its full-width grid position.",
+        "description": "Rename a dashboard section or move it to a new 0-indexed position. Null name converts the section to anonymous. Member tiles stay in the section.",
         "category": "Dashboards",
         "feature": "dashboards",
         "summary": "Update dashboard group",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -8537,7 +8537,10 @@ export namespace Schemas {
       text: Text;
       button_tile: ButtonTile;
       widget?: DashboardWidget | null;
-      /** @nullable */
+      /**
+         * Section this content tile belongs to. Null on dashboards with no groups.
+         * @nullable
+         */
       readonly parent_group_id: string | null;
       layouts?: unknown;
       /**
@@ -17413,31 +17416,18 @@ export namespace Schemas {
       memory_gb?: number;
     }
 
-    export interface TileLayoutBox {
-      /** Column position in the dashboard grid (0-indexed). */
-      x?: number;
-      /** Row position in the dashboard grid (0-indexed). */
-      y?: number;
-      /** Width in grid columns. The desktop grid is 12 columns wide. */
-      w?: number;
-      /** Height in grid rows. */
-      h?: number;
-    }
-
-    export interface TileLayouts {
-      /** Layout for the standard (desktop) breakpoint. The grid is 12 columns wide. */
-      sm?: TileLayoutBox;
-    }
-
     export interface CreateDashboardGroupRequest {
       /**
-         * Name displayed in the dashboard group row.
-         * @minLength 1
+         * Section name. Null or empty creates an anonymous section (a bare grid with no header). Omit to create an anonymous section.
          * @maxLength 400
+         * @nullable
          */
-      name: string;
-      /** Optional grid layout for the group row. Group rows always span the desktop grid. */
-      layouts?: TileLayouts;
+      name?: string | null;
+      /**
+         * 0-indexed section position. Omit to append after existing sections.
+         * @minimum 0
+         */
+      position?: number;
     }
 
     /**
@@ -17710,6 +17700,22 @@ export namespace Schemas {
       always_include?: boolean;
     }
 
+    export interface TileLayoutBox {
+      /** Column position in the dashboard grid (0-indexed). */
+      x?: number;
+      /** Row position in the dashboard grid (0-indexed). */
+      y?: number;
+      /** Width in grid columns. The desktop grid is 12 columns wide. */
+      w?: number;
+      /** Height in grid rows. */
+      h?: number;
+    }
+
+    export interface TileLayouts {
+      /** Layout for the standard (desktop) breakpoint. The grid is 12 columns wide. */
+      sm?: TileLayoutBox;
+    }
+
     export interface CreateTextTileRequest {
       /**
          * Markdown body for the text tile. Supports headings, lists, and inline formatting. Useful as a dashboard section heading, divider, or annotation between insights. Max 4000 characters.
@@ -17717,7 +17723,7 @@ export namespace Schemas {
          * @maxLength 4000
          */
       body: string;
-      /** Optional grid layout per breakpoint. If omitted, the tile is placed at the bottom of the dashboard using the default size. Text tiles typically use a thin full-width banner (e.g. w=12, h=1). */
+      /** Optional grid layout per breakpoint. If omitted, the tile is placed at the bottom of the destination section using the default size. Text tiles typically use a thin full-width banner (e.g. w=12, h=1). */
       layouts?: TileLayouts;
       /**
          * Optional accent color name (e.g. 'blue', 'green', 'purple', 'black').
@@ -17725,6 +17731,8 @@ export namespace Schemas {
          * @nullable
          */
       color?: string | null;
+      /** Section to add the tile to. On a grouped dashboard, omit to append to the trailing anonymous section (created if needed). */
+      group_id?: string;
     }
 
     export interface CreateVersionFromSourceInput {
@@ -18404,12 +18412,14 @@ export namespace Schemas {
 
     export interface DashboardGroup {
       readonly id: string;
-      readonly name: string;
-      /** Grid tile ID for this group row. */
-      readonly tile_id: number;
-      /** Grid layout for the group row. */
-      readonly layouts: TileLayouts;
-      /** Content tile IDs assigned to this group. */
+      /**
+         * Section name. Null or empty means an anonymous section (bare grid, no header).
+         * @nullable
+         */
+      name: string | null;
+      /** 0-indexed order of this section on the dashboard. */
+      position: number;
+      /** Content tile IDs assigned to this section. */
       readonly member_tile_ids: readonly number[];
       readonly created_at: string;
       /** @nullable */
@@ -18487,7 +18497,7 @@ export namespace Schemas {
          * @nullable
          */
       quick_filter_ids?: string[] | null;
-      /** Ordered groups configured on this dashboard. */
+      /** Ordered sections on this dashboard. Empty when the dashboard has no groups. */
       readonly groups: readonly DashboardGroup[];
       /** @nullable */
       readonly tiles: readonly DashboardTilesItem[] | null;
@@ -24242,26 +24252,24 @@ export namespace Schemas {
 
     /**
      * * `delete_tiles` - delete_tiles
-     * * `move_to_ungrouped` - move_to_ungrouped
+     * * `ungroup` - ungroup
      */
     export type MemberHandlingEnum = typeof MemberHandlingEnum[keyof typeof MemberHandlingEnum];
 
 
     export const MemberHandlingEnum = {
       DeleteTiles: 'delete_tiles',
-      MoveToUngrouped: 'move_to_ungrouped',
+      Ungroup: 'ungroup',
     } as const;
 
     export interface DeleteDashboardGroupRequest {
       /** Dashboard group ID to delete. */
       group_id: string;
-      /** How to handle content tiles currently assigned to the group.
+      /** How to handle tiles in the section. 'delete_tiles' soft-deletes the tiles and removes the section. 'ungroup' clears the section name in place so it becomes anonymous; tiles stay put.
        *
        * * `delete_tiles` - delete_tiles
-       * * `move_to_ungrouped` - move_to_ungrouped */
+       * * `ungroup` - ungroup */
       member_handling: MemberHandlingEnum;
-      /** Layout for the small (mobile) breakpoint. The grid is 1 column wide. */
-      xs?: TileLayoutBox;
     }
 
     export interface DeleteTileRequest {
@@ -45882,13 +45890,24 @@ export namespace Schemas {
     export interface MoveDashboardTileToGroupRequest {
       /** Content tile ID to move. */
       tile_id: number;
+      /** Destination section ID. Provide this or create_at_position, not both. */
+      group_id?: string;
       /**
-         * Destination group ID, or null to move the tile to the ungrouped section.
-         * @nullable
+         * Create an anonymous section at this 0-indexed position and move the tile into it. Provide this or group_id, not both.
+         * @minimum 0
          */
-      group_id?: string | null;
-      /** Optional new layout for the moved tile. */
+      create_at_position?: number;
+      /** Optional new layout for the moved tile, relative to the destination section. */
       layouts?: TileLayouts;
+    }
+
+    export interface MoveDashboardTileToGroupResponse {
+      /** The moved tile, including its new parent_group_id. */
+      tile: DashboardTile;
+      /** The anonymous section created when create_at_position was used. Null otherwise. */
+      created_group: DashboardGroup | null;
+      /** Anonymous source sections removed because they had no remaining tiles. */
+      deleted_group_ids: string[];
     }
 
     export interface MoveTileTile {
@@ -60905,13 +60924,16 @@ export namespace Schemas {
       /** Dashboard group ID to update. */
       group_id?: string;
       /**
-         * New group name. Omit to keep the existing name.
-         * @minLength 1
+         * New section name. Null converts the section to anonymous. Omit to keep the current name.
          * @maxLength 400
+         * @nullable
          */
-      name?: string;
-      /** New grid layout for the group row. Omit to keep its current layout. */
-      layouts?: TileLayouts;
+      name?: string | null;
+      /**
+         * New 0-indexed section position. Omit to keep the current position.
+         * @minimum 0
+         */
+      position?: number;
     }
 
     export type SessionReplayListWidgetUpdateRequestOpenApiWidgetType = typeof SessionReplayListWidgetUpdateRequestOpenApiWidgetType[keyof typeof SessionReplayListWidgetUpdateRequestOpenApiWidgetType];
@@ -67026,7 +67048,7 @@ export namespace Schemas {
          * @minItems 1
          */
       tile_order: number[];
-      /** How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per row). 'full_width' forces each tile to span the full 12-column row at height 5.
+      /** How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per row). 'full_width' forces each tile to span the full 12-column row at height 5. On a grouped dashboard the submitted order is partitioned by section and each section is packed independently, so a tile cannot be reordered into a different section here.
        *
        * * `preserve` - preserve
        * * `two_column` - two_column

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -1088,13 +1088,19 @@ export const DashboardsCreateTextTileCreateBody = /* @__PURE__ */ zod.object({
         })
         .optional()
         .describe(
-            'Optional grid layout per breakpoint. If omitted, the tile is placed at the bottom of the dashboard using the default size. Text tiles typically use a thin full-width banner (e.g. w=12, h=1).'
+            'Optional grid layout per breakpoint. If omitted, the tile is placed at the bottom of the destination section using the default size. Text tiles typically use a thin full-width banner (e.g. w=12, h=1).'
         ),
     color: zod
         .string()
         .max(dashboardsCreateTextTileCreateBodyColorMax)
         .nullish()
         .describe("Optional accent color name (e.g. 'blue', 'green', 'purple', 'black')."),
+    group_id: zod
+        .string()
+        .optional()
+        .describe(
+            'Section to add the tile to. On a grouped dashboard, omit to append to the trailing anonymous section (created if needed).'
+        ),
 })
 
 /**
@@ -1136,26 +1142,21 @@ export const DashboardsGroupsCreateQueryParams = /* @__PURE__ */ zod.object({
 
 export const dashboardsGroupsCreateBodyNameMax = 400
 
+export const dashboardsGroupsCreateBodyPositionMin = 0
+
 export const DashboardsGroupsCreateBody = /* @__PURE__ */ zod.object({
     name: zod
         .string()
-        .min(1)
         .max(dashboardsGroupsCreateBodyNameMax)
-        .describe('Name displayed in the dashboard group row.'),
-    layouts: zod
-        .object({
-            sm: zod
-                .object({
-                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
-                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
-                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
-                    h: zod.number().optional().describe('Height in grid rows.'),
-                })
-                .optional()
-                .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
-        })
+        .nullish()
+        .describe(
+            'Section name. Null or empty creates an anonymous section (a bare grid with no header). Omit to create an anonymous section.'
+        ),
+    position: zod
+        .number()
+        .min(dashboardsGroupsCreateBodyPositionMin)
         .optional()
-        .describe('Optional grid layout for the group row. Group rows always span the desktop grid.'),
+        .describe('0-indexed section position. Omit to append after existing sections.'),
 })
 
 export const DashboardsGroupsDeleteCreateParams = /* @__PURE__ */ zod.object({
@@ -1174,20 +1175,11 @@ export const DashboardsGroupsDeleteCreateQueryParams = /* @__PURE__ */ zod.objec
 export const DashboardsGroupsDeleteCreateBody = /* @__PURE__ */ zod.object({
     group_id: zod.string().describe('Dashboard group ID to delete.'),
     member_handling: zod
-        .enum(['delete_tiles', 'move_to_ungrouped'])
-        .describe('\* `delete_tiles` - delete_tiles\n\* `move_to_ungrouped` - move_to_ungrouped')
+        .enum(['delete_tiles', 'ungroup'])
+        .describe('\* `delete_tiles` - delete_tiles\n\* `ungroup` - ungroup')
         .describe(
-            'How to handle content tiles currently assigned to the group.\n\n\* `delete_tiles` - delete_tiles\n\* `move_to_ungrouped` - move_to_ungrouped'
+            "How to handle tiles in the section. 'delete_tiles' soft-deletes the tiles and removes the section. 'ungroup' clears the section name in place so it becomes anonymous; tiles stay put.\n\n\* `delete_tiles` - delete_tiles\n\* `ungroup` - ungroup"
         ),
-    xs: zod
-        .object({
-            x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
-            y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
-            w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
-            h: zod.number().optional().describe('Height in grid rows.'),
-        })
-        .optional()
-        .describe('Layout for the small (mobile) breakpoint. The grid is 1 column wide.'),
 })
 
 export const DashboardsGroupsMoveTileCreateParams = /* @__PURE__ */ zod.object({
@@ -1203,12 +1195,18 @@ export const DashboardsGroupsMoveTileCreateQueryParams = /* @__PURE__ */ zod.obj
     format: zod.enum(['json', 'txt']).optional(),
 })
 
+export const dashboardsGroupsMoveTileCreateBodyCreateAtPositionMin = 0
+
 export const DashboardsGroupsMoveTileCreateBody = /* @__PURE__ */ zod.object({
     tile_id: zod.number().describe('Content tile ID to move.'),
-    group_id: zod
-        .string()
-        .nullish()
-        .describe('Destination group ID, or null to move the tile to the ungrouped section.'),
+    group_id: zod.string().optional().describe('Destination section ID. Provide this or create_at_position, not both.'),
+    create_at_position: zod
+        .number()
+        .min(dashboardsGroupsMoveTileCreateBodyCreateAtPositionMin)
+        .optional()
+        .describe(
+            'Create an anonymous section at this 0-indexed position and move the tile into it. Provide this or group_id, not both.'
+        ),
     layouts: zod
         .object({
             sm: zod
@@ -1222,7 +1220,7 @@ export const DashboardsGroupsMoveTileCreateBody = /* @__PURE__ */ zod.object({
                 .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
         })
         .optional()
-        .describe('Optional new layout for the moved tile.'),
+        .describe('Optional new layout for the moved tile, relative to the destination section.'),
 })
 
 export const DashboardsGroupsUpdatePartialUpdateParams = /* @__PURE__ */ zod.object({
@@ -1240,28 +1238,20 @@ export const DashboardsGroupsUpdatePartialUpdateQueryParams = /* @__PURE__ */ zo
 
 export const dashboardsGroupsUpdatePartialUpdateBodyNameMax = 400
 
+export const dashboardsGroupsUpdatePartialUpdateBodyPositionMin = 0
+
 export const DashboardsGroupsUpdatePartialUpdateBody = /* @__PURE__ */ zod.object({
     group_id: zod.string().optional().describe('Dashboard group ID to update.'),
     name: zod
         .string()
-        .min(1)
         .max(dashboardsGroupsUpdatePartialUpdateBodyNameMax)
+        .nullish()
+        .describe('New section name. Null converts the section to anonymous. Omit to keep the current name.'),
+    position: zod
+        .number()
+        .min(dashboardsGroupsUpdatePartialUpdateBodyPositionMin)
         .optional()
-        .describe('New group name. Omit to keep the existing name.'),
-    layouts: zod
-        .object({
-            sm: zod
-                .object({
-                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
-                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
-                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
-                    h: zod.number().optional().describe('Height in grid rows.'),
-                })
-                .optional()
-                .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
-        })
-        .optional()
-        .describe('New grid layout for the group row. Omit to keep its current layout.'),
+        .describe('New 0-indexed section position. Omit to keep the current position.'),
 })
 
 export const DashboardsMoveTilePartialUpdateParams = /* @__PURE__ */ zod.object({
@@ -1312,7 +1302,7 @@ export const DashboardsReorderTilesCreateBody = /* @__PURE__ */ zod.object({
         .describe('\* `preserve` - preserve\n\* `two_column` - two_column\n\* `full_width` - full_width')
         .default(dashboardsReorderTilesCreateBodyLayoutDefault)
         .describe(
-            "How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per row). 'full_width' forces each tile to span the full 12-column row at height 5.\n\n\* `preserve` - preserve\n\* `two_column` - two_column\n\* `full_width` - full_width"
+            "How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per row). 'full_width' forces each tile to span the full 12-column row at height 5. On a grouped dashboard the submitted order is partitioned by section and each section is packed independently, so a tile cannot be reordered into a different section here.\n\n\* `preserve` - preserve\n\* `two_column` - two_column\n\* `full_width` - full_width"
         ),
 })
 

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -167,6 +167,9 @@ const dashboardCreateTextTile = (): ToolBase<
         if (params.color !== undefined) {
             body['color'] = params.color
         }
+        if (params.group_id !== undefined) {
+            body['group_id'] = params.group_id
+        }
         const result = await context.api.request<Schemas.DashboardTile>({
             method: 'POST',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/create_text_tile/`,
@@ -192,8 +195,8 @@ const dashboardGroupCreate = (): ToolBase<
         if (params.name !== undefined) {
             body['name'] = params.name
         }
-        if (params.layouts !== undefined) {
-            body['layouts'] = params.layouts
+        if (params.position !== undefined) {
+            body['position'] = params.position
         }
         const result = await context.api.request<Schemas.DashboardGroup>({
             method: 'POST',
@@ -223,8 +226,8 @@ const dashboardGroupUpdate = (): ToolBase<
         if (params.name !== undefined) {
             body['name'] = params.name
         }
-        if (params.layouts !== undefined) {
-            body['layouts'] = params.layouts
+        if (params.position !== undefined) {
+            body['position'] = params.position
         }
         const result = await context.api.request<Schemas.DashboardGroup>({
             method: 'PATCH',
@@ -241,7 +244,7 @@ const DashboardGroupMoveTileSchema = DashboardsGroupsMoveTileCreateParams.omit({
 
 const dashboardGroupMoveTile = (): ToolBase<
     typeof DashboardGroupMoveTileSchema,
-    WithPostHogUrl<Schemas.DashboardTile>
+    WithPostHogUrl<Schemas.MoveDashboardTileToGroupResponse>
 > => ({
     name: 'dashboard-group-move-tile',
     schema: DashboardGroupMoveTileSchema,
@@ -254,10 +257,13 @@ const dashboardGroupMoveTile = (): ToolBase<
         if (params.group_id !== undefined) {
             body['group_id'] = params.group_id
         }
+        if (params.create_at_position !== undefined) {
+            body['create_at_position'] = params.create_at_position
+        }
         if (params.layouts !== undefined) {
             body['layouts'] = params.layouts
         }
-        const result = await context.api.request<Schemas.DashboardTile>({
+        const result = await context.api.request<Schemas.MoveDashboardTileToGroupResponse>({
             method: 'POST',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/groups/move-tile/`,
             body,
@@ -281,9 +287,6 @@ const dashboardGroupDelete = (): ToolBase<typeof DashboardGroupDeleteSchema, unk
         }
         if (params.member_handling !== undefined) {
             body['member_handling'] = params.member_handling
-        }
-        if (params.xs !== undefined) {
-            body['xs'] = params.xs
         }
         const result = await context.api.request<unknown>({
             method: 'POST',

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-create-text-tile.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-create-text-tile.json
@@ -19,12 +19,16 @@
             ],
             "description": "Optional accent color name (e.g. 'blue', 'green', 'purple', 'black')."
         },
+        "group_id": {
+            "description": "Section to add the tile to. On a grouped dashboard, omit to append to the trailing anonymous section (created if needed).",
+            "type": "string"
+        },
         "id": {
             "description": "A unique integer value identifying this dashboard.",
             "type": "number"
         },
         "layouts": {
-            "description": "Optional grid layout per breakpoint. If omitted, the tile is placed at the bottom of the dashboard using the default size. Text tiles typically use a thin full-width banner (e.g. w=12, h=1).",
+            "description": "Optional grid layout per breakpoint. If omitted, the tile is placed at the bottom of the destination section using the default size. Text tiles typically use a thin full-width banner (e.g. w=12, h=1).",
             "properties": {
                 "sm": {
                     "description": "Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-group-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-group-create.json
@@ -5,41 +5,24 @@
             "description": "A unique integer value identifying this dashboard.",
             "type": "number"
         },
-        "layouts": {
-            "description": "Optional grid layout for the group row. Group rows always span the desktop grid.",
-            "properties": {
-                "sm": {
-                    "description": "Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.",
-                    "properties": {
-                        "h": {
-                            "description": "Height in grid rows.",
-                            "type": "number"
-                        },
-                        "w": {
-                            "description": "Width in grid columns. The desktop grid is 12 columns wide.",
-                            "type": "number"
-                        },
-                        "x": {
-                            "description": "Column position in the dashboard grid (0-indexed).",
-                            "type": "number"
-                        },
-                        "y": {
-                            "description": "Row position in the dashboard grid (0-indexed).",
-                            "type": "number"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
         "name": {
-            "description": "Name displayed in the dashboard group row.",
-            "maxLength": 400,
-            "minLength": 1,
-            "type": "string"
+            "anyOf": [
+                {
+                    "maxLength": 400,
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Section name. Null or empty creates an anonymous section (a bare grid with no header). Omit to create an anonymous section."
+        },
+        "position": {
+            "description": "0-indexed section position. Omit to append after existing sections.",
+            "minimum": 0,
+            "type": "number"
         }
     },
-    "required": ["id", "name"],
+    "required": ["id"],
     "type": "object"
 }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-group-delete.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-group-delete.json
@@ -10,31 +10,9 @@
             "type": "number"
         },
         "member_handling": {
-            "description": "How to handle content tiles currently assigned to the group.\n\n* `delete_tiles` - delete_tiles\n* `move_to_ungrouped` - move_to_ungrouped",
-            "enum": ["delete_tiles", "move_to_ungrouped"],
+            "description": "How to handle tiles in the section. 'delete_tiles' soft-deletes the tiles and removes the section. 'ungroup' clears the section name in place so it becomes anonymous; tiles stay put.\n\n* `delete_tiles` - delete_tiles\n* `ungroup` - ungroup",
+            "enum": ["delete_tiles", "ungroup"],
             "type": "string"
-        },
-        "xs": {
-            "description": "Layout for the small (mobile) breakpoint. The grid is 1 column wide.",
-            "properties": {
-                "h": {
-                    "description": "Height in grid rows.",
-                    "type": "number"
-                },
-                "w": {
-                    "description": "Width in grid columns. The desktop grid is 12 columns wide.",
-                    "type": "number"
-                },
-                "x": {
-                    "description": "Column position in the dashboard grid (0-indexed).",
-                    "type": "number"
-                },
-                "y": {
-                    "description": "Row position in the dashboard grid (0-indexed).",
-                    "type": "number"
-                }
-            },
-            "type": "object"
         }
     },
     "required": ["id", "group_id", "member_handling"],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-group-move-tile.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-group-move-tile.json
@@ -1,23 +1,21 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
+        "create_at_position": {
+            "description": "Create an anonymous section at this 0-indexed position and move the tile into it. Provide this or group_id, not both.",
+            "minimum": 0,
+            "type": "number"
+        },
         "group_id": {
-            "anyOf": [
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "null"
-                }
-            ],
-            "description": "Destination group ID, or null to move the tile to the ungrouped section."
+            "description": "Destination section ID. Provide this or create_at_position, not both.",
+            "type": "string"
         },
         "id": {
             "description": "A unique integer value identifying this dashboard.",
             "type": "number"
         },
         "layouts": {
-            "description": "Optional new layout for the moved tile.",
+            "description": "Optional new layout for the moved tile, relative to the destination section.",
             "properties": {
                 "sm": {
                     "description": "Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-group-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-group-update.json
@@ -9,39 +9,22 @@
             "description": "A unique integer value identifying this dashboard.",
             "type": "number"
         },
-        "layouts": {
-            "description": "New grid layout for the group row. Omit to keep its current layout.",
-            "properties": {
-                "sm": {
-                    "description": "Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.",
-                    "properties": {
-                        "h": {
-                            "description": "Height in grid rows.",
-                            "type": "number"
-                        },
-                        "w": {
-                            "description": "Width in grid columns. The desktop grid is 12 columns wide.",
-                            "type": "number"
-                        },
-                        "x": {
-                            "description": "Column position in the dashboard grid (0-indexed).",
-                            "type": "number"
-                        },
-                        "y": {
-                            "description": "Row position in the dashboard grid (0-indexed).",
-                            "type": "number"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
         "name": {
-            "description": "New group name. Omit to keep the existing name.",
-            "maxLength": 400,
-            "minLength": 1,
-            "type": "string"
+            "anyOf": [
+                {
+                    "maxLength": 400,
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "New section name. Null converts the section to anonymous. Omit to keep the current name."
+        },
+        "position": {
+            "description": "New 0-indexed section position. Omit to keep the current position.",
+            "minimum": 0,
+            "type": "number"
         }
     },
     "required": ["id"],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-reorder-tiles.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-reorder-tiles.json
@@ -7,7 +7,7 @@
         },
         "layout": {
             "default": "preserve",
-            "description": "How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per row). 'full_width' forces each tile to span the full 12-column row at height 5.\n\n* `preserve` - preserve\n* `two_column` - two_column\n* `full_width` - full_width",
+            "description": "How to size tiles when reordering. 'preserve' (default) keeps each tile's existing width and height and only repacks positions in the new order. 'two_column' forces a 6-wide × 5-tall grid (two tiles per row). 'full_width' forces each tile to span the full 12-column row at height 5. On a grouped dashboard the submitted order is partitioned by section and each section is packed independently, so a tile cannot be reordered into a different section here.\n\n* `preserve` - preserve\n* `two_column` - two_column\n* `full_width` - full_width",
             "enum": ["preserve", "two_column", "full_width"],
             "type": "string"
         },


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->