### PR TITLE
fix(warehouse-sources): surface unclassified CDC extraction failures to triage

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/activities.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/activities.py
@@ -1597,6 +1597,12 @@ class CDCExtractActivity:
         # here, mirroring what update_external_job_status does for non-CDC syncs.
         if terminal and not marked_broken:
             self._schedule_failure_digest()
+        # An unclassified failure stays retryable and never pauses the schedule, so a deterministic
+        # one re-fails every scheduled run indefinitely. Only _capture_non_retryable emits analytics,
+        # so these never reach error triage — capture the terminal case so the taxonomy can be taught
+        # to recognise it (and, where fatal, stop retrying).
+        if terminal and info.category == CDCErrorCategory.UNKNOWN:
+            self._capture_unclassified(exc)
         self._emit_run_duration("failed")
         return info
 
@@ -1624,6 +1630,30 @@ class CDCExtractActivity:
             )
         except Exception:
             self.log.warning("cdc_non_retryable_capture_failed", exc_info=True)
+
+    def _capture_unclassified(self, exc: BaseException) -> None:
+        # Send the exception types in the cause chain — never str(exc), which can embed the customer's
+        # host, database, schema, or table names — so the taxonomy can be extended to catch this.
+        seen: set[int] = set()
+        type_names: list[str] = []
+        current: BaseException | None = exc
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            type_names.append(type(current).__name__)
+            current = current.__cause__ or current.__context__
+        # Best-effort: analytics must never mask the failure the caller is about to re-raise.
+        try:
+            posthoganalytics.capture(
+                distinct_id=get_machine_id(),
+                event="cdc extraction unclassified error",
+                properties={
+                    "team_id": self.inputs.team_id,
+                    "source_id": str(self.inputs.source_id),
+                    "exception_types": type_names,
+                },
+            )
+        except Exception:
+            self.log.warning("cdc_unclassified_capture_failed", exc_info=True)
 
     def _create_failure_visibility_jobs(self, friendly_error: str) -> None:
         """Create one terminal FAILED ExternalDataJob per job-less CDC schema for this run.

--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_extract_activity.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_extract_activity.py
@@ -20,6 +20,7 @@ from products.warehouse_sources.backend.models.external_data_source import Exter
 from products.warehouse_sources.backend.temporal.data_imports.cdc.activities import (
     CDC_BACKPRESSURE_STUCK_AGE,
     CDC_MAX_CHANGES_PER_READ,
+    CDC_MAX_EXTRACTION_ATTEMPTS,
     CDC_ORPHAN_JOB_MIN_AGE,
     CDC_ORPHANED_JOB_MESSAGE,
     SLOT_INVALIDATION_RECOVERY_MESSAGE,
@@ -2426,6 +2427,68 @@ class TestErrorClassification:
 
         assert schema.latest_error == cdc_error_info(CDCErrorCategory.CONNECTION_FAILED).friendly_message
         mock_posthoganalytics.capture.assert_not_called()
+
+    @patch(
+        "products.warehouse_sources.backend.temporal.data_imports.cdc.activities.get_machine_id",
+        return_value="machine-1",
+    )
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.posthoganalytics")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.activity")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.get_cdc_adapter")
+    @patch.object(CDCExtractActivity, "_get_cdc_schemas")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.ExternalDataSource")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.ExternalDataJob")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.close_old_connections")
+    def test_terminal_unclassified_error_is_captured_for_triage(
+        self,
+        mock_close_conns,
+        MockJob,
+        MockSourceModel,
+        mock_get_schemas,
+        mock_get_adapter,
+        mock_activity,
+        mock_posthoganalytics,
+        mock_get_machine_id,
+    ):
+        # An unclassified failure stays retryable and never pauses the schedule, so a deterministic one
+        # re-fails every scheduled run forever. Only the non-retryable path emits analytics, so without
+        # this capture these highest-volume retry loops stay invisible to error triage.
+        source = _make_source()
+        MockSourceModel.objects.get.return_value = source
+        schema = _make_schema("users", cdc_mode="streaming", source=source)
+        mock_get_schemas.return_value = [schema]
+
+        # A non-psycopg error the adapter can't classify falls back to retryable UNKNOWN.
+        mock_reader = MagicMock()
+        mock_reader.read_changes.side_effect = RuntimeError("arrow merge blew up")
+        mock_reader.truncated_tables = []
+        mock_adapter = MagicMock()
+        mock_adapter.create_reader.return_value = mock_reader
+        mock_adapter.is_slot_invalidation_error.return_value = False
+        mock_adapter.classify_error = PostgresCDCAdapter().classify_error
+        mock_get_adapter.return_value = mock_adapter
+
+        mock_activity.heartbeat = MagicMock()
+        # Retries exhausted: the failure is terminal, so the capture fires (unlike a mid-retry attempt).
+        mock_activity.info.return_value = MagicMock(
+            workflow_id="wf-1", workflow_run_id="run-1", attempt=CDC_MAX_EXTRACTION_ATTEMPTS
+        )
+
+        inputs = CDCExtractInput(team_id=1, source_id=source.id)
+        with (
+            patch("products.data_warehouse.backend.facade.tasks.schedule_external_data_failure_digest"),
+            pytest.raises(RuntimeError, match="arrow merge blew up"),
+        ):
+            cdc_extract_activity(inputs)
+
+        assert schema.latest_error == cdc_error_info(CDCErrorCategory.UNKNOWN).friendly_message
+        mock_posthoganalytics.capture.assert_called_once()
+        captured = mock_posthoganalytics.capture.call_args.kwargs
+        assert captured["event"] == "cdc extraction unclassified error"
+        assert captured["properties"]["source_id"] == str(source.id)
+        # The exception type — not str(exc), which could embed customer host/table names — is what a
+        # human needs to teach the taxonomy to recognise this failure.
+        assert "RuntimeError" in captured["properties"]["exception_types"]
 
 
 class TestSlotInvalidationRecovery:


### PR DESCRIPTION
## Problem

- A change-data-capture source hitting a deterministic error we do not recognise re-fails on every scheduled run, indefinitely, and no one is alerted.
- Our error triage only fires on newly created Error Tracking issues. The CDC taxonomy catches an unrecognised failure, rewrites it to a friendly "unexpected error" message, and keeps it retryable — so it never becomes an exception and never reaches triage.
- These invisible retry loops are among the highest-volume CDC sync failures across both regions, yet they leave no signal a human can act on.

## Changes

- `_handle_failure` now captures a `cdc extraction unclassified error` analytics event when an `UNKNOWN`-category failure becomes terminal (retries exhausted for the run).
- The event carries the exception types in the cause chain, not `str(exc)` — the raw message can embed the customer's host, database, schema, or table names.
- Mirrors the existing `_capture_non_retryable` path, which already emits analytics for classified non-retryable failures. Best-effort: a failing capture never masks the error being re-raised.
- No change to retry or schedule behaviour. This makes the failures visible so the taxonomy can be extended to recognise them; it does not itself stop the retries.

> [!NOTE]
> The non-CDC consecutive-failure backoff in #78224 deliberately excludes CDC (slowing extraction risks invalidating the replication slot), and CDC's only breaker (`mark_cdc_broken`) fires solely for known slot/publication categories — never for `UNKNOWN`. Making these failures visible is the safe first lever for CDC.

## How did you test this code?

- Added `test_terminal_unclassified_error_is_captured_for_triage`: a terminal `UNKNOWN` failure emits the capture with the exception type, and re-raises the original error for Temporal to retry. Guards the gap that leaves the highest-volume CDC retry loops invisible; the existing retryable test only covers the mid-retry attempt, where nothing is captured.
- Ran `TestErrorClassification` and the full `test_extract_activity.py` module locally with the mocked harness. The database-backed classes in that file (`TestReconcileOrphanedPriorJobs`, `TestFailureVisibilityCooldown`) were not run — this sandbox has no Postgres.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored by Claude (Claude Code) while triaging a batch of data-warehouse sync failure classes. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/writing-code-comments`.
- Decision: the underlying errors behind these loops are masked by the friendly rewrite and cannot be identified from the stored message alone, so a specific classification could not be added safely. The correct, minimal step is to surface the exception type to triage rather than guess a mapping or change retry semantics.
- No customer data is included in this PR. The failure classes that motivated it were described qualitatively; the test uses an invented error.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
