### PR TITLE
chore(review-hog): pass activity inputs to helpers as dataclasses

### DIFF
--- a/posthog/test/dataclass_frozen_baseline.txt
+++ b/posthog/test/dataclass_frozen_baseline.txt
@@ -8,7 +8,6 @@
 1 ee/hogai/artifacts/handlers/base.py
 1 ee/hogai/core/agent_modes/factory.py
 1 ee/hogai/queue.py
-1 ee/hogai/session_summaries/session/prompt_data.py
 1 posthog/api/capture.py
 1 posthog/api/oauth/toolbar_service.py
 1 posthog/api/test/test_event_definition.py
@@ -82,7 +81,6 @@
 1 posthog/temporal/mcp_analytics/intent_clustering/team_discovery.py
 1 posthog/temporal/product_analytics/upgrade_queries_workflow.py
 1 posthog/temporal/session_replay/rasterize_recording/activities/stuck_counter.py
-1 posthog/temporal/session_replay/session_summary/activities/capture_timing.py
 1 posthog/temporal/tests/common/test_logger.py
 1 posthog/temporal/tests/data_modeling/test_log_routing.py
 1 posthog/test/test_journeys.py
@@ -128,9 +126,6 @@
 1 products/data_warehouse/backend/logic/data_load/create_table.py
 1 products/data_warehouse/backend/logic/webhook_consumer/config.py
 1 products/demo/backend/logic/products/hedgebox/matrix.py
-1 products/desktop/tools/pr-approval-agent/familiarity.py
-1 products/desktop/tools/pr-approval-agent/github.py
-1 products/desktop/tools/pr-approval-agent/review_pr.py
 1 products/error_tracking/backend/hogql_queries/error_tracking_issue_correlation_query_runner.py
 1 products/error_tracking/backend/logic/symbol_sets.py
 1 products/error_tracking/backend/temporal/weekly_digest/test/test_weekly_digest_temporal.py
@@ -178,7 +173,6 @@
 1 products/replay_vision/backend/tests/test_gemini_cleanup_activities.py
 1 products/revenue_analytics/backend/views/schemas/_definitions.py
 1 products/review_hog/backend/reviewer/persistence.py
-1 products/review_hog/backend/reviewer/status_comment.py
 1 products/review_hog/backend/reviewer/tests/test_select_perspectives.py
 1 products/review_hog/backend/reviewer/tools/publish_review.py
 1 products/review_hog/backend/temporal/types.py
@@ -214,6 +208,7 @@
 1 products/tasks/backend/temporal/process_task/activities/emit_progress_activity.py
 1 products/tasks/backend/temporal/process_task/activities/enforce_self_driving_quota.py
 1 products/tasks/backend/temporal/process_task/activities/feature_flags.py
+1 products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
 1 products/tasks/backend/temporal/process_task/activities/post_slack_update.py
 1 products/tasks/backend/temporal/process_task/activities/read_sandbox_logs.py
 1 products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
@@ -1443,7 +1438,6 @@
 2 products/data_modeling/backend/logic/freshness.py
 2 products/demo/backend/logic/matrix/models.py
 2 products/demo/backend/logic/products/hedgebox/models.py
-2 products/desktop/tools/owners/posthog_owners/schema.py
 2 products/experiments/backend/experiment_summary_data_service.py
 2 products/experiments/stats/shared/cuped.py
 2 products/growth/backend/product_push/service.py
@@ -1493,7 +1487,6 @@
 2 products/tasks/backend/temporal/process_task/activities/execute_task_in_sandbox.py
 2 products/tasks/backend/temporal/process_task/activities/get_pr_context.py
 2 products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
-2 products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
 2 products/tasks/backend/temporal/process_task/activities/refresh_sandbox_credentials.py
 2 products/tasks/backend/temporal/process_task/sandbox_credentials.py
 2 products/tasks/backend/temporal/process_task/slack_agent_design_relay.py
@@ -1559,7 +1552,6 @@
 3 products/data_modeling/backend/logic/gitsync/config_parser.py
 3 products/data_modeling/backend/management/commands/consolidate_dags.py
 3 products/data_warehouse/backend/logic/external_data_source/webhooks.py
-3 products/desktop/tools/owners/posthog_owners/resolver.py
 3 products/experiments/stats/shared/statistics.py
 3 products/marketing_analytics/backend/services/data_source_health.py
 3 products/marketing_analytics/backend/services/marketing_diagnostic.py
@@ -1590,7 +1582,6 @@
 4 products/approvals/backend/services.py
 4 products/batch_exports/backend/temporal/destinations/file_download_batch_export.py
 4 products/conversations/backend/temporal/coordinator.py
-4 products/desktop/tools/owners/posthog_owners/fmt.py
 4 products/endpoints/backend/materialization_transforms.py
 4 products/managed_warehouse/backend/temporal/ducklake_register_data_imports_workflow.py
 4 products/marketing_analytics/backend/services/campaign_mapping_suggester.py
