### PR TITLE
fix(signals): surface a PR opened from a report's discuss task

### DIFF
--- a/products/signals/backend/implementation_pr.py
+++ b/products/signals/backend/implementation_pr.py
@@ -31,23 +31,31 @@ def fetch_implementation_pr_state_for_reports(report_ids: list[str]) -> dict[str
     the facade then resolves the latest PR-bearing run for each task, so multiple runs of a task
     collapse to the newest PR.
 
-    A report can be associated with several implementation tasks (retries), but only one PR is
-    surfaced — the first associated task that has one. The merge flag is read from *that* task, so
-    the URL and its state always describe the same PR. Reading them independently would let a
-    retry's merged PR vouch for a different PR's URL.
+    Every signals task associated with the report is a candidate, not just the `implementation`
+    ones: a task started from the inbox's "Discuss" button runs the same agent against the same
+    repo, so it can push a branch and open a PR too, and that PR is the report's PR as much as an
+    auto-started one is. Implementation tasks are still consulted first, so a report that has both
+    surfaces exactly what it surfaced before.
+
+    A report can be associated with several tasks (retries, plus any discussion), but only one PR is
+    surfaced — the first candidate that has one. The merge flag is read from *that* task, so the URL
+    and its state always describe the same PR. Reading them independently would let a retry's merged
+    PR vouch for a different PR's URL.
     """
     if not report_ids:
         return {}
 
-    # (report_id, task_id) for each report's implementation task(s); signals owns this mapping.
+    # (report_id, task_id) for each report's signals task(s); signals owns this mapping.
     # Batched across the whole page so association costs two queries, not two per report (N+1).
     runs_by_report = SignalReport.associated_task_runs_for_reports(
         report_ids=[str(report_id) for report_id in report_ids],
         product=SIGNALS_PRODUCT,
-        type=TASK_RUN_TYPE_IMPLEMENTATION,
     )
     pairs: list[tuple[str, str]] = [
-        (report_id, run.task_id) for report_id, runs in runs_by_report.items() for run in runs
+        (report_id, run.task_id)
+        for report_id, runs in runs_by_report.items()
+        # Stable sort, so implementation tasks lead and each group keeps its oldest-first order.
+        for run in sorted(runs, key=lambda run: run.type != TASK_RUN_TYPE_IMPLEMENTATION)
     ]
     if not pairs:
         return {}
@@ -65,7 +73,7 @@ def fetch_implementation_pr_state_for_reports(report_ids: list[str]) -> dict[str
 
 
 def fetch_implementation_pr_urls_for_reports(report_ids: list[str]) -> dict[str, str]:
-    """PR URL from the latest implementation task run for each report, when available."""
+    """PR URL from the latest PR-bearing task run for each report, when available."""
     return {report_id: pr.url for report_id, pr in fetch_implementation_pr_state_for_reports(report_ids).items()}
 
 

--- a/products/signals/backend/temporal/inbox_notification.py
+++ b/products/signals/backend/temporal/inbox_notification.py
@@ -22,7 +22,6 @@ from posthog.models import Team
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.scoped import scoped_temporal
 
-from products.signals.backend.implementation_pr import fetch_implementation_pr_urls_for_reports
 from products.signals.backend.models import SignalReport
 from products.signals.backend.support_writeback import post_report_findings_to_tickets
 from products.signals.backend.task_run_artefacts import SIGNALS_PRODUCT, TASK_RUN_TYPE_IMPLEMENTATION
@@ -55,7 +54,10 @@ def _compute_inbox_notification_state(team_id: int, report_id: str) -> InboxNoti
     if not impl_task_ids:
         return InboxNotificationState(has_implementation_task=False, pr_available=False, task_terminal=False)
 
-    pr_available = bool(fetch_implementation_pr_urls_for_reports([report_id]))
+    # Resolved from the implementation tasks alone, not the report's surfaced PR: the wait exists to
+    # give the implementation task time to open its PR, so a PR from some other task (a "Discuss"
+    # chat that opened one) must not end it early.
+    pr_available = bool(tasks_facade.get_latest_pr_url_by_task(impl_task_ids))
     # Most recent run across the report's implementation task(s).
     latest_run = max(
         tasks_facade.get_latest_run_by_task(impl_task_ids).values(),

--- a/products/signals/backend/test/test_inbox_notification_workflow.py
+++ b/products/signals/backend/test/test_inbox_notification_workflow.py
@@ -13,7 +13,7 @@ from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 from posthog.models import Organization, Team
 
 from products.signals.backend.models import SignalReport, SignalReportTask
-from products.signals.backend.task_run_artefacts import TASK_RUN_TYPE_IMPLEMENTATION
+from products.signals.backend.task_run_artefacts import TASK_RUN_TYPE_DISCUSSION, TASK_RUN_TYPE_IMPLEMENTATION
 from products.signals.backend.temporal.inbox_notification import (
     InboxNotificationInput,
     InboxNotificationState,
@@ -31,13 +31,20 @@ def _make_report(team: Team, status: str = SignalReport.Status.READY) -> SignalR
     )
 
 
-def _link_implementation_task(team: Team, report: SignalReport, *, pr_url: str | None, run_status: str) -> None:
+def _link_implementation_task(
+    team: Team,
+    report: SignalReport,
+    *,
+    pr_url: str | None,
+    run_status: str,
+    relationship: str = TASK_RUN_TYPE_IMPLEMENTATION,
+) -> None:
     Task = apps.get_model("tasks", "Task")
     TaskRun = apps.get_model("tasks", "TaskRun")
     task = Task.objects.create(
         team=team, title="impl", description="d", origin_product=Task.OriginProduct.SIGNAL_REPORT
     )
-    SignalReportTask.objects.create(team=team, report=report, task=task, relationship=TASK_RUN_TYPE_IMPLEMENTATION)
+    SignalReportTask.objects.create(team=team, report=report, task=task, relationship=relationship)
     TaskRun.objects.create(team=team, task=task, status=run_status, output={"pr_url": pr_url})
 
 
@@ -71,6 +78,24 @@ def test_state_task_running_no_pr(team):
     TaskRun = apps.get_model("tasks", "TaskRun")
     report = _make_report(team)
     _link_implementation_task(team, report, pr_url=None, run_status=TaskRun.Status.IN_PROGRESS)
+    state = _compute_inbox_notification_state(team.id, str(report.id))
+    assert state == InboxNotificationState(has_implementation_task=True, pr_available=False, task_terminal=False)
+
+
+@pytest.mark.django_db
+def test_state_discussion_pr_does_not_end_the_implementation_wait(team):
+    # The wait buys the implementation task time to open its PR. A PR from a discuss task is a
+    # different PR, so it must not end the wait and send the card early.
+    TaskRun = apps.get_model("tasks", "TaskRun")
+    report = _make_report(team)
+    _link_implementation_task(team, report, pr_url=None, run_status=TaskRun.Status.IN_PROGRESS)
+    _link_implementation_task(
+        team,
+        report,
+        pr_url="https://github.com/o/r/pull/1",
+        run_status=TaskRun.Status.COMPLETED,
+        relationship=TASK_RUN_TYPE_DISCUSSION,
+    )
     state = _compute_inbox_notification_state(team.id, str(report.id))
     assert state == InboxNotificationState(has_implementation_task=True, pr_available=False, task_terminal=False)
 

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -36,7 +36,13 @@ from products.signals.backend.implementation_pr import (
 )
 from products.signals.backend.models import SignalReport, SignalReportArtefact, SignalReportTask
 from products.signals.backend.signal_metadata import ReportSignalMeta
-from products.signals.backend.task_run_artefacts import append_task_run_artefact, record_implementation_task
+from products.signals.backend.task_run_artefacts import (
+    TASK_RUN_TYPE_DISCUSSION,
+    TASK_RUN_TYPE_IMPLEMENTATION,
+    append_task_run_artefact,
+    record_implementation_task,
+    record_report_task,
+)
 
 if TYPE_CHECKING:
     from products.tasks.backend.models import Task, TaskRun
@@ -574,7 +580,12 @@ class TestSignalReportListAPI(APIBaseTest):
     # --- implementation_pr_url ---
 
     def _create_implementation_task_with_run(
-        self, report: SignalReport, *, pr_url: str | None = None, output: dict | None = None
+        self,
+        report: SignalReport,
+        *,
+        pr_url: str | None = None,
+        output: dict | None = None,
+        relationship: str = TASK_RUN_TYPE_IMPLEMENTATION,
     ) -> "tuple[Task, TaskRun]":
         Task = apps.get_model("tasks", "Task")
         TaskRun = apps.get_model("tasks", "TaskRun")
@@ -584,10 +595,11 @@ class TestSignalReportListAPI(APIBaseTest):
             description="Fix the bug",
             origin_product=Task.OriginProduct.SIGNAL_REPORT,
         )
-        record_implementation_task(
+        record_report_task(
             team_id=self.team.id,
             report_id=str(report.id),
             task_id=str(task.id),
+            relationship=relationship,
         )
         run_output = output if output is not None else ({"pr_url": pr_url} if pr_url else None)
         run = TaskRun.objects.create(
@@ -644,6 +656,28 @@ class TestSignalReportListAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
         assert row["implementation_pr_url"] == "https://github.com/o/r/pull/7"
+
+    @parameterized.expand(
+        [
+            # A "Discuss" task runs the same agent against the same repo, so the PR it opens is the
+            # report's PR. Without it the report offers "Create PR" for work that already shipped.
+            ("discussion_only", False, "https://github.com/o/r/pull/5"),
+            # Implementation still wins when both have one, even though the discussion task is older
+            # and would come first on association order alone.
+            ("implementation_wins_over_discussion", True, "https://github.com/o/r/pull/6"),
+        ]
+    )
+    def test_implementation_pr_url_resolves_discussion_task_pr(self, _name, with_implementation, expected_url):
+        report = self._create_report()
+        self._create_implementation_task_with_run(
+            report, pr_url="https://github.com/o/r/pull/5", relationship=TASK_RUN_TYPE_DISCUSSION
+        )
+        if with_implementation:
+            self._create_implementation_task_with_run(report, pr_url="https://github.com/o/r/pull/6")
+
+        row = next(r for r in self.client.get(self._list_url()).json()["results"] if r["id"] == str(report.id))
+
+        assert row["implementation_pr_url"] == expected_url
 
     @parameterized.expand(
         [

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -1241,8 +1241,8 @@ class SignalReportViewSet(
     def _annotate_implementation_pr_url(self, queryset):
         # Latest TaskRun output->pr_url across the tasks associated with each report, unified over
         # the task_run artefact log + legacy SignalReportTask rows (see associated_task_runs_filter).
-        # Only implementation runs carry a pr_url, so the non-empty-pr_url filter inside the facade
-        # subquery makes "any associated task" resolve to the implementation PR.
+        # The non-empty-pr_url filter inside the facade subquery is what narrows "any associated
+        # task" to the one that opened the report's PR.
         latest_impl_pr_url = tasks_facade.latest_task_run_pr_url_subquery(
             SignalReport.associated_task_runs_filter(OuterRef(OuterRef("id"))),
         )


### PR DESCRIPTION
## Problem

- Someone who opens a PR from an inbox report's "Discuss" chat sees no PR on that report afterwards. The report still offers "Create PR", so it invites them to redo work that already shipped.
- The report resolves its PR only from tasks labelled `implementation` ([implementation_pr.py](https://github.com/PostHog/posthog/blob/master/products/signals/backend/implementation_pr.py#L44-L48)). A discuss task is labelled `discussion`, so its PR is filtered out.
- The report's `implementation_pr_url` stays null. That one field drives "Open in GitHub", the PR conversation, the CI checks panel, and whether "Create PR" is offered.
- The "Files changed" tab still renders, because it reads the commit artefact instead. The report shows a branch and a diff next to a "Create PR" button.
- A discuss task is an ordinary task: same agent, same repo, same signed-commit and webhook path that records the PR URL. Only the label differs.
- Reported from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1786723215348239).

## Changes

- Every signals task associated with a report is now a candidate when resolving its PR, not just the `implementation` ones.
- Implementation tasks are ranked first, so a report that has one surfaces exactly what it surfaced before. The change is additive.
- The inbox notification workflow keeps an implementation-only view of the PR. Its wait exists to give the implementation task time to open a PR, so a discuss task's PR must not end it early. It now reads the task ids it already holds, which also drops a duplicate lookup.
- I rejected relabelling a discuss task as `implementation` once it opens a PR. That label also writes the auto-start gate row that billing and quota release key on, so a user-driven chat would start counting as self-driving spend.
- Billing is untouched. It filters `SignalReportTask.relationship` directly and never calls this resolver, so a discuss PR displays without being billed.

> [!NOTE]
> Suppressing or snoozing a report closes its PR. A report whose only PR came from a discuss task now has that PR closed, where before nothing was closed. That follows from the PR being shown as the report's PR, but it is the one behavior change beyond display.

No visual change. The affected components already handle a populated `implementation_pr_url`.

## How did you test this code?

- Added two parameterized cases to `test_implementation_pr_url_resolves_discussion_task_pr`. The first catches the regression this PR fixes: re-narrowing the resolver to `implementation` drops a discuss task's PR. The second catches an implementation PR losing to an older discussion PR, which is what the ranking prevents.
- Added `test_state_discussion_pr_does_not_end_the_implementation_wait`. It catches the notification workflow sending early when a discuss task has a PR and the implementation task is still running.
- No existing case covered any of these. Both suites only built `implementation` tasks.
- Ran locally against Postgres: `test_signal_report_api.py -k implementation_pr`, plus `test_dismissal_pr_close.py`, `test_inbox_notification_workflow.py`, `test_auto_start.py`, `test_billing.py`, `test_refunds.py` and `test_task_run_artefacts.py`. All passed.
- mypy passes on the changed modules. I could not run it repo-wide, because the sandbox runs out of memory.
- Not checked: the end-to-end flow in a browser, and the webhook path that writes the PR URL onto the task run. I did not reproduce the original report in a running app. Four `TestSignalReportDeleteAPI` cases fail locally against a missing Temporal server, unrelated to this change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via the PostHog Slack app) traced this from a report where the PR was visibly missing. The report's own artefacts showed a `task_run` artefact typed `discussion` and a commit artefact for the pushed branch, which is what pinned the cause to the type filter rather than to a missing PR URL.

I considered broadening the filter everywhere it appears. I did not, because the auto-start dedup gate uses the same constant, and widening it there would make a report with only a discussion task look already implemented and block auto-start forever.

The notification scoping came from a Codex review finding on the first commit. I had checked that caller and wrongly cleared it, because I only considered a report with no implementation task at all.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

A stale comment in `views.py` claimed only implementation runs carry a `pr_url`. That is what this PR disproves, so I corrected it.
