### PR TITLE
feat(workflows): open the AI panel for broadcast email editing

### DIFF
--- a/products/workflows/frontend/Broadcasts/BroadcastScene.tsx
+++ b/products/workflows/frontend/Broadcasts/BroadcastScene.tsx
@@ -1,12 +1,20 @@
-import { BindLogic, useValues } from 'kea'
+import { BindLogic, useActions, useValues } from 'kea'
+import { useMemo } from 'react'
 
 import { SpinnerOverlay } from '@posthog/lemon-ui'
 
 import { NotFound } from 'lib/components/NotFound'
+import { useDebouncedValue } from 'lib/hooks/useDebouncedValue'
+import { sceneAgentPanelLogic } from 'scenes/max/sceneAgentPanelLogic'
+import { useSceneAgentPanel } from 'scenes/max/useSceneAgentPanel'
 import { SceneExport } from 'scenes/sceneTypes'
 
 import { ProductKey } from '~/queries/schema/schema-general'
 
+import { useToolStreamListener } from 'products/posthog_ai/frontend/api/logics'
+import { resolveToolCall } from 'products/posthog_ai/frontend/api/tools'
+
+import { BROADCAST_AGENT_HEADLINES, buildBroadcastAgentContext } from './broadcastAgentContext'
 import { BroadcastSummary } from './BroadcastSummary'
 import { BroadcastWizard } from './BroadcastWizard'
 import { BroadcastWizardLogicProps, broadcastWizardLogic } from './broadcastWizardLogic'
