### PR TITLE
fix(surveys): apply hosted survey dark background from backgroundColor, not inputBackground default

### DIFF
--- a/posthog/templates/surveys/public_survey.html
+++ b/posthog/templates/surveys/public_survey.html
@@ -104,10 +104,17 @@
                 root.style.setProperty('--ph-survey-page-background', appearance.backgroundColor)
             }
 
-            const cardBg = appearance.inputBackground || appearance.backgroundColor
+            // Card background follows the user's survey background color, not the
+            // input background default. Prioritizing inputBackground here made dark
+            // hosted surveys render white (inputBackground is always '#ffffff' from
+            // HOSTED_SURVEY_DEFAULTS even when the user only set backgroundColor).
+            const cardBg = appearance.backgroundColor || appearance.inputBackground
             if (cardBg) {
-                root.style.setProperty('--ph-survey-input-background', cardBg)
                 root.style.setProperty('--ph-survey-background-color', cardBg)
+            }
+            const inputBg = appearance.inputBackground || appearance.backgroundColor
+            if (inputBg) {
+                root.style.setProperty('--ph-survey-input-background', inputBg)
             }
             if (appearance.borderColor) {
                 root.style.setProperty('--ph-survey-border-color', appearance.borderColor)


### PR DESCRIPTION
## Problem

When a hosted survey is created with a dark background color, the embedded iframe renders a **white** background instead.

## Root cause

In `posthog/templates/surveys/public_survey.html`, `applyPageAppearance` computes the card/surface background as:

```js
const cardBg = appearance.inputBackground || appearance.backgroundColor
```

`HOSTED_SURVEY_DEFAULTS` always provides `inputBackground: '#ffffff'`, so `cardBg` is **always** `'#ffffff'` even when the user only customized `backgroundColor` to a dark value. Both `--ph-survey-input-background` **and** `--ph-survey-background-color` were set to white, making the whole embedded survey render white.

## Fix

Prioritize `backgroundColor` for the card/surface background (`--ph-survey-background-color`), and use `inputBackground` only for the input controls (`--ph-survey-input-background`). This matches how `posthog-js` handles the same variables in `addSurveyCSSVariablesToElement` (which sets `--ph-survey-background-color` from `effectiveAppearance.backgroundColor`).

```js
const cardBg = appearance.backgroundColor || appearance.inputBackground
const inputBg = appearance.inputBackground || appearance.backgroundColor
```

## How to verify

1. Create a hosted survey with a dark background color.
2. Copy the iframe embed code and paste it into an empty HTML page.
3. The iframe now renders the dark background instead of white.

Fixes #81649
