### PR TITLE
fix(desktop): bound the resume log fetch with a deadline

### DIFF
--- a/products/desktop/packages/agent/src/posthog-api.test.ts
+++ b/products/desktop/packages/agent/src/posthog-api.test.ts
@@ -46,6 +46,25 @@ describe("PostHogAPIClient", () => {
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
+  it("bounds the task run logs request with an abort deadline", async () => {
+    const client = new PostHogAPIClient({
+      apiUrl: "https://app.posthog.com",
+      getApiKey: vi.fn().mockResolvedValue("token"),
+      projectId: 1,
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: vi.fn().mockResolvedValue(""),
+    });
+
+    await client.fetchTaskRunLogs({ id: "run-1", task: "task-1" } as never);
+
+    const signal = mockFetch.mock.calls[0][1].signal;
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal.aborted).toBe(false);
+  });
+
   it("loads policies for managed MCP servers and keeps unmanaged servers", async () => {
     const client = new PostHogAPIClient({
       apiUrl: "https://app.posthog.com",

--- a/products/desktop/packages/agent/src/posthog-api.ts
+++ b/products/desktop/packages/agent/src/posthog-api.ts
@@ -20,6 +20,9 @@ export { getGatewayUsageUrl, getLlmGatewayUrl };
 
 const DEFAULT_USER_AGENT = `posthog/agent.hog.dev; version: ${packageJson.version}`;
 
+// Resume runs before the session exists, inside the backend's bounded health wait.
+const TASK_RUN_LOGS_TIMEOUT_MS = 20_000;
+
 export interface TaskArtifactUploadPayload {
   name: string;
   type: ArtifactType;
@@ -570,7 +573,9 @@ export class PostHogAPIClient {
     const endpoint = `/api/projects/${teamId}/tasks/${taskRun.task}/runs/${taskRun.id}/logs`;
 
     try {
-      const response = await this.performRequestWithRetry(endpoint);
+      const response = await this.performRequestWithRetry(endpoint, {
+        signal: AbortSignal.timeout(TASK_RUN_LOGS_TIMEOUT_MS),
+      });
 
       if (!response.ok) {
         if (response.status === 404) {


### PR DESCRIPTION
## Problem

Resume rebuilds the conversation by downloading the previous run's whole log before the agent can open a session, and that request had no timeout. BE waits a bounded time (120s) for the agent to report a live session, so a slow log fetch consumed the entire boot budget. The launch activity then failed and retried until it ran out of attempts.

The log grows with every turn, and the endpoint concatenates the full resume chain, so long-running tasks are the ones that hit this.

## Changes

- `fetchTaskRunLogs` now sends a 20s abort deadline, matching the other bounded requests in the client.
- On timeout the existing resume error path already falls back to a fresh session, so boot completes with summarized history instead of failing the run.

