### PR TITLE
chore(replay-vision): run the golden-dataset eval on a shared runner

### DIFF
--- a/.github/workflows/ci-replay-vision-evals.yml
+++ b/.github/workflows/ci-replay-vision-evals.yml
@@ -5,7 +5,7 @@
 # empty dataset) surface in the step summary rather than as a red X.
 # The dataset (real dogfood session recordings) is collected fresh on the ephemeral runner each run,
 # which re-verifies AI data-processing consent; it is never cached, uploaded as an artifact, or
-# otherwise persisted. Only aggregate scores reach the step summary.
+# otherwise persisted. Only aggregate scores reach the public job log and step summary.
 # The job executes the PR's own code with secrets, so it only runs once a maintainer applies the
 # replay-vision-evals-ready label, or on manual dispatch. The label approves the labeled revision
 # only: pushes never trigger this workflow, so re-running on a new revision takes removing and
@@ -178,8 +178,6 @@ jobs:
               # Advisory: eval failures (LLM 5xx, harness crash) must not paint a red X; the
               # verdict lives in the step summary.
               continue-on-error: true
-              # bash (not the default shell) for pipefail: without it a failing harness piped into a
-              # succeeding tee reports this step green.
               shell: bash
               env:
                   REPLAY_VISION_EVAL_DATASET: ${{ env.DATASET_DIR }}
@@ -191,8 +189,12 @@ jobs:
                   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
                   TRIALS: ${{ inputs.trials || '1' }}
               run: |
+                  # To the runner-local file only, never the public job log: the eval calls run_scan
+                  # directly, without the activity-level exception sanitizer, so a provider error can
+                  # echo prompt and session-derived request content. The summary step publishes the
+                  # safe aggregate lines.
                   python -m products.posthog_ai.eval_harness.harness eval_scanner_quality \
-                      --trials "$TRIALS" 2>&1 | tee /tmp/eval-output.log
+                      --trials "$TRIALS" > /tmp/eval-output.log 2>&1
 
             - name: Publish score summary
               # Publish whatever the run produced, including on failure; the suite is private, so
@@ -200,6 +202,7 @@ jobs:
               if: always() && steps.gate.outputs.enabled == 'true'
               shell: bash
               run: |
+                  # tee: the same sanitized lines double as the job log's only eval output.
                   {
                       echo "## Replay Vision scanner eval"
                       echo ""
@@ -209,11 +212,11 @@ jobs:
                       echo '```'
                       # Only the stable aggregate lines: this summary is public, and case payloads
                       # (session-derived content) must never leave the runner even if the harness's
-                      # console output grows.
-                      grep -E '^(CASE|SUITE|EXPERIMENT DONE|Sandboxed eval summary|Status:|Suites:|Cases:|Mean score:|Score gate:|Duration:)' \
+                      # console output grows. CASE lines stay out too: their names carry observation ids.
+                      grep -E '^(SUITE|EXPERIMENT DONE|Sandboxed eval summary|Status:|Suites:|Cases:|Mean score:|Score gate:|Duration:)' \
                           /tmp/eval-output.log 2>/dev/null || echo "no eval output produced"
                       echo '```'
-                  } >> "$GITHUB_STEP_SUMMARY"
+                  } | tee -a "$GITHUB_STEP_SUMMARY"
 
             - name: Remove dataset
               # The runner is ephemeral anyway; this just makes the no-persistence guarantee explicit.

--- a/.github/workflows/ci-replay-vision-evals.yml
+++ b/.github/workflows/ci-replay-vision-evals.yml
@@ -125,6 +125,7 @@ jobs:
 
             - name: Collect golden dataset
               if: steps.gate.outputs.enabled == 'true'
+              shell: bash
               env:
                   POSTHOG_API_KEY: ${{ secrets.REPLAY_VISION_EVAL_POSTHOG_API_KEY }}
                   DEBUG: '1'
@@ -136,11 +137,21 @@ jobs:
                       --per-type "$PER_TYPE" \
                       --max-observations 50 \
                       --output "$DATASET_DIR"
+                  # An empty dataset (expired assets, warehouse lag) must fail loudly, not score green over nothing.
+                  python - <<'EOF'
+                  import json, os, pathlib, sys
+                  cases = json.loads((pathlib.Path(os.environ["DATASET_DIR"]) / "manifest.json").read_text())["cases"]
+                  print(f"{len(cases)} cases in the collected dataset")
+                  sys.exit(1 if not cases else 0)
+                  EOF
 
             - name: Run scanner quality suite
               if: steps.gate.outputs.enabled == 'true'
+              # bash (not the default shell) for pipefail: without it a failing harness piped into a
+              # succeeding tee reports this step green.
+              shell: bash
               env:
-                  REPLAY_VISION_EVAL_DATASET: /tmp/replay-vision-golden-dataset
+                  REPLAY_VISION_EVAL_DATASET: ${{ env.DATASET_DIR }}
                   GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
                   BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
                   # The one-shot preflight name for a plain Anthropic key (used directly, no gateway).
@@ -156,6 +167,7 @@ jobs:
               # Publish whatever the run produced, including on failure; the suite is private, so
               # scores exist only in this runner's local logs.
               if: always() && steps.gate.outputs.enabled == 'true'
+              shell: bash
               run: |
                   {
                       echo "## Replay Vision scanner eval"
@@ -164,7 +176,11 @@ jobs:
                       echo "Directional signal only: Gemini is nondeterministic and the dataset is re-sampled per run."
                       echo ""
                       echo '```'
-                      tail -n 80 /tmp/eval-output.log 2>/dev/null || echo "no eval output produced"
+                      # Only the stable aggregate lines: this summary is public, and case payloads
+                      # (session-derived content) must never leave the runner even if the harness's
+                      # console output grows.
+                      grep -E '^(CASE|EXPERIMENT DONE|Suites:|Cases:|Mean score:|Score gate:|Duration:)|eval summary' \
+                          /tmp/eval-output.log 2>/dev/null || echo "no eval output produced"
                       echo '```'
                   } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/ci-replay-vision-evals.yml
