### PR TITLE
fix(canvas): require task:write to request a canvas fix

### DIFF
--- a/products/canvas/backend/presentation/views.py
+++ b/products/canvas/backend/presentation/views.py
@@ -893,7 +893,10 @@ class CanvasViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             429: OpenApiResponse(description="The team's compute quota is exhausted; retry later."),
         },
     )
-    @action(methods=["POST"], detail=True)
+    # task:write as well: the dispatched fix run executes with the creator's
+    # credentials, so canvas:write alone must not be able to start or steer it —
+    # consistent with the task-run endpoints themselves.
+    @action(methods=["POST"], detail=True, required_scopes=["canvas:write", "task:write"])
     def request_fix(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """Wake the canvas's authoring agent to fix a failing build or runtime error.
 

--- a/products/canvas/backend/tests/test_canvas_api.py
+++ b/products/canvas/backend/tests/test_canvas_api.py
@@ -13,8 +13,10 @@ from rest_framework.test import APIClient
 
 from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.oauth import OAuthAccessToken, OAuthApplication
+from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.scoping import team_scope
 from posthog.models.user import User
+from posthog.models.utils import generate_random_token_personal, hash_key_value
 from posthog.temporal.oauth import ARRAY_APP_CLIENT_ID_DEV
 
 from products.canvas.backend import activity_visibility, build_service
@@ -1324,6 +1326,25 @@ class TestCanvasErrorReports(CanvasAPIBaseTest):
         assert response.status_code == status.HTTP_202_ACCEPTED, response.json()
         assert response.json()["dispatch_outcome"] == "already_queued"
         assert TaskRun.objects.filter(task=task).count() == 1
+
+    def test_scoped_keys_need_task_write_to_request_a_fix(self):
+        # The dispatched fix run executes with the creator's credentials, so a
+        # canvas:write-only token must not be able to start or steer it.
+        canvas_id, build_id, _task = self._authored_canvas()
+        raw_key = generate_random_token_personal()
+        PersonalAPIKey.objects.create(
+            label="canvas-fix", user=self.user, secure_value=hash_key_value(raw_key), scopes=["canvas:write"]
+        )
+        self.client.logout()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/canvases/{canvas_id}/request_fix/",
+            {"build_id": build_id},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {raw_key}",
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
 
     def test_request_fix_rejects_sandbox_callers(self):
         # An agent dispatching fixes to itself is a paid-run loop; the wake is


### PR DESCRIPTION
## Problem

A personal API key or OAuth token holding only `canvas:write` can call `request_fix` and start or steer a creator-credentialed task run — consuming compute and handing an arbitrary prompt to the run's read-scoped tools. The equivalent gap on the new `request_agent` endpoint was flagged by review on #83018 and fixed there; this endpoint already shipped with the same shape.

## Changes

- `request_fix` now requires `task:write` alongside `canvas:write` for scoped credentials, consistent with the task-run endpoints. Session users are unaffected.

## How did you test this code?

- Added a scoped-key test: a `canvas:write`-only personal API key gets 403. Ran the canvas request_fix suite locally (10 passed).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude carried the reviewer-flagged scope requirement from #83018's request_agent to the pre-existing request_fix endpoint. Skills invoked: improving-drf-endpoints, writing-tests.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*