### PR TITLE
fix(desktop): show loading while a cloud transcript hydrates

### DIFF
--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -6209,9 +6209,16 @@ export class SessionService {
       return undefined;
     });
     this.cloudHydrationPromises.set(hydrationKey, hydration);
+    this.d.store.updateSession(taskRunId, { isHydrating: true });
     void hydration.finally(() => {
       if (this.cloudHydrationPromises.get(hydrationKey) === hydration) {
         this.cloudHydrationPromises.delete(hydrationKey);
+      }
+      const stillHydrating = [...this.cloudHydrationPromises.keys()].some(
+        (key) => key.startsWith(`${taskRunId}:`),
+      );
+      if (!stillHydrating) {
+        this.d.store.updateSession(taskRunId, { isHydrating: false });
       }
     });
     return hydration;

--- a/products/desktop/packages/core/src/sessions/sessionServiceHydrationFlag.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionServiceHydrationFlag.test.ts
@@ -1,0 +1,164 @@
+import type { AgentSession } from "@posthog/shared";
+import type { TaskRunStatus } from "@posthog/shared/domain-types";
+import { describe, expect, it, vi } from "vitest";
+import { SessionService, type SessionServiceDeps } from "./sessionService";
+
+interface HydratableService {
+  hydrateCloudTaskSessionFromLogs(
+    taskId: string,
+    taskRunId: string,
+    logUrl?: string,
+    taskDescription?: string,
+    runStatus?: TaskRunStatus,
+    runState?: Record<string, unknown>,
+  ): Promise<unknown>;
+}
+
+function makeSession(): AgentSession {
+  return {
+    taskRunId: "run-1",
+    taskId: "task-1",
+    taskTitle: "Test task",
+    channel: "",
+    events: [],
+    startedAt: 1,
+    status: "connected",
+    isPromptPending: false,
+    isCompacting: false,
+    promptStartedAt: null,
+    pendingPermissions: new Map(),
+    pausedDurationMs: 0,
+    messageQueue: [],
+    optimisticItems: [],
+    isCloud: true,
+    cloudStatus: "in_progress",
+  } as AgentSession;
+}
+
+function createHarness(
+  options: {
+    fetchAuthState?: () => Promise<unknown>;
+    getTaskRunSessionLogsResult?: ReturnType<typeof vi.fn>;
+  } = {},
+) {
+  const session = makeSession();
+  const updateSession = vi.fn();
+  const warn = vi.fn();
+  const deps = {
+    store: {
+      getSessionByTaskId: (taskId: string) =>
+        session.taskId === taskId ? session : undefined,
+      getSessions: () => ({ [session.taskRunId]: session }),
+      updateSession,
+      clearTailOptimisticItems: vi.fn(),
+    },
+    log: { info: vi.fn(), warn, error: vi.fn(), debug: vi.fn() },
+    fetchAuthState:
+      options.fetchAuthState ??
+      (async () => ({ cloudRegion: "us", currentProjectId: 2 })),
+    createAuthenticatedClient: () => ({
+      getTaskRunSessionLogsResult:
+        options.getTaskRunSessionLogsResult ??
+        vi.fn(async () => ({ complete: true, entries: [] })),
+    }),
+    trpc: {
+      agent: {
+        onSessionIdleKilled: { subscribe: () => ({ unsubscribe: vi.fn() }) },
+      },
+      logs: {
+        readLocalLogs: { query: vi.fn(async () => null) },
+        fetchS3Logs: { query: vi.fn(async () => null) },
+      },
+    },
+  } as unknown as SessionServiceDeps;
+
+  const service = new SessionService(deps) as unknown as HydratableService;
+  return { service, updateSession, warn };
+}
+
+describe("SessionService cloud hydration flag", () => {
+  it("sets isHydrating while a hydration is in flight and clears it after", async () => {
+    const { service, updateSession } = createHarness();
+
+    const hydration = service.hydrateCloudTaskSessionFromLogs(
+      "task-1",
+      "run-1",
+      undefined,
+      undefined,
+      "in_progress",
+    );
+
+    expect(updateSession).toHaveBeenCalledWith("run-1", { isHydrating: true });
+    expect(updateSession).not.toHaveBeenCalledWith("run-1", {
+      isHydrating: false,
+    });
+
+    await hydration;
+
+    expect(updateSession).toHaveBeenLastCalledWith("run-1", {
+      isHydrating: false,
+    });
+  });
+
+  it("clears isHydrating when the transcript fetch fails", async () => {
+    const fetchResult = vi.fn().mockRejectedValue(new Error("fetch failed"));
+    const { service, updateSession, warn } = createHarness({
+      getTaskRunSessionLogsResult: fetchResult,
+    });
+
+    await service.hydrateCloudTaskSessionFromLogs(
+      "task-1",
+      "run-1",
+      undefined,
+      undefined,
+      "completed",
+    );
+
+    expect(fetchResult).toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      "Failed to hydrate cloud task session from logs",
+      expect.objectContaining({ taskRunId: "run-1" }),
+    );
+    expect(updateSession).toHaveBeenLastCalledWith("run-1", {
+      isHydrating: false,
+    });
+  });
+
+  it("keeps isHydrating while a sibling hydration for the run is in flight", async () => {
+    let releaseAuth: (value: unknown) => void = () => {};
+    const gatedAuth = new Promise((resolve) => {
+      releaseAuth = resolve;
+    });
+    const { service, updateSession } = createHarness({
+      fetchAuthState: () => gatedAuth,
+    });
+
+    const singleHydration = service.hydrateCloudTaskSessionFromLogs(
+      "task-1",
+      "run-1",
+      undefined,
+      undefined,
+      "in_progress",
+    );
+    const terminalHydration = service.hydrateCloudTaskSessionFromLogs(
+      "task-1",
+      "run-1",
+      undefined,
+      undefined,
+      "completed",
+    );
+
+    await singleHydration;
+
+    expect(updateSession).not.toHaveBeenCalledWith("run-1", {
+      isHydrating: false,
+    });
+
+    releaseAuth({ status: "restoring" });
+    await terminalHydration;
+
+    expect(updateSession).toHaveBeenLastCalledWith("run-1", {
+      isHydrating: false,
+    });
+  });
+});

