### PR TITLE
chore(flags): replace mcp-servers flag with mcp-gateway

### DIFF
--- a/ee/hogai/chat_agent/test/test_executables.py
+++ b/ee/hogai/chat_agent/test/test_executables.py
@@ -23,7 +23,7 @@ class TestChatAgentWebSearchToolInclusion(BaseTest):
         with (
             patch("ee.hogai.chat_agent.toolkit.get_llm_gateway_variant", return_value=variant),
             patch("ee.hogai.chat_agent.toolkit.settings") as mock_settings,
-            patch("ee.hogai.chat_agent.toolkit.has_mcp_servers_feature_flag", return_value=False),
+            patch("ee.hogai.chat_agent.toolkit.has_mcp_gateway_feature_flag", return_value=False),
         ):
             mock_settings.LLM_GATEWAY_URL = "http://gateway:3308"
             mock_settings.LLM_GATEWAY_API_KEY = "test-key"

--- a/ee/hogai/chat_agent/toolkit.py
+++ b/ee/hogai/chat_agent/toolkit.py
@@ -37,7 +37,7 @@ from ee.hogai.tools.call_mcp_server.tool import CallMCPServerTool
 from ee.hogai.tools.finalize_plan.tool import FinalizePlanTool
 from ee.hogai.utils.feature_flags import (
     get_llm_gateway_variant,
-    has_mcp_servers_feature_flag,
+    has_mcp_gateway_feature_flag,
     has_memory_tool_feature_flag,
     has_phai_tasks_feature_flag,
     has_task_tool_feature_flag,
@@ -137,7 +137,7 @@ class ChatAgentToolkitManager(AgentToolkitManager):
                 available_tools.append(tool)
 
         # Add MCP server tool if user has installations and flag is enabled
-        if has_mcp_servers_feature_flag(self._team, self._user):
+        if has_mcp_gateway_feature_flag(self._team, self._user):
             mcp_tool = await CallMCPServerTool.create_tool_class(
                 team=self._team,
                 user=self._user,

--- a/ee/hogai/utils/feature_flags.py
+++ b/ee/hogai/utils/feature_flags.py
@@ -94,9 +94,9 @@ def is_core_memory_disabled(team: Team, user: User) -> bool:
     )
 
 
-def has_mcp_servers_feature_flag(team: Team, user: User) -> bool:
+def has_mcp_gateway_feature_flag(team: Team, user: User) -> bool:
     return feature_enabled_or_false(
-        "mcp-servers",
+        "mcp-gateway",
         str(user.distinct_id),
         groups={"organization": str(team.organization_id)},
         group_properties={"organization": {"id": str(team.organization_id)}},

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -400,7 +400,6 @@ export const FEATURE_FLAGS = {
     MCP_ANALYTICS: 'mcp-analytics', // owner: #project-mcp-analytics
     MCP_ANALYTICS_INTENT_ROUTING: 'mcp-analytics-intent-routing', // owner: #project-mcp-analytics
     MCP_GATEWAY: 'mcp-gateway', // owner: #team-self-driving — gates the MCP gateway UI AND backend enforcement of built-in agent MCP access (delegated-only installs + restricted sandbox token scope); roll out by organization
-    MCP_SERVERS: 'mcp-servers', // owner: #team-posthog-ai
     MESSAGING_SES: 'messaging-ses', // owner #team-workflows
     METRICS: 'metrics', // owner: #team-apm (@jonmcwest, @frankh)
     NEW_TAB_PROJECT_EXPLORER: 'new-tab-project-explorer', // owner: #team-platform-ux

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -364,7 +364,7 @@ export const SETTINGS_MAP: SettingSection[] = [
         id: 'mcp-servers',
         title: 'MCP servers',
         group: 'AI',
-        flag: 'MCP_SERVERS',
+        flag: 'MCP_GATEWAY',
         settings: [
             {
                 id: 'mcp-servers-manage',

--- a/products/mcp_store/README.md
+++ b/products/mcp_store/README.md
@@ -1,19 +1,18 @@
 # MCP store
 
-A curated marketplace of third-party MCP servers (Linear, Notion, Sentry, ...) that users browse and connect from Settings → MCP servers (behind the `MCP_SERVERS` feature flag).
+A curated marketplace of third-party MCP servers (Linear, Notion, Sentry, ...) that users browse and connect from Settings → MCP servers (behind the `mcp-gateway` feature flag).
 Connected servers are consumed by agent surfaces via the `backend/facade/` package.
 
 This is unrelated to `products/*/mcp/tools.yaml`, which exposes PostHog's own endpoints as MCP tools.
 
 ## Settings experience and rollout
 
-Two independent feature flags gate two surfaces — neither flag depends on the other:
+The `mcp-gateway` feature flag (`MCP_GATEWAY`) gates both surfaces:
 
-- The Settings → MCP servers page is gated by the `mcp-servers` feature flag (`MCP_SERVERS`).
-  On that page, the `mcp-gateway` feature flag (`MCP_GATEWAY`) selects the gateway experience described below; when it is off, Settings renders the existing marketplace UI.
-- The standalone gateway scene at `/mcp-servers` and its nav entry are gated solely by `mcp-gateway` and are reachable even with `mcp-servers` off.
+- The Settings → MCP servers page, which renders the gateway experience described below.
+- The standalone gateway scene at `/mcp-servers` and its nav entry.
 
-Keep both layers until the legacy `mcp-servers` flag and marketplace logic are removed in a follow-up change.
+The marketplace UI that `McpStoreSettings` falls back to when the flag is off is unreachable, since the Settings section itself requires the flag; remove it together with the rest of the marketplace logic in a follow-up change.
 
 The gateway experience has these pages and workflows:
 

--- a/products/signals/frontend/inbox/components/config/scouts/ScoutMcpServersPicker.stories.tsx
+++ b/products/signals/frontend/inbox/components/config/scouts/ScoutMcpServersPicker.stories.tsx
@@ -78,7 +78,7 @@ const meta: Meta<typeof ScoutMcpServersPicker> = {
     ],
     parameters: {
         testOptions: { waitForLoadersToDisappear: true },
-        featureFlags: [FEATURE_FLAGS.MCP_SERVERS],
+        featureFlags: [FEATURE_FLAGS.MCP_GATEWAY],
     },
 }
 export default meta

--- a/products/signals/frontend/inbox/components/config/scouts/ScoutMcpServersPicker.tsx
+++ b/products/signals/frontend/inbox/components/config/scouts/ScoutMcpServersPicker.tsx
@@ -33,7 +33,7 @@ interface ScoutMcpServersPickerProps {
  */
 export function ScoutMcpServersPicker(props: ScoutMcpServersPickerProps): JSX.Element | null {
     const { featureFlags } = useValues(featureFlagLogic)
-    if (!featureFlags[FEATURE_FLAGS.MCP_SERVERS]) {
+    if (!featureFlags[FEATURE_FLAGS.MCP_GATEWAY]) {
         return null
     }
     return props.compact ? <CompactPicker {...props} /> : <FullPicker {...props} />


### PR DESCRIPTION
## Problem

- Whoever manages the MCP gateway rollout has to keep two feature flags in sync: `mcp-servers` and `mcp-gateway` gate parts of the same product with identical targeting.
- Turning one flag off without the other splits the product: the settings section and Max's MCP tool follow one flag, the gateway pages follow the other.

## Changes

- Every surface gated on `mcp-servers` now checks `mcp-gateway`: the MCP servers settings section, the scout MCP server picker, and Max's MCP server tool.
- Removes the `MCP_SERVERS` constant and renames the backend helper to `has_mcp_gateway_feature_flag`.
- Nothing looks different while both flags keep identical rollouts. The `mcp-servers` flag can be disabled in PostHog after this deploys.

## How did you test this code?

- `ruff check` and `hogli ci:preflight --fix` pass.
- The frontend TypeScript check reports no errors in the changed files. The remaining errors come from the unbuilt quill workspace in this sandbox and exist without this change.
- Not run: the Django suites, because this sandbox has no database. The only test change renames a mock patch target.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude (PostHog Desktop cloud task) authored the change at Chris's direction.
- Skills invoked: `cleaning-up-stale-feature-flags`, `/writing-pr-descriptions`.
- Checked in PostHog before editing: both flags are active with identical release conditions, no linked experiments, and no dependent flags.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
