### PR TITLE
chore(mcp-store): cross-link web and desktop MCP store UI docs

### DIFF
--- a/.claude/rules/mcp-store-parity.md
+++ b/.claude/rules/mcp-store-parity.md
@@ -1,0 +1,17 @@
+---
+paths:
+  - 'products/mcp_store/**'
+  - 'products/desktop/packages/ui/src/features/mcp-servers/**'
+  - 'products/desktop/packages/ui/src/features/mcp-gateway/**'
+  - 'products/desktop/packages/ui/src/features/mcp-server-manager/**'
+  - 'products/desktop/packages/api-client/src/mcp-gateway.ts'
+---
+
+The MCP store UI is implemented twice against the same backend and feature flags, with no shared UI code:
+the web app (`products/mcp_store/frontend/`, Kea + LemonUI) and PostHog Desktop
+(`products/desktop/packages/ui/src/features/mcp-servers/`, `mcp-gateway/`, `mcp-server-manager/`; TanStack Query + quill).
+The feature set always changes for both apps together: when you change the feature set or UI in one app,
+make the equivalent change in the other, in the same PR or an explicitly linked follow-up.
+Changes to serializers the gateway UI consumes also need the desktop's hand-written type mirrors in
+`products/desktop/packages/api-client/src/mcp-gateway.ts` updated.
+See "Keep the desktop UI in sync" in `products/mcp_store/README.md` for the directory mapping.

--- a/products/desktop/packages/ui/src/features/mcp-gateway/README.md
+++ b/products/desktop/packages/ui/src/features/mcp-gateway/README.md
@@ -1,0 +1,14 @@
+# MCP gateway (desktop)
+
+The desktop UI for the team MCP gateway: servers home, server/agent/member detail pages, team settings, and the audit log.
+Rendered by `../mcp-servers/components/McpServersView.tsx` when the `MCP_GATEWAY_FLAG` feature flag is on.
+
+## Keep the web app in sync
+
+This is one half of a deliberately duplicated UI.
+The PostHog web app ships its own implementation at `products/mcp_store/frontend/gateway/` (Kea + LemonUI), plus a Settings-embedded variant in `products/mcp_store/frontend/settings/`.
+Both consume the same gateway REST API (`products/mcp_store/backend/presentation/gateway_views.py`).
+The desktop's request/response types are hand-written mirrors in `packages/api-client/src/mcp-gateway.ts`, so serializer changes must update those too.
+The MCP store feature set always changes for both apps together: when you change the feature set or UI here, make the equivalent change in the web app in the same PR, or open an explicitly linked follow-up — and vice versa.
+
+`products/mcp_store/README.md` is the canonical doc for the whole product, including the directory mapping between the two apps.

--- a/products/desktop/packages/ui/src/features/mcp-server-manager/README.md
+++ b/products/desktop/packages/ui/src/features/mcp-server-manager/README.md
@@ -1,0 +1,10 @@
+# MCP server manager (desktop)
+
+The add-custom-MCP-server flow (dialog, form, and connect hook), used by the marketplace in `../mcp-servers/` and by agent configuration.
+
+## Keep the web app in sync
+
+The PostHog web app ships its own custom-server flow at `products/mcp_store/frontend/scene/AddCustomServerForm.tsx` against the same backend.
+The MCP store feature set always changes for both apps together: when you change the flow here, make the equivalent change in the web app in the same PR, or open an explicitly linked follow-up — and vice versa.
+
+See `../mcp-servers/README.md` and `products/mcp_store/README.md` (the canonical doc for the whole product).

--- a/products/desktop/packages/ui/src/features/mcp-servers/README.md
+++ b/products/desktop/packages/ui/src/features/mcp-servers/README.md
@@ -1,0 +1,13 @@
+# MCP servers (desktop)
+
+The desktop marketplace UI for the MCP store: browse the curated catalog, connect servers, and manage installations.
+`components/McpServersView.tsx` is the entry point; when the `MCP_GATEWAY_FLAG` feature flag is on it renders the team gateway experience from `../mcp-gateway/` instead of the legacy marketplace.
+
+## Keep the web app in sync
+
+This is one half of a deliberately duplicated UI.
+The PostHog web app ships its own implementation of the same product at `products/mcp_store/frontend/` (Kea + LemonUI; the marketplace lives in `scene/`).
+Both consume the same backend (`products/mcp_store/backend/`) and the same feature flags, but share no UI code.
+The MCP store feature set always changes for both apps together: when you change the feature set or UI here, make the equivalent change in the web app in the same PR, or open an explicitly linked follow-up — and vice versa.
+
+`products/mcp_store/README.md` is the canonical doc for the whole product, including the directory mapping between the two apps.

