### PR TITLE
fix(ingestion-consumer): count executing batches in in-flight gauge

### DIFF
--- a/rust/ingestion-consumer/src/consumer.rs
+++ b/rust/ingestion-consumer/src/consumer.rs
@@ -67,6 +67,26 @@ struct InFlightBatch {
     handle: JoinHandle<anyhow::Result<ProcessedBatch>>,
 }
 
+/// RAII guard for the `ingestion_consumer_in_flight_batches` gauge, held by a
+/// batch's processing task for exactly as long as the batch is processed. The
+/// consumer loop joins finished tasks lazily (only at the concurrency cap or
+/// after an empty collect), so deque length would keep counting batches that
+/// already finished and pin the gauge near the cap under any sustained load.
+struct BatchProcessingGuard;
+
+impl BatchProcessingGuard {
+    fn new() -> Self {
+        gauge!("ingestion_consumer_in_flight_batches").increment(1.0);
+        Self
+    }
+}
+
+impl Drop for BatchProcessingGuard {
+    fn drop(&mut self) {
+        gauge!("ingestion_consumer_in_flight_batches").decrement(1.0);
+    }
+}
+
 /// Options for constructing an [`IngestionConsumer`] from pre-built parts.
 /// Used in integration tests where the Kafka consumer is created externally.
 pub struct IngestionConsumerOptions {
@@ -246,10 +266,6 @@ impl IngestionConsumer {
         let mut accepting_new_batches = true;
 
         while accepting_new_batches || !in_flight_batches.is_empty() {
-            // Consumer-level concurrency: how many Kafka batches are being
-            // processed in parallel, bounded by `max_in_flight_batches`.
-            gauge!("ingestion_consumer_in_flight_batches").set(in_flight_batches.len() as f64);
-
             if accepting_new_batches && in_flight_batches.len() < self.max_in_flight_batches {
                 tokio::select! {
                     _ = self.handle.shutdown_recv() => {
@@ -312,7 +328,9 @@ impl IngestionConsumer {
         let group_id = self.group_id.clone();
         let max_batch_size = self.batch_size;
 
+        let guard = BatchProcessingGuard::new();
         let handle = tokio::spawn(async move {
+            let _guard = guard;
             Self::process_collected_batch(
                 collected,
                 task_batch_id,


### PR DESCRIPTION
## Problem

- Operators reading `ingestion_consumer_in_flight_batches` see a constant cap−1 under any sustained load, so the gauge cannot show whether a consumer pod is saturated or idle.
- The consumer loop joins finished batch tasks lazily: only at the concurrency cap, or after an empty collect.
- The gauge sampled deque length at the top of the loop, so it counted batches that finished long ago.

## Changes

- An RAII guard now increments the gauge when a batch's processing task spawns and decrements it when the task finishes, mirroring the transport's per-worker `InFlightGuard`.
- The loop no longer sets the gauge from deque length.
- The gauge now reads genuine dispatch concurrency: below the cap when batch collection is the constraint, pinned at the cap when dispatch is (slow workers or consumer CPU contention on serialization; disambiguate with CPU and backpressure metrics).

## How did you test this code?

- `cargo test -p ingestion-consumer --lib` passes locally.
- No test asserts this gauge; a new one would assert metric plumbing rather than observable behavior, so none added.
- Not run: the e2e integration tests (they need a Kafka broker).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code while validating autoscaling signals for the split consumer/processor stack: the gauge read a constant value at every load level, which traced to the lazy join of finished tasks. Skills invoked: /writing-pr-descriptions. No session material beyond this repository's code informed the diff.

