### PR TITLE
chore(data-catalog): stop telling agents the catalog is empty

### DIFF
--- a/products/posthog_ai/skills/querying-posthog-data/SKILL.md
+++ b/products/posthog_ai/skills/querying-posthog-data/SKILL.md
@@ -30,7 +30,7 @@ When the user wants analytics data (trends, funnels, retention, paths, sessions,
 
 When the user asks for a governed business number (MRR, activation rate, active users, ...), check the data catalog's semantic layer before deriving it from raw data — the project may have a canonical, human-approved definition to reuse instead of guessing.
 
-1. Look for a canonical metric with `posthog:execute-sql` (there is no list tool). The table is usually empty; an empty result just means no governed definition exists, so derive the number normally.
+1. Look for a canonical metric with `posthog:execute-sql` (there is no list tool). Do this before the first `query-*` or `execute-sql` call that would produce the number. An empty result means no governed definition exists, so derive the number yourself and label it noncanonical.
 
    ```sql
    SELECT name, description, status, is_drifted, definition_kind, unit

--- a/products/posthog_ai/skills/querying-posthog-data/SKILL.md
+++ b/products/posthog_ai/skills/querying-posthog-data/SKILL.md
@@ -30,7 +30,7 @@ When the user wants analytics data (trends, funnels, retention, paths, sessions,
 
 When the user asks for a governed business number (MRR, activation rate, active users, ...), check the data catalog's semantic layer before deriving it from raw data — the project may have a canonical, human-approved definition to reuse instead of guessing.
 
-1. Look for a canonical metric with `posthog:execute-sql` (there is no list tool). Do this before the first `query-*` or `execute-sql` call that would produce the number. An empty result means no governed definition exists, so derive the number yourself and label it noncanonical.
+1. Look for a canonical metric with `posthog:execute-sql` (there is no list tool). Do this before the first `query-*` or `execute-sql` call that would produce the number. An empty result means no governed definition exists, and an unknown-table error means this project has no data catalog at all; either way, derive the number yourself and label it noncanonical.
 
    ```sql
    SELECT name, description, status, is_drifted, definition_kind, unit

--- a/products/posthog_ai/skills/querying-posthog-data/references/guidelines.md
+++ b/products/posthog_ai/skills/querying-posthog-data/references/guidelines.md
@@ -88,7 +88,7 @@ Run separately for each model. Available models: `'text-embedding-3-small-1536'`
 
 Use `embedText(text, model_name)` and `cosineDistance()` for semantic search. See the `signals` skill for detailed query patterns around the signals product specifically, including required deduplication and metadata extraction.
 
-If higher-priority project guidance requires a semantic lookup before data discovery, follow it first. Otherwise use the schema workflow below.
+For a named business or operational measure, look it up in the data catalog (`system.information_schema.metrics`) before any schema discovery, and run an approved, non-drifted match with `data-catalog-metric-run` instead of deriving it. Everything else starts with the schema workflow below.
 
 #### Schema discovery (information_schema)
 

--- a/products/posthog_ai/skills/querying-posthog-data/references/guidelines.md
+++ b/products/posthog_ai/skills/querying-posthog-data/references/guidelines.md
@@ -88,7 +88,9 @@ Run separately for each model. Available models: `'text-embedding-3-small-1536'`
 
 Use `embedText(text, model_name)` and `cosineDistance()` for semantic search. See the `signals` skill for detailed query patterns around the signals product specifically, including required deduplication and metadata extraction.
 
-For a named business or operational measure, look it up in the data catalog (`system.information_schema.metrics`) before any schema discovery, and run an approved, non-drifted match with `data-catalog-metric-run` instead of deriving it. Everything else starts with the schema workflow below.
+For a named business or operational measure, look it up in the data catalog (`system.information_schema.metrics`) before any schema discovery, and run an approved, non-drifted match with `data-catalog-metric-run` instead of deriving it.
+A project without the data catalog has neither that table nor that tool: if the lookup reports an unknown table, derive the measure with the schema workflow below and stop checking the catalog for the rest of the session.
+Everything else starts with that workflow.
 
 #### Schema discovery (information_schema)
 

--- a/products/posthog_ai/skills/querying-posthog-data/references/guidelines.md
+++ b/products/posthog_ai/skills/querying-posthog-data/references/guidelines.md
@@ -88,8 +88,10 @@ Run separately for each model. Available models: `'text-embedding-3-small-1536'`
 
 Use `embedText(text, model_name)` and `cosineDistance()` for semantic search. See the `signals` skill for detailed query patterns around the signals product specifically, including required deduplication and metadata extraction.
 
-For a named business or operational measure, look it up in the data catalog (`system.information_schema.metrics`) before any schema discovery, and run an approved, non-drifted match with `data-catalog-metric-run` instead of deriving it.
-A project without the data catalog has neither that table nor that tool: if the lookup reports an unknown table, derive the measure with the schema workflow below and stop checking the catalog for the rest of the session.
+For a named business or operational measure, look it up in the data catalog (`system.information_schema.metrics`) before any schema discovery.
+Run an approved, non-drifted match with `data-catalog-metric-run` instead of deriving it.
+Every other outcome means there is no canonical definition to reuse — no match, a drifted match, or a match that is not approved: derive the measure with the schema workflow below and label the result noncanonical.
+A project without the data catalog has neither that table nor that tool, so an unknown-table error is that case too, and it holds for the rest of the session: stop checking.
 Everything else starts with that workflow.
 
 #### Schema discovery (information_schema)


### PR DESCRIPTION
## Problem

The `querying-posthog-data` skill told agents the canonical metrics table "is usually empty", and the shared guidelines treated the catalog lookup as optional whenever other guidance was in context. Both lines argue against the rule they sit next to, and agents follow them: one told the lookup will find nothing skips it and derives the number by hand.

That text reaches every agent that reads the skill or the `execute-sql` description, so it undercuts the catalog on the widest surface there is.

## Changes

- The skill says to check the catalog before the call that would produce the number, and to label a hand-derived number noncanonical.
- The skill no longer predicts the result of the lookup.
- The guidelines put the catalog lookup ahead of schema discovery for any named business or operational measure, rather than deferring to whatever else might be in context.

## How did you test this code?

No tests. This changes prose only, and no test pins the text of either file. `services/mcp/shared/guidelines.md` is a gitignored build copy, so nothing needed regenerating.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude Opus 5, in Claude Code) made these edits from a plan Thiago supplied. Skills invoked: `/writing-user-facing-copy`, `/writing-pr-descriptions`.

The plan also asked me to point the "Run with AI" button's prompt at `data-catalog-metric-run`. I left it alone: that tool is registered on the MCP surface only, so the in-app assistant this button opens cannot call it.

Nothing here draws on material that is not already in this repository.
