### PR TITLE
fix(postgres): stop retrying a proxy plan-limit restriction

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -644,6 +644,17 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 "connect until the database is available again. Upgrade your provider's plan or wait "
                 "for the quota to reset, then re-enable the sync."
             ),
+            # A database proxy (observed on Prisma Accelerate) refuses the connection because the
+            # account hit a plan limit, reporting "Your account has restrictions: planLimitReached".
+            # The restriction is account-level state only the customer can lift (upgrade the plan or
+            # contact the provider), so every retry re-hits the same refusal. Match the stable
+            # camelCase reason code, which carries no host or account detail.
+            "planLimitReached": (
+                "Your database provider has restricted the account because a plan limit was reached "
+                '("planLimitReached"), so PostHog can\'t connect. This usually comes from a database '
+                "proxy such as Prisma. Upgrade the plan or contact your provider to lift the "
+                "restriction, then re-enable the sync."
+            ),
             # The provider has put the cluster into read-only mode, so it rejects our read (the
             # server-side cursor runs its SELECT inside a read/write transaction). PlanetScale's
             # pg_readonly reports "invalid statement because cluster is read-only"; the cluster only

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -422,6 +422,10 @@ class TestPostgresSourceNonRetryableErrors:
             # customer RLS policy, view, or pooler. Permanent until the customer changes it — must not
             # keep retrying. Parameter name is invented, not a real customer value.
             'unrecognized configuration parameter "app.current_tenant"',
+            # A database proxy (e.g. Prisma Accelerate) refuses the connection because the account
+            # hit a plan limit. Account-level state only the customer can lift, so retrying re-hits
+            # the same refusal — must not keep retrying. Host/port are invented, not a real value.
+            'connection failed: connection to server at "db.example.com", port 5432 failed: Your account has restrictions: planLimitReached. Please contact your provider to resolve account restrictions.',
         ],
     )
     def test_permanent_connection_errors_are_non_retryable(self, source, error_msg):
@@ -457,6 +461,19 @@ class TestPostgresSourceNonRetryableErrors:
         assert matches, "connect timeout must be classified non-retryable"
         assert matches[0] is not None, "connect timeout must surface an actionable message, not raw driver text"
         assert "firewall" in matches[0].lower()
+
+    def test_plan_limit_restriction_surfaces_actionable_message(self, source):
+        # A proxy plan-limit refusal must stop retrying and explain how to lift the restriction,
+        # rather than storing the raw provider text. Mirror the finalizer's first-match selection.
+        error_msg = "Your account has restrictions: planLimitReached. Please contact your provider to resolve account restrictions."
+        matches = [
+            friendly
+            for pattern, friendly in source.get_non_retryable_errors().items()
+            if error_message_matches(error_msg, [pattern])
+        ]
+        assert matches, "plan-limit restriction must be classified non-retryable"
+        assert matches[0] is not None, "plan-limit restriction must surface an actionable message, not raw driver text"
+        assert "plan" in matches[0].lower()
 
     @pytest.mark.parametrize(
         "error_msg",


### PR DESCRIPTION
## Problem

- A customer's Postgres sync fails every run and never recovers when their database proxy (Prisma Accelerate) refuses the connection with `Your account has restrictions: planLimitReached`.
- The restriction is account-level state only the customer can lift, but PostHog did not recognize it: the sync retried for the full activity budget and reported the raw driver text with no next step.

## Changes

- Classify the stable `planLimitReached` reason code as non-retryable in the Postgres source, so the sync stops instead of burning its retry budget.
- Surface an actionable message telling the customer to upgrade the plan or contact the provider to lift the restriction.
- Match only the camelCase code, which carries no host or account detail.

## How did you test this code?

- Added a case to `test_permanent_connection_errors_are_non_retryable` and a `test_plan_limit_restriction_surfaces_actionable_message` in `test_postgres.py`. Together they catch a regression that drops the classification (retry loop returns) or leaves the message as raw driver text. The host and port in the fixture are invented.
- Ran `TestPostgresSourceNonRetryableErrors` locally (139 passed). Did not run the database-backed suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

This PR was authored by Claude Code (agent) while triaging a batch of data-warehouse sync failure classes. Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`. The failure was identified from a recorded `latest_error` on `ExternalDataJob`; the committed fixture data is invented (reserved `example.com` host), not copied from any customer environment.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