@@ -1629,6 +1620,7 @@
 6 products/marketing_analytics/backend/services/attribution_health.py
 6 products/marketing_analytics/backend/services/mapping_suggester.py
 6 products/tasks/backend/temporal/task_management/workflow.py
+7 posthog/session_recordings/synthetic_playlists.py
 7 posthog/temporal/experiments/models.py
 7 products/batch_exports/backend/temporal/monitoring.py
 7 products/growth/backend/sdk_health.py
@@ -1638,11 +1630,9 @@
 7 products/web_analytics/backend/temporal/digest_notification/types.py
 7 products/web_analytics/backend/temporal/weekly_digest/types.py
 8 ee/vercel/integration.py
-8 posthog/session_recordings/synthetic_playlists.py
 8 posthog/temporal/ai/slack_app/types.py
 8 posthog/temporal/ai_observability/evaluation_clustering/activities.py
 8 posthog/temporal/delete_teams/types.py
-8 posthog/temporal/session_replay/summarization_sweep/types.py
 8 products/signals/backend/temporal/signal_queries.py
 9 posthog/clickhouse/cluster.py
 9 posthog/temporal/backfill_materialized_property/activities.py

--- a/posthog/test/dataclass_frozen_baseline.txt
+++ b/posthog/test/dataclass_frozen_baseline.txt
@@ -178,6 +178,7 @@
 1 products/replay_vision/backend/tests/test_gemini_cleanup_activities.py
 1 products/revenue_analytics/backend/views/schemas/_definitions.py
 1 products/review_hog/backend/reviewer/persistence.py
+1 products/review_hog/backend/reviewer/status_comment.py
 1 products/review_hog/backend/reviewer/tests/test_select_perspectives.py
 1 products/review_hog/backend/reviewer/tools/publish_review.py
 1 products/review_hog/backend/temporal/types.py
@@ -1523,7 +1524,7 @@
 2 products/web_analytics/backend/hogql_queries/web_stats_lazy_precompute.py
 2 products/web_analytics/backend/path_cleaning_suggestions/service.py
 22 products/batch_exports/backend/service.py
-27 products/review_hog/backend/temporal/activities.py
+26 products/review_hog/backend/temporal/activities.py
 3 ee/api/vercel/types.py
 3 ee/clickhouse/views/test/test_clickhouse_trends.py
 3 posthog/api/app_metrics2.py

--- a/products/review_hog/backend/reviewer/status_comment.py
+++ b/products/review_hog/backend/reviewer/status_comment.py
@@ -13,6 +13,7 @@ retry a review, so all exceptions are swallowed after logging.
 
 import random
 import logging
+from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
 
@@ -371,38 +372,45 @@ def maybe_refresh_status_comment(team_id: int, report_id: str) -> None:
         logger.exception("Could not refresh the ReviewHog status comment; the review continues without it")
 
 
-def finalize_status_comment(
-    team_id: int,
-    report_id: str,
-    *,
-    run_index: int,
-    urgency_threshold: str,
-    review_url: str | None,
-    resolved_from: str = "author",
-) -> None:
+@dataclass
+class FinalizeStatusCommentInput:
+    team_id: int
+    report_id: str
+    run_index: int
+    # The run's snapshotted threshold, so the held-back explanation matches what publish enforced.
+    urgency_threshold: str
+    review_url: str | None = None
+    # Whose threshold gated the run ("author" / "override" / "default", from the resolve snapshot) —
+    # the held-back sentence must blame the right settings. Defaulted so pre-field payloads deserialize.
+    resolved_from: str = "author"
+
+
+def finalize_status_comment(input: FinalizeStatusCommentInput) -> None:
     """Rewrite the status comment with the turn's outcome: everything found vs. what was published."""
     try:
-        report = ReviewReport.objects.for_team(team_id).filter(id=report_id).first()
+        report = ReviewReport.objects.for_team(input.team_id).filter(id=input.report_id).first()
         if report is None or report.status_comment_id is None or report.pr_number is None:
             return
         counts = dict.fromkeys(IssuePriority, 0)
-        for finding, verdict in load_valid_findings(team_id=team_id, report_id=report_id, run_index=run_index):
+        for finding, verdict in load_valid_findings(
+            team_id=input.team_id, report_id=input.report_id, run_index=input.run_index
+        ):
             counts[effective_priority(finding.priority, verdict.adjusted_priority)] += 1
-        threshold = IssuePriority(urgency_threshold)
+        threshold = IssuePriority(input.urgency_threshold)
         published = published_priorities_for(threshold)
         published_count = sum(count for priority, count in counts.items() if priority in published)
         held_back_count = sum(count for priority, count in counts.items() if priority not in published)
         body = render_final_body(
-            report_id,
+            input.report_id,
             counts=counts,
             published_count=published_count,
             held_back_count=held_back_count,
             threshold=threshold,
-            review_url=review_url,
-            resolved_from=resolved_from,
-            report_url=report_deep_link(team_id, report_id),
+            review_url=input.review_url,
+            resolved_from=input.resolved_from,
+            report_url=report_deep_link(input.team_id, input.report_id),
         )
