### PR TITLE
perf(notebooks): share one HogQL context across a frame's print passes

### DIFF
--- a/products/notebooks/backend/temporal/frame_materialize.py
+++ b/products/notebooks/backend/temporal/frame_materialize.py
@@ -424,6 +424,11 @@ def _generate_sql(
     if output_format:
         executor.context.output_format = output_format
     started = time.perf_counter()
+    # A placeholder is named `hogql_val_{len(values)}`, and the executor shares this dict by
+    # reference rather than resetting it. Carrying a previous pass's entries would number this
+    # pass's placeholders from where that one stopped and ship its dead values to ClickHouse, so
+    # each pass prints against an empty dict and keeps the numbering a single pass would produce.
+    context.values.clear()
     sql, resolved = executor.generate_clickhouse_sql()
     seconds = time.perf_counter() - started
     # The executor keeps the database it built on its own `dataclasses.replace` copy, so
@@ -435,7 +440,9 @@ def _generate_sql(
     recorded = executor.timings.to_dict()
     return _GeneratedSQL(
         sql=sql,
-        values=resolved.values,
+        # Copied because the shared dict is cleared for the next pass, and a caller holds this
+        # pass's SQL and values together (the DESCRIBE between the passes reads them).
+        values=dict(resolved.values),
         seconds=seconds,
         parse_seconds=_hogql_leaf_seconds(recorded, "query"),
         resolve_seconds=_hogql_leaf_seconds(recorded, "prepare_ast_for_printing"),

--- a/products/notebooks/backend/temporal/frame_materialize.py
+++ b/products/notebooks/backend/temporal/frame_materialize.py
@@ -52,9 +52,11 @@ from posthog.schema import QueryStatus
 
 from posthog.hogql import ast
 from posthog.hogql.constants import HogQLGlobalSettings, LimitContext
+from posthog.hogql.context import HogQLContext
 from posthog.hogql.errors import ExposedHogQLError
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import HogQLQueryExecutor
+from posthog.hogql.visitor import clone_expr
 
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import (
@@ -384,19 +386,37 @@ class _GeneratedSQL:
     print_ast_seconds: float
 
 
+def _printing_context(team: Team, user: User | None) -> HogQLContext:
+    """One context for every print pass of a materialization.
+
+    A frame is printed twice whenever a column needs stringifying, and the second pass used
+    to build its own context, database and access controls from scratch. They depend only on
+    (team, user), which do not change between passes, so the passes share them — the executor
+    reuses a database already on the context and documents that callers may do this.
+    """
+    return HogQLContext(
+        team_id=team.pk,
+        user=user,
+        user_access_control=UserAccessControl(user=user, team=team) if user else None,
+    )
+
+
 def _generate_sql(
     team: Team,
     user: User | None,
-    query: "str | ast.SelectQuery | ast.SelectSetQuery",
+    query: "ast.SelectQuery | ast.SelectSetQuery",
     *,
     output_format: str | None,
+    context: HogQLContext,
 ) -> _GeneratedSQL:
     """Print HogQL to guarded ClickHouse SQL with the standing caps applied."""
     executor = HogQLQueryExecutor(
-        query=query,
+        # Cloned because the executor applies the row ceiling to the node it is handed, in
+        # place, and the wrapper pass nests the same node.
+        query=clone_expr(query, True),
         team=team,
         user=user,
-        user_access_control=UserAccessControl(user=user, team=team) if user else None,
+        context=context,
         limit_context=LimitContext.NOTEBOOK_MATERIALIZE,
         settings=_capped_settings(team.pk),
         pretty=False,
@@ -404,12 +424,18 @@ def _generate_sql(
     if output_format:
         executor.context.output_format = output_format
     started = time.perf_counter()
-    sql, context = executor.generate_clickhouse_sql()
+    sql, resolved = executor.generate_clickhouse_sql()
     seconds = time.perf_counter() - started
+    # The executor keeps the database it built on its own `dataclasses.replace` copy, so
+    # without this hand-back the shared context still looks empty and the next pass builds a
+    # second one. It resets the per-execution state it shares by reference, so a database
+    # carried across passes is the reuse it already accounts for.
+    if context.database is None:
+        context.database = resolved.database
     recorded = executor.timings.to_dict()
     return _GeneratedSQL(
         sql=sql,
-        values=context.values,
+        values=resolved.values,
         seconds=seconds,
         parse_seconds=_hogql_leaf_seconds(recorded, "query"),
         resolve_seconds=_hogql_leaf_seconds(recorded, "prepare_ast_for_printing"),
@@ -518,7 +544,11 @@ def _print_clickhouse_sql(
     where the s3() function argument defines the object format and a FORMAT clause would
     be invalid inside the INSERT.
     """
-    plain = _generate_sql(team, user, query, output_format=None)
+    # Parsed once and reused: the wrapper pass nests this node instead of re-parsing the
+    # source, which is the other half of what the second pass used to redo from scratch.
+    parsed = parse_select(query)
+    context = _printing_context(team, user)
+    plain = _generate_sql(team, user, parsed, output_format=None, context=context)
     describe_started = time.perf_counter()
     described = describe(plain.sql, plain.values)
     describe_seconds = time.perf_counter() - describe_started
@@ -538,15 +568,15 @@ def _print_clickhouse_sql(
     if not any(function for _name, function in conversions):
         if output_format is None:
             return printed(None)
-        return printed(_generate_sql(team, user, query, output_format=output_format))
+        return printed(_generate_sql(team, user, parsed, output_format=output_format, context=context))
     select_fields: list[ast.Expr] = [
         ast.Alias(expr=ast.Call(name=function, args=[ast.Field(chain=[name])]), alias=name)
         if function
         else ast.Field(chain=[name])
         for name, function in conversions
     ]
-    stringified = ast.SelectQuery(select=select_fields, select_from=ast.JoinExpr(table=parse_select(query)))
-    return printed(_generate_sql(team, user, stringified, output_format=output_format))
+    stringified = ast.SelectQuery(select=select_fields, select_from=ast.JoinExpr(table=parsed))
+    return printed(_generate_sql(team, user, stringified, output_format=output_format, context=context))
 
 
 class FrameTooLargeError(Exception):

--- a/products/notebooks/backend/test/test_frame_materialize.py
+++ b/products/notebooks/backend/test/test_frame_materialize.py
@@ -16,6 +16,9 @@ from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from posthog.schema import QueryStatus
 
+from posthog.hogql.database.database import Database
+from posthog.hogql.parser import parse_select
+
 from posthog.clickhouse.client.execute import _KILL_SWITCH_SETTINGS, KillSwitchLevel
 from posthog.clickhouse.client.execute_async import QueryStatusManager
 from posthog.errors import ExposedCHQueryError, InternalCHQueryError
@@ -463,7 +466,13 @@ class TestFrameMaterializeKillSwitchCaps(APIBaseTest):
     )
     def test_printed_sql_carries_kill_switch_ceilings(self, _name: str, overrides: dict[str, int]):
         with patch.object(frame_materialize, "kill_switch_overrides", return_value=overrides):
-            sql = frame_materialize._generate_sql(self.team, self.user, "select 1", output_format=None).sql
+            sql = frame_materialize._generate_sql(
+                self.team,
+                self.user,
+                parse_select("select 1"),
+                output_format=None,
+                context=frame_materialize._printing_context(self.team, self.user),
+            ).sql
 
         memory_ceiling = overrides.get("max_memory_usage")
         if memory_ceiling is None:
@@ -494,6 +503,22 @@ class TestFrameMaterializePrintPasses(APIBaseTest):
 
         assert printed.passes == expected_passes
         assert ("toString" in printed.sql) is (expected_passes == 2)
+
+    def test_both_print_passes_share_one_database(self):
+        # The executor keeps the database it builds on a private copy of the context, so the
+        # shared context only carries one if it is handed back. Getting that wrong is
+        # invisible in the output — identical SQL, built twice — so assert on the build.
+        with patch.object(Database, "create_for", wraps=Database.create_for) as create_for:
+            printed = frame_materialize._print_clickhouse_sql(
+                lambda _sql, _values: [("uuid", "UUID")],
+                self.team,
+                self.user,
+                "select 1 as uuid",
+                output_format=None,
+            )
+
+        assert printed.passes == 2
+        assert create_for.call_count == 1
 
     def test_resolve_time_is_actually_recorded(self):
         # The reported split reads leaf keys out of HogQLQueryExecutor's own timings, so a

--- a/products/notebooks/backend/test/test_frame_materialize.py
+++ b/products/notebooks/backend/test/test_frame_materialize.py
@@ -1,4 +1,5 @@
 import io
+import re
 import uuid
 from types import SimpleNamespace
 
@@ -519,6 +520,23 @@ class TestFrameMaterializePrintPasses(APIBaseTest):
 
         assert printed.passes == 2
         assert create_for.call_count == 1
+
+    def test_each_pass_numbers_its_own_placeholders(self):
+        # The executor shares the context's `values` dict by reference and never resets it, while
+        # a placeholder is named from that dict's length. Without a per-pass reset the wrapper pass
+        # numbers its placeholders from where the first pass stopped, and the first pass's dead
+        # values ride along to ClickHouse.
+        printed = frame_materialize._print_clickhouse_sql(
+            lambda _sql, _values: [("a", "String"), ("uuid", "UUID")],
+            self.team,
+            self.user,
+            "select 'alpha' as a, 1 as uuid",
+            output_format=None,
+        )
+
+        assert printed.passes == 2
+        assert set(re.findall(r"%\((hogql_val_\w+)\)s", printed.sql)) == set(printed.values)
+        assert "hogql_val_0" in printed.values
 
     def test_resolve_time_is_actually_recorded(self):
         # The reported split reads leaf keys out of HogQLQueryExecutor's own timings, so a


### PR DESCRIPTION
> Stacked on #83135, which adds the timings this PR should be judged against. Review that one first.

## Problem

A frame that selects a UUID, Enum, IP or FixedString column gets printed twice. `_print_clickhouse_sql` prints once so it can DESCRIBE the output types, then — if any column would leave ClickHouse as Arrow binary — prints again through a wrapper that stringifies those columns.

The second pass rebuilt everything the first pass had already built:

- a second `HogQLContext`
- a second `Database` (`create_hogql_database`)
- a second `UserAccessControl`
- a second `parse_select` of the same HogQL source

None of it depends on anything the DESCRIBE returned. It's all a function of `(team, user)`, which don't change between passes.

On US prod, selecting `uuid` alongside three ordinary columns took a 91,541-row frame from 12.73 s to 22.80 s (12.51 s → 25.00 s on a repeat over a different window). Same rows, same window, one column different.

## Changes

Both passes now share one context, and the wrapper nests the node parsed at the start instead of re-parsing the source.

`HogQLQueryExecutor` only builds a `Database` when the context doesn't already carry one, and the comment above that branch anticipates "callers reusing a HogQLContext across executors". But it keeps the database it builds on its own `dataclasses.replace` copy, so a shared context never learns about it on its own — `_generate_sql` hands it back explicitly. `posthog/temporal/data_modeling/run_workflow.py` reaches the same end by setting `context.database` before the first print.

The node is cloned per pass. `_apply_limit` writes the row ceiling onto the node it's handed, in place, and the wrapper nests that same node — so without a clone the first pass's limit would be visible inside the second pass's subquery. Cloning is cheap next to resolving.

`_generate_sql` now takes a parsed AST rather than a string, and a required `context`.

No behavior change intended: same SQL out, same number of passes, same queries to ClickHouse.

## How did you test this code?

I'm an agent. I have not run this against a worker; the prod numbers above were measured **before** this PR.

Automated, run locally:

- `pytest products/notebooks/backend/test/test_frame_materialize.py` — 27 passed.

One test added: `test_both_print_passes_share_one_database` patches `Database.create_for` and asserts it runs once across a two-pass print. It catches the exact regression this PR nearly shipped with — the hand-back is invisible in the output, since both versions emit identical SQL and differ only in building the schema twice. Verified it fails without the fix (`call_count == 2`) and passes with it.

The rest of the suite covers the correctness side: `TestFrameMaterializePrintPasses` pins that an Arrow-binary column still produces 2 passes and still emits `toString`, and `test_printed_sql_carries_kill_switch_ceilings` pins that the printed SQL still carries the row/scan/threads ceilings — the assertion that would fail if sharing a context or reusing the parsed node changed the output.

**No test asserts the latency claim**, and I'd rather not add a timing assertion. #83135 is what makes it measurable: after both land, `print_seconds` split by `print_passes` says whether this helped and by how much.

## Sizing expectations

Worth being explicit, because the framing above could oversell it. Production traces put `create_hogql_database` at p50 43 ms / p95 113 ms, so the duplicate database build is *not* 10 seconds. The parse isn't either.

What this PR removes is duplicated setup. What it does not remove is the second resolve-and-print of the wrapped query, which is my current best guess for the bulk of the cost and which no amount of context sharing avoids — the wrapper is a different query and has to be resolved.

So: a bounded, well-precedented cleanup that should help, sized honestly. If #83135's numbers show the remaining cost is the resolve, the next step is a different change — not printing a wrapper at all, either by applying the conversions to the already-printed SQL or by skipping the DESCRIBE for columns whose types the HogQL schema already knows.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Opus 5 in Claude Code. Skills invoked: `/stacking-prs` for the stack mechanics, `/writing-tests` for the added test.

This is the second half of an investigation into why notebook Python cells wait ~23 s. The isolation experiment (`SELECT 1` vs events-without-UUID vs events-with-UUID, repeated on a second window) is described in #83135.

Two things I checked before writing this, because both would have made it wrong:

- Whether the executor mutates the AST it's given. It does — `_apply_limit` writes `.limit` in place before the internal `clone_expr` — hence the per-pass clone rather than passing one node to both.
- Whether a shared context is a supported pattern or an accident. It's supported: the database branch is conditional on `context.database` being unset, and the reset of `data_warehouse_sync_warnings` / `external_tables` immediately above it exists specifically so a reused context doesn't leak state between executions.

@greptile-apps caught that the first version of this PR didn't actually achieve the database reuse it claimed: the executor stores the database only on its private context copy, so the shared context stayed empty and the second pass rebuilt it. Fixed by handing it back, and pinned with the test above.

Nothing here draws on non-public material.
