### PR TITLE
fix(data-warehouse): stop failing on a raced bucket-creation retry

### DIFF
--- a/products/data_warehouse/backend/s3.py
+++ b/products/data_warehouse/backend/s3.py
@@ -135,6 +135,14 @@ def ensure_bucket_exists(s3_url: str, s3_key: str, s3_secret: str, s3_endpoint: 
             raise
 
         if int(error_code) == 404:
-            s3_client.create_bucket(Bucket=bucket_name)
+            try:
+                s3_client.create_bucket(Bucket=bucket_name)
+            except botocore.exceptions.ClientError as create_error:
+                # Concurrent callers can both see the 404 above before either creates the bucket; the
+                # loser's create_bucket then reports it already owns the bucket the winner just made.
+                # That's the intended end state, not a failure.
+                create_error_code = create_error.response.get("Error", {}).get("Code")
+                if create_error_code != "BucketAlreadyOwnedByYou":
+                    raise
         else:
             raise

--- a/products/data_warehouse/backend/tests/test_s3.py
+++ b/products/data_warehouse/backend/tests/test_s3.py
@@ -4,9 +4,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.test import SimpleTestCase, override_settings
 
+from botocore.exceptions import ClientError
 from parameterized import parameterized
 
-from products.data_warehouse.backend.s3 import aget_s3_client, get_size_of_folder
+from products.data_warehouse.backend.s3 import aget_s3_client, ensure_bucket_exists, get_size_of_folder
+
+
+def _client_error(code: str) -> ClientError:
+    return ClientError({"Error": {"Code": code}}, "operation")
 
 
 class TestAgetS3Client(SimpleTestCase):
@@ -72,3 +77,58 @@ class TestGetSizeOfFolder(SimpleTestCase):
             get_size_of_folder("s3://bucket/path")
 
         mock_close_session.assert_called_once_with(s3.loop, s3._s3creator)
+
+
+class TestEnsureBucketExists(SimpleTestCase):
+    @patch("products.data_warehouse.backend.s3.boto3.client")
+    def test_does_nothing_when_bucket_already_reachable(self, mock_boto3_client) -> None:
+        s3_client = MagicMock()
+        mock_boto3_client.return_value = s3_client
+
+        ensure_bucket_exists("s3://my-bucket", "key", "secret")
+
+        s3_client.create_bucket.assert_not_called()
+
+    @patch("products.data_warehouse.backend.s3.boto3.client")
+    def test_creates_bucket_when_missing(self, mock_boto3_client) -> None:
+        s3_client = MagicMock()
+        s3_client.head_bucket.side_effect = _client_error("404")
+        mock_boto3_client.return_value = s3_client
+
+        ensure_bucket_exists("s3://my-bucket", "key", "secret")
+
+        s3_client.create_bucket.assert_called_once_with(Bucket="my-bucket")
+
+    @parameterized.expand(
+        [
+            ("owned_by_us", "BucketAlreadyOwnedByYou", False),
+            ("owned_by_someone_else", "BucketAlreadyExists", True),
+            ("access_denied", "AccessDenied", True),
+        ]
+    )
+    @patch("products.data_warehouse.backend.s3.boto3.client")
+    def test_create_bucket_race_after_a_404(self, _name, create_error_code, should_raise, mock_boto3_client) -> None:
+        # A concurrent caller can create the bucket between our head_bucket 404 and our own
+        # create_bucket call. BucketAlreadyOwnedByYou means we lost that race but still own the
+        # bucket, so it must not surface as a failure; any other create_bucket error is real.
+        s3_client = MagicMock()
+        s3_client.head_bucket.side_effect = _client_error("404")
+        s3_client.create_bucket.side_effect = _client_error(create_error_code)
+        mock_boto3_client.return_value = s3_client
+
+        if should_raise:
+            with self.assertRaises(ClientError):
+                ensure_bucket_exists("s3://my-bucket", "key", "secret")
+        else:
+            ensure_bucket_exists("s3://my-bucket", "key", "secret")
+
+    @patch("products.data_warehouse.backend.s3.boto3.client")
+    def test_reraises_non_404_head_bucket_errors(self, mock_boto3_client) -> None:
+        s3_client = MagicMock()
+        s3_client.head_bucket.side_effect = _client_error("403")
+        mock_boto3_client.return_value = s3_client
+
+        with self.assertRaises(ClientError):
+            ensure_bucket_exists("s3://my-bucket", "key", "secret")
+
+        s3_client.create_bucket.assert_not_called()


### PR DESCRIPTION
## Problem

- A data-warehouse sync can fail with an unhandled `BucketAlreadyOwnedByYou` error, surfaced via error tracking during a Redshift sync.
- `ensure_bucket_exists` calls `create_bucket` after a 404 on `head_bucket`, but two concurrent callers can both observe that 404 before either one finishes creating the bucket.
- The losing caller's `create_bucket` then reports it already owns the bucket the winner just created, and that error propagated as a real failure instead of being treated as the expected outcome.

## Changes

- Catch `BucketAlreadyOwnedByYou` from `create_bucket` in `ensure_bucket_exists` and treat it as success.
- Any other `create_bucket` error (for example `BucketAlreadyExists`, meaning someone else owns the name) still raises unchanged.

## How did you test this code?

- Added `TestEnsureBucketExists` to `products/data_warehouse/backend/tests/test_s3.py`: covers the no-op path when the bucket already exists, bucket creation on a genuine 404, the `BucketAlreadyOwnedByYou` race being swallowed, `BucketAlreadyExists`/`AccessDenied` still raising, and non-404 `head_bucket` errors still raising.
- Ran `pytest products/data_warehouse/backend/tests/test_s3.py` (10 passed) and `ruff check`/`ruff format --check` on both changed files.
- Not run: `hogli ci:preflight` (hogli unavailable in this environment) and the ClickHouse/database-backed warehouse suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- I (Claude) triaged the `BucketAlreadyOwnedByYou` error from an error-tracking webhook, traced the exception chain (`head_bucket` 404 followed by a `create_bucket` conflict) to `products/data_warehouse/backend/s3.py::ensure_bucket_exists`, and confirmed it's a real race rather than user/upstream error — this codebase already treats `BucketAlreadyOwnedByYou`/`BucketAlreadyExists` as benign in one other place (a ClickHouse test fixture), so the same handling was missing here.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Checked for duplicate open PRs (by exception type, function name, and module path, and across the warehouse maintainer's own open PRs) — none address this race.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*