### PR TITLE
fix(desktop): let dev canvas artifacts load past local network access checks

### DIFF
--- a/products/desktop/apps/code/src/main/bootstrap.ts
+++ b/products/desktop/apps/code/src/main/bootstrap.ts
@@ -89,6 +89,14 @@ if (isDev) {
   );
 }
 
+// Chromium's Local Network Access checks treat the dev artifact origin
+// (localhost) as local network and the sandboxed canvas iframe's opaque origin
+// as public, so the artifact navigation is blocked with no way to grant the
+// permission. Production artifact origins are public and unaffected.
+if (isDev) {
+  app.commandLine.appendSwitch("disable-features", "LocalNetworkAccessChecks");
+}
+
 crashReporter.start({ uploadToServer: false });
 
 // Force IPv4 resolution when "localhost" is used so the agent hits 127.0.0.1


### PR DESCRIPTION
## Problem

A published canvas in the local dev desktop app renders nothing: the artifact iframe fails with "Access to internal resource at 'http://localhost:8010/canvas-artifacts/…' from origin 'null' has been blocked by CORS policy".

- Chromium's Local Network Access checks treat the localhost artifact origin as local network.
- The canvas iframe is sandboxed without allow-same-origin, so its opaque origin counts as public and cannot be granted the permission.
- Found while manually testing canvases against a local stack (raised in the canvas phase 4 testing thread).

## Changes

- The Electron main process disables the LocalNetworkAccessChecks feature, in dev only.
- Production artifact origins are public, so release builds keep the checks.

## How did you test this code?

- Not run: a local Electron session against a dev stack — this sandbox cannot launch the app. The reporter reproduces the block on every published canvas locally; this is Chromium's documented kill switch for the feature.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude diagnosed the reported CORS error as a Chromium Local Network Access block on the sandboxed artifact iframe and added the dev-only feature switch. Skills invoked: posthog-desktop, writing-pr-descriptions.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*