-        _edit_and_stamp(team_id, report, body)
+        _edit_and_stamp(input.team_id, report, body)
     except Exception:
         logger.exception("Could not finalize the ReviewHog status comment; the review is unaffected")
 

--- a/products/review_hog/backend/reviewer/status_comment.py
+++ b/products/review_hog/backend/reviewer/status_comment.py
@@ -13,7 +13,6 @@ retry a review, so all exceptions are swallowed after logging.
 
 import random
 import logging
-from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
 
@@ -21,6 +20,7 @@ from django.conf import settings
 from django.db.models import Q
 from django.utils import timezone
 
+from posthog.dataclasses import frozen
 from posthog.models.integration import GitHubIntegration
 
 from products.review_hog.backend.models import ReviewReport
@@ -372,7 +372,7 @@ def maybe_refresh_status_comment(team_id: int, report_id: str) -> None:
         logger.exception("Could not refresh the ReviewHog status comment; the review continues without it")
 
 
-@dataclass
+@frozen
 class FinalizeStatusCommentInput:
     team_id: int
     report_id: str

--- a/products/review_hog/backend/temporal/activities.py
+++ b/products/review_hog/backend/temporal/activities.py
@@ -97,6 +97,7 @@ from products.review_hog.backend.reviewer.skill_loader import (
     load_validation_skill_for_run,
 )
 from products.review_hog.backend.reviewer.status_comment import (
+    FinalizeStatusCommentInput,
     ensure_status_comment,
     fail_status_comment,
     finalize_status_comment,
@@ -428,19 +429,6 @@ class StatusCommentInput:
     report_id: str
 
 
-@dataclass
-class FinalizeStatusCommentInput:
-    team_id: int
-    report_id: str
-    run_index: int
-    # The run's snapshotted threshold, so the held-back explanation matches what publish enforced.
-    urgency_threshold: str
-    review_url: str | None = None
-    # Whose threshold gated the run ("author" / "override" / "default", from the resolve snapshot) —
-    # the held-back sentence must blame the right settings. Defaulted so pre-field payloads deserialize.
-    resolved_from: str = "author"
-
-
 # --- Setup activities ------------------------------------------------------------------------------
 
 
@@ -635,30 +623,25 @@ def _login_to_user_id(team_id: int, login: str | None) -> int | None:
     return user.id if user is not None else None
 
 
-def _resolve_acting_user(
-    team_id: int,
-    author_login: str,
-    override_user_id: int | None,
-    report_id: str | None = None,
-    trigger_source: str = TRIGGER_MANUAL,
-    default_user_id: int | None = None,
-) -> ResolveActingUserResult:
+def _resolve_acting_user(input: ResolveActingUserInput) -> ResolveActingUserResult:
     acting_user_id: int | None
-    if override_user_id is not None:
-        acting_user_id, resolved_from = override_user_id, "override"
+    if input.override_user_id is not None:
+        acting_user_id, resolved_from = input.override_user_id, "override"
     else:
-        acting_user_id, resolved_from = _login_to_user_id(team_id, author_login), "author"
+        acting_user_id, resolved_from = _login_to_user_id(input.team_id, input.author_login), "author"
         # Label-trigger fallback — someone explicitly asked for this review, so borrow the run user
         # the trigger already resolved. Other triggers keep the author-only contract and skip.
-        if acting_user_id is None and trigger_source == TRIGGER_LABEL:
-            acting_user_id, resolved_from = default_user_id, "default"
+        if acting_user_id is None and input.trigger_source == TRIGGER_LABEL:
+            acting_user_id, resolved_from = input.default_user_id, "default"
     if acting_user_id is None:
         return ResolveActingUserResult(acting_user_id=None)
     if resolved_from == "default":
-        logger.info("PR author %r has no PostHog user; acting as the default user %s", author_login, acting_user_id)
-    if report_id is not None:
-        ReviewReport.objects.for_team(team_id).filter(id=report_id).update(acting_user_id=acting_user_id)
-    settings = ReviewUserSettings.load(team_id, acting_user_id)
+        logger.info(
+            "PR author %r has no PostHog user; acting as the default user %s", input.author_login, acting_user_id
+        )
+    if input.report_id is not None:
+        ReviewReport.objects.for_team(input.team_id).filter(id=input.report_id).update(acting_user_id=acting_user_id)
+    settings = ReviewUserSettings.load(input.team_id, acting_user_id)
     return ResolveActingUserResult(
         acting_user_id=acting_user_id,
         # The labeled-PR opt-out protects authors ("don't review my PRs") — the borrowed default
@@ -692,14 +675,7 @@ async def resolve_acting_user_activity(input: ResolveActingUserInput) -> Resolve
     other triggers return None on an unmapped author and the parent skips the review.
     The CLI/eval passes an explicit `override_user_id` to test a known user's perspectives on any PR.
     """
-    return await database_sync_to_async(_resolve_acting_user, thread_sensitive=False)(
-        input.team_id,
-        input.author_login,
-        input.override_user_id,
-        input.report_id,
-        input.trigger_source,
-        input.default_user_id,
-    )
+    return await database_sync_to_async(_resolve_acting_user, thread_sensitive=False)(input)
 
 
 def _sync_review_skills(team_id: int) -> None:
@@ -1209,39 +1185,35 @@ async def validate_chunk_activity(input: ValidateChunkInput) -> ValidateChunkRes
 # --- Build body + finalize + publish ---------------------------------------------------------------
 
 
-def _build_and_finalize(
-    team_id: int,
-    report_id: str,
-    head_sha: str,
-    run_index: int,
-    issue_ids: list[str],
-    urgency_threshold: str,
-    will_publish: bool,
-) -> None:
-    issues = load_run_issues(team_id=team_id, report_id=report_id, run_index=run_index, issue_ids=issue_ids)
+def _build_and_finalize(input: BuildBodyInput) -> None:
+    issues = load_run_issues(
+        team_id=input.team_id, report_id=input.report_id, run_index=input.run_index, issue_ids=input.issue_ids
+    )
     # Verdicts come from the DB (the same rows publish reads), so a partially-failed chunk shows the
     # same findings in the body and the posted comments.
-    validations = load_run_validations(team_id=team_id, report_id=report_id, run_index=run_index, issues=issues)
+    validations = load_run_validations(
+        team_id=input.team_id, report_id=input.report_id, run_index=input.run_index, issues=issues
+    )
     # The reviewed diff decides which valid findings can't be anchored inline — the body surfaces those
     # in an "Other findings" section (the same snapshot publish positions inline comments against).
-    snapshot = load_pr_snapshot(team_id=team_id, report_id=report_id, head_sha=head_sha)
+    snapshot = load_pr_snapshot(team_id=input.team_id, report_id=input.report_id, head_sha=input.head_sha)
     pr_files = snapshot.pr_files if snapshot is not None else []
     body = build_review_body(
         issues=issues,
         validations=validations,
         pr_files=pr_files,
-        published_priorities=published_priorities_for(IssuePriority(urgency_threshold)),
+        published_priorities=published_priorities_for(IssuePriority(input.urgency_threshold)),
     )
     finalize_review_report(
-        team_id=team_id,
-        report_id=report_id,
+        team_id=input.team_id,
+        report_id=input.report_id,
         body_markdown=body,
-        run_index=run_index,
-        head_sha=head_sha,
+        run_index=input.run_index,
+        head_sha=input.head_sha,
         # The same snapshot the body above and the publish gate consume — stamped so the detail view
         # buckets this turn's findings by the gate that actually ran.
-        urgency_threshold=urgency_threshold,
-        will_publish=will_publish,
+        urgency_threshold=input.urgency_threshold,
+        will_publish=input.will_publish,
     )
 
 
@@ -1250,38 +1222,21 @@ def _build_and_finalize(
 @close_db_connections
 async def build_body_activity(input: BuildBodyInput) -> None:
     """Render the review body and finalize the turn (store the body, bump the run watermark)."""
-    await database_sync_to_async(_build_and_finalize, thread_sensitive=False)(
-        input.team_id,
-        input.report_id,
-        input.head_sha,
-        input.run_index,
-        input.issue_ids,
-        input.urgency_threshold,
-        input.will_publish,
-    )
+    await database_sync_to_async(_build_and_finalize, thread_sensitive=False)(input)
 
 
-def _publish(
-    team_id: int,
-    report_id: str,
-    head_sha: str,
-    run_index: int,
-    owner: str,
-    repo: str,
-    pr_number: int,
-    urgency_threshold: str,
-) -> PublishResult:
-    token, installation_id = _installation_auth(team_id, f"{owner}/{repo}")
+def _publish(input: PublishInput) -> PublishResult:
+    token, installation_id = _installation_auth(input.team_id, f"{input.owner}/{input.repo}")
     outcome = publish_persisted_review(
-        team_id=team_id,
-        report_id=report_id,
-        head_sha=head_sha,
-        run_index=run_index,
-        owner=owner,
-        repo=repo,
-        pr_number=pr_number,
+        team_id=input.team_id,
+        report_id=input.report_id,
+        head_sha=input.head_sha,
+        run_index=input.run_index,
+        owner=input.owner,
+        repo=input.repo,
+        pr_number=input.pr_number,
         token=token,
-        urgency_threshold=IssuePriority(urgency_threshold),
+        urgency_threshold=IssuePriority(input.urgency_threshold),
         installation_id=installation_id,
     )
     return PublishResult(posted=outcome.posted, review_url=outcome.review_url)
@@ -1296,24 +1251,15 @@ async def publish_review_activity(input: PublishInput) -> PublishResult:
     The per-run publish gate lives in the workflow (`inputs.publish`): this activity is dispatched
     only when publishing is enabled and the turn has a PR to post to.
     """
-    return await database_sync_to_async(_publish, thread_sensitive=False)(
-        input.team_id,
-        input.report_id,
-        input.head_sha,
-        input.run_index,
-        input.owner,
-        input.repo,
-        input.pr_number,
-        input.urgency_threshold,
-    )
+    return await database_sync_to_async(_publish, thread_sensitive=False)(input)
 
 
-def _remove_trigger_label(team_id: int, owner: str, repo: str, pr_number: int) -> None:
-    token, installation_id = _installation_auth(team_id, f"{owner}/{repo}")
+def _remove_trigger_label(input: RemoveTriggerLabelInput) -> None:
+    token, installation_id = _installation_auth(input.team_id, f"{input.owner}/{input.repo}")
     try:
         github_api_request(
             "DELETE",
-            f"/repos/{owner}/{repo}/issues/{pr_number}/labels/reviewhog",
+            f"/repos/{input.owner}/{input.repo}/issues/{input.pr_number}/labels/reviewhog",
             token=token,
             endpoint="/repos/{owner}/{repo}/issues/{issue_number}/labels/{name}",
             installation_id=installation_id,
@@ -1328,9 +1274,7 @@ def _remove_trigger_label(team_id: int, owner: str, repo: str, pr_number: int) -
 @close_db_connections
 async def remove_trigger_label_activity(input: RemoveTriggerLabelInput) -> None:
     """Remove the label that started a label-triggered review, if it is still present."""
-    await database_sync_to_async(_remove_trigger_label, thread_sensitive=False)(
-        input.team_id, input.owner, input.repo, input.pr_number
-    )
+    await database_sync_to_async(_remove_trigger_label, thread_sensitive=False)(input)
 
 
 def _review_event_identity(report: ReviewReport) -> str:
@@ -1509,14 +1453,7 @@ async def post_status_comment_activity(input: StatusCommentInput) -> None:
 @close_db_connections
 async def finalize_status_comment_activity(input: FinalizeStatusCommentInput) -> None:
     """Rewrite the status comment with the turn's outcome: full found counts vs. what was published."""
-    await database_sync_to_async(finalize_status_comment, thread_sensitive=False)(
-        input.team_id,
-        input.report_id,
-        run_index=input.run_index,
-        urgency_threshold=input.urgency_threshold,
-        review_url=input.review_url,
-        resolved_from=input.resolved_from,
-    )
+    await database_sync_to_async(finalize_status_comment, thread_sensitive=False)(input)
 
 
 def _fail_run(team_id: int, report_id: str) -> None:

--- a/products/review_hog/backend/temporal/workflow.py
+++ b/products/review_hog/backend/temporal/workflow.py
@@ -31,13 +31,13 @@ from products.review_hog.backend.reviewer.constants import (
     MAX_CONCURRENT_SANDBOXES,
     VALIDATION_MAX_ATTEMPTS,
 )
+from products.review_hog.backend.reviewer.status_comment import FinalizeStatusCommentInput
 from products.review_hog.backend.reviewer.tools.select_perspectives import PerspectiveSelectionDTO, apply_selection
 from products.review_hog.backend.temporal.activities import (
     AppendCodeReviewArtefactInput,
     BuildBodyInput,
     DedupResult,
     FetchPRDataInput,
-    FinalizeStatusCommentInput,
     GenerateSchemasInput,
     LoadBlindSpotsInput,
     LoadedBlindSpotsSkillDTO,

--- a/products/review_hog/backend/tests/test_acting_user.py
+++ b/products/review_hog/backend/tests/test_acting_user.py
@@ -4,7 +4,7 @@ from parameterized import parameterized
 from social_django.models import UserSocialAuth
 
 from products.review_hog.backend.models import ReviewReport, ReviewUserSettings
-from products.review_hog.backend.temporal.activities import _resolve_acting_user
+from products.review_hog.backend.temporal.activities import ResolveActingUserInput, _resolve_acting_user
 from products.review_hog.backend.temporal.types import TRIGGER_LABEL, TRIGGER_MANUAL
 
 _SELF = "SELF"
@@ -28,7 +28,9 @@ class TestResolveActingUser(BaseTest):
         ]
     )
     def test_resolve_acting_user(self, _name: str, author: str, override: int | None, expected: object) -> None:
-        result = _resolve_acting_user(self.team.id, author, override)
+        result = _resolve_acting_user(
+            ResolveActingUserInput(team_id=self.team.id, author_login=author, override_user_id=override)
+        )
         assert result.acting_user_id == (self.user.id if expected == _SELF else expected)
 
     def test_settings_default_when_user_has_no_row(self) -> None:
@@ -37,7 +39,9 @@ class TestResolveActingUser(BaseTest):
         # chain resolution — for users who never opened the UI. resolve_comments is the opposite of
         # its DATACLASS default (False, the replay-safe skip value), so dropping its passthrough
         # line would silently disable the resolution stage for everyone with the suite still green.
-        result = _resolve_acting_user(self.team.id, "octocat", None)
+        result = _resolve_acting_user(
+            ResolveActingUserInput(team_id=self.team.id, author_login="octocat", override_user_id=None)
+        )
         assert result.review_labeled_prs is True
         assert result.review_inbox_prs is False
         assert result.urgency_threshold == "consider"
@@ -56,7 +60,9 @@ class TestResolveActingUser(BaseTest):
             urgency_threshold=ReviewUserSettings.UrgencyThreshold.MUST_FIX,
             resolve_comments=False,
         )
-        result = _resolve_acting_user(self.team.id, "octocat", None)
+        result = _resolve_acting_user(
+            ResolveActingUserInput(team_id=self.team.id, author_login="octocat", override_user_id=None)
+        )
         assert result.review_labeled_prs is False
         assert result.review_inbox_prs is True
         assert result.urgency_threshold == "must_fix"
@@ -68,13 +74,25 @@ class TestResolveActingUser(BaseTest):
         # Unmapped author on a labeled PR → the run user the trigger already resolved, passed
         # through as default_user_id so acting and sandbox identity can never drift.
         result = _resolve_acting_user(
-            self.team.id, "ghost", None, trigger_source=TRIGGER_LABEL, default_user_id=self.user.id
+            ResolveActingUserInput(
+                team_id=self.team.id,
+                author_login="ghost",
+                override_user_id=None,
+                trigger_source=TRIGGER_LABEL,
+                default_user_id=self.user.id,
+            )
         )
         assert (result.acting_user_id, result.resolved_from) == (self.user.id, "default")
 
     def test_non_label_triggers_keep_the_author_only_contract(self) -> None:
         result = _resolve_acting_user(
-            self.team.id, "ghost", None, trigger_source=TRIGGER_MANUAL, default_user_id=self.user.id
+            ResolveActingUserInput(
+                team_id=self.team.id,
+                author_login="ghost",
+                override_user_id=None,
+                trigger_source=TRIGGER_MANUAL,
+                default_user_id=self.user.id,
+            )
         )
         assert result.acting_user_id is None
 
@@ -84,13 +102,23 @@ class TestResolveActingUser(BaseTest):
             team_id=self.team.id, user_id=self.user.id, review_labeled_prs=False, resolve_comments=False
         )
         # Acting as the author: their own opt-outs apply (the workflow will skip / stop at publish).
