### PR TITLE
fix(warehouse-sources): stop reporting exhausted wordpress retries to error tracking

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/source.py
@@ -114,6 +114,12 @@ To sync private content or authenticate, create an [Application Password](https:
             "CertificateError": "The WordPress site's TLS certificate doesn't match its domain. This is often caused by a hosting platform's default certificate not covering a custom domain. Ask your hosting provider to install a certificate for this domain, then try again.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # Raised by get_rows()'s fetch_page for a 429/5xx response, only once its own tenacity
+        # retry budget (5 attempts with backoff) is already exhausted. The status code and URL
+        # that follow are variable, so match the stable prefix only.
+        return {"WordPress API error (retryable):"}
+
     def get_canonical_descriptions(self) -> CanonicalDescriptions:
         from products.warehouse_sources.backend.temporal.data_imports.sources.wordpress.canonical_descriptions import (
             CANONICAL_DESCRIPTIONS,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/tests/test_wordpress_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/tests/test_wordpress_source.py
@@ -79,6 +79,16 @@ class TestWordpressSource:
         matches = [friendly for key, friendly in errors.items() if key in raised]
         assert matches and matches[0] is not None
 
+    @pytest.mark.parametrize("status_code", [429, 503])
+    def test_exhausted_retryable_error_message_matches_retryable_error(self, status_code):
+        # get_rows()'s fetch_page raises this once its own tenacity retry budget for a 429/5xx
+        # response is exhausted. The status code and URL that follow are variable, so the
+        # classifier must match on the stable prefix alone to keep this out of error tracking.
+        raised = (
+            f"WordPress API error (retryable): status={status_code}, url=https://example.com/wp-json/wp/v2/categories"
+        )
+        assert any(pattern.lower() in raised.lower() for pattern in self.source.get_retryable_errors())
+
     def test_get_schemas_returns_all_endpoints(self):
         schemas = self.source.get_schemas(self.config, self.team_id)
         assert {s.name for s in schemas} == set(ENDPOINTS)


### PR DESCRIPTION
## Problem

A WordPress sync that hits a transient 429 or 5xx from the customer's site still shows up in error tracking as an unclassified exception, even after it already exhausted its own in-process retry budget and Temporal is retrying the whole activity anyway. This surfaced as [issue 019ffd39](https://us.posthog.com/project/2/error_tracking/019ffd39-cf86-7f42-b2ea-9e3818dfd24e), a single occurrence of a 503 from a customer's site.

## Changes

- Add `WordpressSource.get_retryable_errors()`, matching the stable `"WordPress API error (retryable):"` prefix that `get_rows()` raises once its tenacity retry budget for a 429/5xx response is exhausted.
- This routes the failure through the same benign, self-recovering path Stripe already uses in `import_data_sync._handle_import_error` (logged as a warning, not reported) instead of falling through to the generic "log as exception and re-raise" branch. Temporal still retries the whole activity exactly as before — no change to retry counts, backoff, or timeouts.
- Left `get_non_retryable_errors()` untouched: a 503 is a transient upstream failure, not a customer credential/config problem, so it should stay retryable rather than disabling the schema.

## How did you test this code?

- Added a parametrized test asserting exhausted-retry messages for both a 429 and a 503 match `get_retryable_errors()` — no existing test covered this method for the WordPress source (only `get_non_retryable_errors()` was tested).
- Ran `pytest products/warehouse_sources/backend/temporal/data_imports/sources/wordpress/tests/` (117 passed) and `uv run mypy --cache-fine-grained .` (clean, 18197 files).
- Not run: a live sync against a WordPress site returning 503, since that needs an external server. Verified correctness by reading `_handle_import_error`'s classification order and confirming `get_retryable_errors()` is checked before the final unclassified fallback.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing or API behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking MCP tools (issue details, stack trace, representative event) to confirm the failure originates in `wordpress.py`'s `fetch_page`. Read the WordPress and Stripe source implementations and `import_data_sync._handle_import_error` to understand the retryable/non-retryable classification flow. No skills were invoked for the fix itself; `/writing-tests` and `/writing-pr-descriptions` were invoked before writing the test and this description, respectively.