### PR TITLE
feat(desktop): manual resync button for cloud task streams

### DIFF
--- a/products/desktop/packages/ui/src/features/sessions/components/ResyncCloudRunButton.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ResyncCloudRunButton.tsx
@@ -7,7 +7,7 @@ import {
 import { useService } from "@posthog/di/react";
 import { Button as QuillButton } from "@posthog/quill";
 import { Tooltip } from "@posthog/ui/primitives/Tooltip";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { shallow } from "zustand/shallow";
 import { useSessionResyncStore } from "../sessionResyncStore";
 import { useSessionSelector } from "../useSession";
@@ -33,6 +33,14 @@ export function ResyncCloudRunButton({ taskId }: ResyncCloudRunButtonProps) {
     shallow,
   );
   const [resyncing, setResyncing] = useState(false);
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (resetTimer.current) clearTimeout(resetTimer.current);
+    },
+    [],
+  );
 
   if (!isCloud || isTerminalStatus(cloudStatus)) return null;
 
@@ -43,7 +51,7 @@ export function ResyncCloudRunButton({ taskId }: ResyncCloudRunButtonProps) {
     bump(taskId);
     // Brief double-click guard; the rebuilt watcher replays a full snapshot,
     // so there is no completion signal to await here.
-    setTimeout(() => setResyncing(false), 2_000);
+    resetTimer.current = setTimeout(() => setResyncing(false), 2_000);
   };
 
   return (

--- a/products/desktop/packages/ui/src/features/sessions/components/ResyncCloudRunButton.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ResyncCloudRunButton.tsx
@@ -1,0 +1,68 @@
+import { ArrowsClockwise } from "@phosphor-icons/react";
+import { isTerminalStatus } from "@posthog/core/cloud-task/schemas";
+import {
+  SESSION_SERVICE,
+  type SessionService,
+} from "@posthog/core/sessions/sessionService";
+import { useService } from "@posthog/di/react";
+import { Button as QuillButton } from "@posthog/quill";
+import { Tooltip } from "@posthog/ui/primitives/Tooltip";
+import { useState } from "react";
+import { shallow } from "zustand/shallow";
+import { useSessionResyncStore } from "../sessionResyncStore";
+import { useSessionSelector } from "../useSession";
+
+interface ResyncCloudRunButtonProps {
+  taskId: string;
+}
+
+/**
+ * Escape hatch for a stale cloud stream: tears the watcher down and lets the
+ * reconcile effect rebuild it with a fresh subscription and snapshot replay —
+ * the same recovery an app reload performs, scoped to this task.
+ */
+export function ResyncCloudRunButton({ taskId }: ResyncCloudRunButtonProps) {
+  const sessionService = useService<SessionService>(SESSION_SERVICE);
+  const bump = useSessionResyncStore((s) => s.bump);
+  const { isCloud, cloudStatus } = useSessionSelector(
+    taskId,
+    (session) => ({
+      isCloud: session?.isCloud ?? false,
+      cloudStatus: session?.cloudStatus ?? null,
+    }),
+    shallow,
+  );
+  const [resyncing, setResyncing] = useState(false);
+
+  if (!isCloud || isTerminalStatus(cloudStatus)) return null;
+
+  const handleResync = () => {
+    if (resyncing) return;
+    setResyncing(true);
+    sessionService.stopCloudTaskWatch(taskId);
+    bump(taskId);
+    // Brief double-click guard; the rebuilt watcher replays a full snapshot,
+    // so there is no completion signal to await here.
+    setTimeout(() => setResyncing(false), 2_000);
+  };
+
+  return (
+    <Tooltip content="Resync stream" side="bottom">
+      <div className="no-drag flex items-center">
+        <QuillButton
+          variant="outline"
+          size="sm"
+          aria-label="Resync stream"
+          disabled={resyncing}
+          onClick={handleResync}
+        >
+          <ArrowsClockwise
+            size={14}
+            weight="regular"
+            className={resyncing ? "shrink-0 animate-spin" : "shrink-0"}
+          />
+        </QuillButton>
+      </div>
+    </Tooltip>
+  );
+}

--- a/products/desktop/packages/ui/src/features/sessions/hooks/useSessionConnection.ts
+++ b/products/desktop/packages/ui/src/features/sessions/hooks/useSessionConnection.ts
@@ -14,6 +14,7 @@ import { useUserPresence } from "@posthog/ui/hooks/useUserPresence";
 import { logger } from "@posthog/ui/shell/logger";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo } from "react";
+import { useSessionResyncStore } from "../sessionResyncStore";
 import { useChatTitleGenerator } from "./useChatTitleGenerator";
 
 const log = logger.scope("session-connection");
