### PR TITLE
fix(aio): cap heavy payload fields in eval-report get_generation_detail

### DIFF
--- a/posthog/temporal/ai_observability/eval_reports/report_agent/test/test_tools_ai_events_routing.py
+++ b/posthog/temporal/ai_observability/eval_reports/report_agent/test/test_tools_ai_events_routing.py
@@ -8,10 +8,13 @@ other query sites in `tools.py` deliberately stay on `events` directly via
 rationale).
 """
 
+import json
 from typing import cast
 
 from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
+
+from parameterized import parameterized
 
 from posthog.hogql import ast
 
@@ -169,6 +172,60 @@ class TestGetGenerationDetailRoutesThroughResolver(BaseTest):
             result = _get_detail_fn(state=_state(self.team.id), generation_id="not-a-uuid")
             assert "error" in result.lower()
             assert mock_resolver.call_count == 0
+
+
+class TestGetGenerationDetailTruncation(BaseTest):
+    """The heavy payload fields are snippet-capped by default and returned whole only on full=true.
+
+    Guards the context-cost regression: without the cap, a single deep-dive inlines the entire
+    prompt/response (tens of thousands of chars) into the agent's context on every subsequent turn.
+    """
+
+    _HEAVY_FIELDS = ("input", "output", "tools_available", "input_state", "output_state")
+
+    def _big_row(self, blob: str) -> list:
+        from datetime import datetime
+
+        return [
+            _VALID_GEN_ID,
+            "gpt-4o",  # model
+            "openai",  # provider
+            blob,  # input
+            blob,  # output
+            10,  # input_tokens
+            5,  # output_tokens
+            0.001,  # cost
+            0.4,  # latency
+            "trace-1",
+            "https://api.openai.com/v1/",
+            datetime(2026, 4, 27, 7, 0),
+            False,  # is_error
+            None,  # error
+            None,  # tools_called
+            None,  # tool_call_count
+            blob,  # tools_available
+            blob,  # input_state
+            blob,  # output_state
+        ]
+
+    @parameterized.expand([("default", False), ("full", True)])
+    @patch("posthog.hogql_queries.ai.ai_table_resolver.query_ai_events")
+    @patch("posthog.hogql.query.execute_hogql_query")
+    @patch(_RESOLVE_PATH, return_value={_VALID_GEN_ID: "trace-1"})
+    def test_heavy_fields_capped_unless_full(self, _name, full, _mock_lookup, mock_events, mock_resolver):
+        blob = "x" * 5_000
+        mock_resolver.return_value = _resolver_response([self._big_row(blob)])
+        mock_events.return_value = MagicMock(results=[])
+
+        result = json.loads(_get_detail_fn(state=_state(self.team.id), generation_id=_VALID_GEN_ID, full=full))
+
+        for field in self._HEAVY_FIELDS:
+            if full:
+                assert result[field] == blob
+            else:
+                assert result[field].startswith("x" * 2_000)
+                assert "[truncated 3000 of 5000 chars" in result[field]
+                assert len(result[field]) < len(blob)
 
 
 class TestGetGenerationTextReprRoutesThroughResolver(BaseTest):

--- a/posthog/temporal/ai_observability/eval_reports/report_agent/tools.py
+++ b/posthog/temporal/ai_observability/eval_reports/report_agent/tools.py
@@ -71,6 +71,24 @@ _MAX_OPAQUE_ID_LENGTH = 255
 _MAX_TRACE_SAMPLE_IDS = 10
 _MAX_TRACE_SAMPLE_CHARS = 3_000
 _MAX_TRACE_DETAIL_CHARS = 12_000
+# Per-field cap for the heavy generation payloads (input/output/state/tools) in get_generation_detail.
+# These are the only unbounded fields the agent can pull, and they dominate context cost once inlined.
+_MAX_GENERATION_FIELD_CHARS = 2_000
+
+
+def _clip_generation_field(value: object, max_chars: int | None) -> str:
+    """Bound a heavy generation field, noting what was dropped so the agent can refetch if it needs to.
+
+    A max_chars of None disables clipping (the full=True path), preserving the raw payload verbatim.
+    """
+    text = str(value) if value else ""
+    if max_chars is None or len(text) <= max_chars:
+        return text
+    dropped = len(text) - max_chars
+    return (
+        f"{text[:max_chars]}… [truncated {dropped} of {len(text)} chars — "
+        f"call get_generation_detail again with full=true for the complete payload]"
+    )
 
 
 def _target_id_key(state: dict) -> str:
@@ -766,15 +784,25 @@ def sample_generation_details(
 def get_generation_detail(
     state: Annotated[dict, InjectedState],
     generation_id: str,
+    full: bool = False,
 ) -> str:
-    """Get full details for a single generation — no truncation.
+    """Get details for a single generation.
 
     Use this to deep-dive into a specific generation when the 500-char preview
     from sample_generation_details isn't enough to understand what happened.
-    Returns the complete input, output, all properties, and eval results.
+    Returns all metadata (model, tokens, cost, latency, eval results) losslessly.
+
+    The heavy payload fields (input, output, input_state, output_state, tools)
+    are truncated to a snippet by default — enough to tell what the generation
+    was doing without inlining tens of thousands of characters into context.
+    A truncation marker records the full length. Only when the snippet is
+    genuinely not enough, call again with full=true to get the complete,
+    untruncated payload for that same generation.
 
     Args:
         generation_id: The generation event UUID to look up
+        full: Return the complete untruncated input/output/state/tools payload
+            instead of the default snippet. Use sparingly — this can be very large.
     """
     team_id = state["team_id"]
 
