### PR TITLE
feat(dashboards): migrate header tiles to section positions

### DIFF
--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -1118,7 +1118,6 @@ class DashboardTileSerializer(serializers.ModelSerializer):
             # Denormalization for HogQL printing; combined with depth=1, leaving it
             # in expands `team` into a full nested Team dict on every tile response.
             "team",
-            "dashboard_group",
             "parent_group",
         ]
         read_only_fields = ["id", "insight"]
@@ -1767,7 +1766,6 @@ class DashboardSerializer(DashboardMetadataSerializer):
                 group_map[source_group.id] = copied_group
             existing_tiles = (
                 DashboardTile.objects.filter(dashboard=existing_dashboard)
-                .filter(dashboard_group__isnull=True)
                 .exclude(deleted=True)
                 .select_related("insight", "text", "button_tile", "widget", "parent_group")
             )
@@ -3182,7 +3180,7 @@ class DashboardsViewSet(
         serializer = MoveDashboardTileToGroupRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         tile = get_object_or_404(
-            DashboardTile.objects.filter(dashboard=dashboard, dashboard_group__isnull=True),
+            DashboardTile.objects.filter(dashboard=dashboard),
             id=serializer.validated_data["tile_id"],
         )
         user = cast(User, request.user)

--- a/products/dashboards/backend/api/test/test_dashboard_groups.py
+++ b/products/dashboards/backend/api/test/test_dashboard_groups.py
@@ -168,7 +168,6 @@ class TestDashboardGroups(APIBaseTest):
         groups = list(dashboard.groups.order_by("position"))
         self.assertEqual([(group.name, group.position) for group in groups], [(None, 0), ("Acquisition", 1), (None, 2)])
         self.assertEqual([group.member_tiles.get().text.body for group in groups], ["Before", "Signups", "After"])
-        self.assertFalse(DashboardTile.objects.filter(dashboard=dashboard, dashboard_group__isnull=False).exists())
 
     def test_template_unknown_group_key_without_headers_stays_ungrouped(self) -> None:
         template = DashboardTemplate(

--- a/products/dashboards/backend/migrations/0020_migrate_dashboard_group_sections.py
+++ b/products/dashboards/backend/migrations/0020_migrate_dashboard_group_sections.py
@@ -1,0 +1,82 @@
+from typing import Any
+
+from django.db import migrations
+
+
+def _layout_y(tile: Any) -> int:
+    layouts = tile.layouts if isinstance(tile.layouts, dict) else {}
+    sm = layouts.get("sm") or {}
+    y = sm.get("y", 0)
+    try:
+        return int(y)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _group_y(group: Any, header_by_group_id: dict[Any, Any]) -> int:
+    header = header_by_group_id.get(group.id)
+    return _layout_y(header) if header is not None else 0
+
+
+def migrate_dashboard_group_sections(apps: Any, schema_editor: Any) -> None:
+    # Inlined from partition_tiles_into_sections: migrations must not import app code.
+    Dashboard = apps.get_model("dashboards", "Dashboard")
+    DashboardGroup = apps.get_model("dashboards", "DashboardGroup")
+    DashboardTile = apps.get_model("dashboards", "DashboardTile")
+    groups_manager = getattr(DashboardGroup, "all_teams", DashboardGroup.objects)
+
+    dashboard_ids = groups_manager.values_list("dashboard_id", flat=True).distinct()
+    for dashboard_id in dashboard_ids.iterator():
+        dashboard = Dashboard.objects.get(id=dashboard_id)
+        groups = list(groups_manager.filter(dashboard_id=dashboard_id))
+        header_tiles = list(DashboardTile.objects.filter(dashboard_id=dashboard_id, dashboard_group_id__isnull=False))
+        header_by_group_id = {tile.dashboard_group_id: tile for tile in header_tiles}
+
+        sorted_groups = sorted(groups, key=lambda group, mapping=header_by_group_id: _group_y(group, mapping))
+        ungrouped_tiles = list(
+            DashboardTile.objects.filter(
+                dashboard_id=dashboard_id,
+                dashboard_group_id__isnull=True,
+                parent_group_id__isnull=True,
+                deleted=False,
+            )
+        )
+        header_ys = [_group_y(group, header_by_group_id) for group in sorted_groups]
+        anonymous_tiles_by_bucket: dict[int, list[Any]] = {}
+        for tile in ungrouped_tiles:
+            tile_y = _layout_y(tile)
+            bucket = sum(header_y <= tile_y for header_y in header_ys)
+            anonymous_tiles_by_bucket.setdefault(bucket, []).append(tile)
+
+        section_entries: list[tuple[int, Any, list[Any]]] = [
+            (_group_y(group, header_by_group_id), group, []) for group in sorted_groups
+        ]
+        for tiles in anonymous_tiles_by_bucket.values():
+            group = groups_manager.create(
+                dashboard_id=dashboard_id,
+                team_id=dashboard.team_id,
+                name=None,
+                position=0,
+            )
+            section_entries.append((min(_layout_y(tile) for tile in tiles), group, tiles))
+
+        section_entries.sort(key=lambda entry: (entry[0], entry[2] != []))
+        groups_to_update = []
+        tiles_to_update = []
+        for position, (_, group, tiles) in enumerate(section_entries):
+            group.position = position
+            groups_to_update.append(group)
+            for tile in tiles:
+                tile.parent_group_id = group.id
+                tiles_to_update.append(tile)
+
+        groups_manager.bulk_update(groups_to_update, ["position"])
+        if tiles_to_update:
+            DashboardTile.objects.bulk_update(tiles_to_update, ["parent_group"])
+        DashboardTile.objects.filter(id__in=[tile.id for tile in header_tiles]).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [("dashboards", "0019_dashboardgroup_position_and_nullable_name")]
+
+    operations = [migrations.RunPython(migrate_dashboard_group_sections, migrations.RunPython.noop)]

--- a/products/dashboards/backend/migrations/0021_remove_dashboardtile_dashboard_group_state.py
+++ b/products/dashboards/backend/migrations/0021_remove_dashboardtile_dashboard_group_state.py
@@ -1,0 +1,32 @@
+from django.db import migrations, models
+
+import posthog.models.utils
+
+
+class Migration(migrations.Migration):
+    dependencies = [("dashboards", "0020_migrate_dashboard_group_sections")]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveConstraint(
+                    model_name="dashboardtile",
+                    name="dash_tile_exactly_one_related_object",
+                ),
+                migrations.RemoveField(
+                    model_name="dashboardtile",
+                    name="dashboard_group",
+                ),
+                migrations.AddConstraint(
+                    model_name="dashboardtile",
+                    constraint=models.CheckConstraint(
+                        condition=posthog.models.utils.build_unique_relationship_check(
+                            ("insight", "text", "button_tile", "widget")
+                        ),
+                        name="dash_tile_exactly_one_related_object",
+                    ),
+                ),
+            ],
+            database_operations=[],
+        )
+    ]

