### PR TITLE
feat(replay-vision): scope negative-filter exclusion to backfill candidates

### DIFF
--- a/products/replay_vision/backend/queries/excluded_sessions.py
+++ b/products/replay_vision/backend/queries/excluded_sessions.py
@@ -21,26 +21,20 @@ membership, group and person properties) resolve at query time exactly as they d
 """
 
 import time
-from typing import Protocol
 
 from opentelemetry import trace
 
-from posthog.hogql import ast
-
 from posthog.models import Team
 
-from products.replay_vision.backend.queries.scanner_candidate_query import CandidateSession, execute_candidate_query
+from products.replay_vision.backend.queries.scanner_candidate_query import (
+    BackfillCandidateQuery,
+    CandidateSession,
+    ScannerCandidateQuery,
+    execute_candidate_query,
+)
 
-
-class CandidateQuery(Protocol):
-    """A query that can say which of a set of sessions its negative filters exclude.
-
-    Both the sweep and the backfill fetch candidates with the in-query blocklists off, so both owe
-    the caller this. Taking the protocol rather than either class keeps the two on one code path.
-    """
-
-    def excluded_sessions_queries(self, session_ids: list[str]) -> list[ast.SelectQuery]: ...
-
+# Both fetch candidates with the in-query blocklists off, so both owe the caller this question.
+CandidateQuery = ScannerCandidateQuery | BackfillCandidateQuery
 
 tracer = trace.get_tracer(__name__)
 

--- a/products/replay_vision/backend/queries/excluded_sessions.py
+++ b/products/replay_vision/backend/queries/excluded_sessions.py
@@ -21,16 +21,26 @@ membership, group and person properties) resolve at query time exactly as they d
 """
 
 import time
+from typing import Protocol
 
 from opentelemetry import trace
 
+from posthog.hogql import ast
+
 from posthog.models import Team
 
-from products.replay_vision.backend.queries.scanner_candidate_query import (
-    CandidateSession,
-    ScannerCandidateQuery,
-    execute_candidate_query,
-)
+from products.replay_vision.backend.queries.scanner_candidate_query import CandidateSession, execute_candidate_query
+
+
+class CandidateQuery(Protocol):
+    """A query that can say which of a set of sessions its negative filters exclude.
+
+    Both the sweep and the backfill fetch candidates with the in-query blocklists off, so both owe
+    the caller this. Taking the protocol rather than either class keeps the two on one code path.
+    """
+
+    def excluded_sessions_queries(self, session_ids: list[str]) -> list[ast.SelectQuery]: ...
+
 
 tracer = trace.get_tracer(__name__)
 
@@ -50,7 +60,7 @@ _MAX_IDS_PER_QUERY = 1_000
 def excluded_session_ids(
     *,
     team: Team,
-    candidate_query: ScannerCandidateQuery,
+    candidate_query: CandidateQuery,
     candidates: list[CandidateSession],
     scanner_id: str | None = None,
     seconds_remaining: float | None = None,

--- a/products/replay_vision/backend/queries/scanner_candidate_query.py
+++ b/products/replay_vision/backend/queries/scanner_candidate_query.py
@@ -201,11 +201,7 @@ class ScannerCandidateQuery:
 
     @tracer.start_as_current_span("ScannerCandidateQuery.run")
     def excluded_sessions_queries(self, session_ids: list[str]) -> list[ast.SelectQuery]:
-        """Which of `session_ids` this scanner's negative filters exclude, as queries to run.
-
-        Delegates so the exclusion inherits the window and preprocessed filters this query fetched
-        with. Empty when nothing is excluded.
-        """
+        """Delegates, so the exclusion inherits the window and filters this query fetched with."""
         return self._inner.excluded_sessions_queries(session_ids)
 
     def run(self) -> list[CandidateSession]:
@@ -378,11 +374,7 @@ class BackfillCandidateQuery:
         )
 
     def excluded_sessions_queries(self, session_ids: list[str]) -> list[ast.SelectQuery]:
