### PR TITLE
fix(docker): tell the sourcemap-retention states apart and record them

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,9 +65,12 @@ COPY --from=frontend-build /code/frontend/dist /code/frontend/dist
 
 # Upload sourcemaps to error tracking, recording whether it GENUINELY succeeded so the later strip
 # only deletes the .map files when an uploaded copy exists. The build never fails on a sourcemap
-# problem (missing secret, CLI download / network / auth failure): in that case the status is
-# "retained" and the .map files are kept in the image. Uses explicit && chaining rather than `set -e`,
-# which bash ignores inside a `||`-guarded subshell — any failing link drops us into the retained branch.
+# problem. Two distinct things stop an upload and they want different responses, so they get
+# different statuses: "no-secret" is the expected state for a build that was never given the secret
+# (forks, self-hosted), while "upload-failed" means the secret was there and the upload still did
+# not happen — a build-infrastructure problem, not a configuration one. Both keep the .map files, so
+# the only remaining copy is never lost either way. Uses explicit && chaining rather than `set -e`,
+# which bash ignores inside a `||`-guarded subshell — any failing link drops us into upload-failed.
 #
 # The CLI installer is pinned to an immutable release tag and checksum-verified before execution:
 # the processed frontend/dist ships in the final image, so the CLI must not be mutable remote code.
@@ -76,8 +79,10 @@ COPY --from=frontend-build /code/frontend/dist /code/frontend/dist
 ARG POSTHOG_CLI_VERSION=0.11.0
 ARG POSTHOG_CLI_INSTALLER_SHA256=74b0e2d967b688f57432be5bbb78f96cb5dde69f9283c0d8930a01efc132fbc2
 RUN --mount=type=secret,id=posthog_upload_sourcemaps_cli_api_key \
