### PR TITLE
fix(exports): scale the capture rate to the recording being exported

### DIFF
--- a/posthog/temporal/session_replay/rasterize_recording/activities/rasterize.py
+++ b/posthog/temporal/session_replay/rasterize_recording/activities/rasterize.py
@@ -24,6 +24,7 @@ from ..types import (
     RasterizationActivityInput,
     RasterizationActivityOutput,
     compute_params_fingerprint,
+    resolve_render_rate,
 )
 
 logger = structlog.get_logger(__name__)
@@ -43,6 +44,23 @@ _FAILURE_FIELDS = ["exception", "exception_type", "failure_type"]
 _PERSISTED_OUTPUT_FIELDS: frozenset[str] = frozenset(
     {"video_duration_s", "playback_speed", "truncated", "file_size_bytes", "inactivity_periods"}
 )
+
+
+def _rendered_span_s(
+    duration: float | None,
+    start_offset_s: float | None,
+    end_offset_s: float | None,
+) -> float | None:
+    """Seconds of recording this export covers, or None when the caller didn't say.
+
+    A range export renders its range rather than the whole session, so the offsets decide the span
+    whenever a duration wasn't given directly.
+    """
+    if duration is not None:
+        return float(duration)
+    if end_offset_s is not None:
+        return float(end_offset_s) - float(start_offset_s or 0)
+    return None
 
 
 def report_export_event(asset: ExportedAsset, event: str, **properties: Any) -> None:
@@ -91,14 +109,14 @@ def build_rasterization_input(exported_asset_id: int) -> BuildRasterizationResul
     if viewport_height is not None:
         viewport_height = max(300, min(2160, int(viewport_height)))
 
-    # The output video is always real-time (the ffmpeg setpts filter undoes the speed-up); speed
-    # only reduces the virtual time a render spends playing the session. 1x for short clips keeps
-    # capture simple; 4x for full sessions bounds virtual time on long recordings.
-    default_speed = 1 if (duration is not None and duration <= 5) else 4
+    # Derived from how much recording is being rendered, so a long session can't ask for more frames
+    # than the render captures before its timeout. An explicit speed or frame rate wins: that caller
+    # asked for a particular look, and the AI session-moments path relies on it.
+    rate = resolve_render_rate(_rendered_span_s(duration, start_offset_s, end_offset_s))
     # `or` rather than a .get default so an explicit null in export_context also falls back instead
     # of failing pydantic validation three retries in a row.
-    playback_speed = ctx.get("playback_speed") or default_speed
-    recording_fps = ctx.get("recording_fps") or 24
+    playback_speed = ctx.get("playback_speed") or rate.playback_speed
+    recording_fps = ctx.get("recording_fps") or rate.recording_fps
     # Clamp the render rate so a large fps × speed product can't exhaust the shared rasterizer pool.
     # The lower bound matches Node's validateInput: speeds below 1 have no slow-motion filter chain
     # and would misreport the video duration.

--- a/posthog/temporal/session_replay/rasterize_recording/types.py
+++ b/posthog/temporal/session_replay/rasterize_recording/types.py
@@ -1,3 +1,4 @@
+import math
 import hashlib
 from datetime import timedelta
 from typing import Literal
@@ -21,6 +22,77 @@ RASTERIZE_WORKFLOW_TIMEOUT = RASTERIZE_RENDER_TIMEOUT * RASTERIZE_RENDER_MAX_ATT
 # with their own phase budget (the replay_vision sweep and evaluation). It still exceeds the render
 # start-to-close, so a fast first failure leaves room to schedule a retry that fits the budget.
 RASTERIZE_WORKFLOW_SINGLE_ATTEMPT_TIMEOUT = RASTERIZE_RENDER_TIMEOUT + timedelta(minutes=10)
