### PR TITLE
feat(replay-vision): warn when the current config version has scanned nothing

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -7300,6 +7300,10 @@ snapshots:
         hash: v1.k794b7964.28d2e6262234073c713fa9d589a87c901380463ee20c3a716ef64d61fec1b838.0KN54tARtI6lbifsHuYDgc7wHtMokFDGIEOWVLJ-HSk
     scenes-app-replay-vision--scanner-on-demand--light:
         hash: v1.k794b7964.c7fb3bef0e6746a00dee5acf2ea13684f9ceaafbf719a292c7c83ba6f1e66ce0.wXTvBQVYYqTn1h9VeKathC07umJLHQVSRaSI95Ddupo
+    scenes-app-replay-vision--scanner-scan-drought--dark:
+        hash: v1.k794b7964.645b4298695c0faaa6ce59fbc64f575f8a06c8f81ca03c46fdeb61dbd7c37118.e4UUyWY4Z1dRJmVhPQo_M59fR3fjBOwFqhiJP4RWDYw
+    scenes-app-replay-vision--scanner-scan-drought--light:
+        hash: v1.k794b7964.04cee1856f76c7975432a18c1e3e8e3d9ebd7b03cfeb80c47b246e8262ff1428.RfhQ3_f5sR1MSglvHlFb513u4b0ISfmaNTNFlRdvoog
     scenes-app-replay-vision--scanner-templates--dark:
         hash: v1.k794b7964.9cac03fc02e7232ff1e7c332839eea0d2c5c51a79eecec58db797a06c8309516.IciAPSnOS_10OjdqcVp_uSlL7UoaqM5cYZLLyFdbzlE
     scenes-app-replay-vision--scanner-templates--light:

