### PR TITLE
fix(marketing-analytics): evaluate the Setup flag for the requesting person

### DIFF
--- a/products/marketing_analytics/backend/api.py
+++ b/products/marketing_analytics/backend/api.py
@@ -75,23 +75,33 @@ from products.warehouse_sources.backend.facade.models import DataWarehouseTable
 logger = structlog.get_logger(__name__)
 
 
-def _setup_enabled(team: Team) -> bool:
-    """Evaluate the Setup flag once per team instance.
+def _setup_enabled(request: Request, team: Team) -> bool:
+    """Evaluate the Setup flag once per request.
 
-    Grouped on organization, matching how every other marketing-analytics flag is
-    evaluated, so a team can't disagree with its org. Cached on the instance because a
-    second call in the same request would fire a redundant `$feature_flag_called`.
+    Evaluated for the requesting person, because the flag's release conditions target
+    people and the frontend renders the Setup tab off that same per-person answer.
+    Evaluating it against anything else is how the tab ends up sitting on top of an
+    endpoint that 404s. The organization group still goes along, so a group release
+    condition matches too. Cached on the request because a second call in the same one
+    would fire a redundant `$feature_flag_called`.
     """
-    cached = getattr(team, "_ma_setup_flag", None)
+    cached = getattr(request, "_ma_setup_flag", None)
     if cached is not None:
         return cached
+    person_properties = {}
+    email = getattr(request.user, "email", None)
+    if email:
+        person_properties["email"] = email
     enabled = feature_enabled_or_false(
         "marketing-analytics-setup",
-        str(team.uuid),
+        # Service credentials authenticate as a synthetic user with no person behind them;
+        # the team UUID keeps the call well-formed, and a person condition won't match it.
+        getattr(request.user, "distinct_id", None) or str(team.uuid),
         groups={"organization": str(team.organization.id)},
+        person_properties=person_properties,
         group_properties={"organization": {"id": str(team.organization.id)}},
     )
-    team._ma_setup_flag = enabled  # type: ignore[attr-defined]
+    request._ma_setup_flag = enabled  # type: ignore[attr-defined]
     return enabled
 
 
@@ -1457,7 +1467,7 @@ class MarketingAnalyticsViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
     @action(methods=["GET"], detail=False, url_path="setup_plan", required_scopes=["marketing_analytics:read"])
     def setup_plan(self, request: Request, *args, **kwargs) -> Response:
         # 404 rather than 403: an unreleased endpoint should look absent, not forbidden.
-        if not _setup_enabled(self.team):
+        if not _setup_enabled(request, self.team):
             raise NotFound("Marketing analytics setup is not enabled for this project.")
 
         date_from = request.validated_query_data["date_from"]
@@ -1513,7 +1523,7 @@ class MarketingAnalyticsViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
     def apply_setup_ops(self, request: Request, *args, **kwargs) -> Response:
         # Same gate as setup_plan: the ops only come from a plan, so an unreleased
         # read side means there is nothing legitimate to apply.
-        if not _setup_enabled(self.team):
+        if not _setup_enabled(request, self.team):
             raise NotFound("Marketing analytics setup is not enabled for this project.")
 
         # Every op here writes a field the team PATCH puts in TEAM_CONFIG_ADMIN_FIELDS_SET,

--- a/products/marketing_analytics/backend/test_api_setup_plan.py
+++ b/products/marketing_analytics/backend/test_api_setup_plan.py
@@ -164,12 +164,19 @@ class TestSetupPlanFeatureFlag(APIBaseTest):
 
         assert flag.call_count == 1
 
-    def test_the_flag_is_grouped_on_the_organization(self):
-        # Every other marketing-analytics flag is org-grouped; a team-only evaluation
-        # here would let one project disagree with the rest of its org.
+    def test_the_flag_is_evaluated_for_the_requesting_person(self):
+        # The flag targets people, and the frontend renders the Setup tab off that same
+        # per-person answer. Evaluating it against the team instead answers for nobody, so
+        # the tab lands on an endpoint that 404s. Two people to also catch an answer
+        # cached somewhere that outlives one request.
+        other_user = User.objects.create_and_join(self.organization, "second@posthog.com", None)
+
         with patch(_FLAG_TARGET, return_value=True) as flag, patch(_PLAN_TARGET, return_value=_plan()):
             self.client.get(self.url)
+            self.client.force_login(other_user)
+            self.client.get(self.url)
 
+        assert [call.args[1] for call in flag.call_args_list] == [self.user.distinct_id, other_user.distinct_id]
         assert flag.call_args.kwargs["groups"] == {"organization": str(self.team.organization.id)}
 
 


### PR DESCRIPTION
## Problem

- Anyone in the `marketing-analytics-setup` rollout sees the Setup tab in Marketing analytics, opens it, and gets the toast "Load setup plan failed: Marketing analytics setup is not enabled for this project."
- The frontend renders the tab from the flag as posthog-js evaluates it, which is per person.
- The backend evaluated the same flag against `str(team.uuid)` as the distinct ID, so no person condition could match it.
- The flag's release conditions target people, so the backend answer was always false, and `setup_plan` and `apply_setup_ops` always returned 404.

## Changes

- `_setup_enabled` now evaluates the flag for the requesting person, so the tab and the endpoint agree.
- The organization group still goes along with the call, so a group release condition keeps working.
- Service credentials authenticate as a synthetic user with no person behind them. Those calls fall back to the team UUID, which no person condition matches.
- The cached answer moves from the `Team` instance to the request, because the result now depends on who is asking. It still stops a second `$feature_flag_called` in one request.

I (actually Claude) considered making the flag org-scoped instead, which needs no code. That widens Setup to every team in the org and drops the person targeting the flag was set up with, so the evaluation moved instead.

Sibling flags are unaffected: `marketing-analytics-precomputation` and `marketing-analytics-costs-precomputation` are group flags, so their team-level evaluation in `marketing_analytics_config.py` is correct.

## How did you test this code?

- I (actually Claude) replaced `test_the_flag_is_grouped_on_the_organization` with `test_the_flag_is_evaluated_for_the_requesting_person`. It asserts the distinct ID of each request's user across two users, so it catches both this bug and an answer cached beyond one request.
- I confirmed the new test fails on the old `str(team.uuid)` evaluation before the fix.
- Ran locally: `products/marketing_analytics/backend/test_api_setup_plan.py` and repo-wide mypy, which reports only the pre-existing `posthog/settings/managed_migrations.py` error.
- Not done: no manual run against the app. The 404 to 200 change on `GET /api/projects/<id>/marketing_analytics/setup_plan` still wants a human check with an account inside the rollout.
- No UI code changed, so nothing looks different beyond the toast no longer firing.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus) drove this from a screenshot of the failing toast. Skills invoked: `/writing-tests` and `/writing-pr-descriptions`.

The session started as a diagnosis of why the tab renders when the API says the feature is off. Reading the flag's release conditions in the app showed it is person-scoped with a cohort condition, which ruled out the "backend and frontend read different flags" theory and pointed at the distinct ID. The choice between fixing the evaluation and rescoping the flag went to a human, who picked the code fix.


---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
