### PR TITLE
fix(desktop): reconnect disconnected cloud task streams on focus and system resume

### DIFF
--- a/products/desktop/packages/core/src/cloud-task/cloud-task-engine.ts
+++ b/products/desktop/packages/core/src/cloud-task/cloud-task-engine.ts
@@ -152,6 +152,10 @@ interface WatcherState {
   connSentLastEventId: string | null;
   connDataEventsReceived: number;
   isBootstrapping: boolean;
+  // True for the whole of bootstrapWatcher, including the leading task-run
+  // fetch that runs before isBootstrapping is set. Bootstrap owns the stream
+  // for that span, so nothing else may open one.
+  isBootstrapInFlight: boolean;
   hasEmittedSnapshot: boolean;
   bufferedLogBatches: StoredLogEntry[][];
   // Live entries emitted since the last snapshot, retained so a re-subscribe snapshot can reconcile
@@ -801,6 +805,10 @@ export class CloudTaskEngine extends TypedEventEmitter<CloudTaskEvents> {
       watcher.failed ||
       watcher.sseAbortController ||
       watcher.reconnectTimeoutId ||
+      // Covers the window before isBootstrapping is set, while bootstrap is
+      // still awaiting the task-run fetch: connecting there would leave a
+      // second stream alongside the one bootstrap is about to open.
+      watcher.isBootstrapInFlight ||
       watcher.isBootstrapping ||
       isTerminalStatus(watcher.lastStatus)
     ) {
@@ -1058,6 +1066,7 @@ export class CloudTaskEngine extends TypedEventEmitter<CloudTaskEvents> {
       connSentLastEventId: null,
       connDataEventsReceived: 0,
       isBootstrapping: false,
+      isBootstrapInFlight: false,
       hasEmittedSnapshot: false,
       bufferedLogBatches: [],
       emittedLogEntries: [],
@@ -1109,6 +1118,18 @@ export class CloudTaskEngine extends TypedEventEmitter<CloudTaskEvents> {
     const watcher = this.watchers.get(key);
     if (!watcher) return;
 
+    watcher.isBootstrapInFlight = true;
+    try {
+      await this.runBootstrap(key, watcher);
+    } finally {
+      watcher.isBootstrapInFlight = false;
+    }
+  }
+
+  private async runBootstrap(
+    key: string,
+    watcher: WatcherState,
+  ): Promise<void> {
     watcher.failed = false;
     watcher.needsPostBootstrapReconnect = false;
     watcher.needsStopAfterBootstrap = false;

--- a/products/desktop/packages/core/src/cloud-task/cloud-task-engine.ts
+++ b/products/desktop/packages/core/src/cloud-task/cloud-task-engine.ts
@@ -796,6 +796,9 @@ export class CloudTaskEngine extends TypedEventEmitter<CloudTaskEvents> {
     const watcher = this.watchers.get(key);
     if (
       !watcher ||
+      // A failed watcher needs retry()'s full re-bootstrap: reconnecting its
+      // SSE leg alone would stream into a watcher that drops every event.
+      watcher.failed ||
       watcher.sseAbortController ||
       watcher.reconnectTimeoutId ||
       watcher.isBootstrapping ||
@@ -805,6 +808,19 @@ export class CloudTaskEngine extends TypedEventEmitter<CloudTaskEvents> {
     }
 
     void this.connectSse(key);
+  }
+
+  /**
+   * Nudge every watcher whose SSE leg is down to reconnect immediately.
+   * System sleep and network switches kill sockets without an error or EOF;
+   * the idle timeout notices eventually, but a wake/focus nudge closes the
+   * gap right away. A no-op for connected, reconnecting, bootstrapping,
+   * failed, and terminal watchers.
+   */
+  reconnectAllIfDisconnected(): void {
+    for (const watcher of this.watchers.values()) {
+      this.reconnectIfDisconnected(watcher.taskId, watcher.runId);
+    }
   }
 
   // Resets a watcher to its pre-bootstrap state so bootstrapWatcher can rebuild it from server truth.

--- a/products/desktop/packages/core/src/cloud-task/cloud-task-service.test.ts
+++ b/products/desktop/packages/core/src/cloud-task/cloud-task-service.test.ts
@@ -2,26 +2,61 @@ import { describe, expect, it, vi } from "vitest";
 import { CloudTaskService } from "./cloud-task";
 import { CloudTaskEngine } from "./cloud-task-engine";
 
+function createScopedLog() {
+  const scopedLog = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  return { ...scopedLog, scope: vi.fn(() => scopedLog) };
+}
+
 describe("CloudTaskService", () => {
   it("preserves the injectable service API as a thin engine wrapper", () => {
-    const scopedLog = {
-      debug: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    };
     const service = new CloudTaskService(
       {
         authenticatedFetch: vi.fn(),
         getCloudContext: vi.fn(),
       },
       { track: vi.fn() } as never,
-      { ...scopedLog, scope: vi.fn(() => scopedLog) },
+      createScopedLog(),
     );
 
     expect(service).toBeInstanceOf(CloudTaskEngine);
     expect(service.watch).toBeTypeOf("function");
     expect(service.retry).toBeTypeOf("function");
     expect(service.unwatchAll).toBeTypeOf("function");
+  });
+
+  it("nudges disconnected watchers to reconnect on power resume", () => {
+    let resumeHandler: (() => void) | undefined;
+    const disposeResume = vi.fn();
+    const powerManager = {
+      onResume: vi.fn((handler: () => void) => {
+        resumeHandler = handler;
+        return disposeResume;
+      }),
+      preventSleep: vi.fn(() => () => {}),
+      hasBuiltInBattery: vi.fn(async () => false),
+    };
+
+    const service = new CloudTaskService(
+      {
+        authenticatedFetch: vi.fn(),
+        getCloudContext: vi.fn(),
+      },
+      { track: vi.fn() } as never,
+      createScopedLog(),
+      null,
+      powerManager,
+    );
+    const reconnectAll = vi.spyOn(service, "reconnectAllIfDisconnected");
+
+    resumeHandler?.();
+    expect(reconnectAll).toHaveBeenCalledTimes(1);
+
+    service.unwatchAll();
+    expect(disposeResume).toHaveBeenCalledTimes(1);
   });
 });

--- a/products/desktop/packages/core/src/cloud-task/cloud-task.test.ts
+++ b/products/desktop/packages/core/src/cloud-task/cloud-task.test.ts
@@ -150,6 +150,37 @@ describe("CloudTaskEngine", () => {
     vi.unstubAllGlobals();
   });
 
+  it("nudges every watcher on reconnectAllIfDisconnected", async () => {
+    const reconnectSpy = vi.spyOn(service, "reconnectIfDisconnected");
+    mockNetFetch
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          id: "run-1",
+          status: "in_progress",
+          stage: null,
+          output: null,
+          error_message: null,
+          branch: null,
+          updated_at: "2026-01-01T00:00:00Z",
+        }),
+      )
+      .mockResolvedValue(
+        createJsonResponse([], 200, { "X-Has-More": "false" }),
+      );
+    mockStreamFetch.mockResolvedValue(createOpenSseResponse(""));
+
+    service.watch({
+      taskId: "task-1",
+      runId: "run-1",
+      apiHost: "https://app.example.com",
+      teamId: 2,
+    });
+
+    service.reconnectAllIfDisconnected();
+
+    expect(reconnectSpy).toHaveBeenCalledWith("task-1", "run-1");
+  });
+
   it("emits a replayed permission_request frame only once", async () => {
     const updates: unknown[] = [];
     service.on(CloudTaskEvent.Update, (payload) => updates.push(payload));

--- a/products/desktop/packages/core/src/cloud-task/cloud-task.test.ts
+++ b/products/desktop/packages/core/src/cloud-task/cloud-task.test.ts
@@ -181,6 +181,47 @@ describe("CloudTaskEngine", () => {
     expect(reconnectSpy).toHaveBeenCalledWith("task-1", "run-1");
   });
 
+  it("opens no second stream when nudged while bootstrap fetches the run", async () => {
+    let releaseRun: ((response: Response) => void) | undefined;
+    mockNetFetch
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            releaseRun = resolve;
+          }),
+      )
+      .mockResolvedValue(
+        createJsonResponse([], 200, { "X-Has-More": "false" }),
+      );
+    mockStreamFetch.mockResolvedValue(createOpenSseResponse(""));
+
+    service.watch({
+      taskId: "task-1",
+      runId: "run-1",
+      apiHost: "https://app.example.com",
+      teamId: 2,
+    });
+    await waitFor(() => releaseRun !== undefined);
+
+    service.reconnectAllIfDisconnected();
+    expect(mockStreamFetch).not.toHaveBeenCalled();
+
+    releaseRun?.(
+      createJsonResponse({
+        id: "run-1",
+        status: "in_progress",
+        stage: null,
+        output: null,
+        error_message: null,
+        branch: null,
+        updated_at: "2026-01-01T00:00:00Z",
+      }),
+    );
+    await waitFor(() => mockStreamFetch.mock.calls.length > 0);
+
+    expect(mockStreamFetch).toHaveBeenCalledTimes(1);
+  });
+
   it("emits a replayed permission_request frame only once", async () => {
     const updates: unknown[] = [];
     service.on(CloudTaskEvent.Update, (payload) => updates.push(payload));

--- a/products/desktop/packages/core/src/cloud-task/cloud-task.ts
+++ b/products/desktop/packages/core/src/cloud-task/cloud-task.ts
@@ -3,6 +3,10 @@ import {
   ANALYTICS_SERVICE,
   type IAnalytics,
 } from "@posthog/platform/analytics";
+import {
+  type IPowerManager,
+  POWER_MANAGER_SERVICE,
+} from "@posthog/platform/power-manager";
 import { inject, injectable, optional, preDestroy } from "inversify";
 import { CloudTaskEngine } from "./cloud-task-engine";
 import {
@@ -14,6 +18,8 @@ import {
 
 @injectable()
 export class CloudTaskService extends CloudTaskEngine {
+  private readonly disposeResumeListener: (() => void) | null;
+
   constructor(
     @inject(CLOUD_TASK_AUTH)
     auth: ICloudTaskAuth,
@@ -24,12 +30,20 @@ export class CloudTaskService extends CloudTaskEngine {
     @inject(MCP_RELAY_EXECUTOR)
     @optional()
     mcpRelayExecutor: McpRelayExecutor | null = null,
+    @inject(POWER_MANAGER_SERVICE)
+    @optional()
+    powerManager: IPowerManager | null = null,
   ) {
     super({ auth, analytics, logger, mcpRelayExecutor });
+    // Sleep kills the SSE sockets without an error or EOF, so without this
+    // nudge a wake waits out the full idle timeout before reconnecting.
+    this.disposeResumeListener =
+      powerManager?.onResume(() => this.reconnectAllIfDisconnected()) ?? null;
   }
 
   @preDestroy()
   override unwatchAll(): void {
+    this.disposeResumeListener?.();
     super.unwatchAll();
   }
 }

--- a/products/desktop/packages/core/src/cloud-task/schemas.ts
+++ b/products/desktop/packages/core/src/cloud-task/schemas.ts
@@ -52,6 +52,11 @@ export const retryInput = z.object({
   runId: z.string(),
 });
 
+export const reconnectIfDisconnectedInput = z.object({
+  taskId: z.string(),
+  runId: z.string(),
+});
+
 export const onUpdateInput = z.object({
   taskId: z.string(),
   runId: z.string(),

--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -228,6 +228,7 @@ export interface SessionTrpc {
     watch: TrpcMutation;
     unwatch: TrpcMutation;
     retry: TrpcMutation;
+    reconnectIfDisconnected: TrpcMutation;
     sendCommand: TrpcMutation;
     stop: TrpcMutation;
     designateRelayedMcpServers: TrpcMutation;
@@ -6968,6 +6969,31 @@ export class SessionService {
           error,
         });
       });
+    }
+  }
+
+  /**
+   * Nudges every actively watched cloud stream to reconnect if its SSE leg
+   * is down. Complements retryUnhealthyCloudSessions: that one only reaches
+   * sessions whose stream already failed hard (status "error"), while this
+   * covers streams that died silently — e.g. a socket killed by system
+   * sleep — before the failure budget was exhausted. A no-op for healthy
+   * streams. Invoked on window focus; the main process runs the same nudge
+   * on power resume.
+   */
+  public reconnectDisconnectedCloudStreams(): void {
+    for (const [taskId, watcher] of this.cloudTaskWatchers) {
+      const session = this.d.store.getSessions()[watcher.runId];
+      // Errored streams need retryCloudTaskWatch's full re-bootstrap instead.
+      if (session?.status === "error") continue;
+      this.d.trpc.cloudTask.reconnectIfDisconnected
+        .mutate({ taskId, runId: watcher.runId })
+        .catch((error: unknown) => {
+          this.d.log.warn("Cloud stream reconnect nudge failed", {
+            taskId,
+            error,
+          });
+        });
     }
   }
 

--- a/products/desktop/packages/core/src/sessions/sessionServiceCloudReconnectNudge.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionServiceCloudReconnectNudge.test.ts
@@ -8,7 +8,13 @@ function makeSession(taskId: string, runId: string): AgentSession {
     taskId,
     taskTitle: taskId,
     channel: "",
-    events: [{ jsonrpc: "2.0", method: "noop" }],
+    events: [
+      {
+        type: "acp_message",
+        ts: 1,
+        message: { jsonrpc: "2.0", method: "noop" },
+      },
+    ],
     processedLineCount: 1,
     startedAt: 1,
     status: "connected",
@@ -23,7 +29,7 @@ function makeSession(taskId: string, runId: string): AgentSession {
     isTaskAuthor: true,
     adapter: "claude",
     cloudStatus: "in_progress",
-  } as unknown as AgentSession;
+  };
 }
 
 function createHarness() {

--- a/products/desktop/packages/core/src/sessions/sessionServiceCloudReconnectNudge.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionServiceCloudReconnectNudge.test.ts
@@ -1,0 +1,143 @@
+import type { AgentSession } from "@posthog/shared";
+import { describe, expect, it, vi } from "vitest";
+import { SessionService, type SessionServiceDeps } from "./sessionService";
+
+function makeSession(taskId: string, runId: string): AgentSession {
+  return {
+    taskRunId: runId,
+    taskId,
+    taskTitle: taskId,
+    channel: "",
+    events: [{ jsonrpc: "2.0", method: "noop" }],
+    processedLineCount: 1,
+    startedAt: 1,
+    status: "connected",
+    isPromptPending: false,
+    isCompacting: false,
+    promptStartedAt: null,
+    pendingPermissions: new Map(),
+    pausedDurationMs: 0,
+    messageQueue: [],
+    optimisticItems: [],
+    isCloud: true,
+    isTaskAuthor: true,
+    adapter: "claude",
+    cloudStatus: "in_progress",
+  } as unknown as AgentSession;
+}
+
+function createHarness() {
+  const sessions: Record<string, AgentSession> = {};
+  const store = {
+    getSessions: () => sessions,
+    getSessionByTaskId: (taskId: string) =>
+      Object.values(sessions).find((s) => s.taskId === taskId),
+    setSession: vi.fn((session: AgentSession) => {
+      sessions[session.taskRunId] = session;
+    }),
+    updateSession: vi.fn(
+      (taskRunId: string, updates: Partial<AgentSession>) => {
+        const session = sessions[taskRunId];
+        if (session) Object.assign(session, updates);
+      },
+    ),
+    updateCloudStatus: vi.fn(),
+  };
+  const reconnectMutate = vi.fn().mockResolvedValue(undefined);
+
+  const deps = {
+    store,
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    getPersistedConfigOptions: () => undefined,
+    setPersistedConfigOptions: vi.fn(),
+    removePersistedConfigOptions: vi.fn(),
+    adapterStore: {
+      getAdapter: () => undefined,
+      setAdapter: vi.fn(),
+      removeAdapter: vi.fn(),
+    },
+    trpc: {
+      agent: {
+        getPreviewConfigOptions: {
+          query: vi.fn().mockRejectedValue(new Error("not in test")),
+        },
+        onSessionIdleKilled: {
+          subscribe: () => ({ unsubscribe: vi.fn() }),
+        },
+      },
+      cloudTask: {
+        onUpdate: {
+          subscribe: vi.fn(() => ({ unsubscribe: vi.fn() })),
+        },
+        watch: { mutate: vi.fn().mockResolvedValue(undefined) },
+        unwatch: { mutate: vi.fn().mockResolvedValue(undefined) },
+        reconnectIfDisconnected: { mutate: reconnectMutate },
+      },
+    },
+  } as unknown as SessionServiceDeps;
+
+  const service = new SessionService(deps);
+  return { service, sessions, reconnectMutate };
+}
+
+function watchTask(service: SessionService, taskId: string, runId: string) {
+  service.watchCloudTask(
+    taskId,
+    runId,
+    "https://us.posthog.com",
+    2,
+    undefined,
+    undefined,
+    undefined,
+    "claude",
+    undefined,
+    undefined,
+    undefined,
+    "in_progress",
+  );
+}
+
+describe("SessionService reconnectDisconnectedCloudStreams", () => {
+  it("nudges every actively watched cloud stream", () => {
+    const { service, sessions, reconnectMutate } = createHarness();
+    sessions["run-1"] = makeSession("task-1", "run-1");
+    sessions["run-2"] = makeSession("task-2", "run-2");
+    watchTask(service, "task-1", "run-1");
+    watchTask(service, "task-2", "run-2");
+
+    service.reconnectDisconnectedCloudStreams();
+
+    expect(reconnectMutate).toHaveBeenCalledTimes(2);
+    expect(reconnectMutate).toHaveBeenCalledWith({
+      taskId: "task-1",
+      runId: "run-1",
+    });
+    expect(reconnectMutate).toHaveBeenCalledWith({
+      taskId: "task-2",
+      runId: "run-2",
+    });
+  });
+
+  it("skips sessions already in the error state", () => {
+    const { service, sessions, reconnectMutate } = createHarness();
+    sessions["run-1"] = makeSession("task-1", "run-1");
+    sessions["run-2"] = makeSession("task-2", "run-2");
+    watchTask(service, "task-1", "run-1");
+    watchTask(service, "task-2", "run-2");
+    sessions["run-2"].status = "error";
+
+    service.reconnectDisconnectedCloudStreams();
+
+    expect(reconnectMutate).toHaveBeenCalledTimes(1);
+    expect(reconnectMutate).toHaveBeenCalledWith({
+      taskId: "task-1",
+      runId: "run-1",
+    });
+  });
+
+  it("does nothing without active watchers", () => {
+    const { service, reconnectMutate } = createHarness();
+    service.reconnectDisconnectedCloudStreams();
+    expect(reconnectMutate).not.toHaveBeenCalled();
+  });
+});

--- a/products/desktop/packages/host-router/src/routers/cloud-task.router.ts
+++ b/products/desktop/packages/host-router/src/routers/cloud-task.router.ts
@@ -5,6 +5,7 @@ import {
   cloudContextOutput,
   designateRelayedMcpServersInput,
   onUpdateInput,
+  reconnectIfDisconnectedInput,
   retryInput,
   sendCommandInput,
   sendCommandOutput,
@@ -42,6 +43,14 @@ export const cloudTaskRouter = router({
       ctx.container
         .get<CloudTaskService>(CLOUD_TASK_SERVICE)
         .retry(input.taskId, input.runId),
+    ),
+
+  reconnectIfDisconnected: publicProcedure
+    .input(reconnectIfDisconnectedInput)
+    .mutation(({ ctx, input }) =>
+      ctx.container
+        .get<CloudTaskService>(CLOUD_TASK_SERVICE)
+        .reconnectIfDisconnected(input.taskId, input.runId),
     ),
 
   designateRelayedMcpServers: publicProcedure

--- a/products/desktop/packages/ui/src/shell/GlobalEventHandlers.tsx
+++ b/products/desktop/packages/ui/src/shell/GlobalEventHandlers.tsx
@@ -311,6 +311,7 @@ export function GlobalEventHandlers({
     const handleFocus = () => {
       loadFolders();
       sessionService.retryUnhealthyCloudSessions();
+      sessionService.reconnectDisconnectedCloudStreams();
       piSessionController?.retryUnhealthyCloudSessions();
     };
     window.addEventListener("focus", handleFocus);


### PR DESCRIPTION
## TL;DR

When a laptop sleeps or switches networks, the connection streaming a task's output can die without any error. The app only noticed after a long timeout — or never — so the task looked frozen. Now returning to the app window, or the machine waking up, immediately pokes every stream to reconnect if it's down. The mobile app already did this; this brings desktop up to par.

## Problem

System sleep and network switches kill the cloud task SSE socket without an error or EOF. Desktop's recovery triggers (window focus, offline→online) only act on sessions already in `status: "error"` — i.e. after the engine exhausted its full reconnect budget — so a silently dead stream stays stale. Mobile solved this with `CloudTaskEngine.reconnectIfDisconnected()` on every app-foreground; the method existed but was unrouted and unused on desktop.

## Changes

- `CloudTaskEngine.reconnectAllIfDisconnected()`: nudges every watcher; a no-op for connected, reconnecting, bootstrapping, failed, and terminal watchers.
- `reconnectIfDisconnected` now also skips failed watchers — reconnecting the SSE leg of a failed watcher would stream into one that drops every event; those need `retry()`'s full re-bootstrap.
- It also skips a watcher whose bootstrap is still in flight. `isBootstrapping` is only set after bootstrap's task-run fetch resolves, so a nudge landing in that window used to open a stream and let bootstrap open a second one. A new `isBootstrapInFlight` flag covers the whole of `bootstrapWatcher`.
- `CloudTaskService` wires `IPowerManager.onResume` (optional injection) to the nudge, so a wake reconnects immediately instead of waiting out the 90s idle timeout.
- New `cloudTask.reconnectIfDisconnected` router procedure; `SessionService.reconnectDisconnectedCloudStreams()` calls it for every watched stream (skipping errored sessions, which the existing focus retry already covers) and runs on window focus alongside `retryUnhealthyCloudSessions`.

## How did you test this code?

Automated only; no manual testing. New tests: engine delegation (`reconnectAllIfDisconnected` nudges each watcher), a mid-bootstrap nudge opening no second stream (fails without the `isBootstrapInFlight` guard), `CloudTaskService` power-resume wiring incl. listener disposal, and `reconnectDisconnectedCloudStreams` nudging active watchers while skipping errored sessions. `packages/core` cloud-task + sessions suites pass locally; `biome lint` clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code from a PostHog Desktop cloud task, as part of a set fixing silently-stalling task streams. Companion PRs: [#83192](https://github.com/PostHog/posthog/pull/83192) (auto-recover dead renderer subscription), plus a manual resync button and a heartbeat watchdog.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