--- a/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
@@ -5,6 +5,7 @@ import { LemonBanner, LemonButton, LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
+import { percentage } from 'lib/utils/numbers'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
@@ -28,6 +29,7 @@ import { ScannerRunTab } from './components/ScannerRunTab'
 import { VisionActionsTab } from './components/VisionActionsTab'
 import { replayScannerLogic } from './replayScannerLogic'
 import { ReplayScannerTab, replayScannerSceneLogic } from './replayScannerSceneLogic'
+import { scanDrought } from './scanDrought'
 import { LIMIT_REACHED_TOOLTIP } from './scannerCopy'
 
 export const scene: SceneExport = {
@@ -97,6 +99,7 @@ export function ReplayScannerSceneComponent(): JSX.Element {
 
             <IngestionLimitBanner />
             <QuotaBanner />
+            <ScanDroughtBanner scannerId={scannerId} />
 
             <LemonTabs
                 activeKey={activeTab}
@@ -170,6 +173,35 @@ function QuotaBanner(): JSX.Element | null {
                 : onFreePlan
                   ? `You've used ${Math.round(state.quota.credits_used).toLocaleString('en-US')} of your ${Math.round(state.quota.credit_limit ?? 0).toLocaleString('en-US')} free credits this month. New observations will pause once they run out. Resets ${state.resetsOn}.`
                   : `You've used ${formatCreditsRange(state.quota.credits_used, state.quota.credit_limit ?? 0)} this month. New observations will pause once you hit the limit. Resets ${state.resetsOn}.`}
+        </LemonBanner>
+    )
+}
+
+// Silence after a config change reads as "the product is broken", so name the real cause: filters that
+// match nothing, or sampling skipping the few sessions that do match.
+function ScanDroughtBanner({ scannerId }: { scannerId: string }): JSX.Element | null {
+    const { scanner, observationStatsApi } = useValues(replayScannerLogic({ id: scannerId }))
+    const { quota } = useValues(visionQuotaLogic)
+    // An exhausted quota already explains the silence in its own banner above.
+    if (!scanner || quotaBannerState(quota).kind === 'exhausted') {
+        return null
+    }
+    const drought = scanDrought(scanner, observationStatsApi?.labels.version_markers ?? null, new Date())
+    if (!drought) {
+        return null
+    }
+    const samplingNote =
+        drought.samplingRate < 1
+            ? `, and sampling only scans ${percentage(drought.samplingRate)} of the sessions that do`
+            : ''
+    return (
+        <LemonBanner
+            type="warning"
+            action={{ children: 'Review filters', to: urls.replayVisionScannerTriggers(scannerId) }}
+        >
+            {drought.everScanned
+                ? `No sessions have been scanned since this scanner's configuration last changed, even though sweeps have run since. The filters may match no recordings${samplingNote}.`
+                : `This scanner hasn't scanned any sessions yet, even though sweeps have run. The filters may match no recordings${samplingNote}.`}
         </LemonBanner>
     )
 }

--- a/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.stories.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScannersScene.stories.tsx
@@ -521,6 +521,55 @@ export const SummarizerOverview: StoryObj = {
     parameters: { pageUrl: urls.replayVision(summarizerScanner.id) },
 }
 
+// The scan-drought banner: current version 4 has no marker, and the sweep watermark sits past the
+// last config change, so the page warns that the filters matched nothing. No other story renders it.
+export const ScannerScanDrought: StoryObj = {
+    parameters: { pageUrl: urls.replayVision(summarizerScanner.id) },
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/projects/:team_id/vision/scanners/:id/': scanner({
+                    id: summarizerScanner.id,
+                    name: 'Confused checkout',
+                    scanner_type: 'monitor',
+                    scanner_config: { prompt: 'Did the user struggle?' },
+                    scanner_version: 4,
+                    sampling_rate: 0.1,
+                    updated_at: '2026-05-10T00:00:00Z',
+                    last_swept_at: '2026-05-12T00:00:00Z',
+                    created_by: alice,
+                }),
+                '/api/projects/:team_id/vision/scanners/:id/observations/stats/': {
+                    ...summarizerStats,
+                    summarizer: null,
+                    monitor: { yes_total: 12, no_total: 130, inconclusive_total: 0 },
+                    labels: {
+                        ...summarizerStats.labels,
+                        version_markers: [
+                            {
+                                date: '2026-05-01',
+                                version: 3,
+                                prompt: 'Did the user struggle?',
+                                scanner_config: { prompt: 'Did the user struggle?' },
+                                scanner_type: 'monitor',
+                                model: 'gemini-3.7-flash',
+                                provider: 'google',
+                                emits_signals: false,
+                                query: null,
+                                sampling_rate: 1,
+                                sampling_mode: 'comprehensive',
+                                up: 6,
+                                down: 2,
+                                total: 142,
+                            },
+                        ],
+                    },
+                } satisfies ObservationStatsApi,
+            },
+        }),
+    ],
+}
+
 export const ScannerObservations: StoryObj = {
     parameters: { pageUrl: `${urls.replayVision(summarizerScanner.id)}?tab=observations` },
 }

