### PR TITLE
fix(surveys): keep response table columns through query rebuilds

### DIFF
--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -374,7 +374,7 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
         hasActiveDateRange,
         propertyFilters,
     } = useValues(surveyLogic)
-    const { clearFilters } = useActions(surveyLogic)
+    const { clearFilters, setDataTableQuery } = useActions(surveyLogic)
     const isInitialSurveyLoad = surveyLoading && survey.id === NEW_SURVEY.id
     const surveyColumnRenderers = useSurveyResponseColumns()
 
@@ -414,6 +414,7 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
                                 <div className="survey-table-results">
                                     <Query
                                         query={dataTableQuery}
+                                        setQuery={setDataTableQuery}
                                         context={{
                                             columns: surveyColumnRenderers,
                                             rowProps: (record: unknown) => {

--- a/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
+++ b/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyViewRedesign.tsx
@@ -679,7 +679,7 @@ function SurveyResponsesContent(): JSX.Element {
         isAnyResultsLoading,
         resultsRequeryInProgress,
     } = useValues(surveyLogic)
-    const { setResponseExpanded, toggleResponseExpansion } = useActions(surveyLogic)
+    const { setResponseExpanded, toggleResponseExpansion, setDataTableQuery } = useActions(surveyLogic)
     const isInitialSurveyLoad = surveyLoading && survey.id === NEW_SURVEY.id
     const isRefreshingResults = resultsRequeryInProgress || isAnyResultsLoading
     const surveyColumnRenderers = useSurveyResponseColumns()
@@ -702,6 +702,7 @@ function SurveyResponsesContent(): JSX.Element {
                 >
                     <Query
                         query={dataTableQuery}
+                        setQuery={setDataTableQuery}
                         context={{
                             columns: surveyColumnRenderers,
                             rowProps: (record: unknown) => {

--- a/frontend/src/scenes/surveys/surveyLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyLogic.test.ts
@@ -17,6 +17,7 @@ import { initKeaTests } from '~/test/init'
 import {
     AccessControlLevel,
     AnyPropertyFilter,
+    BasicSurveyQuestion,
     ChoiceQuestionProcessedResponses,
     EventPropertyFilter,
     LinkSurveyQuestion,
@@ -29,6 +30,7 @@ import {
     SurveyEventProperties,
     SurveyEventStats,
     SurveyPosition,
+    SurveyQuestion,
     SurveyQuestionBranchingType,
     SurveyQuestionType,
     SurveyRates,
@@ -2740,26 +2742,50 @@ describe('mergeResponsesByQuestion', () => {
     })
 })
 
-describe('survey response column selection', () => {
+describe('survey responses table state', () => {
     let logic: ReturnType<typeof surveyLogic.build>
 
-    const customColumns = ['*', 'properties.$browser', 'timestamp', 'person']
+    const openQuestion = (id: string, question: string): BasicSurveyQuestion => ({
+        type: SurveyQuestionType.Open,
+        question,
+        description: '',
+        id,
+    })
 
-    const selectedColumns = (): string[] | undefined =>
-        (logic.values.dataTableQuery?.source as EventsQuery | undefined)?.select
+    const HOW_DID_YOU_HEAR = openQuestion('q1', 'How did you hear about us?')
+    const WHAT_CAN_WE_IMPROVE = openQuestion('q2', 'What can we improve?')
 
-    const chooseColumns = (columns: string[]): void => {
+    const TWO_QUESTION_SURVEY: Survey = {
+        ...MULTIPLE_CHOICE_SURVEY,
+        questions: [HOW_DID_YOU_HEAR, WHAT_CAN_WE_IMPROVE],
+    }
+    const withQuestions = (questions: SurveyQuestion[]): Survey => ({ ...TWO_QUESTION_SURVEY, questions })
+
+    const responseColumn = (index: number, id: string, question: string): string =>
+        `getSurveyResponse(${index}, '${id}') -- ${question}`
+
+    const Q1_COLUMN = responseColumn(0, 'q1', HOW_DID_YOU_HEAR.question)
+    const Q2_COLUMN = responseColumn(1, 'q2', WHAT_CAN_WE_IMPROVE.question)
+    const ALL_COLUMNS = ['*', Q1_COLUMN, Q2_COLUMN, 'timestamp', 'person']
+
+    const source = (): EventsQuery | undefined => logic.values.dataTableQuery?.source as EventsQuery | undefined
+
+    /** Mirrors how `DataTable` hands a query back: spread the current one, override what changed. */
+    const editTable = (patch: Partial<DataTableNode> & { source?: Partial<EventsQuery> }): void => {
         const query = logic.values.dataTableQuery as DataTableNode
         logic.actions.setDataTableQuery({
             ...query,
-            source: { ...(query.source as EventsQuery), select: columns },
+            ...patch,
+            source: { ...(query.source as EventsQuery), ...patch.source },
         })
     }
 
     beforeEach(async () => {
+        // The reducer persists, and `initKeaTests` doesn't clear storage between cases.
+        localStorage.clear()
         useMocks({
             get: {
-                [`/api/projects/:team/surveys/${MULTIPLE_CHOICE_SURVEY.id}/`]: () => [200, MULTIPLE_CHOICE_SURVEY],
+                [`/api/projects/:team/surveys/${MULTIPLE_CHOICE_SURVEY.id}/`]: () => [200, TWO_QUESTION_SURVEY],
                 [`/api/projects/:team/surveys/${MULTIPLE_CHOICE_SURVEY.id}/archived-response-uuids/`]: () => [200, []],
             },
         })
@@ -2769,8 +2795,8 @@ describe('survey response column selection', () => {
         await expectLogic(logic).toFinishAllListeners()
     })
 
-    // Each of these rebuilds the derived dataTableQuery. Before the table owned its column
-    // selection, the rebuild replaced the user's columns with the defaults.
+    // Each of these rebuilds the derived dataTableQuery. Before the table owned its own state, the
+    // rebuild replaced whatever the user had changed with the defaults.
     it.each([
         ['archived response uuids finish loading', () => logic.actions.loadArchivedResponseUuidsSuccess(new Set())],
         ['the date range changes', () => logic.actions.setDateRange({ date_from: '-14d', date_to: null }, false)],
@@ -2789,21 +2815,73 @@ describe('survey response column selection', () => {
                     false
                 ),
         ],
-        ['the survey is refetched', () => logic.actions.loadSurveySuccess(MULTIPLE_CHOICE_SURVEY)],
-    ])('keeps the chosen columns when %s', (_description, rebuildQuery) => {
-        chooseColumns(customColumns)
-        expect(selectedColumns()).toEqual(customColumns)
+        ['the survey is refetched', () => logic.actions.loadSurveySuccess(TWO_QUESTION_SURVEY)],
+    ])('keeps the chosen columns and sort when %s', (_description, rebuildQuery) => {
+        const chosen = ['*', Q1_COLUMN, 'timestamp']
+        editTable({ source: { select: chosen, orderBy: ['timestamp'] } })
 
         rebuildQuery()
 
-        expect(selectedColumns()).toEqual(customColumns)
+        expect(source()?.select).toEqual(chosen)
+        expect(source()?.orderBy).toEqual(['timestamp'])
     })
 
-    it('falls back to the defaults when a chosen column points at a removed question', () => {
-        const defaultColumns = logic.values.dataTableQuery?.defaultColumns
+    // Sorting only changes `orderBy`, so the query it hands back shares its `select` array with the
+    // one the selector emitted. A reducer that tracks columns alone sees no change and never re-emits.
+    it('applies a sort that leaves the columns untouched', () => {
+        editTable({ source: { orderBy: ['person'] } })
 
-        chooseColumns(['*', "getSurveyResponse(7, 'deleted-question') -- Gone", 'timestamp'])
+        expect(source()?.orderBy).toEqual(['person'])
+    })
 
-        expect(selectedColumns()).toEqual(defaultColumns)
+    it('restores the columns after a remount', async () => {
+        const chosen = ['*', Q2_COLUMN, 'timestamp']
+        editTable({ source: { select: chosen } })
+        logic.unmount()
+
+        logic = surveyLogic({ id: MULTIPLE_CHOICE_SURVEY.id })
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(source()?.select).toEqual(chosen)
+    })
+
+    it.each([
+        ['a question is deleted', [HOW_DID_YOU_HEAR], ALL_COLUMNS, ['*', Q1_COLUMN, 'timestamp', 'person']],
+        [
+            'a question is reworded',
+            [HOW_DID_YOU_HEAR, { ...WHAT_CAN_WE_IMPROVE, question: 'What should we fix?' }],
+            ALL_COLUMNS,
+            ['*', Q1_COLUMN, responseColumn(1, 'q2', 'What should we fix?'), 'timestamp', 'person'],
+        ],
+        [
+            'a question is added',
+            [HOW_DID_YOU_HEAR, WHAT_CAN_WE_IMPROVE, openQuestion('q3', 'Anything else?')],
+            ['*', Q1_COLUMN, Q2_COLUMN, 'timestamp'],
+            ['*', Q1_COLUMN, Q2_COLUMN, responseColumn(2, 'q3', 'Anything else?'), 'timestamp'],
+        ],
+        [
+            'a question the user hid is still there',
+            [HOW_DID_YOU_HEAR, WHAT_CAN_WE_IMPROVE],
+            ['*', Q1_COLUMN, 'timestamp'],
+            ['*', Q1_COLUMN, 'timestamp'],
+        ],
+    ])('reconciles the columns when %s', (_description, questions, chosen, expected) => {
+        editTable({ source: { select: chosen } })
+
+        logic.actions.loadSurveySuccess(withQuestions(questions))
+
+        expect(source()?.select).toEqual(expected)
+    })
+
+    // An order by on a column reconciliation just dropped names a question that no longer exists,
+    // which fails the query outright rather than returning nothing.
+    it('drops a sort on a question that was deleted', () => {
+        editTable({ source: { select: ALL_COLUMNS, orderBy: [Q2_COLUMN] } })
+
+        logic.actions.loadSurveySuccess(withQuestions([HOW_DID_YOU_HEAR]))
+
+        expect(source()?.select).not.toContain(Q2_COLUMN)
+        expect(source()?.orderBy).toEqual(['timestamp DESC'])
     })
 })

--- a/frontend/src/scenes/surveys/surveyLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyLogic.test.ts
@@ -2771,7 +2771,7 @@ describe('survey responses table state', () => {
     const source = (): EventsQuery | undefined => logic.values.dataTableQuery?.source as EventsQuery | undefined
 
     /** Mirrors how `DataTable` hands a query back: spread the current one, override what changed. */
-    const editTable = (patch: Partial<DataTableNode> & { source?: Partial<EventsQuery> }): void => {
+    const editTable = (patch: Omit<Partial<DataTableNode>, 'source'> & { source?: Partial<EventsQuery> }): void => {
         const query = logic.values.dataTableQuery as DataTableNode
         logic.actions.setDataTableQuery({
             ...query,

--- a/frontend/src/scenes/surveys/surveyLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyLogic.test.ts
@@ -12,6 +12,7 @@ import {
 import { OpenEndedColumnMap } from 'scenes/surveys/utils'
 
 import { useMocks } from '~/mocks/jest'
+import { DataTableNode, EventsQuery } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import {
     AccessControlLevel,
@@ -2736,5 +2737,73 @@ describe('mergeResponsesByQuestion', () => {
         const other = result.data.filter((d) => !d.isPredefined)
         expect(other).toHaveLength(1)
         expect(other[0].label).toBe('My own reason')
+    })
+})
+
+describe('survey response column selection', () => {
+    let logic: ReturnType<typeof surveyLogic.build>
+
+    const customColumns = ['*', 'properties.$browser', 'timestamp', 'person']
+
+    const selectedColumns = (): string[] | undefined =>
+        (logic.values.dataTableQuery?.source as EventsQuery | undefined)?.select
+
+    const chooseColumns = (columns: string[]): void => {
+        const query = logic.values.dataTableQuery as DataTableNode
+        logic.actions.setDataTableQuery({
+            ...query,
+            source: { ...(query.source as EventsQuery), select: columns },
+        })
+    }
+
+    beforeEach(async () => {
+        useMocks({
+            get: {
+                [`/api/projects/:team/surveys/${MULTIPLE_CHOICE_SURVEY.id}/`]: () => [200, MULTIPLE_CHOICE_SURVEY],
+                [`/api/projects/:team/surveys/${MULTIPLE_CHOICE_SURVEY.id}/archived-response-uuids/`]: () => [200, []],
+            },
+        })
+        initKeaTests()
+        logic = surveyLogic({ id: MULTIPLE_CHOICE_SURVEY.id })
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+    })
+
+    // Each of these rebuilds the derived dataTableQuery. Before the table owned its column
+    // selection, the rebuild replaced the user's columns with the defaults.
+    it.each([
+        ['archived response uuids finish loading', () => logic.actions.loadArchivedResponseUuidsSuccess(new Set())],
+        ['the date range changes', () => logic.actions.setDateRange({ date_from: '-14d', date_to: null }, false)],
+        [
+            'a property filter changes',
+            () =>
+                logic.actions.setPropertyFilters(
+                    [
+                        {
+                            key: 'email',
+                            value: 'test@posthog.com',
+                            operator: PropertyOperator.Exact,
+                            type: PropertyFilterType.Person,
+                        },
+                    ],
+                    false
+                ),
+        ],
+        ['the survey is refetched', () => logic.actions.loadSurveySuccess(MULTIPLE_CHOICE_SURVEY)],
+    ])('keeps the chosen columns when %s', (_description, rebuildQuery) => {
+        chooseColumns(customColumns)
+        expect(selectedColumns()).toEqual(customColumns)
+
+        rebuildQuery()
+
+        expect(selectedColumns()).toEqual(customColumns)
+    })
+
+    it('falls back to the defaults when a chosen column points at a removed question', () => {
+        const defaultColumns = logic.values.dataTableQuery?.defaultColumns
+
+        chooseColumns(['*', "getSurveyResponse(7, 'deleted-question') -- Gone", 'timestamp'])
+
+        expect(selectedColumns()).toEqual(defaultColumns)
     })
 })

--- a/frontend/src/scenes/surveys/surveyLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyLogic.test.ts
@@ -2866,6 +2866,13 @@ describe('survey responses table state', () => {
             ['*', Q1_COLUMN, 'timestamp'],
             ['*', Q1_COLUMN, 'timestamp'],
         ],
+        [
+            // `*` renders no column of its own, so keeping it alone would leave a blank table.
+            'the only question left in the selection is deleted',
+            [HOW_DID_YOU_HEAR],
+            ['*', Q2_COLUMN],
+            ['*', Q1_COLUMN, 'timestamp', 'person'],
+        ],
     ])('reconciles the columns when %s', (_description, questions, chosen, expected) => {
         editTable({ source: { select: chosen } })
 
@@ -2883,5 +2890,28 @@ describe('survey responses table state', () => {
 
         expect(source()?.select).not.toContain(Q2_COLUMN)
         expect(source()?.orderBy).toEqual(['timestamp DESC'])
+    })
+
+    // The events query runner only defaults to `timestamp DESC` when `orderBy` is absent. Sending
+    // the empty array that "Reset sorting" produces runs the query unordered, so paging by offset
+    // repeats and skips responses.
+    it('restores the default sort when sorting is reset', () => {
+        editTable({ source: { orderBy: [] } })
+
+        expect(source()?.orderBy).toEqual(['timestamp DESC'])
+    })
+
+    // `removeExpressionComment` splits on the last `--`, so question text containing one used to
+    // leave part of the wording in the column's identity.
+    it('keeps a removed column removed when its question text contains a comment marker', () => {
+        const tricky = { ...WHAT_CAN_WE_IMPROVE, question: 'What can we improve -- honestly?' }
+        logic.actions.loadSurveySuccess(withQuestions([HOW_DID_YOU_HEAR, tricky]))
+        editTable({ source: { select: ['*', Q1_COLUMN, 'timestamp'] } })
+
+        logic.actions.loadSurveySuccess(
+            withQuestions([HOW_DID_YOU_HEAR, { ...tricky, question: 'What could we improve -- honestly?' }])
+        )
+
+        expect(source()?.select).toEqual(['*', Q1_COLUMN, 'timestamp'])
     })
 })

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -28,6 +28,7 @@ import { dayjs } from 'lib/dayjs'
 import { FeatureFlagsSet, featureFlagLogic as enabledFlagLogic } from 'lib/logic/featureFlagLogic'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { getCurrentTeamId } from 'lib/utils/getAppContext'
 import { isObject } from 'lib/utils/guards'
 import { hasFormErrors, objectClean } from 'lib/utils/objects'
 import { allOperatorsMapping } from 'lib/utils/operators'
@@ -51,6 +52,7 @@ import { userLogic } from 'scenes/userLogic'
 import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
 import { refreshTreeItem } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
+import { removeExpressionComment } from '~/queries/nodes/DataTable/utils'
 import {
     CompareFilter,
     DataTableNode,
@@ -60,7 +62,7 @@ import {
     ProductKey,
 } from '~/queries/schema/schema-general'
 import { SurveyAnalysisQuestionGroup, SurveyAnalysisResponseItem } from '~/queries/schema/schema-surveys'
-import { HogQLQueryString } from '~/queries/utils'
+import { HogQLQueryString, isEventsQuery } from '~/queries/utils'
 import {
     ActivityScope,
     AnyPropertyFilter,
@@ -712,6 +714,7 @@ export interface surveyLogicValues {
     reusableSurveyNotifications: HogFunctionType[]
     reusableSurveyNotificationsLoading: boolean
     selectedPageIndex: number | null
+    selectedResponseColumns: string[] | null
     selectedSection: SurveyEditSection | null
     showArchivedResponses: boolean
     showSurveyErrors: boolean
@@ -1176,6 +1179,9 @@ export interface surveyLogicActions {
     setDataCollectionType: (dataCollectionType: DataCollectionType) => {
         dataCollectionType: DataCollectionType
     }
+    setDataTableQuery: (query: DataTableNode) => {
+        query: DataTableNode
+    }
     setDateRange: (
         dateRange: SurveyDateRange,
         reloadResults?: boolean
@@ -1566,6 +1572,7 @@ export const surveyLogic = kea<surveyLogicType>([
             reloadResults,
         }),
         setDateRange: (dateRange: SurveyDateRange, reloadResults: boolean = true) => ({ dateRange, reloadResults }),
+        setDataTableQuery: (query: DataTableNode) => ({ query }),
         clearFilters: true,
         setInterval: (interval: IntervalType) => ({ interval }),
         setCompareFilter: (compareFilter: CompareFilter) => ({ compareFilter }),
@@ -2415,7 +2422,7 @@ export const surveyLogic = kea<surveyLogicType>([
             }
         },
     })),
-    reducers({
+    reducers(({ props }) => ({
         activeTab: [
             SurveyTab.SUMMARY as SurveyTab,
             {
@@ -2783,6 +2790,28 @@ export const surveyLogic = kea<surveyLogicType>([
                 setDateRange: (_, { dateRange }) => dateRange,
             },
         ],
+        // The responses table is rendered from the derived `dataTableQuery` selector, which rebuilds
+        // on every filter, date, and archive change. Holding the column selection here is what makes
+        // it outlive those rebuilds; without it the choice lives only in `Query`'s local React state
+        // and is discarded the next time the selector emits.
+        selectedResponseColumns: [
+            null as string[] | null,
+            {
+                persist: true,
+                // Scope by team so columns don't leak across projects (e.g. after impersonation).
+                storageKey: `scenes.surveys.surveyLogic.${getCurrentTeamId()}.${props.id}.selectedResponseColumns`,
+            },
+            {
+                setDataTableQuery: (state, { query }) => {
+                    // Every unsaved survey shares the 'new' logic key, so persisting here would
+                    // bleed columns from one draft into the next.
+                    if (props.id === NEW_SURVEY.id || !isEventsQuery(query.source)) {
+                        return state
+                    }
+                    return query.source.select ?? state
+                },
+            },
+        ],
         interval: [
             null as IntervalType | null,
             {
@@ -2811,7 +2840,7 @@ export const surveyLogic = kea<surveyLogicType>([
                 resetSurvey: () => null,
             },
         ],
-    }),
+    })),
     selectors({
         enrichedConsolidatedSurveyResults: [
             (s) => [s.consolidatedSurveyResults, s.personNames],
@@ -3087,6 +3116,7 @@ export const surveyLogic = kea<surveyLogicType>([
                 s.partialResponsesFilter,
                 s.archivedResponsesFilter,
                 s.dateRange,
+                s.selectedResponseColumns,
                 s.archivedResponseUuids,
                 s.showArchivedResponses,
             ],
@@ -3096,7 +3126,8 @@ export const surveyLogic = kea<surveyLogicType>([
                 answerFilterHogQLExpression: string,
                 partialResponsesFilter: string,
                 archivedResponsesFilter: string,
-                dateRange: SurveyDateRange
+                dateRange: SurveyDateRange,
+                selectedResponseColumns: string[] | null
             ): DataTableNode | null => {
                 if (survey.id === 'new') {
                     return null
@@ -3128,11 +3159,21 @@ export const surveyLogic = kea<surveyLogicType>([
                     'person',
                 ]
 
+                // Deleting a question shifts the remaining response expressions, so a stored
+                // selection can point at a question that no longer exists. Comparing expressions
+                // with their comments stripped keeps a selection through question rewording,
+                // which leaves the expression itself untouched.
+                const currentExpressions = new Set(defaultColumns.map(removeExpressionComment))
+                const hasStaleColumn = selectedResponseColumns?.some((column) => {
+                    const expression = removeExpressionComment(column)
+                    return expression.includes('getSurveyResponse(') && !currentExpressions.has(expression)
+                })
+
                 return {
                     kind: NodeKind.DataTableNode,
                     source: {
                         kind: NodeKind.EventsQuery,
-                        select: defaultColumns,
+                        select: !selectedResponseColumns || hasStaleColumn ? defaultColumns : selectedResponseColumns,
                         orderBy: ['timestamp DESC'],
                         where,
                         after: dateRange?.date_from || startDate,

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -28,9 +28,8 @@ import { dayjs } from 'lib/dayjs'
 import { FeatureFlagsSet, featureFlagLogic as enabledFlagLogic } from 'lib/logic/featureFlagLogic'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
-import { getCurrentTeamId } from 'lib/utils/getAppContext'
 import { isObject } from 'lib/utils/guards'
-import { hasFormErrors, objectClean } from 'lib/utils/objects'
+import { hasFormErrors, objectClean, objectsEqual } from 'lib/utils/objects'
 import { allOperatorsMapping } from 'lib/utils/operators'
 import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
 import { projectLogic } from 'scenes/projectLogic'
@@ -52,7 +51,6 @@ import { userLogic } from 'scenes/userLogic'
 import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
 import { refreshTreeItem } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
-import { removeExpressionComment } from '~/queries/nodes/DataTable/utils'
 import {
     CompareFilter,
     DataTableNode,
@@ -146,10 +144,13 @@ import {
     getSurveyEndDateForQuery,
     getSurveyResponse,
     getSurveyStartDateForQuery,
+    isSurveyResponseOrderByStale,
     isSurveyRunning,
     isThumbQuestion,
+    reconcileSurveyResponseColumns,
     sanitizeSurvey,
     sanitizeSurveyAppearance,
+    surveyResponseExpressions,
     validateSurveyAppearance,
 } from './utils'
 
@@ -198,6 +199,16 @@ type TranslationFieldCheck<T extends string> = {
 const SURVEY_QUERY_TAG_BASE = { scene: 'Survey' as const, productKey: 'surveys' as const }
 const DRAFT_TRANSLATION_QUESTION_ID_PREFIX = '__draft_question_'
 const SURVEY_NOTIFICATION_LIST_LIMIT = 100
+const DEFAULT_RESPONSES_ORDER_BY = ['timestamp DESC']
+
+/** The parts of the responses table query the user can change, held so a rebuild doesn't drop them. */
+export interface SurveyResponseTableState {
+    select: string[]
+    orderBy?: string[]
+    showAbsoluteTime?: boolean
+    /** Response expressions the survey had when this was stored, to tell a removed question from a new one. */
+    knownResponseExpressions: string[]
+}
 
 function getSurveyIdsFromNotificationFilters(filters?: CyclotronJobFiltersType | null): Set<string> {
     const surveyIds = new Set<string>()
@@ -710,11 +721,11 @@ export interface surveyLogicValues {
     processedSurveyStats: SurveyStats | null
     projectTreeRef: ProjectTreeRef
     propertyFilters: AnyPropertyFilter[]
+    responseTableState: SurveyResponseTableState | null
     resultsRequeryInProgress: boolean
     reusableSurveyNotifications: HogFunctionType[]
     reusableSurveyNotificationsLoading: boolean
     selectedPageIndex: number | null
-    selectedResponseColumns: string[] | null
     selectedSection: SurveyEditSection | null
     showArchivedResponses: boolean
     showSurveyErrors: boolean
@@ -1427,6 +1438,7 @@ export interface surveyLogicMeta {
             partialResponsesFilter: string,
             archivedResponsesFilter: string,
             dateRange: SurveyDateRange | null,
+            responseTableState: SurveyResponseTableState | null,
             archivedResponseUuids: Set<string>,
             showArchivedResponses: boolean
         ) => DataTableNode | null
@@ -2790,17 +2802,12 @@ export const surveyLogic = kea<surveyLogicType>([
                 setDateRange: (_, { dateRange }) => dateRange,
             },
         ],
-        // The responses table is rendered from the derived `dataTableQuery` selector, which rebuilds
-        // on every filter, date, and archive change. Holding the column selection here is what makes
-        // it outlive those rebuilds; without it the choice lives only in `Query`'s local React state
-        // and is discarded the next time the selector emits.
-        selectedResponseColumns: [
-            null as string[] | null,
-            {
-                persist: true,
-                // Scope by team so columns don't leak across projects (e.g. after impersonation).
-                storageKey: `scenes.surveys.surveyLogic.${getCurrentTeamId()}.${props.id}.selectedResponseColumns`,
-            },
+        // `dataTableQuery` is derived, so it rebuilds on every filter, date, and archive change and
+        // discards whatever the user changed on the table. Capturing the editable parts of the query
+        // here is what makes them outlive a rebuild and a reload.
+        responseTableState: [
+            null as SurveyResponseTableState | null,
+            { persist: true },
             {
                 setDataTableQuery: (state, { query }) => {
                     // Every unsaved survey shares the 'new' logic key, so persisting here would
@@ -2808,7 +2815,17 @@ export const surveyLogic = kea<surveyLogicType>([
                     if (props.id === NEW_SURVEY.id || !isEventsQuery(query.source)) {
                         return state
                     }
-                    return query.source.select ?? state
+                    const next: SurveyResponseTableState = {
+                        select: query.source.select,
+                        orderBy: query.source.orderBy,
+                        showAbsoluteTime: query.showAbsoluteTime,
+                        knownResponseExpressions: query.defaultColumns
+                            ? surveyResponseExpressions(query.defaultColumns)
+                            : (state?.knownResponseExpressions ?? []),
+                    }
+                    // The selector puts this reducer's own arrays back into the query, so an edit that
+                    // leaves them untouched would otherwise churn identity and re-emit for nothing.
+                    return objectsEqual(state, next) ? state : next
                 },
             },
         ],
@@ -3116,7 +3133,7 @@ export const surveyLogic = kea<surveyLogicType>([
                 s.partialResponsesFilter,
                 s.archivedResponsesFilter,
                 s.dateRange,
-                s.selectedResponseColumns,
+                s.responseTableState,
                 s.archivedResponseUuids,
                 s.showArchivedResponses,
             ],
@@ -3127,7 +3144,7 @@ export const surveyLogic = kea<surveyLogicType>([
                 partialResponsesFilter: string,
                 archivedResponsesFilter: string,
                 dateRange: SurveyDateRange,
-                selectedResponseColumns: string[] | null
+                responseTableState: SurveyResponseTableState | null
             ): DataTableNode | null => {
                 if (survey.id === 'new') {
                     return null
@@ -3159,22 +3176,26 @@ export const surveyLogic = kea<surveyLogicType>([
                     'person',
                 ]
 
-                // Deleting a question shifts the remaining response expressions, so a stored
-                // selection can point at a question that no longer exists. Comparing expressions
-                // with their comments stripped keeps a selection through question rewording,
-                // which leaves the expression itself untouched.
-                const currentExpressions = new Set(defaultColumns.map(removeExpressionComment))
-                const hasStaleColumn = selectedResponseColumns?.some((column) => {
-                    const expression = removeExpressionComment(column)
-                    return expression.includes('getSurveyResponse(') && !currentExpressions.has(expression)
-                })
+                const select = responseTableState
+                    ? reconcileSurveyResponseColumns(
+                          responseTableState.select,
+                          responseTableState.knownResponseExpressions,
+                          defaultColumns
+                      )
+                    : defaultColumns
+                // A sort on a column that reconciliation just dropped would reference a question
+                // that no longer exists, which fails the query rather than returning nothing.
+                const orderBy =
+                    responseTableState && !isSurveyResponseOrderByStale(responseTableState.orderBy, select)
+                        ? responseTableState.orderBy
+                        : DEFAULT_RESPONSES_ORDER_BY
 
                 return {
                     kind: NodeKind.DataTableNode,
                     source: {
                         kind: NodeKind.EventsQuery,
-                        select: !selectedResponseColumns || hasStaleColumn ? defaultColumns : selectedResponseColumns,
-                        orderBy: ['timestamp DESC'],
+                        select,
+                        orderBy,
                         where,
                         after: dateRange?.date_from || startDate,
                         before: dateRange?.date_to || endDate,
@@ -3189,6 +3210,7 @@ export const surveyLogic = kea<surveyLogicType>([
                         ],
                     },
                     defaultColumns,
+                    showAbsoluteTime: responseTableState?.showAbsoluteTime,
                     propertiesViaUrl: true,
                     showExport: true,
                     showReload: true,

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -3176,19 +3176,20 @@ export const surveyLogic = kea<surveyLogicType>([
                     'person',
                 ]
 
-                const select = responseTableState
+                // Reading a persisted value, so treat anything but a usable selection as absent
+                // rather than letting a stale shape throw out of the selector.
+                const select = responseTableState?.select?.length
                     ? reconcileSurveyResponseColumns(
                           responseTableState.select,
-                          responseTableState.knownResponseExpressions,
+                          responseTableState.knownResponseExpressions ?? [],
                           defaultColumns
                       )
                     : defaultColumns
                 // A sort on a column that reconciliation just dropped would reference a question
                 // that no longer exists, which fails the query rather than returning nothing.
-                const orderBy =
-                    responseTableState && !isSurveyResponseOrderByStale(responseTableState.orderBy, select)
-                        ? responseTableState.orderBy
-                        : DEFAULT_RESPONSES_ORDER_BY
+                const orderBy = isSurveyResponseOrderByStale(responseTableState?.orderBy, select)
+                    ? DEFAULT_RESPONSES_ORDER_BY
+                    : responseTableState?.orderBy
 
                 return {
                     kind: NodeKind.DataTableNode,

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -14,6 +14,7 @@ import {
 } from 'scenes/surveys/constants'
 import { SurveyRatingResults } from 'scenes/surveys/surveyLogic'
 
+import { removeExpressionComment } from '~/queries/nodes/DataTable/utils'
 import {
     BasicSurveyQuestion,
     CyclotronJobInvocationGlobals,
@@ -393,6 +394,77 @@ export function getSurveyResponse(question: SurveyQuestion, index: number): stri
     }
 
     return question.id ? `getSurveyResponse(${index}, '${question.id}')` : `getSurveyResponse(${index})`
+}
+
+const SURVEY_RESPONSE_CALL = 'getSurveyResponse('
+
+export function isSurveyResponseColumn(column: string): boolean {
+    return removeExpressionComment(column).includes(SURVEY_RESPONSE_CALL)
+}
+
+export function surveyResponseExpressions(columns: string[]): string[] {
+    return columns.filter(isSurveyResponseColumn).map(removeExpressionComment)
+}
+
+/**
+ * Merge a stored responses-table column selection with the survey's current questions.
+ *
+ * `knownExpressions` is the set of response expressions that existed when the selection was stored.
+ * Without it, a question the user deliberately removed is indistinguishable from one added since,
+ * so every rebuild would put the removed column back.
+ */
+export function reconcileSurveyResponseColumns(
+    storedColumns: string[],
+    knownExpressions: string[],
+    defaultColumns: string[]
+): string[] {
+    const currentByExpression = new Map(
+        defaultColumns.filter(isSurveyResponseColumn).map((column) => [removeExpressionComment(column), column])
+    )
+    const known = new Set(knownExpressions)
+
+    const matched = new Set<string>()
+    const columns: string[] = []
+    for (const column of storedColumns) {
+        if (!isSurveyResponseColumn(column)) {
+            columns.push(column)
+            continue
+        }
+        // Rebuild from the current default so a reworded question refreshes its header, and drop
+        // columns whose question was deleted or reordered, since the index is part of the expression.
+        const expression = removeExpressionComment(column)
+        const current = currentByExpression.get(expression)
+        if (current) {
+            columns.push(current)
+            matched.add(expression)
+        }
+    }
+
+    const added = [...currentByExpression.entries()]
+        .filter(([expression]) => !matched.has(expression) && !known.has(expression))
+        .map(([, column]) => column)
+    if (added.length) {
+        // Response columns sit right after `*` in the defaults, and the row renderers read the event
+        // payload at `*`'s index, so a new column must never land ahead of it.
+        const lastResponse = columns.findLastIndex(isSurveyResponseColumn)
+        columns.splice(lastResponse >= 0 ? lastResponse + 1 : columns.indexOf('*') + 1, 0, ...added)
+    }
+
+    return columns.length ? columns : defaultColumns
+}
+
+/** True when `orderBy` sorts on a response column that `select` no longer contains. */
+export function isSurveyResponseOrderByStale(orderBy: string[] | undefined, select: string[]): boolean {
+    if (!orderBy?.length) {
+        return false
+    }
+    const selected = new Set(select.map(removeExpressionComment))
+    return orderBy.some((entry) => {
+        const expression = removeExpressionComment(entry)
+            .replace(/\s+DESC$/i, '')
+            .trim()
+        return expression.includes(SURVEY_RESPONSE_CALL) && !selected.has(expression)
+    })
 }
 
 /**

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -14,7 +14,6 @@ import {
 } from 'scenes/surveys/constants'
 import { SurveyRatingResults } from 'scenes/surveys/surveyLogic'
 
-import { removeExpressionComment } from '~/queries/nodes/DataTable/utils'
 import {
     BasicSurveyQuestion,
     CyclotronJobInvocationGlobals,
@@ -398,12 +397,26 @@ export function getSurveyResponse(question: SurveyQuestion, index: number): stri
 
 const SURVEY_RESPONSE_CALL = 'getSurveyResponse('
 
+/**
+ * The bare expression a survey column selects, used as its stable identity.
+ *
+ * `removeExpressionComment` splits on the *last* `--`, so question text containing `--` leaves part
+ * of the wording in the result and rewording the question then changes the identity. The generated
+ * expressions never contain `--` themselves, so the first one always opens the comment.
+ */
+function surveyColumnKey(column: string): string {
+    return column
+        .split('--')[0]
+        .replace(/\s+DESC$/i, '')
+        .trim()
+}
+
 export function isSurveyResponseColumn(column: string): boolean {
-    return removeExpressionComment(column).includes(SURVEY_RESPONSE_CALL)
+    return surveyColumnKey(column).includes(SURVEY_RESPONSE_CALL)
 }
 
 export function surveyResponseExpressions(columns: string[]): string[] {
-    return columns.filter(isSurveyResponseColumn).map(removeExpressionComment)
+    return columns.filter(isSurveyResponseColumn).map(surveyColumnKey)
 }
 
 /**
@@ -419,20 +432,30 @@ export function reconcileSurveyResponseColumns(
     defaultColumns: string[]
 ): string[] {
     const currentByExpression = new Map(
-        defaultColumns.filter(isSurveyResponseColumn).map((column) => [removeExpressionComment(column), column])
+        defaultColumns.filter(isSurveyResponseColumn).map((column) => [surveyColumnKey(column), column])
     )
     const known = new Set(knownExpressions)
 
     const matched = new Set<string>()
     const columns: string[] = []
+    let hasStar = false
     for (const column of storedColumns) {
+        if (column === '*') {
+            // `*` marks the event payload rather than a column, and the configurator's reset can
+            // hand back a selection carrying two of them, which would fetch every payload twice.
+            if (!hasStar) {
+                hasStar = true
+                columns.push(column)
+            }
+            continue
+        }
         if (!isSurveyResponseColumn(column)) {
             columns.push(column)
             continue
         }
         // Rebuild from the current default so a reworded question refreshes its header, and drop
         // columns whose question was deleted or reordered, since the index is part of the expression.
-        const expression = removeExpressionComment(column)
+        const expression = surveyColumnKey(column)
         const current = currentByExpression.get(expression)
         if (current) {
             columns.push(current)
@@ -444,25 +467,31 @@ export function reconcileSurveyResponseColumns(
         .filter(([expression]) => !matched.has(expression) && !known.has(expression))
         .map(([, column]) => column)
     if (added.length) {
-        // Response columns sit right after `*` in the defaults, and the row renderers read the event
-        // payload at `*`'s index, so a new column must never land ahead of it.
+        // Keep new response columns grouped with the existing ones, and never ahead of `*`, whose
+        // index the survey row renderers use to read the event payload.
         const lastResponse = columns.findLastIndex(isSurveyResponseColumn)
         columns.splice(lastResponse >= 0 ? lastResponse + 1 : columns.indexOf('*') + 1, 0, ...added)
     }
 
-    return columns.length ? columns : defaultColumns
+    // `*` carries the event payload for row expansion but renders no column of its own, so a
+    // selection that reconciles down to just `*` would leave a table with nothing in it.
+    return columns.some((column) => column !== '*') ? columns : defaultColumns
 }
 
-/** True when `orderBy` sorts on a response column that `select` no longer contains. */
+/**
+ * True when `orderBy` cannot be used as-is and the caller should fall back to its default.
+ *
+ * An empty `orderBy` is not "no preference": the events query runner only falls back to
+ * `timestamp DESC` when `orderBy` is absent, so sending `[]` runs the query genuinely unordered and
+ * makes offset pagination repeat and skip rows.
+ */
 export function isSurveyResponseOrderByStale(orderBy: string[] | undefined, select: string[]): boolean {
     if (!orderBy?.length) {
-        return false
+        return true
     }
-    const selected = new Set(select.map(removeExpressionComment))
+    const selected = new Set(select.map(surveyColumnKey))
     return orderBy.some((entry) => {
-        const expression = removeExpressionComment(entry)
-            .replace(/\s+DESC$/i, '')
-            .trim()
+        const expression = surveyColumnKey(entry)
         return expression.includes(SURVEY_RESPONSE_CALL) && !selected.has(expression)
     })
 }


### PR DESCRIPTION
## Problem

- Someone customizes the columns on a survey's Responses table, then changes the date range, applies a filter, or archives a response, and the table snaps back to the default columns.
- The column choice is also lost on reload, so re-applying it is the only way to keep it, every time.
- The Responses table is the only `contextKey` data table that never passed `setQuery` to `<Query>`. Persons, groups, cohorts and the activity tables all pass it.
- Without `setQuery`, `Query.tsx` keeps the query in local React state and resyncs it whenever the incoming `query` prop changes identity.
- `surveyLogic.dataTableQuery` is a derived selector that returns a fresh object on every change to `survey`, `propertyFilters`, `answerFilterHogQLExpression`, `partialResponsesFilter`, `archivedResponsesFilter`, `dateRange`, `archivedResponseUuids`, or `showArchivedResponses`. Each rebuild discards the column edit.
- `archivedResponseUuids` resolves from its own request after mount, so the reset also fires once on a normal page load, before the user touches anything.

## Changes

- `surveyLogic` now owns the table's editable state in a `responseTableState` reducer, and `dataTableQuery` reads it back, so an edit survives a rebuild instead of living only in React state.
- Both Responses tables pass `setQuery={setDataTableQuery}`, which is also what moves `Query.tsx` off the local-state path.
- The reducer holds `select`, `orderBy` and `showAbsoluteTime`, not the columns alone. `setQuery` is the single channel for every edit `DataTable` makes, so a reducer that keeps only the columns drops the rest. Sorting is the case that bites: it leaves `select` untouched, so the reducer would see no change, the selector would never re-emit, and clicking a sort header would do nothing at all.
- `orderBy` is no longer hardcoded to `['timestamp DESC']`. That value is now the default the selector falls back to.
- The reducer persists per survey, so a reload restores the table. This follows `cohortEditLogic`'s `persistedColumns`, which solves the same problem for the cohort persons table.
- A stored selection is reconciled against the survey's current questions rather than discarded whole when one column goes stale:
  - A matched column is rebuilt from the current default, so rewording a question refreshes its header instead of pinning the old wording forever.
  - A column whose question was deleted or reordered is dropped. The question index is part of the expression, so it no longer resolves.
  - A question added since the selection was stored is appended next to the other response columns.
  - A column the user removed stays removed. The reducer records which questions existed when the selection was stored, which is what tells a deliberate removal apart from a new question.
- A sort left pointing at a dropped column falls back to the default order. Sending it would name a question that no longer exists, which fails the query rather than returning nothing.
- Saved server-side column configurations start applying too. `columnConfiguratorLogic` already loaded them on mount and called `setColumns`, but that call previously dead-ended in the discarded local state.

- Sorting resets to `timestamp DESC` rather than storing the empty `orderBy` that "Reset sorting" produces. The events query runner only defaults to `timestamp DESC` when `orderBy` is absent, so an empty array runs the query unordered and makes offset paging repeat and skip responses.
- A response column is keyed on the text before its first `--`, not its last. Question text can contain `--`, which otherwise leaves part of the wording in the column's identity and resurrects a removed column when the question is reworded.

> [!NOTE]
> Two behaviors this makes durable are left alone, both rooted in `DataTable`/`columnConfiguratorLogic`, which five scenes share.
> A team that saves a default column set overwrites each member's own choice on every page load, because `columnConfiguratorLogic` calls `setColumns` on mount and that now reaches the reducer.
> Adding an aggregate column strips `*` from the selection, which silently stops archived-row dimming and row expansion, because both read the event payload from `*`. "Reset to defaults" in the column configurator restores it.

## How did you test this code?

- Added `survey responses table state` to `surveyLogic.test.ts`: four parameterized cases for the rebuild triggers a user hits, four for the question edits reconciliation handles, and one each for applying a sort, restoring after a remount, and dropping a sort on a deleted question.
- Confirmed each case fails against a deliberately broken version rather than merely describing the fix. Hardcoding `orderBy` fails 5, disabling reconciliation fails 4, dropping the known-question set fails 6, removing `persist` fails the remount case, and reverting either the empty-`orderBy` or the `--` keying fix fails its own case.
- `pnpm --filter=@posthog/frontend fix` is clean. `typescript:check` reports 316 errors, none in the three files this branch touches. They sit in `products/*` and `lib/components/*`, and most cascade from `@posthog/quill` failing to resolve in this sandbox.
- `typegen:file` on `surveyLogic.tsx` followed by `format` leaves the tree clean, which is the sequence CI runs.
- **Not done: I did not run the app.** The reset loop, the sort, and the reload behavior are unconfirmed outside the logic tests.
- **Not done: `hogli ci:preflight`.** It needs a Python environment this sandbox does not have.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing docs cover column persistence on this table, and this adds no visible strings.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude via PostHog Code, from a support report about columns resetting on this table. Skills invoked: `/debugging-surveys`, `/writing-tests`, `/writing-pr-descriptions`, `/writing-code-comments`.

The first version of this PR passed `setQuery` but kept only `source.select` in the reducer. Review caught that this broke sorting outright, and that the all-or-nothing stale-column fallback both hid questions added after a selection was stored and kept the old wording of reworded ones. It also missed the kea-typegen meta block for `dataTableQuery`, which turned CI red.

A second review pass over the widened reducer found three more defects it had introduced: an empty `orderBy` persisting as a genuinely unordered query, `--` in question text corrupting a column's identity, and a selection reconciling down to only `*` rendering a table with no columns.

The report was ambiguous about whether the user had missed the "Save as default for all project members" checkbox. Reading the code ruled that out as the explanation: the reset happens on the next rebuild whether or not anything was saved, so this PR fixes the rebuild, not the save path.

Two adjacent defects were left alone deliberately. `columnConfiguratorLogic` only writes to the API when that checkbox is ticked, and the checkbox is disabled below project admin and resets on every modal open, so most users cannot persist at all. That is shared across five scenes and is already the subject of an open draft, [#75840](https://github.com/PostHog/posthog/pull/75840). Separately, `ColumnConfigurationViewSet.safely_get_object` rejects a PATCH from anyone who is not the row's creator, so a second project admin saving a shared configuration gets a 403 rather than an update. Both deserve their own PRs.

No customer data, quotes, or identifiers appear anywhere in this PR. The tests use survey fixtures written in the file.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*