@@ -29,7 +37,52 @@ export function BroadcastScene({ id }: BroadcastWizardLogicProps): JSX.Element {
 }
 
 function BroadcastSceneContent({ id }: BroadcastWizardLogicProps): JSX.Element {
-    const { broadcast, broadcastLoading } = useValues(broadcastWizardLogic)
+    const { broadcast, broadcastLoading, broadcastId, name, email, isReadOnly } = useValues(broadcastWizardLogic)
+    const { refreshFromAgentEdit } = useActions(broadcastWizardLogic)
+    const { sceneIntegrationEnabled } = useValues(sceneAgentPanelLogic)
+
+    // Debounced so per-keystroke edits don't re-serialize the email into the agent context. The id
+    // rides along with the email as one value so a navigation between broadcasts can never pair one
+    // broadcast's ref with the other's editor state during the debounce window.
+    const debouncedAgentSource = useDebouncedValue(
+        useMemo(() => ({ broadcastId, name, email }), [broadcastId, name, email]),
+        500
+    )
+    const agentContextItems = useMemo(
+        () =>
+            sceneIntegrationEnabled
+                ? buildBroadcastAgentContext(
+                      debouncedAgentSource.broadcastId,
+                      debouncedAgentSource.name,
+                      debouncedAgentSource.email
+                  )
+                : null,
+        [sceneIntegrationEnabled, debouncedAgentSource]
+    )
+    useSceneAgentPanel({
+        sceneKey: 'broadcast',
+        contextItems: agentContextItems,
+        // Only while the wizard is editable: the sent/scheduled summary view has nothing to patch.
+        active: !isReadOnly && (id === 'new' || !!broadcast),
+        headlines: BROADCAST_AGENT_HEADLINES,
+    })
+    // An approved email patch mutates the flow server-side while the wizard keeps pre-patch state,
+    // so refetch and re-hydrate the email on completion. The refetch is idempotent, so absorbing an
+    // event whose target we can't parse is harmless.
+    useToolStreamListener({
+        tools: ['workflows-patch-action-email', 'workflows-patch-graph', 'workflows-update'],
+        onEvent: (event) => {
+            if (event.phase !== 'completed' || !broadcastId) {
+                return
+            }
+            const innerInput = resolveToolCall(event.invocation).innerInput
+            const targetId = typeof innerInput?.id === 'string' ? innerInput.id : null
+            if (targetId && targetId !== broadcastId) {
+                return
+            }
+            refreshFromAgentEdit()
+        },
+    })
 
     if (id !== 'new') {
         if (!broadcast && broadcastLoading) {

--- a/products/workflows/frontend/Broadcasts/broadcastAgentContext.ts
+++ b/products/workflows/frontend/Broadcasts/broadcastAgentContext.ts
@@ -1,0 +1,113 @@
+import { AttachedContextItem } from 'products/posthog_ai/frontend/api/types'
+
+import { WORKFLOWS_MCP_TOOLS } from '../generated/agentContext'
+import type { BroadcastEmailValue } from './broadcastWizardLogic'
+
+// Each visible chip and the hidden payload items it stands for share a dismiss group, so closing
+// the chip actually detaches the payload instead of only hiding the chip.
+const BROADCAST_STATE_DISMISS_GROUP = 'broadcast-scene-state'
+const GUIDANCE_DISMISS_GROUP = 'broadcast-scene-guidance'
+
+// The wizard only edits one email step, so the agent needs the email-focused slice of the
+// workflows tool catalog rather than the full graph-editing set.
+const BROADCAST_TOOL_NAMES = [
+    'workflows-get',
+    'workflows-patch-action-email',
+    'workflows-list-email-templates',
+    'workflows-get-email-template',
+]
+
+const TOOL_CONTEXT_ITEMS: AttachedContextItem[] = WORKFLOWS_MCP_TOOLS.filter((tool) =>
+    BROADCAST_TOOL_NAMES.includes(tool.name)
+).map((tool) => ({
+    type: 'instructions',
+    hidden: true,
+    dismissGroup: GUIDANCE_DISMISS_GROUP,
+    value: `MCP tool ${tool.name}: ${tool.description}`,
+}))
+
+export const BROADCAST_AGENT_HEADLINES: string[] = [
+    'How can I help with this broadcast?',
+    'What should this email say?',
+]
+
+// pinned: must match EMAIL_ACTION_ID in broadcastWizardLogic — the wizard builds every broadcast
+// flow with this email step id, and the agent addresses its patches to it.
+const EMAIL_ACTION_ID = 'email_node'
+
+/** Email designs beyond this budget get elided so the context payload stays bounded. */
+export const EMAIL_STATE_MAX_CHARS = 32_000
+
+/**
+ * Serialize the wizard's live email value for agent context. The rendered html is dropped when a
+ * design is present (the server re-renders html from the design on every patch, so it is derived
+ * weight), and an oversized design is swapped for a fetch hint so the JSON stays parseable.
+ */
+export function serializeBroadcastEmailState(email: BroadcastEmailValue): string {
+    const prepared: Record<string, unknown> = { ...email }
+    if (prepared.design && prepared.html) {
+        delete prepared.html
+    }
+    const serialized = JSON.stringify(prepared)
+    if (serialized.length <= EMAIL_STATE_MAX_CHARS) {
+        return serialized
+    }
+    prepared.design = '[design elided for size: read it with workflows-get]'
+    return JSON.stringify(prepared)
+}
+
+// All static strings below are build-time constants from our own repo, which is what makes them
+// safe to attach as trusted `instructions` items — never interpolate ids or user text into them.
+const PREAMBLE_BASE =
+    'The user has the PostHog broadcast wizard open. A broadcast is a workflow (hog flow) of kind ' +
+    `"broadcast" with a single email step whose action id is "${EMAIL_ACTION_ID}". The ` +
+    'broadcast_email_editor_state item is the current, possibly unsaved email in the editor - prefer it ' +
+    'over a fetched definition when reading. '
+
+const PREAMBLE_UNSAVED =
+    PREAMBLE_BASE +
+    'This broadcast has not been saved yet, so there is no flow to patch. Help with subject lines, ' +
+    'copy, and structure in chat; the draft flow is created once the user continues past a wizard step, ' +
+    'after which you can apply edits directly.'
+
+const PREAMBLE_SAVED =
+    PREAMBLE_BASE +
+    "To change the email, call workflows-patch-action-email with id set to the attached hog_flow item's " +
+    `key and action_id "${EMAIL_ACTION_ID}" - the wizard picks the edit up automatically. Do not use ` +
+    'graph-editing tools to restructure the flow: the wizard owns the trigger/email/exit shape.'
+
+/**
+ * The default agent context for the broadcast wizard: guidance on how to edit the broadcast's
+ * email step, the email-focused MCP tool slice, and the live email editor state (plus a visible
+ * ref chip once the draft flow exists).
+ */
+export function buildBroadcastAgentContext(
+    broadcastId: string | null,
+    name: string,
+    email: BroadcastEmailValue
+): AttachedContextItem[] {
+    const items: AttachedContextItem[] = [
+        {
+            type: 'instructions',
+            hidden: true,
+            dismissGroup: GUIDANCE_DISMISS_GROUP,
+            value: broadcastId ? PREAMBLE_SAVED : PREAMBLE_UNSAVED,
+        },
+        ...TOOL_CONTEXT_ITEMS,
+    ]
+    if (broadcastId) {
+        items.push({
+            type: 'hog_flow',
+            key: broadcastId,
+            label: name || 'Current broadcast',
+            dismissGroup: BROADCAST_STATE_DISMISS_GROUP,
+        })
+    }
+    items.push({
+        type: 'broadcast_email_editor_state',
+        hidden: true,
+        dismissGroup: BROADCAST_STATE_DISMISS_GROUP,
+        value: serializeBroadcastEmailState(email),
+    })
+    return items
+}

--- a/products/workflows/frontend/Broadcasts/broadcastWizardLogic.ts
+++ b/products/workflows/frontend/Broadcasts/broadcastWizardLogic.ts
@@ -193,6 +193,9 @@ export interface broadcastWizardLogicActions {
     prevStep: () => {
         value: true
     }
+    refreshFromAgentEdit: () => {
+        value: true
+    }
     saveBroadcastFinished: (broadcast: HogFlowApi | null) => {
         broadcast: HogFlowApi | null
     }
@@ -321,6 +324,7 @@ export const broadcastWizardLogic = kea<broadcastWizardLogicType>([
         saveBroadcastFinished: (broadcast: HogFlowApi | null) => ({ broadcast }),
         launchBroadcast: true,
         launchBroadcastFinished: true,
+        refreshFromAgentEdit: true,
     }),
 
     loaders(({ props, values }) => ({
@@ -792,6 +796,26 @@ export const broadcastWizardLogic = kea<broadcastWizardLogicType>([
         },
         loadBroadcastFailure: () => {
             lemonToast.error("Couldn't load the broadcast. Refresh the page to try again.")
+        },
+        refreshFromAgentEdit: async (_, breakpoint) => {
+            if (!values.broadcastId || !values.currentProjectId) {
+                return
+            }
+            // Coalesce bursts of agent patches into one refetch.
+            await breakpoint(300)
+            try {
+                const refreshed = await hogFlowsRetrieve(String(values.currentProjectId), values.broadcastId)
+                breakpoint()
+                actions.saveBroadcastFinished(refreshed)
+                // Only the email is re-hydrated: the agent edits the email step, and pulling the other
+                // wizard fields from the server would clobber edits the user hasn't saved yet.
+                const value = findAction(refreshed, 'function_email')?.config?.inputs?.email?.value
+                if (value) {
+                    actions.setEmail({ ...DEFAULT_BROADCAST_EMAIL, ...value })
+                }
+            } catch {
+                // The editor keeps its current state; the next patch or a reload will resync.
+            }
         },
     })),
 


### PR DESCRIPTION
## Problem

Editing an email in the workflow editor comes with the PostHog AI side panel, so users can chat their way to a template. The broadcast wizard edits the same kind of email step but offers no AI help — users have to write the email by hand or detour through the workflow editor.

## Why

Requested as a follow-up on the broadcasts prototype ([#82343](https://github.com/PostHog/posthog/pull/82343)): the email step of the wizard should offer the same AI chat sidebar users already get on workflow emails.

## Changes

- The broadcast wizard now registers scene-level agent context (same `useSceneAgentPanel` integration as the workflow editor): instructions for patching the broadcast's email step via `workflows-patch-action-email`, the email-focused slice of the workflows MCP tool catalog, the live (possibly unsaved) email editor state, and a `hog_flow` ref chip once the draft exists.
- A tool-stream listener refetches the draft after a completed email patch and re-hydrates only the email into the wizard, so agent edits appear in the editor without clobbering unsaved edits on other wizard steps.
- For unsaved broadcasts the attached instructions tell the agent there is no flow to patch yet and to help with copy in chat instead.

Stacked on `posthog/broadcasts-prototype` ([#82343](https://github.com/PostHog/posthog/pull/82343)).

## How did you test this code?

- `tsgo --noEmit` (full frontend typecheck) passes; kea typegen regenerated for the changed logic; oxlint/oxfmt clean.
- Not manually tested in a running app: the panel rides the scene-integration rollout flag, and this environment has no browser session against a booted stack.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — prototype surface, not yet documented.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code in a PostHog Desktop task session. Mirrored the existing `WorkflowScene` scene-agent-panel wiring and the `HogFunctionConfiguration` tool-stream refetch pattern rather than the deprecated MaxTool path, per `scenes/max` guidance that new AI affordances go on the sandbox runtime.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*