### PR TITLE
fix(data-warehouse): stop full-refresh google ads syncs truncating the table

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
@@ -521,6 +521,11 @@ def google_ads_source(
     name = NamingConvention.normalize_identifier(resource_name)
     table = get_schemas(config, team_id, api_version)[resource_name]
 
+    # Report tables always need a date filter, so a full-refresh schema is forced onto the
+    # incremental query path here. Record whether the pipeline itself is incremental first: only an
+    # incremental pipeline persists a cursor between runs, and the bounded windowed drain below is
+    # only sound when it does.
+    pipeline_is_incremental = should_use_incremental_field
     if table.requires_filter and not should_use_incremental_field:
         should_use_incremental_field = True
         incremental_field = "segments.date"
@@ -572,7 +577,13 @@ def google_ads_source(
         # finishes never lands a chunk, so the cursor stays empty and the next run repeats the same
         # unbounded scan — the very death spiral the windows exist to break, except nothing could
         # escape it. A first sync instead starts a bounded backfill window behind today.
-        if table.requires_filter and incremental_field_type == IncrementalFieldType.Date:
+        #
+        # Only incremental pipelines take this path. The per-run window budget assumes the cursor
+        # lands between runs so the next run continues where this one stopped. A full-refresh run
+        # persists no cursor, so a budgeted drain restarts from the same backfill date every run,
+        # and the refresh then replaces the whole table with that same first slice of history:
+        # silent data loss that reports Completed.
+        if pipeline_is_incremental and table.requires_filter and incremental_field_type == IncrementalFieldType.Date:
             start = (
                 _incremental_value_as_date(db_incremental_field_last_value)
                 if db_incremental_field_last_value is not None
@@ -606,8 +617,9 @@ def google_ads_source(
             resumable_source_manager.clear_state()
             return
 
-        # Not a date-partitioned report table, or a non-date cursor: single open-ended ascending
-        # scan. These have no date windows to walk, so there is nothing to bound them by.
+        # Everything else runs a single open-ended ascending scan: non-date cursors have no date
+        # windows to walk, and full-refresh report tables must extract the whole range in one run
+        # because nothing persists between runs to continue a partial walk from.
         if db_incremental_field_last_value is None:
             last_value: int | dt.datetime | dt.date | str = incremental_type_to_initial_value(incremental_field_type)
         else:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -1507,6 +1507,22 @@ class TestGoogleAdsQueryConstruction:
         assert all("2100-01-01" not in q for q in queries)
         assert all("1970-01-01" not in q for q in queries)
 
+    def test_full_refresh_report_table_scans_the_full_range_without_windows(self):
+        # A full-refresh pipeline persists no cursor, so a budgeted windowed drain restarts from
+        # the same backfill date every run and the refresh replaces the whole table with that same
+        # first slice of history. The run must stay a single open-ended scan over the full range.
+        with freeze_time("2026-07-17"):
+            _response, queries = self._run_source(
+                self._stats_table(),
+                should_use_incremental_field=False,
+            )
+
+        assert queries == [
+            "SELECT campaign.id,segments.date FROM campaign_stats "
+            "WHERE segments.date >= '1970-01-01' AND segments.date < '2100-01-01' "
+            "ORDER BY segments.date ASC"
+        ]
+
     def test_run_stops_after_max_data_windows(self):
         # Every window has data; the run must stop after GOOGLE_ADS_MAX_DATA_WINDOWS_PER_RUN
         # non-empty windows so a single run stays short enough to complete and durably advance the


### PR DESCRIPTION
## Problem

- A Google Ads report table on a full-refresh schedule loses data on every sync: the run imports a small, stale slice of history, replaces the whole table with it, and reports Completed.
- Broken by #82517, which runs the bounded windowed drain whenever no cursor exists. A full-refresh run never has a cursor.
- The drain budget assumes the cursor lands between runs. Full refresh persists nothing, so every run restarts from the same backfill date, drains the same first windows, and stops.
- Reported in [support ticket 67304](https://us.posthog.com/project/2/support/tickets/019ffce2-85c8-0000-da57-44f6e03e6186), where the table repeated the same stale snapshot on every run after the deploy.

## Changes

- `google_ads_source` records whether the pipeline itself is incremental before report tables are forced onto the incremental query path.
- Only incremental pipelines enter the bounded windowed drain.
- Full-refresh report tables return to the single open-ended scan they ran before #82517, so a run extracts the whole range again.
- Incremental first syncs keep the bounded backfill that #82517 added.

## How did you test this code?

- `test_full_refresh_report_table_scans_the_full_range_without_windows` fails on current master and passes with the fix. No existing test exercised a report table on a full-refresh pipeline.
- I ran the Google Ads source test tree locally; all tests pass.
- Not run: a live sync against a Google Ads account. The query shape is asserted, not executed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing surface changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tom asked me to investigate the support ticket and fix the cause. I (actually Claude) traced the regression to #82517 in Claude Code and wrote the fix and test. The test data is invented; nothing from the ticket or the agent session is in the diff. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
