### PR TITLE
fix(warehouse-sources): explain the Stripe webhook endpoint limit error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/stripe.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/stripe.py
@@ -1195,6 +1195,18 @@ def _is_stripe_account_access_error(error: Exception, error_str: str) -> bool:
     )
 
 
+def _is_stripe_webhook_limit_error(error_str: str) -> bool:
+    """Detect Stripe's webhook-endpoint cap rejection.
+
+    Stripe caps an account's webhook endpoints and rejects further creates with an
+    ``invalid_request_error`` that carries no distinct ``code``, so it never matches the
+    permission/403 branch. Classifying it lets us tell the user the cap is the cause and point them
+    at the manual-setup fallback instead of surfacing Stripe's raw message.
+    """
+    lowered = error_str.lower()
+    return "maximum of" in lowered and "webhook endpoint" in lowered
+
+
 def create_webhook(
     api_key: str,
     stripe_account_id: str | None,
@@ -1251,6 +1263,16 @@ def create_webhook(
                     "Stripe account. The 'Account id' in your source settings only applies to Stripe Connect "
                     "platform accounts — remove or correct it if your key belongs directly to the account, "
                     "then retry. Otherwise, set up the webhook manually below."
+                ),
+            )
+
+        if _is_stripe_webhook_limit_error(error_str):
+            return WebhookCreationResult(
+                success=False,
+                error=(
+                    "Your Stripe account has reached its webhook endpoint limit. Delete an unused "
+                    "endpoint in the Stripe dashboard (Developers → Webhooks) and retry, or set up "
+                    "the webhook manually below."
                 ),
             )
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
@@ -1421,6 +1421,27 @@ class TestCreateWebhookPermissionErrorCopy:
         assert expected_phrase in (result.error or "")
 
 
+class TestCreateWebhookLimitErrorCopy:
+    # Regression test: hitting Stripe's webhook-endpoint cap used to surface Stripe's raw error
+    # verbatim, so the user couldn't tell the account-wide limit was the cause or how to recover.
+    def test_webhook_limit_error_gives_actionable_message(self):
+        with patch.object(stripe_module, "StripeClient") as mock_client_cls:
+            mock_client = mock_client_cls.return_value
+            mock_client.webhook_endpoints.create.side_effect = stripe_lib.InvalidRequestError(
+                "You have reached the maximum of 100 test webhook endpoints.", param=None
+            )
+
+            result = create_webhook(
+                api_key="sk_test_123",
+                stripe_account_id=None,
+                webhook_url="https://example.com/webhook",
+            )
+
+        assert result.success is False
+        assert "webhook endpoint limit" in (result.error or "")
+        assert "manually" in (result.error or "")
+
+
 class TestStripeAppManifestCoversSourcePermissions:
     # Regression test: PERMISSIONS drives the pre-filled restricted-key form, while the Stripe app
     # manifest drives what an OAuth connection is granted. The two drifted twice (rak_webhook_write


### PR DESCRIPTION
## Problem

- A user connecting a Stripe data warehouse source whose account has hit Stripe's webhook endpoint cap sees Stripe's raw error on the webhook step, with no explanation of the cause or how to recover.
- PostHog auto-creates a Stripe webhook endpoint during setup. When the account is at its endpoint limit, Stripe rejects the create with an `invalid_request_error` that carries no distinct `code`.
- That falls through to the generic fallback, which passes Stripe's message through verbatim. The account-wide limit reads like a PostHog problem, and nothing points to the fix.

## Changes

- Classify the webhook-endpoint-cap rejection like the existing account-access and permission cases, and return an actionable message: delete an unused endpoint in the Stripe dashboard, then retry, or set up the webhook manually.
- The source is still created regardless of webhook outcome, so this only changes the copy shown on the webhook step. The message flows through the existing `WebhookCreationResult.error` path, so no frontend change is needed.

## How did you test this code?

- Added `TestCreateWebhookLimitErrorCopy`: a `create_webhook` call whose Stripe client raises the "maximum of 100 webhook endpoints" error now returns the actionable message instead of Stripe's raw text. No existing test covered this branch. Ran the new test plus the existing permission-copy tests locally: 3 passed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

This PR was authored by Claude Code from a review of anonymized onboarding session summaries that flagged a Stripe connection stalling on the automatic webhook step. Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`. The error copy went through the user-facing copy skill (sentence case, states the next action, no em-dash). No customer data from the source sessions is present in this PR.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