+++ b/.github/workflows/ci-replay-vision-evals.yml
@@ -184,7 +184,10 @@ jobs:
                       # Only the stable aggregate lines: this summary is public, and case payloads
                       # (session-derived content) must never leave the runner even if the harness's
                       # console output grows. CASE lines stay out too: their names carry observation ids.
-                      grep -E '^(SUITE|EXPERIMENT DONE|Sandboxed eval summary|Status:|Suites:|Cases:|Mean score:|Score gate:|Duration:)' \
+                      # The indented PostHog line links the /ai-evals experiment the harness published
+                      # this run's scores to. It is safe to publish: the URL carries the project id and
+                      # a per-run random experiment UUID, nothing case-derived.
+                      grep -E '^(SUITE|EXPERIMENT DONE|Sandboxed eval summary|Status:|Suites:|Cases:|Mean score:|Score gate:|Duration:| +PostHog: )' \
                           /tmp/eval-output.log 2>/dev/null || echo "no eval output produced"
                       echo '```'
                   } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-replay-vision-evals.yml
+++ b/.github/workflows/ci-replay-vision-evals.yml
@@ -120,10 +120,12 @@ jobs:
               env:
                   POSTHOG_API_KEY: ${{ secrets.REPLAY_VISION_EVAL_POSTHOG_API_KEY }}
                   DEBUG: '1'
+                  # Through env, not inline ${{ }}, so a dispatch input can never inject into the shell.
+                  PER_TYPE: ${{ inputs.per_type || '3' }}
               run: |
                   python -m products.replay_vision.evals.collect \
                       --project-id 2 \
-                      --per-type "${{ inputs.per_type || '3' }}" \
+                      --per-type "$PER_TYPE" \
                       --max-observations 50 \
                       --output "$DATASET_DIR"
 
@@ -137,9 +139,10 @@ jobs:
                   LLM_GATEWAY_ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
                   # The summary_alignment judge (autoevals) calls its model with the OpenAI client.
                   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+                  TRIALS: ${{ inputs.trials || '1' }}
               run: |
                   python -m products.posthog_ai.eval_harness.harness eval_scanner_quality \
-                      --trials "${{ inputs.trials || '1' }}" 2>&1 | tee /tmp/eval-output.log
+                      --trials "$TRIALS" 2>&1 | tee /tmp/eval-output.log
 
             - name: Publish score summary
               # Publish whatever the run produced, including on failure; the suite is private, so

--- a/.github/workflows/ci-replay-vision-evals.yml
+++ b/.github/workflows/ci-replay-vision-evals.yml
@@ -1,18 +1,25 @@
 # Golden-dataset eval for Replay Vision scanner prompts (products/replay_vision/evals).
 #
-# Advisory only, never a required check: Gemini scores are a directional signal, not a merge gate.
+# Advisory only, never a required check: Gemini scores are a directional signal, not a merge gate,
+# and the collect/eval steps run with continue-on-error so infra failures (LLM 5xx, warehouse lag,
+# empty dataset) surface in the step summary rather than as a red X.
 # The dataset (real dogfood session recordings) is collected fresh on the ephemeral runner each run,
 # which re-verifies AI data-processing consent; it is never cached, uploaded as an artifact, or
 # otherwise persisted. Only aggregate scores reach the step summary.
 # The job executes the PR's own code with secrets, so it only runs once a maintainer applies the
-# replay-vision-evals-ready label (the ci-ai.yml trust gate), or on manual dispatch.
-# Without the REPLAY_VISION_EVAL_POSTHOG_API_KEY secret the job skips green, so forks and
+# replay-vision-evals-ready label, or on manual dispatch. The label approves the labeled revision
+# only: pushes never trigger this workflow, so re-running on a new revision takes removing and
+# re-applying the label.
+# If any required secret is missing the job skips green with a warning, so forks and
 # not-yet-configured environments are unaffected.
 name: Replay Vision Evals
 
 on:
     pull_request:
-        types: [opened, synchronize, reopened, labeled]
+        # No synchronize: the label must approve each revision, not the PR, or a labeled PR's later
+        # pushes would run their own code with secrets unreviewed. An unlabeled run skips, but
+        # dispatching it cancels any in-flight run via the concurrency group.
+        types: [labeled, unlabeled]
         paths:
             - '.github/workflows/ci-replay-vision-evals.yml'
             - 'products/replay_vision/backend/temporal/scanners/prompts/**'
@@ -53,15 +60,26 @@ jobs:
         env:
             DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USER }}
             DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-            COLLECTION_API_KEY: ${{ secrets.REPLAY_VISION_EVAL_POSTHOG_API_KEY }}
 
         steps:
-            - name: Check collection key
+            - name: Check required secrets
               id: gate
+              # All five up front: one rotated key must not boot the Docker stack and collect a
+              # dataset before failing inside the eval.
+              env:
+                  REPLAY_VISION_EVAL_POSTHOG_API_KEY: ${{ secrets.REPLAY_VISION_EVAL_POSTHOG_API_KEY }}
+                  GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+                  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+                  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+                  BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
               run: |
