### PR TITLE
fix(celery): move verify_and_fix_team_metadata_cache_task to FEATURE_FLAGS_LONG_RUNNING queue

### DIFF
--- a/posthog/tasks/hypercache_verification.py
+++ b/posthog/tasks/hypercache_verification.py
@@ -230,7 +230,7 @@ def verify_and_fix_flags_cache_task(self: PushGatewayTask) -> None:
     base=PushGatewayTask,
     ignore_result=True,
     name=VERIFY_TEAM_METADATA_CACHE_TASK_NAME,
-    queue=CeleryQueue.DEFAULT.value,
+    queue=CeleryQueue.FEATURE_FLAGS_LONG_RUNNING.value,
     soft_time_limit=20 * 60,  # 20 min soft limit
     time_limit=25 * 60,  # 25 min hard limit (matches LOCK_TIMEOUT_SECONDS)
 )

--- a/posthog/tasks/test/test_hypercache_verification.py
+++ b/posthog/tasks/test/test_hypercache_verification.py
@@ -22,6 +22,7 @@ from posthog.tasks.hypercache_verification import (
     verify_and_fix_team_metadata_cache_task,
 )
 from posthog.tasks.test.utils import PushGatewayTaskTestMixin
+from posthog.tasks.utils import CeleryQueue
 
 
 def _incomplete_runs(cache_type: str, reason: str) -> float:
@@ -176,6 +177,11 @@ class TestVerifyAndFixTeamMetadataCacheTask(PushGatewayTaskTestMixin, TestCase):
         )
         assert success == 1
         assert duration is not None and duration >= 0
+
+    def test_runs_on_feature_flags_long_running_queue(self) -> None:
+        # Ensure the task is on FEATURE_FLAGS_LONG_RUNNING, not DEFAULT, to avoid
+        # expiry-based starvation on the shared DEFAULT queue.
+        assert verify_and_fix_team_metadata_cache_task.queue == CeleryQueue.FEATURE_FLAGS_LONG_RUNNING.value
 
 
 @override_settings(FLAGS_REDIS_URL=None)


### PR DESCRIPTION
## Problem

`verify_and_fix_team_metadata_cache_task` runs on the shared `DEFAULT` Celery queue with `expires_seconds=60*60`. When the `DEFAULT` queue backlog exceeds an hour, beat messages expire before a worker picks them up — the worker discards them silently with no failure counter, no exception, no log line.

Closes #81006

Completions over 24h (2026-08-10) confirmed the gap:
- `verify_and_fix_team_metadata_cache_task` on `DEFAULT`: 2/day (prod-us), 12/day (prod-eu)
- `verify_and_fix_flag_definitions_cache_task` on `FEATURE_FLAGS_LONG_RUNNING`: 15/day (prod-us), 23/day (prod-eu)

Same hourly cadence, same 1h expiry — only the queue differs.

## Changes

One-line fix in `posthog/tasks/hypercache_verification.py`: move the task from `CeleryQueue.DEFAULT` to `CeleryQueue.FEATURE_FLAGS_LONG_RUNNING`, matching its two sibling tasks (`verify_and_fix_flags_cache_task` and `verify_and_fix_flag_definitions_cache_task`). The task's 20-min soft limit fits that queue's profile.

## How did you test this code?

Added `test_runs_on_feature_flags_long_running_queue` in `TestVerifyAndFixTeamMetadataCacheTask` asserting the task's queue matches `FEATURE_FLAGS_LONG_RUNNING`. Ran the full `test_hypercache_verification.py` suite locally — all tests passed, no regressions.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?