### PR TITLE
feat(desktop): make report canvases actionable

### DIFF
--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -2530,6 +2530,10 @@ export class PostHogAPIClient {
           | "signal_report"
         >
       > & {
+        signal_report_task_relationship?:
+          | "discussion"
+          | "implementation"
+          | "research";
         github_integration?: number | null;
         github_user_integration?: string | null;
         branch?: string | null;

--- a/products/desktop/packages/core/src/canvas/dashboardSchemas.ts
+++ b/products/desktop/packages/core/src/canvas/dashboardSchemas.ts
@@ -20,6 +20,9 @@ export const dashboardRecordSchema = z.object({
   // Id of the task currently generating this canvas (freeform gen runs as a
   // dedicated task, like CONTEXT.md). null/absent = no generation in flight.
   generationTaskId: z.string().nullish(),
+  // Stable task used for shared canvas comments. Report canvases also use it
+  // to resolve their backing Signal report without exposing pipeline internals.
+  discussionTaskId: z.string().nullish(),
   // Display name of the creator (from the backend's created_by user).
   createdBy: z.string().optional(),
   createdByUuid: z.string().optional(),

--- a/products/desktop/packages/core/src/canvas/dashboardsService.test.ts
+++ b/products/desktop/packages/core/src/canvas/dashboardsService.test.ts
@@ -11,6 +11,7 @@ function apiCanvas(overrides: Record<string, unknown> = {}) {
     template_id: "freeform",
     context: "",
     generation_task_id: null,
+    discussion_task_id: "discussion-1",
     pinned_at: null,
     current_version_id: "v1",
     published_build_id: null,
@@ -69,6 +70,7 @@ describe("DashboardsService.list", () => {
       name: "Revenue board",
       createdBy: "Ada L",
       currentVersionId: "v1",
+      discussionTaskId: "discussion-1",
     });
     expect(rows[0].createdAt).toBe(Date.parse("2026-07-01T00:00:00Z"));
   });

--- a/products/desktop/packages/core/src/canvas/dashboardsService.ts
+++ b/products/desktop/packages/core/src/canvas/dashboardsService.ts
@@ -35,6 +35,7 @@ interface ApiCanvas {
   template_id: string;
   context: string;
   generation_task_id: string | null;
+  discussion_task_id: string | null;
   pinned_at: string | null;
   current_version_id: string | null;
   published_build_id: string | null;
@@ -89,6 +90,7 @@ function toRecord(api: ApiCanvas): DashboardRecord {
     templateId: api.template_id || FREEFORM_TEMPLATE_ID,
     context: api.context ?? "",
     generationTaskId: api.generation_task_id,
+    discussionTaskId: api.discussion_task_id,
     createdBy: creatorLabel(api.created_by),
     createdByUuid: api.created_by?.uuid,
     createdAt: toEpoch(api.created_at) ?? 0,

--- a/products/desktop/packages/core/src/canvas/freeformSchemas.test.ts
+++ b/products/desktop/packages/core/src/canvas/freeformSchemas.test.ts
@@ -96,6 +96,29 @@ describe("canvasToHostMessageSchema", () => {
     ).toBe(true);
   });
 
+  it("only accepts the host-defined report action", () => {
+    const action = {
+      channel: "posthog-canvas",
+      type: "report-action",
+      id: "action-1",
+      action: "create-pull-request",
+    };
+
+    expect(canvasToHostMessageSchema.safeParse(action).success).toBe(true);
+    expect(
+      canvasToHostMessageSchema.safeParse({
+        ...action,
+        action: "delete-report",
+      }).success,
+    ).toBe(false);
+    expect(
+      canvasToHostMessageSchema.parse({
+        ...action,
+        reportId: "another-report",
+      }),
+    ).not.toHaveProperty("reportId");
+  });
+
   it("accepts bounded comment highlights", () => {
     expect(
       hostToCanvasMessageSchema.safeParse({

--- a/products/desktop/packages/core/src/canvas/freeformSchemas.ts
+++ b/products/desktop/packages/core/src/canvas/freeformSchemas.ts
@@ -252,6 +252,13 @@ export const hostToCanvasMessageSchema = z.discriminatedUnion("type", [
     result: z.unknown().optional(),
     error: z.string().optional(),
   }),
+  z.object({
+    channel: z.literal(CANVAS_CHANNEL),
+    type: z.literal("report-action-response"),
+    id: z.string(),
+    ok: z.boolean(),
+    error: z.string().optional(),
+  }),
 ]);
 export type HostToCanvasMessage = z.infer<typeof hostToCanvasMessageSchema>;
 
@@ -316,6 +323,12 @@ export const canvasToHostMessageSchema = z.discriminatedUnion("type", [
     channel: z.literal(CANVAS_CHANNEL),
     type: z.literal("navigate"),
     nav: canvasNavIntentSchema,
+  }),
+  z.object({
+    channel: z.literal(CANVAS_CHANNEL),
+    type: z.literal("report-action"),
+    id: z.string().min(1).max(128),
+    action: z.literal("create-pull-request"),
   }),
   // Open a URL outside the sandbox. The PostHog-only https allowlist is part
   // of the schema, so no consumer can forward an unvalidated URL.

--- a/products/desktop/packages/core/src/task-detail/taskCreationSaga.test.ts
+++ b/products/desktop/packages/core/src/task-detail/taskCreationSaga.test.ts
@@ -960,6 +960,7 @@ describe("TaskCreationSaga", () => {
       branch: "main",
       cloudRunSource: "signal_report",
       signalReportId: "report-123",
+      signalReportTaskRelationship: "discussion",
       githubIntegrationId: 123,
     });
 
@@ -969,6 +970,7 @@ describe("TaskCreationSaga", () => {
         github_integration: 123,
         github_user_integration: undefined,
         origin_product: "signal_report",
+        signal_report_task_relationship: "discussion",
       }),
     );
     expect(createTaskRunMock).toHaveBeenCalledWith(

--- a/products/desktop/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/products/desktop/packages/core/src/task-detail/taskCreationSaga.ts
@@ -818,8 +818,8 @@ export class TaskCreationSaga extends Saga<
           origin_product: input.signalReportId
             ? "signal_report"
             : "user_created",
-          // The server associates the task with the report and records the implementation
-          // task_run artefact — no relationship label is sent (associations are unlabelled).
+          // The server associates the task with the report and records its
+          // relationship so report discussions remain separate from implementation.
           branch:
             input.workspaceMode === "cloud" && canActivateWarmRun
               ? (input.branch ?? null)
@@ -851,6 +851,8 @@ export class TaskCreationSaga extends Saga<
               ? input.customImageId
               : undefined,
           signal_report: input.signalReportId ?? undefined,
+          signal_report_task_relationship:
+            input.signalReportTaskRelationship ?? undefined,
           channel: input.channelId ?? undefined,
           runtime: input.runtime ?? "acp",
           pending_user_message: warmPayload?.pendingUserMessage,

--- a/products/desktop/packages/shared/src/task-creation-domain.ts
+++ b/products/desktop/packages/shared/src/task-creation-domain.ts
@@ -58,6 +58,7 @@ export interface TaskCreationInput {
    */
   cloudRtkEnabled?: boolean;
   signalReportId?: string;
+  signalReportTaskRelationship?: "discussion" | "implementation" | "research";
   additionalDirectories?: string[];
   /**
    * CONTEXT.md of the channel a task was created in, if any. Appended to the

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteLayout.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteLayout.tsx
@@ -1,5 +1,6 @@
 import {
   ArrowClockwiseIcon,
+  ArrowSquareOutIcon,
   ChatCircleIcon,
   DotsThreeIcon,
   LinkIcon,
@@ -8,6 +9,8 @@ import {
   TrashIcon,
   XIcon,
 } from "@phosphor-icons/react";
+import { extractRepoSelectionRepository } from "@posthog/core/inbox/artefacts";
+import { canCreateImplementationPr } from "@posthog/core/inbox/reportActions";
 import { useHostTRPC } from "@posthog/host-router/react";
 import {
   AlertDialog,
@@ -54,6 +57,16 @@ import {
   CONTENT_CHROME_RIGHT_VAR,
   useRightPanelOpen,
 } from "@posthog/ui/features/navigation/rightPanelSide";
+import { useCreatePrReport } from "@posthog/ui/features/inbox/hooks/useCreatePrReport";
+import {
+  useInboxReportArtefacts,
+  useInboxReportById,
+} from "@posthog/ui/features/inbox/hooks/useInboxReports";
+import {
+  findContinuableImplementationTask,
+  getTaskPrUrl,
+  useReportTasks,
+} from "@posthog/ui/features/inbox/hooks/useReportTasks";
 import { buildCommentThreads } from "@posthog/ui/features/sessions/components/commentViewTypes";
 import { useCommentsQuery } from "@posthog/ui/features/sessions/components/useComments";
 import {
@@ -61,12 +74,14 @@ import {
   PRIVATE_SPACE_MENTIONS_DISABLED,
 } from "@posthog/ui/features/sessions/mentionAvailability";
 import { TaskHeaderActions } from "@posthog/ui/features/task-detail/components/TaskHeaderActions";
+import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
 import { toast } from "@posthog/ui/primitives/toast";
+import { useOpenTask } from "@posthog/ui/router/useOpenTask";
 import { track } from "@posthog/ui/shell/analytics";
 import { useHeaderStore } from "@posthog/ui/shell/headerStore";
 import { Flex } from "@radix-ui/themes";
-import { useIsMutating, useQueryClient } from "@tanstack/react-query";
+import { useIsMutating, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Outlet,
   useNavigate,
@@ -74,6 +89,97 @@ import {
   useRouterState,
 } from "@tanstack/react-router";
 import { type CSSProperties, type ReactNode, useState } from "react";
+
+function ReportCanvasActions({ dashboardId }: { dashboardId: string }) {
+  const { dashboard } = useDashboard(dashboardId);
+  const discussionTaskId = dashboard?.discussionTaskId ?? null;
+
+  if (!discussionTaskId) return null;
+
+  return <ReportCanvasActionsForDiscussion taskId={discussionTaskId} />;
+}
+
+function ReportCanvasActionsForDiscussion({ taskId }: { taskId: string }) {
+  const { data: discussionTask } = useQuery({
+    ...taskDetailQuery(taskId),
+  });
+  const reportId =
+    discussionTask?.origin_product === "signal_report"
+      ? (discussionTask.signal_report ?? null)
+      : null;
+  const { data: report } = useInboxReportById(reportId, {
+    enabled: !!reportId,
+    staleTime: 10_000,
+  });
+  const { data: artefacts } = useInboxReportArtefacts(reportId ?? "", {
+    enabled: !!reportId,
+    staleTime: 10_000,
+  });
+  const repository = extractRepoSelectionRepository(artefacts?.results);
+  const { data: reportTasks, isLoading: reportTasksLoading } = useReportTasks(
+    reportId ?? "",
+    report?.status ?? "ready",
+  );
+  const continuableTask = findContinuableImplementationTask(reportTasks);
+  const taskPrUrl = continuableTask ? getTaskPrUrl(continuableTask) : null;
+  const prUrl = report?.implementation_pr_url ?? taskPrUrl;
+  const openChat = useCanvasChatPanelStore((state) => state.openChat);
+  const openTask = useOpenTask();
+  const { createPrReport, isCreatingPr } = useCreatePrReport({
+    reportId: reportId ?? "",
+    reportTitle: report?.title ?? null,
+    cloudRepository: repository,
+  });
+
+  if (!report || !reportId) return null;
+
+  return (
+    <>
+      <Button size="sm" variant="outline" onClick={openChat}>
+        <ChatCircleIcon />
+        Chat
+      </Button>
+      {prUrl && (
+        <Button
+          size="sm"
+          variant="outline"
+          render={
+            <a
+              href={prUrl}
+              target="_blank"
+              rel="noreferrer"
+              aria-label="Open pull request in GitHub"
+            >
+              <span className="sr-only">Open pull request in GitHub</span>
+            </a>
+          }
+        >
+          <ArrowSquareOutIcon />
+          Open in GitHub
+        </Button>
+      )}
+      {continuableTask ? (
+        <Button
+          size="sm"
+          variant="primary"
+          onClick={() => void openTask(continuableTask)}
+        >
+          Continue PR
+        </Button>
+      ) : canCreateImplementationPr(report) ? (
+        <Button
+          size="sm"
+          variant="primary"
+          loading={isCreatingPr}
+          disabled={isCreatingPr || reportTasksLoading}
+          onClick={() => void createPrReport()}
+        >
+          Create PR
+        </Button>
+      ) : null}
+    </>
+  );
+}
 
 // Edit toggle + autosave status for a canvas. Source is server-versioned now —
 // version browsing and revert live in the canvas view's own toolbar — so the
@@ -306,9 +412,10 @@ function CanvasBreadcrumb({
     dashboard?.generationTaskId,
     versions,
   );
+  const stableCommentTaskId = dashboard?.discussionTaskId ?? commentTaskId;
   const comments = useCommentsQuery(
-    commentTaskId ? commentTarget : null,
-    commentTaskId ?? "",
+    stableCommentTaskId ? commentTarget : null,
+    stableCommentTaskId ?? "",
     { live: true },
   );
   const openCommentCount = buildCommentThreads(comments.data ?? []).filter(
@@ -330,7 +437,7 @@ function CanvasBreadcrumb({
       onRename={(next) => void renameDashboard(dashboardId, next)}
       trailing={
         <>
-          {commentTaskId && (
+          {stableCommentTaskId && (
             <Button size="sm" variant="outline" onClick={openComments}>
               <ChatCircleIcon />
               Comments
@@ -427,10 +534,13 @@ export function WebsiteLayout() {
               channelId={channelId}
               dashboardId={dashboardId}
               trailing={
-                <FreeformEditControls
-                  channelId={channelId}
-                  dashboardId={dashboardId}
-                />
+                <>
+                  <ReportCanvasActions dashboardId={dashboardId} />
+                  <FreeformEditControls
+                    channelId={channelId}
+                    dashboardId={dashboardId}
+                  />
+                </>
               }
             />
           ) : (

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteLayout.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteLayout.tsx
@@ -1,6 +1,5 @@
 import {
   ArrowClockwiseIcon,
-  ArrowSquareOutIcon,
   ChatCircleIcon,
   DotsThreeIcon,
   LinkIcon,
@@ -9,8 +8,6 @@ import {
   TrashIcon,
   XIcon,
 } from "@phosphor-icons/react";
-import { extractRepoSelectionRepository } from "@posthog/core/inbox/artefacts";
-import { canCreateImplementationPr } from "@posthog/core/inbox/reportActions";
 import { useHostTRPC } from "@posthog/host-router/react";
 import {
   AlertDialog,
@@ -57,16 +54,6 @@ import {
   CONTENT_CHROME_RIGHT_VAR,
   useRightPanelOpen,
 } from "@posthog/ui/features/navigation/rightPanelSide";
-import { useCreatePrReport } from "@posthog/ui/features/inbox/hooks/useCreatePrReport";
-import {
-  useInboxReportArtefacts,
-  useInboxReportById,
-} from "@posthog/ui/features/inbox/hooks/useInboxReports";
-import {
-  findContinuableImplementationTask,
-  getTaskPrUrl,
-  useReportTasks,
-} from "@posthog/ui/features/inbox/hooks/useReportTasks";
 import { buildCommentThreads } from "@posthog/ui/features/sessions/components/commentViewTypes";
 import { useCommentsQuery } from "@posthog/ui/features/sessions/components/useComments";
 import {
@@ -74,14 +61,12 @@ import {
   PRIVATE_SPACE_MENTIONS_DISABLED,
 } from "@posthog/ui/features/sessions/mentionAvailability";
 import { TaskHeaderActions } from "@posthog/ui/features/task-detail/components/TaskHeaderActions";
-import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
 import { toast } from "@posthog/ui/primitives/toast";
-import { useOpenTask } from "@posthog/ui/router/useOpenTask";
 import { track } from "@posthog/ui/shell/analytics";
 import { useHeaderStore } from "@posthog/ui/shell/headerStore";
 import { Flex } from "@radix-ui/themes";
-import { useIsMutating, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useIsMutating, useQueryClient } from "@tanstack/react-query";
 import {
   Outlet,
   useNavigate,
@@ -89,97 +74,6 @@ import {
   useRouterState,
 } from "@tanstack/react-router";
 import { type CSSProperties, type ReactNode, useState } from "react";
-
-function ReportCanvasActions({ dashboardId }: { dashboardId: string }) {
-  const { dashboard } = useDashboard(dashboardId);
-  const discussionTaskId = dashboard?.discussionTaskId ?? null;
-
-  if (!discussionTaskId) return null;
-
-  return <ReportCanvasActionsForDiscussion taskId={discussionTaskId} />;
-}
-
-function ReportCanvasActionsForDiscussion({ taskId }: { taskId: string }) {
-  const { data: discussionTask } = useQuery({
-    ...taskDetailQuery(taskId),
-  });
-  const reportId =
-    discussionTask?.origin_product === "signal_report"
-      ? (discussionTask.signal_report ?? null)
-      : null;
-  const { data: report } = useInboxReportById(reportId, {
-    enabled: !!reportId,
-    staleTime: 10_000,
-  });
-  const { data: artefacts } = useInboxReportArtefacts(reportId ?? "", {
-    enabled: !!reportId,
-    staleTime: 10_000,
-  });
-  const repository = extractRepoSelectionRepository(artefacts?.results);
-  const { data: reportTasks, isLoading: reportTasksLoading } = useReportTasks(
-    reportId ?? "",
-    report?.status ?? "ready",
-  );
-  const continuableTask = findContinuableImplementationTask(reportTasks);
-  const taskPrUrl = continuableTask ? getTaskPrUrl(continuableTask) : null;
-  const prUrl = report?.implementation_pr_url ?? taskPrUrl;
-  const openChat = useCanvasChatPanelStore((state) => state.openChat);
-  const openTask = useOpenTask();
-  const { createPrReport, isCreatingPr } = useCreatePrReport({
-    reportId: reportId ?? "",
-    reportTitle: report?.title ?? null,
-    cloudRepository: repository,
-  });
-
-  if (!report || !reportId) return null;
-
-  return (
-    <>
-      <Button size="sm" variant="outline" onClick={openChat}>
-        <ChatCircleIcon />
-        Chat
-      </Button>
-      {prUrl && (
-        <Button
-          size="sm"
-          variant="outline"
-          render={
-            <a
-              href={prUrl}
-              target="_blank"
-              rel="noreferrer"
-              aria-label="Open pull request in GitHub"
-            >
-              <span className="sr-only">Open pull request in GitHub</span>
-            </a>
-          }
-        >
-          <ArrowSquareOutIcon />
-          Open in GitHub
-        </Button>
-      )}
-      {continuableTask ? (
-        <Button
-          size="sm"
-          variant="primary"
-          onClick={() => void openTask(continuableTask)}
-        >
-          Continue PR
-        </Button>
-      ) : canCreateImplementationPr(report) ? (
-        <Button
-          size="sm"
-          variant="primary"
-          loading={isCreatingPr}
-          disabled={isCreatingPr || reportTasksLoading}
-          onClick={() => void createPrReport()}
-        >
-          Create PR
-        </Button>
-      ) : null}
-    </>
-  );
-}
 
 // Edit toggle + autosave status for a canvas. Source is server-versioned now —
 // version browsing and revert live in the canvas view's own toolbar — so the
@@ -534,13 +428,10 @@ export function WebsiteLayout() {
               channelId={channelId}
               dashboardId={dashboardId}
               trailing={
-                <>
-                  <ReportCanvasActions dashboardId={dashboardId} />
-                  <FreeformEditControls
-                    channelId={channelId}
-                    dashboardId={dashboardId}
-                  />
-                </>
+                <FreeformEditControls
+                  channelId={channelId}
+                  dashboardId={dashboardId}
+                />
               }
             />
           ) : (

--- a/products/desktop/packages/ui/src/features/canvas/freeform/BuiltCanvas.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/BuiltCanvas.tsx
@@ -96,6 +96,7 @@ export interface BuiltCanvasProps {
   onReady?: () => void;
   onRendered?: () => void;
   onNavigate?: (intent: CanvasNavIntent) => void;
+  onReportAction?: (action: "create-pull-request") => Promise<void>;
   onTextSelection?: (selection: CanvasTextSelection | null) => void;
   onCommentActivate?: (id: string) => void;
   commentHighlights?: CanvasCommentHighlight[];
@@ -110,6 +111,7 @@ export function BuiltCanvas({
   onReady,
   onRendered,
   onNavigate,
+  onReportAction,
   onTextSelection,
   onCommentActivate,
   commentHighlights = EMPTY_COMMENT_HIGHLIGHTS,
@@ -133,6 +135,7 @@ export function BuiltCanvas({
     onReady,
     onRendered,
     onNavigate,
+    onReportAction,
     theme,
     onTextSelection,
     onCommentActivate,
@@ -145,6 +148,7 @@ export function BuiltCanvas({
     onReady,
     onRendered,
     onNavigate,
+    onReportAction,
     theme,
     onTextSelection,
     onCommentActivate,
@@ -178,6 +182,14 @@ export function BuiltCanvas({
         },
         onRendered: () => latest.current.onRendered?.(),
         onNavigate: (intent) => latest.current.onNavigate?.(intent),
+        onReportAction: (action) => {
+          const handler = latest.current.onReportAction;
+          return handler
+            ? handler(action)
+            : Promise.reject(
+                new Error("This action is not available for this canvas"),
+              );
+        },
         onTextSelection: (selection) => {
           if (!selection) {
             latest.current.onTextSelection?.(null);

--- a/products/desktop/packages/ui/src/features/canvas/freeform/CanvasFrameHost.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/CanvasFrameHost.tsx
@@ -57,6 +57,7 @@ export function CanvasFrameHost() {
                 onError={slot.inputs.onError}
                 onRendered={slot.inputs.onRendered}
                 onNavigate={slot.inputs.onNavigate}
+                onReportAction={slot.inputs.onReportAction}
                 onTextSelection={slot.inputs.onTextSelection}
                 onCommentActivate={slot.inputs.onCommentActivate}
                 commentHighlights={slot.inputs.commentHighlights}

--- a/products/desktop/packages/ui/src/features/canvas/freeform/CanvasFramePlaceholder.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/CanvasFramePlaceholder.tsx
@@ -20,6 +20,7 @@ export function CanvasFramePlaceholder({
   onError,
   onRendered,
   onNavigate,
+  onReportAction,
   onTextSelection,
   onCommentActivate,
   commentHighlights,
@@ -32,6 +33,7 @@ export function CanvasFramePlaceholder({
   onError?: (message: string, stack?: string) => void;
   onRendered?: () => void;
   onNavigate?: (intent: CanvasNavIntent) => void;
+  onReportAction?: (action: "create-pull-request") => Promise<void>;
   onTextSelection?: (selection: CanvasTextSelection | null) => void;
   onCommentActivate?: (id: string) => void;
   commentHighlights?: CanvasCommentHighlight[];
@@ -52,6 +54,7 @@ export function CanvasFramePlaceholder({
       onError,
       onRendered,
       onNavigate,
+      onReportAction,
       onTextSelection,
       onCommentActivate,
       commentHighlights,
@@ -64,6 +67,7 @@ export function CanvasFramePlaceholder({
       onError,
       onRendered,
       onNavigate,
+      onReportAction,
       onTextSelection,
       onCommentActivate,
       commentHighlights,

--- a/products/desktop/packages/ui/src/features/canvas/freeform/CanvasSidePanel.stories.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/CanvasSidePanel.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { ReportDiscussionStarterView } from "./CanvasSidePanel";
+
+const suggestions = [
+  "Investigate this further",
+  "Explain the evidence",
+  "What should happen next?",
+];
+
+function ReportDiscussionStarterStory({
+  initialQuestion = "",
+  isDiscussing = false,
+}: {
+  initialQuestion?: string;
+  isDiscussing?: boolean;
+}) {
+  const [question, setQuestion] = useState(initialQuestion);
+
+  return (
+    <div className="h-[620px] w-[360px] border bg-gray-1">
+      <ReportDiscussionStarterView
+        question={question}
+        isDiscussing={isDiscussing}
+        suggestions={suggestions}
+        onQuestionChange={setQuestion}
+        onSubmit={() => {}}
+      />
+    </div>
+  );
+}
+
+const meta: Meta<typeof ReportDiscussionStarterStory> = {
+  title: "Canvas/Report discussion starter",
+  component: ReportDiscussionStarterStory,
+  decorators: [
+    (Story) => (
+      <div className="flex min-h-screen items-center justify-center p-8">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ReportDiscussionStarterStory>;
+
+export const Blank: Story = {};
+
+export const SuggestedQuestion: Story = {
+  args: { initialQuestion: "Explain the evidence" },
+};
+
+export const Starting: Story = {
+  args: {
+    initialQuestion: "Investigate this further",
+    isDiscussing: true,
+  },
+};

--- a/products/desktop/packages/ui/src/features/canvas/freeform/CanvasSidePanel.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/CanvasSidePanel.test.tsx
@@ -1,3 +1,5 @@
+import type { Task } from "@posthog/shared/domain-types";
+import type { SignalReport } from "@posthog/shared/types";
 import { useCanvasChatPanelStore } from "@posthog/ui/features/canvas/stores/canvasChatPanelStore";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -32,6 +34,15 @@ vi.mock("@posthog/ui/features/canvas/freeform/FreeformGenerateBar", () => ({
 vi.mock("@posthog/ui/features/canvas/freeform/ContextEditor", () => ({
   CanvasContextEditor: () => null,
 }));
+vi.mock("@posthog/ui/features/inbox/hooks/useDiscussReport", () => ({
+  useDiscussReport: () => ({ discussReport: vi.fn(), isDiscussing: false }),
+}));
+
+const report = {
+  id: "report-1",
+  title: "Conversion dropped",
+  status: "ready",
+} as SignalReport;
 
 describe("CanvasSidePanel", () => {
   beforeEach(() => {
@@ -81,5 +92,52 @@ describe("CanvasSidePanel", () => {
 
     fireEvent.click(screen.getByText("Chat"));
     expect(screen.getByTestId("task-chat")).toBeInTheDocument();
+  });
+
+  it("starts report chat without exposing the canvas builder transcript", () => {
+    render(
+      <CanvasSidePanel
+        effectiveTaskId="builder-task"
+        commentTaskId="shared-discussion-task"
+        interactive={false}
+        onMinimize={vi.fn()}
+        dashboardId="canvas-1"
+        channelId="channel-1"
+        channelName="General"
+        name="Conversion dropped"
+        displayedVersionId="version-2"
+        commentVersionLabel={(versionId) => versionId}
+        onCommentOpen={vi.fn()}
+        reportId="report-1"
+        report={report}
+      />,
+    );
+
+    expect(screen.getByText("Work from this report")).toBeInTheDocument();
+    expect(screen.queryByTestId("task-chat")).not.toBeInTheDocument();
+  });
+
+  it("resumes the viewer's report discussion", () => {
+    render(
+      <CanvasSidePanel
+        effectiveTaskId="builder-task"
+        commentTaskId="shared-discussion-task"
+        interactive={false}
+        onMinimize={vi.fn()}
+        dashboardId="canvas-1"
+        channelId="channel-1"
+        channelName="General"
+        name="Conversion dropped"
+        displayedVersionId="version-2"
+        commentVersionLabel={(versionId) => versionId}
+        onCommentOpen={vi.fn()}
+        reportId="report-1"
+        report={report}
+        reportDiscussionTask={{ id: "user-discussion-task" } as Task}
+      />,
+    );
+
+    expect(screen.getByTestId("task-chat")).toBeInTheDocument();
+    expect(screen.queryByText("Work from this report")).not.toBeInTheDocument();
   });
 });

--- a/products/desktop/packages/ui/src/features/canvas/freeform/CanvasSidePanel.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/CanvasSidePanel.tsx
@@ -5,21 +5,24 @@ import {
   TabsList,
   TabsTrigger,
   Text,
+  Textarea,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@posthog/quill";
 import type { Task } from "@posthog/shared/domain-types";
+import type { SignalReport } from "@posthog/shared/types";
 import { TaskCommentsList } from "@posthog/ui/features/canvas/components/TaskCommentsList";
 import { CanvasContextEditor } from "@posthog/ui/features/canvas/freeform/ContextEditor";
 import { FreeformGenerateBar } from "@posthog/ui/features/canvas/freeform/FreeformGenerateBar";
 import { useThreadConversation } from "@posthog/ui/features/canvas/hooks/useThreadConversation";
 import { useCanvasChatPanelStore } from "@posthog/ui/features/canvas/stores/canvasChatPanelStore";
+import { useDiscussReport } from "@posthog/ui/features/inbox/hooks/useDiscussReport";
 import type { EditorHandle } from "@posthog/ui/features/message-editor/types";
 import { EmbeddedSessionView } from "@posthog/ui/features/sessions/components/EmbeddedSessionView";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { useQuery } from "@tanstack/react-query";
-import { type Ref, useEffect, useRef } from "react";
+import { type Ref, useCallback, useEffect, useRef, useState } from "react";
 
 // The canvas's right-hand dock. While a generation/edit run is in flight it
 // shows that run's live chat (steering/queue included); otherwise it shows the
@@ -41,6 +44,11 @@ export function CanvasSidePanel({
   isEdit,
   editorRef,
   onStarted,
+  reportId,
+  report,
+  reportRepository,
+  reportDiscussionTask,
+  onReportDiscussionStarted,
 }: {
   effectiveTaskId: string | null;
   commentTaskId: string | null;
@@ -62,13 +70,22 @@ export function CanvasSidePanel({
   // Exposes the edit composer's editor so self-repair can prefill it.
   editorRef?: Ref<EditorHandle>;
   onStarted?: (taskId: string) => void;
+  reportId?: string | null;
+  report?: SignalReport | null;
+  reportRepository?: string | null;
+  reportDiscussionTask?: Task | null;
+  onReportDiscussionStarted?: (task: Task) => void;
 }) {
   const tab = useCanvasChatPanelStore((state) => state.tab);
   const setTab = useCanvasChatPanelStore((state) => state.setTab);
   const previousTaskId = useRef(effectiveTaskId);
   // With no run in flight, edit mode gets the composer for the next change,
   // while view mode gets the chat of the run that produced this canvas.
-  const chatTaskId = effectiveTaskId ?? (interactive ? null : commentTaskId);
+  const chatTaskId = interactive
+    ? effectiveTaskId
+    : reportId
+      ? (reportDiscussionTask?.id ?? null)
+      : (effectiveTaskId ?? commentTaskId);
 
   useEffect(() => {
     if (effectiveTaskId && effectiveTaskId !== previousTaskId.current) {
@@ -126,6 +143,16 @@ export function CanvasSidePanel({
           />
         ) : chatTaskId ? (
           <CanvasChatLoader taskId={chatTaskId} />
+        ) : report ? (
+          <ReportDiscussionStarter
+            report={report}
+            cloudRepository={reportRepository ?? null}
+            onTaskCreated={onReportDiscussionStarted}
+          />
+        ) : reportId ? (
+          <div className="flex h-full items-center justify-center">
+            <SpinnerGapIcon size={18} className="animate-spin text-gray-9" />
+          </div>
         ) : (
           <div className="flex h-full min-h-0 flex-col gap-3 p-3">
             <FreeformGenerateBar
@@ -153,6 +180,104 @@ export function CanvasSidePanel({
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+function ReportDiscussionStarter({
+  report,
+  cloudRepository,
+  onTaskCreated,
+}: {
+  report: SignalReport;
+  cloudRepository: string | null;
+  onTaskCreated?: (task: Task) => void;
+}) {
+  const [question, setQuestion] = useState("");
+  const { discussReport, isDiscussing } = useDiscussReport({
+    reportId: report.id,
+    reportTitle: report.title ?? null,
+    cloudRepository,
+    onTaskCreated,
+    redirectOnSuccess: false,
+    allowMissingRepository: true,
+  });
+  const submit = useCallback(() => {
+    const value = question.trim();
+    if (!value || isDiscussing) return;
+    void discussReport(value);
+  }, [discussReport, isDiscussing, question]);
+  const suggestions = [
+    "Investigate this further",
+    "Explain the evidence",
+    "What should happen next?",
+  ];
+
+  return (
+    <ReportDiscussionStarterView
+      question={question}
+      isDiscussing={isDiscussing}
+      suggestions={suggestions}
+      onQuestionChange={setQuestion}
+      onSubmit={submit}
+    />
+  );
+}
+
+export function ReportDiscussionStarterView({
+  question,
+  isDiscussing,
+  suggestions,
+  onQuestionChange,
+  onSubmit,
+}: {
+  question: string;
+  isDiscussing: boolean;
+  suggestions: string[];
+  onQuestionChange: (question: string) => void;
+  onSubmit: () => void;
+}) {
+  return (
+    <div className="flex h-full flex-col justify-end gap-3 p-3">
+      <div className="mb-auto rounded-md border bg-gray-2 p-3">
+        <Text weight="medium">Work from this report</Text>
+        <Text size="sm" variant="muted" className="mt-1 block">
+          Ask PostHog to investigate, explain the evidence, or take the next
+          step. This conversation stays connected to the canvas.
+        </Text>
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {suggestions.map((suggestion) => (
+          <Button
+            key={suggestion}
+            size="sm"
+            variant="outline"
+            onClick={() => onQuestionChange(suggestion)}
+          >
+            {suggestion}
+          </Button>
+        ))}
+      </div>
+      <Textarea
+        aria-label="Message PostHog about this report"
+        placeholder="Ask about this report..."
+        value={question}
+        onChange={(event) => onQuestionChange(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+            event.preventDefault();
+            onSubmit();
+          }
+        }}
+      />
+      <Button
+        variant="primary"
+        loading={isDiscussing}
+        disabled={isDiscussing || !question.trim()}
+        onClick={onSubmit}
+      >
+        Start conversation
+      </Button>
     </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/canvas/freeform/FreeformCanvas.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/FreeformCanvas.tsx
@@ -42,6 +42,7 @@ export interface FreeformCanvasProps {
    * just forwards it — the caller maps it to actual routing.
    */
   onNavigate?: (intent: CanvasNavIntent) => void;
+  onReportAction?: (action: "create-pull-request") => Promise<void>;
   onTextSelection?: (selection: CanvasTextSelection | null) => void;
   onCommentActivate?: (id: string) => void;
   commentHighlights?: CanvasCommentHighlight[];
@@ -63,6 +64,7 @@ export function FreeformCanvas({
   onError,
   onRendered,
   onNavigate,
+  onReportAction,
   onTextSelection,
   onCommentActivate,
   commentHighlights = EMPTY_COMMENT_HIGHLIGHTS,
@@ -93,6 +95,7 @@ export function FreeformCanvas({
     onError,
     onRendered,
     onNavigate,
+    onReportAction,
     onTextSelection,
     onCommentActivate,
     code,
@@ -105,6 +108,7 @@ export function FreeformCanvas({
     onError,
     onRendered,
     onNavigate,
+    onReportAction,
     onTextSelection,
     onCommentActivate,
     code,
@@ -159,6 +163,14 @@ export function FreeformCanvas({
         },
         onRendered: () => latest.current.onRendered?.(),
         onNavigate: (intent) => latest.current.onNavigate?.(intent),
+        onReportAction: (action) => {
+          const handler = latest.current.onReportAction;
+          return handler
+            ? handler(action)
+            : Promise.reject(
+                new Error("This action is not available for this canvas"),
+              );
+        },
         onTextSelection: (selection) => {
           if (!selection) {
             latest.current.onTextSelection?.(null);

--- a/products/desktop/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
@@ -25,9 +25,9 @@ import {
   canvasAgentRequestInputSchema,
   limitCanvasCommentHighlights,
 } from "@posthog/core/canvas/freeformSchemas";
-import { textToContent } from "@posthog/core/message-editor/content";
 import { extractRepoSelectionRepository } from "@posthog/core/inbox/artefacts";
 import { canCreateImplementationPr } from "@posthog/core/inbox/reportActions";
+import { textToContent } from "@posthog/core/message-editor/content";
 import { useHostTRPC } from "@posthog/host-router/react";
 import {
   Badge,
@@ -71,7 +71,6 @@ import {
   useFreeformChatStore,
   useFreeformThread,
 } from "@posthog/ui/features/canvas/stores/freeformChatStore";
-import { useDraftStore } from "@posthog/ui/features/message-editor/draftStore";
 import { useCreatePrReport } from "@posthog/ui/features/inbox/hooks/useCreatePrReport";
 import {
   useInboxReportArtefacts,
@@ -82,6 +81,7 @@ import {
   findUserDiscussionTask,
   useReportTasks,
 } from "@posthog/ui/features/inbox/hooks/useReportTasks";
+import { useDraftStore } from "@posthog/ui/features/message-editor/draftStore";
 import type { EditorHandle } from "@posthog/ui/features/message-editor/types";
 import { useCommentNavigationStore } from "@posthog/ui/features/sessions/commentNavigationStore";
 import {

--- a/products/desktop/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
@@ -26,6 +26,7 @@ import {
   limitCanvasCommentHighlights,
 } from "@posthog/core/canvas/freeformSchemas";
 import { textToContent } from "@posthog/core/message-editor/content";
+import { extractRepoSelectionRepository } from "@posthog/core/inbox/artefacts";
 import { useHostTRPC } from "@posthog/host-router/react";
 import {
   Badge,
@@ -47,6 +48,9 @@ import {
 } from "@posthog/quill";
 import { CANVAS_COMPONENT_PATH } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import type { Task } from "@posthog/shared/domain-types";
+import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
+import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
 import {
   isCanvasGenerating,
   isCanvasGenerationRunning,
@@ -67,6 +71,14 @@ import {
   useFreeformThread,
 } from "@posthog/ui/features/canvas/stores/freeformChatStore";
 import { useDraftStore } from "@posthog/ui/features/message-editor/draftStore";
+import {
+  useInboxReportArtefacts,
+  useInboxReportById,
+} from "@posthog/ui/features/inbox/hooks/useInboxReports";
+import {
+  findUserDiscussionTask,
+  useReportTasks,
+} from "@posthog/ui/features/inbox/hooks/useReportTasks";
 import type { EditorHandle } from "@posthog/ui/features/message-editor/types";
 import { useCommentNavigationStore } from "@posthog/ui/features/sessions/commentNavigationStore";
 import {
@@ -200,6 +212,40 @@ export function FreeformCanvasView({
   );
   const genTaskId = dashboard?.generationTaskId ?? null;
   const channelId = dashboard?.channelId ?? "";
+  const stableDiscussionTaskId = dashboard?.discussionTaskId ?? null;
+  const { data: stableDiscussionTask } = useQuery({
+    ...taskDetailQuery(stableDiscussionTaskId ?? ""),
+    enabled: !!stableDiscussionTaskId,
+  });
+  const reportId =
+    stableDiscussionTask?.origin_product === "signal_report"
+      ? (stableDiscussionTask.signal_report ?? null)
+      : null;
+  const { data: report } = useInboxReportById(reportId, {
+    enabled: !!reportId,
+    staleTime: 10_000,
+  });
+  const { data: reportArtefacts } = useInboxReportArtefacts(reportId ?? "", {
+    enabled: !!reportId,
+    staleTime: 10_000,
+  });
+  const reportRepository = extractRepoSelectionRepository(
+    reportArtefacts?.results,
+  );
+  const { data: reportTasks } = useReportTasks(
+    reportId ?? "",
+    report?.status ?? "ready",
+  );
+  const authClient = useOptionalAuthenticatedClient();
+  const { data: currentUser } = useCurrentUser({ client: authClient });
+  const persistedReportDiscussionTask = findUserDiscussionTask(
+    reportTasks,
+    currentUser?.uuid,
+  );
+  const [startedReportDiscussionTask, setStartedReportDiscussionTask] =
+    useState<Task | null>(null);
+  const reportDiscussionTask =
+    startedReportDiscussionTask ?? persistedReportDiscussionTask;
 
   useEffect(() => {
     if (genTaskId) setStartedTaskId(null);
@@ -324,7 +370,8 @@ export function FreeformCanvasView({
   const { drafts, isLoading: draftsLoading } = useCanvasDrafts(
     interactive ? dashboardId : undefined,
   );
-  const commentTaskId = canvasCommentTaskId(genTaskId, versions);
+  const commentTaskId =
+    dashboard?.discussionTaskId ?? canvasCommentTaskId(genTaskId, versions);
   // The browsed version is a draft preview when it matches a staged draft
   // rather than a published version. Drives the Draft label and Promote action.
   const browsingDraft = drafts.some(
@@ -1245,6 +1292,11 @@ export function FreeformCanvasView({
             isEdit={hasSource}
             editorRef={editorRef}
             onStarted={setStartedTaskId}
+            reportId={reportId}
+            report={report ?? null}
+            reportRepository={reportRepository}
+            reportDiscussionTask={reportDiscussionTask}
+            onReportDiscussionStarted={setStartedReportDiscussionTask}
           />
         </ResizableSidebar>
       )}

--- a/products/desktop/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
@@ -27,6 +27,7 @@ import {
 } from "@posthog/core/canvas/freeformSchemas";
 import { textToContent } from "@posthog/core/message-editor/content";
 import { extractRepoSelectionRepository } from "@posthog/core/inbox/artefacts";
+import { canCreateImplementationPr } from "@posthog/core/inbox/reportActions";
 import { useHostTRPC } from "@posthog/host-router/react";
 import {
   Badge,
@@ -71,11 +72,13 @@ import {
   useFreeformThread,
 } from "@posthog/ui/features/canvas/stores/freeformChatStore";
 import { useDraftStore } from "@posthog/ui/features/message-editor/draftStore";
+import { useCreatePrReport } from "@posthog/ui/features/inbox/hooks/useCreatePrReport";
 import {
   useInboxReportArtefacts,
   useInboxReportById,
 } from "@posthog/ui/features/inbox/hooks/useInboxReports";
 import {
+  findContinuableImplementationTask,
   findUserDiscussionTask,
   useReportTasks,
 } from "@posthog/ui/features/inbox/hooks/useReportTasks";
@@ -246,6 +249,12 @@ export function FreeformCanvasView({
     useState<Task | null>(null);
   const reportDiscussionTask =
     startedReportDiscussionTask ?? persistedReportDiscussionTask;
+  const { createPrReport, isCreatingPr } = useCreatePrReport({
+    reportId: reportId ?? "",
+    reportTitle: report?.title ?? null,
+    cloudRepository: reportRepository,
+  });
+  const reportActionRunningRef = useRef(false);
 
   useEffect(() => {
     if (genTaskId) setStartedTaskId(null);
@@ -763,6 +772,37 @@ export function FreeformCanvasView({
 
   // Routes the canvas's allowlisted nav intents within this channel.
   const onNavigate = useCanvasNavigation(channelId);
+  const onReportAction = useCallback(
+    async (action: "create-pull-request") => {
+      if (
+        action !== "create-pull-request" ||
+        !reportId ||
+        !report ||
+        !reportRepository ||
+        !canCreateImplementationPr(report) ||
+        report.implementation_pr_url ||
+        findContinuableImplementationTask(reportTasks) ||
+        isCreatingPr ||
+        reportActionRunningRef.current
+      ) {
+        throw new Error("A pull request cannot be created from this report");
+      }
+      reportActionRunningRef.current = true;
+      try {
+        await createPrReport();
+      } finally {
+        reportActionRunningRef.current = false;
+      }
+    },
+    [
+      createPrReport,
+      isCreatingPr,
+      report,
+      reportId,
+      reportRepository,
+      reportTasks,
+    ],
+  );
 
   // The edit composer's editor handle, so self-repair can prefill it.
   const editorRef = useRef<EditorHandle>(null);
@@ -1187,6 +1227,7 @@ export function FreeformCanvasView({
                 onReady={onArtifactReady}
                 onRendered={onRendered}
                 onNavigate={onNavigate}
+                onReportAction={reportId ? onReportAction : undefined}
                 onTextSelection={setTextSelection}
                 onCommentActivate={activateComment}
                 commentHighlights={commentHighlights}
@@ -1207,6 +1248,7 @@ export function FreeformCanvasView({
                 onError={onError}
                 onRendered={onRendered}
                 onNavigate={onNavigate}
+                onReportAction={reportId ? onReportAction : undefined}
                 onTextSelection={setTextSelection}
                 onCommentActivate={activateComment}
                 commentHighlights={commentHighlights}

--- a/products/desktop/packages/ui/src/features/canvas/freeform/canvasFrameStore.ts
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/canvasFrameStore.ts
@@ -36,6 +36,7 @@ export interface CanvasFrameInputs {
   onError?: (message: string, stack?: string) => void;
   onRendered?: () => void;
   onNavigate?: (intent: CanvasNavIntent) => void;
+  onReportAction?: (action: "create-pull-request") => Promise<void>;
   onTextSelection?: (selection: CanvasTextSelection | null) => void;
   onCommentActivate?: (id: string) => void;
   commentHighlights?: CanvasCommentHighlight[];

--- a/products/desktop/packages/ui/src/features/canvas/freeform/canvasHostMessageRouter.test.ts
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/canvasHostMessageRouter.test.ts
@@ -1,3 +1,4 @@
+import type { HostToCanvasMessage } from "@posthog/core/canvas/freeformSchemas";
 import { describe, expect, it, vi } from "vitest";
 import { createCanvasHostMessageRouter } from "./canvasHostMessageRouter";
 
@@ -184,5 +185,54 @@ describe("createCanvasHostMessageRouter", () => {
     expect(post.mock.calls.every(([message]) => message.ok === true)).toBe(
       true,
     );
+  });
+
+  const reportActionMessage = {
+    channel: "posthog-canvas" as const,
+    type: "report-action" as const,
+    id: "action-1",
+    action: "create-pull-request" as const,
+  };
+
+  it("runs a report action only after a user interaction", async () => {
+    const post = vi.fn<(message: HostToCanvasMessage) => void>();
+    const onReportAction = vi.fn().mockResolvedValue(undefined);
+    const route = createCanvasHostMessageRouter({
+      post,
+      callbacks: () => ({ onDataRequest: vi.fn(), onReportAction }),
+      hasUserActivation: () => false,
+      openExternal: vi.fn(),
+    });
+
+    await route(reportActionMessage);
+
+    expect(onReportAction).not.toHaveBeenCalled();
+    expect(post).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "report-action-response",
+        ok: false,
+      }),
+    );
+  });
+
+  it("returns the report action result to the canvas", async () => {
+    const post = vi.fn<(message: HostToCanvasMessage) => void>();
+    const onReportAction = vi.fn().mockResolvedValue(undefined);
+    const route = createCanvasHostMessageRouter({
+      post,
+      callbacks: () => ({ onDataRequest: vi.fn(), onReportAction }),
+      hasUserActivation: () => true,
+      openExternal: vi.fn(),
+    });
+
+    await route(reportActionMessage);
+
+    expect(onReportAction).toHaveBeenCalledWith("create-pull-request");
+    expect(post).toHaveBeenCalledWith({
+      channel: "posthog-canvas",
+      type: "report-action-response",
+      id: "action-1",
+      ok: true,
+    });
   });
 });

--- a/products/desktop/packages/ui/src/features/canvas/freeform/canvasHostMessageRouter.ts
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/canvasHostMessageRouter.ts
@@ -29,6 +29,7 @@ export interface CanvasHostCallbacks {
   onReady?: () => void;
   onRendered?: () => void;
   onNavigate?: (intent: CanvasNavIntent) => void;
+  onReportAction?: (action: "create-pull-request") => Promise<void>;
   onTextSelection?: (selection: CanvasTextSelection | null) => void;
   onCommentActivate?: (id: string) => void;
 }
@@ -158,6 +159,46 @@ export function createCanvasHostMessageRouter(
         // message.nav is already allowlist-validated by the schema parse.
         options.callbacks().onNavigate?.(message.nav);
         break;
+      case "report-action": {
+        const onReportAction = options.callbacks().onReportAction;
+        let error: string | undefined;
+        if (!options.hasUserActivation()) {
+          error = "Use this action from a button or link in the canvas";
+        } else if (!onReportAction) {
+          error = "This action is not available for this canvas";
+        }
+        if (error) {
+          options.post({
+            channel: "posthog-canvas",
+            type: "report-action-response",
+            id: message.id,
+            ok: false,
+            error,
+          });
+          break;
+        }
+        try {
+          await onReportAction?.(message.action);
+          options.post({
+            channel: "posthog-canvas",
+            type: "report-action-response",
+            id: message.id,
+            ok: true,
+          });
+        } catch (actionError) {
+          options.post({
+            channel: "posthog-canvas",
+            type: "report-action-response",
+            id: message.id,
+            ok: false,
+            error:
+              actionError instanceof Error
+                ? actionError.message
+                : String(actionError),
+          });
+        }
+        break;
+      }
       case "text-selection":
         options.callbacks().onTextSelection?.(message.selection);
         break;

--- a/products/desktop/packages/ui/src/features/canvas/freeform/sandboxRuntime.ts
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/sandboxRuntime.ts
@@ -221,6 +221,12 @@ export function buildSandboxDocument(
         pending.set(id, { resolve, reject });
         post({ type: "data-request", id, method, payload });
       });
+    const callReportAction = (action) =>
+      new Promise((resolve, reject) => {
+        const id = String(++reqSeq);
+        pending.set(id, { resolve, reject });
+        post({ type: "report-action", id, action });
+      });
     // posthog-js runs IN here (the only way replay records the app's DOM). It is
     // booted by init when analytics config is present; until then capture falls
     // back to the host-mediated path.
@@ -300,6 +306,9 @@ export function buildSandboxDocument(
         toNewTask: () => post({ type: "navigate", nav: { target: "new-task" } }),
         toCanvas: (dashboardId) => post({ type: "navigate", nav: { target: "canvas", dashboardId } }),
         toNewCanvas: () => post({ type: "navigate", nav: { target: "new-canvas" } }),
+      },
+      report: {
+        createPullRequest: () => callReportAction("create-pull-request"),
       },
     };
 
@@ -632,7 +641,7 @@ export function buildSandboxDocument(
         renderCommentHighlights(d.highlights);
       } else if (d.type === "clear-text-selection") {
         clearNativeTextSelection();
-      } else if (d.type === "data-response") {
+      } else if (d.type === "data-response" || d.type === "report-action-response") {
         const p = pending.get(d.id);
         if (!p) return;
         pending.delete(d.id);

--- a/products/desktop/packages/ui/src/features/canvas/stores/canvasChatPanelStore.ts
+++ b/products/desktop/packages/ui/src/features/canvas/stores/canvasChatPanelStore.ts
@@ -37,7 +37,7 @@ export const useCanvasChatPanelStore = create<CanvasChatPanelState>()(
         set(collapsed ? { collapsed, viewOpen: false } : { collapsed }),
       setWidth: (width) => set({ width }),
       setTab: (tab) => set({ tab }),
-      openChat: () => set({ collapsed: false, tab: "chat", viewOpen: false }),
+      openChat: () => set({ collapsed: false, tab: "chat", viewOpen: true }),
       openComments: () =>
         set({ collapsed: false, tab: "comments", viewOpen: true }),
     }),

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useCreatePrReport.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useCreatePrReport.ts
@@ -133,7 +133,9 @@ export function useCreatePrReport({
   const createPrReport = useCallback(
     async (feedback?: string) => {
       feedbackRef.current = feedback?.trim() || undefined;
-      await run();
+      if (!(await run())) {
+        throw new Error("Could not start pull request");
+      }
     },
     [run],
   );

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useDiscussReport.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useDiscussReport.test.tsx
@@ -77,7 +77,7 @@ describe("useDiscussReport", () => {
     createTask.mockResolvedValue({ success: true, task: { id: "task-1" } });
   });
 
-  it("skips task creation and shows an error when no cloud repository is set", async () => {
+  it("skips task creation and shows an error when a repository is required", async () => {
     const { result } = renderHook(
       () =>
         useDiscussReport({
@@ -94,6 +94,30 @@ describe("useDiscussReport", () => {
       expect.objectContaining({
         description: "Pick a cloud repository before starting a discussion",
       }),
+    );
+  });
+
+  it("creates a repo-less report discussion when the caller allows it", async () => {
+    const { result } = renderHook(
+      () =>
+        useDiscussReport({
+          reportId: "r1",
+          reportTitle: "T",
+          cloudRepository: null,
+          allowMissingRepository: true,
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    await result.current.discussReport("why?");
+
+    expect(createTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repository: null,
+        allowNoRepo: true,
+        signalReportTaskRelationship: "discussion",
+      }),
+      expect.any(Function),
     );
   });
 
@@ -115,5 +139,6 @@ describe("useDiscussReport", () => {
     expect(input.workspaceMode).toBe("cloud");
     expect(input.cloudRunSource).toBe("signal_report");
     expect(input.signalReportId).toBe("r1");
+    expect(input.signalReportTaskRelationship).toBe("discussion");
   });
 });

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useDiscussReport.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useDiscussReport.ts
@@ -1,5 +1,6 @@
 import { buildDiscussReportPrompt } from "@posthog/core/inbox/reportActions";
 import type { TaskCreationInput } from "@posthog/core/task-detail/taskService";
+import type { Task } from "@posthog/shared/domain-types";
 import {
   type InboxCloudTaskInputContext,
   useInboxCloudTaskRunner,
@@ -10,6 +11,9 @@ interface UseDiscussReportOptions {
   reportId: string;
   reportTitle: string | null;
   cloudRepository: string | null;
+  onTaskCreated?: (task: Task) => void;
+  redirectOnSuccess?: boolean;
+  allowMissingRepository?: boolean;
 }
 
 interface UseDiscussReportReturn {
@@ -23,6 +27,9 @@ export function useDiscussReport({
   reportId,
   reportTitle,
   cloudRepository,
+  onTaskCreated,
+  redirectOnSuccess = true,
+  allowMissingRepository = false,
 }: UseDiscussReportOptions): UseDiscussReportReturn {
   // Carry the per-invocation question through to `buildInput`. A ref (not
   // state) so `discussReport`'s identity stays stable across question changes.
@@ -49,6 +56,8 @@ export function useDiscussReport({
         cloudPrAuthorshipMode: "user",
         cloudRunSource: "signal_report",
         signalReportId: reportId,
+        signalReportTaskRelationship: "discussion",
+        allowNoRepo: !ctx.cloudRepository,
       };
     },
     [reportId, reportTitle],
@@ -70,6 +79,9 @@ export function useDiscussReport({
     },
     buildInput,
     analyticsExtras: { has_branch: false },
+    onTaskCreated,
+    redirectOnSuccess,
+    allowMissingRepository,
   });
 
   const discussReport = useCallback(

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
@@ -103,7 +103,7 @@ export interface UseInboxCloudTaskRunnerOptions {
 
 export interface UseInboxCloudTaskRunnerReturn {
   /** Kick off the cloud-task flow. Resolves after the task is created (or failed). */
-  run: () => Promise<void>;
+  run: () => Promise<boolean>;
   /** True while a task is being created. */
   isRunning: boolean;
 }
@@ -136,17 +136,17 @@ export function useInboxCloudTaskRunner({
   const { isOnline } = useConnectivity();
 
   const run = useCallback(async () => {
-    if (isRunning) return;
+    if (isRunning) return false;
     const log = logger.scope(loggerScope);
 
     if (!isOnline) {
       showOfflineToast();
-      return;
+      return false;
     }
 
     if (!cloudRepository && !allowMissingRepository) {
       toast.error(copy.errorTitle, { description: copy.missingRepository });
-      return;
+      return false;
     }
 
     // A repo-less run has no GitHub identity; only resolve/require the user
@@ -156,12 +156,12 @@ export function useInboxCloudTaskRunner({
       : null;
     if (cloudRepository && !githubUserIntegrationId) {
       toast.error(copy.errorTitle, { description: copy.missingIntegration });
-      return;
+      return false;
     }
 
     if (!cloudRegion) {
       toast.error(copy.errorTitle, { description: copy.signedOut });
-      return;
+      return false;
     }
 
     setIsRunning(true);
@@ -191,7 +191,7 @@ export function useInboxCloudTaskRunner({
       toast.dismiss(toastId);
       toast.error(copy.errorTitle, { description: copy.missingModel });
       setIsRunning(false);
-      return;
+      return false;
     }
 
     // The persisted effort belongs to `lastUsedModel`; if the resolver swapped in
@@ -266,6 +266,7 @@ export function useInboxCloudTaskRunner({
           adapter,
           ...analyticsExtras,
         });
+        return true;
       } else {
         toast.dismiss(toastId);
         // Usage-limit blocks already show the upgrade modal; don't double-toast.
@@ -278,6 +279,7 @@ export function useInboxCloudTaskRunner({
             reportTitle,
           });
         }
+        return false;
       }
     } catch (error) {
       toast.dismiss(toastId);
@@ -286,6 +288,7 @@ export function useInboxCloudTaskRunner({
         error,
         reportId,
       });
+      return false;
     } finally {
       setIsRunning(false);
     }

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useReportTasks.test.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useReportTasks.test.ts
@@ -2,6 +2,7 @@ import type { Task, TaskRun, TaskRunStatus } from "@posthog/shared/types";
 import { describe, expect, it } from "vitest";
 import {
   findContinuableImplementationTask,
+  findUserDiscussionTask,
   getTaskPrUrl,
   type ReportTaskData,
   type ReportTaskPurpose,
@@ -103,6 +104,26 @@ describe("findContinuableImplementationTask", () => {
     expect(
       findContinuableImplementationTask([entry(failed), entry(running)]),
     ).toBe(running);
+  });
+});
+
+describe("findUserDiscussionTask", () => {
+  it("returns only the current user's report discussion", () => {
+    const mine = {
+      ...makeTask("mine"),
+      created_by: { uuid: "user-1", id: 1, email: "me@example.com" },
+    };
+    const theirs = {
+      ...makeTask("theirs"),
+      created_by: { uuid: "user-2", id: 2, email: "them@example.com" },
+    };
+
+    expect(
+      findUserDiscussionTask(
+        [entry(theirs, "discussion"), entry(mine, "discussion")],
+        "user-1",
+      ),
+    ).toBe(mine);
   });
 });
 

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useReportTasks.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useReportTasks.ts
@@ -7,10 +7,14 @@ import type {
 import { isTerminalStatus } from "@posthog/shared/types";
 import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
 
-// Task↔report associations are unlabelled — a task's purpose is derived from the report's
-// `task_run` artefacts (the signals pipeline writes product="signals" with one of these types;
-// custom agents write their own (product, type) pair).
-export type ReportTaskPurpose = "research" | "implementation" | "other";
+// A task's report purpose is derived from the report's `task_run` artefact.
+// Signals writes research, implementation, and discussion relationship types;
+// custom agents can write their own product and type pair.
+export type ReportTaskPurpose =
+  | "research"
+  | "implementation"
+  | "discussion"
+  | "other";
 
 export interface ReportTaskData {
   task: Task;
@@ -31,6 +35,9 @@ function derivePurpose(taskRun: {
     if (taskRun.type === "implementation") {
       return { purpose: "implementation", purposeLabel: "Implementation" };
     }
+    if (taskRun.type === "discussion") {
+      return { purpose: "discussion", purposeLabel: "Discussion" };
+    }
     // repo_selection runs are plumbing, not report work — never displayed (matches the
     // pre-derivation behavior of only showing research/implementation).
     return null;
@@ -43,6 +50,7 @@ function derivePurpose(taskRun: {
 
 const PURPOSE_ORDER: ReportTaskPurpose[] = [
   "implementation",
+  "discussion",
   "research",
   "other",
 ];
@@ -59,7 +67,7 @@ export function useReportTasks(
   return useAuthenticatedQuery<ReportTaskData[]>(
     ["inbox", "report-tasks", reportId],
     async (client) => {
-      // task_run artefacts ARE the task↔report association — one entry per associated task,
+      // Task-run artefacts are the task↔report association — one entry per associated task,
       // keyed by content.task_id (earliest artefact wins for startedAt). The runtime `type`
       // check is authoritative (the generic fallback artefact keeps `type: string` and
       // defeats static narrowing).
@@ -110,6 +118,19 @@ export function useReportTasks(
       staleTime: isActive ? 5_000 : 10_000,
       refetchInterval: isActive ? 5_000 : false,
     },
+  );
+}
+
+export function findUserDiscussionTask(
+  reportTasks: ReportTaskData[] | undefined,
+  userUuid: string | undefined,
+): Task | null {
+  if (!reportTasks || !userUuid) return null;
+  return (
+    reportTasks.find(
+      ({ purpose, task }) =>
+        purpose === "discussion" && task.created_by?.uuid === userUuid,
+    )?.task ?? null
   );
 }
 


### PR DESCRIPTION
## Problem

People can read generated report canvases, but the canvas does not provide a clear path into investigation or implementation. The existing Chat panel exposes generation machinery instead of a report conversation.

## Changes

- Chat starts or resumes a user-owned discussion attached to the report.
- Comments remain anchored to the shared report discussion task.
- Report discussions can investigate without a repository.
- Canvas controls expose Chat, Create PR, Continue PR, and Open in GitHub when relevant.
- Generated canvases retain richer report context from the preceding stack layer.

![report-canvas-discussion-starter](https://raw.githubusercontent.com/PostHog/pr-assets/52c2fc14079289b628e86e36d3989e52aa29b2f7/2026/08/62f16cee-270f-4e2e-a542-eebabc14629d.png)

## How did you test this code?

- Focused UI tests catch builder transcripts replacing report chat and discussion tasks losing their relationship.
- Focused core tests catch the relationship payload being dropped before task creation.
- Desktop and web typechecks passed.
- Storybook built and rendered the invented report state above.
- The full workspace suite reached unrelated native SQLite binding and Git default-branch failures in this cloud checkout.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No published documentation covers this draft report-canvas workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this with the posthog-desktop, writing-user-facing-copy, writing-tests, storybook-stories, stacking-prs, and writing-pr-descriptions skills. The design keeps shared comments separate from user-owned agent sessions. All committed fixtures and screenshots use invented data.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*