-        """Which of `session_ids` this scanner's negative filters exclude, as queries to run.
-
-        Delegates so the exclusion inherits the window and preprocessed filters this query fetched
-        with. Empty when nothing is excluded.
-        """
+        """Delegates, so the exclusion inherits the window and filters this query fetched with."""
         return self._inner.excluded_sessions_queries(session_ids)
 
     @tracer.start_as_current_span("BackfillCandidateQuery.run")

--- a/products/replay_vision/backend/queries/scanner_candidate_query.py
+++ b/products/replay_vision/backend/queries/scanner_candidate_query.py
@@ -326,6 +326,9 @@ class BackfillCandidateQuery:
         # the caller rather than from the `$recording_observed` event, so it can carry observations in
         # any state and cannot be influenced by ingested events.
         exclude_session_ids: list[str] | None = None,
+        # Only for callers that drop negative-filter matches from the rows they fetched. The quote
+        # path counts rather than dispatching, so it keeps the in-query blocklist and stays exact.
+        skip_negative_blocklists: bool = False,
         candidate_limit: int = DEFAULT_CANDIDATE_LIMIT,
         max_execution_time_seconds: int = DEFAULT_MAX_EXECUTION_SECONDS,
         scanner_id: str | None = None,
@@ -371,7 +374,16 @@ class BackfillCandidateQuery:
             query=inner_query,
             extra_having_predicates=extra_having,
             session_ids_to_exclude=exclude_session_ids,
+            skip_negative_blocklists=skip_negative_blocklists,
         )
+
+    def excluded_sessions_queries(self, session_ids: list[str]) -> list[ast.SelectQuery]:
+        """Which of `session_ids` this scanner's negative filters exclude, as queries to run.
+
+        Delegates so the exclusion inherits the window and preprocessed filters this query fetched
+        with. Empty when nothing is excluded.
+        """
+        return self._inner.excluded_sessions_queries(session_ids)
 
     @tracer.start_as_current_span("BackfillCandidateQuery.run")
     def run(self) -> list[CandidateSession]:

--- a/products/replay_vision/backend/temporal/activities/backfill.py
+++ b/products/replay_vision/backend/temporal/activities/backfill.py
@@ -24,6 +24,7 @@ from products.replay_vision.backend.models.replay_scanner_backfill import (
     BackfillStatus,
     ReplayScannerBackfill,
 )
+from products.replay_vision.backend.queries import excluded_sessions
 from products.replay_vision.backend.queries.scanner_candidate_query import BackfillCandidateQuery
 from products.replay_vision.backend.quota import compute_scanner_budget, quota_state
 from products.replay_vision.backend.temporal.activities.count_in_flight_applies import (
@@ -154,7 +155,7 @@ def find_backfill_candidates_activity(inputs: FindBackfillCandidatesInputs) -> F
             f"ReplayScannerBackfill {inputs.backfill_id} has malformed frozen query: {exc}", non_retryable=True
         ) from exc
 
-    candidates = BackfillCandidateQuery(
+    candidate_query = BackfillCandidateQuery(
         team=backfill.team,
         query=query,
         window_start=backfill.window_start,
@@ -167,7 +168,16 @@ def find_backfill_candidates_activity(inputs: FindBackfillCandidatesInputs) -> F
         cursor_end_time=backfill.cursor_end_time,
         cursor_session_id=backfill.cursor_session_id or None,
         candidate_limit=inputs.candidate_limit,
-    ).run()
+        skip_negative_blocklists=True,
+    )
+    candidates = candidate_query.run()
+    # Not wrapped: the in-query blocklists are off, so a swallowed failure would dispatch unfiltered.
+    excluded = excluded_sessions.excluded_session_ids(
+        team=backfill.team,
+        candidate_query=candidate_query,
+        candidates=candidates,
+        scanner_id=str(backfill.scanner_id),
+    )
 
     # Succeeded only, matching the `$recording_observed` event the creation-time count excludes on.
     # Postgres rather than that count's fail-soft ClickHouse read, whose hiccup would report every session
