### PR TITLE
feat(data-warehouse): promote Neon source to beta

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/neon/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/neon/source.py
@@ -95,7 +95,7 @@ class NeonSource(PostgresSource):
             caption="Enter your Neon credentials to automatically pull your data into the PostHog Data warehouse",
             docsUrl="https://posthog.com/docs/cdp/sources/neon",
             fields=fields,
-            releaseStatus=ReleaseStatus.ALPHA,
+            releaseStatus=ReleaseStatus.BETA,
         )
 
     def check_cdc_prerequisites(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/neon/test_neon_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/neon/test_neon_source.py
@@ -38,13 +38,13 @@ def test_neon_schema_field_is_optional():
     assert schema_field.label == "Schema"
 
 
-def test_neon_is_visible_and_alpha():
+def test_neon_is_visible_and_beta():
     config = NeonSource().get_source_config
 
     # A finished source must not be hidden behind unreleasedSource or a gating flag.
     assert not config.unreleasedSource
     assert config.featureFlag is None
-    assert config.releaseStatus == ReleaseStatus.ALPHA
+    assert config.releaseStatus == ReleaseStatus.BETA
 
 
 def test_neon_host_field_guides_to_the_direct_host():


### PR DESCRIPTION
## Problem

Someone connecting a data warehouse source sees Neon labelled Alpha, which reads as lightly tested and discourages use. Neon now clears the beta bar.

- Over the last 7 days 42 teams use the Neon source, above the 30-team threshold.
- Its import error rate is 0.4% over the same window, below the 5% threshold.

## Changes

- Set `releaseStatus` on the Neon source from `ReleaseStatus.ALPHA` to `ReleaseStatus.BETA`.
- Update the visibility test to assert the beta status.
- No connector behaviour, schema, or sync logic changed. Neon already ships visible and connectable with no gating flag, so nothing else moved.

## How did you test this code?

- Ran the Neon source tests: `pytest products/warehouse_sources/backend/temporal/data_imports/sources/neon/test_neon_source.py`.
- Not run: database-backed and integration suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (actually Claude) made this change. It is a status-only promotion: the metrics above were provided as the trigger, and I confirmed the release status lives on `NeonSource.get_source_config` under `products/warehouse_sources/backend/temporal/data_imports/sources/neon/`. Skills invoked: `/implementing-warehouse-sources` for source conventions and `/writing-pr-descriptions` for this body. I checked for a duplicate human-authored PR (searching the source name, "releaseStatus", "promote", and the maintainer's open PRs) and found none.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
