### PR TITLE
fix(aio): drop in-flight dataset loads when the trace view unmounts

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4758,10 +4758,10 @@ snapshots:
         hash: v1.k794b7964.ea754a4783f7653247f127337c407a8cdd4a9c6bc3f1b908d8d00dd1a090b966.KQ3yKnRzi4l3ZeYVThZdmo4L6mAbxtNa2uQh7y-kGWA
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--tile-filters-read-only--light:
         hash: v1.k794b7964.b2ca2efc52a9ccf56953159c66d3c8766acd1d3a17379d5faec45a4715ae24a9.fK76p7ZVcgvFJNcKJ5Ixy3YnBm_BcBSFnoytLS2jZdU
-    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark:
-        hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
-    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light:
-        hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
+    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark
+    :   hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
+    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light
+    :   hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--dark:
         hash: v1.k794b7964.b1e0f5f542426e34dec73826f3135902a392c0c13dade4fec14037c615186b13.kbxxijyDI1SdvgdKwkRnIRLLgmsine5AYvOcD79DYsY
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--light:
@@ -7399,9 +7399,9 @@ snapshots:
     scenes-app-settings-environment--settings-environment-surveys--light:
         hash: v1.k794b7964.82a6d0673ae37171eb0f50012e837e8417d965f747a21d0a728425dd53209fc1.YyKQuLivmwjiIilN3bvDszBRrnZ207pshWSu8nSp_j4
     scenes-app-settings-environment--settings-environment-web-analytics--dark:
-        hash: v1.k794b7964.345c0a0e72de6e02a76677bf0e67b9eb7d91d07a30f3c94b8a5f4d98676ca8ce.zpjJqvTV7a_PYYxjl99FcHYQp4IakvV7bTwfRaB5NH4
+        hash: v1.k794b7964.a567e4149d492d035796f56fba2a0d9ce9b92c728e0482caf7a0411b8f6c2cfa.iB20iEO2ClZEgTxEgoJyBGUCjDTp7zYjnXkUfG0S-bE
     scenes-app-settings-environment--settings-environment-web-analytics--light:
-        hash: v1.k794b7964.c45e1d9def388dcbc3e178352fe89c60802c8d439f9c5ab6a0f7d5b655a982f3.7Yaa0aoTJCoQ2JQl05KVW_sxK7pRgyd-XrQHy4ZS0a0
+        hash: v1.k794b7964.e319bd2edb8a9c629f2e8c6c01900ac1d603faf2e751ec10bcaa9021305c71f3.92jZVjrbRQ_R17e0vaR0uRtzu6t6ss_cuAWyg9-1md8
     scenes-app-settings-organization--settings-organization-authentication--dark:
         hash: v1.k794b7964.6ddb506ed211a3f8de0d302d47d070cb16ff121a93b22e78cf47d71582084971.rD1vE9nirvysLXvvRet6q3N2Jn8yqEeY6kj49SMtz3c
     scenes-app-settings-organization--settings-organization-authentication--light:

--- a/products/ai_observability/frontend/datasets/saveToDatasetButtonLogic.test.ts
+++ b/products/ai_observability/frontend/datasets/saveToDatasetButtonLogic.test.ts
@@ -1,5 +1,6 @@
 import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
+import posthog from 'posthog-js'
 
 import { ApiError } from 'lib/api-error'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
@@ -294,26 +295,6 @@ describe('saveToDatasetButtonLogic', () => {
                 expect(logic.values.searchForm.search).toBe('')
                 expect(logic.values.searchForm.datasetId).toBeNull()
             })