-        as_author = _resolve_acting_user(self.team.id, "octocat", None, trigger_source=TRIGGER_LABEL)
+        as_author = _resolve_acting_user(
+            ResolveActingUserInput(
+                team_id=self.team.id, author_login="octocat", override_user_id=None, trigger_source=TRIGGER_LABEL
+            )
+        )
         assert (as_author.resolved_from, as_author.review_labeled_prs) == ("author", False)
         assert as_author.resolve_comments is False
         # Acting as the borrowed run user on someone else's PR: the same row must NOT kill the
         # review, nor switch off resolution for a PR that isn't theirs (the default posture applies).
         as_default = _resolve_acting_user(
-            self.team.id, "ghost", None, trigger_source=TRIGGER_LABEL, default_user_id=self.user.id
+            ResolveActingUserInput(
+                team_id=self.team.id,
+                author_login="ghost",
+                override_user_id=None,
+                trigger_source=TRIGGER_LABEL,
+                default_user_id=self.user.id,
+            )
         )
         assert (as_default.acting_user_id, as_default.resolved_from) == (self.user.id, "default")
         assert as_default.review_labeled_prs is True
@@ -103,12 +131,26 @@ class TestResolveActingUser(BaseTest):
         ReviewUserSettings.objects.for_team(self.team.id).create(
             team_id=self.team.id, user_id=self.user.id, urgency_threshold=ReviewUserSettings.UrgencyThreshold.MUST_FIX
         )
