### PR TITLE
chore(ai-observability): pass eval report inputs as dataclasses

### DIFF
--- a/posthog/temporal/ai_observability/eval_reports/activities.py
+++ b/posthog/temporal/ai_observability/eval_reports/activities.py
@@ -650,23 +650,7 @@ async def run_eval_report_agent_activity(
 
             evaluation_target = _load_evaluation_target(inputs.team_id, inputs.evaluation_id)
             return (
-                run_eval_report_agent(
-                    team_id=inputs.team_id,
-                    report_id=inputs.report_id,
-                    trace_id=inputs.trace_id,
-                    session_id=inputs.session_id,
-                    evaluation_id=inputs.evaluation_id,
-                    evaluation_name=inputs.evaluation_name,
-                    evaluation_description=inputs.evaluation_description,
-                    evaluation_prompt=inputs.evaluation_prompt,
-                    evaluation_type=inputs.evaluation_type,
-                    evaluation_target=evaluation_target,
-                    output_type=inputs.output_type,
-                    period_start=inputs.period_start,
-                    period_end=inputs.period_end,
-                    previous_period_start=inputs.previous_period_start,
-                    report_prompt_guidance=inputs.report_prompt_guidance,
-                ),
+                run_eval_report_agent(inputs, evaluation_target=evaluation_target),
                 evaluation_target,
             )
 

--- a/posthog/temporal/ai_observability/eval_reports/report_agent/graph.py
+++ b/posthog/temporal/ai_observability/eval_reports/report_agent/graph.py
@@ -32,6 +32,7 @@ from posthog.temporal.ai_observability.eval_reports.targets import (
     TRACE_ID_ALLOWLIST_KEY,
     get_target_descriptor,
 )
+from posthog.temporal.ai_observability.eval_reports.types import RunEvalReportAgentInput
 from posthog.temporal.ai_observability.llm_endpoint import build_langchain_callbacks, build_langchain_chat_client
 
 logger = structlog.get_logger(__name__)
@@ -205,21 +206,8 @@ def _validate_agent_output(content: EvalReportContent) -> str | None:
 
 
 def run_eval_report_agent(
-    team_id: int,
-    evaluation_id: str,
-    evaluation_name: str,
-    evaluation_description: str,
-    evaluation_prompt: str,
-    evaluation_type: str,
-    period_start: str,
-    period_end: str,
-    previous_period_start: str,
-    report_prompt_guidance: str = "",
-    output_type: str = "boolean",
+    inputs: RunEvalReportAgentInput,
     evaluation_target: str = "generation",
-    report_id: str = "",
-    trace_id: str = "",
-    session_id: str = "",
 ) -> EvalReportContent:
     """Run the evaluation report agent and return the generated content.
 
@@ -236,12 +224,12 @@ def run_eval_report_agent(
     # Compute metrics first — we need them for both the final content AND the
     # fallback path, so guarantee they're ready before the agent even runs.
     metrics = _compute_metrics(
-        team_id,
-        evaluation_id,
-        period_start,
-        period_end,
-        previous_period_start,
-        output_type=output_type,
+        inputs.team_id,
+        inputs.evaluation_id,
+        inputs.period_start,
+        inputs.period_end,
+        inputs.previous_period_start,
+        output_type=inputs.output_type,
         evaluation_target=evaluation_target,
     )
 
@@ -254,18 +242,18 @@ def run_eval_report_agent(
         increment_errors("metrics_unavailable")
         logger.warning(
             "llma_eval_reports_metrics_unavailable",
-            team_id=team_id,
-            evaluation_id=evaluation_id,
+            team_id=inputs.team_id,
+            evaluation_id=inputs.evaluation_id,
         )
         return _metrics_unavailable_content(evaluation_target)
 
-    resolved_trace_id = trace_id or str(uuid.uuid4())
-    resolved_session_id = session_id or resolved_trace_id
-    resolved_distinct_id = team_distinct_id(team_id)
+    resolved_trace_id = inputs.trace_id or str(uuid.uuid4())
+    resolved_session_id = inputs.session_id or resolved_trace_id
+    resolved_distinct_id = team_distinct_id(inputs.team_id)
     observability_properties = {
-        "team_id": str(team_id),
-        "evaluation_id": evaluation_id,
-        **({"report_id": report_id} if report_id else {}),
+        "team_id": str(inputs.team_id),
+        "evaluation_id": inputs.evaluation_id,
+        **({"report_id": inputs.report_id} if inputs.report_id else {}),
     }
     llm = build_langchain_chat_client(
         EVAL_REPORT_AGENT_MODEL,
@@ -278,20 +266,20 @@ def run_eval_report_agent(
     )
 
     system_prompt = build_eval_report_system_prompt(
-        evaluation_name=evaluation_name,
-        evaluation_description=evaluation_description,
-        evaluation_type=evaluation_type,
+        evaluation_name=inputs.evaluation_name,
+        evaluation_description=inputs.evaluation_description,
+        evaluation_type=inputs.evaluation_type,
         evaluation_target=evaluation_target,
-        evaluation_prompt=evaluation_prompt,
-        output_type=output_type,
-        period_start=period_start,
-        period_end=period_end,
-        report_prompt_guidance=report_prompt_guidance,
+        evaluation_prompt=inputs.evaluation_prompt,
+        output_type=inputs.output_type,
+        period_start=inputs.period_start,
+        period_end=inputs.period_end,
+        report_prompt_guidance=inputs.report_prompt_guidance,
     )
 
     agent = create_react_agent(
         model=llm,
-        tools=get_eval_report_tools(evaluation_target, output_type),
+        tools=get_eval_report_tools(evaluation_target, inputs.output_type),
         prompt=system_prompt,
         state_schema=EvalReportAgentState,
     )
@@ -301,18 +289,18 @@ def run_eval_report_agent(
     # we overwrite with the trusted metrics after the agent finishes anyway.
     initial_state: dict[str, Any] = {
         "messages": [HumanMessage(content="Please generate the evaluation report.")],
-        "team_id": team_id,
-        "evaluation_id": evaluation_id,
-        "evaluation_name": evaluation_name,
-        "evaluation_description": evaluation_description,
-        "evaluation_prompt": evaluation_prompt,
-        "evaluation_type": evaluation_type,
+        "team_id": inputs.team_id,
+        "evaluation_id": inputs.evaluation_id,
+        "evaluation_name": inputs.evaluation_name,
+        "evaluation_description": inputs.evaluation_description,
+        "evaluation_prompt": inputs.evaluation_prompt,
+        "evaluation_type": inputs.evaluation_type,
         "evaluation_target": evaluation_target,
-        "output_type": output_type,
-        "period_start": period_start,
-        "period_end": period_end,
-        "previous_period_start": previous_period_start,
-        "report_prompt_guidance": report_prompt_guidance,
+        "output_type": inputs.output_type,
+        "period_start": inputs.period_start,
+        "period_end": inputs.period_end,
+        "previous_period_start": inputs.previous_period_start,
+        "report_prompt_guidance": inputs.report_prompt_guidance,
         "report": EvalReportContent(evaluation_target=evaluation_target, metrics=metrics),
         TRACE_ID_ALLOWLIST_KEY: [],
         SESSION_ID_ALLOWLIST_KEY: [],
@@ -348,15 +336,15 @@ def run_eval_report_agent(
 
             logger.warning(
                 "llma_eval_reports_agent_validation_failed",
-                team_id=team_id,
-                evaluation_id=evaluation_id,
+                team_id=inputs.team_id,
+                evaluation_id=inputs.evaluation_id,
                 reason=validation_error,
                 title=content.title,
                 section_count=len(content.sections),
                 trace_id=resolved_trace_id,
                 session_id=resolved_session_id,
             )
-            return _fallback_content(evaluation_name, metrics, validation_error, evaluation_target)
+            return _fallback_content(inputs.evaluation_name, metrics, validation_error, evaluation_target)
 
         _append_references_section(content)
 
@@ -364,8 +352,8 @@ def run_eval_report_agent(
 
         logger.info(
             "llma_eval_reports_agent_completed",
-            team_id=team_id,
-            evaluation_id=evaluation_id,
+            team_id=inputs.team_id,
+            evaluation_id=inputs.evaluation_id,
             title=content.title,
             section_count=len(content.sections),
             citation_count=len(content.citations),
@@ -383,13 +371,13 @@ def run_eval_report_agent(
             "llma_eval_reports_agent_error",
             error=str(e),
             error_type=type(e).__name__,
-            team_id=team_id,
-            evaluation_id=evaluation_id,
+            team_id=inputs.team_id,
+            evaluation_id=inputs.evaluation_id,
             trace_id=resolved_trace_id,
             session_id=resolved_session_id,
         )
         return _fallback_content(
-            evaluation_name,
+            inputs.evaluation_name,
             metrics,
             f"agent raised {type(e).__name__}",
             evaluation_target,

--- a/posthog/temporal/ai_observability/eval_reports/report_agent/test/test_graph.py
+++ b/posthog/temporal/ai_observability/eval_reports/report_agent/test/test_graph.py
@@ -21,6 +21,7 @@ from posthog.temporal.ai_observability.eval_reports.report_agent.schema import (
     EvalReportMetrics,
     ReportSection,
 )
+from posthog.temporal.ai_observability.eval_reports.types import RunEvalReportAgentInput
 
 
 class TestSystemPromptFormat(SimpleTestCase):
@@ -376,18 +377,20 @@ class TestRunEvalReportAgentRouting(SimpleTestCase):
         mock_create_agent.return_value = mock_agent
 
         graph.run_eval_report_agent(
-            team_id=1,
-            report_id="report-1",
-            trace_id="report-run-1",
-            session_id="report-session-1",
-            evaluation_id="eval-1",
-            evaluation_name="Relevance",
-            evaluation_description="",
-            evaluation_prompt="",
-            evaluation_type="llm_judge",
-            period_start="2026-04-08T14:00:00+00:00",
-            period_end="2026-04-08T15:00:00+00:00",
-            previous_period_start="2026-04-08T13:00:00+00:00",
+            RunEvalReportAgentInput(
+                team_id=1,
+                report_id="report-1",
+                trace_id="report-run-1",
+                session_id="report-session-1",
+                evaluation_id="eval-1",
+                evaluation_name="Relevance",
+                evaluation_description="",
+                evaluation_prompt="",
+                evaluation_type="llm_judge",
+                period_start="2026-04-08T14:00:00+00:00",
+                period_end="2026-04-08T15:00:00+00:00",
+                previous_period_start="2026-04-08T13:00:00+00:00",
+            )
         )
 
         mock_build_llm.assert_called_once_with(
@@ -419,15 +422,18 @@ class TestRunEvalReportAgentMetricsUnavailable(SimpleTestCase):
             ) as mock_increment_generated,
         ):
             content = graph.run_eval_report_agent(
-                team_id=1,
-                evaluation_id="eval-1",
-                evaluation_name="Relevance",
-                evaluation_description="",
-                evaluation_prompt="",
-                evaluation_type="llm_judge",
-                period_start="2026-04-08T14:00:00+00:00",
-                period_end="2026-04-08T15:00:00+00:00",
-                previous_period_start="2026-04-08T13:00:00+00:00",
+                RunEvalReportAgentInput(
+                    team_id=1,
+                    report_id="report-1",
+                    evaluation_id="eval-1",
+                    evaluation_name="Relevance",
+                    evaluation_description="",
+                    evaluation_prompt="",
+                    evaluation_type="llm_judge",
+                    period_start="2026-04-08T14:00:00+00:00",
+                    period_end="2026-04-08T15:00:00+00:00",
+                    previous_period_start="2026-04-08T13:00:00+00:00",
+                )
             )
 
         mock_create_agent.assert_not_called()
@@ -462,18 +468,20 @@ class TestRunEvalReportAgentInstrumentation(SimpleTestCase):
         }
         mock_create_agent.return_value = mock_agent
         graph.run_eval_report_agent(
-            team_id=1,
-            report_id="report-1",
-            trace_id="report-run-1",
-            session_id="report-session-1",
-            evaluation_id="eval-1",
-            evaluation_name="Relevance",
-            evaluation_description="",
-            evaluation_prompt="",
-            evaluation_type="llm_judge",
-            period_start="2026-04-08T14:00:00+00:00",
-            period_end="2026-04-08T15:00:00+00:00",
-            previous_period_start="2026-04-08T13:00:00+00:00",
+            RunEvalReportAgentInput(
+                team_id=1,
+                report_id="report-1",
+                trace_id="report-run-1",
+                session_id="report-session-1",
+                evaluation_id="eval-1",
+                evaluation_name="Relevance",
+                evaluation_description="",
+                evaluation_prompt="",
+                evaluation_type="llm_judge",
+                period_start="2026-04-08T14:00:00+00:00",
+                period_end="2026-04-08T15:00:00+00:00",
+                previous_period_start="2026-04-08T13:00:00+00:00",
+            )
         )
 
         expected_properties = {"team_id": "1", "evaluation_id": "eval-1", "report_id": "report-1"}
@@ -509,18 +517,20 @@ class TestRunEvalReportAgentInstrumentation(SimpleTestCase):
         mock_create_agent.return_value.invoke.side_effect = RuntimeError("agent failed")
 
         graph.run_eval_report_agent(
-            team_id=1,
-            report_id="report-1",
-            trace_id="report-run-1",
-            session_id="report-session-1",
-            evaluation_id="eval-1",
-            evaluation_name="Relevance",
-            evaluation_description="",
-            evaluation_prompt="",
-            evaluation_type="llm_judge",
-            period_start="2026-04-08T14:00:00+00:00",
-            period_end="2026-04-08T15:00:00+00:00",
-            previous_period_start="2026-04-08T13:00:00+00:00",
+            RunEvalReportAgentInput(
+                team_id=1,
+                report_id="report-1",
+                trace_id="report-run-1",
+                session_id="report-session-1",
+                evaluation_id="eval-1",
+                evaluation_name="Relevance",
+                evaluation_description="",
+                evaluation_prompt="",
+                evaluation_type="llm_judge",
+                period_start="2026-04-08T14:00:00+00:00",
+                period_end="2026-04-08T15:00:00+00:00",
+                previous_period_start="2026-04-08T13:00:00+00:00",
+            )
         )
 
         mock_logger_exception.assert_called_once_with(

--- a/posthog/temporal/ai_observability/eval_reports/test/test_activities.py
+++ b/posthog/temporal/ai_observability/eval_reports/test/test_activities.py
@@ -186,11 +186,8 @@ async def test_run_agent_activity_loads_target_and_forwards_output_type(
     assert result.content["metrics"]["output_type"] == output_type
     assert result.content["evaluation_target"] == evaluation_target
     assert result.generation_status == "completed"
-    assert run_agent.call_args.kwargs["output_type"] == output_type
+    assert run_agent.call_args.args[0] is inputs
     assert run_agent.call_args.kwargs["evaluation_target"] == evaluation_target
-    assert run_agent.call_args.kwargs["report_id"] == "report-id"
-    assert run_agent.call_args.kwargs["trace_id"] == "report-run-id"
-    assert run_agent.call_args.kwargs["session_id"] == "report-session-id"
     load_target.assert_called_once_with(inputs.team_id, inputs.evaluation_id)
 
 

--- a/posthog/temporal/ai_observability/eval_reports/workflow.py
+++ b/posthog/temporal/ai_observability/eval_reports/workflow.py
@@ -276,23 +276,10 @@ def _log_fan_out_failures(kind: str, report_ids: list[str], results: list) -> No
         )
 
 
-async def _update_report_schedule(
-    report_id: str,
-    period_end: str,
-    generation_status: str,
-    *,
-    record_attempt: bool = True,
-    advance_data_cursor: bool | None = None,
-) -> None:
+async def _update_report_schedule(inputs: UpdateNextDeliveryDateInput) -> None:
     await temporalio.workflow.execute_activity(
         update_next_delivery_date_activity,
-        UpdateNextDeliveryDateInput(
-            report_id=report_id,
-            period_end=period_end,
-            generation_status=generation_status,
-            record_attempt=record_attempt,
-            advance_data_cursor=advance_data_cursor,
-        ),
+        inputs,
         start_to_close_timeout=UPDATE_SCHEDULE_ACTIVITY_TIMEOUT,
         retry_policy=UPDATE_SCHEDULE_RETRY_POLICY,
     )
@@ -368,10 +355,12 @@ class GenerateAndDeliverEvalReportWorkflow(PostHogWorkflow):
 
         if not inputs.manual and (attempt_before_delivery or not generation_completed):
             await _update_report_schedule(
-                inputs.report_id,
-                context.period_end,
-                generation_status,
-                advance_data_cursor=False if attempt_before_delivery else None,
+                UpdateNextDeliveryDateInput(
+                    report_id=inputs.report_id,
+                    period_end=context.period_end,
+                    generation_status=generation_status,
+                    advance_data_cursor=False if attempt_before_delivery else None,
+                )
             )
 
         # 3b. Emit a signal for this report run (fire-and-forget).
@@ -429,9 +418,11 @@ class GenerateAndDeliverEvalReportWorkflow(PostHogWorkflow):
         # 5. Advance the successful data cursor (skip for manual runs to avoid disrupting schedule)
         if not inputs.manual and generation_completed:
             await _update_report_schedule(
-                inputs.report_id,
-                context.period_end,
-                generation_status,
-                record_attempt=not attempt_before_delivery,
-                advance_data_cursor=True,
+                UpdateNextDeliveryDateInput(
+                    report_id=inputs.report_id,
+                    period_end=context.period_end,
+                    generation_status=generation_status,
+                    record_attempt=not attempt_before_delivery,
+                    advance_data_cursor=True,
+                )
             )


### PR DESCRIPTION
## Problem

`run_eval_report_agent` took 15 parameters, 14 of them the exact fields of `RunEvalReportAgentInput` and most of them strings.
The activity unpacked the dataclass field by field to call it, so two swapped string arguments would pass silently.
`_update_report_schedule` mirrored the 5 fields of `UpdateNextDeliveryDateInput` the same way and rebuilt it 1:1.

## Changes

- `run_eval_report_agent` now takes its `RunEvalReportAgentInput` plus `evaluation_target`, the one parameter not on the dataclass; the activity passes its input straight through.
- `_update_report_schedule` takes an `UpdateNextDeliveryDateInput`; both workflow call sites construct it keyword-only.
- No `@activity.defn` or `@workflow.run` signature changed and the activity payloads are byte-identical, so wire compatibility and replay determinism are unaffected.

## How did you test this code?

Updated the existing tests in `test_graph.py` and `test_activities.py` to the new call shape; the behavior assertions are unchanged.
Ran `python -m py_compile`, `ruff check`, and `ruff format --check` on the changed files locally; CI runs the suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Generated by Claude Fable 5 via PostHog Desktop.
Mechanical refactor, no behavior change intended; commit pushed via the GitHub API for verified signing.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
