### PR TITLE
fix(warehouse-sources): make Postgres credential errors actionable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -101,10 +101,16 @@ _DNS_RESOLUTION_ERROR = (
     "and reachable from the public internet, then re-enable the sync."
 )
 
+# Same failure at credential-validation time (no sync exists yet), so point at re-entering details
+# rather than re-enabling a sync.
+_INVALID_CREDENTIALS_VALIDATION_ERROR = (
+    "The database rejected the username or password. Check the user and password for this source and try again."
+)
+
 PostgresErrors = {
-    "password authentication failed for user": "Invalid user or password",
+    "password authentication failed for user": _INVALID_CREDENTIALS_VALIDATION_ERROR,
     # libpq reports a bad password via SCRAM with a different wording than the line above.
-    "error received from server in SCRAM exchange: Wrong password": "Invalid user or password",
+    "error received from server in SCRAM exchange: Wrong password": _INVALID_CREDENTIALS_VALIDATION_ERROR,
     # Supabase/Supavisor poolers report a missing tenant/user during credential validation with
     # "FATAL: (ENOTFOUND) tenant/user <user> not found" — the project is paused/deleted or the
     # pooler username/host is wrong. `get_non_retryable_errors` already handles this on the
@@ -156,7 +162,7 @@ PostgresErrors = {
     "Network is unreachable": _HOST_UNREACHABLE_ERROR,
     "No route to host": _HOST_UNREACHABLE_ERROR,
     "Is the server running on that host and accepting TCP/IP connections": "Could not connect to the host on the port given",
-    'database "': "Database does not exist",
+    'database "': "The database named in your connection details doesn't exist on this server. Check the database name is correct and try again.",
     "timeout expired": "Connection timed out. Check that your database is reachable from the public internet and that PostHog's egress IP addresses are allowed through your firewall (see the docs). For a database that can't be exposed publicly, use the SSH tunnel option.",
     "the database system is starting up": "Your database is starting up or recovering. Wait a moment and try again.",
     "SSL/TLS connection is required": "SSL/TLS connection is required but your database does not support it. Please enable SSL/TLS on your PostgreSQL server.",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -3570,7 +3570,7 @@ class TestValidateCredentialsErrorMapping:
             (
                 'connection failed: connection to server at "1.2.3.4", port 5432 failed: '
                 "error received from server in SCRAM exchange: Wrong password",
-                "Invalid user or password",
+                "The database rejected the username or password. Check the user and password for this source and try again.",
             ),
             (
                 'connection failed: connection to server at "1.2.3.4", port 5432 failed: '


### PR DESCRIPTION
## Problem

A user connecting a Postgres data warehouse source who mistypes their password or database name sees a bare label: "Invalid user or password" or "Database does not exist". Neither says what to check or do next. Session recordings of new-source onboarding show users stalling and retrying on the Postgres credentials step.

Both messages are outliers in `PostgresErrors`, the map that translates driver errors for source validation. Every other entry in that map already gives a next step (which field to check, whether the host is reachable, how a pooler username must be formed).

## Changes

- The bad-password message now reads: "The database rejected the username or password. Check the user and password for this source and try again." It applies to both libpq wordings (plain and SCRAM).
- The missing-database message now reads: "The database named in your connection details doesn't exist on this server. Check the database name is correct and try again."
- The new create-time wording sits in a constant next to the existing sync-time twin, which points at re-enabling a sync instead. The two paths need different next steps.
- No behavior change: same driver-error keys, same validation flow, only the surfaced strings differ.

## How did you test this code?

- Updated the parametrized assertion in `TestValidateCredentialsErrorMapping` for the SCRAM wrong-password case.
- Ran `TestValidateCredentialsErrorMapping` (18 cases) and the Supabase source suite (19 cases, reuses this validation path); both pass locally.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) made this change while reviewing data-warehouse new-source onboarding session summaries for low-risk friction fixes. The Postgres credential step recurred as a stumbling point, and these two messages were the least actionable strings on that path.

Skills invoked: /writing-user-facing-copy, /writing-tests, /writing-pr-descriptions.

No customer data informed the copy; the wording is generic and follows the style of the sibling messages already in the same map.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
