### PR TITLE
feat(dashboards): add dashboard group model and API

### DIFF
--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -115,8 +115,9 @@ from products.dashboards.backend.api.widget_openapi_serializers import (
     WidgetCatalogResponseSerializer,
 )
 from products.dashboards.backend.constants import DASHBOARD_GRID_COLUMN_COUNT, MAX_WIDGETS_BATCH_SIZE
-from products.dashboards.backend.feature_flags import dashboard_widgets_enabled
+from products.dashboards.backend.feature_flags import dashboard_groups_enabled, dashboard_widgets_enabled
 from products.dashboards.backend.models.dashboard import Dashboard
+from products.dashboards.backend.models.dashboard_group import DashboardGroup
 from products.dashboards.backend.models.dashboard_tile import ButtonTile, DashboardTile, Text
 from products.dashboards.backend.models.dashboard_widget import DashboardWidget
 from products.dashboards.backend.widget_access import (
@@ -540,6 +541,51 @@ class TileLayoutsSerializer(serializers.Serializer):
     )
 
 
+class CreateDashboardGroupRequestSerializer(serializers.Serializer):
+    name = serializers.CharField(
+        max_length=400,
+        help_text="Display name for the group header.",
+    )
+    layouts = TileLayoutsSerializer(
+        required=False,
+        help_text="Optional layout for the group header tile. Defaults to a full-width row at the bottom of the dashboard.",
+    )
+
+
+class UpdateDashboardGroupRequestSerializer(serializers.Serializer):
+    group_id = serializers.UUIDField(help_text="ID of the dashboard group to update.")
+    name = serializers.CharField(
+        max_length=400,
+        required=False,
+        help_text="New display name for the group header.",
+    )
+    layouts = TileLayoutsSerializer(
+        required=False,
+        help_text="New layout for the group header tile. Header tiles are always full width and one row tall.",
+    )
+
+
+class MoveDashboardTileToGroupRequestSerializer(serializers.Serializer):
+    tile_id = serializers.IntegerField(help_text="ID of the content tile to move.")
+    group_id = serializers.UUIDField(
+        required=False,
+        allow_null=True,
+        help_text="Destination group ID, or null to remove the tile from its group.",
+    )
+    layouts = TileLayoutsSerializer(
+        required=False,
+        help_text="Optional updated layout for the moved tile.",
+    )
+
+
+class DeleteDashboardGroupRequestSerializer(serializers.Serializer):
+    group_id = serializers.UUIDField(help_text="ID of the dashboard group to delete.")
+    member_handling = serializers.ChoiceField(
+        choices=["delete_tiles", "move_to_ungrouped"],
+        help_text="delete_tiles soft-deletes member tiles. move_to_ungrouped leaves them on the dashboard outside any group.",
+    )
+
+
 class CreateTextTileRequestSerializer(serializers.Serializer):
     body = serializers.CharField(
         min_length=1,
@@ -898,12 +944,54 @@ class SharedDashboardWidgetMetadataSerializer(serializers.ModelSerializer):
         return config
 
 
+class DashboardGroupSerializer(serializers.ModelSerializer):
+    tile_id = serializers.IntegerField(
+        read_only=True,
+        allow_null=True,
+        help_text="ID of the header tile for this group. Used as the react-grid-layout item key.",
+    )
+    layouts = TileLayoutsSerializer(
+        read_only=True,
+        help_text="Layout of the group header tile. Always full width and one row tall on desktop.",
+    )
+    member_tile_ids = serializers.ListField(
+        child=serializers.IntegerField(),
+        read_only=True,
+        help_text="IDs of content tiles that currently belong to this group.",
+    )
+
+    class Meta:
+        model = DashboardGroup
+        fields = ["id", "name", "tile_id", "layouts", "member_tile_ids"]
+        read_only_fields = ["id", "name", "tile_id", "layouts", "member_tile_ids"]
+
+    def to_representation(self, instance: DashboardGroup) -> dict[str, Any]:
+        try:
+            header_tile = instance.tile
+        except DashboardTile.DoesNotExist:
+            header_tile = None
+        member_ids = list(instance.member_tiles.exclude(deleted=True).order_by("id").values_list("id", flat=True))
+        return {
+            "id": str(instance.id),
+            "name": instance.name,
+            "tile_id": header_tile.id if header_tile is not None else None,
+            "layouts": header_tile.layouts if header_tile is not None else {},
+            "member_tile_ids": member_ids,
+        }
+
+
 class DashboardTileSerializer(serializers.ModelSerializer):
     id: serializers.IntegerField = serializers.IntegerField(required=False)
     insight: InsightBasicSerializer = InsightSerializer()
     text = TextSerializer()
     button_tile = ButtonTileSerializer()
     widget = DashboardWidgetSerializer(required=False, allow_null=True)
+    parent_group_id = serializers.UUIDField(
+        required=False,
+        allow_null=True,
+        read_only=True,
+        help_text="ID of the dashboard group this tile belongs to, if any.",
+    )
 
     class Meta:
         model = DashboardTile
@@ -917,8 +1005,10 @@ class DashboardTileSerializer(serializers.ModelSerializer):
             # Denormalization for HogQL printing; combined with depth=1, leaving it
             # in expands `team` into a full nested Team dict on every tile response.
             "team",
+            "dashboard_group",
+            "parent_group",
         ]
-        read_only_fields = ["id", "insight"]
+        read_only_fields = ["id", "insight", "parent_group_id"]
         depth = 1
 
     @tracer.start_as_current_span("DashboardTileSerializer.to_representation")
@@ -1408,18 +1498,29 @@ class DashboardSerializer(DashboardMetadataSerializer):
         help_text="When deleting, also delete insights that are only on this dashboard.",
     )
     _create_in_folder = serializers.CharField(required=False, allow_blank=True, write_only=True)
+    groups = serializers.SerializerMethodField(
+        help_text="Named groups of tiles on this dashboard. Null on list responses.",
+    )
 
     class Meta:
         model = Dashboard
         fields = [
             *DASHBOARD_SHARED_FIELDS,
             "tiles",
+            "groups",
             "use_template",
             "use_dashboard",
             "delete_insights",
             "_create_in_folder",
         ]
         read_only_fields = ["creation_mode", "effective_restriction_level", "is_shared", "user_access_level"]
+
+    @extend_schema_field(DashboardGroupSerializer(many=True))
+    def get_groups(self, dashboard: Dashboard) -> Optional[list[ReturnDict]]:
+        if self.context["view"].action == "list":
+            return None
+        groups = dashboard.groups.select_related("tile").prefetch_related("member_tiles").all()
+        return cast(list[ReturnDict], DashboardGroupSerializer(groups, many=True, context=self.context).data)
 
     def validate_variables(self, value) -> dict:
         if not isinstance(value, dict):
@@ -1529,15 +1630,24 @@ class DashboardSerializer(DashboardMetadataSerializer):
             existing_tiles = (
                 DashboardTile.objects.filter(dashboard=existing_dashboard)
                 .exclude(deleted=True)
-                .select_related("insight", "text", "button_tile", "widget")
+                .select_related("insight", "text", "button_tile", "widget", "parent_group")
             )
+            group_id_map = self._clone_dashboard_groups(existing_dashboard, dashboard, request.user)
             duplicate_tiles = self.initial_data.get("duplicate_tiles", False)
             for existing_tile in existing_tiles:
-                # Widget tiles move with their widget row; other tiles re-link shared insight/text/button rows.
+                if existing_tile.dashboard_group_id is not None:
+                    continue
+                new_tile: DashboardTile | None = None
                 if duplicate_tiles or existing_tile.widget_id is not None:
-                    self._deep_duplicate_tiles(dashboard, existing_tile, user_access_control)
+                    new_tile = self._deep_duplicate_tiles(dashboard, existing_tile, user_access_control)
                 else:
                     existing_tile.copy_to_dashboard(dashboard)
+                    new_tile = self._find_copied_tile(dashboard, existing_tile)
+                if new_tile is not None and existing_tile.parent_group_id is not None:
+                    remapped_group_id = group_id_map.get(existing_tile.parent_group_id)
+                    if remapped_group_id is not None:
+                        new_tile.parent_group_id = remapped_group_id
+                        new_tile.save(update_fields=["parent_group"])
 
         # Manual tag creation since this create method doesn't call super()
         self._attempt_set_tags(tags, dashboard)
