### PR TITLE
chore(notebooks): time the pre-query half of a frame materialization

### DIFF
--- a/products/notebooks/backend/temporal/frame_materialize.py
+++ b/products/notebooks/backend/temporal/frame_materialize.py
@@ -55,6 +55,7 @@ from posthog.hogql.constants import HogQLGlobalSettings, LimitContext
 from posthog.hogql.errors import ExposedHogQLError
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import HogQLQueryExecutor
+from posthog.hogql.timings import HogQLTimings
 
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import (
@@ -218,6 +219,25 @@ FRAME_UPLOAD_SECONDS_HISTOGRAM = Histogram(
     "Time a successful materialize spent blocked on the object-store side of the relay (part handoff and S3 backpressure).",
     buckets=[0.5, 1, 5, 15, 30, 60, 120, 300, 600],
 )
+# The pre-query window, which dominates a materialization's wall clock and which
+# clickhouse_seconds/upload_seconds do not cover: those start once the query is issued.
+# Buckets run finer at the bottom than the transport histograms — these phases are expected
+# to be sub-second, and the interesting signal is one of them quietly not being.
+FRAME_PHASE_SECONDS_HISTOGRAM = Histogram(
+    "posthog_notebooks_frame_phase_seconds",
+    "Wall-clock of one phase of a successful materialize. setup: activity start to the write "
+    "branch (team/user reads, status round-trip, slot acquisition). print: every HogQL print "
+    "pass. describe: the DESCRIBE round-trip. stat: the post-write object HEAD.",
+    labelnames=["phase"],
+    buckets=[0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60],
+)
+FRAME_PRINT_PASSES_COUNTER = Counter(
+    "posthog_notebooks_frame_print_passes",
+    "Materializations by how many HogQL print passes they needed. A frame selecting a column "
+    "ClickHouse emits as Arrow binary (UUID, Enum, IP, FixedString) needs a second pass, so "
+    "this is how often the expensive shape is hit.",
+    labelnames=["passes"],
+)
 
 
 @dataclass
@@ -352,13 +372,23 @@ def _capped_settings(team_id: int) -> HogQLGlobalSettings:
     return settings
 
 
+@frozen
+class _GeneratedSQL:
+    sql: str
+    values: dict[str, object]
+    seconds: float
+    # `create_hogql_database` as the executor itself measured it, so a slow print can be
+    # blamed on the schema build or on the parse/resolve/print around it, not just "printing".
+    database_seconds: float
+
+
 def _generate_sql(
     team: Team,
     user: User | None,
     query: "str | ast.SelectQuery | ast.SelectSetQuery",
     *,
     output_format: str | None,
-) -> tuple[str, dict[str, object]]:
+) -> _GeneratedSQL:
     """Print HogQL to guarded ClickHouse SQL with the standing caps applied."""
     executor = HogQLQueryExecutor(
         query=query,
@@ -371,8 +401,26 @@ def _generate_sql(
     )
     if output_format:
         executor.context.output_format = output_format
+    started = time.perf_counter()
     sql, context = executor.generate_clickhouse_sql()
-    return sql, context.values
+    seconds = time.perf_counter() - started
+    return _GeneratedSQL(
+        sql=sql,
+        values=context.values,
+        seconds=seconds,
+        database_seconds=_hogql_database_seconds(executor.timings),
+    )
+
+
+def _hogql_database_seconds(timings: HogQLTimings) -> float:
+    """Sum every `create_hogql_database` span the executor recorded.
+
+    The key is hierarchical (`./a/b/create_hogql_database`) and a query with subqueries
+    records more than one, so match on the leaf rather than a fixed path.
+    """
+    return sum(
+        seconds for key, seconds in timings.to_dict().items() if key.rsplit("/", 1)[-1] == "create_hogql_database"
+    )
 
 
 _DescribeFn = Callable[[str, dict[str, object]], list[tuple[str, str]]]
@@ -439,9 +487,22 @@ def _stringify_function_for(ch_type: str) -> str | None:
     return None
 
 
+@frozen
+class _PrintedFrameSQL:
+    sql: str
+    values: dict[str, object]
+    # 2 whenever the query is re-printed through a stringifying wrapper. Reported rather than
+    # kept internal: the second pass is its own full parse/resolve/print, so it is the largest
+    # controllable slice of the pre-query window and worth watching per-run.
+    passes: int
+    print_seconds: float
+    describe_seconds: float
+    database_seconds: float
+
+
 def _print_clickhouse_sql(
     describe: _DescribeFn, team: Team, user: User | None, query: str, *, output_format: str | None
-) -> tuple[str, dict[str, object]]:
+) -> _PrintedFrameSQL:
     """Print the HogQL to guarded ClickHouse SQL with the standing caps.
 
     Two passes when needed (the data-modeling recipe): print once, DESCRIBE the printed
@@ -452,13 +513,27 @@ def _print_clickhouse_sql(
     where the s3() function argument defines the object format and a FORMAT clause would
     be invalid inside the INSERT.
     """
