### PR TITLE
feat(replay-vision): show the goal-based scanner draft box to everyone

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -7301,13 +7301,9 @@ snapshots:
     scenes-app-replay-vision--scanner-on-demand--light:
         hash: v1.k794b7964.c7fb3bef0e6746a00dee5acf2ea13684f9ceaafbf719a292c7c83ba6f1e66ce0.wXTvBQVYYqTn1h9VeKathC07umJLHQVSRaSI95Ddupo
     scenes-app-replay-vision--scanner-templates--dark:
-        hash: v1.k794b7964.17c86de8d508a20a261eae92f8a15cc20596e99e1db5876faa2d63df29e1ee71.qcH7P7zDlzB08Qjywje_-GwRH7bAIYLeE6VLPkZDoZY
+        hash: v1.k794b7964.9cac03fc02e7232ff1e7c332839eea0d2c5c51a79eecec58db797a06c8309516.IciAPSnOS_10OjdqcVp_uSlL7UoaqM5cYZLLyFdbzlE
     scenes-app-replay-vision--scanner-templates--light:
-        hash: v1.k794b7964.6c5b4b711fb1af56d29b5788348313d5a963e8f90c672a11ebc1d1e059884cb0.5vN5Bjf0TpzXvT_4cvpisjrfxVaveVdzA0_OALSdeEQ
-    scenes-app-replay-vision--scanner-templates-with-goal-draft--dark:
-        hash: v1.k794b7964.9cac03fc02e7232ff1e7c332839eea0d2c5c51a79eecec58db797a06c8309516.kossFzsQQ35l_U9p2JLqGtXv1Ne8_hBM-IO_HO5CSbI
-    scenes-app-replay-vision--scanner-templates-with-goal-draft--light:
-        hash: v1.k794b7964.f06941a37e15f6bb198044515a6c8e3768d3ffd78f7976f27a01cec1b8007551.jXyO8vo1_hrQFM-3vkpMxyzbjdHJ71zL0mExuJqLqvo
+        hash: v1.k794b7964.f06941a37e15f6bb198044515a6c8e3768d3ffd78f7976f27a01cec1b8007551.7fPVsUy-0Y874d_CvqvhnZ3HRrBMn0yzXn3mUsfQ_hQ
     scenes-app-replay-vision--scanners-list--dark:
         hash: v1.k794b7964.f26ddd49023d8bd519d1b7519683f9584214fad7c572a028ccbcc94350daf5e5.AFY_giJl1OgV7nY3jGw5xsTmZT-35VA66AKv6chsNZI
     scenes-app-replay-vision--scanners-list--light:

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -474,7 +474,6 @@ export const FEATURE_FLAGS = {
     REPLAY_PLAYLIST_SURFACING_SCORE: 'replay-playlist-surfacing-score', // owner: #team-replay
     REPLAY_TRIGGERS_V2: 'replay-triggers-v2', // owner: #team-replay
     REPLAY_UI_REDESIGN_2026: 'replay-ui-redesign-2026', // owner: #team-replay, New UI layout for replay
-    REPLAY_VISION_GOAL_DRAFT: 'replay-vision-goal-draft', // owner: #team-replay, goal-based AI scanner creation flow
     REPLAY_VISION_MODEL_TIER_NAMING_EXPERIMENT: 'replay-vision-model-tier-naming-experiment', // owner: #team-replay multivariate=control,test,lite-standard-pro
     REPLAY_VISION_SEND_REASONING: 'replay-vision-send-reasoning', // owner: #team-replay, gates the "include reasoning" checkbox on scanner alerts
     REVAMPED_PY_NOTEBOOKS: 'revamped-py-notebooks', // owner: #team-data-tools

--- a/products/replay_vision/backend/api/scanners.py
+++ b/products/replay_vision/backend/api/scanners.py
@@ -9,7 +9,6 @@ from django.utils import timezone
 
 import structlog
 import django_filters
-import posthoganalytics
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import (
     OpenApiParameter,
@@ -34,7 +33,6 @@ from posthog.event_usage import report_user_action
 from posthog.exceptions import QuotaLimitExceeded
 from posthog.models.tag import tagify
 from posthog.models.tagged_item import TaggedItem
-from posthog.models.team import Team
 from posthog.models.user import User
 from posthog.permissions import get_authenticator_scopes
 from posthog.rate_limit import (
@@ -1355,20 +1353,6 @@ class AffectedCohortResponseSerializer(serializers.Serializer):
     )
 
 
-def _is_goal_draft_enabled(user: User, team: Team) -> bool:
-    """Server-side half of the REPLAY_VISION_GOAL_DRAFT rollout flag; the client hides the box when it's off."""
-    return bool(
-        posthoganalytics.feature_enabled(
-            "replay-vision-goal-draft",
-            str(user.distinct_id),
-            groups={"organization": str(team.organization_id), "project": str(team.id)},
-            group_properties={"organization": {"id": str(team.organization_id)}},
-            only_evaluate_locally=False,
-            send_feature_flag_events=False,
-        )
-    )
-
-
 @extend_schema_view(
     list=extend_schema(
         parameters=[
@@ -1971,8 +1955,6 @@ class ReplayScannerViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, vi
         # The draft feeds a scanner that will expose recording contents, so mirror the config actions' gate.
         if not self.user_access_control.check_access_level_for_resource("session_recording", required_level="viewer"):
             raise PermissionDenied("Drafting a Replay Vision scanner requires session_recording read access.")
-        if not _is_goal_draft_enabled(cast(User, request.user), self.team):
-            raise PermissionDenied("This feature is not available.")
         # Same consent requirement as scanner creation: the goal and the team's taxonomy go to the model.
         if not self.team.organization.is_ai_data_processing_approved:
             raise ValidationError(

--- a/products/replay_vision/backend/tests/test_scanner_draft.py
+++ b/products/replay_vision/backend/tests/test_scanner_draft.py
@@ -23,7 +23,6 @@ from products.replay_vision.backend.tests.test_api import _VisionAPITestCase
 
 _GENERATE_PATH = "products.replay_vision.backend.scanner_draft._generate"
 _CORE_MEMORY_FLAG_PATH = "products.replay_vision.backend.scanner_draft.is_core_memory_disabled"
-_GOAL_DRAFT_FLAG_PATH = "products.replay_vision.backend.api.scanners.posthoganalytics.feature_enabled"
 
 
 def _access_control(*, allow: bool) -> MagicMock:
@@ -271,13 +270,6 @@ class TestGenerate:
 
 
 class TestDraftScannerEndpoint(_VisionAPITestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        # The endpoint is flag-gated server-side; default it open so every test isn't about the flag.
-        flag_patcher = patch(_GOAL_DRAFT_FLAG_PATH, return_value=True)
-        flag_patcher.start()
-        self.addCleanup(flag_patcher.stop)
-
     @property
     def draft_url(self) -> str:
         return f"{self.scanners_url}draft/"
@@ -415,18 +407,6 @@ class TestDraftScannerEndpoint(_VisionAPITestCase):
             resp = self.client.post(self.draft_url, data={"goal": "find rage clicks"}, format="json")
 
         assert resp.status_code == status.HTTP_403_FORBIDDEN, resp.json()
-        mock_generate.assert_not_called()
-
-    @patch(_GENERATE_PATH)
-    def test_flag_off_is_a_clean_403(self, mock_generate):
-        # The frontend hides the box when the flag is off; the endpoint must not stay reachable regardless.
-        mock_generate.return_value = _draft()
-
-        with patch(_GOAL_DRAFT_FLAG_PATH, return_value=False):
-            resp = self.client.post(self.draft_url, data={"goal": "find rage clicks"}, format="json")
-
-        assert resp.status_code == status.HTTP_403_FORBIDDEN
-        assert "not available" in resp.content.decode()
         mock_generate.assert_not_called()
 
     def test_is_gated_by_the_shared_ai_throttles(self):

--- a/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.stories.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.stories.tsx
@@ -566,14 +566,6 @@ export const ScannerTemplates: StoryObj = {
     parameters: { pageUrl: urls.replayVisionTemplates() },
 }
 
-// The flag-gated "tell PostHog AI what you want to accomplish" box below the template grid.
-export const ScannerTemplatesWithGoalDraft: StoryObj = {
-    parameters: {
-        pageUrl: urls.replayVisionTemplates(),
-        featureFlags: [FEATURE_FLAGS.REPLAY_VISION_GOAL_DRAFT],
-    },
-}
-
 export const ScannerEditorConfigure: StoryObj = {
     parameters: { pageUrl: urls.replayVisionScannerConfigure(summarizerScanner.id) },
 }

--- a/products/replay_vision/frontend/replay_scanners/ScannerEditorScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ScannerEditorScene.tsx
@@ -75,7 +75,6 @@ const STEP_HEADERS: Record<
 
 export function ScannerEditorSceneComponent(): JSX.Element {
     const { scannerId, step, isNew, visibleSteps } = useValues(scannerEditorSceneLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     const scannerLogic = replayScannerLogic({ id: scannerId })
     useAttachedLogic(scannerLogic, scannerEditorSceneLogic)
@@ -160,7 +159,7 @@ export function ScannerEditorSceneComponent(): JSX.Element {
                                 </p>
                             </div>
                             <ScannerTemplatePicker />
-                            {featureFlags[FEATURE_FLAGS.REPLAY_VISION_GOAL_DRAFT] ? <ScannerGoalDraft /> : null}
+                            <ScannerGoalDraft />
                         </>
                     ) : (
                         <Form

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerGoalDraft.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerGoalDraft.tsx
@@ -4,6 +4,7 @@ import { useRef } from 'react'
 import { IconArrowRight, IconSparkles } from '@posthog/icons'
 import { LemonButton, LemonTextArea } from '@posthog/lemon-ui'
 
+import { getReplayVisionEditDisabledReason } from '../../utils/accessControl'
 import { replayScannerLogic } from '../replayScannerLogic'
 
 /** "Tell PostHog AI what you want to accomplish" box on the template step: drafts a full scanner
@@ -14,8 +15,11 @@ export function ScannerGoalDraft(): JSX.Element {
     const { goalDraftInput, goalDraftLoading } = useValues(logic)
     const { draftScannerFromGoal, setGoalDraftInput } = useActions(logic)
 
+    // Drafting creates a scanner, so it needs the same editor access as the rest of the wizard.
+    const editDisabledReason = getReplayVisionEditDisabledReason()
+
     const handleSubmit = (): void => {
-        if (goalDraftInput.trim() && !goalDraftLoading) {
+        if (!editDisabledReason && goalDraftInput.trim() && !goalDraftLoading) {
             draftScannerFromGoal(goalDraftInput.trim())
         }
     }
@@ -61,7 +65,8 @@ export function ScannerGoalDraft(): JSX.Element {
                             loading={goalDraftLoading}
                             onClick={handleSubmit}
                             disabledReason={
-                                !goalDraftInput.trim() ? 'Describe what the scanner should look for' : undefined
+                                editDisabledReason ??
+                                (!goalDraftInput.trim() ? 'Describe what the scanner should look for' : undefined)
                             }
                             data-attr="vision-goal-draft-submit"
                         >


### PR DESCRIPTION
## Problem

The "tell PostHog AI what you want to accomplish" drafting box on the scanner template page is gated behind the `replay-vision-goal-draft` feature flag. That flag was never created in the PostHog project, so the box is currently hidden for everyone. The box is purely additive (it sits below the template grid and drafts a scanner from a written goal), so there is no reason to keep it gated.

## Changes

- Render `ScannerGoalDraft` unconditionally on the template step of the scanner editor.
- Remove the matching server-side flag check on `POST /vision/scanners/draft/`. The editor-access, session-recording-access, and AI-consent gates stay.
- Remove the `REPLAY_VISION_GOAL_DRAFT` flag constant.
- Remove the flag-only `ScannerTemplatesWithGoalDraft` story (the base `ScannerTemplates` story now renders the box) and the flag patching in the endpoint tests.

Before:

![goal-draft-before](https://raw.githubusercontent.com/PostHog/pr-assets/9314852c5afe78cf0329cf45c3eb3fc446a46be8/2026/08/9d882566-598e-4180-a32a-6fafb60a27e3.png)

After:

![goal-draft-after](https://raw.githubusercontent.com/PostHog/pr-assets/e7c17b6f30a350bb2144b54017de5ecae6abd90e/2026/08/d7ac23ac-8510-41bb-a042-d99dc0ccc2a0.png)

## How did you test this code?

- Ran `pytest products/replay_vision/backend/tests/test_scanner_draft.py` locally: 26 passed. The `TestDraftScannerEndpoint` class errored on a local shared-test-database lock unrelated to this change; relying on CI for that class.
- Captured the before/after screenshots above from the `ScannerTemplates` story in local Storybook, on master and on this branch.
- ruff, oxlint, oxfmt, and the full frontend TypeScript check pass locally; `ty check` passed in pre-commit.
- No new tests: this removes a gate. The remaining endpoint tests still cover access control, AI consent, throttling, and drafting behavior, all previously running with the flag patched open.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Desktop (generated by Claude Fable 5). Skills invoked: /improving-drf-endpoints, /writing-pr-descriptions.
- Verified via the PostHog MCP that the `replay-vision-goal-draft` flag was never created in the app project (no live, deleted, or tombstoned flag) and that no experiment references it, so this PR only removes dead gating code.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
