### PR TITLE
chore(dashboards): add dashboard engineering skill

### DIFF
--- a/.agents/skills/managing-dashboards/SKILL.md
+++ b/.agents/skills/managing-dashboards/SKILL.md
@@ -17,12 +17,12 @@ Use [`manage-dashboard-widgets`](../manage-dashboard-widgets/SKILL.md) for a new
 
 ## 1. Route the request
 
-| Request | Primary path |
-| --- | --- |
-| Dashboard metadata, tile lifecycle, filters, variables, refresh, list, or layout | This skill |
-| Public links, sharing settings, embeds, exports, or product-embedded dashboards | This skill |
-| Dashboard template creation, editing, scope, or copying | This skill |
-| New or changed `widget_type`, widget config, widget query, or WidgetCard | `manage-dashboard-widgets` |
+| Request                                                                          | Primary path               |
+| -------------------------------------------------------------------------------- | -------------------------- |
+| Dashboard metadata, tile lifecycle, filters, variables, refresh, list, or layout | This skill                 |
+| Public links, sharing settings, embeds, exports, or product-embedded dashboards  | This skill                 |
+| Dashboard template creation, editing, scope, or copying                          | This skill                 |
+| New or changed `widget_type`, widget config, widget query, or WidgetCard         | `manage-dashboard-widgets` |
 
 Before coding, decide the effect on each surface. Record `affected`, `unaffected`, or `not applicable`.
 
@@ -70,15 +70,15 @@ State these decisions before implementation.
 
 Use this checklist as a design gate. Read the linked reference when an item applies.
 
-| Area | Check |
-| --- | --- |
-| Access | [RBAC, sharing, and embeds](references/access-sharing-and-embeds.md) |
-| Filter state | [Filters, variables, and tile overrides](references/filters-variables-and-overrides.md) |
-| Data and scale | [Querying, caching, and scale](references/querying-caching-and-scale.md) |
-| Layout and templates | [Layout, responsive behavior, and templates](references/layout-responsive-and-templates.md) |
-| Backend and operations | [Backend contracts and operations](references/backend-contracts-and-operations.md) |
-| Feature lifecycle | [Feature lifecycle and rollout](references/feature-lifecycle-and-rollout.md) |
-| New state or relation | [Data models and collaboration](references/data-models-and-collaboration.md) |
+| Area                   | Check                                                                                       |
+| ---------------------- | ------------------------------------------------------------------------------------------- |
+| Access                 | [RBAC, sharing, and embeds](references/access-sharing-and-embeds.md)                        |
+| Filter state           | [Filters, variables, and tile overrides](references/filters-variables-and-overrides.md)     |
+| Data and scale         | [Querying, caching, and scale](references/querying-caching-and-scale.md)                    |
+| Layout and templates   | [Layout, responsive behavior, and templates](references/layout-responsive-and-templates.md) |
+| Backend and operations | [Backend contracts and operations](references/backend-contracts-and-operations.md)          |
+| Feature lifecycle      | [Feature lifecycle and rollout](references/feature-lifecycle-and-rollout.md)                |
+| New state or relation  | [Data models and collaboration](references/data-models-and-collaboration.md)                |
 
 ## 4. Implement across layers
 
