### PR TITLE
feat(desktop): paginate cloud transcripts with on-demand history

### DIFF
--- a/products/desktop/packages/api-client/src/posthog-client.test.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.test.ts
@@ -2222,6 +2222,22 @@ describe("PostHogAPIClient", () => {
       ).toBeInstanceOf(AbortSignal);
     });
 
+    it("reports a null matching count when the header is absent", async () => {
+      const fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => makeEntries(10, "a"),
+        headers: new Headers({ "X-Has-More": "true" }),
+      });
+      const client = makeClient(fetch);
+
+      const result = await client.getTaskRunSessionLogsPage("task-1", "run-1", {
+        limit: 10,
+      });
+
+      expect(result.matchingCount).toBeNull();
+      expect(result.hasMore).toBe(true);
+    });
+
     it("does not retry a definite client error", async () => {
       const fetch = vi.fn().mockRejectedValue(new ApiRequestError(404, "{}"));
       const client = makeClient(fetch);

--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -230,6 +230,13 @@ type SessionLogsPage =
   | { ok: true; entries: StoredLogEntry[]; headers: Headers }
   | { ok: false; status: number; statusText: string };
 
+export interface TaskRunSessionLogsPage {
+  entries: StoredLogEntry[];
+  hasMore: boolean;
+  /** Total entries matching the query, or null when the server omits the header. */
+  matchingCount: number | null;
+}
+
 export interface TaskListOptions {
   repository?: string;
   createdBy?: number;
@@ -3734,6 +3741,39 @@ export class PostHogAPIClient {
     }
   }
 
+  async getTaskRunSessionLogsPage(
+    taskId: string,
+    runId: string,
+    options: { limit: number; offset?: number; after?: string },
+  ): Promise<TaskRunSessionLogsPage> {
+    const teamId = await this.getTeamId();
+    const path = `/api/projects/${teamId}/tasks/${taskId}/runs/${runId}/session_logs/`;
+    const url = new URL(`${this.api.baseUrl}${path}`);
+    url.searchParams.set("limit", String(options.limit));
+    if (options.offset) {
+      url.searchParams.set("offset", String(options.offset));
+    }
+    if (options.after) {
+      url.searchParams.set("after", options.after);
+    }
+    const page = await this.fetchSessionLogsPage(
+      url,
+      path,
+      options.offset ?? 0,
+    );
+    if (!page.ok) {
+      throw new Error(
+        `Failed to fetch session logs page at offset ${options.offset ?? 0}: ${page.status} ${page.statusText}`,
+      );
+    }
+    const matchingHeader = Number(page.headers.get("X-Matching-Count"));
+    return {
+      entries: page.entries,
+      hasMore: page.headers.get("X-Has-More") === "true",
+      matchingCount: Number.isFinite(matchingHeader) ? matchingHeader : null,
+    };
+  }
+
   async getTaskRunSessionLogsResult(
     taskId: string,
     runId: string,
@@ -3743,46 +3783,28 @@ export class PostHogAPIClient {
     const entries: StoredLogEntry[] = [];
     let truncatedHeadCount = 0;
     try {
-      const teamId = await this.getTeamId();
-      const path = `/api/projects/${teamId}/tasks/${taskId}/runs/${runId}/session_logs/`;
       let offset = 0;
       let isFirstPage = true;
       while (entries.length < maxEntries) {
-        const url = new URL(`${this.api.baseUrl}${path}`);
-        url.searchParams.set(
-          "limit",
-          String(
-            Math.min(SESSION_LOGS_MAX_PAGE_SIZE, maxEntries - entries.length),
+        const page = await this.getTaskRunSessionLogsPage(taskId, runId, {
+          limit: Math.min(
+            SESSION_LOGS_MAX_PAGE_SIZE,
+            maxEntries - entries.length,
           ),
-        );
-        if (offset > 0) {
-          url.searchParams.set("offset", String(offset));
-        }
-        if (options?.after) {
-          url.searchParams.set("after", options.after);
-        }
-        const page = await this.fetchSessionLogsPage(url, path, offset);
-
-        if (!page.ok) {
-          log.warn(
-            `Failed to fetch session logs page at offset ${offset}: ${page.status} ${page.statusText}`,
-          );
-          return { entries, complete: false, truncatedHeadCount };
-        }
-
+          offset,
+          after: options?.after,
+        });
         if (isFirstPage) {
           isFirstPage = false;
-          const matchingCount = Number(page.headers.get("X-Matching-Count"));
-          if (Number.isFinite(matchingCount) && matchingCount > maxEntries) {
+          if (page.matchingCount !== null && page.matchingCount > maxEntries) {
             // Restart from the tail so the newest maxEntries survive the cap.
-            truncatedHeadCount = matchingCount - maxEntries;
+            truncatedHeadCount = page.matchingCount - maxEntries;
             offset = truncatedHeadCount;
             continue;
           }
         }
         entries.push(...page.entries);
-        const hasMore = page.headers.get("X-Has-More") === "true";
-        if (!hasMore || page.entries.length === 0) {
+        if (!page.hasMore || page.entries.length === 0) {
           return { entries, complete: true, truncatedHeadCount };
         }
         offset += page.entries.length;

--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -3766,11 +3766,18 @@ export class PostHogAPIClient {
         `Failed to fetch session logs page at offset ${options.offset ?? 0}: ${page.status} ${page.statusText}`,
       );
     }
-    const matchingHeader = Number(page.headers.get("X-Matching-Count"));
+    // An absent header must stay null: Number(null) is 0, and callers treat
+    // the count as authoritative when it is present.
+    const matchingHeader = page.headers.get("X-Matching-Count");
+    const matchingCount =
+      matchingHeader === null ? null : Number(matchingHeader);
     return {
       entries: page.entries,
       hasMore: page.headers.get("X-Has-More") === "true",
-      matchingCount: Number.isFinite(matchingHeader) ? matchingHeader : null,
+      matchingCount:
+        matchingCount !== null && Number.isFinite(matchingCount)
+          ? matchingCount
+          : null,
     };
   }
 

--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -233,7 +233,6 @@ type SessionLogsPage =
 export interface TaskRunSessionLogsPage {
   entries: StoredLogEntry[];
   hasMore: boolean;
-  /** Total entries matching the query, or null when the server omits the header. */
   matchingCount: number | null;
 }
 
@@ -3766,8 +3765,7 @@ export class PostHogAPIClient {
         `Failed to fetch session logs page at offset ${options.offset ?? 0}: ${page.status} ${page.statusText}`,
       );
     }
-    // An absent header must stay null: Number(null) is 0, and callers treat
-    // the count as authoritative when it is present.
+    // Number(null) is 0, so an absent header must stay null.
     const matchingHeader = page.headers.get("X-Matching-Count");
     const matchingCount =
       matchingHeader === null ? null : Number(matchingHeader);

--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -226,14 +226,12 @@ interface CloudHydrationResult {
   liveStreamLineCount: number;
 }
 
-/** Oldest entries a hydration keeps in memory across a cloud resume chain. */
 const CLOUD_HYDRATION_MAX_ENTRIES = 100_000;
 
 interface ChainTranscriptWindow {
   entries: StoredLogEntry[];
   /** Absolute index in the chain log of `entries[0]`. */
   windowStart: number;
-  /** Chain log entry count at fetch time. */
   chainTotal: number;
 }
 
@@ -6542,12 +6540,8 @@ export class SessionService {
   }
 
   /**
-   * Fetch the newest window of a run's chain log: one probe page to learn the
-   * total, then the tail pages. Small logs come back whole (windowStart 0);
-   * oversized ones come back as just the newest page - older pages load on
-   * demand as the thread scrolls up. Returns null when the fetch fails.
-   * Trade-off: an oversized log pays for one discarded probe page so the
-   * common small log stays a single request.
+   * One probe page learns the chain total, then only the tail pages are
+   * fetched; small logs come back whole (windowStart 0). Null on failure.
    */
   private async fetchChainTranscriptWindow(
     client: SessionLogsClient,
@@ -6566,8 +6560,6 @@ export class SessionService {
         };
       }
       if (first.matchingCount === null) {
-        // Servers without the matching-count header cannot report the total,
-        // so fall back to the sequential capped fetch.
         const result = await client.getTaskRunSessionLogsResult(
           taskId,
           taskRunId,
@@ -6628,11 +6620,8 @@ export class SessionService {
   }
 
   /**
-   * Fetch the page of chain history just above the hydrated window and
-   * prepend it. Driven by the thread scrolling near the top; each call loads
-   * one page. Older pages carry no stream positions - position stamping only
-   * matters for live-stream dedup, and windowed hydration only runs for
-   * terminal runs.
+   * Prepend the page of chain history just above the hydrated window.
+   * Driven by the thread scrolling near the top; one page per call.
    */
   async loadOlderCloudTranscript(taskId: string): Promise<void> {
     const session = this.d.store.getSessionByTaskId(taskId);
@@ -6852,12 +6841,9 @@ export class SessionService {
     const chainTotal =
       transcriptWindow?.chainTotal ?? rawEntries.length + truncatedHeadCount;
     const windowStart = transcriptWindow?.windowStart ?? 0;
-    // Resume-chain positions are leaf-relative (stamped from the leaf marker);
-    // single-run positions are indexes into the run's own log, so a tail
-    // window offsets them by its absolute start. A truncated resume window
-    // that lost its leaf marker has no usable anchor - stamping from the
-    // window start would mislabel every entry's position, so leave those
-    // unpositioned and let reconciliation fall back to content matching.
+    // Resume positions are leaf-relative; windowed single runs offset by the
+    // window start. A truncated resume window that lost its leaf marker stays
+    // unpositioned rather than mislabeled from index 0.
     const positionOptions = isResumeRun
       ? windowStart === 0 || resumeLeafEntryStartIndex !== undefined
         ? {

--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -6546,6 +6546,8 @@ export class SessionService {
    * total, then the tail pages. Small logs come back whole (windowStart 0);
    * oversized ones come back as just the newest page - older pages load on
    * demand as the thread scrolls up. Returns null when the fetch fails.
+   * Trade-off: an oversized log pays for one discarded probe page so the
+   * common small log stays a single request.
    */
   private async fetchChainTranscriptWindow(
     client: SessionLogsClient,
@@ -6852,17 +6854,23 @@ export class SessionService {
     const windowStart = transcriptWindow?.windowStart ?? 0;
     // Resume-chain positions are leaf-relative (stamped from the leaf marker);
     // single-run positions are indexes into the run's own log, so a tail
-    // window offsets them by its absolute start.
-    let events = convertStoredEntriesToEvents(
-      rawEntries,
-      undefined,
-      isResumeRun || windowStart === 0
+    // window offsets them by its absolute start. A truncated resume window
+    // that lost its leaf marker has no usable anchor - stamping from the
+    // window start would mislabel every entry's position, so leave those
+    // unpositioned and let reconciliation fall back to content matching.
+    const positionOptions = isResumeRun
+      ? windowStart === 0 || resumeLeafEntryStartIndex !== undefined
         ? {
             taskRunId,
             startEntryIndex: 0,
             firstPositionedEntryIndex: resumeLeafEntryStartIndex,
           }
-        : { taskRunId, startEntryIndex: windowStart },
+        : undefined
+      : { taskRunId, startEntryIndex: windowStart };
+    let events = convertStoredEntriesToEvents(
+      rawEntries,
+      undefined,
+      positionOptions,
     );
     if (isResumeRun && session.events.length > 0) {
       const inheritedEvents = reconcileLiveEventsWithHydratedEvents(

--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -6595,17 +6595,24 @@ export class SessionService {
       const tailStart = Math.max(0, probe.matchingCount - INITIAL_TAIL_WINDOW);
       const tail: StoredLogEntry[] = [];
       let offset = tailStart;
-      while (offset < probe.matchingCount) {
+      // The probe's count is a snapshot, and a run whose log is still being
+      // persisted grows behind it. Following the server's own end-of-log signal
+      // as well keeps those newest entries from going missing until a restart —
+      // older-history paging only moves backward, so nothing else recovers them.
+      let chainEnd = probe.matchingCount;
+      while (offset < chainEnd && tail.length < CLOUD_HYDRATION_MAX_ENTRIES) {
         const page = await client.getTaskRunSessionLogsPage(taskId, taskRunId, {
-          limit: Math.min(
-            SESSION_LOGS_MAX_PAGE_SIZE,
-            probe.matchingCount - offset,
-          ),
+          limit: Math.min(SESSION_LOGS_MAX_PAGE_SIZE, chainEnd - offset),
           offset,
         });
         if (page.entries.length === 0) break;
         tail.push(...page.entries);
         offset += page.entries.length;
+        if (page.matchingCount !== null && page.matchingCount > chainEnd) {
+          chainEnd = page.matchingCount;
+        } else if (offset >= chainEnd && page.hasMore) {
+          chainEnd = offset + SESSION_LOGS_MAX_PAGE_SIZE;
+        }
       }
       const chainTotal = tailStart + tail.length;
       if (tailStart > 0) {

--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -10,10 +10,12 @@ import type {
   SessionUpdate,
 } from "@agentclientprotocol/sdk";
 import { requestErrorStatus } from "@posthog/api-client/fetcher";
-import type {
-  CreateResourceCommentRequest,
-  ResourceComment,
-  TaskRunSessionLogsResult,
+import {
+  type CreateResourceCommentRequest,
+  type PostHogAPIClient,
+  type ResourceComment,
+  SESSION_LOGS_MAX_PAGE_SIZE,
+  type TaskRunSessionLogsResult,
 } from "@posthog/api-client/posthog-client";
 import {
   type AcpMessage,
@@ -223,6 +225,22 @@ interface CloudHydrationResult {
   historyEntryCount: number;
   liveStreamLineCount: number;
 }
+
+/** Oldest entries a hydration keeps in memory across a cloud resume chain. */
+const CLOUD_HYDRATION_MAX_ENTRIES = 100_000;
+
+interface ChainTranscriptWindow {
+  entries: StoredLogEntry[];
+  /** Absolute index in the chain log of `entries[0]`. */
+  windowStart: number;
+  /** Chain log entry count at fetch time. */
+  chainTotal: number;
+}
+
+type SessionLogsClient = Pick<
+  PostHogAPIClient,
+  "getTaskRunSessionLogsPage" | "getTaskRunSessionLogsResult"
+>;
 
 interface CloudTaskWatcher {
   runId: string;
@@ -1688,6 +1706,7 @@ export class SessionService {
   private silenceCheckHandle: ReturnType<typeof setInterval> | null = null;
   /** Active cloud task watchers, keyed by taskId */
   private cloudTaskWatchers = new Map<string, CloudTaskWatcher>();
+  private olderTranscriptLoads = new Set<string>();
   private cloudLogGapReconciler: CloudLogGapReconciler;
   /** Maps toolCallId → cloud requestId for routing permission responses */
   private cloudPermissionRequestIds = new Map<string, string>();
@@ -6522,6 +6541,159 @@ export class SessionService {
     }
   }
 
+  /**
+   * Fetch the newest window of a run's chain log: one probe page to learn the
+   * total, then the tail pages. Small logs come back whole (windowStart 0);
+   * oversized ones come back as just the newest page - older pages load on
+   * demand as the thread scrolls up. Returns null when the fetch fails.
+   */
+  private async fetchChainTranscriptWindow(
+    client: SessionLogsClient,
+    taskId: string,
+    taskRunId: string,
+  ): Promise<ChainTranscriptWindow | null> {
+    try {
+      const first = await client.getTaskRunSessionLogsPage(taskId, taskRunId, {
+        limit: SESSION_LOGS_MAX_PAGE_SIZE,
+      });
+      if (!first.hasMore || first.entries.length === 0) {
+        return {
+          entries: first.entries,
+          windowStart: 0,
+          chainTotal: first.entries.length,
+        };
+      }
+      if (first.matchingCount === null) {
+        // Servers without the matching-count header cannot report the total,
+        // so fall back to the sequential capped fetch.
+        const result = await client.getTaskRunSessionLogsResult(
+          taskId,
+          taskRunId,
+          { limit: CLOUD_HYDRATION_MAX_ENTRIES },
+        );
+        if (!result.complete) return null;
+        return {
+          entries: result.entries,
+          windowStart: result.truncatedHeadCount,
+          chainTotal: result.truncatedHeadCount + result.entries.length,
+        };
+      }
+      const tailStart = Math.max(
+        first.entries.length,
+        first.matchingCount - SESSION_LOGS_MAX_PAGE_SIZE,
+      );
+      const tail: StoredLogEntry[] = [];
+      let offset = tailStart;
+      while (offset < first.matchingCount) {
+        const page = await client.getTaskRunSessionLogsPage(taskId, taskRunId, {
+          limit: Math.min(
+            SESSION_LOGS_MAX_PAGE_SIZE,
+            first.matchingCount - offset,
+          ),
+          offset,
+        });
+        if (page.entries.length === 0) break;
+        tail.push(...page.entries);
+        offset += page.entries.length;
+      }
+      const chainTotal = tailStart + tail.length;
+      if (tailStart === first.entries.length) {
+        return {
+          entries: [...first.entries, ...tail],
+          windowStart: 0,
+          chainTotal,
+        };
+      }
+      this.d.log.info("Hydrating cloud transcript tail window", {
+        taskId,
+        taskRunId,
+        windowStart: tailStart,
+        chainTotal,
+      });
+      return {
+        entries: tail,
+        windowStart: tailStart,
+        chainTotal,
+      };
+    } catch (error) {
+      this.d.log.warn("Cloud transcript window fetch failed", {
+        taskId,
+        taskRunId,
+        error,
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Fetch the page of chain history just above the hydrated window and
+   * prepend it. Driven by the thread scrolling near the top; each call loads
+   * one page. Older pages carry no stream positions - position stamping only
+   * matters for live-stream dedup, and windowed hydration only runs for
+   * terminal runs.
+   */
+  async loadOlderCloudTranscript(taskId: string): Promise<void> {
+    const session = this.d.store.getSessionByTaskId(taskId);
+    if (!session?.isCloud) return;
+    const taskRunId = session.taskRunId;
+    const windowStart = session.transcriptWindowStart ?? 0;
+    if (windowStart <= 0 || this.olderTranscriptLoads.has(taskRunId)) return;
+    this.olderTranscriptLoads.add(taskRunId);
+    this.d.store.updateSession(taskRunId, { isLoadingOlderTranscript: true });
+    try {
+      const authStatus = await this.getAuthCredentialsStatus();
+      if (authStatus.kind !== "ready") return;
+
+      const pageStart = Math.max(0, windowStart - SESSION_LOGS_MAX_PAGE_SIZE);
+      const older: StoredLogEntry[] = [];
+      let offset = pageStart;
+      while (offset < windowStart) {
+        const page = await authStatus.auth.client.getTaskRunSessionLogsPage(
+          taskId,
+          taskRunId,
+          {
+            limit: Math.min(SESSION_LOGS_MAX_PAGE_SIZE, windowStart - offset),
+            offset,
+          },
+        );
+        if (page.entries.length === 0) break;
+        older.push(...page.entries.slice(0, windowStart - offset));
+        offset += page.entries.length;
+      }
+      if (older.length === 0) return;
+
+      const current = this.d.store.getSessionByTaskId(taskId);
+      if (!current || current.taskRunId !== taskRunId) return;
+      if ((current.transcriptWindowStart ?? 0) !== windowStart) return;
+
+      const olderEvents = convertStoredEntriesToEvents(older);
+      this.d.store.updateSession(taskRunId, {
+        events: [...olderEvents, ...current.events],
+        transcriptWindowStart: windowStart - older.length,
+      });
+      this.d.log.info("Older cloud transcript page loaded", {
+        taskId,
+        taskRunId,
+        pageStart,
+        loadedCount: older.length,
+      });
+    } catch (error) {
+      this.d.log.warn("Older cloud transcript page load failed", {
+        taskId,
+        taskRunId,
+        windowStart,
+        error,
+      });
+    } finally {
+      this.olderTranscriptLoads.delete(taskRunId);
+      if (this.d.store.getSessions()[taskRunId]) {
+        this.d.store.updateSession(taskRunId, {
+          isLoadingOlderTranscript: false,
+        });
+      }
+    }
+  }
+
   private async performCloudTaskSessionHydration(
     taskId: string,
     taskRunId: string,
@@ -6533,9 +6705,11 @@ export class SessionService {
     let rawEntries: StoredLogEntry[];
     let liveStreamLineCount: number;
     let resumeLeafEntryStartIndex: number | undefined;
-    // How many entries the tail fetch dropped off the front of rawEntries. The
-    // stream cursors count from the start of the chain, and the engine's own
-    // totals still include those entries, so they have to be added back.
+    let transcriptWindow: ChainTranscriptWindow | null = null;
+    // How many entries a capped fetch dropped off the front of rawEntries on
+    // paths that produce no window. The stream cursors count from the start of
+    // the chain, and the engine's own totals still include those entries, so
+    // they have to be added back.
     let truncatedHeadCount = 0;
     const resumeFromRunId =
       typeof runState?.resume_from_run_id === "string"
@@ -6554,13 +6728,12 @@ export class SessionService {
       }
       if (resumeFromRunId) {
         if (isTerminalStatus(runStatus)) {
-          const result =
-            await authStatus.auth.client.getTaskRunSessionLogsResult(
-              taskId,
-              taskRunId,
-              { limit: 100000 },
-            );
-          if (!result.complete) {
+          const window = await this.fetchChainTranscriptWindow(
+            authStatus.auth.client,
+            taskId,
+            taskRunId,
+          );
+          if (!window) {
             this.d.log.warn("Resume session log hydration was incomplete", {
               taskId,
               taskRunId,
@@ -6568,9 +6741,8 @@ export class SessionService {
             });
             return;
           }
-          this.logHydrationTruncation(taskId, taskRunId, result);
-          rawEntries = result.entries;
-          truncatedHeadCount = result.truncatedHeadCount;
+          transcriptWindow = window;
+          rawEntries = window.entries;
           const markedLeafStart = rawEntries.findIndex(
             (entry) => getEntryTaskRunMarker(entry) === taskRunId,
           );
@@ -6585,12 +6757,12 @@ export class SessionService {
             authStatus.auth.client.getTaskRunSessionLogsResult(
               taskId,
               resumeFromRunId,
-              { limit: 100000 },
+              { limit: CLOUD_HYDRATION_MAX_ENTRIES },
             ),
             authStatus.auth.client.getTaskRunSessionLogsResult(
               taskId,
               taskRunId,
-              { limit: 100000 },
+              { limit: CLOUD_HYDRATION_MAX_ENTRIES },
             ),
           ]);
           if (!ancestorResult.complete || !currentRunResult.complete) {
@@ -6636,28 +6808,28 @@ export class SessionService {
           );
         }
       } else {
-        const result = await authStatus.auth.client.getTaskRunSessionLogsResult(
+        const window = await this.fetchChainTranscriptWindow(
+          authStatus.auth.client,
           taskId,
           taskRunId,
-          { limit: 100000 },
         );
-        if (!result.complete) {
+        if (!window) {
           this.d.log.warn("Session log hydration was incomplete", {
             taskId,
             taskRunId,
           });
           return;
         }
-        this.logHydrationTruncation(taskId, taskRunId, result);
-        rawEntries = result.entries;
-        truncatedHeadCount = result.truncatedHeadCount;
-        liveStreamLineCount = rawEntries.length;
+        transcriptWindow = window;
+        rawEntries = window.entries;
+        liveStreamLineCount = window.chainTotal;
         // A terminal run whose persisted chain comes back empty can still
         // have a complete S3 session log (persistence raced teardown); fall
         // back to it rather than hydrating an empty final transcript.
         if (rawEntries.length === 0 && logUrl) {
           const parsed = await this.fetchSessionLogs(logUrl, taskRunId);
           if (parsed.rawEntries.length > 0) {
+            transcriptWindow = null;
             rawEntries = parsed.rawEntries;
             truncatedHeadCount = 0;
             liveStreamLineCount = parsed.totalLineCount;
@@ -6675,11 +6847,23 @@ export class SessionService {
       return;
     }
 
-    let events = convertStoredEntriesToEvents(rawEntries, undefined, {
-      taskRunId,
-      startEntryIndex: 0,
-      firstPositionedEntryIndex: resumeLeafEntryStartIndex,
-    });
+    const chainTotal =
+      transcriptWindow?.chainTotal ?? rawEntries.length + truncatedHeadCount;
+    const windowStart = transcriptWindow?.windowStart ?? 0;
+    // Resume-chain positions are leaf-relative (stamped from the leaf marker);
+    // single-run positions are indexes into the run's own log, so a tail
+    // window offsets them by its absolute start.
+    let events = convertStoredEntriesToEvents(
+      rawEntries,
+      undefined,
+      isResumeRun || windowStart === 0
+        ? {
+            taskRunId,
+            startEntryIndex: 0,
+            firstPositionedEntryIndex: resumeLeafEntryStartIndex,
+          }
+        : { taskRunId, startEntryIndex: windowStart },
+    );
     if (isResumeRun && session.events.length > 0) {
       const inheritedEvents = reconcileLiveEventsWithHydratedEvents(
         session.events,
@@ -6740,12 +6924,11 @@ export class SessionService {
       };
     }
 
-    const chainEntryCount = rawEntries.length + truncatedHeadCount;
     // If live updates already populated a processed count, don't overwrite
     // that newer state with the persisted baseline fetched during startup.
     // Terminal hydration is different: it is the final transcript, so apply
     // it whenever the persisted chain has more lines than the local stream.
-    const effectiveLineCount = Math.max(liveStreamLineCount, chainEntryCount);
+    const effectiveLineCount = Math.max(liveStreamLineCount, chainTotal);
     const alreadyApplied = isTerminalRun
       ? (session.processedLineCount ?? 0) >= effectiveLineCount
       : session.processedLineCount !== undefined &&
@@ -6755,7 +6938,7 @@ export class SessionService {
       this.surfacePersistedPendingPermissions(taskRunId, rawEntries);
       this.pendingPermissionHydratedRuns.add(taskRunId);
       return {
-        historyEntryCount: chainEntryCount,
+        historyEntryCount: chainTotal,
         liveStreamLineCount: session.processedLineCount ?? liveStreamLineCount,
       };
     }
@@ -6773,7 +6956,8 @@ export class SessionService {
       events,
       isCloud: true,
       logUrl: logUrl ?? session.logUrl,
-      cloudTranscriptEntryCount: chainEntryCount,
+      cloudTranscriptEntryCount: chainTotal,
+      transcriptWindowStart: windowStart,
       // Terminal hydration records the whole chain as processed so nothing
       // re-applies it; live resume runs keep the leaf-stream cursor.
       processedLineCount: isTerminalRun
@@ -6790,7 +6974,7 @@ export class SessionService {
       this.clearTerminalCloudPromptState(taskRunId);
     }
     return {
-      historyEntryCount: chainEntryCount,
+      historyEntryCount: chainTotal,
       liveStreamLineCount,
     };
   }

--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -8453,11 +8453,16 @@ export class SessionService {
       this.d.store.clearTailOptimisticItems(taskRunId);
     }
     this.cloudRunIdleTracker.delete(taskRunId);
+    // The reconciled log is the complete chain, so any hydration window is
+    // gone; resetting the window start also trips loadOlderCloudTranscript's
+    // stale-window guard if a prepend was in flight, instead of duplicating
+    // entries the reconcile already committed.
     this.d.store.updateSession(taskRunId, {
       events,
       isCloud: true,
       logUrl,
       processedLineCount,
+      transcriptWindowStart: 0,
     });
     this.updatePromptStateFromEvents(taskRunId, events);
   }

--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -228,6 +228,13 @@ interface CloudHydrationResult {
 
 const CLOUD_HYDRATION_MAX_ENTRIES = 100_000;
 
+/** Entries the first paint of a big transcript renders; the rest pages in on scroll. */
+const INITIAL_TAIL_WINDOW = 2000;
+
+/** How long hydration waits for auth to finish restoring before giving up. */
+const AUTH_RESTORE_WAIT_MS = 30_000;
+const AUTH_RESTORE_POLL_MS = 250;
+
 interface ChainTranscriptWindow {
   entries: StoredLogEntry[];
   /** Absolute index in the chain log of `entries[0]`. */
@@ -6448,6 +6455,9 @@ export class SessionService {
     if (existing) {
       return existing;
     }
+    if (hydrationMode === "terminal-chain") {
+      this.d.store.updateSession(taskRunId, { isHydratingTranscript: true });
+    }
     const hydration = this.performCloudTaskSessionHydration(
       taskId,
       taskRunId,
@@ -6467,6 +6477,14 @@ export class SessionService {
     void hydration.finally(() => {
       if (this.cloudHydrationPromises.get(hydrationKey) === hydration) {
         this.cloudHydrationPromises.delete(hydrationKey);
+      }
+      if (
+        hydrationMode === "terminal-chain" &&
+        this.d.store.getSessions()[taskRunId]
+      ) {
+        this.d.store.updateSession(taskRunId, {
+          isHydratingTranscript: false,
+        });
       }
     });
     return hydration;
@@ -6540,8 +6558,10 @@ export class SessionService {
   }
 
   /**
-   * One probe page learns the chain total, then only the tail pages are
-   * fetched; small logs come back whole (windowStart 0). Null on failure.
+   * A one-entry probe learns the chain total without downloading a page an
+   * oversized log would throw away, then only the newest
+   * INITIAL_TAIL_WINDOW entries are fetched; older pages load on scroll.
+   * Null on failure.
    */
   private async fetchChainTranscriptWindow(
     client: SessionLogsClient,
@@ -6549,17 +6569,17 @@ export class SessionService {
     taskRunId: string,
   ): Promise<ChainTranscriptWindow | null> {
     try {
-      const first = await client.getTaskRunSessionLogsPage(taskId, taskRunId, {
-        limit: SESSION_LOGS_MAX_PAGE_SIZE,
+      const probe = await client.getTaskRunSessionLogsPage(taskId, taskRunId, {
+        limit: 1,
       });
-      if (!first.hasMore || first.entries.length === 0) {
+      if (!probe.hasMore) {
         return {
-          entries: first.entries,
+          entries: probe.entries,
           windowStart: 0,
-          chainTotal: first.entries.length,
+          chainTotal: probe.entries.length,
         };
       }
-      if (first.matchingCount === null) {
+      if (probe.matchingCount === null) {
         const result = await client.getTaskRunSessionLogsResult(
           taskId,
           taskRunId,
@@ -6572,17 +6592,14 @@ export class SessionService {
           chainTotal: result.truncatedHeadCount + result.entries.length,
         };
       }
-      const tailStart = Math.max(
-        first.entries.length,
-        first.matchingCount - SESSION_LOGS_MAX_PAGE_SIZE,
-      );
+      const tailStart = Math.max(0, probe.matchingCount - INITIAL_TAIL_WINDOW);
       const tail: StoredLogEntry[] = [];
       let offset = tailStart;
-      while (offset < first.matchingCount) {
+      while (offset < probe.matchingCount) {
         const page = await client.getTaskRunSessionLogsPage(taskId, taskRunId, {
           limit: Math.min(
             SESSION_LOGS_MAX_PAGE_SIZE,
-            first.matchingCount - offset,
+            probe.matchingCount - offset,
           ),
           offset,
         });
@@ -6591,19 +6608,14 @@ export class SessionService {
         offset += page.entries.length;
       }
       const chainTotal = tailStart + tail.length;
-      if (tailStart === first.entries.length) {
-        return {
-          entries: [...first.entries, ...tail],
-          windowStart: 0,
+      if (tailStart > 0) {
+        this.d.log.info("Hydrating cloud transcript tail window", {
+          taskId,
+          taskRunId,
+          windowStart: tailStart,
           chainTotal,
-        };
+        });
       }
-      this.d.log.info("Hydrating cloud transcript tail window", {
-        taskId,
-        taskRunId,
-        windowStart: tailStart,
-        chainTotal,
-      });
       return {
         entries: tail,
         windowStart: tailStart,
@@ -6713,8 +6725,15 @@ export class SessionService {
       // active; otherwise a renderer restart hydrates only the final run.
       // Non-resume in-progress runs keep using the single-run log so hydrate
       // cannot race the live stream and double the active turn.
-      const authStatus = await this.getAuthCredentialsStatus();
+      // Boot reaches here while auth is still restoring; bailing would leave
+      // the thread blank until something happens to re-trigger hydration.
+      const authStatus = await this.awaitAuthCredentialsSettled();
       if (authStatus.kind !== "ready") {
+        this.d.log.warn("Cloud session hydration skipped without credentials", {
+          taskId,
+          taskRunId,
+          auth: authStatus.kind,
+        });
         return;
       }
       if (resumeFromRunId) {
@@ -8252,6 +8271,19 @@ export class SessionService {
         error: String(error),
       });
       return prompt;
+    }
+  }
+
+  /** Poll auth out of its boot-time "restoring" state, bounded so a broken
+   *  restore can't hold callers forever. */
+  private async awaitAuthCredentialsSettled(): Promise<AuthCredentialsStatus> {
+    const deadline = Date.now() + AUTH_RESTORE_WAIT_MS;
+    for (;;) {
+      const status = await this.getAuthCredentialsStatus();
+      if (status.kind !== "restoring" || Date.now() >= deadline) return status;
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, AUTH_RESTORE_POLL_MS),
+      );
     }
   }
 

--- a/products/desktop/packages/core/src/sessions/sessionStore.ts
+++ b/products/desktop/packages/core/src/sessions/sessionStore.ts
@@ -145,6 +145,7 @@ export const sessionStoreSetters = {
       if (session && session.events.length > 0) {
         session.events = [];
         session.processedLineCount = 0;
+        session.transcriptWindowStart = 0;
       }
     });
   },
@@ -152,6 +153,10 @@ export const sessionStoreSetters = {
   /**
    * Replace a session's transcript in place (rehydration after eviction),
    * preserving its live status/config. No-op if the session is gone.
+   *
+   * The restore reads a whole log rather than a window, so it also retires any
+   * paging index: left behind, it would offer to prepend chain entries the
+   * restored transcript already holds.
    */
   restoreEvents: (
     taskRunId: string,
@@ -164,6 +169,7 @@ export const sessionStoreSetters = {
         for (const event of events) Object.freeze(event);
         session.events = events;
         session.processedLineCount = lineCount;
+        session.transcriptWindowStart = 0;
       }
     });
   },

--- a/products/desktop/packages/core/src/sessions/sessionStoreEviction.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionStoreEviction.test.ts
@@ -51,6 +51,26 @@ describe("evictEvents / restoreEvents", () => {
     expect(Object.isFrozen(s.events[0])).toBe(true);
   });
 
+  it.each([
+    ["evictEvents", () => sessionStoreSetters.evictEvents(RUN)],
+    [
+      "restoreEvents",
+      () =>
+        sessionStoreSetters.restoreEvents(
+          RUN,
+          [{ ts: 2, message: {} } as unknown as AcpMessage],
+          7,
+        ),
+    ],
+  ])("%s retires the older-history paging index", (_name, transition) => {
+    seedWithEvents();
+    sessionStoreSetters.updateSession(RUN, { transcriptWindowStart: 10_000 });
+
+    transition();
+
+    expect(sessionStore.getState().sessions[RUN].transcriptWindowStart).toBe(0);
+  });
+
   it("appendEvents and replaceOptimisticWithEvent freeze each stored event", () => {
     seedWithEvents();
     sessionStoreSetters.replaceOptimisticWithEvent(RUN, {

--- a/products/desktop/packages/core/src/sessions/sessionViewState.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionViewState.test.ts
@@ -71,6 +71,26 @@ describe("deriveSessionViewState", () => {
     expect(state.isCloudRunNotTerminal).toBe(true);
   });
 
+  it.each([
+    { isHydratingTranscript: true, expected: true },
+    { isHydratingTranscript: undefined, expected: false },
+  ])(
+    "shows an empty terminal thread as initializing only while its transcript hydrates (hydrating: $isHydratingTranscript)",
+    ({ isHydratingTranscript, expected }) => {
+      const session = makeSession("completed");
+      session.isHydratingTranscript = isHydratingTranscript;
+
+      const state = deriveSessionViewState(
+        session,
+        makeTask("completed"),
+        null,
+        true,
+      );
+
+      expect(state.isInitializing).toBe(expected);
+    },
+  );
+
   it("treats not_started as a non-terminal cloud state", () => {
     const state = deriveSessionViewState(
       undefined,

--- a/products/desktop/packages/core/src/sessions/sessionViewState.ts
+++ b/products/desktop/packages/core/src/sessions/sessionViewState.ts
@@ -51,8 +51,12 @@ export function deriveSessionViewState(
   const isNewSessionWithInitialPrompt =
     !task.latest_run?.id && !!task.description;
   const isResumingExistingSession = !!task.latest_run?.id;
+  const isHydratingEmptyTranscript =
+    isCloud && events.length === 0 && (session?.isHydratingTranscript ?? false);
   const isInitializing = isCloud
-    ? !hasError && (!session || (events.length === 0 && isCloudRunNotTerminal))
+    ? isHydratingEmptyTranscript ||
+      (!hasError &&
+        (!session || (events.length === 0 && isCloudRunNotTerminal)))
     : !session ||
       (session.status === "connecting" && events.length === 0) ||
       (session.status === "connected" &&

--- a/products/desktop/packages/core/src/sessions/sessionViewState.ts
+++ b/products/desktop/packages/core/src/sessions/sessionViewState.ts
@@ -20,8 +20,6 @@ export interface SessionViewState {
   errorTitle: string | undefined;
   errorMessage: string | undefined;
   errorRetryable: boolean | undefined;
-  hasOlderTranscript: boolean;
-  isLoadingOlderTranscript: boolean;
 }
 
 export function deriveSessionViewState(
@@ -83,7 +81,5 @@ export function deriveSessionViewState(
       session?.errorMessage ??
       (isCloud ? (session?.cloudErrorMessage ?? undefined) : undefined),
     errorRetryable: session?.errorRetryable,
-    hasOlderTranscript: isCloud && (session?.transcriptWindowStart ?? 0) > 0,
-    isLoadingOlderTranscript: session?.isLoadingOlderTranscript ?? false,
   };
 }

--- a/products/desktop/packages/core/src/sessions/sessionViewState.ts
+++ b/products/desktop/packages/core/src/sessions/sessionViewState.ts
@@ -20,6 +20,8 @@ export interface SessionViewState {
   errorTitle: string | undefined;
   errorMessage: string | undefined;
   errorRetryable: boolean | undefined;
+  hasOlderTranscript: boolean;
+  isLoadingOlderTranscript: boolean;
 }
 
 export function deriveSessionViewState(
@@ -81,5 +83,7 @@ export function deriveSessionViewState(
       session?.errorMessage ??
       (isCloud ? (session?.cloudErrorMessage ?? undefined) : undefined),
     errorRetryable: session?.errorRetryable,
+    hasOlderTranscript: isCloud && (session?.transcriptWindowStart ?? 0) > 0,
+    isLoadingOlderTranscript: session?.isLoadingOlderTranscript ?? false,
   };
 }

--- a/products/desktop/packages/shared/src/sessions.ts
+++ b/products/desktop/packages/shared/src/sessions.ts
@@ -68,6 +68,8 @@ export interface AgentSession {
   /** Absolute chain index of the first hydrated entry; >0 while older history is not loaded. */
   transcriptWindowStart?: number;
   isLoadingOlderTranscript?: boolean;
+  /** True while the terminal transcript is being fetched, so an empty thread shows as loading. */
+  isHydratingTranscript?: boolean;
   /** Leaf-run cursor used to reconcile live cloud log updates. */
   processedLineCount?: number;
   framework?: "claude";

--- a/products/desktop/packages/shared/src/sessions.ts
+++ b/products/desktop/packages/shared/src/sessions.ts
@@ -67,7 +67,6 @@ export interface AgentSession {
   cloudTranscriptEntryCount?: number;
   /** Absolute chain index of the first hydrated entry; >0 while older history is not loaded. */
   transcriptWindowStart?: number;
-  /** True while an older transcript page is being fetched for the scrolled-up thread. */
   isLoadingOlderTranscript?: boolean;
   /** Leaf-run cursor used to reconcile live cloud log updates. */
   processedLineCount?: number;

--- a/products/desktop/packages/shared/src/sessions.ts
+++ b/products/desktop/packages/shared/src/sessions.ts
@@ -65,6 +65,10 @@ export interface AgentSession {
   logUrl?: string;
   /** Full cloud transcript entry count across the resume chain. */
   cloudTranscriptEntryCount?: number;
+  /** Absolute chain index of the first hydrated entry; >0 while older history is not loaded. */
+  transcriptWindowStart?: number;
+  /** True while an older transcript page is being fetched for the scrolled-up thread. */
+  isLoadingOlderTranscript?: boolean;
   /** Leaf-run cursor used to reconcile live cloud log updates. */
   processedLineCount?: number;
   framework?: "claude";

--- a/products/desktop/packages/ui/src/features/sessions/components/ConversationView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ConversationView.tsx
@@ -99,6 +99,12 @@ export interface ConversationViewProps {
    * plain Up/Down presses (caret at the input boundary) to it.
    */
   promptRecallRef?: RefObject<PromptRecallHandler | null>;
+  /** True when older transcript history exists above the loaded window. */
+  hasOlderHistory?: boolean;
+  /** True while an older history page is loading. */
+  isLoadingOlderHistory?: boolean;
+  /** Invoked when the thread scrolls near the top of the loaded window. */
+  onLoadOlderHistory?: () => void;
 }
 
 export function ConversationView({

--- a/products/desktop/packages/ui/src/features/sessions/components/ConversationView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ConversationView.tsx
@@ -99,7 +99,8 @@ export interface ConversationViewProps {
    * plain Up/Down presses (caret at the input boundary) to it.
    */
   promptRecallRef?: RefObject<PromptRecallHandler | null>;
-  hasOlderHistory?: boolean;
+  /** See `SharedChatThreadProps.olderHistoryCursor`. */
+  olderHistoryCursor?: number;
   isLoadingOlderHistory?: boolean;
   onLoadOlderHistory?: () => void;
 }

--- a/products/desktop/packages/ui/src/features/sessions/components/ConversationView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ConversationView.tsx
@@ -99,11 +99,8 @@ export interface ConversationViewProps {
    * plain Up/Down presses (caret at the input boundary) to it.
    */
   promptRecallRef?: RefObject<PromptRecallHandler | null>;
-  /** True when older transcript history exists above the loaded window. */
   hasOlderHistory?: boolean;
-  /** True while an older history page is loading. */
   isLoadingOlderHistory?: boolean;
-  /** Invoked when the thread scrolls near the top of the loaded window. */
   onLoadOlderHistory?: () => void;
 }
 

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -258,9 +258,8 @@ export function SessionView({
   const currentModeId = modeOption?.currentValue;
   const handoffInProgress = useSessionHandoffInProgress(taskId);
   const showInlineBanner = hasError && errorRetryable && events.length > 0;
-  const hasOlderHistory = useSessionSelector(
-    taskId,
-    (session) => isCloud && (session?.transcriptWindowStart ?? 0) > 0,
+  const olderHistoryCursor = useSessionSelector(taskId, (session) =>
+    isCloud ? (session?.transcriptWindowStart ?? 0) : 0,
   );
   const isLoadingOlderHistory = useSessionSelector(
     taskId,
@@ -736,7 +735,7 @@ export function SessionView({
                   compact={compact}
                   scrollX={false}
                   promptRecallRef={promptRecallRef}
-                  hasOlderHistory={hasOlderHistory}
+                  olderHistoryCursor={olderHistoryCursor}
                   isLoadingOlderHistory={isLoadingOlderHistory}
                   onLoadOlderHistory={handleLoadOlderHistory}
                 />

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -258,6 +258,18 @@ export function SessionView({
   const currentModeId = modeOption?.currentValue;
   const handoffInProgress = useSessionHandoffInProgress(taskId);
   const showInlineBanner = hasError && errorRetryable && events.length > 0;
+  const hasOlderHistory = useSessionSelector(
+    taskId,
+    (session) => isCloud && (session?.transcriptWindowStart ?? 0) > 0,
+  );
+  const isLoadingOlderHistory = useSessionSelector(
+    taskId,
+    (session) => session?.isLoadingOlderTranscript ?? false,
+  );
+  const handleLoadOlderHistory = useCallback(() => {
+    if (!taskId) return;
+    void sessionService.loadOlderCloudTranscript(taskId);
+  }, [sessionService, taskId]);
 
   useEffect(() => {
     if (!taskId) return;
@@ -724,6 +736,9 @@ export function SessionView({
                   compact={compact}
                   scrollX={false}
                   promptRecallRef={promptRecallRef}
+                  hasOlderHistory={hasOlderHistory}
+                  isLoadingOlderHistory={isLoadingOlderHistory}
+                  onLoadOlderHistory={handleLoadOlderHistory}
                 />
 
                 <PlanStatusBar plan={latestPlan} />

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
@@ -215,6 +215,34 @@ describe("buildConversationItems", () => {
     ]);
   });
 
+  it("keeps item ids stable when older history is prepended", () => {
+    // The virtualized thread anchors the viewport on item ids across a
+    // prepend of older transcript pages, so an id must depend only on its
+    // own turn's events, never on how many items precede it.
+    const older: AcpMessage[] = [
+      userPromptMsg(1, 1, "first question"),
+      agentMessageMsg(2, "first reply"),
+      promptResponseMsg(3, 1),
+      userPromptMsg(4, 2, "second question"),
+      agentMessageMsg(5, "second reply"),
+      promptResponseMsg(6, 2),
+    ];
+    const tail: AcpMessage[] = [
+      userPromptMsg(10, 3, "later question"),
+      agentMessageMsg(11, "later reply"),
+      consoleMsg(12, "later tool output"),
+      promptResponseMsg(13, 3),
+    ];
+
+    const tailIds = buildConversationItems(tail, null).items.map((i) => i.id);
+    const fullIds = buildConversationItems([...older, ...tail], null).items.map(
+      (i) => i.id,
+    );
+
+    expect(tailIds.length).toBeGreaterThan(0);
+    expect(fullIds.slice(-tailIds.length)).toEqual(tailIds);
+  });
+
   it("clears the compacting spinner on a successful completion status, without duplicating the row", () => {
     // A successful compaction sends a terminal `status: compacting, isComplete:
     // true`. It must flip the existing status row, not append a second one.

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
@@ -216,9 +216,6 @@ describe("buildConversationItems", () => {
   });
 
   it("keeps item ids stable when older history is prepended", () => {
-    // The virtualized thread anchors the viewport on item ids across a
-    // prepend of older transcript pages, so an id must depend only on its
-    // own turn's events, never on how many items precede it.
     const older: AcpMessage[] = [
       userPromptMsg(1, 1, "first question"),
       agentMessageMsg(2, "first reply"),

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
@@ -1088,6 +1088,27 @@ describe("buildConversationItems", () => {
       expect(distinctContexts.size).toBe(4);
     });
 
+    it("keeps item ids distinct across implicit turns that share a timestamp", () => {
+      // Entries with a missing or unparseable timestamp all resolve to one `ts`.
+      // The virtualizer keys its measurement cache and its prepend anchor on the
+      // item id, so a duplicate anchors older history onto the wrong row.
+      const events = [
+        userPromptMsg(1, 1, "use a monitor"),
+        agentMessageMsg(2, "Monitor is running."),
+        turnCompleteMsg(3),
+        agentMessageMsg(10, "ping 1 received."),
+        backgroundTurnCompleteMsg(10),
+        agentMessageMsg(10, "ping 2 received."),
+        backgroundTurnCompleteMsg(10),
+      ];
+
+      const ids = buildConversationItems(events, true).items.map(
+        (item) => item.id,
+      );
+
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
     it("computes a real duration for an implicit turn once a background reply completes it", () => {
       const events = [
         userPromptMsg(1, 1, "use a monitor"),

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -979,7 +979,9 @@ function ensureImplicitTurn(b: ItemBuilder, ts: number) {
   if (b.currentTurn && !b.currentTurn.isComplete) return;
 
   b.currentTurnStartIndex = b.items.length;
-  const turnId = `turn-${ts}-implicit`;
+  // Entries with a missing or unparseable timestamp all share one `ts`, so the
+  // item index is what keeps two implicit turns from emitting the same item ids.
+  const turnId = `turn-${ts}-implicit-${b.currentTurnStartIndex}`;
   const toolCalls = new Map<string, ToolCall>();
   const childItems = new Map<string, ConversationItem[]>();
   const context: TurnContext = {

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -118,6 +118,10 @@ interface TurnState {
   context: TurnContext;
   gitAction: ReturnType<typeof parseGitActionMessage>;
   itemCount: number;
+  /** Per-turn id sequence. Derived from the turn's own events alone, so item
+   *  ids stay identical when older history is prepended and the whole
+   *  conversation rebuilds - the virtualized thread anchors on them. */
+  nextItemId: number;
 }
 
 export interface ItemBuilder {
@@ -131,7 +135,6 @@ export interface ItemBuilder {
   shellExecutes: Map<string, { item: UserShellExecute; index: number }>;
   isCompacting: boolean;
   isClearing: boolean;
-  nextId: () => number;
   /** Progress cards keyed by the backend-supplied `group` id. The first event
    *  for a group opens the card inline where it arrived; every subsequent
    *  event for the same id mutates the same card, regardless of which turn is
@@ -156,7 +159,6 @@ export interface ItemBuilder {
 }
 
 export function createItemBuilder(): ItemBuilder {
-  let idCounter = 0;
   return {
     items: [],
     currentTurn: null,
@@ -165,7 +167,6 @@ export function createItemBuilder(): ItemBuilder {
     shellExecutes: new Map(),
     isCompacting: false,
     isClearing: false,
-    nextId: () => idCounter++,
     progressCards: new Map(),
     lowestTouchedProgressIndex: Number.POSITIVE_INFINITY,
     completedToolCallCount: 0,
@@ -237,7 +238,7 @@ function pushItem(b: ItemBuilder, update: RenderItem, ts?: number) {
   turn.itemCount++;
   b.items.push({
     type: "session_update",
-    id: `${turn.id}-item-${b.nextId()}`,
+    id: `${turn.id}-item-${turn.nextItemId++}`,
     update,
     turnContext: turn.context,
     timestamp: ts,
@@ -566,6 +567,7 @@ function handlePromptRequest(
     context,
     gitAction,
     itemCount: 0,
+    nextItemId: 0,
   };
 
   b.pendingPrompts.set(msg.id, b.currentTurn);
@@ -998,6 +1000,7 @@ function ensureImplicitTurn(b: ItemBuilder, ts: number) {
     context,
     gitAction: { isGitAction: false, actionType: null, prompt: "" },
     itemCount: 0,
+    nextItemId: 0,
   };
 }
 
@@ -1034,7 +1037,7 @@ function pushChildItem(b: ItemBuilder, parentId: string, update: RenderItem) {
   turn.itemCount++;
   children.push({
     type: "session_update",
-    id: `${turn.id}-child-${b.nextId()}`,
+    id: `${turn.id}-child-${turn.nextItemId++}`,
     update,
     turnContext: turn.context,
   });
@@ -1080,7 +1083,7 @@ function appendTextChunkToChildren(
     turn.itemCount++;
     children.push({
       type: "session_update",
-      id: `${turn.id}-child-${b.nextId()}`,
+      id: `${turn.id}-child-${turn.nextItemId++}`,
       update: { ...update, content: { ...update.content } },
       turnContext: turn.context,
     });

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -118,9 +118,7 @@ interface TurnState {
   context: TurnContext;
   gitAction: ReturnType<typeof parseGitActionMessage>;
   itemCount: number;
-  /** Per-turn id sequence. Derived from the turn's own events alone, so item
-   *  ids stay identical when older history is prepended and the whole
-   *  conversation rebuilds - the virtualized thread anchors on them. */
+  /** Per-turn so item ids survive older-history prepends; the virtualized thread anchors on them. */
   nextItemId: number;
 }
 

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -1244,6 +1244,12 @@ interface SharedChatThreadProps {
   taskId?: string;
   footerState?: Omit<BuildResult, "items">;
   hasPendingPermission?: boolean;
+  /** True when older transcript history exists above the loaded window. */
+  hasOlderHistory?: boolean;
+  /** True while an older history page is loading. */
+  isLoadingOlderHistory?: boolean;
+  /** Invoked when the thread scrolls near the top of the loaded window. */
+  onLoadOlderHistory?: () => void;
 }
 
 export interface ChatThreadProps extends SharedChatThreadProps {
@@ -1342,6 +1348,9 @@ function ChatThreadRenderer({
   footerState,
   hasPendingPermission,
   promptRecallRef,
+  hasOlderHistory,
+  isLoadingOlderHistory,
+  onLoadOlderHistory,
 }: ChatThreadRendererProps) {
   const diffWorkerFactory = useService<DiffWorkerFactory>(DIFF_WORKER_FACTORY);
   const diffsPoolOptions = useMemo(
@@ -1538,6 +1547,9 @@ function ChatThreadRenderer({
                 footer={footer}
                 renderNav={renderNav}
                 resumeRef={threadResumeRef}
+                hasOlderHistory={hasOlderHistory}
+                isLoadingOlderHistory={isLoadingOlderHistory}
+                onLoadOlderHistory={onLoadOlderHistory}
               />
             ) : (
               <>

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -67,6 +67,7 @@ import { ToolGroup } from "@posthog/ui/features/sessions/components/chat-thread/
 import { THREAD_HOTKEY_OPTIONS } from "@posthog/ui/features/sessions/components/chat-thread/threadHotkeys";
 import {
   type AgentTurn,
+  CHAT_THREAD_VIRTUALIZATION_THRESHOLD,
   completedTurnTimestamp,
   countFlatRows,
   type FlatThreadRow,
@@ -74,10 +75,10 @@ import {
   flattenTurnRows,
   keyTurnRows,
   nextThreadFollowState,
+  OLDER_HISTORY_LOAD_THRESHOLD_PX,
   SCROLL_PREVIOUS_ITEM_PEEK,
   SCROLL_UP_KEYS,
   sampleThreadScroll,
-  shouldVirtualizeThread,
   type ThreadFollowState,
   type ThreadItem,
   type ThreadScrollResume,
@@ -945,6 +946,63 @@ function ThreadAutoFollow({
 }
 
 /**
+ * Older-history paging for the non-virtualized body: fires one page load per gesture when the
+ * reader scrolls near the top of the loaded window, plus once when the viewport is already parked
+ * there (a viewport at scrollTop 0 produces no scroll events). Once a loaded page pushes the row
+ * count past the virtualization threshold, the ratchet flips and the virtualized body's own
+ * loader takes over.
+ */
+function ThreadOlderHistoryLoader({
+  hasOlderHistory,
+  isLoadingOlderHistory,
+  onLoadOlderHistory,
+}: {
+  hasOlderHistory: boolean;
+  isLoadingOlderHistory: boolean;
+  onLoadOlderHistory?: () => void;
+}) {
+  const probeRef = useRef<HTMLSpanElement>(null);
+  const armedRef = useRef(false);
+  const onLoadRef = useRef(onLoadOlderHistory);
+  useEffect(() => {
+    onLoadRef.current = onLoadOlderHistory;
+  }, [onLoadOlderHistory]);
+
+  useEffect(() => {
+    armedRef.current =
+      hasOlderHistory && !isLoadingOlderHistory && onLoadOlderHistory != null;
+    if (!armedRef.current) return;
+    const viewport = probeRef.current
+      ?.closest('[data-slot="chat-message-scroller"]')
+      ?.querySelector('[data-slot="chat-message-scroller-viewport"]');
+    if (!(viewport instanceof HTMLElement)) return;
+    const maybeLoad = () => {
+      if (!armedRef.current) return;
+      if (viewport.scrollTop > OLDER_HISTORY_LOAD_THRESHOLD_PX) return;
+      armedRef.current = false;
+      onLoadRef.current?.();
+    };
+    const id = window.setTimeout(maybeLoad, 250);
+    viewport.addEventListener("scroll", maybeLoad, { passive: true });
+    return () => {
+      window.clearTimeout(id);
+      viewport.removeEventListener("scroll", maybeLoad);
+    };
+  }, [hasOlderHistory, isLoadingOlderHistory, onLoadOlderHistory]);
+
+  return (
+    <>
+      <span ref={probeRef} className="hidden" aria-hidden="true" />
+      {isLoadingOlderHistory && (
+        <div className="-translate-x-1/2 pointer-events-none absolute top-2 left-1/2 z-10 rounded-full border border-(--gray-5) bg-(--gray-2) px-3 py-1 text-(--gray-11) text-xs">
+          Loading earlier messages…
+        </div>
+      )}
+    </>
+  );
+}
+
+/**
  * Keyboard message navigation (Alt/Option+Up/Down) and the Cmd/Ctrl+J jump picker. Rendered inside
  * `ChatMessageScrollerProvider` so it can call `scrollToMessage` from the engine — the same primitive
  * `MessageMinimap` uses to jump back to an earlier turn.
@@ -1093,6 +1151,9 @@ function ThreadScrollBody({
   onUserInteract,
   resumeStateRef,
   autoFollowRef,
+  hasOlderHistory = false,
+  isLoadingOlderHistory = false,
+  onLoadOlderHistory,
 }: {
   items: ConversationItem[];
   rows: TurnRow[];
@@ -1105,6 +1166,9 @@ function ThreadScrollBody({
   /** Continuously updated so the virtualized body can take over mid-session (see {@link ThreadScrollResume}). */
   resumeStateRef: RefObject<ThreadScrollResume>;
   autoFollowRef: RefObject<ThreadFollowState>;
+  hasOlderHistory?: boolean;
+  isLoadingOlderHistory?: boolean;
+  onLoadOlderHistory?: () => void;
 }) {
   const keyedRows = useMemo(() => keyTurnRows(rows), [rows]);
 
@@ -1119,6 +1183,11 @@ function ThreadScrollBody({
     >
       <MessageMinimap items={items} />
       <ThreadAutoFollow items={items} followRef={autoFollowRef} />
+      <ThreadOlderHistoryLoader
+        hasOlderHistory={hasOlderHistory}
+        isLoadingOlderHistory={isLoadingOlderHistory}
+        onLoadOlderHistory={onLoadOlderHistory}
+      />
       <ThreadScrollStateRecorder stateRef={resumeStateRef} />
       <ChatMessageScrollerViewport>
         <ChatMessageScrollerContent
@@ -1377,12 +1446,10 @@ function ChatThreadRenderer({
   // sessions start virtualized from the first render; a live session flips once mid-stream,
   // resuming from the scroll state the non-virtualized body recorded.
   const flatCount = useMemo(() => countFlatRows(rows), [rows]);
-  const shouldVirtualize = shouldVirtualizeThread(
-    flatCount,
-    hasOlderHistory === true,
+  const [virtualized, setVirtualized] = useState(
+    () => flatCount > CHAT_THREAD_VIRTUALIZATION_THRESHOLD,
   );
-  const [virtualized, setVirtualized] = useState(() => shouldVirtualize);
-  if (!virtualized && shouldVirtualize) {
+  if (!virtualized && flatCount > CHAT_THREAD_VIRTUALIZATION_THRESHOLD) {
     setVirtualized(true);
   }
   const flatRows = useMemo(
@@ -1561,6 +1628,9 @@ function ChatThreadRenderer({
                   onUserInteract={clearKeyboardFocus}
                   footer={footer}
                   resumeStateRef={threadResumeRef}
+                  hasOlderHistory={hasOlderHistory}
+                  isLoadingOlderHistory={isLoadingOlderHistory}
+                  onLoadOlderHistory={onLoadOlderHistory}
                 />
                 {renderNav()}
               </>

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -75,7 +75,6 @@ import {
   flattenTurnRows,
   keyTurnRows,
   nextThreadFollowState,
-  OLDER_HISTORY_LOAD_THRESHOLD_PX,
   SCROLL_PREVIOUS_ITEM_PEEK,
   SCROLL_UP_KEYS,
   sampleThreadScroll,
@@ -946,63 +945,6 @@ function ThreadAutoFollow({
 }
 
 /**
- * Older-history paging for the non-virtualized body: fires one page load per gesture when the
- * reader scrolls near the top of the loaded window, plus once when the viewport is already parked
- * there (a viewport at scrollTop 0 produces no scroll events). Once a loaded page pushes the row
- * count past the virtualization threshold, the ratchet flips and the virtualized body's own
- * loader takes over.
- */
-function ThreadOlderHistoryLoader({
-  hasOlderHistory,
-  isLoadingOlderHistory,
-  onLoadOlderHistory,
-}: {
-  hasOlderHistory: boolean;
-  isLoadingOlderHistory: boolean;
-  onLoadOlderHistory?: () => void;
-}) {
-  const probeRef = useRef<HTMLSpanElement>(null);
-  const armedRef = useRef(false);
-  const onLoadRef = useRef(onLoadOlderHistory);
-  useEffect(() => {
-    onLoadRef.current = onLoadOlderHistory;
-  }, [onLoadOlderHistory]);
-
-  useEffect(() => {
-    armedRef.current =
-      hasOlderHistory && !isLoadingOlderHistory && onLoadOlderHistory != null;
-    if (!armedRef.current) return;
-    const viewport = probeRef.current
-      ?.closest('[data-slot="chat-message-scroller"]')
-      ?.querySelector('[data-slot="chat-message-scroller-viewport"]');
-    if (!(viewport instanceof HTMLElement)) return;
-    const maybeLoad = () => {
-      if (!armedRef.current) return;
-      if (viewport.scrollTop > OLDER_HISTORY_LOAD_THRESHOLD_PX) return;
-      armedRef.current = false;
-      onLoadRef.current?.();
-    };
-    const id = window.setTimeout(maybeLoad, 250);
-    viewport.addEventListener("scroll", maybeLoad, { passive: true });
-    return () => {
-      window.clearTimeout(id);
-      viewport.removeEventListener("scroll", maybeLoad);
-    };
-  }, [hasOlderHistory, isLoadingOlderHistory, onLoadOlderHistory]);
-
-  return (
-    <>
-      <span ref={probeRef} className="hidden" aria-hidden="true" />
-      {isLoadingOlderHistory && (
-        <div className="-translate-x-1/2 pointer-events-none absolute top-2 left-1/2 z-10 rounded-full border border-(--gray-5) bg-(--gray-2) px-3 py-1 text-(--gray-11) text-xs">
-          Loading earlier messages…
-        </div>
-      )}
-    </>
-  );
-}
-
-/**
  * Keyboard message navigation (Alt/Option+Up/Down) and the Cmd/Ctrl+J jump picker. Rendered inside
  * `ChatMessageScrollerProvider` so it can call `scrollToMessage` from the engine — the same primitive
  * `MessageMinimap` uses to jump back to an earlier turn.
@@ -1151,9 +1093,6 @@ function ThreadScrollBody({
   onUserInteract,
   resumeStateRef,
   autoFollowRef,
-  hasOlderHistory = false,
-  isLoadingOlderHistory = false,
-  onLoadOlderHistory,
 }: {
   items: ConversationItem[];
   rows: TurnRow[];
@@ -1166,9 +1105,6 @@ function ThreadScrollBody({
   /** Continuously updated so the virtualized body can take over mid-session (see {@link ThreadScrollResume}). */
   resumeStateRef: RefObject<ThreadScrollResume>;
   autoFollowRef: RefObject<ThreadFollowState>;
-  hasOlderHistory?: boolean;
-  isLoadingOlderHistory?: boolean;
-  onLoadOlderHistory?: () => void;
 }) {
   const keyedRows = useMemo(() => keyTurnRows(rows), [rows]);
 
@@ -1183,11 +1119,6 @@ function ThreadScrollBody({
     >
       <MessageMinimap items={items} />
       <ThreadAutoFollow items={items} followRef={autoFollowRef} />
-      <ThreadOlderHistoryLoader
-        hasOlderHistory={hasOlderHistory}
-        isLoadingOlderHistory={isLoadingOlderHistory}
-        onLoadOlderHistory={onLoadOlderHistory}
-      />
       <ThreadScrollStateRecorder stateRef={resumeStateRef} />
       <ChatMessageScrollerViewport>
         <ChatMessageScrollerContent
@@ -1313,7 +1244,11 @@ interface SharedChatThreadProps {
   taskId?: string;
   footerState?: Omit<BuildResult, "items">;
   hasPendingPermission?: boolean;
-  hasOlderHistory?: boolean;
+  /**
+   * Chain index of the oldest loaded entry; 0 means the whole transcript is loaded. Above 0 the
+   * thread renders windowed regardless of length, because only that body survives a prepend.
+   */
+  olderHistoryCursor?: number;
   isLoadingOlderHistory?: boolean;
   onLoadOlderHistory?: () => void;
 }
@@ -1414,7 +1349,7 @@ function ChatThreadRenderer({
   footerState,
   hasPendingPermission,
   promptRecallRef,
-  hasOlderHistory,
+  olderHistoryCursor = 0,
   isLoadingOlderHistory,
   onLoadOlderHistory,
 }: ChatThreadRendererProps) {
@@ -1445,11 +1380,15 @@ function ChatThreadRenderer({
   // stays there for the life of this mount (see CHAT_THREAD_VIRTUALIZATION_THRESHOLD). Long
   // sessions start virtualized from the first render; a live session flips once mid-stream,
   // resuming from the scroll state the non-virtualized body recorded.
+  //
+  // A pageable transcript is windowed however short it is: prepending older history shifts the
+  // non-virtualized body's ordinal keys, which rebinds mounted rows to older content and loses the
+  // reader's place (see {@link keyTurnRows}).
   const flatCount = useMemo(() => countFlatRows(rows), [rows]);
-  const [virtualized, setVirtualized] = useState(
-    () => flatCount > CHAT_THREAD_VIRTUALIZATION_THRESHOLD,
-  );
-  if (!virtualized && flatCount > CHAT_THREAD_VIRTUALIZATION_THRESHOLD) {
+  const needsWindowing =
+    flatCount > CHAT_THREAD_VIRTUALIZATION_THRESHOLD || olderHistoryCursor > 0;
+  const [virtualized, setVirtualized] = useState(() => needsWindowing);
+  if (!virtualized && needsWindowing) {
     setVirtualized(true);
   }
   const flatRows = useMemo(
@@ -1613,7 +1552,7 @@ function ChatThreadRenderer({
                 footer={footer}
                 renderNav={renderNav}
                 resumeRef={threadResumeRef}
-                hasOlderHistory={hasOlderHistory}
+                olderHistoryCursor={olderHistoryCursor}
                 isLoadingOlderHistory={isLoadingOlderHistory}
                 onLoadOlderHistory={onLoadOlderHistory}
               />
@@ -1628,9 +1567,6 @@ function ChatThreadRenderer({
                   onUserInteract={clearKeyboardFocus}
                   footer={footer}
                   resumeStateRef={threadResumeRef}
-                  hasOlderHistory={hasOlderHistory}
-                  isLoadingOlderHistory={isLoadingOlderHistory}
-                  onLoadOlderHistory={onLoadOlderHistory}
                 />
                 {renderNav()}
               </>

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -67,7 +67,6 @@ import { ToolGroup } from "@posthog/ui/features/sessions/components/chat-thread/
 import { THREAD_HOTKEY_OPTIONS } from "@posthog/ui/features/sessions/components/chat-thread/threadHotkeys";
 import {
   type AgentTurn,
-  CHAT_THREAD_VIRTUALIZATION_THRESHOLD,
   completedTurnTimestamp,
   countFlatRows,
   type FlatThreadRow,
@@ -78,6 +77,7 @@ import {
   SCROLL_PREVIOUS_ITEM_PEEK,
   SCROLL_UP_KEYS,
   sampleThreadScroll,
+  shouldVirtualizeThread,
   type ThreadFollowState,
   type ThreadItem,
   type ThreadScrollResume,
@@ -1377,10 +1377,12 @@ function ChatThreadRenderer({
   // sessions start virtualized from the first render; a live session flips once mid-stream,
   // resuming from the scroll state the non-virtualized body recorded.
   const flatCount = useMemo(() => countFlatRows(rows), [rows]);
-  const [virtualized, setVirtualized] = useState(
-    () => flatCount > CHAT_THREAD_VIRTUALIZATION_THRESHOLD,
+  const shouldVirtualize = shouldVirtualizeThread(
+    flatCount,
+    hasOlderHistory === true,
   );
-  if (!virtualized && flatCount > CHAT_THREAD_VIRTUALIZATION_THRESHOLD) {
+  const [virtualized, setVirtualized] = useState(() => shouldVirtualize);
+  if (!virtualized && shouldVirtualize) {
     setVirtualized(true);
   }
   const flatRows = useMemo(

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -1244,11 +1244,8 @@ interface SharedChatThreadProps {
   taskId?: string;
   footerState?: Omit<BuildResult, "items">;
   hasPendingPermission?: boolean;
-  /** True when older transcript history exists above the loaded window. */
   hasOlderHistory?: boolean;
-  /** True while an older history page is loading. */
   isLoadingOlderHistory?: boolean;
-  /** Invoked when the thread scrolls near the top of the loaded window. */
   onLoadOlderHistory?: () => void;
 }
 

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/MessageMinimap.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/MessageMinimap.tsx
@@ -14,7 +14,9 @@ import {
 } from "@posthog/ui/primitives/OverflowTickerText";
 import { useCallback, useMemo, useRef, useState } from "react";
 
-/** Ticks drawn in the collapsed rail. Older turns fall off the top so the rail stays small. */
+/** Ticks drawn in the collapsed rail. The tick window slides with the reading
+ *  position so the current turn always has a tick, wherever it sits in the
+ *  loaded history. */
 const MAX_TICKS = 12;
 const MAX_LABEL_LENGTH = 200;
 /** Message length (chars) at which a tick reaches full width. */
@@ -136,6 +138,19 @@ export function MessageMinimap({
     return result;
   }, [items]);
 
+  const railEntries = useMemo<MinimapEntry[]>(() => {
+    if (entries.length <= MAX_TICKS) return entries;
+    const anchorIndex = entries.findIndex(
+      (entry) => entry.id === currentAnchorId,
+    );
+    if (anchorIndex === -1) return entries.slice(-MAX_TICKS);
+    const start = Math.min(
+      Math.max(0, anchorIndex - Math.floor(MAX_TICKS / 2)),
+      entries.length - MAX_TICKS,
+    );
+    return entries.slice(start, start + MAX_TICKS);
+  }, [entries, currentAnchorId]);
+
   const handleOpenChange = useCallback((nextOpen: boolean) => {
     if (!nextOpen) reopenBlockedUntil.current = Date.now() + 250;
     setOpen(nextOpen);
@@ -178,7 +193,7 @@ export function MessageMinimap({
             "focus-visible:outline-(--accent-8) focus-visible:outline-2 focus-visible:outline-offset-1",
           )}
         >
-          {entries.slice(-MAX_TICKS).map((entry) => (
+          {railEntries.map((entry) => (
             <span
               key={entry.id}
               aria-hidden="true"

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/VirtualThreadScrollBody.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/VirtualThreadScrollBody.tsx
@@ -11,6 +11,7 @@ import {
   type FlatThreadRow,
   FOLLOWING_END,
   nextThreadFollowState,
+  OLDER_HISTORY_LOAD_THRESHOLD_PX,
   SCROLL_PREVIOUS_ITEM_PEEK,
   SCROLL_UP_KEYS,
   type StickyAnchorEntry,
@@ -43,7 +44,6 @@ import {
 // tuning these rows share (same item mix, same measure-then-settle churn).
 const ESTIMATED_ROW_SIZE = 80;
 const OVERSCAN = 12;
-const OLDER_HISTORY_LOAD_THRESHOLD_PX = 800;
 /** Top of the virtual coordinate space — stands in for the non-virtualized content's `py-4`. */
 const PADDING_START = 16;
 /** Frames a programmatic scroll keeps re-issuing while rows around the target still measure. */

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/VirtualThreadScrollBody.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/VirtualThreadScrollBody.tsx
@@ -43,6 +43,7 @@ import {
 // tuning these rows share (same item mix, same measure-then-settle churn).
 const ESTIMATED_ROW_SIZE = 80;
 const OVERSCAN = 12;
+const OLDER_HISTORY_LOAD_THRESHOLD_PX = 800;
 /** Top of the virtual coordinate space — stands in for the non-virtualized content's `py-4`. */
 const PADDING_START = 16;
 /** Frames a programmatic scroll keeps re-issuing while rows around the target still measure. */
@@ -301,6 +302,9 @@ export function VirtualThreadScrollBody({
   onUserInteract,
   renderNav,
   resumeRef,
+  hasOlderHistory = false,
+  isLoadingOlderHistory = false,
+  onLoadOlderHistory,
 }: {
   items: ConversationItem[];
   flatRows: FlatThreadRow[];
@@ -317,6 +321,12 @@ export function VirtualThreadScrollBody({
   renderNav?: (jumpToMessage: (id: string) => boolean) => ReactNode;
   /** Where the non-virtualized body left off, read once when this body takes over mid-session. */
   resumeRef: RefObject<ThreadScrollResume>;
+  /** True when older transcript history exists above the loaded window. */
+  hasOlderHistory?: boolean;
+  /** True while an older history page is loading. */
+  isLoadingOlderHistory?: boolean;
+  /** Invoked when the reader scrolls near the top of the loaded window. */
+  onLoadOlderHistory?: () => void;
 }) {
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const footerRef = useRef<HTMLDivElement | null>(null);
@@ -336,8 +346,19 @@ export function VirtualThreadScrollBody({
     scrollEndThreshold: THREAD_AT_END_THRESHOLD,
     paddingStart: PADDING_START,
     paddingEnd: footerHeight,
-    getItemKey: (index) => flatRows[index]?.key ?? index,
+    // Keyed by item id, not row key: user-turn row keys are ordinals that
+    // shift when older history prepends, and the end-anchored virtualizer
+    // relies on key identity to hold the viewport still across that prepend.
+    getItemKey: (index) => flatRows[index]?.item.id ?? index,
   });
+
+  // Re-armed by the props flipping back rather than by re-render, so one
+  // scroll gesture near the top loads exactly one older page.
+  const loadOlderArmedRef = useRef(false);
+  loadOlderArmedRef.current =
+    hasOlderHistory && !isLoadingOlderHistory && onLoadOlderHistory != null;
+  const onLoadOlderHistoryRef = useRef(onLoadOlderHistory);
+  onLoadOlderHistoryRef.current = onLoadOlderHistory;
 
   const { followRef, leaveEnd, settleAtEnd, settleToIndex } = useSettleControls(
     virtualizer,
@@ -404,6 +425,13 @@ export function VirtualThreadScrollBody({
       const sample = sampleThreadScroll(el, lastScrollTopRef.current);
       lastScrollTopRef.current = el.scrollTop;
       followRef.current = nextThreadFollowState(followRef.current, sample);
+      if (
+        loadOlderArmedRef.current &&
+        el.scrollTop <= OLDER_HISTORY_LOAD_THRESHOLD_PX
+      ) {
+        loadOlderArmedRef.current = false;
+        onLoadOlderHistoryRef.current?.();
+      }
     }
     scheduleStickyRecompute();
   }, [scheduleStickyRecompute, followRef]);
@@ -429,6 +457,11 @@ export function VirtualThreadScrollBody({
           onJump={jumpToMessage}
           anchorId={stickyState.anchorId}
         />
+        {isLoadingOlderHistory && (
+          <div className="-translate-x-1/2 pointer-events-none absolute top-2 left-1/2 z-10 rounded-full border border-(--gray-5) bg-(--gray-2) px-3 py-1 text-(--gray-11) text-xs">
+            Loading earlier messages…
+          </div>
+        )}
         <ChatMessageScrollerViewport
           ref={viewportRef}
           onScroll={handleScroll}

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/VirtualThreadScrollBody.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/VirtualThreadScrollBody.tsx
@@ -366,19 +366,26 @@ export function VirtualThreadScrollBody({
       canLoad: canLoadOlderRef.current,
       isLoading: isLoadingOlderRef.current,
       scrollTop: el.scrollTop,
+      maxScrollTop: el.scrollHeight - el.clientHeight,
     });
     loadOlderArmedRef.current = next.armed;
     if (next.load) onLoadOlderHistoryRef.current?.();
   }, []);
 
-  // Keyed on the cursor rather than the in-flight flag: the cursor moves only
-  // when a page lands, so arming here cannot retry a failure. A viewport parked
-  // at the very top produces no scroll events, hence the timer.
+  // Arming belongs to the scroll handler, so one gesture buys one page. This
+  // only covers what a gesture cannot reach: the first cursor the body sees, and
+  // a viewport parked with no scroll room, which emits no scroll events at all.
+  // Arming on every cursor move would instead chain page after page, because a
+  // page of collapsed tool rows lands the viewport back inside the threshold.
   useEffect(() => {
-    canLoadOlderRef.current =
-      olderHistoryCursor > 0 && onLoadOlderHistory != null;
-    loadOlderArmedRef.current = canLoadOlderRef.current;
-    if (!loadOlderArmedRef.current) return;
+    const canLoad = olderHistoryCursor > 0 && onLoadOlderHistory != null;
+    const becameAvailable = canLoad && !canLoadOlderRef.current;
+    canLoadOlderRef.current = canLoad;
+    if (!canLoad) {
+      loadOlderArmedRef.current = false;
+      return;
+    }
+    if (becameAvailable) loadOlderArmedRef.current = true;
     const id = window.setTimeout(maybeLoadOlderHistory, 250);
     return () => window.clearTimeout(id);
   }, [olderHistoryCursor, onLoadOlderHistory, maybeLoadOlderHistory]);

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/VirtualThreadScrollBody.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/VirtualThreadScrollBody.tsx
@@ -43,6 +43,7 @@ import {
 // tuning these rows share (same item mix, same measure-then-settle churn).
 const ESTIMATED_ROW_SIZE = 80;
 const OVERSCAN = 12;
+/** Roughly a viewport of estimated rows: far enough to prefetch mid-fling, near enough that a slow read to the top doesn't chain loads. */
 const OLDER_HISTORY_LOAD_THRESHOLD_PX = 800;
 /** Top of the virtual coordinate space — stands in for the non-virtualized content's `py-4`. */
 const PADDING_START = 16;
@@ -346,10 +347,7 @@ export function VirtualThreadScrollBody({
     scrollEndThreshold: THREAD_AT_END_THRESHOLD,
     paddingStart: PADDING_START,
     paddingEnd: footerHeight,
-    // Keyed by item id, not row key: user-turn row keys are ordinals that
-    // shift when older history prepends, and the end-anchored virtualizer
-    // relies on key identity to hold the viewport still across that prepend.
-    getItemKey: (index) => flatRows[index]?.item.id ?? index,
+    getItemKey: (index) => flatRows[index]?.key ?? index,
   });
 
   // Re-armed by the props flipping back rather than by re-render, so one
@@ -371,7 +369,8 @@ export function VirtualThreadScrollBody({
   // A viewport parked at the very top produces no scroll events (Home or a
   // wheel-up at scrollTop 0 changes nothing), so arming alone must also
   // attempt a load: on mount at the top, and again after each page lands
-  // while the reader stays parked there.
+  // while the reader stays parked there. The delay lets the end-anchored
+  // initial layout settle so a fresh mount reads its real scrollTop, not 0.
   useEffect(() => {
     if (!hasOlderHistory || isLoadingOlderHistory) return;
     const id = window.setTimeout(maybeLoadOlderHistory, 250);

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/VirtualThreadScrollBody.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/VirtualThreadScrollBody.tsx
@@ -348,10 +348,10 @@ export function VirtualThreadScrollBody({
 
   // Re-armed by the props flipping back, so one gesture loads one page.
   const loadOlderArmedRef = useRef(false);
-  loadOlderArmedRef.current =
-    hasOlderHistory && !isLoadingOlderHistory && onLoadOlderHistory != null;
   const onLoadOlderHistoryRef = useRef(onLoadOlderHistory);
-  onLoadOlderHistoryRef.current = onLoadOlderHistory;
+  useEffect(() => {
+    onLoadOlderHistoryRef.current = onLoadOlderHistory;
+  }, [onLoadOlderHistory]);
 
   const maybeLoadOlderHistory = useCallback(() => {
     const el = viewportRef.current;
@@ -364,10 +364,17 @@ export function VirtualThreadScrollBody({
   // A viewport parked at the very top produces no scroll events, so arming
   // must also attempt a load once the end-anchored layout has settled.
   useEffect(() => {
-    if (!hasOlderHistory || isLoadingOlderHistory) return;
+    loadOlderArmedRef.current =
+      hasOlderHistory && !isLoadingOlderHistory && onLoadOlderHistory != null;
+    if (!loadOlderArmedRef.current) return;
     const id = window.setTimeout(maybeLoadOlderHistory, 250);
     return () => window.clearTimeout(id);
-  }, [hasOlderHistory, isLoadingOlderHistory, maybeLoadOlderHistory]);
+  }, [
+    hasOlderHistory,
+    isLoadingOlderHistory,
+    onLoadOlderHistory,
+    maybeLoadOlderHistory,
+  ]);
 
   const { followRef, leaveEnd, settleAtEnd, settleToIndex } = useSettleControls(
     virtualizer,

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/VirtualThreadScrollBody.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/VirtualThreadScrollBody.tsx
@@ -43,7 +43,6 @@ import {
 // tuning these rows share (same item mix, same measure-then-settle churn).
 const ESTIMATED_ROW_SIZE = 80;
 const OVERSCAN = 12;
-/** Roughly a viewport of estimated rows: far enough to prefetch mid-fling, near enough that a slow read to the top doesn't chain loads. */
 const OLDER_HISTORY_LOAD_THRESHOLD_PX = 800;
 /** Top of the virtual coordinate space — stands in for the non-virtualized content's `py-4`. */
 const PADDING_START = 16;
@@ -322,11 +321,8 @@ export function VirtualThreadScrollBody({
   renderNav?: (jumpToMessage: (id: string) => boolean) => ReactNode;
   /** Where the non-virtualized body left off, read once when this body takes over mid-session. */
   resumeRef: RefObject<ThreadScrollResume>;
-  /** True when older transcript history exists above the loaded window. */
   hasOlderHistory?: boolean;
-  /** True while an older history page is loading. */
   isLoadingOlderHistory?: boolean;
-  /** Invoked when the reader scrolls near the top of the loaded window. */
   onLoadOlderHistory?: () => void;
 }) {
   const viewportRef = useRef<HTMLDivElement | null>(null);
@@ -350,8 +346,7 @@ export function VirtualThreadScrollBody({
     getItemKey: (index) => flatRows[index]?.key ?? index,
   });
 
-  // Re-armed by the props flipping back rather than by re-render, so one
-  // scroll gesture near the top loads exactly one older page.
+  // Re-armed by the props flipping back, so one gesture loads one page.
   const loadOlderArmedRef = useRef(false);
   loadOlderArmedRef.current =
     hasOlderHistory && !isLoadingOlderHistory && onLoadOlderHistory != null;
@@ -366,11 +361,8 @@ export function VirtualThreadScrollBody({
     onLoadOlderHistoryRef.current?.();
   }, []);
 
-  // A viewport parked at the very top produces no scroll events (Home or a
-  // wheel-up at scrollTop 0 changes nothing), so arming alone must also
-  // attempt a load: on mount at the top, and again after each page lands
-  // while the reader stays parked there. The delay lets the end-anchored
-  // initial layout settle so a fresh mount reads its real scrollTop, not 0.
+  // A viewport parked at the very top produces no scroll events, so arming
+  // must also attempt a load once the end-anchored layout has settled.
   useEffect(() => {
     if (!hasOlderHistory || isLoadingOlderHistory) return;
     const id = window.setTimeout(maybeLoadOlderHistory, 250);

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/VirtualThreadScrollBody.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/VirtualThreadScrollBody.tsx
@@ -360,6 +360,24 @@ export function VirtualThreadScrollBody({
   const onLoadOlderHistoryRef = useRef(onLoadOlderHistory);
   onLoadOlderHistoryRef.current = onLoadOlderHistory;
 
+  const maybeLoadOlderHistory = useCallback(() => {
+    const el = viewportRef.current;
+    if (!el || !loadOlderArmedRef.current) return;
+    if (el.scrollTop > OLDER_HISTORY_LOAD_THRESHOLD_PX) return;
+    loadOlderArmedRef.current = false;
+    onLoadOlderHistoryRef.current?.();
+  }, []);
+
+  // A viewport parked at the very top produces no scroll events (Home or a
+  // wheel-up at scrollTop 0 changes nothing), so arming alone must also
+  // attempt a load: on mount at the top, and again after each page lands
+  // while the reader stays parked there.
+  useEffect(() => {
+    if (!hasOlderHistory || isLoadingOlderHistory) return;
+    const id = window.setTimeout(maybeLoadOlderHistory, 250);
+    return () => window.clearTimeout(id);
+  }, [hasOlderHistory, isLoadingOlderHistory, maybeLoadOlderHistory]);
+
   const { followRef, leaveEnd, settleAtEnd, settleToIndex } = useSettleControls(
     virtualizer,
     viewportRef,
@@ -425,16 +443,10 @@ export function VirtualThreadScrollBody({
       const sample = sampleThreadScroll(el, lastScrollTopRef.current);
       lastScrollTopRef.current = el.scrollTop;
       followRef.current = nextThreadFollowState(followRef.current, sample);
-      if (
-        loadOlderArmedRef.current &&
-        el.scrollTop <= OLDER_HISTORY_LOAD_THRESHOLD_PX
-      ) {
-        loadOlderArmedRef.current = false;
-        onLoadOlderHistoryRef.current?.();
-      }
+      maybeLoadOlderHistory();
     }
     scheduleStickyRecompute();
-  }, [scheduleStickyRecompute, followRef]);
+  }, [scheduleStickyRecompute, followRef, maybeLoadOlderHistory]);
 
   useFollowBottom({
     virtualizer,

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/VirtualThreadScrollBody.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/VirtualThreadScrollBody.tsx
@@ -10,8 +10,8 @@ import {
   computeStickyAnchor,
   type FlatThreadRow,
   FOLLOWING_END,
+  nextOlderHistoryLoadState,
   nextThreadFollowState,
-  OLDER_HISTORY_LOAD_THRESHOLD_PX,
   SCROLL_PREVIOUS_ITEM_PEEK,
   SCROLL_UP_KEYS,
   type StickyAnchorEntry,
@@ -302,7 +302,7 @@ export function VirtualThreadScrollBody({
   onUserInteract,
   renderNav,
   resumeRef,
-  hasOlderHistory = false,
+  olderHistoryCursor = 0,
   isLoadingOlderHistory = false,
   onLoadOlderHistory,
 }: {
@@ -321,7 +321,11 @@ export function VirtualThreadScrollBody({
   renderNav?: (jumpToMessage: (id: string) => boolean) => ReactNode;
   /** Where the non-virtualized body left off, read once when this body takes over mid-session. */
   resumeRef: RefObject<ThreadScrollResume>;
-  hasOlderHistory?: boolean;
+  /**
+   * Chain index of the oldest loaded entry; 0 means the whole transcript is loaded. Doubles as the
+   * loader's progress signal, because it only moves when a page actually lands.
+   */
+  olderHistoryCursor?: number;
   isLoadingOlderHistory?: boolean;
   onLoadOlderHistory?: () => void;
 }) {
@@ -346,8 +350,10 @@ export function VirtualThreadScrollBody({
     getItemKey: (index) => flatRows[index]?.key ?? index,
   });
 
-  // Re-armed by the props flipping back, so one gesture loads one page.
   const loadOlderArmedRef = useRef(false);
+  const canLoadOlderRef = useRef(false);
+  const isLoadingOlderRef = useRef(isLoadingOlderHistory);
+  isLoadingOlderRef.current = isLoadingOlderHistory;
   const onLoadOlderHistoryRef = useRef(onLoadOlderHistory);
   useEffect(() => {
     onLoadOlderHistoryRef.current = onLoadOlderHistory;
@@ -355,26 +361,27 @@ export function VirtualThreadScrollBody({
 
   const maybeLoadOlderHistory = useCallback(() => {
     const el = viewportRef.current;
-    if (!el || !loadOlderArmedRef.current) return;
-    if (el.scrollTop > OLDER_HISTORY_LOAD_THRESHOLD_PX) return;
-    loadOlderArmedRef.current = false;
-    onLoadOlderHistoryRef.current?.();
+    if (!el) return;
+    const next = nextOlderHistoryLoadState(loadOlderArmedRef.current, {
+      canLoad: canLoadOlderRef.current,
+      isLoading: isLoadingOlderRef.current,
+      scrollTop: el.scrollTop,
+    });
+    loadOlderArmedRef.current = next.armed;
+    if (next.load) onLoadOlderHistoryRef.current?.();
   }, []);
 
-  // A viewport parked at the very top produces no scroll events, so arming
-  // must also attempt a load once the end-anchored layout has settled.
+  // Keyed on the cursor rather than the in-flight flag: the cursor moves only
+  // when a page lands, so arming here cannot retry a failure. A viewport parked
+  // at the very top produces no scroll events, hence the timer.
   useEffect(() => {
-    loadOlderArmedRef.current =
-      hasOlderHistory && !isLoadingOlderHistory && onLoadOlderHistory != null;
+    canLoadOlderRef.current =
+      olderHistoryCursor > 0 && onLoadOlderHistory != null;
+    loadOlderArmedRef.current = canLoadOlderRef.current;
     if (!loadOlderArmedRef.current) return;
     const id = window.setTimeout(maybeLoadOlderHistory, 250);
     return () => window.clearTimeout(id);
-  }, [
-    hasOlderHistory,
-    isLoadingOlderHistory,
-    onLoadOlderHistory,
-    maybeLoadOlderHistory,
-  ]);
+  }, [olderHistoryCursor, onLoadOlderHistory, maybeLoadOlderHistory]);
 
   const { followRef, leaveEnd, settleAtEnd, settleToIndex } = useSettleControls(
     virtualizer,

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
@@ -7,7 +7,9 @@ import {
   countFlatRows,
   flattenTurnRows,
   keyTurnRows,
+  nextOlderHistoryLoadState,
   nextThreadFollowState,
+  OLDER_HISTORY_LOAD_THRESHOLD_PX,
   type StickyAnchorEntry,
   sampleThreadScroll,
   type ThreadScrollSample,
@@ -299,6 +301,46 @@ describe("nextThreadFollowState", () => {
     ],
   ])("%s", (_name, state, event, expected) => {
     expect(nextThreadFollowState(state, event)).toEqual(expected);
+  });
+});
+
+describe("nextOlderHistoryLoadState", () => {
+  const AT_TOP = 0;
+  const AWAY = OLDER_HISTORY_LOAD_THRESHOLD_PX + 1;
+
+  it.each([
+    [
+      "spends the armed gesture on reaching the threshold",
+      true,
+      { canLoad: true, isLoading: false, scrollTop: AT_TOP },
+      { armed: false, load: true },
+    ],
+    [
+      "will not retry a failed load while the viewport stays at the top",
+      false,
+      { canLoad: true, isLoading: false, scrollTop: AT_TOP },
+      { armed: false, load: false },
+    ],
+    [
+      "re-arms once the reader scrolls back out of the threshold",
+      false,
+      { canLoad: true, isLoading: false, scrollTop: AWAY },
+      { armed: true, load: false },
+    ],
+    [
+      "holds the armed gesture while a page is still in flight",
+      true,
+      { canLoad: true, isLoading: true, scrollTop: AT_TOP },
+      { armed: true, load: false },
+    ],
+    [
+      "disarms once the whole transcript is loaded",
+      true,
+      { canLoad: false, isLoading: false, scrollTop: AT_TOP },
+      { armed: false, load: false },
+    ],
+  ])("%s", (_name, armed, input, expected) => {
+    expect(nextOlderHistoryLoadState(armed, input)).toEqual(expected);
   });
 });
 

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
@@ -307,36 +307,80 @@ describe("nextThreadFollowState", () => {
 describe("nextOlderHistoryLoadState", () => {
   const AT_TOP = 0;
   const AWAY = OLDER_HISTORY_LOAD_THRESHOLD_PX + 1;
+  // Enough room to scroll back out of the threshold band, so a gesture is possible.
+  const SCROLLABLE = OLDER_HISTORY_LOAD_THRESHOLD_PX * 4;
 
   it.each([
     [
       "spends the armed gesture on reaching the threshold",
       true,
-      { canLoad: true, isLoading: false, scrollTop: AT_TOP },
+      {
+        canLoad: true,
+        isLoading: false,
+        scrollTop: AT_TOP,
+        maxScrollTop: SCROLLABLE,
+      },
       { armed: false, load: true },
     ],
     [
       "will not retry a failed load while the viewport stays at the top",
       false,
-      { canLoad: true, isLoading: false, scrollTop: AT_TOP },
+      {
+        canLoad: true,
+        isLoading: false,
+        scrollTop: AT_TOP,
+        maxScrollTop: SCROLLABLE,
+      },
+      { armed: false, load: false },
+    ],
+    [
+      "will not chain a second page after one lands at the top",
+      false,
+      {
+        canLoad: true,
+        isLoading: false,
+        scrollTop: OLDER_HISTORY_LOAD_THRESHOLD_PX,
+        maxScrollTop: SCROLLABLE,
+      },
       { armed: false, load: false },
     ],
     [
       "re-arms once the reader scrolls back out of the threshold",
       false,
-      { canLoad: true, isLoading: false, scrollTop: AWAY },
+      {
+        canLoad: true,
+        isLoading: false,
+        scrollTop: AWAY,
+        maxScrollTop: SCROLLABLE,
+      },
       { armed: true, load: false },
     ],
     [
       "holds the armed gesture while a page is still in flight",
       true,
-      { canLoad: true, isLoading: true, scrollTop: AT_TOP },
+      {
+        canLoad: true,
+        isLoading: true,
+        scrollTop: AT_TOP,
+        maxScrollTop: SCROLLABLE,
+      },
       { armed: true, load: false },
+    ],
+    [
+      "keeps paging a window that leaves the viewport nothing to scroll",
+      false,
+      { canLoad: true, isLoading: false, scrollTop: AT_TOP, maxScrollTop: 0 },
+      { armed: false, load: true },
     ],
     [
       "disarms once the whole transcript is loaded",
       true,
-      { canLoad: false, isLoading: false, scrollTop: AT_TOP },
+      {
+        canLoad: false,
+        isLoading: false,
+        scrollTop: AT_TOP,
+        maxScrollTop: SCROLLABLE,
+      },
       { armed: false, load: false },
     ],
   ])("%s", (_name, armed, input, expected) => {

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
@@ -10,6 +10,7 @@ import {
   nextThreadFollowState,
   type StickyAnchorEntry,
   sampleThreadScroll,
+  shouldVirtualizeThread,
   type ThreadScrollSample,
   type TurnRow,
 } from "./threadVirtualization";
@@ -206,6 +207,21 @@ describe("flattenTurnRows", () => {
     const flat = flattenTurnRows([streaming]);
     expect(flat.every((r) => r.turnTimestamp === undefined)).toBe(true);
   });
+});
+
+describe("shouldVirtualizeThread", () => {
+  // A short windowed thread must still virtualize: only the virtualized body
+  // pages in older history, so the non-virtualized body would dead-end it.
+  it.each([
+    { flatCount: 10, hasOlderHistory: true, expected: true },
+    { flatCount: 10, hasOlderHistory: false, expected: false },
+    { flatCount: 251, hasOlderHistory: false, expected: true },
+  ])(
+    "flatCount $flatCount, hasOlderHistory $hasOlderHistory -> $expected",
+    ({ flatCount, hasOlderHistory, expected }) => {
+      expect(shouldVirtualizeThread(flatCount, hasOlderHistory)).toBe(expected);
+    },
+  );
 });
 
 describe("countFlatRows", () => {

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
@@ -10,7 +10,6 @@ import {
   nextThreadFollowState,
   type StickyAnchorEntry,
   sampleThreadScroll,
-  shouldVirtualizeThread,
   type ThreadScrollSample,
   type TurnRow,
 } from "./threadVirtualization";
@@ -207,21 +206,6 @@ describe("flattenTurnRows", () => {
     const flat = flattenTurnRows([streaming]);
     expect(flat.every((r) => r.turnTimestamp === undefined)).toBe(true);
   });
-});
-
-describe("shouldVirtualizeThread", () => {
-  // A short windowed thread must still virtualize: only the virtualized body
-  // pages in older history, so the non-virtualized body would dead-end it.
-  it.each([
-    { flatCount: 10, hasOlderHistory: true, expected: true },
-    { flatCount: 10, hasOlderHistory: false, expected: false },
-    { flatCount: 251, hasOlderHistory: false, expected: true },
-  ])(
-    "flatCount $flatCount, hasOlderHistory $hasOlderHistory -> $expected",
-    ({ flatCount, hasOlderHistory, expected }) => {
-      expect(shouldVirtualizeThread(flatCount, hasOlderHistory)).toBe(expected);
-    },
-  );
 });
 
 describe("countFlatRows", () => {

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
@@ -373,6 +373,12 @@ describe("nextOlderHistoryLoadState", () => {
       { armed: false, load: true },
     ],
     [
+      "re-arms at the bottom of a window too short to clear the threshold",
+      false,
+      { canLoad: true, isLoading: false, scrollTop: 300, maxScrollTop: 300 },
+      { armed: true, load: false },
+    ],
+    [
       "disarms once the whole transcript is loaded",
       true,
       {

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
@@ -96,19 +96,29 @@ describe("keyTurnRows", () => {
 });
 
 describe("flattenTurnRows", () => {
-  it("passes standalone rows through with ordinal keys for user messages", () => {
+  it("keys standalone rows by their content-derived ids", () => {
     const rows: TurnRow[] = [
       userMessage("u1"),
       { type: "git_action", id: "g1", actionType: "commit" as never },
       userMessage("u2"),
     ];
     const flat = flattenTurnRows(rows);
-    expect(flat.map((r) => r.key)).toEqual([
-      "user-turn-0",
-      "g1",
-      "user-turn-1",
-    ]);
+    expect(flat.map((r) => r.key)).toEqual(["u1", "g1", "u2"]);
     expect(flat.every((r) => !r.inTurn && !r.isTrailingInTurn)).toBe(true);
+  });
+
+  it("keeps a row's key unchanged when older rows are prepended", () => {
+    const tail: TurnRow[] = [
+      userMessage("u2"),
+      agentTurn("a", [sessionUpdate("a1")]),
+    ];
+    const before = flattenTurnRows(tail);
+    const after = flattenTurnRows([
+      userMessage("u1"),
+      agentTurn("b", [sessionUpdate("b1")]),
+      ...tail,
+    ]);
+    expect(after.slice(2).map((r) => r.key)).toEqual(before.map((r) => r.key));
   });
 
   it("flattens an agent turn to one row per item, flagging only the last as trailing", () => {
@@ -119,7 +129,7 @@ describe("flattenTurnRows", () => {
       userMessage("u1"),
       agentTurn("a", [a, b, c]),
     ]);
-    expect(flat.map((r) => r.key)).toEqual(["user-turn-0", "a", "b", "c"]);
+    expect(flat.map((r) => r.key)).toEqual(["u1", "a", "b", "c"]);
     expect(flat.map((r) => r.inTurn)).toEqual([false, true, true, true]);
     expect(flat.map((r) => r.isTrailingInTurn)).toEqual([
       false,

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
@@ -124,16 +124,27 @@ export interface OlderHistoryLoadState {
  * that fails or comes back empty leaves the cursor where it was, so nothing re-arms the loader until
  * the reader scrolls back out and in — otherwise the arming timer would retry a failing request
  * every few hundred milliseconds for as long as the thread sat near the top.
+ *
+ * A window that does not fill the viewport is the one case with no gesture to wait for: it emits no
+ * scroll events at all, so it stays armed and keeps paging until there is something to scroll.
  */
 export function nextOlderHistoryLoadState(
   armed: boolean,
-  input: { canLoad: boolean; isLoading: boolean; scrollTop: number },
+  input: {
+    canLoad: boolean;
+    isLoading: boolean;
+    scrollTop: number;
+    /** Largest `scrollTop` the viewport can reach; 0 when the window does not fill it. */
+    maxScrollTop: number;
+  },
 ): OlderHistoryLoadState {
   if (!input.canLoad) return { armed: false, load: false };
   if (input.scrollTop > OLDER_HISTORY_LOAD_THRESHOLD_PX) {
     return { armed: true, load: false };
   }
-  if (!armed || input.isLoading) return { armed, load: false };
+  if (input.isLoading) return { armed, load: false };
+  if (input.maxScrollTop <= 0) return { armed: false, load: true };
+  if (!armed) return { armed, load: false };
   return { armed: false, load: true };
 }
 

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
@@ -107,16 +107,8 @@ export function completedTurnTimestamp(turn: AgentTurn): number | undefined {
   return undefined;
 }
 
-/**
- * A windowed transcript virtualizes regardless of row count: scroll-up paging
- * of the older history only exists in the virtualized body.
- */
-export function shouldVirtualizeThread(
-  flatCount: number,
-  hasOlderHistory: boolean,
-): boolean {
-  return flatCount > CHAT_THREAD_VIRTUALIZATION_THRESHOLD || hasOlderHistory;
-}
+/** Viewport distance from the top of the loaded window that triggers an older-history page load. */
+export const OLDER_HISTORY_LOAD_THRESHOLD_PX = 800;
 
 /** Flatten turn rows into the windowed row list (see {@link FlatThreadRow}). */
 export function flattenTurnRows(rows: TurnRow[]): FlatThreadRow[] {

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
@@ -126,7 +126,9 @@ export interface OlderHistoryLoadState {
  * every few hundred milliseconds for as long as the thread sat near the top.
  *
  * A window that does not fill the viewport is the one case with no gesture to wait for: it emits no
- * scroll events at all, so it stays armed and keeps paging until there is something to scroll.
+ * scroll events at all, so it stays armed and keeps paging until there is something to scroll. A
+ * window that fills it but stays shorter than the band re-arms on reaching the bottom instead,
+ * since `scrollTop` there can never clear the band.
  */
 export function nextOlderHistoryLoadState(
   armed: boolean,
@@ -144,6 +146,11 @@ export function nextOlderHistoryLoadState(
   }
   if (input.isLoading) return { armed, load: false };
   if (input.maxScrollTop <= 0) return { armed: false, load: true };
+  // A window shorter than the band never lets `scrollTop` clear it, so reaching the bottom is the
+  // only gesture the reader has left. A landed page never leaves them there, so this cannot chain.
+  if (input.scrollTop >= input.maxScrollTop) {
+    return { armed: true, load: false };
+  }
   if (!armed) return { armed, load: false };
   return { armed: false, load: true };
 }

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
@@ -110,6 +110,33 @@ export function completedTurnTimestamp(turn: AgentTurn): number | undefined {
 /** Viewport distance from the top of the loaded window that triggers an older-history page load. */
 export const OLDER_HISTORY_LOAD_THRESHOLD_PX = 800;
 
+export interface OlderHistoryLoadState {
+  /** Whether reaching the threshold should still spend a page load. */
+  armed: boolean;
+  /** Whether to request a page now. */
+  load: boolean;
+}
+
+/**
+ * Whether the older-history loader fires, and what it is armed for next.
+ *
+ * One page per gesture, where the gesture is the viewport re-entering the threshold band. A load
+ * that fails or comes back empty leaves the cursor where it was, so nothing re-arms the loader until
+ * the reader scrolls back out and in — otherwise the arming timer would retry a failing request
+ * every few hundred milliseconds for as long as the thread sat near the top.
+ */
+export function nextOlderHistoryLoadState(
+  armed: boolean,
+  input: { canLoad: boolean; isLoading: boolean; scrollTop: number },
+): OlderHistoryLoadState {
+  if (!input.canLoad) return { armed: false, load: false };
+  if (input.scrollTop > OLDER_HISTORY_LOAD_THRESHOLD_PX) {
+    return { armed: true, load: false };
+  }
+  if (!armed || input.isLoading) return { armed, load: false };
+  return { armed: false, load: true };
+}
+
 /** Flatten turn rows into the windowed row list (see {@link FlatThreadRow}). */
 export function flattenTurnRows(rows: TurnRow[]): FlatThreadRow[] {
   const out: FlatThreadRow[] = [];
@@ -185,7 +212,9 @@ function turnRowKeyPrefix(row: TurnRow): string | null {
  * jumps to the oldest one the engine has not already scrolled to, which on the first such remount
  * is the start of the conversation.
  *
- * Rows are only ever appended, so an ordinal is stable for the life of the row.
+ * Rows are only ever appended here, so an ordinal is stable for the life of the row. A transcript
+ * that can page older history renders windowed instead, precisely because a prepend would shift
+ * every ordinal after it.
  */
 export function keyTurnRows(rows: TurnRow[]): KeyedTurnRow[] {
   const ordinals = new Map<string, number>();

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
@@ -107,6 +107,17 @@ export function completedTurnTimestamp(turn: AgentTurn): number | undefined {
   return undefined;
 }
 
+/**
+ * A windowed transcript virtualizes regardless of row count: scroll-up paging
+ * of the older history only exists in the virtualized body.
+ */
+export function shouldVirtualizeThread(
+  flatCount: number,
+  hasOlderHistory: boolean,
+): boolean {
+  return flatCount > CHAT_THREAD_VIRTUALIZATION_THRESHOLD || hasOlderHistory;
+}
+
 /** Flatten turn rows into the windowed row list (see {@link FlatThreadRow}). */
 export function flattenTurnRows(rows: TurnRow[]): FlatThreadRow[] {
   const out: FlatThreadRow[] = [];

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
@@ -73,11 +73,10 @@ export interface ThreadScrollResume {
  */
 export interface FlatThreadRow {
   /**
-   * Stable list key: the row's content-derived item id, so keys hold steady when older history
-   * is prepended and the end-anchored virtualizer can keep the viewport still. Trade-off: the
-   * optimistic->real id swap of a just-sent user message remounts that one row, which the
-   * virtual engine absorbs by re-measuring — unlike the non-virtualized scroller engine, which
-   * needs ordinal keys (see {@link keyTurnRows}).
+   * Stable list key: the row's content-derived item id, so keys survive older-history prepends
+   * and the end-anchored virtualizer holds the viewport. The optimistic->real swap of a just-sent
+   * user message remounts its row, which this engine absorbs; the non-virtualized scroller cannot
+   * (see {@link keyTurnRows}).
    */
   key: string;
   item: ThreadItem;

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
@@ -73,8 +73,11 @@ export interface ThreadScrollResume {
  */
 export interface FlatThreadRow {
   /**
-   * Stable list key. User messages are keyed by ordinal so the optimistic->real id swap of a
-   * just-sent message doesn't remount its row (same scheme as the non-virtualized path).
+   * Stable list key: the row's content-derived item id, so keys hold steady when older history
+   * is prepended and the end-anchored virtualizer can keep the viewport still. Trade-off: the
+   * optimistic->real id swap of a just-sent user message remounts that one row, which the
+   * virtual engine absorbs by re-measuring — unlike the non-virtualized scroller engine, which
+   * needs ordinal keys (see {@link keyTurnRows}).
    */
   key: string;
   item: ThreadItem;
@@ -108,7 +111,6 @@ export function completedTurnTimestamp(turn: AgentTurn): number | undefined {
 /** Flatten turn rows into the windowed row list (see {@link FlatThreadRow}). */
 export function flattenTurnRows(rows: TurnRow[]): FlatThreadRow[] {
   const out: FlatThreadRow[] = [];
-  let userTurn = 0;
   for (const row of rows) {
     if (row.type === "agent_turn") {
       const timestamp = completedTurnTimestamp(row);
@@ -132,7 +134,7 @@ export function flattenTurnRows(rows: TurnRow[]): FlatThreadRow[] {
       continue;
     }
     out.push({
-      key: row.type === "user_message" ? `user-turn-${userTurn++}` : row.id,
+      key: row.id,
       item: row,
       inTurn: false,
       isTrailingInTurn: false,

--- a/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -138,6 +138,7 @@ const mockAuthenticatedClient = vi.hoisted(() => ({
   startGithubUserIntegrationConnect: vi.fn(),
   getTaskRunSessionLogs: vi.fn(),
   getTaskRunSessionLogsResult: vi.fn(),
+  getTaskRunSessionLogsPage: vi.fn(),
 }));
 
 type MockAuthenticatedClient = typeof mockAuthenticatedClient;
@@ -501,6 +502,11 @@ describe("SessionService", () => {
       entries: [],
       complete: true,
       truncatedHeadCount: 0,
+    });
+    mockAuthenticatedClient.getTaskRunSessionLogsPage.mockResolvedValue({
+      entries: [],
+      hasMore: false,
+      matchingCount: 0,
     });
     mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(undefined);
     mockSessionStoreSetters.getSessions.mockReturnValue({});
@@ -1719,10 +1725,10 @@ describe("SessionService", () => {
           },
         } as AcpMessage,
       ];
-      mockAuthenticatedClient.getTaskRunSessionLogsResult.mockResolvedValue({
+      mockAuthenticatedClient.getTaskRunSessionLogsPage.mockResolvedValue({
         entries: finalEntries,
-        complete: true,
-        truncatedHeadCount: 0,
+        hasMore: false,
+        matchingCount: finalEntries.length,
       });
       mockConvertStoredEntriesToEvents.mockReturnValueOnce(finalEvents);
 
@@ -1758,8 +1764,8 @@ describe("SessionService", () => {
       expect(onStatusChange).not.toHaveBeenCalled();
       await vi.waitFor(() => {
         expect(
-          mockAuthenticatedClient.getTaskRunSessionLogsResult,
-        ).toHaveBeenCalledWith("task-123", "run-123", { limit: 100000 });
+          mockAuthenticatedClient.getTaskRunSessionLogsPage,
+        ).toHaveBeenCalledWith("task-123", "run-123", { limit: 5000 });
       });
       expect(mockSessionStoreSetters.updateSession).toHaveBeenCalledWith(
         "run-123",
@@ -1783,6 +1789,13 @@ describe("SessionService", () => {
       mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(session);
       mockSessionStoreSetters.getSessions.mockReturnValue({
         "run-123": session,
+      });
+      // Without a matching-count header the window fetch falls back to the
+      // capped sequential fetch, which is the path that reports a dropped head.
+      mockAuthenticatedClient.getTaskRunSessionLogsPage.mockResolvedValue({
+        entries: [{ timestamp: "2024-01-01T00:00:00Z", notification: {} }],
+        hasMore: true,
+        matchingCount: null,
       });
       mockAuthenticatedClient.getTaskRunSessionLogsResult.mockResolvedValue({
         entries: [
@@ -1819,6 +1832,114 @@ describe("SessionService", () => {
           }),
         );
       });
+    });
+
+    it("renders the tail of an oversized chain and loads older pages on demand", async () => {
+      const service = getSessionService();
+      const session = createMockSession({
+        taskId: "task-123",
+        taskRunId: "run-123",
+        cloudStatus: "in_progress",
+        isCloud: true,
+        events: [],
+      });
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(session);
+      mockSessionStoreSetters.getSessions.mockReturnValue({
+        "run-123": session,
+      });
+      const chainEntries = Array.from({ length: 12000 }, (_, i) => ({
+        timestamp: `2024-01-01T00:00:${String(i % 60).padStart(2, "0")}Z`,
+        notification: { method: `entry-${i}` },
+      }));
+      mockAuthenticatedClient.getTaskRunSessionLogsPage.mockImplementation(
+        async (
+          _taskId: string,
+          _runId: string,
+          options: { limit: number; offset?: number },
+        ) => {
+          const offset = options.offset ?? 0;
+          const entries = chainEntries.slice(offset, offset + options.limit);
+          return {
+            entries,
+            hasMore: offset + entries.length < chainEntries.length,
+            matchingCount: chainEntries.length,
+          };
+        },
+      );
+      mockConvertStoredEntriesToEvents.mockImplementation(
+        (entries: unknown[]) =>
+          entries.map(
+            (_, i) =>
+              ({
+                type: "acp_message",
+                ts: i,
+                message: { jsonrpc: "2.0", method: "session/update" },
+              }) as AcpMessage,
+          ),
+      );
+
+      service.watchCloudTask(
+        "task-123",
+        "run-123",
+        "https://api.anthropic.com",
+        123,
+        undefined,
+        "https://example.com/logs/run-123",
+        undefined,
+        "claude",
+        undefined,
+        undefined,
+        undefined,
+        "completed",
+      );
+
+      // Tail window commit: only the newest page renders, offset by its
+      // absolute start.
+      await vi.waitFor(() => {
+        expect(mockSessionStoreSetters.updateSession).toHaveBeenCalledWith(
+          "run-123",
+          expect.objectContaining({
+            transcriptWindowStart: 7000,
+            cloudTranscriptEntryCount: 12000,
+          }),
+        );
+      });
+      expect(mockConvertStoredEntriesToEvents).toHaveBeenCalledWith(
+        chainEntries.slice(7000),
+        undefined,
+        { taskRunId: "run-123", startEntryIndex: 7000 },
+      );
+      // Hydration fetches the probe and the tail page and nothing else - no
+      // eager backfill of the older history.
+      const hydrationOffsets = new Set(
+        mockAuthenticatedClient.getTaskRunSessionLogsPage.mock.calls.map(
+          (call) => (call[2] as { offset?: number }).offset ?? 0,
+        ),
+      );
+      expect(hydrationOffsets).toEqual(new Set([0, 7000]));
+
+      // Scrolling up loads exactly one older page and prepends it.
+      const hydrated = createMockSession({
+        taskId: "task-123",
+        taskRunId: "run-123",
+        cloudStatus: "completed",
+        isCloud: true,
+        events: [],
+        transcriptWindowStart: 7000,
+      });
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(hydrated);
+      await service.loadOlderCloudTranscript("task-123");
+
+      expect(
+        mockAuthenticatedClient.getTaskRunSessionLogsPage,
+      ).toHaveBeenLastCalledWith("task-123", "run-123", {
+        limit: 5000,
+        offset: 2000,
+      });
+      expect(mockSessionStoreSetters.updateSession).toHaveBeenCalledWith(
+        "run-123",
+        expect.objectContaining({ transcriptWindowStart: 2000 }),
+      );
     });
 
     it("falls back to the run log URL when terminal chain hydration is empty", async () => {
@@ -2021,8 +2142,8 @@ describe("SessionService", () => {
       // instead of being deduped onto the in-flight resume-chain hydration.
       await vi.waitFor(() => {
         expect(
-          mockAuthenticatedClient.getTaskRunSessionLogsResult,
-        ).toHaveBeenCalledTimes(3);
+          mockAuthenticatedClient.getTaskRunSessionLogsPage,
+        ).toHaveBeenCalledWith("task-123", "run-123", { limit: 5000 });
       });
       resolveFirstHydration({
         entries: [],
@@ -4234,63 +4355,64 @@ describe("SessionService", () => {
       mockSessionStoreSetters.getSessions.mockReturnValue({
         "run-123": completedSession,
       });
-      mockAuthenticatedClient.getTaskRunSessionLogsResult.mockResolvedValue({
-        complete: true,
-        truncatedHeadCount: 0,
-        entries: [
-          {
-            type: "notification",
-            notification: {
-              method: "_posthog/sdk_session",
-              params: {
-                taskRunId: "run-123",
-                sessionId: "acp-session-1",
-                adapter: "claude",
-              },
+      const pendingQuestionEntries = [
+        {
+          type: "notification",
+          notification: {
+            method: "_posthog/sdk_session",
+            params: {
+              taskRunId: "run-123",
+              sessionId: "acp-session-1",
+              adapter: "claude",
             },
           },
-          {
-            type: "notification",
-            notification: {
-              method: "_posthog/run_started",
-              params: {
-                sessionId: "acp-session-1",
-                runId: "run-123",
-                taskId: "task-123",
-              },
+        },
+        {
+          type: "notification",
+          notification: {
+            method: "_posthog/run_started",
+            params: {
+              sessionId: "acp-session-1",
+              runId: "run-123",
+              taskId: "task-123",
             },
           },
-          {
-            type: "notification",
-            notification: {
-              method: "_posthog/permission_request",
-              params: {
-                requestId: "request-1",
-                toolCall: {
-                  toolCallId: "tool-1",
-                  title: "What animal do you prefer?",
-                  kind: "other",
-                  _meta: {
-                    codeToolKind: "question",
-                    questions: [
-                      {
-                        question: "What animal do you prefer?",
-                        options: [
-                          { label: "cats", description: "Cats" },
-                          { label: "dogs", description: "Dogs" },
-                        ],
-                      },
-                    ],
-                  },
+        },
+        {
+          type: "notification",
+          notification: {
+            method: "_posthog/permission_request",
+            params: {
+              requestId: "request-1",
+              toolCall: {
+                toolCallId: "tool-1",
+                title: "What animal do you prefer?",
+                kind: "other",
+                _meta: {
+                  codeToolKind: "question",
+                  questions: [
+                    {
+                      question: "What animal do you prefer?",
+                      options: [
+                        { label: "cats", description: "Cats" },
+                        { label: "dogs", description: "Dogs" },
+                      ],
+                    },
+                  ],
                 },
-                options: [
-                  { optionId: "option_0", name: "cats", kind: "allow_once" },
-                  { optionId: "option_1", name: "dogs", kind: "allow_once" },
-                ],
               },
+              options: [
+                { optionId: "option_0", name: "cats", kind: "allow_once" },
+                { optionId: "option_1", name: "dogs", kind: "allow_once" },
+              ],
             },
           },
-        ],
+        },
+      ];
+      mockAuthenticatedClient.getTaskRunSessionLogsPage.mockResolvedValue({
+        entries: pendingQuestionEntries,
+        hasMore: false,
+        matchingCount: pendingQuestionEntries.length,
       });
 
       service.watchCloudTask(

--- a/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -1942,6 +1942,144 @@ describe("SessionService", () => {
       );
     });
 
+    it("falls back to the sequential fetch when the server omits the matching count", async () => {
+      const service = getSessionService();
+      const session = createMockSession({
+        taskId: "task-123",
+        taskRunId: "run-123",
+        cloudStatus: "in_progress",
+        isCloud: true,
+        events: [],
+      });
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(session);
+      mockSessionStoreSetters.getSessions.mockReturnValue({
+        "run-123": session,
+      });
+      const chainEntries = Array.from({ length: 3 }, (_, i) => ({
+        timestamp: `2024-01-01T00:00:0${i}Z`,
+        notification: { method: `entry-${i}` },
+      }));
+      mockAuthenticatedClient.getTaskRunSessionLogsPage.mockResolvedValue({
+        entries: chainEntries.slice(0, 1),
+        hasMore: true,
+        matchingCount: null,
+      });
+      mockAuthenticatedClient.getTaskRunSessionLogsResult.mockResolvedValue({
+        entries: chainEntries,
+        complete: true,
+        truncatedHeadCount: 0,
+      });
+
+      service.watchCloudTask(
+        "task-123",
+        "run-123",
+        "https://api.anthropic.com",
+        123,
+        undefined,
+        "https://example.com/logs/run-123",
+        undefined,
+        "claude",
+        undefined,
+        undefined,
+        undefined,
+        "completed",
+      );
+
+      await vi.waitFor(() => {
+        expect(
+          mockAuthenticatedClient.getTaskRunSessionLogsResult,
+        ).toHaveBeenCalledWith("task-123", "run-123", { limit: 100000 });
+      });
+      expect(mockSessionStoreSetters.updateSession).toHaveBeenCalledWith(
+        "run-123",
+        expect.objectContaining({
+          transcriptWindowStart: 0,
+          cloudTranscriptEntryCount: 3,
+        }),
+      );
+    });
+
+    it("recovers from a failed older-page fetch and can retry", async () => {
+      const service = getSessionService();
+      const session = createMockSession({
+        taskId: "task-123",
+        taskRunId: "run-123",
+        cloudStatus: "completed",
+        isCloud: true,
+        events: [],
+        transcriptWindowStart: 5000,
+      });
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(session);
+      mockSessionStoreSetters.getSessions.mockReturnValue({
+        "run-123": session,
+      });
+      mockAuthenticatedClient.getTaskRunSessionLogsPage.mockRejectedValue(
+        new Error("network down"),
+      );
+
+      await service.loadOlderCloudTranscript("task-123");
+
+      expect(mockSessionStoreSetters.updateSession).toHaveBeenLastCalledWith(
+        "run-123",
+        { isLoadingOlderTranscript: false },
+      );
+      expect(mockSessionStoreSetters.updateSession).not.toHaveBeenCalledWith(
+        "run-123",
+        expect.objectContaining({ events: expect.anything() }),
+      );
+
+      mockAuthenticatedClient.getTaskRunSessionLogsPage.mockResolvedValue({
+        entries: Array.from({ length: 5000 }, () => ({
+          timestamp: "2024-01-01T00:00:00Z",
+          notification: {},
+        })),
+        hasMore: true,
+        matchingCount: null,
+      });
+      await service.loadOlderCloudTranscript("task-123");
+      expect(
+        mockAuthenticatedClient.getTaskRunSessionLogsPage,
+      ).toHaveBeenCalledTimes(2);
+    });
+
+    it("discards an older page when the window moved while it was in flight", async () => {
+      const service = getSessionService();
+      const sessionAtFetch = createMockSession({
+        taskId: "task-123",
+        taskRunId: "run-123",
+        cloudStatus: "completed",
+        isCloud: true,
+        events: [],
+        transcriptWindowStart: 5000,
+      });
+      const sessionAfterMove = createMockSession({
+        taskId: "task-123",
+        taskRunId: "run-123",
+        cloudStatus: "completed",
+        isCloud: true,
+        events: [],
+        transcriptWindowStart: 2000,
+      });
+      mockSessionStoreSetters.getSessionByTaskId
+        .mockReturnValueOnce(sessionAtFetch)
+        .mockReturnValue(sessionAfterMove);
+      mockSessionStoreSetters.getSessions.mockReturnValue({
+        "run-123": sessionAtFetch,
+      });
+      mockAuthenticatedClient.getTaskRunSessionLogsPage.mockResolvedValue({
+        entries: [{ timestamp: "2024-01-01T00:00:00Z", notification: {} }],
+        hasMore: true,
+        matchingCount: null,
+      });
+
+      await service.loadOlderCloudTranscript("task-123");
+
+      expect(mockSessionStoreSetters.updateSession).not.toHaveBeenCalledWith(
+        "run-123",
+        expect.objectContaining({ events: expect.anything() }),
+      );
+    });
+
     it("falls back to the run log URL when terminal chain hydration is empty", async () => {
       const service = getSessionService();
       const session = createMockSession({

--- a/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -3872,6 +3872,7 @@ describe("SessionService", () => {
             isCloud: true,
             logUrl: "https://logs.example.com/run-123",
             processedLineCount: 14,
+            transcriptWindowStart: 0,
           }),
         );
       });

--- a/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -1893,8 +1893,6 @@ describe("SessionService", () => {
         "completed",
       );
 
-      // Tail window commit: only the newest page renders, offset by its
-      // absolute start.
       await vi.waitFor(() => {
         expect(mockSessionStoreSetters.updateSession).toHaveBeenCalledWith(
           "run-123",
@@ -1909,8 +1907,6 @@ describe("SessionService", () => {
         undefined,
         { taskRunId: "run-123", startEntryIndex: 7000 },
       );
-      // Hydration fetches the probe and the tail page and nothing else - no
-      // eager backfill of the older history.
       const hydrationOffsets = new Set(
         mockAuthenticatedClient.getTaskRunSessionLogsPage.mock.calls.map(
           (call) => (call[2] as { offset?: number }).offset ?? 0,
@@ -1918,7 +1914,6 @@ describe("SessionService", () => {
       );
       expect(hydrationOffsets).toEqual(new Set([0, 7000]));
 
-      // Scrolling up loads exactly one older page and prepends it.
       const hydrated = createMockSession({
         taskId: "task-123",
         taskRunId: "run-123",

--- a/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -1765,7 +1765,7 @@ describe("SessionService", () => {
       await vi.waitFor(() => {
         expect(
           mockAuthenticatedClient.getTaskRunSessionLogsPage,
-        ).toHaveBeenCalledWith("task-123", "run-123", { limit: 5000 });
+        ).toHaveBeenCalledWith("task-123", "run-123", { limit: 1 });
       });
       expect(mockSessionStoreSetters.updateSession).toHaveBeenCalledWith(
         "run-123",
@@ -1897,22 +1897,22 @@ describe("SessionService", () => {
         expect(mockSessionStoreSetters.updateSession).toHaveBeenCalledWith(
           "run-123",
           expect.objectContaining({
-            transcriptWindowStart: 7000,
+            transcriptWindowStart: 10000,
             cloudTranscriptEntryCount: 12000,
           }),
         );
       });
       expect(mockConvertStoredEntriesToEvents).toHaveBeenCalledWith(
-        chainEntries.slice(7000),
+        chainEntries.slice(10000),
         undefined,
-        { taskRunId: "run-123", startEntryIndex: 7000 },
+        { taskRunId: "run-123", startEntryIndex: 10000 },
       );
       const hydrationOffsets = new Set(
         mockAuthenticatedClient.getTaskRunSessionLogsPage.mock.calls.map(
           (call) => (call[2] as { offset?: number }).offset ?? 0,
         ),
       );
-      expect(hydrationOffsets).toEqual(new Set([0, 7000]));
+      expect(hydrationOffsets).toEqual(new Set([0, 10000]));
 
       const hydrated = createMockSession({
         taskId: "task-123",
@@ -1920,7 +1920,7 @@ describe("SessionService", () => {
         cloudStatus: "completed",
         isCloud: true,
         events: [],
-        transcriptWindowStart: 7000,
+        transcriptWindowStart: 10000,
       });
       mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(hydrated);
       await service.loadOlderCloudTranscript("task-123");
@@ -1929,11 +1929,59 @@ describe("SessionService", () => {
         mockAuthenticatedClient.getTaskRunSessionLogsPage,
       ).toHaveBeenLastCalledWith("task-123", "run-123", {
         limit: 5000,
-        offset: 2000,
+        offset: 5000,
       });
       expect(mockSessionStoreSetters.updateSession).toHaveBeenCalledWith(
         "run-123",
-        expect.objectContaining({ transcriptWindowStart: 2000 }),
+        expect.objectContaining({ transcriptWindowStart: 5000 }),
+      );
+    });
+
+    it("waits out a restoring auth before hydrating instead of bailing", async () => {
+      const service = getSessionService();
+      const session = createMockSession({
+        taskId: "task-123",
+        taskRunId: "run-123",
+        cloudStatus: "completed",
+        isCloud: true,
+        events: [],
+      });
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(session);
+      mockSessionStoreSetters.getSessions.mockReturnValue({
+        "run-123": session,
+      });
+      mockAuth.fetchAuthState.mockResolvedValueOnce({
+        status: "restoring",
+        bootstrapComplete: false,
+      });
+      mockAuthenticatedClient.getTaskRunSessionLogsPage.mockResolvedValue({
+        entries: [{ timestamp: "2024-01-01T00:00:00Z", notification: {} }],
+        hasMore: false,
+        matchingCount: 1,
+      });
+
+      service.watchCloudTask(
+        "task-123",
+        "run-123",
+        "https://api.anthropic.com",
+        123,
+        undefined,
+        "https://example.com/logs/run-123",
+        undefined,
+        "claude",
+        undefined,
+        undefined,
+        undefined,
+        "completed",
+      );
+
+      await vi.waitFor(
+        () => {
+          expect(
+            mockAuthenticatedClient.getTaskRunSessionLogsPage,
+          ).toHaveBeenCalledWith("task-123", "run-123", { limit: 1 });
+        },
+        { timeout: 2000 },
       );
     });
 
@@ -2276,7 +2324,7 @@ describe("SessionService", () => {
       await vi.waitFor(() => {
         expect(
           mockAuthenticatedClient.getTaskRunSessionLogsPage,
-        ).toHaveBeenCalledWith("task-123", "run-123", { limit: 5000 });
+        ).toHaveBeenCalledWith("task-123", "run-123", { limit: 1 });
       });
       resolveFirstHydration({
         entries: [],

--- a/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -1985,6 +1985,70 @@ describe("SessionService", () => {
       );
     });
 
+    it("follows the log past a probe count the run grew behind", async () => {
+      const service = getSessionService();
+      const session = createMockSession({
+        taskId: "task-123",
+        taskRunId: "run-123",
+        cloudStatus: "completed",
+        isCloud: true,
+        events: [],
+      });
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(session);
+      mockSessionStoreSetters.getSessions.mockReturnValue({
+        "run-123": session,
+      });
+      // The probe sees 30 entries; terminal log persistence lands 10 more while
+      // the tail page is in flight.
+      const chainEntries = Array.from({ length: 40 }, (_, i) => ({
+        timestamp: `2024-01-01T00:00:${String(i % 60).padStart(2, "0")}Z`,
+        notification: { method: `entry-${i}` },
+      }));
+      let probed = false;
+      mockAuthenticatedClient.getTaskRunSessionLogsPage.mockImplementation(
+        async (
+          _taskId: string,
+          _runId: string,
+          options: { limit: number; offset?: number },
+        ) => {
+          const offset = options.offset ?? 0;
+          const visible = probed ? chainEntries.length : 30;
+          probed = true;
+          const entries = chainEntries.slice(offset, offset + options.limit);
+          return {
+            entries,
+            hasMore: offset + entries.length < visible,
+            matchingCount: visible,
+          };
+        },
+      );
+
+      service.watchCloudTask(
+        "task-123",
+        "run-123",
+        "https://api.anthropic.com",
+        123,
+        undefined,
+        "https://example.com/logs/run-123",
+        undefined,
+        "claude",
+        undefined,
+        undefined,
+        undefined,
+        "completed",
+      );
+
+      await vi.waitFor(() => {
+        expect(mockSessionStoreSetters.updateSession).toHaveBeenCalledWith(
+          "run-123",
+          expect.objectContaining({
+            transcriptWindowStart: 0,
+            cloudTranscriptEntryCount: 40,
+          }),
+        );
+      });
+    });
+
     it("falls back to the sequential fetch when the server omits the matching count", async () => {
       const service = getSessionService();
       const session = createMockSession({


### PR DESCRIPTION
## Problem

Opening a large cloud task still eagerly fetched up to 100k log entries across ~25 serial requests.

## Changes

- Opening a task now costs two requests: a probe that learns the total from `X-Matching-Count` and the newest page. The thread renders immediately.
- Scrolling to the top of loaded history fetches one older 5000-entry page at a time, with a "Loading earlier messages" pill.
- Conversation item ids derive from their turn instead of a global counter, so the virtualizer holds the viewport still when history prepends.
- Servers without the count header fall back to #82979's capped fetch.

## How did you test this code?

Host test pins the two-request open and the one-page on-demand load. Verified the open path live on a 126k-entry chain over CDP; the scroll gesture itself needs a human hand (CDP input doesn't reach the window).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Claude Code session continuing #82979; reworked from eager backfill to scroll-driven paging at the user's direction. Skills: /test-electron-app, /writing-tests, /stacking-prs, /writing-pr-descriptions. No session data committed.
