### PR TITLE
fix(desktop): heartbeat-driven liveness watchdog for cloud task streams

### DIFF
--- a/products/desktop/packages/core/src/cloud-task/cloud-task-engine.ts
+++ b/products/desktop/packages/core/src/cloud-task/cloud-task-engine.ts
@@ -436,6 +436,13 @@ export interface CloudTaskEngineDependencies {
   logger: RootLogger;
   mcpRelayExecutor?: McpRelayExecutor | null;
   streamFetch?: CloudTaskFetch;
+  /**
+   * Forward SSE keepalives as `heartbeat` updates so subscribers can run a
+   * liveness watchdog. Off by default: consumers that listen on the emitter
+   * directly (mobile) have their own foreground reconnect handling and no
+   * use for the extra events.
+   */
+  emitHeartbeats?: boolean;
 }
 
 export type CloudTaskFetch = (
@@ -456,6 +463,7 @@ export class CloudTaskEngine extends TypedEventEmitter<CloudTaskEvents> {
   private readonly analytics: IAnalytics;
   private readonly mcpRelayExecutor: McpRelayExecutor | null;
   private readonly streamFetch: CloudTaskFetch;
+  private readonly emitHeartbeats: boolean;
 
   constructor({
     auth,
@@ -463,12 +471,14 @@ export class CloudTaskEngine extends TypedEventEmitter<CloudTaskEvents> {
     logger,
     mcpRelayExecutor = null,
     streamFetch = globalThis.fetch.bind(globalThis),
+    emitHeartbeats = false,
   }: CloudTaskEngineDependencies) {
     super();
     this.auth = auth;
     this.analytics = analytics;
     this.mcpRelayExecutor = mcpRelayExecutor;
     this.streamFetch = streamFetch;
+    this.emitHeartbeats = emitHeartbeats;
     this.log = logger.scope("cloud-task");
   }
 
@@ -738,6 +748,13 @@ export class CloudTaskEngine extends TypedEventEmitter<CloudTaskEvents> {
         subscribers: existing.subscriberCount,
       });
       void this.emitCurrentSnapshot(key);
+      // A re-watch is a recovery signal (renderer reload, rebuilt
+      // subscription): the snapshot catches the subscriber up, and this
+      // revives the SSE leg if it died without scheduling a reconnect.
+      // Failed watchers are excluded — they need retry()'s full re-bootstrap.
+      if (!existing.failed) {
+        this.reconnectIfDisconnected(input.taskId, input.runId);
+      }
       return;
     }
 
@@ -1674,6 +1691,13 @@ export class CloudTaskEngine extends TypedEventEmitter<CloudTaskEvents> {
     watcher.reconnectAttempts = 0;
 
     if (isKeepaliveEvent(event)) {
+      if (this.emitHeartbeats) {
+        this.emit(CloudTaskEvent.Update, {
+          taskId: watcher.taskId,
+          runId: watcher.runId,
+          kind: "heartbeat",
+        });
+      }
       return null;
     }
 

--- a/products/desktop/packages/core/src/cloud-task/cloud-task.test.ts
+++ b/products/desktop/packages/core/src/cloud-task/cloud-task.test.ts
@@ -150,6 +150,128 @@ describe("CloudTaskEngine", () => {
     vi.unstubAllGlobals();
   });
 
+  it("forwards keepalives as heartbeat updates when enabled", async () => {
+    const scopedLog = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const heartbeatEngine = createCloudTaskEngine({
+      auth: mockAuthService as never,
+      analytics: analyticsMock as never,
+      logger: { ...scopedLog, scope: vi.fn(() => scopedLog) },
+      streamFetch: fetchRouter,
+      emitHeartbeats: true,
+    });
+    const updates: Array<{ kind?: string }> = [];
+    heartbeatEngine.on(CloudTaskEvent.Update, (payload) =>
+      updates.push(payload as { kind?: string }),
+    );
+
+    mockNetFetch
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          id: "run-1",
+          status: "in_progress",
+          stage: null,
+          output: null,
+          error_message: null,
+          branch: null,
+          updated_at: "2026-01-01T00:00:00Z",
+        }),
+      )
+      .mockResolvedValue(
+        createJsonResponse([], 200, { "X-Has-More": "false" }),
+      );
+    mockStreamFetch.mockResolvedValueOnce(
+      createOpenSseResponse("event: keepalive\ndata: {}\n\n"),
+    );
+
+    heartbeatEngine.watch({
+      taskId: "task-1",
+      runId: "run-1",
+      apiHost: "https://app.example.com",
+      teamId: 2,
+    });
+
+    await waitFor(() => updates.some((u) => u.kind === "heartbeat"));
+    heartbeatEngine.unwatchAll();
+  });
+
+  it("does not emit heartbeat updates by default", async () => {
+    const updates: Array<{ kind?: string }> = [];
+    service.on(CloudTaskEvent.Update, (payload) =>
+      updates.push(payload as { kind?: string }),
+    );
+
+    mockNetFetch
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          id: "run-1",
+          status: "in_progress",
+          stage: null,
+          output: null,
+          error_message: null,
+          branch: null,
+          updated_at: "2026-01-01T00:00:00Z",
+        }),
+      )
+      .mockResolvedValue(
+        createJsonResponse([], 200, { "X-Has-More": "false" }),
+      );
+    mockStreamFetch.mockResolvedValueOnce(
+      createOpenSseResponse("event: keepalive\ndata: {}\n\n"),
+    );
+
+    service.watch({
+      taskId: "task-1",
+      runId: "run-1",
+      apiHost: "https://app.example.com",
+      teamId: 2,
+    });
+
+    await waitFor(() => updates.some((u) => u.kind === "snapshot"));
+    expect(updates.some((u) => u.kind === "heartbeat")).toBe(false);
+  });
+
+  it("revives the SSE leg when an existing watcher is re-watched", async () => {
+    const updates: Array<{ kind?: string }> = [];
+    service.on(CloudTaskEvent.Update, (payload) =>
+      updates.push(payload as { kind?: string }),
+    );
+    mockNetFetch
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          id: "run-1",
+          status: "in_progress",
+          stage: null,
+          output: null,
+          error_message: null,
+          branch: null,
+          updated_at: "2026-01-01T00:00:00Z",
+        }),
+      )
+      .mockResolvedValue(
+        createJsonResponse([], 200, { "X-Has-More": "false" }),
+      );
+    mockStreamFetch.mockResolvedValue(createOpenSseResponse(""));
+
+    const input = {
+      taskId: "task-1",
+      runId: "run-1",
+      apiHost: "https://app.example.com",
+      teamId: 2,
+    };
+    service.watch(input);
+    await waitFor(() => updates.some((u) => u.kind === "snapshot"));
+
+    const reconnectSpy = vi.spyOn(service, "reconnectIfDisconnected");
+    service.watch(input);
+
+    expect(reconnectSpy).toHaveBeenCalledWith("task-1", "run-1");
+  });
+
   it("emits a replayed permission_request frame only once", async () => {
     const updates: unknown[] = [];
     service.on(CloudTaskEvent.Update, (payload) => updates.push(payload));

--- a/products/desktop/packages/core/src/cloud-task/cloud-task.ts
+++ b/products/desktop/packages/core/src/cloud-task/cloud-task.ts
@@ -25,7 +25,7 @@ export class CloudTaskService extends CloudTaskEngine {
     @optional()
     mcpRelayExecutor: McpRelayExecutor | null = null,
   ) {
-    super({ auth, analytics, logger, mcpRelayExecutor });
+    super({ auth, analytics, logger, mcpRelayExecutor, emitHeartbeats: true });
   }
 
   @preDestroy()

--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -127,6 +127,9 @@ const CLOUD_SUBSCRIPTION_RECOVERY_BACKOFF = {
  * session shows the retryable error banner instead of stalling silently.
  */
 const CLOUD_SUBSCRIPTION_RECOVERY_NOTIFY_ATTEMPTS = 3;
+const CLOUD_SUBSCRIPTION_ERROR_TITLE = "Stream connection lost";
+const CLOUD_SUBSCRIPTION_ERROR_MESSAGE =
+  "Lost connection to the cloud run. Reconnecting…";
 const LOCAL_SESSION_RECOVERY_MESSAGE =
   "Lost connection to the agent. Reconnecting…";
 const LOCAL_SESSION_RECOVERY_FAILED_MESSAGE =
@@ -6863,6 +6866,7 @@ export class SessionService {
   ): Promise<void> {
     const watcher = this.cloudTaskWatchers.get(taskId);
     if (!watcher || watcher.runId !== runId) return;
+    const startToken = watcher.startToken;
 
     watcher.subscriptionRecoveryAttempts += 1;
     watcher.subscription.unsubscribe();
@@ -6880,12 +6884,22 @@ export class SessionService {
         teamId: watcher.teamId,
         resumeFromEntryCount: watcher.resumeFromEntryCount,
       });
+
+      // Same compensation as the initial watch path: if teardown won while this
+      // watch request was in flight, the main-process watcher is now running
+      // with no renderer subscriber, so unwatch it.
+      if (!this.isCurrentCloudTaskWatcher(taskId, runId, startToken)) {
+        await this.d.trpc.cloudTask.unwatch.mutate({ taskId, runId });
+        return;
+      }
+
       this.d.log.info("Cloud task subscription recovered", {
         taskId,
         attempts: watcher.subscriptionRecoveryAttempts,
       });
       this.clearCloudSubscriptionRecoveryError(taskId, runId);
     } catch (err) {
+      if (!this.isCurrentCloudTaskWatcher(taskId, runId, startToken)) return;
       this.d.log.warn("Cloud task subscription recovery failed", {
         taskId,
         attempt: watcher.subscriptionRecoveryAttempts,
@@ -6915,8 +6929,8 @@ export class SessionService {
     watcher.subscriptionErrorSurfaced = true;
     this.d.store.updateSession(runId, {
       status: "error",
-      errorTitle: "Stream connection lost",
-      errorMessage: "Lost connection to the cloud run. Reconnecting…",
+      errorTitle: CLOUD_SUBSCRIPTION_ERROR_TITLE,
+      errorMessage: CLOUD_SUBSCRIPTION_ERROR_MESSAGE,
       errorRetryable: true,
       isPromptPending: false,
     });
@@ -6932,7 +6946,15 @@ export class SessionService {
 
     watcher.subscriptionErrorSurfaced = false;
     const session = this.d.store.getSessions()[runId];
-    if (session?.status !== "error") return;
+    // Only clear the banner this recovery raised: a real task error can land
+    // (over the rebuilt subscription) before the watch call resolves, and
+    // wiping it would hide the actual failure.
+    if (
+      session?.status !== "error" ||
+      session.errorTitle !== CLOUD_SUBSCRIPTION_ERROR_TITLE
+    ) {
+      return;
+    }
     this.d.store.updateSession(runId, {
       status: "disconnected",
       errorTitle: undefined,

--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -130,6 +130,15 @@ const CLOUD_SUBSCRIPTION_RECOVERY_NOTIFY_ATTEMPTS = 3;
 const CLOUD_SUBSCRIPTION_ERROR_TITLE = "Stream connection lost";
 const CLOUD_SUBSCRIPTION_ERROR_MESSAGE =
   "Lost connection to the cloud run. Reconnecting…";
+const CLOUD_STREAM_WATCHDOG_INTERVAL_MS = 30_000;
+/**
+ * A healthy watcher is never quiet this long: the engine forwards SSE
+ * keepalives as heartbeat updates every ~25-30s even while the run is idle,
+ * and its idle timeout plus reconnect backoff keep a recovering stream's
+ * silence under ~2.5 minutes worst-case. Silence past this threshold means
+ * updates are no longer reaching this process at all.
+ */
+const CLOUD_STREAM_SILENCE_THRESHOLD_MS = 180_000;
 const LOCAL_SESSION_RECOVERY_MESSAGE =
   "Lost connection to the agent. Reconnecting…";
 const LOCAL_SESSION_RECOVERY_FAILED_MESSAGE =
@@ -255,6 +264,7 @@ interface CloudTaskWatcher {
   /** An error that arrived mid-recovery, retried once that recovery settles. */
   subscriptionRecoveryQueued: boolean;
   subscriptionErrorSurfaced: boolean;
+  lastUpdateAt: number;
   onStatusChange?: () => void;
 }
 
@@ -6312,9 +6322,11 @@ export class SessionService {
       subscriptionRecoveryInFlight: false,
       subscriptionRecoveryQueued: false,
       subscriptionErrorSurfaced: false,
+      lastUpdateAt: Date.now(),
       onStatusChange,
     };
     this.cloudTaskWatchers.set(taskId, watcher);
+    this.ensureCloudStreamWatchdog();
 
     // Subscribe before starting the main-process watcher so the first replayed
     // SSE/log burst cannot race ahead of the renderer subscription.
@@ -6804,6 +6816,55 @@ export class SessionService {
     return watcher?.runId === runId && watcher.startToken === startToken;
   }
 
+  private cloudStreamWatchdogId: ReturnType<typeof setInterval> | null = null;
+
+  /**
+   * Last-resort liveness check for cloud streams. The engine forwards SSE
+   * keepalives as heartbeat updates, so a healthy watcher never goes quiet
+   * for long, even while its run is idle. Silence past the threshold means
+   * updates stopped reaching this process without any error — the failure
+   * class the error-triggered recovery can't see — so rebuild the
+   * subscription and re-watch, which replays a snapshot and revives the
+   * stream.
+   */
+  private ensureCloudStreamWatchdog(): void {
+    if (this.cloudStreamWatchdogId) return;
+    this.cloudStreamWatchdogId = setInterval(() => {
+      this.checkCloudStreamLiveness();
+    }, CLOUD_STREAM_WATCHDOG_INTERVAL_MS);
+  }
+
+  private stopCloudStreamWatchdog(): void {
+    if (!this.cloudStreamWatchdogId) return;
+    clearInterval(this.cloudStreamWatchdogId);
+    this.cloudStreamWatchdogId = null;
+  }
+
+  private checkCloudStreamLiveness(): void {
+    const now = Date.now();
+    for (const [taskId, watcher] of this.cloudTaskWatchers) {
+      const session = this.d.store.getSessions()[watcher.runId];
+      if (!session) continue;
+      // Errored streams already show the retry banner and are retried on
+      // focus/online; terminal runs have nothing left to stream.
+      if (session.status === "error") continue;
+      if (isTerminalStatus(session.cloudStatus)) continue;
+      // A recovery is already rebuilding this stream. Leave lastUpdateAt alone
+      // so the next tick still fires if that recovery didn't revive it.
+      if (watcher.subscriptionRecoveryInFlight) continue;
+      if (watcher.subscriptionRecoveryTimeoutId) continue;
+      const silentForMs = now - watcher.lastUpdateAt;
+      if (silentForMs < CLOUD_STREAM_SILENCE_THRESHOLD_MS) continue;
+
+      this.d.log.warn("Cloud stream silent past threshold, resyncing", {
+        taskId,
+        silentForMs,
+      });
+      watcher.lastUpdateAt = now;
+      this.scheduleCloudSubscriptionRecovery(taskId, watcher.runId);
+    }
+  }
+
   private attachCloudTaskSubscription(
     taskId: string,
     runId: string,
@@ -6826,6 +6887,11 @@ export class SessionService {
             return;
           }
           activeWatcher.subscriptionRecoveryAttempts = 0;
+          activeWatcher.lastUpdateAt = Date.now();
+          // Heartbeats only prove liveness; there is nothing to process.
+          if (update.kind === "heartbeat") {
+            return;
+          }
           if (activeWatcher.bufferResumeUpdates) {
             activeWatcher.bufferedResumeUpdates.push(update);
             return;
@@ -7018,6 +7084,9 @@ export class SessionService {
     }
     watcher.subscription.unsubscribe();
     this.cloudLogGapReconciler.forgetDeficiency(watcher.runId);
+    if (this.cloudTaskWatchers.size === 0) {
+      this.stopCloudStreamWatchdog();
+    }
   }
 
   async preflightToLocal(taskId: string, repoPath: string) {

--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -117,6 +117,16 @@ const LOCAL_SESSION_RECONNECT_BACKOFF = {
   initialDelayMs: 1_000,
   maxDelayMs: 5_000,
 };
+const CLOUD_SUBSCRIPTION_RECOVERY_BACKOFF = {
+  initialDelayMs: 1_000,
+  maxDelayMs: 30_000,
+};
+/**
+ * Recovery keeps retrying past this point (a later attempt can still succeed,
+ * e.g. after the main process finishes restarting), but from here on the
+ * session shows the retryable error banner instead of stalling silently.
+ */
+const CLOUD_SUBSCRIPTION_RECOVERY_NOTIFY_ATTEMPTS = 3;
 const LOCAL_SESSION_RECOVERY_MESSAGE =
   "Lost connection to the agent. Reconnecting…";
 const LOCAL_SESSION_RECOVERY_FAILED_MESSAGE =
@@ -234,6 +244,9 @@ interface CloudTaskWatcher {
   bufferedResumeUpdates: CloudTaskUpdatePayload[];
   processCloudUpdate: (update: CloudTaskUpdatePayload) => void;
   subscription: { unsubscribe: () => void };
+  subscriptionRecoveryAttempts: number;
+  subscriptionRecoveryTimeoutId: ReturnType<typeof setTimeout> | null;
+  subscriptionErrorSurfaced: boolean;
   onStatusChange?: () => void;
 }
 
@@ -6285,38 +6298,19 @@ export class SessionService {
       bufferedResumeUpdates: [],
       processCloudUpdate,
       subscription: { unsubscribe: () => undefined },
+      subscriptionRecoveryAttempts: 0,
+      subscriptionRecoveryTimeoutId: null,
+      subscriptionErrorSurfaced: false,
       onStatusChange,
     };
     this.cloudTaskWatchers.set(taskId, watcher);
 
     // Subscribe before starting the main-process watcher so the first replayed
     // SSE/log burst cannot race ahead of the renderer subscription.
-    watcher.subscription = this.d.trpc.cloudTask.onUpdate.subscribe(
-      { taskId, runId },
-      {
-        onData: (update: CloudTaskUpdatePayload) => {
-          const activeWatcher = this.cloudTaskWatchers.get(taskId);
-          if (!activeWatcher || activeWatcher.runId !== runId) {
-            return;
-          }
-          if (activeWatcher.bufferResumeUpdates) {
-            activeWatcher.bufferedResumeUpdates.push(update);
-            return;
-          }
-          activeWatcher.processCloudUpdate(update);
-        },
-        onError: (err: unknown) =>
-          this.d.log.error("Cloud task subscription error", { taskId, err }),
-        onComplete: () => {
-          if (!this.isCurrentCloudTaskWatcher(taskId, runId, startToken)) {
-            return;
-          }
-          this.d.log.warn(
-            "Cloud task subscription ended without an error, updates stop until the task is reopened",
-            { taskId, runId },
-          );
-        },
-      },
+    watcher.subscription = this.attachCloudTaskSubscription(
+      taskId,
+      runId,
+      startToken,
     );
 
     if (shouldHydrateSession) {
@@ -6798,6 +6792,155 @@ export class SessionService {
     return watcher?.runId === runId && watcher.startToken === startToken;
   }
 
+  private attachCloudTaskSubscription(
+    taskId: string,
+    runId: string,
+    startToken: number,
+  ): { unsubscribe: () => void } {
+    return this.d.trpc.cloudTask.onUpdate.subscribe(
+      { taskId, runId },
+      {
+        onData: (update: CloudTaskUpdatePayload) => {
+          const activeWatcher = this.cloudTaskWatchers.get(taskId);
+          if (!activeWatcher || activeWatcher.runId !== runId) {
+            return;
+          }
+          activeWatcher.subscriptionRecoveryAttempts = 0;
+          if (activeWatcher.bufferResumeUpdates) {
+            activeWatcher.bufferedResumeUpdates.push(update);
+            return;
+          }
+          activeWatcher.processCloudUpdate(update);
+        },
+        onError: (err: unknown) => {
+          this.d.log.error("Cloud task subscription error", { taskId, err });
+          this.scheduleCloudSubscriptionRecovery(taskId, runId);
+        },
+        onComplete: () => {
+          if (!this.isCurrentCloudTaskWatcher(taskId, runId, startToken)) {
+            return;
+          }
+          this.d.log.warn(
+            "Cloud task subscription ended without an error, updates stop until the task is reopened",
+            { taskId, runId },
+          );
+        },
+      },
+    );
+  }
+
+  /**
+   * The tRPC subscription carrying cloud updates died (an error in the host
+   * stream, or transport teardown). Without recovery the transcript silently
+   * stops advancing until an app reload rebuilds the subscription — none of
+   * the existing recovery triggers fire, because the session never reaches an
+   * error status. Rebuild both sides here: a fresh subscription, plus a watch
+   * call whose snapshot replay backfills whatever was missed while the
+   * channel was down (the dead subscription's server-side teardown may also
+   * have unwatched, and thereby stopped, the main-process watcher).
+   */
+  private scheduleCloudSubscriptionRecovery(
+    taskId: string,
+    runId: string,
+  ): void {
+    const watcher = this.cloudTaskWatchers.get(taskId);
+    if (!watcher || watcher.runId !== runId) return;
+    if (watcher.subscriptionRecoveryTimeoutId) return;
+
+    const delay = getBackoffDelay(
+      watcher.subscriptionRecoveryAttempts,
+      CLOUD_SUBSCRIPTION_RECOVERY_BACKOFF,
+    );
+    watcher.subscriptionRecoveryTimeoutId = setTimeout(() => {
+      watcher.subscriptionRecoveryTimeoutId = null;
+      void this.recoverCloudSubscription(taskId, runId);
+    }, delay);
+  }
+
+  private async recoverCloudSubscription(
+    taskId: string,
+    runId: string,
+  ): Promise<void> {
+    const watcher = this.cloudTaskWatchers.get(taskId);
+    if (!watcher || watcher.runId !== runId) return;
+
+    watcher.subscriptionRecoveryAttempts += 1;
+    watcher.subscription.unsubscribe();
+    watcher.subscription = this.attachCloudTaskSubscription(
+      taskId,
+      runId,
+      watcher.startToken,
+    );
+
+    try {
+      await this.d.trpc.cloudTask.watch.mutate({
+        taskId,
+        runId,
+        apiHost: watcher.apiHost,
+        teamId: watcher.teamId,
+        resumeFromEntryCount: watcher.resumeFromEntryCount,
+      });
+      this.d.log.info("Cloud task subscription recovered", {
+        taskId,
+        attempts: watcher.subscriptionRecoveryAttempts,
+      });
+      this.clearCloudSubscriptionRecoveryError(taskId, runId);
+    } catch (err) {
+      this.d.log.warn("Cloud task subscription recovery failed", {
+        taskId,
+        attempt: watcher.subscriptionRecoveryAttempts,
+        err,
+      });
+      this.maybeSurfaceCloudSubscriptionError(taskId, runId);
+      this.scheduleCloudSubscriptionRecovery(taskId, runId);
+    }
+  }
+
+  private maybeSurfaceCloudSubscriptionError(
+    taskId: string,
+    runId: string,
+  ): void {
+    const watcher = this.cloudTaskWatchers.get(taskId);
+    if (!watcher || watcher.runId !== runId) return;
+    if (watcher.subscriptionErrorSurfaced) return;
+    if (
+      watcher.subscriptionRecoveryAttempts <
+      CLOUD_SUBSCRIPTION_RECOVERY_NOTIFY_ATTEMPTS
+    ) {
+      return;
+    }
+    const session = this.d.store.getSessions()[runId];
+    if (!session || session.status === "error") return;
+
+    watcher.subscriptionErrorSurfaced = true;
+    this.d.store.updateSession(runId, {
+      status: "error",
+      errorTitle: "Stream connection lost",
+      errorMessage: "Lost connection to the cloud run. Reconnecting…",
+      errorRetryable: true,
+      isPromptPending: false,
+    });
+  }
+
+  private clearCloudSubscriptionRecoveryError(
+    taskId: string,
+    runId: string,
+  ): void {
+    const watcher = this.cloudTaskWatchers.get(taskId);
+    if (!watcher || watcher.runId !== runId) return;
+    if (!watcher.subscriptionErrorSurfaced) return;
+
+    watcher.subscriptionErrorSurfaced = false;
+    const session = this.d.store.getSessions()[runId];
+    if (session?.status !== "error") return;
+    this.d.store.updateSession(runId, {
+      status: "disconnected",
+      errorTitle: undefined,
+      errorMessage: undefined,
+      errorRetryable: undefined,
+    });
+  }
+
   /**
    * Fully stop a cloud task watcher. The tRPC subscription unwatches from the
    * main process in its finally handler; the in-flight watch path below sends a
@@ -6808,6 +6951,10 @@ export class SessionService {
     if (!watcher) return;
 
     this.cloudTaskWatchers.delete(taskId);
+    if (watcher.subscriptionRecoveryTimeoutId) {
+      clearTimeout(watcher.subscriptionRecoveryTimeoutId);
+      watcher.subscriptionRecoveryTimeoutId = null;
+    }
     watcher.subscription.unsubscribe();
     this.cloudLogGapReconciler.forgetDeficiency(watcher.runId);
   }

--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -247,8 +247,13 @@ interface CloudTaskWatcher {
   bufferedResumeUpdates: CloudTaskUpdatePayload[];
   processCloudUpdate: (update: CloudTaskUpdatePayload) => void;
   subscription: { unsubscribe: () => void };
+  /** Bumped on every attach, so a replaced subscription's late callbacks are ignored. */
+  subscriptionGeneration: number;
   subscriptionRecoveryAttempts: number;
   subscriptionRecoveryTimeoutId: ReturnType<typeof setTimeout> | null;
+  subscriptionRecoveryInFlight: boolean;
+  /** An error that arrived mid-recovery, retried once that recovery settles. */
+  subscriptionRecoveryQueued: boolean;
   subscriptionErrorSurfaced: boolean;
   onStatusChange?: () => void;
 }
@@ -6301,8 +6306,11 @@ export class SessionService {
       bufferedResumeUpdates: [],
       processCloudUpdate,
       subscription: { unsubscribe: () => undefined },
+      subscriptionGeneration: 0,
       subscriptionRecoveryAttempts: 0,
       subscriptionRecoveryTimeoutId: null,
+      subscriptionRecoveryInFlight: false,
+      subscriptionRecoveryQueued: false,
       subscriptionErrorSurfaced: false,
       onStatusChange,
     };
@@ -6314,6 +6322,7 @@ export class SessionService {
       taskId,
       runId,
       startToken,
+      watcher.subscriptionGeneration,
     );
 
     if (shouldHydrateSession) {
@@ -6799,7 +6808,15 @@ export class SessionService {
     taskId: string,
     runId: string,
     startToken: number,
+    generation: number,
   ): { unsubscribe: () => void } {
+    // Recovery replaces the subscription while the watcher stays current, so
+    // the generation is what tells a live handler from one belonging to the
+    // subscription we just discarded.
+    const isCurrentSubscription = () =>
+      this.isCurrentCloudTaskWatcher(taskId, runId, startToken) &&
+      this.cloudTaskWatchers.get(taskId)?.subscriptionGeneration === generation;
+
     return this.d.trpc.cloudTask.onUpdate.subscribe(
       { taskId, runId },
       {
@@ -6816,13 +6833,12 @@ export class SessionService {
           activeWatcher.processCloudUpdate(update);
         },
         onError: (err: unknown) => {
+          if (!isCurrentSubscription()) return;
           this.d.log.error("Cloud task subscription error", { taskId, err });
           this.scheduleCloudSubscriptionRecovery(taskId, runId);
         },
         onComplete: () => {
-          if (!this.isCurrentCloudTaskWatcher(taskId, runId, startToken)) {
-            return;
-          }
+          if (!isCurrentSubscription()) return;
           this.d.log.warn(
             "Cloud task subscription ended without an error, updates stop until the task is reopened",
             { taskId, runId },
@@ -6848,6 +6864,14 @@ export class SessionService {
   ): void {
     const watcher = this.cloudTaskWatchers.get(taskId);
     if (!watcher || watcher.runId !== runId) return;
+    // A running recovery already rebuilds the subscription. Queue the failure
+    // for it to retry rather than starting a second, overlapping recovery: the
+    // main-process watcher is reference counted, so two watch calls against one
+    // teardown leave it running forever.
+    if (watcher.subscriptionRecoveryInFlight) {
+      watcher.subscriptionRecoveryQueued = true;
+      return;
+    }
     if (watcher.subscriptionRecoveryTimeoutId) return;
 
     const delay = getBackoffDelay(
@@ -6869,11 +6893,15 @@ export class SessionService {
     const startToken = watcher.startToken;
 
     watcher.subscriptionRecoveryAttempts += 1;
+    watcher.subscriptionRecoveryInFlight = true;
+    watcher.subscriptionRecoveryQueued = false;
     watcher.subscription.unsubscribe();
+    watcher.subscriptionGeneration += 1;
     watcher.subscription = this.attachCloudTaskSubscription(
       taskId,
       runId,
-      watcher.startToken,
+      startToken,
+      watcher.subscriptionGeneration,
     );
 
     try {
@@ -6906,7 +6934,18 @@ export class SessionService {
         err,
       });
       this.maybeSurfaceCloudSubscriptionError(taskId, runId);
-      this.scheduleCloudSubscriptionRecovery(taskId, runId);
+      watcher.subscriptionRecoveryQueued = true;
+    } finally {
+      watcher.subscriptionRecoveryInFlight = false;
+      // Either this attempt failed, or the rebuilt subscription died while the
+      // watch call was still in flight. Both mean the stream is still down.
+      if (
+        watcher.subscriptionRecoveryQueued &&
+        this.isCurrentCloudTaskWatcher(taskId, runId, startToken)
+      ) {
+        watcher.subscriptionRecoveryQueued = false;
+        this.scheduleCloudSubscriptionRecovery(taskId, runId);
+      }
     }
   }
 

--- a/products/desktop/packages/core/src/sessions/sessionServiceCloudStreamWatchdog.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionServiceCloudStreamWatchdog.test.ts
@@ -1,0 +1,222 @@
+import type { AgentSession } from "@posthog/shared";
+import type { CloudTaskUpdatePayload } from "@posthog/shared/domain-types";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionService, type SessionServiceDeps } from "./sessionService";
+
+const TASK_ID = "task-1";
+const RUN_ID = "run-1";
+
+type SubscriptionHandlers = {
+  onData: (data: CloudTaskUpdatePayload) => void;
+  onError?: (err: unknown) => void;
+};
+
+function makeSession(): AgentSession {
+  return {
+    taskRunId: RUN_ID,
+    taskId: TASK_ID,
+    taskTitle: "Test task",
+    channel: "",
+    events: [
+      {
+        type: "acp_message",
+        ts: 1,
+        message: { jsonrpc: "2.0", method: "noop" },
+      },
+    ],
+    processedLineCount: 1,
+    startedAt: 1,
+    status: "connected",
+    isPromptPending: false,
+    isCompacting: false,
+    promptStartedAt: null,
+    pendingPermissions: new Map(),
+    pausedDurationMs: 0,
+    messageQueue: [],
+    optimisticItems: [],
+    isCloud: true,
+    isTaskAuthor: true,
+    adapter: "claude",
+    cloudStatus: "in_progress",
+  };
+}
+
+function createHarness() {
+  const sessions: Record<string, AgentSession> = { [RUN_ID]: makeSession() };
+  const store = {
+    getSessions: () => sessions,
+    getSessionByTaskId: (taskId: string) =>
+      Object.values(sessions).find((s) => s.taskId === taskId),
+    setSession: vi.fn((session: AgentSession) => {
+      sessions[session.taskRunId] = session;
+    }),
+    updateSession: vi.fn(
+      (taskRunId: string, updates: Partial<AgentSession>) => {
+        const session = sessions[taskRunId];
+        if (session) Object.assign(session, updates);
+      },
+    ),
+    updateCloudStatus: vi.fn(),
+    appendEvents: vi.fn(),
+    clearTailOptimisticItems: vi.fn(),
+    clearMessageQueue: vi.fn(),
+  };
+
+  const subscriptions: Array<{
+    handlers: SubscriptionHandlers;
+    unsubscribe: ReturnType<typeof vi.fn>;
+  }> = [];
+  const subscribe = vi.fn((_input: unknown, handlers: SubscriptionHandlers) => {
+    const unsubscribe = vi.fn();
+    subscriptions.push({ handlers, unsubscribe });
+    return { unsubscribe };
+  });
+  const watchMutate = vi.fn().mockResolvedValue(undefined);
+
+  const deps = {
+    store,
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    getPersistedConfigOptions: () => undefined,
+    setPersistedConfigOptions: vi.fn(),
+    removePersistedConfigOptions: vi.fn(),
+    adapterStore: {
+      getAdapter: () => undefined,
+      setAdapter: vi.fn(),
+      removeAdapter: vi.fn(),
+    },
+    trpc: {
+      agent: {
+        getPreviewConfigOptions: {
+          query: vi.fn().mockRejectedValue(new Error("not in test")),
+        },
+        onSessionIdleKilled: {
+          subscribe: () => ({ unsubscribe: vi.fn() }),
+        },
+      },
+      cloudTask: {
+        onUpdate: { subscribe },
+        watch: { mutate: watchMutate },
+        unwatch: { mutate: vi.fn().mockResolvedValue(undefined) },
+      },
+    },
+  } as unknown as SessionServiceDeps;
+
+  const service = new SessionService(deps);
+  return { service, sessions, subscriptions, watchMutate };
+}
+
+function watchTask(service: SessionService) {
+  service.watchCloudTask(
+    TASK_ID,
+    RUN_ID,
+    "https://us.posthog.com",
+    2,
+    undefined,
+    undefined,
+    undefined,
+    "claude",
+    undefined,
+    undefined,
+    undefined,
+    "in_progress",
+  );
+}
+
+function heartbeat(): CloudTaskUpdatePayload {
+  return { taskId: TASK_ID, runId: RUN_ID, kind: "heartbeat" };
+}
+
+describe("SessionService cloud stream watchdog", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resyncs a stream that went silent past the threshold", async () => {
+    const { service, subscriptions, watchMutate } = createHarness();
+    watchTask(service);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(subscriptions).toHaveLength(1);
+    expect(watchMutate).toHaveBeenCalledTimes(1);
+
+    // 180s of silence trips the watchdog; the scheduled recovery then
+    // rebuilds the subscription and re-issues watch after its backoff.
+    await vi.advanceTimersByTimeAsync(181_000);
+
+    expect(subscriptions[0].unsubscribe).toHaveBeenCalled();
+    expect(subscriptions).toHaveLength(2);
+    expect(watchMutate).toHaveBeenCalledTimes(2);
+  });
+
+  it("stays quiet while heartbeats arrive", async () => {
+    const { service, subscriptions, watchMutate } = createHarness();
+    watchTask(service);
+    await vi.advanceTimersByTimeAsync(0);
+
+    for (let i = 0; i < 10; i++) {
+      await vi.advanceTimersByTimeAsync(25_000);
+      subscriptions[0].handlers.onData(heartbeat());
+    }
+
+    expect(subscriptions).toHaveLength(1);
+    expect(watchMutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores errored and terminal sessions", async () => {
+    const { service, sessions, subscriptions, watchMutate } = createHarness();
+    watchTask(service);
+    await vi.advanceTimersByTimeAsync(0);
+
+    sessions[RUN_ID].status = "error";
+    await vi.advanceTimersByTimeAsync(300_000);
+    expect(subscriptions).toHaveLength(1);
+
+    sessions[RUN_ID].status = "connected";
+    sessions[RUN_ID].cloudStatus = "completed";
+    await vi.advanceTimersByTimeAsync(300_000);
+    expect(subscriptions).toHaveLength(1);
+    expect(watchMutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves a stream alone while its recovery is still running", async () => {
+    const { service, subscriptions, watchMutate } = createHarness();
+    watchTask(service);
+    await vi.advanceTimersByTimeAsync(0);
+
+    let resolveWatch = () => {};
+    watchMutate.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveWatch = () => resolve();
+        }),
+    );
+
+    subscriptions[0].handlers.onError?.(new Error("stream died"));
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(subscriptions).toHaveLength(2);
+
+    // The rebuilt stream is silent because its watch call hasn't landed yet.
+    // Treating that as a stall would queue a pointless second rebuild.
+    await vi.advanceTimersByTimeAsync(300_000);
+    expect(subscriptions).toHaveLength(2);
+
+    resolveWatch();
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(subscriptions).toHaveLength(2);
+    expect(watchMutate).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops checking once the last watcher is gone", async () => {
+    const { service, subscriptions } = createHarness();
+    watchTask(service);
+    await vi.advanceTimersByTimeAsync(0);
+
+    service.stopCloudTaskWatch(TASK_ID);
+    await vi.advanceTimersByTimeAsync(600_000);
+
+    expect(subscriptions).toHaveLength(1);
+  });
+});

--- a/products/desktop/packages/core/src/sessions/sessionServiceCloudSubscriptionRecovery.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionServiceCloudSubscriptionRecovery.test.ts
@@ -17,7 +17,9 @@ function makeSession(): AgentSession {
     taskId: TASK_ID,
     taskTitle: "Test task",
     channel: "",
-    events: [{ jsonrpc: "2.0", method: "noop" }],
+    events: [
+      { type: "acp_message", ts: 1, message: { jsonrpc: "2.0", method: "noop" } },
+    ],
     processedLineCount: 1,
     startedAt: 1,
     status: "connected",
@@ -32,7 +34,7 @@ function makeSession(): AgentSession {
     isTaskAuthor: true,
     adapter: "claude",
     cloudStatus: "in_progress",
-  } as unknown as AgentSession;
+  };
 }
 
 function createHarness() {
@@ -97,7 +99,14 @@ function createHarness() {
   } as unknown as SessionServiceDeps;
 
   const service = new SessionService(deps);
-  return { service, sessions, store, subscriptions, watchMutate };
+  return {
+    service,
+    sessions,
+    store,
+    subscriptions,
+    watchMutate,
+    unwatchMutate,
+  };
 }
 
 function watchTask(service: SessionService) {
@@ -187,6 +196,57 @@ describe("SessionService cloud subscription recovery", () => {
     await vi.advanceTimersByTimeAsync(8_000);
     expect(sessions[RUN_ID].status).toBe("disconnected");
     expect(sessions[RUN_ID].errorTitle).toBeUndefined();
+  });
+
+  it("keeps a task error that lands while recovery is in flight", async () => {
+    const { service, sessions, store, subscriptions, watchMutate } =
+      createHarness();
+    watchTask(service);
+    await flushMicrotasks();
+    watchMutate.mockRejectedValue(new Error("main process unavailable"));
+
+    subscriptions[0].handlers.onError?.(new Error("stream died"));
+    await vi.advanceTimersByTimeAsync(1_000 + 2_000 + 4_000);
+    expect(sessions[RUN_ID].errorTitle).toBe("Stream connection lost");
+
+    store.updateSession(RUN_ID, {
+      status: "error",
+      errorTitle: "Task failed",
+      errorMessage: "The run crashed",
+    });
+    watchMutate.mockResolvedValue(undefined);
+    await vi.advanceTimersByTimeAsync(8_000);
+
+    expect(sessions[RUN_ID].status).toBe("error");
+    expect(sessions[RUN_ID].errorTitle).toBe("Task failed");
+  });
+
+  it("unwatches the main process when teardown wins the recovery race", async () => {
+    const { service, subscriptions, watchMutate, unwatchMutate } =
+      createHarness();
+    watchTask(service);
+    await flushMicrotasks();
+
+    let resolveWatch = () => {};
+    watchMutate.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveWatch = () => resolve();
+        }),
+    );
+
+    subscriptions[0].handlers.onError?.(new Error("stream died"));
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(watchMutate).toHaveBeenCalledTimes(2);
+
+    service.stopCloudTaskWatch(TASK_ID);
+    resolveWatch();
+    await flushMicrotasks();
+
+    expect(unwatchMutate).toHaveBeenCalledWith({
+      taskId: TASK_ID,
+      runId: RUN_ID,
+    });
   });
 
   it("stops recovering once the watch is torn down", async () => {

--- a/products/desktop/packages/core/src/sessions/sessionServiceCloudSubscriptionRecovery.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionServiceCloudSubscriptionRecovery.test.ts
@@ -18,7 +18,11 @@ function makeSession(): AgentSession {
     taskTitle: "Test task",
     channel: "",
     events: [
-      { type: "acp_message", ts: 1, message: { jsonrpc: "2.0", method: "noop" } },
+      {
+        type: "acp_message",
+        ts: 1,
+        message: { jsonrpc: "2.0", method: "noop" },
+      },
     ],
     processedLineCount: 1,
     startedAt: 1,

--- a/products/desktop/packages/core/src/sessions/sessionServiceCloudSubscriptionRecovery.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionServiceCloudSubscriptionRecovery.test.ts
@@ -1,0 +1,228 @@
+import type { AgentSession } from "@posthog/shared";
+import type { CloudTaskUpdatePayload } from "@posthog/shared/domain-types";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionService, type SessionServiceDeps } from "./sessionService";
+
+const TASK_ID = "task-1";
+const RUN_ID = "run-1";
+
+type SubscriptionHandlers = {
+  onData: (data: CloudTaskUpdatePayload) => void;
+  onError?: (err: unknown) => void;
+};
+
+function makeSession(): AgentSession {
+  return {
+    taskRunId: RUN_ID,
+    taskId: TASK_ID,
+    taskTitle: "Test task",
+    channel: "",
+    events: [{ jsonrpc: "2.0", method: "noop" }],
+    processedLineCount: 1,
+    startedAt: 1,
+    status: "connected",
+    isPromptPending: false,
+    isCompacting: false,
+    promptStartedAt: null,
+    pendingPermissions: new Map(),
+    pausedDurationMs: 0,
+    messageQueue: [],
+    optimisticItems: [],
+    isCloud: true,
+    isTaskAuthor: true,
+    adapter: "claude",
+    cloudStatus: "in_progress",
+  } as unknown as AgentSession;
+}
+
+function createHarness() {
+  const sessions: Record<string, AgentSession> = { [RUN_ID]: makeSession() };
+  const store = {
+    getSessions: () => sessions,
+    getSessionByTaskId: (taskId: string) =>
+      Object.values(sessions).find((s) => s.taskId === taskId),
+    setSession: vi.fn((session: AgentSession) => {
+      sessions[session.taskRunId] = session;
+    }),
+    updateSession: vi.fn(
+      (taskRunId: string, updates: Partial<AgentSession>) => {
+        const session = sessions[taskRunId];
+        if (session) Object.assign(session, updates);
+      },
+    ),
+    updateCloudStatus: vi.fn(),
+    appendEvents: vi.fn(),
+    clearTailOptimisticItems: vi.fn(),
+    clearMessageQueue: vi.fn(),
+  };
+
+  const subscriptions: Array<{
+    handlers: SubscriptionHandlers;
+    unsubscribe: ReturnType<typeof vi.fn>;
+  }> = [];
+  const subscribe = vi.fn((_input: unknown, handlers: SubscriptionHandlers) => {
+    const unsubscribe = vi.fn();
+    subscriptions.push({ handlers, unsubscribe });
+    return { unsubscribe };
+  });
+  const watchMutate = vi.fn().mockResolvedValue(undefined);
+  const unwatchMutate = vi.fn().mockResolvedValue(undefined);
+
+  const deps = {
+    store,
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    getPersistedConfigOptions: () => undefined,
+    setPersistedConfigOptions: vi.fn(),
+    removePersistedConfigOptions: vi.fn(),
+    adapterStore: {
+      getAdapter: () => undefined,
+      setAdapter: vi.fn(),
+      removeAdapter: vi.fn(),
+    },
+    trpc: {
+      agent: {
+        getPreviewConfigOptions: {
+          query: vi.fn().mockRejectedValue(new Error("not in test")),
+        },
+        onSessionIdleKilled: {
+          subscribe: () => ({ unsubscribe: vi.fn() }),
+        },
+      },
+      cloudTask: {
+        onUpdate: { subscribe },
+        watch: { mutate: watchMutate },
+        unwatch: { mutate: unwatchMutate },
+      },
+    },
+  } as unknown as SessionServiceDeps;
+
+  const service = new SessionService(deps);
+  return { service, sessions, store, subscriptions, watchMutate };
+}
+
+function watchTask(service: SessionService) {
+  service.watchCloudTask(
+    TASK_ID,
+    RUN_ID,
+    "https://us.posthog.com",
+    2,
+    undefined,
+    undefined,
+    undefined,
+    "claude",
+    undefined,
+    undefined,
+    undefined,
+    "in_progress",
+  );
+}
+
+async function flushMicrotasks() {
+  await vi.advanceTimersByTimeAsync(0);
+}
+
+describe("SessionService cloud subscription recovery", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("rebuilds the subscription and re-issues watch after a subscription error", async () => {
+    const { service, subscriptions, watchMutate } = createHarness();
+    watchTask(service);
+    await flushMicrotasks();
+    expect(subscriptions).toHaveLength(1);
+    expect(watchMutate).toHaveBeenCalledTimes(1);
+
+    subscriptions[0].handlers.onError?.(new Error("stream died"));
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(subscriptions[0].unsubscribe).toHaveBeenCalled();
+    expect(subscriptions).toHaveLength(2);
+    expect(watchMutate).toHaveBeenCalledTimes(2);
+    expect(watchMutate).toHaveBeenLastCalledWith({
+      taskId: TASK_ID,
+      runId: RUN_ID,
+      apiHost: "https://us.posthog.com",
+      teamId: 2,
+      resumeFromEntryCount: undefined,
+    });
+  });
+
+  it("keeps retrying with backoff while the watch call fails", async () => {
+    const { service, subscriptions, watchMutate } = createHarness();
+    watchTask(service);
+    await flushMicrotasks();
+    watchMutate.mockRejectedValue(new Error("main process unavailable"));
+
+    subscriptions[0].handlers.onError?.(new Error("stream died"));
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(subscriptions).toHaveLength(2);
+
+    // Attempt counter is now 1, so the next retry waits 2s, not 1s.
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(subscriptions).toHaveLength(2);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(subscriptions).toHaveLength(3);
+  });
+
+  it("surfaces a retryable error after repeated failed recoveries and clears it on success", async () => {
+    const { service, sessions, subscriptions, watchMutate } = createHarness();
+    watchTask(service);
+    await flushMicrotasks();
+    watchMutate.mockRejectedValue(new Error("main process unavailable"));
+
+    subscriptions[0].handlers.onError?.(new Error("stream died"));
+    // Attempts 1 (1s), 2 (2s), 3 (4s) — banner appears on the third failure.
+    await vi.advanceTimersByTimeAsync(1_000 + 2_000);
+    expect(sessions[RUN_ID].status).not.toBe("error");
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(sessions[RUN_ID].status).toBe("error");
+    expect(sessions[RUN_ID].errorRetryable).toBe(true);
+
+    watchMutate.mockResolvedValue(undefined);
+    await vi.advanceTimersByTimeAsync(8_000);
+    expect(sessions[RUN_ID].status).toBe("disconnected");
+    expect(sessions[RUN_ID].errorTitle).toBeUndefined();
+  });
+
+  it("stops recovering once the watch is torn down", async () => {
+    const { service, subscriptions, watchMutate } = createHarness();
+    watchTask(service);
+    await flushMicrotasks();
+
+    subscriptions[0].handlers.onError?.(new Error("stream died"));
+    service.stopCloudTaskWatch(TASK_ID);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(subscriptions).toHaveLength(1);
+    expect(watchMutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the backoff once data flows again", async () => {
+    const { service, subscriptions } = createHarness();
+    watchTask(service);
+    await flushMicrotasks();
+
+    subscriptions[0].handlers.onError?.(new Error("stream died"));
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(subscriptions).toHaveLength(2);
+
+    subscriptions[1].handlers.onData({
+      taskId: TASK_ID,
+      runId: RUN_ID,
+      kind: "logs",
+      newEntries: [],
+      totalEntryCount: 1,
+    });
+
+    // A later error starts back at the initial delay instead of continuing
+    // the previous backoff sequence.
+    subscriptions[1].handlers.onError?.(new Error("stream died again"));
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(subscriptions).toHaveLength(3);
+  });
+});

--- a/products/desktop/packages/core/src/sessions/sessionServiceCloudSubscriptionRecovery.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionServiceCloudSubscriptionRecovery.test.ts
@@ -9,6 +9,7 @@ const RUN_ID = "run-1";
 type SubscriptionHandlers = {
   onData: (data: CloudTaskUpdatePayload) => void;
   onError?: (err: unknown) => void;
+  onComplete?: () => void;
 };
 
 function makeSession(): AgentSession {
@@ -288,5 +289,55 @@ describe("SessionService cloud subscription recovery", () => {
     subscriptions[1].handlers.onError?.(new Error("stream died again"));
     await vi.advanceTimersByTimeAsync(1_000);
     expect(subscriptions).toHaveLength(3);
+  });
+
+  it("queues one retry instead of racing a second recovery", async () => {
+    const { service, subscriptions, watchMutate } = createHarness();
+    watchTask(service);
+    await flushMicrotasks();
+
+    let resolveWatch = () => {};
+    watchMutate.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveWatch = () => resolve();
+        }),
+    );
+
+    subscriptions[0].handlers.onError?.(new Error("stream died"));
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(subscriptions).toHaveLength(2);
+    expect(watchMutate).toHaveBeenCalledTimes(2);
+
+    // The rebuilt subscription dies while its watch call is still in flight.
+    // Recovering again now would leave the reference-counted main-process
+    // watcher with two watch calls against one teardown.
+    subscriptions[1].handlers.onError?.(new Error("stream died again"));
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(subscriptions).toHaveLength(2);
+    expect(watchMutate).toHaveBeenCalledTimes(2);
+
+    resolveWatch();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(subscriptions).toHaveLength(3);
+    expect(watchMutate).toHaveBeenCalledTimes(3);
+  });
+
+  it("ignores callbacks from a subscription recovery replaced", async () => {
+    const { service, subscriptions, watchMutate } = createHarness();
+    watchTask(service);
+    await flushMicrotasks();
+
+    subscriptions[0].handlers.onError?.(new Error("stream died"));
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(subscriptions).toHaveLength(2);
+
+    subscriptions[0].handlers.onError?.(new Error("late error"));
+    subscriptions[0].handlers.onComplete?.();
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(subscriptions).toHaveLength(2);
+    expect(watchMutate).toHaveBeenCalledTimes(2);
   });
 });

--- a/products/desktop/packages/shared/src/domain-types.ts
+++ b/products/desktop/packages/shared/src/domain-types.ts
@@ -469,6 +469,15 @@ export interface CloudTaskErrorUpdate extends CloudTaskUpdateBase {
   retryable: boolean;
 }
 
+/**
+ * Liveness signal forwarded from the SSE keepalive so subscribers can tell a
+ * quiet-but-healthy stream from a dead one. Carries no data; consumers that
+ * don't track liveness ignore it.
+ */
+export interface CloudTaskHeartbeatUpdate extends CloudTaskUpdateBase {
+  kind: "heartbeat";
+}
+
 export interface CloudPermissionOption {
   kind: string;
   optionId: string;
@@ -495,6 +504,7 @@ export type CloudTaskUpdatePayload =
   | CloudTaskStatusUpdate
   | CloudTaskSnapshotUpdate
   | CloudTaskErrorUpdate
+  | CloudTaskHeartbeatUpdate
   | CloudTaskPermissionRequestUpdate;
 
 // Mention types for editors

--- a/products/desktop/packages/shared/src/task.test.ts
+++ b/products/desktop/packages/shared/src/task.test.ts
@@ -41,7 +41,12 @@ describe("cloud task contract exports", () => {
       name: string;
     }>();
     expectTypeOf<CloudTaskUpdatePayload["kind"]>().toEqualTypeOf<
-      "logs" | "status" | "snapshot" | "error" | "permission_request"
+      | "logs"
+      | "status"
+      | "snapshot"
+      | "error"
+      | "heartbeat"
+      | "permission_request"
     >();
   });
 


### PR DESCRIPTION
## TL;DR

The server pings each task stream every ~25 seconds, but the app window never saw those pings — so it couldn't tell "the agent is quietly thinking" from "the stream is dead". Now the pings are forwarded as heartbeats, and if a task's stream goes silent for 3 minutes the app rebuilds it automatically and catches up. This is the catch-all for stream stalls we haven't specifically diagnosed.

> **Stacked on [#83192](https://github.com/PostHog/posthog/pull/83192)** — includes its commits; rebases to just the watchdog once that merges.

## Problem

Cloud task streams can stall with no error: the transcript stops and only an app reload fixes it. [#83192](https://github.com/PostHog/posthog/pull/83192) fixes the diagnosed cause (dead subscription with a log-only error handler), but a watchdog is the durable answer for the classes we haven't diagnosed. The blocker was that the renderer had no liveness signal — SSE keepalives died inside the main-process engine, so a healthy-but-idle run and a dead pipe looked identical.

## Changes

- `CloudTaskHeartbeatUpdate` (`kind: "heartbeat"`) added to `CloudTaskUpdatePayload`; carries no data. All existing consumers use non-exhaustive kind checks and ignore it.
- Engine forwards SSE keepalives as heartbeat updates behind a new `emitHeartbeats` dependency flag — enabled for the DI `CloudTaskService` (desktop/web); mobile constructs the engine directly and stays unchanged.
- Renderer tracks `lastUpdateAt` per watcher (heartbeats count, then get dropped before processing). A 30s interval flags any watched, non-terminal, non-errored stream silent past 180s and triggers the subscription-recovery path from #83192 (rebuild subscription + re-watch + snapshot replay). Threshold rationale: keepalives arrive every ~25-30s, and the engine's idle timeout (90s) plus reconnect backoff keep a *recovering* stream's silence under ~2.5 minutes — beyond that, updates have stopped reaching the renderer at all.
- The watchdog skips a watcher whose recovery is already scheduled or in flight. A rebuilt stream stays silent until its watch call lands, and reading that as a stall queued a second, pointless rebuild.
- `CloudTaskEngine.watch()` on an existing watcher now also revives the SSE leg if it died without a scheduled reconnect (skipping failed watchers, which need `retry()`'s full re-bootstrap) — so any re-watch, including reload and recovery, repairs a zombie stream.

## How did you test this code?

Automated only; no manual testing. New engine tests: keepalives produce heartbeats only when enabled; re-watch revives the SSE leg. New `sessionServiceCloudStreamWatchdog.test.ts`: silent stream gets resubscribed and re-watched; heartbeats keep the watchdog quiet; errored/terminal sessions skipped; a stream with a recovery in flight is left alone; watchdog stops with the last watcher. Full `packages/core` cloud-task + sessions suites (518 tests) and the `packages/shared` contract test pass locally; `biome check` clean; `@posthog/core` typecheck clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code from a PostHog Desktop cloud task, as part of a set fixing silently-stalling task streams. Companions: [#83192](https://github.com/PostHog/posthog/pull/83192) (base of this stack), [#83193](https://github.com/PostHog/posthog/pull/83193) (focus/resume nudge), [#83194](https://github.com/PostHog/posthog/pull/83194) (manual resync button).

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
