### PR TITLE
chore(request): make the SSRF tests assert when DEBUG is set

### DIFF
--- a/nodejs/src/common/utils/request.test.ts
+++ b/nodejs/src/common/utils/request.test.ts
@@ -63,6 +63,7 @@ describe('fetch', () => {
         jest.mocked(dns.lookup).mockImplementation(realDnsLookup)
         // NOTE: We are testing production-only features hence the override
         process.env.NODE_ENV = 'production'
+        delete process.env.DEBUG
     })
     describe('raiseIfUserProvidedUrlUnsafe', () => {
         it.each([
@@ -271,6 +272,7 @@ describe('legacyFetch', () => {
         jest.mocked(dns.lookup).mockImplementation(realDnsLookup)
         // NOTE: We are testing production-only features hence the override
         process.env.NODE_ENV = 'production'
+        delete process.env.DEBUG
     })
 
     describe('calls', () => {


### PR DESCRIPTION
## Problem

- Anyone who runs `request.test.ts` locally sees it pass while 55 of its assertions check nothing.
- `determineNodeEnv()` answers `Development` whenever `DEBUG` is set, whatever `NODE_ENV` says.
- `.env` in this repo sets `DEBUG=1`, so `isProdEnv()` stayed false however the test set `NODE_ENV`, and every check took the permissive branch.
- The vacuous assertions include every private-range case and every IPv6-literal bypass case.
- CI does not set `DEBUG`, so the suite has always looked healthy there. This is a local-only problem, and the cost is that a real regression in the SSRF checks would not show up until CI.

## Changes

- Two `beforeEach` blocks delete `process.env.DEBUG` alongside the existing `NODE_ENV` override.
- Test only. No production file changes.

## How did you test this code?

- `request.test.ts` reported 55 failures on this branch before the change and passes after. The failures reproduce on `master`, so they predate any recent work.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) found this while building an unrelated session replay lane that calls into `request.ts`. I first proposed changing the production gate as well, on the theory that a pod running with `DEBUG` set would lose its SSRF checks. Robbie closed that PR, because `request.ts` is core shared code we do not own. He then asked how `DEBUG` would ever reach a pod, and it cannot: `.env` is gitignored, and no ingestion chart sets the variable. So the production concern was unfounded and only the test fix remains.

Skills invoked: `/writing-pr-descriptions`, `/writing-code-comments`.
