### PR TITLE
fix(integrations): give a clear error when TikTok Ads OAuth grants no ad account

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -1695,6 +1695,15 @@ class OauthIntegration:
             # token to cover these scopes before it will wield the connection's grant.
             config["granted_scopes"] = sorted({s for s in (config.get("scope") or "").split() if ":" in s})
 
+        # TikTok can complete OAuth without the user granting any advertiser account, leaving
+        # `advertiser_ids` empty. Surface an actionable reconnect message rather than the generic
+        # "failed to extract integration ID" 500 the guard below would otherwise raise.
+        if kind == "tiktok-ads" and isinstance(integration_id, list) and len(integration_id) == 0:
+            raise ValidationError(
+                "No TikTok ad accounts were authorized. In TikTok, grant access to at least one "
+                "advertiser account, then reconnect."
+            )
+
         if isinstance(integration_id, int):
             integration_id = str(integration_id)
         elif isinstance(integration_id, list) and len(integration_id) > 0:

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -533,6 +533,26 @@ class TestOauthIntegrationModel(BaseTest):
                 )
 
     @patch("posthog.models.integration.requests.post")
+    def test_tiktok_ads_oauth_without_advertiser_accounts_raises_validation_error(self, mock_post):
+        # TikTok completes OAuth even when the user granted no advertiser account, leaving
+        # `advertiser_ids` empty. That must surface as a ValidationError (→ 400 with an actionable
+        # message) rather than the bare Exception (→ 500) the missing-id guard would otherwise raise.
+        with self.settings(**self.mock_settings):
+            mock_post.return_value.status_code = 200
+            mock_post.return_value.json.return_value = {
+                "code": 0,
+                "data": {"access_token": "FAKE_ACCESS_TOKEN", "advertiser_ids": []},
+            }
+
+            with pytest.raises(ValidationError, match="ad accounts"):
+                OauthIntegration.integration_from_oauth_response(
+                    "tiktok-ads",
+                    self.team.id,
+                    self.user,
+                    {"code": "code", "state": "next=/projects/test"},
+                )
+
+    @patch("posthog.models.integration.requests.post")
     @patch("posthog.models.integration.requests.get")
     def test_integration_fetches_info_from_token_info_url(self, mock_get, mock_post):
         with self.settings(**self.mock_settings):


### PR DESCRIPTION
## Problem

- A user connecting TikTok Ads as a data warehouse source hits a "server error occurred" screen after authorizing in TikTok, with no way to recover.
- TikTok completes its OAuth flow even when the user grants access to zero advertiser accounts, which leaves `advertiser_ids` empty.
- The generic missing-id guard then raised a bare `Exception`, which DRF turns into a 500. The user only sees "server error occurred" and an exception is logged.

## Changes

- Detect the empty-advertiser case in the `tiktok-ads` branch of `integration_from_oauth_response` and raise a `ValidationError` (→ 400) with an actionable message: grant access to at least one advertiser account, then reconnect.
- This mirrors the existing handling for the empty-Jira-sites case a few lines above.
- Only TikTok's `id_path` resolves to a list, so scalar-id providers (Google Ads, Meta Ads) cannot hit this path.

## How did you test this code?

- Added `test_tiktok_ads_oauth_without_advertiser_accounts_raises_validation_error`: a TikTok token response with an empty `advertiser_ids` now raises `ValidationError`, not a bare `Exception`. No existing test exercised the TikTok OAuth-response path. Ran it locally against Postgres and ClickHouse: 1 passed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

This PR was authored by Claude Code from a review of anonymized onboarding session summaries that flagged repeated TikTok Ads connection failures. Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`. The error message wording went through the user-facing copy skill (sentence case, states the next action, no em-dash). No customer data from the source sessions is present in this PR.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