-                  if [ -z "$COLLECTION_API_KEY" ]; then
+                  missing=""
+                  for name in REPLAY_VISION_EVAL_POSTHOG_API_KEY GEMINI_API_KEY OPENAI_API_KEY ANTHROPIC_API_KEY BRAINTRUST_API_KEY; do
+                      [ -n "${!name}" ] || missing="$missing $name"
+                  done
+                  if [ -n "$missing" ]; then
                       echo "enabled=false" >> "$GITHUB_OUTPUT"
-                      echo "::notice::REPLAY_VISION_EVAL_POSTHOG_API_KEY is not set; skipping the golden-dataset eval"
+                      echo "::warning::Missing secrets:$missing; skipping the golden-dataset eval"
                   else
                       echo "enabled=true" >> "$GITHUB_OUTPUT"
                   fi
@@ -124,7 +142,11 @@ jobs:
               run: sudo echo "127.0.0.1 db redis7 kafka clickhouse clickhouse-coordinator objectstorage seaweedfs temporal" | sudo tee -a /etc/hosts
 
             - name: Collect golden dataset
+              id: collect
               if: steps.gate.outputs.enabled == 'true'
+              # Advisory: collection failures (warehouse lag, empty dataset, expired assets) must
+              # not paint a red X; the eval step is skipped and the summary explains.
+              continue-on-error: true
               shell: bash
               env:
                   POSTHOG_API_KEY: ${{ secrets.REPLAY_VISION_EVAL_POSTHOG_API_KEY }}
@@ -132,10 +154,16 @@ jobs:
                   # Through env, not inline ${{ }}, so a dispatch input can never inject into the shell.
                   PER_TYPE: ${{ inputs.per_type || '3' }}
               run: |
+                  # An unrebased branch can check out a collect.py that predates --max-observations;
+                  # only pass the flag when the script advertises it.
+                  max_obs_args=()
+                  if python -m products.replay_vision.evals.collect --help 2>/dev/null | grep -q -- '--max-observations'; then
+                      max_obs_args=(--max-observations 50)
+                  fi
                   python -m products.replay_vision.evals.collect \
                       --project-id 2 \
                       --per-type "$PER_TYPE" \
-                      --max-observations 50 \
+                      "${max_obs_args[@]}" \
                       --output "$DATASET_DIR"
                   # An empty dataset (expired assets, warehouse lag) must fail loudly, not score green over nothing.
                   python - <<'EOF'
@@ -146,7 +174,10 @@ jobs:
                   EOF
 
             - name: Run scanner quality suite
-              if: steps.gate.outputs.enabled == 'true'
+              if: steps.gate.outputs.enabled == 'true' && steps.collect.outcome == 'success'
+              # Advisory: eval failures (LLM 5xx, harness crash) must not paint a red X; the
+              # verdict lives in the step summary.
+              continue-on-error: true
               # bash (not the default shell) for pipefail: without it a failing harness piped into a
               # succeeding tee reports this step green.
               shell: bash
@@ -179,7 +210,7 @@ jobs:
                       # Only the stable aggregate lines: this summary is public, and case payloads
                       # (session-derived content) must never leave the runner even if the harness's
                       # console output grows.
-                      grep -E '^(CASE|EXPERIMENT DONE|Suites:|Cases:|Mean score:|Score gate:|Duration:)|eval summary' \
+                      grep -E '^(CASE|SUITE|EXPERIMENT DONE|Sandboxed eval summary|Status:|Suites:|Cases:|Mean score:|Score gate:|Duration:)' \
                           /tmp/eval-output.log 2>/dev/null || echo "no eval output produced"
                       echo '```'
                   } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-replay-vision-evals.yml
