### PR TITLE
feat(desktop): capture os_platform and os_arch on analytics events

### DIFF
--- a/products/desktop/apps/code/src/main/platform-adapters/posthog-analytics.ts
+++ b/products/desktop/apps/code/src/main/platform-adapters/posthog-analytics.ts
@@ -60,6 +60,8 @@ export class PosthogNodeAnalytics implements IAnalytics {
         team: "posthog-code",
         ...properties,
         app_version: getAppVersion(),
+        os_platform: process.platform,
+        os_arch: process.arch,
         $process_person_profile: !!this.currentUserId,
       },
     });
@@ -96,6 +98,8 @@ export class PosthogNodeAnalytics implements IAnalytics {
       ...additionalProperties,
       ...(this.sessionId ? { $session_id: this.sessionId } : {}),
       app_version: getAppVersion(),
+      os_platform: process.platform,
+      os_arch: process.arch,
     });
   }
 

--- a/products/desktop/apps/code/src/renderer/contributions/app-boot.contributions.ts
+++ b/products/desktop/apps/code/src/renderer/contributions/app-boot.contributions.ts
@@ -2,6 +2,7 @@ import type { Contribution } from "@posthog/di/contribution";
 import {
   initializePostHog,
   registerAppVersion,
+  registerHostInfo,
 } from "@posthog/ui/shell/posthogAnalyticsImpl";
 import { trpcClient } from "@renderer/trpc/client";
 import { logger } from "@utils/logger";
@@ -22,12 +23,16 @@ export class AnalyticsBootContribution implements Contribution {
         }
         initializePostHog(sessionId);
       }
-      trpcClient.os.getAppVersion
-        .query()
-        .then(registerAppVersion)
-        .catch((error) => {
-          log.warn("Failed to register app version super property", { error });
-        });
+      try {
+        registerAppVersion(await trpcClient.os.getAppVersion.query());
+      } catch (error) {
+        log.warn("Failed to register app version super property", { error });
+      }
+      try {
+        registerHostInfo(await trpcClient.os.getHostInfo.query());
+      } catch (error) {
+        log.warn("Failed to register host info super properties", { error });
+      }
     })();
   }
 }

--- a/products/desktop/packages/host-router/src/routers/os.router.ts
+++ b/products/desktop/packages/host-router/src/routers/os.router.ts
@@ -9,6 +9,7 @@ import {
   checkWriteAccessInput,
   claudePermissionsOutput,
   downscaleImageFileInput,
+  hostInfoOutput,
   openExternalInput,
   readFileAsDataUrlInput,
   saveClipboardFileInput,
@@ -83,6 +84,10 @@ export const osRouter = router({
   getAppVersion: publicProcedure.query(({ ctx }) =>
     ctx.container.get<OsService>(OS_SERVICE).getAppVersion(),
   ),
+
+  getHostInfo: publicProcedure
+    .output(hostInfoOutput)
+    .query(({ ctx }) => ctx.container.get<OsService>(OS_SERVICE).getHostInfo()),
 
   getWorktreeLocation: publicProcedure.query(({ ctx }) =>
     ctx.container.get<OsService>(OS_SERVICE).getWorktreeLocation(),

--- a/products/desktop/packages/ui/src/shell/posthogAnalyticsImpl.ts
+++ b/products/desktop/packages/ui/src/shell/posthogAnalyticsImpl.ts
@@ -29,10 +29,13 @@ const log = logger.scope("analytics");
 // posthog's frontend/src/scenes/inbox/inboxAnalytics.ts.
 const INBOX_CLIENT = "code" as const;
 
+export type HostInfoProperties = { platform: string; arch: string };
+
 let isInitialized = false;
 
 // Cached so it can be re-applied after posthog.reset() clears super properties.
 let registeredAppVersion: string | null = null;
+let registeredHostInfo: HostInfoProperties | null = null;
 
 // posthog.reset() wipes super properties, so these are re-registered after each reset.
 function registerPersistentSuperProperties() {
@@ -41,7 +44,17 @@ function registerPersistentSuperProperties() {
     ...(registeredAppVersion !== null
       ? { app_version: registeredAppVersion }
       : {}),
+    ...(registeredHostInfo !== null
+      ? hostInfoProperties(registeredHostInfo)
+      : {}),
   });
+}
+
+function hostInfoProperties({ platform, arch }: HostInfoProperties): {
+  os_platform: string;
+  os_arch: string;
+} {
+  return { os_platform: platform, os_arch: arch };
 }
 
 type PendingFlagListener = {
@@ -176,6 +189,16 @@ export function registerAppVersion(appVersion: string) {
   }
 
   posthog.register({ app_version: appVersion });
+}
+
+export function registerHostInfo(hostInfo: HostInfoProperties) {
+  registeredHostInfo = hostInfo;
+
+  if (!isInitialized) {
+    return;
+  }
+
+  posthog.register(hostInfoProperties(hostInfo));
 }
 
 export function identifyUser(

--- a/products/desktop/packages/workspace-server/src/services/os/os.ts
+++ b/products/desktop/packages/workspace-server/src/services/os/os.ts
@@ -32,6 +32,7 @@ import {
 import { inject, injectable } from "inversify";
 import type {
   ClaudePermissions,
+  HostInfo,
   ImageAttachment,
   MessageBoxOptions,
   SavedAttachment,
@@ -468,6 +469,10 @@ export class OsService {
 
   getAppVersion(): string {
     return this.appMeta.version;
+  }
+
+  getHostInfo(): HostInfo {
+    return { platform: this.appMeta.platform, arch: this.appMeta.arch };
   }
 
   getWorktreeLocation(): string {

--- a/products/desktop/packages/workspace-server/src/services/os/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/os/schemas.ts
@@ -100,6 +100,12 @@ export const saveClipboardFileInput = z.object({
   originalName: z.string().optional(),
 });
 
+export const hostInfoOutput = z.object({
+  platform: z.string(),
+  arch: z.string(),
+});
+export type HostInfo = z.infer<typeof hostInfoOutput>;
+
 export interface SavedAttachment {
   path: string;
   name: string;


### PR DESCRIPTION
## Problem

Electron's user agent reports `Intel Mac OS X` on every Mac, including Apple Silicon, so `$os` collapses arm64 and x64 into one bucket. The only way to guess the arm/Intel mix today is release asset download counts, which is not ideal.

## Changes

- `OsService.getHostInfo()` returns `{ platform, arch }` from the existing `IAppMeta`, exposed as the `os.getHostInfo` tRPC query with a Zod output schema.
- The renderer registers `os_platform` / `os_arch` as posthog-js super properties at boot, re-applied after `posthog.reset()` alongside `app_version`.
- Main-process `track` / `captureException` stamp the same two properties.


