### PR TITLE
fix(data-warehouse): count a progressing over-budget repartition as progress

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
@@ -518,11 +518,17 @@ def _handle_budget_exceeded(
     """Record a rewrite that ran out of one activity's budget, distinguishing progress from a stall.
 
     Checkpoint/resume lets a table too large to rewrite in one activity converge across runs (see
-    `RepartitionBudgetExceededError`), so an attempt that advanced the checkpoint is forward progress,
-    not a failure: counting it against the finite `MAX_REPARTITION_ATTEMPTS` would abandon a table that
-    simply needs more than three budgets mid-convergence and leave it un-repartitioned. Only an attempt
-    that wrote no new rows since the last checkpoint is stuck; that one falls through to
-    `_handle_failure` so a rewrite which genuinely can't advance in one budget still gives up.
+    `RepartitionBudgetExceededError`), so an attempt that appended new rows is forward progress, not a
+    failure: counting it against the finite `MAX_REPARTITION_ATTEMPTS` would abandon a table that simply
+    needs more than three budgets mid-convergence and leave it un-repartitioned. Only an attempt that
+    appended nothing this run is stuck; that one falls through to `_handle_failure` so a rewrite which
+    genuinely can't advance in one budget still gives up.
+
+    Progress is judged from the rows this attempt wrote (`error.rows_written`), not the checkpoint's
+    cumulative temp size against a stored high-water mark: the rewrite restarts from row 0 whenever its
+    checkpoint is discarded (the source's Delta version moved between runs), so the cumulative size is
+    not monotonic across attempts, and a genuinely progressing fresh rebuild that read back below an
+    earlier, longer attempt's mark was charged a spurious failure.
 
     Returns the metric outcome: "superseded" when a newer attempt owns the claim, "progressing" when
     the rewrite advanced, otherwise whatever `_handle_failure` returns.
@@ -534,22 +540,20 @@ def _handle_budget_exceeded(
         return "superseded"
 
     pending = schema.repartition_pending or pending or {}
-    rows_written = int((schema.repartition_rewrite or {}).get("rows_written", 0))
-    high_water = int(pending.get("rewrite_high_water", 0))
-    if rows_written > high_water:
-        # Forward progress this attempt: keep the checkpoint, record the new high-water mark, and reset
-        # the failure counter — a rewrite still advancing is not the doomed one the cap exists to stop.
-        # The next run resumes from the checkpoint rather than re-streaming from row 0.
-        schema.set_repartition_pending({**pending, "attempts": 0, "rewrite_high_water": rows_written})
+    if error.rows_written > 0:
+        # Forward progress this attempt: keep the checkpoint and reset the failure counter — a rewrite
+        # still advancing is not the doomed one the cap exists to stop. The next run resumes from the
+        # checkpoint (or rebuilds fresh if it was invalidated) rather than giving up.
+        schema.set_repartition_pending({**pending, "attempts": 0})
         logger.info(
-            f"repartition: over budget but rewrite advanced to {rows_written} rows, resuming next run",
-            rows_written=rows_written,
+            f"repartition: over budget but rewrite advanced {error.rows_written} rows this attempt, resuming next run",
+            rows_written=error.rows_written,
         )
         _capture_stood_down(schema, inputs, trigger_reason, "rewrite_progressing", logger)
         return "progressing"
 
-    # No new rows since the last checkpoint: the rewrite can't make headway inside one budget, so count
-    # it as a real failed attempt and let `MAX_REPARTITION_ATTEMPTS` eventually give up on it.
+    # Nothing appended this attempt: the rewrite can't make headway inside one budget, so count it as a
+    # real failed attempt and let `MAX_REPARTITION_ATTEMPTS` eventually give up on it.
     return _handle_failure(inputs, schema, pending, trigger_reason, error, claim_token, logger)
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
@@ -217,16 +217,16 @@ class TestBudgetExhaustion:
         _mock_capture_event: MagicMock,
         _mock_capture_exception: MagicMock,
     ) -> None:
-        # A rewrite that wrote no new rows since the last checkpoint (rows_written == high_water) is
-        # stuck, so budget exhaustion counts as a real failed attempt.
+        # A rewrite that appended no rows this run (e.g. a resume that spent its whole budget skipping
+        # to the checkpoint) is stuck, so budget exhaustion counts as a real failed attempt.
         schema = _schema(
             name="public.usages",
             s3_folder_name="usages",
-            pending={**PENDING_TARGET, "attempts": prior_attempts, "rewrite_high_water": 12},
+            pending={**PENDING_TARGET, "attempts": prior_attempts},
             rewrite={"rows_written": 12},
         )
         mock_schema_model.objects.select_related.return_value.get.return_value = schema
-        mock_repartition.side_effect = RepartitionBudgetExceededError("out of budget")
+        mock_repartition.side_effect = RepartitionBudgetExceededError("out of budget", rows_written=0)
 
         _maybe_repartition_table(
             RepartitionActivityInputs(team_id=TEAM_ID, schema_id=SCHEMA_ID, job_id=JOB_ID, source_id=SOURCE_ID),
@@ -246,7 +246,7 @@ class TestBudgetExhaustion:
             schema.stamp_last_repartition_at.assert_not_called()
             schema.clear_repartition_rewrite.assert_not_called()
 
-    @parameterized.expand([("first_attempt", 0, 0), ("last_attempt_before_give_up", 2, 100)])
+    @parameterized.expand([("first_attempt", 0), ("last_attempt_before_give_up", 2)])
     @patch(f"{MODULE}.capture_exception")
     @patch(f"{MODULE}.capture_repartition_event")
     @patch(f"{MODULE}.HeartbeaterSync")
@@ -259,7 +259,6 @@ class TestBudgetExhaustion:
         self,
         _name: str,
         prior_attempts: int,
-        prior_high_water: int,
         mock_schema_model: MagicMock,
         _mock_job_model: MagicMock,
         _mock_enabled: MagicMock,
@@ -269,18 +268,20 @@ class TestBudgetExhaustion:
         mock_capture_event: MagicMock,
         _mock_capture_exception: MagicMock,
     ) -> None:
-        # The checkpoint advanced (rows_written > high_water), so a table too large for one budget is
-        # converging across runs. It must never give up — even sitting at the last attempt before the
-        # cap — and must reset the failure counter and record the new high-water mark so the next run
-        # resumes rather than re-streaming from row 0.
+        # This attempt appended new rows, so a table too large for one budget is converging across runs.
+        # It must never give up — even at the last attempt before the cap — and must reset the failure
+        # counter. The checkpoint's cumulative temp size (`repartition_rewrite.rows_written`) sits far
+        # below a longer earlier attempt's high-water mark here: the case a fresh rebuild hits after its
+        # checkpoint is discarded. Judging progress by that cumulative size mislabeled it a stall and
+        # emitted a spurious `warehouse_repartition_failed`; the rows written this run are the signal.
         schema = _schema(
             name="public.usages",
             s3_folder_name="usages",
-            pending={**PENDING_TARGET, "attempts": prior_attempts, "rewrite_high_water": prior_high_water},
-            rewrite={"rows_written": prior_high_water + 500},
+            pending={**PENDING_TARGET, "attempts": prior_attempts, "rewrite_high_water": 5_000_000},
+            rewrite={"rows_written": 230_000},
         )
         mock_schema_model.objects.select_related.return_value.get.return_value = schema
-        mock_repartition.side_effect = RepartitionBudgetExceededError("out of budget")
+        mock_repartition.side_effect = RepartitionBudgetExceededError("out of budget", rows_written=230_000)
 
         _maybe_repartition_table(
             RepartitionActivityInputs(team_id=TEAM_ID, schema_id=SCHEMA_ID, job_id=JOB_ID, source_id=SOURCE_ID),
@@ -292,7 +293,6 @@ class TestBudgetExhaustion:
         schema.stamp_last_repartition_at.assert_not_called()
         updated = schema.set_repartition_pending.call_args.args[0]
         assert updated["attempts"] == 0
-        assert updated["rewrite_high_water"] == prior_high_water + 500
         emitted = [c.args[0] for c in mock_capture_event.call_args_list]
         assert "warehouse_repartition_failed" not in emitted
         assert "warehouse_repartition_skipped" in emitted


### PR DESCRIPTION
## Problem

- A large data-warehouse table stops repartitioning and stays on its memory-unsafe layout, even though each sync was rewriting more of it.
- The repartition runs inside one Temporal activity's budget. A table too big to finish in one budget checkpoints its half-built temp table and resumes next run, converging across runs.
- An over-budget attempt that made no progress counts toward `MAX_REPARTITION_ATTEMPTS`, so a genuinely stuck rewrite still gives up.
- The progress test misfired: it compared the checkpoint's cumulative temp size against a stored high-water mark. That size is not monotonic across attempts.
- The rewrite restarts from row 0 whenever its checkpoint is discarded, which happens when the source's Delta version moves between runs. A fresh rebuild then reads back below the mark an earlier, longer attempt set.
- So a rewrite that appended hundreds of millions of rows this run was labeled a stall, emitted `warehouse_repartition_failed`, and burned an attempt. Three of those abandon a converging table.

## Changes

- `_handle_budget_exceeded` now judges progress from the rows written this attempt (`RepartitionBudgetExceededError.rows_written`), not the checkpoint's cumulative size.
- An attempt that appended any rows resets the failure counter and stands down as `progressing`; an attempt that appended nothing falls through to the failure path and counts toward the cap.
- Dropped the now-unused `rewrite_high_water` bookkeeping from the pending marker. The checkpoint that drives resume lives in `repartition_rewrite` and is untouched.
- No change to sync semantics, partition sizing, or the give-up cap.

## How did you test this code?

- Reworked the two budget-exhaustion cases in `test_repartition_table.py`. The progressing case now sets a checkpoint temp size far below a stale high-water mark while the attempt appended rows this run: it fails on the old cumulative comparison and passes on the per-attempt one, which is the exact regression.
- The stalled case injects an attempt that appended nothing and asserts it still burns an attempt and gives up with a cooldown.
- Ran the `test_repartition_table.py` unit suite locally: all pass. Ruff check and format clean on both files.
- Not run: the database-backed `test_repartition_controller.py` and `test_repartition.py` suites, because this sandbox has no Postgres; they error at DB setup, unrelated to this change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior, API, or config changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored by Claude (Opus 4.8) via Claude Code, triaging a `warehouse_repartition_failed` failure mode (`RepartitionBudgetExceededError`, `proactive_threshold` trigger).
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Traced the emit path from `_handle_failure` back through `_handle_budget_exceeded`, and confirmed the checkpoint discard path in `repartition_table_in_place` resets temp to row 0 while the high-water mark in the pending marker persists — the mismatch that mislabeled progress as a stall.
- Ruled out duplicates: PR #78454 fixes a distinct give-up-with-staged-swap data-loss path; PR #73080 predates this high-water logic. Neither touches the progress-vs-stall decision.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