@@ -1560,7 +1670,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
 
     def _deep_duplicate_tiles(
         self, dashboard: Dashboard, existing_tile: DashboardTile, user_access_control: UserAccessControl
-    ) -> None:
+    ) -> DashboardTile | None:
         if existing_tile.insight:
             # Deep duplication serializes and recreates the source insight, so the caller must have viewer
             # access to that specific insight — an insight can be restricted independently of its dashboard.
@@ -1585,7 +1695,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
             # Create new insight's tags separately. Force create tags on dashboard duplication.
             self._attempt_set_tags(new_tags, insight)
 
-            DashboardTile.objects.create(
+            return DashboardTile.objects.create(
                 dashboard=dashboard,
                 team_id=dashboard.team_id,
                 insight=insight,
@@ -1605,7 +1715,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
             text_serializer.is_valid()
             text_serializer.save()
             text = cast(Text, text_serializer.instance)
-            DashboardTile.objects.create(
+            return DashboardTile.objects.create(
                 dashboard=dashboard,
                 team_id=dashboard.team_id,
                 text=text,
@@ -1625,7 +1735,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
             button_tile_serializer.is_valid()
             button_tile_serializer.save()
             button_tile = cast(ButtonTile, button_tile_serializer.instance)
-            DashboardTile.objects.create(
+            return DashboardTile.objects.create(
                 dashboard=dashboard,
                 team_id=dashboard.team_id,
                 button_tile=button_tile,
@@ -1637,11 +1747,47 @@ class DashboardSerializer(DashboardMetadataSerializer):
             )
         elif existing_tile.widget:
             request = self.context["request"]
-            DashboardSerializer._clone_widget_tile_to_dashboard(
+            return DashboardSerializer._clone_widget_tile_to_dashboard(
                 existing_tile,
                 dashboard,
                 cast(User, request.user),
             )
+        return None
+
+    def _clone_dashboard_groups(
+        self, source: Dashboard, destination: Dashboard, user: User
+    ) -> dict[uuid.UUID, uuid.UUID]:
+        group_id_map: dict[uuid.UUID, uuid.UUID] = {}
+        for group in source.groups.select_related("tile").all():
+            new_group = DashboardGroup.objects.create(
+                dashboard=destination,
+                team_id=destination.team_id,
+                name=group.name,
+                created_by=user,
+                last_modified_by=user,
+            )
+            try:
+                header_layouts = group.tile.layouts
+            except DashboardTile.DoesNotExist:
+                header_layouts = {}
+            DashboardTile.objects.create(
+                dashboard=destination,
+                team_id=destination.team_id,
+                dashboard_group=new_group,
+                layouts=header_layouts,
+            )
+            group_id_map[group.id] = new_group.id
+        return group_id_map
+
+    @staticmethod
+    def _find_copied_tile(dashboard: Dashboard, source_tile: DashboardTile) -> DashboardTile | None:
+        if source_tile.insight_id is not None:
+            return DashboardTile.objects.filter(dashboard=dashboard, insight_id=source_tile.insight_id).first()
+        if source_tile.text_id is not None:
+            return DashboardTile.objects.filter(dashboard=dashboard, text_id=source_tile.text_id).first()
+        if source_tile.button_tile_id is not None:
+            return DashboardTile.objects.filter(dashboard=dashboard, button_tile_id=source_tile.button_tile_id).first()
+        return None
 
     @staticmethod
     def _clone_widget_tile_to_dashboard(
@@ -2718,7 +2864,9 @@ class DashboardsViewSet(
                 tile.dashboard_id = to_dashboard
                 # Destination is scoped to the current project; align team_id when moving within it.
                 tile.team_id = to_dashboard_obj.team_id
-                tile.save(update_fields=["dashboard_id", "team_id"])
+                # Membership is per-dashboard; a leftover parent would point at the source group.
+                tile.parent_group_id = None
+                tile.save(update_fields=["dashboard_id", "team_id", "parent_group"])
         except DjangoValidationError:
             logger.exception("validation_error_while_moving_dashboard_tile")
             raise exceptions.ValidationError("Invalid request data for moving tile.")
@@ -2846,6 +2994,200 @@ class DashboardsViewSet(
         DashboardTile.objects.bulk_update(tile_map.values(), ["layouts"])
 
         return Response(DashboardSerializer(dashboard, context=self.get_serializer_context()).data)
+
+    def _require_dashboard_groups_enabled(self) -> None:
+        if not dashboard_groups_enabled(team=self.team, user=cast(User, self.request.user)):
+            raise exceptions.PermissionDenied("Dashboard groups are not enabled for this project.")
+
+    @extend_schema(request=CreateDashboardGroupRequestSerializer, responses={201: DashboardGroupSerializer})
+    @action(methods=["POST"], detail=True, url_path="groups", required_scopes=["dashboard:write"])
+    def create_group(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        self._require_dashboard_groups_enabled()
+        dashboard = self.get_object()
+        if dashboard.deleted:
+            raise exceptions.NotFound()
+        if not self.user_permissions.dashboard(dashboard).can_edit:
+            raise exceptions.PermissionDenied("You don't have edit permissions for this dashboard.")
+
+        serializer = CreateDashboardGroupRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        user = cast(User, request.user)
+        with transaction.atomic():
+            dashboard = Dashboard.objects.select_for_update().get(id=dashboard.id)
+            layouts = serializer.validated_data.get("layouts", {})
+            if "sm" not in layouts:
+                existing_layouts = collect_dashboard_sm_layouts_for_dashboard(dashboard)
+                max_bottom = max((layout["y"] + layout["h"] for layout in existing_layouts), default=0)
+                layouts = {
+                    **layouts,
+                    "sm": {"x": 0, "y": max_bottom, "w": DASHBOARD_GRID_COLUMN_COUNT, "h": 1},
+                }
+            else:
+                layouts["sm"] = {**layouts["sm"], "x": 0, "w": DASHBOARD_GRID_COLUMN_COUNT, "h": 1}
+            group = DashboardGroup.objects.create(
+                dashboard=dashboard,
+                team_id=dashboard.team_id,
+                name=serializer.validated_data["name"],
+                created_by=user,
+                last_modified_by=user,
+            )
+            DashboardTile.objects.create(
+                dashboard=dashboard,
+                team_id=dashboard.team_id,
+                dashboard_group=group,
+                layouts=layouts,
+            )
+
+        report_user_action(
+            user,
+            "dashboard group created",
+            {"dashboard_id": dashboard.id, "group_id": str(group.id)},
+            team=dashboard.team,
+            request=request,
+        )
+        return Response(
+            DashboardGroupSerializer(group, context=self.get_serializer_context()).data,
+            status=status.HTTP_201_CREATED,
+        )
+
+    @extend_schema(request=UpdateDashboardGroupRequestSerializer, responses={200: DashboardGroupSerializer})
+    @action(methods=["POST"], detail=True, url_path="groups/update", required_scopes=["dashboard:write"])
+    def update_group(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        self._require_dashboard_groups_enabled()
+        dashboard = self.get_object()
+        if dashboard.deleted:
+            raise exceptions.NotFound()
+        if not self.user_permissions.dashboard(dashboard).can_edit:
+            raise exceptions.PermissionDenied("You don't have edit permissions for this dashboard.")
+
+        serializer = UpdateDashboardGroupRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        fields_changed: list[str] = []
+        with transaction.atomic():
+            dashboard = Dashboard.objects.select_for_update().get(id=dashboard.id)
+            group = get_object_or_404(
+                dashboard.groups.select_related("tile").select_for_update(of=("self",)),
+                id=serializer.validated_data["group_id"],
+            )
+            if "name" in serializer.validated_data:
+                group.name = serializer.validated_data["name"]
+                group.last_modified_by = request.user
+                group.last_modified_at = now()
+                group.save(update_fields=["name", "last_modified_by", "last_modified_at"])
+                fields_changed.append("name")
+            if "layouts" in serializer.validated_data:
+                layouts = {**group.tile.layouts, **serializer.validated_data["layouts"]}
+                if "sm" in layouts:
+                    layouts["sm"] = {**layouts["sm"], "x": 0, "w": DASHBOARD_GRID_COLUMN_COUNT, "h": 1}
+                group_tile = DashboardTile.objects.select_for_update().get(id=group.tile.id)
+                previous_y = group_tile.layouts.get("sm", {}).get("y")
+                next_y = layouts.get("sm", {}).get("y")
+                group_tile.layouts = layouts
+                group_tile.save(update_fields=["layouts"])
+
+                if isinstance(previous_y, int) and isinstance(next_y, int) and previous_y != next_y:
+                    members = list(group.member_tiles.select_for_update())
+                    for member in members:
+                        member_layout = member.layouts.get("sm")
+                        if member_layout is not None and isinstance(member_layout.get("y"), int):
+                            member.layouts = {
+                                **member.layouts,
+                                "sm": {**member_layout, "y": member_layout["y"] + next_y - previous_y},
+                            }
+                    DashboardTile.objects.bulk_update(members, ["layouts"])
+                group.tile = group_tile
+                fields_changed.append("layouts")
+
+        if fields_changed:
+            report_user_action(
+                cast(User, request.user),
+                "dashboard group updated",
+                {"dashboard_id": dashboard.id, "group_id": str(group.id), "fields_changed": fields_changed},
+                team=dashboard.team,
+                request=request,
+            )
+        return Response(DashboardGroupSerializer(group, context=self.get_serializer_context()).data)
+
+    @extend_schema(request=MoveDashboardTileToGroupRequestSerializer, responses={200: DashboardTileSerializer})
+    @action(methods=["POST"], detail=True, url_path="groups/move-tile", required_scopes=["dashboard:write"])
+    def move_tile_to_group(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        self._require_dashboard_groups_enabled()
+        dashboard = self.get_object()
+        if dashboard.deleted:
+            raise exceptions.NotFound()
+        if not self.user_permissions.dashboard(dashboard).can_edit:
+            raise exceptions.PermissionDenied("You don't have edit permissions for this dashboard.")
+
+        serializer = MoveDashboardTileToGroupRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        with transaction.atomic():
+            dashboard = Dashboard.objects.select_for_update().get(id=dashboard.id)
+            tile = get_object_or_404(
+                DashboardTile.objects.select_for_update().filter(dashboard=dashboard, dashboard_group__isnull=True),
+                id=serializer.validated_data["tile_id"],
+            )
+            group_id = serializer.validated_data.get("group_id")
+            group = get_object_or_404(dashboard.groups, id=group_id) if group_id is not None else None
+            source_group_id = tile.parent_group_id
+
+            tile.parent_group = group
+            update_fields = ["parent_group"]
+            if "layouts" in serializer.validated_data:
+                tile.layouts = {**tile.layouts, **serializer.validated_data["layouts"]}
+                update_fields.append("layouts")
+            tile.save(update_fields=update_fields)
+
+        report_user_action(
+            cast(User, request.user),
+            "dashboard tile moved between groups",
+            {
+                "dashboard_id": dashboard.id,
+                "tile_id": tile.id,
+                "source_group_id": str(source_group_id) if source_group_id else None,
+                "destination_group_id": str(group.id) if group else None,
+            },
+            team=dashboard.team,
+            request=request,
+        )
+        return Response(DashboardTileSerializer(tile, context=self.get_serializer_context()).data)
+
+    @extend_schema(request=DeleteDashboardGroupRequestSerializer, responses={204: None})
+    @action(methods=["POST"], detail=True, url_path="groups/delete", required_scopes=["dashboard:write"])
+    def delete_group(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        self._require_dashboard_groups_enabled()
+        dashboard = self.get_object()
+        if dashboard.deleted:
+            raise exceptions.NotFound()
+        if not self.user_permissions.dashboard(dashboard).can_edit:
+            raise exceptions.PermissionDenied("You don't have edit permissions for this dashboard.")
+
+        serializer = DeleteDashboardGroupRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        member_handling = serializer.validated_data["member_handling"]
+
+        with transaction.atomic():
+            dashboard = Dashboard.objects.select_for_update().get(id=dashboard.id)
+            group = get_object_or_404(dashboard.groups.select_for_update(), id=serializer.validated_data["group_id"])
+            members = group.member_tiles.select_for_update()
+            if member_handling == "delete_tiles":
+                members.update(parent_group=None, deleted=True)
+            else:
+                members.update(parent_group=None)
+            group.delete()
+
+        report_user_action(
+            cast(User, request.user),
+            "dashboard group deleted",
+            {
+                "dashboard_id": dashboard.id,
+                "group_id": str(serializer.validated_data["group_id"]),
+                "member_handling": member_handling,
+            },
+            team=dashboard.team,
+            request=request,
+        )
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
     @extend_schema(
         request=CreateTextTileRequestSerializer,

--- a/products/dashboards/backend/api/test/test_dashboard_groups.py
+++ b/products/dashboards/backend/api/test/test_dashboard_groups.py
@@ -1,0 +1,193 @@
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from rest_framework import status
+
+from posthog.api.test.dashboards import DashboardAPI
+
+from products.dashboards.backend.models.dashboard_group import DashboardGroup
+from products.dashboards.backend.models.dashboard_tile import DashboardTile
+
+
+class TestDashboardGroups(APIBaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.dashboard_api = DashboardAPI(self.client, self.team, self.assertEqual)
+        self.dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "Grouped dashboard"})
+        self._groups_flag_patcher = patch(
+            "products.dashboards.backend.api.dashboard.dashboard_groups_enabled",
+            return_value=True,
+        )
+        self._groups_flag_patcher.start()
+
+    def tearDown(self) -> None:
+        self._groups_flag_patcher.stop()
+        super().tearDown()
+
+    def test_group_lifecycle_and_tile_membership(self) -> None:
+        create_response = self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/",
+            {"name": "Acquisition"},
+        )
+        self.assertEqual(create_response.status_code, status.HTTP_201_CREATED)
+        group = create_response.json()
+        self.assertEqual(group["name"], "Acquisition")
+        self.assertEqual(group["layouts"]["sm"], {"x": 0, "y": 0, "w": 12, "h": 1})
+
+        rename_response = self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/update/",
+            {"group_id": group["id"], "name": "Activation"},
+        )
+        self.assertEqual(rename_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(rename_response.json()["name"], "Activation")
+
+        _, dashboard = self.dashboard_api.create_text_tile(self.dashboard_id, text="Signups")
+        tile_id = dashboard["tiles"][0]["id"]
+        move_response = self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/move-tile/",
+            {"tile_id": tile_id, "group_id": group["id"]},
+        )
+        self.assertEqual(move_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(move_response.json()["parent_group_id"], group["id"])
+
+        dashboard_response = self.client.get(f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/")
+        self.assertEqual(dashboard_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(dashboard_response.json()["groups"][0]["member_tile_ids"], [tile_id])
+        self.assertEqual(len(dashboard_response.json()["tiles"]), 1)
+
+        delete_response = self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/delete/",
+            {"group_id": group["id"], "member_handling": "move_to_ungrouped"},
+        )
+        self.assertEqual(delete_response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(DashboardGroup.all_teams.filter(id=group["id"]).exists())
+        self.assertIsNone(DashboardTile.objects.get(id=tile_id).parent_group_id)
+
+    def test_delete_tiles_soft_deletes_members(self) -> None:
+        group = self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/",
+            {"name": "Acquisition"},
+        ).json()
+        _, dashboard = self.dashboard_api.create_text_tile(self.dashboard_id, text="Signups")
+        tile_id = dashboard["tiles"][0]["id"]
+        self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/move-tile/",
+            {"tile_id": tile_id, "group_id": group["id"]},
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/delete/",
+            {"group_id": group["id"], "member_handling": "delete_tiles"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(DashboardTile.objects.filter(id=tile_id).exists())
+        self.assertTrue(DashboardTile.objects_including_soft_deleted.filter(id=tile_id, deleted=True).exists())
+
+    def test_moving_a_group_moves_its_members(self) -> None:
+        group = self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/",
+            {"name": "Acquisition"},
+        ).json()
+        _, dashboard = self.dashboard_api.create_text_tile(self.dashboard_id, text="Signups")
+        tile = dashboard["tiles"][0]
+        self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/move-tile/",
+            {"tile_id": tile["id"], "group_id": group["id"], "layouts": {"sm": {"x": 0, "y": 1, "w": 12, "h": 2}}},
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/update/",
+            {"group_id": group["id"], "layouts": {"sm": {"x": 0, "y": 5, "w": 12, "h": 1}}},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(DashboardTile.objects.get(id=tile["id"]).layouts["sm"]["y"], 6)
+
+    def test_group_rejects_cross_dashboard_membership(self) -> None:
+        group_response = self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/",
+            {"name": "Acquisition"},
+        )
+        other_dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "Other"})
+        _, other_dashboard = self.dashboard_api.create_text_tile(other_dashboard_id, text="Other tile")
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/move-tile/",
+            {"tile_id": other_dashboard["tiles"][0]["id"], "group_id": group_response.json()["id"]},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_cannot_move_a_group_header_into_a_group(self) -> None:
+        group = self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/",
+            {"name": "Acquisition"},
+        ).json()
+        other = self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/",
+            {"name": "Retention"},
+        ).json()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/move-tile/",
+            {"tile_id": group["tile_id"], "group_id": other["id"]},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_copy_dashboard_remaps_group_membership(self) -> None:
+        group = self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/",
+            {"name": "Acquisition"},
+        ).json()
+        _, dashboard = self.dashboard_api.create_text_tile(self.dashboard_id, text="Signups")
+        tile_id = dashboard["tiles"][0]["id"]
+        self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/move-tile/",
+            {"tile_id": tile_id, "group_id": group["id"]},
+        )
+
+        _, copied = self.dashboard_api.create_dashboard({"name": "copy", "use_dashboard": self.dashboard_id})
+
+        self.assertEqual(len(copied["groups"]), 1)
+        self.assertNotEqual(copied["groups"][0]["id"], group["id"])
+        self.assertEqual(copied["groups"][0]["name"], "Acquisition")
+        self.assertEqual(len(copied["tiles"]), 1)
+        self.assertEqual(copied["tiles"][0]["parent_group_id"], copied["groups"][0]["id"])
+        self.assertEqual(copied["groups"][0]["member_tile_ids"], [copied["tiles"][0]["id"]])
+
+    def test_mutations_are_forbidden_when_the_flag_is_off(self) -> None:
+        self._groups_flag_patcher.stop()
+        try:
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/",
+                {"name": "Acquisition"},
+            )
+        finally:
+            self._groups_flag_patcher.start()
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_moving_a_tile_to_another_dashboard_clears_group_membership(self) -> None:
+        group = self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/",
+            {"name": "Acquisition"},
+        ).json()
+        _, dashboard = self.dashboard_api.create_text_tile(self.dashboard_id, text="Signups")
+        tile = dashboard["tiles"][0]
+        self.client.post(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/groups/move-tile/",
+            {"tile_id": tile["id"], "group_id": group["id"]},
+        )
+        other_dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "Other"})
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/dashboards/{self.dashboard_id}/move_tile",
+            {"tile": tile, "to_dashboard": other_dashboard_id},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        moved = DashboardTile.objects.get(id=tile["id"])
+        self.assertEqual(moved.dashboard_id, other_dashboard_id)
+        self.assertIsNone(moved.parent_group_id)

--- a/products/dashboards/backend/feature_flags.py
+++ b/products/dashboards/backend/feature_flags.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from posthog.models.user import User
 
 DASHBOARD_WIDGETS_FLAG = "dashboard-widgets"
+DASHBOARD_GROUPS_FLAG = "dashboard-groups"
 
 
 def widget_flag_enabled(flag: str, *, team: Team, user: User | None = None) -> bool:
@@ -36,3 +37,7 @@ def widget_flag_enabled(flag: str, *, team: Team, user: User | None = None) -> b
 
 def dashboard_widgets_enabled(*, team: Team, user: User | None = None) -> bool:
     return widget_flag_enabled(DASHBOARD_WIDGETS_FLAG, team=team, user=user)
+
+
+def dashboard_groups_enabled(*, team: Team, user: User | None = None) -> bool:
+    return widget_flag_enabled(DASHBOARD_GROUPS_FLAG, team=team, user=user)

--- a/products/dashboards/backend/migrations/0015_dashboard_groups.py
+++ b/products/dashboards/backend/migrations/0015_dashboard_groups.py
@@ -1,0 +1,81 @@
+import django.utils.timezone
+import django.db.models.manager
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+import posthog.models.utils
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("dashboards", "0014_backfill_dashboardtemplate_button_tile_type"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="DashboardGroup",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=posthog.models.utils.uuid7,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("name", models.CharField(max_length=400)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "last_modified_at",
+                    models.DateTimeField(default=django.utils.timezone.now),
+                ),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        db_constraint=False,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "dashboard",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="groups",
+                        to="dashboards.dashboard",
+                    ),
+                ),
+                (
+                    "last_modified_by",
+                    models.ForeignKey(
+                        blank=True,
+                        db_constraint=False,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="modified_dashboard_groups",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "team",
+                    models.ForeignKey(
+                        db_constraint=False,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="posthog.team",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "posthog_dashboardgroup",
+                "default_manager_name": "all_teams",
+            },
+            managers=[
+                ("all_teams", django.db.models.manager.Manager()),
+            ],
+        ),
+    ]

--- a/products/dashboards/backend/migrations/0016_dashboardtile_group_fks.py
+++ b/products/dashboards/backend/migrations/0016_dashboardtile_group_fks.py
@@ -1,0 +1,66 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+from posthog.migration_helpers import AddForeignKeyNotValid
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("dashboards", "0015_dashboard_groups"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddField(
+                    model_name="dashboardtile",
+                    name="dashboard_group",
+                    field=models.OneToOneField(
+                        db_constraint=False,
+                        db_index=False,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="tile",
+                        to="dashboards.dashboardgroup",
+                    ),
+                ),
+                migrations.AddField(
+                    model_name="dashboardtile",
+                    name="parent_group",
+                    field=models.ForeignKey(
+                        blank=True,
+                        db_constraint=False,
+                        db_index=False,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="member_tiles",
+                        to="dashboards.dashboardgroup",
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="""
+                        ALTER TABLE "posthog_dashboardtile" ADD COLUMN "dashboard_group_id" uuid NULL;
+                        ALTER TABLE "posthog_dashboardtile" ADD COLUMN "parent_group_id" uuid NULL;
+                    """,
+                    reverse_sql="""
+                        ALTER TABLE "posthog_dashboardtile" DROP COLUMN IF EXISTS "parent_group_id";
+                        ALTER TABLE "posthog_dashboardtile" DROP COLUMN IF EXISTS "dashboard_group_id";
+                    """,
+                ),
+            ],
+        ),
+        AddForeignKeyNotValid(
+            model_name="dashboardtile",
+            name="posthog_dashboardtile_dashboard_group_id_fk",
+            column="dashboard_group_id",
+            to_table="posthog_dashboardgroup",
+        ),
+        AddForeignKeyNotValid(
+            model_name="dashboardtile",
+            name="posthog_dashboardtile_parent_group_id_fk",
+            column="parent_group_id",
+            to_table="posthog_dashboardgroup",
+        ),
+    ]

