### PR TITLE
fix(cdp): report in-app browsers as the app, not the host browser

### DIFF
--- a/nodejs/src/cdp/legacy-plugins/_transformations/user-agent-plugin/index.test.ts
+++ b/nodejs/src/cdp/legacy-plugins/_transformations/user-agent-plugin/index.test.ts
@@ -273,4 +273,84 @@ describe('useragent-plugin', () => {
             )
         })
     })
+
+    describe('in-app browsers', () => {
+        // Each pair is the same app on both platforms where it ships one, so the
+        // regression these catch is a platform split: `detect-browser` names the iOS
+        // build and lets the Android build fall through to chrome/chromium-webview.
+        const cases: [string, string, string][] = [
+            [
+                'facebook',
+                'iOS',
+                'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/21A329 [FBAN/FBIOS;FBDV/iPhone14,3;FBSV/17.0;]',
+            ],
+            [
+                'facebook',
+                'Android',
+                'Mozilla/5.0 (Linux; Android 13; SM-S908B Build/TP1A.220624.014; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/119.0.6045.163 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/440.0.0.30.108;]',
+            ],
+            [
+                'instagram',
+                'iOS',
+                'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/21A329 Instagram 302.0.0.23.113 (iPhone14,3; iOS 17_0; en_US)',
+            ],
+            [
+                'instagram',
+                'Android',
+                'Mozilla/5.0 (Linux; Android 13; SM-S908B) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/119.0.6045.163 Mobile Safari/537.36 Instagram 302.0.0.23.113 Android (33/13; 420dpi; 1080x2138; samsung)',
+            ],
+            [
+                'linkedin',
+                'Android',
+                'Mozilla/5.0 (Linux; Android 13; SM-S908B) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/119.0.6045.163 Mobile Safari/537.36 [LinkedInApp]',
+            ],
+            [
+                'tiktok',
+                'iOS',
+                'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/21A329 musical_ly_2022803040 JsSdk/2.0 NetType/WIFI Channel/App Store ByteLocale/en Region/US',
+            ],
+            [
+                'wechat',
+                'iOS',
+                'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 MicroMessenger/8.0.32.2300(0x28002037) NetType/WIFI Language/en',
+            ],
+            [
+                'line',
+                'iOS',
+                'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/21A329 Line/13.9.1/IAB',
+            ],
+            [
+                'twitter',
+                'iOS',
+                'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/21A329 Twitter for iPhone',
+            ],
+        ]
+
+        test.each(cases)('reports %s on %s as the app, not the host browser', (expected, _platform, userAgent) => {
+            const event = { properties: { $useragent: userAgent } } as unknown as PluginEvent
+
+            const processedEvent = processEvent(event, makeMeta())
+
+            expect(processedEvent.properties!.$browser).toEqual(expected)
+        })
+
+        // Guards the regexes against matching an ordinary mobile browser, which would
+        // relabel traffic that is already reported correctly today.
+        test.each([
+            [
+                'chrome',
+                'Mozilla/5.0 (Linux; Android 13; SM-S908B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.6045.163 Mobile Safari/537.36',
+            ],
+            [
+                'ios',
+                'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+            ],
+        ])('leaves %s alone', (expected, userAgent) => {
+            const event = { properties: { $useragent: userAgent } } as unknown as PluginEvent
+
+            const processedEvent = processEvent(event, makeMeta())
+
+            expect(processedEvent.properties!.$browser).toEqual(expected)
+        })
+    })
 })

--- a/nodejs/src/cdp/legacy-plugins/_transformations/user-agent-plugin/index.ts
+++ b/nodejs/src/cdp/legacy-plugins/_transformations/user-agent-plugin/index.ts
@@ -93,6 +93,7 @@ export function processEvent(event: PluginEvent, { global, logger }: UserAgentMe
     }
 
     const agentInfo = detect(userAgent)
+    const inAppBrowser = detectInAppBrowser(userAgent)
     const device = detectDevice(userAgent)
     const deviceType = detectDeviceType(userAgent)
 
