### PR TITLE
fix(desktop): shorten personal space label

### DIFF
--- a/products/desktop/packages/core/src/canvas/channelName.test.ts
+++ b/products/desktop/packages/core/src/canvas/channelName.test.ts
@@ -32,7 +32,6 @@ describe("channelDisplayLabel", () => {
   it.each([
     ["me", undefined, "personal"],
     ["personal", undefined, "personal"],
-    ["personal space", undefined, "personal"],
     ["personal", "personal" as const, "personal"],
     ["personal", "public" as const, "#personal"],
     ["engineering", "public" as const, "#engineering"],

--- a/products/desktop/packages/core/src/canvas/channelName.test.ts
+++ b/products/desktop/packages/core/src/canvas/channelName.test.ts
@@ -30,10 +30,10 @@ describe("normalizeChannelName", () => {
 
 describe("channelDisplayLabel", () => {
   it.each([
-    ["me", undefined, "personal space"],
-    ["personal", undefined, "personal space"],
-    ["personal space", undefined, "personal space"],
-    ["personal", "personal" as const, "personal space"],
+    ["me", undefined, "personal"],
+    ["personal", undefined, "personal"],
+    ["personal space", undefined, "personal"],
+    ["personal", "personal" as const, "personal"],
     ["personal", "public" as const, "#personal"],
     ["engineering", "public" as const, "#engineering"],
   ])("formats %j (%s) as %j", (name, channelType, expected) => {

--- a/products/desktop/packages/core/src/canvas/channelName.ts
+++ b/products/desktop/packages/core/src/canvas/channelName.ts
@@ -13,7 +13,6 @@ export const PERSONAL_CHANNEL_NAME = "me";
  * list — an activity row and a mention both carry one of their own.
  */
 export const PERSONAL_CHANNEL_LABEL = "personal";
-const LEGACY_PERSONAL_CHANNEL_LABEL = "personal space";
 
 /** A channel's name as a reader should see it. */
 export function channelDisplayName(name: string): string;
@@ -28,9 +27,7 @@ function isPersonalChannelLabel(
 ): boolean {
   return channelType !== undefined
     ? channelType === "personal"
-    : name === PERSONAL_CHANNEL_NAME ||
-        name === PERSONAL_CHANNEL_LABEL ||
-        name === LEGACY_PERSONAL_CHANNEL_LABEL;
+    : name === PERSONAL_CHANNEL_NAME || name === PERSONAL_CHANNEL_LABEL;
 }
 
 export function channelDisplayLabel(

--- a/products/desktop/packages/core/src/canvas/channelName.ts
+++ b/products/desktop/packages/core/src/canvas/channelName.ts
@@ -12,8 +12,8 @@ export const PERSONAL_CHANNEL_NAME = "me";
  * Lives in core because names reach a reader by more routes than the channel
  * list — an activity row and a mention both carry one of their own.
  */
-export const PERSONAL_CHANNEL_LABEL = "personal space";
-const LEGACY_PERSONAL_CHANNEL_LABEL = "personal";
+export const PERSONAL_CHANNEL_LABEL = "personal";
+const LEGACY_PERSONAL_CHANNEL_LABEL = "personal space";
 
 /** A channel's name as a reader should see it. */
 export function channelDisplayName(name: string): string;
@@ -47,7 +47,7 @@ export function channelDisplayReference(
   channelType?: "public" | "personal",
 ): string {
   return isPersonalChannelLabel(name, channelType)
-    ? `your ${PERSONAL_CHANNEL_LABEL}`
+    ? "your personal space"
     : `#${channelDisplayName(name)}`;
 }
 
@@ -79,7 +79,7 @@ export function normalizeChannelName(name: string): string {
  */
 const RESERVED_CHANNEL_NAMES = new Set([
   PERSONAL_CHANNEL_NAME,
-  LEGACY_PERSONAL_CHANNEL_LABEL,
+  PERSONAL_CHANNEL_LABEL,
 ]);
 
 export function validateChannelName(name: string): string | null {

--- a/products/desktop/packages/core/src/context-menu/context-menu.test.ts
+++ b/products/desktop/packages/core/src/context-menu/context-menu.test.ts
@@ -183,7 +183,7 @@ describe("ContextMenuService.showTaskContextMenu", () => {
     await menu.shown;
     const submenu = findItem(menu.lastItems, "File to…").submenu ?? [];
     expect(labels(submenu)).toEqual([
-      "personal space",
+      "personal",
       "#beta",
       "#delta",
       "#alpha",
@@ -293,7 +293,7 @@ describe("ContextMenuService.showBulkTaskContextMenu", () => {
     });
     await menu.shown;
     const submenu = findItem(menu.lastItems, "File to…").submenu ?? [];
-    expect(labels(submenu)).toEqual(["#design", "personal space", "#support"]);
+    expect(labels(submenu)).toEqual(["#design", "personal", "#support"]);
   });
 
   it("gates archive on confirmation", async () => {

--- a/products/desktop/packages/ui/src/features/canvas/AGENTS.md
+++ b/products/desktop/packages/ui/src/features/canvas/AGENTS.md
@@ -51,12 +51,12 @@ The root `AGENTS.md` architecture rules still apply.
   horizontal swipe moves between them (`useChannelPaneSwipe`, wheel `deltaX`
   accumulated per gesture and locked until the wheel goes quiet).
 - In the list, "Starred"/"Spaces" are headings above lightly indented rows. The
-  private "personal space" row leads the Starred section and takes the same inset as the
+  private "personal" row leads the Starred section and takes the same inset as the
   spaces beside it. It is the one row that carries a glyph: the lock is the only
   thing saying nobody else can see this space, which is worth its name starting a
   glyph's width right of the others. The alpha's more deeply indented Channels
   tree and hash glyphs are unchanged.
-- **The private space reads as "personal space" without a hash, and only on screen.** The row is `me`
+- **The private space reads as "personal" without a hash, and only on screen.** The row is `me`
   on the backend; `channelDisplayName` (core) swaps it on the way to a reader.
   `channelDisplayLabel` adds a hash to shared spaces but leaves personal bare.
   Four routes carry a channel's name — the channel list, an activity row, a

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.test.tsx
@@ -206,16 +206,16 @@ describe("ChannelsList", () => {
     expect(mocks.navigate).not.toHaveBeenCalled();
   });
 
-  it("pins the personal space above the channels, with its ⌘1 shortcut", () => {
+  it("pins personal above the channels, with its ⌘1 shortcut", () => {
     renderList();
-    const me = screen.getByText("personal space");
+    const me = screen.getByText("personal");
     const eng = screen.getByText("engineering");
     expect(
       me.compareDocumentPosition(eng) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     // ChannelHotkeys binds ⌘1-9 to the same slots; the list is where they're
     // advertised now that the switcher popover is gone.
-    expect(me.parentElement?.textContent).toMatch(/personal space(⌘|Ctrl)/);
+    expect(me.parentElement?.textContent).toMatch(/personal(⌘|Ctrl)/);
   });
 
   describe("group headings", () => {
@@ -244,7 +244,7 @@ describe("ChannelsList", () => {
 
       expect(screen.getByText("engineering")).toBeTruthy();
       expect(screen.queryByText("design")).toBeNull();
-      expect(screen.queryByText("personal space")).toBeNull();
+      expect(screen.queryByText("personal")).toBeNull();
     });
 
     // Grouping is for browsing; once you've named what you want, "Starred" and
@@ -267,9 +267,9 @@ describe("ChannelsList", () => {
       mocks.channelsLayout = false;
       renderList();
       expect(screen.queryByLabelText("Search spaces")).toBeNull();
-      expect(
-        screen.getByText("personal space").parentElement?.textContent,
-      ).toBe("personal space");
+      expect(screen.getByText("personal").parentElement?.textContent).toBe(
+        "personal",
+      );
     });
 
     it("says so when nothing matches", async () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/channelGlyph.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/channelGlyph.test.tsx
@@ -5,9 +5,9 @@ import { channelGlyph, isPrivateChannel } from "./channelGlyph";
 
 describe("isPrivateChannel", () => {
   it.each([
-    ["personal space", true],
-    ["  Personal Space  ", true],
-    ["PERSONAL SPACE", true],
+    ["personal", true],
+    ["  Personal  ", true],
+    ["PERSONAL", true],
     // The backend's own name for it, which no longer reaches here: every name
     // a reader sees has been through `channelDisplayName` first.
     ["me", false],
@@ -28,8 +28,7 @@ describe("channelGlyph", () => {
     ["channel", false, HashIcon],
     ["private space", true, LockSimpleIcon],
   ])("renders the %s glyph", (_, space, expectedIcon) => {
-    const name =
-      expectedIcon === LockSimpleIcon ? "personal space" : "engineering";
+    const name = expectedIcon === LockSimpleIcon ? "personal" : "engineering";
     const glyph = channelGlyph(name, { space }) as ReactElement;
 
     expect(glyph.type).toBe(expectedIcon);

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useTaskChannels.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useTaskChannels.test.tsx
@@ -58,11 +58,9 @@ describe("useTaskChannels", () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(result.current.channels.map((c) => c.id)).toEqual(["1", "p1"]);
-    // Relabelled on the way in: the row is `me` on the backend and
-    // "personal space" everywhere a person reads it.
     expect(result.current.personalChannel).toEqual({
       ...personal,
-      name: "personal space",
+      name: "personal",
     });
   });
 

--- a/products/desktop/packages/ui/src/features/command/keyboard-shortcuts.ts
+++ b/products/desktop/packages/ui/src/features/command/keyboard-shortcuts.ts
@@ -141,7 +141,7 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
   {
     id: "switch-starred-channel",
     keys: "mod+1-9",
-    description: "Switch to space (⌘1 = personal space, ⌘2-9 = starred)",
+    description: "Switch to space (⌘1 = personal, ⌘2-9 = starred)",
     category: "navigation",
     context: "Spaces",
     availability: "channels-layout",


### PR DESCRIPTION
## Problem

The private space appears as "personal space" in desktop channel labels, but its intended label is "personal".

## Changes

- Show the private space as "personal" in the sidebar, menus, and other channel labels.
- Restore the model from #82656: "me" is the backend name, and "personal" is the display label.
- Remove the temporary "personal space" alias introduced by #82994.
- Keep sentence references as "your personal space" for natural grammar.
- Update the desktop canvas guidance and existing label tests.
- Screenshot not included because the source image came from the task context and is not a repository artifact.

## How did you test this code?

- The core and UI Vitest suites verify that the private channel renders as "personal".
- `pnpm --dir products/desktop --filter @posthog/core typecheck`
- `pnpm --dir products/desktop --filter @posthog/ui typecheck`
- `uv run hogli ci:preflight --fix`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the desktop canvas guidance to use the "personal" label.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- OpenAI's coding agent used pi with read, edit, and bash tools. This cloud session has no public link.
- Skills: `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, and `/writing-simplified-technical-english`.
- A history check found that #82994 introduced the alias one day after #82656 established the original naming model.