--- a/products/dashboards/backend/migrations/0017_dashboard_group_constraints.py
+++ b/products/dashboards/backend/migrations/0017_dashboard_group_constraints.py
@@ -1,0 +1,34 @@
+from django.db import migrations, models
+from django.db.models import Q
+
+import posthog.models.utils
+from posthog.migration_helpers import AddConstraintNotValid
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("dashboards", "0016_dashboardtile_group_fks"),
+    ]
+
+    operations = [
+        migrations.RemoveConstraint(
+            model_name="dashboardtile",
+            name="dash_tile_exactly_one_related_object",
+        ),
+        AddConstraintNotValid(
+            model_name="dashboardtile",
+            constraint=models.CheckConstraint(
+                condition=posthog.models.utils.build_unique_relationship_check(
+                    ("insight", "text", "button_tile", "widget", "dashboard_group")
+                ),
+                name="dash_tile_exactly_one_related_object",
+            ),
+        ),
+        AddConstraintNotValid(
+            model_name="dashboardtile",
+            constraint=models.CheckConstraint(
+                condition=~Q(dashboard_group__isnull=False, parent_group__isnull=False),
+                name="dash_tile_group_header_not_member",
+            ),
+        ),
+    ]

--- a/products/dashboards/backend/migrations/0018_validate_dashboard_group_constraints.py
+++ b/products/dashboards/backend/migrations/0018_validate_dashboard_group_constraints.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+from posthog.migration_helpers import ValidateConstraint, ValidateForeignKey
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("dashboards", "0017_dashboard_group_constraints"),
+    ]
+
+    operations = [
+        ValidateConstraint(model_name="dashboardtile", name="dash_tile_exactly_one_related_object"),
+        ValidateConstraint(model_name="dashboardtile", name="dash_tile_group_header_not_member"),
+        ValidateForeignKey(model_name="dashboardtile", name="posthog_dashboardtile_dashboard_group_id_fk"),
+        ValidateForeignKey(model_name="dashboardtile", name="posthog_dashboardtile_parent_group_id_fk"),
+    ]

