### PR TITLE
fix(web-analytics): page performance overview and leaderboard never load

### DIFF
--- a/frontend/src/scenes/web-analytics/PagePerformance.tsx
+++ b/frontend/src/scenes/web-analytics/PagePerformance.tsx
@@ -240,14 +240,15 @@ export const PagePerformance = (): JSX.Element => {
     const {
         pageTableQuery,
         pageCandidates,
-        pageDataError,
-        pageDataLoading,
+        candidatesError,
+        candidatesLoading,
         overviewCards,
+        overviewError,
         overviewLoading,
         footerText,
         aiSectionQueries,
     } = useValues(pagePerformanceLogic)
-    const { loadPageData } = useActions(pagePerformanceLogic)
+    const { loadOverview, loadCandidates } = useActions(pagePerformanceLogic)
 
     const context = useMemo(
         (): QueryContext => ({
@@ -292,21 +293,31 @@ export const PagePerformance = (): JSX.Element => {
                 site. AI referrals are a lower bound: some assistants strip the referrer, so those visits land in
                 Direct.
             </LemonBanner>
-            <OverviewGrid
-                items={overviewCards}
-                loading={overviewLoading && overviewCards.length === 0}
-                numSkeletons={4}
-                labelFromKey={(key) => OVERVIEW_CARD_LABELS[key] ?? key}
-            />
+            {overviewError ? (
+                <LemonBanner type="error" className="mb-4" action={{ children: 'Try again', onClick: loadOverview }}>
+                    Could not load the summary metrics. Try again to reload.
+                </LemonBanner>
+            ) : (
+                <OverviewGrid
+                    items={overviewCards}
+                    loading={overviewLoading && overviewCards.length === 0}
+                    numSkeletons={4}
+                    labelFromKey={(key) => OVERVIEW_CARD_LABELS[key] ?? key}
+                />
+            )}
             <div className="border rounded bg-surface-primary flex flex-col mt-4">
                 <div className="flex items-baseline justify-between gap-2 px-3 pt-3">
                     <h3 className="font-semibold m-0">Pages ranked by visitors</h3>
                 </div>
-                {pageDataError ? (
-                    <LemonBanner type="error" className="m-3" action={{ children: 'Try again', onClick: loadPageData }}>
+                {candidatesError ? (
+                    <LemonBanner
+                        type="error"
+                        className="m-3"
+                        action={{ children: 'Try again', onClick: loadCandidates }}
+                    >
                         Could not load page performance. Try again to reload the leaderboard.
                     </LemonBanner>
-                ) : pageDataLoading && pageCandidates === null ? (
+                ) : candidatesLoading && pageCandidates === null ? (
                     <div className="flex items-center justify-center py-12">
                         <Spinner className="text-2xl" />
                     </div>

--- a/frontend/src/scenes/web-analytics/PagePerformanceFilters.tsx
+++ b/frontend/src/scenes/web-analytics/PagePerformanceFilters.tsx
@@ -26,8 +26,8 @@ export const PagePerformanceFilters = ({ tabs }: { tabs: JSX.Element }): JSX.Ele
     const { setDates, setCompareFilter, setConversionGoal, setIsPathCleaningEnabled } = useActions(webAnalyticsLogic)
     const { areAnyLoading } = useValues(dataNodeCollectionLogic({ key: WEB_ANALYTICS_DATA_COLLECTION_NODE_ID }))
     const { reloadAll } = useActions(dataNodeCollectionLogic({ key: WEB_ANALYTICS_DATA_COLLECTION_NODE_ID }))
-    const { pageDataLoading } = useValues(pagePerformanceLogic)
-    const isReloading = areAnyLoading || pageDataLoading
+    const { overviewLoading, candidatesLoading } = useValues(pagePerformanceLogic)
+    const isReloading = areAnyLoading || overviewLoading || candidatesLoading
 
     return (
         <FilterBar

--- a/frontend/src/scenes/web-analytics/pagePerformanceLogic.ts
+++ b/frontend/src/scenes/web-analytics/pagePerformanceLogic.ts
@@ -492,7 +492,7 @@ export interface pagePerformanceLogicMeta {
         ) => AiSectionQueries
         overviewHumanQuery: (window: PagePerformanceWindow, pathExpr: string) => string
         overviewCrawlerQuery: (window: PagePerformanceWindow) => string
-        overviewInput: (overviewHumanQuery: string, overviewCrawlerQuery: string) => string
+        overviewInput: (overviewHumanQuery: string, overviewCrawlerQuery: string, filterTestAccounts: boolean) => string
         candidatesInput: (pageCandidateQuery: WebStatsTableQuery) => string
         breakdownQuery: (
             breakdownModal: PagePerformanceBreakdownState | null,
@@ -852,9 +852,9 @@ export const pagePerformanceLogic = kea<pagePerformanceLogicType>([
             (window: PagePerformanceWindow): string => buildOverviewCrawlerQuery(window),
         ],
         overviewInput: [
-            (s) => [s.overviewHumanQuery, s.overviewCrawlerQuery],
-            (overviewHumanQuery: string, overviewCrawlerQuery: string): string =>
-                JSON.stringify([overviewHumanQuery, overviewCrawlerQuery]),
+            (s) => [s.overviewHumanQuery, s.overviewCrawlerQuery, s.filterTestAccounts],
+            (overviewHumanQuery: string, overviewCrawlerQuery: string, filterTestAccounts: boolean): string =>
+                JSON.stringify([overviewHumanQuery, overviewCrawlerQuery, filterTestAccounts]),
         ],
         candidatesInput: [
             (s) => [s.pageCandidateQuery],

--- a/frontend/src/scenes/web-analytics/pagePerformanceLogic.ts
+++ b/frontend/src/scenes/web-analytics/pagePerformanceLogic.ts
@@ -66,6 +66,8 @@ import type { DateFilterState } from './webAnalyticsLogic'
 
 const PAGE_PERFORMANCE_EVENTS = "('$pageview', '$screen', '$http_log')"
 
+const HUMAN_EVENTS = "('$pageview', '$screen')"
+
 const PAGE_TABLE_LIMIT = 20
 
 const PAGE_CANDIDATE_LIMIT = 200
@@ -293,7 +295,7 @@ LIMIT ${PAGE_TABLE_LIMIT}
 `
 }
 
-const buildOverviewQuery = (window: PagePerformanceWindow, pathExpr: string): string => {
+const buildOverviewHumanQuery = (window: PagePerformanceWindow, pathExpr: string): string => {
     const { cur, prev, full } = windowPredicates(window)
     const pageKey = pageKeyExpr(pathExpr)
 
@@ -305,9 +307,25 @@ SELECT
     uniqIf(person_id, (${GOOGLE_VIEW}) AND ${prev}) AS google_previous,
     uniqIf(person_id, (${AI_VIEW}) AND ${cur}) AS llm,
     uniqIf(person_id, (${AI_VIEW}) AND ${prev}) AS llm_previous,
-    countIf((${CRAWLER}) AND ${cur}) AS crawls,
-    countIf((${CRAWLER}) AND ${prev}) AS crawls_previous,
     uniqIf(${pageKey}, (${HUMAN_VIEW}) AND ${cur}) AS pages
+FROM events
+WHERE and(
+    event IN ${HUMAN_EVENTS},
+    properties.$pathname IS NOT NULL,
+    properties.$pathname != '',
+    (${full}),
+    {filters}
+)
+`
+}
+
+const buildOverviewCrawlerQuery = (window: PagePerformanceWindow): string => {
+    const { cur, prev, full } = windowPredicates(window)
+
+    return `
+SELECT
+    countIf((${CRAWLER}) AND ${cur}) AS crawls,
+    countIf((${CRAWLER}) AND ${prev}) AS crawls_previous
 FROM events
 WHERE and(
     event IN ${PAGE_PERFORMANCE_EVENTS},
@@ -391,18 +409,21 @@ export interface pagePerformanceLogicValues {
     aiSectionQueries: AiSectionQueries
     breakdownModal: PagePerformanceBreakdownState | null
     breakdownQuery: DataTableNode | null
+    candidatesError: string | null
+    candidatesInput: string
+    candidatesLoading: boolean
     footerText: string
     goalLabel: string | null
     orderBy: PagePerformanceOrderBy
     overviewCards: OverviewItem[]
+    overviewCrawlerQuery: string
+    overviewError: string | null
+    overviewHumanQuery: string
+    overviewInput: string
     overviewLoading: boolean
-    overviewQuery: string
     overviewTotals: OverviewTotals | null
     pageCandidateQuery: WebStatsTableQuery
     pageCandidates: string[] | null
-    pageDataError: string | null
-    pageDataInput: string
-    pageDataLoading: boolean
     pageTableQuery: DataTableNode
     pathExpr: string
     previousPathExpr: string
@@ -414,17 +435,22 @@ export interface pagePerformanceLogicActions {
     closeBreakdown: () => {
         value: true
     }
-    loadPageData: () => {
+    loadOverview: () => {
         value: true
     }
-    loadPageDataFailure: (error: string) => {
+    loadOverviewFailure: (error: string) => {
         error: string
     }
-    loadPageDataSuccess: (
-        overviewTotals: OverviewTotals,
-        pageCandidates: string[]
-    ) => {
+    loadOverviewSuccess: (overviewTotals: OverviewTotals) => {
         overviewTotals: OverviewTotals
+    }
+    loadCandidates: () => {
+        value: true
+    }
+    loadCandidatesFailure: (error: string) => {
+        error: string
+    }
+    loadCandidatesSuccess: (pageCandidates: string[]) => {
         pageCandidates: string[]
     }
     openBreakdown: (breakdown: PagePerformanceBreakdownState) => {
@@ -464,8 +490,10 @@ export interface pagePerformanceLogicMeta {
             conversionGoal: WebAnalyticsConversionGoal | null,
             compareFilter: CompareFilter
         ) => AiSectionQueries
-        overviewQuery: (window: PagePerformanceWindow, pathExpr: string) => string
-        pageDataInput: (overviewQuery: string, pageCandidateQuery: WebStatsTableQuery) => string
+        overviewHumanQuery: (window: PagePerformanceWindow, pathExpr: string) => string
+        overviewCrawlerQuery: (window: PagePerformanceWindow) => string
+        overviewInput: (overviewHumanQuery: string, overviewCrawlerQuery: string) => string
+        candidatesInput: (pageCandidateQuery: WebStatsTableQuery) => string
         breakdownQuery: (
             breakdownModal: PagePerformanceBreakdownState | null,
             window: PagePerformanceWindow,
@@ -512,12 +540,12 @@ export const pagePerformanceLogic = kea<pagePerformanceLogicType>([
         setOrderBy: (column: string, direction: 'ASC' | 'DESC') => ({ column, direction }),
         openBreakdown: (breakdown: PagePerformanceBreakdownState) => ({ breakdown }),
         closeBreakdown: true,
-        loadPageData: true,
-        loadPageDataFailure: (error: string) => ({ error }),
-        loadPageDataSuccess: (overviewTotals: OverviewTotals, pageCandidates: string[]) => ({
-            overviewTotals,
-            pageCandidates,
-        }),
+        loadOverview: true,
+        loadOverviewFailure: (error: string) => ({ error }),
+        loadOverviewSuccess: (overviewTotals: OverviewTotals) => ({ overviewTotals }),
+        loadCandidates: true,
+        loadCandidatesFailure: (error: string) => ({ error }),
+        loadCandidatesSuccess: (pageCandidates: string[]) => ({ pageCandidates }),
     }),
     reducers({
         orderBy: [
@@ -536,38 +564,45 @@ export const pagePerformanceLogic = kea<pagePerformanceLogicType>([
         overviewTotals: [
             null as OverviewTotals | null,
             {
-                loadPageData: () => null,
-                loadPageDataSuccess: (_, { overviewTotals }) => overviewTotals,
+                loadOverview: () => null,
+                loadOverviewSuccess: (_, { overviewTotals }) => overviewTotals,
             },
         ],
-        pageCandidates: [
-            null as string[] | null,
-            {
-                loadPageData: () => null,
-                loadPageDataSuccess: (_, { pageCandidates }) => pageCandidates,
-            },
-        ],
-        pageDataError: [
+        overviewError: [
             null as string | null,
             {
-                loadPageData: () => null,
-                loadPageDataFailure: (_, { error }) => error,
-            },
-        ],
-        pageDataLoading: [
-            false,
-            {
-                loadPageData: () => true,
-                loadPageDataSuccess: () => false,
-                loadPageDataFailure: () => false,
+                loadOverview: () => null,
+                loadOverviewFailure: (_, { error }) => error,
             },
         ],
         overviewLoading: [
             false,
             {
-                loadPageData: () => true,
-                loadPageDataSuccess: () => false,
-                loadPageDataFailure: () => false,
+                loadOverview: () => true,
+                loadOverviewSuccess: () => false,
+                loadOverviewFailure: () => false,
+            },
+        ],
+        pageCandidates: [
+            null as string[] | null,
+            {
+                loadCandidates: () => null,
+                loadCandidatesSuccess: (_, { pageCandidates }) => pageCandidates,
+            },
+        ],
+        candidatesError: [
+            null as string | null,
+            {
+                loadCandidates: () => null,
+                loadCandidatesFailure: (_, { error }) => error,
+            },
+        ],
+        candidatesLoading: [
+            false,
+            {
+                loadCandidates: () => true,
+                loadCandidatesSuccess: () => false,
+                loadCandidatesFailure: () => false,
             },
         ],
     }),
@@ -808,14 +843,22 @@ export const pagePerformanceLogic = kea<pagePerformanceLogicType>([
                 }
             },
         ],
-        overviewQuery: [
+        overviewHumanQuery: [
             (s) => [s.window, s.pathExpr],
-            (window: PagePerformanceWindow, pathExpr: string): string => buildOverviewQuery(window, pathExpr),
+            (window: PagePerformanceWindow, pathExpr: string): string => buildOverviewHumanQuery(window, pathExpr),
         ],
-        pageDataInput: [
-            (s) => [s.overviewQuery, s.pageCandidateQuery],
-            (overviewQuery: string, pageCandidateQuery: WebStatsTableQuery): string =>
-                JSON.stringify([overviewQuery, pageCandidateQuery]),
+        overviewCrawlerQuery: [
+            (s) => [s.window],
+            (window: PagePerformanceWindow): string => buildOverviewCrawlerQuery(window),
+        ],
+        overviewInput: [
+            (s) => [s.overviewHumanQuery, s.overviewCrawlerQuery],
+            (overviewHumanQuery: string, overviewCrawlerQuery: string): string =>
+                JSON.stringify([overviewHumanQuery, overviewCrawlerQuery]),
+        ],
+        candidatesInput: [
+            (s) => [s.pageCandidateQuery],
+            (pageCandidateQuery: WebStatsTableQuery): string => JSON.stringify(pageCandidateQuery),
         ],
         breakdownQuery: [
             (s) => [s.breakdownModal, s.window, s.filterTestAccounts, s.pathExpr],
@@ -898,68 +941,104 @@ export const pagePerformanceLogic = kea<pagePerformanceLogicType>([
         ],
     })),
     listeners(({ values, actions, cache }) => ({
-        loadPageData: async (_, breakpoint) => {
+        loadOverview: async (_, breakpoint) => {
             await breakpoint(300)
-            cache.disposables.dispose('pageDataRequest')
+            cache.disposables.dispose('overviewRequest')
             const abortController = new AbortController()
-            cache.disposables.add(() => abortController.abort(), 'pageDataRequest')
+            cache.disposables.add(() => () => abortController.abort(), 'overviewRequest', {
+                pauseOnPageHidden: false,
+            })
 
-            const overviewNode: HogQLQuery = {
+            const humanNode: HogQLQuery = {
                 kind: NodeKind.HogQLQuery,
-                query: values.overviewQuery,
+                query: values.overviewHumanQuery,
+                filters: { filterTestAccounts: values.filterTestAccounts },
+                tags: WEB_ANALYTICS_DEFAULT_QUERY_TAGS,
+            }
+            const crawlerNode: HogQLQuery = {
+                kind: NodeKind.HogQLQuery,
+                query: values.overviewCrawlerQuery,
                 filters: { filterTestAccounts: values.filterTestAccounts },
                 tags: WEB_ANALYTICS_DEFAULT_QUERY_TAGS,
             }
             try {
-                const [overviewResponse, candidatesResponse] = await Promise.all([
-                    performQuery(overviewNode, { signal: abortController.signal }),
-                    performQuery(values.pageCandidateQuery, { signal: abortController.signal }),
+                const [humanResponse, crawlerResponse] = await Promise.all([
+                    performQuery(humanNode, { signal: abortController.signal }),
+                    performQuery(crawlerNode, { signal: abortController.signal }),
                 ])
                 breakpoint()
-                const row = overviewResponse.results?.[0] ?? []
-                const columns: string[] = overviewResponse.columns ?? []
-                const at = (name: string): number => {
-                    const idx = columns.indexOf(name)
-                    return idx >= 0 ? Number(row[idx] ?? 0) : 0
+                const readColumn = (response: typeof humanResponse): ((name: string) => number) => {
+                    const row = response.results?.[0] ?? []
+                    const columns: string[] = response.columns ?? []
+                    return (name: string): number => {
+                        const idx = columns.indexOf(name)
+                        return idx >= 0 ? Number(row[idx] ?? 0) : 0
+                    }
                 }
+                const human = readColumn(humanResponse)
+                const crawler = readColumn(crawlerResponse)
+                actions.loadOverviewSuccess({
+                    visitors: human('visitors'),
+                    visitorsPrevious: human('visitors_previous'),
+                    google: human('google'),
+                    googlePrevious: human('google_previous'),
+                    llm: human('llm'),
+                    llmPrevious: human('llm_previous'),
+                    crawls: crawler('crawls'),
+                    crawlsPrevious: crawler('crawls_previous'),
+                    pages: human('pages'),
+                })
+            } catch (error) {
+                if ((error instanceof Error && isBreakpoint(error)) || isAbortedRequest(error)) {
+                    return
+                }
+                actions.loadOverviewFailure(error instanceof Error ? error.message : 'Could not load page performance')
+            }
+        },
+        loadCandidates: async (_, breakpoint) => {
+            await breakpoint(300)
+            cache.disposables.dispose('candidatesRequest')
+            const abortController = new AbortController()
+            cache.disposables.add(() => () => abortController.abort(), 'candidatesRequest', {
+                pauseOnPageHidden: false,
+            })
+            try {
+                const candidatesResponse = await performQuery(values.pageCandidateQuery, {
+                    signal: abortController.signal,
+                })
+                breakpoint()
                 const pageCandidates = (candidatesResponse.results ?? []).flatMap((candidate) => {
                     if (!Array.isArray(candidate) || typeof candidate[0] !== 'string' || candidate[0] === '') {
                         return []
                     }
                     return [candidate[0]]
                 })
-                actions.loadPageDataSuccess(
-                    {
-                        visitors: at('visitors'),
-                        visitorsPrevious: at('visitors_previous'),
-                        google: at('google'),
-                        googlePrevious: at('google_previous'),
-                        llm: at('llm'),
-                        llmPrevious: at('llm_previous'),
-                        crawls: at('crawls'),
-                        crawlsPrevious: at('crawls_previous'),
-                        pages: at('pages'),
-                    },
-                    pageCandidates
-                )
+                actions.loadCandidatesSuccess(pageCandidates)
             } catch (error) {
                 if ((error instanceof Error && isBreakpoint(error)) || isAbortedRequest(error)) {
                     return
                 }
-                actions.loadPageDataFailure(error instanceof Error ? error.message : 'Could not load page performance')
+                actions.loadCandidatesFailure(
+                    error instanceof Error ? error.message : 'Could not load page performance'
+                )
             }
         },
         reloadAll: () => {
-            actions.loadPageData()
+            actions.loadOverview()
+            actions.loadCandidates()
         },
     })),
     subscriptions(({ actions }) => ({
-        pageDataInput: () => {
-            actions.loadPageData()
+        overviewInput: () => {
+            actions.loadOverview()
+        },
+        candidatesInput: () => {
+            actions.loadCandidates()
         },
     })),
     afterMount(({ actions }) => {
-        actions.loadPageData()
+        actions.loadOverview()
+        actions.loadCandidates()
     }),
 ])
 


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem
New SEO / AEO queries were slow in production and page leaderboard was failing to load

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Register each request’s abort controller as a cache.disposables teardown instead of its setup, so it cancels the query on cleanup rather than on mount.

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->
