### PR TITLE
fix(tasks): send dev stack bake heartbeats

### DIFF
--- a/products/tasks/backend/temporal/bake_dev_stack_image/activities.py
+++ b/products/tasks/backend/temporal/bake_dev_stack_image/activities.py
@@ -1,12 +1,10 @@
+import asyncio
 import logging
-import threading
-import contextvars
 from dataclasses import dataclass
 from typing import Any, Literal
 
+from asgiref.sync import sync_to_async
 from temporalio import activity
-
-from posthog.temporal.common.utils import asyncify
 
 from products.tasks.backend.logic.services.dev_stack_image import (
     DEV_STACK_IMAGE_NAME,
@@ -31,31 +29,27 @@ class BakeDevStackImageInput:
 
 
 @activity.defn
-@asyncify
-def bake_and_publish_dev_stack_image(input: BakeDevStackImageInput) -> str:
+async def bake_and_publish_dev_stack_image(input: BakeDevStackImageInput) -> str:
     """Run the bake and publish the snapshot under the input's Modal image name.
 
-    Heartbeats from a side thread while the sync bake blocks (15-90 minutes), so a
-    worker crash or redeploy mid-bake is detected within the workflow's heartbeat
-    timeout and retried promptly, instead of burning the full 3-hour start_to_close
-    (mirrors send_followup_to_sandbox).
+    Heartbeats while the sync bake blocks so worker failures are detected within the
+    workflow's heartbeat timeout.
     """
-    stop_heartbeat = threading.Event()
-    heartbeat_ctx = contextvars.copy_context()
+    stop_heartbeat = asyncio.Event()
 
-    def _heartbeat_loop() -> None:
-        while not stop_heartbeat.wait(BAKE_HEARTBEAT_INTERVAL_SECONDS):
+    async def _heartbeat_loop() -> None:
+        while True:
             try:
-                activity.heartbeat()
-            except Exception:
+                await asyncio.wait_for(stop_heartbeat.wait(), timeout=BAKE_HEARTBEAT_INTERVAL_SECONDS)
                 return
+            except TimeoutError:
+                activity.heartbeat()
 
-    heartbeat_thread = threading.Thread(target=lambda: heartbeat_ctx.run(_heartbeat_loop), daemon=True)
-    heartbeat_thread.start()
+    heartbeat_task = asyncio.create_task(_heartbeat_loop())
     try:
         with log_activity_execution("bake_and_publish_dev_stack_image", **input.to_log_context()):
             try:
-                image_id = bake_dev_stack_image(input.publish_name)
+                image_id = await sync_to_async(bake_dev_stack_image, thread_sensitive=False)(input.publish_name)
             except DevStackImageBakeError:
                 observe_dev_stack_image_bake("bake_failed", trigger=input.trigger)
                 raise
@@ -66,4 +60,4 @@ def bake_and_publish_dev_stack_image(input: BakeDevStackImageInput) -> str:
             return image_id
     finally:
         stop_heartbeat.set()
-        heartbeat_thread.join(timeout=2)
+        await heartbeat_task


### PR DESCRIPTION
## Problem

**Why:** Dev-stack image bakes can miss their heartbeat timeout while the bake is still running, which starts duplicate attempts.

## Changes

- Run the blocking bake outside Temporal’s event loop
- Send heartbeats from an async task on the event loop