--- a/products/dashboards/backend/migrations/0019_dashboard_group_indexes.py
+++ b/products/dashboards/backend/migrations/0019_dashboard_group_indexes.py
@@ -1,0 +1,27 @@
+from django.db import migrations
+
+from posthog.migration_helpers import CreateIndexConcurrently
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("dashboards", "0018_validate_dashboard_group_constraints"),
+    ]
+
+    operations = [
+        CreateIndexConcurrently(
+            index_name="posthog_dashboardtile_dashboard_group_id_key",
+            table_name="posthog_dashboardtile",
+            columns='("dashboard_group_id")',
+            where='WHERE "dashboard_group_id" IS NOT NULL',
+            unique=True,
+        ),
+        CreateIndexConcurrently(
+            index_name="posthog_dashboardtile_parent_group_id_idx",
+            table_name="posthog_dashboardtile",
+            columns='("parent_group_id")',
+            where='WHERE "parent_group_id" IS NOT NULL',
+        ),
+    ]

--- a/products/dashboards/backend/migrations/max_migration.txt
+++ b/products/dashboards/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0014_backfill_dashboardtemplate_button_tile_type
+0019_dashboard_group_indexes

--- a/products/dashboards/backend/models/__init__.py
+++ b/products/dashboards/backend/models/__init__.py
@@ -1,4 +1,5 @@
 from .dashboard import Dashboard