+++ b/.github/workflows/ci-replay-vision-evals.yml
@@ -1,0 +1,163 @@
+# Golden-dataset eval for Replay Vision scanner prompts (products/replay_vision/evals).
+#
+# Advisory only, never a required check: Gemini scores are a directional signal, not a merge gate.
+# The dataset (real dogfood session recordings) is collected fresh on the ephemeral runner each run,
+# which re-verifies AI data-processing consent; it is never cached, uploaded as an artifact, or
+# otherwise persisted. Only aggregate scores reach the step summary.
+# Without the REPLAY_VISION_EVAL_POSTHOG_API_KEY secret the job skips green, so forks and
+# not-yet-configured environments are unaffected.
+name: Replay Vision Evals
+
+on:
+    pull_request:
+        paths:
+            - '.github/workflows/ci-replay-vision-evals.yml'
+            - 'products/replay_vision/backend/temporal/scanners/prompts/**'
+            - 'products/replay_vision/evals/**'
+    workflow_dispatch:
+        inputs:
+            per_type:
+                description: 'Cases to collect per scanner type'
+                default: '5'
+                type: string
+            trials:
+                description: 'Trials per case, for variance on Gemini nondeterminism'
+                default: '1'
+                type: string
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+    contents: read
+
+env:
+    DATASET_DIR: /tmp/replay-vision-golden-dataset
+
+jobs:
+    golden-eval:
+        name: Golden-dataset scanner eval
+        timeout-minutes: 60
+        runs-on: ubuntu-latest
+        # Fork PRs have no secrets, so the eval can only run on internal branches.
+        if: github.repository == 'PostHog/posthog' && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.fork == false)
+        env:
+            DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USER }}
+            DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+            COLLECTION_API_KEY: ${{ secrets.REPLAY_VISION_EVAL_POSTHOG_API_KEY }}
+
+        steps:
+            - name: Check collection key
+              id: gate
+              run: |
+                  if [ -z "$COLLECTION_API_KEY" ]; then
+                      echo "enabled=false" >> "$GITHUB_OUTPUT"
+                      echo "::notice::REPLAY_VISION_EVAL_POSTHOG_API_KEY is not set; skipping the golden-dataset eval"
+                  else
+                      echo "enabled=true" >> "$GITHUB_OUTPUT"
+                  fi
+
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              if: steps.gate.outputs.enabled == 'true'
+
+            - name: Log in to Docker Hub
+              if: steps.gate.outputs.enabled == 'true' && env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != ''
+              uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+              with:
+                  username: ${{ vars.DOCKERHUB_USER }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Start stack with Docker Compose
+              if: steps.gate.outputs.enabled == 'true'
+              env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
+              run: bin/ci-wait-for-docker launch --down
+
+            - name: Wait for Docker services
+              if: steps.gate.outputs.enabled == 'true'
+              env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
+              run: bin/ci-wait-for-docker wait
+
+            - name: Set up Python
+              if: steps.gate.outputs.enabled == 'true'
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+              with:
+                  python-version-file: 'pyproject.toml'
+
+            - name: Install uv
+              if: steps.gate.outputs.enabled == 'true'
+              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              with:
+                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+                  enable-cache: true
+                  cache-dependency-glob: uv.lock
+                  save-cache: false
+
+            - name: Install python dependencies
+              if: steps.gate.outputs.enabled == 'true'
+              shell: bash
+              run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
+
+            - name: Install Rust
+              if: steps.gate.outputs.enabled == 'true'
+              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+              with:
+                  toolchain: 1.91.1
+                  components: cargo
+
+            - name: Install sqlx-cli
+              if: steps.gate.outputs.enabled == 'true'
+              uses: ./.github/actions/setup-sqlx-cli
+
+            - name: Add service hostnames to /etc/hosts
+              if: steps.gate.outputs.enabled == 'true'
+              run: sudo echo "127.0.0.1 db redis7 kafka clickhouse clickhouse-coordinator objectstorage seaweedfs temporal" | sudo tee -a /etc/hosts
+
+            - name: Collect golden dataset
+              if: steps.gate.outputs.enabled == 'true'
+              env:
+                  POSTHOG_API_KEY: ${{ secrets.REPLAY_VISION_EVAL_POSTHOG_API_KEY }}
+                  DEBUG: '1'
+              run: |
+                  python -m products.replay_vision.evals.collect \
+                      --project-id 2 \
+                      --per-type "${{ inputs.per_type || '3' }}" \
+                      --max-observations 50 \
+                      --output "$DATASET_DIR"
+
+            - name: Run scanner quality suite
+              if: steps.gate.outputs.enabled == 'true'
+              env:
+                  REPLAY_VISION_EVAL_DATASET: /tmp/replay-vision-golden-dataset
+                  GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+                  BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
+                  # The one-shot preflight name for a plain Anthropic key (used directly, no gateway).
+                  LLM_GATEWAY_ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+                  # The summary_alignment judge (autoevals) calls its model with the OpenAI client.
+                  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+              run: |
+                  python -m products.posthog_ai.eval_harness.harness eval_scanner_quality \
+                      --trials "${{ inputs.trials || '1' }}" 2>&1 | tee /tmp/eval-output.log
+
+            - name: Publish score summary
+              # Publish whatever the run produced, including on failure; the suite is private, so
+              # scores exist only in this runner's local logs.
+              if: always() && steps.gate.outputs.enabled == 'true'
+              run: |
+                  {
+                      echo "## Replay Vision scanner eval"
+                      echo ""
+                      echo "Scores compare fresh scans against recorded outputs and human thumbs labels."
+                      echo "Directional signal only: Gemini is nondeterministic and the dataset is re-sampled per run."
+                      echo ""
+                      echo '```'
+                      tail -n 80 /tmp/eval-output.log 2>/dev/null || echo "no eval output produced"
+                      echo '```'
+                  } >> "$GITHUB_STEP_SUMMARY"
+
+            - name: Remove dataset
+              # The runner is ephemeral anyway; this just makes the no-persistence guarantee explicit.
+              if: always()
+              run: rm -rf "$DATASET_DIR"

--- a/.github/workflows/ci-replay-vision-evals.yml
+++ b/.github/workflows/ci-replay-vision-evals.yml
@@ -1,29 +1,18 @@
 # Golden-dataset eval for Replay Vision scanner prompts (products/replay_vision/evals).
 #
-# Advisory only, never a required check: Gemini scores are a directional signal, not a merge gate,
-# and the collect/eval steps run with continue-on-error so infra failures (LLM 5xx, warehouse lag,
-# empty dataset) surface in the step summary rather than as a red X.
-# The dataset (real dogfood session recordings) is collected fresh on the ephemeral runner each run,
-# which re-verifies AI data-processing consent; it is never cached, uploaded as an artifact, or
-# otherwise persisted. Only aggregate scores reach the public job log and step summary.
-# The job executes the PR's own code with secrets, so it only runs once a maintainer applies the
-# replay-vision-evals-ready label, or on manual dispatch. The label approves the labeled revision
-# only: pushes never trigger this workflow, so re-running on a new revision takes removing and
-# re-applying the label.
-# If any required secret is missing the job skips green with a warning, so forks and
-# not-yet-configured environments are unaffected.
+# Manual dispatch only, deliberately. The suite re-runs production scans over real dogfood session
+# recordings, so a run spends secrets and LLM calls, and the number it returns moves on its own:
+# Gemini is nondeterministic and the dataset is re-sampled per run. That makes the score a
+# directional signal rather than a merge gate, which is not worth attaching to every push.
+#
+# The dataset is collected fresh on the ephemeral runner each run, which re-verifies AI
+# data-processing consent; it is never cached, uploaded as an artifact, or otherwise persisted.
+# Only aggregate scores reach the public job log and step summary.
+# If any required secret is missing the job skips green with a warning, so a fork or a
+# not-yet-configured environment is unaffected.
 name: Replay Vision Evals
 
 on:
-    pull_request:
-        # No synchronize: the label must approve each revision, not the PR, or a labeled PR's later
-        # pushes would run their own code with secrets unreviewed. An unlabeled run skips, but
-        # dispatching it cancels any in-flight run via the concurrency group.
-        types: [labeled, unlabeled]
-        paths:
-            - '.github/workflows/ci-replay-vision-evals.yml'
-            - 'products/replay_vision/backend/temporal/scanners/prompts/**'
-            - 'products/replay_vision/evals/**'
     workflow_dispatch:
         inputs:
             per_type:
@@ -34,10 +23,6 @@ on:
                 description: 'Trials per case, for variance on Gemini nondeterminism'
                 default: '1'
                 type: string
-
-concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
     contents: read
@@ -50,13 +35,6 @@ jobs:
         name: Golden-dataset scanner eval
         timeout-minutes: 60
         runs-on: ubuntu-latest
-        # The PR's own collector/harness code runs with secrets, so a PR revision is only trusted
-        # once a maintainer has looked at it and applied the label; manual dispatch is maintainer-initiated.
-        if: |
-            github.repository == 'PostHog/posthog' &&
-            (github.event_name == 'workflow_dispatch' ||
-             (github.event.pull_request.head.repo.fork == false &&
-              contains(github.event.pull_request.labels.*.name, 'replay-vision-evals-ready')))
         env:
             DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USER }}
             DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -142,30 +120,20 @@ jobs:
               run: sudo echo "127.0.0.1 db redis7 kafka clickhouse clickhouse-coordinator objectstorage seaweedfs temporal" | sudo tee -a /etc/hosts
 
             - name: Collect golden dataset