-        as_author = _resolve_acting_user(self.team.id, "octocat", None, trigger_source=TRIGGER_LABEL)
+        as_author = _resolve_acting_user(
+            ResolveActingUserInput(
+                team_id=self.team.id, author_login="octocat", override_user_id=None, trigger_source=TRIGGER_LABEL
+            )
+        )
         assert (as_author.resolved_from, as_author.urgency_threshold) == ("author", "must_fix")
-        as_override = _resolve_acting_user(self.team.id, "ghost", self.user.id, trigger_source=TRIGGER_LABEL)
+        as_override = _resolve_acting_user(
+            ResolveActingUserInput(
+                team_id=self.team.id, author_login="ghost", override_user_id=self.user.id, trigger_source=TRIGGER_LABEL
+            )
+        )
         assert (as_override.resolved_from, as_override.urgency_threshold) == ("override", "must_fix")
         as_default = _resolve_acting_user(
-            self.team.id, "ghost", None, trigger_source=TRIGGER_LABEL, default_user_id=self.user.id
+            ResolveActingUserInput(
+                team_id=self.team.id,
+                author_login="ghost",
+                override_user_id=None,
+                trigger_source=TRIGGER_LABEL,
+                default_user_id=self.user.id,
+            )
         )
         assert (as_default.resolved_from, as_default.urgency_threshold) == ("default", "consider")
 
