### PR TITLE
fix(desktop): open canvas links in the app, not the browser

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/MentionText.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/MentionText.test.tsx
@@ -11,6 +11,10 @@ vi.mock("@posthog/ui/router/navigationBridge", () => ({
   navigateToChannelTask: vi.fn(),
 }));
 
+vi.mock("@posthog/ui/utils/urls", () => ({
+  getPostHogUrl: (path: string) => `https://us.posthog.com${path}`,
+}));
+
 beforeEach(() => {
   vi.clearAllMocks();
 });

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useShareLinkInterceptor.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useShareLinkInterceptor.ts
@@ -1,0 +1,10 @@
+import { interceptShareLinkClicks } from "@posthog/ui/utils/shareLinks";
+import { useEffect } from "react";
+
+/**
+ * App-wide fallback so a canvas or channel link opens in the app rather than the
+ * browser, whichever surface rendered it. See {@link interceptShareLinkClicks}.
+ */
+export function useShareLinkInterceptor(): void {
+  useEffect(() => interceptShareLinkClicks(document), []);
+}

--- a/products/desktop/packages/ui/src/router/routes/__root.tsx
+++ b/products/desktop/packages/ui/src/router/routes/__root.tsx
@@ -30,6 +30,7 @@ import {
 import { useCanvasDeepLink } from "@posthog/ui/features/canvas/hooks/useCanvasDeepLink";
 import { useChannelDeepLink } from "@posthog/ui/features/canvas/hooks/useChannelDeepLink";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
+import { useShareLinkInterceptor } from "@posthog/ui/features/canvas/hooks/useShareLinkInterceptor";
 import { usePostHogWebFeedbackStore } from "@posthog/ui/features/canvas/stores/posthogWebFeedbackStore";
 import { CommandMenu } from "@posthog/ui/features/command/CommandMenu";
 import { CommandSearchBar } from "@posthog/ui/features/command/CommandSearchBar";
@@ -236,6 +237,7 @@ function RootLayout() {
   useCanvasDeepLink();
   useChannelDeepLink();
   useLoopDeepLink();
+  useShareLinkInterceptor();
   const approvalDeepLink = useApprovalDeepLink();
   useSetupDiscovery();
   useNewTaskDeepLink();

--- a/products/desktop/packages/ui/src/utils/shareLinks.test.ts
+++ b/products/desktop/packages/ui/src/utils/shareLinks.test.ts
@@ -1,5 +1,8 @@
-import { handleShareLinkClick } from "@posthog/ui/utils/shareLinks";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  handleShareLinkClick,
+  interceptShareLinkClicks,
+} from "@posthog/ui/utils/shareLinks";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const navigateToChannel = vi.fn();
 const navigateToChannelDashboard = vi.fn();
@@ -10,6 +13,10 @@ vi.mock("@posthog/ui/router/navigationBridge", () => ({
   navigateToChannelDashboard: (...args: unknown[]) =>
     navigateToChannelDashboard(...args),
   navigateToChannelTask: (...args: unknown[]) => navigateToChannelTask(...args),
+}));
+
+vi.mock("@posthog/ui/utils/urls", () => ({
+  getPostHogUrl: (path: string) => `https://us.posthog.com${path}`,
 }));
 
 beforeEach(() => {
@@ -62,6 +69,31 @@ describe("handleShareLinkClick", () => {
     },
   );
 
+  it("leaves a canvas on another PostHog instance to the browser", () => {
+    const event = { preventDefault: vi.fn() };
+
+    const handled = handleShareLinkClick(
+      "https://eu.posthog.com/code/canvas/chan1/dash1",
+      event,
+    );
+
+    expect(handled).toBe(false);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(navigateToChannelDashboard).not.toHaveBeenCalled();
+  });
+
+  it("stands down when something already handled the click", () => {
+    const event = { preventDefault: vi.fn(), defaultPrevented: true };
+
+    const handled = handleShareLinkClick(
+      "https://us.posthog.com/code/canvas/chan1/dash1",
+      event,
+    );
+
+    expect(handled).toBe(false);
+    expect(navigateToChannelDashboard).not.toHaveBeenCalled();
+  });
+
   it("leaves an external link alone", () => {
     const event = { preventDefault: vi.fn() };
 
@@ -79,5 +111,60 @@ describe("handleShareLinkClick", () => {
 
     expect(handleShareLinkClick(undefined, event)).toBe(false);
     expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+});
+
+describe("interceptShareLinkClicks", () => {
+  let uninstall: () => void;
+
+  function clickAnchor(href: string): boolean {
+    const anchor = document.createElement("a");
+    anchor.href = href;
+    anchor.target = "_blank";
+    const label = document.createElement("span");
+    label.textContent = "link";
+    anchor.append(label);
+    document.body.append(anchor);
+    // Clicking the inner span, not the anchor, also covers the `closest` walk
+    // from whatever element the user actually hit.
+    return label.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+  }
+
+  beforeEach(() => {
+    uninstall = interceptShareLinkClicks(document);
+  });
+
+  afterEach(() => {
+    uninstall();
+    document.body.replaceChildren();
+  });
+
+  it("opens a canvas link the app rendered without asking the browser", () => {
+    const notCancelled = clickAnchor(
+      "https://us.posthog.com/code/canvas/chan1/dash1",
+    );
+
+    expect(notCancelled).toBe(false);
+    expect(navigateToChannelDashboard).toHaveBeenCalledWith("chan1", "dash1");
+  });
+
+  it("lets an external link through to the browser", () => {
+    const notCancelled = clickAnchor("https://example.com/docs");
+
+    expect(notCancelled).toBe(true);
+    expect(navigateToChannelDashboard).not.toHaveBeenCalled();
+  });
+
+  it("stops intercepting once uninstalled", () => {
+    uninstall();
+
+    const notCancelled = clickAnchor(
+      "https://us.posthog.com/code/canvas/chan1/dash1",
+    );
+
+    expect(notCancelled).toBe(true);
+    expect(navigateToChannelDashboard).not.toHaveBeenCalled();
   });
 });

--- a/products/desktop/packages/ui/src/utils/shareLinks.ts
+++ b/products/desktop/packages/ui/src/utils/shareLinks.ts
@@ -7,6 +7,7 @@ import {
   parseShareLink,
   type ShareLinkTarget,
 } from "@posthog/ui/utils/posthogLinks";
+import { getPostHogUrl } from "@posthog/ui/utils/urls";
 
 export function navigateToShareTarget(target: ShareLinkTarget): void {
   switch (target.kind) {
@@ -23,8 +24,29 @@ export function navigateToShareTarget(target: ShareLinkTarget): void {
   }
 }
 
+/**
+ * The canvas or channel an href points at, but only when the link belongs to the
+ * PostHog instance the user is signed in to. Canvas and channel ids are
+ * per-instance, so a link from another region names rows that don't exist here —
+ * opening it in-app would land on an empty canvas. Those stay browser links.
+ */
+export function parseLocalShareLink(
+  href: string | undefined | null,
+): ShareLinkTarget | null {
+  if (!href) return null;
+  const base = getPostHogUrl("/");
+  if (!base) return null;
+  try {
+    if (new URL(href).origin !== new URL(base).origin) return null;
+  } catch {
+    return null;
+  }
+  return parseShareLink(href);
+}
+
 interface ShareLinkClickEvent {
   preventDefault: () => void;
+  defaultPrevented?: boolean;
   metaKey?: boolean;
   ctrlKey?: boolean;
   shiftKey?: boolean;
@@ -46,10 +68,34 @@ export function handleShareLinkClick(
   href: string | undefined,
   event: ShareLinkClickEvent,
 ): boolean {
-  if (!href || isModifiedClick(event)) return false;
-  const target = parseShareLink(href);
+  if (event.defaultPrevented || isModifiedClick(event)) return false;
+  const target = parseLocalShareLink(href);
   if (!target) return false;
   event.preventDefault();
   navigateToShareTarget(target);
   return true;
+}
+
+/**
+ * Open canvas and channel links in the app instead of the browser, wherever the
+ * link is rendered — agent prose, thread messages, an inbox report, a canvas's
+ * own HTML. Electron hands any anchor it doesn't recognise to `shell.openExternal`,
+ * so a surface that doesn't call {@link handleShareLinkClick} itself sends the
+ * user out to the web page for a canvas the app can show directly.
+ *
+ * Capture phase on the document, so it runs before React's own handlers; those
+ * then see `defaultPrevented` and stand down rather than navigating twice.
+ * Links to another instance and modified clicks fall through untouched, keeping
+ * "open in a new window" working.
+ */
+export function interceptShareLinkClicks(root: Document): () => void {
+  const onClick = (event: MouseEvent): void => {
+    const node = event.target;
+    if (!(node instanceof Element)) return;
+    const anchor = node.closest("a[href]");
+    if (!(anchor instanceof HTMLAnchorElement)) return;
+    handleShareLinkClick(anchor.href, event);
+  };
+  root.addEventListener("click", onClick, true);
+  return () => root.removeEventListener("click", onClick, true);
 }


### PR DESCRIPTION
## TL;DR

Click a canvas link in PostHog Desktop and it used to bounce you out to your web browser, even though the app can show that canvas itself. Now it opens in the app.

## Problem

Someone using PostHog Desktop clicks a canvas link an agent just posted in the chat thread. The app opens their web browser instead of the canvas.

Canvas and channel share links already routed in-app, but only on surfaces that opted in by calling `handleShareLinkClick` — markdown, thread mentions, artifact cards. Any other surface fell through to Electron's `setWindowOpenHandler` / `will-navigate`, which hands the URL to `shell.openExternal`.

The chat thread's `ChatMarkdown` is one of those surfaces: a plain `<a target="_blank">`. It intercepts task-artifact links but not share links.

## Changes

- `interceptShareLinkClicks` in `packages/ui/src/utils/shareLinks.ts` — one capture-phase listener on the document that catches any anchor pointing at a canvas or channel and navigates in-app. Mounted via `useShareLinkInterceptor()` in `__root.tsx`, next to the deep-link hooks.
- Opt-in per surface was the bug, so the fix is a catch-all rather than a fourth call site. Capture phase means it runs before React's handlers; the three surfaces that already wired themselves up see `defaultPrevented` and stand down instead of navigating twice.
- Two things still pass through untouched: modified clicks (cmd/ctrl/shift/middle), so "open in a new window" keeps working, and links to a different PostHog instance.
- `handleShareLinkClick` now checks the link belongs to the signed-in instance, matching what the artifact cards already did. Ids are per-instance, so an EU link clicked in a US workspace used to navigate to a canvas that doesn't exist locally and land on an empty view.

Not covered: clicks inside a sandboxed canvas iframe don't reach the host document, so a canvas linking to another canvas still opens the browser. Fixing that needs interception in the Electron main process, which can't see the signed-in region — separate change.

## How did you test this code?

Automated only — I did not launch the app or click a link.

Full `@posthog/ui` suite: 2643 tests pass, 0 failures. 23 test files fail to *load*, all `Failed to resolve import "@posthog/agent/*"` / `"@posthog/git/*"` from files this PR doesn't touch. I checked out the parent commit and ran the same files: byte-identical failures, same three resolve errors, same file passing. Pre-existing, from unbuilt sibling packages in my environment. Biome clean on the changed files; `tsc` reports nothing in them.

New tests and the regression each catches:

- `interceptShareLinkClicks` — a canvas anchor that no surface wired up gets intercepted. This is the reported bug, and no existing test covered an anchor outside the three opted-in surfaces. Clicks the inner span, not the anchor, so the `closest` walk is exercised.
- external link passes through, and interception stops after uninstall — guards the listener against swallowing ordinary links or outliving its mount.
- cross-instance link falls through to the browser — new behaviour in `handleShareLinkClick`; previously an EU link navigated in-app.
- `defaultPrevented` short-circuit — the double-navigation this would otherwise cause on the already-wired surfaces.

I verified the URL shape against the live API rather than assuming it: `canvas-list` returns `url` as `https://<instance>/code/canvas/<channelId>/<canvasId>`, which is what `parseShareLink` matches.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (PostHog Desktop cloud task). No repo skills invoked.

Worth flagging for review: the work started against the archived `PostHog/code` snapshot, which is read-only, so I ported it here. I diffed every touched file against `products/desktop` first — `shareLinks.ts`, `shareLinks.test.ts`, `MentionText.test.tsx`, `posthogLinks.ts`, `urls.ts`, and `MentionText.tsx` were byte-identical; `__root.tsx` had drifted, so those two lines are hand-applied. All test runs quoted above are against this tree, not the snapshot.

The alternative I discarded: intercepting in the Electron main process, which would also cover the sandboxed-iframe case. The main process can't see the signed-in cloud region, so it can't tell a local canvas link from another region's, and would navigate to a canvas that doesn't exist. The renderer has auth state, so the check belongs there.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