-              id: collect
               if: steps.gate.outputs.enabled == 'true'
-              # Advisory: collection failures (warehouse lag, empty dataset, expired assets) must
-              # not paint a red X; the eval step is skipped and the summary explains.
-              continue-on-error: true
               shell: bash
               env:
                   POSTHOG_API_KEY: ${{ secrets.REPLAY_VISION_EVAL_POSTHOG_API_KEY }}
+                  # Django refuses to boot with the checked-in SECRET_KEY unless DEBUG is set.
                   DEBUG: '1'
                   # Through env, not inline ${{ }}, so a dispatch input can never inject into the shell.
-                  PER_TYPE: ${{ inputs.per_type || '3' }}
+                  PER_TYPE: ${{ inputs.per_type }}
               run: |
-                  # An unrebased branch can check out a collect.py that predates --max-observations;
-                  # only pass the flag when the script advertises it.
-                  max_obs_args=()
-                  if python -m products.replay_vision.evals.collect --help 2>/dev/null | grep -q -- '--max-observations'; then
-                      max_obs_args=(--max-observations 50)
-                  fi
                   # To the runner-local file only, never the public job log: the collector emits
                   # session and observation ids for missing-event and failed cases.
                   python -m products.replay_vision.evals.collect \
                       --project-id 2 \
                       --per-type "$PER_TYPE" \
-                      "${max_obs_args[@]}" \
                       --output "$DATASET_DIR" > /tmp/collect-output.log 2>&1 || {
                       status=$?
                       echo "collect exited with status $status; collector output stays off the public log"
@@ -180,10 +148,7 @@ jobs:
                   EOF
 
             - name: Run scanner quality suite
-              if: steps.gate.outputs.enabled == 'true' && steps.collect.outcome == 'success'
-              # Advisory: eval failures (LLM 5xx, harness crash) must not paint a red X; the
-              # verdict lives in the step summary.
-              continue-on-error: true
+              if: steps.gate.outputs.enabled == 'true'
               shell: bash
               env:
                   REPLAY_VISION_EVAL_DATASET: ${{ env.DATASET_DIR }}
@@ -193,7 +158,7 @@ jobs:
                   LLM_GATEWAY_ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
                   # The summary_alignment judge (autoevals) calls its model with the OpenAI client.
                   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-                  TRIALS: ${{ inputs.trials || '1' }}
+                  TRIALS: ${{ inputs.trials }}
               run: |
                   # To the runner-local file only, never the public job log: the eval calls run_scan
                   # directly, without the activity-level exception sanitizer, so a provider error can

--- a/.github/workflows/ci-replay-vision-evals.yml
+++ b/.github/workflows/ci-replay-vision-evals.yml
@@ -160,11 +160,17 @@ jobs:
                   if python -m products.replay_vision.evals.collect --help 2>/dev/null | grep -q -- '--max-observations'; then
                       max_obs_args=(--max-observations 50)
                   fi
+                  # To the runner-local file only, never the public job log: the collector emits
+                  # session and observation ids for missing-event and failed cases.
                   python -m products.replay_vision.evals.collect \
                       --project-id 2 \
                       --per-type "$PER_TYPE" \
                       "${max_obs_args[@]}" \
-                      --output "$DATASET_DIR"
+                      --output "$DATASET_DIR" > /tmp/collect-output.log 2>&1 || {
+                      status=$?
+                      echo "collect exited with status $status; collector output stays off the public log"
+                      exit "$status"
+                  }
                   # An empty dataset (expired assets, warehouse lag) must fail loudly, not score green over nothing.
                   python - <<'EOF'
                   import json, os, pathlib, sys

--- a/.github/workflows/ci-replay-vision-evals.yml
+++ b/.github/workflows/ci-replay-vision-evals.yml
@@ -4,12 +4,15 @@
 # The dataset (real dogfood session recordings) is collected fresh on the ephemeral runner each run,
 # which re-verifies AI data-processing consent; it is never cached, uploaded as an artifact, or
 # otherwise persisted. Only aggregate scores reach the step summary.
+# The job executes the PR's own code with secrets, so it only runs once a maintainer applies the
+# replay-vision-evals-ready label (the ci-ai.yml trust gate), or on manual dispatch.
 # Without the REPLAY_VISION_EVAL_POSTHOG_API_KEY secret the job skips green, so forks and
 # not-yet-configured environments are unaffected.
 name: Replay Vision Evals
 
 on:
     pull_request:
+        types: [opened, synchronize, reopened, labeled]
         paths:
             - '.github/workflows/ci-replay-vision-evals.yml'
             - 'products/replay_vision/backend/temporal/scanners/prompts/**'
@@ -40,8 +43,13 @@ jobs:
         name: Golden-dataset scanner eval
         timeout-minutes: 60
         runs-on: ubuntu-latest
-        # Fork PRs have no secrets, so the eval can only run on internal branches.
-        if: github.repository == 'PostHog/posthog' && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.fork == false)
+        # The PR's own collector/harness code runs with secrets, so a PR revision is only trusted
+        # once a maintainer has looked at it and applied the label; manual dispatch is maintainer-initiated.
+        if: |
+            github.repository == 'PostHog/posthog' &&
+            (github.event_name == 'workflow_dispatch' ||
+             (github.event.pull_request.head.repo.fork == false &&
+              contains(github.event.pull_request.labels.*.name, 'replay-vision-evals-ready')))
         env:
             DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USER }}
             DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/products/replay_vision/evals/README.md
