### PR TITLE
fix(desktop): let the artifact version pager step off a commented version

### DIFF
--- a/products/desktop/packages/ui/src/features/sessions/commentNavigationStore.ts
+++ b/products/desktop/packages/ui/src/features/sessions/commentNavigationStore.ts
@@ -11,7 +11,10 @@ type CommentFocusIntent = "navigate" | "reveal-thread" | "focus-only";
 type CommentFocus = {
   target: CommentTarget;
   threadId: string;
-  /** Bumped on every request so re-picking the same thread scrolls again. */
+  /** Bumped on every request so re-picking the same thread scrolls again.
+   *  A consumer that acts on focus takes each nonce once, and takes it only
+   *  once it can act — returning without taking leaves the request to apply
+   *  when the consumer is ready. */
   nonce: number;
   openCommentsTab: boolean;
   intent: CommentFocusIntent;

--- a/products/desktop/packages/ui/src/features/sessions/components/ArtifactPreview.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ArtifactPreview.test.tsx
@@ -1119,6 +1119,11 @@ describe("ArtifactPreview", () => {
     expect(screen.getByText("v2/2")).toBeInTheDocument();
     lastCall = useQuery.mock.calls.at(-1)?.[0] as { queryKey: unknown[] };
     expect(lastCall.queryKey).toContain("artifact-1");
+
+    // A focus request that already landed must not keep pulling the pager back.
+    fireEvent.click(screen.getByRole("button", { name: "Older version" }));
+
+    expect(screen.getByText("v1/2")).toBeInTheDocument();
   });
 
   it("saves edited source as a new output version under the same name", async () => {

--- a/products/desktop/packages/ui/src/features/sessions/components/ArtifactPreview.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ArtifactPreview.tsx
@@ -167,20 +167,19 @@ export function ArtifactPreview({
     (state) => state.setCommentResolutions,
   );
   const focus = useCommentNavigationStore((state) => state.focusByTask[taskId]);
-  // Focus is durable state rather than a consumed event, so each request may
-  // point the tab at its version only once. Otherwise stepping the pager off a
-  // commented version re-runs this and snaps straight back to it.
-  const appliedFocusNonce = useRef<number | null>(null);
+  // Take each request once: focus is durable, so otherwise stepping the pager
+  // off a commented version snaps straight back to it.
+  const takenNonce = useRef<number | null>(null);
   useEffect(() => {
     if (
       !focus ||
       focus.target.scope !== "task_artifact" ||
-      appliedFocusNonce.current === focus.nonce ||
+      takenNonce.current === focus.nonce ||
       !versions.some((version) => version.id === focus.target.itemId)
     ) {
       return;
     }
-    appliedFocusNonce.current = focus.nonce;
+    takenNonce.current = focus.nonce;
     setSelectedVersionId(focus.target.itemId);
   }, [focus, versions]);
   const editing = useArtifactEditing({

--- a/products/desktop/packages/ui/src/features/sessions/components/ArtifactPreview.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ArtifactPreview.tsx
@@ -167,17 +167,22 @@ export function ArtifactPreview({
     (state) => state.setCommentResolutions,
   );
   const focus = useCommentNavigationStore((state) => state.focusByTask[taskId]);
+  // Focus is durable state rather than a consumed event, so each request may
+  // point the tab at its version only once. Otherwise stepping the pager off a
+  // commented version re-runs this and snaps straight back to it.
+  const appliedFocusNonce = useRef<number | null>(null);
   useEffect(() => {
     if (
       !focus ||
       focus.target.scope !== "task_artifact" ||
-      focus.target.itemId === activeArtifactId ||
+      appliedFocusNonce.current === focus.nonce ||
       !versions.some((version) => version.id === focus.target.itemId)
     ) {
       return;
     }
+    appliedFocusNonce.current = focus.nonce;
     setSelectedVersionId(focus.target.itemId);
-  }, [activeArtifactId, focus, versions]);
+  }, [focus, versions]);
   const editing = useArtifactEditing({
     sessionService,
     artifactResult,


### PR DESCRIPTION
## Problem

- Opening an artifact from a comment pins the preview to that comment's version. Stepping to the next version flashes it, then snaps back.
- The pager cannot leave that version in either direction, so the newest version of a file stays unreachable from a comment link.
- Comment focus is durable state, not a consumed event, because an artifact tab can mount after the request and its comments arrive later still.
- The effect that applied focus guarded on the version currently shown and also depended on it, so every step away re-triggered it.

## Changes

- `ArtifactPreview` now applies each comment focus request once, keyed by the request's nonce.
- Re-picking the same thread still re-targets its version, because every request bumps the nonce.
- `useCommentFocusRequest` already takes focus requests once by nonce, so this follows the existing protocol in the feature.
- Opening at the commented version rather than the newest one stays as it was. A comment link has to show the version the comment is about.

Nothing moves on screen except which version the pager lands on, so there is no before and after screenshot to compare.

## How did you test this code?

- I extended the existing version-stepping test in `ArtifactPreview.test.tsx`. After focus lands on a version, the pager must reach the older one and stay there.
- That assertion catches the snap-back. It fails without the fix, reading `v2/2` where `v1/2` is expected.
- I ran the `features/sessions` and `features/canvas/components` vitest suites and the `@posthog/ui` typecheck locally.
- Not done: I did not launch the desktop app and click through this by hand.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No published doc covers the artifact version pager.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, running in PostHog Desktop) wrote this after a report that an artifact opened from an agent's update showed an older version, and that stepping forward flashed the newer one and reverted. I reproduced it as a failing assertion first, then changed the guard.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

The alternative I rejected is in Changes. Both changed lines are covered by the extended test. Nothing in this diff, its fixtures, or this description carries material from the session that is not already public.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
