### PR TITLE
fix(integrations): narrow stripe app oauth scopes to the five it calls

### DIFF
--- a/ee/partners/stripe/api/provisioning/constants.py
+++ b/ee/partners/stripe/api/provisioning/constants.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import re
 
-from posthog.models.integration import StripeIntegration
-
 SUPPORTED_VERSIONS = ["0.1d"]
 MAX_TIMESTAMP_DRIFT_SECONDS = 300
 
@@ -21,7 +19,26 @@ ACCESS_TOKEN_EXPIRY_SECONDS = 365 * 24 * 3600
 
 # Default scopes for a Stripe-issued token when the auth code requested none.
 # This namespace enforces no scope ceiling; a code that names scopes gets those.
-STRIPE_CONTRACTED_SCOPES: list[str] = StripeIntegration.SCOPES.split()
+# Listed explicitly rather than aliasing StripeIntegration.SCOPES: that list bounds a
+# credential shared across a merchant's Stripe account, while these back a provisioned
+# user's own PAT. Narrowing one must not silently narrow the other.
+STRIPE_CONTRACTED_SCOPES: list[str] = [
+    "customer_journey:read",
+    "query:read",
+    "conversation:read",
+    "conversation:write",
+    "experiment:read",
+    "feature_flag:read",
+    "insight:read",
+    "organization:read",
+    "person:read",
+    "project:read",
+    "ticket:read",
+    "ticket:write",
+    "user:read",
+    "hog_flow:read",
+    "hog_flow:write",
+]
 
 # Mirrors PersonalAPIKey.label's CharField(max_length=40) - keep in sync if that ever changes.
 PROVISIONED_PAT_LABEL_MAX_LENGTH = 40

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -112,9 +112,10 @@ from products.workflows.backend.services.integration_usage import get_active_hog
 
 logger = structlog.get_logger(__name__)
 
