### PR TITLE
fix(custom): stop retrying a proxy-rejected (407) request

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
@@ -884,6 +884,13 @@ class CustomSource(SimpleSource[CustomSourceConfig]):
             # manifest-driven, so the 404 recurs on every retry — stop and point at the config.
             # The message omits the URL, which carries the customer's hostname.
             "404 Client Error": "The upstream API returned HTTP 404 Not Found. Check that the base URL and the resource's path in the manifest are correct and that the endpoint exists, then try again.",
+            # A network proxy rejected the request before it reached the upstream API. On PostHog
+            # Cloud this is the egress proxy refusing a URL it isn't allowed to reach (a private or
+            # internal address); it can also be an upstream proxy in front of the customer's API
+            # demanding credentials. The manifest-driven request recurs identically on every retry,
+            # so stop and point at the manifest URLs. The message omits the URL, which carries the
+            # customer's hostname.
+            "407 Client Error": "A network proxy rejected the request before it reached the upstream API (HTTP 407). This usually means a URL in the manifest points at an address PostHog can't reach (for example a private or internal address), or the API sits behind a proxy that needs credentials. Check the URLs in the manifest, then try again.",
             # A schema points to a resource the manifest no longer defines (renamed or removed
             # in an edit while the table's sync stayed scheduled). Permanent until the config is
             # fixed — match the stable suffix, not the variable resource name in the message.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/custom/test_custom_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/custom/test_custom_source.py
@@ -1781,6 +1781,25 @@ class TestCustomSourceNonRetryableErrors(SimpleTestCase):
         non_retryable = CustomSource().get_non_retryable_errors()
         assert any(key in str(ctx.exception) for key in non_retryable)
 
+    def test_http_407_proxy_auth_is_classified_non_retryable(self):
+        # A proxy that refuses the request (the egress proxy blocking a disallowed address, or an
+        # upstream proxy needing credentials) returns 407 deterministically, so retrying can't fix
+        # it. Build the real requests HTTPError raise_for_status() produces, so this breaks if the
+        # matched substring drifts. Route through the classifier's message so a regression that
+        # leaves it None (raw driver text) is caught too. The URL is a placeholder.
+        response = Response()
+        response.status_code = 407
+        response.reason = "Proxy Authentication Required"
+        response.url = "https://api.example.com/data"
+        with self.assertRaises(requests.exceptions.HTTPError) as ctx:
+            response.raise_for_status()
+
+        non_retryable = CustomSource().get_non_retryable_errors()
+        matches = [friendly for key, friendly in non_retryable.items() if key in str(ctx.exception)]
+        assert matches
+        assert matches[0] is not None
+        assert "proxy" in matches[0].lower()
+
     def test_non_json_response_message_is_classified_non_retryable(self):
         # The REST client raises RESTClientNonRetryableError when a configured endpoint
         # returns non-JSON (an HTML/plain-text error page) on a 2xx. Build the real error the


### PR DESCRIPTION
## Problem

- A Custom source sync fails every run and never recovers when a network proxy rejects the request with HTTP 407 before it reaches the upstream API.
- On PostHog Cloud this is the egress proxy refusing a URL the manifest points at (for example a private or internal address); it can also be an upstream proxy in front of the customer's API demanding credentials.
- The request is manifest-driven and deterministic, so PostHog retried the same rejection for the full activity budget and stored the raw driver text with no next step.

## Changes

- Classify HTTP 407 as non-retryable in the Custom source, alongside the existing 400/401/403/404 handling.
- Surface an actionable message pointing at the manifest URLs. The message omits the URL, which carries the customer's hostname.

## How did you test this code?

- Added `test_http_407_proxy_auth_is_classified_non_retryable` in `test_custom_source.py`, built from the real `requests` `raise_for_status()` error. It catches a regression that drops the classification (retry loop returns) or leaves the message as raw driver text. The URL is a placeholder.
- Ran `TestCustomSourceNonRetryableErrors` locally (7 passed). Did not run the database-backed suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (agent) while triaging a batch of data-warehouse sync failure classes. Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`. The failure was identified from a recorded `latest_error` on `ExternalDataJob`; the committed fixture uses a reserved `example.com` URL, not any customer value.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