+++ b/products/replay_vision/evals/README.md
@@ -53,6 +53,13 @@ Use `--trials N` for variance on Gemini nondeterminism and `--eval <case-substri
 
 `output_stability` and `labeled_outcome` deliberately pull in opposite directions, so read them as a pair: a prompt change that only adds churn shows up as `labeled_outcome` flat or up while `output_stability` drops.
 
+## CI
+
+`.github/workflows/ci-replay-vision-evals.yml` runs a small version of this loop on PRs that touch the prompt templates or the evals themselves, and on manual dispatch with bigger `per_type`/`trials` knobs.
+It collects a fresh dataset on the ephemeral runner (so consent is re-verified every run; nothing is cached, uploaded, or persisted), runs the suite, and writes the score table to the job's step summary.
+It is advisory and never a required check: Gemini is nondeterministic and the dataset is re-sampled per run, so treat the scores as a directional signal.
+The job needs the `REPLAY_VISION_EVAL_POSTHOG_API_KEY` repo secret (a personal API key with scanner, session recording, export, and query read access to the dogfood project); without it the job skips green.
+
 ## Data handling
 
 The dataset contains real session recordings and event data.

--- a/products/replay_vision/evals/README.md
+++ b/products/replay_vision/evals/README.md
@@ -56,6 +56,7 @@ Use `--trials N` for variance on Gemini nondeterminism and `--eval <case-substri
 ## CI
 
 `.github/workflows/ci-replay-vision-evals.yml` runs a small version of this loop on PRs that touch the prompt templates or the evals themselves, and on manual dispatch with bigger `per_type`/`trials` knobs.
+Because the job executes the PR's own code with secrets, it only runs once a maintainer applies the `replay-vision-evals-ready` label to the PR (the same trust gate as `ci-ai.yml`'s `evals-ready`).
 It collects a fresh dataset on the ephemeral runner (so consent is re-verified every run; nothing is cached, uploaded, or persisted), runs the suite, and writes the score table to the job's step summary.
 It is advisory and never a required check: Gemini is nondeterministic and the dataset is re-sampled per run, so treat the scores as a directional signal.
 The job needs the `REPLAY_VISION_EVAL_POSTHOG_API_KEY` repo secret (a personal API key with scanner, session recording, export, and query read access to the dogfood project); without it the job skips green.

--- a/products/replay_vision/evals/README.md
+++ b/products/replay_vision/evals/README.md
@@ -53,17 +53,13 @@ Use `--trials N` for variance on Gemini nondeterminism and `--eval <case-substri
 
 `output_stability` and `labeled_outcome` deliberately pull in opposite directions, so read them as a pair: a prompt change that only adds churn shows up as `labeled_outcome` flat or up while `output_stability` drops.
 
-## CI
+## Running it on a GitHub runner
 
-`.github/workflows/ci-replay-vision-evals.yml` runs a small version of this loop against a PR, and on manual dispatch with bigger `per_type`/`trials` knobs (GitHub only offers the dispatch once the workflow is on master).
+`.github/workflows/ci-replay-vision-evals.yml` runs the same loop on an ephemeral runner, on manual dispatch only, with `per_type` and `trials` as inputs (GitHub only offers the dispatch once the workflow is on master).
+It is deliberately not attached to `pull_request`: Gemini is nondeterministic and the dataset is re-sampled per run, so the score is a directional signal rather than a merge gate, and spending secrets and LLM calls on every push buys nothing that a dispatch after a prompt change does not.
 
-Because the job executes the PR's own collector and harness code with secrets, a maintainer has to approve each revision by hand: it runs only on a `replay-vision-evals-ready` label event, on a PR whose diff touches the prompt templates or the evals.
-Pushing to a labeled PR does not re-run it, since the label approved the revision a maintainer looked at, not the PR.
-To score a new revision, remove the label and apply it again; removing it also cancels an in-flight run.
-
-It collects a fresh dataset on the ephemeral runner (so consent is re-verified every run; nothing is cached, uploaded, or persisted), runs the suite, and writes the aggregate scores to the job's step summary.
+It collects a fresh dataset on the runner (so consent is re-verified every run; nothing is cached, uploaded, or persisted), runs the suite, and writes the aggregate scores to the job's step summary.
 Only those allowlisted summary lines are public: collector and harness output stay in runner-local files, because they carry session and observation ids.
-It is advisory and never a required check. Gemini is nondeterministic and the dataset is re-sampled per run, so treat the scores as a directional signal, and infra failures (provider 5xx, warehouse lag, an empty dataset) land in the step summary rather than as a red X.
 The job needs `REPLAY_VISION_EVAL_POSTHOG_API_KEY` (a personal API key with scanner, session recording, export, and query read access to the dogfood project) plus the `GEMINI_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, and `BRAINTRUST_API_KEY` secrets `ci-ai.yml` already uses; if any is missing the job skips green and warns which.
 
 ## Data handling
