### PR TITLE
fix(warehouse_sources): repin linkedin_ads off its sunset api version

### DIFF
--- a/products/warehouse_sources/backend/migrations/0139_repin_linkedin_ads_api_version.py
+++ b/products/warehouse_sources/backend/migrations/0139_repin_linkedin_ads_api_version.py
@@ -1,0 +1,38 @@
+from django.db import migrations
+
+# LinkedIn sunsets each versioned API header a minimum of one year after release. The legacy
+# unversioned label ("v1") sends the header the source has always sent (202508, August 2025),
+# which reached that one-year mark and now gets a 426 NONEXISTENT_VERSION on every call. This
+# repins existing source-level pins from "v1" to "202607" (the current default) so they stop
+# sending a header LinkedIn no longer accepts. The request/response shape LinkedIn serves under
+# 202607 for the tables this source reads is unchanged from what "v1" (202508) served, so no
+# data/schema transform is needed — only the pin moves.
+LINKEDIN_ADS_SOURCE_TYPE = "LinkedinAds"
+OLD_VERSION = "v1"
+NEW_VERSION = "202607"
+
+
+def repin_linkedin_ads_v1_to_202607(apps, schema_editor):
+    ExternalDataSource = apps.get_model("warehouse_sources", "ExternalDataSource")
+
+    # Only the source-level pin is touched. Schema-level `ExternalDataSchema.api_version`
+    # overrides are user-managed (a customer intentionally pinned that schema) and are left
+    # alone — the schema-level deprecation warning prompts the user to migrate those.
+    #
+    # NULL pins already resolve to the source's `default_version` (already "202607"), so they
+    # need no update. Matching only `api_version="v1"` keeps this idempotent: a second run
+    # matches nothing.
+    ExternalDataSource.objects.filter(source_type=LINKEDIN_ADS_SOURCE_TYPE, api_version=OLD_VERSION).update(
+        api_version=NEW_VERSION
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [("warehouse_sources", "0138_scaffold_wisprflow_source")]
+
+    operations = [
+        # Reverse is a no-op: once repinned, these rows are indistinguishable from natively-created
+        # ones, so a blanket downgrade would clobber legitimate "202607" pins and move customers back
+        # onto the sunset v1 header.
+        migrations.RunPython(repin_linkedin_ads_v1_to_202607, migrations.RunPython.noop, elidable=False),
+    ]

--- a/products/warehouse_sources/backend/migrations/max_migration.txt
+++ b/products/warehouse_sources/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0138_scaffold_wisprflow_source
+0139_repin_linkedin_ads_api_version

--- a/products/warehouse_sources/backend/migrations/test/test_migration_0139.py
+++ b/products/warehouse_sources/backend/migrations/test/test_migration_0139.py
@@ -1,0 +1,63 @@
+import uuid
+import importlib
+
+import pytest
+
+from django.apps import apps
+
+from products.warehouse_sources.backend.facade.models import ExternalDataSource
+
+migration_module = importlib.import_module(
+    "products.warehouse_sources.backend.migrations.0139_repin_linkedin_ads_api_version"
+)
+repin_linkedin_ads_v1_to_202607 = migration_module.repin_linkedin_ads_v1_to_202607
+
+
+@pytest.fixture
+def source_factory(team):
+    def _create(source_type, api_version=None):
+        return ExternalDataSource.objects.create(
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            destination_id=str(uuid.uuid4()),
+            team=team,
+            status="running",
+            source_type=source_type,
+            api_version=api_version,
+            job_inputs={},
+        )
+
+    return _create
+
+
+@pytest.mark.django_db
+class TestRepinLinkedinAdsApiVersion:
+    def test_repins_only_v1_pinned_linkedin_ads_rows(self, source_factory):
+        legacy_pinned = source_factory("LinkedinAds", api_version="v1")
+        already_current = source_factory("LinkedinAds", api_version="202607")
+        unpinned = source_factory("LinkedinAds", api_version=None)
+        other_source = source_factory("Stripe", api_version="v1")
+
+        repin_linkedin_ads_v1_to_202607(apps, None)
+
+        legacy_pinned.refresh_from_db()
+        already_current.refresh_from_db()
+        unpinned.refresh_from_db()
+        other_source.refresh_from_db()
+        assert legacy_pinned.api_version == "202607"
+        # A pin already on the current default is untouched.
+        assert already_current.api_version == "202607"
+        # NULL already resolves to the (now "202607") default, so it's left alone rather than
+        # stamped with a concrete value.
+        assert unpinned.api_version is None
+        # Non-LinkedinAds sources on the same legacy label are untouched.
+        assert other_source.api_version == "v1"
+
+    def test_is_idempotent(self, source_factory):
+        source = source_factory("LinkedinAds", api_version="v1")
+
+        repin_linkedin_ads_v1_to_202607(apps, None)
+        repin_linkedin_ads_v1_to_202607(apps, None)
+
+        source.refresh_from_db()
+        assert source.api_version == "202607"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/source.py
@@ -1,3 +1,4 @@
+from datetime import date
 from typing import Optional, cast
 
 from posthog.schema import (
@@ -18,6 +19,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.bas
     UNVERSIONED_API_VERSION,
     FieldType,
     ResumableSource,
+    VersionDeprecation,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
     CanonicalDescriptions,
@@ -66,6 +68,10 @@ class LinkedInAdsSource(ResumableSource[LinkedinAdsSourceConfig, LinkedInAdsResu
 
     supported_versions = (UNVERSIONED_API_VERSION, LINKEDIN_ADS_VERSION_202606, LINKEDIN_ADS_VERSION_202607)
     default_version = LINKEDIN_ADS_VERSION_202607
+    # LinkedIn supports each version for a minimum of one year, then starts rejecting it with a 426
+    # `NONEXISTENT_VERSION` (see `get_non_retryable_errors`). The legacy `v1` pin sends the header it
+    # always has (202508, August 2025 — `_API_HEADER_BY_VERSION`), which reached that one-year mark.
+    deprecated_versions = (VersionDeprecation(version=UNVERSIONED_API_VERSION, sunset_at=date(2026, 8, 1)),)
 
     lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
 
@@ -112,6 +118,10 @@ class LinkedInAdsSource(ResumableSource[LinkedinAdsSourceConfig, LinkedInAdsResu
             # user must re-authorize. Model-specific so we don't swallow unrelated `DoesNotExist`
             # errors from other models, which may be real bugs.
             "Integration matching query does not exist": "Your LinkedIn Ads connection is no longer available — it may have been disconnected. Please re-authorize the LinkedIn Ads integration.",
+            # LinkedIn rejects a deprecated/sunset version header with this stable code (see
+            # `deprecated_versions`). It happens on every call under that pin regardless of resource
+            # or account, so retrying can never succeed — only repinning to a supported version does.
+            "NONEXISTENT_VERSION": "PostHog is using a LinkedIn Ads API version that LinkedIn has sunset. This is being fixed on our side — no action is needed from you.",
         }
 
     def get_retryable_errors(self) -> set[str]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
@@ -1,8 +1,10 @@
 import json
+from datetime import date
 
 import pytest
 from unittest import mock
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import VersionDeprecation
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.linkedinads import (
     LinkedinAdsSourceConfig,
 )
@@ -33,6 +35,9 @@ class TestLinkedInAdsSource:
             'LinkedIn API error (401): {"status":401,"serviceErrorCode":65608,"code":"RESTRICTED_MEMBER","message":"Member is restricted"}',
             # Integration.DoesNotExist when the OAuth integration row was deleted/disconnected.
             "Integration matching query does not exist.",
+            # A sunset version header (see `deprecated_versions`) — happens on every call under that
+            # pin regardless of resource, so it must never be left to retry forever.
+            'LinkedIn API error (426): {"status":426,"code":"NONEXISTENT_VERSION","message":"Requested version 20250801 is not active"}',
         ],
     )
     def test_non_retryable_errors_match_upstream_failures(self, observed_error):
@@ -79,6 +84,11 @@ class TestLinkedInAdsSource:
     def test_defaults_new_sources_to_202607(self):
         assert self.source.default_version == LINKEDIN_ADS_VERSION_202607
         assert set(self.source.supported_versions) == {"v1", LINKEDIN_ADS_VERSION_202606, LINKEDIN_ADS_VERSION_202607}
+
+    def test_legacy_v1_pin_is_deprecated(self):
+        # "v1" backs the sunset 202508 header (see client.API_VERSION) — the in-product deprecation
+        # banner depends on this metadata staying declared.
+        assert self.source.deprecated_versions == (VersionDeprecation(version="v1", sunset_at=date(2026, 8, 1)),)
 
     @pytest.mark.parametrize(
         "pinned_version,expected_header",


### PR DESCRIPTION
## Problem

LinkedIn Ads imports on the source's legacy API version pin fail every sync with `LinkedinAdsApiError: LinkedIn API error (426): {"status":426,"code":"NONEXISTENT_VERSION","message":"Requested version 20250801 is not active"}`. Confirmed in [error tracking](https://us.posthog.com/project/2/error_tracking/01a0095d-0c72-7811-bfd1-7b5a1ec40d0a) — the stack originates in `LinkedinAdsClient._call_finder`, on a `conversions` sync, but the same pin fails on every resource.

LinkedIn's [versioning policy](https://learn.microsoft.com/en-us/linkedin/marketing/versioning) supports each version for a minimum of one year. The legacy `v1` pin sends the header it has always sent (`202508`, August 2025), which just crossed that mark and now gets a documented 426 on every request.

> [!NOTE]
> #83488 opened minutes before this one on the same error (a different error-tracking issue id, same root cause). It stops the retry loop but concludes there's "no in-place repair path" and tells users to recreate the source. That's avoidable: this codebase already has a precedent (the Ably repin, `0109_repin_ably_api_version_v2`) for moving existing sources off a sunset pin via migration, which this PR follows. Flagging both for reconciliation at review time rather than picking a winner myself.

## Changes

- Mark `v1` deprecated (`deprecated_versions`), with the sunset date implied by LinkedIn's one-year policy.
- Add `NONEXISTENT_VERSION` to `get_non_retryable_errors` — a source still on the sunset pin fails fast instead of retrying a call that can never succeed.
- Add migration `0139_repin_linkedin_ads_api_version` to repin existing `LinkedinAds` sources from `v1` to `202607` (today's default). The response shape LinkedIn serves for the tables this source reads is unchanged between the two, so only the pin moves. Mirrors the existing Ably repin (`0109_repin_ably_api_version_v2`).

## How did you test this code?

- Added a case to `test_non_retryable_errors_match_upstream_failures` reproducing the exact error tracking message, and `test_legacy_v1_pin_is_deprecated` for the deprecation metadata.
- Added `test_migration_0139.py`: repins only `v1`-pinned `LinkedinAds` rows, leaves NULL/other-source/already-current pins untouched, and is idempotent.
- Ran the full `linkedin_ads` and `test_source_versions` suites, plus `manage.py makemigrations --check --dry-run warehouse_sources` (no model drift) and `manage.py migrate --check` (passes with the new migration applied) locally.
- Not run: a live LinkedIn Ads sync — no test credentials in this environment. This sandbox's ClickHouse container also has stale pre-existing migration state unrelated to this diff (Postgres-only change), so `hogli ci:preflight`'s migrations check flags that unrelated environment gap.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing config or workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged directly from the linked error tracking issue. Read the `linkedin_ads` source and client, then used the `warehouse-source-new-version` skill to recognize this as a version-sunset issue rather than a one-off bug in the `conversions` endpoint — the 426/`NONEXISTENT_VERSION` shape and one-year support window were confirmed against LinkedIn's public versioning and error-response docs. Followed the existing Ably repin migration as the shape template. While finishing up, discovered #83488, a second independent autonomous run that landed on the same root cause first but a narrower fix — noted above for reviewers to reconcile. Skills invoked: `warehouse-source-new-version`, `/django-migrations`, `/writing-tests`, `/writing-pr-descriptions`. No customer-specific data is involved anywhere in this change — the error and its fix are generic to the API version, not any one connection.