### PR TITLE
feat(desktop): add Home, a stacked page of the work already in PostHog

### DIFF
--- a/products/desktop/AGENTS.md
+++ b/products/desktop/AGENTS.md
@@ -331,6 +331,7 @@ See [docs/testing.md](./docs/testing.md).
 - [docs/testing.md](./docs/testing.md)
 - [docs/ANNOUNCEMENTS.md](./docs/ANNOUNCEMENTS.md)
 - [docs/DEEP-LINKS.md](./docs/DEEP-LINKS.md)
+- [docs/HOME.md](./docs/HOME.md)
 - [docs/LOCAL-DEVELOPMENT.md](./docs/LOCAL-DEVELOPMENT.md)
 - [docs/UPDATES.md](./docs/UPDATES.md)
 - [docs/TROUBLESHOOTING.md](./docs/TROUBLESHOOTING.md)

--- a/products/desktop/apps/code/src/main/di/container.ts
+++ b/products/desktop/apps/code/src/main/di/container.ts
@@ -45,6 +45,7 @@ import { gitPrModule } from "@posthog/core/git-pr/git-pr.module";
 import { GIT_DIFF_SOURCE } from "@posthog/core/git-pr/identifiers";
 import { handoffModule } from "@posthog/core/handoff/handoff.module";
 import { HANDOFF_HOST } from "@posthog/core/handoff/identifiers";
+import { homeCoreModule } from "@posthog/core/home/home.module";
 import { integrationsModule } from "@posthog/core/integrations/integrations.module";
 import { ApprovalLinkService } from "@posthog/core/links/approval-link";
 import { CanvasLinkService } from "@posthog/core/links/canvas-link";
@@ -816,6 +817,10 @@ container.bind(MAIN_MISSION_CONTROL_SERVICE).to(MissionControlService);
 // live in @posthog/core (bound via canvasCoreModule) and resolve through
 // ctx.container in the host-router routers.
 container.load(canvasCoreModule);
+
+// Home's prefetched groups of work — feature flags and experiments read back
+// through the same ProjectApiClient the canvas services use.
+container.load(homeCoreModule);
 
 // Browser tabs for the Channels canvas surface. Authoritative sqlite-backed
 // service in the main process; resolved by the host-router browserTabs router.

--- a/products/desktop/apps/code/src/main/trpc/router.ts
+++ b/products/desktop/apps/code/src/main/trpc/router.ts
@@ -25,6 +25,7 @@ import { fsRouter } from "@posthog/host-router/routers/fs.router";
 import { gitRouter } from "@posthog/host-router/routers/git.router";
 import { githubIntegrationRouter } from "@posthog/host-router/routers/github-integration.router";
 import { handoffRouter } from "@posthog/host-router/routers/handoff.router";
+import { homeRouter } from "@posthog/host-router/routers/home.router";
 import { integrationRouter } from "@posthog/host-router/routers/integration.router";
 import { linearIntegrationRouter } from "@posthog/host-router/routers/linear-integration.router";
 import { llmGatewayRouter } from "@posthog/host-router/routers/llm-gateway.router";
