### PR TITLE
fix(tasks): defer workflow dispatch from run requests

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -4030,6 +4030,7 @@ def _trigger_task_processing_workflow(
                     actor_user_id=user_id,
                     message_id=str(uuid4()),
                 ),
+                defer=True,
             )
         else:
             execute_task_processing_workflow(
@@ -4038,6 +4039,7 @@ def _trigger_task_processing_workflow(
                 team_id=task.team.id,
                 user_id=user_id,
                 posthog_mcp_scopes=posthog_mcp_scopes,
+                defer=True,
             )
         logger.info("Workflow trigger completed for task %s, run %s", task.id, run.id)
     except Exception as e:

--- a/products/tasks/backend/tasks/tasks.py
+++ b/products/tasks/backend/tasks/tasks.py
@@ -3,8 +3,41 @@ from uuid import UUID
 
 from celery import shared_task
 
+from posthog.temporal.oauth import PosthogMcpScopes
+
 from products.tasks.backend.facade.api import record_comment_activity
 from products.tasks.backend.logic.services.comment_slack_dm import send_comment_slack_dms
+
+
+@shared_task(ignore_result=True)
+def dispatch_task_processing_workflow(
+    *,
+    task_id: str,
+    run_id: str,
+    team_id: int,
+    user_id: int | None,
+    create_pr: bool,
+    slack_thread_context: dict | None,
+    posthog_mcp_scopes: PosthogMcpScopes,
+    prewarmed: bool,
+    workflow_id_prefix: str | None,
+    initial_message: dict | None,
+) -> None:
+    from products.tasks.backend.temporal.client import execute_task_processing_workflow
+    from products.tasks.backend.temporal.process_task.workflow import PendingFollowup
+
+    execute_task_processing_workflow(
+        task_id=task_id,
+        run_id=run_id,
+        team_id=team_id,
+        user_id=user_id,
+        create_pr=create_pr,
+        slack_thread_context=slack_thread_context,
+        posthog_mcp_scopes=posthog_mcp_scopes,
+        prewarmed=prewarmed,
+        workflow_id_prefix=workflow_id_prefix,
+        initial_message=PendingFollowup(**initial_message) if initial_message else None,
+    )
 
 
 @shared_task(ignore_result=True, autoretry_for=(Exception,), retry_backoff=True, max_retries=5)

--- a/products/tasks/backend/temporal/client.py
+++ b/products/tasks/backend/temporal/client.py
@@ -1,6 +1,7 @@
 import uuid
 import asyncio
 import logging
+from dataclasses import asdict
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from django.conf import settings
@@ -281,17 +282,35 @@ def execute_task_processing_workflow(
     team_id: int,
     user_id: Optional[int] = None,
     create_pr: bool = True,
-    slack_thread_context: Optional["SlackThreadContext"] = None,
+    slack_thread_context: Optional["SlackThreadContext | dict[str, Any]"] = None,
     skip_user_check: bool = False,
     posthog_mcp_scopes: PosthogMcpScopes = "read_only",
     prewarmed: bool = False,
     workflow_id_prefix: Optional[str] = None,
     initial_message: PendingFollowup | None = None,
+    defer: bool = False,
 ) -> None:
     """
     Start the task processing workflow synchronously. Fire-and-forget.
     Use this from sync contexts (e.g., API endpoints).
     """
+    if defer:
+        from products.tasks.backend.tasks.tasks import dispatch_task_processing_workflow
+
+        dispatch_task_processing_workflow.delay(
+            task_id=task_id,
+            run_id=run_id,
+            team_id=team_id,
+            user_id=user_id,
+            create_pr=create_pr,
+            slack_thread_context=_normalize_slack_context(slack_thread_context),
+            posthog_mcp_scopes=posthog_mcp_scopes,
+            prewarmed=prewarmed,
+            workflow_id_prefix=workflow_id_prefix,
+            initial_message=asdict(initial_message) if initial_message else None,
+        )
+        return
+
     # Metrics lookups stay inside the try so a failure here can't bypass terminalization and
     # leave the run orphaned in QUEUED (see the async variant above).
     task_run_for_metrics: TaskRun | None = None

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -2198,6 +2198,7 @@ class TestTaskAPI(BaseTaskAPITest):
             team_id=task.team.id,
             user_id=self.user.id,
             posthog_mcp_scopes="full",
+            defer=True,
         )
 
         self.assertEqual(latest_run["task"], str(task.id))

--- a/products/tasks/backend/tests/test_temporal_client.py
+++ b/products/tasks/backend/tests/test_temporal_client.py
@@ -23,6 +23,7 @@ from products.tasks.backend.temporal.constants import (
     STEERING_PROTOCOL_QUERY,
     STEERING_PROTOCOL_QUERY_TIMEOUT,
 )
+from products.tasks.backend.temporal.process_task.workflow import PendingFollowup
 
 
 @override_settings(DEBUG=False)
@@ -117,6 +118,46 @@ class TestSignalTaskFollowupMessage(SimpleTestCase):
             )
         else:
             handle.query.assert_not_awaited()
+
+
+class TestDeferredTaskWorkflowDispatch(SimpleTestCase):
+    @patch("products.tasks.backend.tasks.tasks.dispatch_task_processing_workflow.delay")
+    def test_defers_temporal_work_outside_request(self, mock_delay):
+        execute_task_processing_workflow(
+            task_id="task-id",
+            run_id="run-id",
+            team_id=1,
+            user_id=2,
+            posthog_mcp_scopes="full",
+            initial_message=PendingFollowup(
+                message="Continue",
+                artifact_ids=["artifact-id"],
+                actor_user_id=2,
+                message_id="message-id",
+            ),
+            defer=True,
+        )
+
+        mock_delay.assert_called_once_with(
+            task_id="task-id",
+            run_id="run-id",
+            team_id=1,
+            user_id=2,
+            create_pr=True,
+            slack_thread_context=None,
+            posthog_mcp_scopes="full",
+            prewarmed=False,
+            workflow_id_prefix=None,
+            initial_message={
+                "message": "Continue",
+                "artifact_ids": ["artifact-id"],
+                "actor_user_id": 2,
+                "message_id": "message-id",
+                "context": {},
+                "steer": False,
+                "sequence": 0,
+            },
+        )
 
 
 @override_settings(DEBUG=False)


### PR DESCRIPTION
## Problem

Starting or resuming a task blocks the API response while Temporal accepts the workflow, making the task appear unresponsive when that dependency is slow.

## Changes

- Queue workflow dispatch through Celery so task run requests return immediately.
- Preserve initial messages and workflow options across deferred dispatch.
- Cover deferred dispatch and the run endpoint contract.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*