### PR TITLE
feat(dashboards): add grouped dashboard grid

### DIFF
--- a/frontend/src/lib/components/Cards/CardMeta.tsx
+++ b/frontend/src/lib/components/Cards/CardMeta.tsx
@@ -36,6 +36,8 @@ export interface CardMetaProps extends Pick<React.HTMLAttributes<HTMLDivElement>
     /** Tooltip for the details button. */
     detailsTooltip?: string
     topHeading?: JSX.Element | null
+    /** When set, replaces the default insight-type heading. */
+    headerContent?: JSX.Element | null
     samplingFactor?: number | null
     /** Additional controls to show in the top controls area */
     extraControls?: JSX.Element | null
@@ -63,6 +65,7 @@ export function CardMeta({
     moreButtons,
     moreTooltip,
     topHeading,
+    headerContent,
     areDetailsShown,
     setAreDetailsShown,
     detailsTooltip,
@@ -132,7 +135,7 @@ export function CardMeta({
                     {compact ? (
                         <>
                             <div className="CardMeta__top">
-                                <div className="CardMeta__heading">{topHeading}</div>
+                                <div className="CardMeta__heading">{headerContent ?? topHeading}</div>
                                 <div className="CardMeta__controls">
                                     {refreshControl}
                                     {showEditingControls &&
@@ -150,20 +153,26 @@ export function CardMeta({
                     ) : (
                         <>
                             <div className="CardMeta__top" ref={topRef}>
-                                <h5 ref={headingRef}>
-                                    {topHeading}
-                                    {samplingFactor && samplingFactor < 1 && (
-                                        <Tooltip
-                                            title={`Results calculated from ${100 * samplingFactor}% of users`}
-                                            placement="right"
-                                        >
-                                            <IconPieChart
-                                                className="ml-1.5 text-base align-[-0.25em]"
-                                                style={{ color: 'var(--primary-3000-hover)' }}
-                                            />
-                                        </Tooltip>
-                                    )}
-                                </h5>
+                                {headerContent ? (
+                                    <div className="CardMeta__header-content min-w-0 flex-1" ref={headingRef}>
+                                        {headerContent}
+                                    </div>
+                                ) : (
+                                    <h5 ref={headingRef}>
+                                        {topHeading}
+                                        {samplingFactor && samplingFactor < 1 && (
+                                            <Tooltip
+                                                title={`Results calculated from ${100 * samplingFactor}% of users`}
+                                                placement="right"
+                                            >
+                                                <IconPieChart
+                                                    className="ml-1.5 text-base align-[-0.25em]"
+                                                    style={{ color: 'var(--primary-3000-hover)' }}
+                                                />
+                                            </Tooltip>
+                                        )}
+                                    </h5>
+                                )}
                                 <div className="CardMeta__controls">
                                     {refreshControl}
                                     {extraControlsWithLabel}

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -283,6 +283,7 @@ export const FEATURE_FLAGS = {
     CUSTOMER_ANALYTICS_JOURNEYS: 'customer-analytics-journeys', // owner: @arthurdedeus #team-customer-analytics
     CUSTOMER_PROFILE_CONFIG_BUTTON: 'customer-profile-config-button', // owner: @arthurdedeus #team-customer-analytics
     DASHBOARD_AUTO_PREVIEW_LIMIT: 'dashboard-auto-preview-limit', // owner: @pauldambra #team-product-analytics
+    DASHBOARD_GROUPS: 'dashboard-groups', // owner: @mattp #team-analytics-platform
     DASHBOARD_INLINE_TILE_INSERTION: 'dashboard-inline-tile-insertion', // owner: @MattPua #team-analytics-platform
     DASHBOARD_LAYOUT_DISCARD_PROMPT: 'dashboard-layout-discard-prompt', // owner: @cory.s #team-analytics-platform
     DASHBOARD_TEMPLATE_CHOOSER_EXPERIMENT: 'dashboard-template-chooser-experiment', // owner: @mattp #team-analytics-platform multivariate=control,simple,new

--- a/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeaderActions.tsx
@@ -27,14 +27,18 @@ export function getAddTileMenuItems({
     onAddInsight,
     push,
     setAddWidgetModalOpen,
+    onAddGroup,
     onBeforeSelect,
+    groupDisabledReason,
 }: {
     dashboardId: number
     dashboardWidgetsEnabled: boolean
     onAddInsight: () => void
     push: (url: string) => void
     setAddWidgetModalOpen: (open: boolean) => void
+    onAddGroup?: () => void
     onBeforeSelect?: () => void
+    groupDisabledReason?: string
 }): LemonMenuItem[] {
     const withBeforeSelect =
         (onClick: () => void): (() => void) =>
@@ -43,7 +47,7 @@ export function getAddTileMenuItems({
             onClick()
         }
 
-    return [
+    const items: LemonMenuItem[] = [
         {
             label: 'Insight',
             onClick: withBeforeSelect(onAddInsight),
@@ -59,26 +63,42 @@ export function getAddTileMenuItems({
             onClick: withBeforeSelect(() => push(urls.dashboardButtonTile(dashboardId, 'new'))),
             'data-attr': 'dashboard-add-button-tile',
         },
-        dashboardWidgetsEnabled
-            ? {
-                  label: 'Widget',
-                  tag: 'new' as const,
-                  onClick: withBeforeSelect(() => setAddWidgetModalOpen(true)),
-                  'data-attr': 'dashboard-add-widget',
-              }
-            : {
-                  label: 'Widget',
-                  tag: 'beta' as const,
-                  tooltip: 'Opens settings to enable the Dashboard widgets beta',
-                  onClick: withBeforeSelect(() => push(urls.featurePreview(FEATURE_FLAGS.DASHBOARD_WIDGETS))),
-                  'data-attr': 'dashboard-add-widget-preview',
-              },
     ]
+
+    if (onAddGroup) {
+        items.push({
+            label: 'Group',
+            tag: 'new',
+            onClick: withBeforeSelect(onAddGroup),
+            'data-attr': 'dashboard-add-group',
+            disabledReason: groupDisabledReason,
+        })
+    }
+
+    if (dashboardWidgetsEnabled) {
+        items.push({
+            label: 'Widget',
+            tag: 'new',
+            onClick: withBeforeSelect(() => setAddWidgetModalOpen(true)),
+            'data-attr': 'dashboard-add-widget',
+        })
+    } else {
+        items.push({
+            label: 'Widget',
+            tag: 'beta',
+            tooltip: 'Opens settings to enable the Dashboard widgets beta',
+            onClick: withBeforeSelect(() => push(urls.featurePreview(FEATURE_FLAGS.DASHBOARD_WIDGETS))),
+            'data-attr': 'dashboard-add-widget-preview',
+        })
+    }
+
+    return items
 }
 
 export function DashboardAddTileButton(): JSX.Element | null {
-    const { dashboard, dashboardWidgetsEnabled } = useValues(dashboardLogic)
-    const { loadDashboard, setAddWidgetModalOpen, setPendingInsertion, openAddInsightModal } =
+    const { dashboard, dashboardWidgetsEnabled, canCreateDashboardGroups, createDashboardGroupLoading } =
+        useValues(dashboardLogic)
+    const { loadDashboard, setAddWidgetModalOpen, setPendingInsertion, openAddInsightModal, createDashboardGroup } =
         useActions(dashboardLogic)
     const { push } = useActions(router)
 
@@ -118,6 +138,8 @@ export function DashboardAddTileButton(): JSX.Element | null {
                         onAddInsight: openAddInsightModal,
                         push,
                         setAddWidgetModalOpen,
+                        onAddGroup: canCreateDashboardGroups ? () => createDashboardGroup('New group') : undefined,
+                        groupDisabledReason: createDashboardGroupLoading ? 'Adding group' : undefined,
                         // Adding from the header appends at the bottom; drop any stale inline-insertion target.
                         onBeforeSelect: () => setPendingInsertion(null),
                     })}

--- a/frontend/src/scenes/dashboard/DashboardItems.scss
+++ b/frontend/src/scenes/dashboard/DashboardItems.scss
@@ -30,6 +30,64 @@
     }
 }
 
+.react-grid-layout.dashboard-group-transition {
+    transition: height 240ms cubic-bezier(0.22, 1, 0.36, 1);
+
+    .react-grid-item {
+        transition: transform 240ms cubic-bezier(0.22, 1, 0.36, 1);
+    }
+}
+
+.DashboardGroupSection {
+    position: absolute;
+    z-index: 0;
+    pointer-events: none;
+    background: var(--color-bg-surface-tertiary);
+    border: 1px solid var(--color-border-primary);
+    border-radius: var(--radius);
+    transition:
+        background-color 150ms ease,
+        border-color 150ms ease;
+
+    [theme='dark'] & {
+        background: var(--color-bg-surface-secondary);
+    }
+
+    &--transitioning {
+        transition:
+            background-color 150ms ease,
+            border-color 150ms ease,
+            top 240ms cubic-bezier(0.22, 1, 0.36, 1),
+            height 240ms cubic-bezier(0.22, 1, 0.36, 1);
+    }
+
+    &--drop-target {
+        background: var(--color-accent-highlight-secondary);
+        border-color: var(--color-accent);
+    }
+}
+
+.DashboardGroupSectionFooter {
+    pointer-events: none;
+}
+
+.DashboardGroupItem {
+    background: transparent;
+
+    .CardMeta {
+        justify-content: center;
+        height: 100%;
+        max-height: none;
+        background: transparent;
+    }
+}
+
+.DashboardGroupItem--compact {
+    .CardMeta__primary {
+        padding: 0.25rem 0.75rem;
+    }
+}
+
 .react-grid-item.cssTransforms {
     transition-property: transform;
 }
@@ -46,7 +104,9 @@
     .CardMeta,
     .TextCard__body,
     .ButtonTileCard__body,
-    .WidgetCard__header {
+    .WidgetCard__header,
+    &.drag-handle,
+    .drag-handle {
         // CardMeta: insight + widget (dashboard_tile layout). Bodies: text/button tiles. Header: widget (simple layout).
         cursor: grab;
         user-select: none; // Prevent accidental text selection while dragging

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -6,6 +6,7 @@ import { router } from 'kea-router'
 import { RefObject, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Layout, Responsive as ReactGridLayout, useContainerWidth } from 'react-grid-layout'
 import { GridBackground } from 'react-grid-layout/extras'
+import { z } from 'zod'
 
 import { DashboardWidgetItem } from '@posthog/products-dashboards/frontend/components/DashboardWidgetItem/DashboardWidgetItem'
 import { getDashboardWidgetFetchDisplayError } from '@posthog/products-dashboards/frontend/widgets/constants'
@@ -14,8 +15,10 @@ import { ApiError } from 'lib/api'
 import { InsightCard } from 'lib/components/Cards/InsightCard'
 import { EditModeEdge, useResizeHandleScrollbarPassThrough } from 'lib/components/Cards/InsightCard/EditModeEdgeOverlay'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
+import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { LemonMenuItem } from 'lib/lemon-ui/LemonMenu'
 import { DashboardEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { localStorageSlot } from 'lib/utils/localStorageSlot'
 import { objectsEqual } from 'lib/utils/objects'
 import { addInsightToDashboardLogic } from 'scenes/dashboard/addInsightToDashboardModalLogic'
 import { getAddTileMenuItems } from 'scenes/dashboard/DashboardHeaderActions'
@@ -38,7 +41,9 @@ import { DashboardLayoutSize, DashboardMode, DashboardPlacement, DashboardType }
 
 import { DashboardButtonTileItem } from './items/DashboardButtonTileItem'
 import { DashboardErrorTileItem } from './items/DashboardErrorTileItem'
+import { DashboardGroupItem } from './items/DashboardGroupItem'
 import { DashboardTextItem } from './items/DashboardTextItem'
+import { GROUP_FOOTER_PREFIX, collapseDashboardGroupLayouts, stripGroupFooterLayouts } from './tileLayouts'
 
 const DRAG_AUTO_SCROLL_THRESHOLD = 100
 const DRAG_AUTO_SCROLL_SPEED = 50
@@ -46,6 +51,7 @@ const DRAG_AUTO_SCROLL_SPEED = 50
 const BASE_ROW_HEIGHT = 80
 const BASE_MARGIN: [number, number] = [16, 16]
 const CONTAINER_PADDING: [number, number] = [0, 0]
+const collapsedGroupsSchema = z.array(z.string())
 
 interface DashboardItemsProps {
     showCreateAnomalyAlertButton?: boolean
@@ -117,9 +123,22 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         setDashboardMode,
         setAddWidgetModalOpen,
         setPendingInsertion,
+        moveDashboardTileToGroup,
+        updateDashboardGroupLayout,
+        deleteDashboardGroup,
     } = useActions(dashboardLogic)
+    const [collapsedGroupIds, setCollapsedGroupIds] = useState<Set<string>>(() => new Set())
+    const [groupLayoutTransitioning, setGroupLayoutTransitioning] = useState(false)
+    const [interactionLayouts, setInteractionLayouts] = useState<Partial<Record<DashboardLayoutSize, Layout>> | null>(
+        null
+    )
+    const [pendingGroupDrop, setPendingGroupDrop] = useState<{
+        tileId: number
+        groupId: string | null
+        layout: Layout[number]
+    } | null>(null)
     const { showAddInsightToDashboardModal } = useActions(addInsightToDashboardLogic)
-    const { updateWidgetTile } = useAsyncActions(dashboardLogic)
+    const { updateWidgetTile, renameDashboardGroup } = useAsyncActions(dashboardLogic)
     const { renameInsight } = useActions(insightsModel)
     const { reportDashboardTileRepositioned } = useActions(eventUsageLogic)
     const { push } = useActions(router)
@@ -141,11 +160,115 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
     // (every InsightCard) that make the dragged tile lag the cursor. Stash the latest layout and commit once on stop.
     const interactionInProgress = useRef(false)
     const pendingLayouts = useRef<Partial<Record<DashboardLayoutSize, Layout>> | null>(null)
+    const pendingInteractionLayouts = useRef<Partial<Record<DashboardLayoutSize, Layout>> | null>(null)
+    const interactionLayoutFrame = useRef<number | null>(null)
     const dragEndTimeout = useRef<number | null>(null)
+    const dragTargetGroupId = useRef<string | null | undefined>(undefined)
+    const groupSectionElements = useRef<Array<{ id: string; element: HTMLElement; collapsed: boolean }>>([])
+    const groupHeaderTileIds = useRef<Set<string>>(new Set())
+    const groupLayoutTransitionTimeout = useRef<number | null>(null)
+    const pendingGroupDropTimeout = useRef<number | null>(null)
     const scrollAnimationRef = useRef<number | null>(null)
     const scrollContainerRef = useRef<HTMLElement | null>(null)
     const scrollContainerRectRef = useRef<DOMRect | null>(null)
     const lastScrollSignalRef = useRef(scrollToBottomSignal)
+
+    const queueInteractionLayouts = useCallback((nextLayouts: Partial<Record<DashboardLayoutSize, Layout>>) => {
+        pendingInteractionLayouts.current = nextLayouts
+        if (interactionLayoutFrame.current === null) {
+            interactionLayoutFrame.current = requestAnimationFrame(() => {
+                setInteractionLayouts(pendingInteractionLayouts.current)
+                interactionLayoutFrame.current = null
+            })
+        }
+    }, [])
+
+    useEffect(() => {
+        if (!dashboard?.id || placement === DashboardPlacement.Export) {
+            setCollapsedGroupIds(new Set())
+            return
+        }
+        const stored = localStorageSlot(`dashboard-groups-collapsed-v1-${dashboard.id}`, collapsedGroupsSchema).get()
+        setCollapsedGroupIds(new Set(stored ?? []))
+    }, [dashboard?.id, placement])
+
+    const toggleGroupCollapsed = useCallback(
+        (groupId: string) => {
+            if (!dashboard?.id || placement === DashboardPlacement.Export) {
+                return
+            }
+            setCollapsedGroupIds((current) => {
+                const next = new Set(current)
+                if (next.has(groupId)) {
+                    next.delete(groupId)
+                } else {
+                    next.add(groupId)
+                }
+                localStorageSlot(`dashboard-groups-collapsed-v1-${dashboard.id}`, collapsedGroupsSchema).set([...next])
+                return next
+            })
+            setGroupLayoutTransitioning(true)
+            if (groupLayoutTransitionTimeout.current) {
+                window.clearTimeout(groupLayoutTransitionTimeout.current)
+            }
+            groupLayoutTransitionTimeout.current = window.setTimeout(() => setGroupLayoutTransitioning(false), 240)
+        },
+        [dashboard?.id, placement]
+    )
+
+    const displayLayouts = useMemo(() => {
+        const activeLayouts = interactionLayouts ?? layouts
+        const collapsed = collapseDashboardGroupLayouts(
+            pendingGroupDrop
+                ? {
+                      ...activeLayouts,
+                      sm: activeLayouts.sm?.map((layout) =>
+                          layout.i === String(pendingGroupDrop.tileId) ? pendingGroupDrop.layout : layout
+                      ),
+                  }
+                : activeLayouts,
+            dashboard?.groups ?? [],
+            collapsedGroupIds
+        )
+        if (!layoutEditMode || !dashboard?.groups?.length) {
+            return collapsed
+        }
+        const withFooters: Partial<Record<DashboardLayoutSize, Layout>> = {}
+        for (const [breakpoint, source] of Object.entries(collapsed) as [DashboardLayoutSize, Layout][]) {
+            const items = [...(source ?? [])]
+            for (const group of dashboard.groups) {
+                if (collapsedGroupIds.has(group.id)) {
+                    continue
+                }
+                const header = items.find((layout) => layout.i === String(group.tile_id))
+                if (!header) {
+                    continue
+                }
+                const memberTileIds = new Set(group.member_tile_ids.map(String))
+                let bottom = header.y + header.h
+                for (const layout of items) {
+                    if (memberTileIds.has(layout.i)) {
+                        bottom = Math.max(bottom, layout.y + layout.h)
+                    }
+                }
+                items.push({
+                    i: `${GROUP_FOOTER_PREFIX}${group.id}`,
+                    x: 0,
+                    y: bottom,
+                    w: BREAKPOINT_COLUMN_COUNTS[breakpoint] ?? BREAKPOINT_COLUMN_COUNTS.sm,
+                    h: 1,
+                    static: true,
+                })
+            }
+            withFooters[breakpoint] = items
+        }
+        return withFooters
+    }, [interactionLayouts, layouts, dashboard?.groups, collapsedGroupIds, pendingGroupDrop, layoutEditMode])
+
+    const visibleTiles = useMemo(
+        () => tiles.filter((tile) => !tile.parent_group_id || !collapsedGroupIds.has(tile.parent_group_id)),
+        [tiles, collapsedGroupIds]
+    )
 
     useEffect(() => {
         return () => {
@@ -155,10 +278,39 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
             if (dragEndTimeout.current) {
                 window.clearTimeout(dragEndTimeout.current)
             }
+            if (groupLayoutTransitionTimeout.current) {
+                window.clearTimeout(groupLayoutTransitionTimeout.current)
+            }
+            if (interactionLayoutFrame.current) {
+                cancelAnimationFrame(interactionLayoutFrame.current)
+            }
+            if (pendingGroupDropTimeout.current) {
+                window.clearTimeout(pendingGroupDropTimeout.current)
+            }
             scrollContainerRef.current = null
             scrollContainerRectRef.current = null
         }
     }, [])
+
+    useEffect(() => {
+        if (!pendingGroupDrop) {
+            return
+        }
+        const tile = tiles.find((candidate) => candidate.id === pendingGroupDrop.tileId)
+        const tileLayout = layouts.sm?.find((layout) => layout.i === String(pendingGroupDrop.tileId))
+        const layoutMatches =
+            tileLayout?.x === pendingGroupDrop.layout.x &&
+            tileLayout.y === pendingGroupDrop.layout.y &&
+            tileLayout.w === pendingGroupDrop.layout.w &&
+            tileLayout.h === pendingGroupDrop.layout.h
+        if ((tile?.parent_group_id ?? null) === pendingGroupDrop.groupId && layoutMatches) {
+            setPendingGroupDrop(null)
+            if (pendingGroupDropTimeout.current) {
+                window.clearTimeout(pendingGroupDropTimeout.current)
+                pendingGroupDropTimeout.current = null
+            }
+        }
+    }, [layouts.sm, pendingGroupDrop, tiles])
 
     // Scroll the dashboard to the bottom when the logic requests it (e.g. after adding tiles).
     // Two animation frames let React commit and react-grid-layout grow the container before we measure.
@@ -182,11 +334,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
     }, [scrollToBottomSignal])
     const className = clsx({
         'dashboard-view-mode mb-8': !layoutEditMode,
-        // In edit mode, dragging is bounded to the grid's own clientHeight, which is exactly the
-        // content height — so there's nowhere to drag a tile into to create a new bottom row.
-        // box-content + padding-bottom grows clientHeight (padding only counts under content-box,
-        // since preflight defaults everything to border-box), opening up draggable space below the
-        // last tile that scales with content. A margin wouldn't work — it sits outside clientHeight.
+        'dashboard-group-transition': groupLayoutTransitioning,
         'dashboard-edit-mode box-content pb-[40vh]': layoutEditMode,
     })
 
@@ -243,6 +391,43 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
     const rowHeight = BASE_ROW_HEIGHT * effectiveZoom
     const spacingFactor = effectiveZoom < 1 ? 0.9 : 1
     const margin = useMemo(() => BASE_MARGIN.map((m) => m * spacingFactor) as [number, number], [spacingFactor])
+    const groupSections = useMemo(() => {
+        const smLayouts = displayLayouts.sm ?? []
+        const groupLayouts = (dashboard?.groups ?? [])
+            .flatMap((group) => {
+                const layout = smLayouts.find((candidate) => String(group.tile_id) === candidate.i)
+                return layout ? [{ group, layout }] : []
+            })
+            .sort((a, b) => a.layout.y - b.layout.y)
+
+        return groupLayouts.map(({ group, layout }) => {
+            const collapsed = collapsedGroupIds.has(group.id)
+            const sectionTop = layout.y
+            let sectionBottom = layout.y + layout.h
+
+            if (!collapsed) {
+                const memberTileIds = new Set(group.member_tile_ids.map(String))
+                const memberLayouts = smLayouts.filter((candidate) => memberTileIds.has(candidate.i))
+                sectionBottom = memberLayouts.reduce(
+                    (bottom, candidate) => Math.max(bottom, candidate.y + candidate.h),
+                    sectionBottom
+                )
+                if (layoutEditMode) {
+                    sectionBottom += 1
+                }
+            }
+
+            const rowSpan = Math.max(1, sectionBottom - sectionTop)
+            return {
+                id: group.id,
+                collapsed,
+                startY: sectionTop,
+                endY: sectionBottom,
+                top: sectionTop * (rowHeight + margin[1]),
+                height: rowSpan * rowHeight + (rowSpan - 1) * margin[1],
+            }
+        })
+    }, [dashboard?.groups, displayLayouts.sm, collapsedGroupIds, margin, rowHeight, layoutEditMode])
 
     const getInsertMenuItems = useCallback(
         (targetX: number, targetY: number, targetW?: number): LemonMenuItem[] =>
@@ -277,7 +462,7 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         () => ({
             enabled: layoutEditMode && !isMobileView,
             handle: '.CardMeta,.TextCard__body,.ButtonTileCard__body,.WidgetCard__header,.drag-handle',
-            cancel: 'a,table,button,input,.Popover',
+            cancel: 'a,table,button:not(.drag-handle),input,.Popover',
             bounded: true,
         }),
         [layoutEditMode, isMobileView]
@@ -352,23 +537,28 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
             if (!layoutEditMode) {
                 return
             }
-            // Defer commits while dragging/resizing — the final layout is flushed on gesture stop.
             if (interactionInProgress.current) {
                 pendingLayouts.current = newLayouts
+                queueInteractionLayouts(newLayouts)
                 return
             }
-            updateLayouts(newLayouts)
+            updateLayouts(stripGroupFooterLayouts(newLayouts))
         },
-        [layoutEditMode, updateLayouts]
+        [layoutEditMode, queueInteractionLayouts, updateLayouts]
     )
 
     const flushPendingLayouts = useCallback(() => {
         interactionInProgress.current = false
+        if (interactionLayoutFrame.current) {
+            cancelAnimationFrame(interactionLayoutFrame.current)
+            interactionLayoutFrame.current = null
+        }
+        pendingInteractionLayouts.current = null
+        setInteractionLayouts(null)
         if (pendingLayouts.current) {
-            updateLayouts(pendingLayouts.current)
+            updateLayouts(stripGroupFooterLayouts(pendingLayouts.current))
             pendingLayouts.current = null
         }
-        // Remeasure once the gesture settles, since height updates were suppressed during it.
         requestAnimationFrame(() => {
             if (containerRef.current) {
                 setContainerHeight(containerRef.current.clientHeight)
@@ -388,10 +578,16 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         interactionInProgress.current = true
     }, [])
 
-    const handleResize = useCallback((_layout: any, _oldItem: any, newItem: any) => {
-        // Setting state to the same id bails out of re-rendering, so this only re-renders once per gesture.
-        setResizingTileId(newItem.i)
-    }, [])
+    const handleResize = useCallback(
+        (liveLayout: Layout, _oldItem: Layout[number] | null, newItem: Layout[number] | null) => {
+            if (!newItem) {
+                return
+            }
+            setResizingTileId(newItem.i)
+            queueInteractionLayouts({ ...layouts, sm: liveLayout })
+        },
+        [layouts, queueInteractionLayouts]
+    )
 
     const handleResizeStop = useCallback(() => {
         setResizingTileId(null)
@@ -403,13 +599,41 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
 
     const handleDragStart = useCallback(() => {
         interactionInProgress.current = true
+        dragTargetGroupId.current = undefined
+        groupHeaderTileIds.current = new Set((dashboard?.groups ?? []).map((group) => String(group.tile_id)))
+        groupSectionElements.current = Array.from(
+            document.querySelectorAll<HTMLElement>('[data-attr="dashboard-group-section"][data-group-id]')
+        ).flatMap((element) => {
+            const id = element.getAttribute('data-group-id')
+            return id ? [{ id, element, collapsed: element.getAttribute('data-collapsed') === 'true' }] : []
+        })
         scrollContainerRef.current = document.getElementById('main-content')
         scrollContainerRectRef.current = scrollContainerRef.current?.getBoundingClientRect() ?? null
-    }, [])
+    }, [dashboard?.groups])
 
     const handleDrag = useCallback(
-        (_layout: unknown, _oldItem: unknown, _newItem: unknown, _placeholder: unknown, e: unknown) => {
+        (_layout: unknown, _oldItem: unknown, newItem: unknown, _placeholder: unknown, e: unknown) => {
             isDragging.current = true
+            const mouseY = (e as MouseEvent).clientY
+            const draggedTileId = (newItem as { i?: string } | null)?.i
+            const draggingGroupHeader = !!draggedTileId && groupHeaderTileIds.current.has(draggedTileId)
+            let destinationId: string | null = null
+            if (!draggingGroupHeader) {
+                for (const { id, element } of groupSectionElements.current) {
+                    const rect = element.getBoundingClientRect()
+                    if (mouseY >= rect.top && mouseY <= rect.bottom) {
+                        destinationId = id
+                        break
+                    }
+                }
+            }
+            dragTargetGroupId.current = destinationId
+            for (const { id, element } of groupSectionElements.current) {
+                element.classList.toggle(
+                    'DashboardGroupSection--drop-target',
+                    !draggingGroupHeader && id === destinationId
+                )
+            }
             if (dragEndTimeout.current) {
                 window.clearTimeout(dragEndTimeout.current)
             }
@@ -423,8 +647,6 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
             if (!scrollContainer || !containerRect) {
                 return
             }
-
-            const mouseY = (e as MouseEvent).clientY
 
             let scrollSpeed = 0
             if (mouseY < containerRect.top + DRAG_AUTO_SCROLL_THRESHOLD) {
@@ -451,24 +673,94 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         []
     )
 
-    const handleDragStop = useCallback(() => {
-        if (scrollAnimationRef.current) {
-            cancelAnimationFrame(scrollAnimationRef.current)
-            scrollAnimationRef.current = null
-        }
-        scrollContainerRef.current = null
-        scrollContainerRectRef.current = null
-        if (dragEndTimeout.current) {
-            window.clearTimeout(dragEndTimeout.current)
-        }
-        dragEndTimeout.current = window.setTimeout(() => {
-            isDragging.current = false
-        }, 250)
-        flushPendingLayouts()
-        if (dashboard?.id) {
-            reportDashboardTileRepositioned(dashboard.id, 'moved', effectiveZoom)
-        }
-    }, [dashboard?.id, reportDashboardTileRepositioned, effectiveZoom, flushPendingLayouts])
+    const handleDragStop = useCallback(
+        (
+            _layout: unknown,
+            _oldItem: unknown,
+            newItem: { i: string; x: number; y: number; w: number; h: number } | null
+        ) => {
+            if (!newItem) {
+                return
+            }
+            if (scrollAnimationRef.current) {
+                cancelAnimationFrame(scrollAnimationRef.current)
+                scrollAnimationRef.current = null
+            }
+            scrollContainerRef.current = null
+            scrollContainerRectRef.current = null
+            if (dragEndTimeout.current) {
+                window.clearTimeout(dragEndTimeout.current)
+            }
+            dragEndTimeout.current = window.setTimeout(() => {
+                isDragging.current = false
+            }, 250)
+            const pointerDestinationGroupId = dragTargetGroupId.current
+            dragTargetGroupId.current = undefined
+            for (const { element } of groupSectionElements.current) {
+                element.classList.remove('DashboardGroupSection--drop-target')
+            }
+            groupSectionElements.current = []
+            const droppedLayouts = pendingLayouts.current ?? displayLayouts
+            flushPendingLayouts()
+            const group = dashboard?.groups?.find((candidate) => String(candidate.tile_id) === newItem.i)
+            if (group) {
+                updateDashboardGroupLayout({
+                    groupId: group.id,
+                    layouts: { sm: { x: 0, y: newItem.y, w: BREAKPOINT_COLUMN_COUNTS.sm, h: 1 } },
+                })
+            } else {
+                const tile = tiles.find((candidate) => String(candidate.id) === newItem.i)
+                if (tile) {
+                    const orderedGroups = (dashboard?.groups ?? [])
+                        .flatMap((candidate) => {
+                            const layout = droppedLayouts.sm?.find((item) => item.i === String(candidate.tile_id))
+                            return layout ? [{ group: candidate, layout }] : []
+                        })
+                        .sort((a, b) => a.layout.y - b.layout.y)
+                    const destination = orderedGroups.filter((candidate) => candidate.layout.y < newItem.y).at(-1)
+                    const section = groupSections.find(
+                        (candidate) =>
+                            !candidate.collapsed && newItem.y >= candidate.startY && newItem.y < candidate.endY
+                    )
+                    let destinationGroupId = section?.id ?? destination?.group.id ?? null
+                    if (pointerDestinationGroupId !== undefined) {
+                        destinationGroupId = pointerDestinationGroupId
+                    }
+                    if ((tile.parent_group_id ?? null) !== destinationGroupId) {
+                        const droppedTileLayout = {
+                            ...newItem,
+                            i: String(tile.id),
+                        }
+                        setPendingGroupDrop({ tileId: tile.id, groupId: destinationGroupId, layout: droppedTileLayout })
+                        if (pendingGroupDropTimeout.current) {
+                            window.clearTimeout(pendingGroupDropTimeout.current)
+                        }
+                        pendingGroupDropTimeout.current = window.setTimeout(() => setPendingGroupDrop(null), 5000)
+                        moveDashboardTileToGroup({
+                            tileId: tile.id,
+                            groupId: destinationGroupId,
+                            layouts: { sm: { x: newItem.x, y: newItem.y, w: newItem.w, h: newItem.h } },
+                        })
+                    }
+                }
+            }
+            if (dashboard?.id) {
+                reportDashboardTileRepositioned(dashboard.id, 'moved', effectiveZoom)
+            }
+        },
+        [
+            dashboard?.id,
+            dashboard?.groups,
+            displayLayouts,
+            groupSections,
+            reportDashboardTileRepositioned,
+            effectiveZoom,
+            flushPendingLayouts,
+            moveDashboardTileToGroup,
+            updateDashboardGroupLayout,
+            tiles,
+        ]
+    )
 
     return (
         <div className="dashboard-items-wrapper" ref={containerRef as RefObject<HTMLDivElement>}>
@@ -492,13 +784,30 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                             color="var(--color-bg-surface-secondary)"
                         />
                     )}
-
+                    {groupSections.map((section) => (
+                        <div
+                            key={section.id}
+                            data-attr="dashboard-group-section"
+                            data-group-id={section.id}
+                            data-collapsed={section.collapsed}
+                            className={clsx(
+                                'DashboardGroupSection',
+                                groupLayoutTransitioning && 'DashboardGroupSection--transitioning'
+                            )}
+                            style={{
+                                top: section.top - margin[1] / 2,
+                                height: section.height + margin[1],
+                                left: -margin[0] / 2,
+                                right: -margin[0] / 2,
+                            }}
+                        />
+                    ))}
                     <ReactGridLayout
                         width={gridWidth}
                         className={className}
                         dragConfig={dragConfig}
                         resizeConfig={resizeConfig}
-                        layouts={layouts as Partial<Record<DashboardLayoutSize, Layout>>}
+                        layouts={displayLayouts as Partial<Record<DashboardLayoutSize, Layout>>}
                         rowHeight={rowHeight}
                         margin={margin}
                         containerPadding={CONTAINER_PADDING}
@@ -513,9 +822,46 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
                         onDrag={handleDrag}
                         onDragStop={handleDragStop}
                     >
-                        {tiles?.map((tile) => {
+                        {dashboard?.groups?.map((group) => (
+                            <DashboardGroupItem
+                                key={group.tile_id}
+                                group={group}
+                                collapsed={collapsedGroupIds.has(group.id)}
+                                onToggle={() => toggleGroupCollapsed(group.id)}
+                                showActions={canEditDashboard && isEditablePlacement}
+                                compact={isLayoutZoomToggled}
+                                onDragHandleMouseDown={onDragHandleMouseDown}
+                                onRename={(name) => renameDashboardGroup(group.id, name)}
+                                onDelete={() =>
+                                    LemonDialog.open({
+                                        title: 'Delete this group?',
+                                        description: `${group.member_tile_ids.length} tiles are in this group. You can delete them or move them out of the group.`,
+                                        primaryButton: {
+                                            children: 'Delete group and tiles',
+                                            status: 'danger',
+                                            onClick: () => deleteDashboardGroup(group.id, 'delete_tiles'),
+                                        },
+                                        secondaryButton: {
+                                            children: 'Move tiles to ungrouped',
+                                            onClick: () => deleteDashboardGroup(group.id, 'move_to_ungrouped'),
+                                        },
+                                        tertiaryButton: { children: 'Cancel' },
+                                    })
+                                }
+                            />
+                        ))}
+                        {layoutEditMode &&
+                            dashboard?.groups
+                                ?.filter((group) => !collapsedGroupIds.has(group.id))
+                                .map((group) => (
+                                    <div
+                                        key={`${GROUP_FOOTER_PREFIX}${group.id}`}
+                                        className="DashboardGroupSectionFooter"
+                                    />
+                                ))}
+                        {visibleTiles.map((tile) => {
                             const { insight, text, button_tile, widget } = tile
-                            const smLayout = layouts['sm']?.find((l) => {
+                            const smLayout = displayLayouts['sm']?.find((l) => {
                                 return l.i == tile.id.toString()
                             })
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -359,6 +359,23 @@ describe('dashboardLogic', () => {
             expect(api.update).not.toHaveBeenCalled()
         })
 
+        it('preserves layouts for tiles omitted from a grid update', async () => {
+            await expectLogic(logic).toFinishAllListeners()
+
+            const hiddenTile = logic.values.dashboard!.tiles[1]
+            const hiddenTileLayouts = hiddenTile.layouts
+            const visibleLayouts = {
+                ...logic.values.layouts,
+                sm: logic.values.layouts.sm?.filter((layout) => layout.i !== String(hiddenTile.id)),
+            }
+
+            await expectLogic(logic, () => {
+                logic.actions.updateLayouts(visibleLayouts)
+            }).toFinishAllListeners()
+
+            expect(logic.values.dashboard!.tiles[1].layouts).toEqual(hiddenTileLayouts)
+        })
+
         it('saving after layout change calls api', async () => {
             await expectLogic(logic).toFinishAllListeners()
 
@@ -1294,6 +1311,121 @@ describe('dashboardLogic', () => {
                     expect.objectContaining({ breakdownValue: 'x', colorToken: 'preset-1' }),
                 ])
             })
+        })
+    })
+
+    describe('dashboard groups', () => {
+        beforeEach(() => {
+            useMocks({
+                get: {
+                    '/api/environments/:team_id/dashboards/5/': {
+                        ...dashboards[5],
+                        groups: [
+                            {
+                                id: 'group-1',
+                                name: 'Acquisition',
+                                tile_id: 99,
+                                layouts: { sm: { x: 0, y: 8, w: 12, h: 1 } },
+                                member_tile_ids: [],
+                            },
+                        ],
+                    },
+                },
+            })
+            logic = dashboardLogic({ id: 5 })
+            logic.mount()
+        })
+
+        it('persists a moved group header when saving layout changes', async () => {
+            await expectLogic(logic).toFinishAllListeners()
+
+            const modifiedLayouts = {
+                ...logic.values.layouts,
+                sm: logic.values.layouts.sm?.map((layout) => (layout.i === '99' ? { ...layout, y: 12 } : layout)),
+            }
+
+            await expectLogic(logic, () => {
+                logic.actions.updateLayouts(modifiedLayouts)
+            }).toFinishAllListeners()
+
+            expect(logic.values.hasUnsavedLayoutChanges).toBe(true)
+
+            const updateSpy = jest.spyOn(api, 'update')
+
+            await expectLogic(logic, () => {
+                logic.actions.saveEditModeChanges()
+            }).toFinishAllListeners()
+
+            expect(updateSpy).toHaveBeenCalledWith(
+                `api/environments/${MOCK_TEAM_ID}/dashboards/5`,
+                expect.objectContaining({
+                    tiles: expect.arrayContaining([
+                        expect.objectContaining({
+                            id: 99,
+                            layouts: { sm: { x: 0, y: 12, w: 12, h: 1 } },
+                        }),
+                    ]),
+                })
+            )
+        })
+
+        it('createDashboardGroup posts then reloads the dashboard', async () => {
+            await expectLogic(logic).toFinishAllListeners()
+
+            const createSpy = jest.spyOn(api, 'create').mockResolvedValueOnce({
+                id: 'group-2',
+                name: 'New group',
+                tile_id: 100,
+                layouts: { sm: { x: 0, y: 0, w: 12, h: 1 } },
+                member_tile_ids: [],
+            })
+
+            await expectLogic(logic, () => {
+                logic.actions.createDashboardGroup('New group')
+            })
+                .toDispatchActions(['createDashboardGroup', 'loadDashboard', 'createDashboardGroupFinished'])
+                .toFinishAllListeners()
+
+            expect(createSpy).toHaveBeenCalledWith(`api/environments/${MOCK_TEAM_ID}/dashboards/5/groups/`, {
+                name: 'New group',
+            })
+        })
+
+        it.each([
+            {
+                name: 'renames a group',
+                act: (): void => logic.actions.renameDashboardGroup('group-1', 'Activation'),
+                path: `api/environments/${MOCK_TEAM_ID}/dashboards/5/groups/update/`,
+                body: { group_id: 'group-1', name: 'Activation' },
+            },
+            {
+                name: 'moves a tile into a group',
+                act: (): void =>
+                    logic.actions.moveDashboardTileToGroup({
+                        tileId: 4,
+                        groupId: 'group-1',
+                        layouts: { sm: { x: 0, y: 9, w: 12, h: 2 } },
+                    }),
+                path: `api/environments/${MOCK_TEAM_ID}/dashboards/5/groups/move-tile/`,
+                body: {
+                    tile_id: 4,
+                    group_id: 'group-1',
+                    layouts: { sm: { x: 0, y: 9, w: 12, h: 2 } },
+                },
+            },
+            {
+                name: 'deletes a group and its tiles',
+                act: (): void => logic.actions.deleteDashboardGroup('group-1', 'delete_tiles'),
+                path: `api/environments/${MOCK_TEAM_ID}/dashboards/5/groups/delete/`,
+                body: { group_id: 'group-1', member_handling: 'delete_tiles' },
+            },
+        ])('$name', async ({ act, path, body }) => {
+            await expectLogic(logic).toFinishAllListeners()
+            const createSpy = jest.spyOn(api, 'create').mockResolvedValueOnce({})
+
+            await expectLogic(logic, act).toFinishAllListeners()
+
+            expect(createSpy).toHaveBeenCalledWith(path, body)
         })
     })
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -56,7 +56,9 @@ import {
     calculateDuplicateLayout,
     calculateInsertionLayout,
     calculateLayouts,
+    calculateLayoutsWithGroups,
     DEFAULT_INSERTED_TILE_SIZE,
+    stripGroupFooterLayouts,
 } from 'scenes/dashboard/tileLayouts'
 import {
     chunkTileIds,
@@ -199,12 +201,22 @@ export interface PendingInsertion {
     w: number | null
 }
 
+const groupHeaderSmLayout = (sm?: TileLayout): TileLayout => ({
+    x: 0,
+    y: sm?.y ?? 0,
+    w: BREAKPOINT_COLUMN_COUNTS.sm,
+    h: 1,
+})
+
 const tileLayoutsFromDashboard = (
     dashboard: DashboardType<QueryBasedInsightModel> | null | undefined
 ): Record<number, DashboardTile['layouts']> => {
     const tileIdToLayouts: Record<number, DashboardTile['layouts']> = {}
     dashboard?.tiles.forEach((tile: DashboardTile<QueryBasedInsightModel>) => {
         tileIdToLayouts[tile.id] = tile.layouts
+    })
+    dashboard?.groups?.forEach((group) => {
+        tileIdToLayouts[group.tile_id] = group.layouts
     })
     return tileIdToLayouts
 }
@@ -260,15 +272,18 @@ export interface dashboardLogicValues {
     breakdownValuesIncomplete: boolean
     buttonTileId: number | 'new' | null
     canAutoPreview: boolean
+    canCreateDashboardGroups: boolean
     canEditDashboard: boolean
     canRestrictDashboard: boolean
     canSaveProjectDashboardTemplate: boolean
     cancellingPreview: boolean
     columns: number | null
     containerWidth: number | null
+    createDashboardGroupLoading: boolean
     currentLayoutSize: 'sm' | 'xs'
     dashboard: DashboardType<QueryBasedInsightModel> | null
     dashboardFailedToLoad: boolean
+    dashboardGroupsEnabled: boolean
     dashboardLayouts: Record<DashboardTile['id'], DashboardTile['layouts']>
     dashboardLoadData: {
         action: DashboardLoadAction | undefined
@@ -459,8 +474,21 @@ export interface dashboardLogicActions {
             toDashboardName: string
         }
     }
+    createDashboardGroup: (name: string) => {
+        name: string
+    }
+    createDashboardGroupFinished: () => {
+        value: true
+    }
     dashboardNotFound: () => {
         value: true
+    }
+    deleteDashboardGroup: (
+        groupId: string,
+        memberHandling: 'delete_tiles' | 'move_to_ungrouped'
+    ) => {
+        groupId: string
+        memberHandling: 'delete_tiles' | 'move_to_ungrouped'
     }
     duplicateTile: (tile: DashboardTile<QueryBasedInsightModel>) => {
         tile: DashboardTile<QueryBasedInsightModel<Node<Record<string, any>>>>
@@ -576,6 +604,29 @@ export interface dashboardLogicActions {
             toDashboardName: string
         }
     }
+    moveDashboardTileToGroup: (payload: {
+        groupId: string | null
+        layouts: {
+            sm: {
+                h: number
+                w: number
+                x: number
+                y: number
+            }
+        }
+        tileId: number
+    }) => {
+        groupId: string | null
+        layouts: {
+            sm: {
+                h: number
+                w: number
+                x: number
+                y: number
+            }
+        }
+        tileId: number
+    }
     openAddInsightModal: () => {
         value: true
     }
@@ -629,6 +680,13 @@ export interface dashboardLogicActions {
     }
     reportDashboardViewed: () => {
         value: true
+    }
+    renameDashboardGroup: (
+        groupId: string,
+        name: string
+    ) => {
+        groupId: string
+        name: string
     }
     reportInsightsViewed: (insights: QueryBasedInsightModel[]) => {
         insights: QueryBasedInsightModel<Node<Record<string, any>>>[]
@@ -884,6 +942,27 @@ export interface dashboardLogicActions {
     updateDashboardLastRefresh: (lastDashboardRefresh: Dayjs) => {
         lastDashboardRefresh: Dayjs
     }
+    updateDashboardGroupLayout: (payload: {
+        groupId: string
+        layouts: {
+            sm: {
+                h: number
+                w: number
+                x: number
+                y: number
+            }
+        }
+    }) => {
+        groupId: string
+        layouts: {
+            sm: {
+                h: number
+                w: number
+                x: number
+                y: number
+            }
+        }
+    }
     updateDashboardTags: (tags: string[]) => {
         tags: string[]
     }
@@ -1046,6 +1125,12 @@ export interface dashboardLogicMeta {
             tiles: DashboardTile<QueryBasedInsightModel<Node<Record<string, any>>>>[],
             placement: DashboardPlacement
         ) => boolean
+        dashboardGroupsEnabled: (
+            featureFlags: FeatureFlagsSet,
+            dashboard: DashboardType<QueryBasedInsightModel<Node<Record<string, any>>>> | null,
+            placement: DashboardPlacement
+        ) => boolean
+        canCreateDashboardGroups: (featureFlags: FeatureFlagsSet) => boolean
         inlineTileInsertionEnabled: (featureFlags: FeatureFlagsSet) => boolean
         insightTiles: (
             tiles: DashboardTile<QueryBasedInsightModel<Node<Record<string, any>>>>[]
@@ -1085,7 +1170,8 @@ export interface dashboardLogicMeta {
         ) => boolean
         sizeKey: (columns: number | null) => DashboardLayoutSize | undefined
         layouts: (
-            tiles: DashboardTile<QueryBasedInsightModel<Node<Record<string, any>>>>[]
+            tiles: DashboardTile<QueryBasedInsightModel<Node<Record<string, any>>>>[],
+            dashboard: DashboardType<QueryBasedInsightModel<Node<Record<string, any>>>> | null
         ) => Partial<Record<DashboardLayoutSize, Layout>>
         layout: (
             layouts: Partial<Record<DashboardLayoutSize, Layout>>,
@@ -1356,6 +1442,22 @@ export const dashboardLogic = kea<dashboardLogicType>([
         setButtonTileId: (buttonTileId: number | 'new' | null) => ({ buttonTileId }),
         openAddInsightModal: true,
         setTileOverride: (tile: DashboardTile<QueryBasedInsightModel>) => ({ tile }),
+        createDashboardGroup: (name: string) => ({ name }),
+        createDashboardGroupFinished: true,
+        moveDashboardTileToGroup: (payload: {
+            tileId: number
+            groupId: string | null
+            layouts: { sm: { x: number; y: number; w: number; h: number } }
+        }) => payload,
+        updateDashboardGroupLayout: (payload: {
+            groupId: string
+            layouts: { sm: { x: number; y: number; w: number; h: number } }
+        }) => payload,
+        renameDashboardGroup: (groupId: string, name: string) => ({ groupId, name }),
+        deleteDashboardGroup: (groupId: string, memberHandling: 'delete_tiles' | 'move_to_ungrouped') => ({
+            groupId,
+            memberHandling,
+        }),
 
         /**
          * Usage tracking.
@@ -1460,10 +1562,16 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     cache.dashboardChangesPersisted = false
                     try {
                         // Only persist sm layouts; xs layouts are derived on the fly
-                        const layoutsToUpdate = (values.dashboard?.tiles || []).map((tile) => ({
-                            id: tile.id,
-                            layouts: tile.layouts?.sm ? { sm: tile.layouts.sm } : {},
-                        }))
+                        const layoutsToUpdate = [
+                            ...(values.dashboard?.tiles || []).map((tile) => ({
+                                id: tile.id,
+                                layouts: tile.layouts?.sm ? { sm: tile.layouts.sm } : {},
+                            })),
+                            ...(values.dashboard?.groups || []).map((group) => ({
+                                id: group.tile_id,
+                                layouts: { sm: groupHeaderSmLayout(group.layouts?.sm) },
+                            })),
+                        ]
 
                         const currentDashboard = values.dashboard
                         if (!currentDashboard) {
@@ -1494,10 +1602,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         const breakdownColorsChanged = !equal(persistedBreakdownColors, breakdownColorsToSave)
                         const themeChanged = (values.dataColorThemeId ?? null) !== persistedThemeId
 
-                        const layoutsChanged = (currentDashboard.tiles || []).some((tile) => {
+                        const layoutsChanged = layoutsToUpdate.some((tile) => {
                             const originalLayouts = values.dashboardLayouts?.[tile.id]?.sm
-                            const updatedLayouts = layoutsToUpdate.find((t) => t.id === tile.id)?.layouts?.sm
-                            return !equal(originalLayouts || {}, updatedLayouts || {})
+                            return !equal(originalLayouts || {}, tile.layouts?.sm || {})
                         })
 
                         if (
@@ -1884,15 +1991,18 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 dashboardNotFound: () => null,
                 setAccessDeniedToDashboard: () => null,
                 updateLayouts: (state, { layouts }) => {
-                    const itemLayouts = layoutsByTile(layouts)
+                    const itemLayouts = layoutsByTile(stripGroupFooterLayouts(layouts))
 
-                    // Only persist sm layouts; xs layouts are derived on the fly
                     return {
                         ...state,
                         tiles: state?.tiles?.map((tile) => ({
                             ...tile,
-                            layouts: itemLayouts[tile.id]?.sm ? { sm: itemLayouts[tile.id].sm } : {},
+                            layouts: itemLayouts[tile.id]?.sm ? { sm: itemLayouts[tile.id].sm } : tile.layouts,
                         })),
+                        groups: state?.groups?.map((group) => {
+                            const sm = itemLayouts[group.tile_id]?.sm
+                            return sm ? { ...group, layouts: { sm: groupHeaderSmLayout(sm) } } : group
+                        }),
                     } as DashboardType<QueryBasedInsightModel>
                 },
                 setTileProperty: (state, { tileId, properties }) => {
@@ -1906,6 +2016,10 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     return {
                         ...state,
                         tiles: state?.tiles?.filter((t) => t.id !== tile.id),
+                        groups: state?.groups?.map((group) => ({
+                            ...group,
+                            member_tile_ids: group.member_tile_ids.filter((id) => id !== tile.id),
+                        })),
                     } as DashboardType<QueryBasedInsightModel>
                 },
                 [dashboardsModel.actionTypes.tileMovedToDashboard]: (state, { tile, dashboardId }) => {
@@ -2389,6 +2503,13 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 addWidgetTileFinished: () => false,
             },
         ],
+        createDashboardGroupLoading: [
+            false,
+            {
+                createDashboardGroup: () => true,
+                createDashboardGroupFinished: () => false,
+            },
+        ],
         // Incremented on each scroll-to-bottom request; the view effects on the change.
         scrollToBottomSignal: [
             0,
@@ -2521,11 +2642,17 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 if (!dashboard) {
                     return false
                 }
-                return (dashboard.tiles || []).some((tile: DashboardTile<QueryBasedInsightModel>) => {
+                const tilesChanged = (dashboard.tiles || []).some((tile: DashboardTile<QueryBasedInsightModel>) => {
                     const originalSm = dashboardLayouts?.[tile.id]?.sm
                     const currentSm = tile.layouts?.sm
                     return !equal(originalSm || {}, currentSm || {})
                 })
+                const groupsChanged = (dashboard.groups || []).some((group) => {
+                    const originalSm = dashboardLayouts?.[group.tile_id]?.sm
+                    const currentSm = group.layouts?.sm
+                    return !equal(originalSm || {}, currentSm || {})
+                })
+                return tilesChanged || groupsChanged
             },
         ],
         effectiveVariablesAndAssociatedInsights: [
@@ -2702,6 +2829,24 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 return !!featureFlags[FEATURE_FLAGS.DASHBOARD_WIDGETS]
             },
         ],
+        dashboardGroupsEnabled: [
+            (s) => [s.featureFlags, s.dashboard, s.placement],
+            (
+                featureFlags: import('lib/logic/featureFlagLogic').FeatureFlagsSet,
+                dashboard: DashboardType<QueryBasedInsightModel> | null,
+                placement: DashboardPlacement
+            ): boolean => {
+                if (placement === DashboardPlacement.Public && (dashboard?.groups?.length ?? 0) > 0) {
+                    return true
+                }
+                return !!featureFlags[FEATURE_FLAGS.DASHBOARD_GROUPS] || (dashboard?.groups?.length ?? 0) > 0
+            },
+        ],
+        canCreateDashboardGroups: [
+            (s) => [s.featureFlags],
+            (featureFlags: import('lib/logic/featureFlagLogic').FeatureFlagsSet): boolean =>
+                !!featureFlags[FEATURE_FLAGS.DASHBOARD_GROUPS],
+        ],
         inlineTileInsertionEnabled: [
             (s) => [s.featureFlags],
             (featureFlags: import('lib/logic/featureFlagLogic').FeatureFlagsSet): boolean =>
@@ -2852,12 +2997,16 @@ export const dashboardLogic = kea<dashboardLogicType>([
             },
         ],
         layouts: [
-            (s) => [s.tiles],
+            (s) => [s.tiles, s.dashboard],
             (
                 tiles: DashboardTile<
                     QueryBasedInsightModel<import('~/queries/schema/schema-general').Node<Record<string, any>>>
-                >[]
-            ) => calculateLayouts(tiles),
+                >[],
+                dashboard: DashboardType<QueryBasedInsightModel> | null
+            ) =>
+                dashboard?.groups?.length
+                    ? calculateLayoutsWithGroups(tiles, dashboard.groups)
+                    : calculateLayouts(tiles),
             // Tile refreshes replace `tiles` once per insight response without touching geometry;
             // keeping the result reference stable stops react-grid-layout re-laying-out every tile
             // N times per dashboard refresh cycle.
@@ -3140,6 +3289,73 @@ export const dashboardLogic = kea<dashboardLogicType>([
         },
     })),
     listeners(({ actions, values, cache, props, sharedListeners }) => ({
+        createDashboardGroup: async ({ name }) => {
+            if (cache.creatingDashboardGroup) {
+                return
+            }
+            cache.creatingDashboardGroup = true
+            actions.setPendingInsertion(null)
+            try {
+                await api.create(`api/environments/${values.currentTeamId}/dashboards/${props.id}/groups/`, { name })
+                actions.loadDashboard({ action: DashboardLoadAction.Update })
+                actions.requestScrollToBottom()
+                lemonToast.success('Group added')
+            } catch {
+                lemonToast.error('Could not add group. Try again.')
+            } finally {
+                cache.creatingDashboardGroup = false
+                actions.createDashboardGroupFinished()
+            }
+        },
+        moveDashboardTileToGroup: async ({ tileId, groupId, layouts }) => {
+            try {
+                await api.create(`api/environments/${values.currentTeamId}/dashboards/${props.id}/groups/move-tile/`, {
+                    tile_id: tileId,
+                    group_id: groupId,
+                    layouts,
+                })
+                actions.loadDashboard({ action: DashboardLoadAction.Update })
+            } catch {
+                actions.loadDashboard({ action: DashboardLoadAction.Update })
+                lemonToast.error('Could not move tile. Try again.')
+            }
+        },
+        updateDashboardGroupLayout: async ({ groupId, layouts }) => {
+            try {
+                await api.create(`api/environments/${values.currentTeamId}/dashboards/${props.id}/groups/update/`, {
+                    group_id: groupId,
+                    layouts,
+                })
+                actions.loadDashboard({ action: DashboardLoadAction.Update })
+            } catch {
+                actions.loadDashboard({ action: DashboardLoadAction.Update })
+                lemonToast.error('Could not update group. Try again.')
+            }
+        },
+        renameDashboardGroup: async ({ groupId, name }) => {
+            try {
+                await api.create(`api/environments/${values.currentTeamId}/dashboards/${props.id}/groups/update/`, {
+                    group_id: groupId,
+                    name,
+                })
+                actions.loadDashboard({ action: DashboardLoadAction.Update })
+            } catch {
+                actions.loadDashboard({ action: DashboardLoadAction.Update })
+                lemonToast.error('Could not rename group. Try again.')
+            }
+        },
+        deleteDashboardGroup: async ({ groupId, memberHandling }) => {
+            try {
+                await api.create(`api/environments/${values.currentTeamId}/dashboards/${props.id}/groups/delete/`, {
+                    group_id: groupId,
+                    member_handling: memberHandling,
+                })
+                actions.loadDashboard({ action: DashboardLoadAction.Update })
+            } catch {
+                actions.loadDashboard({ action: DashboardLoadAction.Update })
+                lemonToast.error('Could not delete group. Try again.')
+            }
+        },
         scheduleRefreshDashboardWidgets: ({ tileId }: { tileId: number }) => {
             if (!cache.widgetTileRefreshScheduler) {
                 cache.widgetTileRefreshScheduler = createDashboardWidgetTileRefreshScheduler((id) =>

--- a/frontend/src/scenes/dashboard/items/DashboardGroupItem.tsx
+++ b/frontend/src/scenes/dashboard/items/DashboardGroupItem.tsx
@@ -1,0 +1,143 @@
+import { HTMLAttributes, ForwardedRef, MouseEventHandler, forwardRef, useEffect, useState } from 'react'
+
+import { IconChevronRight } from '@posthog/icons'
+
+import { CardMeta } from 'lib/components/Cards/CardMeta'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonInput } from 'lib/lemon-ui/LemonInput'
+import { pluralize } from 'lib/utils/strings'
+
+import { DashboardGroupType } from '~/types'
+
+interface DashboardGroupItemProps extends HTMLAttributes<HTMLDivElement> {
+    group: DashboardGroupType
+    collapsed: boolean
+    onToggle: () => void
+    showActions: boolean
+    compact: boolean
+    onDragHandleMouseDown?: MouseEventHandler<HTMLDivElement>
+    onRename: (name: string) => Promise<void>
+    onDelete: () => void
+}
+
+function DashboardGroupItemInternal(
+    {
+        group,
+        collapsed,
+        onToggle,
+        showActions,
+        compact,
+        onDragHandleMouseDown,
+        onRename,
+        onDelete,
+        className,
+        style,
+        onMouseDown: onGridMouseDown,
+        ...props
+    }: DashboardGroupItemProps,
+    ref: ForwardedRef<HTMLDivElement>
+): JSX.Element {
+    const [name, setName] = useState(group.name)
+    const [saving, setSaving] = useState(false)
+    const [renaming, setRenaming] = useState(false)
+
+    useEffect(() => setName(group.name), [group.name])
+
+    const saveName = async (): Promise<void> => {
+        const trimmedName = name.trim()
+        if (saving || trimmedName === group.name || !trimmedName) {
+            setName(group.name)
+            setRenaming(false)
+            return
+        }
+        setSaving(true)
+        try {
+            await onRename(trimmedName)
+            setRenaming(false)
+        } finally {
+            setSaving(false)
+        }
+    }
+
+    return (
+        <div
+            ref={ref}
+            className={`${className ?? ''} DashboardGroupItem DashboardTileCard ${compact ? 'DashboardGroupItem--compact' : ''}`}
+            style={style}
+            data-attr="dashboard-group"
+            data-group-id={group.id}
+            onMouseDown={onGridMouseDown}
+            {...props}
+        >
+            <CardMeta
+                className="drag-handle"
+                compact={compact}
+                onMouseDown={onDragHandleMouseDown}
+                showEditingControls={showActions}
+                moreButtons={
+                    <>
+                        <LemonButton fullWidth onClick={() => setRenaming(true)}>
+                            Rename
+                        </LemonButton>
+                        <LemonButton status="danger" fullWidth onClick={onDelete}>
+                            Delete
+                        </LemonButton>
+                    </>
+                }
+                headerContent={
+                    <div className="flex min-w-0 items-center gap-1">
+                        <LemonButton
+                            size="xsmall"
+                            type="tertiary"
+                            icon={
+                                <IconChevronRight
+                                    className={`transition-transform duration-200 ${collapsed ? '' : 'rotate-90'}`}
+                                />
+                            }
+                            onClick={onToggle}
+                            aria-label={collapsed ? `Expand ${group.name}` : `Collapse ${group.name}`}
+                        />
+                        {renaming ? (
+                            <LemonInput
+                                className="min-w-0 flex-1"
+                                size="small"
+                                value={name}
+                                disabled={saving}
+                                onChange={setName}
+                                onBlur={saveName}
+                                stopPropagation
+                                onKeyDown={(event) => {
+                                    if (event.key === 'Enter') {
+                                        event.currentTarget.blur()
+                                    }
+                                    if (event.key === 'Escape') {
+                                        setName(group.name)
+                                        setRenaming(false)
+                                        event.currentTarget.blur()
+                                    }
+                                }}
+                                aria-label="Group name"
+                            />
+                        ) : (
+                            <button
+                                type="button"
+                                className="min-w-0 max-w-full cursor-text appearance-none border-0 bg-transparent p-0 text-left font-inherit text-inherit hover:underline disabled:cursor-default disabled:no-underline disabled:opacity-100"
+                                onClick={() => setRenaming(true)}
+                                disabled={!showActions}
+                            >
+                                <h4 className="mb-0 truncate font-semibold">{group.name}</h4>
+                            </button>
+                        )}
+                        <span className="shrink-0 text-xs text-secondary">
+                            {pluralize(group.member_tile_ids.length, 'tile')}
+                        </span>
+                    </div>
+                }
+            />
+        </div>
+    )
+}
+
+export const DashboardGroupItem = forwardRef<HTMLDivElement, DashboardGroupItemProps>(DashboardGroupItemInternal)
+
+DashboardGroupItem.displayName = 'DashboardGroupItem'

--- a/frontend/src/scenes/dashboard/tileLayouts.test.ts
+++ b/frontend/src/scenes/dashboard/tileLayouts.test.ts
@@ -1,8 +1,14 @@
 import { Layout, LayoutItem } from 'react-grid-layout'
 
-import { calculateDuplicateLayout, calculateInsertionLayout, calculateLayouts } from 'scenes/dashboard/tileLayouts'
+import {
+    calculateDuplicateLayout,
+    calculateInsertionLayout,
+    calculateLayouts,
+    calculateLayoutsWithGroups,
+    collapseDashboardGroupLayouts,
+} from 'scenes/dashboard/tileLayouts'
 
-import { DashboardLayoutSize, DashboardTile, QueryBasedInsightModel, TileLayout } from '~/types'
+import { DashboardGroupType, DashboardLayoutSize, DashboardTile, QueryBasedInsightModel, TileLayout } from '~/types'
 
 function textTileWithLayout(
     layouts: Record<DashboardLayoutSize, TileLayout>,
@@ -16,6 +22,87 @@ function textTileWithLayout(
 }
 
 describe('calculating tile layouts', () => {
+    it('adds group rows and hides collapsed members without changing later section order', () => {
+        const tiles = [
+            textTileWithLayout({ sm: { x: 0, y: 1, w: 6, h: 3 } } as Record<DashboardLayoutSize, TileLayout>, 1),
+            textTileWithLayout({ sm: { x: 0, y: 5, w: 6, h: 2 } } as Record<DashboardLayoutSize, TileLayout>, 2),
+        ]
+        const groups: DashboardGroupType[] = [
+            {
+                id: 'group-1',
+                tile_id: 10,
+                name: 'Acquisition',
+                layouts: { sm: { x: 0, y: 0, w: 12, h: 1 } },
+                member_tile_ids: [1],
+            },
+            {
+                id: 'group-2',
+                tile_id: 11,
+                name: 'Retention',
+                layouts: { sm: { x: 0, y: 4, w: 12, h: 1 } },
+                member_tile_ids: [2],
+            },
+        ]
+
+        const layouts = calculateLayoutsWithGroups(tiles, groups)
+        const collapsed = collapseDashboardGroupLayouts(layouts, groups, new Set(['group-1']))
+
+        expect(collapsed.sm?.map(({ i, y }) => ({ i, y }))).toEqual([
+            { i: '10', y: 0 },
+            { i: '11', y: 1 },
+            { i: '2', y: 2 },
+        ])
+    })
+
+    it('places a group member below its group header', () => {
+        const groups: DashboardGroupType[] = [
+            {
+                id: 'group-1',
+                tile_id: 10,
+                name: 'Acquisition',
+                layouts: { sm: { x: 0, y: 5, w: 12, h: 1 } },
+                member_tile_ids: [1],
+            },
+            {
+                id: 'group-2',
+                tile_id: 11,
+                name: 'Retention',
+                layouts: { sm: { x: 0, y: 5, w: 12, h: 1 } },
+                member_tile_ids: [],
+            },
+        ]
+
+        const layouts = calculateLayoutsWithGroups(
+            [textTileWithLayout({ sm: { x: 0, y: 0, w: 6, h: 2 } } as Record<DashboardLayoutSize, TileLayout>)],
+            groups
+        )
+
+        expect(layouts.sm?.find((layout) => layout.i === '1')?.y).toBe(6)
+        expect(layouts.sm?.find((layout) => layout.i === '11')?.y).toBe(8)
+    })
+
+    it('leaves ungrouped tiles in place while packing misplaced group members', () => {
+        const tiles = [
+            textTileWithLayout({ sm: { x: 0, y: 0, w: 6, h: 2 } } as Record<DashboardLayoutSize, TileLayout>, 1),
+            textTileWithLayout({ sm: { x: 0, y: 0, w: 6, h: 2 } } as Record<DashboardLayoutSize, TileLayout>, 2),
+        ]
+        const groups: DashboardGroupType[] = [
+            {
+                id: 'group-1',
+                tile_id: 10,
+                name: 'Acquisition',
+                layouts: { sm: { x: 0, y: 3, w: 12, h: 1 } },
+                member_tile_ids: [2],
+            },
+        ]
+
+        const layouts = calculateLayoutsWithGroups(tiles, groups)
+
+        expect(layouts.sm?.find((layout) => layout.i === '1')?.y).toBe(0)
+        expect(layouts.sm?.find((layout) => layout.i === '10')?.y).toBe(3)
+        expect(layouts.sm?.find((layout) => layout.i === '2')?.y).toBe(4)
+    })
+
     it('minimum width and height are added if missing', () => {
         const tiles: DashboardTile<QueryBasedInsightModel>[] = [
             textTileWithLayout({

--- a/frontend/src/scenes/dashboard/tileLayouts.ts
+++ b/frontend/src/scenes/dashboard/tileLayouts.ts
@@ -10,7 +10,13 @@ import { BREAKPOINT_COLUMN_COUNTS } from 'scenes/dashboard/dashboardUtils'
 
 import { getQueryBasedInsightModel } from '~/queries/nodes/InsightViz/utils'
 import { isFunnelsQuery, isPathsQuery, isRetentionQuery, isTrendsQuery } from '~/queries/utils'
-import { ChartDisplayType, DashboardLayoutSize, DashboardTile, QueryBasedInsightModel } from '~/types'
+import {
+    ChartDisplayType,
+    DashboardGroupType,
+    DashboardLayoutSize,
+    DashboardTile,
+    QueryBasedInsightModel,
+} from '~/types'
 
 export interface TileLayout {
     x: number
@@ -360,4 +366,145 @@ export const calculateLayouts = (
     }
 
     return allLayouts
+}
+
+export const GROUP_FOOTER_PREFIX = 'group-end-'
+
+export function stripGroupFooterLayouts(
+    layouts: Partial<Record<DashboardLayoutSize, Layout>>
+): Partial<Record<DashboardLayoutSize, Layout>> {
+    const result: Partial<Record<DashboardLayoutSize, Layout>> = {}
+    for (const [breakpoint, source] of Object.entries(layouts) as [DashboardLayoutSize, Layout][]) {
+        result[breakpoint] = source?.filter((layout) => !layout.i.startsWith(GROUP_FOOTER_PREFIX))
+    }
+    return result
+}
+
+export function calculateLayoutsWithGroups(
+    tiles: DashboardTile<QueryBasedInsightModel>[],
+    groups: readonly DashboardGroupType[]
+): Partial<Record<DashboardLayoutSize, Layout>> {
+    const layouts = calculateLayouts(tiles)
+    const sm = [...(layouts.sm ?? [])]
+    const groupTileIds = new Set(groups.map((group) => String(group.tile_id)))
+
+    for (const group of groups) {
+        const groupLayout = group.layouts.sm
+        sm.push({
+            i: String(group.tile_id),
+            x: 0,
+            y: groupLayout?.y ?? 0,
+            w: BREAKPOINT_COLUMN_COUNTS.sm,
+            h: 1,
+            minW: BREAKPOINT_COLUMN_COUNTS.sm,
+            maxW: BREAKPOINT_COLUMN_COUNTS.sm,
+            minH: 1,
+            maxH: 1,
+            isResizable: false,
+        })
+    }
+
+    const orderedGroups = [...groups].sort(
+        (a, b) => (a.layouts.sm?.y ?? 0) - (b.layouts.sm?.y ?? 0) || a.tile_id - b.tile_id
+    )
+
+    for (const group of orderedGroups) {
+        const headerLayout = sm.find((layout) => layout.i === String(group.tile_id))
+        if (!headerLayout) {
+            continue
+        }
+
+        let nextMemberY = headerLayout.y + headerLayout.h
+        const memberLayouts = group.member_tile_ids
+            .map((memberTileId) => sm.find((layout) => layout.i === String(memberTileId)))
+            .filter((layout): layout is Layout[number] => !!layout)
+            .sort((a, b) => a.y - b.y || a.x - b.x)
+        const misplacedMemberLayouts = memberLayouts.filter((layout) => layout.y < headerLayout.y + headerLayout.h)
+        const misplacedMemberHeight = misplacedMemberLayouts.reduce((height, layout) => height + layout.h, 0)
+
+        if (misplacedMemberHeight > 0) {
+            for (const layout of sm) {
+                if (layout !== headerLayout && !misplacedMemberLayouts.includes(layout) && layout.y >= headerLayout.y) {
+                    layout.y += misplacedMemberHeight + (layout.y === headerLayout.y ? headerLayout.h : 0)
+                }
+            }
+        }
+
+        for (const memberLayout of memberLayouts) {
+            if (!misplacedMemberLayouts.includes(memberLayout)) {
+                nextMemberY = Math.max(nextMemberY, memberLayout.y + memberLayout.h)
+                continue
+            }
+            memberLayout.y = nextMemberY
+            nextMemberY += memberLayout.h
+        }
+    }
+
+    sm.sort((a, b) => a.y - b.y || a.x - b.x)
+    const existingXs = new Map((layouts.xs ?? []).map((layout) => [layout.i, layout]))
+    let xsY = 0
+    const xs = sm.map((layout) => {
+        const existing = existingXs.get(layout.i)
+        const isGroup = groupTileIds.has(layout.i)
+        const h = isGroup ? 1 : (existing?.h ?? layout.h)
+        const result = { ...existing, i: layout.i, x: 0, y: xsY, w: 1, h }
+        xsY += h
+        return result
+    })
+
+    return { sm, xs }
+}
+
+export function collapseDashboardGroupLayouts(
+    layouts: Partial<Record<DashboardLayoutSize, Layout>>,
+    groups: readonly DashboardGroupType[],
+    collapsedGroupIds: ReadonlySet<string>
+): Partial<Record<DashboardLayoutSize, Layout>> {
+    const collapsedGroups = groups.filter((group) => collapsedGroupIds.has(group.id))
+    const hiddenTileIds = new Set(collapsedGroups.flatMap((group) => group.member_tile_ids.map(String)))
+    const result: Partial<Record<DashboardLayoutSize, Layout>> = {}
+
+    for (const breakpoint of Object.keys(layouts) as DashboardLayoutSize[]) {
+        const source = layouts[breakpoint] ?? []
+        const groupByHeaderTileId = new Map(collapsedGroups.map((group) => [String(group.tile_id), group.id]))
+        const groupByMemberTileId = new Map(
+            collapsedGroups.flatMap((group) => group.member_tile_ids.map((tileId) => [String(tileId), group.id]))
+        )
+        const collapsedBandsByGroup = new Map<string, { y: number; bottom: number }>()
+
+        for (const layout of source) {
+            const headerGroupId = groupByHeaderTileId.get(layout.i)
+            if (headerGroupId) {
+                collapsedBandsByGroup.set(headerGroupId, { y: layout.y, bottom: layout.y + layout.h })
+            }
+        }
+        for (const layout of source) {
+            const memberGroupId = groupByMemberTileId.get(layout.i)
+            const band = memberGroupId ? collapsedBandsByGroup.get(memberGroupId) : null
+            if (band) {
+                band.bottom = Math.max(band.bottom, layout.y + layout.h)
+            }
+        }
+
+        const collapsedBands = [...collapsedBandsByGroup.values()]
+            .map(({ y, bottom }) => ({ y, hiddenHeight: Math.max(0, bottom - y - 1) }))
+            .sort((a, b) => a.y - b.y)
+        const displayYByTileId = new Map<string, number>()
+        let bandIndex = 0
+        let shift = 0
+
+        for (const layout of [...source].sort((a, b) => a.y - b.y || a.x - b.x)) {
+            while (bandIndex < collapsedBands.length && collapsedBands[bandIndex].y < layout.y) {
+                shift += collapsedBands[bandIndex].hiddenHeight
+                bandIndex += 1
+            }
+            displayYByTileId.set(layout.i, layout.y - shift)
+        }
+
+        result[breakpoint] = source
+            .filter((layout) => !hiddenTileIds.has(layout.i))
+            .map((layout) => ({ ...layout, y: displayYByTileId.get(layout.i) ?? layout.y }))
+    }
+
+    return result
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2489,6 +2489,7 @@ export interface DashboardTile<T = InsightModel> extends Tileable {
     text?: TextModel
     button_tile?: ButtonTileModel
     widget?: DashboardWidgetModel
+    parent_group_id?: string | null
     deleted?: boolean
     is_cached?: boolean
     order?: number
@@ -2682,8 +2683,17 @@ export interface DashboardTemplateListParams {
 
 export type DashboardTemplateScope = 'team' | 'global' | 'feature_flag' | 'organization'
 
+export interface DashboardGroupType {
+    id: string
+    name: string
+    tile_id: number
+    layouts: Partial<Record<DashboardLayoutSize, TileLayout>>
+    member_tile_ids: number[]
+}
+
 export interface DashboardType<T = InsightModel> extends DashboardBasicType {
     tiles: DashboardTile<T>[]
+    groups?: DashboardGroupType[]
     filters: DashboardFilter
     variables?: Record<string, HogQLVariable>
     persisted_filters?: DashboardFilter | null


### PR DESCRIPTION
## Problem

The group API from #82833 exists, but the dashboard still lays every tile out flat.

Editors with the `dashboard-groups` flag on cannot create or collapse groups in the grid.

## Changes

- Group headers render on the existing react-grid-layout. There is no nested grid.
- The Add menu includes Group when the flag is on.
- Dragging a tile in or out of a group updates membership.
- Collapse hides member tiles in localStorage and does not persist to the server.
- Deleting a group can delete its tiles or move them to ungrouped.

No screenshot. This session did not render the dashboard in a browser.

## How did you test this code?

- `tileLayouts.test.ts` catches collapse packing members below their header, including mixed grouped and ungrouped tiles.
- `dashboardLogic.test.ts` catches header layout persistence on save and the group mutation URLs.
- Callers still use handwritten `DashboardGroupType` and `api.create`. Generated `DashboardGroupApi` from #82833 is not wired yet.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Feature remains gated.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Cursor implemented the grid on top of #82833.
- Skills: `/writing-ui-components`, `/writing-kea-logics`, `/writing-user-facing-copy`, `/adopting-generated-api-types`, `/writing-tests`, `/writing-pr-descriptions`, `/stacking-prs`.
- `/adopting-generated-api-types` was deferred. The handwritten types should switch to `dashboardsGroupsCreate` and friends in a follow-up.