### PR TITLE
fix(marketing-analytics): count matched events in the connect suggestion

### DIFF
--- a/products/marketing_analytics/backend/services/setup_plan.py
+++ b/products/marketing_analytics/backend/services/setup_plan.py
@@ -281,7 +281,14 @@ def _integration_suggestion(integration: IntegrationDiagnostic) -> Suggestion | 
     status = integration.overall_status
     source_type = integration.source_type
     ds = integration.data_source
-    volume = integration.attribution.events_unmatched_likely_yours_last_7d if integration.attribution else 0
+    attribution = integration.attribution
+    # Both counters: `events_only` is set when either one is non-zero, so reading just the
+    # likely-yours side reports "0 events" as the reason to connect a platform whose
+    # utm_source matched exactly. They never overlap — a utm_source either matches an alias
+    # or is only fuzzy-suggested — so the sum is every event carrying this platform's source.
+    volume = (
+        attribution.events_matched_last_7d + attribution.events_unmatched_likely_yours_last_7d if attribution else 0
+    )
 
     if status == "events_only":
         # Traffic arrives but no spend data, so cost, ROAS and CAC are all unavailable.

--- a/products/marketing_analytics/backend/services/test_setup_plan.py
+++ b/products/marketing_analytics/backend/services/test_setup_plan.py
@@ -2,6 +2,7 @@ import pytest
 from posthog.test.base import APIBaseTest
 from unittest.mock import AsyncMock, patch
 
+from parameterized import parameterized
 from pydantic import ValidationError
 
 from products.marketing_analytics.backend.services.attribution_health import AttributionHealthResponse
@@ -42,6 +43,7 @@ def _integration(
     last_error=None,
     schema_missing=None,
     unmatched=0,
+    matched=0,
 ) -> IntegrationDiagnostic:
     data_source = None
     if status != "events_only":
@@ -68,14 +70,14 @@ def _integration(
         )
 
     attribution = None
-    if unmatched:
+    if unmatched or matched:
         from products.marketing_analytics.backend.services.attribution_health import AttributionHealthEntry
 
         attribution = AttributionHealthEntry(
             integration_key=key,
             display_name=key,
-            events_with_utm_last_7d=unmatched,
-            events_matched_last_7d=0,
+            events_with_utm_last_7d=unmatched + matched,
+            events_matched_last_7d=matched,
             events_unmatched_likely_yours_last_7d=unmatched,
             last_event_with_matching_utm_at=None,
             matched_pct=0.0,
@@ -592,6 +594,35 @@ class TestIntegrationSuggestions(SetupPlanTestCase):
 
         assert any(s.kind == SuggestionKind.FIX_SYNC for s in plan.suggestions)
         assert not any(s.kind == SuggestionKind.RECONNECT_OAUTH for s in plan.suggestions)
+
+    @parameterized.expand(
+        [
+            ("exact_utm_source_match_only", 0, 700, 700),
+            ("fuzzy_match_only", 500, 0, 500),
+            ("both_kinds_of_match", 500, 700, 1200),
+        ]
+    )
+    @pytest.mark.asyncio
+    async def test_connect_suggestion_counts_every_event_carrying_the_utm_source(
+        self, _name, unmatched, matched, expected
+    ):
+        # `events_only` is set when either counter is non-zero, so a platform whose utm_source
+        # matched exactly used to advertise "0 events" as the reason to connect it.
+        self.diagnostic = MarketingDiagnosticResponse(
+            integrations=[
+                _integration(
+                    "pinterest_ads", "PinterestAds", status="events_only", unmatched=unmatched, matched=matched
+                )
+            ],
+            overall_status="degraded",
+            conversion_goals=ConversionGoalsListResponse(goals=[_goal()]),
+        )
+
+        plan = await get_setup_plan(self.team)
+
+        connect = next(s for s in plan.suggestions if s.kind == SuggestionKind.CONNECT_SOURCE)
+        assert connect.event_volume == expected
+        assert f"{expected:,} events" in connect.evidence
 
     @pytest.mark.asyncio
     async def test_healthy_integration_produces_nothing(self):


### PR DESCRIPTION
## Problem

- The Setup tab tells a team to connect an ad platform, and gives "0 events in the last 7 days carry a <Platform> utm_source" as the reason. The suggestion contradicts itself.
- It ranks first, so the self-refuting row is the first thing on the screen.
- Two disjoint counters track events for an unconnected platform: `events_matched_last_7d` (the utm_source matched a known alias) and `events_unmatched_likely_yours_last_7d` (only a fuzzy match).
- `_diagnose_one` sets the `events_only` status when either counter is non-zero (`marketing_diagnostic.py:253`).
- The suggestion read only the fuzzy counter (`setup_plan.py:284`), so an exactly-tagged platform reported zero.

The zero is the visible half. When both counters are non-zero the suggestion silently undercounts instead, which nobody notices.

| `matched` | `likely_yours` | Reported before |
|---|---|---|
| > 0 | 0 | `0 events` |
| > 0 | > 0 | fuzzy count only |
| 0 | > 0 | correct |

This hits teams that tag correctly. An exact `matched` count means the utm_source matched a known alias, so the suggestion worked only when a team mistagged.

## Changes

- The connect suggestion counts both, so the evidence covers every event carrying the platform's utm_source.
- Summing is safe because the counters never overlap: a raw utm_source either matches an alias or is only fuzzy-suggested (`attribution_health.py:167-186`).
- No `volume > 0` guard. A guard hides row 1 of the table above and leaves row 2 undercounting forever, so it treats the symptom.

## How did you test this code?

- Added a parameterized case over the three shapes above, asserting both `event_volume` and the rendered evidence string.
- Confirmed the exact-only and both-counters cases fail before the fix, and that fuzzy-only passes either way, which pins the unchanged behavior.
- The test helper hardcoded `events_matched_last_7d=0`, so no existing test could reach this. It now takes a `matched` argument.
- Ran locally: the two marketing analytics setup suites. Repo-wide mypy reports only pre-existing errors in `common/ingestion`, which this diff does not touch.
- Not done: no manual run against the app.
- No UI code changed. The only visible difference is the number in the suggestion text.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus) drove this from a screenshot of a real setup plan. Skills invoked: `/writing-tests` and `/writing-pr-descriptions`.

I first read this as a missing volume guard and was going to suppress zero-volume suggestions. Tracing the `events_only` status back to `_diagnose_one` showed the status and the evidence read different counters, which made suppression the wrong fix — it would have hidden the contradiction and kept the undercount. The negative check also needed a second run: the first attempt patched a string the formatter had already rewritten, so the test passed against unmodified code and proved nothing.


---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