+
+# Every captured frame costs a beginFrame round-trip, a screenshot and an ffmpeg write, so the frame
+# count is what decides whether a render finishes inside RASTERIZE_RENDER_TIMEOUT. Budget it from that
+# timeout at a deliberately pessimistic per-frame cost, staying clear of the deadline so setup, upload
+# and a heavy DOM still fit.
+_ASSUMED_MS_PER_FRAME = 150
+_RENDER_BUDGET_HEADROOM = 0.6
+MAX_CAPTURE_FRAMES = int(
+    RASTERIZE_RENDER_TIMEOUT.total_seconds() * 1000 * _RENDER_BUDGET_HEADROOM / _ASSUMED_MS_PER_FRAME
+)
+
+# Output frame rates to fall back through, highest first. A lower frame rate costs smoothness, while a
+# higher speed costs the viewer's ability to follow the session, so frame rate gives way first.
+_FPS_LADDER = (24, 15, 12, 10)
+_FPS_FLOOR = _FPS_LADDER[-1]
+
+# Past this, playback is too fast to follow, so it is only reached once frame rate has bottomed out.
+_COMFORTABLE_PLAYBACK_SPEED = 8.0
+
+# Short enough that speeding it up would leave nothing watchable.
+REALTIME_CLIP_MAX_SECONDS = 5
+
+# Beyond this, scaling stops helping: fitting the budget needs a speed at which each frame covers so
+# much of the session that the video shows nothing useful. Exporting a chosen range is the answer for
+# these, so the API refuses the whole-session export rather than returning something unwatchable.
+MAX_EXPORTABLE_DURATION_SECONDS = 3 * 60 * 60
+_DEFAULT_PLAYBACK_SPEED = 4.0
+_DEFAULT_RECORDING_FPS = 24
+
+
+class RenderRate(BaseModel, frozen=True):
+    """The rate a recording is captured at.
+
+    Named fields rather than a pair: both are numbers, and swapping them silently produces a render
+    nobody asked for.
+    """
+
+    playback_speed: float
+    recording_fps: int
+
+
+def resolve_render_rate(rendered_span_s: float | None) -> RenderRate:
+    """Pick a capture rate whose frame count fits the render budget.
+
+    Frames are `span / playback_speed * recording_fps`, so a long recording at the defaults suited to a
+    short one asks for more frames than any render can reach in time. Trading smoothness, and then
+    speed, for a video that exists beats holding both fixed and producing nothing.
+
+    `rendered_span_s` is wall time. Skipping inactivity means fewer frames than that implies, so this
+    errs toward scaling slightly harder than strictly needed.
+    """
+    if rendered_span_s is None:
+        return RenderRate(playback_speed=_DEFAULT_PLAYBACK_SPEED, recording_fps=_DEFAULT_RECORDING_FPS)
+
+    if rendered_span_s <= REALTIME_CLIP_MAX_SECONDS:
+        return RenderRate(playback_speed=1, recording_fps=_DEFAULT_RECORDING_FPS)
+
+    for fps in _FPS_LADDER:
+        required_speed = rendered_span_s * fps / MAX_CAPTURE_FRAMES
+        if required_speed <= _COMFORTABLE_PLAYBACK_SPEED:
+            return RenderRate(
+                playback_speed=max(_DEFAULT_PLAYBACK_SPEED, math.ceil(required_speed)),
+                recording_fps=fps,
+            )
+
+    # Long enough that even the lowest frame rate needs an uncomfortable speed. The alternative is a
+    # render that never finishes, and the API refuses the recordings where this stops being watchable.
+    return RenderRate(
+        playback_speed=math.ceil(rendered_span_s * _FPS_FLOOR / MAX_CAPTURE_FRAMES),
+        recording_fps=_FPS_FLOOR,
+    )
 
 
 class RasterizeRecordingInputs(BaseModel, frozen=True):

--- a/posthog/temporal/tests/session_replay/rasterize_recording/test_activities.py
+++ b/posthog/temporal/tests/session_replay/rasterize_recording/test_activities.py
@@ -14,11 +14,15 @@ from posthog.temporal.session_replay.rasterize_recording.activities import (
     finalize_rasterization,
 )
 from posthog.temporal.session_replay.rasterize_recording.types import (
+    MAX_CAPTURE_FRAMES,
+    MAX_EXPORTABLE_DURATION_SECONDS,
     FinalizeRasterizationInput,
     InactivityPeriod,
     RasterizationActivityInput,
     RasterizationActivityOutput,
+    RenderRate,
     compute_params_fingerprint,
+    resolve_render_rate,
 )
 
 from products.exports.backend.models.exported_asset import ExportedAsset