+from .dashboard_group import DashboardGroup
 from .dashboard_templates import DashboardTemplate
 from .dashboard_tile import ButtonTile, DashboardTile, Text
 from .dashboard_widget import DashboardWidget
@@ -6,6 +7,7 @@ from .dashboard_widget import DashboardWidget
 __all__ = [
     "ButtonTile",
     "Dashboard",
+    "DashboardGroup",
     "DashboardTemplate",
     "DashboardTile",
     "DashboardWidget",

--- a/products/dashboards/backend/models/dashboard_group.py
+++ b/products/dashboards/backend/models/dashboard_group.py
@@ -1,0 +1,31 @@
+from django.db import models
+from django.utils import timezone
+
+from posthog.models.scoping.root_mixin import TeamScopedRootMixin
+from posthog.models.utils import UUIDModel
+
+
+class DashboardGroup(TeamScopedRootMixin, UUIDModel):
+    dashboard = models.ForeignKey("dashboards.Dashboard", on_delete=models.CASCADE, related_name="groups")
+    name = models.CharField(max_length=400)
+    created_at = models.DateTimeField(auto_now_add=True)
+    created_by = models.ForeignKey(
+        "posthog.User", on_delete=models.SET_NULL, null=True, blank=True, db_constraint=False
+    )
+    last_modified_at = models.DateTimeField(default=timezone.now)
+    last_modified_by = models.ForeignKey(
+        "posthog.User",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="modified_dashboard_groups",
+        db_constraint=False,
+    )
+    # Real FK to posthog_team would take SHARE ROW EXCLUSIVE on a hot table during migrate.
+    team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE, db_constraint=False)
+
+    all_teams = models.Manager()  # noqa: DJ012
+
+    class Meta(TeamScopedRootMixin.Meta):
+        db_table = "posthog_dashboardgroup"
+        default_manager_name = "all_teams"

--- a/products/dashboards/backend/models/dashboard_tile.py
+++ b/products/dashboards/backend/models/dashboard_tile.py
@@ -85,6 +85,23 @@ class DashboardTile(models.Model):
         null=True,
         db_index=False,
     )
+    dashboard_group = models.OneToOneField(
+        "dashboards.DashboardGroup",
+        on_delete=models.CASCADE,
+        related_name="tile",
+        null=True,
+        db_index=False,
+        db_constraint=False,
+    )
+    parent_group = models.ForeignKey(
+        "dashboards.DashboardGroup",
+        on_delete=models.SET_NULL,
+        related_name="member_tiles",
+        null=True,
+        blank=True,
+        db_index=False,
+        db_constraint=False,
+    )
     # Denormalized from `dashboard.team_id` so this table can be exposed via HogQL,
     # whose printer injects `WHERE team_id = <ctx.team_id>` against every PostgresTable.
     # Auto-populated in save() when omitted. The index is created concurrently
@@ -135,8 +152,14 @@ class DashboardTile(models.Model):
                 condition=Q(("widget__isnull", False)),
             ),
             models.CheckConstraint(
-                condition=build_unique_relationship_check(("insight", "text", "button_tile", "widget")),
+                condition=build_unique_relationship_check(
+                    ("insight", "text", "button_tile", "widget", "dashboard_group")
+                ),
                 name="dash_tile_exactly_one_related_object",
+            ),
+            models.CheckConstraint(
+                condition=~Q(dashboard_group__isnull=False, parent_group__isnull=False),
+                name="dash_tile_group_header_not_member",
             ),
         ]
         db_table = "posthog_dashboardtile"
@@ -174,10 +197,18 @@ class DashboardTile(models.Model):
         super().clean()
 
         related_fields = sum(
-            map(bool, [getattr(self, o_field) for o_field in ("insight", "text", "button_tile", "widget")])
+            map(
+                bool,
+                [getattr(self, o_field) for o_field in ("insight", "text", "button_tile", "widget", "dashboard_group")],
+            )
         )
         if related_fields != 1:
-            raise ValidationError("Can only set exactly one of insight, text, button_tile, or widget for this tile")
+            raise ValidationError(
+                "Can only set exactly one of insight, text, button_tile, widget, or dashboard_group for this tile"
+            )
+
+        if self.dashboard_group is not None and self.parent_group is not None:
+            raise ValidationError("Group header tiles cannot belong to another group")
 
         if self.insight is None and (
             self.filters_hash is not None
@@ -209,6 +240,8 @@ class DashboardTile(models.Model):
             qs = DashboardTile.objects_including_soft_deleted.filter(
                 dashboard_id=to_dashboard_id, widget=self.widget
             ).exclude(pk=self.pk)
+        elif self.dashboard_group is not None:
+            raise ValidationError("Group header tiles cannot be moved between dashboards.")
         else:
             return
         for stale in qs:
@@ -236,8 +269,10 @@ class DashboardTile(models.Model):
             ).first()
         elif self.widget is not None:
             raise ValidationError("Widget tiles must be deep-cloned when copying between dashboards.")
+        elif self.dashboard_group is not None:
+            raise ValidationError("Group header tiles must be cloned with their group when copying between dashboards.")
         else:
-            raise ValidationError("Cannot copy tile without insight, text, button_tile, or widget.")
+            raise ValidationError("Cannot copy tile without insight, text, button_tile, widget, or dashboard_group.")
 
         if existing:
             if existing.deleted is not True:
@@ -294,6 +329,7 @@ class DashboardTile(models.Model):
             )
             .prefetch_related("text__dashboard_tiles", "button_tile__dashboard_tiles", "widget__dashboard_tiles")
             .exclude(dashboard__deleted=True, deleted=True)
+            .filter(dashboard_group__isnull=True)
             .filter(Q(insight__deleted=False) | Q(insight__isnull=True))
             .order_by("insight__order")
         )

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -319,6 +319,38 @@ export type DashboardApiPersistedVariables = { [key: string]: unknown } | null
 
 export type DashboardApiTilesItem = { [key: string]: unknown }
 
