### PR TITLE
feat(data-catalog): put approved metric names in front of MCP agents

### DIFF
--- a/products/data_catalog/backend/presentation/serializers.py
+++ b/products/data_catalog/backend/presentation/serializers.py
@@ -28,6 +28,16 @@ class _FreeJSONField(serializers.JSONField):
     """A free-form JSON value (query results / query status shapes)."""
 
 
+@extend_schema_serializer(component_name="DataCatalogApprovedMetricNames")
+class ApprovedMetricNamesSerializer(serializers.Serializer):
+    """The team's canonical metric handles, small enough to prefetch into an agent's context."""
+
+    names = serializers.ListField(
+        child=serializers.CharField(help_text="A metric's run handle, as `data-catalog-metric-run` takes it."),
+        help_text="Names of the team's approved, non-drifted metrics, sorted. Empty when the team has approved none.",
+    )
+
+
 @extend_schema_serializer(component_name="DataCatalogMetricRun")
 class MetricRunResponseSerializer(serializers.Serializer):
     """Normalized envelope returned by the metric-run endpoint."""

--- a/products/data_catalog/backend/presentation/views.py
+++ b/products/data_catalog/backend/presentation/views.py
@@ -28,6 +28,7 @@ from ..facade import api
 from ..facade.enums import HOGQL_DEFINITION_KIND, INSIGHT_DEFINITION_KINDS, NODE_DEFINITION_KINDS
 from ..facade.models import Metric, RelationshipProposal, TableCertification
 from .serializers import (
+    ApprovedMetricNamesSerializer,
     CertificationCreateSerializer,
     CertificationSerializer,
     MetricRunQuerySerializer,
@@ -131,6 +132,24 @@ class MetricViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
     def perform_destroy(self, instance: Metric) -> None:
         api.soft_delete_metric(instance, cast(User, self.request.user), request=self.request)
+
+    @action(
+        detail=False,
+        methods=["GET"],
+        url_path="approved_names",
+        required_scopes=["data_catalog:read"],
+        pagination_class=None,
+        request=None,
+        responses={200: ApprovedMetricNamesSerializer},
+    )
+    def approved_names(self, request: Request, **kwargs) -> Response:
+        """List the names of this team's approved, non-drifted metrics.
+
+        Small and cheap on purpose: it is fetched to put the catalog in front of an agent before it
+        starts deriving a number, where the full metric list would not fit.
+        """
+        names = api.approved_metric_names_for_team(self.team, cast(User, request.user))
+        return Response(ApprovedMetricNamesSerializer({"names": names}).data)
 
     @action(
         detail=True,

--- a/products/data_catalog/backend/tests/test_api.py
+++ b/products/data_catalog/backend/tests/test_api.py
@@ -206,6 +206,16 @@ class TestMetricLifecycleAPI(APIBaseTest):
         assert self.client.post(f"{self.url}mrr/refresh_from_insight/").status_code == status.HTTP_200_OK
         assert self.client.post(f"{self.url}mrr/approve/").status_code == status.HTTP_200_OK
 
+    def test_approved_names_lists_only_approved_metrics(self) -> None:
+        upsert_metric(team=self.team, user=self.user, name="mrr", description="d", definition=_HOGQL)
+        upsert_metric(team=self.team, user=self.user, name="proposed_only", description="d", definition=_HOGQL)
+        self.client.post(f"{self.url}mrr/approve/")
+
+        response = self.client.get(f"{self.url}approved_names/")
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert response.json() == {"names": ["mrr"]}
+
     def _bearer(self, scopes: list[str]) -> dict:
         raw = generate_random_token_personal()
         PersonalAPIKey.objects.create(label="k", user=self.user, secure_value=hash_key_value(raw), scopes=scopes)

--- a/products/data_catalog/frontend/generated/api.schemas.ts
+++ b/products/data_catalog/frontend/generated/api.schemas.ts
@@ -424,6 +424,14 @@ export interface DataCatalogMetricRunApi {
     instructions: string | null
 }
 
+/**
+ * The team's canonical metric handles, small enough to prefetch into an agent's context.
+ */
+export interface DataCatalogApprovedMetricNamesApi {
+    /** Names of the team's approved, non-drifted metrics, sorted. Empty when the team has approved none. */
+    names: string[]
+}
+
 export interface DataCatalogRelationshipProposalApi {
     readonly id: string
     /**

--- a/products/data_catalog/frontend/generated/api.ts
+++ b/products/data_catalog/frontend/generated/api.ts
@@ -10,6 +10,7 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
  */
 import type {
     CertificationCreateApi,
+    DataCatalogApprovedMetricNamesApi,
     DataCatalogCertificationApi,
     DataCatalogCertificationsListParams,
     DataCatalogMetricApi,
@@ -370,6 +371,26 @@ export const dataCatalogMetricsRunCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(dataCatalogMetricRunRequestApi),
+    })
+}
+
+export const getDataCatalogMetricsApprovedNamesRetrieveUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/data_catalog/metrics/approved_names/`
+}
+
+/**
+ * List the names of this team's approved, non-drifted metrics.
+ *
+ * Small and cheap on purpose: it is fetched to put the catalog in front of an agent before it
+ * starts deriving a number, where the full metric list would not fit.
+ */
+export const dataCatalogMetricsApprovedNamesRetrieve = async (
+    projectId: string,
+    options?: RequestInit
+): Promise<DataCatalogApprovedMetricNamesApi> => {
+    return apiMutator<DataCatalogApprovedMetricNamesApi>(getDataCatalogMetricsApprovedNamesRetrieveUrl(projectId), {
+        ...options,
+        method: 'GET',
     })
 }
 

--- a/products/data_catalog/mcp/tools.yaml
+++ b/products/data_catalog/mcp/tools.yaml
@@ -178,6 +178,9 @@ tools:
         rename_params:
             name: new_name
         feature_flag: product-data-catalog
+    data-catalog-metrics-approved-names-retrieve:
+        operation: data_catalog_metrics_approved_names_retrieve
+        enabled: false
     data-catalog-metrics-destroy:
         operation: data_catalog_metrics_destroy
         enabled: false

--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -1464,6 +1464,17 @@ export class ApiClient {
         return result.data
     }
 
+    /** Names of the project's approved, non-drifted canonical metrics. */
+    async getApprovedMetricNames(projectId: string): Promise<string[]> {
+        const result = await this.fetchJson<Schemas.DataCatalogApprovedMetricNames>(
+            `${this.baseUrl}/api/projects/${projectId}/data_catalog/metrics/approved_names/`
+        )
+        if (!result.success) {
+            throw new Error(result.error.message)
+        }
+        return result.data.names
+    }
+
     /** Every third-party MCP tool the caller can reach, across all their gateway connections. */
     async getGatewayTools(projectId: string): Promise<Schemas.AvailableToolsResponse> {
         const result = await this.fetchJson<Schemas.AvailableToolsResponse>(

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -18737,6 +18737,14 @@ export namespace Schemas {
       error: string | null;
     }
 
+    /**
+     * The team's canonical metric handles, small enough to prefetch into an agent's context.
+     */
+    export interface DataCatalogApprovedMetricNames {
+      /** Names of the team's approved, non-drifted metrics, sorted. Empty when the team has approved none. */
+      names: string[];
+    }
+
     export interface DataCatalogCertification {
       readonly id: string;
       /**

--- a/services/mcp/src/hono/instructions.ts
+++ b/services/mcp/src/hono/instructions.ts
@@ -67,6 +67,7 @@ export class InstructionsBuilder {
             metadata: state.metadata,
             groupTypes: state.groupTypes,
             dataCatalogEnabled: state.toolFeatureFlags?.[PRODUCT_DATA_CATALOG_FLAG] === true,
+            approvedMetricNames: state.approvedMetricNames,
         }
     }
 
@@ -77,7 +78,7 @@ export class InstructionsBuilder {
         return {
             name: 'exec',
             title: 'Execute PostHog command',
-            description: this.formatter.buildExecToolDescription(),
+            description: this.formatter.buildExecToolDescription(this.buildContext(state)),
             inputSchema: { type: 'object', properties: ExecSchema, required: ['command'] },
         }
     }
@@ -133,8 +134,8 @@ export class InstructionsBuilder {
         return new ExecHelpCatalog(this.formatter.buildClaudeExecHelpEntries(this.buildContext(state)))
     }
 
-    buildExecToolDescription(): string {
-        return this.formatter.buildExecToolDescription()
+    buildExecToolDescription(state?: ResolvedState): string {
+        return this.formatter.buildExecToolDescription(state ? this.buildContext(state) : undefined)
     }
 
     getGuidelines(): string {

--- a/services/mcp/src/hono/request-state-resolver.ts
+++ b/services/mcp/src/hono/request-state-resolver.ts
@@ -12,12 +12,12 @@ import {
 import type { RequestProperties } from '@/lib/request-properties'
 import { filterStaffOnlyTools } from '@/lib/staff-only-tools'
 import type { McpMode } from '@/lib/utils'
-import { getRequiredFeatureFlags, getScopeGatedTools, type ScopeGatedTool } from '@/tools/toolDefinitions'
 import { TASKS_CONTEXT_TOOL_NAMES } from '@/tools/tasksContext'
+import { getRequiredFeatureFlags, getScopeGatedTools, type ScopeGatedTool } from '@/tools/toolDefinitions'
 import type { Context, Tool, Env, ZodObjectAny } from '@/tools/types'
 
-import type { RedisLike } from './cache/RedisCache'
 import { McpSessionRedisStore } from './cache/McpSessionRedisStore'
+import type { RedisLike } from './cache/RedisCache'
 import {
     buildMCPRequestContext,
     getEffectiveMCPClientContext,
@@ -60,6 +60,10 @@ export interface ResolvedState {
     // reference. Resolved once here so every render path reads the same source.
     metadata: string | undefined
     groupTypes: GroupType[] | undefined
+    // The project's approved canonical metric names, prefetched so the instructions can name them
+    // instead of telling the agent to go look. Only read when the data catalog is on for this
+    // caller, so a catalog-off request pays nothing and renders exactly as it did before.
+    approvedMetricNames: string[] | undefined
 }
 
 // ─── Pure helpers ───
@@ -223,11 +227,14 @@ export class RequestStateResolver {
         // only exists in single-exec mode — skip the extra scan otherwise.
         const scopeGatedTools = useSingleExec ? getScopeGatedTools(apiKeyScopes, filterOptions) : []
 
-        const [groupTypes, metadata] = await Promise.all([
+        const [groupTypes, metadata, approvedMetricNames] = await Promise.all([
             cachedProjectId && hasScope(apiKeyScopes, 'group:read')
                 ? context.stateManager.getOrFetchGroupTypes(cachedProjectId).catch(() => undefined)
                 : undefined,
             context.stateManager.getEnvironmentPrompt(),
+            cachedProjectId && toolFeatureFlags[PRODUCT_DATA_CATALOG_FLAG] === true
+                ? context.stateManager.getOrFetchApprovedMetricNames(cachedProjectId).catch(() => undefined)
+                : undefined,
         ])
 
         return {
@@ -246,6 +253,7 @@ export class RequestStateResolver {
             renderUiEnabled,
             metadata,
             groupTypes,
+            approvedMetricNames,
         }
     }
 

--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -509,7 +509,7 @@ export class ToolExecutor {
         const execTool = createExecTool(
             execTools,
             state.context,
-            this.instructionsBuilder.buildExecToolDescription(),
+            this.instructionsBuilder.buildExecToolDescription(state),
             commandReference,
             clientContext.mcpConsumer,
             trackInnerCall,

--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -1,4 +1,5 @@
 import type { ApiClient, GroupType } from '@/api/client'
+import type { Schemas } from '@/api/generated'
 import { hasScope } from '@/lib/api'
 import type { ScopedCache } from '@/lib/cache/ScopedCache'
 import {
@@ -11,7 +12,6 @@ import {
 import { buildActiveEnvironmentContextPrompt } from '@/lib/instructions'
 import { getPostHogClient } from '@/lib/posthog'
 import { sanitizeHeaderValue } from '@/lib/utils'
-import type { Schemas } from '@/api/generated'
 import type { ApiUser } from '@/schema/api'
 import type { CachedOrg, CachedProject, CachedUser, State } from '@/tools/types'
 
@@ -406,6 +406,16 @@ export class StateManager {
             fetchedAtKey: `gatewayToolsFetchedAt:${projectId}` as const,
             fetcher: () => this._api.getGatewayTools(projectId),
             ttlMs: GATEWAY_TOOLS_CACHE_TTL_MS,
+        })
+    }
+
+    /** The project's approved canonical metric names, for prefetching into the agent's context. */
+    async getOrFetchApprovedMetricNames(projectId: string): Promise<string[] | undefined> {
+        return this.getOrFetchCached({
+            name: 'approved_metric_names',
+            cacheKey: `approvedMetricNames:${projectId}` as const,
+            fetchedAtKey: `approvedMetricNamesFetchedAt:${projectId}` as const,
+            fetcher: () => this._api.getApprovedMetricNames(projectId),
         })
     }
 

--- a/services/mcp/src/lib/instructions-formatter.ts
+++ b/services/mcp/src/lib/instructions-formatter.ts
@@ -1,6 +1,7 @@
 import type { GroupType } from '@/api/client'
 import { MCP_INSTRUCTIONS_CHAR_BUDGET } from '@/lib/constants'
 import {
+    buildApprovedMetricsBlock,
     buildAvailableToolsBlock,
     buildDefinedGroupsBlock,
     buildQueryToolsBlock,
@@ -34,6 +35,12 @@ import TOOL_SEARCH from '@/templates/sections/tool-search.md'
 import URL_PATTERNS from '@/templates/sections/url-patterns.md'
 import { type ExecHelpEntry, LEARN_COMMAND_LINE } from '@/tools/exec-help'
 
+/** Carries its own leading separator, so a catalog-off render stays byte-identical. */
+const CATALOG_FIRST_LINE =
+    "\n\nFor a named business or operational measure, check this project's approved metrics before " +
+    'deriving the number: run an approved match with `data-catalog-metric-run`, and label anything ' +
+    'you derive yourself noncanonical.'
+
 export interface InstructionsContext {
     guidelines: string
     groupTypes?: GroupType[] | undefined
@@ -48,6 +55,10 @@ export interface InstructionsContext {
      *  for this org. Gates the metric-discovery section so flag-off renders never steer
      *  the model at a table it can't query — and stay byte-identical. */
     dataCatalogEnabled?: boolean | undefined
+    /** The project's approved canonical metric names, prefetched. Undefined when the catalog
+     *  is off or the read failed; an empty array is a project with none approved, which is
+     *  worth saying out loud so the agent doesn't go looking. */
+    approvedMetricNames?: string[] | undefined
 }
 
 /**
@@ -104,8 +115,10 @@ export class InstructionsFormatter {
     }
 
     /** Build the top-level description of the `posthog:exec` tool. */
-    buildExecToolDescription(): string {
-        return EXEC_TOOL_BLURB.trim()
+    buildExecToolDescription(ctx?: InstructionsContext): string {
+        return formatPrompt(EXEC_TOOL_BLURB, {
+            catalog_first: ctx?.dataCatalogEnabled ? CATALOG_FIRST_LINE : '',
+        })
     }
 
     /**
@@ -122,17 +135,18 @@ export class InstructionsFormatter {
                 description: ctx.dataCatalogEnabled
                     ? 'Query or analyze PostHog data; governed metrics, certified tables, and verified joins live in the catalog.'
                     : 'Query or analyze PostHog data, metrics, and events.',
-                content: this.compose(
-                    [
-                        ...(ctx.dataCatalogEnabled ? [METRIC_DISCOVERY] : []),
-                        RETRIEVING_DATA,
-                        SCHEMA_WORKFLOW,
-                        ...(ctx.dataCatalogEnabled ? [CATALOG_TRUST_DISCOVERY] : []),
-                        EXAMPLES,
-                    ],
-                    ctx,
-                    { compact: false }
-                ),
+                content:
+                    this.compose(
+                        [
+                            ...(ctx.dataCatalogEnabled ? [METRIC_DISCOVERY] : []),
+                            RETRIEVING_DATA,
+                            SCHEMA_WORKFLOW,
+                            ...(ctx.dataCatalogEnabled ? [CATALOG_TRUST_DISCOVERY] : []),
+                            EXAMPLES,
+                        ],
+                        ctx,
+                        { compact: false }
+                    ) + buildApprovedMetricsBlock(ctx.approvedMetricNames),
             },
         ]
 
@@ -168,6 +182,9 @@ export class InstructionsFormatter {
         const helpEntries = this.buildClaudeExecHelpEntries(ctx)
         const helpTopics = helpEntries.map((entry) => `- ${entry.id}: ${entry.description}`).join('\n')
         const helpSection = formatPrompt(EXEC_LEARN, { help_topics: helpTopics })
+        // The metric listing is deliberately absent here and rides the `analytics` learn topic
+        // instead: this reference counts against claude.ai's hard schema cap (see the budget test)
+        // and there is not enough headroom left for a listing that can run to hundreds of chars.
         const renderCtx: InstructionsContext = {
             guidelines: ctx.guidelines,
             metadata: ctx.metadata,
@@ -239,7 +256,13 @@ export class InstructionsFormatter {
             ? {
                   guidelines: ctx.guidelines,
                   queryTools: ctx.queryTools,
-                  ...(opts.keepEnvContext ? { metadata: ctx.metadata, groupTypes: ctx.groupTypes } : {}),
+                  ...(opts.keepEnvContext
+                      ? {
+                            metadata: ctx.metadata,
+                            groupTypes: ctx.groupTypes,
+                            approvedMetricNames: ctx.approvedMetricNames,
+                        }
+                      : {}),
               }
             : { ...ctx, tools: undefined }
         // Tool domains are temporarily omitted from the command reference while we
@@ -271,6 +294,8 @@ export class InstructionsFormatter {
             guidelines: ctx.guidelines.trim(),
             available_tools: buildAvailableToolsBlock(ctx.renderUiEnabled),
             defined_groups: buildDefinedGroupsBlock(ctx.groupTypes),
+            approved_metrics: buildApprovedMetricsBlock(ctx.approvedMetricNames),
+            catalog_first: ctx.dataCatalogEnabled ? CATALOG_FIRST_LINE : '',
             metadata: ctx.metadata?.trim() ?? '',
             tool_domains: ctx.tools ? renderToolDomains(ctx.tools) : '',
             query_tools: ctx.queryTools ? buildQueryToolsBlock(ctx.queryTools) : '',

--- a/services/mcp/src/lib/instructions.ts
+++ b/services/mcp/src/lib/instructions.ts
@@ -8,6 +8,48 @@ export function buildDefinedGroupsBlock(groupTypes?: GroupType[]): string {
     return `Defined group types: ${groupTypes.map((gt) => gt.group_type).join(', ')}`
 }
 
+const APPROVED_METRICS_MAX_CHARS = 600
+
+/**
+ * The project's canonical metric names, already fetched so the agent doesn't have to remember to look.
+ *
+ * Both branches carry their own leading separator, so a render with no catalog (the names are only
+ * fetched when the product flag is on) stays byte-identical to one from before this existed.
+ * Names are identifier-safe by validation, so the listing needs no escaping.
+ */
+export function buildApprovedMetricsBlock(approvedMetricNames?: string[]): string {
+    if (!approvedMetricNames) {
+        return ''
+    }
+    if (approvedMetricNames.length === 0) {
+        return (
+            '\n\nThis project has approved no canonical metrics, so there is nothing to look up: ' +
+            'derive numbers with the normal workflow and label them noncanonical.'
+        )
+    }
+    return (
+        `\n\nApproved canonical metrics in this project: ${listNamesWithinBudget(approvedMetricNames)}. ` +
+        'When one of them answers the question, run it with `data-catalog-metric-run` rather than ' +
+        'deriving the number yourself, and read its full definition from ' +
+        '`system.information_schema.metrics`. Label anything you derive yourself noncanonical.'
+    )
+}
+
+function listNamesWithinBudget(names: string[]): string {
+    const listed: string[] = []
+    let length = 0
+    for (const name of names) {
+        const cost = name.length + 4 // backticks plus a ", " separator
+        if (length + cost > APPROVED_METRICS_MAX_CHARS) {
+            break
+        }
+        listed.push(`\`${name}\``)
+        length += cost
+    }
+    const omitted = names.length - listed.length
+    return omitted > 0 ? `${listed.join(', ')} (+${omitted} more)` : listed.join(', ')
+}
+
 export function buildActiveEnvironmentContextPrompt(
     user?: CachedUser,
     org?: CachedOrg,

--- a/services/mcp/src/templates/sections/env-context.md
+++ b/services/mcp/src/templates/sections/env-context.md
@@ -1,3 +1,3 @@
 {defined_groups}
 
-{metadata}
+{metadata}{approved_metrics}

--- a/services/mcp/src/templates/sections/exec-tool-blurb.md
+++ b/services/mcp/src/templates/sections/exec-tool-blurb.md
@@ -2,7 +2,7 @@
 
 PostHog makes your product self-driving: it reads your data and ships changes with you, never without you. Spans analytics, experiments, flags, replay, and more.
 
-Pass CLI-style commands in the `command` parameter for all PostHog interactions.
+Pass CLI-style commands in the `command` parameter for all PostHog interactions.{catalog_first}
 
 **Requirements**
 

--- a/services/mcp/src/tools/types.ts
+++ b/services/mcp/src/tools/types.ts
@@ -41,7 +41,9 @@ export type State = {
     Record<PrefixedString<'cachedProject'>, CachedProject | undefined> &
     Record<PrefixedString<'cachedProjectFetchedAt'>, number | undefined> &
     Record<PrefixedString<'gatewayTools'>, Schemas.AvailableToolsResponse | undefined> &
-    Record<PrefixedString<'gatewayToolsFetchedAt'>, number | undefined>
+    Record<PrefixedString<'gatewayToolsFetchedAt'>, number | undefined> &
+    Record<PrefixedString<'approvedMetricNames'>, string[] | undefined> &
+    Record<PrefixedString<'approvedMetricNamesFetchedAt'>, number | undefined>
 
 export type Env = {
     /**

--- a/services/mcp/tests/hono/analytics.test.ts
+++ b/services/mcp/tests/hono/analytics.test.ts
@@ -67,6 +67,7 @@ function makeState(overrides: Partial<ResolvedState> = {}): ResolvedState {
         renderUiEnabled: false,
         metadata: undefined,
         groupTypes: undefined,
+        approvedMetricNames: undefined,
         ...overrides,
     }
 }

--- a/services/mcp/tests/hono/request-state-resolver.test.ts
+++ b/services/mcp/tests/hono/request-state-resolver.test.ts
@@ -67,6 +67,7 @@ vi.mock('@/hono/request-context', () => {
                         getAiConsentGiven: vi.fn(async () => undefined),
                         getOrFetchGroupTypes: vi.fn(async () => undefined),
                         getEnvironmentPrompt: vi.fn(async () => undefined),
+                        getOrFetchApprovedMetricNames: vi.fn(async () => undefined),
                         getAvailableFeatures: vi.fn(async () => undefined),
                     },
                 })),

--- a/services/mcp/tests/hono/tool-executor-intent.test.ts
+++ b/services/mcp/tests/hono/tool-executor-intent.test.ts
@@ -72,6 +72,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
         renderUiEnabled: false,
         metadata: undefined,
         groupTypes: undefined,
+        approvedMetricNames: undefined,
         ...overrides,
     }
 }

--- a/services/mcp/tests/hono/tool-executor-metrics.test.ts
+++ b/services/mcp/tests/hono/tool-executor-metrics.test.ts
@@ -104,6 +104,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
         renderUiEnabled: false,
         metadata: undefined,
         groupTypes: undefined,
+        approvedMetricNames: undefined,
         ...overrides,
     }
 }

--- a/services/mcp/tests/hono/tool-executor-tokens.test.ts
+++ b/services/mcp/tests/hono/tool-executor-tokens.test.ts
@@ -75,6 +75,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
         renderUiEnabled: false,
         metadata: undefined,
         groupTypes: undefined,
+        approvedMetricNames: undefined,
         ...overrides,
     }
 }

--- a/services/mcp/tests/hono/tool-executor.test.ts
+++ b/services/mcp/tests/hono/tool-executor.test.ts
@@ -70,6 +70,7 @@ function makeState(tools: { name: string }[], overrides: Partial<ResolvedState> 
         renderUiEnabled: false,
         metadata: undefined,
         groupTypes: undefined,
+        approvedMetricNames: undefined,
         ...overrides,
     }
 }

--- a/services/mcp/tests/unit/instructions-formatter-snapshot.test.ts
+++ b/services/mcp/tests/unit/instructions-formatter-snapshot.test.ts
@@ -187,6 +187,10 @@ describe('InstructionsFormatter prompt snapshots', () => {
             name_singular: null,
             name_plural: null,
         })) as GroupType[]
+        // A catalog whose names alone overrun the listing budget. There is not enough headroom
+        // under the cap for that listing, which is why it rides the `analytics` learn topic
+        // instead; this pins that decision, since wiring it back here blows the budget.
+        const worstCaseApprovedMetricNames = Array.from({ length: 50 }, (_, i) => `${'m'.repeat(120)}_${i}`)
         const state = {
             allTools: Object.keys(getToolDefinitions()).map((name) => ({ name })),
             clientProfile: new MCPClientProfile({ vendorClient: 'ClaudeAI', userAgent: 'Claude-User' }),
@@ -196,6 +200,7 @@ describe('InstructionsFormatter prompt snapshots', () => {
             renderUiEnabled: true,
             metadata: worstCaseMetadata,
             groupTypes: worstCaseGroupTypes,
+            approvedMetricNames: worstCaseApprovedMetricNames,
         } as unknown as ResolvedState
         const entry = new InstructionsBuilder('').buildExecToolEntry(state)
         const posthog = new PostHogMCP('phc_test', { disabled: true })

--- a/services/mcp/tests/unit/instructions-formatter.test.ts
+++ b/services/mcp/tests/unit/instructions-formatter.test.ts
@@ -165,6 +165,52 @@ describe('InstructionsFormatter', () => {
             expect(result).not.toContain('### Basic functionality')
             expect(result).not.toContain('### Examples')
         })
+
+        it.each([
+            ['on', true, true],
+            ['off', false, false],
+            ['unresolved', undefined, false],
+        ])('carries the catalog-first line only with the catalog %s', (_name, dataCatalogEnabled, expected) => {
+            const formatter = new InstructionsFormatter()
+            const result = formatter.buildExecToolDescription({ ...fullCtx, dataCatalogEnabled })
+            expect(result.includes('data-catalog-metric-run')).toBe(expected)
+        })
+    })
+
+    // The prefetched names are the whole point of the block: an agent that already has them
+    // doesn't have to remember to look the catalog up before deriving a number. They have to
+    // reach every render path, since the paths differ per client.
+    describe('approved metrics in env context', () => {
+        it.each([
+            ['tools-mode', (f: InstructionsFormatter, c: InstructionsContext) => f.buildToolsInstructions(c)],
+            [
+                'exec command reference',
+                (f: InstructionsFormatter, c: InstructionsContext) =>
+                    f.buildExecCommandReference(c, { stripEnvContext: true, keepEnvContext: true }),
+            ],
+            [
+                "claude.ai's analytics learn topic",
+                (f: InstructionsFormatter, c: InstructionsContext) =>
+                    f.buildClaudeExecHelpEntries(c).find((entry) => entry.id === 'analytics')?.content ?? '',
+            ],
+        ])('names the approved metrics in the %s render', (_name, render) => {
+            const formatter = new InstructionsFormatter()
+            const ctx = { ...fullCtx, dataCatalogEnabled: true, approvedMetricNames: ['mrr'] }
+
+            const result = render(formatter, ctx)
+
+            expect(result).toContain('Approved canonical metrics in this project: `mrr`')
+            expect(result).not.toContain('{approved_metrics}')
+        })
+
+        it('renders no metrics block at all when the catalog was never read', () => {
+            const formatter = new InstructionsFormatter()
+
+            const result = formatter.buildToolsInstructions({ ...fullCtx, dataCatalogEnabled: true })
+
+            expect(result).not.toContain('Approved canonical metrics')
+            expect(result).not.toContain('approved no canonical metrics')
+        })
     })
 
     describe('buildExecCommandReference', () => {

--- a/services/mcp/tests/unit/instructions.test.ts
+++ b/services/mcp/tests/unit/instructions.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import type { GroupType } from '@/api/client'
 import {
     buildActiveEnvironmentContextPrompt,
+    buildApprovedMetricsBlock,
     buildDefinedGroupsBlock,
     buildQueryToolsBlock,
     buildToolDomainsBlock,
@@ -40,6 +41,33 @@ describe('buildDefinedGroupsBlock', () => {
 
     it('should return empty string for empty array', () => {
         expect(buildDefinedGroupsBlock([])).toBe('')
+    })
+})
+
+describe('buildApprovedMetricsBlock', () => {
+    it('renders nothing when the catalog was never read', () => {
+        expect(buildApprovedMetricsBlock(undefined)).toBe('')
+    })
+
+    it('says so when the project has approved none, so the agent does not go looking', () => {
+        const result = buildApprovedMetricsBlock([])
+        expect(result).toContain('approved no canonical metrics')
+        expect(result).toContain('noncanonical')
+    })
+
+    it('names the metrics and points at the run tool', () => {
+        const result = buildApprovedMetricsBlock(['arr', 'mrr'])
+        expect(result).toContain('`arr`, `mrr`')
+        expect(result).toContain('data-catalog-metric-run')
+    })
+
+    it('truncates a long catalog and counts what it dropped', () => {
+        const names = Array.from({ length: 40 }, (_, i) => `metric_with_a_long_name_${i}`)
+        const result = buildApprovedMetricsBlock(names)
+
+        expect(result).toContain('metric_with_a_long_name_0')
+        expect(result).toMatch(/\(\+\d+ more\)/)
+        expect(result.length).toBeLessThan(1000)
     })
 })
 


### PR DESCRIPTION
## Problem

An agent only checks the data catalog if it remembers to, and the reminder does not reach every client: claude.ai drops MCP instructions and Codex is sent none. So agents derive governed numbers by hand and report them as if they were canonical.

The one fix that has worked so far was structural rather than prose. The Signals scouts stopped bypassing the catalog once their prompts carried the approved metric names outright.

This generalizes that to every MCP client: an agent that already has the names does not have to remember to look.

## Changes

- The MCP env context now names the project's approved metrics, so tools-mode, the exec command reference, and claude.ai's `learn analytics` topic all carry them.
- A project with no approved metrics gets a sentence saying so. Silence is what made "check the catalog first" untrustworthy: an agent that looked and found nothing learned to stop looking.
- `GET /api/projects/:id/data_catalog/metrics/approved_names/` returns the names, gated on `data_catalog:read`.
- The MCP service fetches that once per session, caches it for 10 minutes, and keeps the last known value when the read fails.
- A request with the data catalog flag off fetches nothing and renders byte-identically to before.
- The exec tool description gains one catalog-first sentence, also only with the flag on.

The listing stays off claude.ai's exec command reference on purpose. That schema is hard-capped at 16,384 characters and had about 140 characters of headroom, far less than a listing needs, and crossing the cap silently drops the whole tool. The names ride the uncapped `learn analytics` topic instead. The budget test now carries a worst-case listing in its fixture, so wiring it back into the capped surface fails the test.

No visual change: this PR touches no UI.

## How did you test this code?

- `tests/unit/instructions.test.ts` covers the block itself: nothing rendered when the catalog was never read, the empty-catalog sentence, the name listing, and truncation with a dropped count.
- `tests/unit/instructions-formatter.test.ts` covers the wiring, which is where this can silently regress. Each render path is built separately per client, so a name that reaches tools-mode proves nothing about Codex or claude.ai.
- `tests/unit/instructions-formatter-snapshot.test.ts` keeps the flag-off renders byte-identical and pins the claude.ai schema budget under a worst-case catalog.
- `products/data_catalog/backend/tests/test_api.py` asserts the endpoint lists approved metrics only.
- Not run: the hono integration and worker suites beyond the local run, and no manual exercise against a live MCP client.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude Opus 5, in Claude Code) wrote this from a plan Thiago supplied. Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-pr-descriptions`.

The plan put the metric listing in claude.ai's exec command reference. The budget test rejected that at 17,122 characters against a 16,384 cap, so the listing moved to the learn topic and the budget test kept the worst case.

Nothing here draws on material that is not already in this repository.
