### PR TITLE
feat(revenue-analytics): add a Checkout.com builder without waiting on the source-isolation refactor

### DIFF
--- a/posthog/api/test/__snapshots__/test_element.ambr
+++ b/posthog/api/test/__snapshots__/test_element.ambr
@@ -125,7 +125,8 @@
   WHERE ("posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL)
-         AND "posthog_externaldatasource"."source_type" IN ('Stripe'))
+         AND "posthog_externaldatasource"."source_type" IN ('Stripe',
+                                                            'CheckoutCom'))
   '''
 # ---
 # name: TestElement.test_element_stats_postgres_queries_are_as_expected.11

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -396,7 +396,8 @@
   WHERE ("posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL)
-         AND "posthog_externaldatasource"."source_type" IN ('Stripe'))
+         AND "posthog_externaldatasource"."source_type" IN ('Stripe',
+                                                            'CheckoutCom'))
   '''
 # ---
 # name: TestDatabase.test_database_with_warehouse_tables_and_saved_queries_n_plus_1.3
@@ -766,7 +767,8 @@
   WHERE ("posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL)
-         AND "posthog_externaldatasource"."source_type" IN ('Stripe'))
+         AND "posthog_externaldatasource"."source_type" IN ('Stripe',
+                                                            'CheckoutCom'))
   '''
 # ---
 # name: TestDatabase.test_serialize_database_no_person_on_events

--- a/posthog/session_recordings/test/__snapshots__/test_session_recording_playlist.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recording_playlist.ambr
@@ -1283,7 +1283,8 @@
   WHERE ("posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL)
-         AND "posthog_externaldatasource"."source_type" IN ('Stripe'))
+         AND "posthog_externaldatasource"."source_type" IN ('Stripe',
+                                                            'CheckoutCom'))
   '''
 # ---
 # name: TestSessionRecordingPlaylist.test_filters_playlist_by_type.31

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -133,7 +133,8 @@
   WHERE ("posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL)
-         AND "posthog_externaldatasource"."source_type" IN ('Stripe'))
+         AND "posthog_externaldatasource"."source_type" IN ('Stripe',
+                                                            'CheckoutCom'))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_returns_newest_first.11
@@ -970,7 +971,8 @@
   WHERE ("posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL)
-         AND "posthog_externaldatasource"."source_type" IN ('Stripe'))
+         AND "posthog_externaldatasource"."source_type" IN ('Stripe',
+                                                            'CheckoutCom'))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_scenarios_0_basic_listing.11
@@ -1804,7 +1806,8 @@
   WHERE ("posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL)
-         AND "posthog_externaldatasource"."source_type" IN ('Stripe'))
+         AND "posthog_externaldatasource"."source_type" IN ('Stripe',
+                                                            'CheckoutCom'))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_scenarios_1_multiple_snapshots.11
@@ -2635,7 +2638,8 @@
   WHERE ("posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL)
-         AND "posthog_externaldatasource"."source_type" IN ('Stripe'))
+         AND "posthog_externaldatasource"."source_type" IN ('Stripe',
+                                                            'CheckoutCom'))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_scenarios_2_many_distinct_ids.11
@@ -3466,7 +3470,8 @@
   WHERE ("posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL)
-         AND "posthog_externaldatasource"."source_type" IN ('Stripe'))
+         AND "posthog_externaldatasource"."source_type" IN ('Stripe',
+                                                            'CheckoutCom'))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_0_descending_original_.11
@@ -4300,7 +4305,8 @@
   WHERE ("posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL)
-         AND "posthog_externaldatasource"."source_type" IN ('Stripe'))
+         AND "posthog_externaldatasource"."source_type" IN ('Stripe',
+                                                            'CheckoutCom'))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_1_descending.11
@@ -5134,7 +5140,8 @@
   WHERE ("posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL)
-         AND "posthog_externaldatasource"."source_type" IN ('Stripe'))
+         AND "posthog_externaldatasource"."source_type" IN ('Stripe',
+                                                            'CheckoutCom'))
   '''
 # ---
 # name: TestSessionRecordings.test_get_session_recordings_sorted_2_ascending.11
@@ -6243,7 +6250,8 @@
   WHERE ("posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL)
-         AND "posthog_externaldatasource"."source_type" IN ('Stripe'))
+         AND "posthog_externaldatasource"."source_type" IN ('Stripe',
+                                                            'CheckoutCom'))
   '''
 # ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.103
@@ -7096,7 +7104,8 @@
   WHERE ("posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL)
-         AND "posthog_externaldatasource"."source_type" IN ('Stripe'))
+         AND "posthog_externaldatasource"."source_type" IN ('Stripe',
+                                                            'CheckoutCom'))
   '''
 # ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.119
@@ -7997,7 +8006,8 @@
   WHERE ("posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL)
-         AND "posthog_externaldatasource"."source_type" IN ('Stripe'))
+         AND "posthog_externaldatasource"."source_type" IN ('Stripe',
+                                                            'CheckoutCom'))
   '''
 # ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.135
@@ -9022,7 +9032,8 @@
   WHERE ("posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL)
-         AND "posthog_externaldatasource"."source_type" IN ('Stripe'))
+         AND "posthog_externaldatasource"."source_type" IN ('Stripe',
+                                                            'CheckoutCom'))
   '''
 # ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.151
@@ -9918,7 +9929,8 @@
   WHERE ("posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL)
-         AND "posthog_externaldatasource"."source_type" IN ('Stripe'))
+         AND "posthog_externaldatasource"."source_type" IN ('Stripe',
+                                                            'CheckoutCom'))
   '''
 # ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.167
@@ -10618,7 +10630,8 @@
   WHERE ("posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL)
-         AND "posthog_externaldatasource"."source_type" IN ('Stripe'))
+         AND "posthog_externaldatasource"."source_type" IN ('Stripe',
+                                                            'CheckoutCom'))
   '''
 # ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.23
@@ -11490,7 +11503,8 @@
   WHERE ("posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL)
-         AND "posthog_externaldatasource"."source_type" IN ('Stripe'))
+         AND "posthog_externaldatasource"."source_type" IN ('Stripe',
+                                                            'CheckoutCom'))
   '''
 # ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.39
@@ -12388,7 +12402,8 @@
   WHERE ("posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL)
-         AND "posthog_externaldatasource"."source_type" IN ('Stripe'))
+         AND "posthog_externaldatasource"."source_type" IN ('Stripe',
+                                                            'CheckoutCom'))
   '''
 # ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.55
@@ -13370,7 +13385,8 @@
   WHERE ("posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL)
-         AND "posthog_externaldatasource"."source_type" IN ('Stripe'))
+         AND "posthog_externaldatasource"."source_type" IN ('Stripe',
+                                                            'CheckoutCom'))
   '''
 # ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.71
@@ -14294,7 +14310,8 @@
   WHERE ("posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL)
-         AND "posthog_externaldatasource"."source_type" IN ('Stripe'))
+         AND "posthog_externaldatasource"."source_type" IN ('Stripe',
+                                                            'CheckoutCom'))
   '''
 # ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.87
@@ -14445,7 +14462,8 @@
   WHERE ("posthog_externaldatasource"."team_id" = 99999
          AND NOT ("posthog_externaldatasource"."deleted"
                   AND "posthog_externaldatasource"."deleted" IS NOT NULL)
-         AND "posthog_externaldatasource"."source_type" IN ('Stripe'))
+         AND "posthog_externaldatasource"."source_type" IN ('Stripe',
+                                                            'CheckoutCom'))
   '''
 # ---
 # name: TestSessionRecordings.test_listing_recordings_is_not_nplus1_for_persons.90

--- a/products/revenue_analytics/backend/views/core.py
+++ b/products/revenue_analytics/backend/views/core.py
@@ -15,7 +15,7 @@ from products.warehouse_sources.backend.facade.contracts import RevenueSource
 
 @frozen
 class SourceHandle:
-    type: Literal["events", "stripe"]
+    type: Literal["events", "stripe", "checkoutcom"]
     team: Team
     source: Optional[RevenueSource] = None
     event: Optional[RevenueAnalyticsEventItem] = None

--- a/products/revenue_analytics/backend/views/orchestrator.py
+++ b/products/revenue_analytics/backend/views/orchestrator.py
@@ -17,7 +17,10 @@ from products.revenue_analytics.backend.views.sources.registry import BUILDERS
 from products.warehouse_sources.backend.facade.api import list_revenue_sources
 from products.warehouse_sources.backend.facade.types import ExternalDataSourceType
 
-SUPPORTED_SOURCES: list[ExternalDataSourceType] = [ExternalDataSourceType.STRIPE]
+SUPPORTED_SOURCES: list[ExternalDataSourceType] = [
+    ExternalDataSourceType.STRIPE,
+    ExternalDataSourceType.CHECKOUTCOM,
+]
 
 
 def _iter_source_handles(team: Team, timings: HogQLTimings) -> Iterable[SourceHandle]:

--- a/products/revenue_analytics/backend/views/sources/checkout_com/__init__.py
+++ b/products/revenue_analytics/backend/views/sources/checkout_com/__init__.py
@@ -14,17 +14,3 @@ kinds present in this dict. Settlement-level figures (fees, payouts) exist in th
 `financial_actions_report` table at (`action_id`, `breakdown_type`) grain, but its
 column set is account-configurable, so no managed view is built on it.
 """
-
-from posthog.schema import DatabaseSchemaManagedViewTableKind
-
-from products.revenue_analytics.backend.views.core import Builder
-
-from .charge import build as charge_builder
-from .customer import build as customer_builder
-from .revenue_item import build as revenue_item_builder
-
-BUILDER: Builder = {
-    DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_CHARGE: charge_builder,
-    DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_CUSTOMER: customer_builder,
-    DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_REVENUE_ITEM: revenue_item_builder,
-}

--- a/products/revenue_analytics/backend/views/sources/checkout_com/__init__.py
+++ b/products/revenue_analytics/backend/views/sources/checkout_com/__init__.py
@@ -1,0 +1,30 @@
+"""Revenue analytics view builders for the Checkout.com warehouse source.
+
+Checkout.com's data model differs from Stripe's, so only the view kinds its data can
+genuinely support are registered:
+
+- charge and revenue_item map onto `payments` + `payment_actions` (a charge is an
+  approved `Capture` action; refunds are `Refund` actions in the same table and are
+  not netted, matching the Stripe builder's gross-revenue semantics).
+- customer maps onto `customers`, with the cohort derived from `payments`.
+
+Checkout.com has no product, subscription or invoice objects, so the product,
+subscription and MRR views are not registered — the orchestrator only builds the view
+kinds present in this dict. Settlement-level figures (fees, payouts) exist in the
+`financial_actions_report` table at (`action_id`, `breakdown_type`) grain, but its
+column set is account-configurable, so no managed view is built on it.
+"""
+
+from posthog.schema import DatabaseSchemaManagedViewTableKind
+
+from products.revenue_analytics.backend.views.core import Builder
+
+from .charge import build as charge_builder
+from .customer import build as customer_builder
+from .revenue_item import build as revenue_item_builder
+
+BUILDER: Builder = {
+    DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_CHARGE: charge_builder,
+    DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_CUSTOMER: customer_builder,
+    DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_REVENUE_ITEM: revenue_item_builder,
+}

--- a/products/revenue_analytics/backend/views/sources/checkout_com/builder.py
+++ b/products/revenue_analytics/backend/views/sources/checkout_com/builder.py
@@ -1,0 +1,15 @@
+"""The view-kind builder registry for the Checkout.com source (see the package docstring)."""
+
+from posthog.schema import DatabaseSchemaManagedViewTableKind
+
+from products.revenue_analytics.backend.views.core import Builder
+
+from .charge import build as charge_builder
+from .customer import build as customer_builder
+from .revenue_item import build as revenue_item_builder
+
+BUILDER: Builder = {
+    DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_CHARGE: charge_builder,
+    DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_CUSTOMER: customer_builder,
+    DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_REVENUE_ITEM: revenue_item_builder,
+}

--- a/products/revenue_analytics/backend/views/sources/checkout_com/charge.py
+++ b/products/revenue_analytics/backend/views/sources/checkout_com/charge.py
@@ -1,0 +1,77 @@
+from posthog.hogql import ast
+
+from products.revenue_analytics.backend.views.core import BuiltQuery, SourceHandle, view_prefix_for_source
+from products.revenue_analytics.backend.views.schemas.charge import SCHEMA
+from products.revenue_analytics.backend.views.sources.checkout_com.helpers import (
+    PAYMENT_ACTION_RESOURCE_NAME,
+    PAYMENT_RESOURCE_NAME,
+    approved_captures_join_expr,
+    approved_captures_where_expr,
+    currency_conversion_fields,
+    customer_id_expr,
+    parse_timestamp,
+)
+
+
+def build(handle: SourceHandle) -> BuiltQuery:
+    """
+    Revenue Analytics Charge View for Checkout.com
+
+    Checkout.com has no standalone charge object: a charge is an approved `Capture`
+    action on a payment, so this view joins `payment_actions` with `payments` (the
+    action carries the captured amount and time; the payment carries the currency and
+    customer). Refund actions live in the same table and are deliberately not netted
+    here, matching the gross-revenue semantics of the Stripe charge view.
+
+    Both tables sync from the payments search API, which only reaches back 90 days by
+    default, so this view only covers full history when the source has a start date
+    configured.
+    """
+    source = handle.source
+    if source is None:
+        raise ValueError("Source is required")
+
+    prefix = view_prefix_for_source(source)
+
+    # Get all schemas for the source, avoid calling `filter` and do the filtering on
+    # Python-land to avoid n+1 queries
+    schemas = source.schemas.all()
+    payments_schema = next((schema for schema in schemas if schema.name == PAYMENT_RESOURCE_NAME), None)
+    actions_schema = next((schema for schema in schemas if schema.name == PAYMENT_ACTION_RESOURCE_NAME), None)
+    if payments_schema is None or actions_schema is None:
+        return BuiltQuery(
+            key=str(source.id),  # Using source rather than table because table hasn't been found yet
+            prefix=prefix,
+            query=ast.SelectQuery.empty(columns=SCHEMA.fields),
+            test_comments="no_schema",
+        )
+
+    payments_table = payments_schema.table
+    actions_table = actions_schema.table
+    if payments_table is None or actions_table is None:
+        return BuiltQuery(
+            key=str(source.id),  # Using source rather than table because table hasn't been found
+            prefix=prefix,
+            query=ast.SelectQuery.empty(columns=SCHEMA.fields),
+            test_comments="no_table",
+        )
+
+    query = ast.SelectQuery(
+        select=[
+            # Base fields to allow insights to work (need `distinct_id` AND `timestamp` fields)
+            ast.Alias(alias="id", expr=ast.Field(chain=["action", "id"])),
+            ast.Alias(alias="source_label", expr=ast.Constant(value=prefix)),
+            ast.Alias(alias="timestamp", expr=parse_timestamp(ast.Field(chain=["action", "processed_on"]))),
+            # Useful for cross joins
+            ast.Alias(alias="customer_id", expr=customer_id_expr()),
+            # Checkout.com has no invoices; empty but required for the merged views to work
+            ast.Alias(alias="invoice_id", expr=ast.Constant(value=None)),
+            ast.Alias(alias="session_id", expr=ast.Constant(value=None)),
+            ast.Alias(alias="event_name", expr=ast.Constant(value=None)),
+            *currency_conversion_fields(handle.team),
+        ],
+        select_from=approved_captures_join_expr(actions_table, payments_table),
+        where=approved_captures_where_expr(),
+    )
+
+    return BuiltQuery(key=str(actions_table.id), prefix=prefix, query=query)

--- a/products/revenue_analytics/backend/views/sources/checkout_com/charge.py
+++ b/products/revenue_analytics/backend/views/sources/checkout_com/charge.py
@@ -33,9 +33,9 @@ def build(handle: SourceHandle) -> BuiltQuery:
 
     prefix = view_prefix_for_source(source)
 
-    # Get all schemas for the source, avoid calling `filter` and do the filtering on
-    # Python-land to avoid n+1 queries
-    schemas = source.schemas.all()
+    # Get all schemas for the source, avoid calling `filter` and do the filtering on Python-land
+    # to avoid n+1 queries
+    schemas = source.schemas
     payments_schema = next((schema for schema in schemas if schema.name == PAYMENT_RESOURCE_NAME), None)
     actions_schema = next((schema for schema in schemas if schema.name == PAYMENT_ACTION_RESOURCE_NAME), None)
     if payments_schema is None or actions_schema is None:

--- a/products/revenue_analytics/backend/views/sources/checkout_com/customer.py
+++ b/products/revenue_analytics/backend/views/sources/checkout_com/customer.py
@@ -31,9 +31,9 @@ def build(handle: SourceHandle) -> BuiltQuery:
 
     prefix = view_prefix_for_source(source)
 
-    # Get all schemas for the source, avoid calling `filter` and do the filtering on
-    # Python-land to avoid n+1 queries
-    schemas = source.schemas.all()
+    # Get all schemas for the source, avoid calling `filter` and do the filtering on Python-land
+    # to avoid n+1 queries
+    schemas = source.schemas
     customer_schema = next((schema for schema in schemas if schema.name == CUSTOMER_RESOURCE_NAME), None)
     if customer_schema is None:
         return BuiltQuery(

--- a/products/revenue_analytics/backend/views/sources/checkout_com/customer.py
+++ b/products/revenue_analytics/backend/views/sources/checkout_com/customer.py
@@ -1,0 +1,125 @@
+from posthog.hogql import ast
+
+from products.revenue_analytics.backend.views.core import BuiltQuery, SourceHandle, view_prefix_for_source
+from products.revenue_analytics.backend.views.schemas.customer import SCHEMA
+from products.revenue_analytics.backend.views.sources.checkout_com.helpers import (
+    CUSTOMER_RESOURCE_NAME,
+    PAYMENT_RESOURCE_NAME,
+    extract_json_string_from,
+    get_table,
+    parse_timestamp,
+)
+from products.revenue_analytics.backend.views.sources.helpers import get_cohort_expr
+
+
+def build(handle: SourceHandle) -> BuiltQuery:
+    """
+    Revenue Analytics Customer View for Checkout.com
+
+    Customers sync as point lookups referenced by payments, so the only timestamp they
+    carry is the request time of the payment that referenced them. Checkout.com customer
+    records have no address or coupon data, so those fields stay empty.
+
+    The cohort is the month of the customer's earliest synced payment. The payments
+    table only reaches back 90 days unless the source has a start date configured, so
+    without one the cohort reflects the earliest payment within that window rather than
+    the customer's true first charge.
+    """
+    source = handle.source
+    if source is None:
+        raise ValueError("Source is required")
+
+    prefix = view_prefix_for_source(source)
+
+    # Get all schemas for the source, avoid calling `filter` and do the filtering on
+    # Python-land to avoid n+1 queries
+    schemas = source.schemas.all()
+    customer_schema = next((schema for schema in schemas if schema.name == CUSTOMER_RESOURCE_NAME), None)
+    if customer_schema is None:
+        return BuiltQuery(
+            key=str(source.id),  # Using source rather than table because table hasn't been found yet
+            prefix=prefix,
+            query=ast.SelectQuery.empty(columns=SCHEMA.fields),
+            test_comments="no_schema",
+        )
+
+    customer_table = customer_schema.table
+    if customer_table is None:
+        return BuiltQuery(
+            key=str(source.id),  # Using source rather than table because table hasn't been found
+            prefix=prefix,
+            query=ast.SelectQuery.empty(columns=SCHEMA.fields),
+            test_comments="no_table",
+        )
+
+    payments_table = get_table(schemas, PAYMENT_RESOURCE_NAME)
+
+    query = ast.SelectQuery(
+        select=[
+            ast.Alias(alias="id", expr=ast.Field(chain=["outer", "id"])),
+            ast.Alias(alias="source_label", expr=ast.Constant(value=prefix)),
+            ast.Alias(
+                alias="timestamp",
+                expr=parse_timestamp(ast.Field(chain=["outer", "payment_requested_on"])),
+            ),
+            ast.Alias(alias="name", expr=ast.Field(chain=["name"])),
+            ast.Alias(alias="email", expr=ast.Field(chain=["email"])),
+            ast.Alias(alias="phone", expr=ast.Field(chain=["phone"])),
+            ast.Alias(alias="address", expr=ast.Constant(value=None)),
+            ast.Alias(alias="metadata", expr=ast.Field(chain=["metadata"])),
+            ast.Alias(alias="country", expr=ast.Constant(value=None)),
+            ast.Alias(alias="cohort", expr=ast.Constant(value=None)),
+            ast.Alias(alias="initial_coupon", expr=ast.Constant(value=None)),
+            ast.Alias(alias="initial_coupon_id", expr=ast.Constant(value=None)),
+        ],
+        select_from=ast.JoinExpr(
+            alias="outer",
+            table=ast.Field(chain=[customer_table.name]),
+        ),
+        order_by=[ast.OrderExpr(expr=ast.Field(chain=["timestamp"]), order="DESC")],
+        limit_by=ast.LimitByExpr(n=ast.Constant(value=1), exprs=[ast.Field(chain=["id"])]),
+    )
+
+    # If there's a payments table we can generate the cohort entry by looking at the
+    # earliest synced payment for each customer
+    if payments_table is not None and query.select_from is not None:
+        cohort_alias = next(
+            (alias for alias in query.select if isinstance(alias, ast.Alias) and alias.alias == "cohort"), None
+        )
+        if cohort_alias is not None:
+            cohort_alias.expr = ast.Field(chain=["cohort"])
+
+            query.select_from.next_join = ast.JoinExpr(
+                alias="cohort_inner",
+                table=ast.SelectQuery(
+                    select=[
+                        ast.Alias(
+                            alias="customer_id",
+                            expr=ast.Call(
+                                name="nullIf",
+                                args=[
+                                    extract_json_string_from(["payment", "customer"], "id"),
+                                    ast.Constant(value=""),
+                                ],
+                            ),
+                        ),
+                        ast.Alias(
+                            alias="cohort",
+                            expr=get_cohort_expr("min(parseDateTimeBestEffort(toString(requested_on)))"),
+                        ),
+                    ],
+                    select_from=ast.JoinExpr(alias="payment", table=ast.Field(chain=[payments_table.name])),
+                    group_by=[ast.Field(chain=["customer_id"])],
+                ),
+                join_type="LEFT JOIN",
+                constraint=ast.JoinConstraint(
+                    constraint_type="ON",
+                    expr=ast.CompareOperation(
+                        left=ast.Field(chain=["cohort_inner", "customer_id"]),
+                        right=ast.Field(chain=["outer", "id"]),
+                        op=ast.CompareOperationOp.Eq,
+                    ),
+                ),
+            )
+
+    return BuiltQuery(key=str(customer_table.id), prefix=prefix, query=query)

--- a/products/revenue_analytics/backend/views/sources/checkout_com/helpers.py
+++ b/products/revenue_analytics/backend/views/sources/checkout_com/helpers.py
@@ -1,5 +1,3 @@
-from django.db.models import QuerySet
-
 from posthog.schema import CurrencyCode
 
 from posthog.hogql import ast
@@ -9,7 +7,7 @@ from posthog.models.exchange_rate.sql import EXCHANGE_RATE_DECIMAL_PRECISION
 from posthog.models.team.team import Team
 
 from products.revenue_analytics.backend.views.sources.helpers import currency_aware_amount
-from products.warehouse_sources.backend.facade.models import DataWarehouseTable, ExternalDataSchema
+from products.warehouse_sources.backend.facade.contracts import RevenueSourceSchema, RevenueSourceTable
 
 # Schema (table) names the Checkout.com warehouse source syncs from the payments search API.
 # These match `PAYMENTS_ENDPOINTS` in the source module
@@ -129,7 +127,7 @@ def customer_id_expr() -> ast.Call:
     )
 
 
-def get_table(schemas: QuerySet[ExternalDataSchema], schema_name: str) -> DataWarehouseTable | None:
+def get_table(schemas: tuple[RevenueSourceSchema, ...], schema_name: str) -> RevenueSourceTable | None:
     schema = next((schema for schema in schemas if schema.name == schema_name), None)
     if schema is None:
         return None
@@ -137,7 +135,7 @@ def get_table(schemas: QuerySet[ExternalDataSchema], schema_name: str) -> DataWa
     return schema.table
 
 
-def approved_captures_join_expr(actions_table: DataWarehouseTable, payments_table: DataWarehouseTable) -> ast.JoinExpr:
+def approved_captures_join_expr(actions_table: RevenueSourceTable, payments_table: RevenueSourceTable) -> ast.JoinExpr:
     """FROM <payment_actions> AS action JOIN <payments> AS payment ON action.payment_id = payment.id.
 
     Approved `Capture` actions are Checkout.com's charges: the payment object only carries

--- a/products/revenue_analytics/backend/views/sources/checkout_com/helpers.py
+++ b/products/revenue_analytics/backend/views/sources/checkout_com/helpers.py
@@ -1,0 +1,238 @@
+from django.db.models import QuerySet
+
+from posthog.schema import CurrencyCode
+
+from posthog.hogql import ast
+from posthog.hogql.database.schema.exchange_rate import convert_currency_call
+
+from posthog.models.exchange_rate.sql import EXCHANGE_RATE_DECIMAL_PRECISION
+from posthog.models.team.team import Team
+
+from products.revenue_analytics.backend.views.sources.helpers import currency_aware_amount
+from products.warehouse_sources.backend.facade.models import DataWarehouseTable, ExternalDataSchema
+
+# Schema (table) names the Checkout.com warehouse source syncs from the payments search API.
+# These match `PAYMENTS_ENDPOINTS` in the source module
+# (products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/payments.py),
+# which owns the persisted schema names.
+PAYMENT_RESOURCE_NAME = "payments"
+PAYMENT_ACTION_RESOURCE_NAME = "payment_actions"
+CUSTOMER_RESOURCE_NAME = "customers"
+
+# Checkout.com represents most currencies in minor units (the amount divided by 100),
+# but two groups are special:
+# - full-value currencies, where the amount is already the final amount
+# - three-decimal currencies, where the amount is divided by 1000
+# Note this differs from Stripe's zero-decimal list (`ZERO_DECIMAL_CURRENCIES_IN_STRIPE`):
+# Checkout.com treats ISK as full-value and CLP/MGA as two-decimal, and has a separate
+# three-decimal group. https://www.checkout.com/docs/payments/accept-payments/format-the-amount-value
+ZERO_DECIMAL_CURRENCIES_IN_CHECKOUT_COM: list[str] = [
+    CurrencyCode.BIF.value,
+    CurrencyCode.DJF.value,
+    CurrencyCode.GNF.value,
+    CurrencyCode.ISK.value,
+    CurrencyCode.JPY.value,
+    CurrencyCode.KMF.value,
+    CurrencyCode.KRW.value,
+    CurrencyCode.PYG.value,
+    CurrencyCode.RWF.value,
+    CurrencyCode.UGX.value,
+    CurrencyCode.VND.value,
+    CurrencyCode.VUV.value,
+    CurrencyCode.XAF.value,
+    CurrencyCode.XOF.value,
+    CurrencyCode.XPF.value,
+]
+
+THREE_DECIMAL_CURRENCIES_IN_CHECKOUT_COM: list[str] = [
+    CurrencyCode.BHD.value,
+    CurrencyCode.IQD.value,
+    CurrencyCode.JOD.value,
+    CurrencyCode.KWD.value,
+    CurrencyCode.LYD.value,
+    CurrencyCode.OMR.value,
+    CurrencyCode.TND.value,
+]
+
+
+def is_zero_decimal_in_checkout_com(field: ast.Field) -> ast.Call:
+    return ast.Call(
+        name="in",
+        args=[field, ast.Constant(value=ZERO_DECIMAL_CURRENCIES_IN_CHECKOUT_COM)],
+    )
+
+
+def currency_aware_divider() -> ast.Alias:
+    """Divider between the raw Checkout.com amount and the decimal amount: 1 for
+    full-value currencies, 1000 for three-decimal currencies, 100 for everything else."""
+    return ast.Alias(
+        alias="currency_aware_divider",
+        expr=ast.Call(
+            name="multiIf",
+            args=[
+                ast.Field(chain=["enable_currency_aware_divider"]),
+                ast.Call(
+                    name="toDecimal",
+                    args=[ast.Constant(value=1), ast.Constant(value=EXCHANGE_RATE_DECIMAL_PRECISION)],
+                ),
+                ast.Call(
+                    name="in",
+                    args=[
+                        ast.Field(chain=["original_currency"]),
+                        ast.Constant(value=THREE_DECIMAL_CURRENCIES_IN_CHECKOUT_COM),
+                    ],
+                ),
+                ast.Call(
+                    name="toDecimal",
+                    args=[ast.Constant(value=1000), ast.Constant(value=EXCHANGE_RATE_DECIMAL_PRECISION)],
+                ),
+                ast.Call(
+                    name="toDecimal",
+                    args=[ast.Constant(value=100), ast.Constant(value=EXCHANGE_RATE_DECIMAL_PRECISION)],
+                ),
+            ],
+        ),
+    )
+
+
+def parse_timestamp(field: ast.Expr) -> ast.Call:
+    # Checkout.com timestamps sync as ISO-8601 strings (the pipeline stores the raw API
+    # values), so they need parsing before they can be used as datetimes. `toString`
+    # keeps this a no-op-ish coercion if the column ever becomes a real datetime.
+    # HogQL's parseDateTimeBestEffort prints as ClickHouse's parseDateTime64BestEffortOrNull.
+    return ast.Call(
+        name="parseDateTimeBestEffort",
+        args=[ast.Call(name="toString", args=[field])],
+    )
+
+
+def extract_json_string_from(field_chain: list[str | int], *path: str) -> ast.Call:
+    """Like the shared helpers.extract_json_string, but for a qualified (aliased-table) field chain."""
+    return ast.Call(
+        name="JSONExtractString",
+        args=[
+            ast.Field(chain=field_chain),
+            *[ast.Constant(value=p) for p in path],
+        ],
+    )
+
+
+def customer_id_expr() -> ast.Call:
+    # The payment's customer is a JSON object; its `id` matches the customers table.
+    # Empty (customer-less payments) becomes NULL so joins and filters behave.
+    return ast.Call(
+        name="nullIf",
+        args=[
+            extract_json_string_from(["payment", "customer"], "id"),
+            ast.Constant(value=""),
+        ],
+    )
+
+
+def get_table(schemas: QuerySet[ExternalDataSchema], schema_name: str) -> DataWarehouseTable | None:
+    schema = next((schema for schema in schemas if schema.name == schema_name), None)
+    if schema is None:
+        return None
+
+    return schema.table
+
+
+def approved_captures_join_expr(actions_table: DataWarehouseTable, payments_table: DataWarehouseTable) -> ast.JoinExpr:
+    """FROM <payment_actions> AS action JOIN <payments> AS payment ON action.payment_id = payment.id.
+
+    Approved `Capture` actions are Checkout.com's charges: the payment object only carries
+    the latest status and the requested amount, while each capture action carries the exact
+    captured amount and time. The parent payment supplies the currency (actions have none),
+    the customer and the payment type.
+    """
+    return ast.JoinExpr(
+        alias="action",
+        table=ast.Field(chain=[actions_table.name]),
+        next_join=ast.JoinExpr(
+            alias="payment",
+            table=ast.Field(chain=[payments_table.name]),
+            join_type="INNER JOIN",
+            constraint=ast.JoinConstraint(
+                constraint_type="ON",
+                expr=ast.CompareOperation(
+                    left=ast.Field(chain=["action", "payment_id"]),
+                    right=ast.Field(chain=["payment", "id"]),
+                    op=ast.CompareOperationOp.Eq,
+                ),
+            ),
+        ),
+    )
+
+
+def approved_captures_where_expr() -> ast.Expr:
+    # Refund and Void actions also live in payment_actions; only approved captures
+    # represent money coming in. Matching case-insensitively guards against casing
+    # drift in the API's action type values.
+    return ast.And(
+        exprs=[
+            ast.CompareOperation(
+                left=ast.Call(name="lower", args=[ast.Field(chain=["action", "type"])]),
+                right=ast.Constant(value="capture"),
+                op=ast.CompareOperationOp.Eq,
+            ),
+            ast.Field(chain=["action", "approved"]),
+        ]
+    )
+
+
+def currency_conversion_fields(team: Team) -> list[ast.Expr]:
+    """The `original_currency` .. `amount` tail shared by the charge and revenue item views.
+
+    Amounts come from the capture action (in Checkout.com's minor units) and the currency
+    from the parent payment, converted into the team's base currency at the `timestamp`
+    aliased earlier in the same select.
+    """
+    return [
+        # Uppercase to match the currency codes in the `exchange_rate` table
+        ast.Alias(
+            alias="original_currency",
+            expr=ast.Call(name="upper", args=[ast.Field(chain=["payment", "currency"])]),
+        ),
+        # The captured amount, in Checkout.com's minor units for the currency
+        ast.Alias(
+            alias="original_amount",
+            expr=ast.Call(
+                name="toDecimal",
+                args=[
+                    ast.Field(chain=["action", "amount"]),
+                    ast.Constant(value=EXCHANGE_RATE_DECIMAL_PRECISION),
+                ],
+            ),
+        ),
+        # Whether the original currency is a full-value currency in Checkout.com's API
+        ast.Alias(
+            alias="enable_currency_aware_divider",
+            expr=is_zero_decimal_in_checkout_com(ast.Field(chain=["original_currency"])),
+        ),
+        # 1, 1000 or 100 depending on the currency's minor-unit rules
+        currency_aware_divider(),
+        # The original amount adjusted into whole currency units
+        currency_aware_amount(),
+        # The team's base currency, which `amount` is converted into
+        ast.Alias(alias="currency", expr=ast.Constant(value=team.base_currency)),
+        ast.Alias(
+            alias="amount",
+            expr=convert_currency_call(
+                amount=ast.Field(chain=["currency_aware_amount"]),
+                currency_from=ast.Field(chain=["original_currency"]),
+                currency_to=ast.Field(chain=["currency"]),
+                timestamp=ast.Call(
+                    name="_toDate",
+                    args=[
+                        ast.Call(
+                            name="ifNull",
+                            args=[
+                                ast.Field(chain=["timestamp"]),
+                                ast.Call(name="toDateTime", args=[ast.Constant(value=0)]),
+                            ],
+                        ),
+                    ],
+                ),
+            ),
+        ),
+    ]

--- a/products/revenue_analytics/backend/views/sources/checkout_com/revenue_item.py
+++ b/products/revenue_analytics/backend/views/sources/checkout_com/revenue_item.py
@@ -1,0 +1,101 @@
+from posthog.hogql import ast
+
+from products.revenue_analytics.backend.views.core import BuiltQuery, SourceHandle, view_prefix_for_source
+from products.revenue_analytics.backend.views.schemas.revenue_item import SCHEMA
+from products.revenue_analytics.backend.views.sources.checkout_com.helpers import (
+    PAYMENT_ACTION_RESOURCE_NAME,
+    PAYMENT_RESOURCE_NAME,
+    approved_captures_join_expr,
+    approved_captures_where_expr,
+    currency_conversion_fields,
+    customer_id_expr,
+    parse_timestamp,
+)
+
+
+def build(handle: SourceHandle) -> BuiltQuery:
+    """
+    Revenue Analytics Revenue Item View for Checkout.com
+
+    Checkout.com has no invoices, subscriptions or products, so there is nothing to
+    split into billing periods: every approved `Capture` action is a single revenue
+    item, the way invoiceless charges are for Stripe. `is_recurring` comes from the
+    parent payment's own `payment_type` (e.g. `Recurring`), which is the only recurring
+    signal Checkout.com carries; there is no subscription to attach it to.
+
+    The underlying tables sync from the payments search API, which only reaches back
+    90 days by default, so this view only covers full history when the source has a
+    start date configured.
+    """
+    source = handle.source
+    if source is None:
+        raise ValueError("Source is required")
+
+    prefix = view_prefix_for_source(source)
+
+    # Get all schemas for the source, avoid calling `filter` and do the filtering on
+    # Python-land to avoid n+1 queries
+    schemas = source.schemas.all()
+    payments_schema = next((schema for schema in schemas if schema.name == PAYMENT_RESOURCE_NAME), None)
+    actions_schema = next((schema for schema in schemas if schema.name == PAYMENT_ACTION_RESOURCE_NAME), None)
+    if payments_schema is None or actions_schema is None:
+        return BuiltQuery(
+            key=str(source.id),  # Using source rather than table because table hasn't been found yet
+            prefix=prefix,
+            query=ast.SelectQuery.empty(columns=SCHEMA.fields),
+            test_comments="no_schema",
+        )
+
+    payments_table = payments_schema.table
+    actions_table = actions_schema.table
+    if payments_table is None or actions_table is None:
+        return BuiltQuery(
+            key=str(source.id),  # Using source rather than table because table hasn't been found
+            prefix=prefix,
+            query=ast.SelectQuery.empty(columns=SCHEMA.fields),
+            test_comments="no_table",
+        )
+
+    query = ast.SelectQuery(
+        select=[
+            ast.Alias(alias="id", expr=ast.Field(chain=["action", "id"])),
+            ast.Alias(alias="invoice_item_id", expr=ast.Field(chain=["action", "id"])),
+            ast.Alias(alias="source_label", expr=ast.Constant(value=prefix)),
+            # Revenue is recognized when the capture is processed; the payment request
+            # time is when the record came into existence
+            ast.Alias(alias="timestamp", expr=parse_timestamp(ast.Field(chain=["action", "processed_on"]))),
+            ast.Alias(alias="created_at", expr=parse_timestamp(ast.Field(chain=["payment", "requested_on"]))),
+            ast.Alias(
+                alias="is_recurring",
+                expr=ast.Call(
+                    name="ifNull",
+                    args=[
+                        ast.CompareOperation(
+                            left=ast.Call(name="lower", args=[ast.Field(chain=["payment", "payment_type"])]),
+                            right=ast.Constant(value="recurring"),
+                            op=ast.CompareOperationOp.Eq,
+                        ),
+                        ast.Constant(value=False),
+                    ],
+                ),
+            ),
+            ast.Alias(alias="product_id", expr=ast.Constant(value=None)),
+            ast.Alias(alias="customer_id", expr=customer_id_expr()),
+            ast.Alias(alias="group_0_key", expr=ast.Constant(value=None)),
+            ast.Alias(alias="group_1_key", expr=ast.Constant(value=None)),
+            ast.Alias(alias="group_2_key", expr=ast.Constant(value=None)),
+            ast.Alias(alias="group_3_key", expr=ast.Constant(value=None)),
+            ast.Alias(alias="group_4_key", expr=ast.Constant(value=None)),
+            ast.Alias(alias="invoice_id", expr=ast.Constant(value=None)),
+            ast.Alias(alias="subscription_id", expr=ast.Constant(value=None)),
+            ast.Alias(alias="session_id", expr=ast.Constant(value=None)),
+            ast.Alias(alias="event_name", expr=ast.Constant(value=None)),
+            ast.Alias(alias="coupon", expr=ast.Constant(value=None)),
+            ast.Alias(alias="coupon_id", expr=ast.Constant(value=None)),
+            *currency_conversion_fields(handle.team),
+        ],
+        select_from=approved_captures_join_expr(actions_table, payments_table),
+        where=approved_captures_where_expr(),
+    )
+
+    return BuiltQuery(key=str(payments_table.id), prefix=prefix, query=query)

--- a/products/revenue_analytics/backend/views/sources/checkout_com/revenue_item.py
+++ b/products/revenue_analytics/backend/views/sources/checkout_com/revenue_item.py
@@ -33,9 +33,9 @@ def build(handle: SourceHandle) -> BuiltQuery:
 
     prefix = view_prefix_for_source(source)
 
-    # Get all schemas for the source, avoid calling `filter` and do the filtering on
-    # Python-land to avoid n+1 queries
-    schemas = source.schemas.all()
+    # Get all schemas for the source, avoid calling `filter` and do the filtering on Python-land
+    # to avoid n+1 queries
+    schemas = source.schemas
     payments_schema = next((schema for schema in schemas if schema.name == PAYMENT_RESOURCE_NAME), None)
     actions_schema = next((schema for schema in schemas if schema.name == PAYMENT_ACTION_RESOURCE_NAME), None)
     if payments_schema is None or actions_schema is None:

--- a/products/revenue_analytics/backend/views/sources/registry.py
+++ b/products/revenue_analytics/backend/views/sources/registry.py
@@ -1,5 +1,5 @@
 from products.revenue_analytics.backend.views.core import Builder
-from products.revenue_analytics.backend.views.sources.checkout_com import BUILDER as CHECKOUT_COM_BUILDER
+from products.revenue_analytics.backend.views.sources.checkout_com.builder import BUILDER as CHECKOUT_COM_BUILDER
 from products.revenue_analytics.backend.views.sources.events import BUILDER as EVENTS_BUILDER
 from products.revenue_analytics.backend.views.sources.stripe import BUILDER as STRIPE_BUILDER
 

--- a/products/revenue_analytics/backend/views/sources/registry.py
+++ b/products/revenue_analytics/backend/views/sources/registry.py
@@ -1,8 +1,10 @@
 from products.revenue_analytics.backend.views.core import Builder
+from products.revenue_analytics.backend.views.sources.checkout_com import BUILDER as CHECKOUT_COM_BUILDER
 from products.revenue_analytics.backend.views.sources.events import BUILDER as EVENTS_BUILDER
 from products.revenue_analytics.backend.views.sources.stripe import BUILDER as STRIPE_BUILDER
 
 BUILDERS: dict[str, Builder] = {
     "events": EVENTS_BUILDER,
     "stripe": STRIPE_BUILDER,
+    "checkoutcom": CHECKOUT_COM_BUILDER,
 }

--- a/products/revenue_analytics/backend/views/sources/test/checkout_com/__snapshots__/test_checkout_com_charge.ambr
+++ b/products/revenue_analytics/backend/views/sources/test/checkout_com/__snapshots__/test_checkout_com_charge.ambr
@@ -1,0 +1,45 @@
+# serializer version: 1
+# name: TestChargeCheckoutComBuilder.test_build_charge_query_with_payments_and_actions_schemas
+  '''
+  SELECT action.id AS id,
+         'checkoutcom.checkout_test' AS source_label,
+         parseDateTimeBestEffort(toString(action.processed_on)) AS timestamp,
+         nullIf(JSONExtractString(payment.customer, 'id'), '') AS customer_id,
+         NULL AS invoice_id,
+         NULL AS session_id,
+         NULL AS event_name,
+         upper(payment.currency) AS original_currency,
+         toDecimal(action.amount, 10) AS original_amount,
+         in(original_currency,
+            ['BIF', 'DJF', 'GNF', 'ISK', 'JPY', 'KMF', 'KRW', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+           multiIf(enable_currency_aware_divider, toDecimal(1, 10), in(original_currency, ['BHD', 'IQD', 'JOD', 'KWD', 'LYD', 'OMR', 'TND']), toDecimal(1000, 10), toDecimal(100, 10)) AS currency_aware_divider,
+           divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+           'USD' AS currency,
+           convertCurrency(original_currency, currency, currency_aware_amount, _toDate(ifNull(timestamp, toDateTime(0)))) AS amount
+  FROM checkout_test_payment_actions AS action
+  INNER JOIN checkout_test_payments AS payment ON equals(action.payment_id, payment.id)
+  WHERE and(equals(lower(action.type), 'capture'), action.approved)
+  '''
+# ---
+# name: TestChargeCheckoutComBuilder.test_charge_query_uses_checkout_com_minor_unit_rules
+  '''
+  SELECT action.id AS id,
+         'checkoutcom.checkout_test' AS source_label,
+         parseDateTimeBestEffort(toString(action.processed_on)) AS timestamp,
+         nullIf(JSONExtractString(payment.customer, 'id'), '') AS customer_id,
+         NULL AS invoice_id,
+         NULL AS session_id,
+         NULL AS event_name,
+         upper(payment.currency) AS original_currency,
+         toDecimal(action.amount, 10) AS original_amount,
+         in(original_currency,
+            ['BIF', 'DJF', 'GNF', 'ISK', 'JPY', 'KMF', 'KRW', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+           multiIf(enable_currency_aware_divider, toDecimal(1, 10), in(original_currency, ['BHD', 'IQD', 'JOD', 'KWD', 'LYD', 'OMR', 'TND']), toDecimal(1000, 10), toDecimal(100, 10)) AS currency_aware_divider,
+           divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+           'EUR' AS currency,
+           convertCurrency(original_currency, currency, currency_aware_amount, _toDate(ifNull(timestamp, toDateTime(0)))) AS amount
+  FROM checkout_test_payment_actions AS action
+  INNER JOIN checkout_test_payments AS payment ON equals(action.payment_id, payment.id)
+  WHERE and(equals(lower(action.type), 'capture'), action.approved)
+  '''
+# ---

--- a/products/revenue_analytics/backend/views/sources/test/checkout_com/__snapshots__/test_checkout_com_customer.ambr
+++ b/products/revenue_analytics/backend/views/sources/test/checkout_com/__snapshots__/test_checkout_com_customer.ambr
@@ -1,0 +1,44 @@
+# serializer version: 1
+# name: TestCustomerCheckoutComBuilder.test_build_customer_query_with_customers_and_payments_schemas
+  '''
+  SELECT outer.id AS id,
+         'checkoutcom.checkout_test' AS source_label,
+         parseDateTimeBestEffort(toString(outer.payment_requested_on)) AS timestamp,
+         name AS name,
+         email AS email,
+         phone AS phone,
+         NULL AS address,
+         metadata AS metadata,
+         NULL AS country,
+         cohort AS cohort,
+         NULL AS initial_coupon,
+         NULL AS initial_coupon_id
+  FROM checkout_test_customers AS outer
+  LEFT JOIN
+    (SELECT nullIf(JSONExtractString(payment.customer, 'id'), '') AS customer_id,
+            formatDateTime(toStartOfMonth(min(parseDateTimeBestEffort(toString(requested_on)))), '%Y-%m') AS cohort
+     FROM checkout_test_payments AS payment
+     GROUP BY customer_id) AS cohort_inner ON equals(cohort_inner.customer_id, outer.id)
+  ORDER BY timestamp DESC
+  LIMIT 1 BY id
+  '''
+# ---
+# name: TestCustomerCheckoutComBuilder.test_build_customer_query_without_payments_schema
+  '''
+  SELECT outer.id AS id,
+         'checkoutcom.checkout_test' AS source_label,
+         parseDateTimeBestEffort(toString(outer.payment_requested_on)) AS timestamp,
+         name AS name,
+         email AS email,
+         phone AS phone,
+         NULL AS address,
+         metadata AS metadata,
+         NULL AS country,
+         NULL AS cohort,
+         NULL AS initial_coupon,
+         NULL AS initial_coupon_id
+  FROM checkout_test_customers AS outer
+  ORDER BY timestamp DESC
+  LIMIT 1 BY id
+  '''
+# ---

--- a/products/revenue_analytics/backend/views/sources/test/checkout_com/__snapshots__/test_checkout_com_revenue_item.ambr
+++ b/products/revenue_analytics/backend/views/sources/test/checkout_com/__snapshots__/test_checkout_com_revenue_item.ambr
@@ -1,0 +1,35 @@
+# serializer version: 1
+# name: TestRevenueItemCheckoutComBuilder.test_build_revenue_item_query_with_payments_and_actions_schemas
+  '''
+  SELECT action.id AS id,
+         action.id AS invoice_item_id,
+         'checkoutcom.checkout_test' AS source_label,
+         parseDateTimeBestEffort(toString(action.processed_on)) AS timestamp,
+         parseDateTimeBestEffort(toString(payment.requested_on)) AS created_at,
+         ifNull(equals(lower(payment.payment_type), 'recurring'), false) AS is_recurring,
+         NULL AS product_id,
+         nullIf(JSONExtractString(payment.customer, 'id'), '') AS customer_id,
+         NULL AS group_0_key,
+         NULL AS group_1_key,
+         NULL AS group_2_key,
+         NULL AS group_3_key,
+         NULL AS group_4_key,
+         NULL AS invoice_id,
+         NULL AS subscription_id,
+         NULL AS session_id,
+         NULL AS event_name,
+         NULL AS coupon,
+         NULL AS coupon_id,
+         upper(payment.currency) AS original_currency,
+         toDecimal(action.amount, 10) AS original_amount,
+         in(original_currency,
+            ['BIF', 'DJF', 'GNF', 'ISK', 'JPY', 'KMF', 'KRW', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+           multiIf(enable_currency_aware_divider, toDecimal(1, 10), in(original_currency, ['BHD', 'IQD', 'JOD', 'KWD', 'LYD', 'OMR', 'TND']), toDecimal(1000, 10), toDecimal(100, 10)) AS currency_aware_divider,
+           divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+           'USD' AS currency,
+           convertCurrency(original_currency, currency, currency_aware_amount, _toDate(ifNull(timestamp, toDateTime(0)))) AS amount
+  FROM checkout_test_payment_actions AS action
+  INNER JOIN checkout_test_payments AS payment ON equals(action.payment_id, payment.id)
+  WHERE and(equals(lower(action.type), 'capture'), action.approved)
+  '''
+# ---

--- a/products/revenue_analytics/backend/views/sources/test/checkout_com/base.py
+++ b/products/revenue_analytics/backend/views/sources/test/checkout_com/base.py
@@ -26,25 +26,35 @@ ALL_CHECKOUT_COM_RESOURCE_NAMES = [
 ]
 
 
-def create_mock_checkout_com_external_data_source(team, schemas: Optional[list[str]] = None):
+def create_mock_checkout_com_external_data_source(
+    team,
+    schemas: Optional[list[str]] = None,
+    schemas_without_tables: Optional[list[str]] = None,
+):
     """
     Create a mock external data source for Checkout.com with specified schemas.
 
     Args:
         team: The team to associate with the external data source
         schemas: List of schema names to include (defaults to all revenue-relevant schemas)
+        schemas_without_tables: Schema names that are synced but have no table yet
 
     Returns:
         RevenueSource with associated schemas and tables
     """
     if schemas is None:
         schemas = ALL_CHECKOUT_COM_RESOURCE_NAMES
+    without_tables = set(schemas_without_tables or [])
 
     prefix = "checkout_test"
     source_schemas = [
         RevenueSourceSchema(
             name=schema_name,
-            table=RevenueSourceTable(id=uuid4(), name=f"{prefix}_{schema_name.lower()}"),
+            table=(
+                None
+                if schema_name in without_tables
+                else RevenueSourceTable(id=uuid4(), name=f"{prefix}_{schema_name.lower()}")
+            ),
         )
         for schema_name in schemas
     ]
@@ -67,18 +77,25 @@ class CheckoutComSourceBaseTest(RevenueAnalyticsViewSourceBaseTest):
     including mock external data sources, schemas, and helper methods.
     """
 
-    def setup_checkout_com_external_data_source(self, schemas: Optional[list[str]] = None):
+    def setup_checkout_com_external_data_source(
+        self,
+        schemas: Optional[list[str]] = None,
+        schemas_without_tables: Optional[list[str]] = None,
+    ):
         """
         Create a mock Checkout.com external data source with specified schemas.
 
         Args:
             schemas: List of schema names to include (defaults to all revenue-relevant schemas)
+            schemas_without_tables: Schema names that are synced but have no table yet
 
         This creates:
         - self.external_data_source: RevenueSource
         - self.checkout_com_handle: SourceHandle for the external data source
         """
-        self.external_data_source = create_mock_checkout_com_external_data_source(team=self.team, schemas=schemas)
+        self.external_data_source = create_mock_checkout_com_external_data_source(
+            team=self.team, schemas=schemas, schemas_without_tables=schemas_without_tables
+        )
         self.checkout_com_handle = SourceHandle(type="checkoutcom", team=self.team, source=self.external_data_source)
 
     def get_checkout_com_schema_by_name(self, schema_name):

--- a/products/revenue_analytics/backend/views/sources/test/checkout_com/base.py
+++ b/products/revenue_analytics/backend/views/sources/test/checkout_com/base.py
@@ -8,8 +8,6 @@ Checkout.com-based revenue analytics view sources.
 from typing import Optional
 from uuid import uuid4
 
-from unittest.mock import Mock
-
 from posthog.schema import CurrencyCode
 
 from products.revenue_analytics.backend.views.core import SourceHandle
@@ -19,7 +17,7 @@ from products.revenue_analytics.backend.views.sources.checkout_com.helpers impor
     PAYMENT_RESOURCE_NAME,
 )
 from products.revenue_analytics.backend.views.sources.test.base import RevenueAnalyticsViewSourceBaseTest
-from products.warehouse_sources.backend.facade.models import DataWarehouseTable, ExternalDataSchema, ExternalDataSource
+from products.warehouse_sources.backend.facade.contracts import RevenueSource, RevenueSourceSchema, RevenueSourceTable
 
 ALL_CHECKOUT_COM_RESOURCE_NAMES = [
     PAYMENT_RESOURCE_NAME,
@@ -37,36 +35,28 @@ def create_mock_checkout_com_external_data_source(team, schemas: Optional[list[s
         schemas: List of schema names to include (defaults to all revenue-relevant schemas)
 
     Returns:
-        Mock ExternalDataSource with associated schemas and tables
+        RevenueSource with associated schemas and tables
     """
     if schemas is None:
         schemas = ALL_CHECKOUT_COM_RESOURCE_NAMES
 
-    source = Mock(spec=ExternalDataSource)
-    source.id = uuid4()
-    source.team = team
-    source.source_type = "CheckoutCom"
-    source.prefix = "checkout_test"
+    prefix = "checkout_test"
+    source_schemas = [
+        RevenueSourceSchema(
+            name=schema_name,
+            table=RevenueSourceTable(id=uuid4(), name=f"{prefix}_{schema_name.lower()}"),
+        )
+        for schema_name in schemas
+    ]
 
-    mock_schemas = []
-    for schema_name in schemas:
-        table = Mock(spec=DataWarehouseTable)
-        table.id = uuid4()
-        table.name = f"{source.prefix}_{schema_name.lower()}"
-        table.team = team
-
-        schema = Mock(spec=ExternalDataSchema)
-        schema.id = uuid4()
-        schema.name = schema_name
-        schema.table = table
-        schema.source = source
-
-        mock_schemas.append(schema)
-
-    source.schemas = Mock()
-    source.schemas.all.return_value = mock_schemas
-
-    return source
+    return RevenueSource(
+        id=uuid4(),
+        source_type="CheckoutCom",
+        prefix=prefix,
+        enabled=True,
+        include_invoiceless_charges=True,
+        schemas=tuple(source_schemas),
+    )
 
 
 class CheckoutComSourceBaseTest(RevenueAnalyticsViewSourceBaseTest):
@@ -85,7 +75,7 @@ class CheckoutComSourceBaseTest(RevenueAnalyticsViewSourceBaseTest):
             schemas: List of schema names to include (defaults to all revenue-relevant schemas)
 
         This creates:
-        - self.external_data_source: Mock ExternalDataSource
+        - self.external_data_source: RevenueSource
         - self.checkout_com_handle: SourceHandle for the external data source
         """
         self.external_data_source = create_mock_checkout_com_external_data_source(team=self.team, schemas=schemas)
@@ -99,9 +89,9 @@ class CheckoutComSourceBaseTest(RevenueAnalyticsViewSourceBaseTest):
             schema_name: The name of the schema to retrieve
 
         Returns:
-            Mock ExternalDataSchema or None if not found
+            RevenueSourceSchema or None if not found
         """
-        schemas = self.external_data_source.schemas.all()
+        schemas = self.external_data_source.schemas
         return next((schema for schema in schemas if schema.name == schema_name), None)
 
     def get_checkout_com_table_by_schema_name(self, schema_name):
@@ -112,7 +102,7 @@ class CheckoutComSourceBaseTest(RevenueAnalyticsViewSourceBaseTest):
             schema_name: The name of the schema to get the table for
 
         Returns:
-            Mock DataWarehouseTable or None if not found
+            RevenueSourceTable or None if not found
         """
         schema = self.get_checkout_com_schema_by_name(schema_name)
         return schema.table if schema else None

--- a/products/revenue_analytics/backend/views/sources/test/checkout_com/base.py
+++ b/products/revenue_analytics/backend/views/sources/test/checkout_com/base.py
@@ -1,0 +1,140 @@
+"""
+Base test class for revenue analytics Checkout.com source tests.
+
+This module provides common setup and utilities specifically for testing
+Checkout.com-based revenue analytics view sources.
+"""
+
+from typing import Optional
+from uuid import uuid4
+
+from unittest.mock import Mock
+
+from posthog.schema import CurrencyCode
+
+from products.revenue_analytics.backend.views.core import SourceHandle
+from products.revenue_analytics.backend.views.sources.checkout_com.helpers import (
+    CUSTOMER_RESOURCE_NAME,
+    PAYMENT_ACTION_RESOURCE_NAME,
+    PAYMENT_RESOURCE_NAME,
+)
+from products.revenue_analytics.backend.views.sources.test.base import RevenueAnalyticsViewSourceBaseTest
+from products.warehouse_sources.backend.facade.models import DataWarehouseTable, ExternalDataSchema, ExternalDataSource
+
+ALL_CHECKOUT_COM_RESOURCE_NAMES = [
+    PAYMENT_RESOURCE_NAME,
+    PAYMENT_ACTION_RESOURCE_NAME,
+    CUSTOMER_RESOURCE_NAME,
+]
+
+
+def create_mock_checkout_com_external_data_source(team, schemas: Optional[list[str]] = None):
+    """
+    Create a mock external data source for Checkout.com with specified schemas.
+
+    Args:
+        team: The team to associate with the external data source
+        schemas: List of schema names to include (defaults to all revenue-relevant schemas)
+
+    Returns:
+        Mock ExternalDataSource with associated schemas and tables
+    """
+    if schemas is None:
+        schemas = ALL_CHECKOUT_COM_RESOURCE_NAMES
+
+    source = Mock(spec=ExternalDataSource)
+    source.id = uuid4()
+    source.team = team
+    source.source_type = "CheckoutCom"
+    source.prefix = "checkout_test"
+
+    mock_schemas = []
+    for schema_name in schemas:
+        table = Mock(spec=DataWarehouseTable)
+        table.id = uuid4()
+        table.name = f"{source.prefix}_{schema_name.lower()}"
+        table.team = team
+
+        schema = Mock(spec=ExternalDataSchema)
+        schema.id = uuid4()
+        schema.name = schema_name
+        schema.table = table
+        schema.source = source
+
+        mock_schemas.append(schema)
+
+    source.schemas = Mock()
+    source.schemas.all.return_value = mock_schemas
+
+    return source
+
+
+class CheckoutComSourceBaseTest(RevenueAnalyticsViewSourceBaseTest):
+    """
+    Base test class for Checkout.com source revenue analytics tests.
+
+    Provides common setup for testing Checkout.com-based revenue analytics views,
+    including mock external data sources, schemas, and helper methods.
+    """
+
+    def setup_checkout_com_external_data_source(self, schemas: Optional[list[str]] = None):
+        """
+        Create a mock Checkout.com external data source with specified schemas.
+
+        Args:
+            schemas: List of schema names to include (defaults to all revenue-relevant schemas)
+
+        This creates:
+        - self.external_data_source: Mock ExternalDataSource
+        - self.checkout_com_handle: SourceHandle for the external data source
+        """
+        self.external_data_source = create_mock_checkout_com_external_data_source(team=self.team, schemas=schemas)
+        self.checkout_com_handle = SourceHandle(type="checkoutcom", team=self.team, source=self.external_data_source)
+
+    def get_checkout_com_schema_by_name(self, schema_name):
+        """
+        Get a specific schema by name from the external data source.
+
+        Args:
+            schema_name: The name of the schema to retrieve
+
+        Returns:
+            Mock ExternalDataSchema or None if not found
+        """
+        schemas = self.external_data_source.schemas.all()
+        return next((schema for schema in schemas if schema.name == schema_name), None)
+
+    def get_checkout_com_table_by_schema_name(self, schema_name):
+        """
+        Get a specific table by schema name from the external data source.
+
+        Args:
+            schema_name: The name of the schema to get the table for
+
+        Returns:
+            Mock DataWarehouseTable or None if not found
+        """
+        schema = self.get_checkout_com_schema_by_name(schema_name)
+        return schema.table if schema else None
+
+    def create_checkout_com_handle_without_source(self):
+        """
+        Create a SourceHandle without an external data source.
+
+        Returns:
+            SourceHandle with source=None for testing error cases
+        """
+        return SourceHandle(type="checkoutcom", team=self.team, source=None)
+
+    def set_team_base_currency(self, currency_code: str):
+        """
+        Set the team's base currency.
+
+        Args:
+            currency_code: 3-letter currency code (e.g., "USD", "EUR")
+        """
+        if currency_code not in [code.value for code in CurrencyCode]:
+            raise ValueError(f"Invalid currency code: {currency_code}")
+
+        self.team.base_currency = currency_code
+        self.team.save()

--- a/products/revenue_analytics/backend/views/sources/test/checkout_com/test_checkout_com_charge.py
+++ b/products/revenue_analytics/backend/views/sources/test/checkout_com/test_checkout_com_charge.py
@@ -44,9 +44,10 @@ class TestChargeCheckoutComBuilder(CheckoutComSourceBaseTest):
 
     @parameterized.expand([(PAYMENT_RESOURCE_NAME,), (PAYMENT_ACTION_RESOURCE_NAME,)])
     def test_build_with_schema_but_no_table_returns_empty_view(self, schema_without_table):
-        self.setup_checkout_com_external_data_source(schemas=[PAYMENT_RESOURCE_NAME, PAYMENT_ACTION_RESOURCE_NAME])
-        schema = self.get_checkout_com_schema_by_name(schema_without_table)
-        schema.table = None
+        self.setup_checkout_com_external_data_source(
+            schemas=[PAYMENT_RESOURCE_NAME, PAYMENT_ACTION_RESOURCE_NAME],
+            schemas_without_tables=[schema_without_table],
+        )
 
         query = build(self.checkout_com_handle)
 

--- a/products/revenue_analytics/backend/views/sources/test/checkout_com/test_checkout_com_charge.py
+++ b/products/revenue_analytics/backend/views/sources/test/checkout_com/test_checkout_com_charge.py
@@ -1,0 +1,84 @@
+from parameterized import parameterized
+
+from products.revenue_analytics.backend.views.schemas.charge import SCHEMA as CHARGE_SCHEMA
+from products.revenue_analytics.backend.views.sources.checkout_com.charge import build
+from products.revenue_analytics.backend.views.sources.checkout_com.helpers import (
+    PAYMENT_ACTION_RESOURCE_NAME,
+    PAYMENT_RESOURCE_NAME,
+)
+from products.revenue_analytics.backend.views.sources.test.checkout_com.base import CheckoutComSourceBaseTest
+
+
+class TestChargeCheckoutComBuilder(CheckoutComSourceBaseTest):
+    def test_build_charge_query_with_payments_and_actions_schemas(self):
+        self.setup_checkout_com_external_data_source(schemas=[PAYMENT_RESOURCE_NAME, PAYMENT_ACTION_RESOURCE_NAME])
+
+        query = build(self.checkout_com_handle)
+        actions_table = self.get_checkout_com_table_by_schema_name(PAYMENT_ACTION_RESOURCE_NAME)
+
+        self.assertQueryContainsFields(query.query, CHARGE_SCHEMA)
+        self.assertBuiltQueryStructure(query, str(actions_table.id), f"checkoutcom.{self.external_data_source.prefix}")
+
+        query_sql = query.query.to_hogql()
+        self.assertQueryMatchesSnapshot(query_sql, replace_all_numbers=True)
+
+    @parameterized.expand(
+        [
+            ("no_schemas_at_all", []),
+            ("only_payments", [PAYMENT_RESOURCE_NAME]),
+            ("only_payment_actions", [PAYMENT_ACTION_RESOURCE_NAME]),
+        ]
+    )
+    def test_build_with_missing_schema_returns_empty_view(self, _name, schemas):
+        self.setup_checkout_com_external_data_source(schemas=schemas)
+
+        query = build(self.checkout_com_handle)
+
+        self.assertQueryContainsFields(query.query, CHARGE_SCHEMA)
+        self.assertBuiltQueryStructure(
+            query,
+            str(self.checkout_com_handle.source.id),  # type: ignore
+            f"checkoutcom.{self.external_data_source.prefix}",
+            expected_test_comments="no_schema",
+        )
+
+    @parameterized.expand([(PAYMENT_RESOURCE_NAME,), (PAYMENT_ACTION_RESOURCE_NAME,)])
+    def test_build_with_schema_but_no_table_returns_empty_view(self, schema_without_table):
+        self.setup_checkout_com_external_data_source(schemas=[PAYMENT_RESOURCE_NAME, PAYMENT_ACTION_RESOURCE_NAME])
+        schema = self.get_checkout_com_schema_by_name(schema_without_table)
+        schema.table = None
+
+        query = build(self.checkout_com_handle)
+
+        self.assertQueryContainsFields(query.query, CHARGE_SCHEMA)
+        self.assertBuiltQueryStructure(
+            query,
+            str(self.checkout_com_handle.source.id),  # type: ignore
+            f"checkoutcom.{self.external_data_source.prefix}",
+            expected_test_comments="no_table",
+        )
+
+    def test_build_with_no_source(self):
+        handle = self.create_checkout_com_handle_without_source()
+
+        with self.assertRaises(ValueError):
+            build(handle)
+
+    def test_charge_query_uses_checkout_com_minor_unit_rules(self):
+        # Guards against reusing Stripe's zero-decimal list: Checkout.com treats ISK as
+        # full-value and CLP as two-decimal, and has a three-decimal group divided by 1000
+        self.set_team_base_currency("EUR")
+        self.setup_checkout_com_external_data_source(schemas=[PAYMENT_RESOURCE_NAME, PAYMENT_ACTION_RESOURCE_NAME])
+
+        query = build(self.checkout_com_handle)
+        query_sql = query.query.to_hogql()
+
+        self.assertIn("EUR", query_sql)
+        # Full-value list per Checkout.com docs: includes ISK, excludes CLP (both differ from Stripe)
+        self.assertIn("ISK", query_sql)
+        self.assertNotIn("CLP", query_sql)
+        # Three-decimal currencies are divided by 1000
+        self.assertIn("BHD", query_sql)
+        self.assertIn("1000", query_sql)
+
+        self.assertQueryMatchesSnapshot(query_sql, replace_all_numbers=True)

--- a/products/revenue_analytics/backend/views/sources/test/checkout_com/test_checkout_com_customer.py
+++ b/products/revenue_analytics/backend/views/sources/test/checkout_com/test_checkout_com_customer.py
@@ -1,0 +1,73 @@
+from products.revenue_analytics.backend.views.schemas.customer import SCHEMA as CUSTOMER_SCHEMA
+from products.revenue_analytics.backend.views.sources.checkout_com.customer import build
+from products.revenue_analytics.backend.views.sources.checkout_com.helpers import (
+    CUSTOMER_RESOURCE_NAME,
+    PAYMENT_RESOURCE_NAME,
+)
+from products.revenue_analytics.backend.views.sources.test.checkout_com.base import CheckoutComSourceBaseTest
+
+
+class TestCustomerCheckoutComBuilder(CheckoutComSourceBaseTest):
+    def test_build_customer_query_with_customers_and_payments_schemas(self):
+        self.setup_checkout_com_external_data_source(schemas=[CUSTOMER_RESOURCE_NAME, PAYMENT_RESOURCE_NAME])
+
+        query = build(self.checkout_com_handle)
+        customer_table = self.get_checkout_com_table_by_schema_name(CUSTOMER_RESOURCE_NAME)
+
+        self.assertQueryContainsFields(query.query, CUSTOMER_SCHEMA)
+        self.assertBuiltQueryStructure(query, str(customer_table.id), f"checkoutcom.{self.external_data_source.prefix}")
+
+        # Cohort comes from the earliest synced payment for each customer
+        query_sql = query.query.to_hogql()
+        self.assertIn(f"{self.external_data_source.prefix}_{PAYMENT_RESOURCE_NAME}", query_sql)
+
+        self.assertQueryMatchesSnapshot(query_sql, replace_all_numbers=True)
+
+    def test_build_customer_query_without_payments_schema(self):
+        # Without the payments table there is no charge history, so cohort stays NULL
+        self.setup_checkout_com_external_data_source(schemas=[CUSTOMER_RESOURCE_NAME])
+
+        query = build(self.checkout_com_handle)
+        customer_table = self.get_checkout_com_table_by_schema_name(CUSTOMER_RESOURCE_NAME)
+
+        self.assertQueryContainsFields(query.query, CUSTOMER_SCHEMA)
+        self.assertBuiltQueryStructure(query, str(customer_table.id), f"checkoutcom.{self.external_data_source.prefix}")
+
+        query_sql = query.query.to_hogql()
+        self.assertNotIn(f"{self.external_data_source.prefix}_{PAYMENT_RESOURCE_NAME}", query_sql)
+
+        self.assertQueryMatchesSnapshot(query_sql, replace_all_numbers=True)
+
+    def test_build_with_no_customers_schema_returns_empty_view(self):
+        self.setup_checkout_com_external_data_source(schemas=[PAYMENT_RESOURCE_NAME])
+
+        query = build(self.checkout_com_handle)
+
+        self.assertQueryContainsFields(query.query, CUSTOMER_SCHEMA)
+        self.assertBuiltQueryStructure(
+            query,
+            str(self.checkout_com_handle.source.id),  # type: ignore
+            f"checkoutcom.{self.external_data_source.prefix}",
+            expected_test_comments="no_schema",
+        )
+
+    def test_build_with_customers_schema_but_no_table_returns_empty_view(self):
+        self.setup_checkout_com_external_data_source(schemas=[CUSTOMER_RESOURCE_NAME])
+        customer_schema = self.get_checkout_com_schema_by_name(CUSTOMER_RESOURCE_NAME)
+        customer_schema.table = None
+
+        query = build(self.checkout_com_handle)
+
+        self.assertQueryContainsFields(query.query, CUSTOMER_SCHEMA)
+        self.assertBuiltQueryStructure(
+            query,
+            str(self.checkout_com_handle.source.id),  # type: ignore
+            f"checkoutcom.{self.external_data_source.prefix}",
+            expected_test_comments="no_table",
+        )
+
+    def test_build_with_no_source(self):
+        handle = self.create_checkout_com_handle_without_source()
+
+        with self.assertRaises(ValueError):
+            build(handle)

--- a/products/revenue_analytics/backend/views/sources/test/checkout_com/test_checkout_com_customer.py
+++ b/products/revenue_analytics/backend/views/sources/test/checkout_com/test_checkout_com_customer.py
@@ -52,9 +52,10 @@ class TestCustomerCheckoutComBuilder(CheckoutComSourceBaseTest):
         )
 
     def test_build_with_customers_schema_but_no_table_returns_empty_view(self):
-        self.setup_checkout_com_external_data_source(schemas=[CUSTOMER_RESOURCE_NAME])
-        customer_schema = self.get_checkout_com_schema_by_name(CUSTOMER_RESOURCE_NAME)
-        customer_schema.table = None
+        self.setup_checkout_com_external_data_source(
+            schemas=[CUSTOMER_RESOURCE_NAME],
+            schemas_without_tables=[CUSTOMER_RESOURCE_NAME],
+        )
 
         query = build(self.checkout_com_handle)
 

--- a/products/revenue_analytics/backend/views/sources/test/checkout_com/test_checkout_com_revenue_item.py
+++ b/products/revenue_analytics/backend/views/sources/test/checkout_com/test_checkout_com_revenue_item.py
@@ -1,0 +1,69 @@
+from parameterized import parameterized
+
+from products.revenue_analytics.backend.views.schemas.revenue_item import SCHEMA as REVENUE_ITEM_SCHEMA
+from products.revenue_analytics.backend.views.sources.checkout_com.helpers import (
+    PAYMENT_ACTION_RESOURCE_NAME,
+    PAYMENT_RESOURCE_NAME,
+)
+from products.revenue_analytics.backend.views.sources.checkout_com.revenue_item import build
+from products.revenue_analytics.backend.views.sources.test.checkout_com.base import CheckoutComSourceBaseTest
+
+
+class TestRevenueItemCheckoutComBuilder(CheckoutComSourceBaseTest):
+    def test_build_revenue_item_query_with_payments_and_actions_schemas(self):
+        self.setup_checkout_com_external_data_source(schemas=[PAYMENT_RESOURCE_NAME, PAYMENT_ACTION_RESOURCE_NAME])
+
+        query = build(self.checkout_com_handle)
+        payments_table = self.get_checkout_com_table_by_schema_name(PAYMENT_RESOURCE_NAME)
+
+        self.assertQueryContainsFields(query.query, REVENUE_ITEM_SCHEMA)
+        self.assertBuiltQueryStructure(query, str(payments_table.id), f"checkoutcom.{self.external_data_source.prefix}")
+
+        # Recurring revenue is derived from the payment's own payment_type
+        query_sql = query.query.to_hogql()
+        self.assertIn("payment_type", query_sql)
+        self.assertIn("recurring", query_sql)
+
+        self.assertQueryMatchesSnapshot(query_sql, replace_all_numbers=True)
+
+    @parameterized.expand(
+        [
+            ("no_schemas_at_all", []),
+            ("only_payments", [PAYMENT_RESOURCE_NAME]),
+            ("only_payment_actions", [PAYMENT_ACTION_RESOURCE_NAME]),
+        ]
+    )
+    def test_build_with_missing_schema_returns_empty_view(self, _name, schemas):
+        self.setup_checkout_com_external_data_source(schemas=schemas)
+
+        query = build(self.checkout_com_handle)
+
+        self.assertQueryContainsFields(query.query, REVENUE_ITEM_SCHEMA)
+        self.assertBuiltQueryStructure(
+            query,
+            str(self.checkout_com_handle.source.id),  # type: ignore
+            f"checkoutcom.{self.external_data_source.prefix}",
+            expected_test_comments="no_schema",
+        )
+
+    @parameterized.expand([(PAYMENT_RESOURCE_NAME,), (PAYMENT_ACTION_RESOURCE_NAME,)])
+    def test_build_with_schema_but_no_table_returns_empty_view(self, schema_without_table):
+        self.setup_checkout_com_external_data_source(schemas=[PAYMENT_RESOURCE_NAME, PAYMENT_ACTION_RESOURCE_NAME])
+        schema = self.get_checkout_com_schema_by_name(schema_without_table)
+        schema.table = None
+
+        query = build(self.checkout_com_handle)
+
+        self.assertQueryContainsFields(query.query, REVENUE_ITEM_SCHEMA)
+        self.assertBuiltQueryStructure(
+            query,
+            str(self.checkout_com_handle.source.id),  # type: ignore
+            f"checkoutcom.{self.external_data_source.prefix}",
+            expected_test_comments="no_table",
+        )
+
+    def test_build_with_no_source(self):
+        handle = self.create_checkout_com_handle_without_source()
+
+        with self.assertRaises(ValueError):
+            build(handle)

--- a/products/revenue_analytics/backend/views/sources/test/checkout_com/test_checkout_com_revenue_item.py
+++ b/products/revenue_analytics/backend/views/sources/test/checkout_com/test_checkout_com_revenue_item.py
@@ -48,9 +48,10 @@ class TestRevenueItemCheckoutComBuilder(CheckoutComSourceBaseTest):
 
     @parameterized.expand([(PAYMENT_RESOURCE_NAME,), (PAYMENT_ACTION_RESOURCE_NAME,)])
     def test_build_with_schema_but_no_table_returns_empty_view(self, schema_without_table):
-        self.setup_checkout_com_external_data_source(schemas=[PAYMENT_RESOURCE_NAME, PAYMENT_ACTION_RESOURCE_NAME])
-        schema = self.get_checkout_com_schema_by_name(schema_without_table)
-        schema.table = None
+        self.setup_checkout_com_external_data_source(
+            schemas=[PAYMENT_RESOURCE_NAME, PAYMENT_ACTION_RESOURCE_NAME],
+            schemas_without_tables=[schema_without_table],
+        )
 
         query = build(self.checkout_com_handle)
 

--- a/products/revenue_analytics/backend/views/test/test_orchestrator.py
+++ b/products/revenue_analytics/backend/views/test/test_orchestrator.py
@@ -13,6 +13,11 @@ from products.revenue_analytics.backend.views import (
     RevenueAnalyticsSubscriptionView,
 )
 from products.revenue_analytics.backend.views.orchestrator import build_all_revenue_analytics_views
+from products.revenue_analytics.backend.views.sources.checkout_com.helpers import (
+    CUSTOMER_RESOURCE_NAME as CHECKOUT_COM_CUSTOMER_RESOURCE_NAME,
+    PAYMENT_ACTION_RESOURCE_NAME as CHECKOUT_COM_PAYMENT_ACTION_RESOURCE_NAME,
+    PAYMENT_RESOURCE_NAME as CHECKOUT_COM_PAYMENT_RESOURCE_NAME,
+)
 from products.revenue_analytics.backend.views.sources.helpers import ZERO_DECIMAL_CURRENCIES_IN_STRIPE
 from products.warehouse_sources.backend.facade.models import (
     DataWarehouseCredential,
@@ -281,3 +286,91 @@ class TestRevenueAnalyticsViews(BaseTest):
         subscription_views = [v for v in source_views if isinstance(v, RevenueAnalyticsSubscriptionView)]
         self.assertEqual(len(subscription_views), 1)
         self.assertEqual(subscription_views[0].name, "stripe.subscription_revenue_view")
+
+
+class TestRevenueAnalyticsViewsForCheckoutCom(BaseTest):
+    def setUp(self):
+        super().setUp()
+
+        self.timings = HogQLTimings()
+
+        # A Checkout.com source and no Stripe source at all
+        self.source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="source_id",
+            connection_id="connection_id",
+            status=ExternalDataSource.Status.COMPLETED,
+            source_type=ExternalDataSourceType.CHECKOUTCOM,
+        )
+
+        # Revenue analytics is only enabled by default for Stripe sources
+        revenue_analytics_config = self.source.revenue_analytics_config_safe
+        revenue_analytics_config.enabled = True
+        revenue_analytics_config.save()
+
+        self.credentials = DataWarehouseCredential.objects.create(
+            access_key="blah", access_secret="blah", team=self.team
+        )
+
+        for schema_name in [
+            CHECKOUT_COM_PAYMENT_RESOURCE_NAME,
+            CHECKOUT_COM_PAYMENT_ACTION_RESOURCE_NAME,
+            CHECKOUT_COM_CUSTOMER_RESOURCE_NAME,
+        ]:
+            table = DataWarehouseTable.objects.create(
+                name=f"checkoutcom_{schema_name}",
+                format="Parquet",
+                team=self.team,
+                external_data_source=self.source,
+                external_data_source_id=self.source.id,
+                credential=self.credentials,
+                url_pattern="https://bucket.s3/data/*",
+                columns={
+                    "id": {"hogql": "StringDatabaseField", "clickhouse": "Nullable(String)", "schema_valid": True}
+                },
+            )
+            ExternalDataSchema.objects.create(
+                team=self.team,
+                name=schema_name,
+                source=self.source,
+                table=table,
+                should_sync=True,
+                last_synced_at="2024-01-01",
+            )
+
+    def test_builds_views_for_checkout_com_source_without_stripe(self):
+        views = build_all_revenue_analytics_views(self.team, self.timings)
+        source_views = [v for v in views if v.source_id == str(self.source.id)]
+
+        names = [view.name for view in source_views]
+        self.assertEqual(
+            sorted(names),
+            [
+                "checkoutcom.charge_revenue_view",
+                "checkoutcom.customer_revenue_view",
+                "checkoutcom.revenue_item_revenue_view",
+            ],
+        )
+
+        charge_views = [v for v in source_views if isinstance(v, RevenueAnalyticsChargeView)]
+        self.assertEqual(len(charge_views), 1)
+
+        customer_views = [v for v in source_views if isinstance(v, RevenueAnalyticsCustomerView)]
+        self.assertEqual(len(customer_views), 1)
+
+        revenue_item_views = [v for v in source_views if isinstance(v, RevenueAnalyticsRevenueItemView)]
+        self.assertEqual(len(revenue_item_views), 1)
+
+        # Checkout.com has no product, subscription or invoice objects, so those views
+        # (and the MRR view built on top of them) must not be fabricated
+        self.assertEqual([v for v in source_views if isinstance(v, RevenueAnalyticsProductView)], [])
+        self.assertEqual([v for v in source_views if isinstance(v, RevenueAnalyticsSubscriptionView)], [])
+        self.assertEqual([v for v in source_views if isinstance(v, RevenueAnalyticsMRRView)], [])
+
+    def test_revenue_view_prefix(self):
+        self.source.prefix = "prefix"
+        self.source.save()
+
+        views = build_all_revenue_analytics_views(self.team, self.timings)
+        source_views = [v for v in views if v.source_id == str(self.source.id)]
+        self.assertIn("checkoutcom.prefix.revenue_item_revenue_view", [s.name for s in source_views])


### PR DESCRIPTION
## Problem

Revenue analytics reads exactly one warehouse source type: `SUPPORTED_SOURCES` lists only Stripe, the registry imports only the `events` and `stripe` builders, and `SourceHandle.type` is `Literal["events", "stripe"]`. The Checkout.com source meanwhile syncs `payments`, `payment_actions`, `customers`, `instruments`, and report tables — so a team running both processors gets full revenue math on the Stripe half and hand-written SQL on the Checkout.com half.

**Why:** the source data is already in the warehouse; only the builder layer is missing. This lands against today's contracts deliberately, rather than waiting on the source-isolation refactor (#82631) — that PR can migrate this builder alongside the Stripe ones, the same way it migrates them.

Closes #82921

## Changes

- New `views/sources/checkout_com/` builder package modelled on `stripe/`, registering only the view kinds Checkout.com data genuinely supports: **charge** (approved `Capture` actions joined to their parent payment — captures carry exact amounts where payments carry only requested amounts, which handles partial/multiple captures), **customer**, and **revenue_item** (one row per capture; `is_recurring` from `payment_type = 'Recurring'`). No product/subscription/MRR views are fabricated — the orchestrator iterates only registered kinds, and a test locks that in.
- Wiring widened by exactly one member each: `SUPPORTED_SOURCES`, the registry dict, and the `SourceHandle.type` literal. No existing Stripe builder is touched.
- Minor-unit currency handling is Checkout.com-specific (package-local constants per their published amount-format docs, including the three-decimal ÷1000 group); the shared Stripe constant is untouched because the two lists genuinely differ.
- Refunds are deliberately not netted, matching the Stripe charge view's gross-revenue semantics; cohort derives from the earliest *synced* payment and docstrings do not claim pre-horizon history (payments reach back 90 days unless the source has a `start_date`). Both decisions documented in the package docstring, as is the deferred `financial_actions_report` settlement mapping (its column set is account-configurable, so there is no stable contract to build a managed view on yet).

**One deliberate gap, for reviewers:** `ExternalDataSourceRevenueAnalyticsConfig` still defaults `enabled` to true only for Stripe, so a Checkout.com team flips the source's existing revenue-analytics toggle once to get views — not zero-touch. Widening that default is a two-line change in two other products' models and a product decision (it would switch views on for existing sources), so it's left as a follow-up rather than folded in here.

## How did you test this code?

Automated tests against real postgres + ClickHouse locally, red first in two stages: with the package absent (collection errors), and with the package present but the wiring stashed — the acceptance-criterion case — a team with only a Checkout.com source built zero revenue views (`'checkoutcom.prefix.revenue_item_revenue_view' not found in []`). Green after: new builder tests with query snapshots (regenerated once, then re-run stable and committed), an orchestrator test asserting a Checkout.com-only team gets views and a both-sources team gets both prefixes, and the full `views/` tree including all pre-existing Stripe/events tests and snapshots (155 passed). Currency-divider math and timestamp parsing were validated directly against ClickHouse (JPY/BHD/USD examples from Checkout.com's docs). Scoped mypy and ruff clean.

Not exercised against a live Checkout.com-sourced warehouse — worth a smoke check on a real team after merge.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Revenue analytics docs (separate repo) should mention Checkout.com support once this ships — flagged as a follow-up.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented by a Claude Code (PostHog Desktop cloud task) subagent from a CS-authored work order, against the linked public issue; reviewed, security-checked, and published by the orchestrating agent. No repo skills were invoked. All fixtures are synthetic; nothing from the session beyond the public issue content is in the diff. Key decisions during the session: minor-unit rules were verified against Checkout.com docs and genuinely differ from Stripe's constant; the enabled-by-default gap (revenue-analytics toggle defaults on only for Stripe) was deliberately left as a flagged follow-up; the builder registry moved to builder.py post-publish to satisfy the no-init-reexports semgrep ratchet.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