@@ -180,7 +190,7 @@ def find_backfill_candidates_activity(inputs: FindBackfillCandidatesInputs) -> F
             session_id__in=[c.session_id for c in candidates],
         ).values_list("session_id", "completed_at")
     )
-    dispatchable = [c for c in candidates if c.session_id not in succeeded_at]
+    dispatchable = [c for c in candidates if c.session_id not in succeeded_at and c.session_id not in excluded]
     # Only sessions the live sweep reached after this backfill was quoted were in its total, so only those
     # count as work done; earlier successes were already excluded at creation.
     overtaken = {

--- a/products/replay_vision/backend/temporal/activities/backfill.py
+++ b/products/replay_vision/backend/temporal/activities/backfill.py
@@ -1,5 +1,6 @@
 """Activities for the per-backfill tick workflow: gatekeeping, candidate walk, cursor advance, schedule ops."""
 
+import time
 import asyncio
 from uuid import UUID
 
@@ -44,6 +45,7 @@ from products.replay_vision.backend.temporal.backfill_types import (
 from products.replay_vision.backend.temporal.constants import (
     BACKFILL_SCHEDULE_ID_PREFIX,
     BACKFILL_SCHEDULE_TYPE,
+    FIND_BACKFILL_CANDIDATES_TIMEOUT,
     backfill_dispatch_budget,
     build_apply_scanner_workflow_id,
 )
@@ -170,14 +172,8 @@ def find_backfill_candidates_activity(inputs: FindBackfillCandidatesInputs) -> F
         candidate_limit=inputs.candidate_limit,
         skip_negative_blocklists=True,
     )
+    started_at = time.monotonic()
     candidates = candidate_query.run()
-    # Not wrapped: the in-query blocklists are off, so a swallowed failure would dispatch unfiltered.
-    excluded = excluded_sessions.excluded_session_ids(
-        team=backfill.team,
-        candidate_query=candidate_query,
-        candidates=candidates,
-        scanner_id=str(backfill.scanner_id),
-    )
 
     # Succeeded only, matching the `$recording_observed` event the creation-time count excludes on.
     # Postgres rather than that count's fail-soft ClickHouse read, whose hiccup would report every session
@@ -190,7 +186,16 @@ def find_backfill_candidates_activity(inputs: FindBackfillCandidatesInputs) -> F
             session_id__in=[c.session_id for c in candidates],
         ).values_list("session_id", "completed_at")
     )