-
-            it('resets search form when beforeUnmount is called', async () => {
-                const logic = saveToDatasetButtonLogic({ partialDatasetItem: mockPartialDatasetItem })
-                logic.mount()
-
-                logic.actions.setSearchFormValue('search', 'test search')
-                expect(logic.values.searchForm.search).toBe('test search')
-
-                // Wait for any async operations to complete before unmounting
-                await expectLogic(logic).toFinishAllListeners()
-
-                // The beforeUnmount listener should reset the form
-                await expectLogic(logic, () => {
-                    logic.unmount()
-                }).toFinishAllListeners()
-
-                // Since the logic is unmounted, we can't check the values after unmount
-                // The test is really about ensuring the beforeUnmount listener is called
-                // which happens automatically during unmount
-            })
         })
 
         describe('dataset item creation', () => {
@@ -525,6 +506,26 @@ describe('saveToDatasetButtonLogic', () => {
                     limit: DATASETS_PER_PAGE,
                     offset: 0,
                 })
+            })
+
+            it('drops an in-flight load that resolves after unmount', async () => {
+                const captureException = jest.spyOn(posthog, 'captureException').mockImplementation(() => undefined)
+                let resolveListDatasets: (response: PaginatedDatasetReadListApi) => void = () => {}
+                mockDatasetsApi.listDatasets.mockReturnValue(
+                    new Promise((resolve) => {
+                        resolveListDatasets = resolve
+                    })
+                )
+
+                const logic = saveToDatasetButtonLogic({ partialDatasetItem: mockPartialDatasetItem })
+                logic.mount()
+                logic.unmount()
+
+                resolveListDatasets(mockDatasetsResponse)
+                await new Promise((resolve) => setTimeout(resolve, 0))
+
+                expect(captureException).not.toHaveBeenCalled()
+                captureException.mockRestore()
             })
 
             it('uses debounce when loading datasets', async () => {

--- a/products/ai_observability/frontend/datasets/saveToDatasetButtonLogic.ts
+++ b/products/ai_observability/frontend/datasets/saveToDatasetButtonLogic.ts
@@ -1,15 +1,4 @@
-import {
-    MakeLogicType,
-    actions,
-    afterMount,
-    beforeUnmount,
-    kea,
-    listeners,
-    path,
-    props,
-    reducers,
-    selectors,
-} from 'kea'
+import { MakeLogicType, actions, afterMount, kea, listeners, path, props, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 import type { DeepPartial, DeepPartialMap, FieldName, ValidationErrorType } from 'kea-forms'
 import { loaders } from 'kea-loaders'
@@ -252,6 +241,7 @@ export const saveToDatasetButtonLogic = kea<saveToDatasetButtonLogicType>([
                     }
                     const storageKey = getStorageKey(values.searchForm.search)
                     const response = await datasetsApi.listDatasets(params)
+                    breakpoint()
                     return {
                         ...values.datasetStore,
                         [storageKey]: response.results,
@@ -277,6 +267,7 @@ export const saveToDatasetButtonLogic = kea<saveToDatasetButtonLogicType>([
                         limit: RECENT_DATASETS_LIMIT,
                         offset: 0,
                     })
+                    breakpoint()
                     const datasetsById = new Map(response.results.map((dataset) => [dataset.id, dataset]))
                     const recentDatasets = values.recentDatasetIds.flatMap((id) => {
                         const dataset = datasetsById.get(id)
@@ -410,10 +401,6 @@ export const saveToDatasetButtonLogic = kea<saveToDatasetButtonLogicType>([
             actions.loadDatasets(false)
             actions.loadRecentDatasets(false)
         }
-    }),
-
-    beforeUnmount(({ actions }) => {
-        actions.setSearchFormValue('search', '')
     }),
 ])
 


### PR DESCRIPTION
## Problem

- A user who leaves an LLM trace while the "Add to dataset" button is still loading datasets triggers an error that reaches error tracking.
- The error is `[KEA] Can not find path "scenes.ai-observability.saveToDatasetButtonLogic" in the store.` ([issue](https://us.posthog.com/project/2/error_tracking/019ffcf4-4cf5-78f3-9e57-0a818dd64925)).
- Nothing visible breaks. The button is already gone, kea-loaders handles the error, and no toast appears.
- Both loaders read `values` after their request resolves, with no `breakpoint()` in between.
- `beforeUnmount` also dispatched `setSearchFormValue`, which started a fresh debounced load during teardown.

## Changes

- `loadDatasets` and `loadRecentDatasets` call `breakpoint()` after their request, so kea aborts the listener once the logic unmounts.
- The logic no longer resets the search field in `beforeUnmount`.
- A breakpoint cannot rescue that teardown dispatch: kea bumps the breakpoint counters first, so the listener it starts looks current.
- The search form lives in the logic and dies with it, so the teardown reset changed nothing a user could see.
- No screenshot: nothing renders differently.

## How did you test this code?

- Added one jest case: a load that resolves after unmount reports nothing to error tracking. Without the fix it fails with the exact error from the issue.
- Deleted `resets search form when beforeUnmount is called`. It asserted nothing and covered the behavior this PR removes.
- I confirmed the abort path against the `kea` 3.1.7 and `kea-loaders` 3.1.1 sources: unmount bumps every listener breakpoint counter, and kea-loaders swallows breakpoint errors.
- Not run: anything past this file's jest suite. The frontend typecheck reports only pre-existing errors in other products, from the unbuilt quill workspace.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- I am the PostHog Slack app (Claude Opus), asked in a [Slack thread](https://posthog.slack.com/archives/C0A006STKHR/p1786655303599609?thread_ts=1786655303.599609&cid=C0A006STKHR) to explain an error tracking alert and then to fix it. Radu Raicea directed the work; I could not verify his GitHub handle this session, so the PR is unassigned.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- I read the issue and a sample event through the PostHog MCP error tracking tools to find the failing surface, then read the kea sources to confirm which of the two unmount paths a breakpoint actually covers.
- Nothing in this PR carries material from the session. The diff touches one logic and its tests.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A006STKHR/p1786655303599609?thread_ts=1786655303.599609&cid=C0A006STKHR)*
