### PR TITLE
fix(desktop): handle refresh_session in the codex adapter

### DIFF
--- a/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
@@ -4391,4 +4391,82 @@ describe("CodexAppServerAgent", () => {
       1,
     );
   });
+
+  it("refresh_session rebinds mcp_servers on the live thread, keeping local tools", async () => {
+    const stub = makeStubRpc({
+      "thread/start": { thread: { id: "t" } },
+      "thread/resume": { thread: { id: "t" } },
+    });
+    const { client } = makeFakeClient();
+    const agent = new CodexAppServerAgent(client, {
+      processOptions: { binaryPath: "/x/codex" },
+      rpcFactory: stub.factory,
+    });
+    await agent.newSession({
+      cwd: "/r",
+      mcpServers: [
+        {
+          name: "posthog",
+          url: "https://mcp.posthog.com/mcp",
+          headers: [{ name: "Authorization", value: "Bearer stale" }],
+        },
+      ],
+    } as unknown as NewSessionRequest);
+
+    await expect(
+      agent.extMethod("_posthog/refresh_session", {
+        mcpServers: [
+          {
+            name: "posthog",
+            url: "https://mcp.posthog.com/mcp",
+            headers: [{ name: "Authorization", value: "Bearer fresh" }],
+          },
+        ],
+      }),
+    ).resolves.toEqual({ refreshed: true });
+
+    const mcpServersFor = (method: string) =>
+      (
+        stub.requests.find((r) => r.method === method)?.params as
+          | { config?: { mcp_servers?: Record<string, unknown> } }
+          | undefined
+      )?.config?.mcp_servers ?? {};
+    const resume = stub.requests.find((r) => r.method === "thread/resume");
+    expect(resume?.params).toMatchObject({ threadId: "t" });
+    expect(mcpServersFor("thread/resume").posthog).toMatchObject({
+      http_headers: { Authorization: "Bearer fresh" },
+    });
+    expect(Object.keys(mcpServersFor("thread/resume"))).toEqual(
+      Object.keys(mcpServersFor("thread/start")),
+    );
+  });
+
+  it("refresh_session is refused while a turn is in flight", async () => {
+    const stub = makeStubRpc({
+      "thread/start": { thread: { id: "thr_1" } },
+      "turn/start": { turn: { id: "turn_1" } },
+    });
+    const { client } = makeFakeClient();
+    const agent = new CodexAppServerAgent(client, {
+      processOptions: { binaryPath: "/x/codex" },
+      rpcFactory: stub.factory,
+    });
+    await agent.newSession({ cwd: "/r" } as unknown as NewSessionRequest);
+
+    const promptDone = agent.prompt({
+      sessionId: "thr_1",
+      prompt: [{ type: "text", text: "hello" }],
+    } as unknown as PromptRequest);
+    await waitUntil(() => stub.requests.some((r) => r.method === "turn/start"));
+
+    await expect(
+      agent.extMethod("_posthog/refresh_session", { mcpServers: [] }),
+    ).rejects.toMatchObject({ code: -32002 });
+    expect(stub.requests.some((r) => r.method === "thread/resume")).toBe(false);
+
+    stub.emit("turn/completed", {
+      turn: { id: "turn_1", status: "completed" },
+    });
+    await promptDone;
+  });
 });

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -8,6 +8,7 @@ import type {
   ListSessionsResponse,
   LoadSessionRequest,
   LoadSessionResponse,
+  McpServer,
   NewSessionRequest,
   NewSessionResponse,
   PromptRequest,
@@ -28,7 +29,9 @@ import {
   serializeError,
 } from "@posthog/shared";
 import {
+  isMethod,
   type NativeGoalState,
+  POSTHOG_METHODS,
   POSTHOG_NOTIFICATIONS,
 } from "../../acp-extensions";
 import type { ModelInfo } from "../../gateway-models";
@@ -246,6 +249,10 @@ export class CodexAppServerAgent extends BaseAcpAgent {
   private additionalDirectories?: string[];
   /** The session workspace stays writable when extra roots are applied per turn. */
   private workspaceDirectory?: string;
+  private threadSetup?: {
+    meta?: AppServerSessionMeta;
+    developerInstructions?: string;
+  };
   /** The in-flight turn's <proposed_plan>, streamed or completed (drives the implement handoff). */
   private planProposal?: { itemId: string; text: string };
   /** Structured plan tool call already emitted while the proposal streams. */
@@ -418,6 +425,78 @@ export class CodexAppServerAgent extends BaseAcpAgent {
     return { sessionId: threadId, configOptions: this.config.options };
   }
 
+  async extMethod(
+    method: string,
+    params: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    if (!isMethod(method, POSTHOG_METHODS.REFRESH_SESSION)) {
+      throw RequestError.methodNotFound(method);
+    }
+    if (params.mcpServers === undefined) {
+      throw new RequestError(
+        -32602,
+        "refresh_session requires at least one refreshable field (e.g. mcpServers)",
+      );
+    }
+    if (!Array.isArray(params.mcpServers)) {
+      throw new RequestError(
+        -32602,
+        "refresh_session: mcpServers must be an array",
+      );
+    }
+    if (!this.threadId) {
+      throw new RequestError(
+        -32002,
+        "Cannot refresh session before a thread is started",
+      );
+    }
+    if (this.turns.isPending || this.nativeGoalTurnId) {
+      throw new RequestError(
+        -32002,
+        "Cannot refresh session while a prompt turn is in flight",
+      );
+    }
+
+    await this.refreshThreadMcpServers(params.mcpServers as McpServer[]);
+    return { refreshed: true };
+  }
+
+  private async refreshThreadMcpServers(servers: McpServer[]): Promise<void> {
+    const cwd = this.workspaceDirectory;
+    let localTools: ReturnType<typeof buildLocalToolsServer> = null;
+    try {
+      localTools = buildLocalToolsServer(
+        { cwd },
+        this.localToolsMeta(this.threadSetup?.meta),
+      );
+    } catch (err) {
+      this.logger.warn(
+        "local-tools server unavailable on refresh; continuing without it",
+        { error: String(err) },
+      );
+    }
+    const mcpServers = toCodexMcpServers(
+      [...servers, ...(localTools ? [localTools] : [])],
+      { gatePosthogExec: true },
+    );
+    const config = buildThreadConfig(mcpServers, this.additionalDirectories);
+    const developerInstructions = this.threadSetup?.developerInstructions;
+
+    await this.rpc.request(APP_SERVER_METHODS.THREAD_RESUME, {
+      model: this.config.model,
+      cwd,
+      threadId: this.threadId,
+      ...(developerInstructions ? { developerInstructions } : {}),
+      ...(config ? { config } : {}),
+    });
+
+    this.logger.info("Refreshed codex thread MCP servers", {
+      threadId: this.threadId,
+      mcpServers: mcpServers ? Object.keys(mcpServers) : [],
+      hasLocalTools: !!localTools,
+    });
+  }
+
   /** Replay a resumed thread's persisted turns (from the thread/resume response) as session updates. */
   private replayHistory(thread: AppServerThread | undefined): void {
     if (!this.sessionId || !thread?.turns?.length) return;
@@ -513,6 +592,7 @@ export class CodexAppServerAgent extends BaseAcpAgent {
         ].filter((s): s is string => !!s),
       ),
     ].join("\n\n");
+    this.threadSetup = { meta: params.meta, developerInstructions };
     // Degrade gracefully: an unresolvable bundled local-tools script skips it with a
     // warning rather than killing thread setup.
     let localTools: ReturnType<typeof buildLocalToolsServer> = null;


### PR DESCRIPTION
## Problem

- A cloud task on the codex runtime dies when you send a follow-up more than three hours into the session. The run is marked failed and its sandbox is destroyed
- The control plane rebinds the run's MCP credentials before it delivers a follow-up, and skips that step only inside a three-hour freshness window
- The rebind sends `_posthog/refresh_session` to the agent. Only the Claude adapter implements `extMethod`, so codex answers JSON-RPC -32601
- A follow-up that cannot confirm the rebind fails closed, and that failure fails the whole run

This was annoying and stress-tested to verify clean lifecycle has been restored

## Changes

- The codex adapter handles `_posthog/refresh_session` and swaps the thread's MCP servers, so the follow-up proceeds
- The swap re-issues `thread/resume` on the same thread id with a fresh config. Codex fixes `mcp_servers` at thread start, and resume is the only swap that keeps the transcript
- The refresh rebuilds the local tools server and appends it. The control plane sends posthog, user and imported servers only, so a verbatim swap would drop local tools
- The handler refuses with -32002 while a turn is in flight, and validates `mcpServers` the way the Claude adapter does
- The refresh replays cached thread setup inputs instead of the full setup path, which would reset the live permission mode
