### PR TITLE
fix(data-modeling): report callers that still mint v1 schedules

### DIFF
--- a/products/data_modeling/backend/models/datawarehouse_saved_query.py
+++ b/products/data_modeling/backend/models/datawarehouse_saved_query.py
@@ -65,6 +65,15 @@ def validate_saved_query_name(value):
         )
 
 
+class V1SchedulingPathReached(Exception):
+    """Reported, never raised. Marks a caller that still mints a v1 per-query schedule.
+
+    v1 scheduling is being retired and the fleet no longer runs it, so this exists to find any
+    remaining path into it before the workflow type is deregistered — a schedule pointing at a
+    deregistered type does not fail loudly, it fires forever with failing workflow tasks.
+    """
+
+
 class DataWarehouseSavedQuery(CreatedMetaFields, UUIDTModel, UpdatedMetaFields, DeletedMetaFields):
     class Status(models.TextChoices):
         """Possible states of this SavedQuery."""
@@ -291,6 +300,18 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDTModel, UpdatedMetaFields, 
                     # runs inside an atomic block); immediate under autocommit.
                     transaction.on_commit(self._start_immediate_materialization)
                 return
+
+            # Both regions hold zero `data-modeling-run` schedules, so nothing should reach here.
+            # Report each arrival with the caller's context, but still schedule: a customer's
+            # materialization must not be what proves this path is dead.
+            capture_exception(
+                V1SchedulingPathReached(f"Saved query {self.id} scheduled through the v1 per-query path"),
+                {
+                    "saved_query_id": str(self.id),
+                    "team_id": self.team_id,
+                    "dag_id": str(node.dag_id) if node is not None else None,
+                },
+            )
 
             self.setup_model_paths()
 

--- a/products/data_modeling/backend/test/test_schedule_materialization.py
+++ b/products/data_modeling/backend/test/test_schedule_materialization.py
@@ -7,9 +7,13 @@ from products.data_modeling.backend.logic.cohort_scheduling import is_tier_sched
 from products.data_modeling.backend.logic.freshness import UnsupportedFrequencyTargetError
 from products.data_modeling.backend.logic.node_frequency import get_declared_target, set_declared_target
 from products.data_modeling.backend.models import DAG, Node
-from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
+from products.data_modeling.backend.models.datawarehouse_saved_query import (
+    DataWarehouseSavedQuery,
+    V1SchedulingPathReached,
+)
 from products.data_modeling.backend.models.node import NodeType
 
+MODEL = "products.data_modeling.backend.models.datawarehouse_saved_query"
 SERVICE = "products.data_warehouse.backend.logic.data_load.saved_query_service"
 GET_V2_DAG_IDS = "products.data_modeling.backend.schedule.get_v2_scheduled_dag_ids"
 RECONCILE = "products.data_modeling.backend.logic.schedule_reconcile"
@@ -50,11 +54,14 @@ class TestScheduleMaterializationV2Guard(BaseTest):
             mock.patch(f"{SERVICE}.saved_query_workflow_exists", return_value=False),
             mock.patch.object(DataWarehouseSavedQuery, "setup_model_paths") as setup_paths,
             mock.patch(f"{NODE_MAT}.sync_connect") as sync_connect,
+            mock.patch(f"{MODEL}.capture_exception") as capture,
             self.captureOnCommitCallbacks(execute=True),
         ):
             self.sq.schedule_materialization()
         sync_wf.assert_not_called()
         setup_paths.assert_not_called()
+        # reporting on the healthy path would bury the one signal that matters
+        capture.assert_not_called()
         # a frequency-only call carries no enable intent, so it must not start a one-off run
         sync_connect.assert_not_called()
         self.sq.refresh_from_db()
@@ -88,11 +95,17 @@ class TestScheduleMaterializationV2Guard(BaseTest):
             mock.patch(f"{SERVICE}.saved_query_workflow_exists", return_value=True),
             mock.patch(f"{RECONCILE}.schedule_exists", return_value=True),
             mock.patch.object(DataWarehouseSavedQuery, "setup_model_paths"),
+            mock.patch(f"{MODEL}.capture_exception") as capture,
         ):
             self.sq.schedule_materialization()
         sync_wf.assert_called_once()
         self.sq.refresh_from_db()
         assert self.sq.sync_frequency_interval == timedelta(hours=12)
+        # the fleet runs no v1 schedules, so an arrival here is the only evidence a minting path
+        # survives; losing this report reads as "minting is closed" and clears the workflow type
+        # for deregistration, which fails silently in production
+        assert isinstance(capture.call_args.args[0], V1SchedulingPathReached)
+        assert capture.call_args.args[1]["team_id"] == self.team.pk
 
     def test_virgin_dag_is_born_on_tiers_instead_of_minting_a_v1_schedule(self):
         # a brand-new team's DAG has no v2 schedule *and* no v1 schedules, so the v2 lookup says


### PR DESCRIPTION
## Problem

- v1 data modeling scheduling is being retired, and both regions now hold **zero** `data-modeling-run` Temporal schedules.
- `schedule_materialization` still has a fall-through that mints a v1 per-query schedule, and it reports nothing when it runs.
- Nobody can tell whether that path is dead or merely quiet, so the retirement cannot proceed on evidence.
- The next step after this is deregistering the `RunWorkflow` type. That step is irreversible and fails quietly: a schedule pointing at a deregistered workflow type does not error, it fires forever with failing workflow tasks.

## Changes

- `schedule_materialization` reports every arrival at the v1 path to error tracking, carrying `saved_query_id`, `team_id` and `dag_id`.
- A new `V1SchedulingPathReached` exception exists only to be reported, never raised, so the signal is greppable in error tracking.
- Scheduling still runs. A raise would make a customer's materialization the thing that proves the path is dead.
- No behavior changes for any query already on v2.

> [!NOTE]
> This is a measurement, not a fix. Bake it, then read error tracking: silence means minting is closed and the workflow type can be deregistered; any hit names the caller nobody knew about.

The v2 bootstrap needs no change here. The block above already offers it (`dag_can_bootstrap_to_tiers`), so reaching the fall-through means the bootstrap was offered and declined — no DAG node, or a DAG that has been scheduled before.

## How did you test this code?

I extended the two existing tests that already cover both branches, rather than adding new ones.

- `test_creates_v1_schedule_when_dag_not_on_v2` now asserts the report fires and carries the team. It catches the report silently going away, which would read as "minting is closed" and clear an irreversible step on false evidence.
- `test_skips_v1_and_nulls_frequency_when_dag_on_v2` now asserts the report does **not** fire on the v2 path. Reporting there would bury the one signal worth watching.

Ran locally: `products/data_modeling/backend/test/` plus `products/data_warehouse/backend/tests/api/test_saved_query.py`, all green. `ruff` clean, `mypy` clean on the touched files.

I did not exercise this against a real Temporal schedule, and I did no manual testing.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) wrote this. Skills invoked: `/quick-fix-pr`, `/writing-tests`, `/writing-pr-descriptions`.

This came out of confirming the fleet is off v1: a full prod-us Temporal sweep returned zero `data-modeling-run` schedules, matching the EU sweep, which makes this path unobservable rather than merely unused. The first sketch also added a v2 bootstrap attempt at the fall-through; reading the surrounding code showed the bootstrap already runs and is declined before that point, so it was dropped.

Nothing in this PR carries material from the agent session that is not already in this repository.