-    if ( \
-        [ -f /run/secrets/posthog_upload_sourcemaps_cli_api_key ] && \
+    if [ ! -f /run/secrets/posthog_upload_sourcemaps_cli_api_key ]; then \
+        echo "sourcemaps not uploaded (no upload secret provided); .map files retained in the image" >&2; \
+        echo no-secret > /tmp/.sourcemaps-status; \
+    elif ( \
         apt-get update && \
         apt-get install -y --no-install-recommends ca-certificates curl && \
         curl --proto '=https' --tlsv1.2 -LsSf -o /tmp/posthog-cli-installer.sh \
@@ -96,8 +101,8 @@ RUN --mount=type=secret,id=posthog_upload_sourcemaps_cli_api_key \
     ); then \
         echo uploaded > /tmp/.sourcemaps-status; \
     else \
-        echo "WARNING: sourcemaps not uploaded (no secret or upload failed); .map files will be retained in the image" >&2; \
-        echo retained > /tmp/.sourcemaps-status; \
+        echo "WARNING: the upload secret was present and the sourcemap upload still failed; .map files retained in the image" >&2; \
+        echo upload-failed > /tmp/.sourcemaps-status; \
     fi && \
     touch /tmp/.sourcemaps-processed
 
@@ -382,8 +387,11 @@ ENV PATH=/python-runtime/bin:$PATH \
 # where the JS sourcemaps have already been stripped.
 COPY --from=posthog-build --chown=posthog:posthog /code/frontend/dist /code/frontend/dist
 
-# Ensure sourcemap-upload stage runs (the file itself is not needed in the final image).
-COPY --from=sourcemap-upload /tmp/.sourcemaps-processed /tmp/.sourcemaps-processed
+# Keep the sourcemap outcome with the image it describes, so whether the .map files were stripped
+# can be read off a published tag (`docker run --rm <image> cat /code/.sourcemaps-status`) rather
+# than inferred from its size. Written by the same RUN as the processed marker, so copying it keeps
+# sourcemap-upload a dependency of this stage.
+COPY --from=sourcemap-upload --chown=posthog:posthog /tmp/.sourcemaps-status /code/.sourcemaps-status
 
 # Copy products.json from the frontend-build stage
 COPY --from=frontend-build --chown=posthog:posthog /code/frontend/src/products.json /code/frontend/src/products.json


### PR DESCRIPTION
## Problem

Someone self-hosting or pulling `posthog/posthog` gets an image that is ~727 MB larger than the one the Dockerfile is trying to produce, about half the time on amd64 and nearly always on arm64, with nothing to tell them which one they got.

The strip at the end of the `posthog-build` stage removes the JS sourcemaps only when the isolated `sourcemap-upload` stage reported `uploaded`:

```dockerfile
RUN if [ "$(cat /tmp/.sourcemaps-status)" = uploaded ]; then \
```

Everything that is not a successful upload — no secret, an apt failure, a bad download, a failed upload — lands in the same `retained` arm, which writes a warning to stderr and never fails the build. `container-images-cd.yml` supplies `posthog_upload_sourcemaps_cli_api_key` to both platforms of the master build, so the "no secret" reading should not apply to published tags. It applies anyway:

| | commit tags | retained |
|---|---|---|
| linux/amd64 | 181 | 93 (51.4%) |
| linux/arm64 | 181 | 163 (90.1%) |

Sizes read from Docker Hub's tag API for every plain 40-hex commit tag published between 2026-08-13 13:43Z and 2026-08-13 23:26Z. The distribution is bimodal by ~700 MB — no tag sits within 200 MB of the split point.

Inside the layers rather than inferred from totals, two amd64 builds 14 minutes apart:

| `posthog/posthog` amd64 | `frontend/dist` layer | entries | `.map` files | `.map` bytes |
|---|---|---|---|---|
| `71299185bb4a` | 111,008,022 | 4,288 | 0 | 0 |
| `467bd2cc7049` | 353,409,696 | 6,721 | 2,433 | 1,105,190,909 |

Across `staticfiles` and `frontend/dist` together the retained build is **+727,103,988 bytes compressed** on a 2,714,767,045 byte image.

**This is weight, not a disclosure problem.** The frontend is MIT and public; those maps describe code that is already on GitHub. What is worth fixing is that a build-side failure is indistinguishable from a build that was correctly never given the secret, and that neither is visible afterwards.

## Changes

Two things, neither of which changes whether any build passes or what gets stripped.

- Split the single failure arm in the `sourcemap-upload` stage into `no-secret` (expected: forks, self-hosted, anything not handed the secret) and `upload-failed` (the secret was there and the upload still did not happen). Both keep the `.map` files. The strip condition is untouched and still fires only on `uploaded`.
- The final stage copies `/tmp/.sourcemaps-status` to `/code/.sourcemaps-status` in place of `/tmp/.sourcemaps-processed`, whose own comment says it "is not needed in the final image". Both files are written by the same `RUN`, so the dependency edge that line existed for is kept, and `docker run --rm <image> cat /code/.sourcemaps-status` now answers the question the size table above had to be built to answer. Neither marker is referenced anywhere else in the repo.

The comment above the upload `RUN` describes the old two-outcome shape, so it is rewritten in the same diff rather than left to contradict the code under it.

**Deliberately left out:** making `upload-failed` fail the build. That is the obvious next question and it belongs to the owning team — it trades a silent 700 MB for a broken master build, and which leg of that condition is the flaky one is not knowable from outside. Naming the state is the prerequisite either way, and it is enough on its own to put the answer in a CI log and in the image.

## How did you test this code?

Automated, and this is the whole list:

- The patched `RUN` was extracted from the rendered file, the apt/curl/upload legs of the `elif` condition were replaced with a controlled exit status, and the real branch structure — the patch's own text, not a paraphrase of it — was executed under `bash -e -o pipefail` for all three inputs. Results: no secret → `no-secret`, exit 0; secret + upload succeeds → `uploaded`, exit 0; secret + upload fails → `upload-failed`, exit 0. The processed marker is written in all three, and no input makes the step exit non-zero.
- The measurement above is a registry and Hub API read of images already published from this repository. It does not depend on anything built here.

**This image was not built.** The environment this patch was written in has no docker daemon, so there is no local build, no `collectstatic` run and no end-to-end check of the strip, and nothing above implies otherwise. The change is confined to which string a branch writes and which of two same-stage files gets copied; the shell control flow is the part that could break and it is the part exercised above. `container-images-ci.yml` builds the real thing.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

No human directed this work, so the PR is left unassigned for the owning team to triage.

Written by an autonomous agent built on Claude (Anthropic), running as `@sujeito-operator`. No repo-provided or public skills from this repository were invoked — `CONTRIBUTING.md`, `AI_POLICY.md` and `.github/pull_request_template.md` were read over the GitHub API and followed directly, which is also why this is a PR and not an issue.

How it got here: the finding started as a scan of the Dockerfile and the scan was wrong about what mattered — it flagged apt and cache hygiene, none of which is the problem. The size histogram of the published tags is what surfaced this, and the layer census came after, to check the histogram was measuring sourcemaps rather than something else that happens to move by the same amount. The first draft of the patch made `upload-failed` exit non-zero; that was cut because it is a policy call for the owning team.

Nothing here draws on any non-public material: every input is this repository, its published images, and Docker Hub's public tag API.