@@ -320,6 +324,25 @@ class TestBuildRasterizationInput:
 
     @parameterized.expand(
         [
+            # A whole-session export sends `duration`; a range export sends offsets instead, and the
+            # span it renders is what has to fit the budget in both cases.
+            ("whole_session", {"session_recording_id": "s1", "duration": 3420}),
+            ("offset_range", {"session_recording_id": "s1", "start_offset_s": 600, "end_offset_s": 4020}),
+        ]
+    )
+    def test_long_span_is_dispatched_within_the_frame_budget(self, _name, export_context):
+        asset = _make_asset(pk=50, export_context=export_context)
+
+        patches, _ = _patches(asset)
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
+            result = build_rasterization_input(50)
+
+        assert result.activity_input is not None
+        frames = 3420 / result.activity_input.playback_speed * result.activity_input.recording_fps
+        assert frames <= MAX_CAPTURE_FRAMES
+
+    @parameterized.expand(
+        [
             ("fractional_speed", {"session_recording_id": "s1", "playback_speed": 1.5}, "playback_speed", 1.5),
             ("integer_speed", {"session_recording_id": "s1", "playback_speed": 8}, "playback_speed", 8),
             ("fractional_trim", {"session_recording_id": "s1", "trim": 30.5}, "trim", 30.5),
@@ -572,6 +595,53 @@ class TestFingerprint:
         a = self._make_input()
         b = self._make_input(**override)
         assert compute_params_fingerprint(a) != compute_params_fingerprint(b)
+
+
+class TestResolveRenderRate:
+    """A rate whose frame count exceeds the budget is a render that cannot finish in time, which is
+    what left long recordings failing instead of exporting."""
+
+    @parameterized.expand(
+        [
+            ("just_past_realtime", 6),
+            ("five_minutes", 300),
+            ("ten_minutes", 600),
+            ("thirty_minutes", 1800),
+            ("fifty_seven_minutes", 3420),
+            ("two_hours", 7200),
+            ("at_the_exportable_limit", MAX_EXPORTABLE_DURATION_SECONDS),
+        ]
+    )
+    def test_frame_count_fits_the_render_budget(self, _name, span_s: float):
+        rate = resolve_render_rate(span_s)
+
+        frames = span_s / rate.playback_speed * rate.recording_fps
+        assert frames <= MAX_CAPTURE_FRAMES
+
+    @parameterized.expand(
+        [
+            # Short recordings shouldn't pay for the long ones: they are the great majority of exports
+            # and their output should look exactly as it did.
+            ("five_minutes", 300, 4, 24),
+            ("ten_minutes", 600, 4, 24),
+            # Real time, because speeding up a few seconds leaves nothing to watch.
+            ("three_second_clip", 3, 1, 24),
+        ]
+    )
+    def test_keeps_the_established_rate_where_it_already_fits(self, _name, span_s, expected_speed, expected_fps):
+        rate = resolve_render_rate(span_s)
+
+        assert (rate.playback_speed, rate.recording_fps) == (expected_speed, expected_fps)
+
+    def test_trades_frame_rate_before_speed(self):
+        """Speed costs the viewer's ability to follow the session, so it gives way second."""
+        rate = resolve_render_rate(3420)
+
+        assert rate.recording_fps < 24
+        assert rate.playback_speed <= 8
+
+    def test_falls_back_to_defaults_without_a_span(self):
+        assert resolve_render_rate(None) == RenderRate(playback_speed=4, recording_fps=24)
 
 
 class TestFinalizeRasterization:

--- a/products/exports/backend/api/exports.py
+++ b/products/exports/backend/api/exports.py
@@ -26,12 +26,12 @@ from posthog.models.organization import Organization
 from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
 from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
 from posthog.security.url_validation import is_url_allowed
-from posthog.settings.temporal import TEMPORAL_WORKFLOW_MAX_ATTEMPTS
 from posthog.slo.types import SloArea, SloConfig, SloOperation
 from posthog.temporal.common.client import async_connect
 from posthog.temporal.common.search_attributes import POSTHOG_SESSION_RECORDING_ID_KEY, POSTHOG_TEAM_ID_KEY
 from posthog.temporal.exports.workflows import ExportAssetWorkflow, ExportAssetWorkflowInputs
 from posthog.temporal.session_replay.rasterize_recording.types import (
+    MAX_EXPORTABLE_DURATION_SECONDS,
     RASTERIZE_WORKFLOW_TIMEOUT,
     RasterizeRecordingInputs,
 )
@@ -104,6 +104,33 @@ class ExportedAssetSerializer(UserAccessControlSerializerMixin, serializers.Mode
 
         return data
 
+    @staticmethod
+    def _validate_exportable_duration(export_context: dict) -> None:
+        """Refuse a span the renderer can only turn into something unwatchable.
+
+        Fitting a very long recording into the render budget takes a speed at which each frame covers
+        seconds of the session. Exporting a chosen range is the way to get one of these, so failing
+        here beats spending a render on a video nobody can use.
+        """
+        duration = export_context.get("duration")
+        if duration is None:
+            return
+        try:
+            requested_seconds = float(duration)
+        except (TypeError, ValueError):
+            raise ValidationError({"export_context": ["duration must be a number."]})
+
+        if requested_seconds > MAX_EXPORTABLE_DURATION_SECONDS:
+            hours = MAX_EXPORTABLE_DURATION_SECONDS // 3600
+            raise ValidationError(
+                {
+                    "export_duration_unsupported": [
+                        f"Video export supports recordings up to {hours} hours long. "
+                        "Export a shorter part of this recording instead."
+                    ]
+                }
+            )
+
     def validate(self, data: dict) -> dict:
         if not data.get("export_format"):
             raise ValidationError("Must provide export format")
@@ -132,6 +159,8 @@ class ExportedAssetSerializer(UserAccessControlSerializerMixin, serializers.Mode
         )
 
         if is_full_video_export:
+            self._validate_exportable_duration(export_context)
+
             # Calculate the start of the current month
             current_time = now()
             start_of_month = current_time.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
@@ -268,7 +297,10 @@ class ExportedAssetSerializer(UserAccessControlSerializerMixin, serializers.Mode
                         RasterizeRecordingInputs(exported_asset_id=instance.id),
                         id=f"export-video-{instance.id}",
                         task_queue=settings.SESSION_REPLAY_TASK_QUEUE,
-                        retry_policy=RetryPolicy(maximum_attempts=int(TEMPORAL_WORKFLOW_MAX_ATTEMPTS)),
+                        # One attempt: the render activity owns its own retries, and a workflow-level
+                        # retry would redo the prep and re-render from the first frame. At this cost
+                        # per render, that only spends the budget the render itself needs.
+                        retry_policy=RetryPolicy(maximum_attempts=1),
                         id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
                         execution_timeout=RASTERIZE_WORKFLOW_TIMEOUT,
                         search_attributes=TypedSearchAttributes(

--- a/products/exports/backend/api/test/test_exports.py
+++ b/products/exports/backend/api/test/test_exports.py
@@ -32,7 +32,10 @@ from posthog.settings import (
     OBJECT_STORAGE_SECRET_ACCESS_KEY,
 )
 from posthog.tasks import exporter
-from posthog.temporal.session_replay.rasterize_recording.types import RASTERIZE_WORKFLOW_TIMEOUT
+from posthog.temporal.session_replay.rasterize_recording.types import (
+    MAX_EXPORTABLE_DURATION_SECONDS,
+    RASTERIZE_WORKFLOW_TIMEOUT,
+)
 
 from products.dashboards.backend.models.dashboard import Dashboard
 from products.dashboards.backend.models.dashboard_tile import DashboardTile
@@ -815,6 +818,39 @@ class TestExports(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         results_by_id = {result["id"]: result for result in response.json()["results"]}
         self.assertEqual(results_by_id[export.id]["exception"] is not None, expected_failed)
+
+    @parameterized.expand(
+        [
+            ("at_the_limit", MAX_EXPORTABLE_DURATION_SECONDS, status.HTTP_201_CREATED),
+            ("past_the_limit", MAX_EXPORTABLE_DURATION_SECONDS + 1, status.HTTP_400_BAD_REQUEST),
+        ]
+    )
+    @patch("products.exports.backend.api.exports.async_to_sync")
+    @patch("products.exports.backend.api.exports.async_connect")
+    def test_refuses_a_recording_too_long_to_render_watchably(
+        self,
+        _name,
+        duration: int,
+        expected_status: int,
+        mock_async_connect,
+        mock_async_to_sync,
+    ) -> None:
+        """Past the limit no rate produces a usable video, so spending a render on one helps nobody.
+
+        Failing at the API keeps the reason in front of the person asking, rather than an hour later on
+        an asset they have stopped watching.
+        """
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/exports",
+            {
+                "export_format": "video/mp4",
+                "export_context": {"session_recording_id": "session_long", "duration": duration},
+            },
+        )
+
+        self.assertEqual(response.status_code, expected_status)
+        if expected_status == status.HTTP_400_BAD_REQUEST:
+            self.assertEqual(response.json()["attr"], "export_duration_unsupported")
 
     def test_listing_stuck_exports_emits_no_analytics_events(self) -> None:
         """Reporting stuck exports is a read path, so polling the list must not emit events.


### PR DESCRIPTION
## Problem

Exporting a long session recording to MP4 produces nothing. This is the failure behind the reports of
long recordings never finishing.

Speed and frame rate were fixed at values chosen for short recordings, so the frame count grew with
the recording. Each captured frame costs a `beginFrame` round-trip, a screenshot and an ffmpeg write,
so an hour-long session asked for tens of thousands of frames and no render reached the end before
`RASTERIZE_RENDER_TIMEOUT`.

Nothing bounded it either: `max_virtual_time` and `trim` are both unset by default, so the capture
loop had no stopping point short of the timeout killing it.

Third of three PRs from one investigation. #83400 stopped these being reported as failed too early,
#83404 made the failure visible, and this one makes them succeed.

Refs #38807

## Changes

Derive the rate from the span being rendered, against a frame budget taken from the render timeout.
Frame rate gives way first, then speed: a lower frame rate costs smoothness, a higher speed costs the
viewer's ability to follow the session.

| recording | before | after | frames |
| --- | --- | --- | --- |
| 10 min | 4x / 24fps | unchanged | 3,600 |
| 30 min | 4x / 24fps | 6x / 24fps | 7,200 |
| 57 min | 4x / 24fps | 8x / 15fps | 6,412 (was ~20,500) |
| 2 h | 4x / 24fps | 10x / 10fps | 7,200 |
| 3 h | 4x / 24fps | 15x / 10fps | 7,200 |

- Recordings up to ten minutes keep the rate they had, so the great majority of exports look exactly
  as before.
- An explicit `playback_speed` or `recording_fps` still wins, which leaves the AI session-moments and
  replay vision callers bit-for-bit unchanged. Both set theirs.
- Past three hours the API refuses the export and says to export part of the recording instead.
  Fitting the budget there needs a speed at which each frame covers seconds of the session, so the
  render would only produce something unusable.
- The video workflow drops to a single attempt. Two render attempts already filled the whole workflow
  envelope, so the workflow-level retry could never finish; it redid the prep and re-rendered from the
  first frame using budget the render itself needed.

> [!NOTE]
> The plan for this PR also set a default `max_virtual_time` as a truncation backstop. I left it out.
> `recorder.ts` treats that value as session seconds while `capture.ts` compares it against the capture
> loop's own tick counter, and those are different clocks for any speed above 1x. Setting it from the
> session span would cut valid exports short at the wrong point. It needs the Node semantics pinned
> down with a test at that layer first.

## How did you test this code?

Automated only. I could not exercise a real render end to end, which needs the Node rasterizer worker
and a Chromium build this environment does not run. So the per-frame cost behind the budget is an
assumption, deliberately pessimistic, not a measurement — the first real long export is what confirms
it, and the budget is one constant to turn if it is wrong.

- The rate resolver is a pure function, tested by the property that matters: frame count stays inside
  the budget across spans from seconds to the three-hour limit. That holds if the ladder is retuned,
  where asserting each speed/frame-rate pair would just churn.
- Separate cases pin that five and ten minute recordings keep their existing rate, so a future change
  cannot quietly degrade the common case to pay for the rare one.
- One activity-level case per input shape (`duration`, and offsets for a range export), because a
  correct resolver that isn't wired to the dispatched input would still fail every long export.
- API cases at and just past the limit, asserting the `export_duration_unsupported` attr.
- Ran the exports and rasterize suites locally, including the existing default-rate tests, which still
  pass unchanged.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. `nodejs/src/session-replay/recording-rasterizer/README.md` documents the activity's inputs and
their defaults, which are unchanged; what changed is which values the Python side sends.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus). Skills invoked: `/writing-tests`, `/writing-code-comments`,
`/writing-user-facing-copy` (the refusal message), `/writing-pr-descriptions`.

Session data guided two decisions worth surfacing. Recordings over an hour are common rather than a
tail case, which is why this scales rather than just raising the timeout. And the share of recordings
long enough to be unwatchable at any workable speed is small, which is what makes refusing them at
three hours reasonable instead of chunking the render, since chunking multiplies the quota accounting,
storage and failure surface to hand someone several files to stitch.

`RenderRate` is a model rather than a pair because both fields are numbers, and swapping them
silently produces a render nobody asked for.

Public artifact: nothing here carries material from the session that is not already public. The
duration distribution informing the three-hour limit came from PostHog's own analytics, and no figures
from it appear in the code, tests, comments, or this description.