@@ -122,6 +164,10 @@ class TestResolveActingUser(BaseTest):
             head_branch="feat",
             base_branch="main",
         )
-        _resolve_acting_user(self.team.id, "octocat", None, report_id=str(report.id))
+        _resolve_acting_user(
+            ResolveActingUserInput(
+                team_id=self.team.id, author_login="octocat", override_user_id=None, report_id=str(report.id)
+            )
+        )
         report.refresh_from_db()
         assert report.acting_user_id == self.user.id

--- a/products/review_hog/backend/tests/test_installation_auth.py
+++ b/products/review_hog/backend/tests/test_installation_auth.py
@@ -7,7 +7,11 @@ from temporalio.exceptions import ApplicationError
 from posthog.models.integration import Integration
 
 from products.review_hog.backend.reviewer.tools.github_client import GitHubAPIError
-from products.review_hog.backend.temporal.activities import _installation_auth, _remove_trigger_label
+from products.review_hog.backend.temporal.activities import (
+    RemoveTriggerLabelInput,
+    _installation_auth,
+    _remove_trigger_label,
+)
 
 # The true network boundary: first_for_team_repository probes GitHub with an authenticated
 # GET /repos/{repository} per candidate integration row.
@@ -53,7 +57,7 @@ class TestRemoveTriggerLabel:
     @patch("products.review_hog.backend.temporal.activities._installation_auth", return_value=("tok", "inst"))
     @patch("products.review_hog.backend.temporal.activities.github_api_request")
     def test_deletes_the_reviewhog_label(self, request: MagicMock, _auth: MagicMock) -> None:
-        _remove_trigger_label(1, "PostHog", "posthog", 7)
+        _remove_trigger_label(RemoveTriggerLabelInput(team_id=1, owner="PostHog", repo="posthog", pr_number=7))
 
         request.assert_called_once_with(
             "DELETE",
@@ -69,7 +73,7 @@ class TestRemoveTriggerLabel:
         side_effect=GitHubAPIError("not found", status=404),
     )
     def test_already_removed_label_is_success(self, _request: MagicMock, _auth: MagicMock) -> None:
-        _remove_trigger_label(1, "PostHog", "posthog", 7)
+        _remove_trigger_label(RemoveTriggerLabelInput(team_id=1, owner="PostHog", repo="posthog", pr_number=7))
 
     @patch("products.review_hog.backend.temporal.activities._installation_auth", return_value=("tok", "inst"))
     @patch(
@@ -78,4 +82,4 @@ class TestRemoveTriggerLabel:
     )
     def test_other_github_errors_are_retried(self, _request: MagicMock, _auth: MagicMock) -> None:
         with pytest.raises(GitHubAPIError, match="server error"):
-            _remove_trigger_label(1, "PostHog", "posthog", 7)
+            _remove_trigger_label(RemoveTriggerLabelInput(team_id=1, owner="PostHog", repo="posthog", pr_number=7))

--- a/products/review_hog/backend/tests/test_publish_idempotency.py
+++ b/products/review_hog/backend/tests/test_publish_idempotency.py
@@ -17,7 +17,7 @@ from products.review_hog.backend.reviewer.tools.publish_review import (
     _review_already_posted,
     _review_marker,
 )
-from products.review_hog.backend.temporal.activities import _publish
+from products.review_hog.backend.temporal.activities import PublishInput, _publish
 
 # `_publish` now delegates to `publish_persisted_review` in the tool, so the GitHub-post seam and the
 # snapshot load are patched there; the installation auth is still resolved in the activity wrapper.
@@ -88,6 +88,19 @@ def test_promo_already_posted_skips_when_readback_fails() -> None:
     assert _promo_posted(_promo_marker("rep-1"), [], boom=True) is True
 
 
