### PR TITLE
fix(clickhouse): classify query-log errors like errors returned over HTTP

### DIFF
--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -386,7 +386,9 @@ class ClickHouseClient:
         return request_data
 
     @staticmethod
-    def raise_clickhouse_error(error_message: str, query: str | None = None) -> typing.NoReturn:
+    def raise_clickhouse_error(
+        error_message: str, query: str | None = None, query_id: str | None = None
+    ) -> typing.NoReturn:
         """Raise the appropriate ClickHouseError subclass based on the error message."""
         ERROR_CODE_TO_EXCEPTION: dict[str, type[ClickHouseError]] = {
             "ALL_REPLICAS_ARE_STALE": ClickHouseAllReplicasAreStaleError,
@@ -398,8 +400,8 @@ class ClickHouseClient:
         }
         for error_code, exc_class in ERROR_CODE_TO_EXCEPTION.items():
             if error_code in error_message:
-                raise exc_class(error_message, query=query)
-        raise ClickHouseError(error_message, query=query)
+                raise exc_class(error_message, query=query, query_id=query_id)
+        raise ClickHouseError(error_message, query=query, query_id=query_id)
 
     async def acheck_response(self, response, query) -> None:
         """Asynchronously check the HTTP response received from ClickHouse."""
@@ -764,8 +766,11 @@ class ClickHouseClient:
         elif "ExceptionWhileProcessing" in events or "ExceptionBeforeStart" in events:
             if raise_on_error:
                 error_message = error or f"Unknown query error in query with ID: {query_id}"
-                # we don't have the original query here so just use the query id
-                raise ClickHouseError(error_message, query_id=query_id)
+                # The query log's `exception` column holds the same text ClickHouse returns over
+                # HTTP, so classify it the same way for consistency. Otherwise, the exception a
+                # caller sees for a query result we fetch from the query log would differ from that
+                # they would get running the query and waiting for the result.
+                self.raise_clickhouse_error(error_message, query_id=query_id)
 
             return ClickHouseQueryStatus.ERROR
         elif "QueryStart" in events:

--- a/posthog/temporal/tests/test_clickhouse.py
+++ b/posthog/temporal/tests/test_clickhouse.py
@@ -340,6 +340,31 @@ async def test_acheck_query_in_query_log_cancelled(clickhouse_client, django_db_
         await _wait_for_query_status(clickhouse_client, query_id, ClickHouseQueryStatus.ERROR, raise_on_error=True)
 
 
+async def test_acheck_query_in_query_log_classifies_the_error(clickhouse_client, django_db_setup):
+    """A failure recovered from the query log is classified like one returned over HTTP.
+
+    A caller that waits out a query which outlived its client timeout reads the failure from the
+    query log instead of the response. Both carry the same error text, so both must yield the same
+    exception class: otherwise whether a caller sees `ClickHouseMemoryLimitExceededError` or a bare
+    `ClickHouseError` depends on how long the query happened to take.
+    """
+    query_id = f"test-memory-limit-query-{uuid.uuid4()}"
+
+    with pytest.raises(ClickHouseMemoryLimitExceededError) as direct:
+        await clickhouse_client.execute_query(
+            "SELECT groupArray(toString(number)) FROM numbers(10000000)",
+            query_id=query_id,
+            settings={"max_memory_usage": "1000000"},
+        )
+
+    with pytest.raises(ClickHouseMemoryLimitExceededError) as from_query_log:
+        await _wait_for_query_status(clickhouse_client, query_id, ClickHouseQueryStatus.ERROR)
+
+    assert "MEMORY_LIMIT_EXCEEDED" in str(direct.value)
+    assert "MEMORY_LIMIT_EXCEEDED" in str(from_query_log.value)
+    assert from_query_log.value.query_id == query_id
+
+
 async def test_acheck_query_in_query_log_not_found(clickhouse_client, django_db_setup):
     """Test that acheck_query_in_query_log raises ClickHouseQueryNotFound for non-existent queries."""
     non_existent_query_id = f"test-non-existent-query-{uuid.uuid4()}"

--- a/posthog/temporal/tests/test_clickhouse.py
+++ b/posthog/temporal/tests/test_clickhouse.py
@@ -351,7 +351,7 @@ async def test_acheck_query_in_query_log_classifies_the_error(clickhouse_client,
     query_id = f"test-memory-limit-query-{uuid.uuid4()}"
 
     with pytest.raises(ClickHouseMemoryLimitExceededError) as direct:
-        await clickhouse_client.execute_query(
+        await clickhouse_client.execute_query_with_summary(
             "SELECT groupArray(toString(number)) FROM numbers(10000000)",
             query_id=query_id,
             settings={"max_memory_usage": "1000000"},


### PR DESCRIPTION
## Problem

Another PR in a stack of PRs aimed at adding resource limits to HogQL batch exports. 

This one was also something that came up when trying to classify ClickHouse errors, and is fixing existing behaviour rather than introducing something new:

The exception class a caller gets for a failed ClickHouse query depends on how long the query took, not on how it failed.

`acheck_query_in_query_log` always raised a bare `ClickHouseError` — the only bare raise in the client outside `raise_clickhouse_error`'s own fallback. So a query killed for exceeding `max_memory_usage` raises `ClickHouseMemoryLimitExceededError` when it fails fast, and a bare `ClickHouseError` when the same failure is recovered from the query log after the client timeout.

Callers that match on the subclasses (`backfill_batch_export`, `frame_materialize`, `delete_recordings`) silently miss the second case.

## Changes

- Route the query-log failure through `raise_clickhouse_error`, so both paths classify the same text the same way.
- Thread `query_id` through `raise_clickhouse_error` so it isn't dropped from the raised exception.
- `insert_into_internal_stage_activity` is the only caller of the query-log polling path in the repo, so no existing consumer changes behaviour today.

## How did you test this code?

Added a test asserting both paths yield the same class for the same failure. No existing test compared them, which is why the inconsistency survived.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*