--- a/products/dashboards/backend/migrations/max_migration.txt
+++ b/products/dashboards/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0019_dashboardgroup_position_and_nullable_name
+0021_remove_dashboardtile_dashboard_group_state

--- a/products/dashboards/backend/models/dashboard_tile.py
+++ b/products/dashboards/backend/models/dashboard_tile.py
@@ -85,14 +85,6 @@ class DashboardTile(models.Model):
         null=True,
         db_index=False,
     )
-    dashboard_group = models.OneToOneField(
-        "dashboards.DashboardGroup",
-        on_delete=models.CASCADE,
-        related_name="tile",
-        null=True,
-        db_index=False,
-        db_constraint=False,
-    )
     parent_group = models.ForeignKey(
         "dashboards.DashboardGroup",
         on_delete=models.PROTECT,
@@ -151,9 +143,7 @@ class DashboardTile(models.Model):
                 condition=Q(("widget__isnull", False)),
             ),
             models.CheckConstraint(
-                condition=build_unique_relationship_check(
-                    ("insight", "text", "button_tile", "widget", "dashboard_group")
-                ),
+                condition=build_unique_relationship_check(("insight", "text", "button_tile", "widget")),
                 name="dash_tile_exactly_one_related_object",
             ),
         ]
@@ -194,23 +184,14 @@ class DashboardTile(models.Model):
         related_fields = sum(
             map(
                 bool,
-                [
-                    getattr(self, relation)
-                    for relation in ("insight", "text", "button_tile", "widget", "dashboard_group")
-                ],
+                [getattr(self, relation) for relation in ("insight", "text", "button_tile", "widget")],
             )
         )
         if related_fields != 1:
-            raise ValidationError(
-                "Can only set exactly one of insight, text, button_tile, widget, or dashboard_group for this tile"
-            )
+            raise ValidationError("Can only set exactly one of insight, text, button_tile, or widget for this tile")
 
-        if self.dashboard_group_id is not None and self.parent_group_id is not None:
-            raise ValidationError("Dashboard group tiles cannot belong to another group")
-
-        for group in (self.dashboard_group, self.parent_group):
-            if group is not None and group.dashboard_id != self.dashboard_id:
-                raise ValidationError("Dashboard groups and tiles must belong to the same dashboard")
+        if self.parent_group is not None and self.parent_group.dashboard_id != self.dashboard_id:
+            raise ValidationError("Dashboard groups and tiles must belong to the same dashboard")
 
         if self.insight is None and (
             self.filters_hash is not None
@@ -321,7 +302,6 @@ class DashboardTile(models.Model):
                 "text",
                 "button_tile",
                 "widget",
-                "dashboard_group",
                 "parent_group",
                 "insight__created_by",
                 "insight__last_modified_by",
@@ -331,7 +311,6 @@ class DashboardTile(models.Model):
             )
             .prefetch_related("text__dashboard_tiles", "button_tile__dashboard_tiles", "widget__dashboard_tiles")
             .exclude(dashboard__deleted=True, deleted=True)
