### PR TITLE
perf(capture): skip the global rate limiter when person processing is off

### DIFF
--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -488,7 +488,18 @@ async fn process_events_inner(
             // `v1::analytics::process::apply_token_distinct_id_limits`.
             let mut warned_distinct_ids: HashSet<&str> = HashSet::new();
             let mut warned_event_count: u64 = 0;
+            let mut already_disabled_event_count: u64 = 0;
             for event in events.iter_mut() {
+                // Person processing is already off, which at this point can only
+                // come from an event restriction: the burst limiter runs after
+                // this stage in `stamp_overflow_reason`, and the limiter's own
+                // stamp is set below. The limiter has nothing left to take away
+                // from this event, so consulting it would change nothing and
+                // still cost a local cache miss and a Redis round trip.
+                if event.metadata.skip_person_processing {
+                    already_disabled_event_count += 1;
+                    continue;
+                }
                 let cache_key =
                     GlobalRateLimitKey::TokenDistinctId(&context.token, &event.event.distinct_id)
                         .to_cache_key();
@@ -529,6 +540,14 @@ async fn process_events_inner(
                     distinct_ids = %preview,
                     "events rate limited by distinct_id -- person processing disabled"
                 );
+            }
+
+            if already_disabled_event_count > 0 {
+                counter!(
+                    "capture_global_rate_limiter_skipped",
+                    "reason" => "person_processing_already_disabled",
+                )
+                .increment(already_disabled_event_count);
             }
 
             if warned_event_count > 0 {
@@ -2396,10 +2415,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn global_rate_limit_does_not_warn_when_person_processing_was_already_off() {
+    async fn global_rate_limit_is_skipped_when_person_processing_was_already_off() {
         // An ops restriction already took person processing away, so the limiter
-        // changed nothing the customer would recognize. It still reroutes the hot
-        // key, but a warning here would overstate the limit's reach.
+        // is not consulted: it has nothing left to take, and the call would cost a
+        // Redis round trip per event. The event keeps its lane and its partition
+        // key, so the limiter's overflow reroute does not apply either. A hot key
+        // under a restriction is left to the burst limiter downstream.
         let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
             .unwrap()
             .with_timezone(&Utc);
@@ -2447,9 +2468,8 @@ mod tests {
         assert_eq!(captured.len(), 1);
         assert!(captured[0].metadata.skip_person_processing);
         assert_eq!(
-            captured[0].metadata.overflow_reason,
-            Some(OverflowReason::ForceLimited),
-            "the hot key is still rerouted to overflow"
+            captured[0].metadata.overflow_reason, None,
+            "the limiter is skipped, so it does not reroute the key to overflow"
         );
     }
 

--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -830,8 +830,9 @@ async fn apply_restrictions(
 /// Per-batch tally of how the shared global rate limiter classified each
 /// evaluated event. All three fields count events (not distinct_ids), so
 /// `allowed + limited + already_disabled` equals the number of non-Drop events
-/// consulted -- the invariant that keeps the emitted counters commensurable
-/// with the legacy path's per-event counter.
+/// reaching this stage. Only `allowed + limited` were consulted against the
+/// limiter: an `already_disabled` event is skipped before the call, so it does
+/// not appear in the limiter's own per-key counts.
 #[derive(Debug, Default, PartialEq, Eq)]
 struct TokenDistinctIdTally {
     allowed: u64,
@@ -854,17 +855,12 @@ async fn apply_token_distinct_id_limits(
         if event.result != EventResult::Ok {
             continue;
         }
-        let cache_key =
-            GlobalRateLimitKey::TokenDistinctId(&context.api_token, &event.event.distinct_id)
-                .to_cache_key();
-        let limited = limiter.is_limited(&cache_key, 1).await.is_some();
-
         // Person processing is already off for this event (illegal distinct_id,
-        // an ops restriction, or a force-limited key upstream). Its volume
-        // still counts toward the shared window above -- v0 and v1 feed one
-        // limiter instance, so both must consult it for every non-dropped event
-        // to keep the per-key counts identical. The stamps below would be
-        // redundant here, so skip them.
+        // an ops restriction, or a force-limited key upstream). The limiter has
+        // nothing left to take away, so it is not consulted at all: the stamps
+        // below would be redundant, and the call itself would cost a local cache
+        // miss and a Redis round trip for a decision that cannot be acted on.
+        // The event's volume therefore does not count toward the shared window.
         //
         // A merely rate-limited burst does NOT land here: it sets
         // `spread_partitions` without touching person processing, so such an
@@ -873,6 +869,11 @@ async fn apply_token_distinct_id_limits(
             already_disabled_count += 1;
             continue;
         }
+
+        let cache_key =
+            GlobalRateLimitKey::TokenDistinctId(&context.api_token, &event.event.distinct_id)
+                .to_cache_key();
+        let limited = limiter.is_limited(&cache_key, 1).await.is_some();
 
         if limited {
             event.result = EventResult::Warning;
@@ -2529,12 +2530,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn td_limits_evaluates_but_does_not_restamp_force_disable_pp() {
+    async fn td_limits_skips_events_with_person_processing_already_off() {
         // An event that already has person processing disabled (illegal
-        // distinct_id, ops restriction, or burst overflow) is still consulted
-        // against the shared limiter -- its volume must count toward the per-key
-        // window exactly as it does on the legacy path -- but the redundant
-        // stamping (Warning result, overflow reroute) is skipped.
+        // distinct_id, ops restriction, or burst overflow) is not consulted
+        // against the shared limiter at all: the limiter has nothing left to take
+        // away, so the call would cost a Redis round trip for a decision that
+        // cannot be acted on. Its stamping is left untouched.
         let (limiter, calls) = mock_limiter_with_log(vec!["phc_tok:user-1"]);
         let ctx = td_context();
         let mut events = vec![
@@ -2547,15 +2548,15 @@ mod tests {
 
         apply_token_distinct_id_limits(&limiter, &ctx, None, &mut events).await;
 
-        // Already-flagged event WAS evaluated against the limiter...
+        // The already-flagged event was never consulted, so it costs no Redis work.
         assert!(
-            calls
+            !calls
                 .lock()
                 .unwrap()
                 .contains(&"phc_tok:user-1".to_string()),
-            "already-disabled event must still be consulted so its volume counts"
+            "already-disabled event must not be consulted"
         );
-        // ...but its stamping is untouched: result stays Ok, no overflow reroute.
+        // Its stamping is untouched: result stays Ok, no overflow reroute.
         let flagged = find_by_did(&events, "user-1");
         assert_eq!(flagged.result, EventResult::Ok);
         assert_eq!(flagged.destination, Destination::AnalyticsMain);
@@ -2569,10 +2570,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn td_limits_evaluates_every_non_dropped_event() {
+    async fn td_limits_evaluates_only_events_it_can_act_on() {
         // Parity with legacy (`events::analytics`): the shared limiter is
-        // consulted for every non-Drop event and only those, so per-key counts
-        // are identical regardless of which pipeline serves the key.
+        // consulted for every event whose fate it can still change, so per-key
+        // counts are identical regardless of which pipeline serves the key. A
+        // dropped event and one whose person processing is already off are both
+        // excluded, for opposite reasons: one is gone, the other is already at
+        // the outcome the limiter would impose.
         let (limiter, calls) = mock_limiter_with_log(vec![]);
         let ctx = td_context();
         let mut events = vec![
@@ -2592,8 +2596,8 @@ mod tests {
         seen.sort();
         assert_eq!(
             seen,
-            vec!["phc_tok:user-1".to_string(), "phc_tok:user-2".to_string()],
-            "limiter must be consulted for every non-Drop event and no others"
+            vec!["phc_tok:user-1".to_string()],
+            "limiter must be consulted only for events it can still act on"
         );
         assert_eq!(
             tally,
@@ -2603,11 +2607,9 @@ mod tests {
                 already_disabled: 1,
             }
         );
-        // Invariant: the tally accounts for exactly the evaluated (non-Drop) events.
-        assert_eq!(
-            tally.allowed + tally.limited + tally.already_disabled,
-            seen.len() as u64
-        );
+        // Invariant: `allowed + limited` accounts for exactly the consulted events,
+        // so the emitted counters stay commensurable with the limiter's own counts.
+        assert_eq!(tally.allowed + tally.limited, seen.len() as u64);
     }
 
     #[tokio::test]

--- a/rust/capture/tests/integration_person_processing_matrix.rs
+++ b/rust/capture/tests/integration_person_processing_matrix.rs
@@ -23,12 +23,17 @@
 //! volume and exactly the traffic the limiter still has a job on. Every case is
 //! run twice, once with the property and once without, and both rows carry the
 //! same expectation: the property must change nothing here.
+//!
+//! Every case runs against both analytics endpoints, `/capture` (v0) and
+//! `/i/v1/analytics/events` (v1), and asserts each against the same explicit
+//! expectation rather than against the other, so two paths that drift together
+//! still fail. The two express the personless choice differently: v0 reads the
+//! `$process_person_profile` property, v1 reads `options.process_person_profile`.
 
 #[path = "common/integration_utils.rs"]
 mod integration_utils;
 
 use axum::http::StatusCode;
-use axum::Router;
 use axum_test_helper::TestClient;
 use capture::config::CaptureMode;
 use capture::event_restrictions::{
@@ -42,6 +47,8 @@ use capture::sinks::kafka::KafkaSinkBase;
 use capture::sinks::producer::MockKafkaProducer;
 use capture::sinks::registry::OutputRegistry;
 use capture::time::TimeSource;
+use capture::v1::router::{router as v1_router, RouterConfig as V1RouterConfig};
+use capture::v1::test_utils::TestStateBuilder;
 use chrono::{DateTime, Utc};
 use common_redis::MockRedisClient;
 use integration_utils::{test_lifecycle_handlers, DEFAULT_CONFIG, DEFAULT_TEST_TIME};
@@ -83,17 +90,25 @@ struct Inputs {
     over_rate_limit: bool,
 }
 
+/// The lane an event landed on, independent of each path's topic names.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+enum Lane {
+    Main,
+    Overflow,
+    Other(&'static str),
+}
+
 #[derive(Debug, PartialEq, Eq)]
 struct Observed {
-    topic: String,
+    lane: Lane,
     has_key: bool,
     force_disable_person_processing: Option<bool>,
     limiter_consultations: u64,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 struct Expected {
-    topic: &'static str,
+    lane: Lane,
     has_key: bool,
     force_disable_person_processing: Option<bool>,
     /// Consultations across the whole two-event batch, not just the observed
@@ -101,9 +116,34 @@ struct Expected {
     limiter_consultations: u64,
 }
 
-async fn build_router(inputs: Inputs, producer: MockKafkaProducer) -> Router {
-    let (readiness, liveness, _monitor) = test_lifecycle_handlers();
+impl From<Expected> for Observed {
+    fn from(e: Expected) -> Self {
+        Self {
+            lane: e.lane,
+            has_key: e.has_key,
+            force_disable_person_processing: e.force_disable_person_processing,
+            limiter_consultations: e.limiter_consultations,
+        }
+    }
+}
 
+/// Count limiter evaluations on the recorder the caller installed. Each
+/// evaluation increments this counter exactly once, so it measures the Redis
+/// work the skip exists to avoid.
+fn consultations(snapshotter: &metrics_util::debugging::Snapshotter) -> u64 {
+    snapshotter
+        .snapshot()
+        .into_vec()
+        .iter()
+        .filter(|(key, _, _, _)| key.key().name() == "global_rate_limiter_eval_counts_total")
+        .filter_map(|(_, _, _, value)| match value {
+            DebugValue::Counter(v) => Some(*v),
+            _ => None,
+        })
+        .sum()
+}
+
+fn build_limiter(inputs: Inputs, redis: Arc<MockRedisClient>) -> GlobalRateLimiter {
     let mut cfg = DEFAULT_CONFIG.clone();
     cfg.capture_mode = CaptureMode::Events;
     cfg.global_rate_limit_enabled = true;
@@ -115,11 +155,11 @@ async fn build_router(inputs: Inputs, producer: MockKafkaProducer) -> Router {
     // Park the background sync well beyond the request so the limiter's verdict
     // comes from the local cache alone and no Redis tick can race the batch.
     cfg.global_rate_limit_tick_interval_ms = 600_000;
+    GlobalRateLimiter::new_token_distinct_id(&cfg, vec![redis])
+        .expect("failed to build the global rate limiter")
+}
 
-    let redis = Arc::new(MockRedisClient::new());
-    let limiter = GlobalRateLimiter::new_token_distinct_id(&cfg, vec![redis.clone()])
-        .expect("failed to build the global rate limiter");
-
+async fn build_restrictions(inputs: Inputs) -> EventRestrictionService {
     let mut restrictions = Vec::new();
     if inputs.skip_person_restriction {
         restrictions.push(Restriction {
@@ -142,12 +182,35 @@ async fn build_router(inputs: Inputs, producer: MockKafkaProducer) -> Router {
     let mut manager = RestrictionManager::new();
     manager.insert_restrictions(Pipeline::Analytics, TOKEN, restrictions);
     service.update(manager).await;
+    service
+}
 
-    let sink = KafkaSinkBase::with_producer(producer, OutputRegistry::from(&cfg.kafka));
+/// Drive the v0 endpoint (`/capture`) into a real `KafkaSinkBase` and read the
+/// second record off the mock producer.
+///
+/// The batch carries two events for one key on purpose: the limiter evaluates
+/// the local cache, so the first is always a miss that passes, and only the
+/// second can exceed a zero threshold. That keeps the limiting case free of
+/// Redis and of the clock.
+async fn run_v0(inputs: Inputs) -> Observed {
+    // The handler runs on this thread: `#[tokio::test]` is a current-thread
+    // runtime, so a thread-local recorder sees the limiter's counters.
+    let recorder = DebuggingRecorder::new();
+    let snapshotter = recorder.snapshotter();
+    let _guard = metrics::set_default_local_recorder(&recorder);
+
+    let (readiness, liveness, _monitor) = test_lifecycle_handlers();
+    let redis = Arc::new(MockRedisClient::new());
+    let cfg = DEFAULT_CONFIG.clone();
+    let limiter = build_limiter(inputs, redis.clone());
+    let service = build_restrictions(inputs).await;
+
+    let producer = MockKafkaProducer::new();
+    let sink = KafkaSinkBase::with_producer(producer.clone(), OutputRegistry::from(&cfg.kafka));
     let quota_limiter =
         CaptureQuotaLimiter::new(&cfg, redis.clone(), Duration::from_secs(60 * 60 * 24 * 7));
 
-    router(
+    let router = router(
         FixedTime {
             time: DateTime::parse_from_rfc3339(DEFAULT_TEST_TIME)
                 .expect("invalid fixed time")
@@ -182,22 +245,9 @@ async fn build_router(inputs: Inputs, producer: MockKafkaProducer) -> Router {
         None,
         false,
         None,
-    )
-}
+    );
 
-/// Post a two-event batch for one key and report the wire facts of the second
-/// record. The first event seeds the limiter's local cache, which is what lets
-/// the second one exceed a zero threshold without any Redis interaction.
-async fn run_case(inputs: Inputs) -> Observed {
-    // The handler runs on this thread: `#[tokio::test]` is a current-thread
-    // runtime, so a thread-local recorder sees the limiter's counters.
-    let recorder = DebuggingRecorder::new();
-    let snapshotter = recorder.snapshotter();
-    let _guard = metrics::set_default_local_recorder(&recorder);
-
-    let producer = MockKafkaProducer::new();
-    let router = build_router(inputs, producer.clone()).await;
-
+    // v0 reads the customer's choice from the event property.
     let mut properties = json!({});
     if inputs.personless {
         properties["$process_person_profile"] = json!(false);
@@ -207,10 +257,7 @@ async fn run_case(inputs: Inputs) -> Observed {
         "distinct_id": DISTINCT_ID,
         "properties": properties,
     });
-    let payload = json!({
-        "api_key": TOKEN,
-        "batch": [event.clone(), event],
-    });
+    let payload = json!({ "api_key": TOKEN, "batch": [event.clone(), event] });
 
     let response = TestClient::new(router)
         .post("/capture")
@@ -219,126 +266,201 @@ async fn run_case(inputs: Inputs) -> Observed {
         .body(payload.to_string())
         .send()
         .await;
-    assert_eq!(response.status(), StatusCode::OK, "capture rejected the batch");
+    assert_eq!(response.status(), StatusCode::OK, "v0 rejected the batch");
 
     let records = producer.get_records();
-    assert_eq!(records.len(), 2, "both events must reach the producer");
+    assert_eq!(records.len(), 2, "v0 must produce both events");
     let observed = &records[1];
 
-    let consultations = snapshotter
-        .snapshot()
-        .into_vec()
-        .iter()
-        .filter(|(key, _, _, _)| key.key().name() == "global_rate_limiter_eval_counts_total")
-        .filter_map(|(_, _, _, value)| match value {
-            DebugValue::Counter(v) => Some(*v),
-            _ => None,
-        })
-        .sum();
-
     Observed {
-        topic: observed.topic.clone(),
+        lane: v0_lane(&observed.topic),
         has_key: observed.key.is_some(),
         force_disable_person_processing: observed.headers.force_disable_person_processing,
-        limiter_consultations: consultations,
+        limiter_consultations: consultations(&snapshotter),
     }
 }
 
-// Topic names come from `DEFAULT_CONFIG.kafka`, which the registry is built from.
-const MAIN: &str = "events_plugin_ingestion";
-const OVERFLOW: &str = "events_plugin_ingestion_overflow";
+/// Drive the v1 endpoint (`/i/v1/analytics/events`) through its own router and
+/// sink, reading the second record off the v1 mock producer.
+async fn run_v1(inputs: Inputs) -> Observed {
+    let recorder = DebuggingRecorder::new();
+    let snapshotter = recorder.snapshotter();
+    let _guard = metrics::set_default_local_recorder(&recorder);
+
+    let redis = Arc::new(MockRedisClient::new());
+    let limiter = build_limiter(inputs, redis);
+    let service = build_restrictions(inputs).await;
+
+    let ts = TestStateBuilder::new()
+        .with_restriction_service(service)
+        .with_global_rate_limiter(Arc::new(limiter))
+        .build();
+
+    let router = v1_router(V1RouterConfig {
+        concurrency_limit: None,
+        max_compressed_body_bytes: 10 * 1024 * 1024,
+    })
+    .with_state(ts.state.clone());
+
+    // v1 reads the customer's choice from the event options, not the property.
+    let options = if inputs.personless {
+        json!({ "process_person_profile": false })
+    } else {
+        json!({})
+    };
+    let event = json!({
+        "event": "$pageview",
+        "uuid": "0198f0a0-0000-7000-8000-000000000001",
+        "distinct_id": DISTINCT_ID,
+        "timestamp": "2026-03-19T14:29:58.123Z",
+        "options": options,
+        "properties": {},
+    });
+    let mut second = event.clone();
+    second["uuid"] = json!("0198f0a0-0000-7000-8000-000000000002");
+    let payload = json!({
+        "created_at": "2026-03-19T14:30:00.000Z",
+        "batch": [event, second],
+    });
+
+    let response = TestClient::new(router)
+        .post("/i/v1/analytics/events")
+        .header("authorization", format!("Bearer {TOKEN}"))
+        .header("content-type", "application/json")
+        .header("X-Forwarded-For", "127.0.0.1")
+        .header("PostHog-Sdk-Info", "posthog-rs/1.0.0")
+        .header("PostHog-Attempt", "1")
+        .header("PostHog-Request-Id", "00000000-0000-0000-0000-000000000001")
+        .header("PostHog-Request-Timestamp", "2026-03-19T14:30:00.000Z")
+        .header("user-agent", "test-client/1.0")
+        .body(payload.to_string())
+        .send()
+        .await;
+    let status = response.status();
+    let body = response.text().await;
+    assert_eq!(status, StatusCode::OK, "v1 rejected the batch: {body}");
+
+    ts.mock_producer.with_records(|records| {
+        assert_eq!(records.len(), 2, "v1 must produce both events");
+        let observed = &records[1];
+        Observed {
+            lane: v1_lane(&observed.topic),
+            has_key: observed.key.is_some(),
+            // The wire header is bytes, so read it back the way a consumer would.
+            force_disable_person_processing: observed
+                .header("force_disable_person_processing")
+                .map(|v| v == "true"),
+            limiter_consultations: consultations(&snapshotter),
+        }
+    })
+}
+
+// Each path names its lanes differently; the matrix compares lanes, not strings.
+fn v0_lane(topic: &str) -> Lane {
+    match topic {
+        "events_plugin_ingestion" => Lane::Main,
+        "events_plugin_ingestion_overflow" => Lane::Overflow,
+        other => Lane::Other(Box::leak(other.to_string().into_boxed_str())),
+    }
+}
+
+fn v1_lane(topic: &str) -> Lane {
+    match topic {
+        "events_main" => Lane::Main,
+        "events_overflow" => Lane::Overflow,
+        other => Lane::Other(Box::leak(other.to_string().into_boxed_str())),
+    }
+}
 
 // Each pair of cases differs only in `personless` and shares one expectation.
 #[rstest]
 // Nothing applies: the limiter runs on both events and changes nothing.
 #[case::plain(
     Inputs::default(),
-    Expected { topic: MAIN, has_key: true, force_disable_person_processing: None, limiter_consultations: 2 }
+    Expected { lane: Lane::Main, has_key: true, force_disable_person_processing: None, limiter_consultations: 2 }
 )]
 #[case::plain_personless(
     Inputs { personless: true, ..Inputs::default() },
-    Expected { topic: MAIN, has_key: true, force_disable_person_processing: None, limiter_consultations: 2 }
+    Expected { lane: Lane::Main, has_key: true, force_disable_person_processing: None, limiter_consultations: 2 }
 )]
 // The limiter alone: it takes person processing away and spreads the key.
 #[case::rate_limited(
     Inputs { over_rate_limit: true, ..Inputs::default() },
-    Expected { topic: OVERFLOW, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 2 }
+    Expected { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 2 }
 )]
 #[case::rate_limited_personless(
     Inputs { over_rate_limit: true, personless: true, ..Inputs::default() },
-    Expected { topic: OVERFLOW, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 2 }
+    Expected { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 2 }
 )]
 // The skip-person restriction alone: person processing off and the key dropped,
 // on the main lane, and the limiter is never consulted.
 #[case::skip_person(
     Inputs { skip_person_restriction: true, ..Inputs::default() },
-    Expected { topic: MAIN, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
+    Expected { lane: Lane::Main, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
 )]
 #[case::skip_person_personless(
     Inputs { skip_person_restriction: true, personless: true, ..Inputs::default() },
-    Expected { topic: MAIN, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
+    Expected { lane: Lane::Main, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
 )]
 // The restriction shadows the limiter entirely: the key is over its window, but
 // the limiter is skipped, so nothing reroutes it.
 #[case::skip_person_and_rate_limited(
     Inputs { skip_person_restriction: true, over_rate_limit: true, ..Inputs::default() },
-    Expected { topic: MAIN, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
+    Expected { lane: Lane::Main, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
 )]
 #[case::skip_person_and_rate_limited_personless(
     Inputs { skip_person_restriction: true, over_rate_limit: true, personless: true, ..Inputs::default() },
-    Expected { topic: MAIN, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
+    Expected { lane: Lane::Main, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
 )]
 // The overflow restriction alone moves the lane but leaves person processing on,
 // so the key survives.
 #[case::force_overflow(
     Inputs { overflow_restriction: true, ..Inputs::default() },
-    Expected { topic: OVERFLOW, has_key: true, force_disable_person_processing: None, limiter_consultations: 2 }
+    Expected { lane: Lane::Overflow, has_key: true, force_disable_person_processing: None, limiter_consultations: 2 }
 )]
 #[case::force_overflow_personless(
     Inputs { overflow_restriction: true, personless: true, ..Inputs::default() },
-    Expected { topic: OVERFLOW, has_key: true, force_disable_person_processing: None, limiter_consultations: 2 }
+    Expected { lane: Lane::Overflow, has_key: true, force_disable_person_processing: None, limiter_consultations: 2 }
 )]
 // Overflow restriction plus the limiter: already on the overflow lane, and the
 // limiter's verdict drops the key.
 #[case::force_overflow_and_rate_limited(
     Inputs { overflow_restriction: true, over_rate_limit: true, ..Inputs::default() },
-    Expected { topic: OVERFLOW, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 2 }
+    Expected { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 2 }
 )]
 #[case::force_overflow_and_rate_limited_personless(
     Inputs { overflow_restriction: true, over_rate_limit: true, personless: true, ..Inputs::default() },
-    Expected { topic: OVERFLOW, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 2 }
+    Expected { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 2 }
 )]
 // Both restrictions: the overflow lane from one, the dropped key from the other.
 #[case::both_restrictions(
     Inputs { skip_person_restriction: true, overflow_restriction: true, ..Inputs::default() },
-    Expected { topic: OVERFLOW, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
+    Expected { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
 )]
 #[case::both_restrictions_personless(
     Inputs { skip_person_restriction: true, overflow_restriction: true, personless: true, ..Inputs::default() },
-    Expected { topic: OVERFLOW, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
+    Expected { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
 )]
 // All three: the limiter is still skipped, and the restrictions alone produce
 // the same wire outcome the limiter would have.
 #[case::everything(
     Inputs { skip_person_restriction: true, overflow_restriction: true, over_rate_limit: true, ..Inputs::default() },
-    Expected { topic: OVERFLOW, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
+    Expected { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
 )]
 #[case::everything_personless(
-    Inputs { skip_person_restriction: true, overflow_restriction: true, over_rate_limit: true, personless: true, ..Inputs::default() },
-    Expected { topic: OVERFLOW, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
+    Inputs { skip_person_restriction: true, overflow_restriction: true, over_rate_limit: true, personless: true },
+    Expected { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
 )]
 #[tokio::test]
 async fn person_processing_and_routing_matrix(#[case] inputs: Inputs, #[case] expected: Expected) {
-    let observed = run_case(inputs).await;
-
     assert_eq!(
-        observed,
-        Observed {
-            topic: expected.topic.to_string(),
-            has_key: expected.has_key,
-            force_disable_person_processing: expected.force_disable_person_processing,
-            limiter_consultations: expected.limiter_consultations,
-        },
-        "inputs: {inputs:?}"
+        run_v0(inputs).await,
+        Observed::from(expected),
+        "v0 endpoint, inputs: {inputs:?}"
+    );
+    assert_eq!(
+        run_v1(inputs).await,
+        Observed::from(expected),
+        "v1 endpoint, inputs: {inputs:?}"
     );
 }

--- a/rust/capture/tests/integration_person_processing_matrix.rs
+++ b/rust/capture/tests/integration_person_processing_matrix.rs
@@ -1,0 +1,344 @@
+//! Interaction matrix for the four mechanisms that decide an analytics event's
+//! person processing and routing: the customer's `$process_person_profile`
+//! property, a `SkipPersonProcessing` restriction, a `ForceOverflow`
+//! restriction, and the global rate limiter.
+//!
+//! Each mechanism has unit coverage on its own. What no other suite covers is
+//! how they compose, and composition is where they are easy to get wrong: three
+//! of the four can disable person processing, and two of them decide the
+//! partition key through the same `person_ordering` rule.
+//!
+//! The assertions are the four facts downstream ingestion actually reads off the
+//! wire, plus whether capture paid for the limiter at all:
+//!
+//! - the topic the record landed on
+//! - whether it carries a partition key
+//! - the `force_disable_person_processing` header
+//! - how many times the limiter was consulted
+//!
+//! The `personless` column is the reason this file exists. `$process_person_profile`
+//! and a skip-person restriction mean the same thing to the consumer, so it would
+//! be easy to derive one from the other in capture. Doing so would silently stop
+//! the limiter from running on personless traffic, which is a large share of
+//! volume and exactly the traffic the limiter still has a job on. Every case is
+//! run twice, once with the property and once without, and both rows carry the
+//! same expectation: the property must change nothing here.
+
+#[path = "common/integration_utils.rs"]
+mod integration_utils;
+
+use axum::http::StatusCode;
+use axum::Router;
+use axum_test_helper::TestClient;
+use capture::config::CaptureMode;
+use capture::event_restrictions::{
+    EventRestrictionService, Pipeline, Restriction, RestrictionManager, RestrictionScope,
+    RestrictionType,
+};
+use capture::global_rate_limiter::GlobalRateLimiter;
+use capture::quota_limiters::CaptureQuotaLimiter;
+use capture::router::router;
+use capture::sinks::kafka::KafkaSinkBase;
+use capture::sinks::producer::MockKafkaProducer;
+use capture::sinks::registry::OutputRegistry;
+use capture::time::TimeSource;
+use chrono::{DateTime, Utc};
+use common_redis::MockRedisClient;
+use integration_utils::{test_lifecycle_handlers, DEFAULT_CONFIG, DEFAULT_TEST_TIME};
+use limiters::token_dropper::TokenDropper;
+use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+use rstest::rstest;
+use serde_json::json;
+use std::sync::Arc;
+use std::time::Duration;
+
+const TOKEN: &str = "phc_matrix_token";
+const DISTINCT_ID: &str = "matrix-user";
+
+/// The limiter evaluates the local cache, so the first event for a key is always
+/// a miss and passes. A threshold of 0 makes the second event for that key
+/// exceed the window deterministically, with no Redis round trip and no clock.
+const THRESHOLD_ALWAYS_LIMITS: u64 = 0;
+const THRESHOLD_NEVER_LIMITS: u64 = 1_000_000;
+
+struct FixedTime {
+    time: DateTime<Utc>,
+}
+
+impl TimeSource for FixedTime {
+    fn current_time(&self) -> DateTime<Utc> {
+        self.time
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct Inputs {
+    /// The event carries `$process_person_profile: false`.
+    personless: bool,
+    /// A `SkipPersonProcessing` restriction covers the token.
+    skip_person_restriction: bool,
+    /// A `ForceOverflow` restriction covers the token.
+    overflow_restriction: bool,
+    /// The limiter's threshold is low enough to limit the observed event.
+    over_rate_limit: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Observed {
+    topic: String,
+    has_key: bool,
+    force_disable_person_processing: Option<bool>,
+    limiter_consultations: u64,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Expected {
+    topic: &'static str,
+    has_key: bool,
+    force_disable_person_processing: Option<bool>,
+    /// Consultations across the whole two-event batch, not just the observed
+    /// event, because the cost this counts is paid per event.
+    limiter_consultations: u64,
+}
+
+async fn build_router(inputs: Inputs, producer: MockKafkaProducer) -> Router {
+    let (readiness, liveness, _monitor) = test_lifecycle_handlers();
+
+    let mut cfg = DEFAULT_CONFIG.clone();
+    cfg.capture_mode = CaptureMode::Events;
+    cfg.global_rate_limit_enabled = true;
+    cfg.global_rate_limit_token_distinctid_threshold = if inputs.over_rate_limit {
+        THRESHOLD_ALWAYS_LIMITS
+    } else {
+        THRESHOLD_NEVER_LIMITS
+    };
+    // Park the background sync well beyond the request so the limiter's verdict
+    // comes from the local cache alone and no Redis tick can race the batch.
+    cfg.global_rate_limit_tick_interval_ms = 600_000;
+
+    let redis = Arc::new(MockRedisClient::new());
+    let limiter = GlobalRateLimiter::new_token_distinct_id(&cfg, vec![redis.clone()])
+        .expect("failed to build the global rate limiter");
+
+    let mut restrictions = Vec::new();
+    if inputs.skip_person_restriction {
+        restrictions.push(Restriction {
+            restriction_type: RestrictionType::SkipPersonProcessing,
+            scope: RestrictionScope::AllEvents,
+            args: None,
+        });
+    }
+    if inputs.overflow_restriction {
+        restrictions.push(Restriction {
+            restriction_type: RestrictionType::ForceOverflow,
+            scope: RestrictionScope::AllEvents,
+            args: None,
+        });
+    }
+    let service = EventRestrictionService::new(
+        Pipeline::for_capture_mode(CaptureMode::Events),
+        Duration::from_secs(300),
+    );
+    let mut manager = RestrictionManager::new();
+    manager.insert_restrictions(Pipeline::Analytics, TOKEN, restrictions);
+    service.update(manager).await;
+
+    let sink = KafkaSinkBase::with_producer(producer, OutputRegistry::from(&cfg.kafka));
+    let quota_limiter =
+        CaptureQuotaLimiter::new(&cfg, redis.clone(), Duration::from_secs(60 * 60 * 24 * 7));
+
+    router(
+        FixedTime {
+            time: DateTime::parse_from_rfc3339(DEFAULT_TEST_TIME)
+                .expect("invalid fixed time")
+                .with_timezone(&Utc),
+        },
+        readiness,
+        liveness,
+        Arc::new(sink),
+        redis,
+        Some(Arc::new(limiter)),
+        quota_limiter,
+        TokenDropper::default(),
+        Some(service),
+        None,
+        CaptureMode::Events,
+        None,
+        25 * 1024 * 1024,
+        false,
+        1_i64,
+        false,
+        0.0_f32,
+        26_214_400,
+        None,
+        256,
+        10 * 1024 * 1024,
+        50 * 1024 * 1024,
+        None,
+        None,
+        None,
+        None,
+        8,
+        None,
+        false,
+        None,
+    )
+}
+
+/// Post a two-event batch for one key and report the wire facts of the second
+/// record. The first event seeds the limiter's local cache, which is what lets
+/// the second one exceed a zero threshold without any Redis interaction.
+async fn run_case(inputs: Inputs) -> Observed {
+    // The handler runs on this thread: `#[tokio::test]` is a current-thread
+    // runtime, so a thread-local recorder sees the limiter's counters.
+    let recorder = DebuggingRecorder::new();
+    let snapshotter = recorder.snapshotter();
+    let _guard = metrics::set_default_local_recorder(&recorder);
+
+    let producer = MockKafkaProducer::new();
+    let router = build_router(inputs, producer.clone()).await;
+
+    let mut properties = json!({});
+    if inputs.personless {
+        properties["$process_person_profile"] = json!(false);
+    }
+    let event = json!({
+        "event": "$pageview",
+        "distinct_id": DISTINCT_ID,
+        "properties": properties,
+    });
+    let payload = json!({
+        "api_key": TOKEN,
+        "batch": [event.clone(), event],
+    });
+
+    let response = TestClient::new(router)
+        .post("/capture")
+        .header("Content-Type", "application/json")
+        .header("X-Forwarded-For", "127.0.0.1")
+        .body(payload.to_string())
+        .send()
+        .await;
+    assert_eq!(response.status(), StatusCode::OK, "capture rejected the batch");
+
+    let records = producer.get_records();
+    assert_eq!(records.len(), 2, "both events must reach the producer");
+    let observed = &records[1];
+
+    let consultations = snapshotter
+        .snapshot()
+        .into_vec()
+        .iter()
+        .filter(|(key, _, _, _)| key.key().name() == "global_rate_limiter_eval_counts_total")
+        .filter_map(|(_, _, _, value)| match value {
+            DebugValue::Counter(v) => Some(*v),
+            _ => None,
+        })
+        .sum();
+
+    Observed {
+        topic: observed.topic.clone(),
+        has_key: observed.key.is_some(),
+        force_disable_person_processing: observed.headers.force_disable_person_processing,
+        limiter_consultations: consultations,
+    }
+}
+
+// Topic names come from `DEFAULT_CONFIG.kafka`, which the registry is built from.
+const MAIN: &str = "events_plugin_ingestion";
+const OVERFLOW: &str = "events_plugin_ingestion_overflow";
+
+// Each pair of cases differs only in `personless` and shares one expectation.
+#[rstest]
+// Nothing applies: the limiter runs on both events and changes nothing.
+#[case::plain(
+    Inputs::default(),
+    Expected { topic: MAIN, has_key: true, force_disable_person_processing: None, limiter_consultations: 2 }
+)]
+#[case::plain_personless(
+    Inputs { personless: true, ..Inputs::default() },
+    Expected { topic: MAIN, has_key: true, force_disable_person_processing: None, limiter_consultations: 2 }
+)]
+// The limiter alone: it takes person processing away and spreads the key.
+#[case::rate_limited(
+    Inputs { over_rate_limit: true, ..Inputs::default() },
+    Expected { topic: OVERFLOW, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 2 }
+)]
+#[case::rate_limited_personless(
+    Inputs { over_rate_limit: true, personless: true, ..Inputs::default() },
+    Expected { topic: OVERFLOW, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 2 }
+)]
+// The skip-person restriction alone: person processing off and the key dropped,
+// on the main lane, and the limiter is never consulted.
+#[case::skip_person(
+    Inputs { skip_person_restriction: true, ..Inputs::default() },
+    Expected { topic: MAIN, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
+)]
+#[case::skip_person_personless(
+    Inputs { skip_person_restriction: true, personless: true, ..Inputs::default() },
+    Expected { topic: MAIN, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
+)]
+// The restriction shadows the limiter entirely: the key is over its window, but
+// the limiter is skipped, so nothing reroutes it.
+#[case::skip_person_and_rate_limited(
+    Inputs { skip_person_restriction: true, over_rate_limit: true, ..Inputs::default() },
+    Expected { topic: MAIN, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
+)]
+#[case::skip_person_and_rate_limited_personless(
+    Inputs { skip_person_restriction: true, over_rate_limit: true, personless: true, ..Inputs::default() },
+    Expected { topic: MAIN, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
+)]
+// The overflow restriction alone moves the lane but leaves person processing on,
+// so the key survives.
+#[case::force_overflow(
+    Inputs { overflow_restriction: true, ..Inputs::default() },
+    Expected { topic: OVERFLOW, has_key: true, force_disable_person_processing: None, limiter_consultations: 2 }
+)]
+#[case::force_overflow_personless(
+    Inputs { overflow_restriction: true, personless: true, ..Inputs::default() },
+    Expected { topic: OVERFLOW, has_key: true, force_disable_person_processing: None, limiter_consultations: 2 }
+)]
+// Overflow restriction plus the limiter: already on the overflow lane, and the
+// limiter's verdict drops the key.
+#[case::force_overflow_and_rate_limited(
+    Inputs { overflow_restriction: true, over_rate_limit: true, ..Inputs::default() },
+    Expected { topic: OVERFLOW, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 2 }
+)]
+#[case::force_overflow_and_rate_limited_personless(
+    Inputs { overflow_restriction: true, over_rate_limit: true, personless: true, ..Inputs::default() },
+    Expected { topic: OVERFLOW, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 2 }
+)]
+// Both restrictions: the overflow lane from one, the dropped key from the other.
+#[case::both_restrictions(
+    Inputs { skip_person_restriction: true, overflow_restriction: true, ..Inputs::default() },
+    Expected { topic: OVERFLOW, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
+)]
+#[case::both_restrictions_personless(
+    Inputs { skip_person_restriction: true, overflow_restriction: true, personless: true, ..Inputs::default() },
+    Expected { topic: OVERFLOW, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
+)]
+// All three: the limiter is still skipped, and the restrictions alone produce
+// the same wire outcome the limiter would have.
+#[case::everything(
+    Inputs { skip_person_restriction: true, overflow_restriction: true, over_rate_limit: true, ..Inputs::default() },
+    Expected { topic: OVERFLOW, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
+)]
+#[case::everything_personless(
+    Inputs { skip_person_restriction: true, overflow_restriction: true, over_rate_limit: true, personless: true, ..Inputs::default() },
+    Expected { topic: OVERFLOW, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
+)]
+#[tokio::test]
+async fn person_processing_and_routing_matrix(#[case] inputs: Inputs, #[case] expected: Expected) {
+    let observed = run_case(inputs).await;
+
+    assert_eq!(
+        observed,
+        Observed {
+            topic: expected.topic.to_string(),
+            has_key: expected.has_key,
+            force_disable_person_processing: expected.force_disable_person_processing,
+            limiter_consultations: expected.limiter_consultations,
+        },
+        "inputs: {inputs:?}"
+    );
+}

