### PR TITLE
fix(signals): show one "Needs input" badge instead of two

### DIFF
--- a/products/desktop/packages/core/src/inbox/reportPresentation.test.ts
+++ b/products/desktop/packages/core/src/inbox/reportPresentation.test.ts
@@ -1,10 +1,58 @@
+import type {
+  SignalReportActionability,
+  SignalReportStatus,
+} from "@posthog/shared/types";
 import { describe, expect, it } from "vitest";
 import {
   deriveHeadline,
   displayConventionalCommitTitle,
   formatSignalReportSummaryMarkdown,
+  isStatusRedundantWithActionability,
   parseConventionalCommitTitle,
 } from "./reportPresentation";
+
+describe("isStatusRedundantWithActionability", () => {
+  it.each<{
+    status: SignalReportStatus;
+    actionability: SignalReportActionability | null;
+    expected: boolean;
+  }>([
+    // Without a verdict the status is the only information, so it always shows.
+    { status: "ready", actionability: null, expected: false },
+    { status: "pending_input", actionability: null, expected: false },
+    // Ready is the default terminal state; any verdict supersedes it.
+    {
+      status: "ready",
+      actionability: "immediately_actionable",
+      expected: true,
+    },
+    { status: "ready", actionability: "requires_human_input", expected: true },
+    // Both badges would say "Needs input".
+    {
+      status: "pending_input",
+      actionability: "requires_human_input",
+      expected: true,
+    },
+    // Different stories, so both badges stay.
+    {
+      status: "pending_input",
+      actionability: "immediately_actionable",
+      expected: false,
+    },
+    {
+      status: "in_progress",
+      actionability: "requires_human_input",
+      expected: false,
+    },
+  ])(
+    "$status + $actionability -> $expected",
+    ({ status, actionability, expected }) => {
+      expect(isStatusRedundantWithActionability(status, actionability)).toBe(
+        expected,
+      );
+    },
+  );
+});
 
 describe("deriveHeadline", () => {
   it("returns null for null/undefined/empty input", () => {

--- a/products/desktop/packages/core/src/inbox/reportPresentation.ts
+++ b/products/desktop/packages/core/src/inbox/reportPresentation.ts
@@ -1,4 +1,7 @@
-import type { SignalReportStatus } from "@posthog/shared/types";
+import type {
+  SignalReportActionability,
+  SignalReportStatus,
+} from "@posthog/shared/types";
 
 const MAX_HEADLINE_LENGTH = 140;
 
@@ -44,6 +47,26 @@ export function deriveHeadline(
   }
 
   return headline;
+}
+
+/**
+ * Whether the status badge should be hidden because the actionability badge
+ * already tells the same story: "ready" is the default terminal state (the
+ * actionability verdict is the more specific fact), and "pending_input" next
+ * to a requires_human_input verdict would render two identical "Needs input"
+ * badges.
+ */
+export function isStatusRedundantWithActionability(
+  status: SignalReportStatus,
+  actionability: SignalReportActionability | null | undefined,
+): boolean {
+  if (!actionability) {
+    return false;
+  }
+  return (
+    status === "ready" ||
+    (status === "pending_input" && actionability === "requires_human_input")
+  );
 }
 
 export function inboxStatusLabel(status: SignalReportStatus): string {

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
@@ -1,5 +1,6 @@
 import type { IconProps } from "@phosphor-icons/react";
 import { renderableReportChartIds } from "@posthog/core/inbox/reportCharts";
+import { isStatusRedundantWithActionability } from "@posthog/core/inbox/reportPresentation";
 import { Tabs, TabsList, TabsTrigger } from "@posthog/quill";
 import type { SignalReport } from "@posthog/shared/types";
 import { DetailSection } from "@posthog/ui/features/inbox/components/DetailSection";
@@ -126,15 +127,16 @@ export function InboxDetailFrame({
               <SignalReportPriorityBadge priority={report.priority} />
             )}
             {/*
-              "Ready" is the default terminal state, so showing it everywhere
-              just adds noise. When the report has been classified by the
-              Responder, surface the actionability verdict (Actionable / Needs
-              input / Not actionable) in that slot instead. Other statuses
-              (in-progress, candidate, failed, …) still surface as a badge.
+              When the report has been classified by the Responder, the
+              actionability verdict (Actionable / Needs input / Not actionable)
+              takes the status badge's slot where the status would only repeat
+              it. Other statuses (in-progress, candidate, failed, …) still
+              surface as a badge.
              */}
-            {(report.status !== "ready" || !report.actionability) && (
-              <SignalReportStatusBadge status={report.status} />
-            )}
+            {!isStatusRedundantWithActionability(
+              report.status,
+              report.actionability,
+            ) && <SignalReportStatusBadge status={report.status} />}
             {report.actionability && (
               <SignalReportActionabilityBadge
                 actionability={report.actionability}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportCard.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportCard.tsx
@@ -7,6 +7,7 @@ import { extractRepoSelectionRepository } from "@posthog/core/inbox/artefacts";
 import {
   deriveHeadline,
   displayConventionalCommitTitle,
+  isStatusRedundantWithActionability,
   parseConventionalCommitTitle,
 } from "@posthog/core/inbox/reportPresentation";
 import { Button } from "@posthog/quill";
@@ -187,9 +188,10 @@ export function ReportCardView(props: ReportCardViewProps) {
               </>
             ) : (
               <>
-                {(!isReady || !report.actionability) && (
-                  <SignalReportStatusBadge status={report.status} />
-                )}
+                {!isStatusRedundantWithActionability(
+                  report.status,
+                  report.actionability,
+                ) && <SignalReportStatusBadge status={report.status} />}
                 {report.actionability && (
                   <SignalReportActionabilityBadge
                     actionability={report.actionability}

--- a/products/desktop/packages/ui/src/features/inbox/components/utils/SignalReportActionabilityBadge.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/utils/SignalReportActionabilityBadge.tsx
@@ -1,6 +1,6 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "@posthog/quill";
 import type { SignalReportActionability } from "@posthog/shared/domain-types";
 import { InboxBadge } from "@posthog/ui/features/inbox/components/utils/InboxBadge";
-import { Tooltip } from "@radix-ui/themes";
 import type { ReactNode } from "react";
 
 const ACTIONABILITY_STYLE: Record<
@@ -44,10 +44,13 @@ export function SignalReportActionabilityBadge({
   }
 
   return (
-    <Tooltip content={style.tooltip}>
-      <InboxBadge variant={style.variant} className="cursor-help">
+    <Tooltip>
+      <TooltipTrigger
+        render={<InboxBadge variant={style.variant} className="cursor-help" />}
+      >
         {style.label}
-      </InboxBadge>
+      </TooltipTrigger>
+      <TooltipContent side="top">{style.tooltip}</TooltipContent>
     </Tooltip>
   );
 }

--- a/products/desktop/packages/ui/src/features/inbox/components/utils/SignalReportActionabilityBadge.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/utils/SignalReportActionabilityBadge.tsx
@@ -1,14 +1,30 @@
 import type { SignalReportActionability } from "@posthog/shared/domain-types";
 import { InboxBadge } from "@posthog/ui/features/inbox/components/utils/InboxBadge";
+import { Tooltip } from "@radix-ui/themes";
 import type { ReactNode } from "react";
 
 const ACTIONABILITY_STYLE: Record<
   SignalReportActionability,
-  { variant: "success" | "warning" | "default"; label: string }
+  { variant: "success" | "warning" | "default"; label: string; tooltip: string }
 > = {
-  immediately_actionable: { variant: "success", label: "Actionable" },
-  requires_human_input: { variant: "warning", label: "Needs input" },
-  not_actionable: { variant: "default", label: "Not actionable" },
+  immediately_actionable: {
+    variant: "success",
+    label: "Actionable",
+    tooltip:
+      "The report can be solved with code. If there isn't a pull request yet, it fell below your auto-PR priority threshold. You can still start one from this report.",
+  },
+  requires_human_input: {
+    variant: "warning",
+    label: "Needs input",
+    tooltip:
+      "Actionable, but it needs your input first to decide how to resolve it: business context, trade-offs, or a choice between several valid approaches.",
+  },
+  not_actionable: {
+    variant: "default",
+    label: "Not actionable",
+    tooltip:
+      "No useful code change can be derived because the report is too vague, lacks supporting evidence, or describes expected behavior.",
+  },
 };
 
 interface SignalReportActionabilityBadgeProps {
@@ -27,5 +43,11 @@ export function SignalReportActionabilityBadge({
     return null;
   }
 
-  return <InboxBadge variant={style.variant}>{style.label}</InboxBadge>;
+  return (
+    <Tooltip content={style.tooltip}>
+      <InboxBadge variant={style.variant} className="cursor-help">
+        {style.label}
+      </InboxBadge>
+    </Tooltip>
+  );
 }

--- a/products/signals/frontend/inbox/components/badges/SignalReportStatusBadge.tsx
+++ b/products/signals/frontend/inbox/components/badges/SignalReportStatusBadge.tsx
@@ -1,6 +1,25 @@
 import { LemonTag, LemonTagType, Tooltip } from '@posthog/lemon-ui'
 
-import { SignalReportStatus } from '../../types'
+import { SignalReportActionability, SignalReportStatus } from '../../types'
+
+/**
+ * Whether the status chip should be hidden because the actionability chip already tells the same
+ * story: "ready" is the default terminal state (the actionability verdict is the more specific
+ * fact), and "pending_input" next to a requires_human_input verdict would render two identical
+ * "Needs input" chips.
+ */
+export function isStatusRedundantWithActionability(
+    status: SignalReportStatus,
+    actionability: SignalReportActionability | null | undefined
+): boolean {
+    if (!actionability) {
+        return false
+    }
+    return (
+        status === SignalReportStatus.READY ||
+        (status === SignalReportStatus.PENDING_INPUT && actionability === 'requires_human_input')
+    )
+}
 
 export const STATUS_TOOLTIPS: Partial<Record<SignalReportStatus, string>> = {
     [SignalReportStatus.READY]: 'Research is complete. You can create a task from this report.',

--- a/products/signals/frontend/inbox/components/cards/ReportCard.tsx
+++ b/products/signals/frontend/inbox/components/cards/ReportCard.tsx
@@ -23,7 +23,7 @@ import {
 import { SignalReportActionabilityBadge } from '../badges/SignalReportActionabilityBadge'
 import { SignalReportBillingBadge } from '../badges/SignalReportBillingBadge'
 import { SignalReportPriorityBadge } from '../badges/SignalReportPriorityBadge'
-import { SignalReportStatusBadge } from '../badges/SignalReportStatusBadge'
+import { isStatusRedundantWithActionability, SignalReportStatusBadge } from '../badges/SignalReportStatusBadge'
 import {
     knownSourceProductEntries,
     SourceProductIconRow,
@@ -197,7 +197,7 @@ export function ReportCard({
                 <div className="flex items-center flex-wrap mt-1.5 min-w-0 gap-x-2.5 gap-y-1 text-xs text-tertiary leading-none select-none">
                     {hasPr && repoSlug ? <span className="truncate font-mono">{repoSlug}</span> : null}
                     <InboxCardSourceMeta sourceProducts={report.source_products} scoutSkillName={report.scout_name} />
-                    {!hasPr && (!isReady || !report.actionability) && (
+                    {!hasPr && !isStatusRedundantWithActionability(report.status, report.actionability) && (
                         <SignalReportStatusBadge status={report.status} />
                     )}
                     {!hasPr && report.actionability && (

--- a/products/signals/frontend/inbox/components/detail/ReportDetail.tsx
+++ b/products/signals/frontend/inbox/components/detail/ReportDetail.tsx
@@ -27,7 +27,7 @@ import {
 import { SignalReportActionabilityBadge } from '../badges/SignalReportActionabilityBadge'
 import { SignalReportBillingBadge } from '../badges/SignalReportBillingBadge'
 import { SignalReportPriorityBadge } from '../badges/SignalReportPriorityBadge'
-import { SignalReportStatusBadge } from '../badges/SignalReportStatusBadge'
+import { isStatusRedundantWithActionability, SignalReportStatusBadge } from '../badges/SignalReportStatusBadge'
 import {
     hasKnownSourceProduct,
     knownSourceProductEntries,
@@ -72,8 +72,9 @@ export function ReportDetailBadges({
     return (
         <>
             <SignalReportPriorityBadge priority={report.priority} explanation={priorityExplanation} />
-            {/* "Ready" is the default terminal state; once actionability is known, surface that instead. */}
-            {(report.status !== 'ready' || !report.actionability) && <SignalReportStatusBadge status={report.status} />}
+            {!isStatusRedundantWithActionability(report.status, report.actionability) && (
+                <SignalReportStatusBadge status={report.status} />
+            )}
             <SignalReportActionabilityBadge
                 actionability={report.actionability}
                 explanation={actionabilityExplanation}
@@ -105,8 +106,7 @@ function ReportDetailMeta({
     scoutSkillName?: string | null
 }): JSX.Element {
     const hasSource = hasKnownSourceProduct(report.source_products)
-    // "Ready" is the default terminal state; surface the status chip only until actionability is known.
-    const showStatus = report.status !== 'ready' || !report.actionability
+    const showStatus = !isStatusRedundantWithActionability(report.status, report.actionability)
 
     const stats: ReactNode[] = []
     if (evidenceCount > 0) {


### PR DESCRIPTION
## Problem

A report waiting on human input shows two identical "Needs input" pills next to each other, in the report detail header and on inbox cards. It looks broken and tells the reader nothing twice.

- The status badge says "Needs input" for the `pending_input` status.
- The actionability badge says "Needs input" for the `requires_human_input` verdict.
- Both surfaces already hide the status badge for `ready` plus a verdict, but not for this pairing.

## Changes

- A report now shows one "Needs input" pill. The actionability pill wins because it carries the rationale tooltip.
- A shared predicate (`isStatusRedundantWithActionability`) decides when the status badge repeats the actionability badge, replacing the inline `ready` checks.
- Applied on the web inbox (detail header, detail meta row, report card) and the desktop app (detail frame, report card).
- Reports whose status and verdict differ (for example `in_progress` plus a verdict) still show both badges.
- The desktop actionability badge now has a tooltip explaining the verdict, matching the web badge, so hiding the status badge loses no explanation.

No screenshot: I could not run either app in this session. Before is two identical "Needs input" pills side by side; after is one.

## How did you test this code?

- Added parameterized cases to the desktop `reportPresentation` test for the new predicate. They catch the duplicate pill returning, and the opposite bug of hiding a status that carries distinct information. No existing test covered this.
- Desktop `@posthog/core` vitest suite and `@posthog/core` / `@posthog/ui` typechecks pass locally.
- Web frontend typecheck passes locally.
- Not run: a visual check in a running app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code, from a screenshot of the duplicated pills. Skills invoked: /writing-ui-components, /writing-code-comments, /writing-tests, /writing-pr-descriptions. The predicate lives in `@posthog/core/inbox/reportPresentation` on desktop (portable, unit tested) and next to `SignalReportStatusBadge` on web.

