### PR TITLE
fix(clickhouse): catch connection errors in direct SQL queries

### DIFF
--- a/posthog/hogql/direct_sql/clickhouse_adapter.py
+++ b/posthog/hogql/direct_sql/clickhouse_adapter.py
@@ -270,6 +270,8 @@ class ClickHouseAdapter:
     def execute(self, request: DirectQueryRequest) -> DirectQueryResult:
         from clickhouse_connect.driver.exceptions import ClickHouseError
 
+        from products.warehouse_sources.backend.facade.source_management import ClickHouseConnectionError
+
         source = request.source
         clickhouse_source, config = self.validate_source_config(source, request.team)
         settings = request.settings
@@ -302,7 +304,13 @@ class ClickHouseAdapter:
                     rows, column_names, column_types = _fetch_capped_clickhouse_rows(
                         client, request.sql, request.values or None, statement_timeout_seconds
                     )
-        except (ClickHouseError, OSError, BaseSSHTunnelForwarderError, ExposedHogQLError) as error:
+        except (
+            ClickHouseError,
+            ClickHouseConnectionError,
+            OSError,
+            BaseSSHTunnelForwarderError,
+            ExposedHogQLError,
+        ) as error:
             span.set_attribute("error_type", error.__class__.__name__)
             if request.debug:
                 return DirectQueryResult(

--- a/posthog/hogql/direct_sql/test/test_clickhouse_adapter.py
+++ b/posthog/hogql/direct_sql/test/test_clickhouse_adapter.py
@@ -24,6 +24,8 @@ from posthog.hogql.parser import parse_select
 from posthog.hogql.printer.utils import prepare_and_print_ast
 from posthog.hogql.timings import HogQLTimings
 
+from products.warehouse_sources.backend.facade.source_management import ClickHouseConnectionError
+
 
 class TestDirectClickHouseTable(SimpleTestCase):
     def _table(self, database: str) -> DirectClickHouseTable:
@@ -118,6 +120,34 @@ class TestClickHouseAdapterExecute(BaseTest):
                 adapter.execute(request)
 
         self.assertEqual(str(error.exception), "Could not establish session to SSH gateway")
+
+    def test_execute_raises_exposed_error_when_client_connection_fails(self):
+        # `_get_client` wraps connect-time failures (e.g. a read timeout waking a cold ClickHouse
+        # Cloud service) in `ClickHouseConnectionError`, a plain Exception rather than a
+        # `ClickHouseError`. Without it in this except clause, the error escapes as unhandled
+        # instead of a clean `ExposedHogQLError` and gets captured as error-tracking noise.
+        source = MagicMock()
+        source.id = "src"
+        clickhouse_source = MagicMock()
+        clickhouse_source.direct_query_client.side_effect = ClickHouseConnectionError("Read timed out")
+
+        adapter = ClickHouseAdapter()
+        request = DirectQueryRequest(
+            source=source,
+            team=self.team,
+            sql="SELECT 1",
+            values=None,
+            settings=HogQLGlobalSettings(),
+            timings=HogQLTimings(),
+            query_type="HogQLQuery",
+            debug=False,
+        )
+
+        with patch.object(adapter, "validate_source_config", return_value=(clickhouse_source, MagicMock())):
+            with self.assertRaises(ExposedHogQLError) as error:
+                adapter.execute(request)
+
+        self.assertEqual(str(error.exception), "Read timed out")
 
 
 class TestClickHouseReadOnlyGuard(SimpleTestCase):

--- a/products/warehouse_sources/backend/facade/source_management.py
+++ b/products/warehouse_sources/backend/facade/source_management.py
@@ -23,6 +23,7 @@ _LAZY = {
     "CDCRepairInProgress": "cdc.repair",
     "repair_cdc_source": "cdc.repair",
     "purge_buffer_prefix": "cdc.buffer",
+    "ClickHouseConnectionError": "sources.clickhouse.clickhouse",
     "ClickHouseSource": "sources.clickhouse.source",
     "AnySource": "sources.common.base",
     "ExternalWebhookInfo": "sources.common.base",


### PR DESCRIPTION
## Problem

A direct HogQL query against a ClickHouse data warehouse source can fail to connect (for example a read timeout while ClickHouse Cloud cold-resumes an idle instance). That failure escaped `ClickHouseAdapter.execute` as an unhandled exception instead of the clean query error every other failure mode returns, and got captured as tracked exception noise.

Surfaced by an [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a0096c-b585-75a2-ad14-e821b057ef97) for a `ClickHouseConnectionError` raised from `_get_client`, reached through `direct_query_client`.

## Changes

- `ClickHouseAdapter.execute` now also catches `ClickHouseConnectionError`, the ClickHouse source's own wrapper for connect-time failures, alongside the driver's `ClickHouseError`.
- Every other direct-SQL adapter (MotherDuck, MySQL, Postgres, Redshift, Snowflake) already catches its source's connection-error type the same way; the ClickHouse adapter was the one missing it.
- Re-exported `ClickHouseConnectionError` from the `warehouse_sources` facade (`source_management.py`), matching how `MotherDuckConnectionError` is already exposed there — the product enforces import isolation, so the adapter can't reach the source's internal module directly.

A read timeout itself stays retryable; this only fixes how the error surfaces when it isn't recovered.

## How did you test this code?

- Added `test_execute_raises_exposed_error_when_client_connection_fails`, asserting a `ClickHouseConnectionError` from `direct_query_client` now surfaces as `ExposedHogQLError` instead of propagating unhandled.
- Ran the full `test_clickhouse_adapter.py` suite (47 tests) locally — all passed.
- Ran `uv run mypy --cache-fine-grained .` and `tach check --dependencies --interfaces` repo-wide — both clean, the latter confirming the facade re-export keeps `warehouse_sources`' isolation boundary intact.
- Not run: a live query against a real ClickHouse instance hitting a connect-time timeout — not reproducible in this sandbox.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — this changes exception handling only, no user-facing behavior or API change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, triaging a PostHog error tracking issue delivered by webhook.
- Skills invoked: `/writing-tests` before adding the regression test, `/writing-pr-descriptions` before writing this body.
- The stack trace initially pointed at the Temporal sync pipeline's source code, but tracing the call path showed it actually came from the separate "direct SQL" query adapter, which has its own, independent exception handling from the scheduled-import activity.
- Confirmed no duplicate PR exists (search excluded `app/posthog`-authored PRs per the isolation-repo convention, and checked the maintainer's other open warehouse-sources PRs).