### PR TITLE
fix(team-deletion): delete retired session summaries before deleting the team

### DIFF
--- a/posthog/models/team/util.py
+++ b/posthog/models/team/util.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from typing import Any
 
 from django.apps import apps
+from django.db import connections
 
 import structlog
 
@@ -35,6 +36,18 @@ TEAM_DELETE_BATCH_SIZE = 2000
 # 30 min is orders of magnitude above any healthy single-batch DELETE yet 4x under the 2h
 # activity bound.
 TEAM_DELETE_RPC_TIMEOUT_SECONDS = 30 * 60
+
+# The retired session-summary tables. products/replay/backend/migrations/0002_remove_session_summary_models.py
+# dropped their models from Django state only, so both the tables and their foreign keys on
+# posthog_team still exist in Postgres. Django's cascade cannot see them any more, and the
+# constraints are DEFERRABLE INITIALLY DEFERRED, so a leftover row fails the team delete at COMMIT
+# with an IntegrityError instead of at the DELETE statement. All three tables are dead: no Django
+# model reads or writes them. This list goes away with the migration that drops them.
+RETIRED_SESSION_SUMMARY_TABLES = (
+    "ee_group_session_summary",
+    "ee_single_session_summary",
+    "ee_teamsessionsummariesconfig",
+)
 
 actions_that_require_current_team = [
     "rotate_secret_token",
@@ -87,6 +100,7 @@ def _delete_misc_small_tables_for_teams(team_ids: list[int]) -> None:
     # FeatureFlagHashKeyOverride references Person, so it must go before persons are deleted.
     _delete_hash_key_overrides_for_teams(team_ids)
     _delete_llm_evaluations_for_teams(team_ids)
+    _delete_retired_session_summaries_for_teams(team_ids)
 
 
 def _delete_llm_evaluations_for_teams(team_ids: list[int]) -> None:
@@ -103,6 +117,32 @@ def _delete_llm_evaluations_for_teams(team_ids: list[int]) -> None:
     from products.ai_observability.backend.models.evaluations import Evaluation
 
     Evaluation.objects.filter(team_id__in=team_ids).delete()
+
+
+def _delete_retired_session_summaries_for_teams(team_ids: list[int], batch_size: int = 10000) -> None:
+    """Batch-delete the teams' rows in the retired session-summary tables.
+
+    A table is skipped when it no longer exists, so team deletion keeps working once the migration
+    that drops these tables lands.
+    """
+    if not team_ids:
+        return
+
+    db_connection = connections["default"]
+    for table in RETIRED_SESSION_SUMMARY_TABLES:
+        # The table name is a module constant, never user input, so interpolating it is safe.
+        statement = f'DELETE FROM "{table}" WHERE ctid IN (SELECT ctid FROM "{table}" WHERE team_id = ANY(%s) LIMIT %s)'
+        with db_connection.cursor() as cursor:
+            cursor.execute("SELECT to_regclass(%s)", [table])
+            row = cursor.fetchone()
+            if row is None or row[0] is None:
+                continue
+
+            while True:
+                cursor.execute(statement, [team_ids, batch_size])
+                if cursor.rowcount < batch_size:
+                    break
+                time.sleep(0.1)
 
 
 def _delete_hash_key_overrides_for_teams(team_ids: list[int]) -> None:

--- a/posthog/temporal/tests/delete_teams/test_retired_table_predelete.py
+++ b/posthog/temporal/tests/delete_teams/test_retired_table_predelete.py
@@ -1,0 +1,40 @@
+import pytest
+
+from django.db import connection
+
+from posthog.models.organization import Organization
+from posthog.models.team import Team
+from posthog.models.team.util import _delete_misc_small_tables_for_teams, delete_team_records
+
+# transaction=True is required, not incidental: the foreign keys these tables hold on posthog_team
+# are DEFERRABLE INITIALLY DEFERRED, so Postgres only checks them at COMMIT. Under a plain TestCase
+# the inner atomic() is a savepoint, releasing it never checks them, and the regression is invisible.
+pytestmark = [pytest.mark.django_db(transaction=True)]
+
+_ROW_INSERTS = {
+    "ee_teamsessionsummariesconfig": (
+        "INSERT INTO ee_teamsessionsummariesconfig (team_id, product_context, custom_tags) VALUES (%s, '', '{}'::jsonb)"
+    ),
+    "ee_single_session_summary": (
+        "INSERT INTO ee_single_session_summary "
+        "(id, created_at, team_id, session_id, summary, exception_event_ids) "
+        "VALUES (gen_random_uuid(), now(), %s, 'session-1', '{}'::jsonb, ARRAY['event-1'])"
+    ),
+    "ee_group_session_summary": (
+        "INSERT INTO ee_group_session_summary (id, created_at, team_id, title, session_ids, summary) "
+        "VALUES (gen_random_uuid(), now(), %s, 'Group summary', ARRAY['session-1'], '{}'::jsonb)"
+    ),
+}
+
+
+@pytest.mark.parametrize("table", sorted(_ROW_INSERTS))
+def test_team_deletion_clears_rows_in_retired_session_summary_table(table: str):
+    _, _, team = Organization.objects.bootstrap(None)
+    team_id = team.id
+    with connection.cursor() as cursor:
+        cursor.execute(_ROW_INSERTS[table], [team_id])
+
+    _delete_misc_small_tables_for_teams([team_id])
+    delete_team_records([team_id])
+
+    assert not Team.objects.filter(id=team_id).exists()


### PR DESCRIPTION
## Problem

Organization and project deletions hang forever in Temporal. The delete-team-records activity fails at COMMIT with an `IntegrityError` and retries without limit, so the org, its projects, and its data all stay alive.

`products/replay/backend/migrations/0002_remove_session_summary_models.py` dropped three session-summary models from Django state only. The tables and their deferred foreign keys on `posthog_team` survive, Django's cascade cannot see them, and Postgres checks the constraint at COMMIT, so any leftover row blocks the delete.

## Changes

- Delete the teams' rows in the three retired session-summary tables, in the same phase as the other pre-deletes the cascade cannot reach.
- Skip a table that no longer exists, so team deletion keeps working once the drop migration lands.
- Delete in batches to keep each statement bounded.

All three tables are dead: no Django model reads or writes them, and the deletes are scoped to the teams being removed.

> [!IMPORTANT]
> This fixes new deletions. The executions already wedged sit past this phase, retrying the team-record delete, so they need a Temporal reset back to the misc-small-tables activity.

## How did you test this code?

- 3 backend cases added, one per table. Each fails without the fix, because the deferred constraint rejects the COMMIT, and passes with it. I verified both directions locally.
- `transaction=True` is load-bearing here. Under a plain `TestCase` the inner `atomic()` is a savepoint, and releasing a savepoint never checks deferred constraints.
- Ran the new cases plus the existing `delete_teams` and team-util suites against a local Postgres. Four cases in `posthog/api/test/test_team_deletion.py` fail on this branch and on master alike, so they are unrelated.
- Not run: anything against production data.
- Agent-authored; only the automated tests above were run.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code, from the production failure payload. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/creating-pull-requests`, `/writing-pr-descriptions`.

A first pass covered every table that holds an invisible foreign key on `posthog_team`, which is ten across four state-only removals, and also detached a live managed-warehouse row. That reached beyond the reported failure and touched a live table, so I cut it back to the session-summary retirement that produced this error.

The cleanup also sat in `delete_team_records` for a while, which would have let the wedged executions recover on deploy. It reads as out of place next to the team-row delete, so it moved to the pre-delete phase and the wedged executions need a reset instead.
