### PR TITLE
fix(experiments): unblock the recordings tab for activation exposures

### DIFF
--- a/posthog/session_recordings/queries/session_recording_list_from_query.py
+++ b/posthog/session_recordings/queries/session_recording_list_from_query.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional, Union, cast
 import structlog
 from dateutil.relativedelta import relativedelta
 from opentelemetry import trace
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import PermissionDenied, ValidationError
 
 from posthog.schema import (
     HogQLQueryModifiers,
@@ -19,6 +19,7 @@ from posthog.hogql.constants import HogQLGlobalSettings
 from posthog.hogql.parser import parse_select
 from posthog.hogql.property import property_to_expr
 
+from posthog.exceptions import ClickHouseClusterMemoryLimitExceeded, ClickHouseQueryMemoryLimitExceeded
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.insights.paginators import HogQLCursorPaginator, HogQLHasMorePaginator
 from posthog.models import Team, User
@@ -227,20 +228,37 @@ class SessionRecordingListFromQuery(SessionRecordingsListingBaseQuery):
         self._resolve_experiment_exposure()
         query = self.get_query()
 
+        settings_args: dict[str, int] = {}
+        if self._max_execution_time is not None:
+            settings_args["max_execution_time"] = self._max_execution_time
+        live_scan_budget = (
+            self._experiment_exposure_linkage.live_scan_budget if self._experiment_exposure_linkage else None
+        )
+        if live_scan_budget is not None:
+            settings_args["max_memory_usage"] = live_scan_budget.max_memory_bytes
+
         with tracer.start_as_current_span("SessionRecordingListFromQuery.paginate"):
-            paginated_response = self._paginator.execute_hogql_query(
-                # TODO I guess the paginator needs to know how to handle union queries or all callers are supposed to collapse them or .... 🤷
-                query=cast(ast.SelectQuery, query),
-                team=self._team,
-                user=self._user,
-                query_type="SessionRecordingListQuery",
-                modifiers=self._hogql_query_modifiers,
-                settings=HogQLGlobalSettings(
-                    **(
-                        {"max_execution_time": self._max_execution_time} if self._max_execution_time is not None else {}
-                    ),
-                ),
-            )
+            try:
+                paginated_response = self._paginator.execute_hogql_query(
+                    # TODO I guess the paginator needs to know how to handle union queries or all callers are supposed to collapse them or .... 🤷
+                    query=cast(ast.SelectQuery, query),
+                    team=self._team,
+                    user=self._user,
+                    query_type="SessionRecordingListQuery",
+                    modifiers=self._hogql_query_modifiers,
+                    settings=HogQLGlobalSettings(**settings_args),
+                )
+            except ClickHouseClusterMemoryLimitExceeded:
+                # Cluster-wide pressure, not this query outgrowing its budget; the transient
+                # error's own retry guidance is the correct rendering.
+                raise
+            except ClickHouseQueryMemoryLimitExceeded:
+                if live_scan_budget is None:
+                    raise
+                # The budget's ceiling was hit, so the linkage's live scan outgrew what this
+                # synchronous endpoint may spend; the raw ClickHouse error would render as an
+                # unactionable 500 here.
+                raise ValidationError(live_scan_budget.over_budget_message)
 
         # After the results are in, check whether the exclusion blocklist hit its row cap,
         # because past the cap the query silently under-excludes. No-op without negated entities, and

--- a/posthog/session_recordings/queries/session_recording_list_from_query.py
+++ b/posthog/session_recordings/queries/session_recording_list_from_query.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional, Union, cast
 import structlog
 from dateutil.relativedelta import relativedelta
 from opentelemetry import trace
-from rest_framework.exceptions import PermissionDenied, ValidationError
+from rest_framework.exceptions import PermissionDenied
 
 from posthog.schema import (
     HogQLQueryModifiers,
@@ -19,7 +19,6 @@ from posthog.hogql.constants import HogQLGlobalSettings
 from posthog.hogql.parser import parse_select
 from posthog.hogql.property import property_to_expr
 
-from posthog.exceptions import ClickHouseClusterMemoryLimitExceeded, ClickHouseQueryMemoryLimitExceeded
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.insights.paginators import HogQLCursorPaginator, HogQLHasMorePaginator
 from posthog.models import Team, User
@@ -231,34 +230,25 @@ class SessionRecordingListFromQuery(SessionRecordingsListingBaseQuery):
         settings_args: dict[str, int] = {}
         if self._max_execution_time is not None:
             settings_args["max_execution_time"] = self._max_execution_time
-        live_scan_budget = (
-            self._experiment_exposure_linkage.live_scan_budget if self._experiment_exposure_linkage else None
-        )
-        if live_scan_budget is not None:
-            settings_args["max_memory_usage"] = live_scan_budget.max_memory_bytes
+        linkage = self._experiment_exposure_linkage
+        if linkage is not None and linkage.live_scan_max_memory_bytes is not None:
+            # Deliberately no exposure-specific rendering of the resulting memory kill: the
+            # ceiling bounds the whole listing query (event filters, blocklist, aggregation),
+            # not just the exposure scan, so only the platform's standard memory-limit error,
+            # with its status, machine code, and narrow-your-filters guidance, is honest for
+            # every cause.
+            settings_args["max_memory_usage"] = linkage.live_scan_max_memory_bytes
 
         with tracer.start_as_current_span("SessionRecordingListFromQuery.paginate"):
-            try:
-                paginated_response = self._paginator.execute_hogql_query(
-                    # TODO I guess the paginator needs to know how to handle union queries or all callers are supposed to collapse them or .... 🤷
-                    query=cast(ast.SelectQuery, query),
-                    team=self._team,
-                    user=self._user,
-                    query_type="SessionRecordingListQuery",
-                    modifiers=self._hogql_query_modifiers,
-                    settings=HogQLGlobalSettings(**settings_args),
-                )
-            except ClickHouseClusterMemoryLimitExceeded:
-                # Cluster-wide pressure, not this query outgrowing its budget; the transient
-                # error's own retry guidance is the correct rendering.
-                raise
-            except ClickHouseQueryMemoryLimitExceeded:
-                if live_scan_budget is None:
-                    raise
-                # The budget's ceiling was hit, so the linkage's live scan outgrew what this
-                # synchronous endpoint may spend; the raw ClickHouse error would render as an
-                # unactionable 500 here.
-                raise ValidationError(live_scan_budget.over_budget_message)
+            paginated_response = self._paginator.execute_hogql_query(
+                # TODO I guess the paginator needs to know how to handle union queries or all callers are supposed to collapse them or .... 🤷
+                query=cast(ast.SelectQuery, query),
+                team=self._team,
+                user=self._user,
+                query_type="SessionRecordingListQuery",
+                modifiers=self._hogql_query_modifiers,
+                settings=HogQLGlobalSettings(**settings_args),
+            )
 
         # After the results are in, check whether the exclusion blocklist hit its row cap,
         # because past the cap the query silently under-excludes. No-op without negated entities, and

--- a/posthog/session_recordings/queries/test/listing_recordings/test_session_recordings_list_by_experiment_exposure.py
+++ b/posthog/session_recordings/queries/test/listing_recordings/test_session_recordings_list_by_experiment_exposure.py
@@ -35,16 +35,16 @@ from posthog.session_recordings.session_recording_api import list_recordings_fro
 from posthog.session_recordings.sql.session_replay_event_sql import TRUNCATE_SESSION_REPLAY_EVENTS_TABLE_SQL
 from posthog.test.persons import add_distinct_id, create_person
 
-# The facade's transitive pydantic.v1 import must happen at module scope, outside the class's
-# frozen time: freezegun's FakeDate breaks pydantic.v1's metaclass construction, and the
-# runner otherwise defers this import to the first test that resolves a linkage.
-import products.experiments.backend.facade.replay  # noqa: F401
 from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import LazyComputationResult
 from products.cohorts.backend.models.cohort import Cohort
+
+# Importing the facade at module scope also keeps its transitive pydantic.v1 import outside the
+# class's frozen time: freezegun's FakeDate breaks pydantic.v1's metaclass construction, and the
+# runner otherwise defers this import to the first test that resolves a linkage.
+from products.experiments.backend.facade.replay import ACTIVATION_LIVE_SCAN_MAX_MEMORY_BYTES
 from products.experiments.backend.hogql_queries.experiment_exposure_query_builder import ExposureQueryBuilder
 from products.experiments.backend.models.experiment import Experiment
 from products.experiments.backend.models.team_experiments_config import TeamExperimentsConfig
-from products.experiments.backend.replay_linkage import ACTIVATION_LIVE_SCAN_MAX_MEMORY_BYTES
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 
 from ee.models.rbac.access_control import AccessControl

--- a/posthog/session_recordings/queries/test/listing_recordings/test_session_recordings_list_by_experiment_exposure.py
+++ b/posthog/session_recordings/queries/test/listing_recordings/test_session_recordings_list_by_experiment_exposure.py
@@ -1,5 +1,6 @@
 import json
 from datetime import UTC, datetime, timedelta
+from typing import cast
 
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, flush_persons_and_events
@@ -10,8 +11,12 @@ from rest_framework.exceptions import PermissionDenied, ValidationError
 
 from posthog.schema import RecordingsQuery
 
+from posthog.hogql.constants import HogQLGlobalSettings
+
 from posthog.clickhouse.client import sync_execute
 from posthog.constants import AvailableFeature
+from posthog.exceptions import ClickHouseClusterMemoryLimitExceeded, ClickHouseQueryMemoryLimitExceeded
+from posthog.hogql_queries.insights.paginators import HogQLCursorPaginator
 from posthog.models import User
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.team.extensions import get_or_create_team_extension
@@ -30,10 +35,16 @@ from posthog.session_recordings.session_recording_api import list_recordings_fro
 from posthog.session_recordings.sql.session_replay_event_sql import TRUNCATE_SESSION_REPLAY_EVENTS_TABLE_SQL
 from posthog.test.persons import add_distinct_id, create_person
 
+# The facade's transitive pydantic.v1 import must happen at module scope, outside the class's
+# frozen time: freezegun's FakeDate breaks pydantic.v1's metaclass construction, and the
+# runner otherwise defers this import to the first test that resolves a linkage.
+import products.experiments.backend.facade.replay  # noqa: F401
 from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import LazyComputationResult
+from products.cohorts.backend.models.cohort import Cohort
 from products.experiments.backend.hogql_queries.experiment_exposure_query_builder import ExposureQueryBuilder
 from products.experiments.backend.models.experiment import Experiment
 from products.experiments.backend.models.team_experiments_config import TeamExperimentsConfig
+from products.experiments.backend.replay_linkage import ACTIVATION_LIVE_SCAN_MAX_MEMORY_BYTES
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 
 from ee.models.rbac.access_control import AccessControl
@@ -579,6 +590,74 @@ class TestSessionRecordingsListByExperimentExposure(ClickhouseTestMixin, APIBase
                 ["session-after-activation"],
             )
         ensure_mock.assert_not_called()
+
+    def test_activation_mode_with_uncalculated_cohort_asks_to_retry(self) -> None:
+        # An uncalculated cohort's membership rows are only partially inserted, so a live
+        # activation scan filtered by it would silently undercount the exposed population;
+        # the linkage must refuse with the retryable cohort error instead.
+        self._enable_precomputation()
+        cohort = Cohort.objects.create(team=self.team, name="mid first calculation", is_static=False)
+        experiment = self._create_experiment(
+            exposure_criteria={
+                "activation_config": {
+                    "kind": "ExperimentEventExposureConfig",
+                    "event": "task_completed",
+                    "properties": [{"key": "id", "type": "cohort", "value": cohort.pk}],
+                }
+            }
+        )
+
+        with self.assertRaises(ValidationError) as error_context:
+            filter_recordings_by(
+                team=self.team,
+                recordings_filter={"experiment_exposure": {"experiment_id": experiment.id}},
+                user=self.user,
+            )
+        self.assertIn("hasn't finished calculating", str(error_context.exception.detail))
+
+    def test_activation_live_scan_runs_memory_bounded_and_refuses_over_budget(self) -> None:
+        # Precomputing teams get no unbounded live path: the listing query must carry the
+        # activation budget's memory ceiling, and a scan killed by it must render the
+        # budget's refusal rather than a raw ClickHouse memory error.
+        self._enable_precomputation()
+        experiment = self._create_experiment(
+            exposure_criteria={
+                "activation_config": {
+                    "kind": "ExperimentEventExposureConfig",
+                    "event": "task_completed",
+                    "properties": [],
+                }
+            }
+        )
+
+        executed_settings: list[HogQLGlobalSettings] = []
+
+        def record_settings_and_hit_the_ceiling(*args: object, **kwargs: object) -> None:
+            executed_settings.append(cast(HogQLGlobalSettings, kwargs["settings"]))
+            raise ClickHouseQueryMemoryLimitExceeded()
+
+        with patch.object(HogQLCursorPaginator, "execute_hogql_query", side_effect=record_settings_and_hit_the_ceiling):
+            with self.assertRaises(ValidationError) as error_context:
+                filter_recordings_by(
+                    team=self.team,
+                    recordings_filter={"experiment_exposure": {"experiment_id": experiment.id}},
+                    user=self.user,
+                )
+        self.assertEqual(executed_settings[0].max_memory_usage, ACTIVATION_LIVE_SCAN_MAX_MEMORY_BYTES)
+
+        # Cluster-wide memory pressure is transient and not this query's fault; translating it
+        # into the budget's permanent-sounding refusal would tell users to stop retrying a
+        # request that would succeed in minutes.
+        with patch.object(
+            HogQLCursorPaginator, "execute_hogql_query", side_effect=ClickHouseClusterMemoryLimitExceeded()
+        ):
+            with self.assertRaises(ClickHouseClusterMemoryLimitExceeded):
+                filter_recordings_by(
+                    team=self.team,
+                    recordings_filter={"experiment_exposure": {"experiment_id": experiment.id}},
+                    user=self.user,
+                )
+        self.assertIn("too much exposure data", str(error_context.exception.detail))
 
     def test_young_experiments_scan_live_even_on_precomputing_teams(self) -> None:
         # Started 6 hours before the frozen now, under the 12-hour precompute minimum. The

--- a/posthog/session_recordings/queries/test/listing_recordings/test_session_recordings_list_by_experiment_exposure.py
+++ b/posthog/session_recordings/queries/test/listing_recordings/test_session_recordings_list_by_experiment_exposure.py
@@ -532,7 +532,11 @@ class TestSessionRecordingsListByExperimentExposure(ClickhouseTestMixin, APIBase
                 )
         self.assertIn("still being computed", str(error_context.exception.detail))
 
-    def test_rejects_activation_mode_on_precomputing_teams(self) -> None:
+    def test_activation_mode_scans_live_even_on_precomputing_teams(self) -> None:
+        # Activation exposures have no preaggregated form, so on precomputing teams they must
+        # scan live rather than refuse, and must not reach ensure_precomputed: a cache built
+        # from the flag predicate alone would ignore the activation ordering and include the
+        # session between flag exposure and activation.
         self._enable_precomputation()
         experiment = self._create_experiment(
             exposure_criteria={
@@ -543,14 +547,38 @@ class TestSessionRecordingsListByExperimentExposure(ClickhouseTestMixin, APIBase
                 }
             }
         )
+        create_person(team=self.team, distinct_ids=["activated-user"])
+        flag_exposure_time = BASE_TIME + timedelta(minutes=30)
+        activation_time = BASE_TIME + timedelta(hours=3)
+        self._create_exposure_event("activated-user", flag_exposure_time, "test")
+        _create_event(
+            team=self.team,
+            event="task_completed",
+            distinct_id="activated-user",
+            timestamp=activation_time,
+            properties={},
+        )
+        flush_persons_and_events()
 
-        with self.assertRaises(ValidationError) as error_context:
-            filter_recordings_by(
-                team=self.team,
-                recordings_filter={"experiment_exposure": {"experiment_id": experiment.id}},
-                user=self.user,
+        self._produce_recording(
+            "activated-user",
+            "session-before-activation",
+            flag_exposure_time + timedelta(minutes=30),
+            flag_exposure_time + timedelta(minutes=45),
+        )
+        self._produce_recording(
+            "activated-user",
+            "session-after-activation",
+            activation_time + timedelta(minutes=30),
+            activation_time + timedelta(minutes=45),
+        )
+
+        with patch("products.experiments.backend.replay_linkage.ensure_precomputed") as ensure_mock:
+            self._assert_query_matches_session_ids(
+                {"experiment_exposure": {"experiment_id": experiment.id}},
+                ["session-after-activation"],
             )
-        self.assertIn("activation event", str(error_context.exception.detail))
+        ensure_mock.assert_not_called()
 
     def test_young_experiments_scan_live_even_on_precomputing_teams(self) -> None:
         # Started 6 hours before the frozen now, under the 12-hour precompute minimum. The

--- a/posthog/session_recordings/queries/test/listing_recordings/test_session_recordings_list_by_experiment_exposure.py
+++ b/posthog/session_recordings/queries/test/listing_recordings/test_session_recordings_list_by_experiment_exposure.py
@@ -15,7 +15,7 @@ from posthog.hogql.constants import HogQLGlobalSettings
 
 from posthog.clickhouse.client import sync_execute
 from posthog.constants import AvailableFeature
-from posthog.exceptions import ClickHouseClusterMemoryLimitExceeded, ClickHouseQueryMemoryLimitExceeded
+from posthog.exceptions import ClickHouseQueryMemoryLimitExceeded
 from posthog.hogql_queries.insights.paginators import HogQLCursorPaginator
 from posthog.models import User
 from posthog.models.personal_api_key import PersonalAPIKey
@@ -615,10 +615,12 @@ class TestSessionRecordingsListByExperimentExposure(ClickhouseTestMixin, APIBase
             )
         self.assertIn("hasn't finished calculating", str(error_context.exception.detail))
 
-    def test_activation_live_scan_runs_memory_bounded_and_refuses_over_budget(self) -> None:
+    def test_activation_live_scan_is_memory_bounded_and_memory_kills_keep_their_rendering(self) -> None:
         # Precomputing teams get no unbounded live path: the listing query must carry the
-        # activation budget's memory ceiling, and a scan killed by it must render the
-        # budget's refusal rather than a raw ClickHouse memory error.
+        # activation memory ceiling. A kill under it must propagate as the platform's
+        # standard memory-limit error, never an exposure-specific translation: the ceiling
+        # bounds the whole listing query, so the runner can't attribute a kill to the
+        # exposure scan.
         self._enable_precomputation()
         experiment = self._create_experiment(
             exposure_criteria={
@@ -637,27 +639,13 @@ class TestSessionRecordingsListByExperimentExposure(ClickhouseTestMixin, APIBase
             raise ClickHouseQueryMemoryLimitExceeded()
 
         with patch.object(HogQLCursorPaginator, "execute_hogql_query", side_effect=record_settings_and_hit_the_ceiling):
-            with self.assertRaises(ValidationError) as error_context:
+            with self.assertRaises(ClickHouseQueryMemoryLimitExceeded):
                 filter_recordings_by(
                     team=self.team,
                     recordings_filter={"experiment_exposure": {"experiment_id": experiment.id}},
                     user=self.user,
                 )
         self.assertEqual(executed_settings[0].max_memory_usage, ACTIVATION_LIVE_SCAN_MAX_MEMORY_BYTES)
-
-        # Cluster-wide memory pressure is transient and not this query's fault; translating it
-        # into the budget's permanent-sounding refusal would tell users to stop retrying a
-        # request that would succeed in minutes.
-        with patch.object(
-            HogQLCursorPaginator, "execute_hogql_query", side_effect=ClickHouseClusterMemoryLimitExceeded()
-        ):
-            with self.assertRaises(ClickHouseClusterMemoryLimitExceeded):
-                filter_recordings_by(
-                    team=self.team,
-                    recordings_filter={"experiment_exposure": {"experiment_id": experiment.id}},
-                    user=self.user,
-                )
-        self.assertIn("too much exposure data", str(error_context.exception.detail))
 
     def test_young_experiments_scan_live_even_on_precomputing_teams(self) -> None:
         # Started 6 hours before the frozen now, under the 12-hour precompute minimum. The

--- a/products/experiments/backend/facade/replay.py
+++ b/products/experiments/backend/facade/replay.py
@@ -1,6 +1,7 @@
 """Replay linkage capability, re-exported for callers outside the experiments product."""
 
 from products.experiments.backend.replay_linkage import (
+    ACTIVATION_LIVE_SCAN_MAX_MEMORY_BYTES,
     ExperimentExposureLinkage,
     exposed_distinct_ids_select,
     resolve_exposure_linkage,
@@ -8,6 +9,7 @@ from products.experiments.backend.replay_linkage import (
 )
 
 __all__ = [
+    "ACTIVATION_LIVE_SCAN_MAX_MEMORY_BYTES",
     "ExperimentExposureLinkage",
     "exposed_distinct_ids_select",
     "resolve_exposure_linkage",

--- a/products/experiments/backend/replay_linkage.py
+++ b/products/experiments/backend/replay_linkage.py
@@ -24,9 +24,9 @@ The exposure scan window is deliberately the full experiment window, unbounded. 
 would change who counts as exposed relative to the analysis. The expensive cases are handled
 instead: precomputing teams read the preaggregated table (converging in TTL-capped chunks for
 long-running experiments), activation-mode exposures always resolve with a live scan because
-they have no preaggregated form, and where neither the preaggregated read nor an affordable
-live scan is available the query is refused with a ValidationError rather than left to time
-out.
+they have no preaggregated form (carrying an explicit memory budget on precomputing teams),
+and where neither the preaggregated read nor an affordable live scan is available the query
+is refused with a ValidationError rather than left to time out.
 """
 
 from dataclasses import dataclass
@@ -77,6 +77,15 @@ COHORT_NOT_CALCULATED_MESSAGE = (
     "This experiment's exposure criteria reference a cohort that hasn't finished calculating. "
     "Try again when the cohort is ready."
 )
+LIVE_SCAN_OVER_BUDGET_MESSAGE = (
+    "This experiment has too much exposure data to resolve while loading recordings. "
+    "Contact support if you need recordings for this experiment."
+)
+
+# Sized an order of magnitude above the peak observed on the largest precompute-enabled team
+# (#83514), so it fires only for a scan far outside anything measured, where hitting the
+# ceiling turns cluster-level memory pressure into the budget's refusal instead.
+ACTIVATION_LIVE_SCAN_MAX_MEMORY_BYTES = 4 * 1024**3
 
 
 def validate_experiment_exposure_access(
@@ -114,6 +123,21 @@ def validate_experiment_exposure_access(
 
 
 @dataclass(frozen=True, kw_only=True)
+class LiveScanBudget:
+    """Resource ceiling for the query embedding a live exposure scan, with the refusal to
+    render when the ceiling is hit.
+
+    Set when the scan runs on a team where precomputation normally bounds exposure reads, so
+    the synchronous recordings-list run is explicitly bounded instead of relying on cluster
+    defaults. Composition callers that execute the linkage's AST through their own async or
+    batch pipelines run under those pipelines' limits and may ignore the budget.
+    """
+
+    max_memory_bytes: int
+    over_budget_message: str
+
+
+@dataclass(frozen=True, kw_only=True)
 class ExperimentExposureLinkage:
     """A validated experiment-exposure filter, resolved to how its population will be read.
 
@@ -125,6 +149,8 @@ class ExperimentExposureLinkage:
     requested_variants: list[str]
     # Set = read the preaggregated exposures written by these jobs. None = live events scan.
     preaggregation_job_ids: list[str] | None
+    # Ceiling the executing query must apply when the live scan needs explicit bounding.
+    live_scan_budget: LiveScanBudget | None = None
 
 
 def resolve_exposure_linkage(team: Team, *, experiment_id: int, variant: str | None) -> ExperimentExposureLinkage:
@@ -190,17 +216,23 @@ def resolve_exposure_linkage(team: Team, *, experiment_id: int, variant: str | N
         cuped_config=CupedQueryConfig(),
         activation_config=exposure_params.activation_config,
     )
+    read = _resolve_exposure_read(team, experiment, context)
     return ExperimentExposureLinkage(
         context=context,
         requested_variants=requested_variants,
-        preaggregation_job_ids=_resolve_preaggregation_job_ids(team, experiment, context),
+        preaggregation_job_ids=read.preaggregation_job_ids,
+        live_scan_budget=read.live_scan_budget,
     )
 
 
-def _resolve_preaggregation_job_ids(
-    team: Team, experiment: Experiment, context: ExperimentQueryContext
-) -> list[str] | None:
-    """Preaggregation job ids covering the experiment window, or None for a live scan.
+@dataclass(frozen=True, kw_only=True)
+class _ExposureRead:
+    preaggregation_job_ids: list[str] | None
+    live_scan_budget: LiveScanBudget | None
+
+
+def _resolve_exposure_read(team: Team, experiment: Experiment, context: ExperimentQueryContext) -> _ExposureRead:
+    """How the exposed population will be read: preaggregation job ids, or a live scan.
 
     The eligibility gates mirror the exposures-chart runner's, but the fallback posture
     inverts: the analysis can always fall back to a direct scan, because it runs through
@@ -211,7 +243,8 @@ def _resolve_preaggregation_job_ids(
     is refused instead of silently attempting the scan that precomputation exists to
     avoid. Activation mode is the exception: it has no preaggregated form at all, and
     its live scan stays affordable because its memory is bounded by the exposed
-    population, so it scans live rather than being permanently refused.
+    population, so it scans live under an explicit memory budget rather than being
+    permanently refused.
     """
     config = get_or_create_team_extension(team, TeamExperimentsConfig)
     # Below the minimum runtime the analysis skips precomputation too: the scan window is
@@ -221,20 +254,29 @@ def _resolve_preaggregation_job_ids(
         experiment.start_date, experiment.end_date
     ):
         tag_queries(experiment_exposures_path="direct_scan")
-        return None
+        return _ExposureRead(preaggregation_job_ids=None, live_scan_budget=None)
+
+    if has_uncalculated_cohorts(team, experiment.exposure_criteria):
+        # Both reads below see the cohort's partially-inserted membership: a precompute build
+        # would freeze the torn snapshot for the frozen-band TTL, and the activation live scan
+        # would silently undercount. Transient, so the error says to retry.
+        raise ValidationError(COHORT_NOT_CALCULATED_MESSAGE)
 
     if has_activation_config(experiment.exposure_criteria):
         # The flag-to-activation ordering crosses the per-day cache buckets, so activation
         # exposures have no preaggregated form. Their live scan stays affordable even on the
         # largest teams, because it is bounded by the experiment window's activation events
         # and the distinct-id expansion's memory scales with the exposed population, so they
-        # scan live instead of being refused.
+        # scan live instead of being refused. The budget keeps the scan explicitly bounded:
+        # one that outgrows the ceiling is refused instead of pressuring the cluster.
         tag_queries(experiment_exposures_path="direct_scan_activation")
-        return None
-    if has_uncalculated_cohorts(team, experiment.exposure_criteria):
-        # A build during the cohort's first materialization would freeze a torn membership
-        # snapshot for the frozen-band TTL; transient, so the error says to retry.
-        raise ValidationError(COHORT_NOT_CALCULATED_MESSAGE)
+        return _ExposureRead(
+            preaggregation_job_ids=None,
+            live_scan_budget=LiveScanBudget(
+                max_memory_bytes=ACTIVATION_LIVE_SCAN_MAX_MEMORY_BYTES,
+                over_budget_message=LIVE_SCAN_OVER_BUDGET_MESSAGE,
+            ),
+        )
 
     query_string, placeholders = ExposureQueryBuilder(context=context).precomputation_query()
     assert experiment.start_date is not None
@@ -261,7 +303,10 @@ def _resolve_preaggregation_job_ids(
         raise ValidationError(EXPOSURES_STILL_COMPUTING_MESSAGE)
 
     tag_queries(experiment_exposures_path="precomputed")
-    return [str(job_id) for job_id in result.job_ids]
+    return _ExposureRead(
+        preaggregation_job_ids=[str(job_id) for job_id in result.job_ids],
+        live_scan_budget=None,
+    )
 
 
 def exposed_distinct_ids_select(linkage: ExperimentExposureLinkage) -> ast.SelectQuery:

--- a/products/experiments/backend/replay_linkage.py
+++ b/products/experiments/backend/replay_linkage.py
@@ -77,14 +77,10 @@ COHORT_NOT_CALCULATED_MESSAGE = (
     "This experiment's exposure criteria reference a cohort that hasn't finished calculating. "
     "Try again when the cohort is ready."
 )
-LIVE_SCAN_OVER_BUDGET_MESSAGE = (
-    "This experiment has too much exposure data to resolve while loading recordings. "
-    "Contact support if you need recordings for this experiment."
-)
-
 # Sized an order of magnitude above the peak observed on the largest precompute-enabled team
-# (#83514), so it fires only for a scan far outside anything measured, where hitting the
-# ceiling turns cluster-level memory pressure into the budget's refusal instead.
+# (#83514), so it fires only for a scan far outside anything measured, and below the cluster's
+# default per-query limit, so the kill renders as the standard memory-limit error before the
+# scan becomes cluster-level pressure.
 ACTIVATION_LIVE_SCAN_MAX_MEMORY_BYTES = 4 * 1024**3
 
 
@@ -123,21 +119,6 @@ def validate_experiment_exposure_access(
 
 
 @dataclass(frozen=True, kw_only=True)
-class LiveScanBudget:
-    """Resource ceiling for the query embedding a live exposure scan, with the refusal to
-    render when the ceiling is hit.
-
-    Set when the scan runs on a team where precomputation normally bounds exposure reads, so
-    the synchronous recordings-list run is explicitly bounded instead of relying on cluster
-    defaults. Composition callers that execute the linkage's AST through their own async or
-    batch pipelines run under those pipelines' limits and may ignore the budget.
-    """
-
-    max_memory_bytes: int
-    over_budget_message: str
-
-
-@dataclass(frozen=True, kw_only=True)
 class ExperimentExposureLinkage:
     """A validated experiment-exposure filter, resolved to how its population will be read.
 
@@ -149,8 +130,13 @@ class ExperimentExposureLinkage:
     requested_variants: list[str]
     # Set = read the preaggregated exposures written by these jobs. None = live events scan.
     preaggregation_job_ids: list[str] | None
-    # Ceiling the executing query must apply when the live scan needs explicit bounding.
-    live_scan_budget: LiveScanBudget | None = None
+    # max_memory_usage ceiling the synchronous recordings-list run must apply when the live
+    # scan needs explicit bounding instead of relying on cluster defaults. It bounds the whole
+    # embedding query, so a kill renders as the platform's generic memory-limit error rather
+    # than anything exposure-specific. Composition callers that execute the linkage's AST
+    # through their own async or batch pipelines run under those pipelines' limits and may
+    # ignore it.
+    live_scan_max_memory_bytes: int | None = None
 
 
 def resolve_exposure_linkage(team: Team, *, experiment_id: int, variant: str | None) -> ExperimentExposureLinkage:
@@ -221,14 +207,14 @@ def resolve_exposure_linkage(team: Team, *, experiment_id: int, variant: str | N
         context=context,
         requested_variants=requested_variants,
         preaggregation_job_ids=read.preaggregation_job_ids,
-        live_scan_budget=read.live_scan_budget,
+        live_scan_max_memory_bytes=read.live_scan_max_memory_bytes,
     )
 
 
 @dataclass(frozen=True, kw_only=True)
 class _ExposureRead:
     preaggregation_job_ids: list[str] | None
-    live_scan_budget: LiveScanBudget | None
+    live_scan_max_memory_bytes: int | None
 
 
 def _resolve_exposure_read(team: Team, experiment: Experiment, context: ExperimentQueryContext) -> _ExposureRead:
@@ -254,7 +240,7 @@ def _resolve_exposure_read(team: Team, experiment: Experiment, context: Experime
         experiment.start_date, experiment.end_date
     ):
         tag_queries(experiment_exposures_path="direct_scan")
-        return _ExposureRead(preaggregation_job_ids=None, live_scan_budget=None)
+        return _ExposureRead(preaggregation_job_ids=None, live_scan_max_memory_bytes=None)
 
     if has_uncalculated_cohorts(team, experiment.exposure_criteria):
         # Both reads below see the cohort's partially-inserted membership: a precompute build
@@ -267,15 +253,13 @@ def _resolve_exposure_read(team: Team, experiment: Experiment, context: Experime
         # exposures have no preaggregated form. Their live scan stays affordable even on the
         # largest teams, because it is bounded by the experiment window's activation events
         # and the distinct-id expansion's memory scales with the exposed population, so they
-        # scan live instead of being refused. The budget keeps the scan explicitly bounded:
-        # one that outgrows the ceiling is refused instead of pressuring the cluster.
+        # scan live instead of being refused. The ceiling keeps the scan explicitly bounded:
+        # one that outgrows it is killed with the standard memory-limit error instead of
+        # pressuring the cluster.
         tag_queries(experiment_exposures_path="direct_scan_activation")
         return _ExposureRead(
             preaggregation_job_ids=None,
-            live_scan_budget=LiveScanBudget(
-                max_memory_bytes=ACTIVATION_LIVE_SCAN_MAX_MEMORY_BYTES,
-                over_budget_message=LIVE_SCAN_OVER_BUDGET_MESSAGE,
-            ),
+            live_scan_max_memory_bytes=ACTIVATION_LIVE_SCAN_MAX_MEMORY_BYTES,
         )
 
     query_string, placeholders = ExposureQueryBuilder(context=context).precomputation_query()
@@ -305,7 +289,7 @@ def _resolve_exposure_read(team: Team, experiment: Experiment, context: Experime
     tag_queries(experiment_exposures_path="precomputed")
     return _ExposureRead(
         preaggregation_job_ids=[str(job_id) for job_id in result.job_ids],
-        live_scan_budget=None,
+        live_scan_max_memory_bytes=None,
     )
 
 

--- a/products/experiments/backend/replay_linkage.py
+++ b/products/experiments/backend/replay_linkage.py
@@ -23,8 +23,10 @@ The work splits in two, because recordings queries build their AST separately fr
 The exposure scan window is deliberately the full experiment window, unbounded. Narrowing it
 would change who counts as exposed relative to the analysis. The expensive cases are handled
 instead: precomputing teams read the preaggregated table (converging in TTL-capped chunks for
-long-running experiments), and where neither the preaggregated read nor an affordable live
-scan is available the query is refused with a ValidationError rather than left to time out.
+long-running experiments), activation-mode exposures always resolve with a live scan because
+they have no preaggregated form, and where neither the preaggregated read nor an affordable
+live scan is available the query is refused with a ValidationError rather than left to time
+out.
 """
 
 from dataclasses import dataclass
@@ -70,10 +72,6 @@ logger = structlog.get_logger(__name__)
 
 EXPOSURES_STILL_COMPUTING_MESSAGE = (
     "Exposed users for this experiment are still being computed. Try again in a few minutes."
-)
-ACTIVATION_NOT_PRECOMPUTABLE_MESSAGE = (
-    "This experiment counts exposure from an activation event, which can't be precomputed, "
-    "and this project is too large to resolve its exposed users live."
 )
 COHORT_NOT_CALCULATED_MESSAGE = (
     "This experiment's exposure criteria reference a cohort that hasn't finished calculating. "
@@ -206,11 +204,14 @@ def _resolve_preaggregation_job_ids(
 
     The eligibility gates mirror the exposures-chart runner's, but the fallback posture
     inverts: the analysis can always fall back to a direct scan, because it runs through
-    the async query pipeline with generous limits. This linkage runs inside a synchronous
-    recordings-list GET, where the production assessment showed the live scan cannot
-    complete on the largest teams. Precomputation being enabled is the team-level marker
-    for exactly those teams, so on them an unavailable preaggregated read is refused
-    instead of silently attempting the scan that precomputation exists to avoid.
+    the async query pipeline with generous limits, while this linkage runs inside a
+    synchronous recordings-list GET. Precomputation being enabled is the team-level
+    marker for the teams where the full-window live scan is a real cost, so on them a
+    transiently unavailable preaggregated read (still computing, cohort mid-calculation)
+    is refused instead of silently attempting the scan that precomputation exists to
+    avoid. Activation mode is the exception: it has no preaggregated form at all, and
+    its live scan stays affordable because its memory is bounded by the exposed
+    population, so it scans live rather than being permanently refused.
     """
     config = get_or_create_team_extension(team, TeamExperimentsConfig)
     # Below the minimum runtime the analysis skips precomputation too: the scan window is
@@ -224,9 +225,12 @@ def _resolve_preaggregation_job_ids(
 
     if has_activation_config(experiment.exposure_criteria):
         # The flag-to-activation ordering crosses the per-day cache buckets, so activation
-        # exposures can't be precomputed. A per-experiment live path for them is deliberately
-        # not built: activation mode is a negligible slice of running experiments.
-        raise ValidationError(ACTIVATION_NOT_PRECOMPUTABLE_MESSAGE)
+        # exposures have no preaggregated form. Their live scan stays affordable even on the
+        # largest teams, because it is bounded by the experiment window's activation events
+        # and the distinct-id expansion's memory scales with the exposed population, so they
+        # scan live instead of being refused.
+        tag_queries(experiment_exposures_path="direct_scan_activation")
+        return None
     if has_uncalculated_cohorts(team, experiment.exposure_criteria):
         # A build during the cohort's first materialization would freeze a torn membership
         # snapshot for the frozen-band TTL; transient, so the error says to retry.


### PR DESCRIPTION
## Problem

The recordings tab of an experiment that counts exposure from an activation event fails with on projects with experiment precomputation enabled ("This experiment counts exposure from an activation event, which can't be precomputed, and this project is too large to resolve its exposed users live")

The error is a deliberate guard from #82588, raised before any query runs. #83421 fixed the memory blow-up in the same filter but left the guard in place.

## Changes

- Activation-mode experiments now resolve their exposed population with the live scan instead of refusing, tagged `experiment_exposures_path="direct_scan_activation"` for observability.
- The guard was written when the live scan aggregated every distinct id of a project and could not complete on the largest ones. #83421's prefilter made the scan's memory scale with the exposed population, which removed the reason to refuse.
- Activation exposures still cannot be precomputed: the flag-to-activation ordering crosses the per-day cache buckets. The live scan is their only path, and the analysis exposures chart already runs the same scan live on every load.
- The listing query runs the activation scan under an explicit 4 GiB memory ceiling, an order of magnitude above the measured peak.
- A scan killed at the ceiling renders as the platform's standard memory-limit error, keeping its 513 status, machine code, and narrow-your-filters guidance. The ceiling bounds the whole listing query, so no exposure-specific message claims a cause the runner cannot attribute.
- The activation branch no longer skips the uncalculated-cohort gate: a cohort mid first materialization refuses with the retryable cohort error instead of silently undercounting the exposed population.
- The other transient refusal stays: a preaggregated read that is still computing.

> [!NOTE]
> Worst-case posture changes: a project whose prefiltered scan outgrows the 4 GiB ceiling gets the standard memory-limit error after the scan runs, instead of an instant refusal before it. No such project runs an activation experiment today, and the query tag makes the path watchable after deploy.

## How did you test this code?

- I (Claude) captured the exact recordings query this code generates (via a temporary query snapshot on the new test) and ran its shape against the production project the guard was protecting, with that project's real predicates from `query_log`:
  - Both running activation experiments there resolve in 1.6-1.9 s at ~400 MiB under an 8 GiB cap. The shipped query runs with `max_execution_time=60`.
  - A 90-day window (20x the real experiment age) stays at 1.8 s / 408 MiB. Memory is bounded by the exposed population, not the window.
  - An inventory query confirmed those two experiments are the only running activation experiments on that project.
- New test `test_activation_mode_scans_live_even_on_precomputing_teams`. It catches two regressions no existing test covers: reintroducing the refusal, and routing activation configs through `ensure_precomputed`, whose cache ignores activation ordering. The pre-activation session in the fixture fails the test if the population silently widens to flag-only exposure.
- New test `test_activation_live_scan_is_memory_bounded_and_memory_kills_keep_their_rendering`. It catches dropping the memory ceiling from the listing query, and reintroducing a translation that swallows the standard memory-limit error.
- New test `test_activation_mode_with_uncalculated_cohort_asks_to_retry`. It catches the activation branch bypassing the cohort gate.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude (Claude Code) investigated and wrote this after Marcel reported the tab still failing post-#83421 on two experiments. The production measurements ran through the Metabase ClickHouse connection; the generated-SQL capture used a temporary `@snapshot_clickhouse_queries` decorator, removed before commit.
- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/writing-pr-descriptions`, `/query-clickhouse-via-metabase`.
- Decision in session: keep the fix to lifting the activation refusal only. The broader question of whether non-activation live scans could also be allowed on precomputing teams is left alone, since the preaggregated read is strictly cheaper where it exists.
- A follow-up commit addressed both review-bot findings (bounded execution path, cohort-gate bypass). A fresh-eyes agent review of that commit caught that the cluster-wide memory error subclass had to keep its transient rendering.
- A second follow-up commit accepted a further review-bot finding: the ceiling's memory kill was translated into an exposure-specific 400 even when an unrelated filter caused the overrun, and the translated error dropped the 513 status and machine code the frontend routes on. The translation is removed; the standard error renders as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
