### PR TITLE
fix(openai_ads): stop reporting body-flagged server errors as bugs

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/openai_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/openai_ads/source.py
@@ -95,6 +95,12 @@ Create an API key in the Settings tab of [OpenAI Ads Manager](https://ads.openai
         return {
             f"for {OPENAI_ADS_BASE_URL}",
             f"from {OPENAI_ADS_BASE_URL}",
+            # A 400 response whose body labels itself `code=server_error` (appended by
+            # `_error_identity` in rest_client.py) is a backend blip on OpenAI's side reported
+            # through an unusual status code — 400s fall outside the 429/5xx range this client
+            # retries in-process, so the body is the only transience signal available. Trust it,
+            # the same way Meta Ads trusts its own documented error codes over raw HTTP status.
+            "code=server_error",
         }
 
     def get_schemas(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/openai_ads/tests/test_openai_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/openai_ads/tests/test_openai_ads_source.py
@@ -146,6 +146,10 @@ class TestRetryableErrors:
                 "malformed_json",
                 "Malformed JSON response from https://api.ads.openai.com/v1/campaigns: Expecting value: line 1 column 1 (char 0)",
             ),
+            (
+                "body_reported_server_error",
+                "400 Client Error: Bad Request for url: https://api.ads.openai.com/v1/ads?ad_group_id=adgrp_123&limit=500&order=asc | api error: code=server_error",
+            ),
         ]
     )
     def test_exhausted_transient_failures_are_recognized(self, _name: str, observed_error: str) -> None:
@@ -161,6 +165,10 @@ class TestRetryableErrors:
             (
                 "not_found",
                 "404 Client Error: Not Found for url: https://api.ads.openai.com/v1/campaigns/123",
+            ),
+            (
+                "genuine_bad_request",
+                "400 Client Error: Bad Request for url: https://api.ads.openai.com/v1/campaigns | api error: code=invalid_request_error",
             ),
         ]
     )


### PR DESCRIPTION
## Problem

An OpenAI Ads sync failed with a plain `HTTPError` and got reported to error tracking as a bug, even though the underlying cause was OpenAI's own backend having a transient issue.

- OpenAI's Ads API can return a `400 Bad Request` whose JSON body labels itself `code=server_error` on campaign/ad group/ad listing requests.
- A 400 status falls outside the 429/5xx range the shared REST client retries in-process, so this exception escaped straight to the activity as an unclassified error.
- Temporal's activity retry policy already retries it regardless of classification, but leaving it unclassified means every occurrence gets logged at `exception` level and paged as a new error tracking issue.

## Changes

- Add the substring `code=server_error` to `OpenAIAdsSource.get_retryable_errors()`, so the source-classification layer recognizes this as an expected transient blip (logged at `warning`, kept out of error tracking) instead of a bug, mirroring how the Meta Ads source trusts its own documented error codes over raw HTTP status.
- Left `get_non_retryable_errors()` untouched: this is not a permanent, user-actionable failure, so it should keep being retried, not stopped.

## How did you test this code?

- Added parameterized test cases to `TestRetryableErrors` in `test_openai_ads_source.py`: one asserting a `400 ... code=server_error` message is recognized as retryable, and one asserting a `400 ... code=invalid_request_error` message (a genuine client error) is not misclassified.
- Ran the full `test_openai_ads_source.py` suite locally: 32 passed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal error-classification change, no user-facing or documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) triaged a live error tracking issue for the `openai_ads` warehouse source (`HTTPError: 400 ... | api error: code=server_error`), confirmed the failing frames are in `openai_ads.py`'s fan-out pagination, and traced how `_error_identity()` in `rest_client.py` appends the vendor's own error body to the exception message. I confirmed via the retry/classification code path in `import_data_sync.py` that Temporal already retries unclassified errors, so this change only affects error-tracking noise and log level, not actual retry behavior. No skills were invoked for this change beyond the standard test-writing conventions already present in the file.