### PR TITLE
fix(linkedin_ads): stop retrying a sync pinned to a decommissioned API version

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/source.py
@@ -112,6 +112,11 @@ class LinkedInAdsSource(ResumableSource[LinkedinAdsSourceConfig, LinkedInAdsResu
             # user must re-authorize. Model-specific so we don't swallow unrelated `DoesNotExist`
             # errors from other models, which may be real bugs.
             "Integration matching query does not exist": "Your LinkedIn Ads connection is no longer available — it may have been disconnected. Please re-authorize the LinkedIn Ads integration.",
+            # LinkedIn returns a 426 with this stable error code when the source's pinned API version
+            # (an undeclared pin is honored verbatim — see `resolve_api_version`) has been fully
+            # decommissioned rather than merely deprecated. It will never become active again, so
+            # retrying can't help; the source needs to be recreated to pick up a supported version.
+            "NONEXISTENT_VERSION": "LinkedIn has deactivated the API version this connection was created with, so it can no longer sync. Please remove this LinkedIn Ads source and set it up again to use a supported version.",
         }
 
     def get_retryable_errors(self) -> set[str]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
@@ -33,6 +33,9 @@ class TestLinkedInAdsSource:
             'LinkedIn API error (401): {"status":401,"serviceErrorCode":65608,"code":"RESTRICTED_MEMBER","message":"Member is restricted"}',
             # Integration.DoesNotExist when the OAuth integration row was deleted/disconnected.
             "Integration matching query does not exist.",
+            # A source pinned to an API version LinkedIn has fully decommissioned (not merely
+            # deprecated) — the version number is volatile, "NONEXISTENT_VERSION" is the stable code.
+            'LinkedIn API error (426): {"status":426,"code":"NONEXISTENT_VERSION","message":"Requested version 20250801 is not active"}',
         ],
     )
     def test_non_retryable_errors_match_upstream_failures(self, observed_error):


### PR DESCRIPTION
## Problem

A LinkedIn Ads sync fails on every retry and never recovers, because it is pinned to an API version LinkedIn has fully decommissioned. [Error tracking](https://us.posthog.com/project/2/error_tracking/01a0095d-1fe4-7082-af4c-8711ab0d890a) shows `LinkedinAdsApiError: LinkedIn API error (426): {"code":"NONEXISTENT_VERSION",...}` raised from `client.py`'s `_call_finder`.

A source's pinned API version is honored verbatim even once undeclared, by design (see `resolve_api_version`), so a stale pin is passed straight to LinkedIn without local validation. LinkedIn's rejection is permanent: the version cannot become active again, so Temporal kept retrying a call that will never succeed.

## Changes

- Add LinkedIn's stable `NONEXISTENT_VERSION` error code to `get_non_retryable_errors`, so the sync stops retrying and disables with a clear message instead of looping.
- The message tells the user to recreate the source, since a source's pinned version is set only at creation and has no in-place repair path today.

## How did you test this code?

- Extended `test_non_retryable_errors_match_upstream_failures` with the observed 426 body — this is the regression: without the new entry, that message did not match any non-retryable pattern and would retry indefinitely.
- Ran the full `linkedin_ads` source test suite locally (40 passed) and `ruff check`/`ruff format --check` on the changed files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing workflow or API changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via the PostHog error-tracking MCP tools (issue details, sampled events with stack trace) to confirm the failure originates in `linkedin_ads/client.py`, then read `source.py`/`client.py`/`common/base.py` to trace how an undeclared API version pin reaches LinkedIn unvalidated. Searched open PRs (human-authored and bot) for duplicates; found none. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.