### PR TITLE
chore(ci): split selective Jest tests into two shards

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -309,13 +309,14 @@ jobs:
                       exit 0
                   fi
 
-                  # Selective mode: single EE-tree job, no chunk sharding. The FOSS
+                  # Selective mode uses two EE-tree shards because a widely imported
+                  # source file can make --findRelatedTests approach a full suite. The FOSS
                   # structural check (ee/ removed) only matters when ee imports are
                   # touched; defer that to the ready-for-review full run. --findRelatedTests
                   # walks jest's import graph from these files and runs the matching
                   # *.test.* files.
                   echo "mode=selective" >> "$GITHUB_OUTPUT"
-                  echo 'matrix={"include":[{"segment":"EE","chunk":1}]}' >> "$GITHUB_OUTPUT"
+                  echo 'matrix={"include":[{"segment":"EE","chunk":1,"shard_count":2},{"segment":"EE","chunk":2,"shard_count":2}]}' >> "$GITHUB_OUTPUT"
                   echo "should_run=true" >> "$GITHUB_OUTPUT"
                   echo "changed_files=$CHANGED_FILES" >> "$GITHUB_OUTPUT"
                   echo "Selective mode: $(echo "$CHANGED_FILES" | wc -w) frontend source files"
@@ -699,10 +700,8 @@ jobs:
 
     jest:
         runs-on: ubuntu-latest
-        # Draft PRs run the selective mode as a single unsharded job over every
-        # test reachable from the changed files. A PR touching a scene component
-        # can pull in much of the suite, so the budget must fit a near-full
-        # unsharded run; the ready-for-review fanout shards well below it.
+        # Draft PRs run two selective shards over tests reachable from changed files.
+        # The ready-for-review fanout uses four shards over the full suite.
         timeout-minutes: 20
         needs: [changes, select-jest-tests]
         # A status function is required because select-jest-tests is skipped on ready
@@ -715,7 +714,7 @@ jobs:
         strategy:
             # If one test fails, still run the others
             fail-fast: false
-            # On draft PRs, select-jest-tests may narrow this to a single EE job
+            # On draft PRs, select-jest-tests may narrow this to two EE jobs
             # running only the tests reachable from changed frontend source files,
             # or skip jest entirely (should_run=false) when selection can't be
             # trusted. On ready PRs and master pushes it's skipped, so
@@ -754,9 +753,7 @@ jobs:
               env:
                   NODE_OPTIONS: --max-old-space-size=16384
                   SHARD_INDEX: ${{ matrix.chunk }}
-                  # Keep shard runtime well under timeout-minutes: at 2 shards the EE
-                  # suite regularly hit the job timeout and failed the whole run.
-                  SHARD_COUNT: 4
+                  SHARD_COUNT: ${{ matrix.shard_count || 4 }}
                   MODE: ${{ needs.select-jest-tests.outputs.mode }}
                   CHANGED_FILES: ${{ needs.select-jest-tests.outputs.changed_files }}
                   JEST_JUNIT_OUTPUT_DIR: ${{ github.workspace }}/junit-results
@@ -768,8 +765,8 @@ jobs:
               run: |
                   if [ "$MODE" = "selective" ]; then
                       # --findRelatedTests walks jest's import graph from the changed
-                      # source files and runs the matching tests. No --shard: single
-                      # job runs the entire selected set.
+                      # source files and runs the matching tests. Sharding keeps broad
+                      # import graphs within the job timeout.
                       #
                       # No --testPathPattern: it is mutually exclusive with
                       # --findRelatedTests (jest folds both into one path regex and
@@ -782,6 +779,7 @@ jobs:
                       pnpm --filter=@posthog/frontend exec jest \
                           --forceExit \
                           --passWithNoTests \
+                          --shard=$SHARD_INDEX/$SHARD_COUNT \
                           --findRelatedTests $CHANGED_FILES
                   else
                       # 100% = one worker per available core. Public-repo ubuntu-latest


### PR DESCRIPTION
i'm seeing Jest jobs timing out...

[Robot-authored PR]

## Problem

Draft frontend checks can exceed their job timeout when related-test selection reaches much of the Jest suite.

## Changes

- Run selective Jest checks across two shards.
- Keep the full ready-for-review suite at four shards.

```mermaid
flowchart LR
    A[Selected tests] --> B[One Jest job]
```

```mermaid
flowchart LR
    A[Selected tests] --> B[Jest shard 1]
    A --> C[Jest shard 2]
```

## How did you test this code?

- Workflow lint and actionlint pass.
- Jest partitions 1,257 selected files into disjoint groups of 629 and 628.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex made this change with the `/authoring-ci-workflows`, `/writing-code-comments`, and `/writing-pr-descriptions` skills.

The change uses native Jest sharding and adds no dependency.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*