@@ -72,6 +68,7 @@ The dataset contains real session recordings and event data.
 
 - Keep it in a local or internal location only; never commit it, upload it, or reference its contents in PRs.
 - A dataset expires 30 days after its last collection: the suite refuses to run it, because the consent verification (and the recordings themselves) can lapse after collection. Re-running collect.py re-verifies consent and refreshes the manifest.
-- The suite is `OneShotPrivateEval`: results stay in the local `eval_harness/logs/` directory and are not sent to Braintrust.
-- `summary_alignment` sends the recorded and fresh session summaries to the LLM judge (`gpt-5.4` via the internal LLM gateway); besides the Gemini scans themselves, this is the only path where dataset-derived content leaves the machine.
+- The suite is `OneShotPrivateEval`, so per-case logs stay in the local `eval_harness/logs/` directory and nothing goes to Braintrust.
+- Dataset-derived content still leaves the machine on three paths, all to PostHog-controlled destinations: the Gemini scans, the `summary_alignment` judge (`gpt-5.4` via the internal LLM gateway, which sees the recorded and fresh summaries), and the harness's `$ai_evaluation` capture.
+- That capture posts every run's scores to project 2, keyed `<scanner_type>-<observation_id>`, with the scanner prompt as `$ai_input` and the recorded and fresh outcomes as `$ai_expected`/`$ai_output`. The scores land in that project's offline experiments view, which is where to compare runs over time.
 - Collecting from projects other than PostHog's own requires a data-governance decision first; see the product's consent gating (`backend/consent.py`) and note that customer-facing copy does not cover internal reuse today.

--- a/products/replay_vision/evals/README.md
+++ b/products/replay_vision/evals/README.md
@@ -55,11 +55,16 @@ Use `--trials N` for variance on Gemini nondeterminism and `--eval <case-substri
 
 ## CI
 
-`.github/workflows/ci-replay-vision-evals.yml` runs a small version of this loop on PRs that touch the prompt templates or the evals themselves, and on manual dispatch with bigger `per_type`/`trials` knobs.
-Because the job executes the PR's own code with secrets, it only runs once a maintainer applies the `replay-vision-evals-ready` label to the PR (the same trust gate as `ci-ai.yml`'s `evals-ready`).
-It collects a fresh dataset on the ephemeral runner (so consent is re-verified every run; nothing is cached, uploaded, or persisted), runs the suite, and writes the score table to the job's step summary.
-It is advisory and never a required check: Gemini is nondeterministic and the dataset is re-sampled per run, so treat the scores as a directional signal.
-The job needs the `REPLAY_VISION_EVAL_POSTHOG_API_KEY` repo secret (a personal API key with scanner, session recording, export, and query read access to the dogfood project); without it the job skips green.
+`.github/workflows/ci-replay-vision-evals.yml` runs a small version of this loop against a PR, and on manual dispatch with bigger `per_type`/`trials` knobs (GitHub only offers the dispatch once the workflow is on master).
+
+Because the job executes the PR's own collector and harness code with secrets, a maintainer has to approve each revision by hand: it runs only on a `replay-vision-evals-ready` label event, on a PR whose diff touches the prompt templates or the evals.
+Pushing to a labeled PR does not re-run it, since the label approved the revision a maintainer looked at, not the PR.
+To score a new revision, remove the label and apply it again; removing it also cancels an in-flight run.
+
+It collects a fresh dataset on the ephemeral runner (so consent is re-verified every run; nothing is cached, uploaded, or persisted), runs the suite, and writes the aggregate scores to the job's step summary.
+Only those allowlisted summary lines are public: collector and harness output stay in runner-local files, because they carry session and observation ids.
+It is advisory and never a required check. Gemini is nondeterministic and the dataset is re-sampled per run, so treat the scores as a directional signal, and infra failures (provider 5xx, warehouse lag, an empty dataset) land in the step summary rather than as a red X.
+The job needs `REPLAY_VISION_EVAL_POSTHOG_API_KEY` (a personal API key with scanner, session recording, export, and query read access to the dogfood project) plus the `GEMINI_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, and `BRAINTRUST_API_KEY` secrets `ci-ai.yml` already uses; if any is missing the job skips green and warns which.
 
 ## Data handling
 

--- a/products/replay_vision/evals/README.md
+++ b/products/replay_vision/evals/README.md
@@ -59,6 +59,7 @@ Use `--trials N` for variance on Gemini nondeterminism and `--eval <case-substri
 It is deliberately not attached to `pull_request`: Gemini is nondeterministic and the dataset is re-sampled per run, so the score is a directional signal rather than a merge gate, and spending secrets and LLM calls on every push buys nothing that a dispatch after a prompt change does not.
 
 It collects a fresh dataset on the runner (so consent is re-verified every run; nothing is cached, uploaded, or persisted), runs the suite, and writes the aggregate scores to the job's step summary.
+The summary also links the run's `/ai-evals` offline experiment, where the harness publishes the same scores.
 Only those allowlisted summary lines are public: collector and harness output stay in runner-local files, because they carry session and observation ids.
 The job needs `REPLAY_VISION_EVAL_POSTHOG_API_KEY` (a personal API key with scanner, session recording, export, and query read access to the dogfood project) plus the `GEMINI_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, and `BRAINTRUST_API_KEY` secrets `ci-ai.yml` already uses; if any is missing the job skips green and warns which.
 