-# Stripe drives this callback, so it carries no PostHog state token and the signature check
-# never fires. The log line alone is searchable, not alertable; count installs by signature
-# state so a rise in unsigned installs can be alerted on rather than discovered afterwards.
+# The published app uses Connect-OAuth, which never signs its callback, so every real install
+# lands unsigned and that alone says nothing. What is alertable is volume: this path can link a
+# Stripe account to whichever project the browser is signed into, so a spike is the abuse signal.
+# The label exists so the split moves if Stripe ever starts signing these.
 stripe_marketplace_install_counter = Counter(
     "stripe_marketplace_install",
     "Stripe marketplace install callbacks, by whether an install signature was present and valid",
@@ -888,7 +889,7 @@ class IntegrationSerializer(serializers.ModelSerializer, UserAccessControlSerial
                         )
                     else:
                         stripe_marketplace_install_counter.labels(signature_state="absent").inc()
-                        logger.warning(
+                        logger.info(
                             "stripe.marketplace_install_no_signature",
                             team_id=team_id,
                             stripe_user_id=stripe_user_id,

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -16,6 +16,7 @@ from django.utils import timezone
 import structlog
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema, extend_schema_serializer
+from prometheus_client import Counter
 from rest_framework import mixins, serializers, status, viewsets
 from rest_framework.exceptions import APIException, PermissionDenied, ValidationError
 from rest_framework.permissions import IsAuthenticated
@@ -110,6 +111,15 @@ from products.tasks.backend.facade.api import count_in_progress_runs_for_github_
 from products.workflows.backend.services.integration_usage import get_active_hog_flows_using_integration
 
 logger = structlog.get_logger(__name__)
+
+# Stripe drives this callback, so it carries no PostHog state token and the signature check
+# never fires. The log line alone is searchable, not alertable; count installs by signature
+# state so a rise in unsigned installs can be alerted on rather than discovered afterwards.
+stripe_marketplace_install_counter = Counter(
+    "stripe_marketplace_install",
+    "Stripe marketplace install callbacks, by whether an install signature was present and valid",
+    labelnames=["signature_state"],
+)
 
 GITHUB_REPOSITORY_NAME_RE = re.compile(r"[A-Za-z0-9_.\-]+")
 
@@ -869,6 +879,7 @@ class IntegrationSerializer(serializers.ModelSerializer, UserAccessControlSerial
                                 "Stripe install signature could not be verified.",
                                 code="stripe_install_signature_invalid",
                             )
+                        stripe_marketplace_install_counter.labels(signature_state="verified").inc()
                         logger.info(
                             "stripe.marketplace_install_signature_verified",
                             team_id=team_id,
@@ -876,7 +887,7 @@ class IntegrationSerializer(serializers.ModelSerializer, UserAccessControlSerial
                             user_id=request.user.id,
                         )
                     else:
-                        # Only signal for the phishing gap accepted in #56373. Nothing else records this path.
+                        stripe_marketplace_install_counter.labels(signature_state="absent").inc()
                         logger.warning(
                             "stripe.marketplace_install_no_signature",
                             team_id=team_id,

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -869,6 +869,20 @@ class IntegrationSerializer(serializers.ModelSerializer, UserAccessControlSerial
                                 "Stripe install signature could not be verified.",
                                 code="stripe_install_signature_invalid",
                             )
+                        logger.info(
+                            "stripe.marketplace_install_signature_verified",
+                            team_id=team_id,
+                            stripe_user_id=stripe_user_id,
+                            user_id=request.user.id,
+                        )
+                    else:
+                        # Only signal for the phishing gap accepted in #56373. Nothing else records this path.
+                        logger.warning(
+                            "stripe.marketplace_install_no_signature",
+                            team_id=team_id,
+                            stripe_user_id=stripe_user_id,
+                            user_id=request.user.id,
+                        )
 
                     conflicting = (
                         Integration.objects.filter(team_id=team_id, kind="stripe")

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -16,6 +16,7 @@ from django.utils import timezone
 
 import requests
 from parameterized import parameterized
+from prometheus_client import REGISTRY
 from rest_framework import status
 from rest_framework.exceptions import ValidationError
 from slack_sdk.errors import SlackApiError
@@ -4048,10 +4049,10 @@ class TestStripeIntegration:
         mock_oauth_response.assert_called_once()
 
     @pytest.mark.parametrize(
-        "include_install_signature,expected_event,expected_level",
+        "include_install_signature,expected_event,expected_level,expected_label",
         [
-            (False, "stripe.marketplace_install_no_signature", "warning"),
-            (True, "stripe.marketplace_install_signature_verified", "info"),
+            (False, "stripe.marketplace_install_no_signature", "warning", "absent"),
+            (True, "stripe.marketplace_install_signature_verified", "info", "verified"),
         ],
     )
     @patch("posthog.api.integration.StripeIntegration")
@@ -4063,6 +4064,7 @@ class TestStripeIntegration:
         include_install_signature,
         expected_event,
         expected_level,
+        expected_label,
         stripe_settings,
         client: HttpClient,
     ):
@@ -4080,6 +4082,9 @@ class TestStripeIntegration:
                 state="", user_id="usr_abc", account_id="acct_123"
             )
 
+        counter_labels = {"signature_state": expected_label}
+        before = REGISTRY.get_sample_value("stripe_marketplace_install_total", counter_labels) or 0.0
+
         client.force_login(self.user)
         with capture_logs() as logs:
             response = client.post(
@@ -4095,6 +4100,9 @@ class TestStripeIntegration:
         assert entries[0]["team_id"] == self.team.pk
         assert entries[0]["stripe_user_id"] == "acct_123"
         assert entries[0]["user_id"] == self.user.pk
+
+        after = REGISTRY.get_sample_value("stripe_marketplace_install_total", counter_labels) or 0.0
+        assert after - before == 1.0
 
     @patch("posthog.api.integration.StripeIntegration")
     @patch("posthog.api.integration.OauthIntegration.integration_from_oauth_response")

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -4051,7 +4051,7 @@ class TestStripeIntegration:
     @pytest.mark.parametrize(
         "include_install_signature,expected_event,expected_level,expected_label",
         [
-            (False, "stripe.marketplace_install_no_signature", "warning", "absent"),
+            (False, "stripe.marketplace_install_no_signature", "info", "absent"),
             (True, "stripe.marketplace_install_signature_verified", "info", "verified"),
         ],
     )

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -19,6 +19,7 @@ from parameterized import parameterized
 from rest_framework import status
 from rest_framework.exceptions import ValidationError
 from slack_sdk.errors import SlackApiError
+from structlog.testing import capture_logs
 
 from posthog.api.github_callback.personal_state import usable_personal_github_token
 from posthog.api.github_callback.state import store_unified_authorize_state
@@ -4046,6 +4047,77 @@ class TestStripeIntegration:
         assert response.status_code == status.HTTP_201_CREATED
         mock_oauth_response.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "include_install_signature,expected_event,expected_level",
+        [
+            (False, "stripe.marketplace_install_no_signature", "warning"),
+            (True, "stripe.marketplace_install_signature_verified", "info"),
+        ],
+    )
+    @patch("posthog.api.integration.StripeIntegration")
+    @patch("posthog.api.integration.OauthIntegration.integration_from_oauth_response")
+    def test_marketplace_callback_logs_signature_state(
+        self,
+        mock_oauth_response,
+        MockStripeIntegration,
+        include_install_signature,
+        expected_event,
+        expected_level,
+        stripe_settings,
+        client: HttpClient,
+    ):
+        mock_oauth_response.return_value = self._create_stripe_integration()
+        MockStripeIntegration.return_value = MagicMock()
+
+        config: dict = {
+            "code": "oauth_code_123",
+            "stripe_user_id": "acct_123",
+            "account_id": "acct_123",
+            "user_id": "usr_abc",
+        }
+        if include_install_signature:
+            config["install_signature"] = self._make_install_signature(
+                state="", user_id="usr_abc", account_id="acct_123"
+            )
+
+        client.force_login(self.user)
+        with capture_logs() as logs:
+            response = client.post(
+                f"/api/environments/{self.team.pk}/integrations",
+                {"kind": "stripe", "config": config},
+                content_type="application/json",
+            )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        entries = [entry for entry in logs if entry["event"] == expected_event]
+        assert len(entries) == 1
+        assert entries[0]["log_level"] == expected_level
+        assert entries[0]["team_id"] == self.team.pk
+        assert entries[0]["stripe_user_id"] == "acct_123"
+        assert entries[0]["user_id"] == self.user.pk
+
+    @patch("posthog.api.integration.StripeIntegration")
+    @patch("posthog.api.integration.OauthIntegration.integration_from_oauth_response")
+    def test_posthog_initiated_install_emits_no_marketplace_log(
+        self, mock_oauth_response, MockStripeIntegration, stripe_settings, client: HttpClient
+    ):
+        mock_oauth_response.return_value = self._create_stripe_integration()
+        MockStripeIntegration.return_value = MagicMock()
+
+        client.force_login(self.user)
+        with capture_logs() as logs:
+            response = client.post(
+                f"/api/environments/{self.team.pk}/integrations",
+                {
+                    "kind": "stripe",
+                    "config": {"state": "next=/foo&token=abc123", "code": "oauth_code_999"},
+                },
+                content_type="application/json",
+            )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert not [entry for entry in logs if entry["event"].startswith("stripe.marketplace_install")]
+
     # The Stripe Apps OAuth flow (used by stripe_api_access_type: oauth) doesn't sign the
     # callback redirect — only the install-link OAuth mechanism emits install_signature.
     # The conflict guard is the defense-in-depth here, not signature verification.
@@ -4433,6 +4505,35 @@ class TestStripeIntegrationOAuthTokens:
         secret_payloads = {call.kwargs["params"]["name"]: call.kwargs["params"]["payload"] for call in calls}
         assert secret_payloads["posthog_project_id"] == str(self.team.pk)
         assert secret_payloads["posthog_oauth_client_id"] == self.oauth_app.client_id
+
+    @patch("stripe.StripeClient")
+    @patch("posthog.models.integration.settings")
+    def test_write_posthog_secrets_mints_read_only_token(self, mock_settings, MockStripeClient):
+        mock_settings.STRIPE_POSTHOG_OAUTH_CLIENT_ID = self.oauth_app.client_id
+        mock_settings.STRIPE_APP_SECRET_KEY = "sk_test"
+        MockStripeClient.return_value = MagicMock()
+
+        integration = Integration.objects.create(
+            team=self.team,
+            kind="stripe",
+            config={},
+            sensitive_config={},
+            integration_id="acct_scope",
+            created_by=self.user,
+        )
+        StripeIntegration(integration).write_posthog_secrets(self.team.pk, self.user)
+
+        token = OAuthAccessToken.objects.filter(application=self.oauth_app).latest("id")
+
+        assert set(token.scope.split()) == {
+            "customer_journey:read",
+            "experiment:read",
+            "feature_flag:read",
+            "insight:read",
+            "query:read",
+        }
+        assert not [scope for scope in token.scope.split() if scope.endswith(":write")]
+        assert token.scoped_teams == [self.team.pk]
 
     @patch("stripe.StripeClient")
     @patch("posthog.models.integration.settings")

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -4816,25 +4816,16 @@ class S3CompatibleIntegration:
 class StripeIntegration:
     integration: Integration
 
-    # These are the scopes we'll give Stripe when creating a local OAuth App
-    # and sending them access
+    # Every endpoint services/stripe-app/src/posthog/client.ts calls, and nothing else.
+    # This token is readable by every member of the customer's Stripe account, so anything
+    # granted here is granted to all of them. Read-only by design; do not add a write scope.
     SCOPES: str = " ".join(
         [
             "customer_journey:read",
-            "query:read",
-            "conversation:read",
-            "conversation:write",
             "experiment:read",
             "feature_flag:read",
             "insight:read",
-            "organization:read",
-            "person:read",
-            "project:read",
-            "ticket:read",
-            "ticket:write",
-            "user:read",
-            "hog_flow:read",
-            "hog_flow:write",
+            "query:read",
         ]
     )
 


### PR DESCRIPTION
## Problem

A PostHog admin who installs the Stripe app gives every member of their Stripe account write access to conversations, tickets, and hog flows, plus read access across most of the project.

PostHog mints an OAuth token for the Stripe app and writes it into the customer's Stripe Secret Store. The secret uses account scope. Stripe makes account-scoped secrets readable by all members of that Stripe account. The token carried 15 scopes. The app calls endpoints that need 5.

The token also carries the identity of the admin who did the install. A person who reads the secret acts as that admin inside PostHog.

## Changes

The scope list now holds only the five scopes the app uses: `customer_journey:read`, `experiment:read`, `feature_flag:read`, `insight:read`, and `query:read`. The shared credential can no longer write anything, and it can no longer reach the person, conversation, ticket, hog flow, organization, or user endpoints.

**What this does not do:** it does not stop the token reading person data. `query:read` permits arbitrary HogQL, and HogQL can select from the persons table. Nothing inside query execution checks scopes per table, so `person:read` was never what gated that. The app needs `query:read` to function, so the only way to close this is to stop the query endpoint accepting arbitrary HogQL for this client, which is a larger piece of work than this PR. Treat this change as removing write access and shrinking the read surface, not as a confidentiality boundary around person data.

To find the correct list, I read each PostHog API call in the Stripe app source and mapped it to the `scope_object` on the matching viewset. The app makes six calls: list feature flags, list experiments, list customer journeys, get one insight, and run a query from three places. I also checked the two ways a request can need more than its default scope. `QueryViewSet.dangerously_get_required_scopes` adds scopes for specific query kinds; the app sends only `HogQLQuery` and `WebOverviewQuery`, and neither is listed. The experiments viewset adds scopes only on `archive`, `end`, and `ship_variant`; the app only lists.

`STRIPE_CONTRACTED_SCOPES` in the provisioning namespace previously aliased this same list. It now names its scopes explicitly and keeps its current 15. The two constants bound different credentials: one is shared across a merchant's Stripe account, the other backs a provisioned user's own personal API key. This PR changes only the first.

Second change: the Stripe marketplace install path now emits a log event and increments a counter.

Stripe controls this OAuth flow, so the callback has no PostHog state token. The `install_signature` check does not run, because Connect-OAuth does not sign callbacks. [#56373](https://github.com/PostHog/posthog/pull/56373) accepted this and added a confirmation screen as the control. No code recorded the path, so nobody could tell how often it ran.

Both events log at info, because the published app uses Connect-OAuth and every real install lands unsigned. They carry the team, the Stripe account, and the PostHog user, and no credentials. A log line is searchable but nothing pages on it, so a `stripe_marketplace_install` counter runs beside it. The alertable signal is volume, not the missing signature: this path can link a Stripe account to whichever project the browser is signed into. The counter keeps a signature-state label so the split moves if Stripe ever starts signing these.

## How did you test this code?

I ran the Stripe tests in `posthog/api/test/test_integration.py` and the provisioning tests in `ee/partners/stripe/api/provisioning/test/` on this branch. All 107 pass. I did not perform a real Stripe install; this change is not exercised end to end.

New tests catch three regressions that no existing test caught:

- The minted token gains a scope it does not need. One test asserts the exact five-scope set, asserts that no `:write` scope is present, and asserts the token stays scoped to one team. Without it, a person can add a scope back and no test fails.
- A marketplace install stops being recorded. A parameterized test asserts the event name, the level, and each field, and asserts the counter increases by one under the right label, for both the signed and the unsigned case. A wrong metric name or label makes the sample lookup return nothing and fails the test.
- The signal fires on the wrong path. One test asserts that a PostHog-initiated install, which carries a state token, emits neither event. This one passes against the previous code too, because the event did not exist then. It guards a future indentation mistake rather than this change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This changes no documented behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tooling: Claude Code (Opus 5, 1M context). Skills invoked: `/pr-ready`, `/unambiguous-agent-text`.

The work started as a review of the Stripe install path. The first plan was to stop binding the token to a human user, so that a reader of the shared secret could not act as an admin. That is not possible today: `OAuthAccessTokenAuthentication` rejects a token with no user, and PostHog has no service-account concept. The second plan was to write the Stripe secret with user scope instead of account scope, so that only the installer could read it. That is also not possible: PostHog writes the secret from the Django backend after the Connect-OAuth callback, and that flow never returns a Stripe user id. Scope reduction is what remains, and it is why this PR is small.

An adversarial review pass changed two things. It found that the scope cut also narrowed the provisioning default, which would have removed scopes from a provisioned user's personal API key; that constant is now independent. It also found the unsigned install path is the normal path for the published app, not an edge case, so the log level moved from warning to info and the counter's rationale changed from signature state to volume.

Known follow-ups, neither addressed here:

- Existing installs keep their 15-scope tokens. Refresh does not narrow them, because the application has no `ceiling_scopes` set and `narrow_scopes_to_ceiling` is a no-op when the ceiling is empty. Setting a ceiling on that application would narrow existing tokens on their next refresh. Production data shows most of these tokens have already expired on their own.
- Arbitrary HogQL through `query:read`, described under Changes.

The scope list is now a security boundary, not a convenience list. A future addition needs a matching call in the Stripe app source.
