### PR TITLE
fix(max): let scoped tokens reach the sandbox conversation opener

### DIFF
--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -713,7 +713,11 @@ class ConversationViewSet(
             "frontend opens SSE against. The conversation row is created on first use from the URL id."
         ),
     )
-    @action(detail=True, methods=["POST"], url_path="open")
+    # Custom actions are outside APIScopePermission's default read/write action
+    # lists, so without explicit scopes every token-authenticated caller (OAuth,
+    # personal API key) gets a 403. Session auth (the web app) bypasses scope
+    # checks, which is why this only bites programmatic clients like the desktop.
+    @action(detail=True, methods=["POST"], url_path="open", required_scopes=["conversation:write"])
     def open(self, request: Request, *args, **kwargs):
         # Both warming and messaging launch a Run, so gate both on the AI-credit quota.
         if is_team_limited(self.team.api_token, QuotaResource.AI_CREDITS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY):

--- a/ee/api/tests/test_conversation.py
+++ b/ee/api/tests/test_conversation.py
@@ -29,8 +29,10 @@ from posthog.schema import (
     SpendHistoryItem,
 )
 
+from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
 from posthog.models.team.team import Team
 from posthog.models.user import User
+from posthog.models.utils import generate_random_token_personal
 from posthog.rate_limit import AIBurstRateThrottle
 from posthog.temporal.ai.chat_agent import ChatAgentWorkflow, ChatAgentWorkflowInputs
 from posthog.temporal.ai.research_agent import ResearchAgentWorkflow, ResearchAgentWorkflowInputs
@@ -1667,6 +1669,36 @@ class TestConversationSandboxRoute(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.mock_select_repo.assert_not_awaited()
         self.assertIsNone(m_session.return_value.open.call_args.kwargs["repository"])
+
+    def test_open_reachable_with_scoped_token_auth(self):
+        # Custom actions sit outside APIScopePermission's default read/write lists, so `open`
+        # 403'd every token-authenticated caller (OAuth, personal API key) until it declared
+        # required_scopes. Session-authenticated callers never hit the scope check.
+        key_value = generate_random_token_personal()
+        PersonalAPIKey.objects.create(
+            label="quick-ask",
+            user=self.user,
+            secure_value=hash_key_value(key_value),
+            scopes=["conversation:write"],
+        )
+        self.client.logout()
+        conversation = self._sandbox_conversation()
+        sentinel = SandboxRouteResult(
+            task_id="t", run_id="r", trace_id=None, run_status="queued", just_created_run=True
+        )
+        with (
+            patch("ee.api.conversation.SandboxSession") as m_session,
+            patch("ee.api.conversation.report_user_action"),
+        ):
+            m_session.return_value.open.return_value = sentinel
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/conversations/{conversation.id}/open/",
+                {"content": "hello"},
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {key_value}",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_open_without_content_warms(self):
         # A null/absent content warms a sandbox; the session returns a fresh warm handle (200), or


### PR DESCRIPTION
## Problem

Any client calling PostHog AI's sandbox conversation opener with a token (OAuth or a personal API key) gets a 403 on every request: `This action does not support personal API key access`.

- `POST /conversations/{id}/open/` is a custom DRF action, and custom actions sit outside `APIScopePermission`'s default read/write action lists.
- Without a `required_scopes` declaration the permission check resolves no scopes for the action and rejects every token-authenticated caller.
- The PostHog AI web app uses session auth, which bypasses scope checks, so the endpoint looked healthy since it shipped.
- The desktop app (quick-ask panel, PostHog/posthog#82996) is the first OAuth client and hit the 403 on every question.

## Changes

- Declare `required_scopes=["conversation:write"]` on the `open` action, matching the scope the LangGraph `create` action already implies for token callers.
- Split out of PostHog/posthog#82996 so the fix deploys ahead of the desktop stack.

## How did you test this code?

- New regression test `test_open_reachable_with_scoped_token_auth`: `open` succeeds with a `conversation:write`-scoped personal API key. It fails with 403 without the fix.
- Ran it plus the neighboring sandbox-route test against the dev stack; both pass.
- `hogli build:openapi` produced no diff - `required_scopes` does not affect the schema.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Diagnosed and written by pi in a PostHog cloud task session, after the desktop quick-ask prototype hit the 403 in manual testing.
- Skills invoked: /improving-drf-endpoints, /writing-pr-descriptions, /writing-tests.
- Cherry-picked from the quick-ask branch so it can merge and deploy independently; the stack rebases on top once this lands.