@@ -891,12 +919,14 @@ def get_generation_detail(
             entry["score"] = er[4]
         evals.append(entry)
 
+    field_limit = None if full else _MAX_GENERATION_FIELD_CHARS
+
     result: dict = {
         "generation_id": str(row[0]) if row[0] else "",
         "model": str(row[1]) if row[1] else "",
         "provider": str(row[2]) if row[2] else "",
-        "input": str(row[3]) if row[3] else "",
-        "output": str(row[4]) if row[4] else "",
+        "input": _clip_generation_field(row[3], field_limit),
+        "output": _clip_generation_field(row[4], field_limit),
         "input_tokens": row[5],
         "output_tokens": row[6],
         "cost": row[7],
@@ -913,11 +943,11 @@ def get_generation_detail(
         result["tools_called"] = str(row[14])
         result["tool_call_count"] = row[15]
     if row[16]:  # tools_available
-        result["tools_available"] = str(row[16])
+        result["tools_available"] = _clip_generation_field(row[16], field_limit)
     if row[17]:  # input_state
-        result["input_state"] = str(row[17])
+        result["input_state"] = _clip_generation_field(row[17], field_limit)
     if row[18]:  # output_state
-        result["output_state"] = str(row[18])
+        result["output_state"] = _clip_generation_field(row[18], field_limit)
 
     return json.dumps(result, indent=2)
 


### PR DESCRIPTION
## Problem

An AI observability eval-report run could cost several times what it should, and the overrun scaled with report size. Investigating two flagged report traces, the cost was almost entirely the agent re-paying for context it had bloated earlier in the run.

- `get_generation_detail` inlined a target generation's raw `input`, `output`, `input_state`, `output_state`, and `tools` with no length cap.
- One deep-dive over a few example generations pushed the agent's context from about 11k to about 143k tokens in a single step.
- Every later turn then re-paid that context, so the report-writing phase, not the data gathering, dominated the run cost.

It is the lone heavy-field tool with no cap: `sample_generation_details` already truncates to 500 chars and `get_generation_text_repr` caps at 10k.

## Changes

- `get_generation_detail` now truncates the heavy payload fields to a 2k-char snippet by default, enough to tell what a generation was doing.
- All metadata (model, tokens, cost, latency, eval results) stays lossless, so the agent's cost and error reasoning is unaffected.
- A truncation marker records the full length so the agent knows text was dropped.
- A new `full=true` argument returns the complete untruncated payload for the rare case the snippet is not enough. Fetching it late is cache-safe, so the agent pays for the large blob once, on demand, instead of on every run.

I capped the fields rather than removing them from the tool because the agent does use the content (for example to tell a contract-comparison request apart from a retry), just not tens of thousands of characters of it.

## How did you test this code?

- Added `TestGetGenerationDetailTruncation`, a parameterized unit test covering the default (capped) and `full=true` (whole) paths. It catches the regression of the cap being dropped, or the full-text path ceasing to return the complete payload; no existing test exercised truncation, since they all use short payloads.
- Not run here: the database-backed test suite, because this sandbox has no Postgres. The new test is a standard `BaseTest` and runs in CI. I verified the truncation logic and its marker string in isolation.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually the PostHog Slack app, running Claude) wrote this from a Slack thread that started from an AI-spend signal on the eval-reports feature. I inspected the two flagged traces over MCP, traced the context blowup to the one unbounded tool, and made the change. Skills invoked: /writing-tests, /writing-pr-descriptions.

The signal also flagged a redundant final agent turn and a cache miss; those are separate and not addressed here. Batching the report-emit calls was considered and set aside, because prompt caching already makes the extra turns cheap once context is capped, so it trades resumability for little.


---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BLK2ZEUSH/p1786637053453599?thread_ts=1786637053.453599&cid=C0BLK2ZEUSH)*
