### PR TITLE
fix(data-imports): skip trimming non-dict job_inputs

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
@@ -72,7 +72,9 @@ NON_RETRYABLE_ERROR_RETRY_LIMIT = 3
 
 
 async def trim_source_job_inputs(source: "ExternalDataSource") -> None:
-    if not source.job_inputs:
+    # job_inputs is an EncryptedJSONField, so it can decode to a non-dict (e.g. a bare string)
+    # for a malformed source config — nothing to trim key-by-key in that case.
+    if not isinstance(source.job_inputs, dict):
         return
 
     did_update_inputs = False

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
@@ -24,6 +24,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.common.e
     persist_primary_keys,
     report_heartbeat_timeout,
     resolve_primary_keys,
+    trim_source_job_inputs,
     validate_incremental_sync,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arrow_utils import (
@@ -134,6 +135,42 @@ class TestPersistPrimaryKeys:
             await persist_primary_keys(schema, resource, True, logger)
 
         logger.aexception.assert_awaited_once()
+
+
+class TestTrimSourceJobInputs:
+    @parameterized.expand(
+        [
+            # A non-empty string decoded out of the EncryptedJSONField used to reach `.items()` and
+            # raise AttributeError — it must be skipped, not crash the whole import activity.
+            ("bare_string_is_skipped", "not-a-dict"),
+            ("list_is_skipped", ["a", "b"]),
+            ("none_is_skipped", None),
+            ("empty_dict_is_skipped", {}),
+        ]
+    )
+    @pytest.mark.asyncio
+    async def test_non_dict_job_inputs_is_a_noop(self, _name: str, job_inputs) -> None:
+        source = MagicMock(job_inputs=job_inputs, save=MagicMock())
+        with patch(f"{_EXTRACT_MODULE}.database_sync_to_async_pool") as pool:
+            await trim_source_job_inputs(source)
+        pool.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dict_job_inputs_is_trimmed_and_saved(self) -> None:
+        source = MagicMock(job_inputs={"host": " example.com ", "port": "5432"}, save=MagicMock())
+        saved = AsyncMock()
+        with patch(f"{_EXTRACT_MODULE}.database_sync_to_async_pool", return_value=saved):
+            await trim_source_job_inputs(source)
+        assert source.job_inputs["host"] == "example.com"
+        assert source.job_inputs["port"] == "5432"
+        saved.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_dict_job_inputs_without_padding_does_not_save(self) -> None:
+        source = MagicMock(job_inputs={"host": "example.com"}, save=MagicMock())
+        with patch(f"{_EXTRACT_MODULE}.database_sync_to_async_pool") as pool:
+            await trim_source_job_inputs(source)
+        pool.assert_not_called()
 
 
 class TestReportHeartbeatTimeoutRecording(BaseTest):


### PR DESCRIPTION
## Problem

- A data-warehouse import fails at the start of the sync activity for a source whose stored config is not a key-value map, surfacing as `AttributeError: 'str' object has no attribute 'items'` in error tracking.
- `job_inputs` is an `EncryptedJSONField`, so it can decode to a bare string (a malformed source config) rather than a dict.
- `trim_source_job_inputs` guarded only on truthiness (`if not source.job_inputs`), then called `source.job_inputs.items()`, so a non-empty string passed the guard and raised.

## Changes

- Guard `trim_source_job_inputs` on `isinstance(source.job_inputs, dict)`, so a non-dict config is skipped instead of crashing the import activity.
- The trimming loop only makes sense on a mapping, so this is the correct place to fix the whole class rather than patch one source.

## How did you test this code?

- Added `TestTrimSourceJobInputs` in `test_extract.py`. It catches a revert of the guard back to a truthiness check: a bare string or list for `job_inputs` now no-ops instead of raising `AttributeError`, and the normal dict path still trims padded values and saves only when something changed.
- Ran the new tests locally; they pass.
- Not run: the database-backed suites in this file (`TestHandleCorruptedDeltaLog`, `TestHandleResetOrFullRefresh`, `TestReportHeartbeatTimeoutRecording`), because this sandbox has no Postgres. The new tests are mock-based and need no database.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored by an agent (Claude) triaging a live error-tracking issue in the data-warehouse import pipeline.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- The failing frame reported by error tracking was in shared pipeline code (`trim_source_job_inputs` in `pipelines/common/extract.py`), not the source connector, so the fix lives in the shared layer. Root cause is our code mishandling a non-dict data shape, not a user/upstream condition, so it is a code fix rather than a `NonRetryableErrors` addition.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
