### PR TITLE
feat(capture): allow tokens to skip the global rate limiter

### DIFF
--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -124,6 +124,13 @@ pub struct Config {
     #[envconfig(default = "false")]
     pub global_rate_limit_dry_run: bool,
 
+    /// CSV of tokens that skip the global rate limiter entirely: no local cache
+    /// entry, no Redis read, no Redis write. Intended for tokens whose
+    /// distinct_id cardinality is high enough that a per-(token, distinct_id)
+    /// key is only ever seen once, so it can never approach the threshold while
+    /// still costing the limiter a cache miss and a Redis round trip per event.
+    pub global_rate_limit_exempt_tokens_csv: Option<String>,
+
     /// Sliding window interval to apply global rate limiting threshold to
     #[envconfig(default = "60")]
     pub global_rate_limit_window_interval_secs: u64,

--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -475,7 +475,24 @@ async fn process_events_inner(
     // per-key counts are identical regardless of which pipeline serves the key.
     // Import is unaffected by both: the GRL never runs (guard below) and no
     // overflowable lane is reachable, so behavior is identical across paths.
-    if context.capture_mode.applies_global_rate_limit() {
+    // The token is constant across the batch, so an exemption resolves once here
+    // instead of once per event, and the whole limiter block below is skipped.
+    let grl_exempt_token = if context.capture_mode.applies_global_rate_limit() {
+        global_rate_limiter
+            .as_ref()
+            .and_then(|limiter| limiter.exempt_token(&context.token))
+    } else {
+        None
+    };
+    if let Some(ref token) = grl_exempt_token {
+        counter!(
+            "capture_global_rate_limiter_exempt_events_total",
+            "token" => token.clone(),
+        )
+        .increment(events.len() as u64);
+    }
+
+    if context.capture_mode.applies_global_rate_limit() && grl_exempt_token.is_none() {
         if let Some(ref limiter) = global_rate_limiter {
             let mut limited_distinct_ids: HashSet<&str> = HashSet::new();
             let mut limited_event_count: u64 = 0;

--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -477,22 +477,18 @@ async fn process_events_inner(
     // overflowable lane is reachable, so behavior is identical across paths.
     // The token is constant across the batch, so an exemption resolves once here
     // instead of once per event, and the whole limiter block below is skipped.
-    let grl_exempt_token = if context.capture_mode.applies_global_rate_limit() {
-        global_rate_limiter
+    // The counter carries no token label: which tokens are exempt is deploy
+    // config, and customer identifiers do not belong in metrics storage.
+    let grl_exempt = context.capture_mode.applies_global_rate_limit()
+        && global_rate_limiter
             .as_ref()
-            .and_then(|limiter| limiter.exempt_token(&context.token))
-    } else {
-        None
-    };
-    if let Some(ref token) = grl_exempt_token {
-        counter!(
-            "capture_global_rate_limiter_exempt_events_total",
-            "token" => token.clone(),
-        )
-        .increment(events.len() as u64);
+            .is_some_and(|limiter| limiter.is_exempt(&context.token));
+    if grl_exempt {
+        counter!("capture_global_rate_limiter_exempt_events_total")
+            .increment(events.len() as u64);
     }
 
-    if context.capture_mode.applies_global_rate_limit() && grl_exempt_token.is_none() {
+    if context.capture_mode.applies_global_rate_limit() && !grl_exempt {
         if let Some(ref limiter) = global_rate_limiter {
             let mut limited_distinct_ids: HashSet<&str> = HashSet::new();
             let mut limited_event_count: u64 = 0;

--- a/rust/capture/src/global_rate_limiter.rs
+++ b/rust/capture/src/global_rate_limiter.rs
@@ -383,7 +383,14 @@ impl GlobalRateLimiter {
         Self {
             limiter: Box::new(limiter),
             dry_run: false,
+            exempt_tokens: HashSet::new(),
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_exempt_tokens(mut self, tokens: &[&str]) -> Self {
+        self.exempt_tokens = tokens.iter().copied().map(Arc::from).collect();
+        self
     }
 
     /// Test helper: build a real limiter with the hierarchical resolver and its
@@ -410,6 +417,7 @@ impl GlobalRateLimiter {
         Self {
             limiter: Box::new(limiter),
             dry_run: false,
+            exempt_tokens: HashSet::new(),
         }
     }
 
@@ -418,6 +426,7 @@ impl GlobalRateLimiter {
         Self {
             limiter: Box::new(limiter),
             dry_run: true,
+            exempt_tokens: HashSet::new(),
         }
     }
 
@@ -428,7 +437,6 @@ impl GlobalRateLimiter {
     #[cfg(test)]
     pub(crate) fn mock_limiting(limited_keys: &[&str]) -> Self {
         use async_trait::async_trait;
-        use std::collections::HashSet;
 
         struct MockLimitingLimiter {
             limited_keys: HashSet<String>,
@@ -892,5 +900,27 @@ mod tests {
             !limiter.is_custom_key("other_tok:any_user"),
             "unrelated token must not match"
         );
+    }
+
+    #[rstest]
+    #[case::single("tok_a", vec!["tok_a"])]
+    #[case::whitespace_around_entries(" tok_a , tok_b ", vec!["tok_a", "tok_b"])]
+    #[case::trailing_comma("tok_a,", vec!["tok_a"])]
+    #[case::blank_entries("tok_a,,  ,tok_b", vec!["tok_a", "tok_b"])]
+    #[case::empty("", vec![])]
+    fn test_parse_exempt_tokens(#[case] csv: &str, #[case] expected: Vec<&str>) {
+        let parsed = GlobalRateLimiter::parse_exempt_tokens(Some(&csv.to_string()));
+
+        let expected: HashSet<Arc<str>> = expected.into_iter().map(Arc::from).collect();
+        assert_eq!(parsed, expected);
+        assert!(
+            !parsed.contains(""),
+            "a blank entry must never become an exempt token, or a tokenless request would match"
+        );
+    }
+
+    #[test]
+    fn test_parse_exempt_tokens_unset() {
+        assert!(GlobalRateLimiter::parse_exempt_tokens(None).is_empty());
     }
 }

--- a/rust/capture/src/global_rate_limiter.rs
+++ b/rust/capture/src/global_rate_limiter.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -48,6 +48,9 @@ impl<'a> GlobalRateLimitKey<'a> {
 pub struct GlobalRateLimiter {
     limiter: Box<dyn CommonGlobalRateLimiter>,
     dry_run: bool,
+    /// Held as `Arc<str>` so a lookup can hand the caller an owned token to use
+    /// as a metric label without allocating per batch.
+    exempt_tokens: HashSet<Arc<str>>,
 }
 
 impl GlobalRateLimiter {
@@ -214,10 +217,44 @@ impl GlobalRateLimiter {
             info!("GlobalRateLimiter initialized in dry-run mode (evaluating but not enforcing)");
         }
 
+        let exempt_tokens =
+            Self::parse_exempt_tokens(config.global_rate_limit_exempt_tokens_csv.as_ref());
+        if !exempt_tokens.is_empty() {
+            info!(
+                count = exempt_tokens.len(),
+                "GlobalRateLimiter initialized with exempt tokens"
+            );
+        }
+
         Ok(Self {
             limiter: Box::new(limiter),
             dry_run,
+            exempt_tokens,
         })
+    }
+
+    /// Tokens the limiter skips entirely, from `GLOBAL_RATE_LIMIT_EXEMPT_TOKENS_CSV`.
+    /// Blank entries are dropped so a trailing comma or an empty variable does not
+    /// produce an empty-string token that would match a request with no token.
+    fn parse_exempt_tokens(csv: Option<&String>) -> HashSet<Arc<str>> {
+        csv.map(|raw| {
+            raw.split(',')
+                .map(str::trim)
+                .filter(|t| !t.is_empty())
+                .map(Arc::from)
+                .collect()
+        })
+        .unwrap_or_default()
+    }
+
+    /// Returns the interned token when it is exempt from rate limiting.
+    ///
+    /// Callers resolve this once per batch, before the per-event loop, because an
+    /// exempt token must skip `is_limited` entirely: that call enqueues a Redis
+    /// write before it even reads the cache, so a check made any deeper would
+    /// still pay the cost the exemption exists to avoid.
+    pub fn exempt_token(&self, token: &str) -> Option<Arc<str>> {
+        self.exempt_tokens.get(token).cloned()
     }
 
     /// Check if a key is rate limited. The key is resolved against the custom-key

--- a/rust/capture/src/global_rate_limiter.rs
+++ b/rust/capture/src/global_rate_limiter.rs
@@ -48,9 +48,7 @@ impl<'a> GlobalRateLimitKey<'a> {
 pub struct GlobalRateLimiter {
     limiter: Box<dyn CommonGlobalRateLimiter>,
     dry_run: bool,
-    /// Held as `Arc<str>` so a lookup can hand the caller an owned token to use
-    /// as a metric label without allocating per batch.
-    exempt_tokens: HashSet<Arc<str>>,
+    exempt_tokens: HashSet<String>,
 }
 
 impl GlobalRateLimiter {
@@ -236,25 +234,25 @@ impl GlobalRateLimiter {
     /// Tokens the limiter skips entirely, from `GLOBAL_RATE_LIMIT_EXEMPT_TOKENS_CSV`.
     /// Blank entries are dropped so a trailing comma or an empty variable does not
     /// produce an empty-string token that would match a request with no token.
-    fn parse_exempt_tokens(csv: Option<&String>) -> HashSet<Arc<str>> {
+    fn parse_exempt_tokens(csv: Option<&String>) -> HashSet<String> {
         csv.map(|raw| {
             raw.split(',')
                 .map(str::trim)
                 .filter(|t| !t.is_empty())
-                .map(Arc::from)
+                .map(str::to_string)
                 .collect()
         })
         .unwrap_or_default()
     }
 
-    /// Returns the interned token when it is exempt from rate limiting.
+    /// Whether `token` is exempt from rate limiting.
     ///
     /// Callers resolve this once per batch, before the per-event loop, because an
     /// exempt token must skip `is_limited` entirely: that call enqueues a Redis
     /// write before it even reads the cache, so a check made any deeper would
     /// still pay the cost the exemption exists to avoid.
-    pub fn exempt_token(&self, token: &str) -> Option<Arc<str>> {
-        self.exempt_tokens.get(token).cloned()
+    pub fn is_exempt(&self, token: &str) -> bool {
+        self.exempt_tokens.contains(token)
     }
 
     /// Check if a key is rate limited. The key is resolved against the custom-key
@@ -389,7 +387,7 @@ impl GlobalRateLimiter {
 
     #[cfg(test)]
     pub(crate) fn with_exempt_tokens(mut self, tokens: &[&str]) -> Self {
-        self.exempt_tokens = tokens.iter().copied().map(Arc::from).collect();
+        self.exempt_tokens = tokens.iter().map(|t| t.to_string()).collect();
         self
     }
 
@@ -911,7 +909,7 @@ mod tests {
     fn test_parse_exempt_tokens(#[case] csv: &str, #[case] expected: Vec<&str>) {
         let parsed = GlobalRateLimiter::parse_exempt_tokens(Some(&csv.to_string()));
 
-        let expected: HashSet<Arc<str>> = expected.into_iter().map(Arc::from).collect();
+        let expected: HashSet<String> = expected.into_iter().map(str::to_string).collect();
         assert_eq!(parsed, expected);
         assert!(
             !parsed.contains(""),

--- a/rust/capture/src/overflow_parity.rs
+++ b/rust/capture/src/overflow_parity.rs
@@ -32,6 +32,7 @@ use common_types::RawEvent;
 /// tokens and distinct ids, so each side gets a limiter keyed for its own.
 const V0_TOKEN: &str = "test_token";
 const V0_DISTINCT_ID: &str = "test_user";
+const V1_TOKEN: &str = "phc_test_token";
 const V1_HOT_KEY: &str = "phc_test_token:user-42";
 
 /// The lane an event landed on, independent of each path's test topic names.
@@ -54,6 +55,9 @@ struct Observed {
 struct Limits {
     /// The token:distinct_id is over the global rate limit window.
     globally_limited: bool,
+    /// The token is in the global rate limiter's exempt list, so the limiter is
+    /// skipped for the whole batch even when the key is over the window.
+    globally_exempt: bool,
     /// A burst limiter is armed. `burst` of 1 limits every event after the first.
     burst_limiter: bool,
     /// The burst limiter keeps partition keys, as prod-US is configured.
@@ -65,6 +69,7 @@ struct Limits {
 impl Limits {
     const NONE: Self = Self {
         globally_limited: false,
+        globally_exempt: false,
         burst_limiter: false,
         preserve_locality: false,
         force_limited: false,
@@ -126,9 +131,13 @@ async fn run_v0(limits: Limits, batch_size: usize, observe: usize) -> Observed {
         test_topics(),
     ));
     let global = limits.globally_limited.then(|| {
-        Arc::new(GlobalRateLimiter::mock_limiting(&[&format!(
-            "{V0_TOKEN}:{V0_DISTINCT_ID}"
-        )]))
+        let limiter =
+            GlobalRateLimiter::mock_limiting(&[&format!("{V0_TOKEN}:{V0_DISTINCT_ID}")]);
+        Arc::new(if limits.globally_exempt {
+            limiter.with_exempt_tokens(&[V0_TOKEN])
+        } else {
+            limiter
+        })
     });
 
     let now = DateTime::parse_from_rfc3339("2026-03-19T14:30:00Z")
@@ -184,8 +193,13 @@ async fn run_v1(limits: Limits, batch_size: usize, observe: usize) -> Observed {
         builder = builder.with_overflow_forced_key("phc_test_token");
     }
     if limits.globally_limited {
-        builder = builder
-            .with_global_rate_limiter(Arc::new(GlobalRateLimiter::mock_limiting(&[V1_HOT_KEY])));
+        let limiter = GlobalRateLimiter::mock_limiting(&[V1_HOT_KEY]);
+        let limiter = if limits.globally_exempt {
+            limiter.with_exempt_tokens(&[V1_TOKEN])
+        } else {
+            limiter
+        };
+        builder = builder.with_global_rate_limiter(Arc::new(limiter));
     }
     let ts = builder.build();
 
@@ -241,6 +255,13 @@ async fn run_v1(limits: Limits, batch_size: usize, observe: usize) -> Observed {
 #[case::globally_limited(
     Limits { globally_limited: true, ..Limits::NONE },
     Observed { lane: Lane::Overflow, has_key: false, person_processing_disabled: true }
+)]
+// An exempt token must come out identical to no_limits even though its key is
+// over the window: the limiter is skipped for the whole batch, so nothing takes
+// person processing away and nothing reroutes the event.
+#[case::globally_limited_but_token_exempt(
+    Limits { globally_limited: true, globally_exempt: true, ..Limits::NONE },
+    Observed { lane: Lane::Main, has_key: true, person_processing_disabled: false }
 )]
 #[case::globally_limited_and_burst_rate_limited(
     Limits { globally_limited: true, burst_limiter: true, ..Limits::NONE },

--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use chrono::{DateTime, Utc};
-use metrics::histogram;
+use metrics::{counter, histogram};
 use uuid::Uuid;
 
 use super::constants::{
@@ -166,13 +166,26 @@ pub async fn process_batch(
     // overflowable lane is reachable, so behavior is identical across paths.
     if state.capture_mode.applies_global_rate_limit() {
         if let Some(ref limiter) = state.global_rate_limiter_token_distinctid {
-            let _ = apply_token_distinct_id_limits(
-                limiter,
-                context,
-                state.ingestion_warning_emitter.as_deref(),
-                &mut events,
-            )
-            .await;
+            // The token is constant across the batch, so an exemption resolves
+            // once here instead of once per event inside the limiter loop.
+            match limiter.exempt_token(&context.api_token) {
+                Some(token) => {
+                    counter!(
+                        "capture_global_rate_limiter_exempt_events_total",
+                        "token" => token,
+                    )
+                    .increment(events.len() as u64);
+                }
+                None => {
+                    let _ = apply_token_distinct_id_limits(
+                        limiter,
+                        context,
+                        state.ingestion_warning_emitter.as_deref(),
+                        &mut events,
+                    )
+                    .await;
+                }
+            }
         }
     }
 

--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -168,23 +168,20 @@ pub async fn process_batch(
         if let Some(ref limiter) = state.global_rate_limiter_token_distinctid {
             // The token is constant across the batch, so an exemption resolves
             // once here instead of once per event inside the limiter loop.
-            match limiter.exempt_token(&context.api_token) {
-                Some(token) => {
-                    counter!(
-                        "capture_global_rate_limiter_exempt_events_total",
-                        "token" => token,
-                    )
+            // The counter carries no token label: which tokens are exempt is
+            // deploy config, and customer identifiers do not belong in metrics
+            // storage.
+            if limiter.is_exempt(&context.api_token) {
+                counter!("capture_global_rate_limiter_exempt_events_total")
                     .increment(events.len() as u64);
-                }
-                None => {
-                    let _ = apply_token_distinct_id_limits(
-                        limiter,
-                        context,
-                        state.ingestion_warning_emitter.as_deref(),
-                        &mut events,
-                    )
-                    .await;
-                }
+            } else {
+                let _ = apply_token_distinct_id_limits(
+                    limiter,
+                    context,
+                    state.ingestion_warning_emitter.as_deref(),
+                    &mut events,
+                )
+                .await;
             }
         }
     }

--- a/rust/capture/src/v1/quota_limiter_shim.rs
+++ b/rust/capture/src/v1/quota_limiter_shim.rs
@@ -125,6 +125,7 @@ mod tests {
             redis_connection_timeout_ms: 5000,
             global_rate_limit_enabled: false,
             global_rate_limit_dry_run: false,
+            global_rate_limit_exempt_tokens_csv: None,
             global_rate_limit_window_interval_secs: 60,
             global_rate_limit_sync_interval_secs: 15,
             global_rate_limit_tick_interval_ms: 1000,

--- a/rust/capture/tests/common/utils.rs
+++ b/rust/capture/tests/common/utils.rs
@@ -41,6 +41,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     redis_connection_timeout_ms: 5000,
     global_rate_limit_enabled: false,
     global_rate_limit_dry_run: false,
+    global_rate_limit_exempt_tokens_csv: None,
     global_rate_limit_window_interval_secs: 60,
     global_rate_limit_sync_interval_secs: 15,
     global_rate_limit_tick_interval_ms: 1000,


### PR DESCRIPTION
## Problem

A customer whose SDK sends a fresh `distinct_id` on every event gets no rate limiting from the global rate limiter, and makes the limiter slower for everyone else on the same capture fleet.

- The limiter keys on `(token, distinct_id)`, so a key that is seen once never approaches its threshold.
- Every such event is a local cache miss, which queues a Redis read and a Redis write.
- The reads and writes go to Redis in one un-chunked batch per tick, under a fixed 100 ms timeout.
- Once a batch needs more than 100 ms, the tick times out, counts stop syncing, and every key on that pod falls open.

Operators have no lever for this today. Lowering the token's custom threshold does not help, because a key that sees one event is only caught by a threshold of 1, which blocks the token outright.

## Changes

- `GLOBAL_RATE_LIMIT_EXEMPT_TOKENS_CSV` lists tokens the limiter skips entirely.
- An exempt token allocates no cache key, queues no Redis read, and queues no Redis write.
- Both analytics paths resolve the exemption once per batch, before their per-event loop.
- `capture_global_rate_limiter_exempt_events_total` counts exempted events, so an exemption cannot sit unnoticed.
- The counter carries no token label, because customer identifiers do not belong in metrics storage.

The check has to sit before the per-event loop rather than inside `is_limited`. That call queues a Redis write before it reads the cache, so a check placed any deeper still pays the cost the exemption exists to remove.

The token is constant for a batch, so resolving once per batch costs one hash lookup rather than one per event.

I chose an environment variable over the existing dynamic threshold blob in Redis. The blob would avoid a redeploy, but its values mean "limit at N", and a sentinel N meaning "skip" reads as a threshold to everyone who meets it later. A separate field in that blob is the better follow-up.

> [!NOTE]
> An exempt token is not rate limited at all. This trades a limiter that cannot act on the traffic for one that does not pay for it.

## How did you test this code?

`cargo test -p capture`, run locally under flox.

- `overflow_parity::v0_and_v1_agree::case_6_globally_limited_but_token_exempt` asserts an exempt token comes out identical to an unlimited one on both pipelines. It catches an exemption wired into one path but not the other, which the existing matrix could not see.
- `global_rate_limiter::tests::test_parse_exempt_tokens` covers spaces around entries, a trailing comma, and blank entries. It catches a parser that turns `"tok_a, tok_b"` into a list matching neither token, and one that lets a blank entry become an exempt token.

Not tested: I did not run this against a real Redis or in any deployed environment. The Redis interaction is exercised only through the existing mock client.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via Claude Code) wrote this change. A person identified the traffic pattern, decided an environment variable was the right first lever, and directed the implementation.

Skills invoked: `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.

Two decisions moved during the session. The first placement put the exemption check inside the limiter wrapper's `is_limited`; reading that method showed it queues the Redis write before the cache lookup, so the check moved out to the two call sites. The test started as a pair of single-path cases and became one row in the existing cross-path parity matrix, which covers both pipelines and asserts against explicit expectations rather than against each other.

No customer data, tokens, or identifiers from the session appear in this diff. The test tokens are the ones already in the parity harness.