@@ -112,26 +112,26 @@ Run the focused tests for each edited layer. Then run the relevant checks from [
 
 ## 6. Code map
 
-| Concern | Start here |
-| --- | --- |
-| Dashboard API, serializers, tile operations, insight and widget runners | `products/dashboards/backend/api/dashboard.py` |
-| Dashboard model and tile model | `products/dashboards/backend/models/dashboard.py`, `models/dashboard_tile.py` |
-| Sharing and collaborator routes | `products/dashboards/backend/routes.py` |
-| Templates | `products/dashboards/backend/api/dashboard_templates.py`, `models/dashboard_templates.py` |
-| Main scene, state, refresh, and layout persistence | `frontend/src/scenes/dashboard/Dashboard.tsx`, `dashboardLogic.tsx`, `DashboardItems.tsx` |
-| Layout geometry and tile size constraints | `frontend/src/scenes/dashboard/tileLayouts.ts`, `dashboardUtils.ts` |
-| Shared and export rendering | `frontend/src/exporter/scenes/ExporterDashboardScene.tsx`, `frontend/src/exporter/Exporter.tsx` |
-| Refresh defaults and shared safety clamp | `posthog/hogql_queries/refresh_policy.py` |
-| Resource transfer | `posthog/models/resource_transfer/visitors/dashboard.py`, `dashboard_tile.py`, `dashboard_widget.py` |
-| MCP tool definitions | `products/dashboards/mcp/tools.yaml` |
+| Concern                                                                 | Start here                                                                                           |
+| ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Dashboard API, serializers, tile operations, insight and widget runners | `products/dashboards/backend/api/dashboard.py`                                                       |
+| Dashboard model and tile model                                          | `products/dashboards/backend/models/dashboard.py`, `models/dashboard_tile.py`                        |
+| Sharing and collaborator routes                                         | `products/dashboards/backend/routes.py`                                                              |
+| Templates                                                               | `products/dashboards/backend/api/dashboard_templates.py`, `models/dashboard_templates.py`            |
+| Main scene, state, refresh, and layout persistence                      | `frontend/src/scenes/dashboard/Dashboard.tsx`, `dashboardLogic.tsx`, `DashboardItems.tsx`            |
+| Layout geometry and tile size constraints                               | `frontend/src/scenes/dashboard/tileLayouts.ts`, `dashboardUtils.ts`                                  |
+| Shared and export rendering                                             | `frontend/src/exporter/scenes/ExporterDashboardScene.tsx`, `frontend/src/exporter/Exporter.tsx`      |
+| Refresh defaults and shared safety clamp                                | `posthog/hogql_queries/refresh_policy.py`                                                            |
+| Resource transfer                                                       | `posthog/models/resource_transfer/visitors/dashboard.py`, `dashboard_tile.py`, `dashboard_widget.py` |
+| MCP tool definitions                                                    | `products/dashboards/mcp/tools.yaml`                                                                 |
 
 ## Companion skills
 
-| Skill | Use when |
-| --- | --- |
-| `manage-dashboard-widgets` | Change a `widget_type`, its config, query, catalog, or `WidgetCard` |
-| `django-migrations` | Change dashboard, tile, template, or widget schema |
-| `improving-drf-endpoints` | Change viewsets, serializer contracts, or OpenAPI output |
-| `adopting-generated-api-types` | Consume changed generated dashboard API types |
-| `writing-kea-logics` | Change `dashboardLogic` or another Kea logic |
-| `writing-tests` | Decide the lowest-cost regression test |
+| Skill                          | Use when                                                            |
+| ------------------------------ | ------------------------------------------------------------------- |
+| `manage-dashboard-widgets`     | Change a `widget_type`, its config, query, catalog, or `WidgetCard` |
+| `django-migrations`            | Change dashboard, tile, template, or widget schema                  |
+| `improving-drf-endpoints`      | Change viewsets, serializer contracts, or OpenAPI output            |
+| `adopting-generated-api-types` | Consume changed generated dashboard API types                       |
+| `writing-kea-logics`           | Change `dashboardLogic` or another Kea logic                        |
+| `writing-tests`                | Decide the lowest-cost regression test                              |

--- a/.agents/skills/managing-dashboards/SKILL.md
+++ b/.agents/skills/managing-dashboards/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: managing-dashboards
+description: >
+  Guides PostHog engineers through dashboard platform and scene changes. Use when changing
+  Dashboard, DashboardTile, dashboardLogic, dashboard layouts, dashboard sharing or embeds,
+  public dashboards, templates, filters, variables, refresh behavior, tile loading, dashboard
+  lists, or dashboard permissions. Covers normal, shared, embedded, export, product-embedded,
+  and template surfaces; RBAC; cache and query behavior; responsive layouts; and large or small
+  dashboards. Use manage-dashboard-widgets instead for a widget_type or WidgetCard change.
+---
+
+# Managing dashboards
+
+Use this skill for a dashboard change that affects the dashboard platform, dashboard scene, or an existing non-widget tile type.
+
+Use [`manage-dashboard-widgets`](../manage-dashboard-widgets/SKILL.md) for a new `widget_type` or a `WidgetCard` change.
+
+## 1. Route the request
+
+| Request | Primary path |
+| --- | --- |
+| Dashboard metadata, tile lifecycle, filters, variables, refresh, list, or layout | This skill |
+| Public links, sharing settings, embeds, exports, or product-embedded dashboards | This skill |
+| Dashboard template creation, editing, scope, or copying | This skill |
+| New or changed `widget_type`, widget config, widget query, or WidgetCard | `manage-dashboard-widgets` |
+
+Before coding, decide the effect on each surface. Record `affected`, `unaffected`, or `not applicable`.
+
+- Authenticated dashboard
+- Public shared dashboard
+- Embedded dashboard
+- Exported dashboard
+- Product-embedded dashboard
+- Dashboard template
+- Dashboard list and project homepage, if the change changes metadata or visibility
+
+Read [surfaces and ownership](references/surfaces-and-ownership.md) before you select files.
+
+## 2. Define feature intake and acceptance criteria
+
+Do this before implementation for a new dashboard feature. Skip it for a narrow bug fix with an existing contract.
+
+1. State the user problem, intended actor, and explicit non-goals.
+2. State the feature action and its default behavior.
+3. State the state owner: dashboard, tile, request, user, or URL.
+4. State the availability, read permission, and mutation permission.
+5. State behavior for new rows, existing rows, and invalid or absent state.
+6. State the acceptance criteria for allowed, denied, shared, and failure paths.
+7. State the expected query, cache, and database-write effect.
+8. State the metric or event that shows adoption, failure, or regression.
+9. If the feature adds persisted state or relations, define migration, cleanup, and concurrent-edit behavior.
+10. Check whether the user-facing API, setting, or workflow needs a documentation update.
+
+Read [feature lifecycle and rollout](references/feature-lifecycle-and-rollout.md) before you choose a persisted feature contract.
+
+## 3. Define the change contract
+
+State these decisions before implementation.
+
+1. Name the user action and the persisted data that changes.
+2. Name every placement that renders the affected UI.
+3. Define view, edit, and mutation permissions for each actor.
+4. Define shared and embedded behavior. Never assume the authenticated behavior is safe there.
+5. Define the result when the dashboard has zero, one, and hundreds of tiles.
+6. Define the result at narrow and wide widths.
+7. Define filter, variable, quick-filter, and tile-override precedence.
+8. Define cache, refresh, query, and failure behavior.
+9. If templates apply, define scope, portability, copy semantics, and later edits.
+10. Define lifecycle, API, streaming, quota, audit, and project-tree effects.
+
+Use this checklist as a design gate. Read the linked reference when an item applies.
+
+| Area | Check |
+| --- | --- |
+| Access | [RBAC, sharing, and embeds](references/access-sharing-and-embeds.md) |
+| Filter state | [Filters, variables, and tile overrides](references/filters-variables-and-overrides.md) |
+| Data and scale | [Querying, caching, and scale](references/querying-caching-and-scale.md) |
+| Layout and templates | [Layout, responsive behavior, and templates](references/layout-responsive-and-templates.md) |
+| Backend and operations | [Backend contracts and operations](references/backend-contracts-and-operations.md) |
+| Feature lifecycle | [Feature lifecycle and rollout](references/feature-lifecycle-and-rollout.md) |
+| New state or relation | [Data models and collaboration](references/data-models-and-collaboration.md) |
+
+## 4. Implement across layers
+
+1. Change the product model, serializer, API action, and generated types together when the persisted contract changes.
+2. Keep dashboard and tile data team-scoped. Use the dashboard’s project context for every lookup and mutation.
+3. Update each placement deliberately. Do not hide a feature only in the frontend when the API still permits it.
+4. Preserve old rows and old layouts. Treat existing layout JSON and template payloads as versioned input.
+5. Keep query work bounded. Do not turn dashboard load into unbounded tile queries or concurrent requests.
+6. Keep grid updates stable during drag, resize, and tile refresh. Avoid a full grid relayout for each tile result.
+7. Add observability when a change creates a new loading, query, cache, access, or refresh path.
+
+## 5. Test the boundary, not only the happy path
+
+Cover each affected boundary.
+
+- View versus edit access.
+- Authenticated, shared, embedded, and export rendering.
+- Public output contains no private metadata or live data that public viewers cannot access.
+- Cache hit, cache miss, stale result, forced refresh, query error, and request cancellation.
+- Empty dashboard, a single tile, and a dense dashboard.
+- Narrow layout, wide layout, drag, resize, insertion, duplication, and persisted layout reload.
+- Template scope, permissions, variable substitution, and project-specific references.
+- API schema and generated types after serializer changes.
+- Filter and variable precedence, shared-token behavior, and quick-filter validation.
+- Soft-delete, restore, move, copy, and project-transfer behavior.
+- Streaming completion, disconnect, and individual tile failure behavior.
+- Resource limits, audit events, and subscription behavior.
+- Schema rollout, relation cleanup, concurrent edits, accessibility, and public content safety.
+
+Run the focused tests for each edited layer. Then run the relevant checks from [the verification guide](references/querying-caching-and-scale.md#verification).
+
+## 6. Code map
+
+| Concern | Start here |
+| --- | --- |
+| Dashboard API, serializers, tile operations, insight and widget runners | `products/dashboards/backend/api/dashboard.py` |
+| Dashboard model and tile model | `products/dashboards/backend/models/dashboard.py`, `models/dashboard_tile.py` |
+| Sharing and collaborator routes | `products/dashboards/backend/routes.py` |
+| Templates | `products/dashboards/backend/api/dashboard_templates.py`, `models/dashboard_templates.py` |
+| Main scene, state, refresh, and layout persistence | `frontend/src/scenes/dashboard/Dashboard.tsx`, `dashboardLogic.tsx`, `DashboardItems.tsx` |
+| Layout geometry and tile size constraints | `frontend/src/scenes/dashboard/tileLayouts.ts`, `dashboardUtils.ts` |
+| Shared and export rendering | `frontend/src/exporter/scenes/ExporterDashboardScene.tsx`, `frontend/src/exporter/Exporter.tsx` |
+| Refresh defaults and shared safety clamp | `posthog/hogql_queries/refresh_policy.py` |
+| Resource transfer | `posthog/models/resource_transfer/visitors/dashboard.py`, `dashboard_tile.py`, `dashboard_widget.py` |
+| MCP tool definitions | `products/dashboards/mcp/tools.yaml` |
+
+## Companion skills
+
+| Skill | Use when |
+| --- | --- |
+| `manage-dashboard-widgets` | Change a `widget_type`, its config, query, catalog, or `WidgetCard` |
+| `django-migrations` | Change dashboard, tile, template, or widget schema |
+| `improving-drf-endpoints` | Change viewsets, serializer contracts, or OpenAPI output |
+| `adopting-generated-api-types` | Consume changed generated dashboard API types |
+| `writing-kea-logics` | Change `dashboardLogic` or another Kea logic |
+| `writing-tests` | Decide the lowest-cost regression test |

--- a/.agents/skills/managing-dashboards/references/access-sharing-and-embeds.md
+++ b/.agents/skills/managing-dashboards/references/access-sharing-and-embeds.md
@@ -44,11 +44,11 @@ When a dashboard becomes shared, check existing tiles before you publish the sta
 
 ## Minimum test matrix
 
-| Actor or surface | Read | Mutate | Refresh |
-| --- | --- | --- | --- |
-| Project viewer | Allowed only when resource access permits | Denied | Only if the endpoint permits it |
-| Project editor | Allowed | Allowed within dashboard restrictions | Allowed |
-| Dashboard collaborator | Follow assigned privilege | Follow assigned privilege | Follow assigned privilege |
-| Public shared viewer | Safe read-only payload | Denied | Denied |
-| Embedded viewer | Follow host and resource access | Denied unless explicitly supported | Must stay bounded |
-| Export renderer | Render-safe payload | Denied | Denied |
+| Actor or surface       | Read                                      | Mutate                                | Refresh                         |
+| ---------------------- | ----------------------------------------- | ------------------------------------- | ------------------------------- |
+| Project viewer         | Allowed only when resource access permits | Denied                                | Only if the endpoint permits it |
+| Project editor         | Allowed                                   | Allowed within dashboard restrictions | Allowed                         |
+| Dashboard collaborator | Follow assigned privilege                 | Follow assigned privilege             | Follow assigned privilege       |
+| Public shared viewer   | Safe read-only payload                    | Denied                                | Denied                          |
+| Embedded viewer        | Follow host and resource access           | Denied unless explicitly supported    | Must stay bounded               |
+| Export renderer        | Render-safe payload                       | Denied                                | Denied                          |

--- a/.agents/skills/managing-dashboards/references/access-sharing-and-embeds.md
+++ b/.agents/skills/managing-dashboards/references/access-sharing-and-embeds.md
@@ -1,0 +1,54 @@
+# RBAC, sharing, and embeds
+
+## Access rules
+
+Check both server and client behavior.
+
+- The server is the authority for view, edit, create, delete, move, copy, and refresh actions.
+- `Dashboard.restriction_level` controls collaboration restrictions.
+- Collaborator access is an EE sub-route under `dashboards/<id>/collaborators`.
+- Dashboard sharing uses the core `SharingConfigurationViewSet` under `dashboards/<id>/sharing`.
+- Public and embedded callers must not gain mutation rights through an endpoint that the UI hides.
+- A related insight or widget can have stricter access than its dashboard. Preserve its access checks and safe error response.
+
+## Shared output is a separate contract
+
+For a public share, check every field in the response and every UI action.
+
+- Hide author, editor, folder, and other private metadata.
+- Use the shared-safe widget metadata serializer for widget tiles.
+- Do not return live widget query results to public viewers.
+- Do not permit a public, shared, or export viewer to force a server-side insight or widget refresh.
+- Keep the shared cache clamp. Anonymous demand must not trigger expensive recomputation.
+- Test an error response. Error serialization must not reveal fields that normal shared serialization hides.
+
+`DashboardTileSerializer`, `SharedDashboardWidgetMetadataSerializer`, and `DashboardTileErrorSerializer` in `products/dashboards/backend/api/dashboard.py` define important response boundaries.
+
+## Embedded dashboards
+
+Embedded dashboards have a distinct access metric and can have distinct host constraints.
+
+- Classify access with `dashboard_access_method` in `products/dashboards/backend/access.py`.
+- Preserve the embedded access method when you add a new read or refresh path.
+- Check the host surface for width, navigation, filter state, and authenticated user assumptions.
+- Do not rely on a full dashboard page or a desktop viewport.
+
+## Sharing changes
+
+When a dashboard becomes shared, check existing tiles before you publish the state.
+
+- Use the server-side sharing publish gate for insight tiles.
+- Check every tile type. A new type needs an explicit public-safety decision.
+- Check changes to existing dashboards. Public sharing can expose stored configuration from rows created before the change.
+- Test enable, disable, read, and denied mutation paths.
+
+## Minimum test matrix
+
+| Actor or surface | Read | Mutate | Refresh |
+| --- | --- | --- | --- |
+| Project viewer | Allowed only when resource access permits | Denied | Only if the endpoint permits it |
+| Project editor | Allowed | Allowed within dashboard restrictions | Allowed |
+| Dashboard collaborator | Follow assigned privilege | Follow assigned privilege | Follow assigned privilege |
+| Public shared viewer | Safe read-only payload | Denied | Denied |
+| Embedded viewer | Follow host and resource access | Denied unless explicitly supported | Must stay bounded |
+| Export renderer | Render-safe payload | Denied | Denied |

--- a/.agents/skills/managing-dashboards/references/backend-contracts-and-operations.md
+++ b/.agents/skills/managing-dashboards/references/backend-contracts-and-operations.md
@@ -86,12 +86,12 @@ Dashboard changes are product events and audit events.
 
 ## Backend test matrix
 
-| Change | Test boundary |
-| --- | --- |
-| Persisted model field | Migration, serializer, OpenAPI, generated types, and MCP schema |
-| Create or delete | Team quota, soft delete, activity log, file-system sync, and restore |
-| Move, copy, or duplicate | Source and destination access, transaction rollback, and tile uniqueness |
-| Read endpoint | REST and stream behavior, shared sanitization, cache policy, and error payload |
-| Query endpoint | Scope, throttle, access method, cache outcome, cancellation, and partial failure |
-| Template or transfer | Old payload, source-specific reference, target team, and excluded derived fields |
-| Subscription path | Permission, duplicate delivery, cache loss, and notification failure |
+| Change                   | Test boundary                                                                    |
+| ------------------------ | -------------------------------------------------------------------------------- |
+| Persisted model field    | Migration, serializer, OpenAPI, generated types, and MCP schema                  |
+| Create or delete         | Team quota, soft delete, activity log, file-system sync, and restore             |
+| Move, copy, or duplicate | Source and destination access, transaction rollback, and tile uniqueness         |
+| Read endpoint            | REST and stream behavior, shared sanitization, cache policy, and error payload   |
+| Query endpoint           | Scope, throttle, access method, cache outcome, cancellation, and partial failure |
+| Template or transfer     | Old payload, source-specific reference, target team, and excluded derived fields |
+| Subscription path        | Permission, duplicate delivery, cache loss, and notification failure             |

--- a/.agents/skills/managing-dashboards/references/backend-contracts-and-operations.md
+++ b/.agents/skills/managing-dashboards/references/backend-contracts-and-operations.md
@@ -1,0 +1,97 @@
+# Backend contracts and operations
+
+## Resource lifecycle
+
+Dashboards and tiles use soft deletion. Do not replace it with hard deletion.
+
+- `Dashboard.objects` hides deleted dashboards. `objects_including_soft_deleted` supports restore paths.
+- Dashboard deletion can also delete insights when the request asks for it. Check shared insight and restore behavior.
+- Deleting a tile keeps its underlying insight, text, button, or widget row when another relation needs it.
+- Moving and copying must preserve the one-related-object tile constraint and destination permissions.
+- Use a narrow `transaction.atomic()` block for a multi-row dashboard mutation.
+- A bulk update bypasses model signals. Synchronize dependent resources explicitly after a bulk update.
+
+Check `products/dashboards/backend/models/dashboard_tile.py` and `products/dashboards/backend/api/dashboard.py` before you change lifecycle behavior.
+
+## Project tree, tags, and resource transfer
+
+Dashboards are project-tree resources, not only API rows. Read this section when a persisted field or relation can transfer between projects.
+
+- `Dashboard` uses `FileSystemSyncMixin`. Create, rename, move, delete, and restore can update file-system entries.
+- Keep dashboard folder data private on shared responses.
+- Preserve tag behavior when a custom serializer create or update path bypasses a mixin.
+- Update resource-transfer visitors when a new persisted field should copy between projects.
+- Exclude derived state from transfers. Existing visitors exclude sharing, refresh, access, and cache fields.
+- Check that a transferred dashboard has valid team ownership and no source-project-only identifiers.
+
+## Lists, discovery, and product-created dashboards
+
+Dashboard list behavior is a separate contract from dashboard detail.
+
+- Preserve pinned ordering, search, tags, folder data, and unlisted-dashboard exclusion.
+- Check list query annotations and prefetches when you add a list field. Avoid per-row file-system or tag queries.
+- Dashboard reads update `last_accessed_at`. Check write amplification when you add polling, embeds, or another read path.
+- Product-created unlisted dashboards need stable lookup data and concurrent-create protection.
+- Keep product-created dashboards out of normal lists unless the product explicitly exposes them.
+
+## API, schema, and MCP contracts
+
+Dashboard behavior has REST and generated frontend consumers. It also has MCP consumers when the changed API operation is enabled in `products/dashboards/mcp/tools.yaml`.
+
+1. Add serializer schema annotations for every new request or response field.
+2. Run `hogli build:openapi` after API contract changes.
+3. Update `products/dashboards/mcp/tools.yaml` only when the changed operation is MCP-enabled or becomes MCP-enabled.
+4. Regenerate MCP code only when the OpenAPI operation or tool definition changes.
+5. Check required API scopes. Dashboard reads, writes, and query execution use different scopes.
+6. Keep one-off filter and variable overrides non-persistent unless the endpoint explicitly persists them.
+7. Keep shared-token rules. Shared requests ignore dashboard filter and variable overrides.
+
+Test REST and MCP behavior separately. An MCP response can intentionally omit fields that the REST endpoint returns.
+
+## Streaming and progressive delivery
+
+Read this section only when the change affects dashboard tile delivery or initial load. `stream_tiles` sends dashboard metadata and tiles through Server-Sent Events.
+
+- Send metadata before remaining tiles.
+- Keep tile order stable for the selected layout size.
+- Treat one tile serialization failure as a tile error. Do not fail the whole dashboard stream.
+- Send a completion event after all tiles.
+- Support both ASGI and WSGI delivery paths.
+- Do not add database work inside the async generator unless the thread and connection behavior is safe.
+- Check client cancellation and stale stream responses when dashboard, filters, variables, or placement changes.
+- Check the `chained_dashboard_tile_refresh` gate and every related `ComputeSurface` before you change a refresh default.
+
+Use the normal retrieve endpoint and `stream_tiles` as two separate read contracts.
+
+## Limits, gates, and abuse resistance
+
+Check limits before you add a path that creates, loads, or runs dashboard work.
+
+- Dashboard creation uses `LimitKey.MAX_DASHBOARDS_PER_TEAM`.
+- Public and embedded access must not bypass quotas or product access checks.
+- Bound request payloads, tile IDs, filter sizes, and pagination before they reach query execution.
+
+Read `manage-dashboard-widgets` for widget-specific limits, gates, and throttles.
+
+## Audit, analytics, subscriptions, and observability
+
+Dashboard changes are product events and audit events.
+
+- Preserve model activity logging for dashboard and widget changes.
+- Preserve user-action events for dashboard and tile create, update, delete, and filter changes.
+- Keep dashboard access and cache metrics classified by human, shared, embedded, and API access.
+- Preserve endpoint monitoring. Assess SLO coverage for a new dashboard delivery or query path.
+- Check dashboard subscriptions and the subscribe nudge when you change dashboard navigation, permissions, or the subscription destination.
+- The subscribe nudge uses a cache sentinel and a durable notification check. Preserve both forms of deduplication.
+
+## Backend test matrix
+
+| Change | Test boundary |
+| --- | --- |
+| Persisted model field | Migration, serializer, OpenAPI, generated types, and MCP schema |
+| Create or delete | Team quota, soft delete, activity log, file-system sync, and restore |
+| Move, copy, or duplicate | Source and destination access, transaction rollback, and tile uniqueness |
+| Read endpoint | REST and stream behavior, shared sanitization, cache policy, and error payload |
+| Query endpoint | Scope, throttle, access method, cache outcome, cancellation, and partial failure |
+| Template or transfer | Old payload, source-specific reference, target team, and excluded derived fields |
+| Subscription path | Permission, duplicate delivery, cache loss, and notification failure |

--- a/.agents/skills/managing-dashboards/references/data-models-and-collaboration.md
+++ b/.agents/skills/managing-dashboards/references/data-models-and-collaboration.md
@@ -1,0 +1,78 @@
+# Data models and collaboration
+
+Read this reference when a feature adds persisted dashboard state, a model, or a relation between dashboard resources.
+
+## Schema evolution
+
+Define the rollout before you add the model or field.
+
+1. Choose nullable, defaulted, or required state for existing rows.
+2. Define the migration order for schema, backfill, constraint, and cleanup.
+3. Add indexes for every detail, list, stream, export, or ordering query that uses the new state.
+4. Keep old clients and old template payloads readable during the rollout.
+5. Define rollback behavior after new rows contain the state.
+6. Use `django-migrations` for model and migration changes.
+
+## Relation lifecycle
+
+For each new relation, define one behavior for every operation.
+
+| Operation | Required decision |
+| --- | --- |
+| Delete parent | Cascade, set null, soft-delete, or reject |
+| Delete related resource | Cascade, clear relation, or reject |
+| Restore | Restore the relation, leave it absent, or report a conflict |
+| Duplicate | Copy, deep-copy, or reset |
+| Template | Serialize, substitute, or omit |
+| Project transfer | Copy, transform, or exclude |
+| Cross-team request | Reject before reading the relation |
+
+Do not leave orphan handling to an implicit database default. Test every selected behavior.
+
+## Query shapes
+
+Write the required query shape before you add a serializer field or a relation.
+
+- Dashboard detail: select and prefetch every relation the serializer reads.
+- Dashboard stream: load the same relation before the async generator starts.
+- Dashboard list: avoid relation work that the list does not display.
+- Export and public share: load only fields that the surface can expose.
+- Reorder and mutation endpoints: lock or validate rows that must remain consistent.
+- Add query-count tests when a new relation can create per-dashboard or per-tile queries.
+
+## Concurrent editing
+
+Choose the conflict contract for every mutation that changes multiple rows, ordering, or layout.
+
+1. Choose last-write-wins, version check, merge, or reject-on-conflict.
+2. Define the client response to a stale write.
+3. Define optimistic update rollback after an API failure.
+4. Keep related writes in one narrow transaction.
+5. Check concurrent reorder, tile move, delete, and duplicate requests.
+6. Check stale responses after dashboard, filter, variable, or placement changes.
+
+State the chosen contract in tests. Do not rely on incidental request order.
+
+## Accessibility and public content
+
+For a new dashboard control or user-authored content, check both accessibility and shared output.
+
+- Support keyboard operation for every interactive action.
+- Keep focus order stable after insert, delete, collapse, expand, or reorder.
+- Give controls an accessible name and state.
+- Do not require drag-only interaction.
+- Decide whether new user-authored text, labels, descriptions, or configuration are safe for public share, embed, and export.
+- Apply the same content-safety rule to successful and error responses.
+
+Use `writing-user-facing-copy` for new labels, help text, empty states, and errors.
+
+## Test matrix
+
+| Risk | Test |
+| --- | --- |
+| Migration | Old row, new row, old payload, and backfill state |
+| Relation | Create, delete, restore, duplicate, template, and transfer |
+| Query shape | Detail, stream, list, export, and public share query count |
+| Collaboration | Concurrent mutation, stale write, optimistic rollback, and refresh race |
+| Accessibility | Keyboard action, focus movement, accessible name, and state |
+| Public content | Shared, embedded, export, and error payload |

--- a/.agents/skills/managing-dashboards/references/data-models-and-collaboration.md
+++ b/.agents/skills/managing-dashboards/references/data-models-and-collaboration.md
@@ -17,15 +17,15 @@ Define the rollout before you add the model or field.
 
 For each new relation, define one behavior for every operation.
 
-| Operation | Required decision |
-| --- | --- |
-| Delete parent | Cascade, set null, soft-delete, or reject |
-| Delete related resource | Cascade, clear relation, or reject |
-| Restore | Restore the relation, leave it absent, or report a conflict |
-| Duplicate | Copy, deep-copy, or reset |
-| Template | Serialize, substitute, or omit |
-| Project transfer | Copy, transform, or exclude |
-| Cross-team request | Reject before reading the relation |
+| Operation               | Required decision                                           |
+| ----------------------- | ----------------------------------------------------------- |
+| Delete parent           | Cascade, set null, soft-delete, or reject                   |
+| Delete related resource | Cascade, clear relation, or reject                          |
+| Restore                 | Restore the relation, leave it absent, or report a conflict |
+| Duplicate               | Copy, deep-copy, or reset                                   |
+| Template                | Serialize, substitute, or omit                              |
+| Project transfer        | Copy, transform, or exclude                                 |
+| Cross-team request      | Reject before reading the relation                          |
 
 Do not leave orphan handling to an implicit database default. Test every selected behavior.
 
@@ -68,11 +68,11 @@ Use `writing-user-facing-copy` for new labels, help text, empty states, and erro
 
 ## Test matrix
 
-| Risk | Test |
-| --- | --- |
-| Migration | Old row, new row, old payload, and backfill state |
-| Relation | Create, delete, restore, duplicate, template, and transfer |
-| Query shape | Detail, stream, list, export, and public share query count |
-| Collaboration | Concurrent mutation, stale write, optimistic rollback, and refresh race |
-| Accessibility | Keyboard action, focus movement, accessible name, and state |
-| Public content | Shared, embedded, export, and error payload |
+| Risk           | Test                                                                    |
+| -------------- | ----------------------------------------------------------------------- |
+| Migration      | Old row, new row, old payload, and backfill state                       |
+| Relation       | Create, delete, restore, duplicate, template, and transfer              |
+| Query shape    | Detail, stream, list, export, and public share query count              |
+| Collaboration  | Concurrent mutation, stale write, optimistic rollback, and refresh race |
+| Accessibility  | Keyboard action, focus movement, accessible name, and state             |
+| Public content | Shared, embedded, export, and error payload                             |

--- a/.agents/skills/managing-dashboards/references/feature-lifecycle-and-rollout.md
+++ b/.agents/skills/managing-dashboards/references/feature-lifecycle-and-rollout.md
@@ -4,15 +4,15 @@
 
 For a new dashboard feature, record these decisions before you select implementation files.
 
-| Decision | Required answer |
-| --- | --- |
-| Actor | Who uses the feature? |
-| State owner | Dashboard, tile, request, user, or URL? |
-| Default | What do existing and new dashboards do? |
-| Availability | Available to every project, feature-gated, or product-gated? |
-| Authorization | Who can view and change the feature? |
-| Failure | What does the user see when data, access, or execution fails? |
-| Non-goal | Which related behavior must not change? |
+| Decision      | Required answer                                               |
+| ------------- | ------------------------------------------------------------- |
+| Actor         | Who uses the feature?                                         |
+| State owner   | Dashboard, tile, request, user, or URL?                       |
+| Default       | What do existing and new dashboards do?                       |
+| Availability  | Available to every project, feature-gated, or product-gated?  |
+| Authorization | Who can view and change the feature?                          |
+| Failure       | What does the user see when data, access, or execution fails? |
+| Non-goal      | Which related behavior must not change?                       |
 
 Do not use a feature flag as a substitute for a permission check.
 
@@ -20,19 +20,19 @@ Do not use a feature flag as a substitute for a permission check.
 
 For persisted feature state, mark each operation as `preserve`, `copy`, `reset`, `omit`, or `not applicable`.
 
-| Operation | Decision |
-| --- | --- |
-| Create dashboard | Default state |
-| Update dashboard | Validation and authorization |
-| Duplicate dashboard | Copy or reset state |
-| Create from template | Copy, substitute, or omit state |
-| Save as template | Include or omit state |
-| Move or copy tile | Preserve, copy, or reset state |
-| Public share and embed | Render, hide, or use a safe default |
-| Export | Render, omit, or use a safe default |
-| Product-created dashboard | Stable creation and default state |
-| Resource transfer | Copy, transform, or exclude state |
-| Soft delete and restore | Preserve or reset state |
+| Operation                 | Decision                            |
+| ------------------------- | ----------------------------------- |
+| Create dashboard          | Default state                       |
+| Update dashboard          | Validation and authorization        |
+| Duplicate dashboard       | Copy or reset state                 |
+| Create from template      | Copy, substitute, or omit state     |
+| Save as template          | Include or omit state               |
+| Move or copy tile         | Preserve, copy, or reset state      |
+| Public share and embed    | Render, hide, or use a safe default |
+| Export                    | Render, omit, or use a safe default |
+| Product-created dashboard | Stable creation and default state   |
+| Resource transfer         | Copy, transform, or exclude state   |
+| Soft delete and restore   | Preserve or reset state             |
 
 If the feature adds a relation, read [data models and collaboration](data-models-and-collaboration.md#relation-lifecycle).
 
@@ -52,13 +52,13 @@ Check both the backend and frontend gate. The backend must reject a mutation tha
 
 Write acceptance criteria before you write tests.
 
-| Acceptance criterion | Preferred test layer |
-| --- | --- |
-| Validation, tenant boundary, or permission | Backend unit or API test |
-| Persisted request and response contract | API test plus generated-type check |
-| Client state, preview, or request shape | Frontend logic test |
-| Placement-specific visibility or action | Component test |
-| Critical user journey across layers | Playwright test |
+| Acceptance criterion                       | Preferred test layer               |
+| ------------------------------------------ | ---------------------------------- |
+| Validation, tenant boundary, or permission | Backend unit or API test           |
+| Persisted request and response contract    | API test plus generated-type check |
+| Client state, preview, or request shape    | Frontend logic test                |
+| Placement-specific visibility or action    | Component test                     |
+| Critical user journey across layers        | Playwright test                    |
 
 At minimum, state an acceptance criterion for each affected case:
 

--- a/.agents/skills/managing-dashboards/references/feature-lifecycle-and-rollout.md
+++ b/.agents/skills/managing-dashboards/references/feature-lifecycle-and-rollout.md
@@ -1,0 +1,91 @@
+# Feature lifecycle and rollout
+
+## Choose the feature contract first
+
+For a new dashboard feature, record these decisions before you select implementation files.
+
+| Decision | Required answer |
+| --- | --- |
+| Actor | Who uses the feature? |
+| State owner | Dashboard, tile, request, user, or URL? |
+| Default | What do existing and new dashboards do? |
+| Availability | Available to every project, feature-gated, or product-gated? |
+| Authorization | Who can view and change the feature? |
+| Failure | What does the user see when data, access, or execution fails? |
+| Non-goal | Which related behavior must not change? |
+
+Do not use a feature flag as a substitute for a permission check.
+
+## Lifecycle matrix
+
+For persisted feature state, mark each operation as `preserve`, `copy`, `reset`, `omit`, or `not applicable`.
+
+| Operation | Decision |
+| --- | --- |
+| Create dashboard | Default state |
+| Update dashboard | Validation and authorization |
+| Duplicate dashboard | Copy or reset state |
+| Create from template | Copy, substitute, or omit state |
+| Save as template | Include or omit state |
+| Move or copy tile | Preserve, copy, or reset state |
+| Public share and embed | Render, hide, or use a safe default |
+| Export | Render, omit, or use a safe default |
+| Product-created dashboard | Stable creation and default state |
+| Resource transfer | Copy, transform, or exclude state |
+| Soft delete and restore | Preserve or reset state |
+
+If the feature adds a relation, read [data models and collaboration](data-models-and-collaboration.md#relation-lifecycle).
+
+## Availability and rollout
+
+If the feature needs a gate, define:
+
+1. The gate name and evaluation actor.
+2. The default when the gate is off.
+3. The data written while the gate is off.
+4. The rollback behavior after data exists.
+5. The gate-removal condition and owner.
+
+Check both the backend and frontend gate. The backend must reject a mutation that the frontend hides.
+
+## Acceptance criteria and test layers
+
+Write acceptance criteria before you write tests.
+
+| Acceptance criterion | Preferred test layer |
+| --- | --- |
+| Validation, tenant boundary, or permission | Backend unit or API test |
+| Persisted request and response contract | API test plus generated-type check |
+| Client state, preview, or request shape | Frontend logic test |
+| Placement-specific visibility or action | Component test |
+| Critical user journey across layers | Playwright test |
+
+At minimum, state an acceptance criterion for each affected case:
+
+- Allowed actor
+- Denied actor
+- New dashboard
+- Existing dashboard
+- Shared, embedded, or export surface
+- Invalid, absent, or old state
+- Query, cache, or network failure
+- Concurrent edit or stale client state, when the feature mutates persisted state
+
+## Operational contract
+
+Before rollout, state:
+
+- Expected request-count change
+- Expected cache behavior
+- Expected database-read and database-write change
+- Adoption signal
+- Error or latency signal
+- Alert requirement, if the feature adds a material operational risk
+
+Use existing endpoint monitoring when it covers the path. Add new metrics only when they answer a new operational question.
+
+## Documentation
+
+If the feature changes a user-visible setting, API, shared behavior, or documented workflow, update the matching documentation in the same change.
+
+Use `writing-user-facing-copy` for new UI text. Keep rollout notes outside code comments.

--- a/.agents/skills/managing-dashboards/references/filters-variables-and-overrides.md
+++ b/.agents/skills/managing-dashboards/references/filters-variables-and-overrides.md
@@ -1,0 +1,44 @@
+# Filters, variables, and tile overrides
+
+## Treat filter state as a layered contract
+
+Dashboard query behavior can combine several layers of state.
+
+| Layer | Persisted | Scope |
+| --- | --- | --- |
+| Dashboard filters | Yes | Every compatible tile |
+| Dashboard variables | Yes | Every compatible tile |
+| Request filter override | No | One dashboard read or query request |
+| Request variable override | No | One dashboard read or query request |
+| Tile filter override | Yes | One insight tile |
+| Quick filters | Yes, by ID | Dashboard filter controls |
+
+Before you change one layer, define its precedence with every other affected layer. Do not infer precedence from the UI.
+
+## Required checks
+
+- Use `normalize_dashboard_filters_properties` for persisted dashboard property filters.
+- Keep `persisted_filters` and `persisted_variables` distinct from request-resolved output.
+- Shared-token requests ignore request filter and variable overrides.
+- Validate quick-filter IDs against the current team. Do not retain a deleted or cross-team ID.
+- Preserve tile `filters_overrides` when you duplicate, copy, move, serialize, or create from a template.
+- Check tiles that opt out of dashboard filters separately from tiles that add their own filters.
+- Apply the same resolved state to dashboard detail, `run_insights`, streaming, export, and the frontend preview.
+
+## Failure cases
+
+| Change | Check |
+| --- | --- |
+| New dashboard filter | Invalid property shape, old filter JSON, and shared rendering |
+| New variable | Missing value, invalid value, template substitution, and request-only override |
+| New quick filter | Missing ID, deleted ID, cross-team ID, and order preservation |
+| New tile override | Dashboard filter opt-out, tile-only filter, copy, duplicate, and template behavior |
+| New read path | Persisted output versus request-resolved output and shared-token behavior |
+
+## Source files
+
+- `products/dashboards/backend/api/dashboard.py`
+- `posthog/hogql_queries/apply_dashboard_filters.py`
+- `frontend/src/scenes/dashboard/DashboardFilters.tsx`
+- `frontend/src/scenes/dashboard/TileFiltersOverride.tsx`
+- `frontend/src/scenes/dashboard/dashboardLogic.tsx`

--- a/.agents/skills/managing-dashboards/references/filters-variables-and-overrides.md
+++ b/.agents/skills/managing-dashboards/references/filters-variables-and-overrides.md
@@ -4,14 +4,14 @@
 
 Dashboard query behavior can combine several layers of state.
 
-| Layer | Persisted | Scope |
-| --- | --- | --- |
-| Dashboard filters | Yes | Every compatible tile |
-| Dashboard variables | Yes | Every compatible tile |
-| Request filter override | No | One dashboard read or query request |
-| Request variable override | No | One dashboard read or query request |
-| Tile filter override | Yes | One insight tile |
-| Quick filters | Yes, by ID | Dashboard filter controls |
+| Layer                     | Persisted  | Scope                               |
+| ------------------------- | ---------- | ----------------------------------- |
+| Dashboard filters         | Yes        | Every compatible tile               |
+| Dashboard variables       | Yes        | Every compatible tile               |
+| Request filter override   | No         | One dashboard read or query request |
+| Request variable override | No         | One dashboard read or query request |
+| Tile filter override      | Yes        | One insight tile                    |
+| Quick filters             | Yes, by ID | Dashboard filter controls           |
 
 Before you change one layer, define its precedence with every other affected layer. Do not infer precedence from the UI.
 
@@ -27,13 +27,13 @@ Before you change one layer, define its precedence with every other affected lay
 
 ## Failure cases
 
-| Change | Check |
-| --- | --- |
-| New dashboard filter | Invalid property shape, old filter JSON, and shared rendering |
-| New variable | Missing value, invalid value, template substitution, and request-only override |
-| New quick filter | Missing ID, deleted ID, cross-team ID, and order preservation |
-| New tile override | Dashboard filter opt-out, tile-only filter, copy, duplicate, and template behavior |
-| New read path | Persisted output versus request-resolved output and shared-token behavior |
+| Change               | Check                                                                              |
+| -------------------- | ---------------------------------------------------------------------------------- |
+| New dashboard filter | Invalid property shape, old filter JSON, and shared rendering                      |
+| New variable         | Missing value, invalid value, template substitution, and request-only override     |
+| New quick filter     | Missing ID, deleted ID, cross-team ID, and order preservation                      |
+| New tile override    | Dashboard filter opt-out, tile-only filter, copy, duplicate, and template behavior |
+| New read path        | Persisted output versus request-resolved output and shared-token behavior          |
 
 ## Source files
 

--- a/.agents/skills/managing-dashboards/references/layout-responsive-and-templates.md
+++ b/.agents/skills/managing-dashboards/references/layout-responsive-and-templates.md
@@ -1,0 +1,63 @@
+# Layout, responsive behavior, and templates
+
+## Responsive layout
+
+Dashboard layouts are persisted per breakpoint in `DashboardTile.layouts`.
+
+- `sm` is the primary persisted dashboard grid layout.
+- Keep backend `DASHBOARD_GRID_COLUMN_COUNT` aligned with frontend `BREAKPOINT_COLUMN_COUNTS.sm`.
+- Use `DashboardItems.tsx` and `tileLayouts.ts` as the layout behavior source of truth.
+- Check narrow view, wide view, zoom, drag, resize, insert, duplicate, move, copy, and reload.
+- Check text, button, insight, error, and widget tiles. Their minimum dimensions differ.
+- Preserve existing layout JSON. Older rows can omit a breakpoint or contain a layout that a new rule no longer creates.
+
+## Dense and sparse dashboards
+
+- Empty dashboards need a useful, permission-aware state.
+- One tile must not gain unnecessary grid controls or excess whitespace.
+- Dense dashboards need stable rendering while tile results refresh.
+- Do not make each drag or resize rerender every tile.
+- Do not re-layout every tile after each response. Preserve layout references when geometry did not change.
+- Test a narrow container. Do not use only a wide desktop Storybook viewport.
+
+## Presentation state
+
+Check these fields when a dashboard change affects chart or tile presentation.
+
+- Dashboard `breakdown_colors` and `data_color_theme` apply across insight tiles.
+- Tile `color`, `transparent_background`, and `show_description` are tile-specific state.
+- Duplicate, copy, template, serializer, and shared-render paths must preserve or deliberately omit each field.
+- Do not treat presentation state as query state. A query refresh must not overwrite a layout or visual preference.
+
+## Template contract
+
+Templates copy a definition. They do not maintain a live relationship with the created dashboard.
+
+Before changing templates, define:
+
+1. Which fields copy to the new dashboard.
+2. Which fields require variable substitution.
+3. Which references work across projects.
+4. Which references are project-specific and need a warning.
+5. Which template scope can read, create, edit, delete, or promote the template.
+6. Whether the change supports old template JSON.
+
+`DashboardTemplate.Scope` includes team, organization, global, and feature-flag scopes. Non-staff users cannot write every scope or every template field.
+
+## Template checks
+
+- Validate a template with no tiles.
+- Validate a template with variables.
+- Test copy into the owning project and another permitted project.
+- Test project-specific actions, cohorts, and warehouse references.
+- Test team, organization, global, and feature-flag scope rules that the change affects.
+- Check that template list endpoints do not perform per-template expensive work.
+
+## Verification
+
+```bash
+hogli test frontend/src/scenes/dashboard/tileLayouts.test.ts
+hogli test frontend/src/scenes/dashboard/insertTileGeometry.test.ts
+hogli test frontend/src/scenes/dashboard/editLayoutGesture.test.ts
+hogli test products/dashboards/backend/api/test/test_dashboard_templates.py
+```

--- a/.agents/skills/managing-dashboards/references/querying-caching-and-scale.md
+++ b/.agents/skills/managing-dashboards/references/querying-caching-and-scale.md
@@ -1,0 +1,65 @@
+# Querying, caching, and scale
+
+## Query and cache contract
+
+Dashboard load and dashboard refresh are different operations.
+
+- `posthog/hogql_queries/refresh_policy.py` defines default execution mode by `ComputeSurface`.
+- Explicit client refresh settings override the surface default.
+- Shared rendering is clamped last. It must not force a blocking recompute.
+- `dashboardLogic` refreshes stale insight tiles and tracks queued, loading, cached, and failed results.
+- `run_insights` is a separate endpoint from dashboard detail and dashboard streaming. Keep their cache and error behavior separate.
+
+Before changing a query path, answer these questions.
+
+1. Does normal dashboard load return cache-only results, cached data, or a synchronous query?
+2. Which caller can force a refresh?
+3. What happens when the cache is stale or empty?
+4. How does one tile failure affect the remaining tiles?
+5. What cancels work after navigation or a new dashboard load?
+6. Which access method records cache hits and misses?
+
+## Keep work bounded
+
+Treat a dense dashboard as the default performance boundary.
+
+- Do not issue one unbounded request per tile.
+- Prefetch all data serializers need. Avoid per-tile database queries in dashboard serialization.
+- Do not compute expensive template diagnostics in a template list response.
+- Avoid N full-grid renders while individual tile results arrive.
+- Cancel in-flight work when dashboard identity, filters, variables, or placement changes.
+
+If the change affects a widget query, read `manage-dashboard-widgets`. Do not duplicate its batch, throttle, or result-limit rules here.
+
+## Test scale deliberately
+
+Use representative fixtures or test helpers. Do not depend on production data.
+
+| Case | Expected result |
+| --- | --- |
+| Empty dashboard | Fast empty state. No tile query. |
+| One tile | Correct content and controls. |
+| Many insight tiles | Bounded requests, stable loading state, independent errors. |
+| Mixed tiles | Text and buttons do not enter query refresh paths. |
+| Slow or failed tile | Other tiles remain usable. Error is tile-scoped. |
+| Repeated refresh | No duplicate requests for the same refresh window. |
+| Navigation during refresh | Abort or ignore obsolete responses. |
+
+## Observability
+
+- Preserve dashboard access counters by `human`, `shared`, `embedded`, and `api` access method.
+- Preserve cache hit and miss counters for dashboard insight results.
+- Preserve endpoint monitoring for dashboard reads. Assess SLO coverage when a new delivery or query path changes user-visible latency.
+- Do not use instrumentation as a substitute for a concurrency or cache bound.
+
+## Verification
+
+Run the smallest relevant set first.
+
+```bash
+hogli test products/dashboards/backend/api/test/test_run_insights.py
+hogli test products/dashboards/backend/api/test/test_run_widgets.py
+hogli test frontend/src/scenes/dashboard/dashboardLogic.test.ts
+hogli test frontend/src/scenes/dashboard/DashboardItems.test.tsx
+```
+Also run focused tests for the changed API, sharing, template, or layout behavior.

--- a/.agents/skills/managing-dashboards/references/querying-caching-and-scale.md
+++ b/.agents/skills/managing-dashboards/references/querying-caching-and-scale.md
@@ -35,15 +35,15 @@ If the change affects a widget query, read `manage-dashboard-widgets`. Do not du
 
 Use representative fixtures or test helpers. Do not depend on production data.
 
-| Case | Expected result |
-| --- | --- |
-| Empty dashboard | Fast empty state. No tile query. |
-| One tile | Correct content and controls. |
-| Many insight tiles | Bounded requests, stable loading state, independent errors. |
-| Mixed tiles | Text and buttons do not enter query refresh paths. |
-| Slow or failed tile | Other tiles remain usable. Error is tile-scoped. |
-| Repeated refresh | No duplicate requests for the same refresh window. |
-| Navigation during refresh | Abort or ignore obsolete responses. |
+| Case                      | Expected result                                             |
+| ------------------------- | ----------------------------------------------------------- |
+| Empty dashboard           | Fast empty state. No tile query.                            |
+| One tile                  | Correct content and controls.                               |
+| Many insight tiles        | Bounded requests, stable loading state, independent errors. |
+| Mixed tiles               | Text and buttons do not enter query refresh paths.          |
+| Slow or failed tile       | Other tiles remain usable. Error is tile-scoped.            |
+| Repeated refresh          | No duplicate requests for the same refresh window.          |
+| Navigation during refresh | Abort or ignore obsolete responses.                         |
 
 ## Observability
 
@@ -62,4 +62,5 @@ hogli test products/dashboards/backend/api/test/test_run_widgets.py
 hogli test frontend/src/scenes/dashboard/dashboardLogic.test.ts
 hogli test frontend/src/scenes/dashboard/DashboardItems.test.tsx
 ```
+
 Also run focused tests for the changed API, sharing, template, or layout behavior.

--- a/.agents/skills/managing-dashboards/references/surfaces-and-ownership.md
+++ b/.agents/skills/managing-dashboards/references/surfaces-and-ownership.md
@@ -12,27 +12,27 @@
 
 Use `DashboardPlacement` as the frontend placement contract.
 
-| Placement | Required behavior |
-| --- | --- |
-| `Dashboard` | Full authenticated dashboard. Editing may be available. |
-| `ProjectHomepage` and `Builtin` | Dashboard content in another authenticated product surface. Check action visibility and available width. |
-| `Public` | Public share. Read-only. Do not expose authorship, folders, private configuration, or force-refresh actions. |
-| `Export` | Export rendering. Do not add interactive controls or assume a browser user session. |
-| `FeatureFlag` and `Group` | Embedded dashboard contexts. Check the host page, URL state, permissions, and refresh behavior. |
+| Placement                       | Required behavior                                                                                            |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `Dashboard`                     | Full authenticated dashboard. Editing may be available.                                                      |
+| `ProjectHomepage` and `Builtin` | Dashboard content in another authenticated product surface. Check action visibility and available width.     |
+| `Public`                        | Public share. Read-only. Do not expose authorship, folders, private configuration, or force-refresh actions. |
+| `Export`                        | Export rendering. Do not add interactive controls or assume a browser user session.                          |
+| `FeatureFlag` and `Group`       | Embedded dashboard contexts. Check the host page, URL state, permissions, and refresh behavior.              |
 
 Also check product-created unlisted dashboards. `Dashboard.CreationMode.UNLISTED` hides these from normal lists but does not remove dashboard rules.
 
 ## Ownership map
 
-| Area | Files |
-| --- | --- |
-| Models | `products/dashboards/backend/models/dashboard.py`, `dashboard_tile.py`, `dashboard_templates.py` |
-| Dashboard endpoints | `products/dashboards/backend/api/dashboard.py` |
-| Templates endpoint | `products/dashboards/backend/api/dashboard_templates.py` |
-| Product routes | `products/dashboards/backend/routes.py` |
-| Scene state | `frontend/src/scenes/dashboard/dashboardLogic.tsx` |
-| Main layout | `frontend/src/scenes/dashboard/DashboardItems.tsx`, `tileLayouts.ts` |
-| Shared/export host | `frontend/src/exporter/scenes/ExporterDashboardScene.tsx`, `frontend/src/exporter/Exporter.tsx` |
+| Area                | Files                                                                                            |
+| ------------------- | ------------------------------------------------------------------------------------------------ |
+| Models              | `products/dashboards/backend/models/dashboard.py`, `dashboard_tile.py`, `dashboard_templates.py` |
+| Dashboard endpoints | `products/dashboards/backend/api/dashboard.py`                                                   |
+| Templates endpoint  | `products/dashboards/backend/api/dashboard_templates.py`                                         |
+| Product routes      | `products/dashboards/backend/routes.py`                                                          |
+| Scene state         | `frontend/src/scenes/dashboard/dashboardLogic.tsx`                                               |
+| Main layout         | `frontend/src/scenes/dashboard/DashboardItems.tsx`, `tileLayouts.ts`                             |
+| Shared/export host  | `frontend/src/exporter/scenes/ExporterDashboardScene.tsx`, `frontend/src/exporter/Exporter.tsx`  |
 
 ## API contract changes
 

--- a/.agents/skills/managing-dashboards/references/surfaces-and-ownership.md
+++ b/.agents/skills/managing-dashboards/references/surfaces-and-ownership.md
@@ -1,0 +1,46 @@
+# Surfaces and ownership
+
+## Start from the domain model
+
+- `Dashboard` owns project-scoped metadata, dashboard filters, variables, sharing state, restriction level, and tile relations.
+- `DashboardTile` owns one tile relation and per-breakpoint layout JSON.
+- A tile is exactly one insight, text card, button, or widget.
+- `DashboardTemplate` stores a copyable dashboard definition. It is not a live dashboard.
+- Dashboard widgets use a separate model. Read `manage-dashboard-widgets` for widget-specific work.
+
+## Render placements
+
+Use `DashboardPlacement` as the frontend placement contract.
+
+| Placement | Required behavior |
+| --- | --- |
+| `Dashboard` | Full authenticated dashboard. Editing may be available. |
+| `ProjectHomepage` and `Builtin` | Dashboard content in another authenticated product surface. Check action visibility and available width. |
+| `Public` | Public share. Read-only. Do not expose authorship, folders, private configuration, or force-refresh actions. |
+| `Export` | Export rendering. Do not add interactive controls or assume a browser user session. |
+| `FeatureFlag` and `Group` | Embedded dashboard contexts. Check the host page, URL state, permissions, and refresh behavior. |
+
+Also check product-created unlisted dashboards. `Dashboard.CreationMode.UNLISTED` hides these from normal lists but does not remove dashboard rules.
+
+## Ownership map
+
+| Area | Files |
+| --- | --- |
+| Models | `products/dashboards/backend/models/dashboard.py`, `dashboard_tile.py`, `dashboard_templates.py` |
+| Dashboard endpoints | `products/dashboards/backend/api/dashboard.py` |
+| Templates endpoint | `products/dashboards/backend/api/dashboard_templates.py` |
+| Product routes | `products/dashboards/backend/routes.py` |
+| Scene state | `frontend/src/scenes/dashboard/dashboardLogic.tsx` |
+| Main layout | `frontend/src/scenes/dashboard/DashboardItems.tsx`, `tileLayouts.ts` |
+| Shared/export host | `frontend/src/exporter/scenes/ExporterDashboardScene.tsx`, `frontend/src/exporter/Exporter.tsx` |
+
+## API contract changes
+
+If the change alters a serializer or viewset:
+
+1. Add or update the request and response schema.
+2. Run `hogli build:openapi`.
+3. Use generated API types in frontend code.
+4. Test the API endpoint and the UI contract.
+
+Do not edit generated files directly.


### PR DESCRIPTION
## Problem

- Dashboard engineers need a single guide for feature work across sharing, filters, templates, lifecycle, scale, and operational boundaries.

**Why:** Dashboard changes cross many contracts that are easy to miss when an engineer starts from one UI surface.

## Changes

- Adds one dashboard engineering skill with conditional references for feature intake, access, state precedence, performance, lifecycle, and collaboration.
- Separates dashboard-platform guidance from the existing widget-platform skill.
- Includes acceptance, test-layer, rollout, schema, accessibility, and public-content checks.

## How did you test this code?

- Verified that the skill linter accepts the entry point and reference structure.
- Verified that Markdown whitespace checks pass.
- Not run: the full skill build requires database-backed template rendering. Local Postgres was unavailable.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No user-facing product documentation applies. This PR adds internal engineering guidance.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Used `writing-skills`, `writing-simplified-technical-english`, `qa-team`, and `writing-pr-descriptions`.
- Consolidated dashboard feature decisions into one entry point with focused references.
- QA reviewers found no actionable findings.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*