### PR TITLE
fix(bing-webmaster-tools): suggest the verified site for a bare host

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bing_webmaster_tools/bing_webmaster_tools.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bing_webmaster_tools/bing_webmaster_tools.py
@@ -2,6 +2,7 @@ import re
 import datetime as dt
 from collections.abc import Iterator
 from typing import Any
+from urllib.parse import urlparse
 
 import requests
 from structlog.types import FilteringBoundLogger
@@ -127,6 +128,25 @@ def _site_key(url: str) -> str:
     return url.strip().rstrip("/").lower()
 
 
+def suggest_verified_site(filter_url: str, verified: list[str]) -> str | None:
+    """The verified site a bare-hostname filter entry most likely meant, else None.
+
+    Bing lists every site with a scheme (e.g. ``https://example.com/``), so an entry that omits the
+    scheme (``example.com``) matches nothing on the scheme-sensitive site key even when that host is
+    verified. When the entry is a bare hostname, point at the verified site sharing that host so the
+    "not verified" error can name the exact value to paste instead of dead-ending."""
+    stripped = filter_url.strip()
+    if not stripped or "://" in stripped:
+        return None
+    host = stripped.strip("/").lower()
+    if not host:
+        return None
+    for url in verified:
+        if urlparse(url).netloc.lower() == host:
+            return url
+    return None
+
+
 def parse_site_urls(raw: str | None) -> list[str]:
     """Parse the optional site filter field: one URL per line, blanks skipped, duplicates dropped."""
     if not raw:
@@ -166,8 +186,16 @@ def select_site_urls(sites: list[dict[str, Any]], site_url_filters: list[str]) -
         else:
             selected.append(matched)
     if missing:
+        suggestions = {
+            entry: match for entry in missing if (match := suggest_verified_site(entry, verified)) is not None
+        }
+        hint = ""
+        if suggestions:
+            pairs = "; ".join(f"'{entered}' is verified as '{match}'" for entered, match in suggestions.items())
+            hint = f"Bing lists sites with their full URL, so {pairs}. "
         raise ValueError(
             f"These site URLs are not verified sites on the connected account: {', '.join(missing)}. "
+            f"{hint}"
             "Enter each site exactly as Bing Webmaster Tools lists it, or clear the field to sync "
             "every verified site."
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bing_webmaster_tools/tests/test_bing_webmaster_tools.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bing_webmaster_tools/tests/test_bing_webmaster_tools.py
@@ -17,6 +17,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.bing_webma
     parse_site_urls,
     parse_wcf_date,
     select_site_urls,
+    suggest_verified_site,
     validate_credentials,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.bing_webmaster_tools.settings import (
@@ -167,6 +168,27 @@ class TestSiteSelection:
     def test_filter_matching_no_verified_site_raises(self):
         with pytest.raises(ValueError, match="not verified sites on the connected account"):
             select_site_urls(_SITES, ["http://unverified.example.org"])
+
+    @pytest.mark.parametrize(
+        "filter_url,expected",
+        [
+            # A bare hostname can never match Bing's scheme-prefixed site key, so it resolves to the
+            # verified site sharing that host, with or without a trailing slash and regardless of case.
+            ("example.com", "https://example.com/"),
+            ("example.com/", "https://example.com/"),
+            ("EXAMPLE.COM", "https://example.com/"),
+            # An entry that already carries a scheme is matched exactly, so no suggestion is offered.
+            ("https://example.com/", None),
+            # A host that isn't verified has nothing to suggest.
+            ("unknown.example.net", None),
+        ],
+    )
+    def test_suggest_verified_site(self, filter_url, expected):
+        assert suggest_verified_site(filter_url, ["https://example.com/"]) == expected
+
+    def test_bare_hostname_error_names_the_verified_form(self):
+        with pytest.raises(ValueError, match=r"'example.com' is verified as 'https://example.com/'"):
+            select_site_urls(_SITES, ["example.com"])
 
 
 class TestRequest:


### PR DESCRIPTION
## Problem

- Setting up a Bing Webmaster Tools source with a bare hostname in the site filter (for example `example.com`) fails with a "not verified" error, even when that site is verified on the account.
- Bing lists every site with a scheme, such as `https://example.com/`. The filter matches on a scheme-sensitive key, so a bare hostname never matches a verified site.
- The old error told the user to enter the site "exactly as Bing lists it" but never said what that value was, leaving them to guess the scheme.

## Changes

- The "not verified" error now names the verified site a bare hostname most likely meant, for example `'example.com' is verified as 'https://example.com/'`.
- Added `suggest_verified_site`, which matches a bare-hostname entry to a verified site by host while ignoring the scheme, and returns nothing when the entry already carries a scheme or no verified host matches.
- This mirrors the sibling Google Search Console source, which already turns a bare-hostname miss into "enter this exact value instead".
- The suggestion only enriches the error message. It does not auto-select a site, so distinct http and https properties stay distinct.

## How did you test this code?

- Added a parameterized test for `suggest_verified_site` covering a resolving bare hostname, trailing-slash and case variants, a scheme-carrying entry, and an unverified host. Added a test that the raised error names the verified form.
- Ran the Bing Webmaster Tools test file locally.
- Not run: database-backed suites. The changed code is pure functions, so they add no coverage here.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The change only adjusts an error message.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a batch of data-warehouse source-creation failures and fixed the one that was a genuine product gap. I (actually Claude) found that Bing Webmaster Tools, unlike its sibling Google Search Console source, offered no guidance when a user entered a bare hostname that could not match Bing's scheme-prefixed site URLs. Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
