### PR TITLE
feat(warehouse-sources): add an organization members table to the Devin AI source

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/devin_ai/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/devin_ai/canonical_descriptions.py
@@ -67,6 +67,16 @@ CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
             "pinned_repo": "Repository the note is pinned to, if any.",
         },
     },
+    "members": {
+        "description": "A member of the Devin organization. Join sessions.user_id to members.user_id to resolve who ran a session to their email and name.",
+        "docs_url": "https://docs.devin.ai/api-reference/v3/users/list-organization-users",
+        "columns": {
+            "user_id": "Unique identifier for the member. The same identifier is recorded as user_id on sessions, so it joins directly to that table.",
+            "email": "Email address of the member.",
+            "name": "Display name of the member.",
+            "role_assignments": "Roles assigned directly to the member, each with a role (role_id, role_name, role_type) and the org it applies to.",
+        },
+    },
     "secrets": {
         "description": "Metadata for an org-level secret available to Devin sessions. Secret values are never returned by the API and are not synced.",
         "docs_url": "https://docs.devin.ai/api-reference/v3/secrets/organizations-secrets",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/devin_ai/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/devin_ai/settings.py
@@ -5,6 +5,8 @@ from products.warehouse_sources.backend.types import IncrementalField
 
 # Devin (Cognition AI) v3 API. Every org-level list endpoint shares the same shape:
 #   GET https://api.devin.ai/v3/organizations/{org_id}/<resource>
+#   (members uses the v3beta1 org path, /v3beta1/organizations/{org_id}/members/users, with the
+#   identical envelope and auth)
 #   cursor pagination via `first` (<=200) / `after`, response envelope
 #   {"items": [...], "end_cursor": str | None, "has_next_page": bool, "total": int | None}
 # Timestamps (`created_at` / `updated_at`) are integer Unix seconds.
@@ -44,6 +46,18 @@ DEVIN_AI_ENDPOINTS: dict[str, DevinAIEndpointConfig] = {
         name="knowledge_notes",
         path="/v3/organizations/{org_id}/knowledge/notes",
         primary_keys=["note_id"],
+    ),
+    # Org members, carrying user_id + email so the opaque user_id on sessions resolves to a person.
+    # Backed by the v3beta1 org-scoped users listing (needs the org-level `ViewOrgMembership`
+    # permission): the stable alternatives require credentials this source doesn't store (the v2
+    # members endpoint takes only enterprise-admin personal `apk_user_*` keys, and the v3 enterprise
+    # listing needs an enterprise-level service user). Member records carry no created_at, so the
+    # table declares no partition key, and the list is small and slow-changing, so full refresh only.
+    "members": DevinAIEndpointConfig(
+        name="members",
+        path="/v3beta1/organizations/{org_id}/members/users",
+        partition_key=None,
+        primary_keys=["user_id"],
     ),
     # Org secrets expose metadata only (key names, type, audit fields) — never the secret values.
     # Off by default so a user opts in rather than silently syncing secret metadata.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/devin_ai/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/devin_ai/source.py
@@ -63,6 +63,7 @@ class DevinAISource(ResumableSource[DevinAISourceConfig, DevinAIResumeConfig]):
 Create a service user API key (prefixed `cog_`) in your [Devin organization settings](https://app.devin.ai/settings). The service user needs the following organization-level permissions:
 - `ViewOrgSessions` — Sessions
 - `ManageAccountKnowledge` — Playbooks and Knowledge notes
+- `ViewOrgMembership` — Members
 - `ManageOrgSecrets` — Secrets (metadata only; values are never synced)
 
 Your organization ID is the `org-...` identifier shown in your Devin organization settings.""",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/devin_ai/tests/test_devin_ai.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/devin_ai/tests/test_devin_ai.py
@@ -83,6 +83,9 @@ class TestEndpointPath:
             ("playbooks", "/v3/organizations/org-abc/playbooks"),
             ("knowledge_notes", "/v3/organizations/org-abc/knowledge/notes"),
             ("secrets", "/v3/organizations/org-abc/secrets"),
+            # Members must stay on the org-scoped users listing: the v2 members endpoint only accepts
+            # enterprise-admin personal API keys, which this source never stores.
+            ("members", "/v3beta1/organizations/org-abc/members/users"),
         ]
     )
     def test_org_id_is_interpolated_into_path(self, endpoint: str, expected: str) -> None:
@@ -211,7 +214,7 @@ class TestGetStatusCode:
 
 
 class TestDevinAISource:
-    @parameterized.expand(list(DEVIN_AI_ENDPOINTS.keys()))
+    @parameterized.expand(["sessions", "playbooks", "knowledge_notes", "secrets"])
     @mock.patch(CLIENT_SESSION_PATCH)
     def test_source_response_uses_endpoint_primary_keys_and_stable_partition(self, endpoint: str, MockSession) -> None:
         response = _source(endpoint, _make_manager())
@@ -221,3 +224,82 @@ class TestDevinAISource:
         # created_at is a stable field — never updated_at — so partitions don't rewrite each sync.
         assert response.partition_keys == ["created_at"]
         assert response.partition_mode == "datetime"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_members_source_response_dedupes_on_user_id_and_has_no_partition(self, MockSession) -> None:
+        response = _source("members", _make_manager())
+        assert response.name == "members"
+        assert response.primary_keys == ["user_id"]
+        # Member records carry no created_at, so the table must not declare a datetime partition.
+        assert response.partition_keys is None
+        assert response.partition_mode is None
+
+
+class TestMembersJoin:
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_member_user_id_and_email_pass_through_for_sessions_join(self, MockSession) -> None:
+        session = MockSession.return_value
+        # Devin identifies people by Auth0-style subjects (`email|<id>`, `google-oauth2|<id>`), and the
+        # sessions table's user_id lands as that same opaque string. The members table must surface
+        # user_id byte-identical to the API value so sessions.user_id = members.user_id resolves an email.
+        _wire(
+            session,
+            [
+                _response(
+                    [
+                        {
+                            "user_id": "email|1a2b3c4d5e6f",
+                            "email": "casey@example.com",
+                            "name": "Casey Doe",
+                            "role_assignments": [
+                                {
+                                    "org_id": "org-abc",
+                                    "role": {"role_id": "r1", "role_name": "Member", "role_type": "org"},
+                                }
+                            ],
+                        },
+                        {
+                            "user_id": "google-oauth2|110000000000000000001",
+                            "email": "riley@example.com",
+                            "name": "Riley Roe",
+                            "role_assignments": [],
+                        },
+                    ]
+                )
+            ],
+        )
+
+        rows = _rows(_source("members", _make_manager()))
+
+        email_by_user_id = {row["user_id"]: row["email"] for row in rows}
+        # user_id exactly as it lands in the synced sessions table.
+        assert email_by_user_id["email|1a2b3c4d5e6f"] == "casey@example.com"
+        assert email_by_user_id["google-oauth2|110000000000000000001"] == "riley@example.com"
+        assert rows[0]["name"] == "Casey Doe"
+        assert rows[0]["role_assignments"][0]["role"]["role_name"] == "Member"
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_members_pagination_follows_cursor_so_later_pages_join(self, MockSession) -> None:
+        session = MockSession.return_value
+        # A member past the first page must still be synced, or their sessions stop resolving to an email.
+        params = _wire(
+            session,
+            [
+                _response(
+                    [{"user_id": "email|aaa111", "email": "casey@example.com", "name": None, "role_assignments": []}],
+                    has_next_page=True,
+                    end_cursor="cur1",
+                ),
+                _response(
+                    [{"user_id": "email|bbb222", "email": "riley@example.com", "name": None, "role_assignments": []}],
+                    has_next_page=False,
+                    end_cursor=None,
+                ),
+            ],
+        )
+
+        rows = _rows(_source("members", _make_manager()))
+
+        assert params[1] == {"first": PAGE_SIZE, "after": "cur1"}
+        email_by_user_id = {row["user_id"]: row["email"] for row in rows}
+        assert email_by_user_id["email|bbb222"] == "riley@example.com"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/devin_ai/tests/test_devin_ai_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/devin_ai/tests/test_devin_ai_source.py
@@ -57,6 +57,17 @@ class TestGetSchemas:
         assert schemas["secrets"].should_sync_default is False
         assert schemas["sessions"].should_sync_default is True
 
+    def test_members_table_is_discovered_full_refresh_with_user_id_key(self) -> None:
+        # The set-equality assertions above compare get_schemas against the same dict the schemas come
+        # from, so only an explicit name check catches the members table going missing from discovery.
+        schemas = {s.name: s for s in DevinAISource().get_schemas(_config(), team_id=1)}
+        members = schemas["members"]
+        assert members.supports_incremental is False
+        assert members.supports_append is False
+        # user_id is the merge key: anything else would duplicate members across full refreshes.
+        assert members.detected_primary_keys == ["user_id"]
+        assert members.should_sync_default is True
+
     def test_names_filter_restricts_output(self) -> None:
         schemas = DevinAISource().get_schemas(_config(), team_id=1, names=["sessions"])
         assert [s.name for s in schemas] == ["sessions"]


### PR DESCRIPTION
## Problem

The Devin AI source syncs `sessions`, `playbooks`, `knowledge_notes`, and `secrets`, but `sessions.user_id` is an opaque identifier that resolves to nothing in any synced table — per-person attribution of Devin usage is impossible from the warehouse alone.

**Why:** teams adopting Devin want to know who is running sessions; the members directory is the missing join dimension.

Closes #82930

## Changes

- Adds a `members` table (name matches this source's short resource names) carrying `user_id`, `email`, and the other member directory fields. Full refresh, primary key `user_id`, no partition key — member records carry no `created_at` and the list is small and slow-changing.
- Backed by `GET /v3beta1/organizations/{org_id}/members/users`. **Deliberate deviation from the endpoint named in the issue:** the v2 organization-members endpoint is deprecated and accepts only enterprise-admin personal keys (`apk_user_*`), and the v3 enterprise listing needs an enterprise-level service user — neither works with the `cog_` service-user key this source stores. The v3beta1 org-scoped listing uses the same auth, envelope, and cursor pagination as the source's other four tables (rationale in a `settings.py` comment).
- The source's setup caption now lists the required `ViewOrgMembership` permission.
- Sessions table untouched: Devin uses one canonical user-id namespace across endpoints, so sessions→members is a direct equality join; a test locks in byte-identical `user_id` passthrough so any future normalization breaks loudly.

## How did you test this code?

Automated tests, run locally (module needs no DB), all red on the unchanged code (`KeyError: 'members'`) and green after: endpoint path interpolation, schema discovery (full refresh + `user_id` key), dedup-on-user_id with no partition, cursor pagination across pages, and the sessions-form join lookup resolving an email. Full module suite passes (53 tests, includes all 48 pre-existing).

Not verified against a live Devin API (no credentials in CI or locally); the `v3beta1` path may be renamed when Devin GAs the API — worth a live-source smoke test after merge.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The public docs table list updates automatically via get_documented_tables; the permission list mention (ViewOrgMembership) is a follow-up in the docs repo.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented by a Claude Code (PostHog Desktop cloud task) subagent from a CS-authored work order, against the linked public issue; reviewed, security-checked, and published by the orchestrating agent. No repo skills were invoked. All fixtures are synthetic; nothing from the session beyond the public issue content is in the diff. Key decision during the session: the issue-referenced v2 endpoint turned out deprecated and incompatible with this source's cog_ service keys, so the v3 org-scoped listing was used instead (documented in settings.py).

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

