### PR TITLE
fix(vapi): stop retrying the v2 phone-number 400 error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/vapi/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/vapi/source.py
@@ -88,6 +88,12 @@ You can find your private API key in the [Vapi dashboard](https://dashboard.vapi
         return {
             "401 Client Error: Unauthorized for url: https://api.vapi.ai": "Your Vapi API key is invalid or has been revoked. Create a new private API key in the Vapi dashboard, then reconnect.",
             "403 Client Error: Forbidden for url: https://api.vapi.ai": "Your Vapi API key does not have permission to read this data. Check the key's permissions in the Vapi dashboard, then reconnect.",
+            # Vapi's v2 phone-number list endpoint rejects our request with a 400 for some
+            # accounts even though the query (limit/page/sortOrder/sortBy=createdAt) matches
+            # Vapi's own published spec byte for byte — every retry replays the identical,
+            # spec-compliant request and gets the same 400 back. Match the path, not the
+            # per-request query string, so this stays scoped to this one known-bad endpoint.
+            "400 Client Error: Bad Request for url: https://api.vapi.ai/v2/phone-number": "Vapi rejected the request to list phone numbers on API v2 for this account. This looks like an issue on Vapi's side rather than your credentials — contact Vapi support, or disable the phone_numbers table if you don't need it.",
         }
 
     def get_schemas(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/vapi/tests/test_vapi_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/vapi/tests/test_vapi_source.py
@@ -53,6 +53,7 @@ class TestVapiSource:
         [
             "401 Client Error: Unauthorized for url: https://api.vapi.ai/call?limit=100",
             "403 Client Error: Forbidden for url: https://api.vapi.ai/assistant?limit=100",
+            "400 Client Error: Bad Request for url: https://api.vapi.ai/v2/phone-number?limit=100&page=1&sortOrder=ASC&sortBy=createdAt",
         ]
     )
     def test_non_retryable_errors_match_auth_failures(self, observed_error):
@@ -64,6 +65,9 @@ class TestVapiSource:
             "429 Client Error: Too Many Requests for url: https://api.vapi.ai/call",
             "500 Server Error: Internal Server Error for url: https://api.vapi.ai/call",
             "HTTPSConnectionPool(host='api.vapi.ai', port=443): Read timed out.",
+            # A 400 on a different endpoint must stay retryable — only the known-bad v2
+            # phone-number path is non-retryable, not every 400 from api.vapi.ai.
+            "400 Client Error: Bad Request for url: https://api.vapi.ai/call?limit=100",
         ]
     )
     def test_non_retryable_errors_do_not_match_transient(self, other_error):


### PR DESCRIPTION
## Problem

Vapi customers syncing the `phone_numbers` table on API v2 get a sync that keeps failing and retrying instead of a clear error. Error tracking shows an `HTTPError` ([issue](https://us.posthog.com/project/2/error_tracking/01a00274-aeb1-7fa3-b8ba-d522418ab104)): Vapi's `GET /v2/phone-number` list endpoint returns `400 Bad Request`, and every retry replays the identical request and gets the same 400 back.

## Changes

- The request we send (`limit`, `page`, `sortOrder=ASC`, `sortBy=createdAt`) matches Vapi's own published OpenAPI spec for this endpoint byte for byte, so this isn't a malformed request on our side - it looks like an issue on Vapi's end for some accounts.
- Extend `VapiSource.get_non_retryable_errors` with a pattern matching `400 Client Error: Bad Request for url: https://api.vapi.ai/v2/phone-number`, so this stops retrying and shows a clear message instead of failing silently on every attempt.
- The pattern matches the path, not the full URL with its query string, and stops at `/v2/phone-number` rather than the whole `api.vapi.ai` host, so a 400 from any other Vapi endpoint stays retryable and isn't accidentally swallowed.

## How did you test this code?

Added two cases to `test_vapi_source.py`:
- `test_non_retryable_errors_match_auth_failures` now also asserts the v2 phone-number 400 message is recognized as non-retryable.
- `test_non_retryable_errors_do_not_match_transient` now also asserts a 400 from a different endpoint (`/call`) is **not** matched, guarding the path-scoped match against widening to swallow unrelated bugs.

Ran the full `vapi` test suite (44 passed) plus `ruff check`/`ruff format --check` on the changed files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - no user-facing config or API schema changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error tracking issue. Verified the request shape against Vapi's live OpenAPI spec (`https://api.vapi.ai/api-json`) rather than assuming a client-side bug, since the parameters matched the documented contract exactly. No skills were invoked for this change beyond `/writing-tests` and `/writing-pr-descriptions`.