### PR TITLE
feat(warehouse-sources): add the four App Store Connect Detailed report variants

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/canonical_descriptions.py
@@ -8,6 +8,7 @@ table. Columns absent here fall back to LLM enrichment.
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
     CanonicalDescriptions,
+    CanonicalEndpoint,
 )
 
 # Columns every analytics report stream shares: the sync's own key columns plus the
@@ -378,3 +379,44 @@ CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
         },
     },
 }
+
+# The acquisition attribution columns Apple publishes only in Detailed report variants.
+_DETAILED_ATTRIBUTION_COLUMNS: dict[str, str] = {
+    "campaign": "Campaign token of the App Analytics campaign that led the user to the app.",
+    "page_title": "Name of the product page or in-app event page that led the user to the app.",
+    "source_info": "App or web referrer that led the user to discover the app; the detail behind source_type.",
+}
+
+
+def _detailed_variant(standard_name: str, description: str) -> CanonicalEndpoint:
+    # Apple documents a Detailed report as its Standard sibling's column set plus the
+    # attribution columns, on the same docs page, so the entry derives from the sibling
+    # rather than restating it.
+    standard = CANONICAL_DESCRIPTIONS[standard_name]
+    return {
+        "description": description,
+        "docs_url": standard["docs_url"],
+        "columns": {**standard["columns"], **_DETAILED_ATTRIBUTION_COLUMNS},
+    }
+
+
+CANONICAL_DESCRIPTIONS["analytics_app_sessions_detailed"] = _detailed_variant(
+    "analytics_app_sessions",
+    "How often people open the app and for how long, with the acquisition attribution columns, "
+    "from Apple's App Sessions Detailed analytics report.",
+)
+CANONICAL_DESCRIPTIONS["analytics_app_store_downloads_detailed"] = _detailed_variant(
+    "analytics_app_store_downloads",
+    "How many times people download the app on the App Store, with the acquisition attribution "
+    "columns, from Apple's App Downloads Detailed analytics report.",
+)
+CANONICAL_DESCRIPTIONS["analytics_installations_deletions_detailed"] = _detailed_variant(
+    "analytics_installations_deletions",
+    "How many times users install and delete the app, with the acquisition attribution columns, "
+    "from Apple's App Store Installation and Deletion Detailed analytics report.",
+)
+CANONICAL_DESCRIPTIONS["analytics_discovery_engagement_detailed"] = _detailed_variant(
+    "analytics_discovery_engagement",
+    "How users find and interact with the app on the App Store, with the acquisition attribution "
+    "columns, from Apple's App Store Discovery and Engagement Detailed analytics report.",
+)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/settings.py
@@ -267,6 +267,32 @@ APP_STORE_CONNECT_ENDPOINTS: dict[str, AppStoreConnectEndpointConfig] = {
         ("App Clip Usage", "App Clip Usage Standard"),
         "APP_USAGE",
     ),