@@ -117,7 +118,7 @@ export function processEvent(event: PluginEvent, { global, logger }: UserAgentMe
     properties['$device_type'] = deviceType
 
     if (agentInfo) {
-        properties['$browser'] = agentInfo.name
+        properties['$browser'] = inAppBrowser ?? agentInfo.name
         properties['$browser_version'] = agentInfo.version
         properties['$os'] = agentInfo.os
         // Custom property
@@ -127,6 +128,33 @@ export function processEvent(event: PluginEvent, { global, logger }: UserAgentMe
     event.properties = properties
 
     return event
+}
+
+// `detect-browser` names a few in-app browsers (facebook, instagram, kakaotalk) but only
+// from their iOS markers. The Android builds of those same apps carry different markers and
+// fall through to `chrome`/`chromium-webview`, so one app reports two different `$browser`
+// values depending on the platform, and the rest of the in-app families are not detected at
+// all. Names here stay lowercase to match the ones `detect-browser` already emits.
+const IN_APP_BROWSERS: [RegExp, string][] = [
+    // FBAN/FBIOS on iOS, FB_IAB/FB4A on Android; FBAV is the app version on both.
+    [/\b(FBAN|FB_IAB|FB4A|FBAV)\b/i, 'facebook'],
+    [/\bInstagram\b/i, 'instagram'],
+    [/\[LinkedInApp\]/i, 'linkedin'],
+    // musical_ly is TikTok's legacy name; BytedanceWebview covers the newer builds.
+    // No trailing \b: the marker ships as `musical_ly_2022803040`, and `_` is a word character.
+    [/\b(musical_ly|BytedanceWebview)/i, 'tiktok'],
+    [/\bMicroMessenger\//i, 'wechat'],
+    [/\bLine\/[\d.]+/i, 'line'],
+    [/\b(TwitterAndroid)\b|Twitter for \w+/i, 'twitter'],
+]
+
+/**
+ * Resolve the in-app browser a user agent belongs to, if any.
+ *
+ * Returns undefined for ordinary browsers so the caller keeps `detect-browser`'s own name.
+ */
+function detectInAppBrowser(userAgent: string): string | undefined {
+    return IN_APP_BROWSERS.find(([pattern]) => pattern.test(userAgent))?.[1]
 }
 
 // detectDevice and detectDeviceType from https://github.com/PostHog/posthog-js/blob/9abedce5ac877caeb09205c4b693988fc09a63ca/src/utils.js#L808-L837


### PR DESCRIPTION
## Problem

Someone opening your site from Facebook, Instagram, LinkedIn, TikTok, WeChat, Line or X is counted as a Chrome or Safari visitor. That traffic can't be segmented, excluded from an experiment, or counted at all.

The User Agent Populator transformation derives `$browser` via `detect-browser`, which recognises in-app browsers only from their iOS markers. Android builds of those same apps carry different markers and fall through to the host webview, so **one app reports two different `$browser` values depending on platform**.

Measured against `detect-browser` directly, before this change:

| user agent | reported as |
| --- | --- |
| Facebook iOS | `facebook` ✅ |
| Facebook Android | `chromium-webview` |
| Instagram iOS | `instagram` ✅ |
| Instagram Android | `chrome` |
| LinkedIn Android | `chrome` |
| TikTok / WeChat / Line / X on iOS | `ios-webview` |

Related to #83413. Not marked as closing it: that issue spans three separate implementations (the `posthog-js` shared core, `posthog-js-lite`, and this transformation), and this PR only covers the one living in this repo.

## Changes

Match the in-app markers ahead of the library's own name, so an app reports the same `$browser` on both platforms.

- Names stay lowercase to match what `detect-browser` already emits for `facebook` / `instagram` / `kakaotalk`, rather than introducing a second naming style.
- Only `$browser` is corrected. `$browser_version` and `$os` are left as `detect-browser` reports them — its version semantics for these are already mixed (Facebook iOS yields the OS version, Instagram the app version), and changing that is a separate decision.
- Ordinary mobile Chrome and Safari are untouched.

No frontend changes, so no screenshots.

## How did you test this code?

Automated only, via the existing Jest suite for this transformation.

The two test groups catch distinct regressions that nothing covered before:

- The in-app cases pin the platform split — reverting the change fails exactly the seven user agents that are misattributed today, while Facebook and Instagram on iOS keep passing because they already worked.
- The control cases pin plain Chrome on Android and Safari on iOS, so a regex that grows too greedy and starts relabelling correctly-reported traffic fails the suite.

One regex bug was caught this way while writing them: `musical_ly` ships as `musical_ly_2022803040`, so a trailing `\b` never matches because `_` is a word character.

What I did not do: I did not run PostHog end to end or send a real event through the CDP pipeline, so this is verified at the transformation's unit boundary only. The user agent strings in the tests are synthetic, written from the markers documented in #83413 — they are not captured from real traffic.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5), directed by @WhoamiI00, who is the DRI. The template asks for that person to be set as assignee; GitHub rejects assignee changes from an external contributor, so that needs a maintainer. No repo-provided skills were invoked — `.claude/skills` resolved empty in the blob-filtered shallow clone used here, so the PR conventions were followed from `.github/pull_request_template.md` directly.

The starting point was measuring `detect-browser`'s actual output for each user agent family rather than trusting the issue's description. That mattered: the issue reports the symptom as `Chrome` / `Mobile Safari`, but this implementation actually returns `chromium-webview`, `chrome` and `ios-webview` depending on the case, and it already handles Facebook and Instagram on iOS. The table above reports what was measured.

Naming was the main open decision. Rather than invent labels, the existing lowercase `detect-browser` names were extended, since the concrete user-visible bug is one app splitting across two `$browser` values. Correcting `$browser_version` was considered and dropped as a separate concern.

No customer data, logs or internal material informed this change; the user agents committed here are invented from public markers.


