### PR TITLE
fix(data-warehouse): treat a raced S3 NoSuchKey as transient during repartition

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
@@ -85,6 +85,11 @@ _TRANSIENT_ERROR_SNIPPETS = (
     "reduce your request rate",  # S3 503 SlowDown surfaced by the delta kernel as OSError
     "error occurred while loading credentials",  # IMDS/credential-provider timeout inside the kernel
     "event loop is closed",  # s3fs client bound to an already-completed async_to_sync loop
+    # S3 NoSuchKey from an s3fs purge/swap op (`_copy`/`_rm`/`_find`) that raced a concurrent delete —
+    # a temp file swept by another attempt, not a bug. A hollow *live* table surfaces the missing file
+    # with its path embedded and is routed to a revive inside `repartition_table_in_place` before it
+    # ever reaches here, so this bare, pathless variant only ever means a raced object-store operation.
+    "the specified key does not exist",
 )
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
@@ -298,6 +298,44 @@ class TestBudgetExhaustion:
         assert "warehouse_repartition_skipped" in emitted
 
 
+class TestTransientObjectStoreFailure:
+    @patch(f"{MODULE}.capture_exception")
+    @patch(f"{MODULE}.capture_repartition_event")
+    @patch(f"{MODULE}.HeartbeaterSync")
+    @patch(f"{MODULE}.repartition_table_in_place", new_callable=AsyncMock)
+    @patch(f"{MODULE}.DeltaTableRef")
+    @patch(f"{MODULE}.is_auto_repartition_enabled", return_value=True)
+    @patch(f"{MODULE}.ExternalDataJob")
+    @patch(f"{MODULE}.ExternalDataSchema")
+    def test_bare_nosuchkey_stands_down_without_burning_an_attempt(
+        self,
+        mock_schema_model: MagicMock,
+        _mock_job_model: MagicMock,
+        _mock_enabled: MagicMock,
+        _mock_helper_cls: MagicMock,
+        mock_repartition: AsyncMock,
+        _mock_heartbeater: MagicMock,
+        mock_capture_event: MagicMock,
+        _mock_capture_exception: MagicMock,
+    ) -> None:
+        # A pathless S3 NoSuchKey from an s3fs purge/swap op that raced a concurrent delete is a
+        # transient object-store blip, not a repartition bug: it must not emit a failure event or
+        # consume one of the table's finite attempts, so the next sync simply retries.
+        schema = _schema(name="public.usages", s3_folder_name="usages", pending={**PENDING_TARGET, "attempts": 0})
+        mock_schema_model.objects.select_related.return_value.get.return_value = schema
+        mock_repartition.side_effect = FileNotFoundError("The specified key does not exist.")
+
+        _maybe_repartition_table(
+            RepartitionActivityInputs(team_id=TEAM_ID, schema_id=SCHEMA_ID, job_id=JOB_ID, source_id=SOURCE_ID),
+            MagicMock(),
+        )
+
+        emitted = [c.args[0] for c in mock_capture_event.call_args_list]
+        assert "warehouse_repartition_failed" not in emitted
+        schema.set_repartition_pending.assert_not_called()
+        schema.clear_repartition_pending.assert_not_called()
+
+
 class TestFeatureFlagGate:
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

- A data-warehouse table can fail its automatic repartition with `FileNotFoundError: The specified key does not exist.` (S3 `NoSuchKey`), which the pipeline records as a `warehouse_repartition_failed`.
- The repartition rewrites a table's Delta files in S3 through s3fs (`_copy`/`_rm`/`_find`). When one of those operations races a concurrent delete — a temp folder swept by another attempt — s3fs raises a bare, pathless NoSuchKey.
- The activity's transient-error classifier did not recognize that wording, so it treated the blip as a real failure: it burned one of the table's finite `MAX_REPARTITION_ATTEMPTS` and captured the exception to error tracking.
- A genuinely hollow live table is a different case and is already handled: its missing file arrives with a path embedded and is routed to a revive inside `repartition_table_in_place`, before this classifier runs.

## Changes

- Added `"the specified key does not exist"` to `_TRANSIENT_ERROR_SNIPPETS` in `repartition_table.py`, so a raced NoSuchKey stands down and retries on the next sync instead of recording a failure.
- The bare, pathless variant only ever means a raced object-store operation, since a hollow live table carries the path and is revived earlier — so this cannot mask a table that needs a revive.
- Added a regression test: a NoSuchKey from the rewrite emits no `warehouse_repartition_failed` and consumes no attempt.

## How did you test this code?

- `test_bare_nosuchkey_stands_down_without_burning_an_attempt` catches the misclassification: it fails on master (the error emits `warehouse_repartition_failed` and increments the attempt counter) and passes with the fix. No existing test exercised the bare-NoSuchKey path in the activity.
- Ran the `test_repartition_table.py` suite locally.
- Not run: the ClickHouse- and database-backed warehouse suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- I (Claude) triaged a repartition failure mode (`FileNotFoundError`, Databricks, proactive threshold) from pipeline telemetry, traced the emit site in `repartition_table.py`, and confirmed the bare NoSuchKey originates from s3fs purge/swap operations rather than the Delta scan that already routes hollow-table errors to a revive.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Related but distinct: [#82460](https://github.com/PostHog/posthog/pull/82460) fixes the same S3 `NoSuchKey` error class in the data-modeling queryable-table copy path; this PR fixes the separate repartition-activity classifier. No overlap in files.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
