### PR TITLE
fix(ci): run dagster suite on PRs only for direct changes

### DIFF
--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -63,6 +63,15 @@ jobs:
         # Set job outputs to values from filter step
         outputs:
             dagster: ${{ steps.filter.outputs.dagster || 'true' }}
+            dagster_direct: ${{ steps.filter.outputs.dagster_direct || 'true' }}
+            # Trunk's merge queue opens its PR from trunk-merge/**. Scope this to
+            # same-repo heads because github.head_ref is author-controlled.
+            merge_queue: >-
+                ${{
+                    github.event_name == 'pull_request'
+                    && github.event.pull_request.head.repo.full_name == github.repository
+                    && startsWith(github.head_ref, 'trunk-merge/')
+                }}
             oldest_supported: ${{ steps.read-versions.outputs.oldest_supported }}
             matrix_include: ${{ steps.build-matrix.outputs.include || '[]' }}
             schema_cache_key: ${{ steps.schema-key.outputs.key }}
@@ -91,6 +100,10 @@ jobs:
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
                   filters: |
+                      # The full filter stays broad because Dagster imports shared backend
+                      # code. Master and merge-queue runs use this tier so those changes
+                      # remain merge-gated. Ordinary PRs use dagster_direct below, which
+                      # avoids rerunning the suite for shared-only changes on every push.
                       dagster:
                         # --- DAG code itself ---
                         - 'posthog/dags/**'
@@ -192,6 +205,10 @@ jobs:
                         - 'tools/hogli-commands/hogli_commands/telemetry_props.py'
                         - 'tools/hogli-commands/hogli_commands/hint_hook.py'
                         - 'tools/hogli-commands/hogli_commands/hints.py'
+                      dagster_direct:
+                        - 'posthog/dags/**'
+                        - 'products/*/dags/**'
+                        - .github/workflows/ci-dagster.yml
 
             - name: Read ClickHouse versions from JSON
               id: read-versions
@@ -284,7 +301,10 @@ jobs:
             fail-fast: false
             matrix:
                 include: ${{ fromJson(needs.changes.outputs.matrix_include || '[]') }}
-        if: needs.changes.outputs.dagster == 'true'
+        if: >-
+            needs.changes.outputs.dagster_direct == 'true'
+            || (needs.changes.outputs.merge_queue == 'true'
+                && needs.changes.outputs.dagster == 'true')
         runs-on: depot-ubuntu-24.04
         env:
             DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USER }}


### PR DESCRIPTION
🤖 Robot-authored PR.

## Problem

Dagster CI runs an expensive test matrix on ordinary PR pushes that change shared backend code but do not change Dagster code.

**Why:** Dagster code changes rarely, but its import graph needs a broad path filter. The filter cannot safely remove shared backend paths.

## Changes

- Ordinary PR pushes run Dagster tests only for direct Dagster or workflow changes.
- Merge-queue runs use the full existing path filter.
- Master pushes continue to run the full suite.
- Both filter outputs run fail-open when change detection has no result.

Before:

```mermaid
flowchart LR
    A[PR push] --> B{Full filter}
    B -->|match| C[Dagster suite]
```

After:

```mermaid
flowchart LR
    A[Ordinary PR push] --> B{Direct filter}
    Q[Merge queue] --> F{Full filter}
    M[Master push] --> C[Dagster suite]
    B -->|match| C
    F -->|match| C
```

> [!WARNING]
> A shared backend change that breaks Dagster now fails in the merge queue instead of the PR. This can cause one queue bounce.

The merge queue and master still use the full filter, so the broken change cannot merge unnoticed.

## How did you test this code?

- `uv run .github/scripts/check-dagster-paths.py`
- YAML parsing with PyYAML
- `bin/hogli lint:workflows`
- `bin/hogli ci:preflight --fix`
- Actionlint was unavailable locally.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update. This changes CI scheduling only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex made this change in PostHog Desktop. It used the `/authoring-ci-workflows` and `/writing-pr-descriptions` skills.

The full filter remains the source of truth for import coverage. The new direct filter only changes when ordinary PRs run the suite.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*