+    # Detailed siblings of the analytics streams that carry acquisition attribution. Apple
+    # publishes each as a separate "<name> Detailed" report — the Standard columns plus the
+    # attribution fields (campaign, page_title, source_info) that exist in no Standard
+    # report, covering only users who opted in to sharing data. No suffix-less fallback
+    # here: the plain name resolves the Standard variant, which would silently fill the
+    # table with rows missing the attribution columns.
+    "analytics_app_sessions_detailed": _analytics_endpoint(
+        "analytics_app_sessions_detailed",
+        ("App Sessions Detailed",),
+        "APP_USAGE",
+    ),
+    "analytics_app_store_downloads_detailed": _analytics_endpoint(
+        "analytics_app_store_downloads_detailed",
+        ("App Downloads Detailed",),
+        "COMMERCE",
+    ),
+    "analytics_installations_deletions_detailed": _analytics_endpoint(
+        "analytics_installations_deletions_detailed",
+        ("App Store Installation and Deletion Detailed",),
+        "APP_USAGE",
+    ),
+    "analytics_discovery_engagement_detailed": _analytics_endpoint(
+        "analytics_discovery_engagement_detailed",
+        ("App Store Discovery and Engagement Detailed",),
+        "APP_STORE_ENGAGEMENT",
+    ),
 }
 
 ENDPOINTS = tuple(APP_STORE_CONNECT_ENDPOINTS.keys())

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/tests/test_app_store_connect.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/tests/test_app_store_connect.py
@@ -643,7 +643,12 @@ def _analytics_api(
     return _FakeAnalyticsApi(bodies, segment_payloads=segment_payloads)
 
 
-def _collect_analytics(api: _FakeAnalyticsApi, manager: _FakeManager, **kwargs: Any) -> list[dict[str, Any]]:
+def _collect_analytics(
+    api: _FakeAnalyticsApi,
+    manager: _FakeManager,
+    endpoint: str = "analytics_app_sessions",
+    **kwargs: Any,
+) -> list[dict[str, Any]]:
     session = MagicMock()
     session.get.side_effect = api.get
     session.post.side_effect = api.post
@@ -657,7 +662,7 @@ def _collect_analytics(api: _FakeAnalyticsApi, manager: _FakeManager, **kwargs: 
             key_id="KEY123",
             private_key=PRIVATE_KEY_PEM,
             vendor_number=None,
-            endpoint="analytics_app_sessions",
+            endpoint=endpoint,
             logger=MagicMock(),
             resumable_source_manager=manager,
             **kwargs,
@@ -919,6 +924,26 @@ class TestAnalyticsReportStreams:
         )
         assert row["app_name"] == "Example"
 
+    def test_detailed_stream_syncs_rows_with_the_attribution_columns(self) -> None:
+        payload = _gzip_csv(
+            "Date,App Name,App Apple Identifier,Source Type,Source Info,Campaign,Page Type,Page Title,Sessions\n"
+            "2026-08-01,Example,123,App referrer,com.example.social,summer-launch,Product page,Alternate page,5\n"
+        )
+        api = _analytics_api(
+            reports=[_resource("analyticsReports", "REP1", name="App Sessions Detailed", category="APP_USAGE")],
+            instances=[_instance("I1", "2026-08-01")],
+            segments_by_instance={"I1": [_segment("S1", "https://r.s3.amazonaws.com/1", payload)]},
+            segment_payloads={"https://r.s3.amazonaws.com/1": payload},
+        )
+
+        rows = _collect_analytics(api, _FakeManager(), endpoint="analytics_app_sessions_detailed")
+
+        # The attribution headers exist only in Detailed files and must land as the three
+        # documented snake_case columns. Metric columns are typed by name in every variant.
+        assert [(row["campaign"], row["page_title"], row["source_info"], row["sessions"]) for row in rows] == [
+            ("summer-launch", "Alternate page", "com.example.social", 5)
+        ]
+
     def test_analytics_source_response_checkpoints_ascending(self) -> None:
         response = app_store_connect_source(
             issuer_id="issuer",
@@ -936,11 +961,12 @@ class TestAnalyticsReportStreams:
 
 
 class TestFindAnalyticsReport:
-    def _resolve(self, endpoint: str, apple_name: str) -> str | None:
+    def _resolve(self, endpoint: str, *apple_names: str) -> str | None:
         config = APP_STORE_CONNECT_ENDPOINTS[endpoint]
         page = _Page(
             resources=[
-                _resource("analyticsReports", "REP1", name=apple_name, category=config.analytics_report_category)
+                _resource("analyticsReports", f"REP{index + 1}", name=name, category=config.analytics_report_category)
+                for index, name in enumerate(apple_names)
             ],
             included=[],
             next_url=None,
@@ -965,6 +991,33 @@ class TestFindAnalyticsReport:
         # Apple's casing of "Pre-Orders" has drifted before; normalization must resolve it without a
         # config change so a cosmetic rename can't silently blank the stream again.
         assert self._resolve("analytics_app_store_preorders", "App Store Pre-orders Standard") == "REP1"
+
+    @parameterized.expand(
+        [
+            ("analytics_app_sessions", "analytics_app_sessions_detailed", "App Sessions"),
+            ("analytics_app_store_downloads", "analytics_app_store_downloads_detailed", "App Downloads"),
+            (
+                "analytics_installations_deletions",
+                "analytics_installations_deletions_detailed",
+                "App Store Installation and Deletion",
+            ),
+            (
+                "analytics_discovery_engagement",
+                "analytics_discovery_engagement_detailed",
+                "App Store Discovery and Engagement",
+            ),
+        ]
+    )
+    def test_standard_and_detailed_variants_resolve_their_own_reports(
+        self, standard_endpoint: str, detailed_endpoint: str, base_name: str
+    ) -> None:
+        # Apple lists both variants of a report under the same request and category, so each config
+        # picks from the same page. Resolving the sibling would silently fill one table with the
+        # other variant's rows — for the detailed table, rows missing the attribution columns.
+        variants = (f"{base_name} Standard", f"{base_name} Detailed")
+
+        assert self._resolve(standard_endpoint, *variants) == "REP1"
+        assert self._resolve(detailed_endpoint, *variants) == "REP2"
 
 
 def _failures() -> _ParseFailureCounter:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/tests/test_app_store_connect_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/tests/test_app_store_connect_source.py
@@ -117,6 +117,34 @@ class TestAppStoreConnectSource:
             if kind == "analytics_report":
                 assert [field["field"] for field in schema.incremental_fields] == ["processing_date"]
 
+    @parameterized.expand(
+        [
+            ("analytics_app_sessions_detailed", "analytics_app_sessions"),
+            ("analytics_app_store_downloads_detailed", "analytics_app_store_downloads"),
+            ("analytics_installations_deletions_detailed", "analytics_installations_deletions"),
+            ("analytics_discovery_engagement_detailed", "analytics_discovery_engagement"),
+        ]
+    )
+    def test_detailed_analytics_streams_extend_their_standard_siblings(self, detailed: str, standard: str) -> None:
+        source = AppStoreConnectSource()
+
+        assert detailed in {schema.name for schema in source.get_schemas(_config(), team_id=1)}
+        # Apple files both variants of a report under the same category; a mismatch would make the
+        # per-request report list come back empty and the table sync nothing, without an error.
+        assert (
+            APP_STORE_CONNECT_ENDPOINTS[detailed].analytics_report_category
+            == APP_STORE_CONNECT_ENDPOINTS[standard].analytics_report_category
+        )
+
+        descriptions = source.get_canonical_descriptions()
+        # A Detailed report is its Standard sibling plus exactly the three acquisition
+        # attribution columns Apple publishes in no Standard report.
+        assert set(descriptions[detailed]["columns"]) == set(descriptions[standard]["columns"]) | {
+            "campaign",
+            "page_title",
+            "source_info",
+        }
+
     def test_canonical_descriptions_cover_the_catalog(self) -> None:
         descriptions = AppStoreConnectSource().get_canonical_descriptions()
 


### PR DESCRIPTION
## Problem

The App Store Connect source registers only the `Standard` analytics report variants. Apple publishes a `Detailed` sibling for each, and the acquisition-attribution columns — `campaign`, `source_info`, `page_title` — exist only in the Detailed reports, so the source cannot answer where an install or session came from.

**Why:** those three columns are the whole of App Store acquisition attribution; without them customers keep a second pipeline alive just for this data.

Closes #82927

## Changes

- Registers four Detailed analytics endpoints (`analytics_app_sessions_detailed`, `analytics_app_store_downloads_detailed`, `analytics_installations_deletions_detailed`, `analytics_discovery_engagement_detailed`) in the source's endpoint catalog, mapping to Apple's "… Detailed" report names. The existing analytics machinery (request/poll/download, daily granularity, `processing_date` incremental walk) handles them unchanged.
- Detailed streams get a single-name report lookup with no suffix-less fallback: the plain name resolves the Standard variant, which would silently fill the table with rows missing the attribution columns.
- Canonical descriptions derive from each Standard sibling plus the three attribution columns, so the "Standard set plus three" contract cannot drift.
- Existing Standard streams are untouched (schema, report names, behaviour).

## How did you test this code?

Automated tests, run locally (this module needs no DB):

- `test_standard_and_detailed_variants_resolve_their_own_reports` — catches a Detailed stream resolving its Standard sibling's report id when Apple lists both under one request; no existing test covered variant disambiguation.
- `test_detailed_stream_syncs_rows_with_the_attribution_columns` — full-chain sync of a Detailed endpoint carries `campaign`/`page_title`/`source_info` values through to rows.
- `test_detailed_analytics_streams_extend_their_standard_siblings` — schema discovery exposes all four, with columns equal to the Standard set plus exactly the three attribution columns.

All were red before the change (endpoints absent from the catalog) and green after; the full module suite passes locally. Not tested against Apple's live API — that needs a live source sync.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The posthog.com source docs (separate repo) should list the four new Detailed tables — flagged as a follow-up.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented by a Claude Code (PostHog Desktop cloud task) subagent from a CS-authored work order, against the linked public issue; reviewed, security-checked, and published by the orchestrating agent. No repo skills were invoked. All fixtures are synthetic; nothing from the session beyond the public issue content is in the diff. Key decision during the session: Detailed streams get a single-name report lookup with no suffix-less fallback, after finding the plain name resolves the Standard variant.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

