### PR TITLE
feat(desktop): full-size chart blocks in agent messages

### DIFF
--- a/products/desktop/packages/ui/src/features/editor/components/MarkdownRenderer.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/MarkdownRenderer.tsx
@@ -2,16 +2,18 @@ import { isPostHogCodeDeeplink } from "@posthog/shared";
 import { ArtifactRefChip } from "@posthog/ui/features/editor/components/ArtifactRefChip";
 import { EvidenceRefChip } from "@posthog/ui/features/editor/components/EvidenceRefChip";
 import { GithubRefChip } from "@posthog/ui/features/editor/components/GithubRefChip";
+import { MessageChartCard } from "@posthog/ui/features/editor/components/MessageChartCard";
 import { parseGithubIssueUrl } from "@posthog/ui/features/message-editor/githubIssueUrl";
 import { CodeBlock } from "@posthog/ui/primitives/CodeBlock";
 import { Divider } from "@posthog/ui/primitives/Divider";
 import { HighlightedCode } from "@posthog/ui/primitives/HighlightedCode";
 import { List, ListItem } from "@posthog/ui/primitives/List";
 import { parseArtifactLink } from "@posthog/ui/utils/artifactLinks";
+import { chartBlockKey, parseChartBlock } from "@posthog/ui/utils/chartBlocks";
 import { parseEvidenceLink } from "@posthog/ui/utils/evidenceLinks";
 import { handleShareLinkClick } from "@posthog/ui/utils/shareLinks";
 import { Blockquote, Checkbox, Code, Kbd, Text } from "@radix-ui/themes";
