### PR TITLE
fix(data-warehouse): scope storage delta write to owned fields

### DIFF
--- a/products/data_warehouse/backend/logic/data_load/create_table.py
+++ b/products/data_warehouse/backend/logic/data_load/create_table.py
@@ -139,7 +139,7 @@ async def create_table_from_saved_query(
                 logger.debug(f"Table size delta in MiB = {table_size_delta:.2f}")
 
                 job.storage_delta_mib = (job.storage_delta_mib or 0) + table_size_delta
-                await job.asave()
+                await job.asave(update_fields=["storage_delta_mib", "updated_at"])
 
                 storage_delta_mib = job.storage_delta_mib
                 total_storage_mib = table_created.size_in_s3_mib


### PR DESCRIPTION
## Problem

When a saved query materializes, `create_table_from_saved_query` updates the job's running storage delta and calls `job.asave()` with no `update_fields`. That writes every column of the `DataModelingJob` row, so any field another writer set concurrently during the same run can be silently overwritten.

## Changes

- Scope the intermediate storage-delta write to the field it owns: `job.asave(update_fields=["storage_delta_mib", "updated_at"])`.
- Left the three terminal sibling writes (`fail_materialization.py`, `succeed_materialization.py`, `materialize_view_duckgres.py`) untouched — those legitimately own the whole row.

## How did you test this code?

No automated tests were run for this one-line change. It narrows the columns written and does not change the value assigned. `updated_at` stays refreshed because it is listed in `update_fields`.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Single-line fix directed by a human. No skills required.
