### PR TITLE
chore(desktop): log what the archive drain found and did

### DIFF
--- a/products/desktop/packages/ui/src/features/archive/useServerArchiveSync.ts
+++ b/products/desktop/packages/ui/src/features/archive/useServerArchiveSync.ts
@@ -66,13 +66,21 @@ export function useServerArchiveSync(): void {
     if (!client || running.current) return;
     // The triggers, checked directly: don't start a drain that would find
     // nothing. The loop below re-reads both sources fresh each pass.
+    const mirrored = new Set(
+      useServerArchiveSyncStore.getState().syncedTaskIds,
+    );
     if (
       pendingUnarchive.length === 0 &&
-      pendingServerArchiveIds(
-        archivedTaskIds,
-        new Set(useServerArchiveSyncStore.getState().syncedTaskIds),
-      ).length === 0
+      pendingServerArchiveIds(archivedTaskIds, mirrored).length === 0
     ) {
+      // Distinguishes "nothing to mirror" from "never ran" — the two are
+      // otherwise identical in the console, and each app instance has its own
+      // archive DB (dev vs packaged), so an unexpectedly small count here is
+      // the tell that you're looking at the other instance's backlog.
+      log.debug("Archive sync idle", {
+        archivedLocally: archivedTaskIds.size,
+        alreadyMirrored: mirrored.size,
+      });
       return;
     }
 
@@ -82,6 +90,14 @@ export function useServerArchiveSync(): void {
       // next launch or trigger, but not by the very next pass of this loop.
       const attempted = new Set<string>();
       let changed = 0;
+      // The drain's outcome IS the diagnosis when a count reads wrong, and a
+      // run that finds work is rare (once per backlog) — so say what was found
+      // and what happened to it, not just the failures.
+      log.info("Draining archive state to the server", {
+        archivedLocally: archivedTaskIds.size,
+        alreadyMirrored: mirrored.size,
+        pendingUnarchive: pendingUnarchive.length,
+      });
       try {
         for (;;) {
           const api = clientRef.current;
@@ -126,6 +142,10 @@ export function useServerArchiveSync(): void {
       } finally {
         running.current = false;
       }
+      log.info("Archive drain finished", {
+        synced: changed,
+        refused: attempted.size,
+      });
       if (changed === 0) return;
       // Refetches the lists the drain just shortened, which is what moves the
       // space counts drawn from them.


### PR DESCRIPTION
## TL;DR

Three log lines that say what the archive→server sync found and did. An idle drain and a broken one look identical in the console; telling them apart in the field took a day.

Stacks on #82622 — merge this into that branch.

## Problem

Dev and packaged builds keep separate userData dirs (`bootstrap.ts`), so each instance has its own local archive DB. A dev build drains its own near-empty archive and goes quiet, while the packaged app's backlog sits in a file the dev build never opens. That silence reads as "the sync is broken".

## Changes

- Idle line (debug): tasks archived locally vs already mirrored.
- Drain start (info): the same counts plus queued restores.
- Drain finish (info): synced / refused totals.

## How did you test this code?

Biome on the touched file. Log calls only, no behavior change; typecheck and tests run in CI.

## Automatic notifications

- [ ] Publish to changelog?

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
