### PR TITLE
fix(adjust): keep exhausted read-timeout errors out of error tracking

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/adjust/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/adjust/source.py
@@ -61,6 +61,13 @@ class AdjustSource(ResumableSource[AdjustSourceConfig, AdjustResumeConfig]):
             "404 Client Error: Not Found for url: https://automate.adjust.com": "Adjust could not find the requested report data. Check the app tokens on this source.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # The tracked session's own urllib3 retries (see common/http/transport.py) cover read
+        # timeouts and connection failures on GET, not just 429/5xx. Once that budget exhausts,
+        # requests wraps the failure as this host-scoped pool error and Temporal retries the
+        # whole activity from there, so it's transient and self-recovering rather than a bug.
+        return {"HTTPSConnectionPool(host='automate.adjust.com', port=443)"}
+
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/adjust/tests/test_adjust_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/adjust/tests/test_adjust_source.py
@@ -90,6 +90,17 @@ class TestAdjustSource:
     def test_throttles_and_5xx_stay_retryable(self, observed_error: str) -> None:
         assert not any(key in observed_error for key in self.source.get_non_retryable_errors())
 
+    def test_exhausted_connection_pool_error_is_classified_retryable(self) -> None:
+        # Matches the message urllib3 raises once the tracked session's own GET retries
+        # (read timeouts, connection failures) exhaust — keeps this transient, self-recovering
+        # failure out of error tracking instead of reaching `logger.aexception`.
+        observed_error = (
+            "HTTPSConnectionPool(host='automate.adjust.com', port=443): Max retries exceeded with "
+            'url: /reports-service/report?dimensions=day (Caused by ReadTimeoutError("HTTPSConnectionPool'
+            "(host='automate.adjust.com', port=443): Read timed out. (read timeout=300)\"))"
+        )
+        assert any(key in observed_error for key in self.source.get_retryable_errors())
+
     def test_get_schemas_covers_every_report(self) -> None:
         schemas = self.source.get_schemas(self.config, self.team_id)
         assert {schema.name for schema in schemas} == set(ENDPOINTS)


### PR DESCRIPTION
## Problem

An Adjust data warehouse sync hit a read timeout against Adjust's Report Service API that survived the tracked HTTP session's own retries, and the resulting `ConnectionError` showed up in [error tracking](https://us.posthog.com/project/2/error_tracking/01a003be-37c8-7052-933c-80d092342b51) as if it were a bug.

The failure is transient and self-recovering: Temporal already retries the whole activity when this error surfaces, and the source's resumable state picks the sync back up from the window that failed. The Adjust source just never told the shared error handler that, so every occurrence gets logged at exception level and pollutes error tracking as noise.

## Changes

- Add `get_retryable_errors()` to `AdjustSource`, matching the host-scoped `HTTPSConnectionPool(host='automate.adjust.com', port=443)` message the tracked session raises once its own GET retries (read timeouts, connection failures) exhaust.
- This mirrors the existing pattern in Vercel, Railway, Notion, and Sentry sources — matching entries are logged at `warning` instead of reaching error tracking, and Temporal's retry behavior is unchanged.

Not classified as non-retryable: this is a transient infrastructure error (a read timeout), not a credential or config problem the user can fix, so it stays retryable rather than disabling the source.

## How did you test this code?

Added `test_exhausted_connection_pool_error_is_classified_retryable` to `test_adjust_source.py`, covering the exact connection-pool message this issue's stack trace raised. This guards against the exact regression above — a retryable transport error going unclassified and reaching error tracking.

Ran the full `test_adjust_source.py` suite locally (35 passed), `mypy` on the changed module (clean), and `ruff check`/`ruff format` on the changed files.

Not run: a live sync against Adjust's API, since this is a message-matching change with no behavioral effect on retry timing or request handling.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal error classification only, no user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error tracking MCP tools to confirm the failure originates in `adjust.py`'s `_request` → `get_rows`, then read the tracked session's retry policy (`common/http/transport.py`) and the shared `_BaseSource.get_retryable_errors()` mechanism, checking sibling sources (Vercel, Railway, Notion, Sentry, Signoz) that already classify this exact shape of transport error. Ruled out a duplicate: PR #83427 (open, human-authored) addresses a different error class on the same source (`AdjustRetryableError` from exhausted 429/5xx status retries), not this transport-level `ConnectionError`. Invoked `/writing-tests` before adding test coverage and `/writing-pr-descriptions` before writing this body.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*