### PR TITLE
fix(desktop): keep artifact comments open while typing

### DIFF
--- a/products/desktop/packages/ui/src/features/sessions/components/selectionCommentAction.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/selectionCommentAction.test.ts
@@ -109,6 +109,34 @@ describe("selectionCommentAction", () => {
     overlay.remove();
   });
 
+  it.each(["Shift", "ArrowLeft", "Home", "End", "PageUp", "PageDown"])(
+    "ignores the %s selection key while focus is inside the comment UI",
+    (key) => {
+      const callbacks = {
+        onGestureStart: vi.fn(),
+        onSelectionSettled: vi.fn(),
+      } satisfies SelectionSettleGateCallbacks;
+      const remove = installSelectionSettleGate(document, callbacks);
+      const overlay = document.createElement("div");
+      overlay.setAttribute("data-selection-comment-overlay", "");
+      const textarea = document.createElement("textarea");
+      overlay.appendChild(textarea);
+      document.body.appendChild(overlay);
+
+      textarea.dispatchEvent(
+        new KeyboardEvent("keydown", { key, bubbles: true }),
+      );
+      textarea.dispatchEvent(
+        new KeyboardEvent("keyup", { key, bubbles: true }),
+      );
+      expect(callbacks.onGestureStart).not.toHaveBeenCalled();
+      expect(callbacks.onSelectionSettled).not.toHaveBeenCalled();
+
+      remove();
+      overlay.remove();
+    },
+  );
+
   it("ignores secondary buttons, which open menus instead of selecting", () => {
     const callbacks = { onGestureStart: vi.fn() };
     const remove = installSelectionSettleGate(document, callbacks);
@@ -174,6 +202,27 @@ describe("selectionCommentAction", () => {
 
     document.dispatchEvent(
       new KeyboardEvent("keyup", { key: "ArrowRight", bubbles: true }),
+    );
+    await settleFrames();
+    expect(callbacks.onSelectionSettled).toHaveBeenCalledTimes(1);
+    remove();
+  });
+
+  it("still treats Shift outside the comment UI as a selection gesture", async () => {
+    const callbacks = {
+      onGestureStart: vi.fn(),
+      onSelectionSettled: vi.fn(),
+    } satisfies SelectionSettleGateCallbacks;
+    const remove = installSelectionSettleGate(document, callbacks);
+    const target = eventTarget();
+
+    target.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Shift", bubbles: true }),
+    );
+    expect(callbacks.onGestureStart).toHaveBeenCalledTimes(1);
+
+    target.dispatchEvent(
+      new KeyboardEvent("keyup", { key: "Shift", bubbles: true }),
     );
     await settleFrames();
     expect(callbacks.onSelectionSettled).toHaveBeenCalledTimes(1);

--- a/products/desktop/packages/ui/src/features/sessions/components/selectionCommentAction.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/selectionCommentAction.ts
@@ -276,7 +276,7 @@ export function installSelectionSettleGate(
     settle();
   };
   const onKeyDown = (event: KeyboardEvent) => {
-    if (!isSelectionKey(event)) {
+    if (inActionUi(event.target) || !isSelectionKey(event)) {
       return;
     }
     keyGesture = true;


### PR DESCRIPTION
## Problem

People lose the artifact comment editor when they press Shift to capitalize text.

**Why:** The selection listener treats Shift inside the editor as a new artifact selection and clears the editor.

## Changes

- The selection listener ignores keyboard events from inside the comment editor.
- Keyboard and pointer selection outside the editor keep their existing behavior.
- Added regression coverage for Shift, arrows, Home, End, Page Up, and Page Down.
- No visual change, so screenshots do not apply.

## How did you test this code?

- Added unit coverage for editor typing and artifact selection boundaries.
- Ran the focused UI test, Biome, and the UI TypeScript check.
- Ran Chromium checks for capitalization, keyboard selection, and pointer selection, including ten repeated runs.
- Repository preflight was unavailable because this workspace lacks both hogli and flox.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change. The fix restores the existing artifact comment behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The PostHog Slack app implemented and validated this fix. It used the posthog-desktop, writing-tests, playwright-test, and writing-pr-descriptions skills.

No private thread content or customer material appears in the commit.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1786699376694819?thread_ts=1786699376.694819&cid=C09G8Q32R6F)*