### PR TITLE
feat(desktop): inline evidence references in agent messages

### DIFF
--- a/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.stories.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.stories.tsx
@@ -71,6 +71,25 @@ export const Clickable: Story = {
   ),
 };
 
+export const WithSparkline: Story = {
+  render: () => (
+    <div className="max-w-md text-[13px]">
+      <EvidenceRefChip
+        target={{
+          kind: "insight",
+          id: "9pQx3",
+          url: "https://us.posthog.com/project/2/insights/9pQx3",
+          value: "28.1%",
+          desc: "down 12.9pts since Jan 3",
+          series: [41.2, 40.8, 41, 39.9, 40.4, 41.1, 28.4, 27.9, 28.1],
+        }}
+      >
+        Checkout funnel
+      </EvidenceRefChip>
+    </div>
+  ),
+};
+
 export const InsideAgentMessage: Story = {
   render: () => (
     <div className="max-w-xl">

--- a/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.stories.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.stories.tsx
@@ -1,0 +1,87 @@
+import { EvidenceRefChip } from "@posthog/ui/features/editor/components/EvidenceRefChip";
+import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta: Meta<typeof EvidenceRefChip> = {
+  title: "Features/Editor/EvidenceRefChip",
+  component: EvidenceRefChip,
+  parameters: {
+    layout: "padded",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof EvidenceRefChip>;
+
+export const AllKinds: Story = {
+  render: () => (
+    <div className="flex max-w-md flex-col items-start gap-2 text-[13px]">
+      <EvidenceRefChip target={{ kind: "insight", id: "9pQx3" }}>
+        Checkout funnel
+      </EvidenceRefChip>
+      <EvidenceRefChip target={{ kind: "error", id: "018f44aa-9c2b" }}>
+        CouponValidator TypeError
+      </EvidenceRefChip>
+      <EvidenceRefChip target={{ kind: "replay", id: "s_01HQ4K" }}>
+        14 rageclick recordings
+      </EvidenceRefChip>
+      <EvidenceRefChip target={{ kind: "flag", id: "new-checkout-flow" }}>
+        new-checkout-flow
+      </EvidenceRefChip>
+      <EvidenceRefChip target={{ kind: "experiment", id: "exp_42" }}>
+        Reminder timing experiment
+      </EvidenceRefChip>
+      <EvidenceRefChip target={{ kind: "survey", id: "srv_11" }}>
+        Checkout survey verbatims
+      </EvidenceRefChip>
+      <EvidenceRefChip target={{ kind: "ticket", id: "conv_88" }}>
+        9 “coupon” tickets
+      </EvidenceRefChip>
+      <EvidenceRefChip target={{ kind: "trace", id: "t_9f2ab4" }}>
+        Slow generation traces
+      </EvidenceRefChip>
+      <EvidenceRefChip target={{ kind: "eval", id: "ev_faith" }}>
+        Faithfulness eval
+      </EvidenceRefChip>
+      <EvidenceRefChip target={{ kind: "event", id: "cart_saved" }}>
+        cart_saved events
+      </EvidenceRefChip>
+      <EvidenceRefChip target={{ kind: "something-new", id: "x1" }}>
+        Unknown kind falls back
+      </EvidenceRefChip>
+    </div>
+  ),
+};
+
+export const Clickable: Story = {
+  render: () => (
+    <div className="max-w-md text-[13px]">
+      <EvidenceRefChip
+        target={{
+          kind: "insight",
+          id: "9pQx3",
+          url: "https://us.posthog.com/project/2/insights/9pQx3",
+        }}
+      >
+        Checkout funnel
+      </EvidenceRefChip>
+    </div>
+  ),
+};
+
+export const InsideAgentMessage: Story = {
+  render: () => (
+    <div className="max-w-xl">
+      <MarkdownRenderer
+        content={[
+          "The [coupon → purchase conversion](evidence:insight/9pQx3) dropped",
+          "41% → 28% on Jan 3, the same day",
+          "[a TypeError in CouponValidator](evidence:error/018f44aa) first",
+          "appeared, and [14 recordings](evidence:replay/s_01HQ4K) show users",
+          "retrying the field before leaving. This area is gated by",
+          "[new-checkout-flow](evidence:flag/new-checkout-flow?url=https%3A%2F%2Fus.posthog.com%2Fproject%2F2%2Ffeature_flags%2F42).",
+        ].join(" ")}
+      />
+    </div>
+  ),
+};

--- a/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.stories.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.stories.tsx
@@ -61,6 +61,8 @@ export const Clickable: Story = {
           kind: "insight",
           id: "9pQx3",
           url: "https://us.posthog.com/project/2/insights/9pQx3",
+          value: "28.1%",
+          desc: "coupon → purchase conversion, down 12.9pts since Jan 3",
         }}
       >
         Checkout funnel
@@ -74,12 +76,12 @@ export const InsideAgentMessage: Story = {
     <div className="max-w-xl">
       <MarkdownRenderer
         content={[
-          "The [coupon → purchase conversion](evidence:insight/9pQx3) dropped",
+          "The [coupon → purchase conversion](evidence:insight/9pQx3?value=28.1%25&desc=down+12.9pts+since+Jan+3) dropped",
           "41% → 28% on Jan 3, the same day",
-          "[a TypeError in CouponValidator](evidence:error/018f44aa) first",
-          "appeared, and [14 recordings](evidence:replay/s_01HQ4K) show users",
+          "[a TypeError in CouponValidator](evidence:error/018f44aa?value=1%2C247+users&desc=first+seen+Jan+3%2C+spiking) first",
+          "appeared, and [14 recordings](evidence:replay/s_01HQ4K?desc=users+retry+3%E2%80%935%C3%97+then+leave) show users",
           "retrying the field before leaving. This area is gated by",
-          "[new-checkout-flow](evidence:flag/new-checkout-flow?url=https%3A%2F%2Fus.posthog.com%2Fproject%2F2%2Ffeature_flags%2F42).",
+          "[new-checkout-flow](evidence:flag/new-checkout-flow?url=https%3A%2F%2Fus.posthog.com%2Fproject%2F2%2Ffeature_flags%2F42&value=100%25&desc=all+users+since+Dec+12).",
         ].join(" ")}
       />
     </div>

--- a/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.test.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.test.tsx
@@ -15,37 +15,27 @@ function renderInTheme(node: React.ReactNode) {
 }
 
 describe("EvidenceRefChip", () => {
-  it("renders the citation label inline", () => {
+  it("renders a plain reference as text, not an interactive element", () => {
     renderInTheme(
       <EvidenceRefChip target={{ kind: "insight", id: "9pQx3" }}>
         Checkout funnel
       </EvidenceRefChip>,
     );
-    expect(
-      screen.getByRole("button", { name: "Checkout funnel" }),
-    ).toBeDefined();
+    expect(screen.getByText("Checkout funnel")).toBeDefined();
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
   });
 
-  it("opens the PostHog url on click when the link carries one", () => {
+  it("opens the PostHog url in the external browser when clicked", () => {
     const url = "https://us.posthog.com/project/2/insights/9pQx3";
     renderInTheme(
       <EvidenceRefChip target={{ kind: "insight", id: "9pQx3", url }}>
         Checkout funnel
       </EvidenceRefChip>,
     );
-    fireEvent.click(screen.getByRole("button", { name: "Checkout funnel" }));
+    const link = screen.getByRole("link", { name: "Checkout funnel" });
+    fireEvent.click(link);
     expect(openExternalUrl).toHaveBeenCalledWith(url);
-  });
-
-  it("does nothing on click without a url", () => {
-    vi.mocked(openExternalUrl).mockClear();
-    renderInTheme(
-      <EvidenceRefChip target={{ kind: "error", id: "018f" }}>
-        TypeError spike
-      </EvidenceRefChip>,
-    );
-    fireEvent.click(screen.getByRole("button", { name: "TypeError spike" }));
-    expect(openExternalUrl).not.toHaveBeenCalled();
   });
 
   it("renders from an evidence: markdown link in agent output", () => {
@@ -54,7 +44,9 @@ describe("EvidenceRefChip", () => {
     renderInTheme(
       <MarkdownRenderer content="The [coupon funnel](evidence:insight/9pQx3) dropped." />,
     );
-    expect(screen.getByRole("button", { name: "coupon funnel" })).toBeDefined();
-    expect(screen.queryByRole("link", { name: /coupon funnel/ })).toBeNull();
+    expect(screen.getByText("coupon funnel")).toBeDefined();
+    // Without a url parameter the reference is not a link at all — a plain
+    // external-link fallback would render one.
+    expect(screen.queryByRole("link")).toBeNull();
   });
 });

--- a/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.test.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.test.tsx
@@ -1,0 +1,60 @@
+import { Theme } from "@radix-ui/themes";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../shell/openExternal", () => ({
+  openExternalUrl: vi.fn(),
+}));
+
+import { openExternalUrl } from "../../../shell/openExternal";
+import { EvidenceRefChip } from "./EvidenceRefChip";
+import { MarkdownRenderer } from "./MarkdownRenderer";
+
+function renderInTheme(node: React.ReactNode) {
+  return render(<Theme>{node}</Theme>);
+}
+
+describe("EvidenceRefChip", () => {
+  it("renders the citation label inline", () => {
+    renderInTheme(
+      <EvidenceRefChip target={{ kind: "insight", id: "9pQx3" }}>
+        Checkout funnel
+      </EvidenceRefChip>,
+    );
+    expect(
+      screen.getByRole("button", { name: "Checkout funnel" }),
+    ).toBeDefined();
+  });
+
+  it("opens the PostHog url on click when the link carries one", () => {
+    const url = "https://us.posthog.com/project/2/insights/9pQx3";
+    renderInTheme(
+      <EvidenceRefChip target={{ kind: "insight", id: "9pQx3", url }}>
+        Checkout funnel
+      </EvidenceRefChip>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Checkout funnel" }));
+    expect(openExternalUrl).toHaveBeenCalledWith(url);
+  });
+
+  it("does nothing on click without a url", () => {
+    vi.mocked(openExternalUrl).mockClear();
+    renderInTheme(
+      <EvidenceRefChip target={{ kind: "error", id: "018f" }}>
+        TypeError spike
+      </EvidenceRefChip>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "TypeError spike" }));
+    expect(openExternalUrl).not.toHaveBeenCalled();
+  });
+
+  it("renders from an evidence: markdown link in agent output", () => {
+    // Guards the whole path: url transform must keep the scheme and the `a`
+    // component must dispatch to the chip instead of an external link.
+    renderInTheme(
+      <MarkdownRenderer content="The [coupon funnel](evidence:insight/9pQx3) dropped." />,
+    );
+    expect(screen.getByRole("button", { name: "coupon funnel" })).toBeDefined();
+    expect(screen.queryByRole("link", { name: /coupon funnel/ })).toBeNull();
+  });
+});

--- a/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.tsx
@@ -12,7 +12,7 @@ import {
   ShieldCheckIcon,
   SparkleIcon,
 } from "@phosphor-icons/react";
-import type { MouseEvent, ReactNode } from "react";
+import { type MouseEvent, type ReactNode, useId } from "react";
 import { Tooltip } from "../../../primitives/Tooltip";
 import { openExternalUrl } from "../../../shell/openExternal";
 import type { EvidenceLinkTarget } from "../../../utils/evidenceLinks";
@@ -89,6 +89,63 @@ export function getEvidenceKindMeta(kind: string): EvidenceKindMeta {
   return EVIDENCE_KIND_META[kind] ?? GENERIC_KIND_META;
 }
 
+const SPARK_W = 100;
+const SPARK_H = 32;
+const SPARK_PAD = 3;
+
+/**
+ * Tiny trend line for the hover card, drawn from the numbers the link itself
+ * carries — same zero-fetch principle as the other display params.
+ */
+function Sparkline({ points }: { points: number[] }) {
+  const gradientId = useId();
+  const max = Math.max(...points);
+  const min = Math.min(...points);
+  const range = max - min || 1;
+  const coords = points.map((point, index) => [
+    (index / (points.length - 1)) * SPARK_W,
+    SPARK_H - SPARK_PAD - ((point - min) / range) * (SPARK_H - 2 * SPARK_PAD),
+  ]);
+  const line = coords
+    .map(
+      ([x, y], index) =>
+        `${index === 0 ? "M" : "L"}${x.toFixed(1)} ${y.toFixed(1)}`,
+    )
+    .join(" ");
+  const [lastX, lastY] = coords[coords.length - 1];
+  return (
+    <svg
+      viewBox={`0 0 ${SPARK_W} ${SPARK_H}`}
+      preserveAspectRatio="none"
+      className="h-9 w-full"
+      role="img"
+      aria-label="Trend sparkline"
+      data-testid="evidence-sparkline"
+    >
+      <defs>
+        <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="var(--accent-9)" stopOpacity={0.2} />
+          <stop offset="100%" stopColor="var(--accent-9)" stopOpacity={0.02} />
+        </linearGradient>
+      </defs>
+      <path
+        d={`${line} L${SPARK_W} ${SPARK_H} L0 ${SPARK_H} Z`}
+        fill={`url(#${gradientId})`}
+      />
+      <path
+        d={line}
+        fill="none"
+        stroke="var(--accent-9)"
+        strokeWidth={1.6}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+        vectorEffect="non-scaling-stroke"
+      />
+      <circle cx={lastX} cy={lastY} r={2} fill="var(--accent-9)" />
+    </svg>
+  );
+}
+
 export function EvidenceRefChip({
   target,
   children,
@@ -123,20 +180,37 @@ export function EvidenceRefChip({
           </span>
         </span>
       </div>
-      {(target.value || target.desc) && (
+      {(target.value || target.desc || target.series) && (
         <div className="border-(--gray-a4) border-t px-3 py-2">
-          {target.value && (
-            <div className="font-[600] text-(--gray-12) text-[17px] leading-tight tracking-[-0.01em]">
-              {target.value}
-            </div>
-          )}
-          {target.desc && (
-            <div
-              className={`text-(--gray-10) text-[11.5px] leading-snug ${target.value ? "mt-1" : ""}`}
-            >
-              {target.desc}
-            </div>
-          )}
+          <div className="flex items-center gap-3">
+            {(target.value || target.desc) && (
+              <span className="min-w-0 flex-1">
+                {target.value && (
+                  <span className="block font-[600] text-(--gray-12) text-[17px] tabular-nums leading-tight tracking-[-0.01em]">
+                    {target.value}
+                  </span>
+                )}
+                {target.desc && (
+                  <span
+                    className={`block text-(--gray-10) text-[11.5px] leading-snug ${target.value ? "mt-1" : ""}`}
+                  >
+                    {target.desc}
+                  </span>
+                )}
+              </span>
+            )}
+            {target.series && (
+              <span
+                className={
+                  target.value || target.desc
+                    ? "w-24 shrink-0"
+                    : "min-w-0 flex-1"
+                }
+              >
+                <Sparkline points={target.series} />
+              </span>
+            )}
+          </div>
         </div>
       )}
       {preview && (

--- a/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.tsx
@@ -21,12 +21,17 @@ import type { EvidenceLinkTarget } from "../../../utils/evidenceLinks";
  * Inline evidence reference inside an agent message.
  *
  * Renders as a dotted-underline span with a small kind icon, so it reads as
- * part of the sentence and wraps like text. Hovering shows a preview card
- * with what the reference points at; clicking opens the underlying object in
- * PostHog when the link carries a `url`.
+ * part of the sentence and wraps like text. The underline is a bottom border
+ * rather than text-decoration: decoration never paints under an atomic
+ * inline like the icon's svg, while a bottom border runs under the full
+ * reference on every wrapped line fragment.
  *
- * UI layer only: the card shows the metadata the link itself carries. A live
- * data preview can slot into `preview` once evidence fetching exists.
+ * Hovering shows a preview card with what the reference points at; clicking
+ * opens the underlying object in PostHog when the link carries a `url`.
+ *
+ * UI layer only: the card shows the metadata the link itself carries
+ * (including the optional `value` and `desc` display params). A live data
+ * preview can slot into `preview` once evidence fetching exists.
  */
 
 interface EvidenceKindMeta {
@@ -104,38 +109,59 @@ export function EvidenceRefChip({
   };
 
   const card = (
-    <div className="w-60">
-      <div className="flex items-center gap-2 px-2.5 py-2">
-        <span className="flex size-5 shrink-0 items-center justify-center rounded-[5px] bg-(--gray-4)">
-          <KindIcon size={12} className="text-(--gray-11)" aria-hidden />
+    <div className="w-72">
+      <div className="flex items-center gap-2.5 px-3 pt-2.5 pb-2">
+        <span className="flex size-6 shrink-0 items-center justify-center rounded-md border border-(--gray-a4) bg-(--gray-a3)">
+          <KindIcon size={14} className="text-(--gray-11)" aria-hidden />
         </span>
         <span className="min-w-0 flex-1">
-          <span className="block truncate font-medium text-(--gray-12) text-xs leading-[1.35]">
+          <span className="block truncate font-medium text-(--gray-12) text-[12.5px] leading-[1.4]">
             {children}
           </span>
-          <span className="block text-(--gray-10) text-[11px] leading-[1.35]">
+          <span className="block text-(--gray-10) text-[11px] leading-[1.4]">
             {meta.kindLabel} · {meta.source}
           </span>
         </span>
       </div>
-      {preview && <div className="px-2.5 pb-2">{preview}</div>}
-      <div className="flex items-center justify-between gap-3 border-(--gray-4) border-t px-2.5 py-1.5 text-(--gray-9) text-[10.5px]">
-        <span className="truncate font-mono">{target.id}</span>
-        {clickable && (
-          <span className="shrink-0 text-(--gray-10)">Opens in PostHog ↗</span>
+      {(target.value || target.desc) && (
+        <div className="border-(--gray-a4) border-t px-3 py-2">
+          {target.value && (
+            <div className="font-[600] text-(--gray-12) text-[17px] leading-tight tracking-[-0.01em]">
+              {target.value}
+            </div>
+          )}
+          {target.desc && (
+            <div
+              className={`text-(--gray-10) text-[11.5px] leading-snug ${target.value ? "mt-1" : ""}`}
+            >
+              {target.desc}
+            </div>
+          )}
+        </div>
+      )}
+      {preview && (
+        <div className="border-(--gray-a4) border-t px-3 py-2">{preview}</div>
+      )}
+      <div className="flex items-center justify-between gap-3 rounded-b-[5px] border-(--gray-a4) border-t bg-(--gray-a2) px-3 py-[7px] text-[10.5px]">
+        <span className="truncate font-mono text-(--gray-9)">{target.id}</span>
+        {clickable ? (
+          <span className="shrink-0 text-(--gray-11)">Opens in PostHog ↗</span>
+        ) : (
+          <span className="shrink-0 text-(--gray-9)">{meta.source}</span>
         )}
       </div>
     </div>
   );
 
   const refClass =
-    "text-(--gray-12) underline decoration-(--gray-8) decoration-dotted underline-offset-[3px] hover:decoration-(--gray-11) hover:decoration-solid";
+    "border-b border-dotted border-(--gray-a8) pb-px text-(--gray-12) no-underline hover:border-solid hover:border-(--gray-a11)";
   const inner = (
     <>
-      {/* inline-block escapes the ancestor underline, keeping it off the icon */}
-      <span className="mr-[3px] inline-block align-[-1px]">
-        <KindIcon size={11} className="text-(--gray-10)" aria-hidden />
-      </span>
+      <KindIcon
+        size={12}
+        className="mr-[3px] inline-block translate-y-[-1px] align-middle text-(--gray-10)"
+        aria-hidden
+      />
       {children}
     </>
   );

--- a/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.tsx
@@ -12,21 +12,21 @@ import {
   ShieldCheckIcon,
   SparkleIcon,
 } from "@phosphor-icons/react";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@posthog/quill";
-import type { ReactNode } from "react";
+import type { MouseEvent, ReactNode } from "react";
+import { Tooltip } from "../../../primitives/Tooltip";
 import { openExternalUrl } from "../../../shell/openExternal";
 import type { EvidenceLinkTarget } from "../../../utils/evidenceLinks";
 
 /**
  * Inline evidence reference inside an agent message.
  *
- * Renders as a quiet dotted-underline span with a small kind icon, so it reads
- * as part of the sentence rather than a UI element. Hovering shows a preview
- * popover with what the reference points at; clicking opens the underlying
- * object in PostHog when the link carries a `url`.
+ * Renders as a dotted-underline span with a small kind icon, so it reads as
+ * part of the sentence and wraps like text. Hovering shows a preview card
+ * with what the reference points at; clicking opens the underlying object in
+ * PostHog when the link carries a `url`.
  *
- * UI layer only: the popover shows the metadata the link itself carries. A
- * live data preview can slot into `preview` once evidence fetching exists.
+ * UI layer only: the card shows the metadata the link itself carries. A live
+ * data preview can slot into `preview` once evidence fetching exists.
  */
 
 interface EvidenceKindMeta {
@@ -91,55 +91,64 @@ export function EvidenceRefChip({
 }: {
   target: EvidenceLinkTarget;
   children: ReactNode;
-  /** Slot for a live data preview inside the popover, once fetching exists. */
+  /** Slot for a live data preview inside the card, once fetching exists. */
   preview?: ReactNode;
 }) {
   const meta = getEvidenceKindMeta(target.kind);
   const KindIcon = meta.icon;
   const clickable = !!target.url;
 
-  const refElement = (
-    <button
-      type="button"
-      onClick={
-        clickable && target.url
-          ? () => openExternalUrl(target.url as string)
-          : undefined
-      }
-      className={`m-0 inline border-(--gray-8) border-0 border-b border-dotted bg-transparent p-0 pb-px text-left align-baseline font-inherit text-(--gray-12) text-[length:inherit] leading-inherit hover:border-(--accent-9) hover:border-solid ${clickable ? "cursor-pointer" : "cursor-default"}`}
-    >
-      <KindIcon
-        size={11}
-        className="mr-1 inline-block align-[-1px] text-(--gray-10)"
-        aria-hidden
-      />
+  const open = (event: MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
+    if (target.url) openExternalUrl(target.url);
+  };
+
+  const card = (
+    <div className="w-60">
+      <div className="flex items-center gap-2 px-2.5 py-2">
+        <span className="flex size-5 shrink-0 items-center justify-center rounded-[5px] bg-(--gray-4)">
+          <KindIcon size={12} className="text-(--gray-11)" aria-hidden />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block truncate font-medium text-(--gray-12) text-xs leading-[1.35]">
+            {children}
+          </span>
+          <span className="block text-(--gray-10) text-[11px] leading-[1.35]">
+            {meta.kindLabel} · {meta.source}
+          </span>
+        </span>
+      </div>
+      {preview && <div className="px-2.5 pb-2">{preview}</div>}
+      <div className="flex items-center justify-between gap-3 border-(--gray-4) border-t px-2.5 py-1.5 text-(--gray-9) text-[10.5px]">
+        <span className="truncate font-mono">{target.id}</span>
+        {clickable && (
+          <span className="shrink-0 text-(--gray-10)">Opens in PostHog ↗</span>
+        )}
+      </div>
+    </div>
+  );
+
+  const refClass =
+    "text-(--gray-12) underline decoration-(--gray-8) decoration-dotted underline-offset-[3px] hover:decoration-(--gray-11) hover:decoration-solid";
+  const inner = (
+    <>
+      {/* inline-block escapes the ancestor underline, keeping it off the icon */}
+      <span className="mr-[3px] inline-block align-[-1px]">
+        <KindIcon size={11} className="text-(--gray-10)" aria-hidden />
+      </span>
       {children}
-    </button>
+    </>
   );
 
   return (
-    <Tooltip>
-      <TooltipTrigger render={refElement} />
-      <TooltipContent side="top" sideOffset={6} className="w-64 p-0">
-        <div className="flex items-center gap-2 px-3 pt-2.5 pb-1.5">
-          <span className="flex size-6 shrink-0 items-center justify-center rounded-md bg-(--gray-4)">
-            <KindIcon size={13} className="text-(--gray-11)" aria-hidden />
-          </span>
-          <span className="min-w-0">
-            <span className="block truncate font-medium text-(--gray-12) text-xs">
-              {children}
-            </span>
-            <span className="block text-(--gray-10) text-[11px]">
-              {meta.kindLabel} · {meta.source}
-            </span>
-          </span>
-        </div>
-        {preview && <div className="px-3 pb-1.5">{preview}</div>}
-        <div className="flex items-center justify-between border-(--gray-4) border-t px-3 py-1.5 text-(--gray-10) text-[11px]">
-          <span className="truncate font-mono">{target.id}</span>
-          {clickable && <span className="shrink-0">Opens in PostHog ↗</span>}
-        </div>
-      </TooltipContent>
+    <Tooltip content={card} contentClassName="block p-0" sideOffset={8}>
+      {clickable ? (
+        <a href={target.url} onClick={open} className={refClass}>
+          {inner}
+        </a>
+      ) : (
+        <span className={refClass}>{inner}</span>
+      )}
     </Tooltip>
   );
 }

--- a/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/EvidenceRefChip.tsx
@@ -1,0 +1,145 @@
+import {
+  BugIcon,
+  ChartLineIcon,
+  ChatCircleTextIcon,
+  ClipboardTextIcon,
+  FlagIcon,
+  FlaskIcon,
+  type Icon,
+  LightningIcon,
+  PlayCircleIcon,
+  PulseIcon,
+  ShieldCheckIcon,
+  SparkleIcon,
+} from "@phosphor-icons/react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@posthog/quill";
+import type { ReactNode } from "react";
+import { openExternalUrl } from "../../../shell/openExternal";
+import type { EvidenceLinkTarget } from "../../../utils/evidenceLinks";
+
+/**
+ * Inline evidence reference inside an agent message.
+ *
+ * Renders as a quiet dotted-underline span with a small kind icon, so it reads
+ * as part of the sentence rather than a UI element. Hovering shows a preview
+ * popover with what the reference points at; clicking opens the underlying
+ * object in PostHog when the link carries a `url`.
+ *
+ * UI layer only: the popover shows the metadata the link itself carries. A
+ * live data preview can slot into `preview` once evidence fetching exists.
+ */
+
+interface EvidenceKindMeta {
+  icon: Icon;
+  /** Human name of the evidence kind, e.g. "Insight". */
+  kindLabel: string;
+  /** Product the evidence comes from, e.g. "Product analytics". */
+  source: string;
+}
+
+const EVIDENCE_KIND_META: Record<string, EvidenceKindMeta> = {
+  insight: {
+    icon: ChartLineIcon,
+    kindLabel: "Insight",
+    source: "Product analytics",
+  },
+  error: { icon: BugIcon, kindLabel: "Error issue", source: "Error tracking" },
+  replay: {
+    icon: PlayCircleIcon,
+    kindLabel: "Session replay",
+    source: "Session replay",
+  },
+  flag: { icon: FlagIcon, kindLabel: "Feature flag", source: "Feature flags" },
+  experiment: {
+    icon: FlaskIcon,
+    kindLabel: "Experiment",
+    source: "Experiments",
+  },
+  survey: { icon: ClipboardTextIcon, kindLabel: "Survey", source: "Surveys" },
+  ticket: {
+    icon: ChatCircleTextIcon,
+    kindLabel: "Support tickets",
+    source: "Conversations",
+  },
+  trace: { icon: SparkleIcon, kindLabel: "LLM trace", source: "LLM analytics" },
+  eval: {
+    icon: ShieldCheckIcon,
+    kindLabel: "Evaluation",
+    source: "LLM analytics",
+  },
+  event: {
+    icon: LightningIcon,
+    kindLabel: "Events",
+    source: "Product analytics",
+  },
+};
+
+const GENERIC_KIND_META: EvidenceKindMeta = {
+  icon: PulseIcon,
+  kindLabel: "Evidence",
+  source: "PostHog",
+};
+
+export function getEvidenceKindMeta(kind: string): EvidenceKindMeta {
+  return EVIDENCE_KIND_META[kind] ?? GENERIC_KIND_META;
+}
+
+export function EvidenceRefChip({
+  target,
+  children,
+  preview,
+}: {
+  target: EvidenceLinkTarget;
+  children: ReactNode;
+  /** Slot for a live data preview inside the popover, once fetching exists. */
+  preview?: ReactNode;
+}) {
+  const meta = getEvidenceKindMeta(target.kind);
+  const KindIcon = meta.icon;
+  const clickable = !!target.url;
+
+  const refElement = (
+    <button
+      type="button"
+      onClick={
+        clickable && target.url
+          ? () => openExternalUrl(target.url as string)
+          : undefined
+      }
+      className={`m-0 inline border-(--gray-8) border-0 border-b border-dotted bg-transparent p-0 pb-px text-left align-baseline font-inherit text-(--gray-12) text-[length:inherit] leading-inherit hover:border-(--accent-9) hover:border-solid ${clickable ? "cursor-pointer" : "cursor-default"}`}
+    >
+      <KindIcon
+        size={11}
+        className="mr-1 inline-block align-[-1px] text-(--gray-10)"
+        aria-hidden
+      />
+      {children}
+    </button>
+  );
+
+  return (
+    <Tooltip>
+      <TooltipTrigger render={refElement} />
+      <TooltipContent side="top" sideOffset={6} className="w-64 p-0">
+        <div className="flex items-center gap-2 px-3 pt-2.5 pb-1.5">
+          <span className="flex size-6 shrink-0 items-center justify-center rounded-md bg-(--gray-4)">
+            <KindIcon size={13} className="text-(--gray-11)" aria-hidden />
+          </span>
+          <span className="min-w-0">
+            <span className="block truncate font-medium text-(--gray-12) text-xs">
+              {children}
+            </span>
+            <span className="block text-(--gray-10) text-[11px]">
+              {meta.kindLabel} · {meta.source}
+            </span>
+          </span>
+        </div>
+        {preview && <div className="px-3 pb-1.5">{preview}</div>}
+        <div className="flex items-center justify-between border-(--gray-4) border-t px-3 py-1.5 text-(--gray-10) text-[11px]">
+          <span className="truncate font-mono">{target.id}</span>
+          {clickable && <span className="shrink-0">Opens in PostHog ↗</span>}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/products/desktop/packages/ui/src/features/editor/components/MarkdownRenderer.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/MarkdownRenderer.tsx
@@ -1,5 +1,6 @@
 import { isPostHogCodeDeeplink } from "@posthog/shared";
 import { ArtifactRefChip } from "@posthog/ui/features/editor/components/ArtifactRefChip";
+import { EvidenceRefChip } from "@posthog/ui/features/editor/components/EvidenceRefChip";
 import { GithubRefChip } from "@posthog/ui/features/editor/components/GithubRefChip";
 import { parseGithubIssueUrl } from "@posthog/ui/features/message-editor/githubIssueUrl";
 import { CodeBlock } from "@posthog/ui/primitives/CodeBlock";
@@ -7,6 +8,7 @@ import { Divider } from "@posthog/ui/primitives/Divider";
 import { HighlightedCode } from "@posthog/ui/primitives/HighlightedCode";
 import { List, ListItem } from "@posthog/ui/primitives/List";
 import { parseArtifactLink } from "@posthog/ui/utils/artifactLinks";
+import { parseEvidenceLink } from "@posthog/ui/utils/evidenceLinks";
 import { handleShareLinkClick } from "@posthog/ui/utils/shareLinks";
 import { Blockquote, Checkbox, Code, Kbd, Text } from "@radix-ui/themes";
 import { memo, useMemo } from "react";
@@ -34,6 +36,9 @@ function markdownUrlTransform(value: string, key: string): string {
   // The scheme survives only on `href` so `![x](chart:y)` can't become an
   // unsanitized image; consumers decide what a chart href renders as.
   if (key === "href" && value.startsWith("chart:")) return value;
+  // Evidence citations (`[label](evidence:<kind>/<id>)`) render as inline
+  // references with a hover preview; see EvidenceRefChip.
+  if (key === "href" && value.startsWith("evidence:")) return value;
   if (isPostHogCodeDeeplink(value)) return value;
   return defaultUrlTransform(value);
 }
@@ -128,6 +133,12 @@ export const baseComponents: Components = {
     <del className="text-(--gray-9) line-through">{children}</del>
   ),
   a: ({ href, children }) => {
+    const evidenceTarget = parseEvidenceLink(href);
+    if (evidenceTarget) {
+      return (
+        <EvidenceRefChip target={evidenceTarget}>{children}</EvidenceRefChip>
+      );
+    }
     const artifactTarget = parseArtifactLink(href);
     if (artifactTarget && href) {
       return (

--- a/products/desktop/packages/ui/src/features/editor/components/MarkdownRenderer.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/MarkdownRenderer.tsx
@@ -2,16 +2,18 @@ import { isPostHogCodeDeeplink } from "@posthog/shared";
 import { ArtifactRefChip } from "@posthog/ui/features/editor/components/ArtifactRefChip";
 import { EvidenceRefChip } from "@posthog/ui/features/editor/components/EvidenceRefChip";
 import { GithubRefChip } from "@posthog/ui/features/editor/components/GithubRefChip";
+import { MessageChartCard } from "@posthog/ui/features/editor/components/MessageChartCard";
 import { parseGithubIssueUrl } from "@posthog/ui/features/message-editor/githubIssueUrl";
 import { CodeBlock } from "@posthog/ui/primitives/CodeBlock";
 import { Divider } from "@posthog/ui/primitives/Divider";
 import { HighlightedCode } from "@posthog/ui/primitives/HighlightedCode";
 import { List, ListItem } from "@posthog/ui/primitives/List";
 import { parseArtifactLink } from "@posthog/ui/utils/artifactLinks";
+import { chartBlockKey, parseChartBlock } from "@posthog/ui/utils/chartBlocks";
 import { parseEvidenceLink } from "@posthog/ui/utils/evidenceLinks";
 import { handleShareLinkClick } from "@posthog/ui/utils/shareLinks";
 import { Blockquote, Checkbox, Code, Kbd, Text } from "@radix-ui/themes";
-import { memo, useMemo } from "react";
+import { isValidElement, memo, useMemo } from "react";
 import type { Components } from "react-markdown";
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -114,9 +116,17 @@ export const baseComponents: Components = {
     </Blockquote>
   ),
   code: ({ children, className }) => {
-    const match = className?.match(/language-(\w+)/);
+    const match = className?.match(/language-([\w-]+)/);
     if (!match) {
       return <Code variant="ghost">{children}</Code>;
+    }
+    if (match[1] === "posthog-chart") {
+      const source = String(children).replace(/\n$/, "");
+      const spec = parseChartBlock(source);
+      // Malformed or half-streamed JSON renders nothing rather than raw JSON;
+      // the block completes (or stays broken) on the next stream snapshot.
+      if (!spec) return null;
+      return <MessageChartCard spec={spec} blockKey={chartBlockKey(source)} />;
     }
     return (
       <HighlightedCode
@@ -125,7 +135,16 @@ export const baseComponents: Components = {
       />
     );
   },
-  pre: ({ children }) => <CodeBlock size="1">{children}</CodeBlock>,
+  pre: ({ children }) => {
+    // A chart block renders as a full card, not inside a code block shell.
+    if (
+      isValidElement<{ className?: string }>(children) &&
+      children.props.className?.includes("language-posthog-chart")
+    ) {
+      return children;
+    }
+    return <CodeBlock size="1">{children}</CodeBlock>;
+  },
   em: ({ children }) => <em>{children}</em>,
   i: ({ children }) => <i>{children}</i>,
   strong: ({ children }) => <strong>{children}</strong>,

--- a/products/desktop/packages/ui/src/features/editor/components/MessageChartCard.stories.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/MessageChartCard.stories.tsx
@@ -1,0 +1,79 @@
+import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
+import { MessageChartCard } from "@posthog/ui/features/editor/components/MessageChartCard";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta: Meta<typeof MessageChartCard> = {
+  title: "Features/Editor/MessageChartCard",
+  component: MessageChartCard,
+  parameters: {
+    layout: "padded",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MessageChartCard>;
+
+const DAU_BLOCK = JSON.stringify({
+  title: "Daily active users",
+  caption: "Weekends dip to roughly half of weekday traffic.",
+  render: "bar",
+  labels: ["Aug 7", "Aug 8", "Aug 9", "Aug 10", "Aug 11", "Aug 12", "Aug 13"],
+  series: [
+    { name: "DAU", points: [69650, 39431, 47804, 85174, 83213, 81434, 79541] },
+  ],
+});
+
+const MULTI_BLOCK = JSON.stringify({
+  title: "Signups vs activations",
+  render: "line",
+  labels: [
+    "2026-08-08",
+    "2026-08-09",
+    "2026-08-10",
+    "2026-08-11",
+    "2026-08-12",
+  ],
+  series: [
+    { name: "Signups", points: [420, 180, 510, 560, 540] },
+    { name: "Activations", points: [210, 90, 260, 300, 310] },
+  ],
+});
+
+export const InlineData: Story = {
+  render: () => (
+    <div className="max-w-xl">
+      <MessageChartCard
+        spec={{
+          mode: "data",
+          title: "Daily active users",
+          render: "bar",
+          labels: ["Aug 7", "Aug 8", "Aug 9", "Aug 10"],
+          series: [{ name: "DAU", points: [69650, 39431, 47804, 85174] }],
+        }}
+        blockKey="story-inline"
+      />
+    </div>
+  ),
+};
+
+export const InsideAgentMessage: Story = {
+  render: () => (
+    <div className="max-w-xl">
+      <MarkdownRenderer
+        content={[
+          "Here's the daily active user count for the last 7 days:",
+          "",
+          "```posthog-chart",
+          DAU_BLOCK,
+          "```",
+          "",
+          "**Weekday vs. weekend pattern** is very clear, with Mon-Thu holding 79K-85K.",
+          "",
+          "```posthog-chart",
+          MULTI_BLOCK,
+          "```",
+        ].join("\n")}
+      />
+    </div>
+  ),
+};

--- a/products/desktop/packages/ui/src/features/editor/components/MessageChartCard.test.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/MessageChartCard.test.tsx
@@ -37,6 +37,21 @@ describe("posthog-chart blocks in agent markdown", () => {
     expect(screen.queryByText(/"series"/)).toBeNull();
   });
 
+  it("leaves ordinary fenced code inside the code-block shell", () => {
+    // The chart dispatch widened the fence-language regex and made `pre`
+    // conditionally unwrap; a plain fence must keep its highlighted
+    // code-block chrome and never become a chart card.
+    const { container } = render(
+      <Theme>
+        <MarkdownRenderer content={"```ts\nconst a = 1;\n```\n"} />
+      </Theme>,
+    );
+    // Highlighting splits the code into spans, so match the joined text.
+    expect(container.querySelector("code")?.textContent).toBe("const a = 1;");
+    expect(screen.getByLabelText("Copy code")).toBeDefined();
+    expect(screen.queryByTestId("report-chart")).toBeNull();
+  });
+
   it("renders nothing for a malformed or half-streamed block", () => {
     render(
       <Theme>

--- a/products/desktop/packages/ui/src/features/editor/components/MessageChartCard.test.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/MessageChartCard.test.tsx
@@ -1,0 +1,51 @@
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// quill-charts is canvas-backed and does not load in the test environment;
+// the card chrome around it is what this test exercises.
+vi.mock("@posthog/quill-charts", () => ({
+  BarChart: () => <div data-testid="chart-plot" />,
+  LineChart: () => <div data-testid="chart-plot" />,
+  TimeSeriesBarChart: () => <div data-testid="chart-plot" />,
+  TimeSeriesLineChart: () => <div data-testid="chart-plot" />,
+  useChartTheme: () => ({}),
+}));
+
+import { MarkdownRenderer } from "./MarkdownRenderer";
+
+const DATA_BLOCK = JSON.stringify({
+  title: "Daily active users",
+  render: "bar",
+  labels: ["Aug 7", "Aug 8"],
+  series: [{ name: "DAU", points: [69650, 39431] }],
+});
+
+describe("posthog-chart blocks in agent markdown", () => {
+  it("renders a chart card instead of a code block", () => {
+    // Guards the whole dispatch: the code component must parse the fence into
+    // a card and the pre component must not wrap it in a code-block shell.
+    render(
+      <Theme>
+        <MarkdownRenderer
+          content={`Numbers:\n\n\`\`\`posthog-chart\n${DATA_BLOCK}\n\`\`\`\n`}
+        />
+      </Theme>,
+    );
+    expect(screen.getByTestId("report-chart")).toBeDefined();
+    expect(screen.getByText("Daily active users")).toBeDefined();
+    expect(screen.queryByText(/"series"/)).toBeNull();
+  });
+
+  it("renders nothing for a malformed or half-streamed block", () => {
+    render(
+      <Theme>
+        <MarkdownRenderer
+          content={'```posthog-chart\n{"series":[{"po\n```\n'}
+        />
+      </Theme>,
+    );
+    expect(screen.queryByTestId("report-chart")).toBeNull();
+    expect(screen.queryByText(/series/)).toBeNull();
+  });
+});

--- a/products/desktop/packages/ui/src/features/editor/components/MessageChartCard.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/MessageChartCard.tsx
@@ -1,0 +1,143 @@
+import {
+  planReportChart,
+  type ReportChartData,
+  reportChartHeightClass,
+  reportChartOpenTarget,
+  shapeReportChartData,
+} from "@posthog/core/inbox/reportCharts";
+import { getCloudUrlFromRegion } from "@posthog/shared";
+import { useAuthStateValue } from "@posthog/ui/features/auth/store";
+import {
+  type ReportChartCardState,
+  ReportChartCardView,
+} from "@posthog/ui/features/inbox/components/detail/ReportChartCard";
+import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
+import type { ChartBlockSpec } from "@posthog/ui/utils/chartBlocks";
+import { useMemo } from "react";
+
+/**
+ * Full-size chart card for a `posthog-chart` block in an agent message.
+ * Renders through the same card and quill-charts pipeline as report charts,
+ * so agent-message charts and report charts look and behave identically.
+ */
+
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+const DATE_TIME = /^\d{4}-\d{2}-\d{2}[T ]\d{2}/;
+
+function shapeInlineData(
+  spec: Extract<ChartBlockSpec, { mode: "data" }>,
+): ReportChartData {
+  const isTimeSeries =
+    spec.labels.length > 0 &&
+    spec.labels.every(
+      (label) => DATE_ONLY.test(label) || DATE_TIME.test(label),
+    );
+  return {
+    type: "series",
+    render: spec.render,
+    labels: spec.labels,
+    series: spec.series.map((entry, index) => ({
+      key: `${index}:${entry.name}`,
+      label: entry.name,
+      data: entry.points,
+    })),
+    isTimeSeries,
+    interval: spec.labels.some((label) => DATE_TIME.test(label))
+      ? "hour"
+      : "day",
+  };
+}
+
+function QueryChartCard({
+  spec,
+  blockKey,
+}: {
+  spec: Extract<ChartBlockSpec, { mode: "query" }>;
+  blockKey: string;
+}) {
+  const projectId = useAuthStateValue((state) => state.currentProjectId);
+  const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
+
+  const plan = useMemo(() => planReportChart(spec.query), [spec.query]);
+  const query = useAuthenticatedQuery<ReportChartData>(
+    ["message-chart-block", blockKey],
+    async (client) => {
+      if (plan.kind !== "run") return { type: "empty" };
+      const response = await client.runQuery(plan.source);
+      return shapeReportChartData(response, plan);
+    },
+    {
+      enabled: plan.kind === "run",
+      staleTime: 5 * 60 * 1000,
+      refetchOnWindowFocus: false,
+      retry: 1,
+    },
+  );
+
+  const openTarget = useMemo(() => {
+    if (!cloudRegion || !projectId) return null;
+    return reportChartOpenTarget(spec.query, {
+      cloudUrl: getCloudUrlFromRegion(cloudRegion),
+      projectId,
+    });
+  }, [spec.query, cloudRegion, projectId]);
+
+  if (plan.kind === "invalid") return null;
+
+  const state: ReportChartCardState =
+    plan.kind !== "run"
+      ? { kind: "link-out" }
+      : query.isPending
+        ? { kind: "loading" }
+        : query.isError
+          ? {
+              kind: "error",
+              message:
+                "Couldn't run the query behind this chart. Open it in PostHog to investigate.",
+            }
+          : { kind: "data", data: query.data };
+
+  return (
+    <ReportChartCardView
+      chartId={blockKey}
+      title={spec.title ?? "Chart"}
+      caption={spec.caption}
+      heightClass={reportChartHeightClass(
+        null,
+        state.kind === "data" ? state.data : null,
+      )}
+      state={state}
+      openTarget={openTarget}
+    />
+  );
+}
+
+export function MessageChartCard({
+  spec,
+  blockKey,
+}: {
+  spec: ChartBlockSpec;
+  /** Stable identity for the block, e.g. a hash of its fence body. */
+  blockKey: string;
+}) {
+  if (spec.mode === "query") {
+    return (
+      <div className="mb-2">
+        <QueryChartCard spec={spec} blockKey={blockKey} />
+      </div>
+    );
+  }
+  const data = shapeInlineData(spec);
+  return (
+    <div className="mb-2">
+      <ReportChartCardView
+        chartId={blockKey}
+        title={spec.title ?? "Chart"}
+        caption={spec.caption}
+        heightClass={reportChartHeightClass(null, data)}
+        state={{ kind: "data", data }}
+        openTarget={null}
+      />
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/primitives/Tooltip.tsx
+++ b/products/desktop/packages/ui/src/primitives/Tooltip.tsx
@@ -5,6 +5,8 @@ import { KeyHint } from "./KeyHint";
 interface TooltipProps {
   children: React.ReactNode;
   content: React.ReactNode;
+  /** Replaces the default inner layout (row flex + padding) for card-style content. The surface (background, border, radius) stays. */
+  contentClassName?: string;
   shortcut?: string;
   side?: "top" | "right" | "bottom" | "left";
   align?: "start" | "center" | "end";
@@ -18,6 +20,7 @@ interface TooltipProps {
 export function Tooltip({
   children,
   content,
+  contentClassName,
   shortcut,
   side = "top",
   align = "center",
@@ -43,7 +46,7 @@ export function Tooltip({
             side={side}
             align={align}
             sideOffset={sideOffset}
-            className="dark flex items-center gap-[8px] rounded-[6px] border border-(--gray-4) bg-(--gray-2) px-[10px] py-[6px] text-(--gray-12) text-xs leading-[1.4]"
+            className={`dark rounded-[6px] border border-(--gray-4) bg-(--gray-2) text-(--gray-12) ${contentClassName ?? "flex items-center gap-[8px] px-[10px] py-[6px] text-xs leading-[1.4]"}`}
             style={{
               whiteSpace: isSimpleContent ? "nowrap" : "normal",
               boxShadow: "0 4px 12px rgba(0, 0, 0, 0.25)",

--- a/products/desktop/packages/ui/src/utils/chartBlocks.test.ts
+++ b/products/desktop/packages/ui/src/utils/chartBlocks.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { parseChartBlock } from "./chartBlocks";
+
+describe("parseChartBlock", () => {
+  it("parses an inline data block", () => {
+    expect(
+      parseChartBlock(
+        JSON.stringify({
+          title: "Daily active users",
+          render: "bar",
+          labels: ["Aug 7", "Aug 8"],
+          series: [{ name: "DAU", points: [69650, 39431] }],
+        }),
+      ),
+    ).toEqual({
+      mode: "data",
+      title: "Daily active users",
+      caption: undefined,
+      render: "bar",
+      labels: ["Aug 7", "Aug 8"],
+      series: [{ name: "DAU", points: [69650, 39431] }],
+    });
+  });
+
+  it("defaults render to line and names unnamed series", () => {
+    const spec = parseChartBlock(
+      JSON.stringify({ series: [{ points: [1, 2] }] }),
+    );
+    expect(spec).toMatchObject({
+      mode: "data",
+      render: "line",
+      series: [{ name: "Series 1", points: [1, 2] }],
+    });
+  });
+
+  it("routes a query payload to query mode without validating the node", () => {
+    const query = { kind: "InsightVizNode", source: { kind: "TrendsQuery" } };
+    expect(parseChartBlock(JSON.stringify({ title: "T", query }))).toEqual({
+      mode: "query",
+      title: "T",
+      caption: undefined,
+      query,
+    });
+  });
+
+  it.each([
+    ["malformed JSON", "{not json"],
+    ["no series or query", '{"title":"x"}'],
+    ["only non-numeric points", '{"series":[{"points":["a","b"]}]}'],
+    ["an array payload", "[1,2,3]"],
+  ])("returns null for %s", (_name, source) => {
+    expect(parseChartBlock(source)).toBeNull();
+  });
+
+  it("caps series count and points so a runaway block cannot flood the card", () => {
+    const spec = parseChartBlock(
+      JSON.stringify({
+        series: Array.from({ length: 30 }, () => ({
+          points: Array.from({ length: 500 }, (_, i) => i),
+        })),
+      }),
+    );
+    expect(spec?.mode).toBe("data");
+    if (spec?.mode === "data") {
+      expect(spec.series.length).toBe(15);
+      expect(spec.series[0].points.length).toBe(366);
+    }
+  });
+});

--- a/products/desktop/packages/ui/src/utils/chartBlocks.ts
+++ b/products/desktop/packages/ui/src/utils/chartBlocks.ts
@@ -1,0 +1,118 @@
+/**
+ * Recognizing chart blocks inside agent messages.
+ *
+ * Where an `evidence:` link is an inline citation, a chart block is the
+ * full-size variant: agents emit a fenced code block tagged `posthog-chart`
+ * whose body is a JSON spec, and the markdown renderer draws it as a chart
+ * card instead of highlighted code.
+ *
+ * Two payload shapes:
+ *
+ * Inline data the agent already has (drawn with no fetching):
+ * ```posthog-chart
+ * { "title": "Daily active users", "render": "bar",
+ *   "labels": ["Aug 7", "Aug 8"], "series": [{ "name": "DAU", "points": [69650, 39431] }] }
+ * ```
+ *
+ * A PostHog query node (executed via `/query/`, like report charts):
+ * ```posthog-chart
+ * { "title": "Daily active users", "query": { "kind": "InsightVizNode", "source": { "kind": "TrendsQuery", ... } } }
+ * ```
+ */
+
+const MAX_POINTS = 366;
+const MAX_SERIES = 15;
+const MAX_TITLE_LENGTH = 120;
+const MAX_CAPTION_LENGTH = 300;
+
+export interface ChartBlockSeries {
+  name: string;
+  points: number[];
+}
+
+export type ChartBlockSpec =
+  | {
+      mode: "data";
+      title?: string;
+      caption?: string;
+      render: "line" | "bar";
+      labels: string[];
+      series: ChartBlockSeries[];
+    }
+  | {
+      mode: "query";
+      title?: string;
+      caption?: string;
+      query: Record<string, unknown>;
+    };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function capText(value: unknown, max: number): string | undefined {
+  return typeof value === "string" && value.trim()
+    ? value.trim().slice(0, max)
+    : undefined;
+}
+
+function toSeries(raw: unknown): ChartBlockSeries[] | null {
+  if (!Array.isArray(raw)) return null;
+  const series: ChartBlockSeries[] = [];
+  for (const entry of raw.slice(0, MAX_SERIES)) {
+    if (!isRecord(entry) || !Array.isArray(entry.points)) continue;
+    const points = entry.points.slice(0, MAX_POINTS).map(Number);
+    if (points.length === 0 || !points.every(Number.isFinite)) continue;
+    series.push({
+      name:
+        typeof entry.name === "string" && entry.name
+          ? entry.name
+          : `Series ${series.length + 1}`,
+      points,
+    });
+  }
+  return series.length > 0 ? series : null;
+}
+
+/** Stable identity for a block: keys React elements and the query cache. */
+export function chartBlockKey(source: string): string {
+  let hash = 5381;
+  for (let i = 0; i < source.length; i++) {
+    hash = ((hash << 5) + hash + source.charCodeAt(i)) | 0;
+  }
+  return `chart-block-${(hash >>> 0).toString(36)}`;
+}
+
+/** Parse a `posthog-chart` fence body into a spec, or null when malformed. */
+export function parseChartBlock(source: string): ChartBlockSpec | null {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(source);
+  } catch {
+    return null;
+  }
+  if (!isRecord(raw)) return null;
+
+  const title = capText(raw.title, MAX_TITLE_LENGTH);
+  const caption = capText(raw.caption, MAX_CAPTION_LENGTH);
+
+  if (isRecord(raw.query)) {
+    // The query node itself stays untrusted JSON: planReportChart decides
+    // whether it is runnable, links out, or is dropped.
+    return { mode: "query", title, caption, query: raw.query };
+  }
+
+  const series = toSeries(raw.series);
+  if (!series) return null;
+  const labels = Array.isArray(raw.labels)
+    ? raw.labels.slice(0, MAX_POINTS).map(String)
+    : [];
+  return {
+    mode: "data",
+    title,
+    caption,
+    render: raw.render === "bar" ? "bar" : "line",
+    labels,
+    series,
+  };
+}

--- a/products/desktop/packages/ui/src/utils/evidenceLinks.test.ts
+++ b/products/desktop/packages/ui/src/utils/evidenceLinks.test.ts
@@ -20,6 +20,27 @@ describe("parseEvidenceLink", () => {
     ).toEqual({ kind: "insight", id: "9pQx3", url });
   });
 
+  it("carries display params for the hover card", () => {
+    expect(
+      parseEvidenceLink(
+        "evidence:insight/9pQx3?value=28.1%25&desc=down+12.9pts+since+Jan+3",
+      ),
+    ).toEqual({
+      kind: "insight",
+      id: "9pQx3",
+      value: "28.1%",
+      desc: "down 12.9pts since Jan 3",
+    });
+  });
+
+  it("caps display params so a runaway link cannot flood the card", () => {
+    const parsed = parseEvidenceLink(
+      `evidence:insight/x?value=${"9".repeat(80)}&desc=${"a".repeat(400)}`,
+    );
+    expect(parsed?.value?.length).toBe(40);
+    expect(parsed?.desc?.length).toBe(160);
+  });
+
   it("drops url values that are not http(s)", () => {
     expect(
       parseEvidenceLink(

--- a/products/desktop/packages/ui/src/utils/evidenceLinks.test.ts
+++ b/products/desktop/packages/ui/src/utils/evidenceLinks.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { parseEvidenceLink } from "./evidenceLinks";
+
+describe("parseEvidenceLink", () => {
+  it.each([
+    ["evidence:insight/9pQx3", { kind: "insight", id: "9pQx3" }],
+    ["evidence:error/018f-44aa", { kind: "error", id: "018f-44aa" }],
+    ["evidence:custom-kind/abc_123", { kind: "custom-kind", id: "abc_123" }],
+    ["evidence:flag/my%2Fflag", { kind: "flag", id: "my/flag" }],
+  ])("parses %s", (href, expected) => {
+    expect(parseEvidenceLink(href)).toEqual(expected);
+  });
+
+  it("carries a PostHog web url from the query", () => {
+    const url = "https://us.posthog.com/project/2/insights/9pQx3";
+    expect(
+      parseEvidenceLink(
+        `evidence:insight/9pQx3?url=${encodeURIComponent(url)}`,
+      ),
+    ).toEqual({ kind: "insight", id: "9pQx3", url });
+  });
+
+  it("drops url values that are not http(s)", () => {
+    expect(
+      parseEvidenceLink(
+        `evidence:insight/x?url=${encodeURIComponent("javascript:alert(1)")}`,
+      ),
+    ).toEqual({ kind: "insight", id: "x" });
+  });
+
+  it.each([
+    [undefined],
+    ["https://example.com/evidence:insight/x"],
+    ["evidence:"],
+    ["evidence:insight"],
+    ["evidence:insight/"],
+    ["evidence:/9pQx3"],
+    ["evidence:Insight/9pQx3"],
+    ["chart:9pQx3"],
+  ])("returns null for %s", (href) => {
+    expect(parseEvidenceLink(href)).toBeNull();
+  });
+});

--- a/products/desktop/packages/ui/src/utils/evidenceLinks.test.ts
+++ b/products/desktop/packages/ui/src/utils/evidenceLinks.test.ts
@@ -41,6 +41,33 @@ describe("parseEvidenceLink", () => {
     expect(parsed?.desc?.length).toBe(160);
   });
 
+  it("parses a series param into sparkline points", () => {
+    expect(
+      parseEvidenceLink("evidence:insight/x?series=41,39.5,+40,28"),
+    ).toEqual({
+      kind: "insight",
+      id: "x",
+      series: [41, 39.5, 40, 28],
+    });
+  });
+
+  it.each([
+    ["a single point", "series=41"],
+    ["junk among the numbers", "series=41,down,28"],
+  ])("drops a series with %s instead of a broken sparkline", (_name, query) => {
+    expect(parseEvidenceLink(`evidence:insight/x?${query}`)).toEqual({
+      kind: "insight",
+      id: "x",
+    });
+  });
+
+  it("caps series points so a runaway link cannot flood the card", () => {
+    const parsed = parseEvidenceLink(
+      `evidence:insight/x?series=${Array.from({ length: 200 }, (_, i) => i).join(",")}`,
+    );
+    expect(parsed?.series?.length).toBe(60);
+  });
+
   it("drops url values that are not http(s)", () => {
     expect(
       parseEvidenceLink(

--- a/products/desktop/packages/ui/src/utils/evidenceLinks.ts
+++ b/products/desktop/packages/ui/src/utils/evidenceLinks.ts
@@ -6,9 +6,12 @@
  * the markdown `a` component renders it as an inline evidence reference with a
  * hover preview, instead of an external link.
  *
- * An optional `url` query parameter carries the PostHog web URL of the
- * underlying object, so clicking the reference can open it:
- * `evidence:insight/9pQx3?url=https%3A%2F%2Fus.posthog.com%2F...`
+ * Optional query parameters enrich the reference without any data fetching:
+ * - `url`: PostHog web URL of the object, makes the reference clickable.
+ * - `value`: headline figure for the hover card, e.g. `28.1%`.
+ * - `desc`: one context line for the hover card, e.g. `down 12.9pts since Jan 3`.
+ *
+ * `evidence:insight/9pQx3?url=https%3A%2F%2Fus.posthog.com%2F...&value=28.1%25&desc=down+12.9pts`
  */
 
 const EVIDENCE_SCHEME = "evidence:";
@@ -20,7 +23,16 @@ export interface EvidenceLinkTarget {
   id: string;
   /** PostHog web URL of the underlying object, when the agent included one. */
   url?: string;
+  /** Headline figure for the hover card, e.g. "28.1%". */
+  value?: string;
+  /** One context line for the hover card. */
+  desc?: string;
 }
+
+// Display params are agent-written text headed for a small card; caps keep a
+// runaway link from flooding the layout.
+const MAX_VALUE_LENGTH = 40;
+const MAX_DESC_LENGTH = 160;
 
 function decodePart(part: string): string {
   try {
@@ -55,6 +67,10 @@ export function parseEvidenceLink(
     if (url && (url.startsWith("https://") || url.startsWith("http://"))) {
       target.url = url;
     }
+    const value = params.get("value")?.trim();
+    if (value) target.value = value.slice(0, MAX_VALUE_LENGTH);
+    const desc = params.get("desc")?.trim();
+    if (desc) target.desc = desc.slice(0, MAX_DESC_LENGTH);
   }
 
   return target;

--- a/products/desktop/packages/ui/src/utils/evidenceLinks.ts
+++ b/products/desktop/packages/ui/src/utils/evidenceLinks.ts
@@ -10,6 +10,8 @@
  * - `url`: PostHog web URL of the object, makes the reference clickable.
  * - `value`: headline figure for the hover card, e.g. `28.1%`.
  * - `desc`: one context line for the hover card, e.g. `down 12.9pts since Jan 3`.
+ * - `series`: comma-separated numbers the agent already has, drawn as a
+ *   sparkline on the hover card, e.g. `41,39,40,28,27`.
  *
  * `evidence:insight/9pQx3?url=https%3A%2F%2Fus.posthog.com%2F...&value=28.1%25&desc=down+12.9pts`
  */
@@ -27,12 +29,23 @@ export interface EvidenceLinkTarget {
   value?: string;
   /** One context line for the hover card. */
   desc?: string;
+  /** Data points for the hover-card sparkline, oldest first. */
+  series?: number[];
 }
 
 // Display params are agent-written text headed for a small card; caps keep a
 // runaway link from flooding the layout.
 const MAX_VALUE_LENGTH = 40;
 const MAX_DESC_LENGTH = 160;
+const MAX_SERIES_POINTS = 60;
+
+/** A sparkline needs 2+ finite numbers; anything else is dropped whole. */
+function parseSeriesParam(raw: string): number[] | null {
+  const parts = raw.split(",").slice(0, MAX_SERIES_POINTS);
+  if (parts.length < 2) return null;
+  const points = parts.map((part) => Number(part.trim()));
+  return points.every(Number.isFinite) ? points : null;
+}
 
 function decodePart(part: string): string {
   try {
@@ -71,6 +84,11 @@ export function parseEvidenceLink(
     if (value) target.value = value.slice(0, MAX_VALUE_LENGTH);
     const desc = params.get("desc")?.trim();
     if (desc) target.desc = desc.slice(0, MAX_DESC_LENGTH);
+    const series = params.get("series");
+    if (series) {
+      const points = parseSeriesParam(series);
+      if (points) target.series = points;
+    }
   }
 
   return target;

--- a/products/desktop/packages/ui/src/utils/evidenceLinks.ts
+++ b/products/desktop/packages/ui/src/utils/evidenceLinks.ts
@@ -1,0 +1,61 @@
+/**
+ * Recognizing evidence links inside agent messages.
+ *
+ * Agents cite the PostHog data they consulted as `[label](evidence:<kind>/<id>)`
+ * links. The scheme survives `markdownUrlTransform` (like `chart:` links do) and
+ * the markdown `a` component renders it as an inline evidence reference with a
+ * hover preview, instead of an external link.
+ *
+ * An optional `url` query parameter carries the PostHog web URL of the
+ * underlying object, so clicking the reference can open it:
+ * `evidence:insight/9pQx3?url=https%3A%2F%2Fus.posthog.com%2F...`
+ */
+
+const EVIDENCE_SCHEME = "evidence:";
+const KIND_ID_RE = /^([a-z][a-z0-9-]*)\/([^/?#]+)$/;
+
+export interface EvidenceLinkTarget {
+  /** Free-form kind slug; well-known kinds get a dedicated icon and source label. */
+  kind: string;
+  id: string;
+  /** PostHog web URL of the underlying object, when the agent included one. */
+  url?: string;
+}
+
+function decodePart(part: string): string {
+  try {
+    return decodeURIComponent(part);
+  } catch {
+    return part;
+  }
+}
+
+/** Parse an `evidence:` href into a target, or null when it isn't one. */
+export function parseEvidenceLink(
+  href: string | undefined,
+): EvidenceLinkTarget | null {
+  if (!href || !href.startsWith(EVIDENCE_SCHEME)) return null;
+
+  const rest = href.slice(EVIDENCE_SCHEME.length);
+  const queryIndex = rest.indexOf("?");
+  const path = queryIndex === -1 ? rest : rest.slice(0, queryIndex);
+  const query = queryIndex === -1 ? "" : rest.slice(queryIndex + 1);
+
+  const match = KIND_ID_RE.exec(path);
+  if (!match) return null;
+
+  const target: EvidenceLinkTarget = {
+    kind: match[1],
+    id: decodePart(match[2]),
+  };
+
+  if (query) {
+    const params = new URLSearchParams(query);
+    const url = params.get("url");
+    if (url && (url.startsWith("https://") || url.startsWith("http://"))) {
+      target.url = url;
+    }
+  }
+
+  return target;
+}

--- a/products/desktop/packages/ui/vitest.config.ts
+++ b/products/desktop/packages/ui/vitest.config.ts
@@ -17,9 +17,22 @@ export default defineConfig({
       "@posthog/host-router": fileURLToPath(
         new URL("../host-router/src", import.meta.url),
       ),
+      // quill-charts' dist imports dayjs plugins without the .js extension,
+      // which Vite's browser resolution accepts but vitest's Node resolution
+      // rejects; map them so any test that loads quill-charts can run.
+      "dayjs/plugin/customParseFormat": "dayjs/plugin/customParseFormat.js",
+      "dayjs/plugin/timezone": "dayjs/plugin/timezone.js",
+      "dayjs/plugin/utc": "dayjs/plugin/utc.js",
     },
   },
   test: {
+    server: {
+      deps: {
+        // Process quill-charts through Vite instead of Node so the dayjs
+        // aliases above apply to its imports too.
+        inline: ["@posthog/quill-charts"],
+      },
+    },
     globals: true,
     ...trunkTestOptions,
     environment: "jsdom",

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.ts
@@ -662,7 +662,12 @@ Optimize for the fewest shell round trips.
 - Batch related commands into one Bash invocation using \`&&\` (e.g. \`npm run typecheck && npm run lint && npm test\`).
 - Emit all independent tool calls in the same response.
 - Read multiple files at once.
-- Never rerun a command solely to reproduce output you already have.`;
+- Never rerun a command solely to reproduce output you already have.
+
+## Rich output in replies
+The chat renders two special markdown forms. Use them when they make an answer clearer:
+- Inline evidence citation: cite a PostHog object you consulted as \`[label](evidence:<kind>/<id>)\` inside a sentence. Known kinds: insight, error, replay, flag, experiment, survey, ticket, trace, eval, event. Optional URL-encoded query params enrich the hover card with facts you already have: \`url\` (PostHog web URL, makes it clickable), \`value\` (headline figure, e.g. \`28.1%\`), \`desc\` (one context line), \`series\` (comma-separated numbers, drawn as a sparkline).
+- Full-size chart: a fenced code block tagged \`posthog-chart\` whose body is JSON. Inline data you already have: \`{"title": "...", "render": "line"|"bar", "labels": [...], "series": [{"name": "...", "points": [...]}], "caption": "..."}\`. Or a PostHog query node to execute: \`{"title": "...", "query": {"kind": "InsightVizNode", "source": {...}}}\`. Prefer a chart block over a markdown table for numeric or time-series results.`;
 
     if (channelMode) {
       prompt += `


### PR DESCRIPTION
## Problem

When a desktop agent backs a claim with PostHog data, the data appears once as tool output and scrolls away with the transcript. A reader cannot tell what a number in the agent's prose points at, preview it, or open it.

This is the first UI piece of the desktop–PostHog synergy work in the desktop-synergy-posthog channel: evidence as inline citations in the agent's own sentences.

## Changes

- Agents can cite PostHog objects as `[label](evidence:<kind>/<id>)` markdown links. They render as a dotted-underline reference with a small kind icon; the underline runs under icon and text, and the reference wraps with the sentence like normal text.
- Hovering shows a preview card: label, kind, source product, an optional stat block, and a footer band with the object id.

![Inline evidence reference with hover card](https://raw.githubusercontent.com/PostHog/pr-assets/fa4fde3eb1cc29c9f45eceb6915dde29ead5dabb/2026/08/14f76a77-5c9c-4e28-852b-b0ff8f070830.png)

- Optional query parameters enrich the reference without any data fetching, using facts the agent already has at citation time: `url` makes it a semantic anchor that opens the object in PostHog web, `value` puts a headline figure on the card, `desc` adds one context line. Display params are length-capped; non-http(s) `url` values are dropped so a `javascript:` url cannot ride in.
- Ten known kinds (insight, error, replay, flag, experiment, survey, ticket, trace, eval, event) map to icons and product names. Unknown kinds render with a generic fallback, so new kinds degrade safely.

![All evidence kinds](https://raw.githubusercontent.com/PostHog/pr-assets/fa4fde3eb1cc29c9f45eceb6915dde29ead5dabb/2026/08/d05d4923-0808-42bd-b32d-609de5f8d1b4.png)

- The card renders through `primitives/Tooltip` (the chat's existing self-styled tooltip), which gains an opt-in `contentClassName` for card layouts. The default tooltip rendering is unchanged: same class set, portal, and positioning. Quill's `TooltipContent` was unsuitable here because its surface styling lives in quill CSS classes not loaded on this surface.
- UI layer only. A `preview` prop is the slot for a live data preview once evidence fetching exists.
- The `evidence:` scheme follows the existing `chart:` precedent in `markdownUrlTransform`, and the chip dispatch sits next to the artifact and GitHub link dispatches in the markdown `a` component.

> [!NOTE]
> The headline stat uses `font-[600]` because the theme in `globals.css` defines no `--font-weight-semibold`, so Tailwind's `font-semibold` emits no rule here. The ~43 existing `font-semibold` usages in `packages/ui` silently render at weight 400 — worth a separate fix.

## How did you test this code?

- Unit tests on the parser. The regression they catch: a malformed or hostile href (`javascript:` url, wrong casing, missing id, over-long display params) parsing into the card.
- An integration test renders an `evidence:` link through `MarkdownRenderer`. The regression it catches: a urlTransform or link-dispatch change silently turning evidence citations into dead external links.
- Component tests cover the anchor-with-url and plain-span variants.
- Rendered the Storybook stories headless and asserted computed styles: the dotted border spans icon + text; the icon is 12px and centered in the line within 0.6px; the card is 290px with solid surface, border, and shadow; the headline stat is 17px weight 600; the footer band is tinted; no layout shift on open; collision flipping keeps an 8px gap; references wrap at a 340px viewport without overflow. This pass is what caught the missing `font-semibold` rule. No page errors.
- Not run: the desktop workspace typecheck is red in this sandbox with 96 pre-existing errors in `packages/workspace-server`; the count is identical with this change stashed. `hogli ci:preflight` could not run here (no Python venv in the sandbox).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The `evidence:` link contract is documented in `evidenceLinks.ts`; agent-side emission lands with the skill that produces these links.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude in a PostHog cloud task session directed by the assignee, as the first implementation step of the desktop-synergy prototypes. Skills invoked: /writing-tests, /writing-pr-descriptions, /writing-code-comments. Decisions across the session: citations are markdown links with a custom scheme rather than XML mention tags, because agent output flows through MarkdownRenderer where the `chart:` scheme already models this. The first cut used quill's TooltipContent and a button trigger; a rendered screenshot showed a transparent, mispositioned popup and broken line wrapping, so commit 2 moved to `primitives/Tooltip` and a span/anchor trigger. Commit 3 answered design review: underline under the icon (border, not text-decoration), 12px icon, and the link-carried stat block that makes the card informative before data fetching exists. All labels and ids in tests, stories, and screenshots are invented.