### PR TITLE
feat(error-tracking): expose severity in system table

### DIFF
--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -1641,6 +1641,9 @@ error_tracking_issues: PostgresTable = PostgresTable(
         "status": StringDatabaseField(
             name="status", description="Issue status, e.g. 'active', 'resolved', 'suppressed'."
         ),
+        "severity": StringDatabaseField(
+            name="severity", nullable=True, description="Assigned issue severity, or null when unassigned."
+        ),
         "name": StringDatabaseField(name="name", description="Issue title (usually the exception type/message)."),
         "description": StringDatabaseField(name="description", description="Issue description."),
     },

--- a/posthog/hogql/database/schema/test/test_system_tables.py
+++ b/posthog/hogql/database/schema/test/test_system_tables.py
@@ -905,6 +905,22 @@ class TestSystemTablesTeamIsolation(NonAtomicBaseTest):
         assert str(obj_team1.pk) in ids
         assert str(obj_team2.pk) not in ids
 
+    def test_error_tracking_issue_severity(self):
+        ErrorTrackingIssue.objects.create(
+            team=self.team,
+            name="high_severity_issue",
+            status=ErrorTrackingIssue.Status.ACTIVE,
+            severity=ErrorTrackingIssue.Severity.HIGH,
+        )
+
+        response = execute_hogql_query(
+            "SELECT count() FROM system.error_tracking_issues WHERE severity IS NOT NULL",
+            team=self.team,
+            user=self.user,
+        )
+
+        assert response.results == [(1,)]
+
 
 class TestDataWarehouseSourcesLiveQueryability(BaseTest):
     """`is_live_queryable` is how an agent finds the sources it can pass as a query's connection id."""

--- a/posthog/hogql/database/schema/test/test_system_tables.py
+++ b/posthog/hogql/database/schema/test/test_system_tables.py
@@ -914,12 +914,12 @@ class TestSystemTablesTeamIsolation(NonAtomicBaseTest):
         )
 
         response = execute_hogql_query(
-            "SELECT count() FROM system.error_tracking_issues WHERE severity IS NOT NULL",
+            "SELECT severity FROM system.error_tracking_issues WHERE severity IS NOT NULL",
             team=self.team,
             user=self.user,
         )
 
-        assert response.results == [(1,)]
+        assert response.results == [("high",)]
 
 
 class TestDataWarehouseSourcesLiveQueryability(BaseTest):

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -6219,6 +6219,16 @@
                   "table": null,
                   "type": "string"
               },
