### PR TITLE
fix(desktop): open canvas chat when editing

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteLayout.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteLayout.test.tsx
@@ -11,6 +11,7 @@ vi.mock("@posthog/host-router/react", () => ({
     dashboards: { saveContext: { mutationKey: () => ["save-context"] } },
   }),
 }));
+vi.mock("@posthog/ui/shell/analytics", () => ({ track: vi.fn() }));
 
 const { useChannelTasks, useDashboard, useParams, usePathname, useTasks } =
   vi.hoisted(() => ({
@@ -166,6 +167,26 @@ describe("WebsiteLayout task header actions", () => {
       });
     },
   );
+
+  it("opens the chat panel when entering edit mode", () => {
+    renderLayout({
+      pathname: "/website/chan-1/dashboards/canvas-1",
+      params: { channelId: "chan-1", dashboardId: "canvas-1" },
+      dashboard: {
+        name: "Launch",
+        templateId: "freeform",
+        generationTaskId: "task-1",
+      },
+    });
+
+    useCanvasChatPanelStore.setState({ collapsed: true, tab: "comments" });
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    expect(useCanvasChatPanelStore.getState()).toMatchObject({
+      collapsed: false,
+      tab: "chat",
+    });
+  });
 
   it("renders the task action row on a channel task detail", () => {
     renderLayout({

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteLayout.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteLayout.tsx
@@ -84,6 +84,7 @@ function FreeformEditControls({
   const containerNoun = spacesLayout ? "space" : "channel";
   const editing = useIsDashboardEditing(dashboardId);
   const setEditing = useDashboardEditStore((s) => s.setEditing);
+  const openChat = useCanvasChatPanelStore((state) => state.openChat);
   const { dashboard } = useDashboard(dashboardId);
   const { setPinned, invalidateDashboards } = useDashboardMutations();
   const isPinned = dashboard?.pinnedAt != null;
@@ -260,6 +261,7 @@ function FreeformEditControls({
             kind: "freeform",
             editing: !editing,
           });
+          if (!editing) openChat();
           setEditing(dashboardId, !editing);
         }}
       >

--- a/products/desktop/packages/ui/src/features/canvas/stores/canvasChatPanelStore.ts
+++ b/products/desktop/packages/ui/src/features/canvas/stores/canvasChatPanelStore.ts
@@ -37,7 +37,7 @@ export const useCanvasChatPanelStore = create<CanvasChatPanelState>()(
         set(collapsed ? { collapsed, viewOpen: false } : { collapsed }),
       setWidth: (width) => set({ width }),
       setTab: (tab) => set({ tab }),
-      openChat: () => set({ collapsed: false, tab: "chat" }),
+      openChat: () => set({ collapsed: false, tab: "chat", viewOpen: false }),
       openComments: () =>
         set({ collapsed: false, tab: "comments", viewOpen: true }),
     }),

--- a/products/desktop/packages/ui/src/features/canvas/stores/canvasChatPanelStore.ts
+++ b/products/desktop/packages/ui/src/features/canvas/stores/canvasChatPanelStore.ts
@@ -20,6 +20,7 @@ interface CanvasChatPanelState {
   setCollapsed: (collapsed: boolean) => void;
   setWidth: (width: number) => void;
   setTab: (tab: CanvasPanelTab) => void;
+  openChat: () => void;
   openComments: () => void;
 }
 
@@ -36,6 +37,7 @@ export const useCanvasChatPanelStore = create<CanvasChatPanelState>()(
         set(collapsed ? { collapsed, viewOpen: false } : { collapsed }),
       setWidth: (width) => set({ width }),
       setTab: (tab) => set({ tab }),
+      openChat: () => set({ collapsed: false, tab: "chat" }),
       openComments: () =>
         set({ collapsed: false, tab: "comments", viewOpen: true }),
     }),


### PR DESCRIPTION
## Problem

Clicking Edit on a canvas leaves the right-side chat closed, so people must open it separately.

## Changes

- Clicking Edit now opens the right-side panel on Chat.
- The new store action updates the panel state in one transition.
- No screenshot: this changes an interaction between existing states, not their appearance.

## How did you test this code?

- Added a regression test for editing while the panel is collapsed on Comments.
- Ran the Desktop UI tests, typecheck, and lint.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes are needed for this existing canvas workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex made this change using the posthog-desktop and writing-pr-descriptions skills.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*