### PR TITLE
fix(warehouse-sources): make the fan-out drift signals countable per schema

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/__init__.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/__init__.py
@@ -300,7 +300,7 @@ def create_resources(
             request_timeout=client_config.get("request_timeout"),
         )
 
-        hooks = create_response_hooks(endpoint_config.get("response_actions"))
+        hooks = create_response_hooks(endpoint_config.get("response_actions"), resource_name=resource_name)
 
         resource_kwargs = exclude_keys(
             endpoint_resource, {"endpoint", "include_from_parent", "data_map", "data_iterator"}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/config_setup.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/config_setup.py
@@ -1,5 +1,4 @@
 import string
-import logging
 import graphlib  # type: ignore[import,unused-ignore]
 import warnings
 from collections.abc import Callable
@@ -37,10 +36,7 @@ from .typing import (
 )
 from .utils import exclude_keys
 
-logger = logging.getLogger(__name__)
-# The module's stdlib logger predates structured logging here and stays for the existing
-# call sites; new events that need queryable fields use this one.
-structured_logger = structlog.get_logger(__name__)
+logger = structlog.get_logger(__name__)
 
 PAGINATOR_MAP: dict[PaginatorType, type[BasePaginator] | None] = {
     "json_response": JSONResponsePaginator,
@@ -397,13 +393,10 @@ def _create_response_actions_hook(
         action_type = matched.get("action") if matched else None
 
         if action_type == "ignore":
-            # Structured, and carrying the resource, so an ignored response is countable per
-            # schema. A fan-out child over a warehouse parent injects a `404 -> ignore` for
-            # parents the vendor has since dropped, and counting those against the reader's
-            # `fanout_parent_rows_streamed` is how snapshot drift gets measured.
+            # Carries the resource so ignores are countable per schema.
             # Use response.text, not response.json(): an ignored response (e.g. a 404) often has an
             # empty or non-JSON body, and parsing it here would raise before the ignore takes effect.
-            structured_logger.info(
+            logger.info(
                 "data_imports.response_action_ignored",
                 resource=resource_name,
                 status_code=response.status_code,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/config_setup.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/config_setup.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from copy import copy
 from typing import Any, NamedTuple, Optional, cast
 
+import structlog
 from requests import Response
 
 from .auth import APIKeyAuth, AuthConfigBase, BearerTokenAuth, HttpBasicAuth, OAuth2Auth
@@ -37,6 +38,9 @@ from .typing import (
 from .utils import exclude_keys
 
 logger = logging.getLogger(__name__)
+# The module's stdlib logger predates structured logging here and stays for the existing
+# call sites; new events that need queryable fields use this one.
+structured_logger = structlog.get_logger(__name__)
 
 PAGINATOR_MAP: dict[PaginatorType, type[BasePaginator] | None] = {
     "json_response": JSONResponsePaginator,
@@ -386,15 +390,25 @@ def _handle_response_actions(response: Response, actions: list[ResponseAction]) 
 
 def _create_response_actions_hook(
     response_actions: list[ResponseAction],
+    resource_name: str | None = None,
 ) -> Callable[[Response, Any, Any], None]:
     def response_actions_hook(response: Response, *args: Any, **kwargs: Any) -> None:
         matched = _handle_response_actions(response, response_actions)
         action_type = matched.get("action") if matched else None
 
         if action_type == "ignore":
+            # Structured, and carrying the resource, so an ignored response is countable per
+            # schema. A fan-out child over a warehouse parent injects a `404 -> ignore` for
+            # parents the vendor has since dropped, and counting those against the reader's
+            # `fanout_parent_rows_streamed` is how snapshot drift gets measured.
             # Use response.text, not response.json(): an ignored response (e.g. a 404) often has an
             # empty or non-JSON body, and parsing it here would raise before the ignore takes effect.
-            logger.info(f"Ignoring response with code {response.status_code} and content '{response.text[:500]}'.")
+            structured_logger.info(
+                "data_imports.response_action_ignored",
+                resource=resource_name,
+                status_code=response.status_code,
+                content=response.text[:500],
+            )
             raise IgnoreResponseException
 
         # Re-issue the request. This is how a source classifies an HTTP-200 body-level error
@@ -418,9 +432,10 @@ def _create_response_actions_hook(
 
 def create_response_hooks(
     response_actions: Optional[list[ResponseAction]],
+    resource_name: Optional[str] = None,
 ) -> Optional[dict[str, Any]]:
     if response_actions:
-        return {"response": [_create_response_actions_hook(response_actions)]}
+        return {"response": [_create_response_actions_hook(response_actions, resource_name)]}
     return None
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/fanout.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/fanout.py
@@ -162,6 +162,7 @@ def build_dependent_resource(
                 parent_name=fanout.parent_name,
                 columns=parent_columns,
                 page_size=parent_config.page_size,
+                schema_name=child_endpoint,
             )
 
     child_path = child_config.path

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_fanout.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_fanout.py
@@ -505,6 +505,9 @@ def test_warehouse_parent_builds_data_iterator_and_404_ignore(
         parent_name="parents",
         columns=["id"],
         page_size=3,
+        # Without this the reader's rows-streamed log has no schema, so snapshot drift can't
+        # be attributed to a child.
+        schema_name="children",
     )
     assert child_resource["endpoint"]["response_actions"] == [{"status_code": 404, "action": "ignore"}]
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_response_action_classification.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_response_action_classification.py
@@ -19,6 +19,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.res
 )
 
 MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client"
+CONFIG_SETUP_MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.config_setup"
 
 
 def _make_response(body: Any, status_code: int = 200, reason: str = "OK") -> Response:
@@ -98,15 +99,21 @@ class TestResponseActionClassification:
         resp._content = b""
         resp.url = "https://api.example.com/items"
         mock_session.send.return_value = resp
-        hooks = create_response_hooks([{"status_code": 404, "action": "ignore"}])
+        hooks = create_response_hooks([{"status_code": 404, "action": "ignore"}], resource_name="issue_hashes")
 
         client = RESTClient(base_url="https://api.example.com", max_retry_attempts=1)
-        pages = list(
-            client.paginate(path="/items", data_selector="results", paginator=SinglePagePaginator(), hooks=hooks)
-        )
+        with patch(f"{CONFIG_SETUP_MODULE}.logger") as mock_logger:
+            pages = list(
+                client.paginate(path="/items", data_selector="results", paginator=SinglePagePaginator(), hooks=hooks)
+            )
 
         assert pages == []
         assert mock_session.send.call_count == 1
+        # A stale fan-out parent is dropped here, so the ignore has to be countable per schema.
+        logged = mock_logger.info.call_args
+        assert logged.args[0] == "data_imports.response_action_ignored"
+        assert logged.kwargs["resource"] == "issue_hashes"
+        assert logged.kwargs["status_code"] == 404
 
     @patch("tenacity.nap.time.sleep")
     @patch(f"{MODULE}.make_tracked_session")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_warehouse_parent.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_warehouse_parent.py
@@ -1,8 +1,7 @@
-from collections.abc import Generator
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 
 import pytest
 from posthog.test.base import APIBaseTest
@@ -112,14 +111,15 @@ def test_reader_pages_and_rekeys_to_api_field_names(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    "consume_all,expected_rows,expected_completed",
-    [(True, 3, True), (False, 1, False)],
+    "ending,expected_rows,expected_outcome",
+    [("drained", 3, "completed"), ("closed", 1, "stopped"), ("raised", 1, "failed")],
 )
-def test_reader_logs_the_row_count_even_when_the_consumer_stops_early(
-    tmp_path: Path, consume_all: bool, expected_rows: int, expected_completed: bool
+def test_reader_logs_the_row_count_and_how_the_scan_ended(
+    tmp_path: Path, ending: str, expected_rows: int, expected_outcome: str
 ) -> None:
     # A resumable child checkpoints mid-fan-out and the pipeline closes the generator, so a
-    # count logged after the loop would be lost for exactly the runs worth measuring.
+    # count logged after the loop would be lost for exactly the runs worth measuring. Only a
+    # drained scan carries a full count, and a crash must not read as a clean early stop.
     uri = _write_parent_table(tmp_path)
     ref = ParentTableRef(uri=uri, version=deltalake.DeltaTable(uri).version())
 
@@ -127,23 +127,24 @@ def test_reader_logs_the_row_count_even_when_the_consumer_stops_early(
         patch.object(warehouse_parent, "delta_storage_options", return_value={}),
         patch.object(warehouse_parent, "logger") as mock_logger,
     ):
-        pages = cast(
-            Generator[list[dict[str, Any]]],
-            warehouse_parent.iter_parent_pages_from_warehouse(
-                table=ref, parent_name="issues", columns=["id"], page_size=1, schema_name="issue_hashes"
-            ),
+        pages = warehouse_parent.iter_parent_pages_from_warehouse(
+            table=ref, parent_name="issues", columns=["id"], page_size=1, schema_name="issue_hashes"
         )
-        if consume_all:
+        if ending == "drained":
             list(pages)
         else:
             next(pages)
-            pages.close()
+            if ending == "closed":
+                pages.close()
+            else:
+                with pytest.raises(RuntimeError):
+                    pages.throw(RuntimeError("consumer blew up"))
 
     logged = mock_logger.info.call_args
     assert logged.args[0] == "data_imports.fanout_parent_rows_streamed"
     assert logged.kwargs["schema"] == "issue_hashes"
     assert logged.kwargs["rows"] == expected_rows
-    assert logged.kwargs["completed"] is expected_completed
+    assert logged.kwargs["outcome"] == expected_outcome
 
 
 def test_resolve_raises_when_parent_has_no_synced_table(tmp_path: Path) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_warehouse_parent.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_warehouse_parent.py
@@ -1,7 +1,8 @@
+from collections.abc import Generator
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from posthog.test.base import APIBaseTest
@@ -38,7 +39,9 @@ def _write_parent_table(tmp_path: Path) -> str:
 def _patched_reader(uri: str, version: int | None = None, **kwargs):
     ref = ParentTableRef(uri=uri, version=deltalake.DeltaTable(uri).version() if version is None else version)
     with patch.object(warehouse_parent, "delta_storage_options", return_value={}):
-        return list(iter_parent_pages_from_warehouse(table=ref, parent_name="issues", **kwargs))
+        return list(
+            iter_parent_pages_from_warehouse(table=ref, parent_name="issues", schema_name="issue_tag_values", **kwargs)
+        )
 
 
 def _patched_resolve(uri: str, snapshot_timestamp=None):
@@ -106,6 +109,41 @@ def test_reader_pages_and_rekeys_to_api_field_names(tmp_path: Path) -> None:
         "3": "2026-03-02",
     }
     assert all(set(row) == {"id", "lastSeen"} for row in rows)
+
+
+@pytest.mark.parametrize(
+    "consume_all,expected_rows,expected_completed",
+    [(True, 3, True), (False, 1, False)],
+)
+def test_reader_logs_the_row_count_even_when_the_consumer_stops_early(
+    tmp_path: Path, consume_all: bool, expected_rows: int, expected_completed: bool
+) -> None:
+    # A resumable child checkpoints mid-fan-out and the pipeline closes the generator, so a
+    # count logged after the loop would be lost for exactly the runs worth measuring.
+    uri = _write_parent_table(tmp_path)
+    ref = ParentTableRef(uri=uri, version=deltalake.DeltaTable(uri).version())
+
+    with (
+        patch.object(warehouse_parent, "delta_storage_options", return_value={}),
+        patch.object(warehouse_parent, "logger") as mock_logger,
+    ):
+        pages = cast(
+            Generator[list[dict[str, Any]]],
+            warehouse_parent.iter_parent_pages_from_warehouse(
+                table=ref, parent_name="issues", columns=["id"], page_size=1, schema_name="issue_hashes"
+            ),
+        )
+        if consume_all:
+            list(pages)
+        else:
+            next(pages)
+            pages.close()
+
+    logged = mock_logger.info.call_args
+    assert logged.args[0] == "data_imports.fanout_parent_rows_streamed"
+    assert logged.kwargs["schema"] == "issue_hashes"
+    assert logged.kwargs["rows"] == expected_rows
+    assert logged.kwargs["completed"] is expected_completed
 
 
 def test_resolve_raises_when_parent_has_no_synced_table(tmp_path: Path) -> None:
@@ -219,7 +257,11 @@ def test_reader_stays_on_the_pinned_version_when_the_parent_re_syncs(tmp_path: P
     )
 
     with patch.object(warehouse_parent, "delta_storage_options", return_value={}):
-        pages = list(iter_parent_pages_from_warehouse(table=pinned, parent_name="issues", columns=["id"], page_size=10))
+        pages = list(
+            iter_parent_pages_from_warehouse(
+                table=pinned, parent_name="issues", columns=["id"], page_size=10, schema_name="issue_tag_values"
+            )
+        )
 
     assert sorted(row["id"] for page in pages for row in page) == ["1", "2", "3"]
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/warehouse_parent.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/warehouse_parent.py
@@ -227,7 +227,7 @@ def iter_parent_pages_from_warehouse(
     parent_name: str,
     columns: list[str],
     page_size: int,
-    schema_name: str | None = None,
+    schema_name: str,
 ) -> Iterator[list[dict[str, Any]]]:
     """Yield fan-out parent rows from the parent schema's already-synced Delta table.
 
@@ -262,25 +262,35 @@ def iter_parent_pages_from_warehouse(
     dataset = delta_table.to_pyarrow_dataset()
 
     rows_streamed = 0
-    page: list[dict[str, Any]] = []
-    for batch in dataset.to_batches(columns=projected, batch_size=page_size):
-        for row in batch.to_pylist():
-            page.append({api_name: row.get(physical) for api_name, physical in physical_by_api_name.items()})
-            rows_streamed += 1
-            if len(page) >= page_size:
-                yield page
-                page = []
-    if page:
-        yield page
-
-    # The snapshot only grows for an incremental parent, while the vendor's own listing drops
-    # rows past its retention. This count against the child's stale-parent skips is how we tell
-    # whether the fan-out set has drifted above what the API would return — see the reuse
-    # follow-up in the plan.
-    logger.info(
-        "data_imports.fanout_parent_rows_streamed",
-        schema=schema_name,
-        parent=parent_name,
-        rows=rows_streamed,
-        version=table.version,
-    )
+    completed = False
+    try:
+        page: list[dict[str, Any]] = []
+        for batch in dataset.to_batches(columns=projected, batch_size=page_size):
+            for row in batch.to_pylist():
+                page.append({api_name: row.get(physical) for api_name, physical in physical_by_api_name.items()})
+                rows_streamed += 1
+                if len(page) >= page_size:
+                    yield page
+                    page = []
+        if page:
+            yield page
+        completed = True
+    finally:
+        # In a `finally` because a consumer can stop early: a resumable child checkpoints
+        # mid-fan-out, and the pipeline's iterator cleanup closes this generator, which raises
+        # GeneratorExit at the `yield` above. Logging after the loop would lose those runs
+        # entirely, and `completed` marks the count as partial so a short scan isn't read as
+        # a shrinking snapshot.
+        #
+        # The snapshot only grows for an incremental parent, while the vendor's own listing
+        # drops rows past its retention. This count against the child's ignored stale-parent
+        # responses is how we tell whether the fan-out set has drifted above what the API
+        # would return — see the reuse follow-up in the plan.
+        logger.info(
+            "data_imports.fanout_parent_rows_streamed",
+            schema=schema_name,
+            parent=parent_name,
+            rows=rows_streamed,
+            version=table.version,
+            completed=completed,
+        )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/warehouse_parent.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/warehouse_parent.py
@@ -1,6 +1,6 @@
 import uuid
 import datetime as dt
-from collections.abc import Iterator
+from collections.abc import Generator
 from dataclasses import dataclass
 from typing import Any
 
@@ -228,7 +228,7 @@ def iter_parent_pages_from_warehouse(
     columns: list[str],
     page_size: int,
     schema_name: str,
-) -> Iterator[list[dict[str, Any]]]:
+) -> Generator[list[dict[str, Any]]]:
     """Yield fan-out parent rows from the parent schema's already-synced Delta table.
 
     Pages are shaped like the REST parent pages the dependent-resource machinery consumes
@@ -262,7 +262,7 @@ def iter_parent_pages_from_warehouse(
     dataset = delta_table.to_pyarrow_dataset()
 
     rows_streamed = 0
-    completed = False
+    outcome = "failed"
     try:
         page: list[dict[str, Any]] = []
         for batch in dataset.to_batches(columns=projected, batch_size=page_size):
@@ -274,13 +274,16 @@ def iter_parent_pages_from_warehouse(
                     page = []
         if page:
             yield page
-        completed = True
+        outcome = "completed"
+    except GeneratorExit:
+        outcome = "stopped"
+        raise
     finally:
         # In a `finally` because a consumer can stop early: a resumable child checkpoints
         # mid-fan-out, and the pipeline's iterator cleanup closes this generator, which raises
         # GeneratorExit at the `yield` above. Logging after the loop would lose those runs
-        # entirely, and `completed` marks the count as partial so a short scan isn't read as
-        # a shrinking snapshot.
+        # entirely. Only `completed` carries a full row count; a `stopped` or `failed` scan must
+        # not be read as a shrinking snapshot.
         #
         # The snapshot only grows for an incremental parent, while the vendor's own listing
         # drops rows past its retention. This count against the child's ignored stale-parent
@@ -292,5 +295,5 @@ def iter_parent_pages_from_warehouse(
             parent=parent_name,
             rows=rows_streamed,
             version=table.version,
-            completed=completed,
+            outcome=outcome,
         )


### PR DESCRIPTION
## Problem

Whoever decides how far to roll out warehouse parent reuse can't measure the thing the decision turns on. The rollout question is whether a parent snapshot drifts above what the vendor still lists ([#72929](https://github.com/PostHog/posthog/pull/72929), plan phase 1.5), which needs stale parents counted against parent rows read. Neither number is usable today for a child converted through the shared fan-out builder.

- The row count logs with `"schema": null` for those children, because the builder never passes the child's name to the reader. Seen on the first production run, team 2 at 16:40 UTC today: `issue_tag_values` logged its name, `issue_events` and `issue_hashes` logged `null`.
- The stale count doesn't exist on that path at all. A parent the vendor dropped is discarded by the injected `404 → ignore` action, which logged one unstructured line with no schema and no count.
- The row count is also lost entirely when a consumer stops early, which is what a resumable child does every time it checkpoints mid-fan-out.

## Changes

- The ignore hook logs `data_imports.response_action_ignored` with the resource name, so stale parents are countable per schema. That is the drift numerator on the builder path.
- The reader logs its row count from a `finally`, with an `outcome` of `completed`, `stopped` or `failed`. Only a completed scan carries a full count, so a crash cannot be read as a clean early stop and shrink the denominator.
- `build_dependent_resource` passes the child endpoint name to the reader, which fixes the `null` label.
- `schema_name` is now required on the reader rather than defaulting to `None`. The optional default is what allowed the builder to omit it, so the next caller would have hit the same gap silently.

No sync behavior changes: every argument here reaches a log line.

> [!NOTE]
> `bind_job_context` already carries `schema_name` and binds four sibling fields into every log in the run, so binding `schema` there would remove this whole class of per-call-site plumbing. I left it out to keep this PR to the measurement fix; it touches shared logging and deserves its own change.

## How did you test this code?

- `test_reader_logs_the_row_count_and_how_the_scan_ended` covers all three endings. The early-stop case fails without the `finally`, which is the regression that silently drops counts for resumable children.
- `test_warehouse_parent_builds_data_iterator_and_404_ignore` asserts the reader receives `schema_name`, and `test_ignore_action_with_non_json_body_is_skipped` asserts the ignore event's `resource`. Without those the labels can go missing while every other assertion still passes, which is how this shipped.
- Not checked: a production run with the new fields present. The only source on the flag is Sentry, whose next scheduled sync is hours out.
- Local full-suite runs for `sources/` are currently unreliable on this machine: concurrent runs from other worktrees share a test database, and the failures I saw there pass in isolation and sit in files this PR doesn't touch. CI is the signal.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. These are internal log fields.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found by reading the first production warehouse-path logs after enabling the flag for the dogfood Sentry source, rather than from a test. Skills invoked: `/writing-pr-descriptions`, `/writing-tests`.

The first version of this PR fixed only the `null` label, and its description claimed that unblocked the drift measurement. An adversarial review pass showed that was wrong: the numerator was missing on the same path, so the ratio stayed uncomputable and the rollout decision was no closer. The scope grew to cover both halves plus the early-stop loss, and the claim is corrected above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
