### PR TITLE
feat(error-tracking): add shared setup diagnostics

### DIFF
--- a/ee/hogai/core/agent_modes/presets/error_tracking.py
+++ b/ee/hogai/core/agent_modes/presets/error_tracking.py
@@ -29,6 +29,20 @@ The assistant used the search tool because:
 3. This is a straightforward search that doesn't require multiple steps
 """.strip()
 
+POSITIVE_EXAMPLE_CHECK_SETUP = """
+User: What errors are affecting the most users right now?
+Assistant: I'll search for active issues ordered by affected users.
+*Uses search_error_tracking_issues with orderBy: "users" and dateRange: { date_from: "-7d" }*
+The search returns no issues, so the assistant uses get_error_tracking_setup_status before explaining the empty result.
+""".strip()
+
+POSITIVE_EXAMPLE_CHECK_SETUP_REASONING = """
+The assistant checked setup status because:
+1. An empty issue search does not show whether exception capture is configured
+2. The setup tool distinguishes project settings, published config, recent ingestion, and SDK-specific requirements
+3. The assistant must report what PostHog can observe without guessing about local SDK initialization
+""".strip()
+
 POSITIVE_EXAMPLE_SEARCH_AND_EXPLAIN = """
 User: What's causing our most frequent error?
 Assistant: I'll search for the most frequent error and then explain what's causing it.
@@ -55,7 +69,7 @@ Assistant: I'll help you analyze how error tracking issues are impacting your ch
 Based on your event taxonomy, the checkout-related events are: checkout_started, payment_submitted, and order_completed. These are the events you should analyze to understand which issues may be blocking or affecting your checkout conversion.
 """.strip()
 
-ERROR_TRACKING_MODE_DESCRIPTION = "Specialized mode for analyzing error tracking issues. This mode allows you to search and filter error tracking issues by status, date range, frequency, and other criteria. You can also retrieve detailed stack trace information for any issue to analyze and explain its root cause."
+ERROR_TRACKING_MODE_DESCRIPTION = "Specialized mode for analyzing error tracking issues and diagnosing setup. This mode allows you to search and filter issues, inspect stack traces, and check project configuration, recent exception ingestion, and observed SDK requirements when searches return no results."
 
 POSITIVE_EXAMPLE_IMPACT_ANALYSIS_REASONING = """
 The assistant used the read_taxonomy tool because:
@@ -76,6 +90,10 @@ class ErrorTrackingAgentToolkit(AgentToolkit):
             reasoning=POSITIVE_EXAMPLE_SEARCH_ERRORS_REASONING,
         ),
         TodoWriteExample(
+            example=POSITIVE_EXAMPLE_CHECK_SETUP,
+            reasoning=POSITIVE_EXAMPLE_CHECK_SETUP_REASONING,
+        ),
+        TodoWriteExample(
             example=POSITIVE_EXAMPLE_SEARCH_AND_EXPLAIN,
             reasoning=POSITIVE_EXAMPLE_SEARCH_AND_EXPLAIN_REASONING,
         ),
@@ -87,9 +105,12 @@ class ErrorTrackingAgentToolkit(AgentToolkit):
 
     @property
     def tools(self) -> list[type["MaxTool"]]:
-        from products.error_tracking.backend.facade.tools import SearchErrorTrackingIssuesTool
+        from products.error_tracking.backend.facade.tools import (
+            GetErrorTrackingSetupStatusTool,
+            SearchErrorTrackingIssuesTool,
+        )
 
-        tools: list[type[MaxTool]] = [SearchErrorTrackingIssuesTool]
+        tools: list[type[MaxTool]] = [SearchErrorTrackingIssuesTool, GetErrorTrackingSetupStatusTool]
         return tools
 
 

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -4046,6 +4046,7 @@
                 "create_message_template",
                 "filter_error_tracking_issues",
                 "search_error_tracking_issues",
+                "get_error_tracking_setup_status",
                 "find_error_tracking_impactful_issue_event_list",
                 "experiment_results_summary",
                 "experiment_session_replays_summary",

--- a/frontend/src/queries/schema/schema-assistant-messages.ts
+++ b/frontend/src/queries/schema/schema-assistant-messages.ts
@@ -462,6 +462,7 @@ export type AssistantTool =
     | 'create_message_template'
     | 'filter_error_tracking_issues'
     | 'search_error_tracking_issues'
+    | 'get_error_tracking_setup_status'
     | 'find_error_tracking_impactful_issue_event_list'
     | 'experiment_results_summary'
     | 'experiment_session_replays_summary'

--- a/frontend/src/scenes/max/max-constants.tsx
+++ b/frontend/src/scenes/max/max-constants.tsx
@@ -714,6 +714,19 @@ export const TOOL_DEFINITIONS: Record<AssistantTool, ToolDefinition> = {
             return 'Searching issues...'
         },
     },
