### PR TITLE
fix(mysql): treat max_connections_per_hour resource limit as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -288,6 +288,14 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # egress / SSH-tunnel host) — retrying connects from the same host fails identically.
             # Match the stable tail phrase, not the volatile host in the message prefix.
             "is not allowed to connect to this MySQL server": "Your MySQL/MariaDB server isn't allowing connections from PostHog's host (error 1130). Ask your database admin to grant access for the connecting host (or allow our IP / SSH-tunnel host), then retry the sync.",
+            # MySQL/MariaDB error 1226 (ER_USER_LIMIT_REACHED): the connecting user account has a
+            # `MAX_CONNECTIONS_PER_HOUR` resource limit set (via `CREATE USER`/`GRANT ... WITH
+            # MAX_CONNECTIONS_PER_HOUR`), and this hour's quota is used up. The counter only resets
+            # at the top of the next clock hour, so retrying immediately keeps failing identically
+            # and just spends more of the next hour's quota re-attempting — only a DB admin raising
+            # or removing the limit fixes it. Match the locale-independent error code (the username
+            # and current-value count are volatile).
+            "(1226,": "Your MySQL/MariaDB user account has a 'max_connections_per_hour' resource limit configured, and PostHog has used it up for this hour (error 1226). The limit resets at the top of the next hour, but retrying now only spends more of that quota. Ask your database admin to raise or remove the limit on the connecting user, then resync.",
             # MySQL/MariaDB error 1142 (ER_TABLEACCESS_DENIED_ERROR): the connecting user authenticated
             # fine but lacks the SELECT privilege on a table the sync reads — distinct from the 1045
             # login failure already handled above. Only a DB admin can GRANT it, and the streaming query

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -2073,6 +2073,25 @@ class TestMySQLSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # Raw pymysql str(error) form.
+            str(
+                pymysql.err.OperationalError(
+                    1226,
+                    "User 'app_user' has exceeded the 'max_connections_per_hour' resource (current value: 10)",
+                )
+            ),
+            # Temporal-wrapped str(e.cause) form — different user/quota, same stable code.
+            "OperationalError: (1226, \"User 'reader'@'10.0.1.5' has exceeded the 'max_connections_per_hour' resource (current value: 5)\")",
+        ],
+    )
+    def test_max_connections_per_hour_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Max-connections-per-hour error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # Raw pymysql str(error) form the import/sync path classifies (`_handle_import_error`
             # matches `str(error)`, which has no class-name prefix).
             str(


### PR DESCRIPTION
## Problem

A MySQL data warehouse sync keeps retrying when the connecting database user has used up its `MAX_CONNECTIONS_PER_HOUR` resource limit, even though every retry fails identically until the next clock hour.

Surfaced by [error tracking](https://us.posthog.com/project/2/error_tracking/019fff51-5ead-7503-baa6-e7919a10a43d): pymysql `OperationalError` 1226, "User ... has exceeded the 'max_connections_per_hour' resource", raised from `_connect_with_transient_retry` in `mysql.py`.

## Changes

- Added MySQL error 1226 to `MySQLSource.get_non_retryable_errors`, matching the stable `(1226,` code prefix since the username and quota value are customer-specific.
- This limit is a customer-configured MySQL user resource cap (`CREATE USER`/`GRANT ... WITH MAX_CONNECTIONS_PER_HOUR`). It resets only at the top of the next hour, so retrying now just spends more of the same hour's quota — only a database admin raising or removing the limit fixes it. This is a different class than the existing `max_connections`/`can't create thread` entries, which self-heal within seconds and stay retryable.

## How did you test this code?

- Added `test_max_connections_per_hour_is_non_retryable`, parametrized over the raw pymysql and Temporal-wrapped error forms, mirroring the existing `test_host_not_privileged_is_non_retryable` pattern.
- Ran the full mysql test suite locally: all tests pass.
- Not run: an end-to-end sync against a live MySQL server with the resource limit configured, since this sandbox has no MySQL server available.

## Docs update

None — no user-facing config or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, triaging a webhook-delivered error tracking issue for the MySQL data-warehouse source.
- Skills invoked: `/triaging-error-issues` to pull the issue's stack trace and confirm it originates in this source's code, `/writing-tests` before adding the regression test, `/writing-pr-descriptions` for this body.
- Decision: classified as non-retryable rather than left retryable, because the quota window is a full clock hour and continued retries directly consume it — unlike the shorter-lived, self-healing connection limits already handled in this file.