-            .filter(dashboard_group__isnull=True)
             .filter(Q(insight__deleted=False) | Q(insight__isnull=True))
             .order_by("insight__order")
         )

--- a/products/dashboards/backend/section_ops.py
+++ b/products/dashboards/backend/section_ops.py
@@ -31,7 +31,7 @@ def lock_dashboard(dashboard: Dashboard) -> Dashboard:
 
 
 def content_tiles_qs(dashboard: Dashboard) -> QuerySet[DashboardTile]:
-    return DashboardTile.objects.filter(dashboard=dashboard, dashboard_group__isnull=True).exclude(deleted=True)
+    return DashboardTile.objects.filter(dashboard=dashboard).exclude(deleted=True)
 
 
 def ordered_groups(dashboard: Dashboard) -> list[DashboardGroup]:

--- a/products/dashboards/backend/test/test_migration_0020.py
+++ b/products/dashboards/backend/test/test_migration_0020.py
@@ -1,0 +1,84 @@
+from typing import Any
+
+from posthog.test.base import TestMigrations
+
+
+class MigrateDashboardGroupSectionsTest(TestMigrations):
+    migrate_from = "0019_dashboardgroup_position_and_nullable_name"
+    migrate_to = "0020_migrate_dashboard_group_sections"
+
+    @property
+    def app(self) -> str:
+        return "dashboards"
+
+    def setUpBeforeMigration(self, apps: Any) -> None:
+        Dashboard = apps.get_model("dashboards", "Dashboard")
+        DashboardGroup = apps.get_model("dashboards", "DashboardGroup")
+        DashboardTile = apps.get_model("dashboards", "DashboardTile")
+        Text = apps.get_model("dashboards", "Text")
+        groups_manager = getattr(DashboardGroup, "all_teams", DashboardGroup.objects)
+
+        grouped_dashboard = Dashboard.objects.create(team_id=self.team.id, name="Grouped")
+        untouched_dashboard = Dashboard.objects.create(team_id=self.team.id, name="Untouched")
+        first_group = groups_manager.create(
+            dashboard=grouped_dashboard,
+            team_id=self.team.id,
+            name="First",
+        )
+        second_group = groups_manager.create(
+            dashboard=grouped_dashboard,
+            team_id=self.team.id,
+            name="Second",
+        )
+        DashboardTile.objects.create(
+            dashboard=grouped_dashboard,
+            team_id=self.team.id,
+            dashboard_group=first_group,
+            layouts={"sm": {"x": 0, "y": 2, "w": 12, "h": 1}},
+        )
+        DashboardTile.objects.create(
+            dashboard=grouped_dashboard,
+            team_id=self.team.id,
+            dashboard_group=second_group,
+            layouts={"sm": {"x": 0, "y": 8, "w": 12, "h": 1}},
+        )
+        for body, y, dashboard in (
+            ("Before", 0, grouped_dashboard),
+            ("Between", 5, grouped_dashboard),
+            ("After", 10, grouped_dashboard),
+            ("Untouched", 0, untouched_dashboard),
+        ):
+            text = Text.objects.create(team_id=self.team.id, body=body)
+            DashboardTile.objects.create(
+                dashboard=dashboard,
+                team_id=self.team.id,
+                text=text,
+                layouts={"sm": {"x": 0, "y": y, "w": 12, "h": 2}},
+            )
+
+        self.grouped_dashboard_id = grouped_dashboard.id
+        self.untouched_dashboard_id = untouched_dashboard.id
+
+    def test_migration_builds_ordered_sections_and_leaves_group_less_dashboards_untouched(self) -> None:
+        DashboardGroup = self.apps.get_model("dashboards", "DashboardGroup")  # type: ignore[union-attr]
+        DashboardTile = self.apps.get_model("dashboards", "DashboardTile")  # type: ignore[union-attr]
+        groups_manager = getattr(DashboardGroup, "all_teams", DashboardGroup.objects)
+
+        groups = list(groups_manager.filter(dashboard_id=self.grouped_dashboard_id).order_by("position"))
+        assert [(group.name, group.position) for group in groups] == [
+            (None, 0),
+            ("First", 1),
+            (None, 2),
+            ("Second", 3),
+            (None, 4),
+        ]
+        assert (
+            DashboardTile.objects.filter(
+                dashboard_id=self.grouped_dashboard_id,
+                dashboard_group_id__isnull=False,
+            ).count()
+            == 0
+        )
+        assert all(group.member_tiles.count() == 1 for group in groups if group.name is None)
+        assert not groups_manager.filter(dashboard_id=self.untouched_dashboard_id).exists()
+        assert DashboardTile.objects.get(dashboard_id=self.untouched_dashboard_id).parent_group_id is None


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->