+              "severity": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "severity",
+                  "id": null,
+                  "name": "severity",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
               "name": {
                   "chain": null,
                   "fields": null,
@@ -16425,6 +16435,16 @@
                   "hogql_value": "status",
                   "id": null,
                   "name": "status",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "severity": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "severity",
+                  "id": null,
+                  "name": "severity",
                   "schema_valid": true,
                   "table": null,
                   "type": "string"

--- a/products/posthog_ai/skills/querying-posthog-data/references/models-error-tracking.md
+++ b/products/posthog_ai/skills/querying-posthog-data/references/models-error-tracking.md
@@ -8,7 +8,7 @@ Error tracking issues represent grouped exceptions captured by PostHog SDKs. Eac
 
 Column | Type | Nullable | Description
 `id` | uuid | NOT NULL | Primary key (UUID)
-`team_id` | integer | NOT NULL | PostHog project ID
+`team_id` | integer | NOT NULL | PostHog project ID; foreign key to `system.teams.id`
 `created_at` | timestamp with tz | NOT NULL | Creation timestamp
 `status` | varchar | NOT NULL | Issue status (see Status Values below)
 `severity` | varchar | NULL | Assigned severity: `low`, `medium`, `high`, or `critical`
@@ -51,7 +51,7 @@ Rows can also track missing symbol sets so future uploads know which stack frame
 
 Column | Type | Nullable | Description
 `id` | uuid | NOT NULL | Primary key (UUID)
-`team_id` | integer | NOT NULL | FK to `system.teams.id`
+`team_id` | integer | NOT NULL | PostHog project ID; foreign key to `system.teams.id`
 `ref` | text | NOT NULL | Symbol set reference matched from stack frames
 `release_id` | uuid | NULL | Associated error tracking release ID
 `created_at` | timestamp with tz | NOT NULL | Creation timestamp

--- a/products/posthog_ai/skills/querying-posthog-data/references/models-error-tracking.md
+++ b/products/posthog_ai/skills/querying-posthog-data/references/models-error-tracking.md
@@ -8,9 +8,10 @@ Error tracking issues represent grouped exceptions captured by PostHog SDKs. Eac
 
 Column | Type | Nullable | Description
 `id` | uuid | NOT NULL | Primary key (UUID)
-`team_id` | integer | NOT NULL | FK to `system.teams.id`
+`team_id` | integer | NOT NULL | PostHog project ID
 `created_at` | timestamp with tz | NOT NULL | Creation timestamp
 `status` | varchar | NOT NULL | Issue status (see Status Values below)
+`severity` | varchar | NULL | Assigned severity: `low`, `medium`, `high`, or `critical`
 `name` | text | NULL | Issue name (typically the exception type/message)
 `description` | text | NULL | User-provided description
 
@@ -34,6 +35,9 @@ Status | Description
 - Issues group exception events by fingerprint (a hash of exception characteristics)
 - The `name` field is typically auto-populated from the first exception's type/message
 - Use the `events` table with `event = '$exception'` and `issue_id` to query actual exception occurrences
+- Use `system.error_tracking_issues` for all-time issue counts by status or severity
+- Access to `system.error_tracking_issues` follows the connected user's Error tracking permissions and only returns rows from the current project
+- Use `posthog:query-error-tracking-issues-list` for issues observed during a date range or for impact counts
 - Issues can be merged (combining fingerprints) or split (separating fingerprints into new issues)
 
 ---
@@ -108,6 +112,16 @@ WHERE name ILIKE '%timeout%'
 SELECT status, count() AS count
 FROM system.error_tracking_issues
 GROUP BY status
+ORDER BY count DESC
+```
+
+**Count issues by severity:**
+
+```sql
+SELECT severity, count() AS count
+FROM system.error_tracking_issues
+WHERE severity IS NOT NULL
+GROUP BY severity
 ORDER BY count DESC
 ```
 


### PR DESCRIPTION
## Problem

SQL and PostHog AI clients cannot count Error tracking issues by assigned severity.

The issue table stores severity, but the project-scoped HogQL system table omits it.

<!-- pr-stack:start -->
## PR stack

Merge in this order:
1. **https://github.com/PostHog/posthog/pull/83279 - this PR**
2. https://github.com/PostHog/posthog/pull/83107

Depends on: none

Followed by: https://github.com/PostHog/posthog/pull/83107

This PR targets `master`. The next layer targets `hp/error-tracking-severity-system-table` and contains only issue-query changes.
<!-- pr-stack:end -->

## Changes

- `system.error_tracking_issues` exposes nullable severity for project-scoped SQL queries.
- The external query skill documents all-time severity counts and permission boundaries.
- No visual changes.

## How did you test this code?

- Added regression coverage for severity queries through the system table.
- Ran the targeted system-table test, schema snapshot tests, Ruff, and the skill linter.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the external Error tracking query reference with severity and access guidance.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi authored this PR with human direction and used repository tools, Jujutsu, hogli, Metabase, and GitHub CLI.

Skills invoked: `/error-tracking`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-skills`, `/hogli`, `/query-clickhouse-via-metabase`, `/stacking-prs`, `/split-pr`, `/running-ci-preflight`, `/writing-pr-descriptions`, and `/pr`.

This is the system-table foundation for a two-layer stack. The next layer adds severity to issue-list queries and MCP output.
