### PR TITLE
chore(desktop): tighten stream 401 retry test assertions

### DIFF
--- a/products/desktop/packages/core/src/cloud-task/cloud-task-engine.ts
+++ b/products/desktop/packages/core/src/cloud-task/cloud-task-engine.ts
@@ -25,7 +25,7 @@ import { type SseEvent, SseEventParser } from "./sse-parser";
 
 // Reconnect backoff: flat base delay for the first SSE_RECONNECT_FLAT_ATTEMPTS attempts, then
 // exponential up to the cap (0.5, 0.5, 0.5, 1, 2, 4, 8, 16, 30s), spanning ~60s before giving up.
-const MAX_SSE_RECONNECT_ATTEMPTS = 9;
+export const MAX_SSE_RECONNECT_ATTEMPTS = 9;
 const MAX_CUMULATIVE_RECONNECT_ATTEMPTS = 30;
 const SSE_RECONNECT_BASE_DELAY_MS = 500;
 const SSE_RECONNECT_FLAT_ATTEMPTS = 3;

--- a/products/desktop/packages/core/src/cloud-task/cloud-task.test.ts
+++ b/products/desktop/packages/core/src/cloud-task/cloud-task.test.ts
@@ -28,6 +28,7 @@ const fetchRouter = vi.hoisted(() =>
 import {
   type CloudTaskEngine,
   createCloudTaskEngine,
+  MAX_SSE_RECONNECT_ATTEMPTS,
 } from "./cloud-task-engine";
 
 const mockAuthService = {
@@ -3212,7 +3213,10 @@ describe("CloudTaskEngine", () => {
       retryable: true,
     });
 
-    expect(mockStreamFetch.mock.calls.length).toBeGreaterThan(2);
+    expect(mockStreamFetch.mock.calls.length).toBe(
+      1 + MAX_SSE_RECONNECT_ATTEMPTS,
+    );
+    expect(mockStreamTokenFetch.mock.calls.length).toBe(1);
     const streamCallsAtFailure = mockStreamFetch.mock.calls.length;
     await vi.advanceTimersByTimeAsync(60_000);
     expect(mockStreamFetch.mock.calls.length).toBe(streamCallsAtFailure);


### PR DESCRIPTION
## Problem

The persistent-401 test from #82395 dropped two guards: nothing proves a Django-leg 401 skips `/stream_token/` on retries, and its loose retry bound still passes if the budget shrinks from 10 attempts to 3.

## Changes

- Assert the exact attempt count: 1 initial call plus `MAX_SSE_RECONNECT_ATTEMPTS` retries (constant now exported).
- Assert `/stream_token/` is called once across the retry loop.

## How did you test this code?

- Ran the cloud-task suite, Biome and the core typecheck locally.

