### PR TITLE
feat(desktop): add side chats to tasks

### DIFF
--- a/products/desktop/apps/web/src/web-container.ts
+++ b/products/desktop/apps/web/src/web-container.ts
@@ -127,6 +127,10 @@ import {
 } from "@posthog/core/sessions/sessionService";
 import { sessionsModule } from "@posthog/core/sessions/sessions.module";
 import {
+  SIDE_CHAT_SERVICE,
+  type SideChatService,
+} from "@posthog/core/sessions/sideChatService";
+import {
   type FileReadClient,
   type GithubPrTitleClient,
   TITLE_GENERATOR_FILE_READ_CLIENT,
@@ -384,6 +388,7 @@ interface WebBindings {
   [CLOUD_ARTIFACT_READ_FILE_AS_BASE64]: ReadFileAsBase64;
   [CLOUD_ARTIFACT_BUNDLE_LOCAL_SKILL]: BundleLocalSkill;
   [CLOUD_ARTIFACT_RESOLVE_SKILL_DEPENDENCIES]: ResolveSkillBundleDependencies;
+  [SIDE_CHAT_SERVICE]: SideChatService;
   [TITLE_GENERATOR_SERVICE]: TitleGeneratorService;
   [TITLE_GENERATOR_FILE_READ_CLIENT]: FileReadClient;
   [TITLE_GENERATOR_GITHUB_PR_TITLE_CLIENT]: GithubPrTitleClient;

--- a/products/desktop/packages/core/src/panels/panelConstants.ts
+++ b/products/desktop/packages/core/src/panels/panelConstants.ts
@@ -15,6 +15,7 @@ export const DEFAULT_PANEL_IDS = {
 
 export const DEFAULT_TAB_IDS = {
   LOGS: "logs",
+  SIDE_CHAT: "side-chat",
   SHELL: "shell",
   FILES: "files",
   CHANGES: "changes",

--- a/products/desktop/packages/core/src/panels/panelLayoutTransforms.ts
+++ b/products/desktop/packages/core/src/panels/panelLayoutTransforms.ts
@@ -335,6 +335,36 @@ export function openReadonlyTab(
   return { panelTree: splitTree, focusedPanelId: newPanelId };
 }
 
+export function openSideChat(layout: TaskLayout): Partial<TaskLayout> {
+  const opened = openReadonlyTab(
+    layout,
+    DEFAULT_TAB_IDS.SIDE_CHAT,
+    "Side chat",
+    { type: "side-chat" },
+  );
+  const nextLayout = { ...layout, ...opened };
+  const mainChat = findTabInTree(nextLayout.panelTree, DEFAULT_TAB_IDS.LOGS);
+  const sideChat = findTabInTree(
+    nextLayout.panelTree,
+    DEFAULT_TAB_IDS.SIDE_CHAT,
+  );
+
+  if (!mainChat || !sideChat || mainChat.panelId !== sideChat.panelId) {
+    return opened;
+  }
+
+  return {
+    ...opened,
+    ...splitPanelTree(
+      nextLayout,
+      DEFAULT_TAB_IDS.SIDE_CHAT,
+      sideChat.panelId,
+      mainChat.panelId,
+      "right",
+    ),
+  };
+}
+
 export function addRecentFile(
   recentFiles: string[] | undefined,
   filePath: string,

--- a/products/desktop/packages/core/src/panels/panelTypes.ts
+++ b/products/desktop/packages/core/src/panels/panelTypes.ts
@@ -25,6 +25,9 @@ export type TabData =
       type: "logs";
     }
   | {
+      type: "side-chat";
+    }
+  | {
       type: "review";
     }
   | {

--- a/products/desktop/packages/core/src/sessions/sessions.module.ts
+++ b/products/desktop/packages/core/src/sessions/sessions.module.ts
@@ -1,10 +1,12 @@
 import { ContainerModule } from "inversify";
 import { CLOUD_ARTIFACT_SERVICE } from "./cloudArtifactIdentifiers";
 import { CloudArtifactService } from "./cloudArtifactService";
+import { SIDE_CHAT_SERVICE, SideChatService } from "./sideChatService";
 import { TITLE_GENERATOR_SERVICE } from "./titleGeneratorIdentifiers";
 import { TitleGeneratorService } from "./titleGeneratorService";
 
 export const sessionsModule = new ContainerModule(({ bind }) => {
   bind(CLOUD_ARTIFACT_SERVICE).to(CloudArtifactService).inSingletonScope();
+  bind(SIDE_CHAT_SERVICE).to(SideChatService).inSingletonScope();
   bind(TITLE_GENERATOR_SERVICE).to(TitleGeneratorService).inSingletonScope();
 });

--- a/products/desktop/packages/core/src/sessions/sideChatService.test.ts
+++ b/products/desktop/packages/core/src/sessions/sideChatService.test.ts
@@ -1,0 +1,65 @@
+import type { LlmGatewayService } from "@posthog/core/llm-gateway/llm-gateway";
+import { describe, expect, it, vi } from "vitest";
+import { SideChatService } from "./sideChatService";
+
+function response(content: string) {
+  return {
+    content,
+    model: "test-model",
+    stopReason: "end_turn",
+    usage: { inputTokens: 10, outputTokens: 5 },
+  };
+}
+
+describe("SideChatService", () => {
+  it("keeps side-chat history separate while refreshing the main-chat context", async () => {
+    const prompt = vi
+      .fn()
+      .mockResolvedValueOnce(response("First answer"))
+      .mockResolvedValueOnce(response("Second answer"));
+    const service = new SideChatService({
+      prompt,
+    } as unknown as LlmGatewayService);
+
+    await service.ask("task-1", "First question", "Main context one");
+    await service.ask("task-1", "Follow up", "Main context two");
+
+    expect(service.store.getState().threads["task-1"]?.messages).toEqual([
+      { id: "side-chat-1", role: "user", content: "First question" },
+      { id: "side-chat-2", role: "assistant", content: "First answer" },
+      { id: "side-chat-3", role: "user", content: "Follow up" },
+      { id: "side-chat-4", role: "assistant", content: "Second answer" },
+    ]);
+    expect(prompt.mock.calls[1]?.[0]).toEqual([
+      { role: "user", content: "First question" },
+      { role: "assistant", content: "First answer" },
+      { role: "user", content: "Follow up" },
+    ]);
+    expect(prompt.mock.calls[1]?.[1].system).toContain("Main context two");
+  });
+
+  it("ignores a second submission while an answer is in flight", async () => {
+    let resolvePrompt:
+      | ((value: ReturnType<typeof response>) => void)
+      | undefined;
+    const prompt = vi.fn(
+      () =>
+        new Promise<ReturnType<typeof response>>((resolve) => {
+          resolvePrompt = resolve;
+        }),
+    );
+    const service = new SideChatService({
+      prompt,
+    } as unknown as LlmGatewayService);
+
+    const first = service.ask("task-1", "First question", "Main context");
+    await service.ask("task-1", "Duplicate question", "Main context");
+    resolvePrompt?.(response("Answer"));
+    await first;
+
+    expect(prompt).toHaveBeenCalledOnce();
+    expect(service.store.getState().threads["task-1"]?.messages).toHaveLength(
+      2,
+    );
+  });
+});

--- a/products/desktop/packages/core/src/sessions/sideChatService.ts
+++ b/products/desktop/packages/core/src/sessions/sideChatService.ts
@@ -1,0 +1,111 @@
+import { LLM_GATEWAY_SERVICE } from "@posthog/core/llm-gateway/identifiers";
+import type { LlmGatewayService } from "@posthog/core/llm-gateway/llm-gateway";
+import { inject, injectable } from "inversify";
+import { createStore, type StoreApi } from "zustand/vanilla";
+
+const MAX_MAIN_CONVERSATION_CHARS = 40_000;
+const SIDE_CHAT_SYSTEM_PROMPT = `You answer questions in a side chat attached to a coding task.
+
+Use the main conversation only as background. Answer the side-chat question directly and concisely. Do not claim to have edited files, run tools, or changed the main task. If the available context is insufficient, say what is unknown and suggest the next question to ask the main agent.`;
+
+export const SIDE_CHAT_SERVICE = Symbol.for(
+  "posthog.core.sessions.sideChatService",
+);
+
+export interface SideChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+}
+
+export interface SideChatThread {
+  messages: SideChatMessage[];
+  isLoading: boolean;
+  hasError: boolean;
+}
+
+export interface SideChatState {
+  threads: Record<string, SideChatThread>;
+}
+
+const emptyThread = (): SideChatThread => ({
+  messages: [],
+  isLoading: false,
+  hasError: false,
+});
+
+@injectable()
+export class SideChatService {
+  readonly store: StoreApi<SideChatState> = createStore<SideChatState>(() => ({
+    threads: {},
+  }));
+
+  private nextMessageId = 1;
+
+  constructor(
+    @inject(LLM_GATEWAY_SERVICE)
+    private readonly llmGateway: LlmGatewayService,
+  ) {}
+
+  async ask(
+    taskId: string,
+    question: string,
+    mainConversation: string,
+  ): Promise<void> {
+    const normalizedQuestion = question.trim();
+    const currentThread =
+      this.store.getState().threads[taskId] ?? emptyThread();
+    if (!normalizedQuestion || currentThread.isLoading) {
+      return;
+    }
+
+    const userMessage = this.createMessage("user", normalizedQuestion);
+    const messages = [...currentThread.messages, userMessage];
+    this.setThread(taskId, {
+      messages,
+      isLoading: true,
+      hasError: false,
+    });
+
+    try {
+      const context = mainConversation.slice(-MAX_MAIN_CONVERSATION_CHARS);
+      const result = await this.llmGateway.prompt(
+        messages.map(({ role, content }) => ({ role, content })),
+        {
+          system: `${SIDE_CHAT_SYSTEM_PROMPT}\n\n<main_conversation>\n${context || "No main conversation is available."}\n</main_conversation>`,
+          maxTokens: 2_000,
+        },
+      );
+      const answer = result.content.trim();
+      if (!answer) {
+        throw new Error("The side chat returned an empty answer");
+      }
+      this.setThread(taskId, {
+        messages: [...messages, this.createMessage("assistant", answer)],
+        isLoading: false,
+        hasError: false,
+      });
+    } catch {
+      this.setThread(taskId, {
+        messages,
+        isLoading: false,
+        hasError: true,
+      });
+    }
+  }
+
+  private createMessage(
+    role: SideChatMessage["role"],
+    content: string,
+  ): SideChatMessage {
+    const id = `side-chat-${this.nextMessageId}`;
+    this.nextMessageId += 1;
+    return { id, role, content };
+  }
+
+  private setThread(taskId: string, thread: SideChatThread): void {
+    this.store.setState((state) => ({
+      threads: { ...state.threads, [taskId]: thread },
+    }));
+  }
+}

--- a/products/desktop/packages/ui/src/features/panels/components/LeafNodeRenderer.tsx
+++ b/products/desktop/packages/ui/src/features/panels/components/LeafNodeRenderer.tsx
@@ -1,10 +1,14 @@
-import { Cloud as CloudIcon } from "@phosphor-icons/react";
+import { ChatCircleDotsIcon, Cloud as CloudIcon } from "@phosphor-icons/react";
 import {
+  Button,
   Empty,
   EmptyDescription,
   EmptyHeader,
   EmptyMedia,
   EmptyTitle,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from "@posthog/quill";
 import type { Task } from "@posthog/shared/domain-types";
 import type React from "react";
@@ -12,7 +16,7 @@ import { useMemo } from "react";
 import { useHostCapabilities } from "../../../shell/useHostCapabilities";
 import { useIsCloudTask } from "../../workspace/useWorkspace";
 import { useTabInjection } from "../hooks/usePanelLayoutHooks";
-import type { SplitDirection } from "../panelLayoutStore";
+import { type SplitDirection, usePanelLayoutStore } from "../panelLayoutStore";
 import type { LeafPanel } from "../panelTypes";
 import { TabbedPanel } from "./TabbedPanel";
 
@@ -62,6 +66,8 @@ export const LeafNodeRenderer: React.FC<LeafNodeRendererProps> = ({
   const activeTabId = tabs.some((t) => t.id === node.content.activeTabId)
     ? node.content.activeTabId
     : (tabs[0]?.id ?? node.content.activeTabId);
+  const activeTab = tabs.find((tab) => tab.id === activeTabId);
+  const openSideChat = usePanelLayoutStore((state) => state.openSideChat);
   const hiddenTabIds = useMemo(() => {
     const visibleTabIds = new Set(tabs.map((tab) => tab.id));
     const hiddenIds: string[] = [];
@@ -109,6 +115,26 @@ export const LeafNodeRenderer: React.FC<LeafNodeRendererProps> = ({
       draggingTabPanelId={draggingTabPanelId}
       allowPanelSplit={!isCloud}
       onAddTerminal={hideTerminal ? undefined : () => onAddTerminal(node.id)}
+      rightContent={
+        activeTab?.data.type === "logs" ? (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="default"
+                  size="icon-xs"
+                  onClick={() => openSideChat(taskId)}
+                  aria-label="Open side chat"
+                  data-attr="open-side-chat"
+                />
+              }
+            >
+              <ChatCircleDotsIcon />
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Open side chat</TooltipContent>
+          </Tooltip>
+        ) : undefined
+      }
       onSplitPanel={
         isCloud ? undefined : (direction) => onSplitPanel(node.id, direction)
       }

--- a/products/desktop/packages/ui/src/features/panels/panelLayoutStore.test.ts
+++ b/products/desktop/packages/ui/src/features/panels/panelLayoutStore.test.ts
@@ -193,6 +193,37 @@ describe("panelLayoutStore", () => {
     });
   });
 
+  describe("openSideChat", () => {
+    beforeEach(() => {
+      usePanelLayoutStore.getState().initializeTask("task-1");
+    });
+
+    it("opens one side chat beside the main chat", () => {
+      usePanelLayoutStore.getState().openSideChat("task-1");
+      usePanelLayoutStore.getState().openSideChat("task-1");
+
+      const tree = getPanelTree("task-1");
+      if (tree.type !== "group") throw new Error("Expected a split panel");
+      const panels = tree.children.filter((child) => child.type === "leaf");
+      expect(panels).toHaveLength(2);
+      expect(
+        panels.flatMap((panel) => panel.content.tabs.map((tab) => tab.id)),
+      ).toEqual(expect.arrayContaining(["logs", "side-chat"]));
+      expect(
+        panels
+          .flatMap((panel) => panel.content.tabs)
+          .filter((tab) => tab.id === "side-chat"),
+      ).toHaveLength(1);
+      expect(
+        panels.some(
+          (panel) =>
+            panel.content.tabs.some((tab) => tab.id === "logs") &&
+            panel.content.tabs.some((tab) => tab.id === "side-chat"),
+        ),
+      ).toBe(false);
+    });
+  });
+
   describe("closeTab", () => {
     beforeEach(() => {
       usePanelLayoutStore.getState().initializeTask("task-1");

--- a/products/desktop/packages/ui/src/features/panels/panelLayoutStore.ts
+++ b/products/desktop/packages/ui/src/features/panels/panelLayoutStore.ts
@@ -9,6 +9,7 @@ import {
   keepTab as coreKeepTab,
   moveTab as coreMoveTab,
   openReadonlyTab as coreOpenReadonlyTab,
+  openSideChat as coreOpenSideChat,
   openTab as coreOpenTab,
   openTabInSplit as coreOpenTabInSplit,
   reorderTabs as coreReorderTabs,
@@ -68,6 +69,7 @@ export interface PanelLayoutStore {
     instructions: { body: string },
   ) => void;
   openAutoresearchTab: (taskId: string) => void;
+  openSideChat: (taskId: string) => void;
   openArtifactTab: (
     taskId: string,
     artifact: { runId: string; artifactId: string; name: string },
@@ -290,6 +292,16 @@ export const usePanelLayoutStore = createWithEqualityFn<PanelLayoutStore>()(
               coreOpenReadonlyTab(layout, "autoresearch", "Autoresearch", {
                 type: "autoresearch",
               }) as Partial<TaskLayout>,
+          ),
+        );
+      },
+
+      openSideChat: (taskId) => {
+        set((state) =>
+          updateTaskLayout(
+            state,
+            taskId,
+            (layout) => coreOpenSideChat(layout) as Partial<TaskLayout>,
           ),
         );
       },

--- a/products/desktop/packages/ui/src/features/side-chat/SideChatPanel.tsx
+++ b/products/desktop/packages/ui/src/features/side-chat/SideChatPanel.tsx
@@ -1,0 +1,67 @@
+import { PI_SESSION_CONTROLLER } from "@posthog/core/pi-runtime/identifiers";
+import type { PiSessionController } from "@posthog/core/pi-runtime/piSessionController";
+import { useService } from "@posthog/di/react";
+import type { AgentConversationEvent } from "@posthog/shared";
+import type { Task } from "@posthog/shared/domain-types";
+import {
+  buildAgentConversationItems,
+  buildConversationItems,
+} from "@posthog/ui/features/sessions/components/buildConversationItems";
+import { useSessionForTask } from "@posthog/ui/features/sessions/sessionStore";
+import { type FormEvent, useMemo, useState } from "react";
+import { useStore } from "zustand";
+import { SideChatView } from "./SideChatView";
+import { buildSideChatMainContext } from "./sideChatContext";
+import { useSideChat } from "./useSideChat";
+
+const EMPTY_PI_EVENTS: AgentConversationEvent[] = [];
+
+export interface SideChatPanelProps {
+  taskId: string;
+  task: Task;
+}
+
+export function SideChatPanel({ taskId, task }: SideChatPanelProps) {
+  const piSessionController = useService<PiSessionController>(
+    PI_SESSION_CONTROLLER,
+  );
+  const piEvents = useStore(
+    piSessionController.store,
+    (state) => state.sessions[taskId]?.events ?? EMPTY_PI_EVENTS,
+  );
+  const acpSession = useSessionForTask(taskId);
+  const conversationItems = useMemo(
+    () =>
+      task.runtime === "pi"
+        ? buildAgentConversationItems(piEvents, false).items
+        : buildConversationItems(
+            acpSession?.events ?? [],
+            acpSession?.isPromptPending ?? null,
+          ).items,
+    [acpSession?.events, acpSession?.isPromptPending, piEvents, task.runtime],
+  );
+  const mainConversation = useMemo(
+    () => buildSideChatMainContext(task.description, conversationItems),
+    [conversationItems, task.description],
+  );
+  const { thread, ask } = useSideChat(taskId, mainConversation);
+  const [question, setQuestion] = useState("");
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    const value = question.trim();
+    if (!value || thread.isLoading) return;
+    setQuestion("");
+    void ask(value);
+  };
+
+  return (
+    <SideChatView
+      taskId={taskId}
+      thread={thread}
+      question={question}
+      onQuestionChange={setQuestion}
+      onSubmit={handleSubmit}
+    />
+  );
+}

--- a/products/desktop/packages/ui/src/features/side-chat/SideChatView.stories.tsx
+++ b/products/desktop/packages/ui/src/features/side-chat/SideChatView.stories.tsx
@@ -1,0 +1,68 @@
+import { SideChatView } from "@posthog/ui/features/side-chat/SideChatView";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta: Meta<typeof SideChatView> = {
+  title: "Features/Side chat/SideChatView",
+  component: SideChatView,
+  decorators: [
+    (Story) => (
+      <div className="h-screen w-full max-w-xl border border-border">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    taskId: "task-1",
+    question: "",
+    onQuestionChange: () => {},
+    onSubmit: (event) => event.preventDefault(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SideChatView>;
+
+export const Empty: Story = {
+  args: {
+    thread: { messages: [], isLoading: false, hasError: false },
+  },
+};
+
+export const Conversation: Story = {
+  args: {
+    thread: {
+      messages: [
+        {
+          id: "question-1",
+          role: "user",
+          content: "Why does the plan separate the migration into two steps?",
+        },
+        {
+          id: "answer-1",
+          role: "assistant",
+          content:
+            "The first step keeps the old and new fields compatible. The second removes the old field after all callers have moved over.",
+        },
+      ],
+      isLoading: false,
+      hasError: false,
+    },
+  },
+};
+
+export const Answering: Story = {
+  args: {
+    question: "Could we combine them?",
+    thread: {
+      messages: [
+        {
+          id: "question-1",
+          role: "user",
+          content: "What is the main risk in this plan?",
+        },
+      ],
+      isLoading: true,
+      hasError: false,
+    },
+  },
+};

--- a/products/desktop/packages/ui/src/features/side-chat/SideChatView.tsx
+++ b/products/desktop/packages/ui/src/features/side-chat/SideChatView.tsx
@@ -1,0 +1,133 @@
+import { PaperPlaneTilt, Question } from "@phosphor-icons/react";
+import type { SideChatThread } from "@posthog/core/sessions/sideChatService";
+import {
+  Button,
+  ChatBubble,
+  ChatBubbleContent,
+  ChatMessage,
+  ChatMessageContent,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+  Field,
+  FieldLabel,
+  Input,
+  SkeletonText,
+  Text,
+} from "@posthog/quill";
+import { ChatMarkdown } from "@posthog/ui/features/sessions/components/chat-thread/ChatMarkdown";
+import { type FormEvent, useCallback } from "react";
+
+export interface SideChatViewProps {
+  taskId: string;
+  thread: SideChatThread;
+  question: string;
+  onQuestionChange: (question: string) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+}
+
+export function SideChatView({
+  taskId,
+  thread,
+  question,
+  onQuestionChange,
+  onSubmit,
+}: SideChatViewProps) {
+  const scrollToLatest = useCallback((node: HTMLDivElement | null): void => {
+    node?.scrollIntoView({ block: "end" });
+  }, []);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-background">
+      <div className="min-h-0 flex-1 overflow-y-auto p-4">
+        {thread.messages.length === 0 ? (
+          <Empty className="h-full border-0">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <Question />
+              </EmptyMedia>
+              <EmptyTitle>Ask a side question</EmptyTitle>
+              <EmptyDescription>
+                Get an answer using the main chat as context. Side chat cannot
+                edit files or change the main chat.
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        ) : (
+          <div className="mx-auto flex w-full max-w-3xl flex-col gap-3">
+            {thread.messages.map((message) => (
+              <ChatMessage
+                key={message.id}
+                align={message.role === "user" ? "end" : "start"}
+              >
+                <ChatMessageContent>
+                  <ChatBubble
+                    variant={message.role === "user" ? "default" : "ghost"}
+                  >
+                    <ChatBubbleContent>
+                      <ChatMarkdown content={message.content} />
+                    </ChatBubbleContent>
+                  </ChatBubble>
+                </ChatMessageContent>
+              </ChatMessage>
+            ))}
+            {thread.isLoading && (
+              <ChatMessage align="start">
+                <ChatMessageContent>
+                  <ChatBubble variant="ghost">
+                    <ChatBubbleContent className="w-64">
+                      <SkeletonText lines={2} />
+                    </ChatBubbleContent>
+                  </ChatBubble>
+                </ChatMessageContent>
+              </ChatMessage>
+            )}
+            <div
+              key={`${thread.messages.length}-${thread.isLoading}`}
+              ref={scrollToLatest}
+            />
+          </div>
+        )}
+      </div>
+
+      <form
+        onSubmit={onSubmit}
+        className="flex shrink-0 items-end gap-2 border-border border-t p-3"
+      >
+        <Field className="min-w-0 flex-1">
+          <FieldLabel
+            htmlFor={`side-chat-question-${taskId}`}
+            className="sr-only"
+          >
+            Side chat question
+          </FieldLabel>
+          <Input
+            id={`side-chat-question-${taskId}`}
+            value={question}
+            onChange={(event) => onQuestionChange(event.target.value)}
+            placeholder="Ask without changing the main chat"
+            autoComplete="off"
+          />
+          {thread.hasError && (
+            <Text size="xs" variant="destructive">
+              Couldn't answer this question. Try sending it again.
+            </Text>
+          )}
+        </Field>
+        <Button
+          type="submit"
+          variant="primary"
+          size="icon"
+          loading={thread.isLoading}
+          disabled={!question.trim()}
+          aria-label="Send side chat question"
+          data-attr="side-chat-send"
+        >
+          <PaperPlaneTilt />
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/side-chat/sideChatContext.test.ts
+++ b/products/desktop/packages/ui/src/features/side-chat/sideChatContext.test.ts
@@ -1,0 +1,44 @@
+import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
+import { describe, expect, it } from "vitest";
+import { buildSideChatMainContext } from "./sideChatContext";
+
+describe("buildSideChatMainContext", () => {
+  it("includes user and assistant messages without agent thoughts or status rows", () => {
+    const items = [
+      {
+        type: "user_message",
+        id: "user-1",
+        content: "Can you inspect the plan?",
+        timestamp: 1,
+      },
+      {
+        type: "session_update",
+        id: "thought-1",
+        update: {
+          sessionUpdate: "agent_thought_chunk",
+          content: { type: "text", text: "Private reasoning" },
+        },
+        turnContext: {},
+      },
+      {
+        type: "session_update",
+        id: "assistant-1",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "The plan has three steps." },
+        },
+        turnContext: {},
+      },
+      {
+        type: "session_update",
+        id: "status-1",
+        update: { sessionUpdate: "status", status: "working" },
+        turnContext: {},
+      },
+    ] as unknown as ConversationItem[];
+
+    expect(buildSideChatMainContext("Refine the rollout plan", items)).toBe(
+      "Task: Refine the rollout plan\n\nUser: Can you inspect the plan?\n\nAssistant: The plan has three steps.",
+    );
+  });
+});

--- a/products/desktop/packages/ui/src/features/side-chat/sideChatContext.ts
+++ b/products/desktop/packages/ui/src/features/side-chat/sideChatContext.ts
@@ -1,0 +1,49 @@
+import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
+
+const MAX_CONTEXT_CHARS = 40_000;
+
+type ConversationTurn = {
+  role: "User" | "Assistant";
+  content: string;
+};
+
+export function buildSideChatMainContext(
+  taskDescription: string,
+  items: ConversationItem[],
+): string {
+  const turns: ConversationTurn[] = [];
+
+  const append = (role: ConversationTurn["role"], content: string): void => {
+    const normalized = content.trim();
+    if (!normalized) return;
+    const previous = turns.at(-1);
+    if (previous?.role === role) {
+      previous.content = `${previous.content}\n${normalized}`;
+    } else {
+      turns.push({ role, content: normalized });
+    }
+  };
+
+  for (const item of items) {
+    if (item.type === "user_message") {
+      append("User", item.content);
+    } else if (
+      item.type === "session_update" &&
+      item.update.sessionUpdate === "agent_message_chunk" &&
+      item.update.content.type === "text"
+    ) {
+      append("Assistant", item.update.content.text);
+    }
+  }
+
+  const taskContext = taskDescription.trim()
+    ? `Task: ${taskDescription.trim()}\n\n`
+    : "";
+  const context = `${taskContext}${turns
+    .map((turn) => `${turn.role}: ${turn.content}`)
+    .join("\n\n")}`;
+
+  return context.length <= MAX_CONTEXT_CHARS
+    ? context
+    : `[Earlier context omitted.]\n${context.slice(-MAX_CONTEXT_CHARS)}`;
+}

--- a/products/desktop/packages/ui/src/features/side-chat/useSideChat.ts
+++ b/products/desktop/packages/ui/src/features/side-chat/useSideChat.ts
@@ -1,0 +1,34 @@
+import {
+  SIDE_CHAT_SERVICE,
+  type SideChatService,
+  type SideChatThread,
+} from "@posthog/core/sessions/sideChatService";
+import { useService } from "@posthog/di/react";
+import { useCallback } from "react";
+import { useStore } from "zustand";
+
+const EMPTY_THREAD: SideChatThread = {
+  messages: [],
+  isLoading: false,
+  hasError: false,
+};
+
+export function useSideChat(
+  taskId: string,
+  mainConversation: string,
+): {
+  thread: SideChatThread;
+  ask: (question: string) => Promise<void>;
+} {
+  const service = useService<SideChatService>(SIDE_CHAT_SERVICE);
+  const thread = useStore(
+    service.store,
+    (state) => state.threads[taskId] ?? EMPTY_THREAD,
+  );
+  const ask = useCallback(
+    (question: string) => service.ask(taskId, question, mainConversation),
+    [mainConversation, service, taskId],
+  );
+
+  return { thread, ask };
+}

--- a/products/desktop/packages/ui/src/features/task-detail/components/TabContentRenderer.test.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TabContentRenderer.test.tsx
@@ -18,6 +18,9 @@ vi.mock("../../code-review/components/LazyReviewPages", () => ({
 vi.mock("../../sessions/components/ArtifactPreview", () => ({
   ArtifactPreview: (): null => null,
 }));
+vi.mock("../../side-chat/SideChatPanel", () => ({
+  SideChatPanel: (): null => null,
+}));
 vi.mock("../../workspace/useWorkspace", () => ({
   useIsCloudTask: () => false,
 }));

--- a/products/desktop/packages/ui/src/features/task-detail/components/TabContentRenderer.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TabContentRenderer.tsx
@@ -8,6 +8,7 @@ import {
 import type { Tab } from "../../panels/panelTypes";
 import { PiSessionView } from "../../pi-sessions/PiSessionView";
 import { ArtifactPreview } from "../../sessions/components/ArtifactPreview";
+import { SideChatPanel } from "../../side-chat/SideChatPanel";
 import { useIsCloudTask } from "../../workspace/useWorkspace";
 import { ActionPanel } from "./ActionPanel";
 import { CanvasInstructionsTab } from "./CanvasInstructionsTab";
@@ -38,6 +39,9 @@ export function TabContentRenderer({
       ) : (
         <TaskLogsPanel taskId={taskId} task={task} />
       );
+
+    case "side-chat":
+      return <SideChatPanel taskId={taskId} task={task} />;
 
     case "terminal":
       return (


### PR DESCRIPTION
## Problem

Task users cannot ask a separate question without adding it to the main agent conversation.

Closes #76258

## Changes

- Add an **Open side chat** action that opens a second chat beside the main task chat.
- Give each task an independent side-chat history with the latest main conversation as read-only context.
- Keep side chats question-only. They cannot edit files, run tools, or change the main conversation.
- Guard side-chat requests against duplicate submissions and show loading and retry states.

![side-chat-conversation](https://raw.githubusercontent.com/PostHog/pr-assets/58d7a3c2bd5135d5b06ddc7b9fccfee682c320ac/2026/08/d60c7cb8-eb22-46ac-88b5-b6ec882e370c.png)

## How did you test this code?

- Added service tests for isolated side-chat history and duplicate-submission protection.
- Added context tests that exclude agent thoughts and status rows.
- Added a panel-layout test that prevents duplicate side-chat panes.
- Ran the affected core and UI Vitest suites.
- Ran type checks for core, UI, web, and the desktop app.
- Built Storybook and rendered the side-chat story in Chromium.
- Ran `hogli ci:preflight --fix`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update. The side-chat empty state explains that it cannot change files or the main conversation.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- The Pi coding agent used repository tools, shell commands, Storybook, and Playwright.
- Invoked `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, and `/writing-pr-descriptions`.
- The uploaded screenshot uses invented task text and contains no customer data.