### PR TITLE
fix(ai-research): stop DEBUG from switching off the SSRF checks

### DIFF
--- a/nodejs/src/common/utils/request-streamed.test.ts
+++ b/nodejs/src/common/utils/request-streamed.test.ts
@@ -20,6 +20,21 @@ function respond(chunks: Buffer[], headers: Record<string, string> = {}): void {
 }
 
 describe('fetchStreamed', () => {
+    it('refuses a private address even when the environment would allow one', async () => {
+        // `determineNodeEnv` answers Development whenever DEBUG is set, whatever NODE_ENV says, and
+        // `.env` in this repo sets DEBUG=1. A lane that reads URLs off a customer's page must not
+        // inherit that, so this call passes the check explicitly rather than taking the default.
+        const originalDebug = process.env.DEBUG
+        process.env.DEBUG = '1'
+        try {
+            await expect(fetchStreamed('https://127.0.0.1/a.png', { headers: {}, timeoutMs: 100 })).rejects.toThrow(
+                'Hostname is not allowed'
+            )
+        } finally {
+            process.env.DEBUG = originalDebug
+        }
+    })
+
     beforeEach(() => {
         requestMock.mockReset()
     })

--- a/nodejs/src/common/utils/request.test.ts
+++ b/nodejs/src/common/utils/request.test.ts
@@ -63,6 +63,10 @@ describe('fetch', () => {
         jest.mocked(dns.lookup).mockImplementation(realDnsLookup)
         // NOTE: We are testing production-only features hence the override
         process.env.NODE_ENV = 'production'
+        // `determineNodeEnv` reads DEBUG as well, and answers Development whenever it is set,
+        // whatever NODE_ENV says. `.env` in this repo sets DEBUG=1, so without this every
+        // assertion below ran against the permissive branch and passed while checking nothing.
+        delete process.env.DEBUG
     })
     describe('raiseIfUserProvidedUrlUnsafe', () => {
         it.each([
@@ -271,6 +275,10 @@ describe('legacyFetch', () => {
         jest.mocked(dns.lookup).mockImplementation(realDnsLookup)
         // NOTE: We are testing production-only features hence the override
         process.env.NODE_ENV = 'production'
+        // `determineNodeEnv` reads DEBUG as well, and answers Development whenever it is set,
+        // whatever NODE_ENV says. `.env` in this repo sets DEBUG=1, so without this every
+        // assertion below ran against the permissive branch and passed while checking nothing.
+        delete process.env.DEBUG
     })
 
     describe('calls', () => {

--- a/nodejs/src/common/utils/request.ts
+++ b/nodejs/src/common/utils/request.ts
@@ -185,7 +185,13 @@ function isIPv4(addr: ipaddr.IPv4 | ipaddr.IPv6): addr is ipaddr.IPv4 {
     return addr.kind().toLowerCase() === 'ipv4'
 }
 
-async function staticLookupAsync(hostname: string): Promise<LookupAddress[]> {
+/**
+ * `allowPrivate` exists for local development, where a caller may need to reach a service on this
+ * machine. It defaults to the environment, which reads DEBUG as well as NODE_ENV, so a pod that
+ * runs with DEBUG set answers Development and turns this check off. A caller whose safety depends
+ * on the check must pass `false` rather than rely on the default.
+ */
+async function staticLookupAsync(hostname: string, allowPrivate = !isProdEnv()): Promise<LookupAddress[]> {
     let addrinfo: LookupAddress[]
     const validAddrinfo: LookupAddress[] = []
     try {
@@ -205,8 +211,7 @@ async function staticLookupAsync(hostname: string): Promise<LookupAddress[]> {
             ipv4 = parsed.toIPv4Address()
         } else {
             // Pure IPv6 — validate directly
-            const allowUnsafe = !isProdEnv()
-            if (!allowUnsafe && !isGlobalIPv6(parsed)) {
+            if (!allowPrivate && !isGlobalIPv6(parsed)) {
                 unsafeRequestCounter.inc({ reason: 'internal_hostname' })
                 logBlockedUrlValidation(hostname, resolvedIps)
                 throw new SecureRequestError('Hostname is not allowed')
@@ -215,11 +220,8 @@ async function staticLookupAsync(hostname: string): Promise<LookupAddress[]> {
             continue
         }
 
-        // TRICKY: We need this for tests and local dev
-        const allowUnsafe = !isProdEnv()
-
         // Check if the IPv4 address is global
-        if (!allowUnsafe && !isGlobalIPv4(ipv4)) {
+        if (!allowPrivate && !isGlobalIPv4(ipv4)) {
             unsafeRequestCounter.inc({ reason: 'internal_hostname' })
             logBlockedUrlValidation(hostname, resolvedIps)
             throw new SecureRequestError('Hostname is not allowed')
@@ -244,6 +246,15 @@ export const httpStaticLookup: net.LookupFunction = async (hostname, _options, c
     }
 }
 
+/** Refuses a private address in every environment, for a caller that has no reason to reach one. */
+const strictStaticLookup: net.LookupFunction = async (hostname, _options, cb) => {
+    try {
+        cb(null, await staticLookupAsync(hostname, false))
+    } catch (err) {
+        cb(err as Error, '', 4)
+    }
+}
+
 /**
  * Legacy function used by parts of the codebase. Generally speaking this should be replaced with secureFetch.
  */
@@ -254,12 +265,12 @@ export async function raiseIfUserProvidedUrlUnsafe(url: string): Promise<void> {
 }
 
 class SecureAgent extends Agent {
-    constructor() {
+    constructor(lookup: net.LookupFunction = httpStaticLookup) {
         super({
             keepAliveTimeout: Number(requestConfig.EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS),
             connections: requestConfig.EXTERNAL_REQUEST_CONNECTIONS,
             connect: {
-                lookup: httpStaticLookup,
+                lookup,
                 timeout: requestConfig.EXTERNAL_REQUEST_CONNECT_TIMEOUT_MS,
             },
         })
@@ -297,7 +308,28 @@ function makeSecureDispatcher(): Dispatcher {
     return new SecureAgent()
 }
 
+/**
+ * The dispatcher for a caller that must never reach a private address, whatever the environment.
+ *
+ * The proxy branch is the same, because smokescreen refuses a private address on its own and does
+ * not read our environment to decide. Only the direct branch needs the stricter lookup.
+ */
+function makeStrictDispatcher(): Dispatcher {
+    const proxyUrl =
+        process.env.HTTPS_PROXY || process.env.HTTP_PROXY || process.env.https_proxy || process.env.http_proxy
+    if (proxyUrl) {
+        return new ProxyAgent({
+            uri: proxyUrl,
+            keepAliveTimeout: requestConfig.EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS,
+            connections: requestConfig.EXTERNAL_REQUEST_CONNECTIONS,
+            requestTls: {},
+        })
+    }
+    return new SecureAgent(strictStaticLookup)
+}
+
 const sharedSecureAgent = makeSecureDispatcher()
+const sharedStrictAgent = makeStrictDispatcher()
 // Unlike `makeSecureDispatcher`, this agent deliberately skips the ProxyAgent branch: CDP workers don't
 // set the proxy env vars, and SSRF stays covered via `httpStaticLookup`. If CDP egress ever moves behind
 // the proxy (see #49170), swap this for a `ProxyAgent` — undici's `ProxyAgent` supports `allowH2` — so
@@ -329,9 +361,12 @@ function destroyBody(body: Dispatcher.ResponseData['body']): void {
 function flattenHeaders(raw: Dispatcher.ResponseData['headers']): Record<string, string> {
     const headers: Record<string, string> = Object.create(null)
     for (const [key, value] of Object.entries(raw)) {
-        const singleValue = Array.isArray(value) ? value[0] : value
-        if (singleValue) {
-            headers[key] = singleValue
+        // Repeated field lines join with a comma, which RFC 9110 section 5.3 allows for every field
+        // except `set-cookie`. Taking the first line alone loses the rest, and a sender is free to
+        // split a list-valued field such as `x-robots-tag` across as many lines as it likes.
+        const joined = Array.isArray(value) ? (key === 'set-cookie' ? value[0] : value.join(', ')) : value
+        if (joined) {
+            headers[key] = joined
         }
     }
     return headers
@@ -492,7 +527,10 @@ async function readCappedBody(
  */
 export async function fetchStreamed(url: string, options: StreamedFetchOptions): Promise<StreamedResponse> {
     const parsed = validateUrl(url)
-    validateHostnameIPLiteral(parsed.hostname, !isProdEnv())
+    // `false` rather than the environment default. This reads content a customer's page named, so
+    // there is no environment in which it should reach a private address, and the default answers
+    // Development whenever DEBUG is set.
+    validateHostnameIPLiteral(parsed.hostname, false)
 
     inflightExternalRequests.inc()
     let result: Dispatcher.ResponseData
@@ -500,7 +538,7 @@ export async function fetchStreamed(url: string, options: StreamedFetchOptions):
         result = await request(parsed.toString(), {
             method: 'GET',
             headers: options.headers,
-            dispatcher: sharedSecureAgent,
+            dispatcher: sharedStrictAgent,
             signal: AbortSignal.timeout(options.timeoutMs),
         })
     } catch (error) {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/README.md
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-fetch/README.md
@@ -152,8 +152,10 @@ write, so an attacker chooses them, and the request leaves from inside our netwo
 
 32. The lane must never connect to an IP address that is not globally routable. That covers
     loopback, the RFC 1918 private ranges, link-local, carrier-grade NAT, multicast, and the
-    reserved ranges, in IPv4 and IPv6. Smokescreen, the egress proxy, enforces this in production.
-    `httpStaticLookup`, our DNS hook for undici, enforces it when no proxy is set.
+    reserved ranges, in IPv4 and IPv6. Smokescreen, the egress proxy, enforces this when a proxy is
+    set. `strictStaticLookup`, our DNS hook for undici, enforces it when none is. Neither asks the
+    environment. The lane reads URLs a customer's page named, so no environment makes a private
+    address safe, and `determineNodeEnv` answers Development whenever `DEBUG` is set.
 33. The check must use the same DNS answer as the connection, so that DNS rebinding cannot slip an
     IP address past it. An attacker who owns a name can return a different IP address on every
     lookup. Code that resolves a name, checks the IP address, then hands the name to something that


### PR DESCRIPTION
## Problem

- The SSRF checks that stop our pods reaching internal services switch off whenever `DEBUG` is set.
- `determineNodeEnv()` answers `Development` when `DEBUG` is set, whatever `NODE_ENV` says. Every check in `request.ts` gates on `isProdEnv()`.
- `.env` in this repo sets `DEBUG=1`, so no developer has run these checks locally.
- 55 assertions in `request.test.ts` passed while checking nothing, including every private-range and IPv6-literal case.

This is the layer above [#82030](https://github.com/PostHog/posthog/pull/82030), which builds the image fetch lane. That lane reads URLs off a customer's page, so it is the caller that most needs these checks to hold.

## Changes

- `fetchStreamed` refuses a private IP address in every environment, rather than asking `isProdEnv()`.
- `staticLookupAsync` takes `allowPrivate` explicitly. The default still follows the environment, for callers that need localhost in development.
- The proxy branch is unchanged. Smokescreen refuses a private address on its own and does not read our environment.
- Repeated response header lines join with a comma instead of keeping only the first, per RFC 9110 section 5.3.
- `request.test.ts` clears `DEBUG` in its setup, so its 55 SSRF assertions run against the branch they were written for.

> [!NOTE]
> `fetchStreamed` has one production caller, the image fetch lane, so making it strict needs no flag threading. `raiseIfUserProvidedUrlUnsafe` and the shared `secureFetch` path keep the environment default.

The header change matters beyond tidiness: `X-Robots-Tag` is routinely split across several lines, and the AI opt-out signals this lane must honour arrive in it.

## How did you test this code?

- `request.test.ts` had 55 failing assertions locally before this change and passes after. Those failures reproduce at the merge base, so they predate the fetch lane.
- One new test in `request-streamed.test.ts` sets `DEBUG=1` and asserts `fetchStreamed` still refuses `https://127.0.0.1/`. It fails if the gate returns to `isProdEnv()`.
- Not run: anything needing a live proxy. The smokescreen branch is unchanged and untested here.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Requirement 32 in the lane README now says the address check does not read the environment.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) found this while chasing 55 failing tests in `request.test.ts`. Robbie asked me not to file them as pre-existing, which is what turned a test-isolation bug into a production finding: the same gate that made the tests vacuous also disables SSRF protection in any pod with `DEBUG` set.

Skills invoked: `/stacking-prs`, `/writing-pr-descriptions`, `/writing-code-comments`, `/asd-ste100`.

This branch is the first layer above the image fetch lane. It exists to hold the follow-up work from a crawling state-of-the-art review and a legal review of robots.txt obligations, starting with the blockers.
