### PR TITLE
chore(error-tracking): verify hobby error ingestion

### DIFF
--- a/bin/hobby-ci-setup-user.py
+++ b/bin/hobby-ci-setup-user.py
@@ -36,6 +36,6 @@ PersonalAPIKey.objects.create(
     label="ci-smoke-test",
     secure_value=hash_key_value(raw_key),
     mask_value=mask_key_value(raw_key),
-    scopes=["query:read", "logs:read"],
+    scopes=["query:read", "logs:read", "session_recording:read"],
 )
 print(f"{team.api_token}|||{raw_key}")  # noqa: T201

--- a/bin/hobby-ci-setup-user.py
+++ b/bin/hobby-ci-setup-user.py
@@ -36,6 +36,6 @@ PersonalAPIKey.objects.create(
     label="ci-smoke-test",
     secure_value=hash_key_value(raw_key),
     mask_value=mask_key_value(raw_key),
-    scopes=["query:read", "logs:read", "session_recording:read"],
+    scopes=["query:read", "logs:read", "session_recording:read", "error_tracking:read"],
 )
 print(f"{team.api_token}|||{raw_key}")  # noqa: T201

--- a/bin/hobby-ci.py
+++ b/bin/hobby-ci.py
@@ -14,6 +14,7 @@ import re
 import sys
 import json
 import time
+import uuid
 import shlex
 import base64
 import datetime
@@ -562,15 +563,83 @@ runcmd:
                     results = logs_resp.json().get("results", [])
                     if results:
                         print(f"✅ Log found after {attempt} poll(s)", flush=True)
-                        return True, "Event and log ingested successfully"
+                        break
                     print(f"   Poll {attempt}: no logs yet", flush=True)
                 else:
                     print(f"   Poll {attempt}: HTTP {logs_resp.status_code}", flush=True)
             except Exception as e:
                 print(f"   Poll {attempt}: {type(e).__name__}", flush=True)
             time.sleep(poll_interval)
+        else:
+            return False, f"Log did not appear within {timeout_seconds}s ({attempt} polls)"
 
-        return False, f"Log did not appear within {timeout_seconds}s ({attempt} polls)"
+        session_id = str(uuid.uuid4())
+        snapshot_timestamp = int(time.time() * 1000)
+        print("📤 Sending test session recording...", flush=True)
+        try:
+            replay_resp = requests.post(
+                f"{base_url}/s/",  # nosemgrep: python.lang.security.audit.insecure-transport.requests.request-with-http.request-with-http
+                json=[
+                    {
+                        "token": project_api_token,
+                        "event": "$snapshot",
+                        "distinct_id": "hobby-ci-replay-user",
+                        "$session_id": session_id,
+                        "properties": {
+                            "$session_id": session_id,
+                            "$window_id": str(uuid.uuid4()),
+                            "$snapshot_source": "web",
+                            "$snapshot_data": [
+                                {
+                                    "type": 4,
+                                    "timestamp": snapshot_timestamp,
+                                    "data": {
+                                        "href": "https://example.com/hobby-ci",
+                                        "width": 1280,
+                                        "height": 720,
+                                    },
+                                },
+                                {
+                                    "type": 2,
+                                    "timestamp": snapshot_timestamp + 1,
+                                    "data": {"node": {"type": 0, "childNodes": []}},
+                                },
+                            ],
+                        },
+                    }
+                ],
+                timeout=30,
+            )
+        except requests.RequestException as e:
+            return False, f"Session recording capture request failed: {e}"
+        if replay_resp.status_code != 200:
+            return False, f"Session recording capture failed: HTTP {replay_resp.status_code} - {replay_resp.text[:200]}"
+
+        print(f"⏳ Polling for session recording (timeout {timeout_seconds}s)...", flush=True)
+        deadline = time.time() + timeout_seconds
+        attempt = 0
+        while time.time() < deadline:
+            attempt += 1
+            try:
+                recordings_resp = requests.get(
+                    f"{base_url}/api/projects/@current/session_recordings",  # nosemgrep: python.lang.security.audit.insecure-transport.requests.request-with-http.request-with-http
+                    params={"session_ids": json.dumps([session_id]), "date_from": "-1d"},
+                    headers=headers,
+                    timeout=10,
+                )
+                if recordings_resp.status_code == 200:
+                    results = recordings_resp.json().get("results", [])
+                    if any(recording.get("id") == session_id for recording in results):
+                        print(f"✅ Session recording found after {attempt} poll(s)", flush=True)
+                        return True, "Event, log, and session recording ingested successfully"
+                    print(f"   Poll {attempt}: no session recording yet", flush=True)
+                else:
+                    print(f"   Poll {attempt}: HTTP {recordings_resp.status_code}", flush=True)
+            except Exception as e:
+                print(f"   Poll {attempt}: {type(e).__name__}", flush=True)
+            time.sleep(poll_interval)
+
+        return False, f"Session recording did not appear within {timeout_seconds}s ({attempt} polls)"
 
     @staticmethod
     def find_existing_droplet_for_pr(token, pr_number):

