### PR TITLE
chore(replay-vision): reword the alert reasoning checkbox and add a tooltip

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/ActionEditorScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ActionEditorScene.tsx
@@ -2,6 +2,7 @@ import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { useMemo } from 'react'
 
+import { IconInfo } from '@posthog/icons'
 import {
     LemonButton,
     LemonCheckbox,
@@ -9,6 +10,7 @@ import {
     LemonInputSelect,
     LemonSegmentedButton,
     LemonSelect,
+    Tooltip,
 } from '@posthog/lemon-ui'
 
 import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/IntegrationChoice'
@@ -536,7 +538,14 @@ function ConditionSection({ scannerId }: { scannerId: string }): JSX.Element {
                 <LemonCheckbox
                     checked={actionForm.alert_include_reasoning}
                     onChange={(checked) => setActionFormValue('alert_include_reasoning', checked)}
-                    label="Include the observation's reasoning in the message"
+                    label={
+                        <span className="flex items-center gap-1">
+                            Send each observation's reasoning as part of the message
+                            <Tooltip title="This makes each message a lot longer, which is useful if an agent parses your alerts. Every alert links back to the observation, where you can read the reasoning too.">
+                                <IconInfo className="text-lg text-secondary" />
+                            </Tooltip>
+                        </span>
+                    }
                     data-attr="vision-action-alert-include-reasoning"
                 />
             ) : null}


### PR DESCRIPTION
## Problem

Someone setting up a Replay Vision scanner alert had no way to judge the "include reasoning" checkbox. The label said what it did, not what it costs them.

Turning it on makes every delivered message substantially longer. It is also often unnecessary, because the alert already links back to the observation, where the reasoning is readable in full.

## Changes

- Label is now "Send each observation's reasoning as part of the message".
- An info icon next to it explains the tradeoff: longer messages, useful when an agent parses the alert, and the link back to the observation is always there.

Copy and an icon only. The `alert_include_reasoning` form field, the request body, and the serializer field are untouched. The checkbox stays behind the `replay-vision-send-reasoning` flag, so this is not visible outside PostHog yet.

## How did you test this code?

No new tests. This changes a string and adds a tooltip, so there is no regression to name that the existing suites do not already cover.

Ran locally: `oxlint` and `oxfmt --check` on the changed file (both clean), the frontend `typescript:check` (no errors attributed to this file), and the two `replay_scanners` Jest suites. I did not render the checkbox in a browser, so the tooltip's visual placement is unverified.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. The session started as a question about why the checkbox from #80731 was not appearing in the UI; the answer was that its feature flag sat at 0% until after the merge, not a code defect. The reword came out of that, since the label alone did not give anyone enough to decide with.

Skills invoked: `/writing-user-facing-copy` for the label and tooltip text, and `/writing-pr-descriptions` for this body. The tooltip follows the existing `LemonCheckbox` label + `Tooltip` + `IconInfo` pattern already used elsewhere in the app rather than introducing a new one.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