-    plain_sql, plain_values = _generate_sql(team, user, query, output_format=None)
-    described = describe(plain_sql, plain_values)
+    plain = _generate_sql(team, user, query, output_format=None)
+    describe_started = time.perf_counter()
+    described = describe(plain.sql, plain.values)
+    describe_seconds = time.perf_counter() - describe_started
     conversions = [(name, _stringify_function_for(ch_type)) for name, ch_type in described]
+
+    def printed(second: _GeneratedSQL | None) -> _PrintedFrameSQL:
+        last = second or plain
+        return _PrintedFrameSQL(
+            sql=last.sql,
+            values=last.values,
+            passes=2 if second else 1,
+            print_seconds=plain.seconds + (second.seconds if second else 0.0),
+            describe_seconds=describe_seconds,
+            database_seconds=plain.database_seconds + (second.database_seconds if second else 0.0),
+        )
+
     if not any(function for _name, function in conversions):
         if output_format is None:
-            return plain_sql, plain_values
-        return _generate_sql(team, user, query, output_format=output_format)
+            return printed(None)
+        return printed(_generate_sql(team, user, query, output_format=output_format))
     select_fields: list[ast.Expr] = [
         ast.Alias(expr=ast.Call(name=function, args=[ast.Field(chain=[name])]), alias=name)
         if function
@@ -466,7 +541,7 @@ def _print_clickhouse_sql(
         for name, function in conversions
     ]
     stringified = ast.SelectQuery(select=select_fields, select_from=ast.JoinExpr(table=parse_select(query)))
-    return _generate_sql(team, user, stringified, output_format=output_format)
+    return printed(_generate_sql(team, user, stringified, output_format=output_format))
 
 
 class FrameTooLargeError(Exception):
@@ -538,23 +613,31 @@ def _bounded_offline_client(team_id: int) -> AbstractContextManager:
     return pool.get_client()
 
 
-def _execute_insert_to_s3(team: Team, user: User | None, query: str, key: str) -> tuple[int, float]:
-    """Materialize by having ClickHouse write the object itself; return (bytes, CH seconds).
+@frozen
+class _WrittenFrame:
+    object_bytes: int
+    clickhouse_seconds: float
+    stat_seconds: float
+    printed: _PrintedFrameSQL
+
+
+def _execute_insert_to_s3(team: Team, user: User | None, query: str, key: str) -> _WrittenFrame:
+    """Materialize by having ClickHouse write the object itself.
 
     Runs through the pooled native clients (sync_execute) with a bounded socket timeout:
     offline workload and hedging hygiene come from the workload routing, errors arrive
     in-band and typed, and no result bytes transit the worker — so the streaming path's
     EOS-marker check and query_log recovery have no equivalent here.
     """
-    printed_sql, values = _print_clickhouse_sql(
+    printed = _print_clickhouse_sql(
         lambda sql, sql_values: _describe_columns_pooled(sql, sql_values, team.pk),
         team,
         user,
         query,
         output_format=None,
     )
-    insert_sql, s3_params = _insert_into_s3_sql(printed_sql, key)
-    insert_values = {**values, **s3_params}
+    insert_sql, s3_params = _insert_into_s3_sql(printed.sql, key)
+    insert_values = {**printed.values, **s3_params}
     ch_settings = {
         # Idempotent retries: a re-attempt overwrites the object, never appends.
         "s3_truncate_on_insert": 1,
@@ -577,7 +660,9 @@ def _execute_insert_to_s3(team: Team, user: User | None, query: str, key: str) -
     clickhouse_seconds = time.perf_counter() - query_started
     # Freshness margin covers worker↔object-store clock skew without admitting a
     # hours-stale prior-run object (see stat_frame).
+    stat_started = time.perf_counter()
     object_bytes = frame_store.stat_frame(key, written_after=write_started_at - dt.timedelta(minutes=5))
+    stat_seconds = time.perf_counter() - stat_started
     if object_bytes > _MAX_RESULT_BYTES:
         # max_result_bytes bounds result sets returned to a client, not an INSERT's sink —
         # the output cap has to be enforced after the fact on this path. The bytes are
@@ -585,7 +670,12 @@ def _execute_insert_to_s3(team: Team, user: User | None, query: str, key: str) -
         with suppress(ObjectStorageError):
             frame_store.delete_frame(key)
         raise FrameTooLargeError(f"Frame object is {object_bytes} bytes, over the {_MAX_RESULT_BYTES} budget")
-    return object_bytes, clickhouse_seconds
+    return _WrittenFrame(
+        object_bytes=object_bytes,
+        clickhouse_seconds=clickhouse_seconds,
+        stat_seconds=stat_seconds,
+        printed=printed,
+    )
 
 
 def _finalize_status(
@@ -726,6 +816,7 @@ def materialize_frame(inputs: FrameMaterializeInputs) -> str:
 
     attempt = activity.info().attempt if activity.in_activity() else 1
     started_at = dt.datetime.now(dt.UTC)
+    activity_started = time.perf_counter()
 
     try:
         status = manager.get_query_status()
@@ -757,8 +848,17 @@ def materialize_frame(inputs: FrameMaterializeInputs) -> str:
                 # limiter is saturated. A blocked attempt now costs one Redis eval and
                 # nothing else; the extra slot-hold (~100-300ms of print/describe) is noise
                 # against the stream duration.
+                # Everything before the write branch: team/user reads, the status round-trip,
+                # and slot acquisition. Measured because the pre-query window dominates a
+                # materialization's wall clock and was previously indivisible.
+                setup_seconds = time.perf_counter() - activity_started
+                stat_seconds = 0.0
                 if ch_writes:
-                    object_bytes, clickhouse_seconds = _execute_insert_to_s3(team, user, inputs.query, key)
+                    written = _execute_insert_to_s3(team, user, inputs.query, key)
+                    object_bytes = written.object_bytes
+                    clickhouse_seconds = written.clickhouse_seconds
+                    stat_seconds = written.stat_seconds
+                    printed = written.printed
                     upload_seconds = None  # CH performs the upload; the relay split doesn't exist
                 else:
                     client = ClickHouseClient(
@@ -783,7 +883,7 @@ def materialize_frame(inputs: FrameMaterializeInputs) -> str:
                         # as a kwarg so the online path sends no such setting at all, exactly
                         # as it did before this flag existed.
                         client.params["use_hedged_requests"] = "0"
-                    printed_sql, context_values = _print_clickhouse_sql(
+                    printed = _print_clickhouse_sql(
                         lambda sql, sql_values: _describe_columns(client, sql, sql_values, ch_query_id),
                         team,
                         user,
@@ -792,8 +892,8 @@ def materialize_frame(inputs: FrameMaterializeInputs) -> str:
                     )
                     query_started = time.perf_counter()
                     with client.post_query(
-                        printed_sql,
-                        query_parameters=context_values,
+                        printed.sql,
+                        query_parameters=printed.values,
                         query_id=ch_query_id,
                         timeout=(_STREAM_CONNECT_TIMEOUT_SECONDS, _STREAM_READ_TIMEOUT_SECONDS),
                     ) as response:
@@ -986,6 +1086,11 @@ def materialize_frame(inputs: FrameMaterializeInputs) -> str:
         # Only the worker-relay path has an observable upload half; a stream of zeros from
         # the CH-writes path would poison the histogram this split exists to interpret.
         FRAME_UPLOAD_SECONDS_HISTOGRAM.observe(upload_seconds)
+    FRAME_PHASE_SECONDS_HISTOGRAM.labels(phase="setup").observe(setup_seconds)
+    FRAME_PHASE_SECONDS_HISTOGRAM.labels(phase="print").observe(printed.print_seconds)
+    FRAME_PHASE_SECONDS_HISTOGRAM.labels(phase="describe").observe(printed.describe_seconds)
+    FRAME_PHASE_SECONDS_HISTOGRAM.labels(phase="stat").observe(stat_seconds)
+    FRAME_PRINT_PASSES_COUNTER.labels(passes=str(printed.passes)).inc()
     logger.info(
         "notebook_frame_materialized",
         team_id=inputs.team_id,
@@ -995,6 +1100,12 @@ def materialize_frame(inputs: FrameMaterializeInputs) -> str:
         ch_writes=ch_writes,
         clickhouse_seconds=round(clickhouse_seconds, 3),
         upload_seconds=round(upload_seconds, 3) if upload_seconds is not None else None,
+        setup_seconds=round(setup_seconds, 3),
+        print_seconds=round(printed.print_seconds, 3),
+        print_passes=printed.passes,
+        describe_seconds=round(printed.describe_seconds, 3),
+        database_seconds=round(printed.database_seconds, 3),
+        stat_seconds=round(stat_seconds, 3),
     )
     return key
 

--- a/products/notebooks/backend/temporal/frame_materialize.py
+++ b/products/notebooks/backend/temporal/frame_materialize.py
@@ -55,7 +55,6 @@ from posthog.hogql.constants import HogQLGlobalSettings, LimitContext
 from posthog.hogql.errors import ExposedHogQLError
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import HogQLQueryExecutor
-from posthog.hogql.timings import HogQLTimings
 
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import (
@@ -377,9 +376,12 @@ class _GeneratedSQL:
     sql: str
     values: dict[str, object]
     seconds: float
-    # `create_hogql_database` as the executor itself measured it, so a slow print can be
-    # blamed on the schema build or on the parse/resolve/print around it, not just "printing".
-    database_seconds: float
+    # The executor's own split of that wall clock. Resolving is the step expected to dominate
+    # and the one a wrapper pass repeats in full, so it is worth separating from parsing and
+    # from emitting the string.
+    parse_seconds: float
+    resolve_seconds: float
+    print_ast_seconds: float
 
 
 def _generate_sql(
@@ -404,23 +406,26 @@ def _generate_sql(
     started = time.perf_counter()
     sql, context = executor.generate_clickhouse_sql()
     seconds = time.perf_counter() - started
+    recorded = executor.timings.to_dict()
     return _GeneratedSQL(
         sql=sql,
         values=context.values,
         seconds=seconds,
-        database_seconds=_hogql_database_seconds(executor.timings),
+        parse_seconds=_hogql_leaf_seconds(recorded, "query"),
+        resolve_seconds=_hogql_leaf_seconds(recorded, "prepare_ast_for_printing"),
+        print_ast_seconds=_hogql_leaf_seconds(recorded, "print_prepared_ast"),
     )
 
 
-def _hogql_database_seconds(timings: HogQLTimings) -> float:
-    """Sum every `create_hogql_database` span the executor recorded.
+def _hogql_leaf_seconds(recorded: dict[str, float], leaf: str) -> float:
+    """Sum every span the executor recorded under `leaf`.
 
-    The key is hierarchical (`./a/b/create_hogql_database`) and a query with subqueries
-    records more than one, so match on the leaf rather than a fixed path.
+    Keys are hierarchical (`./a/b/prepare_ast_for_printing`) and one print records the step
+    once per dialect, plus once more per subquery, so match the leaf rather than a fixed path.
+    Deliberately not `create_hogql_database`: the executor builds the schema itself before the
+    printer's guarded span, so that key is never recorded on this path and would read as 0.
     """
-    return sum(
-        seconds for key, seconds in timings.to_dict().items() if key.rsplit("/", 1)[-1] == "create_hogql_database"
-    )
+    return sum(seconds for key, seconds in recorded.items() if key.rsplit("/", 1)[-1] == leaf)
 
 
 _DescribeFn = Callable[[str, dict[str, object]], list[tuple[str, str]]]
@@ -497,7 +502,7 @@ class _PrintedFrameSQL:
     passes: int
     print_seconds: float
     describe_seconds: float
-    database_seconds: float
+    resolve_seconds: float
 
 
 def _print_clickhouse_sql(
@@ -527,7 +532,7 @@ def _print_clickhouse_sql(
             passes=2 if second else 1,
             print_seconds=plain.seconds + (second.seconds if second else 0.0),
             describe_seconds=describe_seconds,
-            database_seconds=plain.database_seconds + (second.database_seconds if second else 0.0),
+            resolve_seconds=plain.resolve_seconds + (second.resolve_seconds if second else 0.0),
         )
 
     if not any(function for _name, function in conversions):
@@ -1104,7 +1109,7 @@ def materialize_frame(inputs: FrameMaterializeInputs) -> str:
         print_seconds=round(printed.print_seconds, 3),
         print_passes=printed.passes,
         describe_seconds=round(printed.describe_seconds, 3),
-        database_seconds=round(printed.database_seconds, 3),
+        resolve_seconds=round(printed.resolve_seconds, 3),
         stat_seconds=round(stat_seconds, 3),
     )
     return key

--- a/products/notebooks/backend/test/test_frame_materialize.py
+++ b/products/notebooks/backend/test/test_frame_materialize.py
@@ -31,6 +31,13 @@ from products.notebooks.backend.temporal import frame_materialize
 _DISPATCH_TARGET = "products.notebooks.backend.temporal.client.start_frame_materialize_workflow"
 
 
+def _printed_sql(sql: str = "SELECT 1") -> frame_materialize._PrintedFrameSQL:
+    """A stub print result for tests that care about what happens after printing."""
+    return frame_materialize._PrintedFrameSQL(
+        sql=sql, values={}, passes=1, print_seconds=0.0, describe_seconds=0.0, database_seconds=0.0
+    )
+
+
 def _per_query_memory_error() -> ClickHouseQueryMemoryLimitExceeded:
     # wrap_clickhouse_query_error sets this out of band, and it defaults to False — the
     # cluster-pressure reading. Only the query's own budget overrun is terminal.
@@ -126,7 +133,7 @@ class TestFrameMaterializeEnqueue(APIBaseTest):
         inputs, manager = self._registered_inputs()
 
         with (
-            patch.object(frame_materialize, "_print_clickhouse_sql", return_value=("SELECT 1", {})),
+            patch.object(frame_materialize, "_print_clickhouse_sql", return_value=_printed_sql()),
             patch.object(frame_materialize, "_materialize_slots"),
             patch.object(frame_materialize.ClickHouseClient, "post_query", side_effect=clickhouse_error),
         ):
@@ -148,7 +155,7 @@ class TestFrameMaterializeEnqueue(APIBaseTest):
 
         with self.settings(OBJECT_STORAGE_ENABLED=True):
             with (
-                patch.object(frame_materialize, "_print_clickhouse_sql", return_value=("SELECT 1", {})),
+                patch.object(frame_materialize, "_print_clickhouse_sql", return_value=_printed_sql()),
                 patch.object(frame_materialize, "_materialize_slots"),
                 patch.object(frame_materialize.ClickHouseClient, "post_query") as post_query,
                 patch.object(
@@ -184,7 +191,7 @@ class TestFrameMaterializeEnqueue(APIBaseTest):
         inputs, manager = self._registered_inputs()
 
         with (
-            patch.object(frame_materialize, "_print_clickhouse_sql", return_value=("SELECT 1", {})),
+            patch.object(frame_materialize, "_print_clickhouse_sql", return_value=_printed_sql()),
             patch.object(frame_materialize, "_materialize_slots"),
             patch.object(frame_materialize.ClickHouseClient, "post_query") as post_query,
             patch.object(frame_materialize.frame_store, "write_stream", side_effect=ObjectStorageError("torn")),
@@ -352,7 +359,7 @@ class TestFrameMaterializeCHWrites(APIBaseTest):
         inputs, manager = _registered_inputs(self.team.id, self.notebook.short_id, self.user.id, ch_writes=True)
 
         with (
-            patch.object(frame_materialize, "_print_clickhouse_sql", return_value=("SELECT 1", {})),
+            patch.object(frame_materialize, "_print_clickhouse_sql", return_value=_printed_sql()),
             patch.object(frame_materialize, "_materialize_slots"),
             patch.object(frame_materialize, "sync_execute", side_effect=error),
         ):
@@ -375,7 +382,7 @@ class TestFrameMaterializeCHWrites(APIBaseTest):
         key = frame_store.build_frame_key(inputs.team_id, inputs.notebook_short_id, inputs.query_hash)
 
         with (
-            patch.object(frame_materialize, "_print_clickhouse_sql", return_value=("SELECT 1", {})),
+            patch.object(frame_materialize, "_print_clickhouse_sql", return_value=_printed_sql()),
             patch.object(frame_materialize, "_materialize_slots"),
             patch.object(frame_materialize, "sync_execute", return_value=None),
             patch.object(
@@ -457,7 +464,7 @@ class TestFrameMaterializeKillSwitchCaps(APIBaseTest):
     )
     def test_printed_sql_carries_kill_switch_ceilings(self, _name: str, overrides: dict[str, int]):
         with patch.object(frame_materialize, "kill_switch_overrides", return_value=overrides):
-            sql, _values = frame_materialize._generate_sql(self.team, self.user, "select 1", output_format=None)
+            sql = frame_materialize._generate_sql(self.team, self.user, "select 1", output_format=None).sql
 
         memory_ceiling = overrides.get("max_memory_usage")
         if memory_ceiling is None:
@@ -468,3 +475,23 @@ class TestFrameMaterializeKillSwitchCaps(APIBaseTest):
         # rather than widen them to the kill switch's looser numbers.
         assert f"max_threads={frame_materialize._MAX_THREADS}" in sql
         assert f"max_bytes_to_read={frame_materialize._MAX_BYTES_TO_READ}" in sql
+
+
+class TestFrameMaterializePrintPasses(APIBaseTest):
+    @parameterized.expand(
+        [
+            ("arrow_safe_column", "select 1 as n", [("n", "UInt8")], 1),
+            ("arrow_binary_column", "select 1 as uuid", [("uuid", "UUID")], 2),
+        ]
+    )
+    def test_pass_count_tracks_whether_a_column_needs_stringifying(
+        self, _name: str, query: str, described: list[tuple[str, str]], expected_passes: int
+    ):
+        # The second pass re-prints the whole query through a wrapper and is the dominant
+        # cost of a materialization, so the reported count has to reflect what actually ran.
+        printed = frame_materialize._print_clickhouse_sql(
+            lambda _sql, _values: described, self.team, self.user, query, output_format=None
+        )
+
+        assert printed.passes == expected_passes
+        assert ("toString" in printed.sql) is (expected_passes == 2)

--- a/products/notebooks/backend/test/test_frame_materialize.py
+++ b/products/notebooks/backend/test/test_frame_materialize.py
@@ -32,9 +32,8 @@ _DISPATCH_TARGET = "products.notebooks.backend.temporal.client.start_frame_mater
 
 
 def _printed_sql(sql: str = "SELECT 1") -> frame_materialize._PrintedFrameSQL:
-    """A stub print result for tests that care about what happens after printing."""
     return frame_materialize._PrintedFrameSQL(
-        sql=sql, values={}, passes=1, print_seconds=0.0, describe_seconds=0.0, database_seconds=0.0
+        sql=sql, values={}, passes=1, print_seconds=0.0, describe_seconds=0.0, resolve_seconds=0.0
     )
 
 
@@ -495,3 +494,14 @@ class TestFrameMaterializePrintPasses(APIBaseTest):
 
         assert printed.passes == expected_passes
         assert ("toString" in printed.sql) is (expected_passes == 2)
+
+    def test_resolve_time_is_actually_recorded(self):
+        # The reported split reads leaf keys out of HogQLQueryExecutor's own timings, so a
+        # renamed or relocated span downgrades the field to a silent zero rather than an
+        # error — which is exactly how the first version of this shipped, reporting
+        # `create_hogql_database` that the executor never records on this path.
+        printed = frame_materialize._print_clickhouse_sql(
+            lambda _sql, _values: [("n", "UInt8")], self.team, self.user, "select 1 as n", output_format=None
+        )
+
+        assert printed.resolve_seconds > 0


### PR DESCRIPTION
## Problem

A notebook Python cell reading a SQL cell's dataframe waits ~23 s on US prod. Almost none of that is ClickHouse, and until now nothing said where it went.

`clickhouse_seconds` and `upload_seconds` both start once the query is issued, so everything before it was one indivisible block. Measured on prod, that block is most of the wall clock:

| Frame | ClickHouse | End-to-end wait |
| --- | --- | --- |
| `SELECT 1`, 1 row | 0.175 s | 10.73 s |
| events, 91,541 rows, no UUID column | 0.737 s | 12.73 s |
| events, 91,541 rows, **with `uuid`** | 0.845 s | 22.80 s |
| events, 500,000 rows, 2 UUID columns | 1.666 s | 25.42 s |

The dashboards read healthy the whole time — sub-second ClickHouse, sub-second upload — while a user waits 23 s.

Two things stand out and neither is visible today. There is a ~10.5 s floor every materialization pays (`SELECT 1` costs 10.73 s). And selecting a column ClickHouse emits as Arrow binary — UUID, Enum, IP, FixedString — forces `_print_clickhouse_sql` down its two-pass path, which added 10–12.5 s on identical row counts. `uuid` and `person_id` are among the most natural columns to select from `events`, so most real frames take the expensive shape.

## Changes

Splits the pre-query window into named phases and reports them on the existing success log line and as metrics.

- `setup` — activity start to the write branch: team/user reads, the status round-trip, slot acquisition.
- `print` — every HogQL print pass, plus `print_passes` (1 or 2) and the executor's own `parse` / `resolve` / `print_ast` split of it.
- `describe` — the DESCRIBE round-trip.
- `stat` — the post-write object HEAD.

Two new metrics: `posthog_notebooks_frame_phase_seconds{phase}` and `posthog_notebooks_frame_print_passes{passes}`. The pass counter answers a question the histograms can't — how often the two-pass shape is hit fleet-wide.

The print timings aren't new measurement. `HogQLQueryExecutor` already records parse, resolve and print-ast and `_generate_sql` discarded them; this reads them out. `create_hogql_database` is deliberately *not* among them — the executor builds the schema itself before the printer's guarded span, so that key is never recorded on this path.

Three tuple returns became `@frozen` dataclasses (`_GeneratedSQL`, `_PrintedFrameSQL`, `_WrittenFrame`) to carry the extra fields, per the repo convention on multi-value returns.

No behavior change. Same SQL, same passes, same queries.

## How did you test this code?

I'm an agent. I did not run the worker locally; the numbers above come from materializations I ran against US prod **before** this PR, reading the existing `notebook_frame_materialized` log line and the run envelope's `input_wait_s`.

Automated, run locally:

- `pytest products/notebooks/backend/test/test_frame_materialize.py` — 26 passed.

Two tests added under `TestFrameMaterializePrintPasses`. The first is parameterized over an Arrow-safe and an Arrow-binary column. It catches a regression no existing test does: the conversion table in `_stringify_function_for` silently changing which types trigger the second pass. That table decides whether a frame costs 12 s or 23 s, and nothing asserted on it. It stubs the DESCRIBE and drives the real printer, so it also pins that the wrapper actually emits `toString`.

The second asserts `resolve_seconds > 0`. That one exists because the first version of this PR shipped a `database_seconds` field that was always zero — see the review note below — and nothing would have caught it. A relocated timing span now fails the build instead of silently downgrading a reported field.

Existing tests that stubbed `_print_clickhouse_sql`/`_generate_sql` with tuples were updated for the new return types via a `_printed_sql()` helper.

Not verified: the emitted metric values on a live worker. `temporal-worker-general-purpose` emits no APM spans at all, which is why this needed log-line instrumentation rather than tracing.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal instrumentation, no user-facing surface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Opus 5 in Claude Code. Skills invoked: `/writing-tests` conventions applied to the added test (named regression, parameterized, lowest useful level); no repo skill covers Temporal activity instrumentation.

This came out of verifying the `notebooks-frame-store-ch-writes` rollout end to end on prod. Along the way I twice guessed wrong about where the time goes, which is the reason this PR is instrumentation rather than a fix:

- First guess was the HogQL print in general. Production traces put `create_hogql_database` at p50 43 ms / p95 113 ms, so schema building isn't it. My first attempt to report it was also broken, which @greptile-apps caught: `_generate_hogql` builds the schema itself and attaches it to the context, so `prepare_ast_for_printing`'s guarded `create_hogql_database` span never runs and the field read a constant zero. Replaced with parse/resolve/print-ast, which the executor does record, plus a test.
- Second guess was Temporal queue wait. A log-derived span showed ~19 s elapsing *inside* the activity, after it had already started, which rules the queue out.

The controlled experiment (`SELECT 1` vs events-without-UUID vs events-with-UUID, repeated on a second time window) is what isolated the second print pass. A follow-up PR stacked on this one makes the two passes share one `HogQLQueryExecutor`, the way `posthog/temporal/data_modeling/run_workflow.py` already does. Landing them separately so the metrics exist before the fix, and the fix can be judged against them.

Nothing here draws on non-public material: the queries are `SELECT` statements over PostHog's own project 2, and no query results, customer identifiers, or session content appear in the code or this description.