--- a/rust/capture/tests/integration_person_processing_matrix.rs
+++ b/rust/capture/tests/integration_person_processing_matrix.rs
@@ -37,8 +37,8 @@ use axum::http::StatusCode;
 use axum_test_helper::TestClient;
 use capture::config::CaptureMode;
 use capture::event_restrictions::{
-    EventRestrictionService, Pipeline, Restriction, RestrictionManager, RestrictionScope,
-    RestrictionType,
+    EventRestrictionService, Pipeline, Restriction, RestrictionFilters, RestrictionManager,
+    RestrictionScope, RestrictionType,
 };
 use capture::global_rate_limiter::GlobalRateLimiter;
 use capture::quota_limiters::CaptureQuotaLimiter;
@@ -56,11 +56,15 @@ use limiters::token_dropper::TokenDropper;
 use metrics_util::debugging::{DebugValue, DebuggingRecorder};
 use rstest::rstest;
 use serde_json::json;
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
 const TOKEN: &str = "phc_matrix_token";
 const DISTINCT_ID: &str = "matrix-user";
+/// A key the filtered restriction covers, and one it does not.
+const RESTRICTED_DISTINCT_ID: &str = "matrix-user-restricted";
+const OPEN_DISTINCT_ID: &str = "matrix-user-open";
 
 /// The limiter evaluates the local cache, so the first event for a key is always
 /// a miss and passes. A threshold of 0 makes the second event for that key
