### PR TITLE
chore(agents): ask PR bodies to say what a person will notice

### DIFF
--- a/.agents/skills/writing-pr-descriptions/SKILL.md
+++ b/.agents/skills/writing-pr-descriptions/SKILL.md
@@ -35,6 +35,8 @@ You just spent an hour inside the mechanism, so the mechanism comes out first. P
 - Size the problem in one clause where you know it: how many teams, how often, since when.
 - The mechanism follows, in the order a reviewer has to check it.
 - The first bullet of Changes is the change itself. Renames, regenerated snapshots and comment fixes go last.
+- Every Changes bullet a person can notice says what they now see or do differently, then the mechanism under it. One user-facing line in Problem does not discharge this.
+- Say in one line which part of Changes is mechanical. A reviewer cannot otherwise tell a purely internal change from a visible one you described as internal.
 - If one part of the diff is riskier than the rest, name that part and say the rest is mechanical.
 
 Most of the time you already wrote the effect and put it third. Move it up rather than writing a new sentence.
@@ -225,19 +227,20 @@ A "no" anywhere means the body is ordered for the writer, not the reader. Go bac
 2. Does the size of the body track the size of the diff? A six-line change under a full-length body reads as filler.
 3. Are Problem and Changes together longer than the sections under them? If not, cut the lower ones.
 4. Read the body with the diff closed. Can you say why the PR exists and what it does? If not, you cut something a reader needs.
-5. Read each bullet and name the reader who needs it. Delete the ones you cannot.
-6. Read each bullet alone. Does it state one fact? If it states two, split it.
-7. Count the words in the longest sentence. Over 25, split it.
-8. Rewrite every passive sentence in active voice, unless the actor is genuinely unknown. Break every noun string longer than three words with a preposition.
-9. Does any sentence take its author as the subject? Rewrite it around the change. "I", "me" and "my" appear nowhere.
-10. Does the PR change anything a person sees? Include before-and-after screenshots, or say why nothing looks different.
-11. Does the PR change a flow or topology? Include branded before-and-after diagrams.
-12. Does prose compare several values across the same dimensions? Replace it with a table.
-13. Does every claim about what you ran, measured or saw link its evidence, or say it went unchecked? Descriptions of behavior need no link.
-14. Did a `<!-- -->` template comment survive anywhere? That section is unfilled. Fill it or delete it.
-15. Is the `## 🤖 Agent context` section filled, listing the skills invoked?
-16. Does the body claim manual testing that did not happen? Delete it.
-17. Does the body name an internal customer, incident, Slack quote, or operational metric? This repo is public. Delete it.
+5. Read Changes alone. Can you say what a person will now see or do differently, or that nothing user-visible changed? If neither, go back to pass 1.
+6. Read each bullet and name the reader who needs it. Delete the ones you cannot.
+7. Read each bullet alone. Does it state one fact? If it states two, split it.
+8. Count the words in the longest sentence. Over 25, split it.
+9. Rewrite every passive sentence in active voice, unless the actor is genuinely unknown. Break every noun string longer than three words with a preposition.
+10. Does any sentence take its author as the subject? Rewrite it around the change. "I", "me" and "my" appear nowhere.
+11. Does the PR change anything a person sees? Include before-and-after screenshots, or say why nothing looks different.
+12. Does the PR change a flow or topology? Include branded before-and-after diagrams.
+13. Does prose compare several values across the same dimensions? Replace it with a table.
+14. Does every claim about what you ran, measured or saw link its evidence, or say it went unchecked? Descriptions of behavior need no link.
+15. Did a `<!-- -->` template comment survive anywhere? That section is unfilled. Fill it or delete it.
+16. Is the `## 🤖 Agent context` section filled, listing the skills invoked?
+17. Does the body claim manual testing that did not happen? Delete it.
+18. Does the body name an internal customer, incident, Slack quote, or operational metric? This repo is public. Delete it.
 
 ## Background
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,8 @@
 
 ## Changes
 
+<!-- For each change a person can notice, say what they will now see or do differently, not only the code path that does it. Mark the rest as mechanical so a reviewer knows nothing user-visible is hiding in it. -->
+
 <!-- If there are frontend changes, please include screenshots. -->
 <!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ Examples:
 
 **Required:** Before creating any PR, read `.github/pull_request_template.md` and use its exact section structure.
 Do not invent a different format.
-**Shape:** invoke `/writing-pr-descriptions` before writing the body. Lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, and let its size track the change. Then one fact per bullet, sentences under 25 words, active voice, no idioms. A description that got longer as bullets was not cut.
+**Shape:** invoke `/writing-pr-descriptions` before writing the body. Lead with the effect a person sees rather than the code path behind it, and hold Changes to that too: a bullet a person can notice says what they now see or do differently, and one line says which part is mechanical. Make the body stand alone for a reader who opens no files, and let its size track the change. Then one fact per bullet, sentences under 25 words, active voice, no idioms. A description that got longer as bullets was not cut.
 Always fill the `## 🤖 Agent context` section when creating PRs.
 NEVER share sensitive information in a PR description. Users may share sensitive data in an agent session, but those should never surface to a PR description, or comments.
 


### PR DESCRIPTION
## Problem

A reviewer reads the Changes section of a PostHog PR and cannot tell what a person using PostHog will notice, because the bullets describe code paths.

Three places already push user-visible effect into the **first line of Problem**: pass 1 of `/writing-pr-descriptions`, the template comment under `## Problem`, and the shape one-liner in AGENTS.md.
None of them reach the Changes bullets.
The skill's only rule for Changes is ordering, and the template comment under it asks only for screenshots and a Figma link.
So an author can satisfy every existing rule with one user-facing line in Problem and a purely mechanical Changes list, and pass 5's scan test still passes, because it reads only the first bullet of Changes.

## Changes

- A Changes bullet for something a person can notice now has to say what they see or do differently, with the mechanism under it.
- Authors state in one line which part of Changes is mechanical. A reviewer otherwise cannot tell an internal change from a visible one described as internal.
- Pass 5 gains a line check that reads Changes on its own and fails a body that answers neither question.
- The template comment under `## Changes` and the AGENTS.md one-liner carry the same ask, so an author who skips the skill still sees it.
- Renumbering the pass 5 line check is mechanical.

Nothing in the product changes, so there is no screenshot. This only changes what a PR body is asked to contain.

## How did you test this code?

- No automated tests: the change is instruction prose in a skill, the PR template, and AGENTS.md, and none of it is covered by a test.
- I applied the new rules to this PR's own body, which is the only check available.
- Not run: `hogli ci:preflight`, because `hogli` is not on the PATH in this sandbox. No code changed, so no suite is affected.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A PostHog engineer raised that Changes sections explain the technical work but not how the change is experienced, and asked whether anything in the repo nudges agents toward that. I audited the PR template, the AGENTS.md files, and `/writing-pr-descriptions`, found the rules present but scoped to Problem's first line, and made this the minimal fix.

- Agent: PostHog Slack app (Claude Code), tools: Read, Edit, Bash, git_signed_commit.
- Skills: I read `.agents/skills/writing-pr-descriptions/SKILL.md` in full during the audit, since it is the file this PR edits, and applied its five passes to this body. No other skill was invoked.
- Decision: I extended the existing pass 1 rather than adding a new pass or a new template section, so the ask lands where an author is already deciding bullet order. A separate "user impact" heading would have been easy to leave empty.
- I could not resolve the requester's GitHub handle from the Slack thread, so the PR is unassigned rather than assigned to a guessed account.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0113360FFV/p1786697324368179?thread_ts=1786697324.368179&cid=C0113360FFV)*
