### PR TITLE
fix(postgres): explain a database host that won't resolve

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -92,6 +92,15 @@ _INVALID_CREDENTIALS_ERROR = (
     "this source, then re-enable the sync."
 )
 
+# A DNS-resolution failure for the database host, surfaced by libpq ("could not translate host
+# name") or the raw socket wording ("Name or service not known" / "No address associated with
+# hostname"). Already non-retryable, but the bare driver text gives the customer nothing to act on,
+# so surface actionable guidance on the sync path (the validate path already has its own copy).
+_DNS_RESOLUTION_ERROR = (
+    "Could not resolve the database host to an address. Check that the host is spelled correctly "
+    "and reachable from the public internet, then re-enable the sync."
+)
+
 PostgresErrors = {
     "password authentication failed for user": "Invalid user or password",
     # libpq reports a bad password via SCRAM with a different wording than the line above.
@@ -377,7 +386,7 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 "through PAM (for example against the system password database or LDAP), and it "
                 "rejected the username or password. Check your credentials, then re-enable the sync."
             ),
-            "could not translate host name": None,
+            "could not translate host name": _DNS_RESOLUTION_ERROR,
             "timeout expired connection to server at": None,
             "password authentication failed for user": _INVALID_CREDENTIALS_ERROR,
             # Some providers (observed on a Neon-style pooler) report the same auth rejection without
@@ -470,12 +479,12 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
             # it too, instead of burning the retry budget re-scanning the same oversized catalog.
             "listing table columns while discovering the database schema": None,
             "TemporaryFileSizeExceedsLimitException": None,
-            "Name or service not known": None,
+            "Name or service not known": _DNS_RESOLUTION_ERROR,
             # Sibling getaddrinfo failure to "Name or service not known" (EAI_NONAME): EAI_NODATA
             # surfaces as "[Errno -5] No address associated with hostname". Both mean the customer's
             # database host doesn't resolve to an address — a config/DNS issue on their side that
             # retrying won't fix.
-            "No address associated with hostname": None,
+            "No address associated with hostname": _DNS_RESOLUTION_ERROR,
             "Network is unreachable": None,
             # `InsufficientPrivilege` is the psycopg exception class name. It only appears once
             # Temporal wraps the activity failure (`ApplicationError` stringifies as

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -443,6 +443,27 @@ class TestPostgresSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            'could not translate host name "bad-hostname.example.com" to address: Name or service not known',
+            "[Errno -2] Name or service not known",
+            "OperationalError: [Errno -5] No address associated with hostname",
+        ],
+    )
+    def test_dns_resolution_failure_surfaces_actionable_message(self, source, error_msg):
+        # A host that doesn't resolve is non-retryable, but must explain that the host can't be
+        # resolved rather than store the bare getaddrinfo/libpq text. Mirror the finalizer's
+        # first-match selection so a reorder that shadows it with an earlier None key is caught.
+        matches = [
+            friendly
+            for pattern, friendly in source.get_non_retryable_errors().items()
+            if error_message_matches(error_msg, [pattern])
+        ]
+        assert matches, f"DNS resolution failure must be classified non-retryable: {error_msg}"
+        assert matches[0] is not None, "DNS resolution failure must surface an actionable message, not raw driver text"
+        assert "resolve" in matches[0].lower()
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             'OperationalError: connection failed: connection to server at "db.example.com", port 5432 failed: server closed the connection unexpectedly',
             'OperationalError: connection failed: connection to server at "db.example.com", port 5432 failed: SSL connection has been closed unexpectedly',
         ],


### PR DESCRIPTION
## Problem

- A Postgres or Supabase sync whose host doesn't resolve via DNS shows the bare driver text as its error: `[Errno -2] Name or service not known`, `No address associated with hostname`, or libpq's `could not translate host name`.
- The failure was already non-retryable, so it wasn't burning jobs, but the message gives the customer nothing to act on.

## Changes

- Map the three DNS-resolution wordings to an actionable message telling the customer to check the host is spelled correctly and reachable from the public internet.
- Reuse the same guidance the credential-validation path already gives for these errors. Retryability is unchanged.

## How did you test this code?

- Added `test_dns_resolution_failure_surfaces_actionable_message` (parametrized over the three wordings) in `test_postgres.py`. It catches a regression that reverts any of them to raw driver text. The existing non-retryable test already guards classification.
- Ran `TestPostgresSourceNonRetryableErrors` locally (140 passed). Did not run the database-backed suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (agent) while triaging a batch of data-warehouse sync failure classes. Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`. The failure was identified from a recorded `latest_error` on `ExternalDataJob`; the test fixtures use a reserved `example.com` host, not any customer value.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