--- a/products/replay_vision/frontend/replay_scanners/scanDrought.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/scanDrought.test.ts
@@ -1,0 +1,63 @@
+import { ObservationVersionMarkerApi } from '../generated/api.schemas'
+import { ScanDroughtScannerFields, scanDrought } from './scanDrought'
+
+const NOW = new Date('2026-01-10T12:00:00Z')
+
+function scanner(overrides: Partial<ScanDroughtScannerFields> = {}): ScanDroughtScannerFields {
+    return {
+        enabled: true,
+        limit_reached: false,
+        scanner_version: 3,
+        sampling_rate: 1,
+        updated_at: '2026-01-08T12:00:00Z',
+        last_swept_at: '2026-01-10T11:00:00Z',
+        ...overrides,
+    }
+}
+
+function marker(version: number): ObservationVersionMarkerApi {
+    return { version } as ObservationVersionMarkerApi
+}
+
+describe('scanDrought', () => {
+    it('fires when the current version has no observations despite sweeps since the change', () => {
+        expect(scanDrought(scanner(), [marker(1), marker(2)], NOW)).toEqual({
+            everScanned: true,
+            samplingRate: 1,
+        })
+    })
+
+    it('reports a scanner that never scanned anything as everScanned false', () => {
+        expect(scanDrought(scanner({ scanner_version: 1 }), [], NOW)).toEqual({
+            everScanned: false,
+            samplingRate: 1,
+        })
+    })
+
+    it('passes through the sampling rate for the copy', () => {
+        expect(scanDrought(scanner({ sampling_rate: 0.1 }), [], NOW)).toEqual({
+            everScanned: false,
+            samplingRate: 0.1,
+        })
+    })
+
+    it.each([
+        ['stats not loaded yet', scanner(), null],
+        ['scanner disabled', scanner({ enabled: false }), []],
+        ['credit limit reached explains the silence', scanner({ limit_reached: true }), []],
+        ['sampling rate 0 means paused on purpose', scanner({ sampling_rate: 0 }), []],
+        ['current version already has observations', scanner(), [marker(3)]],
+        [
+            'config changed less than a day ago',
+            scanner({ updated_at: '2026-01-10T00:00:00Z', last_swept_at: '2026-01-10T11:00:00Z' }),
+            [],
+        ],
+        [
+            'no sweep has covered sessions ending after the change',
+            scanner({ last_swept_at: '2026-01-08T11:00:00Z' }),
+            [],
+        ],
+    ])('stays silent when %s', (_label, fields, markers) => {
+        expect(scanDrought(fields, markers, NOW)).toBeNull()
+    })
+})

