### PR TITLE
fix(desktop): show personal space without a hash

### DIFF
--- a/products/desktop/packages/core/src/canvas/canvasApplicationService.ts
+++ b/products/desktop/packages/core/src/canvas/canvasApplicationService.ts
@@ -1,4 +1,4 @@
-import { channelDisplayLabel } from "@posthog/core/canvas/channelName";
+import { channelDisplayReference } from "@posthog/core/canvas/channelName";
 import {
   REPORT_MODEL_RESOLVER,
   type ReportModelResolver,
@@ -155,7 +155,7 @@ export class CanvasApplicationService {
         }),
         taskDescription: input.name
           ? `Generate canvas "${input.name}"`
-          : `Generate a canvas in ${channelDisplayLabel(input.channelName)}`,
+          : `Generate a canvas in ${channelDisplayReference(input.channelName)}`,
         // Unattended generation: run in auto mode so it doesn't stall on
         // edit-approval prompts.
         executionMode: "auto" as const,

--- a/products/desktop/packages/core/src/canvas/canvasApplicationService.ts
+++ b/products/desktop/packages/core/src/canvas/canvasApplicationService.ts
@@ -1,3 +1,4 @@
+import { channelDisplayLabel } from "@posthog/core/canvas/channelName";
 import {
   REPORT_MODEL_RESOLVER,
   type ReportModelResolver,
@@ -154,7 +155,7 @@ export class CanvasApplicationService {
         }),
         taskDescription: input.name
           ? `Generate canvas "${input.name}"`
-          : `Generate a canvas in #${input.channelName}`,
+          : `Generate a canvas in ${channelDisplayLabel(input.channelName)}`,
         // Unattended generation: run in auto mode so it doesn't stall on
         // edit-approval prompts.
         executionMode: "auto" as const,

--- a/products/desktop/packages/core/src/canvas/channelName.test.ts
+++ b/products/desktop/packages/core/src/canvas/channelName.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  channelDisplayLabel,
   normalizeChannelName,
   normalizeChannelNameInput,
   validateChannelName,
@@ -23,6 +24,18 @@ describe("normalizeChannelName", () => {
     );
 
     expect(normalized).toBe("my-new-space");
+  });
+});
+
+describe("channelDisplayLabel", () => {
+  it.each([
+    ["me", undefined, "personal"],
+    ["personal", undefined, "personal"],
+    ["personal", "personal" as const, "personal"],
+    ["personal", "public" as const, "#personal"],
+    ["engineering", "public" as const, "#engineering"],
+  ])("formats %j (%s) as %j", (name, channelType, expected) => {
+    expect(channelDisplayLabel(name, channelType)).toBe(expected);
   });
 });
 

--- a/products/desktop/packages/core/src/canvas/channelName.test.ts
+++ b/products/desktop/packages/core/src/canvas/channelName.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   channelDisplayLabel,
+  channelDisplayReference,
   normalizeChannelName,
   normalizeChannelNameInput,
   validateChannelName,