--- a/products/mcp_store/README.md
+++ b/products/mcp_store/README.md
@@ -5,6 +5,23 @@ Connected servers are consumed by agent surfaces via the `backend/facade/` packa
 
 This is unrelated to `products/*/mcp/tools.yaml`, which exposes PostHog's own endpoints as MCP tools.
 
+## Keep the desktop UI in sync
+
+PostHog Desktop ships its own, independently written frontend for this product — same backend, same feature flags, no shared UI code:
+
+| This product (web app)                                | PostHog Desktop equivalent                                      |
+| ----------------------------------------------------- | --------------------------------------------------------------- |
+| `frontend/scene/` (marketplace)                       | `products/desktop/packages/ui/src/features/mcp-servers/`        |
+| `frontend/gateway/` + `frontend/settings/` (gateway)  | `products/desktop/packages/ui/src/features/mcp-gateway/`        |
+| `frontend/scene/AddCustomServerForm.tsx` (custom add) | `products/desktop/packages/ui/src/features/mcp-server-manager/` |
+
+The implementations are parallel, not shared: web uses Kea + LemonUI, desktop uses TanStack Query + quill.
+The desktop also hand-writes its gateway API types in `products/desktop/packages/api-client/src/mcp-gateway.ts` as mirrors of the serializers in `backend/presentation/gateway_views.py`.
+
+The MCP store feature set always changes for both apps together.
+When you change the frontend here — a new workflow, control, state, or flag gate — make the equivalent change in the desktop features above in the same PR, or open an explicitly linked follow-up.
+When you change a serializer the gateway UI consumes, update the desktop's hand-written mirrors too.
+
 ## Settings experience and rollout
 
 Two independent feature flags gate two surfaces — neither flag depends on the other:


### PR DESCRIPTION
## Problem

A contributor changing the MCP store UI in one app has nothing telling them a second implementation exists, so the web and desktop UIs drift apart.

- The web app implements the store in `products/mcp_store/frontend/` (Kea + LemonUI).
- PostHog Desktop reimplements it in `products/desktop/packages/ui/src/features/` (TanStack Query + quill), against the same backend and flags, with no shared code.
- The feature set always changes for both apps together.

## Changes

- A new `.claude/rules/mcp-store-parity.md` states the keep-in-sync rule. Its `paths` globs cover the MCP store directories in both apps plus the desktop's hand-written gateway type mirrors, so agents load it exactly when working on those files and never elsewhere.
- `products/mcp_store/README.md` gains a "Keep the desktop UI in sync" section with the directory mapping between the two apps.
- New `README.md` guides in the three desktop MCP feature directories (`mcp-servers/`, `mcp-gateway/`, `mcp-server-manager/`) carry the same rule for human readers.

> [!NOTE]
> These guides were first shipped as `AGENTS.md` + `CLAUDE.md` pairs, but CI requires `CLAUDE.md` to be a real symlink and GitHub's commit APIs (which cloud-task sandboxes must use for signed commits) cannot create symlink tree entries. The path-scoped rule gives the same targeted agent pickup without symlinks.

Docs only, no code changes.

## How did you test this code?

Docs only. `.github/scripts/check-agents-md-symlinks.sh` and `hogli ci:preflight --fix` (including oxfmt markdown formatting) pass locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This PR is the docs change (contributor docs, not published docs).

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Skills invoked: /writing-pr-descriptions.
- An Explore agent mapped both implementations before writing.
- The first push used `AGENTS.md` + `CLAUDE.md` symlink pairs per repo convention; the symlink CI check failed because the sandbox's signed-commit tooling flattens symlinks to regular files, so the guides moved to a path-scoped `.claude/rules` file plus `README.md`s.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
