### PR TITLE
fix(desktop): hide internal artifacts from task timeline

### DIFF
--- a/products/desktop/packages/core/src/canvas/activityEvents.ts
+++ b/products/desktop/packages/core/src/canvas/activityEvents.ts
@@ -26,6 +26,18 @@ export type ActivityEventKind = (typeof ACTIVITY_EVENTS)[number];
 
 const ACTIVITY_EVENT_SET: ReadonlySet<string> = new Set(ACTIVITY_EVENTS);
 
+const RUN_ARTIFACT_TYPES_WITHOUT_TIMELINE_EVENTS: ReadonlySet<string> = new Set(
+  [
+    "plan",
+    "context",
+    "reference",
+    "artifact",
+    "tree_snapshot",
+    "user_attachment",
+    "skill_bundle",
+  ],
+);
+
 export interface RunStartedPayload {
   runId: string;
   environment: string;
@@ -202,8 +214,12 @@ export function parseActivityEvent(message: {
     case "awaiting_input":
       return { kind: event, payload: { runId: str(payload.run_id) } };
     case "artifact_created":
-    case "artifact_revised":
-      return { kind: event, payload: artifactPayload(payload) };
+    case "artifact_revised": {
+      const parsed = artifactPayload(payload);
+      return RUN_ARTIFACT_TYPES_WITHOUT_TIMELINE_EVENTS.has(parsed.artifactType)
+        ? null
+        : { kind: event, payload: parsed };
+    }
     case "canvas_created":
       return {
         kind: event,

--- a/products/desktop/packages/core/src/canvas/activityTimeline.test.ts
+++ b/products/desktop/packages/core/src/canvas/activityTimeline.test.ts
@@ -322,6 +322,30 @@ describe("activity events", () => {
     });
   });
 
+  it.each([
+    "plan",
+    "context",
+    "reference",
+    "artifact",
+    "tree_snapshot",
+    "user_attachment",
+    "skill_bundle",
+  ])(
+    "drops non-output %s artifacts from historical timelines",
+    (artifactType) => {
+      expect(
+        parseActivityEvent({
+          event: "artifact_created",
+          payload: {
+            artifact_id: "internal-1",
+            name: "checkpoint.index",
+            artifact_type: artifactType,
+          },
+        }),
+      ).toBeNull();
+    },
+  );
+
   it("drops a pull request event with no url, since it can't be opened", () => {
     expect(parseActivityEvent({ event: "pr_merged", payload: {} })).toBeNull();
   });

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -7220,15 +7220,22 @@ def post_comment_thread_update(*, team_id: int, comment_id: UUID) -> None:
 
 
 def _announce_agent_artifact_uploads(run: TaskRun, new_entries: list[dict], manifest: list[dict]) -> None:
-    """Manifest entries carry no version, so an announcement counts same-named entries:
-    re-uploading a file reads as a revision of it, the way the artifacts list groups
-    versions. The artifact_id dedup absorbs a retried upload."""
-    new_ids = {entry.get("id") for entry in new_entries}
+    """Announce files the agent delivered as task outputs.
+
+    The manifest also holds internal state such as git handoff checkpoints and skill
+    bundles. Those files support the run but are not deliverables for the timeline.
+    Manifest entries carry no version, so same-named output entries determine whether
+    an upload created or revised a file. The artifact id deduplicates retried uploads.
+    """
+    output_entries = [entry for entry in new_entries if entry.get("type") == "output"]
+    new_output_ids = {entry.get("id") for entry in output_entries}
     announced_in_batch: dict[str, int] = {}
-    for entry in new_entries:
+    for entry in output_entries:
         name = entry.get("name")
         prior_versions = sum(
-            1 for other in manifest if other.get("name") == name and other.get("id") not in new_ids
+            1
+            for other in manifest
+            if other.get("type") == "output" and other.get("name") == name and other.get("id") not in new_output_ids
         ) + announced_in_batch.get(name or "", 0)
         announced_in_batch[name or ""] = announced_in_batch.get(name or "", 0) + 1
         post_artifact_thread_update(

--- a/products/tasks/backend/tests/test_thread_updates.py
+++ b/products/tasks/backend/tests/test_thread_updates.py
@@ -224,19 +224,29 @@ class TestAgentThreadUpdates(TestCase):
     @patch("posthog.storage.object_storage.tag")
     @patch("posthog.storage.object_storage.write")
     @patch(_FLAG_TARGET, return_value=True)
-    def test_inline_agent_upload_announces_created_then_revised(self, _flag, _write, _tag) -> None:
+    def test_inline_agent_upload_only_announces_output_versions(self, _flag, _write, _tag) -> None:
         from products.tasks.backend.facade.api import upload_task_run_artifacts
 
-        artifact = {"name": "summary.md", "type": "output", "content_bytes": b"v1", "content_type": "text/markdown"}
+        output = {"name": "summary.md", "type": "output", "content_bytes": b"v1", "content_type": "text/markdown"}
+        checkpoint = {
+            "name": "checkpoint.index",
+            "type": "artifact",
+            "content_bytes": b"internal state",
+            "content_type": "application/octet-stream",
+        }
         with team_scope(self.team.id):
             upload_task_run_artifacts(
-                self.task_run.id, self.task.id, self.team.id, artifacts=[artifact], uploaded_by="agent"
+                self.task_run.id,
+                self.task.id,
+                self.team.id,
+                artifacts=[output, checkpoint],
+                uploaded_by="agent",
             )
             upload_task_run_artifacts(
                 self.task_run.id,
                 self.task.id,
                 self.team.id,
-                artifacts=[{**artifact, "content_bytes": b"v2"}],
+                artifacts=[{**output, "content_bytes": b"v2"}],
                 uploaded_by="agent",
             )
 


### PR DESCRIPTION
## Problem

Task timelines show git checkpoint files as agent-created deliverables after cloud file edits.

The artifact upload path announced every agent upload, including internal files used to restore a run.

## Changes

- Announce only run artifacts classified as task outputs.
- Hide historical events for non-output run artifact types.
- Keep living artifacts and task output revisions visible.
- No screenshot: this changes which rows appear, not their rendering.

## How did you test this code?

- Extended the backend thread test to catch internal uploads that create timeline messages.
- Ran the desktop core typecheck and test suite to cover historical event filtering.
- Ran the handoff checkpoint tests to confirm checkpoint capture and restore still work.
- Ran the task thread update test suite, Ruff, Biome, and CI preflight.
- Repo-wide mypy did not complete because the sandbox ran out of memory.
- I did not run a manual desktop session.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update. This fixes unintended rows in an existing timeline without changing its documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: GPT-5.6 through PostHog Desktop. [Session](https://us.posthog.com/project/2/tasks/4124a619-4b24-46e5-85ea-016b920ef6be)
- Skills: `/querying-posthog-data`, `/working-with-task-comments`, `/writing-simplified-technical-english`, `/writing-tests`, `/writing-code-comments`, and `/writing-pr-descriptions`.
- I compared task run manifests with session logs, then added filters at the producer and desktop parser.
- The task included private report context. The committed fixture is invented and includes no copied task data.
