### PR TITLE
fix(logs): widen volume tick latency histogram buckets

### DIFF
--- a/products/logs/backend/temporal/volume_tick/metrics.py
+++ b/products/logs/backend/temporal/volume_tick/metrics.py
@@ -9,13 +9,20 @@ from posthog.temporal.common.metrics import get_metric_meter
 # buckets per-metric. Keep in sync with the histograms emitted below.
 LOGS_VOLUME_TICK_LATENCY_HISTOGRAM_METRICS = ("logs_volume_tick_clickhouse_duration_ms",)
 
+# Dense between 750ms and 3s because the discovery query lives there. Coarser
+# steps put every sample in one bucket, so the high quantiles interpolate to a
+# bucket edge and report a boundary rather than a latency.
 LOGS_VOLUME_TICK_LATENCY_HISTOGRAM_BUCKETS = [
     50.0,
     100.0,
     250.0,
     500.0,
+    750.0,
     1_000.0,
+    1_500.0,
+    2_000.0,
     2_500.0,
+    3_000.0,
     5_000.0,
     10_000.0,
     30_000.0,


### PR DESCRIPTION
## Problem

- Anyone reading the volume tick dashboard sees p95 and p99 as a flat line at 2.5s, whatever the query does.
- The tick's ClickHouse discovery query runs between 950ms and 1850ms.
- The bucket list steps 1000 to 2500 to 5000, so every sample falls in one bucket.
- `histogram_quantile` then interpolates to that bucket's edge and reports a boundary instead of a latency.

## Changes

- Add bucket steps at 750ms, 1.5s, 2s and 3s.

> [!NOTE]
> Buckets apply when the worker restarts. A quantile over a window spanning the restart mixes both bucket sets, so the panel settles once the window clears.

## How did you test this code?

- No test added. The constant has no behavior to assert beyond ordering, and a test asserting its literal values would only restate them.
- I checked the list parses, ascends, and holds no duplicates.
- Ran `ruff check` and `ruff format --check` on the file.
- Not checked: the rendered quantiles. I have no Grafana access, so the panel is unverified until the next deploy.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via Claude Code) made this change. Jon directed it.

The bucket problem surfaced while reviewing the volume tick Grafana dashboard, added in PostHog/grafana-dashboards#384, against live data. The p95 and p99 lines sat flat while p50 moved, which is the signature of a single-bucket distribution rather than of stable latency.

I picked the new steps to cover where the query runs today without over-fitting to it. The tick becomes scan-heavy once the rollup writer lands, so the coarse steps above 5s stay useful.

Skills invoked: `/writing-pr-descriptions`.

Public artifact: nothing here comes from a non-public source. The latency range is this worker's own query timing, read from its logs.
