### PR TITLE
fix(desktop): preserve timeline message chronology

### DIFF
--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -6462,7 +6462,7 @@ export class SessionService {
         type: "user_message",
         content: seedContent,
         timestamp: Date.now(),
-        ...(isResumeRun ? { pinToTop: false } : {}),
+        pinToTop: !isResumeRun,
       });
     }
     if (hasCurrentRunUserPrompt || isTerminalRun) {

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
@@ -9,6 +9,7 @@ vi.mock("@posthog/ui/features/git-interaction/usePrDetails", () => ({
   }),
 }));
 
+import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
 import { useThreadNavigationStore } from "@posthog/ui/features/sessions/threadNavigationStore";
 import { ActivityTimeline } from "./ActivityTimeline";
 
@@ -37,7 +38,10 @@ const conversationItems = [
   },
 ];
 
-function renderTimeline(canOpenInPlace?: boolean, items = conversationItems) {
+function renderTimeline(
+  canOpenInPlace?: boolean,
+  items: ConversationItem[] = conversationItems,
+) {
   return render(
     <ActivityTimeline
       task={task}
@@ -78,6 +82,31 @@ describe("ActivityTimeline", () => {
     fireEvent.click(screen.getByRole("button", { name: /first thing/ }));
 
     expect(screen.getByText(/and more detail/)).toBeInTheDocument();
+  });
+
+  it("places a delayed initial placeholder at task creation", () => {
+    renderTimeline(false, [
+      {
+        type: "user_message",
+        id: "initial-optimistic",
+        content: "initial request",
+        timestamp: Date.parse("2026-07-17T12:00:00Z"),
+        pinToTop: true,
+      },
+      {
+        type: "user_message",
+        id: "later-message",
+        content: "later follow-up",
+        timestamp: Date.parse("2026-07-17T10:00:00Z"),
+      },
+    ]);
+
+    expect(
+      screen.getAllByRole("button").map((button) => button.textContent),
+    ).toEqual([
+      expect.stringContaining("initial request"),
+      expect.stringContaining("later follow-up"),
+    ]);
   });
 
   it("renders structured references natively in conversation previews", () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
@@ -181,49 +181,51 @@ export function ActivityTimeline({
     return byId;
   }, [timeline]);
 
-  const rows = useMemo(
-    () =>
-      buildActivityTimeline({
-        task: {
-          id: task.id,
-          createdAt: task.created_at,
-          updatedAt: task.updated_at,
-          latestRunId: task.latest_run?.id ?? null,
-          latestRunStatus: task.latest_run?.status ?? null,
-          latestRunPrUrl:
-            typeof task.latest_run?.output?.pr_url === "string"
-              ? task.latest_run.output.pr_url
-              : null,
-        },
-        messages,
-        commentThreads: commentThreads.map((thread) => ({
-          id: thread.id,
-          lastActivityAt: thread.last_activity_at,
-          mentionedUserIds: thread.mentioned_user_ids ?? [],
-          resolved: thread.resolved,
-          stateEvent: thread.state_event
-            ? {
-                state: thread.state_event.state,
-                createdAt: thread.state_event.created_at,
-              }
+  const rows = useMemo(() => {
+    const taskCreatedTimestamp = Date.parse(task.created_at);
+    return buildActivityTimeline({
+      task: {
+        id: task.id,
+        createdAt: task.created_at,
+        updatedAt: task.updated_at,
+        latestRunId: task.latest_run?.id ?? null,
+        latestRunStatus: task.latest_run?.status ?? null,
+        latestRunPrUrl:
+          typeof task.latest_run?.output?.pr_url === "string"
+            ? task.latest_run.output.pr_url
             : null,
-        })),
-        userMessages: conversationItems.reduce<UserMessageLike[]>(
-          (items, item) => {
-            if (item.type === "user_message") {
-              items.push({
-                id: item.id,
-                content: item.content,
-                timestamp: item.timestamp,
-              });
+      },
+      messages,
+      commentThreads: commentThreads.map((thread) => ({
+        id: thread.id,
+        lastActivityAt: thread.last_activity_at,
+        mentionedUserIds: thread.mentioned_user_ids ?? [],
+        resolved: thread.resolved,
+        stateEvent: thread.state_event
+          ? {
+              state: thread.state_event.state,
+              createdAt: thread.state_event.created_at,
             }
-            return items;
-          },
-          [],
-        ),
-      }),
-    [task, messages, commentThreads, conversationItems],
-  );
+          : null,
+      })),
+      userMessages: conversationItems.reduce<UserMessageLike[]>(
+        (items, item) => {
+          if (item.type === "user_message") {
+            items.push({
+              id: item.id,
+              content: item.content,
+              timestamp:
+                item.pinToTop === true && Number.isFinite(taskCreatedTimestamp)
+                  ? taskCreatedTimestamp
+                  : item.timestamp,
+            });
+          }
+          return items;
+        },
+        [],
+      ),
+    });
+  }, [task, messages, commentThreads, conversationItems]);
 
   // Numbering a run and deciding whether to number it at all have to come from the same
   // population, or a task with three runs and one row labels that row "run 1".

--- a/products/desktop/packages/ui/src/features/sessions/components/mergeConversationItems.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/mergeConversationItems.test.ts
@@ -24,8 +24,9 @@ function userMessage(
   id: string,
   content: string,
   pinToTop?: boolean,
+  timestamp = 0,
 ): Extract<ConversationItem, { type: "user_message" }> {
-  return { type: "user_message", id, content, timestamp: 0, pinToTop };
+  return { type: "user_message", id, content, timestamp, pinToTop };
 }
 
 describe("mergeConversationItems", () => {
@@ -56,16 +57,21 @@ describe("mergeConversationItems", () => {
     expect(result.map((i) => i.id)).toEqual(["opt", "setup"]);
   });
 
-  it("cloud: filters echoed user_message that matches optimistic content", () => {
+  it("cloud: stitches an echoed user_message into its optimistic row", () => {
     const result = mergeConversationItems({
       conversationItems: [
-        userMessage("echo", "hello"),
-        userMessage("other", "different"),
+        userMessage("echo", "hello", undefined, 100),
+        userMessage("other", "different", undefined, 200),
       ],
-      optimisticItems: [userMessage("opt", "hello")],
+      optimisticItems: [userMessage("opt", "hello", true, 300)],
       isCloud: true,
     });
     expect(result.map((i) => i.id)).toEqual(["opt", "other"]);
+    expect(result[0]).toMatchObject({
+      id: "opt",
+      timestamp: 100,
+      pinToTop: undefined,
+    });
   });
 
   it("cloud: dedupes the echoed prompt even when it carries an appended channel CONTEXT.md", () => {

--- a/products/desktop/packages/ui/src/features/sessions/components/mergeConversationItems.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/mergeConversationItems.ts
@@ -74,9 +74,8 @@ export function mergeConversationItems({
   }
 
   // When the echoed prompt matches a pinned optimistic placeholder, drop the
-  // echo but remember it: it may carry the channel CONTEXT.md block and the
-  // attachment chips the placeholder lacks, so we surface the richer copy on
-  // the pinned bubble below.
+  // echo but remember it. The server copy supplies the authoritative timestamp
+  // as well as context and attachments, while the optimistic id keeps the row stable.
   const echoedItemByKey = new Map<string, UserMessageItem>();
   const consumedPlainEchoByKey = new Set<string>();
   const dedupedConversation =
@@ -111,14 +110,17 @@ export function mergeConversationItems({
       : pinnedOptimisticItems.map((item) => {
           if (item.type !== "user_message") return item;
           const echoed = echoedItemByKey.get(strippedUserContent(item.content));
-          if (
-            !echoed ||
-            (echoed.content === item.content && !echoed.attachments?.length)
-          ) {
-            return item;
+          if (!echoed) return item;
+          const resolvedItem = {
+            ...item,
+            timestamp: echoed.timestamp,
+            pinToTop: undefined,
+          };
+          if (echoed.content === item.content && !echoed.attachments?.length) {
+            return resolvedItem;
           }
           return {
-            ...item,
+            ...resolvedItem,
             content: echoed.content,
             ...(echoed.attachments?.length
               ? { attachments: echoed.attachments }

--- a/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -4056,6 +4056,7 @@ describe("SessionService", () => {
           expect.objectContaining({
             type: "user_message",
             content: "build me a thing",
+            pinToTop: true,
           }),
         );
       });


### PR DESCRIPTION
## Problem

People reopening a task can see its first message at the end of Timeline with a “now” timestamp while cloud history loads.

The timeline kept the optimistic placeholder's reload time after the matching server message arrived.

## Changes

- Timeline places an unresolved initial prompt at task creation, before later activity.
- The stitch adopts the server timestamp when the prompt echo arrives.
- The stitch retains the optimistic row ID to avoid remounting the rendered message.
- The merge remains linear over conversation and optimistic items.

Synthetic Storybook fixtures show the delayed initial prompt before and after the fix.

| Before | After |
| --- | --- |
| ![timeline-before](https://raw.githubusercontent.com/PostHog/pr-assets/7463f988ff20f295adac836f81fe4397ce78b045/2026/08/f7e5af61-4816-4c01-bfa5-056cc63e95be.png) | ![timeline-after](https://raw.githubusercontent.com/PostHog/pr-assets/7463f988ff20f295adac836f81fe4397ce78b045/2026/08/4c8ffaec-d81a-4ff5-8e9f-985c5ebef85d.png) |

## How did you test this code?

- Added merge coverage that catches a delayed echo retaining its optimistic timestamp.
- Added timeline coverage that catches an unresolved initial prompt sorting after later messages.
- Ran the focused Vitest suites for the merge, timeline, and session hydration.
- Ran type checks for `@posthog/core` and `@posthog/ui`.
- Ran Desktop Biome checks, core boundary checks, and `hogli ci:preflight --fix`.
- Did not test against a live cloud task. The screenshots use synthetic Storybook data.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This restores the existing chronological timeline behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Pi with GPT-5.6 authored the change and assigned the directing user as DRI.
- Invoked `/writing-ui-components`, `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, and `/writing-pr-descriptions`.
- Traced the issue through cloud hydration, optimistic merging, and timeline sorting before changing the stitch.
- All committed fixtures and uploaded screenshots use synthetic data.
