### PR TITLE
feat(messaging): return 200 for push registration without an integration

### DIFF
--- a/products/messaging/backend/api/push_subscriptions.py
+++ b/products/messaging/backend/api/push_subscriptions.py
@@ -100,8 +100,11 @@ def _rejection_response(
     status_code: int,
     team_id: int | None = None,
     app_id: str | None = None,
+    exc_info: bool = False,
 ) -> HttpResponse:
     PUSH_SUBSCRIPTION_REJECTION_COUNTER.labels(code=code, method=request.method).inc()
+    # exc_info attaches the active exception's traceback for paths that swallow one (capture_failed),
+    # so a 500 is diagnosable from this single labeled event rather than just the counter.
     logger.warning(
         "push_subscription_rejected",
         code=code,
@@ -109,6 +112,7 @@ def _rejection_response(
         method=request.method,
         team_id=team_id,
         app_id=app_id,
+        exc_info=exc_info,
     )
     return cors_response(
         request,
@@ -316,6 +320,7 @@ def push_subscriptions(request: Request):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             team_id=team.id,
             app_id=app_id,
+            exc_info=True,
         )
 
     return cors_response(

--- a/products/messaging/backend/api/push_subscriptions.py
+++ b/products/messaging/backend/api/push_subscriptions.py
@@ -102,7 +102,12 @@ def _rejection_response(
     app_id: str | None = None,
     exc_info: bool = False,
 ) -> HttpResponse:
-    PUSH_SUBSCRIPTION_REJECTION_COUNTER.labels(code=code, method=request.method).inc()
+    # request.method is an arbitrary attacker-controlled token on the method_not_allowed path (any
+    # HTTP verb reaches this view), so bound the counter label to the supported verbs to keep
+    # Prometheus cardinality fixed. The log below keeps the raw method — structured log fields aren't
+    # a time-series cardinality risk and the real verb helps diagnose who is hitting the endpoint.
+    method_label = request.method if request.method in ("POST", "DELETE") else "other"
+    PUSH_SUBSCRIPTION_REJECTION_COUNTER.labels(code=code, method=method_label).inc()
     # exc_info attaches the active exception's traceback for paths that swallow one (capture_failed),
     # so a 500 is diagnosable from this single labeled event rather than just the counter.
     logger.warning(

--- a/products/messaging/backend/api/push_subscriptions.py
+++ b/products/messaging/backend/api/push_subscriptions.py
@@ -4,6 +4,7 @@ from django.db.models import Q
 from django.http import HttpResponse, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 
+import structlog
 from prometheus_client import Counter
 from rest_framework import status
 from rest_framework.request import Request
@@ -32,6 +33,14 @@ PUSH_IDENTITY_VERIFICATION_COUNTER = Counter(
     "Outcome of push subscription identity token verification.",
     labelnames=["mode", "operation", "outcome"],
 )
+
+PUSH_SUBSCRIPTION_REJECTION_COUNTER = Counter(
+    "push_subscription_rejection",
+    "Push subscription requests rejected, by rejection code.",
+    labelnames=["code", "method"],
+)
+
+logger = structlog.get_logger(__name__)
 
 VALID_PLATFORMS = ("android", "ios")
 
@@ -73,33 +82,61 @@ def _strictest_verification_mode(integrations: list[Integration]) -> str:
     )
 
 
+# The error body goes back to the client only, and Django's own request log records just
+# "Bad Request: /api/push_subscriptions/", so without this counter and log line the rejection
+# reason is unrecoverable from production telemetry.
+def _rejection_response(
+    request: Request,
+    message: str,
+    *,
+    error_type: str,
+    code: str,
+    status_code: int,
+    team_id: int | None = None,
+    app_id: str | None = None,
+) -> HttpResponse:
+    PUSH_SUBSCRIPTION_REJECTION_COUNTER.labels(code=code, method=request.method).inc()
+    logger.warning(
+        "push_subscription_rejected",
+        code=code,
+        status_code=status_code,
+        method=request.method,
+        team_id=team_id,
+        app_id=app_id,
+    )
+    return cors_response(
+        request,
+        generate_exception_response(
+            "push_subscriptions",
+            message,
+            type=error_type,
+            code=code,
+            status_code=status_code,
+        ),
+    )
+
+
 @csrf_exempt
 def push_subscriptions(request: Request):
     if request.method == "OPTIONS":
         return cors_response(request, HttpResponse(""))
 
     if request.method not in ("POST", "DELETE"):
-        return cors_response(
+        return _rejection_response(
             request,
-            generate_exception_response(
-                "push_subscriptions",
-                "Only POST and DELETE requests are supported.",
-                type="validation_error",
-                code="method_not_allowed",
-                status_code=status.HTTP_405_METHOD_NOT_ALLOWED,
-            ),
+            "Only POST and DELETE requests are supported.",
+            error_type="validation_error",
+            code="method_not_allowed",
+            status_code=status.HTTP_405_METHOD_NOT_ALLOWED,
         )
 
     if len(request.body) > MAX_BODY_BYTES:
-        return cors_response(
+        return _rejection_response(
             request,
-            generate_exception_response(
-                "push_subscriptions",
-                "Request body too large.",
-                type="validation_error",
-                code="request_too_large",
-                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-            ),
+            "Request body too large.",
+            error_type="validation_error",
+            code="request_too_large",
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
         )
 
     try:
@@ -110,53 +147,41 @@ def push_subscriptions(request: Request):
             # param). DELETE carries the same gzipped JSON body as POST, so decompress it directly.
             data = decompress(request.body, request.headers.get("content-encoding", "").lower())
     except (RequestParsingError, UnspecifiedCompressionFallbackParsingError):
-        return cors_response(
+        return _rejection_response(
             request,
-            generate_exception_response(
-                "push_subscriptions",
-                "Invalid JSON body.",
-                type="validation_error",
-                code="invalid_json",
-                status_code=status.HTTP_400_BAD_REQUEST,
-            ),
+            "Invalid JSON body.",
+            error_type="validation_error",
+            code="invalid_json",
+            status_code=status.HTTP_400_BAD_REQUEST,
         )
 
     if not isinstance(data, dict):
-        return cors_response(
+        return _rejection_response(
             request,
-            generate_exception_response(
-                "push_subscriptions",
-                "Invalid JSON body.",
-                type="validation_error",
-                code="invalid_json",
-                status_code=status.HTTP_400_BAD_REQUEST,
-            ),
+            "Invalid JSON body.",
+            error_type="validation_error",
+            code="invalid_json",
+            status_code=status.HTTP_400_BAD_REQUEST,
         )
 
     api_key = get_token(data, request)
     if not api_key:
-        return cors_response(
+        return _rejection_response(
             request,
-            generate_exception_response(
-                "push_subscriptions",
-                "Project token not provided. You can find your project token in your PostHog project settings.",
-                type="authentication_error",
-                code="missing_api_key",
-                status_code=status.HTTP_401_UNAUTHORIZED,
-            ),
+            "Project token not provided. You can find your project token in your PostHog project settings.",
+            error_type="authentication_error",
+            code="missing_api_key",
+            status_code=status.HTTP_401_UNAUTHORIZED,
         )
 
     team = Team.objects.get_team_from_cache_or_token(api_key)
     if not team:
-        return cors_response(
+        return _rejection_response(
             request,
-            generate_exception_response(
-                "push_subscriptions",
-                "Invalid project token.",
-                type="authentication_error",
-                code="invalid_api_key",
-                status_code=status.HTTP_401_UNAUTHORIZED,
-            ),
+            "Invalid project token.",
+            error_type="authentication_error",
+            code="invalid_api_key",
+            status_code=status.HTTP_401_UNAUTHORIZED,
         )
 
     distinct_id = data.get("distinct_id")
@@ -175,15 +200,13 @@ def push_subscriptions(request: Request):
         if not value or not isinstance(value, str)
     ]
     if missing_fields:
-        return cors_response(
+        return _rejection_response(
             request,
-            generate_exception_response(
-                "push_subscriptions",
-                f"Missing required fields: {', '.join(missing_fields)}.",
-                type="validation_error",
-                code="missing_fields",
-                status_code=status.HTTP_400_BAD_REQUEST,
-            ),
+            f"Missing required fields: {', '.join(missing_fields)}.",
+            error_type="validation_error",
+            code="missing_fields",
+            status_code=status.HTTP_400_BAD_REQUEST,
+            team_id=team.id,
         )
 
     assert isinstance(distinct_id, str)
@@ -192,29 +215,27 @@ def push_subscriptions(request: Request):
     assert isinstance(app_id, str)
 
     if platform not in VALID_PLATFORMS:
-        return cors_response(
+        return _rejection_response(
             request,
-            generate_exception_response(
-                "push_subscriptions",
-                f"Invalid platform. Must be one of: {', '.join(VALID_PLATFORMS)}.",
-                type="validation_error",
-                code="invalid_platform",
-                status_code=status.HTTP_400_BAD_REQUEST,
-            ),
+            f"Invalid platform. Must be one of: {', '.join(VALID_PLATFORMS)}.",
+            error_type="validation_error",
+            code="invalid_platform",
+            status_code=status.HTTP_400_BAD_REQUEST,
+            team_id=team.id,
+            app_id=app_id,
         )
 
     integrations = _find_integrations(team.id, app_id)
     if not integrations:
-        return cors_response(
+        return _rejection_response(
             request,
-            generate_exception_response(
-                "push_subscriptions",
-                f"No push integration found for app_id '{app_id}'. "
-                "Please configure the integration in your PostHog project settings.",
-                type="validation_error",
-                code="integration_not_found",
-                status_code=status.HTTP_400_BAD_REQUEST,
-            ),
+            f"No push integration found for app_id '{app_id}'. "
+            "Please configure the integration in your PostHog project settings.",
+            error_type="validation_error",
+            code="integration_not_found",
+            status_code=status.HTTP_400_BAD_REQUEST,
+            team_id=team.id,
+            app_id=app_id,
         )
 
     operation = "register" if request.method == "POST" else "unregister"
@@ -235,17 +256,16 @@ def push_subscriptions(request: Request):
             outcome="verified" if verified else "unverified",
         ).inc()
         if not verified and verification_mode == "required":
-            return cors_response(
+            return _rejection_response(
                 request,
-                generate_exception_response(
-                    "push_subscriptions",
-                    "A valid identity token is required for this device. Your backend must sign a "
-                    "short-lived token for the signed-in user with the key configured for this "
-                    "channel's identity verification.",
-                    type="authentication_error",
-                    code="identity_verification_failed",
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                ),
+                "A valid identity token is required for this device. Your backend must sign a "
+                "short-lived token for the signed-in user with the key configured for this "
+                "channel's identity verification.",
+                error_type="authentication_error",
+                code="identity_verification_failed",
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                team_id=team.id,
+                app_id=app_id,
             )
 
     property_key = f"$device_push_subscription_{app_id}"
@@ -272,15 +292,14 @@ def push_subscriptions(request: Request):
             process_person_profile=True,
         )
     except Exception:
-        return cors_response(
+        return _rejection_response(
             request,
-            generate_exception_response(
-                "push_subscriptions",
-                failure_message,
-                type="server_error",
-                code="capture_failed",
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            ),
+            failure_message,
+            error_type="server_error",
+            code="capture_failed",
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            team_id=team.id,
+            app_id=app_id,
         )
 
     return cors_response(

--- a/products/messaging/backend/api/push_subscriptions.py
+++ b/products/messaging/backend/api/push_subscriptions.py
@@ -40,6 +40,12 @@ PUSH_SUBSCRIPTION_REJECTION_COUNTER = Counter(
     labelnames=["code", "method"],
 )
 
+PUSH_SUBSCRIPTION_DISCARD_COUNTER = Counter(
+    "push_subscription_discarded",
+    "Push subscription registrations acknowledged without storing, by reason.",
+    labelnames=["reason"],
+)
+
 logger = structlog.get_logger(__name__)
 
 VALID_PLATFORMS = ("android", "ios")
@@ -226,16 +232,26 @@ def push_subscriptions(request: Request):
         )
 
     integrations = _find_integrations(team.id, app_id)
-    if not integrations:
-        return _rejection_response(
+    # A missing integration is an account state, not a request error: SDKs auto-register on every
+    # app open, so for most teams this is the endpoint's normal case, and a 4xx here turns the
+    # whole fleet into an error firehose. Acknowledge registration with a 200 and skip the store,
+    # so unconsumable tokens don't become person properties and capture events; devices re-register
+    # on every app open, so a team that later configures an integration is covered within a day.
+    # DELETE falls through: logout must clear any subscription stored while an integration existed.
+    if not integrations and request.method == "POST":
+        PUSH_SUBSCRIPTION_DISCARD_COUNTER.labels(reason="no_integration").inc()
+        logger.info("push_subscription_discarded", reason="no_integration", team_id=team.id, app_id=app_id)
+        return cors_response(
             request,
-            f"No push integration found for app_id '{app_id}'. "
-            "Please configure the integration in your PostHog project settings.",
-            error_type="validation_error",
-            code="integration_not_found",
-            status_code=status.HTTP_400_BAD_REQUEST,
-            team_id=team.id,
-            app_id=app_id,
+            JsonResponse(
+                {
+                    "distinct_id": distinct_id,
+                    "platform": platform,
+                    "stored": False,
+                    "push_enabled": False,
+                },
+                status=status.HTTP_200_OK,
+            ),
         )
 
     operation = "register" if request.method == "POST" else "unregister"

--- a/products/messaging/backend/api/test/test_push_subscriptions.py
+++ b/products/messaging/backend/api/test/test_push_subscriptions.py
@@ -489,6 +489,15 @@ class TestPushSubscriptionsAPI(BaseTest):
         assert response.json()["code"] == code
         assert counter._value.get() == before + 1
 
+    def test_unsupported_method_collapses_counter_label(self):
+        counter = PUSH_SUBSCRIPTION_REJECTION_COUNTER.labels(code="method_not_allowed", method="other")
+        before = counter._value.get()
+
+        response = self.client.patch("/api/push_subscriptions/", data="{}", content_type="application/json")
+
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+        assert counter._value.get() == before + 1
+
     @patch("products.messaging.backend.api.push_subscriptions.capture_internal")
     def test_optional_mode_stores_even_without_a_token(self, mock_capture: MagicMock):
         mock_capture.return_value = MagicMock(status_code=200)

--- a/products/messaging/backend/api/test/test_push_subscriptions.py
+++ b/products/messaging/backend/api/test/test_push_subscriptions.py
@@ -8,6 +8,7 @@ from django.test import Client
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog.models.integration import Integration
@@ -15,6 +16,7 @@ from posthog.models.team.team import Team
 from posthog.models.team.team_caching import set_team_in_cache
 
 from products.messaging.backend.api.push_identity_tokens import sign_push_identity_token, sign_push_identity_token_es256
+from products.messaging.backend.api.push_subscriptions import PUSH_SUBSCRIPTION_REJECTION_COUNTER
 
 
 def _es256_keypair() -> tuple[str, str]:
@@ -436,6 +438,39 @@ class TestPushSubscriptionsAPI(BaseTest):
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
         mock_capture.assert_not_called()
+
+    @parameterized.expand(
+        [
+            (
+                "integration_not_found",
+                status.HTTP_400_BAD_REQUEST,
+                {
+                    "distinct_id": "user-1",
+                    "device_token": "fcm-device-token-abc",
+                    "platform": "android",
+                    "app_id": "app-with-no-integration",
+                },
+            ),
+            (
+                "missing_fields",
+                status.HTTP_400_BAD_REQUEST,
+                {
+                    "distinct_id": "user-1",
+                    "platform": "android",
+                    "app_id": "my-firebase-project",
+                },
+            ),
+        ]
+    )
+    def test_rejection_increments_counter_with_code(self, code: str, status_code: int, payload: dict):
+        counter = PUSH_SUBSCRIPTION_REJECTION_COUNTER.labels(code=code, method="POST")
+        before = counter._value.get()
+
+        response = self._post(payload)
+
+        assert response.status_code == status_code
+        assert response.json()["code"] == code
+        assert counter._value.get() == before + 1
 
     @patch("products.messaging.backend.api.push_subscriptions.capture_internal")
     def test_optional_mode_stores_even_without_a_token(self, mock_capture: MagicMock):

--- a/products/messaging/backend/api/test/test_push_subscriptions.py
+++ b/products/messaging/backend/api/test/test_push_subscriptions.py
@@ -16,7 +16,10 @@ from posthog.models.team.team import Team
 from posthog.models.team.team_caching import set_team_in_cache
 
 from products.messaging.backend.api.push_identity_tokens import sign_push_identity_token, sign_push_identity_token_es256
-from products.messaging.backend.api.push_subscriptions import PUSH_SUBSCRIPTION_REJECTION_COUNTER
+from products.messaging.backend.api.push_subscriptions import (
+    PUSH_SUBSCRIPTION_DISCARD_COUNTER,
+    PUSH_SUBSCRIPTION_REJECTION_COUNTER,
+)
 
 
 def _es256_keypair() -> tuple[str, str]:
@@ -215,7 +218,10 @@ class TestPushSubscriptionsAPI(BaseTest):
         call_kwargs = mock_capture.call_args.kwargs
         assert call_kwargs["properties"]["$unset"] == ["$device_push_subscription_com.example.app"]
 
-    def test_unregister_integration_not_found(self):
+    @patch("products.messaging.backend.api.push_subscriptions.capture_internal")
+    def test_unregister_without_integration_still_unsets(self, mock_capture: MagicMock):
+        mock_capture.return_value = MagicMock(status_code=200)
+
         response = self._delete(
             {
                 "distinct_id": "user-1",
@@ -225,8 +231,9 @@ class TestPushSubscriptionsAPI(BaseTest):
             }
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "integration" in response.json()["detail"].lower()
+        assert response.status_code == status.HTTP_200_OK
+        call_kwargs = mock_capture.call_args.kwargs
+        assert call_kwargs["properties"]["$unset"] == ["$device_push_subscription_nonexistent-project"]
 
     def test_missing_api_key_returns_401(self):
         response = self.client.post(
@@ -266,7 +273,11 @@ class TestPushSubscriptionsAPI(BaseTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "Invalid platform" in response.json()["detail"]
 
-    def test_integration_not_found(self):
+    @patch("products.messaging.backend.api.push_subscriptions.capture_internal")
+    def test_register_without_integration_returns_200_and_discards(self, mock_capture: MagicMock):
+        counter = PUSH_SUBSCRIPTION_DISCARD_COUNTER.labels(reason="no_integration")
+        before = counter._value.get()
+
         response = self._post(
             {
                 "distinct_id": "user-1",
@@ -276,10 +287,15 @@ class TestPushSubscriptionsAPI(BaseTest):
             }
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "integration" in response.json()["detail"].lower()
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["stored"] is False
+        assert data["push_enabled"] is False
+        mock_capture.assert_not_called()
+        assert counter._value.get() == before + 1
 
-    def test_team_isolation(self):
+    @patch("products.messaging.backend.api.push_subscriptions.capture_internal")
+    def test_team_isolation(self, mock_capture: MagicMock):
         other_team = Team.objects.create(organization=self.organization, name="Other Team")
         Integration.objects.create(
             team=other_team,
@@ -298,8 +314,9 @@ class TestPushSubscriptionsAPI(BaseTest):
             }
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "integration" in response.json()["detail"].lower()
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["stored"] is False
+        mock_capture.assert_not_called()
 
     def test_get_method_not_allowed(self):
         response = self.client.get(
@@ -442,13 +459,13 @@ class TestPushSubscriptionsAPI(BaseTest):
     @parameterized.expand(
         [
             (
-                "integration_not_found",
+                "invalid_platform",
                 status.HTTP_400_BAD_REQUEST,
                 {
                     "distinct_id": "user-1",
                     "device_token": "fcm-device-token-abc",
-                    "platform": "android",
-                    "app_id": "app-with-no-integration",
+                    "platform": "windows_phone",
+                    "app_id": "my-firebase-project",
                 },
             ),
             (


### PR DESCRIPTION
## Problem

- Mobile SDKs auto-register push tokens on every app open, but most teams have no firebase/apns integration, so `/api/push_subscriptions/` answers the fleet's most common request with a `400 integration_not_found`.
- That error floor dominates the ingress non-200 ratio on the main web cluster and has paged infra critical most days since Aug 8 ([investigation](https://posthog.slack.com/archives/C0BE0ARD761/p1786775005128989)).
- Shipped SDK versions treat the 400 as a failure and engage their retry and halt machinery for a request that was never wrong.
- Separately, on-call could not see why the endpoint rejects a request: the rejection code goes only to the client, and Django logs just `Bad Request`.

## Changes

- A valid, authenticated registration with no matching integration now returns `200 {"stored": false, "push_enabled": false}` instead of a 400. A missing integration is an account state, so it rides in the body; 4xx now only means the request itself was wrong (malformed JSON, missing fields, invalid platform, bad token).
- The token is still not stored. Storing would emit a capture event and mint an encrypted person property on every mobile user of every team without the feature. Devices re-register on every app open, so a team that configures an integration later is covered within a day.
- DELETE still processes the `$unset` when no integration matches: logout must clear a subscription stored while an integration existed.
- Every shipped SDK version benefits immediately: clients treat any 2xx as success and skip their failure paths.
- Telemetry for both paths: rejections increment `push_subscription_rejection{code, method}` and log `push_subscription_rejected` with code, team_id, and app_id; discards increment `push_subscription_discarded{reason}` and log. The discard counter is how the 400 floor's collapse gets verified after deploy.

> [!NOTE]
> Developer-facing behavior change: manually testing push setup against a team without an integration now returns a 200 whose body says `"push_enabled": false`, not an error.

## How did you test this code?

- New parameterized cases assert a rejected request increments the rejection counter with the matching code, catching a refactor that silently drops rejection telemetry (the gap that made this incident blind).
- Rewrote the two `integration_not_found` tests: POST asserts the 200 body, that nothing is captured, and the discard counter; DELETE asserts the `$unset` still goes out. `test_team_isolation` now asserts the cross-team `app_id` is discarded, not errored.
- Ran the full `test_push_subscriptions.py` suite locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None yet. The push notification setup docs should mention the `push_enabled` body field; will follow with the SDK docs pass.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session with Harley: verified the Contour non-200 alerts, traced the 400 floor to push auto-registration meeting an opt-in server (only a handful of configured push integrations exist), and settled the design in discussion: 200-discard over accept-and-store (storing mints person properties and capture events fleet-wide) and over 202 (dishonest for a discard).
- Originally two stacked PRs (telemetry, then the 200 change); collapsed into one at Harley's request for a weekend merge. #83466 is the closed top layer.
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions, /stacking-prs.
- Test-first: both layers' tests failed collection before their implementations landed.
- Related: the alert-side mitigation is PostHog/charts#14357, which gets reverted once this deploys and the 400 floor is confirmed gone.
