### PR TITLE
fix(adjust): keep exhausted retryable errors out of error tracking

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/adjust/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/adjust/source.py
@@ -61,6 +61,13 @@ class AdjustSource(ResumableSource[AdjustSourceConfig, AdjustResumeConfig]):
             "404 Client Error: Not Found for url: https://automate.adjust.com": "Adjust could not find the requested report data. Check the app tokens on this source.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # A 429 or 5xx is retried internally by the tracked session; if those retries still
+        # exhaust, `_request` re-raises AdjustRetryableError and Temporal retries the whole
+        # activity, so the failure is transient and self-recovering — don't surface it as
+        # tracked exception noise.
+        return {"Adjust API error (retryable)"}
+
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/adjust/tests/test_adjust_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/adjust/tests/test_adjust_source.py
@@ -90,6 +90,19 @@ class TestAdjustSource:
     def test_throttles_and_5xx_stay_retryable(self, observed_error: str) -> None:
         assert not any(key in observed_error for key in self.source.get_non_retryable_errors())
 
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            "Adjust API error (retryable): status=500, url=https://automate.adjust.com/reports-service/report",
+            "Adjust API error (retryable): status=429, url=https://automate.adjust.com/reports-service/report",
+        ],
+    )
+    def test_retryable_errors_match_known_failures(self, observed_error: str) -> None:
+        # Matches the message `_request` raises in adjust.py after the tracked session's own
+        # retries exhaust; keeps this benign, self-recovering failure out of error tracking.
+        retryable_errors = self.source.get_retryable_errors()
+        assert any(key in observed_error for key in retryable_errors)
+
     def test_get_schemas_covers_every_report(self) -> None:
         schemas = self.source.get_schemas(self.config, self.team_id)
         assert {schema.name for schema in schemas} == set(ENDPOINTS)


### PR DESCRIPTION
## Problem

An Adjust data warehouse sync hit an upstream 500 that survived the tracked HTTP session's own retries, and the resulting `AdjustRetryableError` showed up in [error tracking](https://us.posthog.com/project/2/error_tracking/01a0039e-7854-7b13-874c-7483c7643cb2) as if it were a bug.

The failure is transient and self-recovering: Temporal already retries the whole activity when this error surfaces. The Adjust source just never told the shared error handler that, so every occurrence gets logged at exception level and pollutes error tracking as noise.

## Changes

- Add `get_retryable_errors()` to `AdjustSource`, matching the stable `"Adjust API error (retryable)"` prefix that `_request` raises after the tracked session's own 429/5xx retries exhaust.
- This mirrors the existing pattern in Matomo, Mixpanel, Bing Ads, and other sources — matching entries are logged at `warning` instead of reaching error tracking, and Temporal's retry behavior is unchanged.

## How did you test this code?

Added 2 parametrized cases to `test_adjust_source.py::test_retryable_errors_match_known_failures`, covering the 500 and 429 status variants of the message `_request` raises. This guards against the exact regression above — a retryable error going unclassified and reaching error tracking.

Ran the full `test_adjust_source.py` suite locally (35 passed) and `ruff check`/`ruff format` on the changed files.

Not run: a live sync against Adjust's API, since this is a message-matching change with no behavioral effect on retry timing.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal error classification only, no user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error tracking MCP tools to confirm the failure originates in `adjust.py`'s `_request`, then read the shared `_BaseSource.get_retryable_errors()` mechanism and several sibling sources (Matomo, Mixpanel, Bing Ads) that already use it for this exact shape of error. Invoked `/writing-tests` before adding test coverage and `/writing-pr-descriptions` before writing this body.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*