### PR TITLE
feat(mcp-store): split connected servers into a gateway left rail

### DIFF
--- a/products/mcp_store/frontend/gateway/GatewayRail.tsx
+++ b/products/mcp_store/frontend/gateway/GatewayRail.tsx
@@ -1,0 +1,107 @@
+import { useActions, useValues } from 'kea'
+
+import { IconGear, IconList, IconPeople, IconPlug } from '@posthog/icons'
+import { LemonButton, LemonDivider, LemonSkeleton, LemonSnack } from '@posthog/lemon-ui'
+
+import { dayjs } from 'lib/dayjs'
+import { urls } from 'scenes/urls'
+
+import { ServerIcon } from '../scene/icons'
+import { GatewayRailStatus, gatewayRailStatus } from './gatewayRailStatus'
+import { GatewayServerEntry, mcpGatewayLogic } from './mcpGatewayLogic'
+import { GatewayTab, mcpGatewaySceneLogic } from './mcpGatewaySceneLogic'
+
+const MANAGE_LINKS: { tab: GatewayTab; label: string; icon: JSX.Element }[] = [
+    { tab: 'servers', label: 'All servers', icon: <IconPlug /> },
+    { tab: 'team', label: 'Team & agents', icon: <IconPeople /> },
+    { tab: 'settings', label: 'Team settings', icon: <IconGear /> },
+    { tab: 'audit', label: 'Audit log', icon: <IconList /> },
+]
+
+const STATUS_SUB: Record<Exclude<GatewayRailStatus, 'connected'>, string> = {
+    pending_oauth: 'Finishing setup',
+    needs_reauth: 'Needs reauth',
+    self_disabled: 'Off for you',
+    team_off: 'Off for the team',
+    revoked: 'Access revoked',
+}
+
+const STATUS_DOT_CLASSES: Record<GatewayRailStatus, string> = {
+    connected: 'bg-success',
+    pending_oauth: 'bg-warning',
+    needs_reauth: 'bg-danger',
+    self_disabled: 'bg-muted',
+    team_off: 'bg-muted',
+    revoked: 'bg-muted',
+}
+
+export function GatewayRail(): JSX.Element {
+    const { connectedServers, serversInitialized, serversLoading } = useValues(mcpGatewayLogic)
+    const { activeTab, availableTabs } = useValues(mcpGatewaySceneLogic)
+    const { setTab } = useActions(mcpGatewaySceneLogic)
+
+    return (
+        <aside className="flex w-60 shrink-0 flex-col gap-1">
+            <RailSectionLabel
+                label="Your connections"
+                count={serversInitialized ? connectedServers.length : undefined}
+            />
+            {!serversInitialized && serversLoading ? (
+                <div className="flex flex-col gap-1 px-2 py-1">
+                    <LemonSkeleton className="h-8" repeat={3} />
+                </div>
+            ) : connectedServers.length === 0 ? (
+                <div className="px-2 py-1 text-sm text-secondary">No connections yet.</div>
+            ) : (
+                connectedServers.map((server) => <RailConnectionRow key={server.id} server={server} />)
+            )}
+
+            <LemonDivider className="my-2" />
+            <RailSectionLabel label="Manage" />
+            {MANAGE_LINKS.filter(({ tab }) => availableTabs.includes(tab)).map(({ tab, label, icon }) => (
+                <LemonButton
+                    key={tab}
+                    fullWidth
+                    icon={icon}
+                    active={activeTab === tab}
+                    onClick={() => setTab(tab)}
+                    data-attr={`mcp-gateway-rail-${tab}`}
+                >
+                    {label}
+                </LemonButton>
+            ))}
+        </aside>
+    )
+}
+
+function RailConnectionRow({ server }: { server: GatewayServerEntry }): JSX.Element {
+    const status = gatewayRailStatus(server) ?? 'connected'
+    const lastUsedAt = server.your_connection?.last_used_at
+    const sub =
+        status === 'connected' ? (lastUsedAt ? `Used ${dayjs(lastUsedAt).fromNow()}` : 'Connected') : STATUS_SUB[status]
+
+    return (
+        <LemonButton
+            fullWidth
+            to={urls.mcpGatewayServer(server.id)}
+            icon={<ServerIcon iconDomain={server.icon_domain} serverUrl={server.url} size={24} />}
+            sideIcon={<span aria-hidden="true" className={`h-1.5 w-1.5 rounded-full ${STATUS_DOT_CLASSES[status]}`} />}
+            tooltip={sub}
+            data-attr="mcp-gateway-rail-connection"
+        >
+            <span className="flex min-w-0 flex-col py-0.5 leading-tight">
+                <span className="truncate text-sm font-medium">{server.name}</span>
+                <span className="truncate text-xs font-normal text-secondary">{sub}</span>
+            </span>
+        </LemonButton>
+    )
+}
+
+function RailSectionLabel({ label, count }: { label: string; count?: number }): JSX.Element {
+    return (
+        <div className="flex items-center justify-between px-2 pt-1">
+            <span className="text-xs font-semibold uppercase tracking-wide text-secondary">{label}</span>
+            {count !== undefined && <LemonSnack>{count}</LemonSnack>}
+        </div>
+    )
+}