@@ -45,6 +46,7 @@ export function useSessionConnection({
   // Presence-gate both so the workspace-server idle timeout can reclaim the
   // agent; the existing idle-kill reconcile path restores it on return.
   const userPresent = useUserPresence();
+  const resyncNonce = useSessionResyncStore((s) => s.nonces[task.id] ?? 0);
 
   useChatTitleGenerator(task);
 
@@ -97,6 +99,7 @@ export function useSessionConnection({
     return sessionService.startActivityHeartbeat(taskRunId);
   }, [taskRunId, sessionService, userPresent]);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies(resyncNonce): the manual resync action stops the cloud watch and bumps the nonce so this effect rebuilds the watcher from scratch
   useEffect(() => {
     return sessionService.reconcileTaskConnection({
       task,
@@ -137,5 +140,6 @@ export function useSessionConnection({
     cloudAuthState.cloudRegion,
     queryClient,
     sessionService,
+    resyncNonce,
   ]);
 }

--- a/products/desktop/packages/ui/src/features/sessions/sessionResyncStore.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/sessionResyncStore.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { useSessionResyncStore } from "./sessionResyncStore";
+
+describe("sessionResyncStore", () => {
+  it("bumps per-task nonces independently", () => {
+    const { bump } = useSessionResyncStore.getState();
+
+    bump("task-1");
+    bump("task-1");
+    bump("task-2");
+
+    const { nonces } = useSessionResyncStore.getState();
+    expect(nonces["task-1"]).toBe(2);
+    expect(nonces["task-2"]).toBe(1);
+    expect(nonces["task-3"]).toBeUndefined();
+  });
+});

--- a/products/desktop/packages/ui/src/features/sessions/sessionResyncStore.ts
+++ b/products/desktop/packages/ui/src/features/sessions/sessionResyncStore.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+
+/**
+ * Per-task counter that forces useSessionConnection's reconcile effect to
+ * re-run. The manual resync action bumps it after stopping the cloud watch,
+ * so the effect rebuilds the watcher — subscription, main-process watch, and
+ * snapshot replay — from scratch: the same recovery an app reload performs,
+ * scoped to one task.
+ */
+interface SessionResyncState {
+  nonces: Record<string, number>;
+  bump: (taskId: string) => void;
+}
+
+export const useSessionResyncStore = create<SessionResyncState>()((set) => ({
+  nonces: {},
+  bump: (taskId) =>
+    set((state) => ({
+      nonces: { ...state.nonces, [taskId]: (state.nonces[taskId] ?? 0) + 1 },
+    })),
+}));

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskHeaderActions.test.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskHeaderActions.test.tsx
@@ -78,6 +78,12 @@ vi.mock(
 vi.mock("@posthog/ui/features/sessions/components/StopCloudRunButton", () => ({
   StopCloudRunButton: () => <div>stop cloud run</div>,
 }));
+vi.mock(
+  "@posthog/ui/features/sessions/components/ResyncCloudRunButton",
+  () => ({
+    ResyncCloudRunButton: () => <div>resync cloud run</div>,
+  }),
+);
 vi.mock("@posthog/ui/features/diff-stats/DiffStatsBadge", () => ({
   DiffStatsBadge: () => null,
 }));
@@ -119,6 +125,7 @@ describe("TaskHeaderActions", () => {
 
     renderActions();
 
+    expect(screen.getByText("resync cloud run")).toBeInTheDocument();
     expect(screen.getByText("stop cloud run")).toBeInTheDocument();
     expect(screen.getByText("cloud actions")).toBeInTheDocument();
     expect(screen.getByText("task menu")).toBeInTheDocument();

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskHeaderActions.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskHeaderActions.tsx
@@ -15,6 +15,7 @@ import { CloudGitInteractionHeader } from "@posthog/ui/features/git-interaction/
 import { TaskActionsMenu } from "@posthog/ui/features/git-interaction/components/TaskActionsMenu";
 import { useReviewInRightPanel } from "@posthog/ui/features/navigation/useReviewInRightPanel";
 import { HandoffConfirmDialog } from "@posthog/ui/features/sessions/components/HandoffConfirmDialog";
+import { ResyncCloudRunButton } from "@posthog/ui/features/sessions/components/ResyncCloudRunButton";
 import { StopCloudRunButton } from "@posthog/ui/features/sessions/components/StopCloudRunButton";
 import { useHandoffDialogStore } from "@posthog/ui/features/sessions/handoffDialogStore";
 import { useSessionCallbacks } from "@posthog/ui/features/sessions/hooks/useSessionCallbacks";
@@ -164,6 +165,7 @@ export function TaskHeaderActions({ task }: { task: Task }) {
         <>
           {isCloudTask ? (
             <>
+              <ResyncCloudRunButton taskId={task.id} />
               <StopCloudRunButton taskId={task.id} />
               <CloudGitInteractionHeader taskId={task.id} task={task} />
             </>


### PR DESCRIPTION
## TL;DR

When a cloud task's live output freezes, the only fix today is reloading the whole app. This adds a small resync button to the task header that does the same repair — tear down and rebuild the task's stream, replaying everything from the server — for just that one task.

## Problem

A cloud task's stream can stall with no error shown (dead subscription, wedged watcher). Reloading the app fixes it because a fresh mount rebuilds the subscription and replays a full snapshot — but users shouldn't have to reload, and the existing Retry banner only appears once the stream has failed hard. Users need an always-available escape hatch on the task itself. Companion PRs attack the root causes; this is the manual fallback for whatever they miss.

## Changes

- `ResyncCloudRunButton` in the task header next to "Stop run" (cloud tasks with a non-terminal run only): an `ArrowsClockwise` icon button with a "Resync stream" tooltip.
- Clicking stops the cloud watch (`stopCloudTaskWatch`) and bumps a per-task nonce in a new `sessionResyncStore`; `useSessionConnection`'s reconcile effect depends on the nonce and rebuilds the watcher from scratch — fresh tRPC subscription, main-process watch, snapshot replay. That is exactly the app-reload recovery path, scoped to one task.
- Button disables briefly after a click to guard against double-clicks; the snapshot replay has no completion signal to await.

## How did you test this code?

Automated only; no manual testing — screenshots omitted (the button is an icon button matching the existing header controls; happy to add one if wanted). New store test covers per-task nonce bumping; TaskHeaderActions test asserts the button renders for cloud workspaces. `@posthog/ui` tests for both files pass locally; `biome lint` clean. The rebuilt-watch path itself is the existing first-mount path, exercised by the core sessions suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code from a PostHog Desktop cloud task, as part of a set fixing silently-stalling task streams. Companion PRs: [#83192](https://github.com/PostHog/posthog/pull/83192) (auto-recover dead subscription), [#83193](https://github.com/PostHog/posthog/pull/83193) (focus/resume reconnect nudge), plus a heartbeat watchdog.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*