### PR TITLE
fix(persons): don't squash deletion tombstones into events.person_id

### DIFF
--- a/posthog/dags/person_overrides.py
+++ b/posthog/dags/person_overrides.py
@@ -26,7 +26,7 @@ class PersonOverridesSnapshotTable(OverridesSnapshotTable):
     def create(self, client: Client) -> None:
         client.execute(
             f"""
-            CREATE TABLE IF NOT EXISTS {self.qualified_name} (team_id Int64, distinct_id String, person_id UUID, version Int64)
+            CREATE TABLE IF NOT EXISTS {self.qualified_name} (team_id Int64, distinct_id String, person_id UUID, version Int64, is_deleted Int8)
             ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/{self.qualified_name}', '{{replica}}-{{shard}}', version)
             ORDER BY (team_id, distinct_id)
             """
@@ -43,8 +43,8 @@ class PersonOverridesSnapshotTable(OverridesSnapshotTable):
 
         client.execute(
             f"""
-            INSERT INTO {self.qualified_name} (team_id, distinct_id, person_id, version)
-            SELECT team_id, distinct_id, argMax(person_id, version), max(version)
+            INSERT INTO {self.qualified_name} (team_id, distinct_id, person_id, version, is_deleted)
+            SELECT team_id, distinct_id, argMax(person_id, version), max(version), argMax(is_deleted, version)
             FROM {settings.CLICKHOUSE_DATABASE}.{PERSON_DISTINCT_ID_OVERRIDES_TABLE}
             WHERE _timestamp < %(timestamp)s
             GROUP BY team_id, distinct_id
@@ -68,7 +68,8 @@ class PersonOverridesSnapshotDictionary(OverridesSnapshotDictionary):
                 team_id Int64,
                 distinct_id String,
                 person_id UUID,
-                version Int64
+                version Int64,
+                is_deleted Int8
             )
             PRIMARY KEY team_id, distinct_id
             SOURCE(CLICKHOUSE(DB %(database)s TABLE %(table)s USER %(user)s PASSWORD %(password)s))
@@ -100,8 +101,13 @@ class PersonOverridesSnapshotDictionary(OverridesSnapshotDictionary):
 
     @property
     def update_commands(self):
+        # Skip keys whose latest override is a deletion tombstone (is_deleted = 1): those are not live mappings, and
+        # rewriting events to a deleted person would misattribute them (and can never be repaired by a later run, since
+        # the tombstone's version outranks lower-versioned live rows.) The tombstoned rows are still removed from the
+        # overrides table by the delete mutation below.
         return {
-            "UPDATE person_id = dictGet(%(name)s, 'person_id', (team_id, distinct_id)) WHERE dictHas(%(name)s, (team_id, distinct_id))"
+            "UPDATE person_id = dictGet(%(name)s, 'person_id', (team_id, distinct_id)) "
+            "WHERE dictHas(%(name)s, (team_id, distinct_id)) AND dictGet(%(name)s, 'is_deleted', (team_id, distinct_id)) = 0"
         }
 
     @property

--- a/posthog/dags/tests/test_person_overrides.py
+++ b/posthog/dags/tests/test_person_overrides.py
@@ -114,6 +114,89 @@ def test_full_job(cluster: ClickhouseCluster):
     assert cluster.any_host(get_distinct_ids_with_overrides).result() == {"z"}
 
 
+def test_squash_ignores_deleted_mappings(cluster: ClickhouseCluster) -> None:
+    """
+    Keys whose latest override row is a deletion tombstone (is_deleted = 1) must not have their events rewritten to
+    the tombstoned person -- but the tombstoned rows should still be removed from the overrides table.
+    """
+    timestamp = datetime(2025, 1, 1)
+
+    def insert_events(client: Client) -> None:
+        client.execute(
+            "INSERT INTO writable_events (distinct_id, person_id, timestamp) VALUES",
+            [
+                # "del": person 10 was deleted, and the distinct id later ended up on live person 11
+                ("del", UUID(int=10), timestamp - timedelta(hours=24)),
+                ("del", UUID(int=11), timestamp - timedelta(hours=3)),
+                # "live": ordinary override, should be squashed as usual
+                ("live", UUID(int=20), timestamp - timedelta(hours=24)),
+                # "revived": tombstone followed by a higher-versioned live row, should be squashed to the live row
+                ("revived", UUID(int=30), timestamp - timedelta(hours=24)),
+            ],
+        )
+
+    cluster.any_host(insert_events).result()
+
+    def insert_overrides(client: Client) -> None:
+        client.execute(
+            "INSERT INTO person_distinct_id_overrides (distinct_id, person_id, _timestamp, version, is_deleted) VALUES",
+            [
+                ("del", UUID(int=11), timestamp - timedelta(hours=12), 1, 0),  # live merge row, outranked by tombstone
+                ("del", UUID(int=10), timestamp - timedelta(hours=10), 100, 1),  # deletion tombstone
+                ("live", UUID(int=21), timestamp - timedelta(hours=12), 1, 0),
+                ("revived", UUID(int=30), timestamp - timedelta(hours=12), 100, 1),  # deletion tombstone
+                ("revived", UUID(int=31), timestamp - timedelta(hours=8), 101, 0),  # later live row wins
+            ],
+        )
+
+    cluster.any_host(insert_overrides).result()
+
+    def get_distinct_ids_on_events_by_person(client: Client) -> dict[UUID, set[str]]:
+        rows = client.execute("SELECT person_id, groupUniqArray(distinct_id) FROM events GROUP BY ALL")
+        result = {person_id: set(distinct_ids) for person_id, distinct_ids in rows}
+        assert len(rows) == len(result)
+        return result
+
+    def get_distinct_ids_with_overrides(client: Client) -> set[str]:
+        rows = client.execute("SELECT distinct_id FROM person_distinct_id_overrides FINAL")
+        result = {distinct_id for [distinct_id] in rows}
+        assert len(rows) == len(result)
+        return result
+
+    # check preconditions
+    assert cluster.any_host(get_distinct_ids_on_events_by_person).result() == {
+        UUID(int=10): {"del"},
+        UUID(int=11): {"del"},
+        UUID(int=20): {"live"},
+        UUID(int=30): {"revived"},
+    }
+    assert cluster.any_host(get_distinct_ids_with_overrides).result() == {"del", "live", "revived"}
+
+    run_result = squash_person_overrides.execute_in_process(
+        run_config=dagster.RunConfig(
+            {populate_snapshot_table.name: PopulateSnapshotTableConfig(timestamp=timestamp.isoformat())}
+        ),
+        resources={"cluster": cluster},
+    )
+
+    # ensure we cleaned up after ourselves
+    table = PersonOverridesSnapshotTable(UUID(run_result.dagster_run.run_id))
+    dictionary = PersonOverridesSnapshotDictionary(table)
+    assert not any(cluster.map_all_hosts(table.exists).result().values())
+    assert not any(cluster.map_all_hosts(dictionary.exists).result().values())
+
+    # check postconditions
+    assert cluster.any_host(get_distinct_ids_on_events_by_person).result() == {
+        # events for the tombstoned key are left untouched (not rewritten to the deleted person 10)
+        UUID(int=10): {"del"},
+        UUID(int=11): {"del"},
+        UUID(int=21): {"live"},
+        UUID(int=31): {"revived"},
+    }
+    # ... but all snapshotted override rows (including the tombstoned key) are removed
+    assert cluster.any_host(get_distinct_ids_with_overrides).result() == set()
+
+
 def test_cleanup_job(cluster: ClickhouseCluster) -> None:
     timestamp = datetime(2025, 1, 1)
 


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->