@@ -88,6 +92,10 @@ struct Inputs {
     overflow_restriction: bool,
     /// The limiter's threshold is low enough to limit the observed event.
     over_rate_limit: bool,
+    /// Narrow the restrictions to one distinct id instead of the whole token.
+    /// Restrictions are keyed by token and may carry filters, so a token can
+    /// have some of its keys restricted and the rest untouched.
+    restricted_distinct_id: Option<&'static str>,
 }
 
 /// The lane an event landed on, independent of each path's topic names.
@@ -98,31 +106,35 @@ enum Lane {
     Other(&'static str),
 }
 
+/// The wire facts of one produced record.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+struct Record {
+    lane: Lane,
+    has_key: bool,
+    force_disable_person_processing: Option<bool>,
+}
+
+/// One record's facts plus the limiter cost for the batch that produced it.
+/// Consultations are a batch total, not per record, because the Redis work this
+/// counts is paid once per consulted event and read back from one counter.
 #[derive(Debug, PartialEq, Eq)]
 struct Observed {
-    lane: Lane,
-    has_key: bool,
-    force_disable_person_processing: Option<bool>,
+    record: Record,
     limiter_consultations: u64,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-struct Expected {
-    lane: Lane,
-    has_key: bool,
-    force_disable_person_processing: Option<bool>,
-    /// Consultations across the whole two-event batch, not just the observed
-    /// event, because the cost this counts is paid per event.
+#[derive(Debug, PartialEq, Eq)]
+struct Batch {
+    records: Vec<Record>,
     limiter_consultations: u64,
 }
 
-impl From<Expected> for Observed {
-    fn from(e: Expected) -> Self {
-        Self {
-            lane: e.lane,
-            has_key: e.has_key,
-            force_disable_person_processing: e.force_disable_person_processing,
-            limiter_consultations: e.limiter_consultations,
+impl Batch {
+    /// The facts of one record, paired with the batch's limiter cost.
+    fn at(&self, index: usize) -> Observed {
+        Observed {
+            record: self.records[index],
+            limiter_consultations: self.limiter_consultations,
         }
     }
 }
@@ -160,18 +172,26 @@ fn build_limiter(inputs: Inputs, redis: Arc<MockRedisClient>) -> GlobalRateLimit
 }
 
 async fn build_restrictions(inputs: Inputs) -> EventRestrictionService {
+    let scope = match inputs.restricted_distinct_id {
+        Some(distinct_id) => RestrictionScope::Filtered(RestrictionFilters {
+            distinct_ids: HashSet::from([distinct_id.to_string()]),
+            ..Default::default()
+        }),
+        None => RestrictionScope::AllEvents,
+    };
+
     let mut restrictions = Vec::new();
     if inputs.skip_person_restriction {
         restrictions.push(Restriction {
             restriction_type: RestrictionType::SkipPersonProcessing,
-            scope: RestrictionScope::AllEvents,
+            scope: scope.clone(),
             args: None,
         });
     }
     if inputs.overflow_restriction {
         restrictions.push(Restriction {
             restriction_type: RestrictionType::ForceOverflow,
-            scope: RestrictionScope::AllEvents,
+            scope,
             args: None,
         });
     }
@@ -185,14 +205,15 @@ async fn build_restrictions(inputs: Inputs) -> EventRestrictionService {
     service
 }
 
-/// Drive the v0 endpoint (`/capture`) into a real `KafkaSinkBase` and read the
-/// second record off the mock producer.
+/// Drive the v0 endpoint (`/capture`) into a real `KafkaSinkBase` and read every
+/// record off the mock producer, in request order.
 ///
-/// The batch carries two events for one key on purpose: the limiter evaluates
-/// the local cache, so the first is always a miss that passes, and only the
-/// second can exceed a zero threshold. That keeps the limiting case free of
-/// Redis and of the clock.
-async fn run_v0(inputs: Inputs) -> Observed {
+/// `distinct_ids` gives one event per entry. Repeating an id is how a case
+/// reaches the limiter's limiting branch: the limiter evaluates the local cache,
+/// so the first event for a key is always a miss that passes, and only a later
+/// one can exceed a zero threshold. That keeps the limiting case free of Redis
+/// and of the clock.
+async fn run_v0(inputs: Inputs, distinct_ids: &[&str]) -> Batch {
     // The handler runs on this thread: `#[tokio::test]` is a current-thread
     // runtime, so a thread-local recorder sees the limiter's counters.
     let recorder = DebuggingRecorder::new();
@@ -252,12 +273,17 @@ async fn run_v0(inputs: Inputs) -> Observed {
     if inputs.personless {
         properties["$process_person_profile"] = json!(false);
     }
-    let event = json!({
-        "event": "$pageview",
-        "distinct_id": DISTINCT_ID,
-        "properties": properties,
-    });
-    let payload = json!({ "api_key": TOKEN, "batch": [event.clone(), event] });
+    let batch: Vec<_> = distinct_ids
+        .iter()
+        .map(|distinct_id| {
+            json!({
+                "event": "$pageview",
+                "distinct_id": distinct_id,
+                "properties": properties,
+            })
+        })
+        .collect();
+    let payload = json!({ "api_key": TOKEN, "batch": batch });
 
     let response = TestClient::new(router)
         .post("/capture")
@@ -268,21 +294,29 @@ async fn run_v0(inputs: Inputs) -> Observed {
         .await;
     assert_eq!(response.status(), StatusCode::OK, "v0 rejected the batch");
 
-    let records = producer.get_records();
-    assert_eq!(records.len(), 2, "v0 must produce both events");
-    let observed = &records[1];
+    let produced = producer.get_records();
+    assert_eq!(
+        produced.len(),
+        distinct_ids.len(),
+        "v0 must produce every event"
+    );
 
-    Observed {
-        lane: v0_lane(&observed.topic),
-        has_key: observed.key.is_some(),
-        force_disable_person_processing: observed.headers.force_disable_person_processing,
+    Batch {
+        records: produced
+            .iter()
+            .map(|r| Record {
+                lane: v0_lane(&r.topic),
+                has_key: r.key.is_some(),
+                force_disable_person_processing: r.headers.force_disable_person_processing,
+            })
+            .collect(),
         limiter_consultations: consultations(&snapshotter),
     }
 }
 
 /// Drive the v1 endpoint (`/i/v1/analytics/events`) through its own router and
-/// sink, reading the second record off the v1 mock producer.
-async fn run_v1(inputs: Inputs) -> Observed {
+/// sink, reading every record off the v1 mock producer, in request order.
+async fn run_v1(inputs: Inputs, distinct_ids: &[&str]) -> Batch {
     let recorder = DebuggingRecorder::new();
     let snapshotter = recorder.snapshotter();
     let _guard = metrics::set_default_local_recorder(&recorder);
@@ -308,19 +342,24 @@ async fn run_v1(inputs: Inputs) -> Observed {
     } else {
         json!({})
     };
-    let event = json!({
-        "event": "$pageview",
-        "uuid": "0198f0a0-0000-7000-8000-000000000001",
-        "distinct_id": DISTINCT_ID,
-        "timestamp": "2026-03-19T14:29:58.123Z",
-        "options": options,
-        "properties": {},
-    });
-    let mut second = event.clone();
-    second["uuid"] = json!("0198f0a0-0000-7000-8000-000000000002");
+    // v1 requires a distinct uuid per event, so index them.
+    let batch: Vec<_> = distinct_ids
+        .iter()
+        .enumerate()
+        .map(|(i, distinct_id)| {
+            json!({
+                "event": "$pageview",
+                "uuid": format!("0198f0a0-0000-7000-8000-00000000000{i}"),
+                "distinct_id": distinct_id,
+                "timestamp": "2026-03-19T14:29:58.123Z",
+                "options": options,
+                "properties": {},
+            })
+        })
+        .collect();
     let payload = json!({
         "created_at": "2026-03-19T14:30:00.000Z",
-        "batch": [event, second],
+        "batch": batch,
     });
 
     let response = TestClient::new(router)
@@ -340,16 +379,25 @@ async fn run_v1(inputs: Inputs) -> Observed {
     let body = response.text().await;
     assert_eq!(status, StatusCode::OK, "v1 rejected the batch: {body}");
 
-    ts.mock_producer.with_records(|records| {
-        assert_eq!(records.len(), 2, "v1 must produce both events");
-        let observed = &records[1];
-        Observed {
-            lane: v1_lane(&observed.topic),
-            has_key: observed.key.is_some(),
-            // The wire header is bytes, so read it back the way a consumer would.
-            force_disable_person_processing: observed
-                .header("force_disable_person_processing")
-                .map(|v| v == "true"),
+    ts.mock_producer.with_records(|produced| {
+        assert_eq!(
+            produced.len(),
+            distinct_ids.len(),
+            "v1 must produce every event"
+        );
+        Batch {
+            records: produced
+                .iter()
+                .map(|r| Record {
+                    lane: v1_lane(&r.topic),
+                    has_key: r.key.is_some(),
+                    // The wire header is bytes, so read it back the way a
+                    // consumer would.
+                    force_disable_person_processing: r
+                        .header("force_disable_person_processing")
+                        .map(|v| v == "true"),
+                })
+                .collect(),
             limiter_consultations: consultations(&snapshotter),
         }
     })
@@ -377,90 +425,176 @@ fn v1_lane(topic: &str) -> Lane {
 // Nothing applies: the limiter runs on both events and changes nothing.
 #[case::plain(
     Inputs::default(),
-    Expected { lane: Lane::Main, has_key: true, force_disable_person_processing: None, limiter_consultations: 2 }
+    Observed { record: Record { lane: Lane::Main, has_key: true, force_disable_person_processing: None }, limiter_consultations: 2 }
 )]
 #[case::plain_personless(
     Inputs { personless: true, ..Inputs::default() },
-    Expected { lane: Lane::Main, has_key: true, force_disable_person_processing: None, limiter_consultations: 2 }
+    Observed { record: Record { lane: Lane::Main, has_key: true, force_disable_person_processing: None }, limiter_consultations: 2 }
 )]
 // The limiter alone: it takes person processing away and spreads the key.
 #[case::rate_limited(
     Inputs { over_rate_limit: true, ..Inputs::default() },
-    Expected { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 2 }
+    Observed { record: Record { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 2 }
 )]
 #[case::rate_limited_personless(
     Inputs { over_rate_limit: true, personless: true, ..Inputs::default() },
-    Expected { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 2 }
+    Observed { record: Record { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 2 }
 )]
 // The skip-person restriction alone: person processing off and the key dropped,
 // on the main lane, and the limiter is never consulted.
 #[case::skip_person(
     Inputs { skip_person_restriction: true, ..Inputs::default() },
-    Expected { lane: Lane::Main, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
+    Observed { record: Record { lane: Lane::Main, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 0 }
 )]
 #[case::skip_person_personless(
     Inputs { skip_person_restriction: true, personless: true, ..Inputs::default() },
-    Expected { lane: Lane::Main, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
+    Observed { record: Record { lane: Lane::Main, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 0 }
 )]
 // The restriction shadows the limiter entirely: the key is over its window, but
 // the limiter is skipped, so nothing reroutes it.
 #[case::skip_person_and_rate_limited(
     Inputs { skip_person_restriction: true, over_rate_limit: true, ..Inputs::default() },
-    Expected { lane: Lane::Main, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
+    Observed { record: Record { lane: Lane::Main, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 0 }
 )]
 #[case::skip_person_and_rate_limited_personless(
     Inputs { skip_person_restriction: true, over_rate_limit: true, personless: true, ..Inputs::default() },
-    Expected { lane: Lane::Main, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
+    Observed { record: Record { lane: Lane::Main, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 0 }
 )]
 // The overflow restriction alone moves the lane but leaves person processing on,
 // so the key survives.
 #[case::force_overflow(
     Inputs { overflow_restriction: true, ..Inputs::default() },
-    Expected { lane: Lane::Overflow, has_key: true, force_disable_person_processing: None, limiter_consultations: 2 }
+    Observed { record: Record { lane: Lane::Overflow, has_key: true, force_disable_person_processing: None }, limiter_consultations: 2 }
 )]
 #[case::force_overflow_personless(
     Inputs { overflow_restriction: true, personless: true, ..Inputs::default() },
-    Expected { lane: Lane::Overflow, has_key: true, force_disable_person_processing: None, limiter_consultations: 2 }
+    Observed { record: Record { lane: Lane::Overflow, has_key: true, force_disable_person_processing: None }, limiter_consultations: 2 }
 )]
 // Overflow restriction plus the limiter: already on the overflow lane, and the
 // limiter's verdict drops the key.
 #[case::force_overflow_and_rate_limited(
     Inputs { overflow_restriction: true, over_rate_limit: true, ..Inputs::default() },
-    Expected { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 2 }
+    Observed { record: Record { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 2 }
 )]
 #[case::force_overflow_and_rate_limited_personless(
     Inputs { overflow_restriction: true, over_rate_limit: true, personless: true, ..Inputs::default() },
-    Expected { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 2 }
+    Observed { record: Record { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 2 }
 )]
 // Both restrictions: the overflow lane from one, the dropped key from the other.
 #[case::both_restrictions(
     Inputs { skip_person_restriction: true, overflow_restriction: true, ..Inputs::default() },
-    Expected { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
+    Observed { record: Record { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 0 }
 )]
 #[case::both_restrictions_personless(
     Inputs { skip_person_restriction: true, overflow_restriction: true, personless: true, ..Inputs::default() },
-    Expected { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
+    Observed { record: Record { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 0 }
 )]
 // All three: the limiter is still skipped, and the restrictions alone produce
 // the same wire outcome the limiter would have.
 #[case::everything(
     Inputs { skip_person_restriction: true, overflow_restriction: true, over_rate_limit: true, ..Inputs::default() },
-    Expected { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
+    Observed { record: Record { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 0 }
 )]
 #[case::everything_personless(
-    Inputs { skip_person_restriction: true, overflow_restriction: true, over_rate_limit: true, personless: true },
-    Expected { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true), limiter_consultations: 0 }
+    Inputs { skip_person_restriction: true, overflow_restriction: true, over_rate_limit: true, personless: true, restricted_distinct_id: None },
+    Observed { record: Record { lane: Lane::Overflow, has_key: false, force_disable_person_processing: Some(true) }, limiter_consultations: 0 }
 )]
 #[tokio::test]
-async fn person_processing_and_routing_matrix(#[case] inputs: Inputs, #[case] expected: Expected) {
+async fn person_processing_and_routing_matrix(#[case] inputs: Inputs, #[case] expected: Observed) {
+    // Two events for one key: the second is the one a zero threshold can limit.
+    let batch = [DISTINCT_ID, DISTINCT_ID];
+
     assert_eq!(
-        run_v0(inputs).await,
-        Observed::from(expected),
+        run_v0(inputs, &batch).await.at(1),
+        expected,
         "v0 endpoint, inputs: {inputs:?}"
     );
     assert_eq!(
-        run_v1(inputs).await,
-        Observed::from(expected),
+        run_v1(inputs, &batch).await.at(1),
+        expected,
         "v1 endpoint, inputs: {inputs:?}"
     );
+}
+
+/// A restriction filtered to one distinct id must not shield the token's other
+/// keys from the limiter.
+///
+/// The skip is a per-event decision, so a batch mixing a restricted key with an
+/// unrestricted one has to split: the restricted events skip the limiter and
+/// keep the main lane, while the unrestricted ones are still consulted and still
+/// rerouted once they exceed the window. Hoisting the check to the batch, or
+/// keying it on the token rather than the event, would silently stop rate
+/// limiting every other key belonging to a token that has any restriction at all.
+#[rstest]
+#[case::skip_person(false)]
+#[case::skip_person_and_force_overflow(true)]
+#[tokio::test]
+async fn restriction_filtered_to_one_distinct_id_leaves_other_keys_rate_limited(
+    #[case] overflow_restriction: bool,
+) {
+    let inputs = Inputs {
+        skip_person_restriction: true,
+        overflow_restriction,
+        over_rate_limit: true,
+        restricted_distinct_id: Some(RESTRICTED_DISTINCT_ID),
+        personless: false,
+    };
+    // Two events per key, so each key reaches the limiter's limiting branch on
+    // its second event if it is consulted at all.
+    let batch = [
+        RESTRICTED_DISTINCT_ID,
+        RESTRICTED_DISTINCT_ID,
+        OPEN_DISTINCT_ID,
+        OPEN_DISTINCT_ID,
+    ];
+    let restricted_lane = if overflow_restriction {
+        Lane::Overflow
+    } else {
+        Lane::Main
+    };
+
+    for (path, observed) in [
+        ("v0", run_v0(inputs, &batch).await),
+        ("v1", run_v1(inputs, &batch).await),
+    ] {
+        // Only the two unrestricted events cost a limiter evaluation.
+        assert_eq!(
+            observed.limiter_consultations, 2,
+            "{path}: the limiter must be consulted for the unrestricted key only"
+        );
+
+        for i in 0..2 {
+            assert_eq!(
+                observed.records[i],
+                Record {
+                    lane: restricted_lane,
+                    has_key: false,
+                    force_disable_person_processing: Some(true),
+                },
+                "{path}: restricted event {i} must carry the restriction's outcome"
+            );
+        }
+
+        // The unrestricted key is untouched by the restriction, so its first
+        // event passes with person processing on and its key intact.
+        assert_eq!(
+            observed.records[2],
+            Record {
+                lane: Lane::Main,
+                has_key: true,
+                force_disable_person_processing: None,
+            },
+            "{path}: the unrestricted key's first event must pass untouched"
+        );
+        // Its second event exceeds the window, so the limiter acts on it.
+        assert_eq!(
+            observed.records[3],
+            Record {
+                lane: Lane::Overflow,
+                has_key: false,
+                force_disable_person_processing: Some(true),
+            },
+            "{path}: the unrestricted key must still be rate limited"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

Capture pays a Redis read and write per event for events the global rate limiter cannot act on.

- The limiter's only effects are disabling person processing and rerouting a hot key to overflow.
- When an ops restriction has already disabled person processing, the first effect is a no-op.
- The partition key is already null in that case, because `person_ordering` keys off the person flag (`ordering.rs:37`).
- Consulting the limiter anyway costs a local cache insert, a pending-sync insert, and a Redis round trip for every such event.

v1 already recognized this and skipped the limiter's stamps, but made the call first and threw the answer away (`v1/analytics/process.rs`). v0 made the call and used it.

## Changes

- Both analytics paths now skip the limiter entirely for an event whose person processing is already off.
- The check moves above the call, because `is_limited` queues the Redis write before it reads the cache.
- `capture_global_rate_limiter_skipped{reason="person_processing_already_disabled"}` counts the skipped events on the v0 path. v1 already reports them as `capture_v1_rate_limiter{outcome="already_disabled"}`.

> [!WARNING]
> Two behavior changes, both on the v0 path.
>
> The limiter no longer applies its `ForceLimited` overflow reroute to these events, so they stay on the main lane instead of moving to the overflow topic. Their records are already round-robin partitioned, so this changes lane isolation, not partition balance. This is what v1 has always done, so the change closes a v0/v1 divergence rather than opening one.
>
> These events no longer count toward the shared per-key window. Where a restriction covers a whole token that is immaterial, since every one of its events has person processing off. Where a restriction is scoped narrower than the key, by `event_name` or `session_id`, the remaining events for that key are judged on their own volume alone.

## How did you test this code?

`cargo test -p capture`, run locally under flox. Green.

**New: `tests/integration_person_processing_matrix.rs`.** Sixteen cases covering every combination of the four mechanisms that decide person processing and routing: the personless choice, a `SkipPersonProcessing` restriction, a `ForceOverflow` restriction, and the limiter. Each case runs against both analytics endpoints, `/capture` and `/i/v1/analytics/events`, and asserts the lane, whether a partition key is present, the `force_disable_person_processing` header, and how many times the limiter was consulted.

Both paths assert against the same explicit expectation rather than against each other, so two paths that drift together still fail. All sixteen agree across both.

It catches two regressions nothing else does:

- Composition drift. Each mechanism has unit coverage alone. Three of the four can disable person processing, and two decide the partition key through the same `person_ordering` rule, so their interactions are where a change goes wrong quietly.
- The conflation this PR's correctness rests on. Every case runs twice, with and without `$process_person_profile: false`, against one shared expectation. Deriving the restriction flag from the property would look like a tidy-up and would silently stop the limiter running on personless traffic.

**Plus `restriction_filtered_to_one_distinct_id_leaves_other_keys_rate_limited`.** Restrictions are keyed by token and may carry `distinct_id`, `session_id`, `event_name`, or `event_uuid` filters, so the skip has to be a per-event decision. The case mixes a restricted key with an unrestricted one in one batch and asserts they split: the restricted events skip the limiter and keep the main lane, while the unrestricted key is still consulted and still rerouted once it exceeds the window. Hoisting the check to the batch, or keying it on the token, would silently stop rate limiting every other key of any token holding a restriction.

I verified both are not vacuous by disabling the skip on both paths and re-running. The matrix fails on exactly the eight skip-person cases and passes the other eight; the scoped case fails on the consultation count, four where two is correct.

Three existing tests pinned the old contract and now pin the new one. Each still catches the regression it was written for, with the expectation moved:

- `global_rate_limit_is_skipped_when_person_processing_was_already_off` (v0) asserted the `ForceLimited` reroute still applied under a restriction. It now asserts no reroute. This is the test that makes the behavior change above explicit rather than silent.
- `td_limits_skips_events_with_person_processing_already_off` (v1) asserted the limiter was consulted for an already-disabled event. It now asserts it is not.
- `td_limits_evaluates_only_events_it_can_act_on` (v1) asserted `allowed + limited + already_disabled` equalled the consulted count. It now asserts `allowed + limited` does.

Key-nulling from the person flag is already covered across lanes in `pipeline.rs`, including the AI-lane exception, so the matrix asserts it end to end rather than duplicating that unit coverage.

Not tested: I did not run this against a real Redis, a real broker, or any deployed environment. The matrix uses a mock producer and a mock Redis, and reaches its limiting case through the local cache rather than a Redis sync.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via Claude Code) wrote this change. A person identified that the limiter runs on events it cannot affect, and directed the fix.

Skills invoked: `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.

Two readings changed the design during the session. I first assumed the reroute removal would cost partition spreading, until reading `ordering.rs:37` and `v0_request.rs:340` showed the key is already null whenever the person flag is set, which narrows the consequence to lane isolation. I also assumed the v0/v1 difference on the reroute was an oversight, until finding it asserted with an explicit comment in the v0 test, so the PR treats it as a deliberate behavior it changes rather than a bug it fixes.

Related to #83004, which removes the same cost for a different case, but independent of it. Either can land first.

