### PR TITLE
chore(replay): force ml-mirror-image-scrub rebuild after ECR expiry

### DIFF
--- a/Dockerfile.ml-mirror-image-scrub
+++ b/Dockerfile.ml-mirror-image-scrub
@@ -14,6 +14,12 @@
 # Exact node version pinned to .nvmrc (24.13.0), matching the main Dockerfile's node stages, so the
 # build is reproducible instead of drifting with the floating major tag; renovate bumps it. -bookworm-slim
 # so glibc matches sharp's prebuilt binaries.
+#
+# Low-churn image: it only rebuilds when the sidecar dir, this Dockerfile, or its CI workflow change
+# (see .github/workflows/ci-ml-mirror-image-scrub-container.yml), while prod pins an exact digest in
+# PostHog/charts state/. The published image therefore has to outlive the gap between builds — in
+# Aug 2026 the Jul 30 digest aged out of ECR's retention window and pinned pods could no longer pull
+# it.
 FROM node:24.13.0-bookworm-slim
 WORKDIR /code/app
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]

--- a/Dockerfile.ml-mirror-image-scrub
+++ b/Dockerfile.ml-mirror-image-scrub
@@ -15,12 +15,11 @@
 # build is reproducible instead of drifting with the floating major tag; renovate bumps it. -bookworm-slim
 # so glibc matches sharp's prebuilt binaries.
 #
-# Low-churn image: a master push only rebuilds it when the sidecar dir, this Dockerfile, or its CI
-# workflow change (see .github/workflows/ci-ml-mirror-image-scrub-container.yml), while prod pins an
-# exact digest in PostHog/charts state/. The published image therefore has to outlive the gap between
-# builds — in Aug 2026 the Jul 30 digest aged out of ECR's retention window and pinned pods could no
-# longer pull it. workflow_dispatch on master republishes to the prod repo without deploying, so
-# recovering a pinned-but-expired digest also needs a charts state bump.
+# ECR retention on posthog-ml-mirror-image-scrub has to outlive the gap between builds, because prod
+# pins an exact digest (PostHog/charts state/) and a master push only rebuilds this image when the
+# paths filtered in .github/workflows/ci-ml-mirror-image-scrub-container.yml change. Once a pinned
+# digest expires, running pods keep serving from their cached copy, so the loss only surfaces as new
+# nodes failing to pull.
 FROM node:24.13.0-bookworm-slim
 WORKDIR /code/app
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]

--- a/Dockerfile.ml-mirror-image-scrub
+++ b/Dockerfile.ml-mirror-image-scrub
@@ -15,11 +15,12 @@
 # build is reproducible instead of drifting with the floating major tag; renovate bumps it. -bookworm-slim
 # so glibc matches sharp's prebuilt binaries.
 #
-# Low-churn image: it only rebuilds when the sidecar dir, this Dockerfile, or its CI workflow change
-# (see .github/workflows/ci-ml-mirror-image-scrub-container.yml), while prod pins an exact digest in
-# PostHog/charts state/. The published image therefore has to outlive the gap between builds — in
-# Aug 2026 the Jul 30 digest aged out of ECR's retention window and pinned pods could no longer pull
-# it.
+# Low-churn image: a master push only rebuilds it when the sidecar dir, this Dockerfile, or its CI
+# workflow change (see .github/workflows/ci-ml-mirror-image-scrub-container.yml), while prod pins an
+# exact digest in PostHog/charts state/. The published image therefore has to outlive the gap between
+# builds — in Aug 2026 the Jul 30 digest aged out of ECR's retention window and pinned pods could no
+# longer pull it. workflow_dispatch on master republishes to the prod repo without deploying, so
+# recovering a pinned-but-expired digest also needs a charts state bump.
 FROM node:24.13.0-bookworm-slim
 WORKDIR /code/app
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]


### PR DESCRIPTION
## Problem

`ingestion-sessionreplay-ml-image-scrub` (prod-us) is paging on `PodImagePullBackOffCritical`. The prod pin — `7b082e9@sha256:e40e26c3…`, built 2026-07-30 — aged out of the `posthog-ml-mirror-image-scrub` ECR repo's 14-day retention window on ~2026-08-13.

Pods on existing nodes keep running from their cached copy, but every fresh Karpenter node comes up in `ImagePullBackOff`. At time of writing, **11 of 104 pods are degraded** with `rpc error: code = NotFound desc = failed to pull and unpack image` — NotFound, not AccessDenied, so the image is deleted rather than unreachable. The count grows with each node rotation. The ArgoCD app still reports Synced/Healthy because the surviving pods keep the Deployment available, so only the pod-level alert catches it.

## Why this needs a code change

- The digest is pinned in `PostHog/charts` `state/ml-mirror-image-scrub.yaml`, so a redeploy re-applies the same dead digest. ArgoCD already synced at 06:28 today with the pin unchanged.
- Non-master builds publish to `posthog-ml-mirror-image-scrub-prs` (`ECR_IMAGE`, workflow line 102), so the prod repo holds only master builds — and the newest of those is the expired Jul 30 one. There is no older digest to roll back to.
- `workflow_dispatch` on master republishes to the prod repo but does **not** bump the charts state file — the `deploy` job is gated on `github.event_name == 'push' && github.ref == 'refs/heads/master'`.

So the only single-step path back to a running service is publishing a new image via a master push. The build is path-filtered on `ml-mirror-image-scrub-sidecar/**`, `Dockerfile.ml-mirror-image-scrub`, and its own workflow file, so this PR touches the Dockerfile to trigger it.

## What this changes

A comment only — no build-affecting change (comments create no layers, and the `# syntax=` parser directive stays on line 1). It records the constraint that caused the outage: a low-churn, path-filtered image whose published artifact has to outlive the gap between builds, plus the `workflow_dispatch` republish path and its charts-bump caveat.

Merging runs build → push → `repository_dispatch` to charts → state bump → ArgoCD deploy, which clears the alert.

## Root cause is handled separately

Historical gaps between image-scrub prod bumps were 1–5 days, so 14-day retention looked ample — until the component shipped to dry-run and went quiet for 15 days. `posthog-cloud-infra` `terraform/environments/aws-accnt-root/ecr.tf` needs `retention = -1` for this repo, matching the existing `posthog-hogdesk` and `lead-gateway` entries, whose comments call out this exact failure mode. `livestream` (pinned Jul 22) and `posthog-agent-proxy` (pinned Jul 30) are already past their windows and need the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)