-    dispatchable = [c for c in candidates if c.session_id not in succeeded_at and c.session_id not in excluded]
+    unobserved = [c for c in candidates if c.session_id not in succeeded_at]
+    # After the Postgres filter, so the scan covers only ids that could still be dispatched.
+    excluded = excluded_sessions.excluded_session_ids(
+        team=backfill.team,
+        candidate_query=candidate_query,
+        candidates=unobserved,
+        scanner_id=str(backfill.scanner_id),
+        seconds_remaining=FIND_BACKFILL_CANDIDATES_TIMEOUT.total_seconds() - (time.monotonic() - started_at),
+    )
+    dispatchable = [c for c in unobserved if c.session_id not in excluded]
     # Only sessions the live sweep reached after this backfill was quoted were in its total, so only those
     # count as work done; earlier successes were already excluded at creation.
     overtaken = {

--- a/products/replay_vision/backend/temporal/activities/find_scanner_candidates.py
+++ b/products/replay_vision/backend/temporal/activities/find_scanner_candidates.py
@@ -189,9 +189,17 @@ def _deep_sweep(
         candidate_limit=limit,
         max_execution_time_seconds=DEEP_SWEEP_MAX_EXECUTION_SECONDS,
         scanner_id=str(scanner.id),
+        skip_negative_blocklists=True,
     )
-    deep_candidates = deep_query.run()
-    if len(deep_candidates) == limit and len(observed_session_ids) < _DEEP_SWEEP_MAX_EXCLUSIONS:
+    fetched = deep_query.run()
+    # Not wrapped: the in-query blocklists are off, so a swallowed failure would dispatch unfiltered.
+    excluded = excluded_sessions.excluded_session_ids(
+        team=scanner.team, candidate_query=deep_query, candidates=fetched, scanner_id=str(scanner.id)
+    )
+    deep_candidates = [c for c in fetched if c.session_id not in excluded]
+    # Truncation is a property of what the window returned, not of what survived exclusion; measuring
+    # it after would advance the watermark past rows the headroom never covered.
+    if len(fetched) == limit and len(observed_session_ids) < _DEEP_SWEEP_MAX_EXCLUSIONS:
         # Truncated by the dispatch headroom rather than by the window running out, so hold the
         # watermark and cover the rest next time. The walk is newest-first, so advancing here would
         # drop the oldest stragglers, which are exactly the ones this pass exists to catch. Re-running

--- a/products/replay_vision/backend/temporal/activities/find_scanner_candidates.py
+++ b/products/replay_vision/backend/temporal/activities/find_scanner_candidates.py
@@ -189,17 +189,13 @@ def _deep_sweep(
         candidate_limit=limit,
         max_execution_time_seconds=DEEP_SWEEP_MAX_EXECUTION_SECONDS,
         scanner_id=str(scanner.id),
-        skip_negative_blocklists=True,
     )
-    fetched = deep_query.run()
-    # Not wrapped: the in-query blocklists are off, so a swallowed failure would dispatch unfiltered.
-    excluded = excluded_sessions.excluded_session_ids(
-        team=scanner.team, candidate_query=deep_query, candidates=fetched, scanner_id=str(scanner.id)
-    )
-    deep_candidates = [c for c in fetched if c.session_id not in excluded]
-    # Truncation is a property of what the window returned, not of what survived exclusion; measuring
-    # it after would advance the watermark past rows the headroom never covered.
-    if len(fetched) == limit and len(observed_session_ids) < _DEEP_SWEEP_MAX_EXCLUSIONS:
+    # Deliberately still on the in-query blocklist. This pass holds its watermark when a batch
+    # saturates, which assumes a full batch spent the headroom; scoped exclusion breaks that, since a
+    # fully excluded batch dispatches nothing and the same rows return forever. It has no keyset to
+    # resume from, so it cannot advance instead.
+    deep_candidates = deep_query.run()
+    if len(deep_candidates) == limit and len(observed_session_ids) < _DEEP_SWEEP_MAX_EXCLUSIONS:
         # Truncated by the dispatch headroom rather than by the window running out, so hold the
         # watermark and cover the rest next time. The walk is newest-first, so advancing here would
         # drop the oldest stragglers, which are exactly the ones this pass exists to catch. Re-running

--- a/products/replay_vision/backend/tests/test_backfills.py
+++ b/products/replay_vision/backend/tests/test_backfills.py
@@ -30,6 +30,8 @@ from products.replay_vision.backend.models.replay_scanner import (
     ScannerType,
 )
 from products.replay_vision.backend.models.replay_scanner_backfill import BackfillStatus, ReplayScannerBackfill
+from products.replay_vision.backend.queries import excluded_sessions
+from products.replay_vision.backend.queries.scanner_candidate_query import CandidateSession
 from products.replay_vision.backend.quota import QuotaState, compute_quota_snapshot, spend_projection
 from products.replay_vision.backend.temporal.activities.backfill import (
     advance_backfill_cursor_activity,
@@ -493,6 +495,45 @@ class TestBackfillTickActivities:
         assert not result.more_work_below_cursor
         assert result.next_cursor_end_time is None
         assert result.skipped_delta == 0
+
+    def test_excluded_sessions_are_walked_over_not_dispatched(self) -> None:
+        # The cursor must pass an excluded session exactly as it passes an already-succeeded one.
+        # Filtering before the walk would leave the cursor short and refetch the same rows forever.
+        scanner = _make_scanner()
+        backfill = _make_backfill(scanner)
+        fetched = [
+            CandidateSession(session_id="keep", session_end=timezone.now() - dt.timedelta(hours=2)),
+            CandidateSession(session_id="blocked", session_end=timezone.now() - dt.timedelta(hours=1)),
+        ]
+        with (
+            patch("products.replay_vision.backend.temporal.activities.backfill.BackfillCandidateQuery") as query_cls,
+            patch.object(excluded_sessions, "excluded_session_ids", return_value={"blocked"}),
+        ):
+            query_cls.return_value.run.return_value = fetched
+            result = find_backfill_candidates_activity(
+                FindBackfillCandidatesInputs(backfill_id=backfill.id, team_id=backfill.team_id, candidate_limit=50)
+            )
+
+        assert query_cls.call_args.kwargs["skip_negative_blocklists"] is True
+        assert [c.session_id for c in result.candidates] == ["keep"]
+        # walked past the excluded row, not stopped at the survivor
+        assert result.next_cursor_session_id == "blocked"
+
+    def test_exclusion_failure_fails_the_tick_rather_than_dispatching(self) -> None:
+        # In-query blocklists are off by this point, so swallowing would dispatch unfiltered.
+        scanner = _make_scanner()
+        backfill = _make_backfill(scanner)
+        with (
+            patch("products.replay_vision.backend.temporal.activities.backfill.BackfillCandidateQuery") as query_cls,
+            patch.object(excluded_sessions, "excluded_session_ids", side_effect=RuntimeError("clickhouse down")),
+        ):
+            query_cls.return_value.run.return_value = [
+                CandidateSession(session_id="s1", session_end=timezone.now() - dt.timedelta(hours=1))
+            ]
+            with pytest.raises(RuntimeError):
+                find_backfill_candidates_activity(
+                    FindBackfillCandidatesInputs(backfill_id=backfill.id, team_id=backfill.team_id, candidate_limit=50)
+                )
 
     def test_advance_loses_to_concurrent_cancel(self) -> None:
         scanner = _make_scanner()

--- a/products/replay_vision/backend/tests/test_sweep.py
+++ b/products/replay_vision/backend/tests/test_sweep.py
@@ -447,66 +447,6 @@ class TestFindScannerCandidatesActivity:
         "properties": [{"key": "$host", "value": ["internal.example.com"], "operator": "is_not", "type": "event"}],
     }
 
-    def test_deep_pass_excludes_negative_filter_matches(self) -> None:
-        # The deep pass re-walks a full-width window, so it is the larger of the two exclusion paths.
-        scanner = _make_scanner(
-            query=self._NEGATIVE_QUERY, last_deep_swept_at=dt.datetime.now(dt.UTC) - dt.timedelta(hours=7)
-        )
-        fetched = [
-            CandidateSession(session_id="deep-keep", session_end=dt.datetime(2026, 5, 1, 6, 0, tzinfo=dt.UTC)),
-            CandidateSession(session_id="deep-blocked", session_end=dt.datetime(2026, 5, 1, 7, 0, tzinfo=dt.UTC)),
-        ]
-        with (
-            patch(
-                "products.replay_vision.backend.temporal.activities.find_scanner_candidates.ScannerCandidateQuery"
-            ) as MockQuery,
-            patch(
-                "products.replay_vision.backend.temporal.activities.find_scanner_candidates.BackfillCandidateQuery"
-            ) as MockDeep,
-            patch.object(excluded_sessions, "excluded_session_ids", side_effect=[set(), {"deep-blocked"}]),
-        ):
-            MockQuery.return_value.run.return_value = []
-            MockDeep.return_value.run.return_value = fetched
-            result = find_scanner_candidates_activity(
-                FindScannerCandidatesInputs(scanner_id=scanner.id, team_id=scanner.team_id)
-            )
-
-        assert MockDeep.call_args.kwargs["skip_negative_blocklists"] is True
-        assert [c.session_id for c in result.deep_candidates] == ["deep-keep"]
-
-    def test_deep_truncation_is_measured_before_exclusion(self) -> None:
-        # A saturated batch that mostly gets excluded still means the window had more rows. Measuring
-        # after exclusion would advance the deep watermark past stragglers the headroom never covered.
-        scanner = _make_scanner(
-            query=self._NEGATIVE_QUERY, last_deep_swept_at=dt.datetime.now(dt.UTC) - dt.timedelta(hours=7)
-        )
-        fetched = [
-            CandidateSession(session_id=f"s{i}", session_end=dt.datetime(2026, 5, 1, 6, 0, tzinfo=dt.UTC))
-            for i in range(DEFAULT_CANDIDATE_LIMIT)
-        ]
-        with (
-            patch(
-                "products.replay_vision.backend.temporal.activities.find_scanner_candidates.ScannerCandidateQuery"
-            ) as MockQuery,
-            patch(
-                "products.replay_vision.backend.temporal.activities.find_scanner_candidates.BackfillCandidateQuery"
-            ) as MockDeep,
-            patch.object(
-                excluded_sessions,
-                "excluded_session_ids",
-                side_effect=[set(), {f"s{i}" for i in range(1, len(fetched))}],
-            ),
-        ):
-            MockQuery.return_value.run.return_value = []
-            MockDeep.return_value.run.return_value = fetched
-            result = find_scanner_candidates_activity(
-                FindScannerCandidatesInputs(scanner_id=scanner.id, team_id=scanner.team_id)
-            )
-
-        # one survivor, but the window was saturated, so the watermark must be held
-        assert len(result.deep_candidates) == 1
-        assert result.deep_swept_through is None
-
     def test_fully_excluded_batch_still_advances_the_keyset(self) -> None:
         # Falling back to the last surviving candidate would leave the keyset where it was and refetch
         # the same excluded rows forever.

--- a/products/replay_vision/backend/tests/test_sweep.py
+++ b/products/replay_vision/backend/tests/test_sweep.py
@@ -447,6 +447,66 @@ class TestFindScannerCandidatesActivity:
         "properties": [{"key": "$host", "value": ["internal.example.com"], "operator": "is_not", "type": "event"}],
     }
 
