### PR TITLE
fix(desktop): center the session hover card on its row

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemHoverCard.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemHoverCard.tsx
@@ -133,9 +133,14 @@ export function ChannelItemPreviewCardProvider({
         {({ payload }) =>
           payload ? (
             <PreviewCard.Portal>
+              {/* Centered on the row rather than starting at its top edge: a
+                  card several times a row's height hung off it downwards, so it
+                  read as belonging to the rows below the one being pointed at.
+                  Base UI shifts it back into view near the top and bottom of
+                  the list on its own. */}
               <PreviewCard.Positioner
                 side="right"
-                align="start"
+                align="center"
                 sideOffset={10}
                 className="z-50"
               >

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemPreview.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemPreview.tsx
@@ -246,8 +246,13 @@ export function ChannelItemPreview({
         <ItemContent className="min-w-0">
           {/* No gutter: the mark is one glyph on one line, and a column for it
               indents everything under it for the whole height of the card. */}
-          <ItemTitle className="flex items-baseline gap-2 break-words">
-            <span className="flex size-4 shrink-0 translate-y-0.5 items-center justify-center">
+          <ItemTitle className="flex items-start gap-2 break-words">
+            {/* A box one line tall, centered on the title's first line, rather
+                than a baseline-aligned box nudged down by half a step: a mark
+                sitting on the text's baseline reads low against it, and the
+                nudge was tuned to one glyph's metrics. `items-start` keeps it on
+                the first line when the title wraps. */}
+            <span className="flex h-[1lh] w-4 shrink-0 items-center justify-center">
               {previewGlyph(item, dot)}
             </span>
             <span className="min-w-0">{item.title}</span>


### PR DESCRIPTION
## Problem

- Resting on a session row in the channels sidebar or the spaces tree opened its hover card level with the row's top edge, then hung the rest of the card downwards.
- The card is about seven times a row's height, so it covered the rows below and read as belonging to one of them rather than to the row under the pointer.
- Inside the card, the status mark beside the title sat 3.5px below the title's optical center.

## Changes

- The card now centers on the row it describes (`align="center"` on the `PreviewCard.Positioner`, which was `align="start"`).
- Base UI still shifts the card down or up for rows near the top or bottom of the list, so nothing gets clipped.
- Space rows share the same popup, so their card centers too.
- The title's status mark now sits in a box one line tall, centered on the title's first line. That replaces a baseline alignment plus a `translate-y-0.5` nudge tuned to one glyph's metrics.

Hovering the fifth row of a session list. The orange outline marks the row under the pointer, the dashed line runs through that row's center, and the blue dot marks the card's center.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/PostHog/pr-assets/1f17d1a0a9b16ce42029e955ef920d0cdac6113b/2026/08/bf922eb7-c9b3-46aa-8e8a-2b97c416f19d.png) | ![after](https://raw.githubusercontent.com/PostHog/pr-assets/1f17d1a0a9b16ce42029e955ef920d0cdac6113b/2026/08/d494dbe5-dc83-4c4b-b40e-18c19b0bc411.png) |

## How did you test this code?

- I measured the card, the row, and the card's title line in a headless browser, driving a throwaway Storybook story that rendered a list of rows around the shared card. The story is not part of this PR.
- Card against a row whose center sits at y=158: the card ran 144→342 (center 243) before, and 59→257 (center 158) after.
- A row near the top of the list still opens a card that Base UI shifts to y=6, which is the collision behavior the change relies on.
- Status mark against a title first line centered at y=78.5: the mark's center was 82.0 before, and 78.6 after. It stays on the first line when the title wraps to two lines.
- Ran the `ChannelItemHoverCard`, `ChannelItemRow`, and `ChannelsList` vitest suites and `tsc --noEmit` for `@posthog/ui`.
- Not done: I did not run the Electron app, so I did not see either change in the product itself.
- No test added: both positions come from layout, and the jsdom suites cannot measure it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by an agent in a PostHog cloud task, from a report that the session hover card in the bluebird spaces navigation was not vertically centered, with a screenshot of the card.
- Skills invoked: `/writing-pr-descriptions`.
- The first version of this PR only moved the card. The reporter looked at the screenshot and still read the card as off-center, so I measured the card's contents as well and found the glyph offset, which is the second commit.
- The screenshots come from a Storybook harness with invented task titles and a fixture author, not from any real workspace. The card renders light there because Base UI portals it to `document.body`, outside the story's theme wrapper.