+    get_error_tracking_setup_status: {
+        name: 'Check error tracking setup',
+        description: 'Check error tracking configuration and recent exception ingestion',
+        product: Scene.ErrorTracking,
+        icon: iconForType('error_tracking'),
+        modes: [AgentMode.ErrorTracking],
+        displayFormatter: (toolCall) => {
+            if (toolCall.status === 'completed') {
+                return 'Checked error tracking setup'
+            }
+            return 'Checking error tracking setup...'
+        },
+    },
     find_error_tracking_impactful_issue_event_list: {
         name: 'Find impactful issues',
         description: 'Find impactful issues affecting your conversion, activation, or any other events',

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -369,6 +369,7 @@ class AssistantTool(StrEnum):
     CREATE_MESSAGE_TEMPLATE = "create_message_template"
     FILTER_ERROR_TRACKING_ISSUES = "filter_error_tracking_issues"
     SEARCH_ERROR_TRACKING_ISSUES = "search_error_tracking_issues"
+    GET_ERROR_TRACKING_SETUP_STATUS = "get_error_tracking_setup_status"
     FIND_ERROR_TRACKING_IMPACTFUL_ISSUE_EVENT_LIST = "find_error_tracking_impactful_issue_event_list"
     EXPERIMENT_RESULTS_SUMMARY = "experiment_results_summary"
     EXPERIMENT_SESSION_REPLAYS_SUMMARY = "experiment_session_replays_summary"

--- a/products/error_tracking/backend/facade/contracts.py
+++ b/products/error_tracking/backend/facade/contracts.py
@@ -246,6 +246,8 @@ class ErrorTrackingRecommendation:
 class ErrorTrackingObservedSDK:
     library: str
     event_count: int
+    latest_version: str | None
+    last_seen_at: datetime
     autocapture_configuration: Literal["project_setting", "local", "unknown"]
     local_option: str | None
 
@@ -265,5 +267,7 @@ class ErrorTrackingSetupStatus:
     recent_period_days: int
     recent_event_count: int | None
     recent_exception_count: int | None
+    last_event_at: datetime | None
+    last_exception_at: datetime | None
     observed_sdks: list[ErrorTrackingObservedSDK]
     warnings: list[ErrorTrackingSetupWarning]

--- a/products/error_tracking/backend/facade/contracts.py
+++ b/products/error_tracking/backend/facade/contracts.py
@@ -11,6 +11,7 @@ facade boundary instead of producing a malformed payload further downstream.
 
 from dataclasses import field
 from datetime import datetime
+from typing import Literal
 from uuid import UUID
 
 from pydantic.dataclasses import dataclass
@@ -239,3 +240,30 @@ class ErrorTrackingRecommendation:
     dismissed_at: datetime | None
     created_at: datetime
     updated_at: datetime
+
+
+@dataclass(frozen=True)
+class ErrorTrackingObservedSDK:
+    library: str
+    event_count: int
+    autocapture_configuration: Literal["project_setting", "local", "unknown"]
+    local_option: str | None
+
+
+@dataclass(frozen=True)
+class ErrorTrackingSetupWarning:
+    code: Literal["node_autocapture_requires_local_configuration"]
+    message: str
+
+
+@dataclass(frozen=True)
+class ErrorTrackingSetupStatus:
+    project_autocapture_enabled: bool
+    remote_config_autocapture_enabled: bool | None
+    has_issues: bool
+    recent_data_available: bool
+    recent_period_days: int
+    recent_event_count: int | None
+    recent_exception_count: int | None
+    observed_sdks: list[ErrorTrackingObservedSDK]
+    warnings: list[ErrorTrackingSetupWarning]

--- a/products/error_tracking/backend/facade/setup.py
+++ b/products/error_tracking/backend/facade/setup.py
@@ -1,0 +1,133 @@
+from typing import Literal
+
+import structlog
+from pydantic.dataclasses import dataclass
+
+from posthog.hogql.parser import parse_select
+from posthog.hogql.query import execute_hogql_query
+
+from posthog.clickhouse.query_tagging import Feature, Product, tags_context
+from posthog.exceptions_capture import capture_exception
+from posthog.models import RemoteConfig, Team
+
+from products.error_tracking.backend import logic
+
+from .contracts import ErrorTrackingObservedSDK, ErrorTrackingSetupStatus, ErrorTrackingSetupWarning
+
+logger = structlog.get_logger(__name__)
+
+_RECENT_PERIOD_DAYS = 7
+_SDK_CONFIGURATIONS: tuple[tuple[str, Literal["project_setting", "local", "unknown"], str | None], ...] = (
+    ("web", "project_setting", None),
+    ("posthog-node", "local", "enableExceptionAutocapture"),
+    ("posthog-python", "unknown", None),
+    ("posthog-react-native", "unknown", None),
+    ("posthog-ruby", "unknown", None),
+    ("posthog-ios", "unknown", None),
+    ("posthog-rs", "unknown", None),
+    ("posthog-android", "unknown", None),
+    ("posthog-go", "unknown", None),
+    ("posthog-php", "unknown", None),
+    ("posthog-flutter", "unknown", None),
+    ("posthog-java", "unknown", None),
+)
+_RECENT_USAGE_QUERY = parse_select("""
+    SELECT
+        count() AS event_count,
+        countIf(event = '$exception') AS exception_count,
+        countIf(properties.$lib = 'web') AS web_events,
+        countIf(properties.$lib = 'posthog-node') AS node_events,
+        countIf(properties.$lib = 'posthog-python') AS python_events,
+        countIf(properties.$lib = 'posthog-react-native') AS react_native_events,
+        countIf(properties.$lib = 'posthog-ruby') AS ruby_events,
+        countIf(properties.$lib = 'posthog-ios') AS ios_events,
+        countIf(properties.$lib = 'posthog-rs') AS rust_events,
+        countIf(properties.$lib = 'posthog-android') AS android_events,
+        countIf(properties.$lib = 'posthog-go') AS go_events,
+        countIf(properties.$lib = 'posthog-php') AS php_events,
+        countIf(properties.$lib = 'posthog-flutter') AS flutter_events,
+        countIf(properties.$lib = 'posthog-java') AS java_events
+    FROM events
+    WHERE timestamp >= now() - INTERVAL 7 DAY
+""")
+
+
+@dataclass(frozen=True)
+class _RecentErrorTrackingUsage:
+    event_count: int
+    exception_count: int
+    observed_sdks: list[ErrorTrackingObservedSDK]
+
+
+def _get_remote_config_autocapture(team_id: int) -> bool | None:
+    config = RemoteConfig.objects.filter(team_id=team_id).values_list("config", flat=True).first()
+    if not isinstance(config, dict):
+        return None
+    value = config.get("autocaptureExceptions")
+    return value if isinstance(value, bool) else None
+
+
+def _get_recent_usage(team: Team) -> _RecentErrorTrackingUsage:
+    with tags_context(
+        product=Product.ERROR_TRACKING,
+        feature=Feature.QUERY,
+        team_id=team.id,
+        org_id=team.organization_id,
+        query_type="error_tracking_setup_status",
+    ):
+        response = execute_hogql_query(_RECENT_USAGE_QUERY, team, query_type="error_tracking_setup_status")
+
+    row = response.results[0] if response.results else [0] * (len(_SDK_CONFIGURATIONS) + 2)
+    observed_sdks = [
+        ErrorTrackingObservedSDK(
+            library=library,
+            event_count=int(row[index]),
+            autocapture_configuration=configuration,
+            local_option=local_option,
+        )
+        for index, (library, configuration, local_option) in enumerate(_SDK_CONFIGURATIONS, start=2)
+        if int(row[index]) > 0
+    ]
+    return _RecentErrorTrackingUsage(
+        event_count=int(row[0]),
+        exception_count=int(row[1]),
+        observed_sdks=observed_sdks,
+    )
+
+
+def get_error_tracking_setup_status(team: Team) -> ErrorTrackingSetupStatus:
+    try:
+        recent_usage = _get_recent_usage(team)
+    except Exception as error:
+        logger.exception("Failed to query recent error tracking setup data", team_id=team.id)
+        capture_exception(error, {"team_id": team.id})
+        recent_usage = None
+
+    warnings: list[ErrorTrackingSetupWarning] = []
+    if (
+        recent_usage
+        and recent_usage.exception_count == 0
+        and any(sdk.library == "posthog-node" for sdk in recent_usage.observed_sdks)
+    ):
+        warnings.append(
+            ErrorTrackingSetupWarning(
+                code="node_autocapture_requires_local_configuration",
+                message=(
+                    "posthog-node requires `enableExceptionAutocapture: true` in the SDK initialization. "
+                    "The project setting does not enable exception autocapture for posthog-node. "
+                    "PostHog cannot verify this local SDK option from event data."
+                ),
+            )
+        )
+
+    return ErrorTrackingSetupStatus(
+        project_autocapture_enabled=bool(team.autocapture_exceptions_opt_in),
+        remote_config_autocapture_enabled=_get_remote_config_autocapture(team.id),
+        has_issues=logic.issue_exists(team.id),
+        recent_data_available=recent_usage is not None,
+        recent_period_days=_RECENT_PERIOD_DAYS,
+        recent_event_count=recent_usage.event_count if recent_usage else None,
+        recent_exception_count=recent_usage.exception_count if recent_usage else None,
+        observed_sdks=recent_usage.observed_sdks if recent_usage else [],
+        warnings=warnings,
+    )

--- a/products/error_tracking/backend/facade/setup.py
+++ b/products/error_tracking/backend/facade/setup.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Literal
 
 import structlog
@@ -17,38 +18,54 @@ from .contracts import ErrorTrackingObservedSDK, ErrorTrackingSetupStatus, Error
 logger = structlog.get_logger(__name__)
 
 _RECENT_PERIOD_DAYS = 7
-_SDK_CONFIGURATIONS: tuple[tuple[str, Literal["project_setting", "local", "unknown"], str | None], ...] = (
-    ("web", "project_setting", None),
-    ("posthog-node", "local", "enableExceptionAutocapture"),
-    ("posthog-python", "unknown", None),
-    ("posthog-react-native", "unknown", None),
-    ("posthog-ruby", "unknown", None),
-    ("posthog-ios", "unknown", None),
-    ("posthog-rs", "unknown", None),
-    ("posthog-android", "unknown", None),
-    ("posthog-go", "unknown", None),
-    ("posthog-php", "unknown", None),
-    ("posthog-flutter", "unknown", None),
-    ("posthog-java", "unknown", None),
+
+
+@dataclass(frozen=True)
+class _SDKTransportConfiguration:
+    library: str
+    autocapture_configuration: Literal["project_setting", "local", "unknown"]
+    local_option: str | None
+
+
+_SDK_CONFIGURATIONS = (
+    _SDKTransportConfiguration(library="web", autocapture_configuration="project_setting", local_option=None),
+    _SDKTransportConfiguration(
+        library="posthog-node", autocapture_configuration="local", local_option="enableExceptionAutocapture"
+    ),
+    _SDKTransportConfiguration(library="posthog-python", autocapture_configuration="unknown", local_option=None),
+    _SDKTransportConfiguration(library="posthog-react-native", autocapture_configuration="unknown", local_option=None),
+    _SDKTransportConfiguration(library="posthog-ruby", autocapture_configuration="unknown", local_option=None),
+    _SDKTransportConfiguration(library="posthog-ios", autocapture_configuration="unknown", local_option=None),
+    _SDKTransportConfiguration(library="posthog-rs", autocapture_configuration="unknown", local_option=None),
+    _SDKTransportConfiguration(library="posthog-android", autocapture_configuration="unknown", local_option=None),
+    _SDKTransportConfiguration(library="posthog-go", autocapture_configuration="unknown", local_option=None),
+    _SDKTransportConfiguration(library="posthog-php", autocapture_configuration="unknown", local_option=None),
+    _SDKTransportConfiguration(library="posthog-flutter", autocapture_configuration="unknown", local_option=None),
+    _SDKTransportConfiguration(library="posthog-java", autocapture_configuration="unknown", local_option=None),
 )
+_SDK_CONFIGURATIONS_BY_LIBRARY = {sdk.library: sdk for sdk in _SDK_CONFIGURATIONS}
+_SUPPORTED_SDK_LIBRARIES = ", ".join(f"'{sdk.library}'" for sdk in _SDK_CONFIGURATIONS)
 _RECENT_USAGE_QUERY = parse_select("""
     SELECT
         count() AS event_count,
         countIf(event = '$exception') AS exception_count,
-        countIf(properties.$lib = 'web') AS web_events,
-        countIf(properties.$lib = 'posthog-node') AS node_events,
-        countIf(properties.$lib = 'posthog-python') AS python_events,
-        countIf(properties.$lib = 'posthog-react-native') AS react_native_events,
-        countIf(properties.$lib = 'posthog-ruby') AS ruby_events,
-        countIf(properties.$lib = 'posthog-ios') AS ios_events,
-        countIf(properties.$lib = 'posthog-rs') AS rust_events,
-        countIf(properties.$lib = 'posthog-android') AS android_events,
-        countIf(properties.$lib = 'posthog-go') AS go_events,
-        countIf(properties.$lib = 'posthog-php') AS php_events,
-        countIf(properties.$lib = 'posthog-flutter') AS flutter_events,
-        countIf(properties.$lib = 'posthog-java') AS java_events
+        if(count() > 0, max(timestamp), NULL) AS last_event_at,
+        if(countIf(event = '$exception') > 0, maxIf(timestamp, event = '$exception'), NULL) AS last_exception_at
     FROM events
     WHERE timestamp >= now() - INTERVAL 7 DAY
+""")
+_RECENT_SDK_USAGE_QUERY = parse_select(f"""
+    SELECT
+        properties.$lib AS library,
+        count() AS event_count,
+        argMax(properties.$lib_version, timestamp) AS latest_version,
+        max(timestamp) AS last_seen_at
+    FROM events
+    WHERE timestamp >= now() - INTERVAL 7 DAY
+      AND properties.$lib IN ({_SUPPORTED_SDK_LIBRARIES})
+    GROUP BY library
+    ORDER BY library ASC
+    LIMIT {len(_SDK_CONFIGURATIONS)}
 """)
 
 
@@ -56,6 +73,8 @@ _RECENT_USAGE_QUERY = parse_select("""
 class _RecentErrorTrackingUsage:
     event_count: int
     exception_count: int
+    last_event_at: datetime | None
+    last_exception_at: datetime | None
     observed_sdks: list[ErrorTrackingObservedSDK]
 
 
@@ -67,6 +86,18 @@ def _get_remote_config_autocapture(team_id: int) -> bool | None:
     return value if isinstance(value, bool) else None
 
 
+def _as_int(value: object) -> int:
+    if not isinstance(value, int):
+        raise ValueError("Expected an integer in error tracking setup query results")
+    return value
+
+
+def _as_optional_datetime(value: object) -> datetime | None:
+    if value is not None and not isinstance(value, datetime):
+        raise ValueError("Expected a timestamp in error tracking setup query results")
+    return value
+
+
 def _get_recent_usage(team: Team) -> _RecentErrorTrackingUsage:
     with tags_context(
         product=Product.ERROR_TRACKING,
@@ -76,21 +107,37 @@ def _get_recent_usage(team: Team) -> _RecentErrorTrackingUsage:
         query_type="error_tracking_setup_status",
     ):
         response = execute_hogql_query(_RECENT_USAGE_QUERY, team, query_type="error_tracking_setup_status")
+        sdk_response = execute_hogql_query(_RECENT_SDK_USAGE_QUERY, team, query_type="error_tracking_setup_status_sdks")
 
-    row = response.results[0] if response.results else [0] * (len(_SDK_CONFIGURATIONS) + 2)
-    observed_sdks = [
-        ErrorTrackingObservedSDK(
-            library=library,
-            event_count=int(row[index]),
-            autocapture_configuration=configuration,
-            local_option=local_option,
+    row = response.results[0] if response.results else [0, 0, None, None]
+    observed_sdks: list[ErrorTrackingObservedSDK] = []
+    for sdk_row in sdk_response.results or []:
+        library = str(sdk_row[0])
+        sdk = _SDK_CONFIGURATIONS_BY_LIBRARY.get(library)
+        if sdk is None:
+            continue
+
+        last_seen_at = sdk_row[3]
+        if not isinstance(last_seen_at, datetime):
+            raise ValueError(f"Missing last seen timestamp for observed SDK {sdk.library}")
+
+        latest_version = sdk_row[2]
+        observed_sdks.append(
+            ErrorTrackingObservedSDK(
+                library=sdk.library,
+                event_count=_as_int(sdk_row[1]),
+                latest_version=str(latest_version) if latest_version else None,
+                last_seen_at=last_seen_at,
+                autocapture_configuration=sdk.autocapture_configuration,
+                local_option=sdk.local_option,
+            )
         )
-        for index, (library, configuration, local_option) in enumerate(_SDK_CONFIGURATIONS, start=2)
-        if int(row[index]) > 0
-    ]
+
     return _RecentErrorTrackingUsage(
-        event_count=int(row[0]),
-        exception_count=int(row[1]),
+        event_count=_as_int(row[0]),
+        exception_count=_as_int(row[1]),
+        last_event_at=_as_optional_datetime(row[2]),
+        last_exception_at=_as_optional_datetime(row[3]),
         observed_sdks=observed_sdks,
     )
 
@@ -128,6 +175,8 @@ def get_error_tracking_setup_status(team: Team) -> ErrorTrackingSetupStatus:
         recent_period_days=_RECENT_PERIOD_DAYS,
         recent_event_count=recent_usage.event_count if recent_usage else None,
         recent_exception_count=recent_usage.exception_count if recent_usage else None,
+        last_event_at=recent_usage.last_event_at if recent_usage else None,
+        last_exception_at=recent_usage.last_exception_at if recent_usage else None,
         observed_sdks=recent_usage.observed_sdks if recent_usage else [],
         warnings=warnings,
     )

--- a/products/error_tracking/backend/facade/tools.py
+++ b/products/error_tracking/backend/facade/tools.py
@@ -7,6 +7,6 @@ importing this lazily (inside the registration call site) to avoid a circular
 import on the ``django.setup()`` path.
 """
 
-from products.error_tracking.backend.max_tools import SearchErrorTrackingIssuesTool
+from products.error_tracking.backend.max_tools import GetErrorTrackingSetupStatusTool, SearchErrorTrackingIssuesTool
 
-__all__ = ["SearchErrorTrackingIssuesTool"]
+__all__ = ["GetErrorTrackingSetupStatusTool", "SearchErrorTrackingIssuesTool"]

--- a/products/error_tracking/backend/max_tools.py
+++ b/products/error_tracking/backend/max_tools.py
@@ -59,8 +59,8 @@ class GetErrorTrackingSetupStatusTool(MaxTool):
 
         Use this tool when an issue search returns no results, or when the user asks whether error tracking is set up.
         It reports the project exception autocapture setting, the published remote config, whether grouped issues exist,
-        recent event and exception counts, and recently observed SDKs. It also identifies SDKs that require local
-        exception autocapture configuration that PostHog cannot verify from event data.
+        recent event and exception activity, and recently observed SDK versions. It also identifies SDKs that require
+        local exception autocapture configuration that PostHog cannot verify from event data.
     """).strip()
     args_schema: type[BaseModel] = GetErrorTrackingSetupStatusArgs
 
@@ -103,8 +103,17 @@ class GetErrorTrackingSetupStatusTool(MaxTool):
                 f"{status.recent_exception_count}."
             )
 
+        if status.last_event_at:
+            lines.append(f"Last event received: {status.last_event_at.isoformat()}.")
+        if status.last_exception_at:
+            lines.append(f"Last exception received: {status.last_exception_at.isoformat()}.")
+
         if status.observed_sdks:
-            observed = ", ".join(f"{sdk.library} ({sdk.event_count} events)" for sdk in status.observed_sdks)
+            observed = ", ".join(
+                f"{sdk.library} {sdk.latest_version or 'version unavailable'} "
+                f"({sdk.event_count} events, last seen {sdk.last_seen_at.isoformat()})"
+                for sdk in status.observed_sdks
+            )
             lines.append(f"Observed SDKs in the last {status.recent_period_days} days: {observed}.")
         else:
             lines.append(f"No supported SDKs were observed in the last {status.recent_period_days} days.")
@@ -122,10 +131,14 @@ class GetErrorTrackingSetupStatusTool(MaxTool):
             "recent_period_days": status.recent_period_days,
             "recent_event_count": status.recent_event_count,
             "recent_exception_count": status.recent_exception_count,
+            "last_event_at": status.last_event_at.isoformat() if status.last_event_at else None,
+            "last_exception_at": status.last_exception_at.isoformat() if status.last_exception_at else None,
             "observed_sdks": [
                 {
                     "library": sdk.library,
                     "event_count": sdk.event_count,
+                    "latest_version": sdk.latest_version,
+                    "last_seen_at": sdk.last_seen_at.isoformat(),
                     "autocapture_configuration": sdk.autocapture_configuration,
                     "local_option": sdk.local_option,
                 }

--- a/products/error_tracking/backend/max_tools.py
+++ b/products/error_tracking/backend/max_tools.py
@@ -7,6 +7,7 @@ from typing import Literal, Optional, cast
 from django.utils import timezone
 
 import structlog
+from asgiref.sync import sync_to_async
 from langchain_core.messages import HumanMessage, SystemMessage
 from posthoganalytics import capture_exception
 from pydantic import BaseModel, Field
@@ -23,6 +24,14 @@ from posthog.schema import (
     PropertyGroupFilterValue,
 )
 
+from posthog.rbac.user_access_control import AccessControlLevel
+from posthog.scopes import APIScopeObject
+
+from products.error_tracking.backend.facade import (
+    contracts as error_tracking_contracts,
+    setup as error_tracking_setup,
+)
+
 from ee.hogai.chat_agent.schema_generator.parsers import PydanticOutputParserException
 from ee.hogai.context.insight.query_executor import AssistantQueryExecutor
 from ee.hogai.llm import MaxChatOpenAI
@@ -37,6 +46,93 @@ from .prompts import (
 )
 
 logger = structlog.get_logger(__name__)
+
+
+class GetErrorTrackingSetupStatusArgs(BaseModel):
+    pass
+
+
+class GetErrorTrackingSetupStatusTool(MaxTool):
+    name: Literal["get_error_tracking_setup_status"] = "get_error_tracking_setup_status"
+    description: str = dedent("""
+        Inspect whether error tracking is configured and receiving data for the current project.
+
+        Use this tool when an issue search returns no results, or when the user asks whether error tracking is set up.
+        It reports the project exception autocapture setting, the published remote config, whether grouped issues exist,
+        recent event and exception counts, and recently observed SDKs. It also identifies SDKs that require local
+        exception autocapture configuration that PostHog cannot verify from event data.
+    """).strip()
+    args_schema: type[BaseModel] = GetErrorTrackingSetupStatusArgs
+
+    def get_required_resource_access(self) -> list[tuple[APIScopeObject, AccessControlLevel]]:
+        return [("error_tracking", "viewer")]
+
+    async def _arun_impl(self) -> tuple[str, dict[str, object]]:
+        status = await sync_to_async(error_tracking_setup.get_error_tracking_setup_status)(self._team)
+        return self._format_status(status), self._serialize_status(status)
+
+    @staticmethod
+    def _format_status(status: error_tracking_contracts.ErrorTrackingSetupStatus) -> str:
+        project_setting = "enabled" if status.project_autocapture_enabled else "disabled"
+        remote_setting = (
+            "enabled"
+            if status.remote_config_autocapture_enabled is True
+            else "disabled"
+            if status.remote_config_autocapture_enabled is False
+            else "unavailable"
+        )
+        lines = [
+            f"Project exception autocapture setting: {project_setting}.",
+            f"Published remote config: {remote_setting}.",
+            f"Grouped error tracking issues exist: {'yes' if status.has_issues else 'no'}.",
+        ]
+
+        if not status.recent_data_available:
+            lines.append(
+                "Recent event data could not be checked. Try again before drawing conclusions about ingestion."
+            )
+            return "\n".join(lines)
+
+        if status.recent_event_count == 0:
+            lines.append(f"No events were received in the last {status.recent_period_days} days.")
+        elif status.recent_exception_count == 0:
+            lines.append(f"No exception events were received in the last {status.recent_period_days} days.")
+        else:
+            lines.append(
+                f"Exception events received in the last {status.recent_period_days} days: "
+                f"{status.recent_exception_count}."
+            )
+
+        if status.observed_sdks:
+            observed = ", ".join(f"{sdk.library} ({sdk.event_count} events)" for sdk in status.observed_sdks)
+            lines.append(f"Observed SDKs in the last {status.recent_period_days} days: {observed}.")
+        else:
+            lines.append(f"No supported SDKs were observed in the last {status.recent_period_days} days.")
+
+        lines.extend(warning.message for warning in status.warnings)
+        return "\n".join(lines)
+
+    @staticmethod
+    def _serialize_status(status: error_tracking_contracts.ErrorTrackingSetupStatus) -> dict[str, object]:
+        return {
+            "project_autocapture_enabled": status.project_autocapture_enabled,
+            "remote_config_autocapture_enabled": status.remote_config_autocapture_enabled,
+            "has_issues": status.has_issues,
+            "recent_data_available": status.recent_data_available,
+            "recent_period_days": status.recent_period_days,
+            "recent_event_count": status.recent_event_count,
+            "recent_exception_count": status.recent_exception_count,
+            "observed_sdks": [
+                {
+                    "library": sdk.library,
+                    "event_count": sdk.event_count,
+                    "autocapture_configuration": sdk.autocapture_configuration,
+                    "local_option": sdk.local_option,
+                }
+                for sdk in status.observed_sdks
+            ],
+            "warnings": [{"code": warning.code, "message": warning.message} for warning in status.warnings],
+        }
 
 
 class UpdateIssueQueryArgs(BaseModel):
@@ -271,6 +367,7 @@ class SearchErrorTrackingIssuesTool(MaxTool):
 
         # What this tool returns:
         A formatted list of matching issues with their name, status, occurrence count, and other key metrics.
+        If no issues are returned, call `get_error_tracking_setup_status` before explaining why the result is empty.
         If more results are available, a cursor will be provided for pagination.
         All timestamps are in UTC timezone.
         """).strip()
@@ -381,7 +478,10 @@ class SearchErrorTrackingIssuesTool(MaxTool):
         """Format query results as text output."""
 
         if not results:
-            return "No issues found matching your criteria."
+            return (
+                "No issues found matching your criteria. Call `get_error_tracking_setup_status` before explaining "
+                "whether exception capture is configured or working."
+            )
 
         total_count = len(results)
         if total_count == 1:

--- a/products/error_tracking/backend/presentation/views/settings.py
+++ b/products/error_tracking/backend/presentation/views/settings.py
@@ -1,11 +1,76 @@
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 
-from products.error_tracking.backend.facade import api as error_tracking_api
+from products.error_tracking.backend.facade import (
+    api as error_tracking_api,
+    setup as error_tracking_setup,
+)
+
+
+class ErrorTrackingObservedSDKSerializer(serializers.Serializer):
+    library = serializers.CharField(help_text="SDK library observed on recent project events.")
+    event_count = serializers.IntegerField(
+        min_value=0,
+        help_text="Number of recent events observed from this SDK library.",
+    )
+    autocapture_configuration = serializers.ChoiceField(
+        choices=["project_setting", "local", "unknown"],
+        help_text="Where exception autocapture is configured for this SDK.",
+    )
+    local_option = serializers.CharField(
+        allow_null=True,
+        help_text="SDK initialization option required for local exception autocapture, when known.",
+    )
+
+
+class ErrorTrackingSetupWarningSerializer(serializers.Serializer):
+    warning_code = serializers.ChoiceField(
+        source="code",
+        choices=["node_autocapture_requires_local_configuration"],
+        help_text="Stable identifier for the setup warning.",
+    )
+    message = serializers.CharField(help_text="Actionable explanation of the setup warning.")
+
+
+class ErrorTrackingSetupStatusSerializer(serializers.Serializer):
+    project_autocapture_enabled = serializers.BooleanField(
+        help_text="Whether exception autocapture is enabled in the current project settings.",
+    )
+    remote_config_autocapture_enabled = serializers.BooleanField(
+        allow_null=True,
+        help_text="Published exception autocapture value, or null when remote config is unavailable.",
+    )
+    has_issues = serializers.BooleanField(help_text="Whether the project has any grouped error tracking issues.")
+    recent_data_available = serializers.BooleanField(
+        help_text="Whether recent event ingestion data was available for this diagnostic.",
+    )
+    recent_period_days = serializers.IntegerField(
+        min_value=1,
+        help_text="Number of days covered by recent event and SDK observations.",
+    )
+    recent_event_count = serializers.IntegerField(
+        min_value=0,
+        allow_null=True,
+        help_text="Total events received during the recent period, or null when recent data is unavailable.",
+    )
+    recent_exception_count = serializers.IntegerField(
+        min_value=0,
+        allow_null=True,
+        help_text="Exception events received during the recent period, or null when recent data is unavailable.",
+    )
+    observed_sdks = ErrorTrackingObservedSDKSerializer(
+        many=True,
+        help_text="SDK libraries observed on events during the recent period.",
+    )
+    warnings = ErrorTrackingSetupWarningSerializer(
+        many=True,
+        help_text="Setup warnings supported by observed project data.",
+    )
 
 
 class ErrorTrackingSettingsSerializer(serializers.Serializer):
@@ -37,8 +102,14 @@ class ErrorTrackingSettingsSerializer(serializers.Serializer):
 
 class ErrorTrackingSettingsViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
     scope_object = "error_tracking"
-    scope_object_read_actions = ["retrieve_settings"]
+    scope_object_read_actions = ["retrieve_settings", "setup_status"]
     scope_object_write_actions = ["update_settings"]
+
+    @extend_schema(responses={200: ErrorTrackingSetupStatusSerializer})
+    @action(detail=False, methods=["get"], url_path="setup_status")
+    def setup_status(self, request: Request, *args: object, **kwargs: object) -> Response:
+        setup_status = error_tracking_setup.get_error_tracking_setup_status(self.team)
+        return Response(ErrorTrackingSetupStatusSerializer(setup_status).data)
 
     @extend_schema(responses={200: ErrorTrackingSettingsSerializer})
     @action(detail=False, methods=["get"])

--- a/products/error_tracking/backend/presentation/views/settings.py
+++ b/products/error_tracking/backend/presentation/views/settings.py
@@ -18,6 +18,13 @@ class ErrorTrackingObservedSDKSerializer(serializers.Serializer):
         min_value=0,
         help_text="Number of recent events observed from this SDK library.",
     )
+    latest_version = serializers.CharField(
+        allow_null=True,
+        help_text="SDK version on the most recent event from this library, or null when unavailable.",
+    )
+    last_seen_at = serializers.DateTimeField(
+        help_text="Timestamp of the most recent event observed from this SDK library.",
+    )
     autocapture_configuration = serializers.ChoiceField(
         choices=["project_setting", "local", "unknown"],
         help_text="Where exception autocapture is configured for this SDK.",
@@ -62,6 +69,14 @@ class ErrorTrackingSetupStatusSerializer(serializers.Serializer):
         min_value=0,
         allow_null=True,
         help_text="Exception events received during the recent period, or null when recent data is unavailable.",
+    )
+    last_event_at = serializers.DateTimeField(
+        allow_null=True,
+        help_text="Timestamp of the most recent event during the recent period, or null when none was received.",
+    )
+    last_exception_at = serializers.DateTimeField(
+        allow_null=True,
+        help_text="Timestamp of the most recent exception during the recent period, or null when none was received.",
     )
     observed_sdks = ErrorTrackingObservedSDKSerializer(
         many=True,

--- a/products/error_tracking/backend/test/test_setup_status.py
+++ b/products/error_tracking/backend/test/test_setup_status.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime, timedelta
+
 from posthog.test.base import ClickhouseTestMixin, NonAtomicBaseTest, _create_event, flush_persons_and_events
 
 from langchain_core.runnables import RunnableConfig
@@ -22,11 +24,13 @@ class TestGetErrorTrackingSetupStatusTool(ClickhouseTestMixin, NonAtomicBaseTest
             defaults={"config": {"autocaptureExceptions": True}},
         )
 
+        self.node_event_timestamp = (datetime.now(UTC) - timedelta(minutes=5)).replace(microsecond=0)
         _create_event(
             event="account_created",
             distinct_id="node-user",
             team=self.team,
             properties={"$lib": "posthog-node", "$lib_version": "5.48.1"},
+            timestamp=self.node_event_timestamp,
         )
         flush_persons_and_events()
 
@@ -55,10 +59,14 @@ class TestGetErrorTrackingSetupStatusTool(ClickhouseTestMixin, NonAtomicBaseTest
             "recent_period_days": 7,
             "recent_event_count": 1,
             "recent_exception_count": 0,
+            "last_event_at": self.node_event_timestamp.isoformat(),
+            "last_exception_at": None,
             "observed_sdks": [
                 {
                     "library": "posthog-node",
                     "event_count": 1,
+                    "latest_version": "5.48.1",
+                    "last_seen_at": self.node_event_timestamp.isoformat(),
                     "autocapture_configuration": "local",
                     "local_option": "enableExceptionAutocapture",
                 }
@@ -74,3 +82,41 @@ class TestGetErrorTrackingSetupStatusTool(ClickhouseTestMixin, NonAtomicBaseTest
                 }
             ],
         }
+
+    async def test_reports_latest_exception_transport_activity(self) -> None:
+        exception_timestamp = (datetime.now(UTC) - timedelta(minutes=1)).replace(microsecond=0)
+        _create_event(
+            event="$exception",
+            distinct_id="node-user",
+            team=self.team,
+            properties={"$lib": "posthog-node", "$lib_version": "5.49.0"},
+            timestamp=exception_timestamp,
+        )
+        flush_persons_and_events()
+
+        config = RunnableConfig()
+        tool = await GetErrorTrackingSetupStatusTool.create_tool_class(
+            team=self.team,
+            user=self.user,
+            state=AssistantState(messages=[]),
+            config=config,
+            context_manager=AssistantContextManager(team=self.team, user=self.user, config=config),
+        )
+
+        content, artifact = await tool._arun_impl()
+
+        assert f"Last event received: {exception_timestamp.isoformat()}" in content
+        assert f"Last exception received: {exception_timestamp.isoformat()}" in content
+        assert artifact["last_event_at"] == exception_timestamp.isoformat()
+        assert artifact["last_exception_at"] == exception_timestamp.isoformat()
+        assert artifact["observed_sdks"] == [
+            {
+                "library": "posthog-node",
+                "event_count": 2,
+                "latest_version": "5.49.0",
+                "last_seen_at": exception_timestamp.isoformat(),
+                "autocapture_configuration": "local",
+                "local_option": "enableExceptionAutocapture",
+            }
+        ]
+        assert artifact["warnings"] == []

--- a/products/error_tracking/backend/test/test_setup_status.py
+++ b/products/error_tracking/backend/test/test_setup_status.py
@@ -1,0 +1,76 @@
+from posthog.test.base import ClickhouseTestMixin, NonAtomicBaseTest, _create_event, flush_persons_and_events
+
+from langchain_core.runnables import RunnableConfig
+
+from posthog.models import RemoteConfig, Team
+
+from products.error_tracking.backend.max_tools import GetErrorTrackingSetupStatusTool
+
+from ee.hogai.context.context import AssistantContextManager
+from ee.hogai.utils.types import AssistantState
+
+
+class TestGetErrorTrackingSetupStatusTool(ClickhouseTestMixin, NonAtomicBaseTest):
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.team.autocapture_exceptions_opt_in = True
+        Team.objects.filter(id=self.team.id).update(autocapture_exceptions_opt_in=True)
+        RemoteConfig.objects.update_or_create(
+            team=self.team,
+            defaults={"config": {"autocaptureExceptions": True}},
+        )
+
+        _create_event(
+            event="account_created",
+            distinct_id="node-user",
+            team=self.team,
+            properties={"$lib": "posthog-node", "$lib_version": "5.48.1"},
+        )
+        flush_persons_and_events()
+
+    async def test_warns_when_node_sdk_needs_local_exception_autocapture(self) -> None:
+        config = RunnableConfig()
+        tool = await GetErrorTrackingSetupStatusTool.create_tool_class(
+            team=self.team,
+            user=self.user,
+            state=AssistantState(messages=[]),
+            config=config,
+            context_manager=AssistantContextManager(team=self.team, user=self.user, config=config),
+        )
+
+        content, artifact = await tool._arun_impl()
+
+        assert "Project exception autocapture setting: enabled" in content
+        assert "Published remote config: enabled" in content
+        assert "No exception events were received in the last 7 days" in content
+        assert "posthog-node requires `enableExceptionAutocapture: true`" in content
+        assert "PostHog cannot verify this local SDK option" in content
+        assert artifact == {
+            "project_autocapture_enabled": True,
+            "remote_config_autocapture_enabled": True,
+            "has_issues": False,
+            "recent_data_available": True,
+            "recent_period_days": 7,
+            "recent_event_count": 1,
+            "recent_exception_count": 0,
+            "observed_sdks": [
+                {
+                    "library": "posthog-node",
+                    "event_count": 1,
+                    "autocapture_configuration": "local",
+                    "local_option": "enableExceptionAutocapture",
+                }
+            ],
+            "warnings": [
+                {
+                    "code": "node_autocapture_requires_local_configuration",
+                    "message": (
+                        "posthog-node requires `enableExceptionAutocapture: true` in the SDK initialization. "
+                        "The project setting does not enable exception autocapture for posthog-node. "
+                        "PostHog cannot verify this local SDK option from event data."
+                    ),
+                }
+            ],
+        }

--- a/products/error_tracking/backend/tests/api/test_settings.py
+++ b/products/error_tracking/backend/tests/api/test_settings.py
@@ -1,4 +1,5 @@
 from posthog.test.base import APIBaseTest
+from unittest.mock import patch
 
 from parameterized import parameterized
 from rest_framework import status
@@ -6,6 +7,7 @@ from rest_framework import status
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.utils import generate_random_token_personal, hash_key_value
 
+from products.error_tracking.backend.facade import contracts
 from products.error_tracking.backend.models import ErrorTrackingSettings
 
 
@@ -88,6 +90,57 @@ class TestErrorTrackingSettingsAPI(APIBaseTest):
             HTTP_AUTHORIZATION=f"Bearer {value}",
         )
         self.assertEqual(response.status_code, expected_status)
+
+    @parameterized.expand(
+        [
+            ("read_scope", ["error_tracking:read"], status.HTTP_200_OK),
+            ("write_scope_satisfies_read", ["error_tracking:write"], status.HTTP_200_OK),
+            ("wrong_scope", ["insight:read"], status.HTTP_403_FORBIDDEN),
+        ]
+    )
+    def test_setup_status_personal_api_key_scopes(self, _name, scopes, expected_status):
+        setup_status = contracts.ErrorTrackingSetupStatus(
+            project_autocapture_enabled=True,
+            remote_config_autocapture_enabled=True,
+            has_issues=False,
+            recent_data_available=True,
+            recent_period_days=7,
+            recent_event_count=12,
+            recent_exception_count=0,
+            observed_sdks=[
+                contracts.ErrorTrackingObservedSDK(
+                    library="posthog-node",
+                    event_count=12,
+                    autocapture_configuration="local",
+                    local_option="enableExceptionAutocapture",
+                )
+            ],
+            warnings=[
+                contracts.ErrorTrackingSetupWarning(
+                    code="node_autocapture_requires_local_configuration",
+                    message="Configure exception autocapture in the Node SDK initialization.",
+                )
+            ],
+        )
+        value = self._personal_api_key(scopes)
+        self.client.logout()
+
+        with patch(
+            "products.error_tracking.backend.presentation.views.settings.error_tracking_setup.get_error_tracking_setup_status",
+            return_value=setup_status,
+        ):
+            response = self.client.get(
+                f"{self._base_url()}/setup_status/",
+                HTTP_AUTHORIZATION=f"Bearer {value}",
+            )
+
+        self.assertEqual(response.status_code, expected_status)
+        if expected_status == status.HTTP_200_OK:
+            self.assertEqual(response.json()["recent_exception_count"], 0)
+            self.assertEqual(
+                response.json()["warnings"][0]["warning_code"],
+                "node_autocapture_requires_local_configuration",
+            )
 
     @parameterized.expand(
         [

--- a/products/error_tracking/backend/tests/api/test_settings.py
+++ b/products/error_tracking/backend/tests/api/test_settings.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime
+
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
@@ -107,10 +109,14 @@ class TestErrorTrackingSettingsAPI(APIBaseTest):
             recent_period_days=7,
             recent_event_count=12,
             recent_exception_count=0,
+            last_event_at=datetime(2026, 8, 14, 12, 0, tzinfo=UTC),
+            last_exception_at=None,
             observed_sdks=[
                 contracts.ErrorTrackingObservedSDK(
                     library="posthog-node",
                     event_count=12,
+                    latest_version="5.49.0",
+                    last_seen_at=datetime(2026, 8, 14, 12, 0, tzinfo=UTC),
                     autocapture_configuration="local",
                     local_option="enableExceptionAutocapture",
                 )
@@ -137,6 +143,8 @@ class TestErrorTrackingSettingsAPI(APIBaseTest):
         self.assertEqual(response.status_code, expected_status)
         if expected_status == status.HTTP_200_OK:
             self.assertEqual(response.json()["recent_exception_count"], 0)
+            self.assertEqual(response.json()["last_event_at"], "2026-08-14T12:00:00Z")
+            self.assertEqual(response.json()["observed_sdks"][0]["latest_version"], "5.49.0")
             self.assertEqual(
                 response.json()["warnings"][0]["warning_code"],
                 "node_autocapture_requires_local_configuration",

--- a/products/error_tracking/frontend/generated/api.schemas.ts
+++ b/products/error_tracking/frontend/generated/api.schemas.ts
@@ -1521,6 +1521,13 @@ export interface ErrorTrackingObservedSDKApi {
      * @minimum 0
      */
     event_count: number
+    /**
+     * SDK version on the most recent event from this library, or null when unavailable.
+     * @nullable
+     */
+    latest_version: string | null
+    /** Timestamp of the most recent event observed from this SDK library. */
+    last_seen_at: string
     /** Where exception autocapture is configured for this SDK.
      *
      * * `project_setting` - project_setting
@@ -1581,6 +1588,16 @@ export interface ErrorTrackingSetupStatusApi {
      * @nullable
      */
     recent_exception_count: number | null
+    /**
+     * Timestamp of the most recent event during the recent period, or null when none was received.
+     * @nullable
+     */
+    last_event_at: string | null
+    /**
+     * Timestamp of the most recent exception during the recent period, or null when none was received.
+     * @nullable
+     */
+    last_exception_at: string | null
     /** SDK libraries observed on events during the recent period. */
     observed_sdks: ErrorTrackingObservedSDKApi[]
     /** Setup warnings supported by observed project data. */

--- a/products/error_tracking/frontend/generated/api.schemas.ts
+++ b/products/error_tracking/frontend/generated/api.schemas.ts
@@ -1499,6 +1499,94 @@ export interface ErrorTrackingSettingsApi {
     per_issue_rate_limit_bucket_size_minutes?: number | null
 }
 
+/**
+ * * `project_setting` - project_setting
+ * * `local` - local
+ * * `unknown` - unknown
+ */
+export type AutocaptureConfigurationEnumApi =
+    (typeof AutocaptureConfigurationEnumApi)[keyof typeof AutocaptureConfigurationEnumApi]
+
+export const AutocaptureConfigurationEnumApi = {
+    ProjectSetting: 'project_setting',
+    Local: 'local',
+    Unknown: 'unknown',
+} as const
+
+export interface ErrorTrackingObservedSDKApi {
+    /** SDK library observed on recent project events. */
+    library: string
+    /**
+     * Number of recent events observed from this SDK library.
+     * @minimum 0
+     */
+    event_count: number
+    /** Where exception autocapture is configured for this SDK.
+     *
+     * * `project_setting` - project_setting
+     * * `local` - local
+     * * `unknown` - unknown */
+    autocapture_configuration: AutocaptureConfigurationEnumApi
+    /**
+     * SDK initialization option required for local exception autocapture, when known.
+     * @nullable
+     */
+    local_option: string | null
+}
+
+/**
+ * * `node_autocapture_requires_local_configuration` - node_autocapture_requires_local_configuration
+ */
+export type WarningCodeEnumApi = (typeof WarningCodeEnumApi)[keyof typeof WarningCodeEnumApi]
+
+export const WarningCodeEnumApi = {
+    NodeAutocaptureRequiresLocalConfiguration: 'node_autocapture_requires_local_configuration',
+} as const
+
+export interface ErrorTrackingSetupWarningApi {
+    /** Stable identifier for the setup warning.
+     *
+     * * `node_autocapture_requires_local_configuration` - node_autocapture_requires_local_configuration */
+    warning_code: WarningCodeEnumApi
+    /** Actionable explanation of the setup warning. */
+    message: string
+}
+
+export interface ErrorTrackingSetupStatusApi {
+    /** Whether exception autocapture is enabled in the current project settings. */
+    project_autocapture_enabled: boolean
+    /**
+     * Published exception autocapture value, or null when remote config is unavailable.
+     * @nullable
+     */
+    remote_config_autocapture_enabled: boolean | null
+    /** Whether the project has any grouped error tracking issues. */
+    has_issues: boolean
+    /** Whether recent event ingestion data was available for this diagnostic. */
+    recent_data_available: boolean
+    /**
+     * Number of days covered by recent event and SDK observations.
+     * @minimum 1
+     */
+    recent_period_days: number
+    /**
+     * Total events received during the recent period, or null when recent data is unavailable.
+     * @minimum 0
+     * @nullable
+     */
+    recent_event_count: number | null
+    /**
+     * Exception events received during the recent period, or null when recent data is unavailable.
+     * @minimum 0
+     * @nullable
+     */
+    recent_exception_count: number | null
+    /** SDK libraries observed on events during the recent period. */
+    observed_sdks: ErrorTrackingObservedSDKApi[]
+    /** Setup warnings supported by observed project data. */
+    warnings: ErrorTrackingSetupWarningApi[]
+}
+
 export interface PatchedErrorTrackingSettingsApi {
     /**
      * Maximum number of exception events ingested per bucket for the entire project. Null removes the limit.

--- a/products/error_tracking/frontend/generated/api.ts
+++ b/products/error_tracking/frontend/generated/api.ts
@@ -48,6 +48,7 @@ import type {
     ErrorTrackingReleaseUpdateRequestApi,
     ErrorTrackingReleasesListParams,
     ErrorTrackingSettingsApi,
+    ErrorTrackingSetupStatusApi,
     ErrorTrackingSpikeDetectionConfigApi,
     ErrorTrackingSpikeEventsListParams,
     ErrorTrackingStackFrameApi,
@@ -1242,6 +1243,20 @@ export const errorTrackingSettingsRetrieveSettingsRetrieve = async (
     options?: RequestInit
 ): Promise<ErrorTrackingSettingsApi> => {
     return apiMutator<ErrorTrackingSettingsApi>(getErrorTrackingSettingsRetrieveSettingsRetrieveUrl(projectId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getErrorTrackingSettingsSetupStatusRetrieveUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/error_tracking/settings/setup_status/`
+}
+
+export const errorTrackingSettingsSetupStatusRetrieve = async (
+    projectId: string,
+    options?: RequestInit
+): Promise<ErrorTrackingSetupStatusApi> => {
+    return apiMutator<ErrorTrackingSetupStatusApi>(getErrorTrackingSettingsSetupStatusRetrieveUrl(projectId), {
         ...options,
         method: 'GET',
     })

--- a/products/error_tracking/mcp/tools.yaml
+++ b/products/error_tracking/mcp/tools.yaml
@@ -417,7 +417,7 @@ tools:
         description: >
             Check whether the current project is configured for error tracking and receiving exception events. Returns
             the project autocapture setting, published remote config, grouped issue existence, recent event and
-            exception counts, observed SDKs, and actionable warnings. Local SDK initialization cannot be observed
+            exception activity, observed SDK versions, and actionable warnings. Local SDK initialization cannot be observed
             directly, so use warnings and observed event data without claiming that a local option is enabled or
             disabled.
     error-tracking-spike-detection-config-list:

--- a/products/error_tracking/mcp/tools.yaml
+++ b/products/error_tracking/mcp/tools.yaml
@@ -404,6 +404,22 @@ tools:
             `*_rate_limit_value` to null to remove that limit. WARNING: exception events above a rate limit are dropped
             at ingestion and cannot be recovered. Lowering a limit silently discards volume — confirm the threshold with
             the user before reducing it.
+    error-tracking-setup-status:
+        operation: error_tracking_settings_setup_status_retrieve
+        enabled: true
+        scopes:
+            - error_tracking:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Diagnose error tracking setup
+        description: >
+            Check whether the current project is configured for error tracking and receiving exception events. Returns
+            the project autocapture setting, published remote config, grouped issue existence, recent event and
+            exception counts, observed SDKs, and actionable warnings. Local SDK initialization cannot be observed
+            directly, so use warnings and observed event data without claiming that a local option is enabled or
+            disabled.
     error-tracking-spike-detection-config-list:
         operation: error_tracking_spike_detection_config_list
         enabled: false

--- a/products/error_tracking/mcp/tools.yaml
+++ b/products/error_tracking/mcp/tools.yaml
@@ -417,9 +417,9 @@ tools:
         description: >
             Check whether the current project is configured for error tracking and receiving exception events. Returns
             the project autocapture setting, published remote config, grouped issue existence, recent event and
-            exception activity, observed SDK versions, and actionable warnings. Local SDK initialization cannot be observed
-            directly, so use warnings and observed event data without claiming that a local option is enabled or
-            disabled.
+            exception activity, observed SDK versions, and actionable warnings. Local SDK initialization cannot be
+            observed directly, so use warnings and observed event data without claiming that a local option is enabled
+            or disabled.
     error-tracking-spike-detection-config-list:
         operation: error_tracking_spike_detection_config_list
         enabled: false

--- a/products/error_tracking/skills/diagnosing-error-tracking-setup/SKILL.md
+++ b/products/error_tracking/skills/diagnosing-error-tracking-setup/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: diagnosing-error-tracking-setup
+description: >
+  Diagnoses whether PostHog Error Tracking is configured and receiving exceptions. Use when issue searches are empty,
+  a user asks whether error tracking is working, exception capture appears inactive, or an SDK sends events but no
+  errors. Distinguishes observable project and ingestion state from local SDK options that PostHog cannot inspect.
+---
+
+# Diagnosing error tracking setup
+
+An empty issue list does not prove that error tracking is disabled or broken. Check configuration and ingestion before explaining the result.
+
+## Tools
+
+| Tool | Purpose |
+| --- | --- |
+| `posthog:error-tracking-setup-status` | Read project configuration, recent ingestion, observed SDKs, and setup warnings |
+| `posthog:query-error-tracking-issues-list` | Confirm whether recent exception events produced grouped issues |
+| `posthog:error-tracking-recommendations-list` | Find improvements after exception ingestion is working |
+
+## Workflow
+
+### 1. Check observable setup state
+
+Call `posthog:error-tracking-setup-status` first.
+
+Treat each field as a separate signal:
+
+- `project_autocapture_enabled` is the project setting.
+- `remote_config_autocapture_enabled` is the published remote value. `null` means it could not be checked.
+- `recent_event_count` shows whether the project received any events during `recent_period_days`.
+- `recent_exception_count` shows whether those events included `$exception`.
+- `observed_sdks` identifies SDK libraries seen on recent events.
+- `has_issues` shows whether the project has grouped issues, including historical issues.
+- `warnings` contains supported conclusions and next actions, identified by `warning_code`.
+
+If `recent_data_available` is false, say that ingestion could not be checked. Do not infer that the project received no events.
+
+### 2. Classify the result
+
+| Evidence | Interpretation |
+| --- | --- |
+| No recent events | PostHog has no recent event evidence for this project. Check the SDK connection before error tracking configuration. |
+| Events present, no exceptions | The SDK sends events, but PostHog has not received exception events during the period. Follow SDK-specific warnings. |
+| Exceptions present, no issues | Exception ingestion works, but grouping may still be processing. Retry the issue query before calling setup broken. |
+| Historical issues, no recent exceptions | Error tracking worked previously. The result does not prove whether the current application still captures exceptions. |
+| Exceptions and issues present | Initial setup works. Continue with issue triage or setup recommendations. |
+
+A difference between the project setting and published remote config is worth reporting, but neither value proves what a local SDK initialized.
+
+### 3. Handle local SDK configuration accurately
+
+For `posthog-node`, exception autocapture requires a local initialization option:
+
+```ts
+new PostHog(apiKey, {
+    enableExceptionAutocapture: true,
+})
+```
+
+PostHog can observe Node events, but it cannot inspect this local option. Say that the option is required and unverified. Never claim it is disabled solely because no exceptions arrived.
+
+For SDKs whose `autocapture_configuration` is `unknown`, identify the observed SDK and ask the user to verify its current error tracking setup instructions.
+
+### 4. Continue after ingestion works
+
+When exceptions are present:
+
+- Use `posthog:query-error-tracking-issues-list` for recent or high-impact issues.
+- Use `posthog:error-tracking-recommendations-list` for alerts, rate limits, source maps, and long-running issues.
+- Load `diagnosing-stacktrace-symbolication` when captured stack traces remain minified or obfuscated.
+- Load `triaging-error-issues` when the user wants a prioritized review.
+- Load `investigating-error-issue` when the user provides one issue.
+
+## Response shape
+
+State what PostHog observed, what remains unknown, and the next check. Keep the distinction explicit:
+
+- Observed: project settings, published config, recent events, recent exceptions, issues, and SDK identifiers.
+- Not observable: local SDK initialization, application exception paths, and whether an untriggered error handler would work.

--- a/products/error_tracking/skills/diagnosing-error-tracking-setup/SKILL.md
+++ b/products/error_tracking/skills/diagnosing-error-tracking-setup/SKILL.md
@@ -30,7 +30,8 @@ Treat each field as a separate signal:
 - `remote_config_autocapture_enabled` is the published remote value. `null` means it could not be checked.
 - `recent_event_count` shows whether the project received any events during `recent_period_days`.
 - `recent_exception_count` shows whether those events included `$exception`.
-- `observed_sdks` identifies SDK libraries seen on recent events.
+- `last_event_at` and `last_exception_at` show the latest observed transport activity within that period.
+- `observed_sdks` identifies SDK libraries, their latest observed versions, and their latest event timestamps.
 - `has_issues` shows whether the project has grouped issues, including historical issues.
 - `warnings` contains supported conclusions and next actions, identified by `warning_code`.
 

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -3023,7 +3023,7 @@
         }
     },
     "error-tracking-setup-status": {
-        "description": "Check whether the current project is configured for error tracking and receiving exception events. Returns the project autocapture setting, published remote config, grouped issue existence, recent event and exception counts, observed SDKs, and actionable warnings. Local SDK initialization cannot be observed directly, so use warnings and observed event data without claiming that a local option is enabled or disabled.",
+        "description": "Check whether the current project is configured for error tracking and receiving exception events. Returns the project autocapture setting, published remote config, grouped issue existence, recent event and exception activity, observed SDK versions, and actionable warnings. Local SDK initialization cannot be observed directly, so use warnings and observed event data without claiming that a local option is enabled or disabled.",
         "category": "Error tracking",
         "feature": "error_tracking",
         "summary": "Diagnose error tracking setup",

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -3022,6 +3022,20 @@
             "readOnlyHint": false
         }
     },
+    "error-tracking-setup-status": {
+        "description": "Check whether the current project is configured for error tracking and receiving exception events. Returns the project autocapture setting, published remote config, grouped issue existence, recent event and exception counts, observed SDKs, and actionable warnings. Local SDK initialization cannot be observed directly, so use warnings and observed event data without claiming that a local option is enabled or disabled.",
+        "category": "Error tracking",
+        "feature": "error_tracking",
+        "summary": "Diagnose error tracking setup",
+        "title": "Diagnose error tracking setup",
+        "required_scopes": ["error_tracking:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "error-tracking-suppression-rules-create": {
         "description": "Create an error tracking suppression rule for the current project. WARNING: matching errors are suppressed indefinitely — dropped at ingestion and will not appear as issues until the rule is disabled or deleted. Scope `filters` tightly to the exact exception type, message, URL, or properties you want gone. Do NOT create match-all rules (omitting `filters`) or broad rules — they silently swallow unrelated errors and cause data loss that is hard to detect after the fact. If unsure, set `sampling_rate` below `1.0` so only a fraction of matches are dropped (e.g. `0.5` drops half) rather than all of them. Confirm with the user before creating any rule that could match more than one distinct error.",
         "category": "Error tracking",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -3051,6 +3051,20 @@
             "readOnlyHint": false
         }
     },
+    "error-tracking-setup-status": {
+        "description": "Check whether the current project is configured for error tracking and receiving exception events. Returns the project autocapture setting, published remote config, grouped issue existence, recent event and exception counts, observed SDKs, and actionable warnings. Local SDK initialization cannot be observed directly, so use warnings and observed event data without claiming that a local option is enabled or disabled.",
+        "category": "Error tracking",
+        "feature": "error_tracking",
+        "summary": "Diagnose error tracking setup",
+        "title": "Diagnose error tracking setup",
+        "required_scopes": ["error_tracking:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "error-tracking-suppression-rules-create": {
         "description": "Create an error tracking suppression rule for the current project. WARNING: matching errors are suppressed indefinitely — dropped at ingestion and will not appear as issues until the rule is disabled or deleted. Scope `filters` tightly to the exact exception type, message, URL, or properties you want gone. Do NOT create match-all rules (omitting `filters`) or broad rules — they silently swallow unrelated errors and cause data loss that is hard to detect after the fact. If unsure, set `sampling_rate` below `1.0` so only a fraction of matches are dropped (e.g. `0.5` drops half) rather than all of them. Confirm with the user before creating any rule that could match more than one distinct error.",
         "category": "Error tracking",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -3052,7 +3052,7 @@
         }
     },
     "error-tracking-setup-status": {
-        "description": "Check whether the current project is configured for error tracking and receiving exception events. Returns the project autocapture setting, published remote config, grouped issue existence, recent event and exception counts, observed SDKs, and actionable warnings. Local SDK initialization cannot be observed directly, so use warnings and observed event data without claiming that a local option is enabled or disabled.",
+        "description": "Check whether the current project is configured for error tracking and receiving exception events. Returns the project autocapture setting, published remote config, grouped issue existence, recent event and exception activity, observed SDK versions, and actionable warnings. Local SDK initialization cannot be observed directly, so use warnings and observed event data without claiming that a local option is enabled or disabled.",
         "category": "Error tracking",
         "feature": "error_tracking",
         "summary": "Diagnose error tracking setup",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -9537,6 +9537,20 @@ export namespace Schemas {
       is_bot: boolean;
     }
 
+    /**
+     * * `project_setting` - project_setting
+     * * `local` - local
+     * * `unknown` - unknown
+     */
+    export type AutocaptureConfigurationEnum = typeof AutocaptureConfigurationEnum[keyof typeof AutocaptureConfigurationEnum];
+
+
+    export const AutocaptureConfigurationEnum = {
+      ProjectSetting: 'project_setting',
+      Local: 'local',
+      Unknown: 'unknown',
+    } as const;
+
     export type AutocompleteCompletionItemKind = typeof AutocompleteCompletionItemKind[keyof typeof AutocompleteCompletionItemKind];
 
 
@@ -25829,6 +25843,27 @@ export namespace Schemas {
       config?: ErrorTrackingListWidgetConfig;
     }
 
+    export interface ErrorTrackingObservedSDK {
+      /** SDK library observed on recent project events. */
+      library: string;
+      /**
+         * Number of recent events observed from this SDK library.
+         * @minimum 0
+         */
+      event_count: number;
+      /** Where exception autocapture is configured for this SDK.
+       *
+       * * `project_setting` - project_setting
+       * * `local` - local
+       * * `unknown` - unknown */
+      autocapture_configuration: AutocaptureConfigurationEnum;
+      /**
+         * SDK initialization option required for local exception autocapture, when known.
+         * @nullable
+         */
+      local_option: string | null;
+    }
+
     export interface ErrorTrackingRecommendation {
       /** Recommendation UUID. */
       id: string;
@@ -25951,6 +25986,60 @@ export namespace Schemas {
          * @nullable
          */
       per_issue_rate_limit_bucket_size_minutes?: number | null;
+    }
+
+    /**
+     * * `node_autocapture_requires_local_configuration` - node_autocapture_requires_local_configuration
+     */
+    export type WarningCodeEnum = typeof WarningCodeEnum[keyof typeof WarningCodeEnum];
+
+
+    export const WarningCodeEnum = {
+      NodeAutocaptureRequiresLocalConfiguration: 'node_autocapture_requires_local_configuration',
+    } as const;
+
+    export interface ErrorTrackingSetupWarning {
+      /** Stable identifier for the setup warning.
+       *
+       * * `node_autocapture_requires_local_configuration` - node_autocapture_requires_local_configuration */
+      warning_code: WarningCodeEnum;
+      /** Actionable explanation of the setup warning. */
+      message: string;
+    }
+
+    export interface ErrorTrackingSetupStatus {
+      /** Whether exception autocapture is enabled in the current project settings. */
+      project_autocapture_enabled: boolean;
+      /**
+         * Published exception autocapture value, or null when remote config is unavailable.
+         * @nullable
+         */
+      remote_config_autocapture_enabled: boolean | null;
+      /** Whether the project has any grouped error tracking issues. */
+      has_issues: boolean;
+      /** Whether recent event ingestion data was available for this diagnostic. */
+      recent_data_available: boolean;
+      /**
+         * Number of days covered by recent event and SDK observations.
+         * @minimum 1
+         */
+      recent_period_days: number;
+      /**
+         * Total events received during the recent period, or null when recent data is unavailable.
+         * @minimum 0
+         * @nullable
+         */
+      recent_event_count: number | null;
+      /**
+         * Exception events received during the recent period, or null when recent data is unavailable.
+         * @minimum 0
+         * @nullable
+         */
+      recent_exception_count: number | null;
+      /** SDK libraries observed on events during the recent period. */
+      observed_sdks: ErrorTrackingObservedSDK[];
+      /** Setup warnings supported by observed project data. */
+      warnings: ErrorTrackingSetupWarning[];
     }
 
     export interface ErrorTrackingSignalExtra {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -25851,6 +25851,13 @@ export namespace Schemas {
          * @minimum 0
          */
       event_count: number;
+      /**
+         * SDK version on the most recent event from this library, or null when unavailable.
+         * @nullable
+         */
+      latest_version: string | null;
+      /** Timestamp of the most recent event observed from this SDK library. */
+      last_seen_at: string;
       /** Where exception autocapture is configured for this SDK.
        *
        * * `project_setting` - project_setting
@@ -26036,6 +26043,16 @@ export namespace Schemas {
          * @nullable
          */
       recent_exception_count: number | null;
+      /**
+         * Timestamp of the most recent event during the recent period, or null when none was received.
+         * @nullable
+         */
+      last_event_at: string | null;
+      /**
+         * Timestamp of the most recent exception during the recent period, or null when none was received.
+         * @nullable
+         */
+      last_exception_at: string | null;
       /** SDK libraries observed on events during the recent period. */
       observed_sdks: ErrorTrackingObservedSDK[];
       /** Setup warnings supported by observed project data. */

--- a/services/mcp/src/generated/error_tracking/api.ts
+++ b/services/mcp/src/generated/error_tracking/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 24 enabled ops
+ * PostHog API - MCP 25 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -6744,6 +6744,14 @@ export const ErrorTrackingRecommendationsListQueryParams = /* @__PURE__ */ zod.o
 })
 
 export const ErrorTrackingSettingsRetrieveSettingsRetrieveParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const ErrorTrackingSettingsSetupStatusRetrieveParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()
         .describe(

--- a/services/mcp/src/tools/generated/error_tracking.ts
+++ b/services/mcp/src/tools/generated/error_tracking.ts
@@ -376,6 +376,25 @@ const errorTrackingSettingsGet = (): ToolBase<
     },
 })
 
+const ErrorTrackingSetupStatusSchema = z.object({})
+
+const errorTrackingSetupStatus = (): ToolBase<
+    typeof ErrorTrackingSetupStatusSchema,
+    Schemas.ErrorTrackingSetupStatus
+> => ({
+    name: 'error-tracking-setup-status',
+    schema: ErrorTrackingSetupStatusSchema,
+    // eslint-disable-next-line no-unused-vars
+    handler: async (context: Context, params: z.infer<typeof ErrorTrackingSetupStatusSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.ErrorTrackingSetupStatus>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/error_tracking/settings/setup_status/`,
+        })
+        return result
+    },
+})
+
 const ErrorTrackingSettingsUpdateSchema = ErrorTrackingSettingsUpdateSettingsPartialUpdateBody
 
 const errorTrackingSettingsUpdate = (): ToolBase<
@@ -776,6 +795,7 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'error-tracking-issues-split-create': errorTrackingIssuesSplitCreate,
     'error-tracking-recommendations-list': errorTrackingRecommendationsList,
     'error-tracking-settings-get': errorTrackingSettingsGet,
+    'error-tracking-setup-status': errorTrackingSetupStatus,
     'error-tracking-settings-update': errorTrackingSettingsUpdate,
     'error-tracking-suppression-rules-create': errorTrackingSuppressionRulesCreate,
     'error-tracking-suppression-rules-list': errorTrackingSuppressionRulesList,

--- a/services/mcp/src/tools/generated/error_tracking.ts
+++ b/services/mcp/src/tools/generated/error_tracking.ts
@@ -376,25 +376,6 @@ const errorTrackingSettingsGet = (): ToolBase<
     },
 })
 
-const ErrorTrackingSetupStatusSchema = z.object({})
-
-const errorTrackingSetupStatus = (): ToolBase<
-    typeof ErrorTrackingSetupStatusSchema,
-    Schemas.ErrorTrackingSetupStatus
-> => ({
-    name: 'error-tracking-setup-status',
-    schema: ErrorTrackingSetupStatusSchema,
-    // eslint-disable-next-line no-unused-vars
-    handler: async (context: Context, params: z.infer<typeof ErrorTrackingSetupStatusSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const result = await context.api.request<Schemas.ErrorTrackingSetupStatus>({
-            method: 'GET',
-            path: `/api/projects/${encodeURIComponent(String(projectId))}/error_tracking/settings/setup_status/`,
-        })
-        return result
-    },
-})
-
 const ErrorTrackingSettingsUpdateSchema = ErrorTrackingSettingsUpdateSettingsPartialUpdateBody
 
 const errorTrackingSettingsUpdate = (): ToolBase<
@@ -422,6 +403,25 @@ const errorTrackingSettingsUpdate = (): ToolBase<
             method: 'PATCH',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/error_tracking/settings/update_settings/`,
             body,
+        })
+        return result
+    },
+})
+
+const ErrorTrackingSetupStatusSchema = z.object({})
+
+const errorTrackingSetupStatus = (): ToolBase<
+    typeof ErrorTrackingSetupStatusSchema,
+    Schemas.ErrorTrackingSetupStatus
+> => ({
+    name: 'error-tracking-setup-status',
+    schema: ErrorTrackingSetupStatusSchema,
+    // eslint-disable-next-line no-unused-vars
+    handler: async (context: Context, params: z.infer<typeof ErrorTrackingSetupStatusSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.ErrorTrackingSetupStatus>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/error_tracking/settings/setup_status/`,
         })
         return result
     },
@@ -795,8 +795,8 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'error-tracking-issues-split-create': errorTrackingIssuesSplitCreate,
     'error-tracking-recommendations-list': errorTrackingRecommendationsList,
     'error-tracking-settings-get': errorTrackingSettingsGet,
-    'error-tracking-setup-status': errorTrackingSetupStatus,
     'error-tracking-settings-update': errorTrackingSettingsUpdate,
+    'error-tracking-setup-status': errorTrackingSetupStatus,
     'error-tracking-suppression-rules-create': errorTrackingSuppressionRulesCreate,
     'error-tracking-suppression-rules-list': errorTrackingSuppressionRulesList,
     'error-tracking-suppression-rules-update': errorTrackingSuppressionRulesUpdate,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-setup-status.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-setup-status.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {},
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

Agents can treat an empty error tracking search as evidence that a project has no errors, even when exception capture is not configured.

Issue results do not expose project settings, published remote config, recent exception ingestion, or SDK-specific requirements.

## Changes

**Before**

```mermaid
flowchart LR
    A[Error tracking question] --> B{{Agent}}
    B --> C[Issue search]
    C --> D[Empty result answer]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class B phBlue;
    class A,D phYellow;
    class C phGray;
```

**After**

```mermaid
flowchart LR
    A[Error tracking question] --> B{{Agent}}
    B --> C[Issue search]
    C -->|No issues| D[Setup status]
    D --> E[Shared diagnostics]
    E --> F[Evidence-based answer]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class B phBlue;
    class A,F phYellow;
    class C,D phRed;
    class E phGray;
```

- Max now checks setup after an empty issue search before explaining why no issues appeared.
- A shared facade and read-only MCP tool report configuration, recent activity timestamps, observed SDK versions, and structured warnings.
- A setup diagnosis skill composes the status tool with recommendations, issue triage, and symbolication workflows.
- Node projects without exceptions receive local `enableExceptionAutocapture` guidance without claiming PostHog can inspect local initialization.
- No screenshot included. The frontend change adds activity text for the Max tool call rather than a new product screen.

## How did you test this code?

- `hogli test products/error_tracking/backend/test/test_setup_status.py products/error_tracking/backend/test/test_search_issues.py --no-cov`
- `hogli test products/error_tracking/backend/tests/api/test_settings.py --no-cov`
- `hogli build:openapi`, `hogli lint:skills`, and `hogli build:skills`
- `uv run mypy --cache-fine-grained .`
- Frontend and MCP type checks, MCP lint, and MCP tool-name validation
- Not run: browser QA for a live Max tool invocation.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Added the `diagnosing-error-tracking-setup` product skill. No public documentation change is required.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Pi implemented the change in a separate Jujutsu workspace and assigned the human DRI.
- Skills invoked: `/error-tracking`, `/implementing-agent-modes`, `/implementing-mcp-tools`, `/improving-drf-endpoints`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-skills`, `/running-ci-preflight`, `/writing-pr-descriptions`, and `/pr`.
- I kept diagnostics in the product facade instead of calling PostHog's MCP server from Max.
- Max and MCP use thin adapters over the same diagnostic logic. The setup skill routes deeper problems to focused existing skills.
- `hogli ci:preflight` could not inspect the Jujutsu workspace because it has no local `.git` directory. I ran the applicable checks directly.