+def _publish_input(team_id: int, report_id: str, head_sha: str) -> PublishInput:
+    return PublishInput(
+        team_id=team_id,
+        report_id=report_id,
+        head_sha=head_sha,
+        run_index=1,
+        owner="PostHog",
+        repo="posthog",
+        pr_number=1,
+        urgency_threshold="should_fix",
+    )
+
+
 def _pr_metadata(head_sha: str) -> PRMetadata:
     return PRMetadata(
         number=1,
@@ -127,7 +140,7 @@ class TestPublishIdempotency(BaseTest):
     def test_first_publish_posts_promo_and_records_watermark(self, _auth, _snapshot, mock_publish) -> None:
         mock_publish.return_value = PublishOutcome(posted=True)
         report_id = self._report()
-        _publish(self.team.id, report_id, "sha1", 1, "PostHog", "posthog", 1, "should_fix")
+        _publish(_publish_input(self.team.id, report_id, "sha1"))
         assert mock_publish.call_count == 1
         assert mock_publish.call_args.kwargs["post_promo"] is True
         # The resolved installation id must reach the GitHub calls — dropping it silently turns the
@@ -148,7 +161,7 @@ class TestPublishIdempotency(BaseTest):
     @patch(_AUTH, return_value=("tok", None))
     def test_republish_same_head_is_skipped(self, _auth, _snapshot, mock_publish) -> None:
         report_id = self._report(published_head_sha="sha1")
-        _publish(self.team.id, report_id, "sha1", 1, "PostHog", "posthog", 1, "should_fix")
+        _publish(_publish_input(self.team.id, report_id, "sha1"))
         mock_publish.assert_not_called()
         # The skip exit must also restore rest: an activity retry can land here with the report
         # still deferred-ACTIVE from finalize.
@@ -160,7 +173,7 @@ class TestPublishIdempotency(BaseTest):
     def test_new_head_publishes_without_promo(self, _auth, _snapshot, mock_publish) -> None:
         mock_publish.return_value = PublishOutcome(posted=True)
         report_id = self._report(published_head_sha="oldsha")
-        _publish(self.team.id, report_id, "sha2", 1, "PostHog", "posthog", 1, "should_fix")
+        _publish(_publish_input(self.team.id, report_id, "sha2"))
         assert mock_publish.call_count == 1
         assert mock_publish.call_args.kwargs["post_promo"] is False
         assert ReviewReport.objects.for_team(self.team.id).get(id=report_id).published_head_sha == "sha2"
@@ -173,7 +186,7 @@ class TestPublishIdempotency(BaseTest):
         # later turn with a valid finding can still publish at the same head.
         mock_publish.return_value = PublishOutcome(posted=False)
         report_id = self._report()
-        _publish(self.team.id, report_id, "sha1", 1, "PostHog", "posthog", 1, "should_fix")
+        _publish(_publish_input(self.team.id, report_id, "sha1"))
         assert mock_publish.call_count == 1
         report = ReviewReport.objects.for_team(self.team.id).get(id=report_id)
         assert report.published_head_sha is None

--- a/products/review_hog/backend/tests/test_status_comment.py
+++ b/products/review_hog/backend/tests/test_status_comment.py
@@ -14,6 +14,7 @@ from products.review_hog.backend.reviewer.models.issue_validation import IssueVa
 from products.review_hog.backend.reviewer.models.issues_review import Issue, IssuePriority, LineRange
 from products.review_hog.backend.reviewer.persistence import persist_findings, persist_verdict, upsert_review_report
 from products.review_hog.backend.reviewer.status_comment import (
+    FinalizeStatusCommentInput,
     ensure_status_comment,
     fail_status_comment,
     finalize_status_comment,
@@ -347,11 +348,13 @@ class TestFinalizeStatusComment(BaseTest):
             persist_verdict(team_id=self.team.id, report_id=report_id, issue=issue, validation=validation, run_index=1)
 
         finalize_status_comment(
-            self.team.id,
-            report_id,
-            run_index=1,
-            urgency_threshold=IssuePriority.SHOULD_FIX.value,
-            review_url="https://g/review",
+            FinalizeStatusCommentInput(
+                team_id=self.team.id,
+                report_id=report_id,
+                run_index=1,
+                urgency_threshold=IssuePriority.SHOULD_FIX.value,
+                review_url="https://g/review",
+            )
         )
 
         assert _patches(mock_request) == ["/repos/o/r/issues/comments/555"]

--- a/products/review_hog/backend/tests/test_temporal_workflow.py
+++ b/products/review_hog/backend/tests/test_temporal_workflow.py
@@ -21,12 +21,12 @@ from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
 
 from products.review_hog.backend.reviewer.constants import BLIND_SPOT_PASS_NUMBER, VALIDATION_MAX_ATTEMPTS
+from products.review_hog.backend.reviewer.status_comment import FinalizeStatusCommentInput
 from products.review_hog.backend.reviewer.tools.select_perspectives import ChunkSelectionDTO, PerspectiveSelectionDTO
 from products.review_hog.backend.temporal.activities import (
     AppendCodeReviewArtefactInput,
     BuildBodyInput,
     DedupResult,
-    FinalizeStatusCommentInput,
     LoadBlindSpotsInput,
     LoadedBlindSpotsSkillDTO,
     LoadedPerspectiveDTO,


### PR DESCRIPTION
## Problem

- A call that swaps two same-typed positional arguments on review_hog's temporal helpers (owner and repo, or report_id and head_sha) compiles and type-checks clean.
- Five helpers take their activity's input unpacked into up to 8 positional fields, and every activity re-lists each field just to forward it.

## Changes

- `_resolve_acting_user`, `_build_and_finalize`, `_publish`, `_remove_trigger_label`, and `finalize_status_comment` now take their Input dataclass and read fields by name.
- `@activity.defn` signatures are unchanged; activities pass `input` straight through, so temporal payloads and replay behavior stay the same.
- `FinalizeStatusCommentInput` moved from `temporal/activities.py` into `reviewer/status_comment.py` so the helper's module needs no reverse import; `activities.py` imports it from there, keeping the name importable for temporal registration.
- The dataclass ratchet baseline tracks the moved class (activities.py 27 to 26, status_comment.py 1).

## How did you test this code?

- Existing tests updated to construct the Input dataclasses; assertions unchanged, so they still catch the same regressions.
- Ran ruff check, ruff format, and the dataclass baseline ratchet test locally on the changed files.
- Not run locally: the pytest suites (no dev DB in this environment); CI runs them.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Generated by Claude Fable 5 via PostHog Desktop. Skills invoked: /writing-pr-descriptions. Mechanical refactor with no intended behavior change; the only judgment call was moving `FinalizeStatusCommentInput` next to its consumer instead of importing the activity module from `status_comment.py`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
