### PR TITLE
fix(warehouse-sources): name the IAM action in S3 access-denied errors

### DIFF
--- a/products/data_warehouse/backend/models/test/test_table.py
+++ b/products/data_warehouse/backend/models/test/test_table.py
@@ -1003,7 +1003,7 @@ class TestTable(BaseTest):
                 "access_denied",
                 "DB::Exception: Access Denied: while reading key: some/path/file.parquet",
                 499,
-                "Access was denied when reading the provided file",
+                "s3:GetObject",
             ),
             (
                 "no_such_bucket",

--- a/products/warehouse_sources/backend/models/table.py
+++ b/products/warehouse_sources/backend/models/table.py
@@ -78,11 +78,11 @@ SERIALIZED_FIELD_TO_CLICKHOUSE_MAPPING: dict[DatabaseSerializedFieldType, str] =
 
 ExtractErrors = {
     "The AWS Access Key Id you provided does not exist": "The Access Key you provided does not exist",
-    "Access Denied: while reading key:": "Access was denied when reading the provided file",
+    "Access Denied: while reading key:": "Access was denied when reading a file from the bucket. Check that the provided credentials can read objects in this bucket (s3:GetObject), then try again.",
     # DeltaLake-kernel object_store errors (Delta-format tables, e.g. all warehouse_sources synced
     # tables) use a different vocabulary than ClickHouse's native S3 errors above.
     "The operation lacked the necessary privileges to complete": "Access was denied when reading the provided file",
-    "Could not list objects in bucket": "Access was denied to the provided bucket",
+    "Could not list objects in bucket": "Access was denied to the provided bucket. Check that the provided credentials can list this bucket (s3:ListBucket), then try again.",
     "file is empty": "The provided file contains no data",
     "The specified key does not exist": "The provided file doesn't exist in the bucket",
     "Cannot extract table structure from CSV format file, because there are no files with provided path in S3 or all files are empty": "The provided file doesn't exist in the bucket",

--- a/products/warehouse_sources/backend/tests/test_table.py
+++ b/products/warehouse_sources/backend/tests/test_table.py
@@ -167,6 +167,21 @@ class TestSafeExposeChError:
         with pytest.raises(Exception, match="Access was denied when reading the provided file"):
             DataWarehouseTable()._safe_expose_ch_error(delta_kernel_error)
 
+    @pytest.mark.parametrize(
+        "raw_message,expected_action",
+        [
+            ("DB::Exception: Access Denied: while reading key: my-data/file.csv, S3 exception", "s3:GetObject"),
+            ("DB::Exception: Could not list objects in bucket my-bucket, S3 exception", "s3:ListBucket"),
+        ],
+    )
+    def test_native_s3_access_denials_name_the_iam_action_to_check(
+        self, raw_message: str, expected_action: str
+    ) -> None:
+        # A self-managed S3 source reads and lists the customer's own bucket, so an access denial
+        # is theirs to fix — name the exact IAM action rather than dead-ending on "access denied".
+        with pytest.raises(Exception, match=expected_action):
+            DataWarehouseTable()._safe_expose_ch_error(ServerException(raw_message, code=499))
+
     def test_delta_kernel_object_store_blip_is_retried_not_blamed_on_the_bucket(self) -> None:
         # ClickHouse's own deltaLake() S3 table function hits the same transient object-store
         # blips as delta-rs (e.g. a dropped connection to our own data-warehouse bucket), just


### PR DESCRIPTION
## Problem

A user connecting a self-managed S3 source who gets an access-denied error is told only that "access was denied to the provided bucket" — with no hint at what to fix. Replay Vision watched users cycle on exactly this error repeatedly during onboarding without resolving it.

## Changes

- The native S3 "access denied while reading a key" error now names `s3:GetObject` as the action to grant.
- The native S3 "could not list objects in bucket" error now names `s3:ListBucket`.
- The DeltaLake-kernel access error, which is about PostHog's own internal storage rather than the customer's bucket, keeps its generic message so we never wrongly blame the customer's IAM policy.

This matches the phrasing already used for S3 access errors elsewhere in the codebase (`managed_migrations`).

## How did you test this code?

Added two parametrized cases to `TestSafeExposeChError` asserting each native S3 access denial surfaces its IAM action, and confirming the internal delta-kernel error still maps to the generic message. Ran `pytest products/warehouse_sources/backend/tests/test_table.py::TestSafeExposeChError` locally — all pass. Ruff check and format clean on the touched files. No manual end-to-end run performed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by an agent triaging data-warehouse onboarding friction surfaced by Replay Vision session summaries. The friction motivating this change (a user repeatedly failing to connect an S3 source on an access-denied error) came from a session summary; no customer identifiers, hosts, or quotes are included here or in the diff. The test fixtures use invented bucket/key names. Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
