### PR TITLE
feat(messaging): return 200 for push registration without an integration

### DIFF
--- a/products/messaging/backend/api/push_subscriptions.py
+++ b/products/messaging/backend/api/push_subscriptions.py
@@ -40,6 +40,12 @@ PUSH_SUBSCRIPTION_REJECTION_COUNTER = Counter(
     labelnames=["code", "method"],
 )
 
+PUSH_SUBSCRIPTION_DISCARD_COUNTER = Counter(
+    "push_subscription_discarded",
+    "Push subscription registrations acknowledged without storing, by reason.",
+    labelnames=["reason"],
+)
+
 logger = structlog.get_logger(__name__)
 
 VALID_PLATFORMS = ("android", "ios")
@@ -226,16 +232,26 @@ def push_subscriptions(request: Request):
         )
 
     integrations = _find_integrations(team.id, app_id)
-    if not integrations:
-        return _rejection_response(
+    # A missing integration is an account state, not a request error: SDKs auto-register on every
+    # app open, so for most teams this is the endpoint's normal case, and a 4xx here turns the
+    # whole fleet into an error firehose. Acknowledge registration with a 200 and skip the store,
+    # so unconsumable tokens don't become person properties and capture events; devices re-register
+    # on every app open, so a team that later configures an integration is covered within a day.
+    # DELETE falls through: logout must clear any subscription stored while an integration existed.
+    if not integrations and request.method == "POST":
+        PUSH_SUBSCRIPTION_DISCARD_COUNTER.labels(reason="no_integration").inc()
+        logger.info("push_subscription_discarded", reason="no_integration", team_id=team.id, app_id=app_id)
+        return cors_response(
             request,
-            f"No push integration found for app_id '{app_id}'. "
-            "Please configure the integration in your PostHog project settings.",
-            error_type="validation_error",
-            code="integration_not_found",
-            status_code=status.HTTP_400_BAD_REQUEST,
-            team_id=team.id,
-            app_id=app_id,
+            JsonResponse(
+                {
+                    "distinct_id": distinct_id,
+                    "platform": platform,
+                    "stored": False,
+                    "push_enabled": False,
+                },
+                status=status.HTTP_200_OK,
+            ),
         )
 
     operation = "register" if request.method == "POST" else "unregister"

--- a/products/messaging/backend/api/test/test_push_subscriptions.py
+++ b/products/messaging/backend/api/test/test_push_subscriptions.py
@@ -16,7 +16,10 @@ from posthog.models.team.team import Team
 from posthog.models.team.team_caching import set_team_in_cache
 
 from products.messaging.backend.api.push_identity_tokens import sign_push_identity_token, sign_push_identity_token_es256
-from products.messaging.backend.api.push_subscriptions import PUSH_SUBSCRIPTION_REJECTION_COUNTER
+from products.messaging.backend.api.push_subscriptions import (
+    PUSH_SUBSCRIPTION_DISCARD_COUNTER,
+    PUSH_SUBSCRIPTION_REJECTION_COUNTER,
+)
 
 
 def _es256_keypair() -> tuple[str, str]:
@@ -215,7 +218,10 @@ class TestPushSubscriptionsAPI(BaseTest):
         call_kwargs = mock_capture.call_args.kwargs
         assert call_kwargs["properties"]["$unset"] == ["$device_push_subscription_com.example.app"]
 
-    def test_unregister_integration_not_found(self):
+    @patch("products.messaging.backend.api.push_subscriptions.capture_internal")
+    def test_unregister_without_integration_still_unsets(self, mock_capture: MagicMock):
+        mock_capture.return_value = MagicMock(status_code=200)
+
         response = self._delete(
             {
                 "distinct_id": "user-1",
@@ -225,8 +231,9 @@ class TestPushSubscriptionsAPI(BaseTest):
             }
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "integration" in response.json()["detail"].lower()
+        assert response.status_code == status.HTTP_200_OK
+        call_kwargs = mock_capture.call_args.kwargs
+        assert call_kwargs["properties"]["$unset"] == ["$device_push_subscription_nonexistent-project"]
 
     def test_missing_api_key_returns_401(self):
         response = self.client.post(
@@ -266,7 +273,11 @@ class TestPushSubscriptionsAPI(BaseTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "Invalid platform" in response.json()["detail"]
 
-    def test_integration_not_found(self):
+    @patch("products.messaging.backend.api.push_subscriptions.capture_internal")
+    def test_register_without_integration_returns_200_and_discards(self, mock_capture: MagicMock):
+        counter = PUSH_SUBSCRIPTION_DISCARD_COUNTER.labels(reason="no_integration")
+        before = counter._value.get()
+
         response = self._post(
             {
                 "distinct_id": "user-1",
@@ -276,10 +287,15 @@ class TestPushSubscriptionsAPI(BaseTest):
             }
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "integration" in response.json()["detail"].lower()
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["stored"] is False
+        assert data["push_enabled"] is False
+        mock_capture.assert_not_called()
+        assert counter._value.get() == before + 1
 
-    def test_team_isolation(self):
+    @patch("products.messaging.backend.api.push_subscriptions.capture_internal")
+    def test_team_isolation(self, mock_capture: MagicMock):
         other_team = Team.objects.create(organization=self.organization, name="Other Team")
         Integration.objects.create(
             team=other_team,
@@ -298,8 +314,9 @@ class TestPushSubscriptionsAPI(BaseTest):
             }
         )
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "integration" in response.json()["detail"].lower()
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["stored"] is False
+        mock_capture.assert_not_called()
 
     def test_get_method_not_allowed(self):
         response = self.client.get(
@@ -442,13 +459,13 @@ class TestPushSubscriptionsAPI(BaseTest):
     @parameterized.expand(
         [
             (
-                "integration_not_found",
+                "invalid_platform",
                 status.HTTP_400_BAD_REQUEST,
                 {
                     "distinct_id": "user-1",
                     "device_token": "fcm-device-token-abc",
-                    "platform": "android",
-                    "app_id": "app-with-no-integration",
+                    "platform": "windows_phone",
+                    "app_id": "my-firebase-project",
                 },
             ),
             (


### PR DESCRIPTION
## Problem

- Mobile SDKs auto-register push tokens on every app open, but most teams have no firebase/apns integration, so `/api/push_subscriptions/` answers the fleet's most common request with a 400.
- That error floor dominates the ingress non-200 ratio on the main web cluster and has paged infra critical most days since Aug 8 ([investigation](https://posthog.slack.com/archives/C0BE0ARD761/p1786775005128989)).
- Shipped SDK versions treat the 400 as a failure and engage their retry and halt machinery for a request that was never wrong.

## Changes

- A valid, authenticated registration with no matching integration now returns `200 {"stored": false, "push_enabled": false}` instead of `400 integration_not_found`. A missing integration is an account state, so it rides in the body; 4xx now only means the request itself was wrong (malformed JSON, missing fields, bad token).
- The token is still not stored. Storing would emit a capture event and mint an encrypted person property on every mobile user of every team without the feature. Devices re-register on every app open, so a team that configures an integration later is covered within a day.
- DELETE still processes the `$unset` when no integration matches: logout must clear a subscription stored while an integration existed.
- Discards are counted (`push_subscription_discarded{reason}`) and logged, so the fleet-wide effect of this change is directly observable.
- Every shipped SDK version benefits immediately: clients treat any 2xx as success and skip their failure paths.

> [!NOTE]
> Developer-facing behavior change: manually testing push setup against a team without an integration now returns a 200 whose body says `"push_enabled": false`, not an error.

## How did you test this code?

- Rewrote the two `integration_not_found` tests: POST asserts the 200 body, that nothing is captured, and the discard counter; DELETE asserts the `$unset` still goes out. `test_team_isolation` now asserts the cross-team `app_id` is discarded, not errored.
- These catch the regressions this PR creates the possibility of: the no-integration branch silently storing, or DELETE losing its fall-through.
- Ran the full `test_push_subscriptions.py` suite locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None yet. The push notification setup docs should mention the `push_enabled` body field; will follow with the SDK docs pass.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session with Harley, continuing the push subscription 400-floor investigation. Design discussion settled on 200-discard over accept-and-store (storing mints person properties and capture events fleet-wide) and over 202 (dishonest for a discard).
- Stacked on #83456 (rejection telemetry) because both change the same rejection paths; the telemetry counter is also how the 400 floor's collapse gets verified after this deploys.
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions, /stacking-prs.
- Test-first: the discard-counter test failed collection before the implementation landed.
