### PR TITLE
fix(chargebee): accept site names with digits and clarify the error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/chargebee/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/chargebee/source.py
@@ -34,6 +34,12 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.generated_
 )
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
+# The site name is interpolated into https://{site_name}.chargebee.com, so it must be a bare DNS
+# subdomain: alphanumerics and hyphens, starting alphanumeric. This keeps outbound traffic pinned
+# to *.chargebee.com (a value with a scheme, dot, or path can't build another host). Digits are
+# allowed; a letters-only check rejected valid site names like "acme2024".
+_SITE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9-]*$")
+
 
 @SourceRegistry.register
 class ChargebeeSource(ResumableSource[ChargebeeSourceConfig, ChargebeeResumeConfig]):
@@ -77,9 +83,12 @@ class ChargebeeSource(ResumableSource[ChargebeeSourceConfig, ChargebeeResumeConf
         schema_name: Optional[str] = None,
         api_version: str | None = None,
     ) -> tuple[bool, str | None]:
-        subdomain_regex = re.compile("^[a-zA-Z-]+$")
-        if not subdomain_regex.match(config.site_name):
-            return False, "Chargebee site name is incorrect"
+        if not _SITE_NAME_RE.match(config.site_name):
+            return (
+                False,
+                "That doesn't look like a Chargebee site name. Enter just the site name "
+                "(the 'acme' in 'acme.chargebee.com'), not the full URL.",
+            )
 
         if validate_chargebee_credentials(config.api_key, config.site_name):
             return True, None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/chargebee/tests/test_chargebee.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/chargebee/tests/test_chargebee.py
@@ -12,7 +12,11 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.chargebee.
     ChargebeeResumeConfig,
     chargebee_source,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.chargebee.source import ChargebeeSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.chargebee import (
+    ChargebeeSourceConfig,
+)
 
 
 class TestChargebeePaginator:
@@ -216,3 +220,46 @@ class TestChargebeeSourceResumeBehavior:
         self._drive("Customers", manager, responses)
 
         manager.load_state.assert_not_called()
+
+
+class TestChargebeeSiteNameValidation:
+    _VALIDATE = (
+        "products.warehouse_sources.backend.temporal.data_imports.sources.chargebee.source"
+        ".validate_chargebee_credentials"
+    )
+
+    @pytest.mark.parametrize(
+        "site_name",
+        [
+            # Digits are valid in a Chargebee subdomain; the site name is a DNS label. A prior
+            # letters-only check rejected these before any request was made.
+            "acme2024",
+            "shop24",
+            "acme-test",
+            "acme",
+        ],
+    )
+    def test_accepts_valid_subdomain_site_names(self, site_name: str) -> None:
+        config = ChargebeeSourceConfig(api_key="key", site_name=site_name)
+        with patch(self._VALIDATE, return_value=True) as mock_validate:
+            is_valid, message = ChargebeeSource().validate_credentials(config, team_id=1)
+        assert (is_valid, message) == (True, None)
+        mock_validate.assert_called_once_with("key", site_name)
+
+    @pytest.mark.parametrize(
+        "site_name",
+        [
+            "acme.chargebee.com",
+            "https://acme.chargebee.com",
+            "-acme",
+            "acme/live",
+            "",
+        ],
+    )
+    def test_rejects_non_subdomain_without_calling_the_api(self, site_name: str) -> None:
+        config = ChargebeeSourceConfig(api_key="key", site_name=site_name)
+        with patch(self._VALIDATE) as mock_validate:
+            is_valid, message = ChargebeeSource().validate_credentials(config, team_id=1)
+        assert is_valid is False
+        assert message is not None and "chargebee.com" in message
+        mock_validate.assert_not_called()


### PR DESCRIPTION
## Problem

- A person creating a Chargebee source whose site name contains a digit (for example `acme2024`) gets "Chargebee site name is incorrect" and cannot connect, even with valid credentials.
- A Chargebee site name is a DNS subdomain, so digits are valid, but validation only allowed letters and hyphens.
- The message named no cause and no fix, so someone who pasted the full URL hit the same dead-end.

## Changes

- `validate_credentials` now accepts any bare subdomain (alphanumerics and hyphens, starting alphanumeric), so digit-containing site names pass.
- The rejection message now shows the expected format and says the full URL is not it.
- The regex still pins outbound traffic to `*.chargebee.com`: a value with a scheme, dot, or path is still rejected.

## How did you test this code?

- Added `TestChargebeeSiteNameValidation`: it locks in that digit names (`acme2024`, `shop24`) pass validation, and that a URL or a value with a path returns the actionable message without making a network call. This catches a re-tightening of the regex to letters-only, the exact regression this PR fixes.
- Ran the Chargebee test file locally.
- Not run: database-backed suites (out of scope for this change).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The wizard field caption and docs already describe the site name as a subdomain.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). I could not verify a GitHub handle for the driver this session, so the PR is left unassigned; the owning team can assign the DRI.

This came out of a triage of data-warehouse source-creation failures. I (actually Claude, via Claude Code) checked where the "Chargebee site name is incorrect" string is raised, found the letters-only regex, and confirmed against Chargebee's docs that a site name is a DNS subdomain (digits allowed). The fix mirrors the existing subdomain-normalization pattern used by the Shopify source.

Skills invoked: `/writing-user-facing-copy` (error string), `/writing-tests` (test gate), `/writing-pr-descriptions` (this body).

No customer data is included: the changed string is our own hardcoded copy, and the test inputs are invented.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
