### PR TITLE
fix(supabase): explain expired realtime.messages partitions in sync error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/supabase/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/supabase/source.py
@@ -70,6 +70,21 @@ _SUPABASE_DIRECT_HOST_IPV4_HINT = (
     "(aws-0-<region>.pooler.supabase.com) with username postgres.<project-ref>."
 )
 
+# Supabase Realtime stores messages in daily partitions of its internal `realtime.messages` table
+# named `realtime.messages_YYYY_MM_DD`, and its retention job drops the old partitions. A sync that
+# targets one of these dated partitions fails with `relation "realtime.messages_..." does not exist`
+# once that day is dropped. Match the stable partition-name prefix (never the volatile date). The
+# inherited generic `"does not exist"` already classifies this non-retryable; this entry only adds an
+# actionable message, so it must precede the generic key in `get_non_retryable_errors` (first match
+# wins) with a non-None value.
+_SUPABASE_REALTIME_PARTITION_ERROR = "realtime.messages_"
+_SUPABASE_REALTIME_PARTITION_MESSAGE = (
+    "Supabase creates a new realtime.messages partition each day and drops old ones automatically, "
+    "so the dated partition this sync read no longer exists. These partitions are temporary and "
+    "aren't meant to be synced. Remove this table from the source's selected tables, then re-enable "
+    "the sync."
+)
+
 
 @SourceRegistry.register
 class SupabaseSource(PostgresSource):
@@ -79,6 +94,12 @@ class SupabaseSource(PostgresSource):
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.SUPABASE
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            _SUPABASE_REALTIME_PARTITION_ERROR: _SUPABASE_REALTIME_PARTITION_MESSAGE,
+            **super().get_non_retryable_errors(),
+        }
 
     @staticmethod
     def _adjust_field(field: _SourceField) -> _SourceField:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/supabase/test_supabase_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/supabase/test_supabase_source.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 from posthog.schema import ReleaseStatus, SourceFieldInputConfig
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import error_message_matches
 from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.source import (
     _HOST_UNREACHABLE_ERROR,
     PostgresSource,
@@ -144,3 +145,32 @@ def test_non_direct_host_failure_uses_postgres_error(host):
 
     assert success is False
     assert error == "postgres error"
+
+
+def _resolve_friendly_error(source: SupabaseSource, raw_error: str) -> str | None:
+    # Mirrors external_data_job.update_external_data_job_model: first matching key wins.
+    for pattern, friendly in source.get_non_retryable_errors().items():
+        if error_message_matches(raw_error, [pattern]):
+            return friendly
+    return None
+
+
+@pytest.mark.parametrize(
+    "raw_error,expect_message",
+    [
+        # Retention dropped the dated realtime.messages partition — actionable message, not the
+        # inherited generic "does not exist" (which resolves to None / the raw driver string).
+        ('relation "realtime.messages_2020_01_01" does not exist', True),
+        # A regular missing table must still fall through to the generic (None) mapping, so the
+        # realtime key stays specific and doesn't swallow every "does not exist".
+        ('relation "public.orders" does not exist', False),
+    ],
+)
+def test_expired_realtime_partition_gets_actionable_message(raw_error, expect_message):
+    friendly = _resolve_friendly_error(SupabaseSource(), raw_error)
+
+    if expect_message:
+        assert friendly is not None
+        assert "realtime.messages" in friendly
+    else:
+        assert friendly is None


### PR DESCRIPTION
## Problem

- A Supabase user syncing one of the internal `realtime.messages` daily partitions saw only a raw Postgres driver string (`relation "realtime.messages_..." does not exist`) with no next step.
- Supabase Realtime writes to daily partitions named `realtime.messages_YYYY_MM_DD` and its retention job drops old ones, so a partition selected for sync stops existing after a few days.
- The failure was spread across several teams, each on a different day's dropped partition.

## Changes

- Supabase now maps this failure to an actionable message: the partitions are temporary, aren't meant to be synced, and the table should be removed from the source.
- The failure was already non-retryable through the inherited generic `"does not exist"` mapping (which resolves to no message), so this only supplies the message.
- The new entry is placed ahead of the generic key so the first-match-wins selection in the job finalizer picks it. It matches the stable `realtime.messages_` prefix, never the volatile date.

## How did you test this code?

- Added a parameterized test asserting the realtime partition error resolves to the actionable message, and that a normal missing table still falls through to the generic mapping. This guards the ordering (a reorder would silently revert to the raw string) and guards against the key being over-broad.
- Ran the Supabase source test suite locally. Did not run any live Supabase sync.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored by Claude (Claude Code) while triaging a batch of data-warehouse sync failure classes.
- Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.
- The error string is already classified non-retryable, so the fix is message-only; no retry or schema semantics change. The failure shape was reproduced from the recorded `latest_error` pattern, with an invented partition date in the test rather than any customer value.
