### PR TITLE
fix(insights): dismiss pinned tooltip when a row opens the persons modal

### DIFF
--- a/products/product_analytics/frontend/insights/shared/InsightSeriesTooltip.tsx
+++ b/products/product_analytics/frontend/insights/shared/InsightSeriesTooltip.tsx
@@ -338,14 +338,17 @@ export function InsightSeriesTooltip<Meta extends InsightSeriesMetaBase>({
         return formattedDate
     }, [context.seriesData, datumByKey, interval, dateRange, timezone, weekStartDay, altTitle])
 
+    const onUnpin = context.onUnpin
     const onRowClickEntry = useCallback(
         (entry: InsightSeriesTooltipEntry<Meta>): void => {
             const datum = datumByKey.get(entry.series.key)
             if (datum) {
+                // The drill-down opens a modal over the chart, so a pin left behind would float on top of it.
+                onUnpin?.()
                 onRowClick?.(datum)
             }
         },
-        [datumByKey, onRowClick]
+        [datumByKey, onRowClick, onUnpin]
     )
 
     return (

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.test.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.test.tsx
@@ -670,6 +670,8 @@ describe('TrendsLineChart', () => {
             await waitFor(() => {
                 expect(personsModal.actorNames()).toEqual(['spike-fan@example.com'])
             })
+            // The pin outlives the click unless the drill-down drops it, leaving the tooltip over the modal.
+            expect(chart.getTooltip()).not.toBeInTheDocument()
         })
 
         it('fires context.onDataPointClick instead of opening the persons modal', async () => {


### PR DESCRIPTION
## Problem

Someone pins a tooltip on a trends chart, clicks a series row to inspect its people, and the tooltip stays on screen on top of the persons modal.

- A pinned tooltip dismisses on pointer-down outside it, on Escape, or on scroll.
- A click on a tooltip row starts the press inside the tooltip, so none of those fire.
- Chart tooltips render above modals, so the leftover pin covers the modal it opened.

## Changes

- The shared insight tooltip adapter drops the pin before it fires the row handler.
- Trends line, bar, pie and lifecycle charts get the fix, along with stickiness and retention, since every one of them renders rows through that adapter.

The fix sits in the adapter rather than in `@posthog/quill-charts` because dismissing on a row click is a choice about this drill-down, not about every chart that makes rows clickable.

No screenshot: I could not drive the browser this session. The behavior is asserted in jsdom instead.

## How did you test this code?

I am an agent. I ran the Jest suites for trends, retention, stickiness and the shared insight components locally, and no manual testing.

I extended the existing "clicking the Spike row shows only Spike actors" case rather than adding a test, since it already performs the exact sequence that reproduces the bug. The new assertion catches a regression that drops the unpin call: without the fix it fails with the pinned tooltip still in the document.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude Opus 5, via Claude Code) traced the report from `useInsightTooltip.ts`, which still exports the pin helpers, to `@posthog/quill-charts`, which owns pinning now that the charts moved off Chart.js. Skills invoked: `/writing-tests` before touching the test, and `/writing-pr-descriptions` for this body.

`pinTooltip` and `unpinTooltip` in `frontend/src/scenes/insights/useInsightTooltip.ts` are dead: no caller passes `isPinnable`. I left them alone rather than widening this PR.