--- a/bin/hobby-ci.py
+++ b/bin/hobby-ci.py
@@ -631,15 +631,76 @@ runcmd:
                     results = recordings_resp.json().get("results", [])
                     if any(recording.get("id") == session_id for recording in results):
                         print(f"✅ Session recording found after {attempt} poll(s)", flush=True)
-                        return True, "Event, log, and session recording ingested successfully"
+                        break
                     print(f"   Poll {attempt}: no session recording yet", flush=True)
                 else:
                     print(f"   Poll {attempt}: HTTP {recordings_resp.status_code}", flush=True)
             except Exception as e:
                 print(f"   Poll {attempt}: {type(e).__name__}", flush=True)
             time.sleep(poll_interval)
+        else:
+            return False, f"Session recording did not appear within {timeout_seconds}s ({attempt} polls)"
 
-        return False, f"Session recording did not appear within {timeout_seconds}s ({attempt} polls)"
+        error_message = f"hobby_ci_error_smoke_test_{time.time_ns()}"
+        error_date_from = datetime.datetime.now(datetime.UTC).isoformat()
+        print("📤 Sending test exception...", flush=True)
+        try:
+            error_resp = requests.post(
+                f"{base_url}/capture/",  # nosemgrep: python.lang.security.audit.insecure-transport.requests.request-with-http.request-with-http
+                json={
+                    "api_key": project_api_token,
+                    "event": "$exception",
+                    "distinct_id": "hobby-ci-error-user",
+                    "properties": {
+                        "$exception_list": [
+                            {
+                                "type": "HobbyCISmokeTestError",
+                                "value": error_message,
+                                "mechanism": {"type": "generic", "handled": False},
+                            }
+                        ],
+                        "$exception_level": "error",
+                        "$exception_handled": False,
+                        "$lib": "hobby-ci",
+                    },
+                },
+                timeout=30,
+            )
+        except requests.RequestException as e:
+            return False, f"Exception capture request failed: {e}"
+        if error_resp.status_code != 200:
+            return False, f"Exception capture failed: HTTP {error_resp.status_code} - {error_resp.text[:200]}"
+
+        print(f"⏳ Polling for error tracking issue (timeout {timeout_seconds}s)...", flush=True)
+        deadline = time.time() + timeout_seconds
+        attempt = 0
+        while time.time() < deadline:
+            attempt += 1
+            try:
+                issues_resp = requests.post(
+                    f"{base_url}/api/projects/@current/error_tracking/query/issues",  # nosemgrep: python.lang.security.audit.insecure-transport.requests.request-with-http.request-with-http
+                    json={
+                        "status": "all",
+                        "dateRange": {"date_from": error_date_from},
+                        "searchQuery": error_message,
+                        "limit": 1,
+                    },
+                    headers=headers,
+                    timeout=10,
+                )
+                if issues_resp.status_code == 200:
+                    results = issues_resp.json().get("results", [])
+                    if results:
+                        print(f"✅ Error tracking issue found after {attempt} poll(s)", flush=True)
+                        return True, "Event, log, session recording, and exception ingested successfully"
+                    print(f"   Poll {attempt}: no error tracking issue yet", flush=True)
+                else:
+                    print(f"   Poll {attempt}: HTTP {issues_resp.status_code}", flush=True)
+            except Exception as e:
+                print(f"   Poll {attempt}: {type(e).__name__}", flush=True)
+            time.sleep(poll_interval)
+
+        return False, f"Error tracking issue did not appear within {timeout_seconds}s ({attempt} polls)"
 
     @staticmethod
     def find_existing_droplet_for_pr(token, pr_number):


### PR DESCRIPTION
Robot:

## Problem

Hobby deployments can pass smoke tests while Error Tracking ingestion is broken.

**Why:** We need an end-to-end check that proves a captured exception becomes an Error Tracking issue.

## Changes

- Capture a unique test exception after the existing replay check.
- Poll Error Tracking until its issue appears.
- Grant the smoke-test key error tracking read access.

## How did you test this code?

Ran Python syntax checks, Ruff lint, Ruff formatting, and `git diff --check`. The full Hobby round trip requires this PR's CI deployment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex created this stacked change at the user's direction. No repository skill was invoked. All test data is invented.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*