### PR TITLE
feat(messaging): name the missing fields in push rejection logs

### DIFF
--- a/products/messaging/backend/api/push_subscriptions.py
+++ b/products/messaging/backend/api/push_subscriptions.py
@@ -100,6 +100,7 @@ def _rejection_response(
     status_code: int,
     team_id: int | None = None,
     app_id: str | None = None,
+    detail: str | None = None,
     exc_info: bool = False,
 ) -> HttpResponse:
     # request.method is an arbitrary attacker-controlled token on the method_not_allowed path (any
@@ -117,6 +118,7 @@ def _rejection_response(
         method=request.method,
         team_id=team_id,
         app_id=app_id,
+        detail=detail,
         exc_info=exc_info,
     )
     return cors_response(
@@ -215,6 +217,12 @@ def push_subscriptions(request: Request):
         if not value or not isinstance(value, str)
     ]
     if missing_fields:
+        # absent vs empty vs invalid separates an SDK that never sends the field (contract drift)
+        # from a client bridge passing an empty or mistyped value: they need different fixes.
+        field_detail = ",".join(
+            f"{field_name}:{'absent' if field_name not in data else 'empty' if data[field_name] == '' else 'invalid'}"
+            for field_name in missing_fields
+        )
         return _rejection_response(
             request,
             f"Missing required fields: {', '.join(missing_fields)}.",
@@ -222,6 +230,7 @@ def push_subscriptions(request: Request):
             code="missing_fields",
             status_code=status.HTTP_400_BAD_REQUEST,
             team_id=team.id,
+            detail=field_detail,
         )
 
     assert isinstance(distinct_id, str)

--- a/products/messaging/backend/api/test/test_push_subscriptions.py
+++ b/products/messaging/backend/api/test/test_push_subscriptions.py
@@ -10,6 +10,7 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from parameterized import parameterized
 from rest_framework import status
+from structlog.testing import capture_logs
 
 from posthog.models.integration import Integration
 from posthog.models.team.team import Team
@@ -488,6 +489,23 @@ class TestPushSubscriptionsAPI(BaseTest):
         assert response.status_code == status_code
         assert response.json()["code"] == code
         assert counter._value.get() == before + 1
+
+    @parameterized.expand(
+        [
+            ("empty_value", {"device_token": ""}, "device_token:empty"),
+            ("absent_key", {}, "device_token:absent"),
+        ]
+    )
+    def test_missing_fields_rejection_logs_field_detail(self, _name: str, extra: dict, expected_detail: str):
+        payload = {"distinct_id": "user-1", "platform": "android", "app_id": "my-firebase-project", **extra}
+
+        with capture_logs() as logs:
+            response = self._post(payload)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        rejected = [entry for entry in logs if entry["event"] == "push_subscription_rejected"]
+        assert len(rejected) == 1
+        assert rejected[0]["detail"] == expected_detail
 
     def test_unsupported_method_collapses_counter_label(self):
         counter = PUSH_SUBSCRIPTION_REJECTION_COUNTER.labels(code="method_not_allowed", method="other")


### PR DESCRIPTION
## Problem

- `missing_fields` is now the dominant rejection on `/api/push_subscriptions/` (~90% of the endpoint's 400s since #83456 removed the no-integration errors), spread across many teams and mobile SDK versions.
- The rejection log names the code but not the field, so nobody can tell which field clients fail to send, or whether it is absent or empty - and those imply different bugs in different places.

## Changes

- The `missing_fields` rejection now logs a `detail` field like `device_token:empty` or `app_id:absent`, one entry per failing field.
- `absent` means the client never sent the key (contract drift in an old SDK); `empty` means a client bridge passed an empty value; `invalid` means a non-string.
- Log-only change: response bodies, status codes, and counters are unchanged.

## How did you test this code?

- Two parameterized cases assert the logged `detail` for an empty value and an absent key. The regression they catch: a refactor silently dropping `detail`, which would blind the next investigation exactly the way the missing code and missing field name blinded the last two.
- Ran the full `test_push_subscriptions.py` suite locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal telemetry only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session with Harley, continuing the push subscription investigation: the deployed telemetry from #83456 revealed the rejection floor is `missing_fields`, and this closes the last observability gap needed to name the failing field.
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- Test-first: both cases failed before the implementation landed.