@@ -29,13 +30,22 @@ describe("normalizeChannelName", () => {
 
 describe("channelDisplayLabel", () => {
   it.each([
-    ["me", undefined, "personal"],
-    ["personal", undefined, "personal"],
-    ["personal", "personal" as const, "personal"],
+    ["me", undefined, "personal space"],
+    ["personal", undefined, "personal space"],
+    ["personal space", undefined, "personal space"],
+    ["personal", "personal" as const, "personal space"],
     ["personal", "public" as const, "#personal"],
     ["engineering", "public" as const, "#engineering"],
   ])("formats %j (%s) as %j", (name, channelType, expected) => {
     expect(channelDisplayLabel(name, channelType)).toBe(expected);
+  });
+
+  it.each([
+    ["me", undefined, "your personal space"],
+    ["personal", undefined, "your personal space"],
+    ["engineering", "public" as const, "#engineering"],
+  ])("references %j (%s) as %j", (name, channelType, expected) => {
+    expect(channelDisplayReference(name, channelType)).toBe(expected);
   });
 });
 

--- a/products/desktop/packages/core/src/canvas/channelName.ts
+++ b/products/desktop/packages/core/src/canvas/channelName.ts
@@ -12,7 +12,8 @@ export const PERSONAL_CHANNEL_NAME = "me";
  * Lives in core because names reach a reader by more routes than the channel
  * list — an activity row and a mention both carry one of their own.
  */
-export const PERSONAL_CHANNEL_LABEL = "personal";
+export const PERSONAL_CHANNEL_LABEL = "personal space";
+const LEGACY_PERSONAL_CHANNEL_LABEL = "personal";
 
 /** A channel's name as a reader should see it. */
 export function channelDisplayName(name: string): string;
@@ -21,15 +22,33 @@ export function channelDisplayName(name: string | null): string | null {
   return name === PERSONAL_CHANNEL_NAME ? PERSONAL_CHANNEL_LABEL : name;
 }
 
+function isPersonalChannelLabel(
+  name: string,
+  channelType?: "public" | "personal",
+): boolean {
+  return channelType !== undefined
+    ? channelType === "personal"
+    : name === PERSONAL_CHANNEL_NAME ||
+        name === PERSONAL_CHANNEL_LABEL ||
+        name === LEGACY_PERSONAL_CHANNEL_LABEL;
+}
+
 export function channelDisplayLabel(
   name: string,
   channelType?: "public" | "personal",
 ): string {
-  const isPersonal =
-    channelType !== undefined
-      ? channelType === "personal"
-      : name === PERSONAL_CHANNEL_NAME || name === PERSONAL_CHANNEL_LABEL;
-  return isPersonal ? PERSONAL_CHANNEL_LABEL : `#${channelDisplayName(name)}`;
+  return isPersonalChannelLabel(name, channelType)
+    ? PERSONAL_CHANNEL_LABEL
+    : `#${channelDisplayName(name)}`;
+}
+
+export function channelDisplayReference(
+  name: string,
+  channelType?: "public" | "personal",
+): string {
+  return isPersonalChannelLabel(name, channelType)
+    ? `your ${PERSONAL_CHANNEL_LABEL}`
+    : `#${channelDisplayName(name)}`;
 }
 
 // A channel's name is used verbatim as its server-side filesystem path segment,
@@ -60,7 +79,7 @@ export function normalizeChannelName(name: string): string {
  */
 const RESERVED_CHANNEL_NAMES = new Set([
   PERSONAL_CHANNEL_NAME,
-  PERSONAL_CHANNEL_LABEL,
+  LEGACY_PERSONAL_CHANNEL_LABEL,
 ]);
 
 export function validateChannelName(name: string): string | null {

--- a/products/desktop/packages/core/src/canvas/channelName.ts
+++ b/products/desktop/packages/core/src/canvas/channelName.ts
@@ -21,6 +21,17 @@ export function channelDisplayName(name: string | null): string | null {
   return name === PERSONAL_CHANNEL_NAME ? PERSONAL_CHANNEL_LABEL : name;
 }
 
+export function channelDisplayLabel(
+  name: string,
+  channelType?: "public" | "personal",
+): string {
+  const isPersonal =
+    channelType !== undefined
+      ? channelType === "personal"
+      : name === PERSONAL_CHANNEL_NAME || name === PERSONAL_CHANNEL_LABEL;
+  return isPersonal ? PERSONAL_CHANNEL_LABEL : `#${channelDisplayName(name)}`;
+}
+
 // A channel's name is used verbatim as its server-side filesystem path segment,
 // so it must be directory-safe: lowercase letters, numbers, and hyphens only.
 export const CHANNEL_NAME_PATTERN = /^[a-z0-9-]+$/;

--- a/products/desktop/packages/core/src/context-menu/context-menu.test.ts
+++ b/products/desktop/packages/core/src/context-menu/context-menu.test.ts
@@ -168,6 +168,12 @@ describe("ContextMenuService.showTaskContextMenu", () => {
     const result = makeService(menu).showTaskContextMenu({
       ...baseTask,
       channels: [
+        {
+          id: "0",
+          name: "personal",
+          channelType: "personal",
+          starred: true,
+        },
         { id: "1", name: "alpha" },
         { id: "2", name: "beta", starred: true },
         { id: "3", name: "gamma" },
@@ -176,7 +182,13 @@ describe("ContextMenuService.showTaskContextMenu", () => {
     });
     await menu.shown;
     const submenu = findItem(menu.lastItems, "File to…").submenu ?? [];
-    expect(labels(submenu)).toEqual(["#beta", "#delta", "#alpha", "#gamma"]);
+    expect(labels(submenu)).toEqual([
+      "personal",
+      "#beta",
+      "#delta",
+      "#alpha",
+      "#gamma",
+    ]);
     findSubmenuItem(menu.lastItems, "File to…", "#delta").click();
     expect(await result).toEqual({
       action: { type: "file-to-channel", channelId: "4" },
@@ -271,11 +283,17 @@ describe("ContextMenuService.showBulkTaskContextMenu", () => {
       channels: [
         { id: "c1", name: "support" },
         { id: "c2", name: "design", starred: true },
+        {
+          id: "c3",
+          name: "personal",
+          channelType: "personal",
+          starred: true,
+        },
       ],
     });
     await menu.shown;
     const submenu = findItem(menu.lastItems, "File to…").submenu ?? [];
-    expect(labels(submenu)).toEqual(["#design", "#support"]);
+    expect(labels(submenu)).toEqual(["#design", "personal", "#support"]);
   });
 
   it("gates archive on confirmation", async () => {

--- a/products/desktop/packages/core/src/context-menu/context-menu.test.ts
+++ b/products/desktop/packages/core/src/context-menu/context-menu.test.ts
@@ -183,7 +183,7 @@ describe("ContextMenuService.showTaskContextMenu", () => {
     await menu.shown;
     const submenu = findItem(menu.lastItems, "File to…").submenu ?? [];
     expect(labels(submenu)).toEqual([
-      "personal",
+      "personal space",
       "#beta",
       "#delta",
       "#alpha",
@@ -293,7 +293,7 @@ describe("ContextMenuService.showBulkTaskContextMenu", () => {
     });
     await menu.shown;
     const submenu = findItem(menu.lastItems, "File to…").submenu ?? [];
-    expect(labels(submenu)).toEqual(["#design", "personal", "#support"]);
+    expect(labels(submenu)).toEqual(["#design", "personal space", "#support"]);
   });
 
   it("gates archive on confirmation", async () => {

--- a/products/desktop/packages/core/src/context-menu/context-menu.ts
+++ b/products/desktop/packages/core/src/context-menu/context-menu.ts
@@ -1,3 +1,4 @@
+import { channelDisplayLabel } from "@posthog/core/canvas/channelName";
 import {
   formatBulkArchiveWarning,
   sessionsLabel,
@@ -134,9 +135,7 @@ export class ContextMenuService {
               type: "submenu",
               label: "File to…",
               items: this.starredFirst(channels).map((c) => ({
-                // Channel names are stored bare; every surface that shows one
-                // adds the hash.
-                label: `#${c.name}`,
+                label: channelDisplayLabel(c.name, c.channelType),
                 action: {
                   type: "file-to-channel" as const,
                   channelId: c.id,
@@ -227,9 +226,7 @@ export class ContextMenuService {
               type: "submenu" as const,
               label: "File to…",
               items: this.starredFirst(channels).map((c) => ({
-                // Channel names are stored bare; every surface that shows one
-                // adds the hash.
-                label: `#${c.name}`,
+                label: channelDisplayLabel(c.name, c.channelType),
                 action: {
                   type: "file-to-channel" as const,
                   channelId: c.id,

--- a/products/desktop/packages/core/src/context-menu/schemas.ts
+++ b/products/desktop/packages/core/src/context-menu/schemas.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 const fileToChannel = z.object({
   id: z.string(),
   name: z.string(),
+  channelType: z.enum(["public", "personal"]).optional(),
   starred: z.boolean().optional(),
 });
 

--- a/products/desktop/packages/ui/src/features/canvas/AGENTS.md
+++ b/products/desktop/packages/ui/src/features/canvas/AGENTS.md
@@ -51,12 +51,12 @@ The root `AGENTS.md` architecture rules still apply.
   horizontal swipe moves between them (`useChannelPaneSwipe`, wheel `deltaX`
   accumulated per gesture and locked until the wheel goes quiet).
 - In the list, "Starred"/"Spaces" are headings above lightly indented rows. The
-  private "personal" row leads the Starred section and takes the same inset as the
+  private "personal space" row leads the Starred section and takes the same inset as the
   spaces beside it. It is the one row that carries a glyph: the lock is the only
   thing saying nobody else can see this space, which is worth its name starting a
   glyph's width right of the others. The alpha's more deeply indented Channels
   tree and hash glyphs are unchanged.
-- **The private space reads as "personal" without a hash, and only on screen.** The row is `me`
+- **The private space reads as "personal space" without a hash, and only on screen.** The row is `me`
   on the backend; `channelDisplayName` (core) swaps it on the way to a reader.
   `channelDisplayLabel` adds a hash to shared spaces but leaves personal bare.
   Four routes carry a channel's name — the channel list, an activity row, a

--- a/products/desktop/packages/ui/src/features/canvas/AGENTS.md
+++ b/products/desktop/packages/ui/src/features/canvas/AGENTS.md
@@ -56,8 +56,9 @@ The root `AGENTS.md` architecture rules still apply.
   thing saying nobody else can see this space, which is worth its name starting a
   glyph's width right of the others. The alpha's more deeply indented Channels
   tree and hash glyphs are unchanged.
-- **The private space reads as "personal", and only on screen.** The row is `me`
+- **The private space reads as "personal" without a hash, and only on screen.** The row is `me`
   on the backend; `channelDisplayName` (core) swaps it on the way to a reader.
+  `channelDisplayLabel` adds a hash to shared spaces but leaves personal bare.
   Four routes carry a channel's name — the channel list, an activity row, a
   mention row, and remote search — and each calls it, because only the first
   goes through `useTaskChannels`.

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
@@ -8,6 +8,7 @@ import {
   buildActivityTimeline,
   type UserMessageLike,
 } from "@posthog/core/canvas/activityTimeline";
+import { channelDisplayLabel } from "@posthog/core/canvas/channelName";
 import type { ThreadTimelineRow } from "@posthog/core/canvas/threadTimeline";
 import { DEFAULT_TAB_IDS } from "@posthog/core/panels/panelConstants";
 import { findTabInTree } from "@posthog/core/panels/panelTree";
@@ -122,7 +123,7 @@ function UserMessageRow({
                 <FileTextIcon size={12} />
                 <span className="truncate text-xs">
                   {channelContext.mention.name
-                    ? `#${channelContext.mention.name} `
+                    ? `${channelDisplayLabel(channelContext.mention.name)} `
                     : ""}
                   CONTEXT.md
                 </span>

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityView.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityView.test.tsx
@@ -101,16 +101,19 @@ describe("activityHeadline", () => {
     expect(getByText(expected)).toBeInTheDocument();
   });
 
-  it("prefixes channel names with a hash", () => {
+  it.each([
+    ["shared channel", "engineering", "#engineering"],
+    ["personal channel", "personal", "personal"],
+  ])("formats the %s label", (_name, channelName, expected) => {
     const { getByText } = render(
       <div>
         {activityHeadline(
-          item({ activityKind: "completed", channelName: "me" }),
+          item({ activityKind: "completed", channelName }),
           "me@posthog.com",
         )}
       </div>,
     );
-    expect(getByText("#me")).toBeInTheDocument();
+    expect(getByText(expected)).toBeInTheDocument();
   });
 
   it("opens an activity mention at its exact comment thread", () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityView.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityView.test.tsx
@@ -103,7 +103,7 @@ describe("activityHeadline", () => {
 
   it.each([
     ["shared channel", "engineering", "#engineering"],
-    ["personal channel", "personal", "personal"],
+    ["personal channel", "personal", "your personal space"],
   ])("formats the %s label", (_name, channelName, expected) => {
     const { getByText } = render(
       <div>

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityView.tsx
@@ -5,7 +5,7 @@ import {
   LinkIcon,
   RobotIcon,
 } from "@phosphor-icons/react";
-import { channelDisplayLabel } from "@posthog/core/canvas/channelName";
+import { channelDisplayReference } from "@posthog/core/canvas/channelName";
 import type { TaskActivityItem } from "@posthog/core/canvas/taskActivity";
 import {
   Avatar,
@@ -68,7 +68,7 @@ function ChannelSuffix({ channelName }: { channelName: string | null }) {
     <>
       {" in "}
       <span className="font-medium text-xs">
-        {channelDisplayLabel(channelName)}
+        {channelDisplayReference(channelName)}
       </span>
     </>
   );

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityView.tsx
@@ -5,6 +5,7 @@ import {
   LinkIcon,
   RobotIcon,
 } from "@phosphor-icons/react";
+import { channelDisplayLabel } from "@posthog/core/canvas/channelName";
 import type { TaskActivityItem } from "@posthog/core/canvas/taskActivity";
 import {
   Avatar,
@@ -66,9 +67,9 @@ function ChannelSuffix({ channelName }: { channelName: string | null }) {
   return (
     <>
       {" in "}
-      <Text as="span" size="1" weight="medium">
-        #{channelName}
-      </Text>
+      <span className="font-medium text-xs">
+        {channelDisplayLabel(channelName)}
+      </span>
     </>
   );
 }

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.test.tsx
@@ -208,14 +208,14 @@ describe("ChannelsList", () => {
 
   it("pins the personal space above the channels, with its ⌘1 shortcut", () => {
     renderList();
-    const me = screen.getByText("personal");
+    const me = screen.getByText("personal space");
     const eng = screen.getByText("engineering");
     expect(
       me.compareDocumentPosition(eng) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     // ChannelHotkeys binds ⌘1-9 to the same slots; the list is where they're
     // advertised now that the switcher popover is gone.
-    expect(me.parentElement?.textContent).toMatch(/personal(⌘|Ctrl)/);
+    expect(me.parentElement?.textContent).toMatch(/personal space(⌘|Ctrl)/);
   });
 
   describe("group headings", () => {
@@ -244,7 +244,7 @@ describe("ChannelsList", () => {
 
       expect(screen.getByText("engineering")).toBeTruthy();
       expect(screen.queryByText("design")).toBeNull();
-      expect(screen.queryByText("personal")).toBeNull();
+      expect(screen.queryByText("personal space")).toBeNull();
     });
 
     // Grouping is for browsing; once you've named what you want, "Starred" and
@@ -267,9 +267,9 @@ describe("ChannelsList", () => {
       mocks.channelsLayout = false;
       renderList();
       expect(screen.queryByLabelText("Search spaces")).toBeNull();
-      expect(screen.getByText("personal").parentElement?.textContent).toBe(
-        "personal",
-      );
+      expect(
+        screen.getByText("personal space").parentElement?.textContent,
+      ).toBe("personal space");
     });
 
     it("says so when nothing matches", async () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -1318,8 +1318,9 @@ function useOpenPersonalChannel(): {
   const ensureChannelId = (): string | undefined => {
     const meChannel = channels.find((c) => c.channelType === "personal");
     if (!meChannel) {
-      toast.error("Couldn't open personal", {
-        description: "Personal is still loading. Try again in a moment.",
+      toast.error("Couldn't open personal space", {
+        description:
+          "Your personal space is still loading. Try again in a moment.",
       });
       return undefined;
     }

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -1296,11 +1296,11 @@ const ChannelSection = memo(
     ),
 );
 
-// The user's private "#me" channel, pinned above the shared channel list.
+// The user's private channel, named personal, is pinned above the shared list.
 // Provisioned lazily server-side when the channel list is fetched, so the row
 // only has to find it — there is no client-side create.
 /**
- * Opening the "me" row, shared by the row itself and the search results.
+ * Opening the personal row, shared by the row itself and the search results.
  *
  * The personal channel appears with the first channel-list fetch; until then
  * the row's actions have nothing truthful to act on, so they explain rather
@@ -1318,8 +1318,8 @@ function useOpenPersonalChannel(): {
   const ensureChannelId = (): string | undefined => {
     const meChannel = channels.find((c) => c.channelType === "personal");
     if (!meChannel) {
-      toast.error("Couldn't open me", {
-        description: "Your personal channel is still loading.",
+      toast.error("Couldn't open personal", {
+        description: "Personal is still loading. Try again in a moment.",
       });
       return undefined;
     }
@@ -1442,7 +1442,7 @@ const PersonalChannelRow = memo(function PersonalChannelRow({
           optionValue={meChannel?.id ?? PERSONAL_ROW_VALUE}
           data-selected={(isActive && !expanded) || undefined}
           onClick={openPersonalChannel}
-          // "me" is a starred space among the others now, so it takes the same
+          // Personal is a starred space among the others, so it takes the same
           // inset rather than sitting out at the heading's margin.
           className={spacesLayout ? "pl-2" : undefined}
         >
@@ -1639,8 +1639,8 @@ function ChannelGroup({
   );
 }
 
-// The channel list — the list pane of the sidebar slider. The private "#me"
-// channel is pinned at the top; starred channels surface in their own section
+// The channel list is the list pane of the sidebar slider. The personal channel
+// is pinned at the top; starred channels surface in their own section
 // so the ones you use most stay in reach; the rest sit under a "Channels"
 // label. Creating anything goes through the floating ChannelsFab, mounted by
 // the sidebar outside this scroll region.
@@ -1664,7 +1664,7 @@ export function ChannelsList() {
   const matches = (name: string) =>
     !normalizedQuery || name.toLowerCase().includes(normalizedQuery);
 
-  // The personal channel renders as the pinned "#me" row, not a shared channel.
+  // The personal channel renders as a pinned row, not a shared channel.
   const me = allChannels.find((c) => c.channelType === "personal");
   const channels = allChannels.filter((c) => c.channelType !== "personal");
   const starred = channels.filter((c) => c.starred);
@@ -1765,7 +1765,7 @@ export function ChannelsList() {
         // section is open — a folded section is still somewhere ↓ can land and
         // → can open.
         { kind: "section", value: starredValue, sectionId: STARRED_SECTION_ID },
-        // "me" leads the starred section rather than floating above it: it is
+        // Personal leads the starred section rather than floating above it. It is
         // the space you always keep, so it belongs with the ones you chose to
         // keep. Folding the section away takes it with them.
         ...(collapsedSections.has(STARRED_SECTION_ID)
@@ -1915,7 +1915,7 @@ export function ChannelsList() {
     </>
   ) : (
     <>
-      {/* Always rendered: "me" lives here, so the section is never empty. */}
+      {/* Always rendered: personal lives here, so the section is never empty. */}
       <ChannelGroup
         sectionId={STARRED_SECTION_ID}
         label="Starred"

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteChannelLoops.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteChannelLoops.tsx
@@ -1,4 +1,5 @@
 import { CloudIcon, PlusIcon } from "@phosphor-icons/react";
+import { channelDisplayLabel } from "@posthog/core/canvas/channelName";
 import { ChannelHeader } from "@posthog/ui/features/canvas/components/ChannelHeader";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
@@ -32,18 +33,19 @@ import { useChannels } from "../hooks/useChannels";
 import { useOrgMembers } from "../hooks/useOrgMembers";
 
 function contextQuickStarts(name: string): { label: string; prompt: string }[] {
+  const contextLabel = channelDisplayLabel(name);
   return [
     {
       label: "Digest to feed",
-      prompt: `On a schedule, post a short digest to #${name}'s feed summarizing `,
+      prompt: `On a schedule, post a short digest to ${contextLabel}'s feed summarizing `,
     },
     {
       label: "Keep context.md current",
-      prompt: `On a schedule, update #${name}'s context.md with the latest `,
+      prompt: `On a schedule, update ${contextLabel}'s context.md with the latest `,
     },
     {
       label: "Refresh a canvas",
-      prompt: `On a schedule, refresh a canvas in #${name} with `,
+      prompt: `On a schedule, refresh a canvas in ${contextLabel} with `,
     },
     {
       label: "Watch and report",
@@ -155,7 +157,8 @@ function SpaceAttachedLoops({
     navigateToNewLoop();
   };
 
-  const title = `Automate #${contextName}`;
+  const contextLabel = channelDisplayLabel(contextName);
+  const title = `Automate ${contextLabel}`;
   const description =
     "Put your work on autopilot. Loops run on a schedule, on an API call, or when something happens on GitHub. You can finally close the laptop!";
   const createButton = (
@@ -271,7 +274,7 @@ function SpaceAttachedLoops({
         >
           <LoopBuilderComposer
             context={{ folderId: channelId, name: contextName }}
-            placeholder={`What should #${contextName} keep an eye on?`}
+            placeholder={`What should ${contextLabel} keep an eye on?`}
             quickStarts={contextQuickStarts(contextName)}
             disabledReason={limitReason}
           />

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteChannelLoops.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteChannelLoops.tsx
@@ -1,5 +1,5 @@
 import { CloudIcon, PlusIcon } from "@phosphor-icons/react";
-import { channelDisplayLabel } from "@posthog/core/canvas/channelName";
+import { channelDisplayReference } from "@posthog/core/canvas/channelName";
 import { ChannelHeader } from "@posthog/ui/features/canvas/components/ChannelHeader";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
@@ -33,19 +33,19 @@ import { useChannels } from "../hooks/useChannels";
 import { useOrgMembers } from "../hooks/useOrgMembers";
 
 function contextQuickStarts(name: string): { label: string; prompt: string }[] {
-  const contextLabel = channelDisplayLabel(name);
+  const contextReference = channelDisplayReference(name);
   return [
     {
       label: "Digest to feed",
-      prompt: `On a schedule, post a short digest to ${contextLabel}'s feed summarizing `,
+      prompt: `On a schedule, post a short digest to ${contextReference}'s feed summarizing `,
     },
     {
       label: "Keep context.md current",
-      prompt: `On a schedule, update ${contextLabel}'s context.md with the latest `,
+      prompt: `On a schedule, update ${contextReference}'s context.md with the latest `,
     },
     {
       label: "Refresh a canvas",
-      prompt: `On a schedule, refresh a canvas in ${contextLabel} with `,
+      prompt: `On a schedule, refresh a canvas in ${contextReference} with `,
     },
     {
       label: "Watch and report",
@@ -157,8 +157,8 @@ function SpaceAttachedLoops({
     navigateToNewLoop();
   };
 
-  const contextLabel = channelDisplayLabel(contextName);
-  const title = `Automate ${contextLabel}`;
+  const contextReference = channelDisplayReference(contextName);
+  const title = `Automate ${contextReference}`;
   const description =
     "Put your work on autopilot. Loops run on a schedule, on an API call, or when something happens on GitHub. You can finally close the laptop!";
   const createButton = (
@@ -274,7 +274,7 @@ function SpaceAttachedLoops({
         >
           <LoopBuilderComposer
             context={{ folderId: channelId, name: contextName }}
-            placeholder={`What should ${contextLabel} keep an eye on?`}
+            placeholder={`What should ${contextReference} keep an eye on?`}
             quickStarts={contextQuickStarts(contextName)}
             disabledReason={limitReason}
           />

--- a/products/desktop/packages/ui/src/features/canvas/components/channelGlyph.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/channelGlyph.test.tsx
@@ -5,9 +5,9 @@ import { channelGlyph, isPrivateChannel } from "./channelGlyph";
 
 describe("isPrivateChannel", () => {
   it.each([
-    ["personal", true],
-    ["  Personal  ", true],
-    ["PERSONAL", true],
+    ["personal space", true],
+    ["  Personal Space  ", true],
+    ["PERSONAL SPACE", true],
     // The backend's own name for it, which no longer reaches here: every name
     // a reader sees has been through `channelDisplayName` first.
     ["me", false],
@@ -28,7 +28,8 @@ describe("channelGlyph", () => {
     ["channel", false, HashIcon],
     ["private space", true, LockSimpleIcon],
   ])("renders the %s glyph", (_, space, expectedIcon) => {
-    const name = expectedIcon === LockSimpleIcon ? "personal" : "engineering";
+    const name =
+      expectedIcon === LockSimpleIcon ? "personal space" : "engineering";
     const glyph = channelGlyph(name, { space }) as ReactElement;
 
     expect(glyph.type).toBe(expectedIcon);
@@ -40,8 +41,8 @@ describe("channelGlyph", () => {
     expect(channelGlyph("engineering", { space: true })).toBeNull();
   });
 
-  // The flag beats the name in both directions. Without it, a public space
-  // called "personal" wore the lock and the real private space showed none.
+  // The channel type beats the fallback name in both directions so public
+  // name collisions stay unmarked and the private space always has a lock.
   it("locks the private space whatever it is called", () => {
     const glyph = channelGlyph("anything", {
       personal: true,

--- a/products/desktop/packages/ui/src/features/canvas/components/channelGlyph.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/channelGlyph.tsx
@@ -9,10 +9,9 @@ import type { ReactNode } from "react";
 /**
  * Whether only its own members can see a channel, judged by its name.
  *
- * A guess, and the fallback for surfaces that hold a name and nothing else. Any
- * caller with the channel in hand should pass `personal` to `channelGlyph`
- * instead — a public space named "personal" reaches this function looking
- * exactly like the private one.
+ * This is a fallback for surfaces that hold a name and nothing else. A caller
+ * with the channel in hand must pass `personal` to avoid deciding privacy from
+ * a display label.
  */
 export function isPrivateChannel(channelName: string | undefined): boolean {
   if (!channelName) return false;

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useTaskChannels.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useTaskChannels.test.tsx
@@ -58,11 +58,11 @@ describe("useTaskChannels", () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(result.current.channels.map((c) => c.id)).toEqual(["1", "p1"]);
-    // Relabelled on the way in: the row is `me` on the backend and "personal"
-    // everywhere a person reads it.
+    // Relabelled on the way in: the row is `me` on the backend and
+    // "personal space" everywhere a person reads it.
     expect(result.current.personalChannel).toEqual({
       ...personal,
-      name: "personal",
+      name: "personal space",
     });
   });
 

--- a/products/desktop/packages/ui/src/features/command/keyboard-shortcuts.ts
+++ b/products/desktop/packages/ui/src/features/command/keyboard-shortcuts.ts
@@ -22,8 +22,8 @@ export const SHORTCUTS = {
   SWITCH_TAB: "ctrl+1,ctrl+2,ctrl+3,ctrl+4,ctrl+5,ctrl+6,ctrl+7,ctrl+8,ctrl+9",
   SWITCH_TASK: "mod+1,mod+2,mod+3,mod+4,mod+5,mod+6,mod+7,mod+8,mod+9",
   // No mod+0: the Electron View menu owns CmdOrCtrl+0 for "Actual Size", and a
-  // renderer preventDefault can't reliably beat a main-process accelerator. #me
-  // takes slot 1 instead.
+  // renderer preventDefault can't reliably beat a main-process accelerator. The
+  // personal space takes slot 1 instead.
   SWITCH_STARRED_CHANNEL:
     "mod+1,mod+2,mod+3,mod+4,mod+5,mod+6,mod+7,mod+8,mod+9",
   FOCUS_SPACE_SEARCH: "mod+shift+s",
@@ -141,7 +141,7 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
   {
     id: "switch-starred-channel",
     keys: "mod+1-9",
-    description: "Switch to space (⌘1 = #me, ⌘2-9 = starred)",
+    description: "Switch to space (⌘1 = personal, ⌘2-9 = starred)",
     category: "navigation",
     context: "Spaces",
     availability: "channels-layout",

--- a/products/desktop/packages/ui/src/features/command/keyboard-shortcuts.ts
+++ b/products/desktop/packages/ui/src/features/command/keyboard-shortcuts.ts
@@ -141,7 +141,7 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
   {
     id: "switch-starred-channel",
     keys: "mod+1-9",
-    description: "Switch to space (⌘1 = personal, ⌘2-9 = starred)",
+    description: "Switch to space (⌘1 = personal space, ⌘2-9 = starred)",
     category: "navigation",
     context: "Spaces",
     availability: "channels-layout",

--- a/products/desktop/packages/ui/src/features/loops/components/LoopContextFields.tsx
+++ b/products/desktop/packages/ui/src/features/loops/components/LoopContextFields.tsx
@@ -1,4 +1,5 @@
 import type { LoopSchemas } from "@posthog/api-client/loops";
+import { channelDisplayLabel } from "@posthog/core/canvas/channelName";
 import { Switch } from "@posthog/quill";
 import { SettingsOptionSelect } from "@posthog/ui/features/settings/SettingsOptionSelect";
 import { Flex, Text } from "@radix-ui/themes";
@@ -53,7 +54,7 @@ export function LoopContextFields({
     { value: NOT_ATTACHED_VALUE, label: "Not attached to a channel" },
     ...channels.map((channel) => ({
       value: channel.id,
-      label: `#${channel.name}`,
+      label: channelDisplayLabel(channel.name, channel.channelType),
     })),
   ];
 

--- a/products/desktop/packages/ui/src/features/loops/components/LoopForm.tsx
+++ b/products/desktop/packages/ui/src/features/loops/components/LoopForm.tsx
@@ -5,6 +5,7 @@ import {
   Check,
 } from "@phosphor-icons/react";
 import { type LoopSchemas, LoopsApiError } from "@posthog/api-client/loops";
+import { channelDisplayLabel } from "@posthog/core/canvas/channelName";
 import { ANALYTICS_EVENTS } from "@posthog/shared";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { useBluebirdFlag } from "@posthog/ui/features/feature-flags/useBluebirdFlag";
@@ -980,7 +981,8 @@ function describeContext(target: LoopContextTargetDraft | null): string {
   if (target.outputs.post_to_feed) outputs.push("feed");
   if (target.outputs.update_context) outputs.push("context.md");
   if (target.outputs.canvas_id) outputs.push("canvas");
+  const targetLabel = channelDisplayLabel(target.name);
   return outputs.length > 0
-    ? `#${target.name} (${outputs.join(", ")})`
-    : `#${target.name}`;
+    ? `${targetLabel} (${outputs.join(", ")})`
+    : targetLabel;
 }

--- a/products/desktop/packages/ui/src/features/loops/components/LoopsEmptyState.tsx
+++ b/products/desktop/packages/ui/src/features/loops/components/LoopsEmptyState.tsx
@@ -1,4 +1,4 @@
-import { channelDisplayLabel } from "@posthog/core/canvas/channelName";
+import { channelDisplayReference } from "@posthog/core/canvas/channelName";
 import { loopHog } from "@posthog/ui/assets/hedgehogs";
 import { Flex, Text } from "@radix-ui/themes";
 
@@ -26,7 +26,7 @@ export function LoopsEmptyState({ contextName }: { contextName?: string }) {
           <Flex direction="column" gap="1">
             <p className="font-semibold text-[16px] text-gray-12">
               {contextName
-                ? `Create a loop for ${channelDisplayLabel(contextName)}`
+                ? `Create a loop for ${channelDisplayReference(contextName)}`
                 : "Create your first loop"}
             </p>
             <Text className="text-[13px] text-gray-11 leading-relaxed">

--- a/products/desktop/packages/ui/src/features/loops/components/LoopsEmptyState.tsx
+++ b/products/desktop/packages/ui/src/features/loops/components/LoopsEmptyState.tsx
@@ -1,3 +1,4 @@
+import { channelDisplayLabel } from "@posthog/core/canvas/channelName";
 import { loopHog } from "@posthog/ui/assets/hedgehogs";
 import { Flex, Text } from "@radix-ui/themes";
 
@@ -23,11 +24,11 @@ export function LoopsEmptyState({ contextName }: { contextName?: string }) {
           className="min-w-0 flex-1"
         >
           <Flex direction="column" gap="1">
-            <Text className="font-semibold text-[16px] text-gray-12">
+            <p className="font-semibold text-[16px] text-gray-12">
               {contextName
-                ? `Create a loop for #${contextName}`
+                ? `Create a loop for ${channelDisplayLabel(contextName)}`
                 : "Create your first loop"}
-            </Text>
+            </p>
             <Text className="text-[13px] text-gray-11 leading-relaxed">
               Set it up once and it keeps running on its own, even with your
               laptop closed.

--- a/products/desktop/packages/ui/src/features/panels/panelLayoutStore.ts
+++ b/products/desktop/packages/ui/src/features/panels/panelLayoutStore.ts
@@ -1,3 +1,4 @@
+import { channelDisplayLabel } from "@posthog/core/canvas/channelName";
 import {
   addRecentFile,
   addActionTab as coreAddActionTab,
@@ -249,7 +250,7 @@ export const usePanelLayoutStore = createWithEqualityFn<PanelLayoutStore>()(
 
       openChannelContextInSplit: (taskId, context) => {
         const tabId = `context-${context.channelName ?? "channel"}`;
-        const label = `${context.channelName ? `#${context.channelName} ` : ""}CONTEXT.md`;
+        const label = `${context.channelName ? `${channelDisplayLabel(context.channelName)} ` : ""}CONTEXT.md`;
         set((state) =>
           updateTaskLayout(
             state,

--- a/products/desktop/packages/ui/src/features/sessions/components/CommentComposer.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/CommentComposer.test.tsx
@@ -32,7 +32,7 @@ describe("CommentComposer", () => {
     const onValueChange = vi.fn();
     render(
       <Theme>
-        <MentionAvailabilityProvider disabledReason="Mentions aren’t available in #me.">
+        <MentionAvailabilityProvider disabledReason="Mentions aren’t available in personal.">
           <CommentComposer
             value="@"
             onValueChange={onValueChange}
@@ -45,7 +45,7 @@ describe("CommentComposer", () => {
     );
 
     expect(screen.getByRole("status")).toHaveTextContent(
-      "Mentions aren’t available in #me.",
+      "Mentions aren’t available in personal.",
     );
     fireEvent.change(screen.getByRole("textbox", { name: "Comment" }), {
       target: { value: "private note" },

--- a/products/desktop/packages/ui/src/features/sessions/components/CommentComposer.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/CommentComposer.test.tsx
@@ -32,7 +32,7 @@ describe("CommentComposer", () => {
     const onValueChange = vi.fn();
     render(
       <Theme>
-        <MentionAvailabilityProvider disabledReason="Mentions aren’t available in personal.">
+        <MentionAvailabilityProvider disabledReason="Mentions aren’t available in your personal space.">
           <CommentComposer
             value="@"
             onValueChange={onValueChange}
@@ -45,7 +45,7 @@ describe("CommentComposer", () => {
     );
 
     expect(screen.getByRole("status")).toHaveTextContent(
-      "Mentions aren’t available in personal.",
+      "Mentions aren’t available in your personal space.",
     );
     fireEvent.change(screen.getByRole("textbox", { name: "Comment" }), {
       target: { value: "private note" },

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -8,6 +8,7 @@ import {
   ThumbsUp,
 } from "@phosphor-icons/react";
 import { WorkerPoolContextProvider } from "@pierre/diffs/react";
+import { channelDisplayLabel } from "@posthog/core/canvas/channelName";
 import { useService } from "@posthog/di/react";
 import {
   Button,
@@ -561,7 +562,7 @@ function UserBubble({
                   icon={<FileText size={12} />}
                   label={`${
                     channelContext.mention.name
-                      ? `#${channelContext.mention.name} `
+                      ? `${channelDisplayLabel(channelContext.mention.name)} `
                       : ""
                   }CONTEXT.md`}
                   onClick={

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.tsx
@@ -5,6 +5,7 @@ import {
   Scroll,
   SlackLogo,
 } from "@phosphor-icons/react";
+import { channelDisplayLabel } from "@posthog/core/canvas/channelName";
 import { PROJECT_BLUEBIRD_FLAG } from "@posthog/shared";
 import { Box, Flex, IconButton } from "@radix-ui/themes";
 import { motion } from "framer-motion";
@@ -149,7 +150,7 @@ export const UserMessage = memo(function UserMessage({
                   icon={<FileText size={12} />}
                   label={`${
                     channelContext.mention.name
-                      ? `#${channelContext.mention.name} `
+                      ? `${channelDisplayLabel(channelContext.mention.name)} `
                       : ""
                   }CONTEXT.md`}
                   onClick={

--- a/products/desktop/packages/ui/src/features/sessions/mentionAvailability.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/mentionAvailability.tsx
@@ -1,7 +1,7 @@
 import { createContext, type ReactNode, useContext } from "react";
 
 export const PRIVATE_SPACE_MENTIONS_DISABLED =
-  "Mentions aren’t available in #me.";
+  "Mentions aren’t available in personal.";
 
 const MentionAvailabilityContext = createContext<string | null>(null);
 

--- a/products/desktop/packages/ui/src/features/sessions/mentionAvailability.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/mentionAvailability.tsx
@@ -1,7 +1,7 @@
 import { createContext, type ReactNode, useContext } from "react";
 
 export const PRIVATE_SPACE_MENTIONS_DISABLED =
-  "Mentions aren’t available in personal.";
+  "Mentions aren’t available in your personal space.";
 
 const MentionAvailabilityContext = createContext<string | null>(null);
 

--- a/products/desktop/packages/ui/src/features/sidebar/components/SidebarBulkActionBar.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/SidebarBulkActionBar.tsx
@@ -6,6 +6,7 @@ import {
   SquaresFourIcon,
   XIcon,
 } from "@phosphor-icons/react";
+import { channelDisplayLabel } from "@posthog/core/canvas/channelName";
 import {
   Button,
   DropdownMenu,
@@ -152,7 +153,7 @@ export function SidebarBulkActionBar({
                       key={channel.id}
                       onClick={() => void actions.fileSelectedTo(channel.id)}
                     >
-                      {`#${channel.name}`}
+                      {channelDisplayLabel(channel.name, channel.channelType)}
                     </DropdownMenuItem>
                   ))}
                 </DropdownMenuContent>

--- a/products/desktop/packages/ui/src/features/sidebar/components/SidebarMenu.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/SidebarMenu.tsx
@@ -223,11 +223,14 @@ function SidebarMenuComponent() {
             allPinned,
             runningCount: bulkActions.runningCount,
             stopsCloudSandbox: bulkActions.stopsCloudSandbox,
-            channels: bulkActions.channels.map(({ id, name, starred }) => ({
-              id,
-              name,
-              starred,
-            })),
+            channels: bulkActions.channels.map(
+              ({ id, name, channelType, starred }) => ({
+                id,
+                name,
+                channelType,
+                starred,
+              }),
+            ),
           });
         if (!result.action) return;
 

--- a/products/desktop/packages/ui/src/features/task-detail/components/ChannelContextChip.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/ChannelContextChip.tsx
@@ -1,3 +1,4 @@
+import { channelDisplayLabel } from "@posthog/core/canvas/channelName";
 import {
   Chip,
   ChipClose,
@@ -42,7 +43,7 @@ export function ChannelContextChip({
           right padding, so a width that changes under the cursor would reflow
           the text being typed. */}
       <ChipClose
-        aria-label={`Remove ${channelName ? `#${channelName} ` : ""}CONTEXT.md`}
+        aria-label={`Remove ${channelName ? `${channelDisplayLabel(channelName)} ` : ""}CONTEXT.md`}
         className="mr-[-2.5px]"
         onClick={(event) => {
           // The chip itself opens the file; removing it must not also do that.

--- a/products/desktop/packages/ui/src/features/task-detail/components/ChannelContextTab.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/ChannelContextTab.tsx
@@ -1,4 +1,4 @@
-import { channelDisplayLabel } from "@posthog/core/canvas/channelName";
+import { channelDisplayReference } from "@posthog/core/canvas/channelName";
 import { Box, ScrollArea } from "@radix-ui/themes";
 import { MarkdownRenderer } from "../../editor/components/MarkdownRenderer";
 
@@ -19,7 +19,7 @@ export function ChannelContextTab({
       <Box p="4">
         <p className="mb-3 text-[12px] text-gray-9">
           Sent with this task's prompt as background context
-          {channelName ? ` from ${channelDisplayLabel(channelName)}` : ""}.
+          {channelName ? ` from ${channelDisplayReference(channelName)}` : ""}.
         </p>
         <Box className="text-[13px]">
           <MarkdownRenderer content={body} />

--- a/products/desktop/packages/ui/src/features/task-detail/components/ChannelContextTab.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/ChannelContextTab.tsx
@@ -1,4 +1,5 @@
-import { Box, ScrollArea, Text } from "@radix-ui/themes";
+import { channelDisplayLabel } from "@posthog/core/canvas/channelName";
+import { Box, ScrollArea } from "@radix-ui/themes";
 import { MarkdownRenderer } from "../../editor/components/MarkdownRenderer";
 
 interface ChannelContextTabProps {
@@ -16,10 +17,10 @@ export function ChannelContextTab({
   return (
     <ScrollArea type="auto" scrollbars="vertical" className="h-full">
       <Box p="4">
-        <Text className="mb-3 block text-[12px] text-gray-9">
+        <p className="mb-3 text-[12px] text-gray-9">
           Sent with this task's prompt as background context
-          {channelName ? ` from #${channelName}` : ""}.
-        </Text>
+          {channelName ? ` from ${channelDisplayLabel(channelName)}` : ""}.
+        </p>
         <Box className="text-[13px]">
           <MarkdownRenderer content={body} />
         </Box>

--- a/products/desktop/packages/ui/src/features/tasks/useTaskContextMenu.ts
+++ b/products/desktop/packages/ui/src/features/tasks/useTaskContextMenu.ts
@@ -88,9 +88,10 @@ export function useTaskContextMenu() {
           isInCommandCenter,
           hasEmptyCommandCenterCell,
           showArchivePrior,
-          channels: channels.map(({ id, name, starred }) => ({
+          channels: channels.map(({ id, name, channelType, starred }) => ({
             id,
             name,
+            channelType,
             starred,
           })),
         });


### PR DESCRIPTION
## Problem

People still see `#me`, `#personal`, or `personal` on personal-space surfaces in PostHog Desktop.

The old wording appears in mention warnings, activity labels, context chips, shortcuts, loop forms, and filing menus.

## Changes

- The personal space now appears without a hash throughout PostHog Desktop.
- Labels use `personal space`.
- Sentences use `your personal space` so the copy reads naturally.
- Shared spaces keep their existing `#name` labels.
- The backend keeps `me` as its channel name for compatibility.

### Copy review

Dynamic examples below use `personal`, which was the display name before this change.

| Surface | Before | After |
| --- | --- | --- |
| Main space label in the sidebar, breadcrumbs, selectors, tabs, search results, and hover cards | `personal` | `personal space` |
| Create action accessibility label | `New in personal` | `New in personal space` |
| Loading error title | `Couldn't open me` | `Couldn't open personal space` |
| Loading error description | `Your personal channel is still loading.` | `Your personal space is still loading. Try again in a moment.` |
| Mentions warning | `Mentions aren’t available in #me.` | `Mentions aren’t available in your personal space.` |
| Keyboard shortcut | `Switch to space (⌘1 = #me, ⌘2-9 = starred)` | `Switch to space (⌘1 = personal space, ⌘2-9 = starred)` |
| Agent waiting activity | `The agent is waiting for your reply in #personal` | `The agent is waiting for your reply in your personal space` |
| Completed task activity | `The agent completed this task in #personal` | `The agent completed this task in your personal space` |
| Agent reply activity | `The agent replied in #personal` | `The agent replied in your personal space` |
| Your reply activity | `You replied in #personal` | `You replied in your personal space` |
| Another person’s reply activity | `[Name] replied in #personal` | `[Name] replied in your personal space` |
| Mention activity | `[Name] mentioned you in #personal` | `[Name] mentioned you in your personal space` |
| Thread reply activity | `[Name] replied to a thread you participated in in #personal` | `[Name] replied to a thread you participated in in your personal space` |
| Canvas comment activity | `[Name] commented on your canvas in #personal` | `[Name] commented on your canvas in your personal space` |
| Artifact comment activity | `[Name] commented on your artifact in #personal` | `[Name] commented on your artifact in your personal space` |
| Task comment activity | `[Name] commented on your task in #personal` | `[Name] commented on your task in your personal space` |
| Activity timeline context label | `#personal CONTEXT.md` | `personal space CONTEXT.md` |
| Chat context label | `#personal CONTEXT.md` | `personal space CONTEXT.md` |
| User-message context label | `#personal CONTEXT.md` | `personal space CONTEXT.md` |
| Context tab title | `#personal CONTEXT.md` | `personal space CONTEXT.md` |
| Context description | `Sent with this task's prompt as background context from #personal.` | `Sent with this task's prompt as background context from your personal space.` |
| Remove-context accessibility label | `Remove #personal CONTEXT.md` | `Remove personal space CONTEXT.md` |
| Single-session filing menu | `File to… > #personal` | `File to… > personal space` |
| Native session context menu | `File to… > #personal` | `File to… > personal space` |
| Native bulk context menu | `File to… > #personal` | `File to… > personal space` |
| Sidebar bulk filing menu | `File to… > #personal` | `File to… > personal space` |
| Loop context picker | `#personal` | `personal space` |
| Loop review with no outputs | `#personal` | `personal space` |
| Loop review with outputs | `#personal (feed, context.md, canvas)` | `personal space (feed, context.md, canvas)` |
| Loop empty state | `Create a loop for #personal` | `Create a loop for your personal space` |
| Loop page title | `Automate #personal` | `Automate your personal space` |
| Loop composer placeholder | `What should #personal keep an eye on?` | `What should your personal space keep an eye on?` |
| Loop digest suggestion | `On a schedule, post a short digest to #personal's feed summarizing ` | `On a schedule, post a short digest to your personal space's feed summarizing ` |
| Loop context suggestion | `On a schedule, update #personal's context.md with the latest ` | `On a schedule, update your personal space's context.md with the latest ` |
| Loop canvas suggestion | `On a schedule, refresh a canvas in #personal with ` | `On a schedule, refresh a canvas in your personal space with ` |
| Canvas-generation task title | `Generate a canvas in #personal` | `Generate a canvas in your personal space` |

### Unchanged copy and contracts

| Context | Text |
| --- | --- |
| Shared spaces | Continue to use labels such as `#engineering` |
| Backend channel name | Remains `me` for compatibility |
| Channel type | Remains `personal` because it is an internal API value |
| Loop visibility | Remains `Personal (only you)` because it describes loop visibility, not the personal space |

## How did you test this code?

- Ran the focused core tests for channel labels, native context menus, and canvas task descriptions.
- Ran the focused UI tests for activity labels, mention warnings, channel lists, glyphs, and loop empty states.
- Ran the full desktop typecheck and desktop CI preflight.
- Rendered the mention warning in Storybook and checked the final text.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the desktop canvas guidance with the personal-space label rule.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- OpenAI GPT-5.6 used pi, shell tools, Playwright, and GitHub CLI. A session link is unavailable in this runner.
- Skills: `/writing-user-facing-copy`, `/writing-ui-components`, `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`, and `/writing-simplified-technical-english`.
- The implementation keeps the backend `me` value and centralizes only the display label.