+    def test_deep_pass_excludes_negative_filter_matches(self) -> None:
+        # The deep pass re-walks a full-width window, so it is the larger of the two exclusion paths.
+        scanner = _make_scanner(
+            query=self._NEGATIVE_QUERY, last_deep_swept_at=dt.datetime.now(dt.UTC) - dt.timedelta(hours=7)
+        )
+        fetched = [
+            CandidateSession(session_id="deep-keep", session_end=dt.datetime(2026, 5, 1, 6, 0, tzinfo=dt.UTC)),
+            CandidateSession(session_id="deep-blocked", session_end=dt.datetime(2026, 5, 1, 7, 0, tzinfo=dt.UTC)),
+        ]
+        with (
+            patch(
+                "products.replay_vision.backend.temporal.activities.find_scanner_candidates.ScannerCandidateQuery"
+            ) as MockQuery,
+            patch(
+                "products.replay_vision.backend.temporal.activities.find_scanner_candidates.BackfillCandidateQuery"
+            ) as MockDeep,
+            patch.object(excluded_sessions, "excluded_session_ids", side_effect=[set(), {"deep-blocked"}]),
+        ):
+            MockQuery.return_value.run.return_value = []
+            MockDeep.return_value.run.return_value = fetched
+            result = find_scanner_candidates_activity(
+                FindScannerCandidatesInputs(scanner_id=scanner.id, team_id=scanner.team_id)
+            )
+
+        assert MockDeep.call_args.kwargs["skip_negative_blocklists"] is True
+        assert [c.session_id for c in result.deep_candidates] == ["deep-keep"]
+
+    def test_deep_truncation_is_measured_before_exclusion(self) -> None:
+        # A saturated batch that mostly gets excluded still means the window had more rows. Measuring
+        # after exclusion would advance the deep watermark past stragglers the headroom never covered.
+        scanner = _make_scanner(
+            query=self._NEGATIVE_QUERY, last_deep_swept_at=dt.datetime.now(dt.UTC) - dt.timedelta(hours=7)
+        )
+        fetched = [
+            CandidateSession(session_id=f"s{i}", session_end=dt.datetime(2026, 5, 1, 6, 0, tzinfo=dt.UTC))
+            for i in range(DEFAULT_CANDIDATE_LIMIT)
+        ]
+        with (
+            patch(
+                "products.replay_vision.backend.temporal.activities.find_scanner_candidates.ScannerCandidateQuery"
+            ) as MockQuery,
+            patch(
+                "products.replay_vision.backend.temporal.activities.find_scanner_candidates.BackfillCandidateQuery"
+            ) as MockDeep,
+            patch.object(
+                excluded_sessions,
+                "excluded_session_ids",
+                side_effect=[set(), {f"s{i}" for i in range(1, len(fetched))}],
+            ),
+        ):
+            MockQuery.return_value.run.return_value = []
+            MockDeep.return_value.run.return_value = fetched
+            result = find_scanner_candidates_activity(
+                FindScannerCandidatesInputs(scanner_id=scanner.id, team_id=scanner.team_id)
+            )
+
+        # one survivor, but the window was saturated, so the watermark must be held
+        assert len(result.deep_candidates) == 1
+        assert result.deep_swept_through is None
+
     def test_fully_excluded_batch_still_advances_the_keyset(self) -> None:
         # Falling back to the last surviving candidate would leave the keyset where it was and refetch
         # the same excluded rows forever.


