### PR TITLE
fix(warehouse-sources): stop retrying Stripe syncs that use a publishable key

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/source.py
@@ -289,6 +289,10 @@ If automatic creation failed with a permissions error, the fix depends on how yo
             # / 'plan_read'). The customer must add the scope in Stripe — retrying won't help. Surface
             # Stripe's raw message (None) since it names the exact scope to enable.
             "does not have the required permissions for this endpoint": None,
+            # The customer pasted a publishable key (pk_...) instead of a secret/restricted key.
+            # Publishable keys can't authenticate any of the read endpoints we sync, so every retry
+            # fails identically — match Stripe's stable rejection text (the request id varies).
+            "This API call cannot be made with a publishable API key": "Your Stripe API key is a publishable key, which cannot be used to sync data. Please use a secret or restricted key instead, then reconnect.",
             # A non-Connect key was sent with a `stripe_account` header (the source's "Account id"),
             # so Stripe rejects the whole request for the account rather than a specific scope.
             "Only Stripe Connect platforms can work with other accounts": "Stripe rejected the request because your API key isn't authorized for the configured Stripe account. The 'Account id' in your source settings only applies to Stripe Connect platform accounts — remove or correct it if your key belongs directly to the account, then reconnect.",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
@@ -226,6 +226,9 @@ class TestStripeSource:
             # account_invalid: key not authorized for the configured account, or revoked app access.
             # Raised mid-sync as stripe.PermissionError, matched on the stable phrase (key/account redacted).
             "The provided key 'sk_test_***qPsl' does not have access to account 'stripe_s***less' (or that account does not exist). Application access may have been revoked.",
+            # A publishable key was used where a secret/restricted key is required — matched on the
+            # stable message text, ignoring the request id prefix.
+            "Request req_abc123: This API call cannot be made with a publishable API key. Please use a secret API key. You can find a list of your API keys at https://dashboard.stripe.com/account/apikeys.",
         ],
     )
     def test_non_retryable_errors_match_permission_failures(self, observed_error):


### PR DESCRIPTION
## Problem

A Stripe warehouse sync that uses a publishable key instead of a secret or restricted key retries every attempt in its Temporal budget before giving up, even though the key can never authenticate a read endpoint. Error tracking shows this happening: [issue 01a001dc](https://us.posthog.com/project/2/error_tracking/01a001dc-3422-79c3-8958-fa2b657c6bf8).

## Changes

- Add a stable-substring match for Stripe's rejection text, "This API call cannot be made with a publishable API key", to `StripeSource.get_non_retryable_errors()`.
- The sync now stops after a few attempts and surfaces a message telling the customer to use a secret or restricted key, instead of exhausting the full retry budget.
- The match ignores the request id prefix, which changes on every attempt.

## How did you test this code?

Added one parametrize case to `test_non_retryable_errors_match_permission_failures` in `test_stripe_source.py`, asserting the new message is recognized as non-retryable. Ran the full `test_stripe_source.py` suite locally (187 passed) plus `ruff check`/`ruff format --check` on both changed files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing config or workflow changed, only the failure classification.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude, via the PostHog Desktop agent) triaged a real error-tracking issue and traced it to `_call_stripe` in `stripe.py`, confirmed it as a customer credential error (publishable key instead of secret key), and extended the existing non-retryable-error classification rather than changing retry policy. Invoked `/writing-tests` before adding the test case and `/writing-pr-descriptions` before writing this body. Searched open PRs (excluding the bot account) and Gilbert09's own PRs for a prior fix; found none.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*