### PR TITLE
fix(saml): handle an optional attribute that is present but empty

### DIFF
--- a/ee/api/authentication.py
+++ b/ee/api/authentication.py
@@ -292,7 +292,9 @@ class MultitenantSAMLAuth(SAMLAuth):
             raise AuthMissingParameter(self, attribute_names[0])
 
         if isinstance(output, list):
-            output = output[0]
+            # An optional attribute that is present but carries no usable value
+            # arrives as an empty list, so this cannot index blindly.
+            output = output[0] if output else None
 
         return output or ""
 

--- a/ee/api/test/test_authentication.py
+++ b/ee/api/test/test_authentication.py
@@ -13,7 +13,7 @@ from django.conf import settings
 from django.core import mail
 from django.core.exceptions import ValidationError
 from django.shortcuts import redirect
-from django.test import override_settings
+from django.test import SimpleTestCase, override_settings
 from django.utils import timezone
 
 from parameterized import parameterized
@@ -1477,3 +1477,29 @@ dcKmj4EG6bfcI3KY6wK46JoogXZdHDaFP+WOJNj/pJ165hYsYLcqkJktj/rEgGQmqAXWPOXHmFJb
         # Should be redirected to login with SSO enforcement error
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
         self.assertIn("/login?error_code=google_sso_enforced", response.headers["Location"])
+
+
+class TestMultitenantSAMLAuthAttributes(SimpleTestCase):
+    """Unit tests for SAML attribute extraction."""
+
+    def setUp(self):
+        # __init__ needs a strategy we do not exercise here.
+        self.auth = MultitenantSAMLAuth.__new__(MultitenantSAMLAuth)
+
+    def test_returns_first_value_of_a_list(self):
+        self.assertEqual(self.auth._get_attr({"first_name": ["Ada"]}, ["first_name"]), "Ada")
+
+    def test_optional_attribute_absent(self):
+        self.assertEqual(self.auth._get_attr({}, ["first_name"], optional=True), "")
+
+    def test_optional_attribute_present_but_empty(self):
+        """An IdP can send `<saml:Attribute Name="first_name"/>` with no usable value.
+
+        python3-saml drops empty and whitespace-only AttributeValues but still
+        assigns the resulting empty list, so `{"first_name": []}` reaches us.
+        """
+        self.assertEqual(self.auth._get_attr({"first_name": []}, ["first_name"], optional=True), "")
+
+    def test_required_attribute_present_but_empty_raises(self):
+        with self.assertRaises(AuthMissingParameter):
+            self.auth._get_attr({"email": []}, ["email"])


### PR DESCRIPTION
## Problem

An IdP that sends a SAML attribute which is present but carries no usable value takes down SSO login for the whole organization with a 500.

`_get_attr` skips the missing-parameter guard when `optional` is set, then indexes the value if it is a list:

```python
if not output and not optional:
    raise AuthMissingParameter(self, attribute_names[0])

if isinstance(output, list):
    output = output[0]        # [] -> IndexError
```

An empty list satisfies `not output`, so `optional=True` walks straight past the guard into the index. `fullname`, `first_name` and `last_name` are all read with `optional=True`.

## Why an empty list gets there

`python3-saml` builds the value list by appending only non-empty, stripped `AttributeValue`s, then assigns it regardless (`onelogin/saml2/response.py`, `get_attributes`):

```python
values = []
for attr in attribute_node.iterchildren('...AttributeValue'):
    attr_text = OneLogin_Saml2_XML.element_text(attr)
    if attr_text:
        attr_text = attr_text.strip()
        if attr_text:
            values.append(attr_text)
...
attributes[attr_key] = values
```

So `<saml:Attribute Name="first_name"/>`, or one whose value is empty or whitespace, produces `{"first_name": []}`.

Running the current `_get_attr` directly:

```
absent attribute, optional     -> ''
normal list value              -> 'Ada'
present-but-empty list         -> IndexError: list index out of range
```

`SocialAuthExceptionMiddleware.process_exception` only handles `AuthException` subclasses and returns `None` for anything else, so this is not turned into the usual redirect. It surfaces as a hard 500 on `/complete/saml/` and nobody in the organization can log in.

The existing fixture `saml_login_response_no_first_name` covers the attribute being *absent*, which is why this case has gone unnoticed.

## Fix

Take the first value only when there is one. `return output or ""` already turns the result into `""`, matching what an absent optional attribute returns today.

A required attribute that is present but empty is unchanged: `not output and not optional` still raises `AuthMissingParameter`.

## Tests

Four cases covering list extraction, an absent optional attribute, an optional attribute present but empty, and a required attribute present but empty. Reverting only the source change fails the third with the `IndexError` above.

I ran these locally (they need no database). I could not run the SAML integration tests in this checkout since they need the full service stack, though the change is limited to the empty case: with a non-empty list the behaviour is identical.