@@ -89,6 +90,7 @@ export const trpcRouter = router({
   githubIntegration: githubIntegrationRouter,
   releaseFeed: releaseFeedRouter,
   handoff: handoffRouter,
+  home: homeRouter,
   integration: integrationRouter,
   linearIntegration: linearIntegrationRouter,
   llmGateway: llmGatewayRouter,

--- a/products/desktop/apps/web/src/web-container.ts
+++ b/products/desktop/apps/web/src/web-container.ts
@@ -67,6 +67,7 @@ import {
   GIT_INTERACTION_SERVICE,
   GIT_WRITE_CLIENT,
 } from "@posthog/core/git-interaction/identifiers";
+import { homeCoreModule } from "@posthog/core/home/home.module";
 import {
   REPORT_MODEL_RESOLVER,
   type ReportModelResolver,
@@ -493,6 +494,9 @@ container.bind(CLOUD_TASK_AUTH).toDynamicValue((ctx) => ({
 container.load(canvasCoreModule);
 container.load(canvasApplicationModule);
 container.load(taskThreadCoreModule);
+
+// Home reads its groups of work through the same ProjectApiClient.
+container.load(homeCoreModule);
 
 // SessionService is built from host-agnostic deps (host tRPC client + UI
 // stores) — same construction the desktop renderer uses.

--- a/products/desktop/apps/web/src/web-host-router.ts
+++ b/products/desktop/apps/web/src/web-host-router.ts
@@ -12,6 +12,7 @@ import { canvasTemplatesRouter } from "@posthog/host-router/routers/canvas-templ
 import { channelTasksRouter } from "@posthog/host-router/routers/channel-tasks.router";
 import { cloudTaskRouter } from "@posthog/host-router/routers/cloud-task.router";
 import { dashboardsRouter } from "@posthog/host-router/routers/dashboards.router";
+import { homeRouter } from "@posthog/host-router/routers/home.router";
 import { publicProcedure, router } from "@posthog/host-trpc/trpc";
 import {
   type CloudRegion,
@@ -502,6 +503,9 @@ export const webHostRouter = router({
   folders: foldersStubRouter,
   fs: fsStubRouter,
   githubIntegration: githubIntegrationRouter,
+  // Home's groups of work: the same REST reads the canvas routers make, so the
+  // web host serves the real router too.
+  home: homeRouter,
   logs: logsStubRouter,
   os: osStubRouter,
   skills: skillsStubRouter,

--- a/products/desktop/docs/HOME.md
+++ b/products/desktop/docs/HOME.md
@@ -1,0 +1,144 @@
+# Home
+
+Home is the app's first destination: the page PostHog Desktop opens on, built
+out of work that already exists in PostHog rather than out of an empty prompt.
+It sits left of Inbox in the spaces nav (`ChannelNav`) and lives at
+`/website/home`, behind `posthog-desktop-home` (which itself requires
+`project-bluebird` — see `useHomeEnabled`).
+
+## The shape
+
+Home is a single scroll column of stacked blocks, all wearing the same frame
+(`HomeSection`), so a page assembled from separate surfaces reads as one page:
+
+1. **Hero.** The org's mark × PostHog's, "Welcome to PostHog Desktop", and one
+   line counting what is below.
+2. **Suggestions.** Recent feature flags, each offering the one move Home can
+   make on it: give the flag a space (`#feature-<key>`), so the work behind it
+   has somewhere to happen. A flag whose space already exists opens it instead.
+3. **Experiments.** What is running, how long it has been running, and a way
+   into the results.
+4. **Your canvases.** The canvases pinned in your personal space, each rendered
+   as a real, live canvas in its own sandboxed frame, laid one under the next.
+
+Blocks 1–3 are the app's own components. Block 4 is where the stacking idea is
+literal: several independent canvases, each with its own build, its own data
+requests, and its own author, presented as consecutive sections of one page.
+
+## Why pinning
+
+A canvas already carries `pinnedAt`, and the canvas toolbar already sets it. So
+"what shows on my Home" needed no new concept: pin a canvas in your personal
+space and it joins the stack, in pin order; unpin it and it leaves. The cap is
+`HOME_CANVAS_LIMIT` (3) because each stacked canvas is a live iframe, and past a
+handful the page costs more to open than it saves.
+
+## Prefetching
+
+Home exists to save the trip to find the work, which a page that fetches as you
+scroll would undo. So every group loads on mount, and the rail's Home button
+warms the work cache on pointer-enter (`usePrefetchHomeWork`) — by the time the
+click lands, the page usually has its data.
+
+`HomeService` (core) reads both groups in parallel through the shared
+`ProjectApiClient`. A group that fails to load comes back in `unavailable`
+rather than failing the whole call, and Home says so: an empty Experiments
+section and a missing `experiment:read` scope look identical otherwise.
+
+## Layering
+
+| Piece | Where | Job |
+| --- | --- | --- |
+| `HomeService`, `homeSchemas` | `packages/core/src/home/` | Read + normalize feature flags and experiments; rank them; report unreadable groups |
+| `home.router` | `packages/host-router/src/routers/` | One-line forward |
+| `useHomeWork`, `useHomeCanvases`, `useHomeOrg` | `packages/ui/src/features/home/` | One query each |
+| `homeSuggestions` | `packages/ui/src/features/home/` | Which flags to offer, and whether their space exists |
+| `HomePage` | `packages/ui/src/features/home/components/` | The page body, entirely from props (so Storybook can show it) |
+| `HomeView` | `packages/ui/src/features/home/` | The container: hooks in, `HomePage` out |
+
+`HomePage.stories.tsx` renders the page with fixture data, including an empty
+Home and a Home missing a group.
+
+## What else a personal Home could show
+
+The sections shipped so far are the two groups the desktop can read cheaply
+today. The list below is the backlog of candidate blocks — each one is a
+section, and each could be either an app component or a canvas. They are sorted
+roughly by how directly they answer "what should I do next?".
+
+### Work you already started
+
+- **Sessions still running.** Agent runs in flight right now, local and cloud,
+  with the last thing each agent said. The one block that is genuinely
+  time-sensitive; everything else can be a day stale.
+- **Waiting on you.** Runs stopped on a permission prompt or a plan approval.
+  A stalled run is invisible today unless you go looking for it.
+- **Your open PRs, by state.** Ready to merge, failing CI, waiting on review,
+  review comments unanswered. The inbox counts these; Home could show the three
+  that need a decision.
+- **Branches without a PR.** Worktrees with commits that never became anything.
+  Either finish it or throw it away — Home is a good place to be asked.
+- **Yesterday.** What you shipped, merged, or closed since you last opened the
+  app. Ends the "where was I?" reconstruction.
+
+### Work the product is asking for
+
+- **Flags stuck at a percentage.** A flag that has sat at 25% for three weeks is
+  a decision nobody made. Offer: finish the rollout, or remove the flag.
+- **Flags that are fully rolled out.** 100% for a fortnight with no experiment
+  attached is dead code plus a config row. Offer: a cleanup task.
+- **Experiments that reached significance.** The result is in and nobody
+  shipped it. Offer: ship the winner, or write the conclusion.
+- **Experiments with no exposures.** Launched, but nothing is arriving —
+  usually a broken integration, and always worth knowing on day one rather than
+  at the end of the run.
+- **Error tracking issues in code you touched.** New or spiking issues whose
+  stack frames land in files from your recent PRs. This is the block most
+  likely to change what someone does with their morning.
+- **Inbox reports that became tasks.** What the scouts filed, and what happened
+  to it.
+
+### The shape of your own work
+
+- **Your spaces, by heat.** Which spaces have moved this week and which have
+  gone quiet. A quiet space is either finished (archive it) or stuck (say so).
+- **Repos you actually work in.** Ranked by your recent sessions, with each
+  repo's current branch state, so opening one is a click instead of a picker.
+- **Cost and usage.** What your agent runs cost this week, against the plan.
+  Belongs on Home only when it is close enough to a limit to change behavior.
+- **Your review queue.** PRs from teammates that name you, with how long they
+  have been waiting.
+
+### Things only a canvas can do
+
+Each of these is more useful as an agent-authored canvas than as a shipped
+component, because the question is personal and the answer changes shape:
+
+- **A metric you personally watch.** One number, your framing, your date range.
+- **A weekly digest of your own product area,** written by an agent against
+  your project's data and pinned once.
+- **A checklist for a migration you are running,** where the checkboxes are
+  queries rather than state a person keeps up to date.
+- **A scratch board for an investigation,** kept for as long as the
+  investigation lasts, then unpinned.
+
+The point of the stack is that the last four are indistinguishable from the
+first three, to a reader. Home is a frame; what goes in it can be shipped code,
+or a canvas somebody wrote on Tuesday.
+
+## Next steps, in order
+
+1. **Sessions in flight and waiting-on-you.** The only genuinely time-sensitive
+   blocks, and both read from data the app already holds.
+2. **Make Home's own blocks canvases.** The hero and suggestions are components
+   today. Once a section can be a canvas template instantiated per user, they
+   become editable: "make the suggestions section only show billing flags".
+3. **Ordering.** Pin order controls the canvas stack; nothing controls whether
+   Experiments sits above or below it. Drag-to-order, persisted per device, is
+   the smallest version.
+4. **`/website` lands on Home.** The spaces index currently redirects to the
+   first channel. Home is a better landing page, but changing it moves the
+   whole spaces world, so it wants its own decision.
+5. **A canvas height that follows its content.** The stack gives each canvas a
+   fixed band because the canvas runtime reports no content height. A
+   `content-height` message on the bridge would let a short canvas be short.

--- a/products/desktop/packages/core/src/home/home.module.ts
+++ b/products/desktop/packages/core/src/home/home.module.ts
@@ -1,0 +1,10 @@
+import { ContainerModule } from "inversify";
+import { HomeService } from "./homeService";
+import { HOME_SERVICE } from "./identifiers";
+
+// Home's prefetched groups of work. Host-agnostic: it needs only the shared
+// ProjectApiClient (bound by canvasCoreModule), so any host can load it.
+export const homeCoreModule = new ContainerModule(({ bind }) => {
+  bind(HomeService).toSelf().inSingletonScope();
+  bind(HOME_SERVICE).toService(HomeService);
+});

--- a/products/desktop/packages/core/src/home/homeSchemas.ts
+++ b/products/desktop/packages/core/src/home/homeSchemas.ts
@@ -1,0 +1,77 @@
+import { z } from "zod";
+
+/**
+ * The shapes behind Home's "groups of work" — the work a person already has in
+ * PostHog, read back so the app can open on it instead of on a blank prompt.
+ *
+ * Everything here is normalized to camelCase and epoch-ms timestamps, the same
+ * treatment DashboardsService gives canvases, so a Home section never handles a
+ * raw API row.
+ */
+
+/** A feature flag the viewer could plausibly still be working on. */
+export const homeFeatureFlagSchema = z.object({
+  id: z.number(),
+  key: z.string(),
+  name: z.string(),
+  active: z.boolean(),
+  /** Percentage of users the flag is rolled out to, where the flag sets one. */
+  rolloutPercentage: z.number().nullable(),
+  /** The flag drives an experiment, so Home shows it as an experiment instead. */
+  hasExperiment: z.boolean(),
+  createdAt: z.number(),
+  /** The viewer created this flag. */
+  yours: z.boolean(),
+  /** Name of the creator, where the backend knows one. */
+  createdBy: z.string().nullable(),
+});
+export type HomeFeatureFlag = z.infer<typeof homeFeatureFlagSchema>;
+
+/** Where an experiment is in its life, as Home talks about it. */
+export const homeExperimentStageSchema = z.enum([
+  "draft",
+  "running",
+  "paused",
+  "concluded",
+]);
+export type HomeExperimentStage = z.infer<typeof homeExperimentStageSchema>;
+
+/** An experiment the viewer created or is running. */
+export const homeExperimentSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  description: z.string().nullable(),
+  featureFlagKey: z.string().nullable(),
+  stage: homeExperimentStageSchema,
+  startedAt: z.number().nullable(),
+  endedAt: z.number().nullable(),
+  /** Variant keys, in the order the experiment declares them. */
+  variants: z.array(z.string()),
+  yours: z.boolean(),
+  createdBy: z.string().nullable(),
+});
+export type HomeExperiment = z.infer<typeof homeExperimentSchema>;
+
+/** Everything Home prefetches in one round trip. */
+export const homeWorkSchema = z.object({
+  featureFlags: z.array(homeFeatureFlagSchema),
+  experiments: z.array(homeExperimentSchema),
+  /**
+   * Groups that did not load — no scope, no product, or a failed request. Home
+   * says so rather than showing an empty section that reads as "you have no
+   * experiments".
+   */
+  unavailable: z.array(z.enum(["featureFlags", "experiments"])),
+});
+export type HomeWork = z.infer<typeof homeWorkSchema>;
+
+export const homeWorkInput = z.object({
+  /**
+   * The viewer's user id, so the service can mark what is theirs. Absent while
+   * the current user is still loading — everything comes back unmarked.
+   */
+  viewerId: z.number().nullish(),
+  /** How many rows to keep per group. */
+  limit: z.number().int().min(1).max(50).default(6),
+});
+export type HomeWorkInput = z.infer<typeof homeWorkInput>;

--- a/products/desktop/packages/core/src/home/homeService.test.ts
+++ b/products/desktop/packages/core/src/home/homeService.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ProjectApiClient } from "../canvas/projectApiClient";
+import { HomeService } from "./homeService";
+
+function apiFlag(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    key: "new-checkout",
+    name: "The rebuilt checkout",
+    active: true,
+    filters: { groups: [{ rollout_percentage: 25 }] },
+    experiment_set: [],
+    created_by: { id: 7, first_name: "Ada", last_name: "L" },
+    created_at: "2026-07-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function apiExperiment(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 11,
+    name: "Checkout copy",
+    description: "Shorter labels",
+    feature_flag_key: "new-checkout",
+    status: "running",
+    start_date: "2026-07-02T00:00:00Z",
+    end_date: null,
+    parameters: {
+      feature_flag_variants: [{ key: "control" }, { key: "test" }],
+    },
+    created_by: { id: 7, first_name: "Ada" },
+    created_at: "2026-07-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+/** A ProjectApiClient whose `json` is resolved per path prefix. */
+function fakeApi(
+  handlers: Record<string, { results?: unknown[] } | Error>,
+): ProjectApiClient {
+  return {
+    json: vi.fn(async (path: string) => {
+      const key = Object.keys(handlers).find((prefix) =>
+        path.startsWith(prefix),
+      );
+      if (key === undefined) throw new Error(`Unhandled path: ${path}`);
+      const handler = handlers[key];
+      if (handler instanceof Error) throw handler;
+      return handler;
+    }),
+  } as unknown as ProjectApiClient;
+}
+
+describe("HomeService.work", () => {
+  it("normalizes both groups and marks the viewer's own rows", async () => {
+    const service = new HomeService(
+      fakeApi({
+        "feature_flags/": { results: [apiFlag()] },
+        "experiments/": { results: [apiExperiment()] },
+      }),
+    );
+
+    const work = await service.work({ viewerId: 7, limit: 6 });
+
+    expect(work.featureFlags).toEqual([
+      {
+        id: 1,
+        key: "new-checkout",
+        name: "The rebuilt checkout",
+        active: true,
+        rolloutPercentage: 25,
+        hasExperiment: false,
+        createdAt: Date.parse("2026-07-01T00:00:00Z"),
+        yours: true,
+        createdBy: "Ada L",
+      },
+    ]);
+    expect(work.experiments).toEqual([
+      {
+        id: 11,
+        name: "Checkout copy",
+        description: "Shorter labels",
+        featureFlagKey: "new-checkout",
+        stage: "running",
+        startedAt: Date.parse("2026-07-02T00:00:00Z"),
+        endedAt: null,
+        variants: ["control", "test"],
+        yours: true,
+        createdBy: "Ada",
+      },
+    ]);
+    expect(work.unavailable).toEqual([]);
+  });
+
+  it("reports a group the token cannot read instead of failing the call", async () => {
+    const service = new HomeService(
+      fakeApi({
+        "feature_flags/": { results: [apiFlag()] },
+        "experiments/": new Error("Failed to list experiments (403)"),
+      }),
+    );
+
+    const work = await service.work({ viewerId: 7, limit: 6 });
+
+    expect(work.featureFlags).toHaveLength(1);
+    expect(work.experiments).toEqual([]);
+    expect(work.unavailable).toEqual(["experiments"]);
+  });
+
+  it("leads with running experiments, then the viewer's own, then the newest", async () => {
+    const service = new HomeService(
+      fakeApi({
+        "feature_flags/": { results: [] },
+        "experiments/": {
+          results: [
+            apiExperiment({ id: 1, status: "draft", created_by: { id: 9 } }),
+            apiExperiment({ id: 2, status: "stopped" }),
+            apiExperiment({ id: 3, status: "exposure_frozen" }),
+            apiExperiment({ id: 4, status: "paused", created_by: { id: 9 } }),
+          ],
+        },
+      }),
+    );
+
+    const work = await service.work({ viewerId: 7, limit: 6 });
+
+    expect(work.experiments.map((e) => [e.id, e.stage])).toEqual([
+      [3, "running"],
+      [4, "paused"],
+      [1, "draft"],
+      [2, "concluded"],
+    ]);
+  });
+
+  it("keeps only `limit` rows per group", async () => {
+    const service = new HomeService(
+      fakeApi({
+        "feature_flags/": {
+          results: [
+            apiFlag({ id: 1, key: "a" }),
+            apiFlag({ id: 2, key: "b" }),
+            apiFlag({ id: 3, key: "c" }),
+          ],
+        },
+        "experiments/": { results: [] },
+      }),
+    );
+
+    const work = await service.work({ viewerId: null, limit: 2 });
+
+    expect(work.featureFlags.map((flag) => flag.key)).toEqual(["a", "b"]);
+    expect(work.featureFlags.every((flag) => !flag.yours)).toBe(true);
+  });
+});

--- a/products/desktop/packages/core/src/home/homeService.ts
+++ b/products/desktop/packages/core/src/home/homeService.ts
@@ -1,0 +1,214 @@
+import {
+  PROJECT_API_CLIENT,
+  type ProjectApiClient,
+} from "@posthog/core/canvas/projectApiClient";
+import { inject, injectable } from "inversify";
+import type {
+  HomeExperiment,
+  HomeExperimentStage,
+  HomeFeatureFlag,
+  HomeWork,
+  HomeWorkInput,
+} from "./homeSchemas";
+
+// One page each, sorted newest-first by the API. Home shows a handful; the rest
+// of the page is headroom for the filtering below (a flag that already drives an
+// experiment drops out, and so does one whose space already exists).
+const FLAG_PAGE_SIZE = 50;
+const EXPERIMENT_PAGE_SIZE = 50;
+
+interface ApiUser {
+  id?: number;
+  first_name?: string;
+  last_name?: string;
+  email?: string;
+}
+
+interface ApiFeatureFlag {
+  id: number;
+  key: string;
+  name?: string | null;
+  active?: boolean;
+  filters?: { groups?: { rollout_percentage?: number | null }[] } | null;
+  experiment_set?: unknown[] | null;
+  created_by?: ApiUser | null;
+  created_at?: string | null;
+}
+
+interface ApiExperiment {
+  id: number;
+  name: string;
+  description?: string | null;
+  feature_flag_key?: string | null;
+  status?: string | null;
+  start_date?: string | null;
+  end_date?: string | null;
+  parameters?: { feature_flag_variants?: { key?: string }[] } | null;
+  created_by?: ApiUser | null;
+  created_at?: string | null;
+}
+
+function displayName(user: ApiUser | null | undefined): string | null {
+  if (!user) return null;
+  const name = [user.first_name, user.last_name].filter(Boolean).join(" ");
+  return name || user.email || null;
+}
+
+function epoch(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+/**
+ * The experiment's API status, in Home's vocabulary. `exposure_frozen` reads as
+ * running because the experiment is still collecting metrics; an unrecognized
+ * status is treated as a draft rather than claimed to be live.
+ */
+function toStage(status: string | null | undefined): HomeExperimentStage {
+  switch (status) {
+    case "running":
+    case "exposure_frozen":
+      return "running";
+    case "paused":
+      return "paused";
+    case "stopped":
+      return "concluded";
+    default:
+      return "draft";
+  }
+}
+
+/** The flag's release rollout, where it has a single release condition. */
+function rolloutPercentage(flag: ApiFeatureFlag): number | null {
+  const groups = flag.filters?.groups ?? [];
+  if (groups.length !== 1) return null;
+  const percentage = groups[0]?.rollout_percentage;
+  return typeof percentage === "number" ? percentage : null;
+}
+
+/**
+ * Reads back the work a person already has in PostHog — the feature flags and
+ * experiments Home opens on. Nothing here writes.
+ *
+ * A group that fails to load comes back in `unavailable` instead of failing the
+ * whole call: a Home missing one section still beats a Home that shows nothing
+ * because one scope is absent.
+ */
+@injectable()
+export class HomeService {
+  constructor(
+    @inject(PROJECT_API_CLIENT)
+    private readonly api: ProjectApiClient,
+  ) {}
+
+  async work(input: HomeWorkInput): Promise<HomeWork> {
+    const viewerId = input.viewerId ?? null;
+    const [flags, experiments] = await Promise.all([
+      this.featureFlags(viewerId),
+      this.experiments(viewerId),
+    ]);
+
+    const unavailable: HomeWork["unavailable"] = [];
+    if (flags === null) unavailable.push("featureFlags");
+    if (experiments === null) unavailable.push("experiments");
+
+    return {
+      featureFlags: (flags ?? []).slice(0, input.limit),
+      experiments: (experiments ?? []).slice(0, input.limit),
+      unavailable,
+    };
+  }
+
+  /** Null when the group did not load (no scope, no product, or a failed call). */
+  private async featureFlags(
+    viewerId: number | null,
+  ): Promise<HomeFeatureFlag[] | null> {
+    const rows = await this.page<ApiFeatureFlag>(
+      `feature_flags/?limit=${FLAG_PAGE_SIZE}&order=-created_at`,
+      "list feature flags",
+    );
+    if (rows === null) return null;
+    return rows
+      .map((flag) => ({
+        id: flag.id,
+        key: flag.key,
+        // The API's `name` field carries the flag's description.
+        name: flag.name?.trim() || flag.key,
+        active: flag.active ?? false,
+        rolloutPercentage: rolloutPercentage(flag),
+        hasExperiment: (flag.experiment_set?.length ?? 0) > 0,
+        createdAt: epoch(flag.created_at) ?? 0,
+        yours: viewerId != null && flag.created_by?.id === viewerId,
+        createdBy: displayName(flag.created_by),
+      }))
+      .sort(rankByOwnershipThenRecency);
+  }
+
+  private async experiments(
+    viewerId: number | null,
+  ): Promise<HomeExperiment[] | null> {
+    const rows = await this.page<ApiExperiment>(
+      `experiments/?limit=${EXPERIMENT_PAGE_SIZE}`,
+      "list experiments",
+    );
+    if (rows === null) return null;
+    return rows
+      .map((experiment) => ({
+        id: experiment.id,
+        name: experiment.name,
+        description: experiment.description?.trim() || null,
+        featureFlagKey: experiment.feature_flag_key ?? null,
+        stage: toStage(experiment.status),
+        startedAt: epoch(experiment.start_date),
+        endedAt: epoch(experiment.end_date),
+        variants: (experiment.parameters?.feature_flag_variants ?? [])
+          .map((variant) => variant.key)
+          .filter((key): key is string => !!key),
+        yours: viewerId != null && experiment.created_by?.id === viewerId,
+        createdBy: displayName(experiment.created_by),
+        createdAt: epoch(experiment.created_at) ?? 0,
+      }))
+      .sort(rankExperiments)
+      .map(({ createdAt: _createdAt, ...experiment }) => experiment);
+  }
+
+  /**
+   * One page of a DRF collection. A failure is a missing group rather than an
+   * error — the caller reports it as such, and Home renders around it.
+   */
+  private async page<T>(path: string, label: string): Promise<T[] | null> {
+    try {
+      const body = await this.api.json<{ results?: T[] }>(path, label);
+      return body.results ?? [];
+    } catch {
+      return null;
+    }
+  }
+}
+
+function rankByOwnershipThenRecency(
+  a: { yours: boolean; createdAt: number },
+  b: { yours: boolean; createdAt: number },
+): number {
+  if (a.yours !== b.yours) return a.yours ? -1 : 1;
+  return b.createdAt - a.createdAt;
+}
+
+/**
+ * Running experiments lead — they are the ones with an outcome moving today —
+ * then the viewer's own, then the most recently created.
+ */
+function rankExperiments(
+  a: { stage: HomeExperimentStage; yours: boolean; createdAt: number },
+  b: { stage: HomeExperimentStage; yours: boolean; createdAt: number },
+): number {
+  const stageOrder: Record<HomeExperimentStage, number> = {
+    running: 0,
+    paused: 1,
+    draft: 2,
+    concluded: 3,
+  };
+  if (a.stage !== b.stage) return stageOrder[a.stage] - stageOrder[b.stage];
+  return rankByOwnershipThenRecency(a, b);
+}

--- a/products/desktop/packages/core/src/home/identifiers.ts
+++ b/products/desktop/packages/core/src/home/identifiers.ts
@@ -1,0 +1,4 @@
+// DI token for the Home work service. Lives in @posthog/core so the
+// host-router router and the host DI container can both reference it without
+// depending on where the concrete class is bound.
+export const HOME_SERVICE = Symbol.for("posthog.core.home.service");

--- a/products/desktop/packages/core/src/home/services.ts
+++ b/products/desktop/packages/core/src/home/services.ts
@@ -1,0 +1,7 @@
+import type { HomeWork, HomeWorkInput } from "./homeSchemas";
+
+// The method surface the host-router home router depends on. The concrete
+// implementation binds to HOME_SERVICE in home.module.ts.
+export interface IHomeService {
+  work(input: HomeWorkInput): Promise<HomeWork>;
+}

--- a/products/desktop/packages/host-router/src/router.ts
+++ b/products/desktop/packages/host-router/src/router.ts
@@ -24,6 +24,7 @@ import { fsRouter } from "./routers/fs.router";
 import { gitRouter } from "./routers/git.router";
 import { githubIntegrationRouter } from "./routers/github-integration.router";
 import { handoffRouter } from "./routers/handoff.router";
+import { homeRouter } from "./routers/home.router";
 import { integrationRouter } from "./routers/integration.router";
 import { linearIntegrationRouter } from "./routers/linear-integration.router";
 import { llmGatewayRouter } from "./routers/llm-gateway.router";
@@ -77,6 +78,7 @@ export const hostRouter = router({
   fs: fsRouter,
   git: gitRouter,
   handoff: handoffRouter,
+  home: homeRouter,
   integration: integrationRouter,
   githubIntegration: githubIntegrationRouter,
   releaseFeed: releaseFeedRouter,

--- a/products/desktop/packages/host-router/src/routers/home.router.ts
+++ b/products/desktop/packages/host-router/src/routers/home.router.ts
@@ -1,0 +1,14 @@
+import { homeWorkInput } from "@posthog/core/home/homeSchemas";
+import { HOME_SERVICE } from "@posthog/core/home/identifiers";
+import type { IHomeService } from "@posthog/core/home/services";
+import { publicProcedure, router } from "@posthog/host-trpc/trpc";
+
+// The groups of work Home opens on. A one-line forward to HomeService, which
+// injects the PostHog credentials host-side.
+export const homeRouter = router({
+  work: publicProcedure
+    .input(homeWorkInput)
+    .query(({ ctx, input }) =>
+      ctx.container.get<IHomeService>(HOME_SERVICE).work(input),
+    ),
+});

--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -260,6 +260,7 @@ export interface CommandMenuActionProperties {
 export type SidebarNavItem =
   | "new_task"
   | "search"
+  | "home"
   | "inbox"
   | "agents"
   | "skills"
@@ -1090,6 +1091,29 @@ export interface ContextActionProperties {
   success?: boolean;
 }
 
+// Home events
+
+/** What Home was able to show when it opened, so an empty Home is legible. */
+export interface HomeViewedProperties {
+  feature_flag_count: number;
+  experiment_count: number;
+  /** Pinned canvases stacked below Home's own sections. */
+  canvas_count: number;
+  /** Groups the viewer's token could not read ("featureFlags", "experiments"). */
+  unavailable: string[];
+}
+
+export type HomeAction =
+  | "start_space_from_flag"
+  | "open_space_from_flag"
+  | "open_experiment"
+  | "open_canvas";
+
+export interface HomeActionProperties {
+  action_type: HomeAction;
+  success?: boolean;
+}
+
 export interface ChannelsSpaceViewedProperties {
   /** Total channels visible when the space mounts. */
   channel_count: number;
@@ -1476,6 +1500,10 @@ export const ANALYTICS_EVENTS = {
   UPGRADE_PROMPT_CLICKED: "Upgrade prompt clicked",
   CLOUD_TASK_USAGE_BLOCKED: "Cloud task usage blocked",
 
+  // Home events
+  HOME_VIEWED: "Home viewed",
+  HOME_ACTION: "Home action",
+
   // Project Bluebird (Channels) events
   CHANNELS_SPACE_VIEWED: "Channels space viewed",
   CHANNEL_ACTION: "Channel action",
@@ -1657,6 +1685,10 @@ export type EventPropertyMap = {
   [ANALYTICS_EVENTS.UPGRADE_PROMPT_SHOWN]: UpgradePromptShownProperties;
   [ANALYTICS_EVENTS.UPGRADE_PROMPT_CLICKED]: UpgradePromptClickedProperties;
   [ANALYTICS_EVENTS.CLOUD_TASK_USAGE_BLOCKED]: CloudTaskUsageBlockedProperties;
+
+  // Home events
+  [ANALYTICS_EVENTS.HOME_VIEWED]: HomeViewedProperties;
+  [ANALYTICS_EVENTS.HOME_ACTION]: HomeActionProperties;
 
   // Project Bluebird (Channels) events
   [ANALYTICS_EVENTS.CHANNELS_SPACE_VIEWED]: ChannelsSpaceViewedProperties;

--- a/products/desktop/packages/shared/src/flags.ts
+++ b/products/desktop/packages/shared/src/flags.ts
@@ -17,6 +17,12 @@ export const PROJECT_BLUEBIRD_FLAG = "project-bluebird";
  * project-bluebird. The key predates the rename, matching the live flag.
  */
 export const CHANNELS_LAYOUT_FLAG = "code-spaces-layout";
+/**
+ * Gates Home: the rail's first destination, a stacked page of the work already
+ * waiting in PostHog. Requires project-bluebird — Home lives in the spaces
+ * chrome and links into spaces.
+ */
+export const HOME_FLAG = "posthog-desktop-home";
 // Gates the Loops feature: the sidebar Loops space and the per-channel Loops tab.
 export const LOOPS_FLAG = "loops";
 export const TASKS_PREWARM_SANDBOX_FLAG = "tasks-prewarm-sandbox";

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelNav.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelNav.test.tsx
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   view: { type: "task-input" },
+  homeEnabled: false,
+  navigateToHome: vi.fn(),
 }));
 
 vi.mock("@posthog/ui/features/canvas/hooks/useTaskActivity", () => ({
@@ -24,8 +26,17 @@ vi.mock("@posthog/ui/router/useAppView", () => ({
 }));
 vi.mock("@posthog/ui/router/navigationBridge", () => ({
   navigateToActivity: vi.fn(),
+  navigateToHome: mocks.navigateToHome,
   navigateToInbox: vi.fn(),
   navigateToWebsiteCommandCenter: vi.fn(),
+}));
+vi.mock("@posthog/ui/features/home/useHomeEnabled", () => ({
+  useHomeEnabled: () => mocks.homeEnabled,
+}));
+// The real hook reads the host tRPC context, which this nav row has no
+// provider for; Home's prefetch is exercised where the page itself is.
+vi.mock("@posthog/ui/features/home/useHomeWork", () => ({
+  usePrefetchHomeWork: () => () => {},
 }));
 vi.mock("@posthog/ui/shell/analytics", () => ({ track: vi.fn() }));
 vi.mock("./ActivityHoverCard", () => ({
@@ -37,6 +48,28 @@ import { ChannelNav } from "./ChannelNav";
 describe("ChannelNav", () => {
   beforeEach(() => {
     mocks.view = { type: "task-input" };
+    mocks.homeEnabled = false;
+    mocks.navigateToHome.mockClear();
+  });
+
+  it("leaves Home out of the row until its flag is on", () => {
+    render(<ChannelNav />);
+
+    expect(screen.queryByLabelText("Home")).not.toBeInTheDocument();
+  });
+
+  it("puts Home left of Inbox, and opens it", async () => {
+    mocks.homeEnabled = true;
+    const user = userEvent.setup();
+    render(<ChannelNav />);
+
+    const labels = screen
+      .getAllByRole("button")
+      .map((button) => button.getAttribute("aria-label"));
+    expect(labels.indexOf("Home")).toBe(labels.indexOf("Inbox") - 1);
+
+    await user.click(screen.getByLabelText("Home"));
+    expect(mocks.navigateToHome).toHaveBeenCalled();
   });
 
   it("opens recent activity from the bell after the hover delay", async () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelNav.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelNav.tsx
@@ -2,6 +2,7 @@ import {
   BellIcon,
   EnvelopeSimple,
   GearSix,
+  HouseIcon,
   Lightning,
 } from "@phosphor-icons/react";
 import {
@@ -27,12 +28,15 @@ import {
 } from "@posthog/ui/features/command/keyboard-shortcuts";
 import { useCommandCenterActiveCount } from "@posthog/ui/features/command-center/useCommandCenterActiveCount";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
+import { useHomeEnabled } from "@posthog/ui/features/home/useHomeEnabled";
+import { usePrefetchHomeWork } from "@posthog/ui/features/home/useHomeWork";
 import { useInboxAllReports } from "@posthog/ui/features/inbox/hooks/useInboxAllReports";
 import { openSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
 import { CountBadge } from "@posthog/ui/primitives/CountBadge";
 import { LoopIcon } from "@posthog/ui/primitives/LoopIcon";
 import {
   navigateToActivity,
+  navigateToHome,
   navigateToInbox,
   navigateToLoops,
   navigateToWebsiteCommandCenter,
@@ -58,6 +62,7 @@ function NavIcon({
   shortcut,
   isActive,
   onClick,
+  onPointerEnter,
   badge,
 }: {
   icon: ReactNode;
@@ -65,6 +70,8 @@ function NavIcon({
   shortcut?: string;
   isActive: boolean;
   onClick: () => void;
+  /** Warm the destination's caches while the pointer is on the way. */
+  onPointerEnter?: () => void;
   badge?: ReactNode;
 }) {
   return (
@@ -81,6 +88,7 @@ function NavIcon({
             aria-label={label}
             data-selected={isActive || undefined}
             onClick={onClick}
+            onPointerEnter={onPointerEnter}
             className="group relative shrink-0 text-muted-foreground data-selected:bg-fill-selected data-selected:text-foreground"
           >
             {icon}
@@ -157,6 +165,30 @@ function ActivityHoverPopover({ trigger }: { trigger: ReactElement }) {
   );
 }
 
+/**
+ * Home's entry, which owns its own prefetch: warming the page's work cache
+ * needs the host tRPC context, and this item only mounts behind the flag, so
+ * the nav row stays usable where Home is off.
+ */
+function HomeNavItem({
+  isActive,
+  onNavigate,
+}: {
+  isActive: boolean;
+  onNavigate: () => void;
+}) {
+  const prefetchHomeWork = usePrefetchHomeWork();
+  return (
+    <NavIcon
+      icon={<HouseIcon size={16} weight={isActive ? "fill" : "regular"} />}
+      label="Home"
+      isActive={isActive}
+      onClick={onNavigate}
+      onPointerEnter={prefetchHomeWork}
+    />
+  );
+}
+
 function ActivityNavItem({
   isActive,
   unreadCount,
@@ -183,6 +215,7 @@ function ActivityNavItem({
 export function ChannelNav() {
   const view = useAppView();
   const loopsEnabled = useFeatureFlag(LOOPS_FLAG, import.meta.env.DEV);
+  const homeEnabled = useHomeEnabled();
 
   const { counts } = useInboxAllReports({
     ignoreFilters: true,
@@ -200,6 +233,7 @@ export function ChannelNav() {
     action();
   };
 
+  const isHome = view.type === "home";
   const isInbox = view.type === "inbox";
   const isActivity = view.type === "activity";
   const isCommandCenter = view.type === "command-center";
@@ -212,6 +246,12 @@ export function ChannelNav() {
     // providers never share it.
     <TooltipProvider delay={400}>
       <div className="flex shrink-0 gap-2 p-2">
+        {homeEnabled ? (
+          <HomeNavItem
+            isActive={isHome}
+            onNavigate={withTrack("home", navigateToHome)}
+          />
+        ) : null}
         <NavIcon
           icon={
             <EnvelopeSimple size={16} weight={isInbox ? "fill" : "regular"} />

--- a/products/desktop/packages/ui/src/features/home/HomeView.tsx
+++ b/products/desktop/packages/ui/src/features/home/HomeView.tsx
@@ -1,0 +1,61 @@
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
+import { HomeCanvasSection } from "@posthog/ui/features/home/components/HomeCanvasSection";
+import { HomePage } from "@posthog/ui/features/home/components/HomePage";
+import { homeFlagSuggestions } from "@posthog/ui/features/home/homeSuggestions";
+import { useHomeCanvases } from "@posthog/ui/features/home/useHomeCanvases";
+import { useHomeOrg } from "@posthog/ui/features/home/useHomeOrg";
+import { useHomeWork } from "@posthog/ui/features/home/useHomeWork";
+import { track } from "@posthog/ui/shell/analytics";
+import { useEffect, useMemo, useRef } from "react";
+
+/**
+ * Home: the page the app opens on, stacked out of the work already waiting in
+ * PostHog. Its own sections come first, then the canvases pinned in your
+ * personal space — each a live canvas, laid one under the next so the column
+ * reads as one page.
+ *
+ * Every group loads up front rather than on scroll: Home exists to save the
+ * trip to find the work, which a page that fetches as you reach it undoes.
+ */
+export function HomeView() {
+  const { work, isLoading: workLoading } = useHomeWork();
+  const { channels } = useChannels();
+  const { canvases, isLoading: canvasesLoading } = useHomeCanvases();
+  const { orgName, logoSrc } = useHomeOrg();
+
+  const suggestions = useMemo(
+    () => homeFlagSuggestions({ flags: work.featureFlags, channels }),
+    [work.featureFlags, channels],
+  );
+
+  const isLoading = workLoading || canvasesLoading;
+  // One view event per visit, once the page knows what it has — reporting at
+  // mount would record every Home as empty.
+  const reported = useRef(false);
+  useEffect(() => {
+    if (isLoading || reported.current) return;
+    reported.current = true;
+    track(ANALYTICS_EVENTS.HOME_VIEWED, {
+      feature_flag_count: work.featureFlags.length,
+      experiment_count: work.experiments.length,
+      canvas_count: canvases.length,
+      unavailable: work.unavailable,
+    });
+  }, [isLoading, work, canvases.length]);
+
+  return (
+    <HomePage
+      isLoading={isLoading}
+      orgName={orgName}
+      logoSrc={logoSrc}
+      suggestions={suggestions}
+      experiments={work.experiments}
+      unavailable={work.unavailable}
+      canvasCount={canvases.length}
+      canvasSections={canvases.map((canvas) => (
+        <HomeCanvasSection key={canvas.id} canvas={canvas} />
+      ))}
+    />
+  );
+}

--- a/products/desktop/packages/ui/src/features/home/components/HomeCanvasSection.tsx
+++ b/products/desktop/packages/ui/src/features/home/components/HomeCanvasSection.tsx
@@ -1,0 +1,80 @@
+import { ArrowRightIcon } from "@phosphor-icons/react";
+import { publishedCanvasBuild } from "@posthog/core/canvas/canvasBuildSchemas";
+import type { DashboardRecord } from "@posthog/core/canvas/dashboardSchemas";
+import { Button, Card } from "@posthog/quill";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import { BuiltCanvas } from "@posthog/ui/features/canvas/freeform/BuiltCanvas";
+import { handleFreeformDataRequest } from "@posthog/ui/features/canvas/freeform/freeformDataBridge";
+import { useCanvasBuilds } from "@posthog/ui/features/canvas/hooks/useCanvasBuilds";
+import { HomeSection } from "@posthog/ui/features/home/components/HomeSection";
+import { navigateToChannelDashboard } from "@posthog/ui/router/navigationBridge";
+import { track } from "@posthog/ui/shell/analytics";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+
+/**
+ * How tall a stacked canvas gets. Canvases are authored to fill a viewport and
+ * the runtime reports no content height, so Home gives each one a band and
+ * leaves the whole canvas one click away.
+ */
+const CANVAS_HEIGHT_PX = 460;
+
+/**
+ * One canvas in Home's stack: the published build, live, in the same sandboxed
+ * frame the canvas's own page uses — so the section is the real canvas rather
+ * than a picture of it. Unpublished canvases say so instead of showing a blank
+ * band.
+ */
+export function HomeCanvasSection({ canvas }: { canvas: DashboardRecord }) {
+  const queryClient = useQueryClient();
+  const { lifecycle } = useCanvasBuilds(canvas.id);
+  const build = lifecycle ? publishedCanvasBuild(lifecycle) : null;
+
+  // The bridge is a pure function; its read cache is the app's QueryClient, so
+  // a canvas open in Home and the same canvas open on its own page share reads.
+  const onDataRequest = useCallback(
+    (method: string, payload: unknown) =>
+      handleFreeformDataRequest(method, payload, queryClient),
+    [queryClient],
+  );
+
+  const open = () => {
+    track(ANALYTICS_EVENTS.HOME_ACTION, { action_type: "open_canvas" });
+    navigateToChannelDashboard(canvas.channelId, canvas.id);
+  };
+
+  return (
+    <HomeSection
+      title={canvas.name}
+      action={
+        <Button variant="outline" onClick={open}>
+          Open
+          <ArrowRightIcon size={14} />
+        </Button>
+      }
+    >
+      {build?.artifactUrl ? (
+        <div
+          className="overflow-hidden rounded-md border border-border"
+          style={{ height: CANVAS_HEIGHT_PX }}
+        >
+          <BuiltCanvas
+            key={build.id}
+            artifactUrl={build.artifactUrl}
+            capabilities={build.manifest?.capabilities}
+            onDataRequest={onDataRequest}
+          />
+        </div>
+      ) : (
+        <Card className="flex flex-row items-center justify-between gap-3 p-3">
+          <span className="text-muted-foreground text-sm">
+            This canvas has no published build yet.
+          </span>
+          <Button variant="outline" onClick={open}>
+            Open canvas
+          </Button>
+        </Card>
+      )}
+    </HomeSection>
+  );
+}

--- a/products/desktop/packages/ui/src/features/home/components/HomeExperiments.tsx
+++ b/products/desktop/packages/ui/src/features/home/components/HomeExperiments.tsx
@@ -1,0 +1,108 @@
+import { ArrowSquareOutIcon, FlaskIcon } from "@phosphor-icons/react";
+import type {
+  HomeExperiment,
+  HomeExperimentStage,
+} from "@posthog/core/home/homeSchemas";
+import { Badge, Button, Card } from "@posthog/quill";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import { track } from "@posthog/ui/shell/analytics";
+import { openExternalUrl } from "@posthog/ui/shell/openExternal";
+import { experimentUrl } from "@posthog/ui/utils/posthogLinks";
+
+const STAGE_LABEL: Record<HomeExperimentStage, string> = {
+  running: "Running",
+  paused: "Paused",
+  draft: "Draft",
+  concluded: "Concluded",
+};
+
+const STAGE_TONE: Record<
+  HomeExperimentStage,
+  "default" | "success" | "warning"
+> = {
+  running: "success",
+  paused: "warning",
+  draft: "default",
+  concluded: "default",
+};
+
+/** Whole days since a timestamp, or null when there is no timestamp. */
+function daysSince(epochMs: number | null): number | null {
+  if (epochMs == null) return null;
+  const days = Math.floor((Date.now() - epochMs) / 86_400_000);
+  return days >= 0 ? days : null;
+}
+
+/** How long the experiment has been collecting, in the plainest terms. */
+function runningFor(experiment: HomeExperiment): string | null {
+  if (experiment.stage === "draft") return "Not launched yet";
+  const days = daysSince(experiment.startedAt);
+  if (days == null) return null;
+  if (days === 0) return "Started today";
+  if (days === 1) return "Running for 1 day";
+  return `Running for ${days} days`;
+}
+
+/**
+ * An experiment as Home talks about it: where it is, how long it has been
+ * there, and what it is testing. The numbers behind it stay in PostHog, so the
+ * card opens there rather than restating a result it cannot compute.
+ */
+function ExperimentCard({ experiment }: { experiment: HomeExperiment }) {
+  const url = experimentUrl(experiment.id);
+  const duration = runningFor(experiment);
+
+  const open = () => {
+    if (!url) return;
+    track(ANALYTICS_EVENTS.HOME_ACTION, { action_type: "open_experiment" });
+    void openExternalUrl(url);
+  };
+
+  return (
+    <Card className="flex flex-row items-center gap-3 p-3">
+      <FlaskIcon size={16} className="shrink-0 text-muted-foreground" />
+      <div className="flex min-w-0 flex-col gap-0.5">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="truncate font-medium text-sm">
+            {experiment.name}
+          </span>
+          <Badge variant={STAGE_TONE[experiment.stage]}>
+            {STAGE_LABEL[experiment.stage]}
+          </Badge>
+          {experiment.yours ? <Badge variant="info">Yours</Badge> : null}
+        </div>
+        <span className="truncate text-muted-foreground text-xs">
+          {[
+            duration,
+            experiment.variants.length > 0
+              ? `${experiment.variants.length} variants`
+              : null,
+            experiment.featureFlagKey,
+          ]
+            .filter(Boolean)
+            .join(" · ")}
+        </span>
+      </div>
+      <div className="ml-auto shrink-0">
+        <Button variant="outline" disabled={!url} onClick={open}>
+          View results
+          <ArrowSquareOutIcon size={14} />
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+export function HomeExperiments({
+  experiments,
+}: {
+  experiments: HomeExperiment[];
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      {experiments.map((experiment) => (
+        <ExperimentCard key={experiment.id} experiment={experiment} />
+      ))}
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/home/components/HomeFlagSuggestions.tsx
+++ b/products/desktop/packages/ui/src/features/home/components/HomeFlagSuggestions.tsx
@@ -1,0 +1,139 @@
+import { ArrowRightIcon, FlagIcon } from "@phosphor-icons/react";
+import type { HomeFeatureFlag } from "@posthog/core/home/homeSchemas";
+import { Badge, Button, Card } from "@posthog/quill";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import { useChannelMutations } from "@posthog/ui/features/canvas/hooks/useChannels";
+import type { HomeFlagSuggestion } from "@posthog/ui/features/home/homeSuggestions";
+import { toast } from "@posthog/ui/primitives/toast";
+import { track } from "@posthog/ui/shell/analytics";
+import { useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
+
+function rolloutLabel(flag: HomeFeatureFlag): string | null {
+  if (!flag.active) return "Disabled";
+  if (flag.rolloutPercentage == null) return null;
+  return `${flag.rolloutPercentage}% rollout`;
+}
+
+/**
+ * A flag, and the one move Home offers on it: give it a space, so the work
+ * behind the flag has somewhere to happen. A flag whose space already exists
+ * opens it instead.
+ */
+function FlagSuggestionCard({
+  suggestion,
+  onOpenSpace,
+  onStartSpace,
+  isStarting,
+}: {
+  suggestion: HomeFlagSuggestion;
+  onOpenSpace: (channelId: string) => void;
+  onStartSpace: (suggestion: HomeFlagSuggestion) => void;
+  isStarting: boolean;
+}) {
+  const { flag, spaceName, existingSpace } = suggestion;
+  const rollout = rolloutLabel(flag);
+
+  return (
+    <Card className="flex flex-row items-center gap-3 p-3">
+      <FlagIcon size={16} className="shrink-0 text-muted-foreground" />
+      <div className="flex min-w-0 flex-col gap-0.5">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="truncate font-medium text-sm">{flag.key}</span>
+          {rollout ? <Badge variant="default">{rollout}</Badge> : null}
+          {flag.yours ? <Badge variant="info">Yours</Badge> : null}
+        </div>
+        <span className="truncate text-muted-foreground text-xs">
+          {existingSpace
+            ? `Already has #${existingSpace.name}`
+            : `Starts #${spaceName}`}
+          {flag.name !== flag.key ? ` · ${flag.name}` : ""}
+        </span>
+      </div>
+      <div className="ml-auto shrink-0">
+        {existingSpace ? (
+          <Button
+            variant="outline"
+            onClick={() => onOpenSpace(existingSpace.id)}
+          >
+            Open space
+            <ArrowRightIcon size={14} />
+          </Button>
+        ) : (
+          <Button
+            variant="primary"
+            loading={isStarting}
+            disabled={isStarting}
+            onClick={() => onStartSpace(suggestion)}
+          >
+            Start a space
+          </Button>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+/**
+ * Home's suggestions: recent feature flags with somewhere to go. Creating the
+ * space stars it, the way the create form does, so it lands where the person
+ * will find it again.
+ */
+export function HomeFlagSuggestions({
+  suggestions,
+}: {
+  suggestions: HomeFlagSuggestion[];
+}) {
+  const navigate = useNavigate();
+  const { createChannel } = useChannelMutations();
+  // Which flag's space is being created, so only that card shows a spinner and
+  // only that button locks.
+  const [startingKey, setStartingKey] = useState<string | null>(null);
+
+  const openSpace = (channelId: string) => {
+    track(ANALYTICS_EVENTS.HOME_ACTION, {
+      action_type: "open_space_from_flag",
+    });
+    void navigate({ to: "/website/$channelId", params: { channelId } });
+  };
+
+  const startSpace = async (suggestion: HomeFlagSuggestion) => {
+    if (startingKey) return;
+    setStartingKey(suggestion.flag.key);
+    try {
+      const channel = await createChannel(suggestion.spaceName, { star: true });
+      track(ANALYTICS_EVENTS.HOME_ACTION, {
+        action_type: "start_space_from_flag",
+        success: true,
+      });
+      await navigate({
+        to: "/website/$channelId",
+        params: { channelId: channel.id },
+      });
+    } catch (error: unknown) {
+      track(ANALYTICS_EVENTS.HOME_ACTION, {
+        action_type: "start_space_from_flag",
+        success: false,
+      });
+      toast.error("Couldn't start the space", {
+        description: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      setStartingKey(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      {suggestions.map((suggestion) => (
+        <FlagSuggestionCard
+          key={suggestion.flag.id}
+          suggestion={suggestion}
+          onOpenSpace={openSpace}
+          onStartSpace={(next) => void startSpace(next)}
+          isStarting={startingKey === suggestion.flag.key}
+        />
+      ))}
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/home/components/HomeHero.tsx
+++ b/products/desktop/packages/ui/src/features/home/components/HomeHero.tsx
@@ -1,0 +1,52 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@posthog/quill";
+import LogosLandscape from "@posthog/ui/primitives/Logo";
+
+/** Up to two letters, so a long org name still fits the avatar. */
+function orgInitials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((word) => word[0]?.toUpperCase() ?? "")
+    .join("");
+}
+
+/**
+ * The top of Home: whose desktop this is, and a line saying what the rest of
+ * the page holds. The org's own mark sits beside PostHog's because the page
+ * below is their work, not a product tour.
+ */
+export function HomeHero({
+  orgName,
+  logoSrc,
+  subhead,
+}: {
+  orgName: string | null;
+  logoSrc?: string;
+  subhead: string;
+}) {
+  return (
+    <section className="flex flex-col items-center gap-4 px-6 pt-14 pb-10 text-center">
+      <div className="flex items-center gap-4">
+        {orgName ? (
+          <>
+            <Avatar size="lg">
+              {logoSrc ? <AvatarImage src={logoSrc} alt={orgName} /> : null}
+              <AvatarFallback>{orgInitials(orgName)}</AvatarFallback>
+            </Avatar>
+            <span aria-hidden className="text-lg text-muted-foreground">
+              ×
+            </span>
+          </>
+        ) : null}
+        <div className="h-9 [&>svg]:h-9 [&>svg]:w-auto">
+          <LogosLandscape code={false} wordmark={false} />
+        </div>
+      </div>
+      <div className="flex flex-col gap-1">
+        <h1 className="font-semibold text-2xl">Welcome to PostHog Desktop</h1>
+        <p className="text-muted-foreground text-sm">{subhead}</p>
+      </div>
+    </section>
+  );
+}

--- a/products/desktop/packages/ui/src/features/home/components/HomePage.stories.tsx
+++ b/products/desktop/packages/ui/src/features/home/components/HomePage.stories.tsx
@@ -1,0 +1,131 @@
+import type { HomeExperiment } from "@posthog/core/home/homeSchemas";
+import type { HomeFlagSuggestion } from "@posthog/ui/features/home/homeSuggestions";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { HomePage } from "./HomePage";
+import { HomeSection } from "./HomeSection";
+
+const DAY_MS = 86_400_000;
+
+function suggestion(
+  key: string,
+  overrides: Partial<HomeFlagSuggestion["flag"]> = {},
+  existingSpace: HomeFlagSuggestion["existingSpace"] = null,
+): HomeFlagSuggestion {
+  return {
+    flag: {
+      id: key.length,
+      key,
+      name: "Rebuilt checkout, behind a flag",
+      active: true,
+      rolloutPercentage: 25,
+      hasExperiment: false,
+      createdAt: Date.now() - DAY_MS,
+      yours: true,
+      createdBy: "Ada Lovelace",
+      ...overrides,
+    },
+    spaceName: `feature-${key}`,
+    existingSpace,
+  };
+}
+
+function experiment(overrides: Partial<HomeExperiment> = {}): HomeExperiment {
+  return {
+    id: 1,
+    name: "Checkout copy",
+    description: "Shorter labels on the pay button",
+    featureFlagKey: "new-checkout",
+    stage: "running",
+    startedAt: Date.now() - 6 * DAY_MS,
+    endedAt: null,
+    variants: ["control", "test"],
+    yours: true,
+    createdBy: "Ada Lovelace",
+    ...overrides,
+  };
+}
+
+/**
+ * A stand-in for a stacked canvas. The real section renders a live sandboxed
+ * iframe, which Storybook has no artifact origin to serve — the band it
+ * occupies is what the story is here to show.
+ */
+function CanvasPlaceholder({ name }: { name: string }) {
+  return (
+    <HomeSection title={name}>
+      <div className="flex h-[460px] items-center justify-center rounded-md border border-border bg-card text-muted-foreground text-sm">
+        Canvas renders here
+      </div>
+    </HomeSection>
+  );
+}
+
+const meta = {
+  title: "Home/HomePage",
+  component: HomePage,
+  args: {
+    isLoading: false,
+    orgName: "Hedgehog Supply Co",
+    suggestions: [
+      suggestion("new-checkout"),
+      suggestion("billing-v2", {
+        id: 2,
+        name: "Metered billing",
+        active: false,
+        rolloutPercentage: null,
+        yours: false,
+        createdBy: "Grace H",
+      }),
+      suggestion(
+        "search-rerank",
+        { id: 3, name: "Reranked search results", rolloutPercentage: 100 },
+        { id: "chan-1", name: "feature-search-rerank" },
+      ),
+    ],
+    experiments: [
+      experiment(),
+      experiment({
+        id: 2,
+        name: "Onboarding checklist",
+        stage: "draft",
+        startedAt: null,
+        featureFlagKey: "onboarding-checklist",
+        yours: false,
+        createdBy: "Grace H",
+      }),
+    ],
+    unavailable: [],
+    canvasCount: 1,
+    canvasSections: <CanvasPlaceholder name="Weekly numbers" />,
+  },
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof HomePage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+/** Nothing to pick up yet: the hero carries the whole message. */
+export const Empty: Story = {
+  args: {
+    suggestions: [],
+    experiments: [],
+    canvasCount: 0,
+    canvasSections: null,
+  },
+};
+
+/** The login can't read one of the groups, so Home says so. */
+export const GroupUnavailable: Story = {
+  args: {
+    experiments: [],
+    unavailable: ["experiments"],
+  },
+};
+
+export const Loading: Story = {
+  args: { isLoading: true },
+  // The skeletons are the story, so don't wait for them to go away.
+  parameters: { testOptions: { waitForLoadersToDisappear: false } },
+};

--- a/products/desktop/packages/ui/src/features/home/components/HomePage.tsx
+++ b/products/desktop/packages/ui/src/features/home/components/HomePage.tsx
@@ -1,0 +1,137 @@
+import type { HomeExperiment, HomeWork } from "@posthog/core/home/homeSchemas";
+import { Skeleton } from "@posthog/quill";
+import { HomeExperiments } from "@posthog/ui/features/home/components/HomeExperiments";
+import { HomeFlagSuggestions } from "@posthog/ui/features/home/components/HomeFlagSuggestions";
+import { HomeHero } from "@posthog/ui/features/home/components/HomeHero";
+import { HomeSection } from "@posthog/ui/features/home/components/HomeSection";
+import type { HomeFlagSuggestion } from "@posthog/ui/features/home/homeSuggestions";
+import type { ReactNode } from "react";
+
+function count(n: number, singular: string, plural: string): string {
+  return `${n} ${n === 1 ? singular : plural}`;
+}
+
+/** The line under the hero, counting what the page below actually holds. */
+export function homeSubhead(counts: {
+  suggestions: number;
+  experiments: number;
+  canvases: number;
+}): string {
+  const parts: string[] = [];
+  if (counts.suggestions > 0) {
+    parts.push(
+      `${count(counts.suggestions, "feature flag", "feature flags")} to pick up`,
+    );
+  }
+  if (counts.experiments > 0) {
+    parts.push(
+      `${count(counts.experiments, "experiment", "experiments")} in flight`,
+    );
+  }
+  if (counts.canvases > 0) {
+    parts.push(`${count(counts.canvases, "pinned canvas", "pinned canvases")}`);
+  }
+  if (parts.length === 0) {
+    return "Start a space to give a piece of work its own place to happen.";
+  }
+  if (parts.length === 1) return `${parts[0]}, below.`;
+  const last = parts[parts.length - 1];
+  const rest = parts.slice(0, -1);
+  // Serial comma only where there are three or more, so two parts read as a
+  // sentence rather than a list.
+  const separator = rest.length > 1 ? ", and " : " and ";
+  return `${rest.join(", ")}${separator}${last}.`;
+}
+
+function SectionSkeleton() {
+  return (
+    <div className="flex flex-col gap-2 px-6 py-6">
+      <Skeleton className="h-4 w-32" />
+      <Skeleton className="h-14 w-full" />
+      <Skeleton className="h-14 w-full" />
+    </div>
+  );
+}
+
+function UnavailableNote({ groups }: { groups: HomeWork["unavailable"] }) {
+  const names = groups.map((group) =>
+    group === "experiments" ? "experiments" : "feature flags",
+  );
+  return (
+    <p className="px-6 py-6 text-muted-foreground text-xs">
+      Home couldn't load your {names.join(" or ")}. If this login doesn't have
+      access to them, sign in again.
+    </p>
+  );
+}
+
+/**
+ * Home's page body, given what to show. Everything it renders arrives as props
+ * so the whole page can be seen in Storybook — the container above it
+ * (`HomeView`) is the only part that knows how to fetch.
+ */
+export function HomePage({
+  isLoading,
+  orgName,
+  logoSrc,
+  suggestions,
+  experiments,
+  unavailable,
+  canvasCount,
+  canvasSections,
+}: {
+  isLoading: boolean;
+  orgName: string | null;
+  logoSrc?: string;
+  suggestions: HomeFlagSuggestion[];
+  experiments: HomeExperiment[];
+  unavailable: HomeWork["unavailable"];
+  /** How many canvases are stacked below, for the hero's line. */
+  canvasCount: number;
+  /** The stacked canvases themselves, each its own live surface. */
+  canvasSections: ReactNode;
+}) {
+  const subhead = isLoading
+    ? "Loading your work…"
+    : homeSubhead({
+        suggestions: suggestions.length,
+        experiments: experiments.length,
+        canvases: canvasCount,
+      });
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto flex w-full max-w-3xl flex-col divide-y divide-border pb-16">
+        <HomeHero orgName={orgName} logoSrc={logoSrc} subhead={subhead} />
+
+        {isLoading ? (
+          <SectionSkeleton />
+        ) : (
+          <>
+            {suggestions.length > 0 && (
+              <HomeSection
+                title="Suggestions"
+                description="Recent feature flags. Give one a space and the work behind it has somewhere to happen."
+              >
+                <HomeFlagSuggestions suggestions={suggestions} />
+              </HomeSection>
+            )}
+
+            {experiments.length > 0 && (
+              <HomeSection
+                title="Experiments"
+                description="What is running, and how long it has been running for."
+              >
+                <HomeExperiments experiments={experiments} />
+              </HomeSection>
+            )}
+
+            {canvasSections}
+
+            {unavailable.length > 0 && <UnavailableNote groups={unavailable} />}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/home/components/HomeSection.tsx
+++ b/products/desktop/packages/ui/src/features/home/components/HomeSection.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+
+/**
+ * One block of Home. Every block — the app's own and the canvases stacked below
+ * it — wears this frame, which is what lets a column of separate surfaces read
+ * as a single page.
+ */
+export function HomeSection({
+  title,
+  description,
+  action,
+  children,
+}: {
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-3 px-6 py-6">
+      <div className="flex items-end justify-between gap-4">
+        <div className="flex flex-col gap-0.5">
+          <h2 className="font-semibold text-base">{title}</h2>
+          {description ? (
+            <p className="text-muted-foreground text-xs">{description}</p>
+          ) : null}
+        </div>
+        {action}
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/products/desktop/packages/ui/src/features/home/components/homeSubhead.test.ts
+++ b/products/desktop/packages/ui/src/features/home/components/homeSubhead.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { homeSubhead } from "./HomePage";
+
+describe("homeSubhead", () => {
+  it.each([
+    [
+      { suggestions: 3, experiments: 2, canvases: 1 },
+      "3 feature flags to pick up, 2 experiments in flight, and 1 pinned canvas.",
+    ],
+    [
+      { suggestions: 1, experiments: 0, canvases: 0 },
+      "1 feature flag to pick up, below.",
+    ],
+    [
+      { suggestions: 0, experiments: 2, canvases: 2 },
+      "2 experiments in flight and 2 pinned canvases.",
+    ],
+  ])("counts what the page holds (%o)", (counts, expected) => {
+    expect(homeSubhead(counts)).toBe(expected);
+  });
+
+  it("asks for a first space when there is nothing to show", () => {
+    expect(homeSubhead({ suggestions: 0, experiments: 0, canvases: 0 })).toBe(
+      "Start a space to give a piece of work its own place to happen.",
+    );
+  });
+});

--- a/products/desktop/packages/ui/src/features/home/homeSuggestions.test.ts
+++ b/products/desktop/packages/ui/src/features/home/homeSuggestions.test.ts
@@ -1,0 +1,73 @@
+import type { HomeFeatureFlag } from "@posthog/core/home/homeSchemas";
+import { describe, expect, it } from "vitest";
+import { homeFlagSuggestions, spaceNameForFlag } from "./homeSuggestions";
+
+function flag(overrides: Partial<HomeFeatureFlag> = {}): HomeFeatureFlag {
+  return {
+    id: 1,
+    key: "new-checkout",
+    name: "The rebuilt checkout",
+    active: true,
+    rolloutPercentage: 25,
+    hasExperiment: false,
+    createdAt: 0,
+    yours: true,
+    createdBy: "Ada",
+    ...overrides,
+  };
+}
+
+describe("homeFlagSuggestions", () => {
+  it("names the space a flag would start, without doubling the prefix", () => {
+    expect(spaceNameForFlag("new_checkout")).toBe("feature-new-checkout");
+    expect(spaceNameForFlag("feature-billing")).toBe("feature-billing");
+  });
+
+  it("leaves out flags that already drive an experiment", () => {
+    const suggestions = homeFlagSuggestions({
+      flags: [flag({ id: 1 }), flag({ id: 2, key: "ab", hasExperiment: true })],
+      channels: [],
+    });
+
+    expect(suggestions.map((s) => s.flag.id)).toEqual([1]);
+  });
+
+  it.each([
+    ["the name Home proposes", "feature-new-checkout"],
+    ["the flag key on its own", "new-checkout"],
+  ])("finds an existing space under %s", (_case, channelName) => {
+    const suggestions = homeFlagSuggestions({
+      flags: [flag()],
+      channels: [{ id: "chan-1", name: channelName }],
+    });
+
+    expect(suggestions[0].existingSpace).toEqual({
+      id: "chan-1",
+      name: channelName,
+    });
+  });
+
+  it("offers a flag whose space does not exist yet", () => {
+    const suggestions = homeFlagSuggestions({
+      flags: [flag()],
+      channels: [{ id: "chan-1", name: "billing" }],
+    });
+
+    expect(suggestions[0].existingSpace).toBeNull();
+    expect(suggestions[0].spaceName).toBe("feature-new-checkout");
+  });
+
+  it("keeps the service's order and caps the list", () => {
+    const suggestions = homeFlagSuggestions({
+      flags: [
+        flag({ id: 1, key: "a" }),
+        flag({ id: 2, key: "b" }),
+        flag({ id: 3, key: "c" }),
+      ],
+      channels: [],
+      limit: 2,
+    });
+
+    expect(suggestions.map((s) => s.flag.key)).toEqual(["a", "b"]);
+  });
+});

--- a/products/desktop/packages/ui/src/features/home/homeSuggestions.ts
+++ b/products/desktop/packages/ui/src/features/home/homeSuggestions.ts
@@ -1,0 +1,57 @@
+import { normalizeChannelName } from "@posthog/core/canvas/channelName";
+import type { HomeFeatureFlag } from "@posthog/core/home/homeSchemas";
+
+/** A flag Home offers to turn into a space, and whether that space exists yet. */
+export interface HomeFlagSuggestion {
+  flag: HomeFeatureFlag;
+  /** The space the flag would get, as a channel name. */
+  spaceName: string;
+  /** The space that already covers this flag, where one does. */
+  existingSpace: { id: string; name: string } | null;
+}
+
+/** Default number of flags Home offers at once. */
+export const HOME_SUGGESTION_LIMIT = 3;
+
+/**
+ * The space name a flag would take: `feature-<key>`, without doubling a prefix
+ * the key already carries. Normalized the way the create form normalizes it, so
+ * the name Home shows is the name the space gets.
+ */
+export function spaceNameForFlag(flagKey: string): string {
+  const normalized = normalizeChannelName(flagKey);
+  return normalized.startsWith("feature-")
+    ? normalized
+    : normalizeChannelName(`feature-${normalized}`);
+}
+
+/**
+ * Which flags Home offers as work to pick up.
+ *
+ * A flag driving an experiment is left out — the experiment section says more
+ * about it than "you made a flag" does. A flag whose space already exists still
+ * shows, because the useful action there is to open that space, and hiding it
+ * would make Home quietly forget work already underway.
+ */
+export function homeFlagSuggestions(input: {
+  flags: HomeFeatureFlag[];
+  channels: { id: string; name: string }[];
+  limit?: number;
+}): HomeFlagSuggestion[] {
+  const byName = new Map(input.channels.map((c) => [c.name, c.id]));
+  const existing = (name: string) => {
+    const id = byName.get(name);
+    return id ? { id, name } : null;
+  };
+  return input.flags
+    .filter((flag) => !flag.hasExperiment)
+    .map((flag) => {
+      const spaceName = spaceNameForFlag(flag.key);
+      // Either name counts as the flag's space: `feature-checkout` is what Home
+      // proposes, but someone who already made `checkout` by hand has one.
+      const existingSpace =
+        existing(spaceName) ?? existing(normalizeChannelName(flag.key));
+      return { flag, spaceName, existingSpace };
+    })
+    .slice(0, input.limit ?? HOME_SUGGESTION_LIMIT);
+}

--- a/products/desktop/packages/ui/src/features/home/useHomeCanvases.ts
+++ b/products/desktop/packages/ui/src/features/home/useHomeCanvases.ts
@@ -1,0 +1,53 @@
+import type { DashboardRecord } from "@posthog/core/canvas/dashboardSchemas";
+import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
+import { useDashboards } from "@posthog/ui/features/canvas/hooks/useDashboards";
+import { useMemo } from "react";
+
+/**
+ * How many canvases the stack renders. Each is a live sandboxed iframe, so the
+ * cap is a budget as much as a layout choice — past a handful the page costs
+ * more to open than it saves.
+ */
+export const HOME_CANVAS_LIMIT = 3;
+
+const NO_CANVASES: DashboardRecord[] = [];
+
+/**
+ * The canvases Home stacks under its own sections: the ones pinned in your
+ * personal space, oldest pin first, so the order is yours and stays put.
+ *
+ * Pinning is the existing signal — a canvas already carries `pinnedAt`, and the
+ * canvas toolbar already sets it — so putting a canvas on Home needs no new
+ * concept, and taking it off is where you'd expect.
+ */
+export function useHomeCanvases(options?: { enabled?: boolean }): {
+  canvases: DashboardRecord[];
+  personalChannelId: string | null;
+  isLoading: boolean;
+} {
+  const enabled = options?.enabled ?? true;
+  const { channels, isLoading: channelsLoading } = useChannels({ enabled });
+  const personalChannelId =
+    channels.find((channel) => channel.channelType === "personal")?.id ?? null;
+
+  const { dashboards, isLoading: canvasesLoading } = useDashboards(
+    enabled ? (personalChannelId ?? undefined) : undefined,
+    // Home is not a live surface; polling a page of iframes off-screen is spend
+    // for nothing.
+    { poll: false },
+  );
+
+  const canvases = useMemo(() => {
+    const pinned = dashboards.filter((canvas) => canvas.pinnedAt != null);
+    if (pinned.length === 0) return NO_CANVASES;
+    return [...pinned]
+      .sort((a, b) => (a.pinnedAt ?? 0) - (b.pinnedAt ?? 0))
+      .slice(0, HOME_CANVAS_LIMIT);
+  }, [dashboards]);
+
+  return {
+    canvases,
+    personalChannelId,
+    isLoading: channelsLoading || (!!personalChannelId && canvasesLoading),
+  };
+}

--- a/products/desktop/packages/ui/src/features/home/useHomeEnabled.ts
+++ b/products/desktop/packages/ui/src/features/home/useHomeEnabled.ts
@@ -1,0 +1,13 @@
+import { HOME_FLAG } from "@posthog/shared";
+import { useBluebirdFlag } from "@posthog/ui/features/feature-flags/useBluebirdFlag";
+import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
+
+/**
+ * The single gate for Home — read this, not the raw flag. Home lives in the
+ * spaces chrome and its suggestions create spaces, so bluebird gates it too.
+ */
+export function useHomeEnabled(): boolean {
+  const bluebirdEnabled = useBluebirdFlag();
+  const homeEnabled = useFeatureFlag(HOME_FLAG, import.meta.env.DEV);
+  return homeEnabled && bluebirdEnabled;
+}

--- a/products/desktop/packages/ui/src/features/home/useHomeOrg.ts
+++ b/products/desktop/packages/ui/src/features/home/useHomeOrg.ts
@@ -1,0 +1,27 @@
+import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
+import { useAuthStateValue } from "@posthog/ui/features/auth/store";
+import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
+import { getPostHogUrl } from "@posthog/ui/utils/urls";
+
+/**
+ * The current organization's name and logo, for Home's hero. Logos aren't in
+ * the auth state's project map, so this cross-references the user's org list —
+ * the same route the project switcher takes.
+ */
+export function useHomeOrg(): { orgName: string | null; logoSrc?: string } {
+  const client = useOptionalAuthenticatedClient();
+  const { data: currentUser } = useCurrentUser({ client });
+  const currentOrgId = useAuthStateValue((state) => state.currentOrgId);
+
+  const organization =
+    currentUser?.organizations?.find((org) => org.id === currentOrgId) ?? null;
+  if (!organization) return { orgName: null };
+
+  return {
+    orgName: organization.name,
+    logoSrc: organization.logo_media_id
+      ? (getPostHogUrl(`/uploaded_media/${organization.logo_media_id}`) ??
+        undefined)
+      : undefined,
+  };
+}

--- a/products/desktop/packages/ui/src/features/home/useHomeWork.ts
+++ b/products/desktop/packages/ui/src/features/home/useHomeWork.ts
@@ -1,0 +1,73 @@
+import type { HomeWork } from "@posthog/core/home/homeSchemas";
+import { useHostTRPC } from "@posthog/host-router/react";
+import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
+import {
+  AUTH_SCOPED_QUERY_META,
+  useCurrentUser,
+} from "@posthog/ui/features/auth/useCurrentUser";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+
+// Home is a landing page, not a live monitor: the work behind it changes on the
+// scale of a working day, so it refetches on mount and otherwise sits still.
+const STALE_TIME_MS = 60_000;
+/** How many rows each group keeps. Home shows a handful and links out. */
+const GROUP_LIMIT = 6;
+
+const EMPTY_WORK: HomeWork = {
+  featureFlags: [],
+  experiments: [],
+  unavailable: [],
+};
+
+/**
+ * The feature flags and experiments Home opens on, marked with whether they are
+ * the viewer's own. Waits for the current user so ownership is known on the
+ * first paint rather than reshuffling the page a moment later.
+ */
+export function useHomeWork(options?: { enabled?: boolean }): {
+  work: HomeWork;
+  isLoading: boolean;
+} {
+  const trpc = useHostTRPC();
+  const client = useOptionalAuthenticatedClient();
+  const { data: currentUser, isLoading: userLoading } = useCurrentUser({
+    client,
+  });
+  const enabled = (options?.enabled ?? true) && !userLoading;
+
+  const { data, isLoading } = useQuery(
+    trpc.home.work.queryOptions(
+      { viewerId: currentUser?.id ?? null, limit: GROUP_LIMIT },
+      {
+        enabled,
+        meta: AUTH_SCOPED_QUERY_META,
+        staleTime: STALE_TIME_MS,
+      },
+    ),
+  );
+
+  return { work: data ?? EMPTY_WORK, isLoading: userLoading || isLoading };
+}
+
+/**
+ * Warm Home's work cache from somewhere else in the app (the rail's Home
+ * button on hover), so the page paints its sections instead of its skeletons.
+ * Same staleTime as the live query, so it no-ops when the data is fresh.
+ */
+export function usePrefetchHomeWork(): () => void {
+  const trpc = useHostTRPC();
+  const queryClient = useQueryClient();
+  const client = useOptionalAuthenticatedClient();
+  const { data: currentUser } = useCurrentUser({ client });
+  const viewerId = currentUser?.id ?? null;
+
+  return useCallback(() => {
+    void queryClient.prefetchQuery(
+      trpc.home.work.queryOptions(
+        { viewerId, limit: GROUP_LIMIT },
+        { meta: AUTH_SCOPED_QUERY_META, staleTime: STALE_TIME_MS },
+      ),
+    );
+  }, [trpc, queryClient, viewerId]);
+}

--- a/products/desktop/packages/ui/src/router/navigationBridge.ts
+++ b/products/desktop/packages/ui/src/router/navigationBridge.ts
@@ -111,6 +111,10 @@ export function openNotificationTarget(target: NotificationTarget): void {
   }
 }
 
+export function navigateToHome(): void {
+  void getRouterOrNull()?.navigate({ to: "/website/home" });
+}
+
 export function navigateToInbox(): void {
   void getRouterOrNull()?.navigate({ to: "/code/inbox" });
 }

--- a/products/desktop/packages/ui/src/router/routeTree.gen.ts
+++ b/products/desktop/packages/ui/src/router/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as CodeIndexRouteImport } from './routes/code/index'
 import { Route as WebsiteSkillsRouteImport } from './routes/website/skills'
 import { Route as WebsiteNewRouteImport } from './routes/website/new'
 import { Route as WebsiteMcpServersRouteImport } from './routes/website/mcp-servers'
+import { Route as WebsiteHomeRouteImport } from './routes/website/home'
 import { Route as WebsiteCommandCenterRouteImport } from './routes/website/command-center'
 import { Route as WebsiteActivityRouteImport } from './routes/website/activity'
 import { Route as SettingsCategoryRouteImport } from './routes/settings/$category'
@@ -138,6 +139,11 @@ const WebsiteNewRoute = WebsiteNewRouteImport.update({
 const WebsiteMcpServersRoute = WebsiteMcpServersRouteImport.update({
   id: '/mcp-servers',
   path: '/mcp-servers',
+  getParentRoute: () => WebsiteRoute,
+} as any)
+const WebsiteHomeRoute = WebsiteHomeRouteImport.update({
+  id: '/home',
+  path: '/home',
   getParentRoute: () => WebsiteRoute,
 } as any)
 const WebsiteCommandCenterRoute = WebsiteCommandCenterRouteImport.update({
@@ -468,6 +474,7 @@ export interface FileRoutesByFullPath {
   '/settings/$category': typeof SettingsCategoryRoute
   '/website/activity': typeof WebsiteActivityRoute
   '/website/command-center': typeof WebsiteCommandCenterRoute
+  '/website/home': typeof WebsiteHomeRoute
   '/website/mcp-servers': typeof WebsiteMcpServersRoute
   '/website/new': typeof WebsiteNewRoute
   '/website/skills': typeof WebsiteSkillsRoute
@@ -537,6 +544,7 @@ export interface FileRoutesByTo {
   '/settings/$category': typeof SettingsCategoryRoute
   '/website/activity': typeof WebsiteActivityRoute
   '/website/command-center': typeof WebsiteCommandCenterRoute
+  '/website/home': typeof WebsiteHomeRoute
   '/website/mcp-servers': typeof WebsiteMcpServersRoute
   '/website/new': typeof WebsiteNewRoute
   '/website/skills': typeof WebsiteSkillsRoute
@@ -601,6 +609,7 @@ export interface FileRoutesById {
   '/settings/$category': typeof SettingsCategoryRoute
   '/website/activity': typeof WebsiteActivityRoute
   '/website/command-center': typeof WebsiteCommandCenterRoute
+  '/website/home': typeof WebsiteHomeRoute
   '/website/mcp-servers': typeof WebsiteMcpServersRoute
   '/website/new': typeof WebsiteNewRoute
   '/website/skills': typeof WebsiteSkillsRoute
@@ -675,6 +684,7 @@ export interface FileRouteTypes {
     | '/settings/$category'
     | '/website/activity'
     | '/website/command-center'
+    | '/website/home'
     | '/website/mcp-servers'
     | '/website/new'
     | '/website/skills'
@@ -744,6 +754,7 @@ export interface FileRouteTypes {
     | '/settings/$category'
     | '/website/activity'
     | '/website/command-center'
+    | '/website/home'
     | '/website/mcp-servers'
     | '/website/new'
     | '/website/skills'
@@ -807,6 +818,7 @@ export interface FileRouteTypes {
     | '/settings/$category'
     | '/website/activity'
     | '/website/command-center'
+    | '/website/home'
     | '/website/mcp-servers'
     | '/website/new'
     | '/website/skills'
@@ -971,6 +983,13 @@ declare module '@tanstack/react-router' {
       path: '/mcp-servers'
       fullPath: '/website/mcp-servers'
       preLoaderRoute: typeof WebsiteMcpServersRouteImport
+      parentRoute: typeof WebsiteRoute
+    }
+    '/website/home': {
+      id: '/website/home'
+      path: '/home'
+      fullPath: '/website/home'
+      preLoaderRoute: typeof WebsiteHomeRouteImport
       parentRoute: typeof WebsiteRoute
     }
     '/website/command-center': {
@@ -1385,6 +1404,7 @@ declare module '@tanstack/react-router' {
 interface WebsiteRouteChildren {
   WebsiteActivityRoute: typeof WebsiteActivityRoute
   WebsiteCommandCenterRoute: typeof WebsiteCommandCenterRoute
+  WebsiteHomeRoute: typeof WebsiteHomeRoute
   WebsiteMcpServersRoute: typeof WebsiteMcpServersRoute
   WebsiteNewRoute: typeof WebsiteNewRoute
   WebsiteSkillsRoute: typeof WebsiteSkillsRoute
@@ -1403,6 +1423,7 @@ interface WebsiteRouteChildren {
 const WebsiteRouteChildren: WebsiteRouteChildren = {
   WebsiteActivityRoute: WebsiteActivityRoute,
   WebsiteCommandCenterRoute: WebsiteCommandCenterRoute,
+  WebsiteHomeRoute: WebsiteHomeRoute,
   WebsiteMcpServersRoute: WebsiteMcpServersRoute,
   WebsiteNewRoute: WebsiteNewRoute,
   WebsiteSkillsRoute: WebsiteSkillsRoute,

--- a/products/desktop/packages/ui/src/router/routes/website/home.tsx
+++ b/products/desktop/packages/ui/src/router/routes/website/home.tsx
@@ -1,0 +1,18 @@
+import { useFeatureFlagsLoaded } from "@posthog/ui/features/feature-flags/useFeatureFlagsLoaded";
+import { HomeView } from "@posthog/ui/features/home/HomeView";
+import { useHomeEnabled } from "@posthog/ui/features/home/useHomeEnabled";
+import { createFileRoute, Navigate } from "@tanstack/react-router";
+
+// The route stays registered regardless of the flag, so a restored session or a
+// persisted tab could land a flag-off user here with no Home button to leave
+// by. Once flags resolve, send them to the spaces index.
+function HomeRoute() {
+  const flagsLoaded = useFeatureFlagsLoaded();
+  const homeEnabled = useHomeEnabled();
+  if (flagsLoaded && !homeEnabled) return <Navigate to="/website" replace />;
+  return <HomeView />;
+}
+
+export const Route = createFileRoute("/website/home")({
+  component: HomeRoute,
+});

--- a/products/desktop/packages/ui/src/router/useAppView.ts
+++ b/products/desktop/packages/ui/src/router/useAppView.ts
@@ -7,6 +7,7 @@ import { useMemo } from "react";
 import { getCurrentMatches } from "./navigationBridge";
 
 export type AppViewType =
+  | "home"
   | "task-detail"
   | "task-pending"
   | "task-input"
@@ -62,6 +63,8 @@ function deriveFromMatches(matches: Match[]): AppView {
       return { type: "task-input" };
     case "/folders/$folderId":
       return { type: "folder-settings", folderId: last.params.folderId };
+    case "/website/home":
+      return { type: "home" };
     case "/website/activity":
       return { type: "activity" };
     case "/code/inbox":


### PR DESCRIPTION
## Problem

PostHog Desktop opens on an empty prompt. Everything a person is already working on — the flag they shipped last week, the experiment running right now, the canvas they pinned — lives elsewhere and has to be gone and found.

This is a first cut of Home: a landing page assembled from work that already exists in PostHog, and a place to riff on what else belongs there.

## Changes

Home is a new destination, left of Inbox in the spaces nav, at `/website/home`. It renders one scroll column of stacked blocks:

- **Hero.** The org's mark × PostHog's, and one line counting what is below.
- **Suggestions.** Recent feature flags. Each offers the one move Home can make: start the flag its own space (`#feature-<key>`). A flag whose space exists opens it instead. A flag driving an experiment is left out.
- **Experiments.** Stage, how long it has been running, and a link to the results.
- **Your canvases.** The canvases pinned in your personal space, each a live canvas in its own sandboxed frame, laid one under the next.

Design notes a reviewer would otherwise have to reverse-engineer:

- **Pinning already existed**, so "what shows on my Home" needed no new concept or backend field. Pin a canvas, it joins the stack in pin order; unpin it, it leaves. Capped at 3, because each one is a live iframe.
- **A group that fails to load is named, not blanked.** An empty Experiments section and a missing `experiment:read` scope look identical otherwise, so `HomeService` returns `unavailable` and the page says so.
- **Everything loads on mount**, and the nav button warms the cache on hover. A page that fetches as you scroll would undo the point of Home.
- **The page body takes all its data as props** (`HomePage`), so Storybook can show it; `HomeView` is the only part that fetches.

Behind `posthog-desktop-home`, which requires `project-bluebird`. Off, the nav item and the route are gone.

`docs/HOME.md` carries the design and a backlog of candidate sections — sessions in flight, waiting-on-you runs, stale rollouts, experiments that reached significance, errors in code you touched — and the argument for making Home's own blocks canvases next.

<details>
<summary>Home with three suggestions, two experiments, and one canvas (text dump from the story)</summary>

```
Welcome to PostHog Desktop
3 feature flags to pick up, 2 experiments in flight, and 1 pinned canvas.

Suggestions
  new-checkout    25% rollout  Yours   Starts #feature-new-checkout          [Start a space]
  billing-v2      Disabled             Starts #feature-billing-v2            [Start a space]
  search-rerank   100% rollout Yours   Already has #feature-search-rerank     [Open space]

Experiments
  Checkout copy         Running Yours  Running for 6 days · 2 variants        [View results]
  Onboarding checklist  Draft          Not launched yet · 2 variants          [View results]

Weekly numbers
  [canvas]
```

</details>

## How did you test this code?

Automated:

- `HomeService` unit tests: normalization of both groups, ownership marking, a group that fails to load reported instead of failing the call, and the running-first ordering.
- `homeFlagSuggestions` unit tests: experiment-backed flags excluded, an existing space found under either name, and the space name a flag would take.
- `homeSubhead` unit tests: the counted line, including the empty case.
- `ChannelNav` tests: Home absent with the flag off, and present immediately left of Inbox with it on.

Not tested by an agent: the app was never run. The canvas stack is the part this leaves unverified — `HomeCanvasSection` mounts the same `BuiltCanvas` a canvas page mounts, but no published build was rendered inside Home.

Rendered instead: `HomePage` in Storybook (four stories, both themes) driven by a headless browser. Verified the DOM and geometry — a centered 768px column, no horizontal overflow, no console errors — and read the copy off the rendered page. The screenshots themselves could not be viewed in this session, so the visual check is structural, not pixel-level.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`products/desktop/docs/HOME.md` is new and linked from the desktop `AGENTS.md` reference list.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with the PostHog Desktop cloud task agent. No repo skills applied cleanly to this work; `/writing-user-facing-copy` and `/writing-simplified-technical-english` shaped the copy and this description.

Decisions worth flagging for review:

- The hero and the first two sections are app components, not canvases. Making them canvases needs a per-user template instantiation that does not exist yet; `docs/HOME.md` names it as the next step. The stacking idea is real in block 4, where several independent canvases render as consecutive sections.
- Each stacked canvas gets a fixed 460px band, because the canvas runtime reports no content height. A `content-height` message on the bridge would fix that and is listed in the doc.
- `/website` still redirects to the first space. Home is arguably the better landing page, but that moves the whole spaces world, so it wants its own decision.
- `hogli ci:preflight` could not run here: the sandbox has no Python environment for it (`bin/hogli` exits with "python: not found"). Ran the desktop CI equivalents instead — `biome ci .`, `pnpm run typecheck` across all 25 packages, `check-host-boundaries.mjs`, and the core, shared, and ui test suites.

Nothing in this PR came from a customer conversation, ticket, or log. The story fixtures are invented.