### PR DESCRIPTION
## Problem

The live sweep no longer builds a full negative-filter blocklist per tick; it asks about the candidates it just fetched instead. The backfill tick still does it the old way, re-deriving every blocked session across its window on each tick.

## Changes

Same treatment: fetch candidates with the in-query blocklists off, then ask one query scoped to the ids just fetched and drop the matches.

- `BackfillCandidateQuery` gains `skip_negative_blocklists` and the `excluded_sessions_queries` delegation, so the exclusion inherits the window and preprocessed filters the fetch used rather than rebuilding them.
- **Opt-in, not default.** The quote path calls `count()` rather than dispatching, so it keeps the exact in-query blocklist. Skipping it there would inflate the session count a backfill is quoted and priced against.
- An excluded session is treated exactly like an already-succeeded one: not dispatched, but walked over by the cursor. Filtering before the walk would leave the cursor short and refetch the same rows forever.
- The exclusion runs after the cheap Postgres check for already-succeeded sessions, so the scan covers only ids that could still be dispatched.
- It is budgeted against the activity's remaining time. Overrunning would kill the attempt after the candidates were found, so the tick would retry from the same cursor without ever dispatching.

> [!NOTE]
> The deep sweep is deliberately **not** included, though it is where most of the cost sits. It holds its watermark when a batch saturates, which assumes a full batch spent the dispatch headroom. Scoped exclusion breaks that assumption: a fully excluded batch dispatches nothing, so the same rows return every tick and the watermark never advances, turning a 6-hourly full-width query into a per-tick one. It has no keyset to resume from, so it cannot safely advance either. Fixing it needs either a keyset for that pass or persisted exclusions, and both are larger than this change.

## How did you test this code?

Automated tests only. I did not exercise this against a running dev stack.

- The cursor walks past an excluded session rather than stopping at the last survivor, and `skip_negative_blocklists` is passed.
- An exclusion failure fails the tick rather than dispatching, since the in-query blocklist is off by then.
- Existing backfill, sweep, exclusion and candidate-query suites pass unchanged (123 tests).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Skills invoked: /shepherd-pr, /simplify, /code-review, /writing-tests, /writing-pr-descriptions.

Follows #82551, which did this for the live sweep and is deployed and verified: queries carrying the blocklist fell from 105,586 a day to 2,027, daily read went from 111.4 TB to 69.9 TB, and a sample of post-deploy observations from negative-filter scanners found none that the old blocklist would have excluded.

Review of this branch found the deep-sweep livelock described above, which the first version of this PR shipped, along with a test that asserted the stalling behaviour as correct. Both are removed. It also found the exclusion running before the cheaper Postgres filter, and the missing time budget.
