### PR TITLE
fix(data-imports): reject non-list source config values with a clean error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/config.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/config.py
@@ -739,7 +739,7 @@ def str_to_optional_list(s: str | list[typing.Any] | None) -> list[str] | None:
         return None
     if isinstance(s, list):
         values = [str(item).strip() for item in s]
-    else:
+    elif isinstance(s, str):
         stripped = s.strip()
         if stripped == "":
             return None
@@ -754,6 +754,11 @@ def str_to_optional_list(s: str | list[typing.Any] | None) -> list[str] | None:
                 values = [stripped]
         else:
             values = [item.strip() for item in stripped.split(",")]
+    else:
+        # A non-str/list value (e.g. a dict submitted for a multi-select field) has no list
+        # interpretation. Raise so `_convert_value` surfaces it as a clean validation error
+        # instead of an unhandled `AttributeError` from calling `.strip()` on it.
+        raise TypeError(f"expected a string, list, or None, got {type(s).__name__}")
     values = [value for value in values if value]
     return values or None
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_config.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_config.py
@@ -100,6 +100,15 @@ def test_str_to_optional_list(value, expected):
     assert config.str_to_optional_list(value) == expected
 
 
+@pytest.mark.parametrize("value", [{"owner": "repo"}, {}, 5])
+def test_str_to_optional_list_rejects_unsupported_types(value):
+    """A non-str/list value (e.g. a dict submitted for a multi-select field) must raise a
+    `TypeError` that `_convert_value` can surface as a validation error, not an `AttributeError`
+    from calling `.strip()` on it."""
+    with pytest.raises(TypeError):
+        config.str_to_optional_list(value)
+
+
 @pytest.mark.parametrize(
     "value,expected",
     [


### PR DESCRIPTION
## Problem

- Creating or updating a data warehouse source whose config carries a multi-select list field failed with a 500, and the failure was reported to [error tracking](https://us.posthog.com/project/2/error_tracking/019ffcf5-8673-7aa3-84c0-09f3786fdbb9) as `AttributeError: 'dict' object has no attribute 'strip'`.
- The list converter `str_to_optional_list` accepts a list, a JSON-array string, a comma-separated string, or `None`, but called `.strip()` on anything else. A dict submitted for a list field (for example GitHub `repositories` or Google Search Console `search_types`) hit that path and crashed.
- The crash raised `AttributeError`, which the config converter wrapper only catches as `ValueError` or `TypeError`, so it escaped as an unhandled 500 instead of a validation error.

## Changes

- Guard the string-parsing branch behind an `isinstance(s, str)` check and raise `TypeError` for any other type.
- `_convert_value` catches that `TypeError` and reports a normal config validation error, so a malformed field now returns a 400 with `Field '<name>' has an invalid value` instead of a 500.
- This mirrors the existing `str_to_optional_int` hardening in the same module, which already guards its `.strip()` call against non-string input.
- No source-specific code changed; the fix covers every field that uses this converter.

## How did you test this code?

- Added `test_str_to_optional_list_rejects_unsupported_types`, covering a dict and an int input. It catches a regression where dropping the `isinstance(s, str)` guard resurfaces the uncaught `AttributeError` — the existing parameterized test only exercises valid list, string, and `None` inputs.
- Ran the `common` config test suite locally; it passed. I did not run the database-backed source create/update endpoint tests in this environment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged from a PostHog error tracking issue. I (Claude) pulled the stack trace and representative events via the PostHog MCP tools, traced the raising frame to `str_to_optional_list`, and confirmed the converter wrapper does not catch `AttributeError`.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Considered coercing the dict into a list but rejected it: a dict has no reliable list interpretation, so raising a clean validation error is the safer behavior. No customer values from the error events appear in the code, tests, or this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