+export interface TileLayoutBoxApi {
+    /** Column position in the dashboard grid (0-indexed). */
+    x?: number
+    /** Row position in the dashboard grid (0-indexed). */
+    y?: number
+    /** Width in grid columns. The desktop grid is 12 columns wide. */
+    w?: number
+    /** Height in grid rows. */
+    h?: number
+}
+
+export interface TileLayoutsApi {
+    /** Layout for the standard (desktop) breakpoint. The grid is 12 columns wide. */
+    sm?: TileLayoutBoxApi
+    /** Layout for the small (mobile) breakpoint. The grid is 1 column wide. */
+    xs?: TileLayoutBoxApi
+}
+
+export interface DashboardGroupApi {
+    readonly id: string
+    readonly name: string
+    /**
+     * ID of the header tile for this group. Used as the react-grid-layout item key.
+     * @nullable
+     */
+    readonly tile_id: number | null
+    /** Layout of the group header tile. Always full width and one row tall on desktop. */
+    readonly layouts: TileLayoutsApi
+    /** IDs of content tiles that currently belong to this group. */
+    readonly member_tile_ids: readonly number[]
+}
+
 /**
  * Serializer mixin that handles tags for objects.
  */
@@ -389,6 +421,8 @@ export interface DashboardApi {
     quick_filter_ids?: string[] | null
     /** @nullable */
     readonly tiles: readonly DashboardApiTilesItem[] | null
+    /** Named groups of tiles on this dashboard. Null on list responses. */
+    readonly groups: readonly DashboardGroupApi[]
     /** Template key to create the dashboard from a predefined template. */
     use_template?: string
     /**
@@ -978,24 +1012,6 @@ export interface CopyDashboardTileRequestApi {
     fromDashboardId: number
     /** Dashboard tile id to copy. */
     tileId: number
-}
-
-export interface TileLayoutBoxApi {
-    /** Column position in the dashboard grid (0-indexed). */
-    x?: number
-    /** Row position in the dashboard grid (0-indexed). */
-    y?: number
-    /** Width in grid columns. The desktop grid is 12 columns wide. */
-    w?: number
-    /** Height in grid rows. */
-    h?: number
-}
-
-export interface TileLayoutsApi {
-    /** Layout for the standard (desktop) breakpoint. The grid is 12 columns wide. */
-    sm?: TileLayoutBoxApi
-    /** Layout for the small (mobile) breakpoint. The grid is 1 column wide. */
-    xs?: TileLayoutBoxApi
 }
 
 export interface CreateTextTileRequestApi {
@@ -8910,6 +8926,11 @@ export interface DashboardTileApi {
     text: TextApi
     button_tile: ButtonTileApi
     widget?: DashboardWidgetApi | null
+    /**
+     * ID of the dashboard group this tile belongs to, if any.
+     * @nullable
+     */
+    readonly parent_group_id: string | null
     layouts?: unknown
     /**
      * @maxLength 400
@@ -8926,6 +8947,61 @@ export interface DashboardTileApi {
 export interface DeleteTileRequestApi {
     /** ID of the dashboard tile to delete. Use dashboard-get to look up tile IDs. */
     tile_id: number
+}
+
+export interface CreateDashboardGroupRequestApi {
+    /**
+     * Display name for the group header.
+     * @maxLength 400
+     */
+    name: string
+    /** Optional layout for the group header tile. Defaults to a full-width row at the bottom of the dashboard. */
+    layouts?: TileLayoutsApi
+}
+
+/**
+ * * `delete_tiles` - delete_tiles
+ * * `move_to_ungrouped` - move_to_ungrouped
+ */
+export type MemberHandlingEnumApi = (typeof MemberHandlingEnumApi)[keyof typeof MemberHandlingEnumApi]
+
+export const MemberHandlingEnumApi = {
+    DeleteTiles: 'delete_tiles',
+    MoveToUngrouped: 'move_to_ungrouped',
+} as const
+
+export interface DeleteDashboardGroupRequestApi {
+    /** ID of the dashboard group to delete. */
+    group_id: string
+    /** delete_tiles soft-deletes member tiles. move_to_ungrouped leaves them on the dashboard outside any group.
+     *
+     * * `delete_tiles` - delete_tiles
+     * * `move_to_ungrouped` - move_to_ungrouped */
+    member_handling: MemberHandlingEnumApi
+}
+
+export interface MoveDashboardTileToGroupRequestApi {
+    /** ID of the content tile to move. */
+    tile_id: number
+    /**
+     * Destination group ID, or null to remove the tile from its group.
+     * @nullable
+     */
+    group_id?: string | null
+    /** Optional updated layout for the moved tile. */
+    layouts?: TileLayoutsApi
+}
+
+export interface UpdateDashboardGroupRequestApi {
+    /** ID of the dashboard group to update. */
+    group_id: string
+    /**
+     * New display name for the group header.
+     * @maxLength 400
+     */
+    name?: string
+    /** New layout for the group header tile. Header tiles are always full width and one row tall. */
+    layouts?: TileLayoutsApi
 }
 
 export interface MoveTileTileApi {
@@ -10013,6 +10089,54 @@ export type DashboardsDeleteTileParams = {
 export type DashboardsDeleteTileFormat = (typeof DashboardsDeleteTileFormat)[keyof typeof DashboardsDeleteTileFormat]
 
 export const DashboardsDeleteTileFormat = {
+    Json: 'json',
+    Txt: 'txt',
+} as const
+
+export type DashboardsGroupsCreateParams = {
+    format?: DashboardsGroupsCreateFormat
+}
+
+export type DashboardsGroupsCreateFormat =
+    (typeof DashboardsGroupsCreateFormat)[keyof typeof DashboardsGroupsCreateFormat]
+
+export const DashboardsGroupsCreateFormat = {
+    Json: 'json',
+    Txt: 'txt',
+} as const
+
+export type DashboardsGroupsDeleteCreateParams = {
+    format?: DashboardsGroupsDeleteCreateFormat
+}
+
+export type DashboardsGroupsDeleteCreateFormat =
+    (typeof DashboardsGroupsDeleteCreateFormat)[keyof typeof DashboardsGroupsDeleteCreateFormat]
+
+export const DashboardsGroupsDeleteCreateFormat = {
+    Json: 'json',
+    Txt: 'txt',
+} as const
+
+export type DashboardsGroupsMoveTileCreateParams = {
+    format?: DashboardsGroupsMoveTileCreateFormat
+}
+
+export type DashboardsGroupsMoveTileCreateFormat =
+    (typeof DashboardsGroupsMoveTileCreateFormat)[keyof typeof DashboardsGroupsMoveTileCreateFormat]
+
+export const DashboardsGroupsMoveTileCreateFormat = {
+    Json: 'json',
+    Txt: 'txt',
+} as const
+
+export type DashboardsGroupsUpdateCreateParams = {
+    format?: DashboardsGroupsUpdateCreateFormat
+}
+
+export type DashboardsGroupsUpdateCreateFormat =
+    (typeof DashboardsGroupsUpdateCreateFormat)[keyof typeof DashboardsGroupsUpdateCreateFormat]
+
+export const DashboardsGroupsUpdateCreateFormat = {
     Json: 'json',
     Txt: 'txt',
 } as const

--- a/products/dashboards/frontend/generated/api.ts
+++ b/products/dashboards/frontend/generated/api.ts
@@ -15,9 +15,11 @@ import type {
     BulkUpdateTagsResponseApi,
     CopyDashboardTemplateApi,
     CopyDashboardTileRequestApi,
+    CreateDashboardGroupRequestApi,
     CreateTextTileRequestApi,
     DashboardApi,
     DashboardCollaboratorApi,
+    DashboardGroupApi,
     DashboardSubscribeNudgeResponseApi,
     DashboardTemplateApi,
     DashboardTemplatesListParams,
@@ -30,6 +32,10 @@ import type {
     DashboardsCreateUnlistedDashboardCreateParams,
     DashboardsDeleteTileParams,
     DashboardsDestroyParams,
+    DashboardsGroupsCreateParams,
+    DashboardsGroupsDeleteCreateParams,
+    DashboardsGroupsMoveTileCreateParams,
+    DashboardsGroupsUpdateCreateParams,
     DashboardsListParams,
     DashboardsMoveTileCreateParams,
     DashboardsMoveTilePartialUpdateParams,
@@ -47,7 +53,9 @@ import type {
     DashboardsWidgetsBatchCreateParams,
     DataColorThemeApi,
     DataColorThemesListParams,
+    DeleteDashboardGroupRequestApi,
     DeleteTileRequestApi,
+    MoveDashboardTileToGroupRequestApi,
     MoveTileRequestApi,
     PaginatedDashboardBasicListApi,
     PaginatedDashboardTemplateListApi,
@@ -60,6 +68,7 @@ import type {
     ReorderTilesRequestApi,
     RunInsightsResponseApi,
     RunWidgetsResponseApi,
+    UpdateDashboardGroupRequestApi,
     UpdateDashboardWidgetsBatchResponseApi,
     UpdateTextTileRequestApi,
     WidgetCatalogResponseApi,
@@ -572,6 +581,142 @@ export const dashboardsDeleteTile = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(deleteTileRequestApi),
+    })
+}
+
+export const getDashboardsGroupsCreateUrl = (projectId: string, id: number, params?: DashboardsGroupsCreateParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/dashboards/${id}/groups/?${stringifiedParams}`
+        : `/api/projects/${projectId}/dashboards/${id}/groups/`
+}
+
+export const dashboardsGroupsCreate = async (
+    projectId: string,
+    id: number,
+    createDashboardGroupRequestApi: CreateDashboardGroupRequestApi,
+    params?: DashboardsGroupsCreateParams,
+    options?: RequestInit
+): Promise<DashboardGroupApi> => {
+    return apiMutator<DashboardGroupApi>(getDashboardsGroupsCreateUrl(projectId, id, params), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(createDashboardGroupRequestApi),
+    })
+}
+
+export const getDashboardsGroupsDeleteCreateUrl = (
+    projectId: string,
+    id: number,
+    params?: DashboardsGroupsDeleteCreateParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/dashboards/${id}/groups/delete/?${stringifiedParams}`
+        : `/api/projects/${projectId}/dashboards/${id}/groups/delete/`
+}
+
+export const dashboardsGroupsDeleteCreate = async (
+    projectId: string,
+    id: number,
+    deleteDashboardGroupRequestApi: DeleteDashboardGroupRequestApi,
+    params?: DashboardsGroupsDeleteCreateParams,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getDashboardsGroupsDeleteCreateUrl(projectId, id, params), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(deleteDashboardGroupRequestApi),
+    })
+}
+
+export const getDashboardsGroupsMoveTileCreateUrl = (
+    projectId: string,
+    id: number,
+    params?: DashboardsGroupsMoveTileCreateParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/dashboards/${id}/groups/move-tile/?${stringifiedParams}`
+        : `/api/projects/${projectId}/dashboards/${id}/groups/move-tile/`
+}
+
+export const dashboardsGroupsMoveTileCreate = async (
+    projectId: string,
+    id: number,
+    moveDashboardTileToGroupRequestApi: MoveDashboardTileToGroupRequestApi,
+    params?: DashboardsGroupsMoveTileCreateParams,
+    options?: RequestInit
+): Promise<DashboardTileApi> => {
+    return apiMutator<DashboardTileApi>(getDashboardsGroupsMoveTileCreateUrl(projectId, id, params), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(moveDashboardTileToGroupRequestApi),
+    })
+}
+
+export const getDashboardsGroupsUpdateCreateUrl = (
+    projectId: string,
+    id: number,
+    params?: DashboardsGroupsUpdateCreateParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/dashboards/${id}/groups/update/?${stringifiedParams}`
+        : `/api/projects/${projectId}/dashboards/${id}/groups/update/`
+}
+
+export const dashboardsGroupsUpdateCreate = async (
+    projectId: string,
+    id: number,
+    updateDashboardGroupRequestApi: UpdateDashboardGroupRequestApi,
+    params?: DashboardsGroupsUpdateCreateParams,
+    options?: RequestInit
+): Promise<DashboardGroupApi> => {
+    return apiMutator<DashboardGroupApi>(getDashboardsGroupsUpdateCreateUrl(projectId, id, params), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(updateDashboardGroupRequestApi),
     })
 }
 

--- a/products/dashboards/frontend/generated/api.zod.ts
+++ b/products/dashboards/frontend/generated/api.zod.ts
@@ -1109,6 +1109,109 @@ export const DashboardsDeleteTileBody = /* @__PURE__ */ zod.object({
     tile_id: zod.number().describe('ID of the dashboard tile to delete. Use dashboard-get to look up tile IDs.'),
 })
 
+export const dashboardsGroupsCreateBodyNameMax = 400
+
+export const DashboardsGroupsCreateBody = /* @__PURE__ */ zod.object({
+    name: zod.string().max(dashboardsGroupsCreateBodyNameMax).describe('Display name for the group header.'),
+    layouts: zod
+        .object({
+            sm: zod
+                .object({
+                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                    h: zod.number().optional().describe('Height in grid rows.'),
+                })
+                .optional()
+                .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
+            xs: zod
+                .object({
+                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                    h: zod.number().optional().describe('Height in grid rows.'),
+                })
+                .optional()
+                .describe('Layout for the small (mobile) breakpoint. The grid is 1 column wide.'),
+        })
+        .optional()
+        .describe(
+            'Optional layout for the group header tile. Defaults to a full-width row at the bottom of the dashboard.'
+        ),
+})
+
+export const DashboardsGroupsDeleteCreateBody = /* @__PURE__ */ zod.object({
+    group_id: zod.uuid().describe('ID of the dashboard group to delete.'),
+    member_handling: zod
+        .enum(['delete_tiles', 'move_to_ungrouped'])
+        .describe('\* `delete_tiles` - delete_tiles\n\* `move_to_ungrouped` - move_to_ungrouped')
+        .describe(
+            'delete_tiles soft-deletes member tiles. move_to_ungrouped leaves them on the dashboard outside any group.\n\n\* `delete_tiles` - delete_tiles\n\* `move_to_ungrouped` - move_to_ungrouped'
+        ),
+})
+
+export const DashboardsGroupsMoveTileCreateBody = /* @__PURE__ */ zod.object({
+    tile_id: zod.number().describe('ID of the content tile to move.'),
+    group_id: zod.uuid().nullish().describe('Destination group ID, or null to remove the tile from its group.'),
+    layouts: zod
+        .object({
+            sm: zod
+                .object({
+                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                    h: zod.number().optional().describe('Height in grid rows.'),
+                })
+                .optional()
+                .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
+            xs: zod
+                .object({
+                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                    h: zod.number().optional().describe('Height in grid rows.'),
+                })
+                .optional()
+                .describe('Layout for the small (mobile) breakpoint. The grid is 1 column wide.'),
+        })
+        .optional()
+        .describe('Optional updated layout for the moved tile.'),
+})
+
+export const dashboardsGroupsUpdateCreateBodyNameMax = 400
+
+export const DashboardsGroupsUpdateCreateBody = /* @__PURE__ */ zod.object({
+    group_id: zod.uuid().describe('ID of the dashboard group to update.'),
+    name: zod
+        .string()
+        .max(dashboardsGroupsUpdateCreateBodyNameMax)
+        .optional()
+        .describe('New display name for the group header.'),
+    layouts: zod
+        .object({
+            sm: zod
+                .object({
+                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                    h: zod.number().optional().describe('Height in grid rows.'),
+                })
+                .optional()
+                .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
+            xs: zod
+                .object({
+                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                    h: zod.number().optional().describe('Height in grid rows.'),
+                })
+                .optional()
+                .describe('Layout for the small (mobile) breakpoint. The grid is 1 column wide.'),
+        })
+        .optional()
+        .describe('New layout for the group header tile. Header tiles are always full width and one row tall.'),
+})
+
 export const DashboardsMoveTileCreateBody = /* @__PURE__ */ zod.object({
     to_dashboard: zod.number().describe('Destination dashboard ID.'),
     tile: zod

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -8537,6 +8537,11 @@ export namespace Schemas {
       text: Text;
       button_tile: ButtonTile;
       widget?: DashboardWidget | null;
+      /**
+         * ID of the dashboard group this tile belongs to, if any.
+         * @nullable
+         */
+      readonly parent_group_id: string | null;
       layouts?: unknown;
       /**
          * @maxLength 400
@@ -17415,6 +17420,34 @@ export namespace Schemas {
       memory_gb?: number;
     }
 
+    export interface TileLayoutBox {
+      /** Column position in the dashboard grid (0-indexed). */
+      x?: number;
+      /** Row position in the dashboard grid (0-indexed). */
+      y?: number;
+      /** Width in grid columns. The desktop grid is 12 columns wide. */
+      w?: number;
+      /** Height in grid rows. */
+      h?: number;
+    }
+
+    export interface TileLayouts {
+      /** Layout for the standard (desktop) breakpoint. The grid is 12 columns wide. */
+      sm?: TileLayoutBox;
+      /** Layout for the small (mobile) breakpoint. The grid is 1 column wide. */
+      xs?: TileLayoutBox;
+    }
+
+    export interface CreateDashboardGroupRequest {
+      /**
+         * Display name for the group header.
+         * @maxLength 400
+         */
+      name: string;
+      /** Optional layout for the group header tile. Defaults to a full-width row at the bottom of the dashboard. */
+      layouts?: TileLayouts;
+    }
+
     /**
      * Typed configuration for a FileDownload batch-export destination.
      */
@@ -17683,24 +17716,6 @@ export namespace Schemas {
       text: string;
       /** When true, this source's content is injected into every support reply prompt as general context (tone, policies, direction). */
       always_include?: boolean;
-    }
-
-    export interface TileLayoutBox {
-      /** Column position in the dashboard grid (0-indexed). */
-      x?: number;
-      /** Row position in the dashboard grid (0-indexed). */
-      y?: number;
-      /** Width in grid columns. The desktop grid is 12 columns wide. */
-      w?: number;
-      /** Height in grid rows. */
-      h?: number;
-    }
-
-    export interface TileLayouts {
-      /** Layout for the standard (desktop) breakpoint. The grid is 12 columns wide. */
-      sm?: TileLayoutBox;
-      /** Layout for the small (mobile) breakpoint. The grid is 1 column wide. */
-      xs?: TileLayoutBox;
     }
 
     export interface CreateTextTileRequest {
@@ -18395,6 +18410,20 @@ export namespace Schemas {
       Number37: 37,
     } as const;
 
+    export interface DashboardGroup {
+      readonly id: string;
+      readonly name: string;
+      /**
+         * ID of the header tile for this group. Used as the react-grid-layout item key.
+         * @nullable
+         */
+      readonly tile_id: number | null;
+      /** Layout of the group header tile. Always full width and one row tall on desktop. */
+      readonly layouts: TileLayouts;
+      /** IDs of content tiles that currently belong to this group. */
+      readonly member_tile_ids: readonly number[];
+    }
+
     /**
      * Serializer mixin that handles tags for objects.
      */
@@ -18465,6 +18494,8 @@ export namespace Schemas {
       quick_filter_ids?: string[] | null;
       /** @nullable */
       readonly tiles: readonly DashboardTilesItem[] | null;
+      /** Named groups of tiles on this dashboard. Null on list responses. */
+      readonly groups: readonly DashboardGroup[];
       /** Template key to create the dashboard from a predefined template. */
       use_template?: string;
       /**
@@ -24213,6 +24244,28 @@ export namespace Schemas {
       Bayesian: 'bayesian',
       Frequentist: 'frequentist',
     } as const;
+
+    /**
+     * * `delete_tiles` - delete_tiles
+     * * `move_to_ungrouped` - move_to_ungrouped
+     */
+    export type MemberHandlingEnum = typeof MemberHandlingEnum[keyof typeof MemberHandlingEnum];
+
+
+    export const MemberHandlingEnum = {
+      DeleteTiles: 'delete_tiles',
+      MoveToUngrouped: 'move_to_ungrouped',
+    } as const;
+
+    export interface DeleteDashboardGroupRequest {
+      /** ID of the dashboard group to delete. */
+      group_id: string;
+      /** delete_tiles soft-deletes member tiles. move_to_ungrouped leaves them on the dashboard outside any group.
+       *
+       * * `delete_tiles` - delete_tiles
+       * * `move_to_ungrouped` - move_to_ungrouped */
+      member_handling: MemberHandlingEnum;
+    }
 
     export interface DeleteTileRequest {
       /** ID of the dashboard tile to delete. Use dashboard-get to look up tile IDs. */
@@ -45857,6 +45910,18 @@ export namespace Schemas {
       no_total: number;
       /** Succeeded observations whose verdict was `inconclusive`. */
       inconclusive_total: number;
+    }
+
+    export interface MoveDashboardTileToGroupRequest {
+      /** ID of the content tile to move. */
+      tile_id: number;
+      /**
+         * Destination group ID, or null to remove the tile from its group.
+         * @nullable
+         */
+      group_id?: string | null;
+      /** Optional updated layout for the moved tile. */
+      layouts?: TileLayouts;
     }
 
     export interface MoveTileTile {
@@ -77867,6 +77932,18 @@ export namespace Schemas {
       memory_gb?: number;
     }
 
+    export interface UpdateDashboardGroupRequest {
+      /** ID of the dashboard group to update. */
+      group_id: string;
+      /**
+         * New display name for the group header.
+         * @maxLength 400
+         */
+      name?: string;
+      /** New layout for the group header tile. Header tiles are always full width and one row tall. */
+      layouts?: TileLayouts;
+    }
+
     export interface UpdateDashboardWidgetsBatchResponse {
       /** Updated dashboard widget tiles in request order. */
       tiles: DashboardTile[];
@@ -82854,6 +82931,54 @@ export namespace Schemas {
 
 
     export const DashboardsDeleteTileFormat = {
+      Json: 'json',
+      Txt: 'txt',
+    } as const;
+
+    export type DashboardsGroupsCreateParams = {
+    format?: DashboardsGroupsCreateFormat;
+    };
+
+    export type DashboardsGroupsCreateFormat = typeof DashboardsGroupsCreateFormat[keyof typeof DashboardsGroupsCreateFormat];
+
+
+    export const DashboardsGroupsCreateFormat = {
+      Json: 'json',
+      Txt: 'txt',
+    } as const;
+
+    export type DashboardsGroupsDeleteCreateParams = {
+    format?: DashboardsGroupsDeleteCreateFormat;
+    };
+
+    export type DashboardsGroupsDeleteCreateFormat = typeof DashboardsGroupsDeleteCreateFormat[keyof typeof DashboardsGroupsDeleteCreateFormat];
+
+
+    export const DashboardsGroupsDeleteCreateFormat = {
+      Json: 'json',
+      Txt: 'txt',
+    } as const;
+
+    export type DashboardsGroupsMoveTileCreateParams = {
+    format?: DashboardsGroupsMoveTileCreateFormat;
+    };
+
+    export type DashboardsGroupsMoveTileCreateFormat = typeof DashboardsGroupsMoveTileCreateFormat[keyof typeof DashboardsGroupsMoveTileCreateFormat];
+
+
+    export const DashboardsGroupsMoveTileCreateFormat = {
+      Json: 'json',
+      Txt: 'txt',
+    } as const;
+
+    export type DashboardsGroupsUpdateCreateParams = {
+    format?: DashboardsGroupsUpdateCreateFormat;
+    };
+
+    export type DashboardsGroupsUpdateCreateFormat = typeof DashboardsGroupsUpdateCreateFormat[keyof typeof DashboardsGroupsUpdateCreateFormat];
+
+
+    export const DashboardsGroupsUpdateCreateFormat = {
       Json: 'json',
       Txt: 'txt',
     } as const;


### PR DESCRIPTION
## Problem

Dashboard editors cannot group related tiles under a named heading.

A group is a header tile plus membership of other tiles on that dashboard. Mutations sit behind the `dashboard-groups` flag.

## Changes

- The dashboard API can create, rename, move, and delete groups when the flag is on.
- Header tiles cannot belong to another group.
- Header layouts stay full width at `x=0`, `w=12`, `h=1`.
- Duplicating a dashboard remaps group membership onto the copy.
- Moving a tile to another dashboard clears its group.
- GET still returns groups when the flag is off, so existing groups keep loading.

> [!NOTE]
> Nested groups and side-by-side group headers are out of scope. Collapse is client-only.

## How did you test this code?

- `test_dashboard_groups.py` covers membership, delete modes, copy, flag-off, and cross-dashboard ungroup.
- Not run on this branch after the cross-dashboard ungroup test. Other worktrees were using local Postgres. CI runs the file.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Feature remains gated.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Cursor implemented this from `master` as a new stack, not a continuation of #77840.
- Skills: `/django-migrations`, `/improving-drf-endpoints`, `/writing-tests`, `/writing-pr-descriptions`, `/stacking-prs`.
- `hogli ci:preflight --fix` generated the OpenAPI types in this layer.