### PR TITLE
fix(onboarding): keep the install step title on one line as events arrive

### DIFF
--- a/frontend/src/scenes/onboarding/legacy/OnboardingStep.tsx
+++ b/frontend/src/scenes/onboarding/legacy/OnboardingStep.tsx
@@ -91,11 +91,13 @@ export const OnboardingStep = ({
                     <OnboardingBreadcrumbs />
                     <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center items-start gap-2 mt-3 px-4 sm:px-0">
                         {!hideTitle && (
-                            <h1 className={clsx('font-bold m-0 px-0 sm:px-2', fullWidth && 'text-center')}>
+                            <h1 className={clsx('font-bold m-0 px-0 sm:px-2 sm:shrink-0', fullWidth && 'text-center')}>
                                 {title || stepKeyToTitle(stepKey)}
                             </h1>
                         )}
-                        {actions && <div className="flex flex-row flex-wrap sm:flex-nowrap gap-2">{actions}</div>}
+                        {actions && (
+                            <div className="flex flex-row flex-wrap sm:flex-nowrap gap-2 min-w-0">{actions}</div>
+                        )}
                     </div>
                 </div>
             </div>

--- a/frontend/src/scenes/onboarding/legacy/sdks/OnboardingInstallStep/MobileInstallHandoff.tsx
+++ b/frontend/src/scenes/onboarding/legacy/sdks/OnboardingInstallStep/MobileInstallHandoff.tsx
@@ -134,7 +134,7 @@ export function MobileInstallHandoff({
             showContinue={false}
             showSkip={!installationComplete}
             actions={
-                <div className="pr-2">
+                <div className="pr-2 min-w-0">
                     <RealtimeCheckIndicator
                         teamPropertyToVerify={teamPropertyToVerify}
                         listeningForName={listeningForName}

--- a/frontend/src/scenes/onboarding/legacy/sdks/OnboardingInstallStep/WizardInstallStep/index.tsx
+++ b/frontend/src/scenes/onboarding/legacy/sdks/OnboardingInstallStep/WizardInstallStep/index.tsx
@@ -165,7 +165,7 @@ function WizardInstallShell({
             continueDisabledReason={continueDisabledReason}
             showSkip={showSkip}
             actions={
-                <div className="pr-2">
+                <div className="pr-2 min-w-0">
                     <RealtimeCheckIndicator
                         teamPropertyToVerify={teamPropertyToVerify}
                         listeningForName={listeningForName}

--- a/frontend/src/scenes/onboarding/legacy/sdks/OnboardingInstallStep/index.tsx
+++ b/frontend/src/scenes/onboarding/legacy/sdks/OnboardingInstallStep/index.tsx
@@ -206,7 +206,7 @@ export const OnboardingInstallStep: OnboardingStepComponentType<OnboardingInstal
             showSkip={showSkipAtBottom}
             actions={
                 hideInstallationCheck ? undefined : (
-                    <div className="pr-2">
+                    <div className="pr-2 min-w-0">
                         <RealtimeCheckIndicator
                             teamPropertyToVerify={teamPropertyToVerify}
                             listeningForName={listeningForName}

--- a/frontend/src/scenes/onboarding/legacy/sdks/OnboardingLiveEvents.tsx
+++ b/frontend/src/scenes/onboarding/legacy/sdks/OnboardingLiveEvents.tsx
@@ -4,58 +4,42 @@ import { useValues } from 'kea'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TZLabel } from 'lib/components/TZLabel'
-import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { liveEventsLogic } from 'scenes/activity/live/liveEventsLogic'
 
-import type { LiveEvent } from '~/types'
-
-const columns: LemonTableColumns<LiveEvent> = [
-    {
-        title: 'Event',
-        key: 'event',
-        className: 'max-w-52',
-        render: function Render(_, event: LiveEvent) {
-            return (
-                <span className="flex items-center gap-x-2">
-                    <span className="relative flex h-2.5 w-2.5">
-                        <span
-                            className={clsx('absolute inline-flex h-full w-full rounded-full bg-success animate-ping')}
-                            // eslint-disable-next-line react/forbid-dom-props
-                            style={{ opacity: 0.75 }}
-                        />
-                        <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-success" />
-                    </span>
-                    <PropertyKeyInfo value={event.event} type={TaxonomicFilterGroupType.Events} />
-                </span>
-            )
-        },
-    },
-    {
-        title: 'Time',
-        key: 'timestamp',
-        className: 'max-w-80',
-        render: function Render(_, event: LiveEvent) {
-            return <TZLabel time={event.timestamp} />
-        },
-    },
-]
-
+/**
+ * Latest live event, shown beside the install step's verification state.
+ *
+ * The width is fixed and the event name truncates: this chip shares a flex row with the step
+ * title, so a content-sized chip re-wrapped the title between one and two lines every time an
+ * event with a longer name arrived.
+ */
 export function OnboardingLiveEvents(): JSX.Element | null {
     const { events } = useValues(liveEventsLogic)
+    const latestEvent = events[0]
 
-    if (events.length === 0) {
+    if (!latestEvent) {
         return null
     }
 
     return (
-        <LemonTable
-            columns={columns}
-            data-attr="onboarding-live-events-table"
-            rowKey="uuid"
-            showHeader={false}
-            dataSource={events.slice(0, 1)}
-            useURLForSorting={false}
-            nouns={['event', 'events']}
-        />
+        <div
+            className="flex items-center gap-2 w-72 max-w-full min-w-0 px-2 py-1 border rounded bg-surface-primary"
+            data-attr="onboarding-live-event"
+        >
+            <span className="relative flex h-2.5 w-2.5 shrink-0">
+                <span
+                    className={clsx('absolute inline-flex h-full w-full rounded-full bg-success animate-ping')}
+                    // eslint-disable-next-line react/forbid-dom-props
+                    style={{ opacity: 0.75 }}
+                />
+                <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-success" />
+            </span>
+            <PropertyKeyInfo
+                value={latestEvent.event}
+                type={TaxonomicFilterGroupType.Events}
+                className="text-sm min-w-0"
+            />
+            <TZLabel time={latestEvent.timestamp} className="ml-auto shrink-0 text-xs text-muted" />
+        </div>
     )
 }

--- a/frontend/src/scenes/onboarding/legacy/sdks/OnboardingLiveEvents.tsx
+++ b/frontend/src/scenes/onboarding/legacy/sdks/OnboardingLiveEvents.tsx
@@ -1,4 +1,3 @@
-import clsx from 'clsx'
 import { useValues } from 'kea'
 
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
@@ -12,6 +11,9 @@ import { liveEventsLogic } from 'scenes/activity/live/liveEventsLogic'
  * The width is fixed and the event name truncates: this chip shares a flex row with the step
  * title, so a content-sized chip re-wrapped the title between one and two lines every time an
  * event with a longer name arrived.
+ *
+ * `data-attr` keeps the `table` suffix from the LemonTable this replaced, because data-attr values
+ * are wire strings that dashboards and tests can depend on.
  */
 export function OnboardingLiveEvents(): JSX.Element | null {
     const { events } = useValues(liveEventsLogic)
@@ -24,11 +26,12 @@ export function OnboardingLiveEvents(): JSX.Element | null {
     return (
         <div
             className="flex items-center gap-2 w-72 max-w-full min-w-0 px-2 py-1 border rounded bg-surface-primary"
-            data-attr="onboarding-live-event"
+            data-attr="onboarding-live-events-table"
+            title={latestEvent.event}
         >
             <span className="relative flex h-2.5 w-2.5 shrink-0">
                 <span
-                    className={clsx('absolute inline-flex h-full w-full rounded-full bg-success animate-ping')}
+                    className="absolute inline-flex h-full w-full rounded-full bg-success animate-ping"
                     // eslint-disable-next-line react/forbid-dom-props
                     style={{ opacity: 0.75 }}
                 />

--- a/frontend/src/scenes/onboarding/legacy/sdks/RealtimeCheckIndicator.tsx
+++ b/frontend/src/scenes/onboarding/legacy/sdks/RealtimeCheckIndicator.tsx
@@ -34,12 +34,12 @@ export function RealtimeCheckIndicator({
     }, [installationComplete])
 
     return (
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 min-w-0">
             {installationComplete ? (
-                <div className="flex flex-row gap-2">
-                    <div className="flex items-center gap-2 px-2 py-1 font-medium">
+                <div className="flex flex-row items-center gap-2 min-w-0">
+                    <div className="flex items-center gap-2 px-2 py-1 font-medium shrink-0">
                         <IconCheck className="text-success" />
-                        <span className="text-success text-sm">Installation complete</span>
+                        <span className="text-success text-sm whitespace-nowrap">Installation complete</span>
                     </div>
                     <OnboardingLiveEvents />
                 </div>

--- a/frontend/src/scenes/onboarding/self-driving/SelfDrivingOnboardingFlow.tsx
+++ b/frontend/src/scenes/onboarding/self-driving/SelfDrivingOnboardingFlow.tsx
@@ -221,7 +221,7 @@ export function SelfDrivingOnboardingFlow(): JSX.Element {
                             />
                         ))}
                     </div>
-                    <div className="shrink-0 flex justify-end">
+                    <div className="min-w-0 flex justify-end">
                         {/* On the install step, live verification: flips when the team's first event
                             lands, whichever install path produced it. Past the install step, the run
                             keeps a quiet presence up here; on the install step itself the tracker


### PR DESCRIPTION
## Problem

On the install step of onboarding, the page title jumped between one line and two while the user watched their first events land. Each new live event with a longer name (for example `query api response` after `$pageview`) widened the event chip next to the title, squeezed the title, and re-wrapped it. The whole step below shifted down with it.

The title and the verification chip share one flex row. The chip was a single-row `LemonTable`, so its width followed the event name.

## Changes

The chip now has a fixed width and truncates long event names, so its size no longer depends on what arrives. On desktop the title also keeps its natural width, and the chip gives way when a longer title needs the room. Hovering the chip shows the full event name.

The chip is hand-rolled rather than reused, against `frontend/src/AGENTS.md` Rule 1. `LemonTable` is what caused the bug: its width tracks its content by design, and pinning it needs more markup than the chip it renders as here (one row, no header, no sorting, no pagination). `LemonSnack` and `LemonTag` hold a single token, not a truncating name plus a right-pinned timestamp. The waiting-state chip directly above it in `RealtimeCheckIndicator` is already a bordered div, so the two states now match. The `data-attr` keeps its old `table` suffix under Rule 4.

Before, on the AI observability step at 1280px wide (h1 88px tall, chip 339px):

![install step header before the fix, title on two lines](https://raw.githubusercontent.com/PostHog/pr-assets/b41cd179d4f679b1ce869e9499118deb636718bb/2026/08/aee616bc-a3b2-4eed-9b9e-c7c1928fbd36.png)

After (h1 44px, chip 271px, the name truncated so the title keeps its line):

![install step header after the fix, title on one line](https://raw.githubusercontent.com/PostHog/pr-assets/2fa855421ccb608358a50fea30bacf8c6b737933/2026/08/716b76c4-2b1a-431d-af24-a568b7c06968.png)

This is the legacy install step, which is also where the AI observability install lands. The self-driving flow renders the same chip in its card header, and its right slot was `shrink-0`, so the chip pushed the header row past the card and the card clipped it. That slot is now `min-w-0`, so the chip truncates and the row fits. Measured 507px of content in a 476px row at a 606px viewport before, 476px after.

## How did you test this code?

Reproduced the wrap in Storybook with the real chip and the header row: cycling the event name between `$pageview`, `query api response`, and a longer name re-wrapped the title before the change and leaves it on one line after. Checked at 1266px, 720px, and the stacked mobile layout, and with the widest install title (`Install product analytics`).

A new story, `AiObservabilityInstalled`, renders the step in its verified state with a live event, which is what both images above come from. It puts the header under visual review: the existing jest test mocks out both the step chrome and the verification indicator, and jsdom does not measure layout, so nothing else here can catch a reflow. The existing onboarding suites still pass locally, and `tsgo --noEmit` is clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5), [session](https://claude.ai/code/session_01Ttp1KiUCGqhQE73WFDDo98). No repo skills were invoked for the code change itself.

Matt reported the wrap from a screen recording. The first candidate fix was to stop the title from wrapping and let the chip overflow; a fixed-width chip was chosen instead because it also removes the horizontal jitter of the chip itself. The one-row `LemonTable` was replaced rather than constrained: its width is content-driven by design, and `table-layout` tricks to pin it were more markup than the plain chip it renders as.

