### PR TITLE
feat(mcp_store): default agent server shares to team scope

### DIFF
--- a/products/mcp_store/frontend/gateway/GatewayServerAccess.tsx
+++ b/products/mcp_store/frontend/gateway/GatewayServerAccess.tsx
@@ -16,7 +16,7 @@ import { dayjs } from 'lib/dayjs'
 
 import { defaultAgentGrantPolicy, isPolicyStateAllowedByCeiling } from './gatewayPolicyUtils'
 import { AgentToolPolicyState, gatewayServerLogic } from './gatewayServerLogic'
-import { AgentGrantScopeControl, RemoveAllSharesButton, toProfileUser } from './gatewayUtils'
+import { AGENT_GRANT_SCOPE_OPTIONS, AgentGrantScopeControl, RemoveAllSharesButton, toProfileUser } from './gatewayUtils'
 import { agentServerAccessKey, mcpGatewayLogic, memberServerAccessKey } from './mcpGatewayLogic'
 
 const AGENT_POLICY_OPTIONS = [
@@ -258,6 +258,7 @@ function GatewayAgentAccessModal(): JSX.Element | null {
     const {
         agentAccessModalOpen,
         agentAccessPolicyMap,
+        agentAccessScope,
         agentAccessSelectedId,
         agentShareDisabledReason,
         agentServerAccessLoadingKeys,
@@ -270,6 +271,7 @@ function GatewayAgentAccessModal(): JSX.Element | null {
     const {
         closeAgentAccessModal,
         loadTeamToolPolicies,
+        setAgentAccessScope,
         setAgentAccessSelectedId,
         setAgentAccessToolPolicy,
         setAllAgentAccessTools,
@@ -340,6 +342,21 @@ function GatewayAgentAccessModal(): JSX.Element | null {
 
                 {agentAccessSelectedId && (
                     <>
+                        <div className="flex items-center justify-between gap-3">
+                            <div>
+                                <div className="font-semibold">Share with</div>
+                                <div className="text-sm text-secondary">
+                                    A team share lets the agent use your connection for every run in this project.
+                                </div>
+                            </div>
+                            <LemonSegmentedButton
+                                size="small"
+                                value={agentAccessScope}
+                                options={AGENT_GRANT_SCOPE_OPTIONS}
+                                onChange={setAgentAccessScope}
+                            />
+                        </div>
+
                         <div className="flex items-center justify-between gap-3">
                             <div>
                                 <div className="font-semibold">Tool access</div>

--- a/products/mcp_store/frontend/gateway/gatewayServerLogic.test.ts
+++ b/products/mcp_store/frontend/gateway/gatewayServerLogic.test.ts
@@ -381,13 +381,32 @@ describe('gatewayServerLogic', () => {
         expect(mockServiceAccountAccess).toHaveBeenCalledWith(expect.any(String), account.id, {
             gateway_server_id: 'server-id',
             enabled: true,
-            scope: 'personal',
+            scope: 'team',
             policies: [
                 { tool_name: 'list_issues', policy_state: 'approved' },
                 { tool_name: 'create_issue', policy_state: 'do_not_use' },
             ],
         })
         expect(logic.values.agentAccessModalOpen).toBe(false)
+    })
+
+    it('sends the scope picked in the share modal instead of the team default', async () => {
+        const account = serviceAccount()
+        parentLogic.actions.loadServiceAccountsSuccess([account])
+        logic.actions.openAgentAccessModal()
+        logic.actions.loadTeamToolPoliciesSuccess([toolPolicy('list_issues')])
+        logic.actions.setAgentAccessSelectedId(account.id)
+        logic.actions.setAgentAccessScope('personal')
+
+        await expectLogic(logic, () => {
+            logic.actions.submitAgentAccess()
+        }).toFinishAllListeners()
+
+        expect(mockServiceAccountAccess).toHaveBeenCalledWith(
+            expect.any(String),
+            account.id,
+            expect.objectContaining({ scope: 'personal' })
+        )
     })
 
     it.each([

--- a/products/mcp_store/frontend/gateway/gatewayServerLogic.ts
+++ b/products/mcp_store/frontend/gateway/gatewayServerLogic.ts
@@ -217,13 +217,13 @@ export interface gatewayServerLogicActions {
         accountId: string,
         serverId: string,
         enabled: boolean,
-        scope?: import('../generated/api.schemas').MCPAgentGrantScopeEnumApi | undefined,
+        scope?: MCPAgentGrantScopeEnumApi | undefined,
         policies?: import('../generated/api.schemas').ToolPolicyEntryApi[] | undefined
     ) => {
         accountId: string
         enabled: boolean
         policies: import('../generated/api.schemas').ToolPolicyEntryApi[] | undefined
-        scope: import('../generated/api.schemas').MCPAgentGrantScopeEnumApi
+        scope: MCPAgentGrantScopeEnumApi
         serverId: string
     } // mcpGatewayLogic
     setAgentServerAccessSuccess: (

--- a/products/mcp_store/frontend/gateway/gatewayServerLogic.ts
+++ b/products/mcp_store/frontend/gateway/gatewayServerLogic.ts
@@ -29,6 +29,7 @@ import {
 } from '../generated/api'
 import {
     GatewayMemberSummaryApi,
+    MCPAgentGrantScopeEnumApi,
     MCPGatewayServerApi,
     MCPToolApprovalStateEnumApi,
     ResolvedToolPolicyApi,
@@ -131,6 +132,7 @@ export interface gatewayServerLogicValues {
     serviceAccountsLoading: boolean // mcpGatewayLogic
     agentAccessModalOpen: boolean
     agentAccessPolicyMap: Record<string, AgentToolPolicyState>
+    agentAccessScope: MCPAgentGrantScopeEnumApi
     agentAccessSelectedId: string | null
     agentShareDisabledReason: string | undefined
     agentSharesByAccountId: Record<string, AgentServerShare>
@@ -290,6 +292,9 @@ export interface gatewayServerLogicActions {
     }
     returnToServers: () => {
         value: true
+    }
+    setAgentAccessScope: (scope: MCPAgentGrantScopeEnumApi) => {
+        scope: MCPAgentGrantScopeEnumApi
     }
     setAgentAccessSelectedId: (accountId: string | null) => {
         accountId: string | null
@@ -487,6 +492,7 @@ export const gatewayServerLogic = kea<gatewayServerLogicType>([
         showAgentAccessModal: true,
         closeAgentAccessModal: true,
         setAgentAccessSelectedId: (accountId: string | null) => ({ accountId }),
+        setAgentAccessScope: (scope: MCPAgentGrantScopeEnumApi) => ({ scope }),
         setAgentAccessToolPolicy: (toolName: string, state: AgentToolPolicyState) => ({ toolName, state }),
         setAllAgentAccessTools: (state: AgentToolPolicyState) => ({ state }),
         submitAgentAccess: true,
@@ -624,6 +630,14 @@ export const gatewayServerLogic = kea<gatewayServerLogicType>([
                 }),
                 closeAgentAccessModal: () => ({}),
                 setAgentServerAccessSuccess: () => ({}),
+            },
+        ],
+        agentAccessScope: [
+            'team' as MCPAgentGrantScopeEnumApi,
+            {
+                setAgentAccessScope: (_, { scope }) => scope,
+                closeAgentAccessModal: () => 'team',
+                setAgentServerAccessSuccess: () => 'team',
             },
         ],
         requestedAgentScopeId: [
@@ -847,7 +861,13 @@ export const gatewayServerLogic = kea<gatewayServerLogicType>([
                         values.agentAccessPolicyMap[policy.tool_name] ??
                         defaultAgentGrantPolicy(policy.tool_name, policy.team_state, policy.is_destructive),
                 }))
-            actions.setAgentServerAccess(values.agentAccessSelectedId, values.server.id, true, 'personal', policies)
+            actions.setAgentServerAccess(
+                values.agentAccessSelectedId,
+                values.server.id,
+                true,
+                values.agentAccessScope,
+                policies
+            )
         },
         syncScopeFromUrl: async ({ scopeParam }, breakpoint) => {
             await breakpoint(0)

--- a/products/mcp_store/frontend/gateway/gatewayUtils.tsx
+++ b/products/mcp_store/frontend/gateway/gatewayUtils.tsx
@@ -42,7 +42,7 @@ export function credentialOwnerLabel(owner: UserBasicApi, grantScope: string): s
     return grantScope === 'team' ? `via ${name}'s connection (team share)` : `via ${name}'s connection`
 }
 
-const AGENT_GRANT_SCOPE_OPTIONS: { value: MCPAgentGrantScopeEnumApi; label: string; tooltip: string }[] = [
+export const AGENT_GRANT_SCOPE_OPTIONS: { value: MCPAgentGrantScopeEnumApi; label: string; tooltip: string }[] = [
     {
         value: 'personal',
         label: 'Just my agents',

--- a/products/mcp_store/frontend/gateway/mcpGatewayLogic.test.ts
+++ b/products/mcp_store/frontend/gateway/mcpGatewayLogic.test.ts
@@ -700,10 +700,10 @@ describe('mcpGatewayLogic', () => {
     })
 
     // The endpoint defaults an omitted scope back to personal, so a share sent without
-    // one silently demotes a team share.
+    // one silently demotes a team share. The action fills in 'team', the product default.
     it.each([
-        ['team' as const, 'team'],
-        [undefined, 'personal'],
+        ['personal' as const, 'personal'],
+        [undefined, 'team'],
     ])('sends scope %s as %s when sharing a server with an agent', async (requested, expected) => {
         mockServiceAccountAccess.mockResolvedValue(serviceAccountWithShare(expected as MCPAgentGrantScopeEnumApi))
 

--- a/products/mcp_store/frontend/gateway/mcpGatewayLogic.ts
+++ b/products/mcp_store/frontend/gateway/mcpGatewayLogic.ts
@@ -730,7 +730,7 @@ export const mcpGatewayLogic = kea<mcpGatewayLogicType>([
             accountId: string,
             serverId: string,
             enabled: boolean,
-            scope: MCPAgentGrantScopeEnumApi = 'personal',
+            scope: MCPAgentGrantScopeEnumApi = 'team',
             policies?: ToolPolicyEntryApi[]
         ) => ({
             accountId,


### PR DESCRIPTION
## Problem

- Sharing an MCP server with an agent always started as "Just my agents", so agent runs that other people or schedules start could not use the connection until the sharer changed the scope afterwards.
- The share pop-up offers no scope choice. The "Just my agents" / "All team agents" picker only appears on the agent row after the share exists.

## Changes

- New shares default to "All team agents", both in the share pop-up and in the share switch on the agent page.
- The share pop-up gains a "Share with" control next to tool access, so the scope is picked at share time.
- The API keeps its personal default for an omitted scope. The UI now always sends the chosen scope.

Screenshot, rendered in Storybook with mocked gateway data:

![share-modal](https://raw.githubusercontent.com/PostHog/pr-assets/725c07dff053f9211ac05ef61b11bcebe1116691/2026/08/3e0c4110-7726-4cfe-b30d-dd7107fbb30f.png)

<details>
<summary>The pop-up in the server page</summary>

![share-modal-full](https://raw.githubusercontent.com/PostHog/pr-assets/f028edd36ee40e52404a2d63d93c31cde4010e1c/2026/08/4b66a52a-8569-4567-8bf8-d443b028df30.png)

</details>

## How did you test this code?

- Updated the two Jest tests that pinned the old default. They now catch the default regressing back to personal.
- Added one Jest test that submits the pop-up with "Just my agents" picked. It catches the new control disconnecting from the share request.
- Rendered the pop-up in Storybook with mocked data for the screenshots above.
- Repo-wide TypeScript check reports no errors introduced by this diff.
- Not run: Playwright and backend suites. The change is frontend-only.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No doc describes the previous default.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude in a PostHog Desktop cloud task. The user directed the default flip, the new control, and a copy revision.
- Skills invoked: /writing-user-facing-copy, /writing-tests, /running-ci-preflight, /writing-pr-descriptions.
- The "Share with" description first ended with "including runs nobody started". Removed at the user's request.
- The screenshots come from a temporary Storybook story with msw-mocked gateway endpoints. The story is not part of the diff.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