--- a/products/replay_vision/frontend/replay_scanners/scanDrought.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/scanDrought.test.ts
@@ -16,7 +16,22 @@ function scanner(overrides: Partial<ScanDroughtScannerFields> = {}): ScanDrought
 }
 
 function marker(version: number): ObservationVersionMarkerApi {
-    return { version } as ObservationVersionMarkerApi
+    return {
+        date: '2026-01-05',
+        version,
+        prompt: 'Did the user struggle?',
+        scanner_config: { prompt: 'Did the user struggle?' },
+        scanner_type: 'monitor',
+        model: 'gemini-3.7-flash',
+        provider: 'google',
+        emits_signals: false,
+        query: null,
+        sampling_rate: 1,
+        sampling_mode: 'comprehensive',
+        up: 0,
+        down: 0,
+        total: 5,
+    }
 }
 
 describe('scanDrought', () => {

--- a/products/replay_vision/frontend/replay_scanners/scanDrought.ts
+++ b/products/replay_vision/frontend/replay_scanners/scanDrought.ts
@@ -1,0 +1,46 @@
+import { ObservationVersionMarkerApi } from '../generated/api.schemas'
+
+// A full day, so a fresh edit gets time to produce observations before we call it a drought.
+export const SCAN_DROUGHT_MIN_AGE_MS = 24 * 60 * 60 * 1000
+
+export interface ScanDroughtScannerFields {
+    enabled: boolean
+    limit_reached: boolean
+    scanner_version: number
+    sampling_rate: number
+    updated_at: string
+    last_swept_at: string
+}
+
+export interface ScanDrought {
+    /** False when no version has ever produced an observation, so the copy can say "yet" instead of "since the change". */
+    everScanned: boolean
+    samplingRate: number
+}
+
+/** A version marker exists for any version with at least one observation of any status, so no marker for the
+ * current version means sweeps enqueued nothing at all — the filters matched no recordings or sampling skipped
+ * them, which users otherwise misread as the product being broken. */
+export function scanDrought(
+    scanner: ScanDroughtScannerFields,
+    versionMarkers: ObservationVersionMarkerApi[] | null,
+    now: Date
+): ScanDrought | null {
+    // sampling_rate 0 is the documented way to pause scanning, so no observations is expected then.
+    if (!versionMarkers || !scanner.enabled || scanner.limit_reached || scanner.sampling_rate === 0) {
+        return null
+    }
+    if (versionMarkers.some((marker) => marker.version === scanner.scanner_version)) {
+        return null
+    }
+    const updatedAt = new Date(scanner.updated_at).getTime()
+    if (now.getTime() - updatedAt < SCAN_DROUGHT_MIN_AGE_MS) {
+        return null
+    }
+    // The sweep watermark trails wallclock by the settle window, so this only fires once sweeps have
+    // actually covered sessions that ended after the last save.
+    if (new Date(scanner.last_swept_at).getTime() <= updatedAt) {
+        return null
+    }
+    return { everScanned: versionMarkers.length > 0, samplingRate: scanner.sampling_rate }
+}

--- a/products/replay_vision/frontend/replay_scanners/scanDrought.ts
+++ b/products/replay_vision/frontend/replay_scanners/scanDrought.ts
@@ -33,6 +33,9 @@ export function scanDrought(
     if (versionMarkers.some((marker) => marker.version === scanner.scanner_version)) {
         return null
     }
+    // updated_at also advances on metadata-only edits (name, description), re-arming the gates below
+    // and hiding an active warning for up to a day. Accepted: the scanner carries no version-change
+    // timestamp, and this errs toward silence, never toward a false warning.
     const updatedAt = new Date(scanner.updated_at).getTime()
     if (now.getTime() - updatedAt < SCAN_DROUGHT_MIN_AGE_MS) {
         return null


### PR DESCRIPTION
## Problem

A scanner whose filters match no recordings goes silent after a config change, and the scanner page gives no hint why. Users read days of silence as the product being broken, when the real cause is a filter that matches nothing or a low sampling rate skipping the few sessions that do match.

The editor already warns at edit time, but nothing warns after saving, when the sweeps quietly find nothing.

## Changes

- Adds a warning banner to the scanner page when the current config version has produced zero observations even though sweeps have covered sessions that ended after the last save.
- The banner names the likely causes (filters matching nothing, sampling rate) and links to the filters step.
- The condition lives in a pure helper, `scanDrought()`. It stays silent when the scanner is disabled, its credit limit is reached, sampling is 0 (documented pause), the change is under a day old, no sweep has run since the change, or the org quota is exhausted (its own banner already explains that).
- No backend changes: version markers only exist for versions with at least one observation of any status, so a missing marker for the current version plus a sweep watermark past `updated_at` already proves sweeps enqueued nothing.
- Adds a story snapshotting the banner state for visual review coverage.

Before (scanner page, no explanation for silence):

![before-scanner-page](https://raw.githubusercontent.com/PostHog/pr-assets/0168264d493092bd05491de83c509bce536be02e/2026/08/eb5987fd-726b-40bd-a4de-1b9f1de29d3c.png)

After (drought state, banner with the cause and a link to the filters step):

![after-scan-drought](https://raw.githubusercontent.com/PostHog/pr-assets/c7dffc97ddcbcf72a440cf9b29985103f69bc608/2026/08/34e0ad8a-11c2-4bac-b3da-4725a5550465.png)

## How did you test this code?

- Unit tests for `scanDrought()` cover the firing condition and each silence guard. They catch a regression where a guard is dropped or the watermark comparison flips, which would show the banner on healthy or freshly edited scanners.
- Ran `jest scanDrought.test.ts` locally (10 tests pass) and `tsgo --noEmit` (no errors in touched files).
- Rendered both stories in local Storybook (screenshots above). The existing stories don't trigger the banner (their sweep watermark doesn't pass `updated_at`), so no other snapshots change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No doc under `docs/` describes the scanner detail page banners.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (Fable 5) via PostHog Desktop, directed by @arnohillen. Origin: a support thread where a scanner produced nothing for days after a filter change and the user concluded the product was broken (https://posthog.slack.com/archives/C0B7TE4R8GH/p1785257300240629).

Skills applied: /writing-pr-descriptions, /writing-tests, /writing-user-facing-copy. Decisions: frontend-only condition instead of a new backend field, because the serializer already exposes `last_swept_at`, `updated_at`, and `scanner_version`, and version markers already encode "this version scanned something".

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