--- a/products/desktop/packages/core/src/sessions/sessionViewState.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionViewState.test.ts
@@ -84,4 +84,31 @@ describe("deriveSessionViewState", () => {
     expect(state.isCloudRunTerminal).toBe(false);
     expect(state.isInitializing).toBe(true);
   });
+
+  it("keeps a hydrating terminal run initializing until events land", () => {
+    const state = deriveSessionViewState(
+      { ...makeSession("completed"), isHydrating: true },
+      makeTask("completed"),
+      null,
+      true,
+    );
+
+    expect(state.isInitializing).toBe(true);
+  });
+
+  it("shows the thread once hydration lands events, even mid-fetch", () => {
+    const event = {
+      type: "acp_message" as const,
+      ts: 1,
+      message: { jsonrpc: "2.0" as const, method: "session/update" },
+    };
+    const state = deriveSessionViewState(
+      { ...makeSession("completed"), isHydrating: true, events: [event] },
+      makeTask("completed"),
+      null,
+      true,
+    );
+
+    expect(state.isInitializing).toBe(false);
+  });
 });

--- a/products/desktop/packages/core/src/sessions/sessionViewState.ts
+++ b/products/desktop/packages/core/src/sessions/sessionViewState.ts
@@ -51,8 +51,7 @@ export function deriveSessionViewState(
   const isNewSessionWithInitialPrompt =
     !task.latest_run?.id && !!task.description;
   const isResumingExistingSession = !!task.latest_run?.id;
-  // A terminal run being hydrated has a session but no events yet; without the
-  // hydration flag the thread renders empty until the transcript fetch lands.
+  // Keeps a terminal run on the loading view until its transcript fetch lands.
   const isHydrating = session?.isHydrating === true;
   const isInitializing = isCloud
     ? !hasError &&

--- a/products/desktop/packages/core/src/sessions/sessionViewState.ts
+++ b/products/desktop/packages/core/src/sessions/sessionViewState.ts
@@ -51,8 +51,13 @@ export function deriveSessionViewState(
   const isNewSessionWithInitialPrompt =
     !task.latest_run?.id && !!task.description;
   const isResumingExistingSession = !!task.latest_run?.id;
+  // A terminal run being hydrated has a session but no events yet; without the
+  // hydration flag the thread renders empty until the transcript fetch lands.
+  const isHydrating = session?.isHydrating === true;
   const isInitializing = isCloud
-    ? !hasError && (!session || (events.length === 0 && isCloudRunNotTerminal))
+    ? !hasError &&
+      (!session ||
+        (events.length === 0 && (isCloudRunNotTerminal || isHydrating)))
     : !session ||
       (session.status === "connecting" && events.length === 0) ||
       (session.status === "connected" &&

--- a/products/desktop/packages/shared/src/sessions.ts
+++ b/products/desktop/packages/shared/src/sessions.ts
@@ -95,6 +95,8 @@ export interface AgentSession {
   editingQueuedId?: string;
   isCloud?: boolean;
   cloudStatus?: TaskRunStatus;
+  /** A cloud transcript fetch is in flight for this session. */
+  isHydrating?: boolean;
   cloudStage?: string | null;
   cloudOutput?: Record<string, unknown> | null;
   cloudArtifacts?: TaskRunArtifact[];

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionInitializingView.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionInitializingView.test.tsx
@@ -25,6 +25,12 @@ describe("SessionInitializingView", () => {
       heading: "Starting the sandbox…",
       subtitle: "Connecting to your cloud runner.",
     },
+    {
+      executionTarget: "cloud" as const,
+      cloudStatus: "completed" as const,
+      heading: "Loading the conversation…",
+      subtitle: "Fetching the transcript for this run.",
+    },
   ])(
     "shows $executionTarget connection copy",
     ({ executionTarget, cloudStatus, heading, subtitle }) => {

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionInitializingView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionInitializingView.tsx
@@ -1,5 +1,8 @@
 import { Spinner } from "@phosphor-icons/react";
-import type { TaskRunStatus } from "@posthog/shared/domain-types";
+import {
+  isTerminalStatus,
+  type TaskRunStatus,
+} from "@posthog/shared/domain-types";
 import { Flex, Text } from "@radix-ui/themes";
 import { useEffect, useState } from "react";
 import zenHedgehog from "../../../assets/images/zen.png";
@@ -21,6 +24,13 @@ function copyFor(
     return {
       heading: "Starting Pi…",
       subtitle: "Connecting to Pi on this device.",
+    };
+  }
+
+  if (isTerminalStatus(cloudStatus)) {
+    return {
+      heading: "Loading the conversation…",
+      subtitle: "Fetching the transcript for this run.",
     };
   }
 


### PR DESCRIPTION
## Problem

Opening a finished cloud run shows an empty chat that pops in once the transcript downloads. Long transcripts fetch several pages, so the blank can last seconds with no sign anything is loading.

## Changes

- The session tracks transcript hydration, and the view stays on the loading screen until the first events land or hydration finishes empty.
- Finished runs get their own loading copy ("Loading the conversation…") instead of "Connecting to your cloud runner."

## How did you test this code?

- View-state tests: a hydrating terminal run stays on the loading screen, and the thread shows as soon as events land.
- A copy test for the new loading variant, the core sessions suite and `pnpm typecheck`.
- Not run: a live check against a long cloud transcript.

