### PR TITLE
fix(desktop): let signed commits finish before MCP timeout

### DIFF
--- a/products/desktop/packages/agent/src/pi/rpc-client.test.ts
+++ b/products/desktop/packages/agent/src/pi/rpc-client.test.ts
@@ -56,6 +56,7 @@ describe("createRuntimeMcpServers", () => {
         env: { POSTHOG_LOCAL_TOOLS_ENABLED: "finish" },
         transport: "stdio",
         lifecycle: "eager",
+        requestTimeoutMs: 300_000,
         directTools: true,
       },
     });

--- a/products/desktop/packages/agent/src/pi/rpc-client.ts
+++ b/products/desktop/packages/agent/src/pi/rpc-client.ts
@@ -82,6 +82,10 @@ export interface PiStdioMcpServer {
   env?: Array<{ name: string; value: string }>;
 }
 
+// Signed git may use three 30-second GitHub attempts before reporting task activity.
+// The client deadline must not report failure while the MCP child continues the push.
+const LOCAL_STDIO_MCP_REQUEST_TIMEOUT_MS = 5 * 60_000;
+
 export function createRuntimeMcpServers(
   servers: McpServerConnection[],
 ): PiRuntimeMcpServers {
@@ -119,6 +123,7 @@ export function createRuntimeMcpStdioServers(
         ),
         transport: "stdio" as const,
         lifecycle: "eager" as const,
+        requestTimeoutMs: LOCAL_STDIO_MCP_REQUEST_TIMEOUT_MS,
         directTools: true,
       },
     ]),


### PR DESCRIPTION
## Problem

Pi reports some signed commits as failed after 30 seconds, even though the commit process can push them later.

- Signed git can use three 30-second GitHub attempts before it reports task activity.
- The MCP child keeps running after Pi's client timeout, so an agent can retry while the first call still runs.
- Task timeline reporting added more work inside the same request and made the timeout easier to reach.

## Changes

- Give local stdio MCP tools a five-minute request timeout.
- The longer deadline covers the signed git retry and activity reporting budgets.

## How did you test this code?

- Extended the Pi runtime mapping test. It catches a return to the 30-second default for local tools.
- Ran the focused Vitest file, the agent package typecheck, and Biome on both changed files.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This fixes an internal request deadline.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi investigated and implemented this fix in [the task session](https://us.posthog.com/project/2/tasks/ca0be9c2-f147-41eb-9b99-9a1b075afa3f).

Skills invoked: `/exploring-mcp-tool-quality`, `/investigating-logs`, `/querying-posthog-data`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, and `/writing-simplified-technical-english`.