-import { memo, useMemo } from "react";
+import { isValidElement, memo, useMemo } from "react";
 import type { Components } from "react-markdown";
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -114,9 +116,17 @@ export const baseComponents: Components = {
     </Blockquote>
   ),
   code: ({ children, className }) => {
-    const match = className?.match(/language-(\w+)/);
+    const match = className?.match(/language-([\w-]+)/);
     if (!match) {
       return <Code variant="ghost">{children}</Code>;
+    }
+    if (match[1] === "posthog-chart") {
+      const source = String(children).replace(/\n$/, "");
+      const spec = parseChartBlock(source);
+      // Malformed or half-streamed JSON renders nothing rather than raw JSON;
+      // the block completes (or stays broken) on the next stream snapshot.
+      if (!spec) return null;
+      return <MessageChartCard spec={spec} blockKey={chartBlockKey(source)} />;
     }
     return (
       <HighlightedCode
@@ -125,7 +135,16 @@ export const baseComponents: Components = {
       />
     );
   },
-  pre: ({ children }) => <CodeBlock size="1">{children}</CodeBlock>,
+  pre: ({ children }) => {
+    // A chart block renders as a full card, not inside a code block shell.
+    if (
+      isValidElement<{ className?: string }>(children) &&
+      children.props.className?.includes("language-posthog-chart")
+    ) {
+      return children;
+    }
+    return <CodeBlock size="1">{children}</CodeBlock>;
+  },
   em: ({ children }) => <em>{children}</em>,
   i: ({ children }) => <i>{children}</i>,
   strong: ({ children }) => <strong>{children}</strong>,

--- a/products/desktop/packages/ui/src/features/editor/components/MessageChartCard.stories.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/MessageChartCard.stories.tsx
@@ -1,0 +1,79 @@
+import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
+import { MessageChartCard } from "@posthog/ui/features/editor/components/MessageChartCard";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta: Meta<typeof MessageChartCard> = {
+  title: "Features/Editor/MessageChartCard",
+  component: MessageChartCard,
+  parameters: {
+    layout: "padded",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MessageChartCard>;
+
+const DAU_BLOCK = JSON.stringify({
+  title: "Daily active users",
+  caption: "Weekends dip to roughly half of weekday traffic.",
+  render: "bar",
+  labels: ["Aug 7", "Aug 8", "Aug 9", "Aug 10", "Aug 11", "Aug 12", "Aug 13"],
+  series: [
+    { name: "DAU", points: [69650, 39431, 47804, 85174, 83213, 81434, 79541] },
+  ],
+});
+
+const MULTI_BLOCK = JSON.stringify({
+  title: "Signups vs activations",
+  render: "line",
+  labels: [
+    "2026-08-08",
+    "2026-08-09",
+    "2026-08-10",
+    "2026-08-11",
+    "2026-08-12",
+  ],
+  series: [
+    { name: "Signups", points: [420, 180, 510, 560, 540] },
+    { name: "Activations", points: [210, 90, 260, 300, 310] },
+  ],
+});
+
+export const InlineData: Story = {
+  render: () => (
+    <div className="max-w-xl">
+      <MessageChartCard
+        spec={{
+          mode: "data",
+          title: "Daily active users",
+          render: "bar",
+          labels: ["Aug 7", "Aug 8", "Aug 9", "Aug 10"],
+          series: [{ name: "DAU", points: [69650, 39431, 47804, 85174] }],
+        }}
+        blockKey="story-inline"
+      />
+    </div>
+  ),
+};
+
+export const InsideAgentMessage: Story = {
+  render: () => (
+    <div className="max-w-xl">
+      <MarkdownRenderer
+        content={[
+          "Here's the daily active user count for the last 7 days:",
+          "",
+          "```posthog-chart",
+          DAU_BLOCK,
+          "```",
+          "",
+          "**Weekday vs. weekend pattern** is very clear, with Mon-Thu holding 79K-85K.",
+          "",
+          "```posthog-chart",
+          MULTI_BLOCK,
+          "```",
+        ].join("\n")}
+      />
+    </div>
+  ),
+};

--- a/products/desktop/packages/ui/src/features/editor/components/MessageChartCard.test.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/MessageChartCard.test.tsx
@@ -37,6 +37,21 @@ describe("posthog-chart blocks in agent markdown", () => {
     expect(screen.queryByText(/"series"/)).toBeNull();
   });
 
+  it("leaves ordinary fenced code inside the code-block shell", () => {
+    // The chart dispatch widened the fence-language regex and made `pre`
+    // conditionally unwrap; a plain fence must keep its highlighted
+    // code-block chrome and never become a chart card.
+    const { container } = render(
+      <Theme>
+        <MarkdownRenderer content={"```ts\nconst a = 1;\n```\n"} />
+      </Theme>,
+    );
+    // Highlighting splits the code into spans, so match the joined text.
+    expect(container.querySelector("code")?.textContent).toBe("const a = 1;");
+    expect(screen.getByLabelText("Copy code")).toBeDefined();
+    expect(screen.queryByTestId("report-chart")).toBeNull();
+  });
+
   it("renders nothing for a malformed or half-streamed block", () => {
     render(
       <Theme>

--- a/products/desktop/packages/ui/src/features/editor/components/MessageChartCard.test.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/MessageChartCard.test.tsx
@@ -1,0 +1,51 @@
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// quill-charts is canvas-backed and does not load in the test environment;
+// the card chrome around it is what this test exercises.
+vi.mock("@posthog/quill-charts", () => ({
+  BarChart: () => <div data-testid="chart-plot" />,
+  LineChart: () => <div data-testid="chart-plot" />,
+  TimeSeriesBarChart: () => <div data-testid="chart-plot" />,
+  TimeSeriesLineChart: () => <div data-testid="chart-plot" />,
+  useChartTheme: () => ({}),
+}));
+
+import { MarkdownRenderer } from "./MarkdownRenderer";
+
+const DATA_BLOCK = JSON.stringify({
+  title: "Daily active users",
+  render: "bar",
+  labels: ["Aug 7", "Aug 8"],
+  series: [{ name: "DAU", points: [69650, 39431] }],
+});
+
+describe("posthog-chart blocks in agent markdown", () => {
+  it("renders a chart card instead of a code block", () => {
+    // Guards the whole dispatch: the code component must parse the fence into
+    // a card and the pre component must not wrap it in a code-block shell.
+    render(
+      <Theme>
+        <MarkdownRenderer
+          content={`Numbers:\n\n\`\`\`posthog-chart\n${DATA_BLOCK}\n\`\`\`\n`}
+        />
+      </Theme>,
+    );
+    expect(screen.getByTestId("report-chart")).toBeDefined();
+    expect(screen.getByText("Daily active users")).toBeDefined();
+    expect(screen.queryByText(/"series"/)).toBeNull();
+  });
+
+  it("renders nothing for a malformed or half-streamed block", () => {
+    render(
+      <Theme>
+        <MarkdownRenderer
+          content={'```posthog-chart\n{"series":[{"po\n```\n'}
+        />
+      </Theme>,
+    );
+    expect(screen.queryByTestId("report-chart")).toBeNull();
+    expect(screen.queryByText(/series/)).toBeNull();
+  });
+});

--- a/products/desktop/packages/ui/src/features/editor/components/MessageChartCard.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/MessageChartCard.tsx
@@ -1,0 +1,143 @@
+import {
+  planReportChart,
+  type ReportChartData,
+  reportChartHeightClass,
+  reportChartOpenTarget,
+  shapeReportChartData,
+} from "@posthog/core/inbox/reportCharts";
+import { getCloudUrlFromRegion } from "@posthog/shared";
+import { useAuthStateValue } from "@posthog/ui/features/auth/store";
+import {
+  type ReportChartCardState,
+  ReportChartCardView,
+} from "@posthog/ui/features/inbox/components/detail/ReportChartCard";
+import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
+import type { ChartBlockSpec } from "@posthog/ui/utils/chartBlocks";
+import { useMemo } from "react";
+
+/**
+ * Full-size chart card for a `posthog-chart` block in an agent message.
+ * Renders through the same card and quill-charts pipeline as report charts,
+ * so agent-message charts and report charts look and behave identically.
+ */
+
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+const DATE_TIME = /^\d{4}-\d{2}-\d{2}[T ]\d{2}/;
+
+function shapeInlineData(
+  spec: Extract<ChartBlockSpec, { mode: "data" }>,
+): ReportChartData {
+  const isTimeSeries =
+    spec.labels.length > 0 &&
+    spec.labels.every(
+      (label) => DATE_ONLY.test(label) || DATE_TIME.test(label),
+    );
+  return {
+    type: "series",
+    render: spec.render,
+    labels: spec.labels,
+    series: spec.series.map((entry, index) => ({
+      key: `${index}:${entry.name}`,
+      label: entry.name,
+      data: entry.points,
+    })),
+    isTimeSeries,
+    interval: spec.labels.some((label) => DATE_TIME.test(label))
+      ? "hour"
+      : "day",
+  };
+}
+
+function QueryChartCard({
+  spec,
+  blockKey,
+}: {
+  spec: Extract<ChartBlockSpec, { mode: "query" }>;
+  blockKey: string;
+}) {
+  const projectId = useAuthStateValue((state) => state.currentProjectId);
+  const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
+
+  const plan = useMemo(() => planReportChart(spec.query), [spec.query]);
+  const query = useAuthenticatedQuery<ReportChartData>(
+    ["message-chart-block", blockKey],
+    async (client) => {
+      if (plan.kind !== "run") return { type: "empty" };
+      const response = await client.runQuery(plan.source);
+      return shapeReportChartData(response, plan);
+    },
+    {
+      enabled: plan.kind === "run",
+      staleTime: 5 * 60 * 1000,
+      refetchOnWindowFocus: false,
+      retry: 1,
+    },
+  );
+
+  const openTarget = useMemo(() => {
+    if (!cloudRegion || !projectId) return null;
+    return reportChartOpenTarget(spec.query, {
+      cloudUrl: getCloudUrlFromRegion(cloudRegion),
+      projectId,
+    });
+  }, [spec.query, cloudRegion, projectId]);
+
+  if (plan.kind === "invalid") return null;
+
+  const state: ReportChartCardState =
+    plan.kind !== "run"
+      ? { kind: "link-out" }
+      : query.isPending
+        ? { kind: "loading" }
+        : query.isError
+          ? {
+              kind: "error",
+              message:
+                "Couldn't run the query behind this chart. Open it in PostHog to investigate.",
+            }
+          : { kind: "data", data: query.data };
+
+  return (
+    <ReportChartCardView
+      chartId={blockKey}
+      title={spec.title ?? "Chart"}
+      caption={spec.caption}
+      heightClass={reportChartHeightClass(
+        null,
+        state.kind === "data" ? state.data : null,
+      )}
+      state={state}
+      openTarget={openTarget}
+    />
+  );
+}
+
+export function MessageChartCard({
+  spec,
+  blockKey,
+}: {
+  spec: ChartBlockSpec;
+  /** Stable identity for the block, e.g. a hash of its fence body. */
+  blockKey: string;
+}) {
+  if (spec.mode === "query") {
+    return (
+      <div className="mb-2">
+        <QueryChartCard spec={spec} blockKey={blockKey} />
+      </div>
+    );
+  }
+  const data = shapeInlineData(spec);
+  return (
+    <div className="mb-2">
+      <ReportChartCardView
+        chartId={blockKey}
+        title={spec.title ?? "Chart"}
+        caption={spec.caption}
+        heightClass={reportChartHeightClass(null, data)}
+        state={{ kind: "data", data }}
+        openTarget={null}
+      />
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/utils/chartBlocks.test.ts
+++ b/products/desktop/packages/ui/src/utils/chartBlocks.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { parseChartBlock } from "./chartBlocks";
+
+describe("parseChartBlock", () => {
+  it("parses an inline data block", () => {
+    expect(
+      parseChartBlock(
+        JSON.stringify({
+          title: "Daily active users",
+          render: "bar",
+          labels: ["Aug 7", "Aug 8"],
+          series: [{ name: "DAU", points: [69650, 39431] }],
+        }),
+      ),
+    ).toEqual({
+      mode: "data",
+      title: "Daily active users",
+      caption: undefined,
+      render: "bar",
+      labels: ["Aug 7", "Aug 8"],
+      series: [{ name: "DAU", points: [69650, 39431] }],
+    });
+  });
+
+  it("defaults render to line and names unnamed series", () => {
+    const spec = parseChartBlock(
+      JSON.stringify({ series: [{ points: [1, 2] }] }),
+    );
+    expect(spec).toMatchObject({
+      mode: "data",
+      render: "line",
+      series: [{ name: "Series 1", points: [1, 2] }],
+    });
+  });
+
+  it("routes a query payload to query mode without validating the node", () => {
+    const query = { kind: "InsightVizNode", source: { kind: "TrendsQuery" } };
+    expect(parseChartBlock(JSON.stringify({ title: "T", query }))).toEqual({
+      mode: "query",
+      title: "T",
+      caption: undefined,
+      query,
+    });
+  });
+
+  it.each([
+    ["malformed JSON", "{not json"],
+    ["no series or query", '{"title":"x"}'],
+    ["only non-numeric points", '{"series":[{"points":["a","b"]}]}'],
+    ["an array payload", "[1,2,3]"],
+  ])("returns null for %s", (_name, source) => {
+    expect(parseChartBlock(source)).toBeNull();
+  });
+
+  it("caps series count and points so a runaway block cannot flood the card", () => {
+    const spec = parseChartBlock(
+      JSON.stringify({
+        series: Array.from({ length: 30 }, () => ({
+          points: Array.from({ length: 500 }, (_, i) => i),
+        })),
+      }),
+    );
+    expect(spec?.mode).toBe("data");
+    if (spec?.mode === "data") {
+      expect(spec.series.length).toBe(15);
+      expect(spec.series[0].points.length).toBe(366);
+    }
+  });
+});

--- a/products/desktop/packages/ui/src/utils/chartBlocks.ts
+++ b/products/desktop/packages/ui/src/utils/chartBlocks.ts
@@ -1,0 +1,118 @@
+/**
+ * Recognizing chart blocks inside agent messages.
+ *
+ * Where an `evidence:` link is an inline citation, a chart block is the
+ * full-size variant: agents emit a fenced code block tagged `posthog-chart`
+ * whose body is a JSON spec, and the markdown renderer draws it as a chart
+ * card instead of highlighted code.
+ *
+ * Two payload shapes:
+ *
+ * Inline data the agent already has (drawn with no fetching):
+ * ```posthog-chart
+ * { "title": "Daily active users", "render": "bar",
+ *   "labels": ["Aug 7", "Aug 8"], "series": [{ "name": "DAU", "points": [69650, 39431] }] }
+ * ```
+ *
+ * A PostHog query node (executed via `/query/`, like report charts):
+ * ```posthog-chart
+ * { "title": "Daily active users", "query": { "kind": "InsightVizNode", "source": { "kind": "TrendsQuery", ... } } }
+ * ```
+ */
+
+const MAX_POINTS = 366;
+const MAX_SERIES = 15;
+const MAX_TITLE_LENGTH = 120;
+const MAX_CAPTION_LENGTH = 300;
+
+export interface ChartBlockSeries {
+  name: string;
+  points: number[];
+}
+
+export type ChartBlockSpec =
+  | {
+      mode: "data";
+      title?: string;
+      caption?: string;
+      render: "line" | "bar";
+      labels: string[];
+      series: ChartBlockSeries[];
+    }
+  | {
+      mode: "query";
+      title?: string;
+      caption?: string;
+      query: Record<string, unknown>;
+    };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function capText(value: unknown, max: number): string | undefined {
+  return typeof value === "string" && value.trim()
+    ? value.trim().slice(0, max)
+    : undefined;
+}
+
+function toSeries(raw: unknown): ChartBlockSeries[] | null {
+  if (!Array.isArray(raw)) return null;
+  const series: ChartBlockSeries[] = [];
+  for (const entry of raw.slice(0, MAX_SERIES)) {
+    if (!isRecord(entry) || !Array.isArray(entry.points)) continue;
+    const points = entry.points.slice(0, MAX_POINTS).map(Number);
+    if (points.length === 0 || !points.every(Number.isFinite)) continue;
+    series.push({
+      name:
+        typeof entry.name === "string" && entry.name
+          ? entry.name
+          : `Series ${series.length + 1}`,
+      points,
+    });
+  }
+  return series.length > 0 ? series : null;
+}
+
+/** Stable identity for a block: keys React elements and the query cache. */
+export function chartBlockKey(source: string): string {
+  let hash = 5381;
+  for (let i = 0; i < source.length; i++) {
+    hash = ((hash << 5) + hash + source.charCodeAt(i)) | 0;
+  }
+  return `chart-block-${(hash >>> 0).toString(36)}`;
+}
+
+/** Parse a `posthog-chart` fence body into a spec, or null when malformed. */
+export function parseChartBlock(source: string): ChartBlockSpec | null {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(source);
+  } catch {
+    return null;
+  }
+  if (!isRecord(raw)) return null;
+
+  const title = capText(raw.title, MAX_TITLE_LENGTH);
+  const caption = capText(raw.caption, MAX_CAPTION_LENGTH);
+
+  if (isRecord(raw.query)) {
+    // The query node itself stays untrusted JSON: planReportChart decides
+    // whether it is runnable, links out, or is dropped.
+    return { mode: "query", title, caption, query: raw.query };
+  }
+
+  const series = toSeries(raw.series);
+  if (!series) return null;
+  const labels = Array.isArray(raw.labels)
+    ? raw.labels.slice(0, MAX_POINTS).map(String)
+    : [];
+  return {
+    mode: "data",
+    title,
+    caption,
+    render: raw.render === "bar" ? "bar" : "line",
+    labels,
+    series,
+  };
+}

--- a/products/desktop/packages/ui/vitest.config.ts
+++ b/products/desktop/packages/ui/vitest.config.ts
@@ -17,9 +17,22 @@ export default defineConfig({
       "@posthog/host-router": fileURLToPath(
         new URL("../host-router/src", import.meta.url),
       ),
+      // quill-charts' dist imports dayjs plugins without the .js extension,
+      // which Vite's browser resolution accepts but vitest's Node resolution
+      // rejects; map them so any test that loads quill-charts can run.
+      "dayjs/plugin/customParseFormat": "dayjs/plugin/customParseFormat.js",
+      "dayjs/plugin/timezone": "dayjs/plugin/timezone.js",
+      "dayjs/plugin/utc": "dayjs/plugin/utc.js",
     },
   },
   test: {
+    server: {
+      deps: {
+        // Process quill-charts through Vite instead of Node so the dayjs
+        // aliases above apply to its imports too.
+        inline: ["@posthog/quill-charts"],
+      },
+    },
     globals: true,
     ...trunkTestOptions,
     environment: "jsdom",

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.ts
@@ -662,7 +662,12 @@ Optimize for the fewest shell round trips.
 - Batch related commands into one Bash invocation using \`&&\` (e.g. \`npm run typecheck && npm run lint && npm test\`).
 - Emit all independent tool calls in the same response.
 - Read multiple files at once.
-- Never rerun a command solely to reproduce output you already have.`;
+- Never rerun a command solely to reproduce output you already have.
+
+## Rich output in replies
+The chat renders two special markdown forms. Use them when they make an answer clearer:
+- Inline evidence citation: cite a PostHog object you consulted as \`[label](evidence:<kind>/<id>)\` inside a sentence. Known kinds: insight, error, replay, flag, experiment, survey, ticket, trace, eval, event. Optional URL-encoded query params enrich the hover card with facts you already have: \`url\` (PostHog web URL, makes it clickable), \`value\` (headline figure, e.g. \`28.1%\`), \`desc\` (one context line), \`series\` (comma-separated numbers, drawn as a sparkline).
+- Full-size chart: a fenced code block tagged \`posthog-chart\` whose body is JSON. Inline data you already have: \`{"title": "...", "render": "line"|"bar", "labels": [...], "series": [{"name": "...", "points": [...]}], "caption": "..."}\`. Or a PostHog query node to execute: \`{"title": "...", "query": {"kind": "InsightVizNode", "source": {...}}}\`. Prefer a chart block over a markdown table for numeric or time-series results.`;
 
     if (channelMode) {
       prompt += `


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->