### PR TITLE
fix(desktop): preserve comments in task deep links

### DIFF
--- a/frontend/src/scenes/code-canvas/CodeTaskLink.test.ts
+++ b/frontend/src/scenes/code-canvas/CodeTaskLink.test.ts
@@ -1,0 +1,38 @@
+import * as kea from 'kea'
+import * as React from 'react'
+
+import { CodeTaskLink, taskDeepLink } from './CodeTaskLink'
+
+jest.mock('react', () => ({
+    ...jest.requireActual('react'),
+    useEffect: jest.fn(),
+}))
+
+describe('CodeTaskLink', () => {
+    afterEach(() => {
+        jest.restoreAllMocks()
+        jest.clearAllMocks()
+    })
+
+    it('forwards the comment target from the browser URL to PostHog Desktop', () => {
+        expect(
+            taskDeepLink('task/1', {
+                comment: 'comment/1',
+                scope: 'task_artifact',
+                item: 'artifact/1',
+            })
+        ).toBe('posthog-code://task/task%2F1?comment=comment%2F1&scope=task_artifact&item=artifact%2F1')
+    })
+
+    it('reads the comment target from the active URL when rendering the bridge', () => {
+        jest.spyOn(kea, 'useValues').mockReturnValue({
+            searchParams: { comment: 'comment-1' },
+        } as never)
+
+        CodeTaskLink({ taskId: 'task-1' })
+
+        expect(React.useEffect).toHaveBeenCalledWith(expect.any(Function), [
+            'posthog-code://task/task-1?comment=comment-1',
+        ])
+    })
+})

--- a/frontend/src/scenes/code-canvas/CodeTaskLink.tsx
+++ b/frontend/src/scenes/code-canvas/CodeTaskLink.tsx
@@ -1,3 +1,5 @@
+import { useValues } from 'kea'
+import { router } from 'kea-router'
 import { useEffect } from 'react'
 
 import { IconLaptop } from '@posthog/icons'
@@ -10,38 +12,33 @@ import { DESKTOP_SCHEME } from './desktopScheme'
 
 export interface CodeTaskLinkProps {
     taskId: string
-    commentId?: string
-    commentScope?: string
-    commentItemId?: string
 }
 
 export const scene: SceneExport<CodeTaskLinkProps> = {
     component: CodeTaskLink,
-    paramsToProps: ({ params: { taskId }, searchParams }) => ({
+    paramsToProps: ({ params: { taskId } }) => ({
         taskId: taskId ?? '',
-        commentId: searchParams.comment || undefined,
-        commentScope: searchParams.scope || undefined,
-        commentItemId: searchParams.item || undefined,
     }),
 }
 
-function taskDeepLink({ taskId, commentId, commentScope, commentItemId }: CodeTaskLinkProps): string {
+export function taskDeepLink(taskId: string, searchParams: Record<string, unknown>): string {
     const params = new URLSearchParams()
-    if (commentId) {
-        params.set('comment', commentId)
+    if (typeof searchParams.comment === 'string') {
+        params.set('comment', searchParams.comment)
     }
-    if (commentScope) {
-        params.set('scope', commentScope)
+    if (typeof searchParams.scope === 'string') {
+        params.set('scope', searchParams.scope)
     }
-    if (commentItemId) {
-        params.set('item', commentItemId)
+    if (typeof searchParams.item === 'string') {
+        params.set('item', searchParams.item)
     }
     const query = params.toString()
     return `${DESKTOP_SCHEME}://task/${encodeURIComponent(taskId)}${query ? `?${query}` : ''}`
 }
 
-export function CodeTaskLink(props: CodeTaskLinkProps): JSX.Element {
-    const deepLink = props.taskId ? taskDeepLink(props) : null
+export function CodeTaskLink({ taskId }: CodeTaskLinkProps): JSX.Element {
+    const { searchParams } = useValues(router)
+    const deepLink = taskId ? taskDeepLink(taskId, searchParams) : null
 
     useEffect(() => {
         if (deepLink) {


### PR DESCRIPTION
## Problem

Task comment links open the correct task in PostHog Desktop but do not select the requested comment.

The web bridge read comment parameters through scene logic props. Scene components only receive path parameters, so the bridge dropped the comment query.

## Changes

- The web bridge now reads the active URL query before it opens PostHog Desktop.
- The bridge forwards the comment ID, scope, and item ID.
- This change has no visual effect.

## How did you test this code?

- Added a focused Jest test that catches dropped comment parameters in the bridge URL.
- Ran the focused Jest test and the frontend formatter and linter.
- The full frontend type check exceeded the sandbox memory limit after the required workspace packages built.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The existing deep-link documentation already describes the intended comment forwarding behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented this fix with repository and shell tools. It invoked `/working-with-task-comments`, `/writing-tests`, `/writing-pr-descriptions`, and `/writing-simplified-technical-english`.

The tests use invented task, comment, and artifact identifiers. No private session material appears in the change.
