### PR TITLE
fix(vercel): catch the JSONDecodeError requests actually raises

### DIFF
--- a/ee/vercel/client.py
+++ b/ee/vercel/client.py
@@ -1,4 +1,3 @@
-import json
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlencode
@@ -85,7 +84,7 @@ class VercelAPIClient:
     def _parse_json_response(self, response: requests.Response) -> dict[str, Any]:
         try:
             return response.json()
-        except json.JSONDecodeError as e:
+        except requests.exceptions.JSONDecodeError as e:
             logger.exception("Failed to parse JSON response", integration="vercel")
             raise APIError("Invalid JSON response", detail=str(e))
 

--- a/ee/vercel/test/test_vercel_client.py
+++ b/ee/vercel/test/test_vercel_client.py
@@ -1,4 +1,3 @@
-import json
 
 import pytest
 from unittest.mock import MagicMock, patch
@@ -30,7 +29,9 @@ class TestVercelAPIClient:
         def json_error():
             mock_response = MagicMock()
             mock_response.status_code = 200
-            mock_response.json.side_effect = json.JSONDecodeError("Invalid JSON", "", 0)
+            # requests raises its own JSONDecodeError, which does not derive from
+            # the stdlib one when simplejson is installed.
+            mock_response.json.side_effect = requests.exceptions.JSONDecodeError("Invalid JSON", "", 0)
             return mock_response
 
     @pytest.fixture


### PR DESCRIPTION
## Problem

`_parse_json_response` cannot catch what it is meant to catch:

```python
try:
    return response.json()
except json.JSONDecodeError as e:
    ...
    raise APIError("Invalid JSON response", detail=str(e))
```

`requests.Response.json()` raises `requests.exceptions.JSONDecodeError`. That class picks its base from whichever JSON library requests is using, and with `simplejson` installed it derives from simplejson's error rather than the standard library one. `simplejson` is in `uv.lock` (pulled in via `dlt`), so in this environment:

```
issubclass(requests.exceptions.JSONDecodeError, json.JSONDecodeError) = False
issubclass(requests.exceptions.JSONDecodeError, ValueError)           = True
```

So the clause never matches and the exception propagates instead of becoming an `APIError`. A non-JSON body is exactly the failure it was written for: an HTML 502/504 from an edge, or a plain-text gateway error. `vercel_connect` has no handler of its own, so this surfaces as a 500 rather than the intended error.

## Why it was invisible

The test raised the standard library class:

```python
mock_response.json.side_effect = json.JSONDecodeError("Invalid JSON", "", 0)
```

Nothing on this path produces that, so the handler looked reachable and the suite stayed green.

## Change

Catch `requests.exceptions.JSONDecodeError`, which is what `response.json()` raises in every case — it is the same class whether or not simplejson is present, so this does not depend on which JSON library is installed.

The test now raises what requests raises. `json` was imported solely for the old clause in both files, so it goes.

## Verification

- With the fix: `ee/vercel/test/test_vercel_client.py` — 26 passed.
- Reverting only `client.py` and keeping the corrected test: `test_sso_token_exchange_errors[error_setup2]` fails with `requests.exceptions.JSONDecodeError: Invalid JSON: line 1 column 1 (char 0)` escaping instead of `APIError`.
- `ruff check` clean on both files.