--- a/products/mcp_store/frontend/gateway/GatewayServersHome.tsx
+++ b/products/mcp_store/frontend/gateway/GatewayServersHome.tsx
@@ -23,13 +23,7 @@ import { InstallCustomAuthTypeEnumApi } from '../generated/api.schemas'
 import { ServerIcon } from '../scene/icons'
 import { GatewayAddServerModal } from './GatewayAddServerModal'
 import { toProfileUser } from './gatewayUtils'
-import {
-    CONNECTED_SERVERS_FILTER,
-    GATEWAY_CATEGORY_LABELS,
-    GatewayServerEntry,
-    isTemplateOnlyServer,
-    mcpGatewayLogic,
-} from './mcpGatewayLogic'
+import { GATEWAY_CATEGORY_LABELS, GatewayServerEntry, isTemplateOnlyServer, mcpGatewayLogic } from './mcpGatewayLogic'
 
 const AUTH_TYPE_OPTIONS = [
     { value: 'oauth' as const, label: 'OAuth' },
@@ -61,7 +55,6 @@ export function GatewayServersHome({ onOpenServer }: { onOpenServer?: (serverId:
         searchQuery,
         categoryFilter,
         categoryCounts,
-        connectedServerCount,
         isAdmin,
         mergedServers,
     } = useValues(mcpGatewayLogic)
@@ -91,17 +84,6 @@ export function GatewayServersHome({ onOpenServer }: { onOpenServer?: (serverId:
                 </LemonButton>
             </div>
 
-            <div className="flex items-center gap-2 flex-wrap">
-                <LemonInput
-                    type="search"
-                    placeholder="Search MCP servers…"
-                    value={searchQuery}
-                    onChange={setSearchQuery}
-                    className="w-full"
-                    aria-label="Search MCP servers"
-                />
-            </div>
-
             <div className="flex items-center justify-between gap-2 text-sm text-secondary">
                 <span>
                     {filteredServers.length} {filteredServers.length === 1 ? 'server' : 'servers'}
@@ -128,14 +110,6 @@ export function GatewayServersHome({ onOpenServer }: { onOpenServer?: (serverId:
                     onClick={() => setCategoryFilter(null)}
                 >
                     All <LemonSnack className="ml-1">{mergedServers.length}</LemonSnack>
-                </LemonButton>
-                <LemonButton
-                    size="small"
-                    type={categoryFilter === CONNECTED_SERVERS_FILTER ? 'primary' : 'tertiary'}
-                    aria-pressed={categoryFilter === CONNECTED_SERVERS_FILTER}
-                    onClick={() => setCategoryFilter(CONNECTED_SERVERS_FILTER)}
-                >
-                    Connected <LemonSnack className="ml-1">{connectedServerCount}</LemonSnack>
                 </LemonButton>
                 {categories.map((category) => (
                     <LemonButton
@@ -237,7 +211,6 @@ export function GatewayServerCard({
             <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2">
                     <span className="font-semibold">{server.name}</span>
-                    {recommended && <LemonTag type="highlight">Recommended</LemonTag>}
                     {connected && <LemonTag type="success">Connected</LemonTag>}
                     {connection?.pending_oauth && <LemonTag type="warning">Finishing setup</LemonTag>}
                     {connection?.needs_reauth && <LemonTag type="danger">Needs reauth</LemonTag>}

--- a/products/mcp_store/frontend/gateway/GatewayServersHome.tsx
+++ b/products/mcp_store/frontend/gateway/GatewayServersHome.tsx
@@ -22,6 +22,7 @@ import { urls } from 'scenes/urls'
 import { InstallCustomAuthTypeEnumApi } from '../generated/api.schemas'
 import { ServerIcon } from '../scene/icons'
 import { GatewayAddServerModal } from './GatewayAddServerModal'
+import { GatewayServersSearch } from './GatewayServersSearch'
 import { toProfileUser } from './gatewayUtils'
 import { GATEWAY_CATEGORY_LABELS, GatewayServerEntry, isTemplateOnlyServer, mcpGatewayLogic } from './mcpGatewayLogic'
 
@@ -101,6 +102,8 @@ export function GatewayServersHome({ onOpenServer }: { onOpenServer?: (serverId:
                     </LemonButton>
                 )}
             </div>
+
+            <GatewayServersSearch />
 
             <div className="flex items-center gap-2 flex-wrap">
                 <LemonButton

--- a/products/mcp_store/frontend/gateway/GatewayServersSearch.tsx
+++ b/products/mcp_store/frontend/gateway/GatewayServersSearch.tsx
@@ -1,0 +1,21 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonInput } from '@posthog/lemon-ui'
+
+import { mcpGatewayLogic } from './mcpGatewayLogic'
+
+export function GatewayServersSearch(): JSX.Element {
+    const { searchQuery } = useValues(mcpGatewayLogic)
+    const { setSearchQuery } = useActions(mcpGatewayLogic)
+
+    return (
+        <LemonInput
+            type="search"
+            placeholder="Search MCP servers…"
+            value={searchQuery}
+            onChange={setSearchQuery}
+            fullWidth
+            aria-label="Search MCP servers"
+        />
+    )
+}

--- a/products/mcp_store/frontend/gateway/McpGatewayScene.tsx
+++ b/products/mcp_store/frontend/gateway/McpGatewayScene.tsx
@@ -1,6 +1,6 @@
-import { useActions, useValues } from 'kea'
+import { useValues } from 'kea'
 
-import { LemonBanner, LemonTabs } from '@posthog/lemon-ui'
+import { LemonBanner } from '@posthog/lemon-ui'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -11,7 +11,9 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 
 import { GatewayAuditLog } from './GatewayAuditLog'
+import { GatewayRail } from './GatewayRail'
 import { GatewayServersHome } from './GatewayServersHome'
+import { GatewayServersSearch } from './GatewayServersSearch'
 import { GatewayTeamAndAgents } from './GatewayTeamAndAgents'
 import { GatewayTeamSettings } from './GatewayTeamSettings'
 import { GatewayTab, mcpGatewaySceneLogic } from './mcpGatewaySceneLogic'
@@ -21,17 +23,9 @@ export const scene: SceneExport = {
     logic: mcpGatewaySceneLogic,
 }
 
-const TAB_LABELS: Record<GatewayTab, string> = {
-    servers: 'Servers',
-    team: 'Team & agents',
-    settings: 'Team settings',
-    audit: 'Audit log',
-}
-
 export function McpGatewayScene(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
     const { activeTab, availableTabs } = useValues(mcpGatewaySceneLogic)
-    const { setTab } = useActions(mcpGatewaySceneLogic)
 
     if (!featureFlags[FEATURE_FLAGS.MCP_GATEWAY]) {
         return (
@@ -55,16 +49,11 @@ export function McpGatewayScene(): JSX.Element {
                 description="Every MCP server your team runs through the gateway. Route people and agents through one control plane."
                 resourceType={{ type: sceneConfigurations[Scene.McpGateway].iconType || 'default_icon_type' }}
             />
-            <LemonTabs
-                activeKey={activeTab}
-                onChange={(key) => setTab(key)}
-                sceneInset
-                tabs={availableTabs.map((tab) => ({
-                    key: tab,
-                    label: TAB_LABELS[tab],
-                    content: tabContent[tab],
-                }))}
-            />
+            {activeTab === 'servers' && <GatewayServersSearch />}
+            <div className="flex items-start gap-6">
+                <GatewayRail />
+                <div className="min-w-0 flex-1">{availableTabs.includes(activeTab) ? tabContent[activeTab] : null}</div>
+            </div>
         </SceneContent>
     )
 }

--- a/products/mcp_store/frontend/gateway/McpGatewayScene.tsx
+++ b/products/mcp_store/frontend/gateway/McpGatewayScene.tsx
@@ -13,7 +13,6 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { GatewayAuditLog } from './GatewayAuditLog'
 import { GatewayRail } from './GatewayRail'
 import { GatewayServersHome } from './GatewayServersHome'
-import { GatewayServersSearch } from './GatewayServersSearch'
 import { GatewayTeamAndAgents } from './GatewayTeamAndAgents'
 import { GatewayTeamSettings } from './GatewayTeamSettings'
 import { GatewayTab, mcpGatewaySceneLogic } from './mcpGatewaySceneLogic'
@@ -49,7 +48,6 @@ export function McpGatewayScene(): JSX.Element {
                 description="Every MCP server your team runs through the gateway. Route people and agents through one control plane."
                 resourceType={{ type: sceneConfigurations[Scene.McpGateway].iconType || 'default_icon_type' }}
             />
-            {activeTab === 'servers' && <GatewayServersSearch />}
             <div className="flex items-start gap-6">
                 <GatewayRail />
                 <div className="min-w-0 flex-1">{availableTabs.includes(activeTab) ? tabContent[activeTab] : null}</div>

--- a/products/mcp_store/frontend/gateway/McpGatewayScene.tsx
+++ b/products/mcp_store/frontend/gateway/McpGatewayScene.tsx
@@ -43,7 +43,7 @@ export function McpGatewayScene(): JSX.Element {
     }
 
     return (
-        <SceneContent className="mx-auto w-full max-w-[1200px]">
+        <SceneContent className="pt-4">
             <SceneTitleSection
                 name={sceneConfigurations[Scene.McpGateway].name}
                 description="Every MCP server your team runs through the gateway. Route people and agents through one control plane."

--- a/products/mcp_store/frontend/gateway/gatewayRailStatus.test.ts
+++ b/products/mcp_store/frontend/gateway/gatewayRailStatus.test.ts
@@ -1,0 +1,69 @@
+import type { GatewayYourConnectionApi, MCPGatewayServerApi } from '../generated/api.schemas'
+import { GatewayRailStatus, gatewayRailStatus } from './gatewayRailStatus'
+
+function gatewayServer(overrides: Partial<MCPGatewayServerApi> = {}): MCPGatewayServerApi {
+    return {
+        id: 'server-id',
+        name: 'Test server',
+        url: 'https://mcp.example.com/mcp',
+        description: '',
+        category: 'dev',
+        template_auth_type: null,
+        is_team_enabled: true,
+        icon_key: '',
+        icon_domain: '',
+        docs_url: '',
+        template_id: null,
+        tool_count: 0,
+        connections: [],
+        your_connection: null,
+        agents: [],
+        revoked_user_ids: [],
+        is_revoked_for_you: false,
+        created_by: null,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        ...overrides,
+    }
+}
+
+function connection(overrides: Partial<GatewayYourConnectionApi> = {}): GatewayYourConnectionApi {
+    return {
+        installation_id: 'installation-id',
+        is_enabled: true,
+        pending_oauth: false,
+        needs_reauth: false,
+        last_used_at: null,
+        ...overrides,
+    }
+}
+
+describe('gatewayRailStatus', () => {
+    it('returns null without a personal connection', () => {
+        expect(gatewayRailStatus(gatewayServer())).toBeNull()
+    })
+
+    it.each<[string, Partial<MCPGatewayServerApi>, GatewayRailStatus]>([
+        ['healthy connection', { your_connection: connection() }, 'connected'],
+        ['pending OAuth', { your_connection: connection({ pending_oauth: true }) }, 'pending_oauth'],
+        ['invalidated token', { your_connection: connection({ needs_reauth: true }) }, 'needs_reauth'],
+        ['self-disabled connection', { your_connection: connection({ is_enabled: false }) }, 'self_disabled'],
+        ['team-disabled server', { your_connection: connection(), is_team_enabled: false }, 'team_off'],
+        [
+            'revoked access outranks connection problems',
+            {
+                your_connection: connection({ needs_reauth: true }),
+                is_team_enabled: false,
+                is_revoked_for_you: true,
+            },
+            'revoked',
+        ],
+        [
+            'team off outranks a pending OAuth round-trip',
+            { your_connection: connection({ pending_oauth: true }), is_team_enabled: false },
+            'team_off',
+        ],
+    ])('%s', (_name, overrides, expected) => {
+        expect(gatewayRailStatus(gatewayServer(overrides))).toBe(expected)
+    })
+})

--- a/products/mcp_store/frontend/gateway/gatewayRailStatus.ts
+++ b/products/mcp_store/frontend/gateway/gatewayRailStatus.ts
@@ -1,0 +1,35 @@
+import { GatewayServerEntry } from './mcpGatewayLogic'
+
+export type GatewayRailStatus =
+    | 'connected'
+    | 'pending_oauth'
+    | 'needs_reauth'
+    | 'self_disabled'
+    | 'team_off'
+    | 'revoked'
+
+/** Folds a connected server's flags into the single status the rail shows.
+ * Blockers outrank connection state: a revoked or team-disabled server is not
+ * usable no matter what the personal connection says. */
+export function gatewayRailStatus(server: GatewayServerEntry): GatewayRailStatus | null {
+    const connection = server.your_connection
+    if (!connection) {
+        return null
+    }
+    if (server.is_revoked_for_you) {
+        return 'revoked'
+    }
+    if (!server.is_team_enabled) {
+        return 'team_off'
+    }
+    if (connection.pending_oauth) {
+        return 'pending_oauth'
+    }
+    if (connection.needs_reauth) {
+        return 'needs_reauth'
+    }
+    if (!connection.is_enabled) {
+        return 'self_disabled'
+    }
+    return 'connected'
+}

--- a/products/mcp_store/frontend/gateway/mcpGatewayLogic.test.ts
+++ b/products/mcp_store/frontend/gateway/mcpGatewayLogic.test.ts
@@ -30,7 +30,7 @@ import type {
     MCPServiceAccountApi,
     UserBasicApi,
 } from '../generated/api.schemas'
-import { CONNECTED_SERVERS_FILTER, GATEWAY_MEMBERS_PAGE_SIZE, mcpGatewayLogic } from './mcpGatewayLogic'
+import { GATEWAY_MEMBERS_PAGE_SIZE, mcpGatewayLogic } from './mcpGatewayLogic'
 
 const YOU: UserBasicApi = {
     id: MOCK_DEFAULT_USER.id,
@@ -607,7 +607,7 @@ describe('mcpGatewayLogic', () => {
         expect(logic.values.recommendedTemplates).toEqual([freshTemplate])
     })
 
-    it('filters to servers with a connection, including connections that need attention', () => {
+    it('lists servers with a connection, including connections that need attention', () => {
         const connectedServer = gatewayServer({
             id: 'connected-server',
             your_connection: {
@@ -621,10 +621,7 @@ describe('mcpGatewayLogic', () => {
         const disconnectedServer = gatewayServer({ id: 'disconnected-server' })
         logic.actions.loadServersSuccess([connectedServer, disconnectedServer])
 
-        logic.actions.setCategoryFilter(CONNECTED_SERVERS_FILTER)
-
-        expect(logic.values.connectedServerCount).toBe(1)
-        expect(logic.values.filteredServers).toEqual([connectedServer])
+        expect(logic.values.connectedServers).toEqual([connectedServer])
     })
 
     it.each([

--- a/products/mcp_store/frontend/gateway/mcpGatewayLogic.ts
+++ b/products/mcp_store/frontend/gateway/mcpGatewayLogic.ts
@@ -63,8 +63,6 @@ export const GATEWAY_CATEGORY_LABELS: Record<string, string> = {
     productivity: 'Productivity & collaboration',
 }
 
-export const CONNECTED_SERVERS_FILTER = 'connected'
-
 function currentProjectId(): string {
     return String(teamLogic.values.currentTeamId)
 }
@@ -196,7 +194,7 @@ export interface mcpGatewayLogicValues {
     config: TeamMCPGatewayConfigApi | null
     configLoading: boolean
     configMutationInProgress: boolean
-    connectedServerCount: number
+    connectedServers: GatewayServerEntry[]
     connectingServerId: string | null
     connectionApiKey: string
     connectionAuthType: InstallCustomAuthTypeEnumApi
@@ -631,7 +629,7 @@ export interface mcpGatewayLogicMeta {
             connectionApiKey: string
         ) => string | null
         categoryCounts: (mergedServers: MCPGatewayServerApi[]) => Record<string, number>
-        connectedServerCount: (mergedServers: MCPGatewayServerApi[]) => number
+        connectedServers: (mergedServers: MCPGatewayServerApi[]) => GatewayServerEntry[]
         filteredServers: (
             mergedServers: MCPGatewayServerApi[],
             searchQuery: string,
@@ -1185,10 +1183,12 @@ export const mcpGatewayLogic = kea<mcpGatewayLogicType>([
                 return counts
             },
         ],
-        connectedServerCount: [
+        connectedServers: [
             (s) => [s.mergedServers],
-            (mergedServers: GatewayServerEntry[]): number =>
-                mergedServers.filter((server) => server.your_connection !== null).length,
+            (mergedServers: GatewayServerEntry[]): GatewayServerEntry[] =>
+                mergedServers
+                    .filter((server) => server.your_connection !== null)
+                    .sort((a, b) => a.name.localeCompare(b.name)),
         ],
         filteredServers: [
             (s) => [s.mergedServers, s.searchQuery, s.categoryFilter],
@@ -1199,14 +1199,7 @@ export const mcpGatewayLogic = kea<mcpGatewayLogicType>([
             ): GatewayServerEntry[] => {
                 const query = searchQuery.trim().toLowerCase()
                 return mergedServers.filter((server) => {
-                    if (categoryFilter === CONNECTED_SERVERS_FILTER && !server.your_connection) {
-                        return false
-                    }
-                    if (
-                        categoryFilter &&
-                        categoryFilter !== CONNECTED_SERVERS_FILTER &&
-                        server.category !== categoryFilter
-                    ) {
+                    if (categoryFilter && server.category !== categoryFilter) {
                         return false
                     }
                     if (!query) {

--- a/products/mcp_store/frontend/settings/McpGatewaySettings.tsx
+++ b/products/mcp_store/frontend/settings/McpGatewaySettings.tsx
@@ -10,7 +10,6 @@ import { GatewayMemberScene } from '../gateway/GatewayMemberScene'
 import { gatewayServerLogic } from '../gateway/gatewayServerLogic'
 import { GatewayServerScene } from '../gateway/GatewayServerScene'
 import { GatewayServersHome } from '../gateway/GatewayServersHome'
-import { GatewayServersSearch } from '../gateway/GatewayServersSearch'
 import { GatewayTeamAndAgents } from '../gateway/GatewayTeamAndAgents'
 import { GatewayTeamSettings } from '../gateway/GatewayTeamSettings'
 import { GatewayTab } from '../gateway/mcpGatewaySceneLogic'
@@ -45,10 +44,7 @@ export function McpGatewaySettings(): JSX.Element {
                 <GatewayServerScene id={detailId} onBack={() => closeDetail('servers')} />
             </BindLogic>
         ) : (
-            <div className="flex flex-col gap-4">
-                <GatewayServersSearch />
-                <GatewayServersHome onOpenServer={openServer} />
-            </div>
+            <GatewayServersHome onOpenServer={openServer} />
         )
     const teamContent =
         detailView === 'agent' && detailId ? (

--- a/products/mcp_store/frontend/settings/McpGatewaySettings.tsx
+++ b/products/mcp_store/frontend/settings/McpGatewaySettings.tsx
@@ -10,6 +10,7 @@ import { GatewayMemberScene } from '../gateway/GatewayMemberScene'
 import { gatewayServerLogic } from '../gateway/gatewayServerLogic'
 import { GatewayServerScene } from '../gateway/GatewayServerScene'
 import { GatewayServersHome } from '../gateway/GatewayServersHome'
+import { GatewayServersSearch } from '../gateway/GatewayServersSearch'
 import { GatewayTeamAndAgents } from '../gateway/GatewayTeamAndAgents'
 import { GatewayTeamSettings } from '../gateway/GatewayTeamSettings'
 import { GatewayTab } from '../gateway/mcpGatewaySceneLogic'
@@ -44,7 +45,10 @@ export function McpGatewaySettings(): JSX.Element {
                 <GatewayServerScene id={detailId} onBack={() => closeDetail('servers')} />
             </BindLogic>
         ) : (
-            <GatewayServersHome onOpenServer={openServer} />
+            <div className="flex flex-col gap-4">
+                <GatewayServersSearch />
+                <GatewayServersHome onOpenServer={openServer} />
+            </div>
         )
     const teamContent =
         detailView === 'agent' && detailId ? (


### PR DESCRIPTION
## Problem

- Finding one of your connected MCP servers on the web MCP servers page means scanning the whole catalog or clicking the "Connected" filter pill under the tabs.
- The Desktop app already splits connections into a left rail. The web page should match.
- The search input was also capped at 240px wide.

## Changes

- A left rail now shows "Your connections": each connected server with its status ("Used 3 hours ago", "Needs reauth", "Finishing setup") and a status dot, linking to the server's page.
- The rail's "Manage" section replaces the horizontal tabs: All servers, Team & agents, Team settings, Audit log. Admin-only links stay hidden for members.
- The "Connected" filter pill is removed. The rail owns that job now.
- The "Recommended" badge is removed from catalog rows.
- The search bar moved above the rail and the list, at full page width. The settings-embedded variant keeps its search through the same extracted component.

Before:

![mcp-servers-before](https://raw.githubusercontent.com/PostHog/pr-assets/2db401a43763e8e4548fb475c6ebb03192e020f5/2026/08/e79ebb3a-0228-4bd1-a0a9-fed83aeb1fe2.png)

After:

![mcp-servers-final](https://raw.githubusercontent.com/PostHog/pr-assets/74c7fdb54b92098b1fae854a2212605c7753f5c2/2026/08/73f4554b-cb8e-4f8d-a04b-41510380c27e.png)

The rail persists across tabs, here on the audit log:

![mcp-audit-tab](https://raw.githubusercontent.com/PostHog/pr-assets/1902da0aa6fa7965183209a5e6532fe6ba44e1f5/2026/08/cf848f56-6dab-4d6d-b38d-8945fd5313ec.png)

## How did you test this code?

- New parameterized test for `gatewayRailStatus` catches a rail row reading "Connected" while the server is revoked or team-disabled.
- The old connected-filter test now covers the `connectedServers` selector that feeds the rail.
- I ran the app locally with seeded servers in four connection states and clicked through: rail rows open the server page, Manage links switch tabs, search filters the list (screenshots above).
- Not run: the full CI matrix and Storybook visual suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The MCP gateway UI is flag-gated alpha with no docs page describing this layout.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude in a PostHog cloud task session, directed by the assignee.
- Skills invoked: /writing-ui-components, /writing-user-facing-copy, /writing-tests, /writing-pr-descriptions.
- The rail mirrors the Desktop app's `GatewayRail` (products/desktop) as the reference design.
- Scope grew across the session: first the rail, then removing the Connected pill and Recommended badge, then the full-width search.
- Screenshots come from a local dev stack seeded with invented example.com servers and fake tokens. No customer data.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