--- a/products/replay_vision/evals/collect.py
+++ b/products/replay_vision/evals/collect.py
@@ -32,7 +32,7 @@ def main() -> None:
         "--max-observations",
         type=int,
         default=200,
-        help="Newest observations to consider per scanner; lower paginates much faster (CI uses 50).",
+        help="Newest observations to consider per scanner; lower paginates much faster.",
     )
     args = parser.parse_args()
 

--- a/products/replay_vision/evals/collect.py
+++ b/products/replay_vision/evals/collect.py
@@ -28,6 +28,12 @@ def main() -> None:
         "--scanner-id", action="append", dest="scanner_ids", help="Restrict to specific scanner ids (repeatable)."
     )
     parser.add_argument("--seed", type=int, default=42, help="Seed for the uniform sample, for reproducibility.")
+    parser.add_argument(
+        "--max-observations",
+        type=int,
+        default=200,
+        help="Newest observations to consider per scanner; lower paginates much faster (CI uses 50).",
+    )
     args = parser.parse_args()
 
     # Env var only, deliberately: a key passed as a CLI flag leaks into shell history and ps output.
@@ -47,6 +53,7 @@ def main() -> None:
         per_type=args.per_type,
         scanner_ids=args.scanner_ids,
         seed=args.seed,
+        max_observations_per_scanner=args.max_observations,
     )
     by_type: dict[str, int] = {}
     for case in dataset.cases:


### PR DESCRIPTION
## Problem

Running the golden-dataset eval (#75128) needs a local dev stack, a personal API key with four scopes, and three LLM keys, so in practice only its author runs it.
A scanner prompt template can change without anyone scoring it against the golden dataset.

## Changes

- Anyone with write access can dispatch the eval from the Actions tab, with `per_type` and `trials` as inputs.
- The job collects a fresh dataset on the runner, runs `eval_scanner_quality`, and writes the aggregate scores to the job step summary.
- The workflow has no `pull_request` trigger, which review asked about.
- Gemini is nondeterministic and the dataset is re-sampled per run, so a per-revision score is a directional signal, not a merge gate.
- Dropping that trigger drops the apparatus it needed: a maintainer label protocol, a paths filter, a fork check, `continue-on-error` on both work steps, and a shim for unrebased branches.
- The dataset (real dogfood recordings) lives only on the ephemeral runner, and collection re-verifies AI data-processing consent every run.
- Collector and harness output go to runner-local files, because they carry session and observation ids. The step summary and the public job log get an allowlisted set of aggregate lines.
- A missing secret skips the job green and names it.
- `collect.py` gains `--max-observations` (default 200, the existing behavior) to bound the pagination that dominates collection time on a laptop run.
- README correction: the data-handling section claimed the LLM judge was the only path where dataset-derived content leaves the machine. The harness posts `$ai_evaluation` to project 2 on every run, keyed `<scanner_type>-<observation_id>`.

A run at the defaults (up to 20 cases) costs about $0.20 of Gemini plus judge pennies, and takes roughly 25 minutes.

> [!NOTE]
> The workflow does nothing until the `REPLAY_VISION_EVAL_POSTHOG_API_KEY` repo secret exists (a personal API key with scanner, session recording, export, and query read access to project 2, ideally from a bot account). `GEMINI_API_KEY`, `BRAINTRUST_API_KEY`, `ANTHROPIC_API_KEY`, and `OPENAI_API_KEY` already exist for `ci-ai.yml`.

## How did you test this code?

- `bin/hogli lint:workflows` passes, 8 checks across 127 workflows.
- Not run end to end: the collection secret does not exist, so the workflow cannot be dispatched yet. Its run steps are the commands verified locally against the dogfood project in #75128.
- The `$ai_evaluation` correction comes from `ph_client.py:15` (the US key is a hardcoded project-2 token), `eval_scanner_quality.py:96` (the case name), and `trace_events.py:314`. Sibling suites on the same harness path already produce `sandboxed-agent/*` evaluation events in project 2; no replay-vision rows exist yet, because the suite has never completed a scored run off a laptop.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

`products/replay_vision/evals/README.md`: the runner section now describes the dispatch-only trigger, and the data-handling section lists all three paths that carry dataset-derived content off the machine.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) wrote this, as a follow-up to #75128.

The first revision ran per PR behind a maintainer label. Review asked whether a product dedicated to evals would be a better host than CI.
The results already go there: the harness publishes `$ai_evaluation` to the `/ai-evals` offline experiments view on every run (`base.py:244-270`), and this revision stops the summary from dropping the link to it.
There is no runner to move to, though. Offline experiments is a read-only HogQL view over those events (`offline_evaluations.py:52-56`) with no create or trigger endpoint, and the one orchestrated eval runner in the repo rejects any module outside `ee/hogai/eval/` (`run_evaluation.py:200-203`).
The suite also needs a checkout, because `prompt_env.py:19` loads the scanner templates with a Jinja `PackageLoader`, so a deployed worker only has the scaffolding baked into its image. Prompt text itself is runtime data (`base.py:194` substitutes it as `user_prompt`), so the checkout requirement covers template changes, not prompt changes.

Skills invoked: `/authoring-ci-workflows`, `/writing-code-comments`, `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
