### PR TITLE
fix(error-tracking): load alert issue property values

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.test.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.test.ts
@@ -57,6 +57,30 @@ describe('taxonomicPropertyFilterLogic', () => {
             expect(logic.values.activeTaxonomicGroup?.type).toBe(TaxonomicFilterGroupType.EventProperties)
         })
 
+        it('selects ErrorTrackingIssues group and its values endpoint for an issue property filter', () => {
+            logic.unmount()
+            logic = taxonomicPropertyFilterLogic({
+                filters: [
+                    {
+                        key: 'severity',
+                        type: PropertyFilterType.ErrorTrackingIssue,
+                        value: null,
+                        operator: PropertyOperator.Exact,
+                    },
+                ],
+                setFilter: () => {},
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.ErrorTrackingIssues],
+                filterIndex: 0,
+                pageKey: 'test-active-group-error-tracking-issue',
+            })
+            logic.mount()
+
+            expect(logic.values.activeTaxonomicGroup?.type).toBe(TaxonomicFilterGroupType.ErrorTrackingIssues)
+            expect(logic.values.activeTaxonomicGroup?.valuesEndpoint?.('severity')).toContain(
+                '/error_tracking/issues/values?key=severity'
+            )
+        })
+
         it('defaults to first group when filter is empty', () => {
             logic.unmount()
             logic = taxonomicPropertyFilterLogic({

--- a/frontend/src/lib/components/PropertyFilters/utils.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.ts
@@ -359,6 +359,7 @@ export function isAnyPropertyfilter(filter?: AnyFilterLike | null): filter is An
         isFeaturePropertyFilter(filter) ||
         isFlagPropertyFilter(filter) ||
         isGroupPropertyFilter(filter) ||
+        isErrorTrackingIssuePropertyFilter(filter) ||
         isLogPropertyFilter(filter) ||
         isMetricPropertyFilter(filter) ||
         isSpanPropertyFilter(filter)


### PR DESCRIPTION
## Problem

People creating an error tracking alert see "Failed to load property values" after selecting an issue property filter.

The filter lost its issue-specific values endpoint and requested the generic resource endpoint instead.

## Changes

- Recognize error tracking issue filters when resolving the active property group.
- Keep the issue values endpoint attached to the value selector.
- Add a logic regression test for the severity property endpoint.
- No visible layout changed, so this PR has no screenshots.

## How did you test this code?

- Ran the targeted `taxonomicPropertyFilterLogic.test.ts` Jest suite.
- Ran Oxlint and Oxfmt checks on both changed files.
- The full TypeScript check exceeded the sandbox memory limit after the required workspace packages built.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This restores the existing alert filter behavior and does not change the documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Pi coding agent using OpenAI inspected the filter flow, implemented the fix, and ran the checks above. No public session link is available.
- Invoked the repository's `/writing-tests`, `/modifying-taxonomic-filter`, and `/writing-pr-descriptions` skills.
